### PR TITLE
🐛  Fix: Fix pypi deployment

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -31,6 +31,14 @@ jobs:
         run: |
           uv sync --dev
 
+      - name: Install tools
+        run: |
+          ./scripts/utils/install-tools.sh --local
+
+      - name: Add tools to PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
       - name: Run tests
         run: |
           uv run pytest --cov=lintro --cov-report=xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2024-12-19
+
+### Fixed
+- **PyPI Publication Workflow**: Fixed test failures in PyPI publish workflow by adding missing tool installation step
+  - Added tool installation step (`./scripts/utils/install-tools.sh --local`) to PyPI workflow
+  - Added PATH setup to ensure tools are available during test execution
+  - Now matches the tool setup used in the main CI workflow
+- **Tool Installation Script**: Improved compatibility with uv-based Python environments
+  - Updated `install-tools.sh` to use `uv pip install` for Python packages when uv is available
+  - Added detection for GitHub Actions environment and uv availability
+  - Maintains fallback to pip for environments without uv
+- **Package Distribution**: Fixed MANIFEST.in file patterns to eliminate build warnings
+  - Updated Dockerfile pattern to match actual file names (`Dockerfile.*`)
+  - Removed unnecessary `.rst` and `.txt` patterns for docs directory
+  - Clean build process with no warnings during package creation
+
+### Technical Details
+- **Files Modified**:
+  - `.github/workflows/publish-pypi.yml` - Added tool installation and PATH setup
+  - `scripts/utils/install-tools.sh` - Improved uv compatibility for Python package installation
+  - `MANIFEST.in` - Fixed file inclusion patterns
+
+- **Root Cause**: PyPI publish workflow was missing external tool dependencies (ruff, darglint, prettier, yamllint, hadolint) that integration tests require
+- **Impact**: All tests now pass in PyPI publication workflow, enabling successful package distribution
+
 ## [Unreleased]
 
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,12 +8,10 @@ recursive-include lintro/ascii-art *
 
 # Include any additional documentation
 recursive-include docs *.md
-recursive-include docs *.rst
-recursive-include docs *.txt
 
 # Include test files for development
 recursive-include tests *.py
 recursive-include test_samples *.py
 recursive-include test_samples *.yml
 recursive-include test_samples *.js
-recursive-include test_samples *.Dockerfile 
+recursive-include test_samples Dockerfile.* 

--- a/scripts/utils/install-tools.sh
+++ b/scripts/utils/install-tools.sh
@@ -148,10 +148,10 @@ main() {
     # Install yamllint (platform-specific)
     echo -e "${BLUE}Installing yamllint...${NC}"
     
-    # Check if we're in a GitHub Actions environment (no sudo privileges)
-    if [ -n "$GITHUB_ACTIONS" ]; then
-        # GitHub Actions - use pip
-        if pip install yamllint; then
+    # Check if we're in a GitHub Actions environment or using uv
+    if [ -n "$GITHUB_ACTIONS" ] || command -v uv &> /dev/null; then
+        # GitHub Actions or uv environment - use uv pip
+        if uv pip install yamllint; then
             echo -e "${GREEN}✓ yamllint installed successfully${NC}"
         else
             echo -e "${RED}✗ Failed to install yamllint${NC}"
@@ -183,13 +183,26 @@ main() {
         fi
     fi
     
-    # Install darglint via pip (Python package)
+    # Install darglint (Python package)
     echo -e "${BLUE}Installing darglint...${NC}"
-    if pip install darglint==1.8.1; then
-        echo -e "${GREEN}✓ darglint installed successfully${NC}"
+    
+    # Check if we're in a GitHub Actions environment or using uv
+    if [ -n "$GITHUB_ACTIONS" ] || command -v uv &> /dev/null; then
+        # GitHub Actions or uv environment - use uv pip
+        if uv pip install darglint==1.8.1; then
+            echo -e "${GREEN}✓ darglint installed successfully${NC}"
+        else
+            echo -e "${RED}✗ Failed to install darglint${NC}"
+            exit 1
+        fi
     else
-        echo -e "${RED}✗ Failed to install darglint${NC}"
-        exit 1
+        # Fallback to pip
+        if pip install darglint==1.8.1; then
+            echo -e "${GREEN}✓ darglint installed successfully${NC}"
+        else
+            echo -e "${RED}✗ Failed to install darglint${NC}"
+            exit 1
+        fi
     fi
     
     echo ""


### PR DESCRIPTION
## Overview

The PyPI publish workflow (`publish-pypi.yml`) was failing during the test phase because it lacked the necessary external tools that the integration tests depend on. While the main CI workflow installed these tools, the PyPI workflow only installed Python dependencies via `uv sync --dev`.

### Specific Issues
1. **Missing Tool Dependencies**: Integration tests require external tools (ruff, darglint, prettier, yamllint, hadolint) that weren't installed
2. **Tool Installation Script**: The `install-tools.sh` script wasn't compatible with uv-based environments
3. **Package Build Warnings**: MANIFEST.in had incorrect file patterns causing build warnings

## Changes Made

### 1. Fixed PyPI Publish Workflow
**File**: `.github/workflows/publish-pypi.yml`

**Changes**:
- Added tool installation step before running tests
- Added PATH setup to ensure tools are available
- Now matches the tool setup used in the main CI workflow
### 2. Improved Tool Installation Script
**File**: `scripts/utils/install-tools.sh`

**Changes**:
- Added uv compatibility for Python package installation
- Enhanced environment detection (GitHub Actions + uv)
- Maintained backward compatibility with pip

**Key Improvements**:
- Uses `uv pip install` when uv is available
- Detects GitHub Actions environment automatically
- Falls back to pip for environments without uv

### 3. Fixed Package Distribution
**File**: `MANIFEST.in`

**Changes**:
- Fixed Dockerfile pattern to match actual file names
- Removed unnecessary file patterns for docs directory
- Eliminated build warnings during package creation

## Testing
All changes have been tested locally:
- [x] All tests pass: `uv run pytest tests/ -x --tb=short`
- [x] Package builds cleanly: `uv run python -m build`
- [x] No linting issues in source code
- [x] Tool installation script works with uv