### PR TITLE
chore(ci): enable semantic-release PR creation after allowlist update

### DIFF
--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Read version from pyproject.toml
         id: version
         run: |
-          python scripts/utils/extract-version.py | tee version.txt
+          uv run python scripts/utils/extract-version.py | tee version.txt
           cat version.txt >> "$GITHUB_OUTPUT"
 
       - name: Detect previous version
@@ -37,7 +37,8 @@ jobs:
         run: |
           git show HEAD^:pyproject.toml > /tmp/prev.toml || true
           if [ -s /tmp/prev.toml ]; then
-            python scripts/utils/extract-version.py --file /tmp/prev.toml \
+            uv run python scripts/utils/extract-version.py \
+              --file /tmp/prev.toml \
               | tee prev.txt
             cat prev.txt >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -71,7 +71,7 @@ jobs:
         id: current
         # yamllint disable rule:line-length
         run: |
-          python scripts/utils/extract-version.py | sed 's/^version=/current_version=/' | tee cur.txt
+          uv run python scripts/utils/extract-version.py | sed 's/^version=/current_version=/' | tee cur.txt
           cat cur.txt >> "$GITHUB_OUTPUT"
         # yamllint enable
 


### PR DESCRIPTION
## Description

Retry the automated release setup now that `peter-evans/create-pull-request@v6` is allow‑listed. Ensures the release flow can open a Release PR, auto-tag, and publish.

## Summary

- Use `uv run` for version extraction in workflows.
- Confirm org allowlist includes `peter-evans/create-pull-request@v6`.
- semantic-release will open a Release PR when eligible commits exist.

## Type

- [x] chore/ci/style

## Lintro & Tests

- [x] Lintro passes (format + check)
- [x] Tests pass and coverage acceptable
- [ ] If user-facing, docs updated

## Details

CI-only changes. If no eligible conventional commits exist, the workflow will print “No new version to release.”

## Type of Change

- [x] CI/CD improvement

## Testing

## Code Quality

- [x] Follows style guidelines

## Documentation

- [x] No docs impact

## Dependencies

- [x] No new dependencies

## Breaking Changes

- [x] None

## Security Considerations

- [x] No security implications