### PR TITLE
feat(ci/docs): align live badges with canonical workflows and auto-update coverage

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -70,6 +70,12 @@ jobs:
         id: coverage
         run: ./scripts/ci/ci-extract-coverage.sh
 
+      - name: Update repository coverage badge (assets/images)
+        if: github.ref == 'refs/heads/main' && success()
+        env:
+          COVERAGE_BADGE_COMMIT: 'true'
+        run: ./scripts/ci/coverage-badge-update.sh
+
   comment-pr-coverage:
     needs: run-test-suite
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Lintro is a unified command-line interface that brings together multiple code qu
 [![Python](https://img.shields.io/badge/python-3.13-blue)](https://www.python.org/downloads/)
 [![Coverage](assets/images/coverage-badge.svg)](docs/coverage-setup.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-scripts--based-blue)](scripts/README.md#local-testsh)
-[![CI](https://img.shields.io/badge/ci-scripts--based-blue)](scripts/README.md#ci)
-[![Docker](https://img.shields.io/badge/docker-supported-blue?logo=docker)](docs/docker.md)
+[![Tests](https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/test-and-coverage.yml?label=tests)](https://github.com/TurboCoder13/py-lintro/actions/workflows/test-and-coverage.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/ci-lintro-analysis.yml?label=ci)](https://github.com/TurboCoder13/py-lintro/actions/workflows/ci-lintro-analysis.yml)
+[![Docker](https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/docker-build-publish.yml?label=docker&logo=docker)](https://github.com/TurboCoder13/py-lintro/actions/workflows/docker-build-publish.yml)
 [![Code Style](https://img.shields.io/badge/code%20style-ruff-black-blue)](https://github.com/astral-sh/ruff)
-[![PyPI](https://img.shields.io/badge/pypi-not%20published-lightgrey)](docs/getting-started.md#installation)
+[![PyPI](https://img.shields.io/pypi/v/lintro?label=pypi)](https://pypi.org/project/lintro/)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Lintro is a unified command-line interface that brings together multiple code qu
 - **🔒 Reliable**: Comprehensive test suite with 84% coverage
 
 [![Python](https://img.shields.io/badge/python-3.13-blue)](https://www.python.org/downloads/)
-[![Coverage](https://img.shields.io/badge/coverage-84.5%25-brightgreen)](https://github.com/TurboCoder13/py-lintro/actions/workflows/lintro-test-coverage.yml)
+[![Coverage](assets/images/coverage-badge.svg)](docs/coverage-setup.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![Tests](https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/lintro-test-coverage.yml?label=tests)](https://github.com/TurboCoder13/py-lintro/actions/workflows/lintro-test-coverage.yml)
-[![CI](https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/lintro-ci.yml?label=ci)](https://github.com/TurboCoder13/py-lintro/actions/workflows/lintro-ci.yml)
-[![Docker](https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/lintro-docker.yml?label=docker)](https://github.com/TurboCoder13/py-lintro/actions/workflows/lintro-docker.yml)
+[![Tests](https://img.shields.io/badge/tests-scripts--based-blue)](scripts/README.md#local-testsh)
+[![CI](https://img.shields.io/badge/ci-scripts--based-blue)](scripts/README.md#ci)
+[![Docker](https://img.shields.io/badge/docker-supported-blue?logo=docker)](docs/docker.md)
 [![Code Style](https://img.shields.io/badge/code%20style-ruff-black-blue)](https://github.com/astral-sh/ruff)
-[![PyPI](https://img.shields.io/pypi/status/lintro)](https://pypi.org/project/lintro/)
+[![PyPI](https://img.shields.io/badge/pypi-not%20published-lightgrey)](docs/getting-started.md#installation)
 
 ## Features
 


### PR DESCRIPTION
## Summary

Replace non-functional badges with live workflow-backed badges, align with existing workflows, and auto-update the local coverage badge on main.

## Changes
- README
  - Point badges to canonical workflows:
    - Tests → `.github/workflows/test-and-coverage.yml`
    - CI → `.github/workflows/ci-lintro-analysis.yml`
    - Docker → `.github/workflows/docker-build-publish.yml`
  - Keep coverage badge served from `assets/images/coverage-badge.svg` (updated by CI)
  - Keep PyPI badge as `shields.io` version for `lintro`
- Workflows
  - Enhance `.github/workflows/test-and-coverage.yml` to update `assets/images/coverage-badge.svg` on `main` via `./scripts/ci/coverage-badge-update.sh`

## Verification
- Tests: `./scripts/local/run-tests.sh` → all tests passed locally.

## Checklist
- [x] Tests pass locally
- [x] README links updated to canonical workflows
- [x] Coverage badge auto-update on `main`