### PR TITLE
feat(ci): run semantic-release on all pushes to main

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -4,11 +4,6 @@ name: Automated Release PR (no direct push to main)
 'on':
   push:
     branches: [main]
-    paths:
-      - '**/*.py'
-      - pyproject.toml
-      - lintro/**
-      - .github/workflows/semantic-release.yml
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

## What’s Changing

Run the Automated Release PR workflow on every push to `main`:
- Removed restrictive `paths:` filter from `.github/workflows/semantic-release.yml`
- Ensures a release PR is computed/opened whenever `main` changes

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests pass locally (`./scripts/local/run-tests.sh`)
- [x] Docs not needed (CI-only)