### PR TITLE
fix(ci): repair internal refs bump and Renovate config; add manual bump

### DIFF
--- a/.github/workflows/auto-bump-internal-refs.yml
+++ b/.github/workflows/auto-bump-internal-refs.yml
@@ -8,6 +8,11 @@ name: Auto-bump internal refs
       - .github/actions/**
       - .github/workflows/reusable-*.yml
   workflow_dispatch:
+    inputs:
+      sha:
+        description: Provide the full 40-char commit SHA to pin internal refs to
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -24,7 +29,12 @@ jobs:
           fetch-depth: 0
 
       - name: Bump internal refs to current SHA
-        run: scripts/ci/bump-internal-refs.sh
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            scripts/ci/bump-internal-refs.sh "${{ inputs.sha }}"
+          else
+            scripts/ci/bump-internal-refs.sh "${{ github.sha }}"
+          fi
 
       - name: Create PR if changes
         id: cpr

--- a/renovate.json
+++ b/renovate.json
@@ -61,7 +61,7 @@
     {
       "fileMatch": ["^\\.github/workflows/.*\\.yml$"],
       "matchStrings": [
-        "TurboCoder13/py-lintro/\\.github/(?:actions|workflows)/(?<depName>[^@\\s]+)@(?<currentDigest>[0-9a-f]{40})"
+        "TurboCoder13/py-lintro/\\.github/(?:actions|workflows)/(?<depPath>[^@\\s]+)@(?<currentValue>[0-9a-f]{40})"
       ],
       "datasourceTemplate": "github-commits",
       "lookupNameTemplate": "TurboCoder13/py-lintro",

--- a/scripts/ci/bump-internal-refs.sh
+++ b/scripts/ci/bump-internal-refs.sh
@@ -33,8 +33,15 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 fi
 
 SHA_TO_PIN="${1:-}"
+
+# Determine and validate SHA to pin
 if [[ -z "${SHA_TO_PIN}" ]]; then
   SHA_TO_PIN="$(git rev-parse HEAD)"
+fi
+
+if ! [[ "${SHA_TO_PIN}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Invalid SHA provided: ${SHA_TO_PIN}" >&2
+  exit 1
 fi
 
 echo "Bumping internal action/workflow refs to SHA: ${SHA_TO_PIN}" >&2
@@ -52,7 +59,7 @@ while IFS= read -r -d '' file; do
   echo "Processing ${file}" >&2
   # Replace action refs
   sed_in_place -E \
-    "s|(TurboCoder13/py-lintro/\.github/(actions|workflows)/[^@[:space:]]+@)[0-9a-f]{40}|\\1${SHA_TO_PIN}|g" \
+    "s#(TurboCoder13/py-lintro/\.github/(actions|workflows)/[^@[:space:]]+@)[0-9a-f]{40}#\\1${SHA_TO_PIN}#g" \
     "$file"
 done < <(find .github/workflows -type f -name '*.yml' -print0)
 


### PR DESCRIPTION
## Commit Summary

Type:
- [x] ci

## What’s Changing

- bump-internal-refs: fix `sed` delimiter for BSD/GNU compatibility and move `SHA` validation into `scripts/ci/bump-internal-refs.sh`.
- workflow hardening: require a 40-char `SHA` on `workflow_dispatch`; default to `github.sha` on push; call the script with the validated `SHA`.
- Renovate: make `regexManagers` schema-compliant by using `currentValue` and capturing `depPath`.
- tests: add tests for ref bump updating, invalid SHA handling, and Renovate config; fix test docstrings and long lines.

## Why

- Prevents sed errors on macOS runners.
- Enforces pinned, validated SHAs per hardened policy.
- Unblocks Renovate by fixing invalid configuration.
- Improves coverage and prevents regressions.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated and passing
- [x] Lintro passing
- [x] No inline shell validation in workflow; logic moved to `scripts/ci/*`
- [x] Renovate config validated (uses `currentValue`)