### PR TITLE
fix(ci): avoid false v1 by skipping when semantic-release reports no_release

### DIFF
--- a/scripts/ci/semantic-release-compute-next.sh
+++ b/scripts/ci/semantic-release-compute-next.sh
@@ -18,14 +18,28 @@ EOF
 fi
 
 NO_COLOR=1 FORCE_COLOR=0 OUTPUT=$(uvx --from python-semantic-release \
-  semantic-release --noop version --print 2>&1 || true)
+  semantic-release -v --noop version 2>&1 || true)
 echo "$OUTPUT"
-# Extract the last full semver-looking line from output, strip optional leading 'v'.
-NEXT_VERSION=$(printf "%s\n" "$OUTPUT" \
-  | sed -e 's/\r//g' \
-  | grep -E '^[vV]?[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$' \
-  | tail -n 1 \
-  | sed -E 's/^[vV]//' || true)
+
+# If tool reports no release, leave NEXT_VERSION empty
+if printf "%s\n" "$OUTPUT" | grep -qiE 'type[^\n]*no_release|no[_ ]release|no release will be made'; then
+  NEXT_VERSION=""
+else
+  # Prefer explicit phrasing from semantic-release logs
+  NEXT_VERSION=$(printf "%s\n" "$OUTPUT" \
+    | sed -n 's/.*The next version is[: ]*\(v\?[0-9][0-9.]*[0-9][0-9A-Za-z.-]*\).*/\1/p' \
+    | head -1 \
+    | sed -E 's/^[vV]//' || true)
+
+  # Fallback: standalone semver line (strip leading v)
+  if [[ -z "$NEXT_VERSION" ]]; then
+    NEXT_VERSION=$(printf "%s\n" "$OUTPUT" \
+      | sed -e 's/\r//g' \
+      | grep -E '^[vV]?[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$' \
+      | tail -n 1 \
+      | sed -E 's/^[vV]//' || true)
+  fi
+fi
 echo "Detected NEXT_VERSION=${NEXT_VERSION:-<empty>}"
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "next_version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What’s Changing
- Run semantic-release with verbose flag and skip when it reports type=no_release.
- Extract the next version from the explicit log line to avoid false v1 bumps.

## Why
- Prevents opening a v1 Release PR when there are no qualifying commits and major_on_zero=false.

## Validation
- Local dry-run shows 'no_release' with no version set; test suite passes.
