### PR TITLE
ci: fix checkout failures in docker publish and renovate

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -56,6 +56,7 @@ jobs:
           allowed-endpoints: |
             github.com:443
             api.github.com:443
+            codeload.github.com:443
             downloads.github.com:443
             objects.githubusercontent.com:443
             pkg-containers.githubusercontent.com:443
@@ -103,6 +104,7 @@ jobs:
           allowed-endpoints: |
             github.com:443
             api.github.com:443
+            codeload.github.com:443
             downloads.github.com:443
             objects.githubusercontent.com:443
             pkg-containers.githubusercontent.com:443

--- a/.github/workflows/lintro-renovate.yml
+++ b/.github/workflows/lintro-renovate.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - name: Harden and Checkout
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@dc34078e24d4328ea4879931677c81564abdcebd
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: true
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@b11417b9eaac3145fe9a8544cee66503724e32b6 # v43.0.8
         with:


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ci: fix checkout failures in docker publish and renovate

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] chore / ci / style

- Breaking change:
  - [ ] ! in title or BREAKING CHANGE footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - feat(...) or feat: → MINOR bump
  - fix(...) / fix: or perf(...) / perf: → PATCH bump
  - Any title with ! after the type or a body containing BREAKING CHANGE: → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

- Add codeload.github.com:443 to harden-runner allowlists in Docker workflow to unblock actions/checkout during publish/build.
- Pass GITHUB_TOKEN to harden-and-checkout in Renovate workflow (older composite requires explicit token).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests unaffected (workflow-only change)
- [x] Local CI sanity passed

## Related Runs

- Docker publish checkout failure: https://github.com/TurboCoder13/py-lintro/actions/runs/17175851240/job/48731696935
- Renovate hardened checkout input error: https://github.com/TurboCoder13/py-lintro/actions/runs/17175855845/job/48731621623?pr=98

## Details

- Checkout in block mode needs codeload.github.com allowlisted in addition to github.com/api.github.com.
- Renovate is pinned to a composite version that expects token; providing GITHUB_TOKEN restores compatibility.
