### PR TITLE
fix(ci): add token to hardened checkout steps

### DIFF
--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           persist-credentials: true
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Guard ensure last commit is a release bump
         id: guard

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -31,6 +31,7 @@ jobs:
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@dc34078e24d4328ea4879931677c81564abdcebd
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Environment setup
         uses: TurboCoder13/py-lintro/.github/actions/setup-env@dc34078e24d4328ea4879931677c81564abdcebd

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Harden and Checkout
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@dc34078e24d4328ea4879931677c81564abdcebd
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@96f518a34f7a870018057716cc4d7a5c014bd61c # v3

--- a/.github/workflows/composite-smoke-tests.yml
+++ b/.github/workflows/composite-smoke-tests.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Harden and Checkout
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@dc34078e24d4328ea4879931677c81564abdcebd
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup environment via composite
         uses: TurboCoder13/py-lintro/.github/actions/setup-env@dc34078e24d4328ea4879931677c81564abdcebd

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Harden and Checkout
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@dc34078e24d4328ea4879931677c81564abdcebd
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Dependency review
         uses: actions/dependency-review-action@bc41886e18ea39df68b1b1245f4184881938e050 # v4.7.2
         with:

--- a/.github/workflows/lintro-report-scheduled.yml
+++ b/.github/workflows/lintro-report-scheduled.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Harden and Checkout
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@dc34078e24d4328ea4879931677c81564abdcebd
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Environment setup
         uses: TurboCoder13/py-lintro/.github/actions/setup-env@dc34078e24d4328ea4879931677c81564abdcebd

--- a/.github/workflows/pages-deploy-coverage.yml
+++ b/.github/workflows/pages-deploy-coverage.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Harden and Checkout
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@dc34078e24d4328ea4879931677c81564abdcebd
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Download coverage artifact
         uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
         with:

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -46,6 +46,7 @@ jobs:
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@dc34078e24d4328ea4879931677c81564abdcebd
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Environment setup
         uses: TurboCoder13/py-lintro/.github/actions/setup-env@dc34078e24d4328ea4879931677c81564abdcebd
         with:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Harden and Checkout
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@dc34078e24d4328ea4879931677c81564abdcebd
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Harden and Checkout
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@dc34078e24d4328ea4879931677c81564abdcebd
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python 3.13
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -32,6 +32,8 @@ jobs:
             storage.googleapis.com:443
       - name: Harden and Checkout
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@dc34078e24d4328ea4879931677c81564abdcebd
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Scorecards analysis
         uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Harden and Checkout
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@dc34078e24d4328ea4879931677c81564abdcebd
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate PR title follows Conventional Commits
         id: semantic


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```
  ci: add token to hardened checkout steps
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Pass `GITHUB_TOKEN` to the composite action `harden-and-checkout` everywhere it is used, so that `actions/checkout` receives a token via `with.token` and jobs stop failing with “Input required and not supplied: token”. This unblocks dependency PRs and restores green checks.

Updated workflows:
- `.github/workflows/ci-lintro-analysis.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/dependency-review.yml`
- `.github/workflows/pages-deploy-coverage.yml`
- `.github/workflows/reusable-build.yml`
- `.github/workflows/reusable-quality.yml`
- `.github/workflows/scorecards.yml`
- `.github/workflows/semantic-pr-title.yml`
- `.github/workflows/lintro-report-scheduled.yml`
- `.github/workflows/auto-tag-on-main.yml`
- `.github/workflows/composite-smoke-tests.yml`
- `.github/workflows/publish-pypi-on-tag.yml`

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (N/A – workflows only; full test suite executed to validate repo health)
- [x] Docs updated if user-facing (N/A)
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

- Related: PR #113
- Failing runs:
  - https://github.com/TurboCoder13/py-lintro/actions/runs/17179896576/job/48740939084\?pr\=113
  - https://github.com/TurboCoder13/py-lintro/actions/runs/17179896581/job/48740939081\?pr\=113
  - https://github.com/TurboCoder13/py-lintro/actions/runs/17179896573/job/48740939060\?pr\=113

## Details

- The composite `.github/actions/harden-and-checkout` forwards `inputs.token` to `actions/checkout`. Without a token, checkout fails.
- We now explicitly pass `token: ${{ secrets.GITHUB_TOKEN }}` at each call site. Permissions remain minimal (`contents: read`) where applicable.
- This change aligns with our policy to pin actions and harden runners while ensuring required inputs are supplied.
- Verified by running the full test suite locally (205 passed, 2 skipped).
