### PR TITLE
fix(ci): pass token to hardened checkout in auto-bump workflow

### DIFF
--- a/.github/workflows/auto-bump-internal-refs.yml
+++ b/.github/workflows/auto-bump-internal-refs.yml
@@ -27,6 +27,7 @@ jobs:
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@dc34078e24d4328ea4879931677c81564abdcebd
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bump internal refs to current SHA
         run: |


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```
  ci: pass token to hardened checkout in auto-bump workflow
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Ensure the `auto-bump-internal-refs` workflow passes `GITHUB_TOKEN` to the `harden-and-checkout` composite so `actions/checkout` has credentials. The prior run failed during the create-pull-request step due to missing credentials.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (N/A – workflow only)
- [x] Docs updated if user-facing (N/A)
- [x] Local CI sanity-check passed

## Related Issues

- Failing run: https://github.com/TurboCoder13/py-lintro/actions/runs/17180034452/job/48741247799
- Related follow-up to: https://github.com/TurboCoder13/py-lintro/pull/114

## Details

- `harden-and-checkout` forwards `inputs.token` to `actions/checkout`. Without passing a token, downstream steps like `peter-evans/create-pull-request` may fail to push branches.
- Add `token: ${{ secrets.GITHUB_TOKEN }}` to the hardened checkout step in the auto-bump workflow. 
