### PR TITLE
ci: replace disallowed setup-python with setup-uv (pinned SHA)

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -11,17 +11,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up Python
-      # yamllint disable-line rule:line-length
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-      with:
-        python-version: ${{ inputs.python-version }}
-
-    - name: Install uv (with cache)
+    - name: Install uv (with cache) and Python
       # yamllint disable-line rule:line-length
       uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6
       with:
         enable-cache: true
+        python-version: ${{ inputs.python-version }}
 
     - name: Bootstrap environment via scripts
       shell: bash

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -29,15 +29,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: ${{ inputs.python-version }}
-
-      - name: Install uv (with cache)
+      - name: Install uv (with cache) and Python
         uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6
         with:
           enable-cache: true
+          python-version: ${{ inputs.python-version }}
 
       - name: Sync dependencies
         run: uv sync --dev --no-progress

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -27,15 +27,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python 3.13
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: 3.13
-
-      - name: Install uv (with cache)
+      - name: Install uv (with cache) and Python 3.13
         uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6
         with:
           enable-cache: true
+          python-version: 3.13
 
       - name: Sync dependencies
         run: uv sync --dev --no-progress


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

```
ci: replace disallowed setup-python with setup-uv (pinned SHA)
```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- This PR title follows Conventional Commits and will not trigger a version bump beyond patch (CI only).

## What’s Changing

Replace the disallowed action with the allowed, pinned alternative and ensure Python toolchain installation via uv:

- Switch `actions/setup-python` → `astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b` (pinned)
- Provide `python-version` via the action so uv installs 3.13 on runners
- Files updated:
  - `.github/actions/setup-env/action.yml`
  - `.github/workflows/reusable-build.yml`
  - `.github/workflows/reusable-quality.yml`

Rationale: the repository action allowlist blocks `actions/setup-python`, which caused the PyPI publish job to fail during "Set up job". `astral-sh/setup-uv` is on the allowlist and provides both uv and the Python toolchain with caching.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (N/A – CI-only change)
- [ ] Docs updated if user-facing (N/A)
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

- Related: https://github.com/TurboCoder13/py-lintro/actions/runs/17249964885/job/48949642039

## Details

- Action pinning: `astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b`
- Python version: 3.13
- Verified locally:
  - 213 passed in ~5.6s
  - Total coverage: ~82% (coverage.xml, htmlcov produced)
- Impact: CI-only. No product code changes. Publish to PyPI/TestPyPI will no longer fail at job setup due to allowlist.
