### PR TITLE
ci: harden workflows, fix publish path, and document policy

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -11,13 +11,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install uv (with cache) and Python
-      # yamllint disable-line rule:line-length
-      uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6
-      with:
-        enable-cache: true
-        python-version: ${{ inputs.python-version }}
-
     - name: Bootstrap environment via scripts
       shell: bash
-      run: ./scripts/utils/bootstrap-env.sh
+      run: scripts/utils/bootstrap-env.sh "${{ inputs.python-version }}"

--- a/.github/workflows/auto-bump-internal-refs.yml
+++ b/.github/workflows/auto-bump-internal-refs.yml
@@ -6,7 +6,6 @@ name: Auto-bump internal refs
     branches: [main]
     paths:
       - .github/actions/**
-      - .github/workflows/reusable-*.yml
   workflow_dispatch:
     inputs:
       sha:
@@ -20,7 +19,12 @@ permissions:
 
 jobs:
   bump:
-    if: ${{ !contains(github.event.head_commit.message, 'bump internal refs') }}
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' || (
+          github.ref == 'refs/heads/main' &&
+          !contains(github.event.head_commit.message, 'bump internal refs') &&
+          !startsWith(github.event.head_commit.message, 'chore(release):')
+      ) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,6 +6,7 @@ name: Dependency Review
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   review:
@@ -16,7 +17,17 @@ jobs:
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@d8df28c952a5849083a78557fed999207e783fd6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Dependency review
+      # Avoid PR comment on forks (token is read-only); still run the check
+      - name: Dependency review (forks - no PR comment)
+        if: github.event.pull_request.head.repo.fork == true
+        uses: actions/dependency-review-action@595b5aeba73380359d98a5e087f648dbb0edce1b # v4.7.3
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: false
+          allow-ghsas: true
+
+      - name: Dependency review (with PR comment)
+        if: github.event.pull_request.head.repo.fork == false
         uses: actions/dependency-review-action@595b5aeba73380359d98a5e087f648dbb0edce1b # v4.7.3
         with:
           fail-on-severity: high

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -74,7 +74,7 @@ jobs:
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2
         with:
           tag_name: ${{ github.ref_name }}
-          name: v${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           generate_release_notes: true
           files: |
             dist/*

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -29,10 +29,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install uv (with cache) and Python
-        uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6
+      - name: Environment setup
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@d8df28c952a5849083a78557fed999207e783fd6
         with:
-          enable-cache: true
           python-version: ${{ inputs.python-version }}
 
       - name: Sync dependencies

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -27,11 +27,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install uv (with cache) and Python 3.13
-        uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6
+      - name: Environment setup
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@d8df28c952a5849083a78557fed999207e783fd6
         with:
-          enable-cache: true
-          python-version: 3.13
+          python-version: '3.13'
 
       - name: Sync dependencies
         run: uv sync --dev --no-progress

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -169,6 +169,20 @@ The repository ships with fully automated semantic releases and PyPI publishing.
   - PyPI publish job: `id-token: write` (for OIDC) and `contents: write` only if creating a GH Release.
   - PR comment jobs: `pull-requests: write`.
 
+### Why we do not allow `astral-sh/setup-uv`
+
+Our Actions policy requires that all actions (including transitive actions used by
+composites) are allowlisted and pinned to a full commit SHA. The
+`astral-sh/setup-uv` action invokes `actions/setup-python@v5` internally, which
+is both not on our allowlist and referenced by tag (not a 40-char SHA). This
+causes policy enforcement to block any job that uses `setup-uv`.
+
+To comply, we replaced it with an internal composite `setup-env` that:
+
+- installs `uv` via `pip` (no nested actions),
+- provisions the requested Python version via `uv python install`, and
+- syncs dependencies, keeping our pipeline policy-compliant.
+
 Deprecated/manual flows (e.g., direct Release creation workflows) are removed to avoid parallel release paths.
 
 ### Labels & guards


### PR DESCRIPTION
## Summary
Harden CI workflows, fix publish path, and document policy.

## Motivation and Context
- Ensure PR and release checks are reliable and permission-safe.
- Remove disallowed/transitive actions to comply with repo policies.
- Stabilize release flow from PR → main → tag → PyPI.

## Changes
- Dependency Review: add `pull-requests: write` and gate PR comments on forks.
- Auto-bump internal refs: narrow trigger to `.github/actions/**` and add job guard
  to skip bump/release commits; keep manual dispatch.
- Env setup: replace external `setup-uv` with internal `setup-env` + `bootstrap-env.sh`
  (pip-install uv; `uv python install <ver>`; scripts only, no curl).
- Reusable workflows: use `setup-env` instead of `setup-uv`.
- Docs: note why `astral-sh/setup-uv` is disallowed under our policy.
- Publish on tag: fix release name (avoid double `v`); switch to Twine token path
  to avoid disallowed actions during publish.

## How Has This Been Tested?
- CI will run on this PR: PR checks, Docker Lintro, tests & coverage, CodeQL.
- Tag publish validated by re-pushing tags; path now avoids disallowed actions.

## Security Considerations
- No curl usage; no nested actions outside allowlist.
- Actions are SHA-pinned; PR comment jobs explicitly use `pull-requests: write`.
- Current publish path uses `PYPI_API_TOKEN` (Twine). OIDC can be restored later
  via a forked/pinned action.

## Breaking Changes
- None.

## Release Notes
- ci: harden workflows, fix publish path, document policy; correct release name.

## Checklist
- [x] Uses repository PR template format
- [x] Actions pinned to full SHAs where applicable
- [x] Disallowed actions removed from publish path (current Twine path)
- [x] No inline shell in workflows; scripts under `scripts/` used
- [x] Docs updated
- [x] Internal refs loop guard added
- [ ] Follow-up: if re-enabling OIDC, allow/setup pinned setup-python or fork/pin
      PyPI action
