### PR TITLE
docs: use canonical Scorecard badge endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Lintro is a unified command-line interface that brings together multiple code qu
 [![PyPI](https://img.shields.io/pypi/v/lintro?label=pypi)](https://pypi.org/project/lintro/)
 
 [![CodeQL](https://github.com/TurboCoder13/py-lintro/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/TurboCoder13/py-lintro/actions/workflows/codeql.yml?query=branch%3Amain)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/turbocoder13/py-lintro/badge)](https://scorecard.dev/viewer/?uri=github.com/turbocoder13/py-lintro)
+[![OpenSSF Scorecard](https://scorecard.dev/badge/github.com/turbocoder13/py-lintro)](https://scorecard.dev/viewer/?uri=github.com/turbocoder13/py-lintro)
 
 ### Why Lintro?
 

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -356,7 +356,7 @@ Add to your README.md:
 Add to your README.md:
 
 ```markdown
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/turbocoder13/py-lintro/badge)](https://scorecard.dev/viewer/?uri=github.com/turbocoder13/py-lintro)
+[![OpenSSF Scorecard](https://scorecard.dev/badge/github.com/turbocoder13/py-lintro)](https://scorecard.dev/viewer/?uri=github.com/turbocoder13/py-lintro)
 ```
 
 Reference installation docs: `https://github.com/ossf/scorecard?tab=readme-ov-file#installation`.


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):



- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [x] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

### What’s Changing

- Switch README and docs badge to .
- Keep viewer link on .

### Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (docs-only change)
- [x] Docs updated if user-facing

### Details

Use the canonical badge endpoint for better reliability. Badge should resolve shortly after Scorecard publishes results.