### PR TITLE
docs: fix OpenSSF Scorecard badge to canonical endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Lintro is a unified command-line interface that brings together multiple code qu
 [![PyPI](https://img.shields.io/pypi/v/lintro?label=pypi)](https://pypi.org/project/lintro/)
 
 [![CodeQL](https://github.com/TurboCoder13/py-lintro/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/TurboCoder13/py-lintro/actions/workflows/codeql.yml?query=branch%3Amain)
-[![OpenSSF Scorecard](https://scorecard.dev/badge/github.com/turbocoder13/py-lintro)](https://scorecard.dev/viewer/?uri=github.com/turbocoder13/py-lintro)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/TurboCoder13/py-lintro/badge)](https://scorecard.dev/viewer/?uri=github.com/TurboCoder13/py-lintro)
 
 ### Why Lintro?
 

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -356,7 +356,7 @@ Add to your README.md:
 Add to your README.md:
 
 ```markdown
-[![OpenSSF Scorecard](https://scorecard.dev/badge/github.com/turbocoder13/py-lintro)](https://scorecard.dev/viewer/?uri=github.com/turbocoder13/py-lintro)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/TurboCoder13/py-lintro/badge)](https://scorecard.dev/viewer/?uri=github.com/TurboCoder13/py-lintro)
 ```
 
 Reference installation docs: `https://github.com/ossf/scorecard?tab=readme-ov-file#installation`.


### PR DESCRIPTION
- switch badge to api.scorecard.dev/projects/.../badge\n- correct owner casing to TurboCoder13\n- update docs example to match\n\nThis ensures the badge image loads and links to the correct report.