### PR TITLE
feat: add OpenSSF Allstar repo-level configuration and docs

### DIFF
--- a/.allstar/allstar.yaml
+++ b/.allstar/allstar.yaml
@@ -1,0 +1,3 @@
+optConfig:
+  optIn: true
+issueLabel: allstar

--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,3 @@
+optConfig:
+  optIn: true
+action: issue

--- a/.allstar/branch_protection.yaml
+++ b/.allstar/branch_protection.yaml
@@ -1,0 +1,3 @@
+optConfig:
+  optIn: true
+action: issue

--- a/.allstar/outside.yaml
+++ b/.allstar/outside.yaml
@@ -1,0 +1,3 @@
+optConfig:
+  optIn: true
+action: issue

--- a/.allstar/security.yaml
+++ b/.allstar/security.yaml
@@ -1,0 +1,3 @@
+optConfig:
+  optIn: true
+action: issue

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -90,6 +90,27 @@ If you want to publish the weekly report to Pages, prefer using the dedicated `p
 - 🔄 **Release integration** - Images published on releases
 - 📦 **GHCR integration** - Images available at `ghcr.io/turbocoder13/py-lintro`
 
+### 7. OpenSSF Allstar (Repository Security Enforcement)
+
+Allstar is an OpenSSF GitHub App that enforces repository security policies
+org-wide or per-repo. To enable at the repo level:
+
+- Create `.allstar/` with:
+  - `allstar.yaml` → enable opt-in at repo level
+  - `branch_protection.yaml`, `binary_artifacts.yaml`, `outside.yaml`, `security.yaml`
+    each with `optConfig: { optIn: true }` and `action: issue` as a safe default.
+
+Install and configure via the Allstar app and docs:
+
+- App install: `https://github.com/apps/allstar-app`
+- Policies and schema: `https://github.com/ossf/allstar#policies`
+- Manual install guide: `https://github.com/ossf/allstar/blob/main/manual-install.md`
+
+Notes:
+
+- Org-wide management prefers an org `.allstar` repository with opt-out strategy.
+- Repo-level configs require org `disableRepoOverride` to be false to take effect.
+
 **Usage in CI/CD:**
 
 You can use the published Docker image in your own CI/CD pipelines:


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

```
feature: add OpenSSF Allstar repo-level configuration and docs
```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing
- Add `.allstar/` with `allstar.yaml` and minimal policies: `branch_protection.yaml`, `binary_artifacts.yaml`, `outside.yaml`, `security.yaml` (optIn=true; action=issue).
- Update `docs/github-integration.md` with Allstar setup and links.

## Checklist
- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues
- N/A

## Details
- References: Allstar docs: https://github.com/ossf/allstar, manual install: https://github.com/ossf/allstar/blob/main/manual-install.md
- Enforcement defaults to issue creation; org-wide enablement can be done by installing `allstar-app` and using an org-level `.allstar` repo (opt-out strategy recommended by Allstar).