### PR TITLE
ci: push release tags using GitHub App installation token

### DIFF
--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -18,15 +18,24 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     timeout-minutes: 10
     # Only run when version actually changed
     steps:
       - name: Harden and Checkout
         uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@d8df28c952a5849083a78557fed999207e783fd6
         with:
-          persist-credentials: true
+          persist-credentials: false
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bf559f85448f9380bcfa2899dbdc01eb5b37be3a # v3.0.0-beta.2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Guard ensure last commit is a release bump
         id: guard
@@ -59,6 +68,13 @@ jobs:
         env:
           TAG: v${{ steps.version.outputs.version }}
         run: scripts/ci/auto-tag-check-exists.sh
+
+      - name: Configure auth for push
+        if: >-
+          steps.prev.outputs.version != steps.version.outputs.version &&
+          steps.check.outputs.exists == 'false'
+        run: |
+          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git
 
       - name: Create and push tag
         if: >-


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

```
ci: push release tags using GitHub App installation token
```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing
- Use `actions/create-github-app-token` (pinned) to mint an installation token.
- Configure git remote to use the App token for tag push.
- Keep checkout credentials off persist, use App token only for push.

## Checklist
- [x] Title follows Conventional Commits
- [x] Docs updated if user-facing (N/A)
- [x] Local CI passed (`make lint`, tests on prior runs)

## Related Issues
- Addresses tag-push workflows not firing when using GITHUB_TOKEN

## Details
- Secrets required: `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`.
- Reference: Authenticating as a GitHub App installation https://docs.github.com/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation