### PR TITLE
docs: add OpenSSF Silver prep docs and DCO sign-off requirement

### DIFF
--- a/DCO.md
+++ b/DCO.md
@@ -1,0 +1,12 @@
+# Developer Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+1. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
+2. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
+3. The contribution was provided directly to me by some other person who certified (1), (2) or (3) and I have not modified it.
+4. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+
+To sign off on your commits, use the `--signoff` or `-s` flag in `git commit` and ensure your commit message contains a line like:
+
+Signed-off-by: Your Name <your.email@example.com>

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,57 @@
+# Project Governance
+
+This document defines the decision-making and roles for the `py-lintro` project. It aims to provide clarity, continuity, and accountability to contributors and users.
+
+## Roles
+
+- Maintainers
+  - Own overall project direction and releases
+  - Review and approve pull requests
+  - Manage repository settings and automation
+- Contributors
+  - Propose changes via pull requests
+  - Participate in reviews and discussions
+- Security Contacts
+  - Triage security reports and coordinate fixes
+  - Listed in `SECURITY.md`
+
+## Decision Process
+
+- Pull Requests
+  - Each change is proposed via a PR following Conventional Commits
+  - At least 1 maintainer review approval is required to merge
+  - Squash merges are required; PR title becomes the merge commit
+- Consensus Seeking
+  - Maintainers seek rough consensus in PR discussions
+  - In case of disagreement, a maintainer proposes a path forward; if needed, a simple majority of maintainers decides
+
+## Membership
+
+- Becoming a Maintainer
+  - Demonstrated sustained contributions (code, reviews, docs)
+  - Consistent adherence to project standards and quality
+  - Nominated by a maintainer; confirmed by simple majority of maintainers
+- Removing Inactive Maintainers
+  - If a maintainer is inactive for > 6 months, remaining maintainers may propose moving them to emeritus status by simple majority
+
+## Release Management
+
+- Versioning and Releases
+  - Semantic versioning via Conventional Commits (squash merges)
+  - Automated tagging and release via CI on `main`
+- Branch Protection
+  - Merges require PR, passing checks, and approval
+  - Enforced by Allstar Branch Protection policy
+
+## Security and Compliance
+
+- Responsible Disclosure
+  - Follow `SECURITY.md` for reporting vulnerabilities
+- Supply Chain and CI
+  - Use pinned or reviewed dependencies and CI workflows
+  - Periodic automated analysis (Scorecards, CodeQL) supports continuous improvement
+
+## Changes to this Document
+
+- Propose updates via PR
+- Requires 2 maintainer approvals to merge

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -53,6 +53,19 @@ Notes:
 - If work is ambiguous (e.g., a large refactor), explicitly signal with `!` or a `BREAKING CHANGE:` footer.
 - The PR title validator (`.github/workflows/semantic-pr-title.yml`) enforces the format before merge.
 
+## Developer Certificate of Origin (required)
+
+All contributions must be signed off under the Developer Certificate of
+Origin (DCO). Use `git commit -s` (or `--signoff`) so your commit message
+contains a line like:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+See `DCO.md` for details. Pull requests without DCO sign-offs will be asked
+to amend commits before merge.
+
 ## Quick Start
 
 1. Clone the repository:

--- a/docs/security/assurance.md
+++ b/docs/security/assurance.md
@@ -1,0 +1,27 @@
+# Security Assurance (Overview)
+
+This assurance note explains how `py-lintro` meets its documented security requirements and provides pointers to evidence.
+
+## Requirements Coverage
+
+- Governance and Roles — see `GOVERNANCE.md`
+- Contribution Integrity — DCO sign-offs required; see `DCO.md` and CI checks
+- Responsible Disclosure — see `SECURITY.md`
+- Branch Protection — enforced via Allstar (`.allstar/branch_protection.yaml`)
+- Dependency Hygiene — Renovate, Dependency Review CI, `uv.lock`
+- Static/SAST — Ruff, Bandit, CodeQL; policy checks for workflows (Actionlint)
+- Container and Dockerfile — Hadolint
+- Documentation and Versioning — `README.md`, `CHANGELOG.md`, semantic releases
+
+## Evidence Pointers
+
+- CI Workflows: `.github/workflows/*.yml`
+- Allstar Policy: `.allstar/branch_protection.yaml`
+- Scorecard: badge in `README.md`
+- Coverage: `coverage.xml` and README badge
+
+## Continuous Improvement
+
+- Periodic updates via Renovate
+- Automated analyses (Scorecard, CodeQL)
+- Maintainer reviews for all changes

--- a/docs/security/requirements.md
+++ b/docs/security/requirements.md
@@ -1,0 +1,42 @@
+# Security Requirements
+
+This document summarizes security requirements adopted by `py-lintro` to support OpenSSF Best Practices (Silver).
+
+## Project and Process
+
+- FLOSS license (MIT) and public repository
+- Governance documented in `GOVERNANCE.md`
+- Responsible disclosure process in `SECURITY.md`
+- DCO required for contributions (`DCO.md`), enforced via commit sign-offs
+
+## Source Integrity and Branch Protection
+
+- All changes land via PR with maintainer review
+- Branch protection enforced on `main` (no force pushes; required reviews; admins included)
+
+## Dependencies and Supply Chain
+
+- Dependencies managed via `pyproject.toml` and `uv.lock`
+- Automated dependency updates (Renovate) with CI validation
+- Dependency Review workflow enabled in CI
+
+## Static and Policy Analysis
+
+- Linting/formatting: Ruff, Black, Prettier, Yamllint, Hadolint, Actionlint
+- Security linting: Bandit; GitHub CodeQL configured
+- OpenSSF Scorecard monitored
+
+## Build and Release
+
+- CI builds, tests, and coverage for PRs and `main`
+- Semantic versioning; signed release artifacts published via CI using OIDC
+
+## Testing and Coverage
+
+- Automated test suite with ~84% statement coverage
+- New code requires tests and coverage reporting
+
+## Secure Defaults
+
+- No execution of untrusted code
+- Docker image and scripts follow hardening practices (pinned actions, validated inputs)


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```
  docs: add OpenSSF Silver prep docs and DCO sign-off requirement
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [x] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- Title follows Conventional Commits; documentation-only (no version bump).
- Squash merge required so the PR title becomes the merge commit title.

## What’s Changing

Add Silver-level documentation and contribution requirements:
- GOVERNANCE.md
- DCO.md (and DCO sign-off required in contributing guide)
- docs/security/requirements.md
- docs/security/assurance.md

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (n/a: docs only)
- [x] Local CI passed (`./scripts/local/run-tests.sh`)
- [x] Docker tests passed (`./scripts/docker/docker-test.sh`)

## Related Issues

Related to OpenSSF Best Practices (Silver) preparation.

## Details

- Establishes governance, contribution sign-offs (DCO), and security requirements/assurance notes to align with Silver criteria.

