### PR TITLE
feat(ci): add reusable SBOM workflow and integrate into publish

### DIFF
--- a/.github/actions/harden-and-checkout/action.yml
+++ b/.github/actions/harden-and-checkout/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: Harden runner and checkout
 description: Apply step-security hardened runner and checkout the repository

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: Setup environment (Python, uv, deps)
 description: >-

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: Publish to PyPI on Tag
 

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -29,9 +29,16 @@ jobs:
     permissions:
       contents: read
 
+  sbom:
+    name: Generate and verify SBOM
+    needs: [build, quality]
+    uses: TurboCoder13/py-lintro/.github/workflows/reusable-sbom.yml@f73ba3032c8e1f25f72c033f8a8b590eec23257a
+    with:
+      bomctl-image: ${{ vars.BOMCTL_IMAGE }}
+
   publish:
     name: Upload to PyPI
-    needs: [build, quality]
+    needs: [build, quality, sbom]
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -1,0 +1,57 @@
+---
+name: Reusable SBOM Job
+
+'on':
+  workflow_call:
+    inputs:
+      bomctl-image:
+        description: Digest-pinned bomctl image
+        required: false
+        type: string
+    outputs:
+      artifact-name:
+        description: Name of uploaded SBOM artifact
+        value: sbom-artifacts
+
+jobs:
+  sbom:
+    name: Generate and verify SBOM
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+    env:
+      BOMCTL_IMAGE: ${{ inputs.bomctl-image }}
+      XDG_CACHE_HOME: ${{ github.workspace }}/.bomctl-cache
+    steps:
+      - name: Harden and Checkout
+        uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@f73ba3032c8e1f25f72c033f8a8b590eec23257a
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Environment setup
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f73ba3032c8e1f25f72c033f8a8b590eec23257a
+        with:
+          python-version: '3.13'
+      - name: Restore bomctl cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: ${{ env.XDG_CACHE_HOME }}
+          key: bomctl-cache-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}-${{ github.sha }}
+          restore-keys: |
+            bomctl-cache-${{ runner.os }}-
+            bomctl-cache-
+      - name: Generate SBOMs (CycloneDX 1.6 JSON & SPDX 2.3)
+        run: bash scripts/ci/sbom-generate.sh --use-docker --format cyclonedx-1.6 --format spdx-2.3 --name "py-lintro-sbom" --alias project
+      - name: Rename SBOM artifacts with tag/sha for traceability
+        run: bash scripts/ci/sbom-rename-artifacts.sh dist/sbom
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom-artifacts
+          path: dist/sbom/*
+          if-no-files-found: error
+      - name: Verify bomctl image with cosign (keyless)
+        run: bash scripts/ci/sbom-verify-container.sh
+      - name: Attest SBOM artifacts with keyless cosign (optional)
+        run: bash scripts/ci/sbom-attest-artifacts.sh dist/sbom

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: Reusable SBOM Job
 
@@ -12,6 +14,10 @@ name: Reusable SBOM Job
       artifact-name:
         description: Name of uploaded SBOM artifact
         value: sbom-artifacts
+
+permissions:
+  contents: read
+  actions: read
 
 jobs:
   sbom:

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: SBOM on main
 

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -1,0 +1,71 @@
+---
+name: SBOM on main
+
+'on':
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sbom-main-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbom:
+    name: Generate and verify SBOM (main)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+    env:
+      BOMCTL_IMAGE: ${{ vars.BOMCTL_IMAGE }}
+      XDG_CACHE_HOME: ${{ github.workspace }}/.bomctl-cache
+    steps:
+      - name: Enforce pinned bomctl image digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          ref="${BOMCTL_IMAGE:-}"
+          if [[ -z "${ref}" ]]; then
+            echo "BOMCTL_IMAGE is not set (vars). Set a digest-pinned image like 'bomctl/bomctl@sha256:...'." >&2
+            exit 1
+          fi
+          if [[ "${ref}" != *@sha256:* ]]; then
+            echo "BOMCTL_IMAGE must be digest-pinned (contains '@sha256:'). Got: ${ref}" >&2
+            exit 1
+          fi
+      - name: Harden and Checkout
+        uses: TurboCoder13/py-lintro/.github/actions/harden-and-checkout@f73ba3032c8e1f25f72c033f8a8b590eec23257a
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Environment setup
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f73ba3032c8e1f25f72c033f8a8b590eec23257a
+        with:
+          python-version: '3.13'
+      - name: Restore bomctl cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: ${{ env.XDG_CACHE_HOME }}
+          key: bomctl-cache-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}-${{ github.sha }}
+          restore-keys: |
+            bomctl-cache-${{ runner.os }}-
+            bomctl-cache-
+      - name: Generate SBOMs (CycloneDX 1.6 JSON & SPDX 2.3)
+        run: bash scripts/ci/sbom-generate.sh --use-docker --format cyclonedx-1.6 --format spdx-2.3 --name "py-lintro-sbom" --alias project
+      - name: Rename SBOM artifacts with tag/sha for traceability
+        run: bash scripts/ci/sbom-rename-artifacts.sh dist/sbom
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom-artifacts
+          path: dist/sbom/*
+          if-no-files-found: error
+      - name: Verify bomctl image with cosign (keyless)
+        run: bash scripts/ci/sbom-verify-container.sh
+      - name: Attest SBOM artifacts with keyless cosign (optional)
+        run: bash scripts/ci/sbom-attest-artifacts.sh dist/sbom

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13-slim@sha256:27f90d79cc85e9b7b2560063ef44fa0e9eaae7a7c3f5a9f74563065c5477cc24
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Lintro is a unified command-line interface that brings together multiple code qu
 [![Tests](https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/test-and-coverage.yml?label=tests&branch=main&logo=githubactions&logoColor=white)](https://github.com/TurboCoder13/py-lintro/actions/workflows/test-and-coverage.yml?query=branch%3Amain)
 [![CI](https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/ci-lintro-analysis.yml?label=ci&branch=main&logo=githubactions&logoColor=white)](https://github.com/TurboCoder13/py-lintro/actions/workflows/ci-lintro-analysis.yml?query=branch%3Amain)
 [![Docker](https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/docker-build-publish.yml?label=docker&logo=docker&branch=main)](https://github.com/TurboCoder13/py-lintro/actions/workflows/docker-build-publish.yml?query=branch%3Amain)
+[![SBOM (main)](<https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/sbom-on-main.yml?label=sbom%20(main)&branch=main>)](https://github.com/TurboCoder13/py-lintro/actions/workflows/sbom-on-main.yml?query=branch%3Amain)
+[![Release pipeline (tags)](<https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/publish-pypi-on-tag.yml?label=release%20pipeline%20(tags)&event=push>)](https://github.com/TurboCoder13/py-lintro/actions/workflows/publish-pypi-on-tag.yml?query=event%3Apush)
 [![PyPI](https://img.shields.io/pypi/v/lintro?label=pypi)](https://pypi.org/project/lintro/)
 
 [![CodeQL](https://github.com/TurboCoder13/py-lintro/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/TurboCoder13/py-lintro/actions/workflows/codeql.yml?query=branch%3Amain)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ Lintro is a unified command-line interface that brings together multiple code qu
 [![PyPI](https://img.shields.io/pypi/v/lintro?label=pypi)](https://pypi.org/project/lintro/)
 
 [![CodeQL](https://github.com/TurboCoder13/py-lintro/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/TurboCoder13/py-lintro/actions/workflows/codeql.yml?query=branch%3Amain)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/TurboCoder13/py-lintro/badge)](https://scorecard.dev/viewer/?uri=github.com/TurboCoder13/py-lintro)
-
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11142/badge)](https://www.bestpractices.dev/projects/11142)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/TurboCoder13/py-lintro/badge)](https://scorecard.dev/viewer/?uri=github.com/TurboCoder13/py-lintro) [![SBOM](https://img.shields.io/badge/SBOM-enabled-brightgreen)](docs/security/assurance.md) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11142/badge)](https://www.bestpractices.dev/projects/11142)
 
 ### Why Lintro?
 

--- a/scripts/ci/sbom-attest-artifacts.sh
+++ b/scripts/ci/sbom-attest-artifacts.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# sbom-attest-artifacts.sh
+# Optionally attest SBOM artifacts with cosign keyless.
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  echo "Usage: $0 [OUTPUT_DIR]"
+  echo ""
+  echo "Create best-effort cosign attestations for SBOM artifacts."
+  echo "Defaults: OUTPUT_DIR=dist/sbom"
+  exit 0
+fi
+
+OUTPUT_DIR=${1:-dist/sbom}
+
+if [ ! -d "${OUTPUT_DIR}" ]; then
+  echo "SBOM output dir not found: ${OUTPUT_DIR}" >&2
+  exit 1
+fi
+
+if ! command -v cosign >/dev/null 2>&1; then
+  echo "cosign not installed; skipping attest"
+  exit 0
+fi
+
+export COSIGN_EXPERIMENTAL=1
+for f in "${OUTPUT_DIR}"/*; do
+  set +e
+  cosign attest --predicate <(echo '{"generated_by":"sbom-generate.sh"}') --type custom --yes "$f"
+  rc=$?
+  set -e
+  if [ $rc -ne 0 ]; then
+    echo "cosign attest failed for $f (non-fatal)" >&2
+  fi
+done
+
+echo "cosign attest done for artifacts in ${OUTPUT_DIR}"
+
+

--- a/scripts/ci/sbom-generate.sh
+++ b/scripts/ci/sbom-generate.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# sbom-generate.sh
+# Generate and export SBOMs using bomctl with optional merge and formats.
+#
+# Features:
+# - Fetch SBOM from GitHub dependency graph (public repos) via bomctl
+# - Import local SBOM files and optionally merge them
+# - Output CycloneDX and/or SPDX variants to an output directory
+# - Dry-run mode to preview planned actions
+# - Optional Docker fallback for bomctl (no host install required)
+#
+# Usage:
+#   scripts/ci/sbom-generate.sh [options]
+#
+# Options:
+#   --help               Show this help and exit
+#   --dry-run            Print actions without executing bomctl
+#   --output-dir DIR     Directory for exported files (default: dist/sbom)
+#   --name NAME          Logical document name (default: py-lintro-sbom)
+#   --alias ALIAS        Alias for merged/output document (default: project)
+#   --format CHOICE      Output format (repeatable). Supported values:
+#                        cyclonedx-1.5, cyclonedx-1.6, spdx-2.3 (default: cyclonedx-1.5)
+#   --encoding CHOICE    Output encoding for CycloneDX (json|xml; default: json)
+#   --repo-url URL       GitHub repo URL to fetch (default inferred from GITHUB_REPOSITORY)
+#   --skip-fetch         Skip bomctl fetch step
+#   --import FILE        Import a local SBOM file (repeat to include multiple)
+#   --use-docker         Use bomctl container if bomctl binary is not installed
+#   --netrc              Pass --netrc to bomctl for authenticated fetch/push
+#
+# Notes:
+# - For fetch from private repos, configure credentials via --netrc and .netrc.
+# - When importing multiple files, a merged document will be created and exported.
+# - By default this script writes artifacts only to the filesystem; remote push
+#   destinations can be added later if desired.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# Source shared utilities if available (optional)
+if [ -f "${REPO_ROOT}/scripts/utils/utils.sh" ]; then
+  # shellcheck disable=SC1091
+  source "${REPO_ROOT}/scripts/utils/utils.sh"
+  log_info "SBOM generation script starting"
+else
+  log_info() { echo "[info] $*"; }
+  log_success() { echo "[ok] $*"; }
+  log_warning() { echo "[warn] $*"; }
+  log_error() { echo "[err] $*"; }
+fi
+
+show_help() {
+  sed -n '1,80p' "$0"
+}
+
+# Defaults
+DRY_RUN=0
+OUTPUT_DIR="dist/sbom"
+DOC_NAME="py-lintro-sbom"
+DOC_ALIAS="project"
+FORMATS=("cyclonedx-1.5")
+ENCODING="json"
+REPO_URL=""
+SKIP_FETCH=0
+USE_DOCKER=0
+PASSTHROUGH_NETRC=0
+IMPORT_FILES=()
+
+# Container configuration (override via environment for CI hardening)
+# - BOMCTL_IMAGE: pin to a specific digest in CI (e.g., bomctl/bomctl@sha256:...)
+# - BOMCTL_NETWORK: set to 'none' for no-network operations (import/merge/push)
+#   Leave empty for default Docker networking.
+BOMCTL_IMAGE="${BOMCTL_IMAGE:-bomctl/bomctl:latest}"
+BOMCTL_NETWORK="${BOMCTL_NETWORK:-}"
+
+# Ensure bomctl cache directory exists and is used (improves fetch/push --tree)
+if [ -z "${XDG_CACHE_HOME:-}" ]; then
+  export XDG_CACHE_HOME="${PWD}/.bomctl-cache"
+fi
+mkdir -p "${XDG_CACHE_HOME}"
+
+while (( "$#" )); do
+  case "$1" in
+    --help|-h)
+      show_help; exit 0 ;;
+    --dry-run)
+      DRY_RUN=1; shift ;;
+    --output-dir)
+      OUTPUT_DIR="${2:-}"; shift 2 ;;
+    --name)
+      DOC_NAME="${2:-}"; shift 2 ;;
+    --alias)
+      DOC_ALIAS="${2:-}"; shift 2 ;;
+    --format)
+      FORMATS+=("${2:-}"); shift 2 ;;
+    --encoding)
+      ENCODING="${2:-}"; shift 2 ;;
+    --repo-url)
+      REPO_URL="${2:-}"; shift 2 ;;
+    --skip-fetch)
+      SKIP_FETCH=1; shift ;;
+    --import)
+      IMPORT_FILES+=("${2:-}"); shift 2 ;;
+    --use-docker)
+      USE_DOCKER=1; shift ;;
+    --netrc)
+      PASSTHROUGH_NETRC=1; shift ;;
+    *)
+      log_error "Unknown argument: $1"; exit 2 ;;
+  esac
+done
+
+# Normalize default formats (avoid duplicate default when user provided --format)
+if [ ${#FORMATS[@]} -gt 1 ]; then
+  # Drop the initial default if additional were specified
+  if [ "${FORMATS[0]}" = "cyclonedx-1.5" ]; then
+    FORMATS=("${FORMATS[@]:1}")
+  fi
+fi
+if [ ${#FORMATS[@]} -eq 0 ]; then
+  FORMATS=("cyclonedx-1.5")
+fi
+
+# Resolve repo URL if not provided
+infer_repo_url() {
+  if [ -n "${REPO_URL}" ]; then
+    echo "${REPO_URL}"
+    return 0
+  fi
+  if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    echo "https://github.com/${GITHUB_REPOSITORY}"
+    return 0
+  fi
+  # Try to translate git@github.com:owner/repo.git -> https://github.com/owner/repo
+  if git remote get-url origin >/dev/null 2>&1; then
+    local raw
+    raw=$(git remote get-url origin)
+    case "$raw" in
+      git@github.com:*)
+        local path
+        path="${raw#git@github.com:}"
+        path="${path%.git}"
+        echo "https://github.com/${path}"
+        return 0
+        ;;
+      https://github.com/*)
+        echo "${raw%.git}"
+        return 0
+        ;;
+    esac
+  fi
+  echo ""  # not found
+}
+
+run_print_cmd() {
+  # Best-effort pretty print for dry-run
+  local shown="$*"
+  echo "$shown"
+}
+
+# Determine bomctl invocation as an array for safe execution
+declare -a BOMCTL_ARR
+resolve_bomctl_arr() {
+  if command -v bomctl >/dev/null 2>&1; then
+    BOMCTL_ARR=("bomctl")
+    return 0
+  fi
+  if [ ${USE_DOCKER} -eq 1 ] || command -v docker >/dev/null 2>&1; then
+    # Map user to avoid root-owned outputs; optionally restrict network
+    local user_flags=()
+    if command -v id >/dev/null 2>&1; then
+      user_flags=("-u" "$(id -u):$(id -g)")
+    fi
+    local network_flags=()
+    if [ -n "${BOMCTL_NETWORK}" ]; then
+      network_flags=("--network=${BOMCTL_NETWORK}")
+    fi
+    local cache_flags=()
+    if [ -n "${XDG_CACHE_HOME:-}" ]; then
+      cache_flags=("-e" "XDG_CACHE_HOME=${XDG_CACHE_HOME}" "-v" "${XDG_CACHE_HOME}:${XDG_CACHE_HOME}")
+    fi
+    BOMCTL_ARR=(
+      "docker" "run" "--rm"
+      ${network_flags[@]:-}
+      ${user_flags[@]:-}
+      ${cache_flags[@]:-}
+      "-v" "$PWD:/work" "-w" "/work"
+      "${BOMCTL_IMAGE}" "bomctl"
+    )
+    return 0
+  fi
+  return 1
+}
+
+REPO_URL_RESOLVED="$(infer_repo_url)"
+if ! resolve_bomctl_arr; then
+  if [ ${DRY_RUN} -eq 0 ]; then
+    log_error "bomctl is not available. Install it or use --use-docker with Docker."
+    exit 1
+  fi
+fi
+
+netrc_flag=""
+if [ ${PASSTHROUGH_NETRC} -eq 1 ]; then
+  netrc_flag="--netrc"
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+chmod +x "$0" >/dev/null 2>&1 || true
+
+# Helpers to run bomctl safely via array
+run_bomctl() {
+  # Usage: run_bomctl <args...>
+  if [ ${DRY_RUN} -eq 1 ]; then
+    echo "# Dry-run: planned action"
+    run_print_cmd "${BOMCTL_ARR[*]} $*"
+    return 0
+  fi
+  log_info "Running: ${BOMCTL_ARR[*]} $*"
+  "${BOMCTL_ARR[@]}" "$@"
+}
+
+HAS_FETCH=0
+if [ ${SKIP_FETCH} -eq 0 ] && [ -n "${REPO_URL_RESOLVED}" ]; then
+  HAS_FETCH=1
+  if [ -n "${netrc_flag}" ]; then
+    run_bomctl fetch "${REPO_URL_RESOLVED}" "${netrc_flag}"
+  else
+    run_bomctl fetch "${REPO_URL_RESOLVED}"
+  fi
+else
+  log_warning "Fetch step skipped or repo URL not resolved; only imports will be processed."
+fi
+
+# Import provided local SBOMs
+for f in "${IMPORT_FILES[@]:-}"; do
+  if [ -n "$f" ]; then
+    run_bomctl import --alias "${DOC_ALIAS}" --tag project:py-lintro --tag "run:$(date +%s)" "$f"
+  fi
+done
+
+# Decide on root document and merging strategy
+ROOT_ID=""
+IMPORT_COUNT=${#IMPORT_FILES[@]}
+MERGE_NEEDED=0
+if [ ${HAS_FETCH} -eq 1 ] || [ ${IMPORT_COUNT} -gt 1 ]; then
+  MERGE_NEEDED=1
+fi
+
+if [ ${MERGE_NEEDED} -eq 1 ]; then
+  if [ ${HAS_FETCH} -eq 1 ] && [ ${IMPORT_COUNT} -gt 0 ]; then
+    # Merge fetched document with imported alias into a single alias
+    run_bomctl merge --alias "${DOC_ALIAS}" --name "${DOC_NAME}" "${REPO_URL_RESOLVED}" "${DOC_ALIAS}"
+  elif [ ${HAS_FETCH} -eq 1 ] && [ ${IMPORT_COUNT} -eq 0 ]; then
+    # Merge single fetched doc into alias to standardize pushes
+    run_bomctl merge --alias "${DOC_ALIAS}" --name "${DOC_NAME}" "${REPO_URL_RESOLVED}"
+  else
+    # Multiple imports under the same alias; perform merge to consolidate
+    run_bomctl merge --alias "${DOC_ALIAS}" --name "${DOC_NAME}" "${DOC_ALIAS}"
+  fi
+  ROOT_ID="${DOC_ALIAS}"
+else
+  # Single import only; alias points to the document
+  if [ ${IMPORT_COUNT} -eq 1 ]; then
+    ROOT_ID="${DOC_ALIAS}"
+  else
+    # Fetch-only without merge should not happen; default to alias
+    ROOT_ID="${DOC_ALIAS}"
+  fi
+fi
+
+# Export SBOMs (push tree to filesystem)
+for fmt in "${FORMATS[@]}"; do
+  case "$fmt" in
+    cyclonedx-* )
+      if [ -n "${netrc_flag}" ]; then
+        run_bomctl push "${netrc_flag}" "${ROOT_ID}" "${OUTPUT_DIR}/${DOC_NAME}.${fmt}.${ENCODING}" -f "${fmt}" -e "${ENCODING}" --tree
+      else
+        run_bomctl push "${ROOT_ID}" "${OUTPUT_DIR}/${DOC_NAME}.${fmt}.${ENCODING}" -f "${fmt}" -e "${ENCODING}" --tree
+      fi
+      ;;
+    spdx-* )
+      if [ -n "${netrc_flag}" ]; then
+        run_bomctl push "${netrc_flag}" "${ROOT_ID}" "${OUTPUT_DIR}/${DOC_NAME}.${fmt}.json" -f "${fmt}" --tree
+      else
+        run_bomctl push "${ROOT_ID}" "${OUTPUT_DIR}/${DOC_NAME}.${fmt}.json" -f "${fmt}" --tree
+      fi
+      ;;
+    * )
+      log_warning "Unsupported format: $fmt (skipping)" ;;
+  esac
+done
+
+log_success "SBOM artifacts written to ${OUTPUT_DIR}"
+
+

--- a/scripts/ci/sbom-rename-artifacts.sh
+++ b/scripts/ci/sbom-rename-artifacts.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# sbom-rename-artifacts.sh
+# Rename SBOM artifacts to include tag and short SHA for traceability.
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  echo "Usage: $0 [OUTPUT_DIR]"
+  echo ""
+  echo "Rename SBOM files to include tag and short SHA prefix."
+  echo "Defaults: OUTPUT_DIR=dist/sbom"
+  exit 0
+fi
+
+TAG="${GITHUB_REF_NAME:-${TAG:-unknown}}"
+SHA_SHORT="${GITHUB_SHA:-${SHA:-unknown}}"
+SHA_SHORT="${SHA_SHORT:0:12}"
+
+OUTPUT_DIR=${1:-dist/sbom}
+
+if [ ! -d "${OUTPUT_DIR}" ]; then
+  echo "SBOM output dir not found: ${OUTPUT_DIR}" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+for f in "${OUTPUT_DIR}/py-lintro-sbom."*; do
+  base=$(basename "$f")
+  mv "$f" "${OUTPUT_DIR}/${TAG}-${SHA_SHORT}-${base}"
+done
+
+echo "Renamed SBOM artifacts in ${OUTPUT_DIR} with ${TAG}-${SHA_SHORT}- prefix"
+
+

--- a/scripts/ci/sbom-verify-container.sh
+++ b/scripts/ci/sbom-verify-container.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# sbom-verify-container.sh
+# Verify a digest-pinned container image using cosign keyless.
+
+REF="${BOMCTL_IMAGE:-}"
+if [[ -z "${REF}" || "${REF}" != *@sha256:* ]]; then
+  echo "BOMCTL_IMAGE not set to a digest-pinned reference; skipping verify"
+  exit 0
+fi
+
+if ! command -v cosign >/dev/null 2>&1; then
+  echo "cosign not installed; skipping verify"
+  exit 0
+fi
+
+export COSIGN_EXPERIMENTAL=1
+set +e
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'https://github\.com/bomctl/bomctl/\.github/.+' \
+  "${REF}"
+rc=$?
+set -e
+if [ $rc -ne 0 ]; then
+  echo "cosign verify failed or signature not found" >&2
+  exit 1
+fi
+echo "cosign verify OK for ${REF}"
+
+

--- a/scripts/local/run-tests.sh
+++ b/scripts/local/run-tests.sh
@@ -82,6 +82,21 @@ discover_tests() {
     echo -e "${GREEN}All tests in the tests directory will be run.${NC}"
 }
 
+# Ensure required Python CLI tools are available in the active uv environment
+ensure_python_cli_tools() {
+    echo -e "${BLUE}Ensuring required Python CLI tools are available...${NC}"
+    # Install bandit if missing or broken
+    if ! uv run python -c "import bandit" >/dev/null 2>&1; then
+        echo -e "${YELLOW}Installing bandit for integration tests...${NC}"
+        uv pip install bandit==1.8.6 >/dev/null 2>&1 || true
+    fi
+    # Install black if missing
+    if ! uv run python -c "import black" >/dev/null 2>&1; then
+        echo -e "${YELLOW}Installing black for formatting policy tests...${NC}"
+        uv pip install black >/dev/null 2>&1 || true
+    fi
+}
+
 # Function to run tests with coverage
 run_tests() {
     echo -e "${BLUE}Running all tests in the tests directory...${NC}"
@@ -176,6 +191,8 @@ main() {
     
     # Setup Python environment
     setup_python_env
+    # Ensure Python CLI tools used by integration tests are present
+    ensure_python_cli_tools
     
     # Discover available tools and tests
     discover_tests

--- a/tests/scripts/test_script_environment.py
+++ b/tests/scripts/test_script_environment.py
@@ -185,6 +185,70 @@ class TestScriptErrorHandling:
             assert_that(result.stdout).contains("percentage=")
             assert_that(result.stdout).contains("percentage=85.0")
 
+    def test_sbom_generate_dry_run_prints_plan(self, scripts_dir, tmp_path):
+        """sbom-generate.sh --dry-run should print a plan and exit 0.
+
+        Runs with --skip-fetch to avoid network access during tests.
+        """
+        script = Path("scripts/ci/sbom-generate.sh").resolve()
+        wrapper = tmp_path / "run_sbom.sh"
+        wrapper.write_text(
+            f"#!/usr/bin/env bash\nset -euo pipefail\ncd '{scripts_dir.parent}'\n"
+            f"'{script}' --dry-run --skip-fetch\n",
+        )
+        wrapper.chmod(0o755)
+        result = subprocess.run([str(wrapper)], capture_output=True, text=True)
+        assert_that(result.returncode).is_equal_to(0)
+        out = result.stdout + result.stderr
+        assert_that(out.lower()).contains("dry-run")
+
+    def test_sbom_generate_dry_run_import_merge_push_plan(self, scripts_dir, tmp_path):
+        """Dry-run should show import, merge, and push steps when multiple imports.
+
+        Uses two placeholder local files and --skip-fetch to avoid network.
+        """
+        # Create dummy files to pass as --import paths
+        file1 = tmp_path / "a.cdx.json"
+        file2 = tmp_path / "b.cdx.json"
+        file1.write_text("{}")
+        file2.write_text("{}")
+        script = Path("scripts/ci/sbom-generate.sh").resolve()
+        wrapper = tmp_path / "run_sbom_merge.sh"
+        wrapper.write_text(
+            f"#!/usr/bin/env bash\nset -euo pipefail\ncd '{scripts_dir.parent}'\n"
+            f"'{script}' --dry-run --skip-fetch --import '{file1}' --import '{file2}'\n",
+        )
+        wrapper.chmod(0o755)
+        result = subprocess.run([str(wrapper)], capture_output=True, text=True)
+        assert_that(result.returncode).is_equal_to(0)
+        plan = result.stdout + result.stderr
+        assert_that(plan).contains("import --alias project")
+        assert_that(plan).contains(" merge ")
+        assert_that(plan).contains(" push ")
+
+    def test_sbom_generate_dry_run_fetch_only_merges_to_alias(
+        self,
+        scripts_dir,
+        tmp_path,
+    ):
+        """Dry-run with fetch-only should show merge to alias and push of alias.
+
+        Forces repo URL via --repo-url to avoid relying on git remotes.
+        """
+        script = Path("scripts/ci/sbom-generate.sh").resolve()
+        wrapper = tmp_path / "run_sbom_fetch.sh"
+        wrapper.write_text(
+            f"#!/usr/bin/env bash\nset -euo pipefail\ncd '{scripts_dir.parent}'\n"
+            f"'{script}' --dry-run --repo-url 'https://github.com/example/acme'\n",
+        )
+        wrapper.chmod(0o755)
+        result = subprocess.run([str(wrapper)], capture_output=True, text=True)
+        assert_that(result.returncode).is_equal_to(0)
+        plan = result.stdout + result.stderr
+        assert_that(plan).contains(" fetch ")
+        assert_that(plan).contains(" merge --alias project")
+        assert_that(plan).contains(" push ")
+
 
 class TestScriptSecurity:
     """Test security aspects of shell scripts."""

--- a/tests/scripts/test_script_environment.py
+++ b/tests/scripts/test_script_environment.py
@@ -189,6 +189,10 @@ class TestScriptErrorHandling:
         """sbom-generate.sh --dry-run should print a plan and exit 0.
 
         Runs with --skip-fetch to avoid network access during tests.
+
+        Args:
+            scripts_dir: Path to the scripts directory.
+            tmp_path: Path to the temporary directory.
         """
         script = Path("scripts/ci/sbom-generate.sh").resolve()
         wrapper = tmp_path / "run_sbom.sh"
@@ -206,6 +210,10 @@ class TestScriptErrorHandling:
         """Dry-run should show import, merge, and push steps when multiple imports.
 
         Uses two placeholder local files and --skip-fetch to avoid network.
+
+        Args:
+            scripts_dir: Path to the scripts directory.
+            tmp_path: Path to the temporary directory.
         """
         # Create dummy files to pass as --import paths
         file1 = tmp_path / "a.cdx.json"
@@ -216,7 +224,9 @@ class TestScriptErrorHandling:
         wrapper = tmp_path / "run_sbom_merge.sh"
         wrapper.write_text(
             f"#!/usr/bin/env bash\nset -euo pipefail\ncd '{scripts_dir.parent}'\n"
-            f"'{script}' --dry-run --skip-fetch --import '{file1}' --import '{file2}'\n",
+            f"'{script}' --dry-run --skip-fetch "
+            f"--import '{file1}' "
+            f"--import '{file2}'\n",
         )
         wrapper.chmod(0o755)
         result = subprocess.run([str(wrapper)], capture_output=True, text=True)
@@ -234,6 +244,10 @@ class TestScriptErrorHandling:
         """Dry-run with fetch-only should show merge to alias and push of alias.
 
         Forces repo URL via --repo-url to avoid relying on git remotes.
+
+        Args:
+            scripts_dir: Path to the scripts directory.
+            tmp_path: Path to the temporary directory.
         """
         script = Path("scripts/ci/sbom-generate.sh").resolve()
         wrapper = tmp_path / "run_sbom_fetch.sh"

--- a/tests/scripts/test_shell_scripts.py
+++ b/tests/scripts/test_shell_scripts.py
@@ -171,6 +171,22 @@ class TestScriptHelp:
         assert_that(result.stdout).contains("Usage:")
         assert_that(result.stdout).contains("Codecov")
 
+    def test_sbom_generate_help(self, scripts_dir):
+        """sbom-generate.sh should provide help and exit 0.
+
+        Args:
+            scripts_dir: Path to the scripts directory.
+        """
+        script = scripts_dir / "ci" / "sbom-generate.sh"
+        result = subprocess.run(
+            [str(script), "--help"],
+            capture_output=True,
+            text=True,
+            cwd=scripts_dir.parent,
+        )
+        assert_that(result.returncode).is_equal_to(0)
+        assert_that(result.stdout).contains("Usage:")
+
 
 class TestScriptFunctionality:
     """Test basic functionality of shell scripts."""


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

```
feat(ci): add SBOM workflows, badges, and hardening
```

- Type:
- [x] chore / ci / style
- [x] docs

## What’s Changing

- Add SBOM-on-main workflow (.github/workflows/sbom-on-main.yml) to run SBOM on pushes to main.
- Integrate SBOM job into tag-based publish workflow; keep Trusted Publishing to PyPI.
- Enforce digest-pinned BOMCTL_IMAGE and add concurrency for SBOM on main.
- Add separate README badges for SBOM (main) and release pipeline (tags).
- Add SBOM scripts (generate/rename/verify/attest) with tests and docs.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (./scripts/local/run-tests.sh)

## Related Issues

Closes N/A

## Details

- SBOM generated via scripts/ci/sbom-generate.sh (Docker fallback, dry-run available).
- Artifacts renamed with GITHUB_REF_NAME and short SHA, uploaded per workflow run.
- SBOM artifacts on main; publish workflow handles releases only on tags.
