### PR TITLE
fix: resolve workflow failures for auto-bump and SBOM generation

### DIFF
--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 20
     env:
       XDG_CACHE_HOME: ${{ github.workspace }}/.bomctl-cache
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
       - name: Install bomctl from GitHub Releases (no registries)
         env:
@@ -54,7 +54,7 @@ jobs:
         run: scripts/ci/sbom-generate-safe.sh
       - name: Fetch SBOM via bomctl binary (GitHub graph)
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: bash scripts/ci/sbom-fetch.sh --format cyclonedx-1.6 --format spdx-2.3
       - name: Rename SBOM artifacts with tag/sha for traceability
         run: bash scripts/ci/sbom-rename-artifacts.sh dist/sbom


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```
  fix: resolve workflow failures for auto-bump and SBOM generation
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

After merging recent changes to main, two workflows started failing:

1. **Maintenance - Auto-bump Internal References**
   - Error: GitHub App refused to modify workflow files without `workflows` permission
   
2. **Security - SBOM Generation**
   - Error: 401 Bad credentials when accessing dependency graph API

**Solutions:**
- Added `workflows: write` permission to auto-bump workflow
- Updated SBOM workflow to use `RELEASE_TOKEN` with fallback to `GITHUB_TOKEN`

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (N/A - workflow configuration only)
- [ ] Docs updated if user-facing (N/A)
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

Fixes workflow failures on main branch after recent merges.

## Details

**Auto-bump Internal References Fix:**
- Added `workflows: write` permission required for modifying workflow files
- GitHub requires this explicit permission as a security feature

**SBOM Generation Fix:**
- Updated all token references to use `RELEASE_TOKEN || GITHUB_TOKEN`
- Applied to: job environment, checkout step, and SBOM fetch step
- The `RELEASE_TOKEN` secret should have `repo` and `workflow` scopes
- Configure at: https://github.com/TurboCoder13/py-lintro/settings/secrets/actions

**Files Changed:**
- `.github/workflows/auto-bump-internal-refs.yml`: +1 line (workflows permission)
- `.github/workflows/sbom-on-main.yml`: 3 token references updated