### PR TITLE
fix(ci): unwrap GitHub SBOM API response before bomctl import

### DIFF
--- a/scripts/ci/sbom-fetch-github-api.sh
+++ b/scripts/ci/sbom-fetch-github-api.sh
@@ -115,7 +115,7 @@ validate_prerequisites() {
   log_info "Prerequisites validated: gh, bomctl, jq"
 }
 
-# Validate JSON structure
+# Validate JSON structure and unwrap GitHub format if needed
 validate_json() {
   local file="$1"
   
@@ -125,9 +125,14 @@ validate_json() {
     return 1
   fi
   
-  # Validate SPDX/CycloneDX structure
+  # Validate SPDX/CycloneDX structure and unwrap GitHub format
   if jq -e '.sbom' "${file}" >/dev/null 2>&1; then
     log_info "Detected GitHub SBOM format (SPDX wrapper)"
+    # Extract the actual SBOM from the wrapper
+    log_info "Extracting SBOM from GitHub wrapper..."
+    jq '.sbom' "${file}" > "${file}.unwrapped"
+    mv "${file}.unwrapped" "${file}"
+    log_success "Extracted SBOM from wrapper"
     return 0
   elif jq -e '.spdxVersion' "${file}" >/dev/null 2>&1; then
     log_info "Detected SPDX format"


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```
  fix(ci): unwrap GitHub SBOM API response before bomctl import
  ```

- Type:
  - [x] fix / perf (patch)
  - [ ] feat (minor)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

This will trigger a PATCH bump when merged.

## What's Changing

Fixes the SBOM generation workflow that has been failing on main since PR #186.

**Root Cause:** The GitHub Dependency Graph API returns SBOM data wrapped in a `{"sbom": {...}}` envelope. The previous version detected this wrapper format but never extracted the actual SBOM before passing it to `bomctl`, causing the import to fail with "unknown SBOM format".

**Solution:** Extract the `.sbom` field from the GitHub API response before importing into `bomctl`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (N/A - CI infrastructure fix)
- [x] Docs updated if user-facing (N/A - internal CI script)
- [ ] Local CI passed (cannot test locally without bomctl installation)

## Related Issues

Resolves the failing SBOM workflow runs on main:
- https://github.com/TurboCoder13/py-lintro/actions/runs/18249354061/job/51961675435

## Details

### Implementation

The fix adds proper SBOM extraction logic in `scripts/ci/sbom-fetch-github-api.sh`:

```bash
# Extract the actual SBOM from the wrapper
log_info "Extracting SBOM from GitHub wrapper..."
jq '.sbom' "${file}" > "${file}.unwrapped"
mv "${file}.unwrapped" "${file}"
log_success "Extracted SBOM from wrapper"
```

### Testing Strategy

This fix will be validated by:
1. The SBOM workflow running successfully when this PR is merged to main
2. Verifying that both CycloneDX and SPDX formats are generated correctly
3. Confirming that bomctl can successfully import and merge the GitHub SBOM

### Error Before Fix

```
[sbom-fetch] ERROR: Failed to import GitHub SBOM into bomctl
FATAL import: importing document: failed to store document: parsing SBOM data: 
detecting SBOM format: detecting format: unknown SBOM format
```

### Expected After Fix

```
[sbom-fetch] INFO: Detected GitHub SBOM format (SPDX wrapper)
[sbom-fetch] INFO: Extracting SBOM from GitHub wrapper...
[sbom-fetch] SUCCESS: Extracted SBOM from wrapper
[sbom-fetch] SUCCESS: Imported GitHub SBOM into bomctl
[sbom-fetch] SUCCESS: Merged GitHub and local SBOMs
```