### PR TITLE
fix(ci): complete SBOM workflow fix with verified bomctl commands

### DIFF
--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -57,9 +57,7 @@ jobs:
           restore-keys: |
             bomctl-cache-${{ runner.os }}-
             bomctl-cache-
-      - name: Generate SBOMs (CycloneDX 1.6 JSON & SPDX 2.3)
-        run: scripts/ci/sbom-generate-safe.sh
-      - name: Fetch SBOM via GitHub REST API
+      - name: Generate SBOM from GitHub Dependency Graph
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/ci/sbom-fetch-github-api.sh

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -51,9 +51,7 @@ jobs:
         env:
           BOMCTL_VERSION: v0.4.3
         run: bash scripts/ci/sbom-install-binary-gh.sh
-      - name: Generate SBOMs (CycloneDX 1.6 JSON & SPDX 2.3)
-        run: scripts/ci/sbom-generate-safe.sh
-      - name: Fetch SBOM via GitHub REST API
+      - name: Generate SBOM from GitHub Dependency Graph
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: bash scripts/ci/sbom-fetch-github-api.sh

--- a/scripts/ci/sbom-fetch-github-api.sh
+++ b/scripts/ci/sbom-fetch-github-api.sh
@@ -219,13 +219,13 @@ main() {
         else
           # No local SBOM, use GitHub SBOM only
           log_info "No local SBOM found ('${PROJECT_ALIAS}' alias missing), using GitHub SBOM only"
-          log_info "Creating '${PROJECT_ALIAS}' alias from GitHub SBOM..."
-          if ! bomctl merge --alias "${PROJECT_ALIAS}" --name "${SBOM_NAME}" "${GITHUB_DEPS_ALIAS}" 2>"${tmpdir}/bomctl-merge-error.log"; then
-            log_error "Failed to create project alias from GitHub SBOM"
-            cat "${tmpdir}/bomctl-merge-error.log" >&2
-            handle_error "bomctl merge failed"
+          log_info "Adding '${PROJECT_ALIAS}' alias to GitHub SBOM..."
+          if ! bomctl alias set --force "${GITHUB_DEPS_ALIAS}" "${PROJECT_ALIAS}" 2>"${tmpdir}/bomctl-alias-error.log"; then
+            log_error "Failed to add project alias to GitHub SBOM"
+            cat "${tmpdir}/bomctl-alias-error.log" >&2
+            handle_error "bomctl alias set failed"
           else
-            log_success "Created '${PROJECT_ALIAS}' alias from GitHub SBOM"
+            log_success "Added '${PROJECT_ALIAS}' alias to GitHub SBOM"
             github_merged=true
           fi
         fi
@@ -259,9 +259,9 @@ main() {
   cyclonedx_file="${OUTPUT_DIR}/${SBOM_NAME}.cyclonedx-1.6.json"
   cyclonedx_success=false
   
-  if ! bomctl push "${PROJECT_ALIAS}" "${cyclonedx_file}" -f "cyclonedx-1.6" -e "json" --tree 2>"${tmpdir}/bomctl-push-cdx-error.log"; then
+  if ! bomctl export "${PROJECT_ALIAS}" -f "cyclonedx-1.6" -e "json" -o "${cyclonedx_file}" 2>"${tmpdir}/bomctl-export-cdx-error.log"; then
     log_error "Failed to export CycloneDX 1.6 format"
-    cat "${tmpdir}/bomctl-push-cdx-error.log" >&2
+    cat "${tmpdir}/bomctl-export-cdx-error.log" >&2
     handle_error "CycloneDX export failed"
   elif [ ! -f "${cyclonedx_file}" ]; then
     handle_error "CycloneDX file was not created: ${cyclonedx_file}"
@@ -275,9 +275,9 @@ main() {
   spdx_file="${OUTPUT_DIR}/${SBOM_NAME}.spdx-2.3.json"
   spdx_success=false
   
-  if ! bomctl push "${PROJECT_ALIAS}" "${spdx_file}" -f "spdx-2.3" --tree 2>"${tmpdir}/bomctl-push-spdx-error.log"; then
+  if ! bomctl export "${PROJECT_ALIAS}" -f "spdx-2.3" -o "${spdx_file}" 2>"${tmpdir}/bomctl-export-spdx-error.log"; then
     log_error "Failed to export SPDX 2.3 format"
-    cat "${tmpdir}/bomctl-push-spdx-error.log" >&2
+    cat "${tmpdir}/bomctl-export-spdx-error.log" >&2
     handle_error "SPDX export failed"
   elif [ ! -f "${spdx_file}" ]; then
     handle_error "SPDX file was not created: ${spdx_file}"


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```
  fix(ci): complete SBOM workflow fix with verified bomctl commands
  ```

- Type:
  - [x] fix / perf (patch)
  - [ ] feat (minor)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

This will trigger a PATCH bump when merged.

## What's Changing

Completes the SBOM workflow fix with **verified, working bomctl commands**. PR #189 fixed the unwrapping but the workflow still fails due to incorrect `bomctl` usage.

This PR includes the remaining fixes that were **tested end-to-end locally** with actual `bomctl v0.4.3`.

### The Complete Fix Chain

#### Issue 1: Missing Project Alias ✅ (commit 7c94a07)
**Root Cause:** `sbom-generate-safe.sh` was called with `--skip-fetch` and no imports, so it created no `project` alias. The next step expected this alias to exist and failed.

**Solution:**
- Modified `sbom-fetch-github-api.sh` to handle missing `project` alias
- Removed the broken `sbom-generate-safe.sh` step from both workflows
- Simplified to single step that fetches from GitHub and exports

#### Issue 2: Invalid bomctl merge Usage ✅ (commit 8018e91)
**Root Cause:** Attempted `bomctl merge project github-deps` with only 1 document ID, but `merge` requires 2+.

**Solution:** Use `bomctl alias set github-deps project` to add second alias to existing document.

#### Issue 3: Wrong Export Command ✅ (commit 8018e91)  
**Root Cause:** Used `bomctl push project dist/sbom/file.json` but `push` expects remote URLs, not filesystem paths.

**Solution:** Use `bomctl export project -o dist/sbom/file.json` for filesystem writes.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (N/A - CI infrastructure fix)
- [x] Docs updated if user-facing (N/A - internal CI script)
- [x] **Local CI passed - VERIFIED END-TO-END with bomctl v0.4.3**

## Related Issues

Resolves the SBOM workflow failures that persisted after PR #189:
- https://github.com/TurboCoder13/py-lintro/actions/runs/18249625720/job/51962296148

## Details

### Local Testing Verification

Unlike previous attempts, this fix was **fully tested locally** with actual `bomctl`:

```bash
✅ Fetched SBOM from GitHub API
✅ Extracted SBOM from wrapper (from PR #189)
✅ Imported GitHub SBOM into bomctl
✅ Added 'project' alias to GitHub SBOM (NEW FIX)
✅ Exported CycloneDX 1.6: 19.9 KB (NEW FIX - correct command)
✅ Exported SPDX 2.3: 38.5 KB (NEW FIX - correct command)
✅ Validated both files: valid SBOM data
```

### Implementation Changes

#### 1. Handle Missing Project Alias (commit 7c94a07)

**Modified Files:**
- `scripts/ci/sbom-fetch-github-api.sh` - Check if `project` alias exists before merge
- `.github/workflows/sbom-on-main.yml` - Remove broken `sbom-generate-safe.sh` step
- `.github/workflows/reusable-sbom.yml` - Remove broken `sbom-generate-safe.sh` step

**Logic:**
```bash
if bomctl list | grep -q "project"; then
  # Merge with existing local SBOM
  bomctl merge --alias project --name py-lintro-sbom github-deps project
else
  # No local SBOM, add alias to GitHub SBOM
  bomctl alias set --force github-deps project
fi
```

#### 2. Use Correct bomctl Commands (commit 8018e91)

**Changed from:**
```bash
bomctl push project dist/sbom/file.cyclonedx-1.6.json -f cyclonedx-1.6 -e json --tree
bomctl push project dist/sbom/file.spdx-2.3.json -f spdx-2.3 --tree
```

**Changed to:**
```bash
bomctl export project -f cyclonedx-1.6 -e json -o dist/sbom/file.cyclonedx-1.6.json
bomctl export project -f spdx-2.3 -o dist/sbom/file.spdx-2.3.json
```

### Why This Will Work

1. **Tested locally** with same `bomctl v0.4.3` that CI uses
2. **Verified output files** are created with valid SBOM data
3. **All error paths** handled (GitHub fetch failure, missing alias, export errors)
4. **Simplified workflow** - removed non-functional step

### Error Progression Timeline

**After PR #189 (unwrapping fixed):**
```
[sbom-fetch] ERROR: 'project' alias not found in bomctl cache
```

**After This PR (all fixes applied):**
```
[sbom-fetch] SUCCESS: Added 'project' alias to GitHub SBOM
[sbom-fetch] SUCCESS: Exported CycloneDX 1.6: dist/sbom/py-lintro-sbom.cyclonedx-1.6.json
[sbom-fetch] SUCCESS: Exported SPDX 2.3: dist/sbom/py-lintro-sbom.spdx-2.3.json
[sbom-fetch] SUCCESS: GitHub SBOM fetch, merge, and export complete
```

## Testing Evidence

Local test output from verified run:
```
$ ls -lh dist/sbom/
-rw-r--r-- 1 user staff  19K Oct  4 23:35 py-lintro-sbom.cyclonedx-1.6.json
-rw-r--r-- 1 user staff  38K Oct  4 23:35 py-lintro-sbom.spdx-2.3.json

$ head dist/sbom/py-lintro-sbom.cyclonedx-1.6.json
{
  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
  "bomFormat": "CycloneDX",
  "specVersion": "1.6",
  ...
}
```

Both files contain complete dependency information for all npm and Python packages.