### PR TITLE
fix(ci): use consistent branch name to prevent duplicate auto-bump PRs

### DIFF
--- a/.github/workflows/auto-bump-internal-refs.yml
+++ b/.github/workflows/auto-bump-internal-refs.yml
@@ -80,6 +80,6 @@ jobs:
           body: |
             Automated update of internal action/workflow references to the
             latest commit SHA to satisfy org policy for pinned refs.
-          branch: chore/bump-internal-refs-${{ github.run_id }}-${{ github.sha }}
+          branch: chore/bump-internal-refs
           labels: maintenance
           delete-branch: true


### PR DESCRIPTION
## Problem

The auto-bump-internal-refs workflow is creating duplicate PRs instead of updating existing ones:
- PR #188: `chore/bump-internal-refs-18249354059-c711e9142e693ef21961088252d4c59c12cfe83a`
- PR #191: `chore/bump-internal-refs-18255291417-3b97378f34381606a521059a041ad1e86165c546`

### Root Cause

Line 83 in `.github/workflows/auto-bump-internal-refs.yml`:

```yaml
branch: chore/bump-internal-refs-${{ github.run_id }}-${{ github.sha }}
```

This creates a **unique branch name** for every workflow run because:
- `github.run_id` - Different for each run (18255291417, 18249354059, etc.)
- `github.sha` - Different commit SHA

Since each run creates a new branch, `peter-evans/create-pull-request` creates a **new PR** instead of updating the existing one.

## Solution

Change to a **consistent branch name**:

```yaml
branch: chore/bump-internal-refs
```

### How peter-evans/create-pull-request Works

When it finds an **existing branch** with the same name:
- ✅ Updates the existing branch with new commits
- ✅ Updates the existing PR (doesn't create a new one)
- ✅ Adds a comment to the PR noting it was updated

With a fixed branch name:
- **First run**: Creates `chore/bump-internal-refs` branch → Creates PR
- **Second run**: Updates `chore/bump-internal-refs` branch → Updates same PR
- **Third run**: Updates `chore/bump-internal-refs` branch → Updates same PR

## Impact

### Before Fix
- ❌ Multiple duplicate PRs accumulate
- ❌ Manual cleanup required (close old PRs)
- ❌ Confusing which PR to merge
- ❌ Cluttered PR list

### After Fix
- ✅ Single PR that gets updated automatically
- ✅ No duplicate PRs
- ✅ Clear which PR contains latest changes
- ✅ Cleaner PR workflow

## Next Steps

After this PR is merged:

1. **Merge PR #191** (newer, has latest SHA pins)
2. **Close PR #188** (older, outdated SHA pins)
3. Future auto-bump runs will update a single PR

## Testing Strategy

After merge, the next push to main that triggers auto-bump will:
1. Update the existing `chore/bump-internal-refs` branch (if one exists)
2. Update the existing PR (if one is open)
3. Or create a new PR (if none exists)

## Checklist

- [x] Title follows Conventional Commits
- [x] One-line change, verified correct
- [x] No linter errors
- [x] Explains root cause and solution
- [x] Documents expected behavior change

## Related

- Fixes duplicate PRs: #188, #191
- Related to auto-bump workflow maintenance