### PR TITLE
fix(ci): use docker-container driver for GHA cache compatibility

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -76,8 +76,6 @@ jobs:
           persist-credentials: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-        with:
-          driver: docker
       - name: Build Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
@@ -135,6 +133,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          driver: docker-container
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -108,10 +108,11 @@ Scripts for containerized development and testing.
 
 Scripts for local development and testing.
 
-| Script             | Purpose                                     | Usage                                     |
-| ------------------ | ------------------------------------------- | ----------------------------------------- |
-| `local-lintro.sh`  | Enhanced local Lintro runner                | `./scripts/local/local-lintro.sh check`   |
-| `sign-all-tags.sh` | Re-sign annotated git tags (GPG/SSH) safely | `./scripts/local/sign-all-tags.sh --help` |
+| Script                       | Purpose                                     | Usage                                           |
+| ---------------------------- | ------------------------------------------- | ----------------------------------------------- |
+| `local-lintro.sh`            | Enhanced local Lintro runner                | `./scripts/local/local-lintro.sh check`         |
+| `sign-all-tags.sh`           | Re-sign annotated git tags (GPG/SSH) safely | `./scripts/local/sign-all-tags.sh --help`       |
+| `validate-docker-buildx.sh`  | Validate Docker Buildx driver configuration | `./scripts/local/validate-docker-buildx.sh`     |
 
 Notes:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -108,11 +108,11 @@ Scripts for containerized development and testing.
 
 Scripts for local development and testing.
 
-| Script                       | Purpose                                     | Usage                                           |
-| ---------------------------- | ------------------------------------------- | ----------------------------------------------- |
-| `local-lintro.sh`            | Enhanced local Lintro runner                | `./scripts/local/local-lintro.sh check`         |
-| `sign-all-tags.sh`           | Re-sign annotated git tags (GPG/SSH) safely | `./scripts/local/sign-all-tags.sh --help`       |
-| `validate-docker-buildx.sh`  | Validate Docker Buildx driver configuration | `./scripts/local/validate-docker-buildx.sh`     |
+| Script                      | Purpose                                     | Usage                                       |
+| --------------------------- | ------------------------------------------- | ------------------------------------------- |
+| `local-lintro.sh`           | Enhanced local Lintro runner                | `./scripts/local/local-lintro.sh check`     |
+| `sign-all-tags.sh`          | Re-sign annotated git tags (GPG/SSH) safely | `./scripts/local/sign-all-tags.sh --help`   |
+| `validate-docker-buildx.sh` | Validate Docker Buildx driver configuration | `./scripts/local/validate-docker-buildx.sh` |
 
 Notes:
 

--- a/scripts/local/validate-docker-buildx.sh
+++ b/scripts/local/validate-docker-buildx.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Docker Buildx Configuration Validator
+# Validates Docker Buildx driver and cache configuration locally
+#
+# Usage: ./scripts/local/validate-docker-buildx.sh [--help]
+#
+# This script is a diagnostic tool to validate that:
+# - Docker Buildx is properly configured
+# - The docker-container driver works with cache backends
+# - The build process completes successfully
+#
+# This is NOT part of the regular test suite. Use it for:
+# - Troubleshooting Docker build issues
+# - Validating CI configuration changes locally
+# - Debugging cache-related problems
+
+set -euo pipefail
+
+# Show help if requested
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    echo "Usage: $0 [--help]"
+    echo ""
+    echo "Docker Buildx Configuration Validator"
+    echo "Validates Docker Buildx driver and cache configuration locally."
+    echo ""
+    echo "This script validates that:"
+    echo "  - Docker Buildx is properly configured"
+    echo "  - The docker-container driver works with cache backends"
+    echo "  - The build process completes successfully"
+    echo ""
+    echo "This is a diagnostic tool for:"
+    echo "  - Troubleshooting Docker build issues"
+    echo "  - Validating CI configuration changes locally"
+    echo "  - Debugging cache-related problems"
+    echo ""
+    echo "This is NOT part of the regular test suite."
+    exit 0
+fi
+
+# Source shared utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../utils/utils.sh"
+
+log_info "Validating Docker Buildx Configuration..."
+
+# Check current buildx version
+log_info "Checking Buildx version..."
+docker buildx version
+
+# Create a test builder with docker-container driver
+log_info "Creating test builder with docker-container driver..."
+docker buildx create --name test-builder --driver docker-container --use
+
+# Inspect the builder
+log_info "Inspecting builder configuration..."
+docker buildx inspect test-builder
+
+# Try building the image with cache
+log_info "Building image with cache..."
+docker buildx build \
+  --platform linux/amd64 \
+  --cache-from type=local,src=/tmp/buildx-cache \
+  --cache-to type=local,dest=/tmp/buildx-cache,mode=max \
+  --load \
+  -t py-lintro:test \
+  .
+
+log_success "Build successful!"
+
+# Cleanup
+log_info "Cleaning up..."
+docker buildx use default
+docker buildx rm test-builder
+rm -rf /tmp/buildx-cache
+
+log_success "Validation completed successfully!"
+log_info "Docker Buildx is properly configured for use with cache backends."


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(ci): use docker-container driver for GHA cache compatibility`

- Type:
  - [x] fix / perf (patch)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

This PR fixes the Docker buildx failure by using the `docker-container` driver (Docker's default and recommended driver) instead of the `docker` driver. This allows us to re-enable GitHub Actions cache, improving build performance while maintaining security.

### Root Cause
In commit `1302f6d`, `driver: docker` was explicitly set during a security hardening refactor. The `docker` driver doesn't support the `type=gha` cache backend, causing all Docker builds to fail with cache errors.

### Solution
- Remove explicit `driver: docker` from build-and-test job (uses default `docker-container`)
- Set `driver: docker-container` explicitly in publish job for clarity
- Re-enable GHA cache (`cache-from`/`cache-to` with `type=gha`)

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (N/A - CI configuration change)
- [ ] Docs updated if user-facing (N/A - internal CI fix)
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

Fixes the Docker build failures in:
- PR #187 and 2 other automated Renovate PRs

## Details

### Why `docker-container` is Better:

**Security:**
- ✅ Better isolation - runs BuildKit in a separate container
- ✅ Follows Docker security best practices
- ✅ Standard for enterprise CI/CD pipelines

**Performance:**
- ✅ Supports GitHub Actions cache backend
- ✅ Multi-platform build support
- ✅ All advanced BuildKit features

**Compatibility:**
- ✅ Docker's default and recommended driver
- ✅ Used by most projects on GitHub Actions

### Testing:
Once this PR is merged, the failing Renovate PRs should automatically rebuild successfully with proper caching enabled.

### Verification Steps:
1. This PR will trigger the `docker-build-publish` workflow
2. Check that the "Build Docker image" step completes successfully
3. Verify cache is being used (look for "cache hit" messages in logs)
4. After merge, rerun failed workflows on PRs #187 and others