### PR TITLE
chore: bump internal refs to latest SHA

### DIFF
--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -61,7 +61,7 @@ jobs:
         run: echo "Not a release bump commit; skipping tag creation."
 
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@3b0ca558326f103e41c515d05d7c7813ed3fee04
         with:
           python-version: '3.13'
         env:

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -63,7 +63,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@3b0ca558326f103e41c515d05d7c7813ed3fee04
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOOTSTRAP_SKIP_SYNC: '1'
@@ -104,7 +104,7 @@ jobs:
 
       - name: Comment PR with Lintro Results (merge-update)
         if: github.event_name == 'pull_request'
-        uses: TurboCoder13/py-lintro/.github/actions/post-pr-comment@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/post-pr-comment@3b0ca558326f103e41c515d05d7c7813ed3fee04
         with:
           file: pr-comment.txt
           marker: '<!-- lintro-report -->'

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -127,7 +127,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Docker (Buildx + login)
-        uses: TurboCoder13/py-lintro/.github/actions/setup-docker@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/setup-docker@3b0ca558326f103e41c515d05d7c7813ed3fee04
         with:
           login: 'true'
           registry: ghcr.io

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup environment
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@3b0ca558326f103e41c515d05d7c7813ed3fee04
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOOTSTRAP_SKIP_SYNC: '1'

--- a/.github/workflows/lintro-report-scheduled.yml
+++ b/.github/workflows/lintro-report-scheduled.yml
@@ -53,7 +53,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@3b0ca558326f103e41c515d05d7c7813ed3fee04
 
       - name: Run Lintro on codebase
         run: ./scripts/ci/lintro-report-generate.sh

--- a/.github/workflows/pages-deploy-coverage.yml
+++ b/.github/workflows/pages-deploy-coverage.yml
@@ -63,6 +63,6 @@ jobs:
         run: ./scripts/ci/pages-deploy.sh --badge-path coverage-badge/coverage-badge.svg
       - name: Deploy coverage to Pages
         id: deployment
-        uses: TurboCoder13/py-lintro/.github/actions/pages-deploy@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/pages-deploy@3b0ca558326f103e41c515d05d7c7813ed3fee04
         with:
           path: _site

--- a/.github/workflows/pr-comment-cleanup.yml
+++ b/.github/workflows/pr-comment-cleanup.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@3b0ca558326f103e41c515d05d7c7813ed3fee04
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -23,20 +23,20 @@ permissions:
 
 jobs:
   quality:
-    uses: TurboCoder13/py-lintro/.github/workflows/reusable-quality.yml@574d5c58f0f75a103e9c01f08679045cc5447fd5
+    uses: TurboCoder13/py-lintro/.github/workflows/reusable-quality.yml@3b0ca558326f103e41c515d05d7c7813ed3fee04
     permissions:
       contents: read
 
   build:
     needs: quality
-    uses: TurboCoder13/py-lintro/.github/workflows/reusable-build.yml@574d5c58f0f75a103e9c01f08679045cc5447fd5
+    uses: TurboCoder13/py-lintro/.github/workflows/reusable-build.yml@3b0ca558326f103e41c515d05d7c7813ed3fee04
     permissions:
       contents: read
 
   sbom:
     name: Generate and verify SBOM
     needs: [build, quality]
-    uses: TurboCoder13/py-lintro/.github/workflows/reusable-sbom.yml@574d5c58f0f75a103e9c01f08679045cc5447fd5
+    uses: TurboCoder13/py-lintro/.github/workflows/reusable-sbom.yml@3b0ca558326f103e41c515d05d7c7813ed3fee04
     permissions:
       contents: read
       actions: read
@@ -76,7 +76,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@3b0ca558326f103e41c515d05d7c7813ed3fee04
         with:
           python-version: '3.13'
       - name: Ensure tag points to a commit on main

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -11,11 +11,11 @@ permissions:
 
 jobs:
   quality:
-    uses: TurboCoder13/py-lintro/.github/workflows/reusable-quality.yml@574d5c58f0f75a103e9c01f08679045cc5447fd5
+    uses: TurboCoder13/py-lintro/.github/workflows/reusable-quality.yml@3b0ca558326f103e41c515d05d7c7813ed3fee04
 
   build:
     needs: quality
-    uses: TurboCoder13/py-lintro/.github/workflows/reusable-build.yml@574d5c58f0f75a103e9c01f08679045cc5447fd5
+    uses: TurboCoder13/py-lintro/.github/workflows/reusable-build.yml@3b0ca558326f103e41c515d05d7c7813ed3fee04
 
   publish:
     name: Upload to TestPyPI

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@3b0ca558326f103e41c515d05d7c7813ed3fee04
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@3b0ca558326f103e41c515d05d7c7813ed3fee04
         with:
           python-version: '3.13'
 

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Validate PR title follows Conventional Commits
         id: semantic
-        uses: TurboCoder13/py-lintro/.github/actions/semantic-pr-title-check@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/semantic-pr-title-check@3b0ca558326f103e41c515d05d7c7813ed3fee04
         with:
           types: |
             chore

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -46,7 +46,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@3b0ca558326f103e41c515d05d7c7813ed3fee04
         with:
           python-version: '3.13'
         env:

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@3b0ca558326f103e41c515d05d7c7813ed3fee04
       - name: Run comprehensive test suite (with Docker tests)
         run: ./scripts/docker/docker-test.sh
       # (moved) Upload coverage badge artifact happens after badge generation below
@@ -158,7 +158,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@3b0ca558326f103e41c515d05d7c7813ed3fee04
       - name: Download coverage XML artifact (fallback for comment generation)
         if: always()
         continue-on-error: true
@@ -177,7 +177,7 @@ jobs:
           ./scripts/ci/coverage-pr-comment.sh
         # yamllint enable
       - name: Comment PR with coverage info
-        uses: TurboCoder13/py-lintro/.github/actions/post-pr-comment@574d5c58f0f75a103e9c01f08679045cc5447fd5
+        uses: TurboCoder13/py-lintro/.github/actions/post-pr-comment@3b0ca558326f103e41c515d05d7c7813ed3fee04
         with:
           file: coverage-pr-comment.txt
           marker: '<!-- coverage-report -->'


### PR DESCRIPTION
Automated update of internal action/workflow references to the
latest commit SHA to satisfy org policy for pinned refs.