### PR TITLE
fix: prevent infinite loop in auto-bump workflow

### DIFF
--- a/.github/workflows/auto-bump-internal-refs.yml
+++ b/.github/workflows/auto-bump-internal-refs.yml
@@ -25,7 +25,7 @@ jobs:
     if: >-
       ${{ github.event_name == 'workflow_dispatch' || (
           github.ref == 'refs/heads/main' &&
-          !contains(github.event.head_commit.message, 'bump internal refs') &&
+          !contains(github.event.head_commit.message, 'bump internal workflow/action refs') &&
           !startsWith(github.event.head_commit.message, 'chore(release):')
       ) }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Problem

The auto-bump-internal-refs workflow was creating an infinite loop by not properly detecting its own commits when they were merged to main.

## Root Cause

The workflow condition on line 28 checked for the string `'bump internal refs'` in the commit message, but the actual commit message format is `'chore: bump internal workflow/action refs to latest SHA'`. Since these strings don't match exactly, the workflow would trigger again after its own PR was merged, creating PRs #199 and #200 in an infinite loop.

## Changes

- Updated `.github/workflows/auto-bump-internal-refs.yml` line 28
- Changed the contains check from `'bump internal refs'` to `'bump internal workflow/action refs'`
- This now properly matches the actual commit message format and prevents the workflow from triggering on its own merges

## Testing

After merging this PR:
- The workflow should continue to detect changes to `.github/actions/` or `.github/workflows/reusable-*.yml`
- It will create ONE PR with bumped refs
- It will NOT trigger again when that PR is merged (commit message will now be properly detected)

## Related Issues

Closes the infinite loop that created PRs #199 and #200