### PR TITLE
fix: invoke functions in semantic-release-helpers script

### DIFF
--- a/scripts/ci/semantic-release-helpers.sh
+++ b/scripts/ci/semantic-release-helpers.sh
@@ -42,4 +42,5 @@ merge_release_pr() {
   gh pr merge --auto --squash "$pr_number" || true
 }
 
-
+# Call the specified function with its arguments
+"$@"


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```
  fix: invoke functions in semantic-release-helpers script
  ```

- Type:
  - [x] fix / perf (patch)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type or a body with `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Fix the release workflow by adding a function dispatcher to `scripts/ci/semantic-release-helpers.sh`.

### Root Cause

The `semantic-release-helpers.sh` script defined helper functions but never actually invoked them. When the workflow called:

```bash
scripts/ci/semantic-release-helpers.sh update_version_files "0.8.0"
```

The script would:
1. Check if the first argument is `--help` (it wasn't)
2. Define all the functions
3. **Exit immediately without calling anything**

This meant that version file updates, tool installation, and other critical release steps were never executed, causing the release PR creation to fail silently (no changes to commit).

### Fix

Added a dispatcher at the end of the script:

```bash
# Call the specified function with its arguments
"$@"
```

Now when the workflow calls `semantic-release-helpers.sh update_version_files "0.8.0"`, it will:
1. Define the functions
2. **Execute the function with its arguments** via `"$@"`
3. Actually modify `pyproject.toml` and `lintro/__init__.py`

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (shell script doesn't need new tests)
- [x] Docs updated if user-facing (not user-facing)
- [x] Local CI passed (script syntax validated)

## Related Issues

Fixes the root cause investigation from commit c171a4efa0f469eaf3c30a838aa8f9355669e55d where the release train didn't trigger. While PR #223 fixed the PyPI egress issue, this PR fixes the actual execution bug that prevented version updates from running.

## Details

This is a critical bug fix for the automated release workflow. Without this fix, the release PR creation workflow would:
- Compute the correct next version (e.g., 0.8.0)
- Attempt to update version files
- **Silently skip the update** because the helper script didn't execute
- Find no changes to commit
- Skip PR creation

With this fix, the full release train will work:
1. Merge a `feat:` or `fix:` PR to main
2. Release workflow computes next version
3. **Version files are actually updated**
4. Release PR is created
5. Merge release PR → tag is pushed → PyPI publish runs