### PR TITLE
feat: add Ruff ANN (annotations) rule support

### DIFF
--- a/docs/tool-analysis/ruff-analysis.md
+++ b/docs/tool-analysis/ruff-analysis.md
@@ -212,6 +212,7 @@ Lintro preserves all Ruff rule categories:
 | **pep8-naming**           | N      | Naming conventions (PEP 8)         |
 | **pydocstyle**            | D      | Docstring style violations         |
 | **pyupgrade**             | UP     | Python upgrade suggestions         |
+| **flake8-annotations**    | ANN    | Type annotation requirements       |
 | **flake8-bugbear**        | B      | Bug detection and complexity       |
 | **flake8-comprehensions** | C4     | Comprehension improvements         |
 | **flake8-simplify**       | SIM    | Code simplification suggestions    |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,8 @@ indent-style = "space"
 skip-magic-trailing-comma = false
 
 [tool.ruff.lint]
-select = [ "E", "F", "W", "I", "COM", "N", "D", "UP",]
-ignore = []
+select = [ "E", "F", "W", "I", "COM", "N", "D", "UP", "ANN",]
+ignore = ["ANN"]
 
 [tool.ruff.pydocstyle]
 convention = "google"

--- a/test_samples/ruff_annotations_violations.py
+++ b/test_samples/ruff_annotations_violations.py
@@ -1,0 +1,53 @@
+"""Sample file with flake8-annotations (ANN) violations for testing Ruff.
+
+Intentionally violates several ANN-rules, such as:
+- ANN101: missing type annotation for self
+- ANN102: missing type annotation for cls
+- ANN201: missing return type annotation for public function
+- ANN204: missing return type annotation for special method
+- ANN205: missing return type annotation for static method
+- ANN003: missing type annotation for **kwargs
+"""
+
+from typing import Any
+
+
+class SampleClass:
+    """Sample class with annotation violations."""
+
+    def __init__(self, value: int):  # ANN101: missing type for self
+        self.value = value
+
+    @classmethod
+    def from_string(cls, s: str):  # ANN102: missing type for cls
+        return cls(int(s))
+
+    @staticmethod
+    def helper_func(x: int):  # ANN205: missing return type
+        return x * 2
+
+    def __str__(self):  # ANN204: missing return type for special method
+        return f"SampleClass({self.value})"
+
+    def public_method(self, data: list[str]):  # ANN201: missing return type
+        return len(data)
+
+    def kwargs_method(self, **kwargs):  # ANN003: missing type for **kwargs
+        return kwargs
+
+
+def public_function(a: int, b: str):  # ANN201: missing return type
+    """Public function without return type annotation."""
+    return f"{a}: {b}"
+
+
+def kwargs_function(**kwargs):  # ANN003: missing type for **kwargs
+    """Function with kwargs without type annotation."""
+    return kwargs
+
+
+def nested_function():
+    """Function that returns a nested function."""
+    def inner(x: int):  # ANN201: missing return type
+        return x + 1
+    return inner

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -9,7 +9,7 @@ from assertpy import assert_that
 from lintro.cli import cli
 
 
-def test_cli_help():
+def test_cli_help() -> None:
     """Test that CLI shows help."""
     from click.testing import CliRunner
 
@@ -19,7 +19,7 @@ def test_cli_help():
     assert_that(result.output).contains("Lintro")
 
 
-def test_cli_version():
+def test_cli_version() -> None:
     """Test that CLI shows version."""
     from click.testing import CliRunner
 
@@ -29,7 +29,7 @@ def test_cli_version():
     assert_that(result.output.lower()).contains("version")
 
 
-def test_cli_commands_registered():
+def test_cli_commands_registered() -> None:
     """Test that all commands are registered."""
     from click.testing import CliRunner
 
@@ -42,7 +42,7 @@ def test_cli_commands_registered():
     assert_that(result.exit_code).is_equal_to(0)
 
 
-def test_main_function():
+def test_main_function() -> None:
     """Test the main function."""
     from click.testing import CliRunner
 
@@ -52,7 +52,7 @@ def test_main_function():
     assert_that(result.output).contains("Lintro")
 
 
-def test_cli_command_aliases():
+def test_cli_command_aliases() -> None:
     """Test that command aliases work."""
     from click.testing import CliRunner
 
@@ -65,7 +65,7 @@ def test_cli_command_aliases():
     assert_that(result.exit_code).is_equal_to(0)
 
 
-def test_cli_with_no_args():
+def test_cli_with_no_args() -> None:
     """Test CLI with no arguments."""
     from click.testing import CliRunner
 
@@ -75,7 +75,7 @@ def test_cli_with_no_args():
     assert_that(result.output).is_equal_to("")
 
 
-def test_main_module_execution():
+def test_main_module_execution() -> None:
     """Test that __main__.py can be executed directly."""
     with patch.object(sys, "argv", ["lintro", "--help"]):
         import lintro.__main__
@@ -83,7 +83,7 @@ def test_main_module_execution():
         assert_that(lintro.__main__).is_not_none()
 
 
-def test_main_module_as_script():
+def test_main_module_as_script() -> None:
     """Test that __main__.py works when run as a script."""
     result = subprocess.run(
         [sys.executable, "-m", "lintro", "--help"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def _ensure_test_docker_images_built() -> None:
     return
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(config, items) -> None:
     """Optionally skip docker tests locally unless explicitly enabled.
 
     If `LINTRO_RUN_DOCKER_TESTS` is not set to "1", mark tests under

--- a/tests/formatters/test_formatters.py
+++ b/tests/formatters/test_formatters.py
@@ -13,7 +13,7 @@ from lintro.formatters.styles.markdown import MarkdownStyle
 from lintro.formatters.styles.plain import PlainStyle
 
 
-def test_output_style_abstract():
+def test_output_style_abstract() -> None:
     """Test that OutputStyle is an abstract base class."""
     from abc import ABC
 
@@ -21,7 +21,7 @@ def test_output_style_abstract():
     assert_that(hasattr(OutputStyle, "format")).is_true()
 
 
-def test_table_descriptor_abstract():
+def test_table_descriptor_abstract() -> None:
     """Test TableDescriptor is an abstract base class."""
     from abc import ABC
 
@@ -30,13 +30,13 @@ def test_table_descriptor_abstract():
     assert_that(hasattr(TableDescriptor, "get_rows")).is_true()
 
 
-def test_table_descriptor_methods():
+def test_table_descriptor_methods() -> None:
     """Test TableDescriptor abstract methods exist."""
     assert_that(callable(TableDescriptor.get_columns)).is_true()
     assert_that(callable(TableDescriptor.get_rows)).is_true()
 
 
-def test_csv_style_format():
+def test_csv_style_format() -> None:
     """Test CSV style formatting."""
     style = CsvStyle()
     result = style.format(["col1", "col2"], [["val1", "val2"], ["val3", "val4"]])
@@ -45,14 +45,14 @@ def test_csv_style_format():
     assert_that(result).contains("val3,val4")
 
 
-def test_csv_style_format_empty():
+def test_csv_style_format_empty() -> None:
     """Test CSV style formatting with empty data."""
     style = CsvStyle()
     result = style.format([], [])
     assert_that(result).is_equal_to("")
 
 
-def test_grid_style_format():
+def test_grid_style_format() -> None:
     """Test grid style formatting."""
     style = GridStyle()
     result = style.format(["col1", "col2"], [["val1", "val2"], ["val3", "val4"]])
@@ -62,14 +62,14 @@ def test_grid_style_format():
     assert_that(result).contains("val2")
 
 
-def test_grid_style_format_empty():
+def test_grid_style_format_empty() -> None:
     """Test grid style formatting with empty data."""
     style = GridStyle()
     result = style.format([], [])
     assert_that(result).is_equal_to("")
 
 
-def test_grid_style_format_fallback():
+def test_grid_style_format_fallback() -> None:
     """Test grid style formatting fallback when tabulate is not available."""
     style = GridStyle()
     with pytest.MonkeyPatch().context() as m:
@@ -83,7 +83,7 @@ def test_grid_style_format_fallback():
         assert_that(result).contains(" | ")
 
 
-def test_grid_style_format_fallback_empty():
+def test_grid_style_format_fallback_empty() -> None:
     """Test grid style formatting fallback with empty data."""
     style = GridStyle()
     with pytest.MonkeyPatch().context() as m:
@@ -93,7 +93,7 @@ def test_grid_style_format_fallback_empty():
         assert_that(result).is_equal_to("")
 
 
-def test_grid_style_format_fallback_single_column():
+def test_grid_style_format_fallback_single_column() -> None:
     """Test grid style formatting fallback with single column."""
     style = GridStyle()
     with pytest.MonkeyPatch().context() as m:
@@ -105,7 +105,7 @@ def test_grid_style_format_fallback_single_column():
         assert_that(result).contains("val2")
 
 
-def test_html_style_format():
+def test_html_style_format() -> None:
     """Test HTML style formatting."""
     style = HtmlStyle()
     result = style.format(["col1", "col2"], [["val1", "val2"], ["val3", "val4"]])
@@ -116,7 +116,7 @@ def test_html_style_format():
     assert_that(result).contains("<td>val2</td>")
 
 
-def test_json_style_format():
+def test_json_style_format() -> None:
     """Test JSON style formatting."""
     style = JsonStyle()
     result = style.format(["col1", "col2"], [["val1", "val2"], ["val3", "val4"]])
@@ -126,7 +126,7 @@ def test_json_style_format():
     assert_that(result).contains("val2")
 
 
-def test_markdown_style_format():
+def test_markdown_style_format() -> None:
     """Test markdown style formatting."""
     style = MarkdownStyle()
     result = style.format(["col1", "col2"], [["val1", "val2"], ["val3", "val4"]])
@@ -135,7 +135,7 @@ def test_markdown_style_format():
     assert_that(result).contains("| val3 | val4 |")
 
 
-def test_plain_style_format():
+def test_plain_style_format() -> None:
     """Test plain style formatting."""
     style = PlainStyle()
     result = style.format(["col1", "col2"], [["val1", "val2"], ["val3", "val4"]])
@@ -145,7 +145,7 @@ def test_plain_style_format():
     assert_that(result).contains("val2")
 
 
-def test_all_styles_produce_output():
+def test_all_styles_produce_output() -> None:
     """Test that all styles produce some output."""
     styles = [
         CsvStyle(),
@@ -163,7 +163,7 @@ def test_all_styles_produce_output():
         assert_that(len(result) > 0).is_true()
 
 
-def test_styles_handle_empty_results():
+def test_styles_handle_empty_results() -> None:
     """Test that all styles handle empty results gracefully."""
     styles = [
         CsvStyle(),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,7 +33,7 @@ def test_files_dir():
 
 
 @pytest.fixture
-def sample_python_file():
+def sample_python_file() -> str:
     """Provide a sample Python file with violations.
 
     Returns:
@@ -50,7 +50,7 @@ def sample_python_file():
 
 
 @pytest.fixture
-def sample_js_file():
+def sample_js_file() -> str:
     """Provide a sample JavaScript file with formatting issues.
 
     Returns:

--- a/tests/integration/test_actionlint_integration.py
+++ b/tests/integration/test_actionlint_integration.py
@@ -33,7 +33,7 @@ def actionlint_available() -> bool:
 
 
 @pytest.mark.actionlint
-def test_actionlint_available():
+def test_actionlint_available() -> None:
     """Skip the suite if actionlint is not present locally.
 
     Ensures local runs behave like CI (which always has actionlint in Docker),
@@ -47,7 +47,7 @@ SAMPLE_BAD = Path("test_samples/actionlint_violations.yml")
 
 
 @pytest.mark.actionlint
-def test_actionlint_reports_violations(tmp_path):
+def test_actionlint_reports_violations(tmp_path) -> None:
     """Assert that Lintro detects violations reported by actionlint.
 
     Args:
@@ -71,7 +71,7 @@ def test_actionlint_reports_violations(tmp_path):
 
 
 @pytest.mark.actionlint
-def test_actionlint_no_files(tmp_path):
+def test_actionlint_no_files(tmp_path) -> None:
     """Assert that Lintro succeeds when no workflow files are present.
 
     Args:

--- a/tests/integration/test_darglint_integration.py
+++ b/tests/integration/test_darglint_integration.py
@@ -65,7 +65,7 @@ def _ensure_darglint_cli_available() -> None:
         pytest.skip("darglint CLI not installed/runnable; skipping direct CLI test")
 
 
-def test_darglint_reports_violations_direct(tmp_path):
+def test_darglint_reports_violations_direct(tmp_path) -> None:
     """Darglint CLI: Should detect and report violations in a sample file.
 
     Args:
@@ -82,7 +82,7 @@ def test_darglint_reports_violations_direct(tmp_path):
     assert "DAR" in output, "Darglint output should contain error codes."
 
 
-def test_darglint_reports_violations_through_lintro(tmp_path):
+def test_darglint_reports_violations_through_lintro(tmp_path) -> None:
     """Lintro DarglintTool: Should detect and report violations in a sample file.
 
     Args:
@@ -111,7 +111,7 @@ def test_darglint_reports_violations_through_lintro(tmp_path):
     ), "Lintro DarglintTool output should contain error codes."
 
 
-def test_darglint_output_consistency_direct_vs_lintro(tmp_path):
+def test_darglint_output_consistency_direct_vs_lintro(tmp_path) -> None:
     """Darglint CLI vs Lintro: Should produce consistent results for the same file.
 
     Args:
@@ -137,7 +137,7 @@ def test_darglint_output_consistency_direct_vs_lintro(tmp_path):
     # Optionally compare error codes if output format is stable
 
 
-def test_darglint_fix_method_not_implemented(tmp_path):
+def test_darglint_fix_method_not_implemented(tmp_path) -> None:
     """Lintro DarglintTool: .fix() should raise NotImplementedError.
 
     Args:

--- a/tests/integration/test_hadolint_integration.py
+++ b/tests/integration/test_hadolint_integration.py
@@ -69,7 +69,7 @@ def run_hadolint_directly(file_path: Path) -> tuple[bool, str, int]:
 
 
 @pytest.mark.hadolint
-def test_hadolint_available():
+def test_hadolint_available() -> None:
     """Check if hadolint is available in PATH."""
     try:
         result = subprocess.run(
@@ -85,7 +85,7 @@ def test_hadolint_available():
 
 
 @pytest.mark.hadolint
-def test_hadolint_reports_violations_direct(tmp_path):
+def test_hadolint_reports_violations_direct(tmp_path) -> None:
     """Hadolint CLI: Should detect and report violations in a sample file.
 
     Args:
@@ -115,7 +115,7 @@ def test_hadolint_reports_violations_direct(tmp_path):
 
 
 @pytest.mark.hadolint
-def test_hadolint_reports_violations_through_lintro(tmp_path):
+def test_hadolint_reports_violations_through_lintro(tmp_path) -> None:
     """Lintro HadolintTool: Should detect and report violations in a sample file.
 
     Args:
@@ -145,7 +145,7 @@ def test_hadolint_reports_violations_through_lintro(tmp_path):
 
 
 @pytest.mark.hadolint
-def test_hadolint_output_consistency_direct_vs_lintro(tmp_path):
+def test_hadolint_output_consistency_direct_vs_lintro(tmp_path) -> None:
     """Hadolint CLI vs Lintro: Should produce consistent results for the same file.
 
     Args:
@@ -184,7 +184,7 @@ def test_hadolint_output_consistency_direct_vs_lintro(tmp_path):
 
 
 @pytest.mark.hadolint
-def test_hadolint_with_ignore_rules(tmp_path):
+def test_hadolint_with_ignore_rules(tmp_path) -> None:
     """Lintro HadolintTool: Should properly ignore specified rules.
 
     Args:
@@ -206,7 +206,7 @@ def test_hadolint_with_ignore_rules(tmp_path):
 
 
 @pytest.mark.hadolint
-def test_hadolint_fix_method_not_implemented(tmp_path):
+def test_hadolint_fix_method_not_implemented(tmp_path) -> None:
     """Lintro HadolintTool: .fix() should raise NotImplementedError.
 
     Args:
@@ -225,7 +225,7 @@ def test_hadolint_fix_method_not_implemented(tmp_path):
 
 
 @pytest.mark.hadolint
-def test_hadolint_empty_directory(tmp_path):
+def test_hadolint_empty_directory(tmp_path) -> None:
     """Lintro HadolintTool: Should handle empty directories gracefully.
 
     Args:
@@ -243,7 +243,7 @@ def test_hadolint_empty_directory(tmp_path):
 
 
 @pytest.mark.hadolint
-def test_hadolint_parser_validation(tmp_path):
+def test_hadolint_parser_validation(tmp_path) -> None:
     """Test that hadolint parser correctly parses output.
 
     Args:

--- a/tests/integration/test_prettier_integration.py
+++ b/tests/integration/test_prettier_integration.py
@@ -68,7 +68,7 @@ def run_prettier_directly(
     return success, full_output, issues_count
 
 
-def test_prettier_reports_violations_direct(temp_prettier_file):
+def test_prettier_reports_violations_direct(temp_prettier_file) -> None:
     """Prettier CLI: Should detect and report violations in a sample file.
 
     Args:
@@ -84,7 +84,7 @@ def test_prettier_reports_violations_direct(temp_prettier_file):
     assert has_warnings, "Prettier output should contain warning indicators."
 
 
-def test_prettier_reports_violations_through_lintro(temp_prettier_file):
+def test_prettier_reports_violations_through_lintro(temp_prettier_file) -> None:
     """Lintro PrettierTool: Should detect and report violations in a sample file.
 
     Args:
@@ -109,7 +109,7 @@ def test_prettier_reports_violations_through_lintro(temp_prettier_file):
     assert has_warnings, "Lintro PrettierTool output should contain warning indicators."
 
 
-def test_prettier_fix_method(temp_prettier_file):
+def test_prettier_fix_method(temp_prettier_file) -> None:
     """Lintro PrettierTool: Should fix formatting issues.
 
     Args:
@@ -147,7 +147,7 @@ def test_prettier_fix_method(temp_prettier_file):
     assert final_result.issues_count == 0, "Should have no issues after fixing"
 
 
-def test_prettier_output_consistency_direct_vs_lintro(temp_prettier_file):
+def test_prettier_output_consistency_direct_vs_lintro(temp_prettier_file) -> None:
     """Prettier CLI vs Lintro: Should produce consistent results for the same file.
 
     Args:
@@ -178,7 +178,7 @@ def test_prettier_output_consistency_direct_vs_lintro(temp_prettier_file):
     )
 
 
-def test_prettier_fix_sets_issues_for_table(temp_prettier_file):
+def test_prettier_fix_sets_issues_for_table(temp_prettier_file) -> None:
     """PrettierTool.fix should populate issues for table rendering.
 
     Args:

--- a/tests/integration/test_ruff_annotations.py
+++ b/tests/integration/test_ruff_annotations.py
@@ -1,0 +1,78 @@
+"""Integration tests for Ruff flake8-annotations (ANN) rule family."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+from assertpy import assert_that
+
+from lintro.tools.implementations.tool_ruff import RuffTool
+
+
+def test_annotations_rules_detected() -> None:
+    """Ensure Ruff reports ANN-family violations on a known sample file."""
+    sample = os.path.abspath("test_samples/ruff_annotations_violations.py")
+    with tempfile.TemporaryDirectory() as tmp:
+        test_file = os.path.join(tmp, "ruff_annotations_case.py")
+        shutil.copy(sample, test_file)
+
+        ruff = RuffTool()
+        ruff.set_options(select=["ANN"])  # only ANN rules
+        result = ruff.check([test_file])
+
+        assert_that(result.success).is_false()
+        codes = [getattr(i, "code", "") for i in (result.issues or [])]
+        # Expect several representative ANN-codes
+        assert_that(any(code.startswith("ANN") for code in codes)).is_true()
+        assert_that(
+            any(
+                code in {"ANN101", "ANN102", "ANN201", "ANN204", "ANN205", "ANN003"}
+                for code in codes
+            ),
+        ).is_true()
+
+
+def test_annotations_rules_with_other_rules() -> None:
+    """Ensure ANN rules work alongside other rule families."""
+    sample = os.path.abspath("test_samples/ruff_annotations_violations.py")
+    with tempfile.TemporaryDirectory() as tmp:
+        test_file = os.path.join(tmp, "ruff_annotations_mixed.py")
+        shutil.copy(sample, test_file)
+
+        ruff = RuffTool()
+        ruff.set_options(select=["ANN", "F"])  # ANN + pyflakes errors
+        result = ruff.check([test_file])
+
+        assert_that(result.success).is_false()
+        codes = [getattr(i, "code", "") for i in (result.issues or [])]
+        # Should have ANN codes (F codes may not be present in this sample)
+        assert_that(any(code.startswith("ANN") for code in codes)).is_true()
+
+
+def test_annotations_rules_fix_capability() -> None:
+    """Test that ANN rules can be fixed automatically where possible."""
+    sample = os.path.abspath("test_samples/ruff_annotations_violations.py")
+    with tempfile.TemporaryDirectory() as tmp:
+        test_file = os.path.join(tmp, "ruff_annotations_fix.py")
+        shutil.copy(sample, test_file)
+
+        ruff = RuffTool()
+        ruff.set_options(select=["ANN"])
+
+        # Check initial issues
+        initial_result = ruff.check([test_file])
+        initial_count = len(initial_result.issues or [])
+
+        # Apply fixes
+        ruff.fix([test_file])
+
+        # Check remaining issues after fix
+        final_result = ruff.check([test_file])
+        final_count = len(final_result.issues or [])
+
+        # Some issues should be fixed (though ANN rules are often not auto-fixable)
+        # We mainly verify the fix process doesn't crash and reduces issue count
+        assert_that(initial_count).is_greater_than_or_equal_to(final_count)
+        # Fix result may be False if issues remain, which is expected for ANN rules

--- a/tests/integration/test_ruff_integration.py
+++ b/tests/integration/test_ruff_integration.py
@@ -95,7 +95,7 @@ def temp_python_file(request):
         print("[DEBUG] temp_python_file contents:")
         print(debug_f.read())
 
-    def cleanup():
+    def cleanup() -> None:
         try:
             os.unlink(file_path)
         except FileNotFoundError:
@@ -108,7 +108,7 @@ def temp_python_file(request):
 class TestRuffTool:
     """Test cases for RuffTool."""
 
-    def test_tool_initialization(self, ruff_tool):
+    def test_tool_initialization(self, ruff_tool) -> None:
         """Test that RuffTool initializes correctly.
 
         Args:
@@ -119,7 +119,7 @@ class TestRuffTool:
         assert_that(ruff_tool.config.file_patterns).contains("*.py")
         assert_that(ruff_tool.config.file_patterns).contains("*.pyi")
 
-    def test_tool_priority(self, ruff_tool):
+    def test_tool_priority(self, ruff_tool) -> None:
         """Test that RuffTool has high priority.
 
         Args:
@@ -127,7 +127,7 @@ class TestRuffTool:
         """
         assert_that(ruff_tool.config.priority).is_equal_to(85)
 
-    def test_lint_check_clean_file(self, ruff_tool, ruff_clean_file):
+    def test_lint_check_clean_file(self, ruff_tool, ruff_clean_file) -> None:
         """Test Ruff lint check on a clean file.
 
         Args:
@@ -141,7 +141,7 @@ class TestRuffTool:
         assert_that(result.success is True).is_true()
         assert_that(result.issues_count).is_equal_to(0)
 
-    def test_lint_check_violations(self, ruff_tool, ruff_violation_file):
+    def test_lint_check_violations(self, ruff_tool, ruff_violation_file) -> None:
         """Test Ruff lint check on a file with violations.
 
         Args:
@@ -155,7 +155,7 @@ class TestRuffTool:
         assert_that(result.success is False).is_true()
         assert_that(result.issues_count > 0).is_true()
 
-    def test_check_nonexistent_file(self, ruff_tool):
+    def test_check_nonexistent_file(self, ruff_tool) -> None:
         """Test checking a nonexistent file.
 
         Args:
@@ -164,7 +164,7 @@ class TestRuffTool:
         with pytest.raises(FileNotFoundError):
             ruff_tool.check(["/nonexistent/file.py"])
 
-    def test_check_empty_paths(self, ruff_tool):
+    def test_check_empty_paths(self, ruff_tool) -> None:
         """Test checking with empty paths.
 
         Args:
@@ -176,7 +176,7 @@ class TestRuffTool:
         assert_that(result.output).is_equal_to("No files to check.")
         assert_that(result.issues_count).is_equal_to(0)
 
-    def test_fix_with_violations(self, ruff_tool, temp_python_file):
+    def test_fix_with_violations(self, ruff_tool, temp_python_file) -> None:
         """Test fixing a file with violations.
 
         Args:
@@ -188,7 +188,7 @@ class TestRuffTool:
         assert_that(result.name).is_equal_to("ruff")
         assert_that(result.output).is_not_equal_to("No fixes applied.")
 
-    def test_set_options_valid(self, ruff_tool):
+    def test_set_options_valid(self, ruff_tool) -> None:
         """Test setting valid options.
 
         Args:
@@ -209,7 +209,7 @@ class TestRuffTool:
         assert_that(ruff_tool.options["unsafe_fixes"] is True).is_true()
         assert_that(ruff_tool.options["format"] is False).is_true()
 
-    def test_set_options_invalid_select(self, ruff_tool):
+    def test_set_options_invalid_select(self, ruff_tool) -> None:
         """Test setting invalid select option.
 
         Args:
@@ -218,7 +218,7 @@ class TestRuffTool:
         with pytest.raises(ValueError, match="select must be a list"):
             ruff_tool.set_options(select="E,F")
 
-    def test_set_options_invalid_line_length(self, ruff_tool):
+    def test_set_options_invalid_line_length(self, ruff_tool) -> None:
         """Test setting invalid line length.
 
         Args:
@@ -229,7 +229,7 @@ class TestRuffTool:
         with pytest.raises(ValueError, match="line_length must be positive"):
             ruff_tool.set_options(line_length=-1)
 
-    def test_build_check_command_basic(self, ruff_tool):
+    def test_build_check_command_basic(self, ruff_tool) -> None:
         """Test building basic check command.
 
         Args:
@@ -243,7 +243,7 @@ class TestRuffTool:
         assert_that(cmd).contains("json")
         assert_that(cmd).contains("test.py")
 
-    def test_build_check_command_with_fix(self, ruff_tool):
+    def test_build_check_command_with_fix(self, ruff_tool) -> None:
         """Test building check command with fix option.
 
         Args:
@@ -253,7 +253,7 @@ class TestRuffTool:
         cmd = ruff_tool._build_check_command(files, fix=True)
         assert_that(cmd).contains("--fix")
 
-    def test_build_check_command_with_options(self, ruff_tool):
+    def test_build_check_command_with_options(self, ruff_tool) -> None:
         """Test building check command with various options.
 
         Args:
@@ -269,7 +269,7 @@ class TestRuffTool:
         assert_that(cmd).contains("--line-length")
         assert_that(cmd).contains("88")
 
-    def test_build_format_command_basic(self, ruff_tool):
+    def test_build_format_command_basic(self, ruff_tool) -> None:
         """Test building basic format command.
 
         Args:
@@ -281,7 +281,7 @@ class TestRuffTool:
         assert_that(cmd[1]).is_equal_to("format")
         assert_that(cmd).contains("test.py")
 
-    def test_build_format_command_check_only(self, ruff_tool):
+    def test_build_format_command_check_only(self, ruff_tool) -> None:
         """Test building format command in check-only mode.
 
         Args:
@@ -291,7 +291,7 @@ class TestRuffTool:
         cmd = ruff_tool._build_format_command(files, check_only=True)
         assert_that(cmd).contains("--check")
 
-    def test_check_reports_formatting_issues(self, ruff_tool, request):
+    def test_check_reports_formatting_issues(self, ruff_tool, request) -> None:
         """Test that check reports formatting issues (not just lint issues).
 
         Args:
@@ -304,7 +304,7 @@ class TestRuffTool:
             f.flush()
             file_path = f.name
 
-        def cleanup():
+        def cleanup() -> None:
             try:
                 os.unlink(file_path)
             except FileNotFoundError:
@@ -334,7 +334,7 @@ class TestRuffTool:
             ),
         ).is_true()
 
-    def test_format_check_clean_file(self, ruff_tool, ruff_clean_file):
+    def test_format_check_clean_file(self, ruff_tool, ruff_clean_file) -> None:
         """Test format check on a clean file.
 
         Args:
@@ -346,7 +346,7 @@ class TestRuffTool:
         assert_that(result.success is True).is_true()
         assert_that(result.issues_count).is_equal_to(0)
 
-    def test_format_check_violations(self, ruff_tool, ruff_violation_file):
+    def test_format_check_violations(self, ruff_tool, ruff_violation_file) -> None:
         """Test format check on a file with violations.
 
         Args:
@@ -359,7 +359,7 @@ class TestRuffTool:
         assert_that(result.issues_count > 0).is_true()
         assert_that(result.issues and len(result.issues) > 0).is_true()
 
-    def test_fmt_fixes_violations(self, ruff_tool, ruff_violation_file):
+    def test_fmt_fixes_violations(self, ruff_tool, ruff_violation_file) -> None:
         """Apply fix to a file and expect fewer or equal issues after.
 
         Args:
@@ -377,7 +377,10 @@ class TestRuffTool:
             f"{check_result.issues_count} (was {initial_issues})"
         )
 
-    def test_ruff_output_consistency_direct_vs_lintro(self, ruff_violation_file):
+    def test_ruff_output_consistency_direct_vs_lintro(
+        self,
+        ruff_violation_file,
+    ) -> None:
         """Ruff CLI vs Lintro: Should produce consistent results for the same file.
 
         Args:

--- a/tests/integration/test_yamllint_integration.py
+++ b/tests/integration/test_yamllint_integration.py
@@ -69,7 +69,7 @@ def run_yamllint_directly(file_path: Path) -> tuple[bool, str, int]:
 
 
 @pytest.mark.yamllint
-def test_yamllint_available():
+def test_yamllint_available() -> None:
     """Check if yamllint is available in PATH."""
     try:
         result = subprocess.run(
@@ -85,7 +85,7 @@ def test_yamllint_available():
 
 
 @pytest.mark.yamllint
-def test_yamllint_reports_violations_direct(tmp_path):
+def test_yamllint_reports_violations_direct(tmp_path) -> None:
     """Yamllint CLI: Should detect and report violations in a sample file.
 
     Args:
@@ -116,7 +116,7 @@ def test_yamllint_reports_violations_direct(tmp_path):
 
 
 @pytest.mark.yamllint
-def test_yamllint_reports_violations_through_lintro(tmp_path):
+def test_yamllint_reports_violations_through_lintro(tmp_path) -> None:
     """Lintro YamllintTool: Should detect and report violations in a sample file.
 
     Args:
@@ -147,7 +147,7 @@ def test_yamllint_reports_violations_through_lintro(tmp_path):
 
 
 @pytest.mark.yamllint
-def test_yamllint_output_consistency_direct_vs_lintro(tmp_path):
+def test_yamllint_output_consistency_direct_vs_lintro(tmp_path) -> None:
     """Yamllint CLI vs Lintro: Should produce consistent results for the same file.
 
     Args:
@@ -187,7 +187,7 @@ def test_yamllint_output_consistency_direct_vs_lintro(tmp_path):
 
 
 @pytest.mark.yamllint
-def test_yamllint_with_config_options(tmp_path):
+def test_yamllint_with_config_options(tmp_path) -> None:
     """Lintro YamllintTool: Should properly handle config options.
 
     Args:
@@ -209,7 +209,7 @@ def test_yamllint_with_config_options(tmp_path):
 
 
 @pytest.mark.yamllint
-def test_yamllint_with_no_warnings_option(tmp_path):
+def test_yamllint_with_no_warnings_option(tmp_path) -> None:
     """Lintro YamllintTool: Should properly handle no-warnings option.
 
     Args:
@@ -231,7 +231,7 @@ def test_yamllint_with_no_warnings_option(tmp_path):
 
 
 @pytest.mark.yamllint
-def test_yamllint_fix_method_implemented(tmp_path):
+def test_yamllint_fix_method_implemented(tmp_path) -> None:
     """Lintro YamllintTool: .fix() should be implemented and work correctly.
 
     Args:
@@ -252,7 +252,7 @@ def test_yamllint_fix_method_implemented(tmp_path):
 
 
 @pytest.mark.yamllint
-def test_yamllint_empty_directory(tmp_path):
+def test_yamllint_empty_directory(tmp_path) -> None:
     """Lintro YamllintTool: Should handle empty directories gracefully.
 
     Args:
@@ -270,7 +270,7 @@ def test_yamllint_empty_directory(tmp_path):
 
 
 @pytest.mark.yamllint
-def test_yamllint_parser_validation(tmp_path):
+def test_yamllint_parser_validation(tmp_path) -> None:
     """Test that yamllint parser correctly parses output.
 
     Args:

--- a/tests/scripts/test_delete_previous_lintro_comments.py
+++ b/tests/scripts/test_delete_previous_lintro_comments.py
@@ -24,7 +24,7 @@ spec.loader.exec_module(del_script)
 
 
 @pytest.fixture(autouse=True)
-def patch_env(monkeypatch):
+def patch_env(monkeypatch) -> None:
     """Patch environment variables for the script.
 
     Args:
@@ -35,7 +35,7 @@ def patch_env(monkeypatch):
     monkeypatch.setenv("PR_NUMBER", "123")
 
 
-def test_deletes_only_marker_comments(monkeypatch):
+def test_deletes_only_marker_comments(monkeypatch) -> None:
     """Test that only comments with the marker are deleted.
 
     Args:
@@ -52,7 +52,7 @@ def test_deletes_only_marker_comments(monkeypatch):
     def mock_get_pr_comments(repo: str, pr_number: str, token: str):
         return comments
 
-    def mock_delete_comment(repo: str, comment_id: int, token: str):
+    def mock_delete_comment(repo: str, comment_id: int, token: str) -> None:
         deleted.append(comment_id)
 
     monkeypatch.setattr(del_script, "get_pr_comments", mock_get_pr_comments)
@@ -69,7 +69,7 @@ def test_deletes_only_marker_comments(monkeypatch):
     assert_that(set(deleted)).is_equal_to({2, 3})
 
 
-def test_no_marker_comments(monkeypatch):
+def test_no_marker_comments(monkeypatch) -> None:
     """Test that script prints message if no marker comments are found.
 
     Args:
@@ -84,7 +84,7 @@ def test_no_marker_comments(monkeypatch):
     def mock_get_pr_comments(repo: str, pr_number: str, token: str):
         return comments
 
-    def mock_delete_comment(repo: str, comment_id: int, token: str):
+    def mock_delete_comment(repo: str, comment_id: int, token: str) -> None:
         deleted.append(comment_id)
 
     monkeypatch.setattr(del_script, "get_pr_comments", mock_get_pr_comments)

--- a/tests/scripts/test_ghcr_prune_untagged.py
+++ b/tests/scripts/test_ghcr_prune_untagged.py
@@ -12,14 +12,14 @@ from scripts.ci.ghcr_prune_untagged import (
 )
 
 
-def test_version_dataclass():
+def test_version_dataclass() -> None:
     """Construct ``GhcrVersion`` and validate fields are populated."""
     v = GhcrVersion(id=123, tags=["latest"])  # type: ignore[call-arg]
     assert v.id == 123
     assert v.tags == ["latest"]
 
 
-def test_list_container_versions_parses_minimal_structure(monkeypatch):
+def test_list_container_versions_parses_minimal_structure(monkeypatch) -> None:
     """Parse a minimal response structure into version objects.
 
     Args:
@@ -27,7 +27,7 @@ def test_list_container_versions_parses_minimal_structure(monkeypatch):
     """
 
     class DummyResp:
-        def __init__(self, data: list[dict[str, Any]]):
+        def __init__(self, data: list[dict[str, Any]]) -> None:
             self._data = data
 
         def raise_for_status(self) -> None:  # pragma: no cover
@@ -51,7 +51,7 @@ def test_list_container_versions_parses_minimal_structure(monkeypatch):
     assert versions[1].tags == []
 
 
-def test_delete_version_calls_delete(monkeypatch):
+def test_delete_version_calls_delete(monkeypatch) -> None:
     """Call delete and ensure correct endpoint is used.
 
     Args:
@@ -78,7 +78,7 @@ def test_delete_version_calls_delete(monkeypatch):
     assert calls and "versions/42" in calls[0][0]
 
 
-def test_delete_version_raises_on_non_204_non_404():
+def test_delete_version_raises_on_non_204_non_404() -> None:
     """Raise when the delete operation returns an unexpected status code.
 
     Raises:
@@ -106,7 +106,7 @@ def test_delete_version_raises_on_non_204_non_404():
     raise AssertionError("Expected RuntimeError on non-204/404 response")
 
 
-def test_main_deletes_only_untagged(monkeypatch):
+def test_main_deletes_only_untagged(monkeypatch) -> None:
     """Delete only untagged versions using the main entry point.
 
     Args:
@@ -195,7 +195,7 @@ def test_main_deletes_only_untagged(monkeypatch):
     assert sorted(deleted) == [22, 44]
 
 
-def test_main_respects_keep_n_and_dry_run(monkeypatch):
+def test_main_respects_keep_n_and_dry_run(monkeypatch) -> None:
     """Respect keep-N and dry-run options when pruning.
 
     Args:

--- a/tests/scripts/test_script_environment.py
+++ b/tests/scripts/test_script_environment.py
@@ -35,7 +35,7 @@ class TestEnvironmentHandling:
         """
         return {"PATH": "/usr/bin:/bin", "HOME": "/tmp", "USER": "testuser"}
 
-    def test_local_test_handles_missing_uv(self, scripts_dir, clean_env):
+    def test_local_test_handles_missing_uv(self, scripts_dir, clean_env) -> None:
         """Test local-test.sh behavior when uv is not available.
 
         Args:
@@ -53,7 +53,11 @@ class TestEnvironmentHandling:
         assert_that(result.returncode).is_equal_to(0)
         assert_that(result.stdout).contains("Usage:")
 
-    def test_bootstrap_env_installs_uv_via_gh_offline(self, scripts_dir, tmp_path):
+    def test_bootstrap_env_installs_uv_via_gh_offline(
+        self,
+        scripts_dir,
+        tmp_path,
+    ) -> None:
         """bootstrap-env.sh should install uv via gh assets without network.
 
         Mocks `gh release view` and `gh release download` to simulate a release
@@ -152,7 +156,7 @@ echo 0.0.0
         )
         assert_that(uv_check.returncode).is_equal_to(0)
 
-    def test_scripts_handle_docker_missing(self, scripts_dir, clean_env):
+    def test_scripts_handle_docker_missing(self, scripts_dir, clean_env) -> None:
         """Test Docker scripts behavior when Docker is not available.
 
         Args:
@@ -183,7 +187,11 @@ echo 0.0.0
             ).is_true()
 
     @pytest.mark.slow
-    def test_install_tools_handles_missing_dependencies(self, scripts_dir, clean_env):
+    def test_install_tools_handles_missing_dependencies(
+        self,
+        scripts_dir,
+        clean_env,
+    ) -> None:
         """Test install-tools.sh behavior with missing dependencies.
 
         Args:
@@ -201,7 +209,7 @@ echo 0.0.0
         )
         assert_that(result.returncode).is_not_none()
 
-    def test_ci_post_pr_comment_merges_existing_by_marker(self, tmp_path):
+    def test_ci_post_pr_comment_merges_existing_by_marker(self, tmp_path) -> None:
         """ci-post-pr-comment should update an existing comment by marker.
 
         Mocks `gh api` to return a JSON array with an existing comment body that
@@ -296,7 +304,7 @@ class TestScriptErrorHandling:
         """
         return Path(__file__).parent.parent.parent / "scripts"
 
-    def test_extract_coverage_handles_missing_file(self, scripts_dir):
+    def test_extract_coverage_handles_missing_file(self, scripts_dir) -> None:
         """Test extract-coverage.py handles missing coverage.xml.
 
         Args:
@@ -314,7 +322,7 @@ class TestScriptErrorHandling:
             assert_that(result.stdout).contains("percentage=")
             assert_that(result.stdout).contains("percentage=0.0")
 
-    def test_extract_coverage_handles_empty_file(self, scripts_dir):
+    def test_extract_coverage_handles_empty_file(self, scripts_dir) -> None:
         """Test extract-coverage.py handles empty coverage.xml.
 
         Args:
@@ -333,7 +341,7 @@ class TestScriptErrorHandling:
             assert_that(result.returncode).is_equal_to(0)
             assert_that(result.stdout).contains("percentage=")
 
-    def test_extract_coverage_handles_valid_file(self, scripts_dir):
+    def test_extract_coverage_handles_valid_file(self, scripts_dir) -> None:
         """Test extract-coverage.py handles valid coverage.xml.
 
         Args:
@@ -369,7 +377,7 @@ class TestScriptErrorHandling:
             assert_that(result.stdout).contains("percentage=")
             assert_that(result.stdout).contains("percentage=85.0")
 
-    def test_sbom_generate_dry_run_prints_plan(self, scripts_dir, tmp_path):
+    def test_sbom_generate_dry_run_prints_plan(self, scripts_dir, tmp_path) -> None:
         """sbom-generate.sh --dry-run should print a plan and exit 0.
 
         Runs with --skip-fetch to avoid network access during tests.
@@ -390,7 +398,11 @@ class TestScriptErrorHandling:
         out = result.stdout + result.stderr
         assert_that(out.lower()).contains("dry-run")
 
-    def test_sbom_generate_dry_run_import_merge_push_plan(self, scripts_dir, tmp_path):
+    def test_sbom_generate_dry_run_import_merge_push_plan(
+        self,
+        scripts_dir,
+        tmp_path,
+    ) -> None:
         """Dry-run should show import, merge, and push steps when multiple imports.
 
         Uses two placeholder local files and --skip-fetch to avoid network.
@@ -424,7 +436,7 @@ class TestScriptErrorHandling:
         self,
         scripts_dir,
         tmp_path,
-    ):
+    ) -> None:
         """Dry-run with fetch-only should show merge to alias and push of alias.
 
         Forces repo URL via --repo-url to avoid relying on git remotes.
@@ -460,7 +472,7 @@ class TestScriptSecurity:
         """
         return Path(__file__).parent.parent.parent / "scripts"
 
-    def test_scripts_avoid_eval_or_exec(self, scripts_dir):
+    def test_scripts_avoid_eval_or_exec(self, scripts_dir) -> None:
         """Test that scripts avoid dangerous eval or exec commands.
 
         Args:
@@ -494,7 +506,7 @@ class TestScriptSecurity:
                             ),
                         )
 
-    def test_scripts_validate_inputs(self, scripts_dir):
+    def test_scripts_validate_inputs(self, scripts_dir) -> None:
         """Test that scripts validate inputs appropriately.
 
         Args:
@@ -524,7 +536,7 @@ class TestScriptSecurity:
                 has_validation
             ), f"{script_name} should validate command line arguments"
 
-    def test_scripts_use_quoted_variables(self, scripts_dir):
+    def test_scripts_use_quoted_variables(self, scripts_dir) -> None:
         """Test that scripts properly quote variables to prevent injection.
 
         Args:
@@ -555,7 +567,7 @@ class TestScriptCompatibility:
         """
         return Path(__file__).parent.parent.parent / "scripts"
 
-    def test_scripts_use_portable_shebang(self, scripts_dir):
+    def test_scripts_use_portable_shebang(self, scripts_dir) -> None:
         """Test that scripts use portable shebang lines.
 
         Args:
@@ -569,7 +581,7 @@ class TestScriptCompatibility:
                 first_line == "#!/bin/bash"
             ), f"{script.name} should use '#!/bin/bash' shebang, found: {first_line}"
 
-    def test_scripts_avoid_bashisms_in_sh_context(self, scripts_dir):
+    def test_scripts_avoid_bashisms_in_sh_context(self, scripts_dir) -> None:
         """Test that scripts avoid bash-specific features where inappropriate.
 
         Args:
@@ -589,7 +601,7 @@ class TestScriptCompatibility:
                         "shebang"
                     )
 
-    def test_python_script_compatibility(self, scripts_dir):
+    def test_python_script_compatibility(self, scripts_dir) -> None:
         """Test that Python scripts use appropriate shebang.
 
         Args:

--- a/tests/scripts/test_shell_scripts.py
+++ b/tests/scripts/test_shell_scripts.py
@@ -37,7 +37,7 @@ class TestShellScriptSyntax:
         """
         return list(scripts_dir.glob("*.sh"))
 
-    def test_all_scripts_have_shebang(self, shell_scripts):
+    def test_all_scripts_have_shebang(self, shell_scripts) -> None:
         """Test that all shell scripts have proper shebang.
 
         Args:
@@ -49,7 +49,7 @@ class TestShellScriptSyntax:
             assert first_line.startswith("#!"), f"{script.name} missing shebang"
             assert "bash" in first_line, f"{script.name} should use bash"
 
-    def test_all_scripts_syntax_valid(self, shell_scripts):
+    def test_all_scripts_syntax_valid(self, shell_scripts) -> None:
         """Test that all shell scripts have valid syntax.
 
         Args:
@@ -65,7 +65,7 @@ class TestShellScriptSyntax:
                 result.returncode == 0
             ), f"Syntax error in {script.name}: {result.stderr}"
 
-    def test_scripts_are_executable(self, shell_scripts):
+    def test_scripts_are_executable(self, shell_scripts) -> None:
         """Test that all shell scripts are executable.
 
         Args:
@@ -74,7 +74,7 @@ class TestShellScriptSyntax:
         for script in shell_scripts:
             assert os.access(script, os.X_OK), f"{script.name} is not executable"
 
-    def test_scripts_have_set_e(self, shell_scripts):
+    def test_scripts_have_set_e(self, shell_scripts) -> None:
         """Test that critical scripts use 'set -e' for error handling.
 
         Args:
@@ -106,7 +106,7 @@ class TestScriptHelp:
         """
         return Path(__file__).parent.parent.parent / "scripts"
 
-    def test_local_test_help(self, scripts_dir):
+    def test_local_test_help(self, scripts_dir) -> None:
         """Test that local-test.sh provides help.
 
         Args:
@@ -123,7 +123,7 @@ class TestScriptHelp:
         assert_that(result.stdout).contains("Usage:")
         assert_that(result.stdout.lower()).contains("verbose")
 
-    def test_local_lintro_help(self, scripts_dir):
+    def test_local_lintro_help(self, scripts_dir) -> None:
         """Test that local-lintro.sh provides help for itself.
 
         Args:
@@ -140,7 +140,7 @@ class TestScriptHelp:
         assert_that(result.stdout).contains("Usage:")
         assert_that(result.stdout.lower()).contains("install")
 
-    def test_install_tools_help(self, scripts_dir):
+    def test_install_tools_help(self, scripts_dir) -> None:
         """Test that install-tools.sh has usage documentation in comments.
 
         Args:
@@ -154,7 +154,7 @@ class TestScriptHelp:
             "--local" in content or "--docker" in content
         ), "Should document command options"
 
-    def test_codecov_upload_help(self, scripts_dir):
+    def test_codecov_upload_help(self, scripts_dir) -> None:
         """codecov-upload.sh should provide help and exit 0.
 
         Args:
@@ -171,7 +171,7 @@ class TestScriptHelp:
         assert_that(result.stdout).contains("Usage:")
         assert_that(result.stdout).contains("Codecov")
 
-    def test_egress_audit_help(self, scripts_dir):
+    def test_egress_audit_help(self, scripts_dir) -> None:
         """egress-audit-lite.sh should provide help and exit 0.
 
         Args:
@@ -187,7 +187,7 @@ class TestScriptHelp:
         assert_that(result.returncode).is_equal_to(0)
         assert_that(result.stdout).contains("Usage:")
 
-    def test_sbom_generate_help(self, scripts_dir):
+    def test_sbom_generate_help(self, scripts_dir) -> None:
         """sbom-generate.sh should provide help and exit 0.
 
         Args:
@@ -226,7 +226,7 @@ class TestScriptFunctionality:
         with tempfile.TemporaryDirectory() as tmpdir:
             yield {"PATH": f"{tmpdir}:{os.environ.get('PATH', '')}", "HOME": tmpdir}
 
-    def test_extract_coverage_python_script(self, scripts_dir):
+    def test_extract_coverage_python_script(self, scripts_dir) -> None:
         """Test that extract-coverage.py runs without syntax errors.
 
         Args:
@@ -242,7 +242,7 @@ class TestScriptFunctionality:
             result.returncode == 0
         ), f"Python syntax error in {script.name}: {result.stderr}"
 
-    def test_utils_script_sources_correctly(self, scripts_dir):
+    def test_utils_script_sources_correctly(self, scripts_dir) -> None:
         """Test that utils.sh can be sourced without errors.
 
         Args:
@@ -264,7 +264,7 @@ class TestScriptFunctionality:
         )
         assert result.returncode == 0, f"utils.sh sourcing failed: {result.stderr}"
 
-    def test_docker_scripts_check_docker_availability(self, scripts_dir):
+    def test_docker_scripts_check_docker_availability(self, scripts_dir) -> None:
         """Test that Docker scripts check for Docker availability.
 
         Args:
@@ -291,7 +291,7 @@ class TestScriptFunctionality:
         self,
         scripts_dir,
         mock_env,
-    ):
+    ) -> None:
         """Test that scripts handle missing dependencies gracefully.
 
         Args:
@@ -311,7 +311,7 @@ class TestScriptFunctionality:
         assert_that(result.returncode).is_equal_to(0)
         assert_that(result.stdout).contains("Usage:")
 
-    def test_egress_audit_reads_env_and_skips_ip_by_default(self, scripts_dir):
+    def test_egress_audit_reads_env_and_skips_ip_by_default(self, scripts_dir) -> None:
         """egress-audit-lite should read env and skip IP literals by default.
 
         Args:
@@ -333,7 +333,7 @@ class TestScriptFunctionality:
         # Should indicate it skipped the IP
         assert "Skipping IP literal" in (proc.stdout + proc.stderr)
 
-    def test_egress_audit_can_include_ip_with_flag(self, scripts_dir):
+    def test_egress_audit_can_include_ip_with_flag(self, scripts_dir) -> None:
         """egress-audit-lite should include IP when --check-ip is provided.
 
         Args:
@@ -366,7 +366,7 @@ class TestScriptIntegration:
         """
         return Path(__file__).parent.parent.parent / "scripts"
 
-    def test_ci_scripts_reference_correct_files(self, scripts_dir):
+    def test_ci_scripts_reference_correct_files(self, scripts_dir) -> None:
         """Test that CI scripts reference files that exist.
 
         Args:
@@ -397,7 +397,7 @@ class TestScriptIntegration:
                     (scripts_dir / "ci" / "detect-changes.sh").exists(),
                 ).is_true()
 
-    def test_detect_changes_help(self):
+    def test_detect_changes_help(self) -> None:
         """detect-changes.sh should provide help and exit 0."""
         script_path = Path("scripts/ci/detect-changes.sh").resolve()
         result = subprocess.run(
@@ -408,7 +408,7 @@ class TestScriptIntegration:
         assert_that(result.returncode).is_equal_to(0)
         assert_that(result.stdout).contains("Usage:")
 
-    def test_semantic_release_compute_python_runs(self):
+    def test_semantic_release_compute_python_runs(self) -> None:
         """semantic_release_compute_next.py should run and print next_version."""
         script_path = Path("scripts/ci/semantic_release_compute_next.py").resolve()
         result = subprocess.run(
@@ -424,7 +424,7 @@ class TestScriptIntegration:
             assert_that(result.returncode).is_equal_to(2)
             assert_that(result.stdout).contains("No v*-prefixed release tag found")
 
-    def test_scripts_use_consistent_color_codes(self, scripts_dir):
+    def test_scripts_use_consistent_color_codes(self, scripts_dir) -> None:
         """Test that scripts use consistent color coding.
 
         Args:
@@ -448,7 +448,7 @@ class TestScriptIntegration:
                     len(red_definitions) > 0
                 ), "Scripts should define RED color consistently"
 
-    def test_script_dependencies_documented(self, scripts_dir):
+    def test_script_dependencies_documented(self, scripts_dir) -> None:
         """Test that script dependencies are documented in comments.
 
         Args:
@@ -468,7 +468,7 @@ class TestScriptIntegration:
                     ),
                 ), f"{script_name} should have descriptive comments"
 
-    def test_bump_internal_refs_updates_refs(self, tmp_path):
+    def test_bump_internal_refs_updates_refs(self, tmp_path) -> None:
         """Test that the bump-internal-refs.sh updates SHAs in workflow files.
 
         Creates a temporary workflow file that includes internal refs and runs the
@@ -509,7 +509,7 @@ class TestScriptIntegration:
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         )
 
-    def test_bump_internal_refs_invalid_sha_fails(self, tmp_path):
+    def test_bump_internal_refs_invalid_sha_fails(self, tmp_path) -> None:
         """Invalid SHA should cause the bump script to fail early.
 
         Args:
@@ -533,7 +533,7 @@ class TestScriptIntegration:
         assert_that(result.returncode).is_not_equal_to(0)
         assert_that(result.stderr).contains("Invalid SHA")
 
-    def test_renovate_regex_manager_current_value(self):
+    def test_renovate_regex_manager_current_value(self) -> None:
         """Ensure Renovate custom managers use currentValue to satisfy schema."""
         config_path = Path("renovate.json")
         content = config_path.read_text()

--- a/tests/unit/test_ascii_normalize.py
+++ b/tests/unit/test_ascii_normalize.py
@@ -9,7 +9,7 @@ from assertpy import assert_that
 from lintro.utils.formatting import normalize_ascii_block, normalize_ascii_file_sections
 
 
-def test_normalize_ascii_block_center_and_alignments():
+def test_normalize_ascii_block_center_and_alignments() -> None:
     """Normalize ASCII blocks across horizontal/vertical alignments."""
     src = ["XX", "XXXX", "X"]
     out = normalize_ascii_block(
@@ -28,7 +28,7 @@ def test_normalize_ascii_block_center_and_alignments():
     assert_that(right[0].startswith("    ") and right[0].endswith("X")).is_true()
 
 
-def test_normalize_ascii_file_sections(tmp_path: Path):
+def test_normalize_ascii_file_sections(tmp_path: Path) -> None:
     """Normalize sections from a file and enforce width/height constraints.
 
     Args:

--- a/tests/unit/test_bandit_parsing.py
+++ b/tests/unit/test_bandit_parsing.py
@@ -110,7 +110,7 @@ def test_parse_bandit_handles_malformed_issue_gracefully(caplog) -> None:
     assert_that(issues).is_equal_to([])
 
 
-def test_bandit_check_parses_mixed_output_json(monkeypatch, tmp_path):
+def test_bandit_check_parses_mixed_output_json(monkeypatch, tmp_path) -> None:
     """BanditTool.check should parse JSON amidst mixed stdout/stderr text.
 
     Args:
@@ -151,7 +151,10 @@ def test_bandit_check_parses_mixed_output_json(monkeypatch, tmp_path):
     assert_that(result.issues_count).is_equal_to(1)
 
 
-def test_bandit_check_handles_nonzero_rc_with_errors_array(monkeypatch, tmp_path):
+def test_bandit_check_handles_nonzero_rc_with_errors_array(
+    monkeypatch,
+    tmp_path,
+) -> None:
     """Ensure nonzero return with JSON errors[] sets success False but parses.
 
     Args:
@@ -181,7 +184,7 @@ def test_bandit_check_handles_nonzero_rc_with_errors_array(monkeypatch, tmp_path
     }
 
     class NS:
-        def __init__(self, stdout, stderr, returncode):
+        def __init__(self, stdout, stderr, returncode) -> None:
             self.stdout = stdout
             self.stderr = stderr
             self.returncode = returncode
@@ -196,7 +199,7 @@ def test_bandit_check_handles_nonzero_rc_with_errors_array(monkeypatch, tmp_path
     assert_that(result.issues_count).is_equal_to(1)
 
 
-def test_bandit_check_handles_unparseable_output(monkeypatch, tmp_path):
+def test_bandit_check_handles_unparseable_output(monkeypatch, tmp_path) -> None:
     """On unparseable output, BanditTool.check should fail gracefully.
 
     Args:

--- a/tests/unit/test_black_formatter.py
+++ b/tests/unit/test_black_formatter.py
@@ -11,7 +11,7 @@ from lintro.formatters.tools.black_formatter import (
 from lintro.parsers.black.black_issue import BlackIssue
 
 
-def test_black_table_descriptor_columns_and_rows():
+def test_black_table_descriptor_columns_and_rows() -> None:
     """Ensure columns and rows render expected values for issues."""
     desc = BlackTableDescriptor()
     assert_that(desc.get_columns()).is_equal_to(["File", "Message"])
@@ -24,7 +24,7 @@ def test_black_table_descriptor_columns_and_rows():
     assert_that(rows[0][1]).contains("reformat")
 
 
-def test_format_black_issues_all_styles():
+def test_format_black_issues_all_styles() -> None:
     """Ensure all styles return a non-empty string for issues list."""
     issues = [
         BlackIssue(file="a.py", message="Would reformat file"),
@@ -36,7 +36,7 @@ def test_format_black_issues_all_styles():
         assert_that(len(out) > 0).is_true()
 
 
-def test_format_black_issues_empty():
+def test_format_black_issues_empty() -> None:
     """Ensure empty issues still produce a valid string output."""
     out = format_black_issues(issues=[], format="grid")
     # Grid formatter returns an empty string when no rows

--- a/tests/unit/test_black_parser.py
+++ b/tests/unit/test_black_parser.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from lintro.parsers.black.black_parser import parse_black_output
 
 
-def test_parse_black_output_would_reformat_single_file():
+def test_parse_black_output_would_reformat_single_file() -> None:
     """Parse a single-file 'would reformat' message into one issue."""
     output = (
         "would reformat src/app.py\nAll done! 💥 💔 💥\n1 file would be reformatted."
@@ -16,7 +16,7 @@ def test_parse_black_output_would_reformat_single_file():
     assert "Would reformat" in issues[0].message
 
 
-def test_parse_black_output_reformatted_multiple_files():
+def test_parse_black_output_reformatted_multiple_files() -> None:
     """Parse multi-file 'reformatted' output into per-file issues."""
     output = (
         "reformatted a.py\nreformatted b.py\nAll done! ✨ 🍰 ✨\n2 files reformatted"
@@ -27,7 +27,7 @@ def test_parse_black_output_reformatted_multiple_files():
     assert all("Reformatted" in i.message for i in issues)
 
 
-def test_parse_black_output_no_issues():
+def test_parse_black_output_no_issues() -> None:
     """Return empty list when Black reports no issues."""
     output = "All done! ✨ 🍰 ✨\n1 file left unchanged."
     issues = parse_black_output(output)

--- a/tests/unit/test_black_tool.py
+++ b/tests/unit/test_black_tool.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from lintro.tools.implementations.tool_black import BlackTool
 
 
-def test_black_check_parses_issues(monkeypatch, tmp_path: Path):
+def test_black_check_parses_issues(monkeypatch, tmp_path: Path) -> None:
     """Ensure check mode recognizes would-reformat output as an issue.
 
     Args:
@@ -45,7 +45,7 @@ def test_black_check_parses_issues(monkeypatch, tmp_path: Path):
     assert res.issues and res.issues[0].file == f.name
 
 
-def test_black_fix_computes_counts(monkeypatch, tmp_path: Path):
+def test_black_fix_computes_counts(monkeypatch, tmp_path: Path) -> None:
     """Ensure fix mode computes initial/fixed/remaining issue counts.
 
     Args:
@@ -89,7 +89,10 @@ def test_black_fix_computes_counts(monkeypatch, tmp_path: Path):
     assert res.success
 
 
-def test_black_options_build_line_length_and_target(monkeypatch, tmp_path: Path):
+def test_black_options_build_line_length_and_target(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
     """Verify line-length and target version flags are passed in check mode.
 
     Args:
@@ -129,7 +132,7 @@ def test_black_options_build_line_length_and_target(monkeypatch, tmp_path: Path)
     assert "--target-version" in cmd and "py313" in cmd
 
 
-def test_black_options_include_fast_and_preview(monkeypatch, tmp_path: Path):
+def test_black_options_include_fast_and_preview(monkeypatch, tmp_path: Path) -> None:
     """Verify fast and preview flags are honored in check mode.
 
     Args:
@@ -166,7 +169,7 @@ def test_black_options_include_fast_and_preview(monkeypatch, tmp_path: Path):
     assert "--preview" in cmd
 
 
-def test_black_diff_flag_in_fix(monkeypatch, tmp_path: Path):
+def test_black_diff_flag_in_fix(monkeypatch, tmp_path: Path) -> None:
     """Ensure the diff flag is present during formatting in fix mode.
 
     Args:

--- a/tests/unit/test_black_tool_more.py
+++ b/tests/unit/test_black_tool_more.py
@@ -9,7 +9,7 @@ import pytest
 from lintro.tools.implementations.tool_black import BlackTool
 
 
-def test_black_set_options_validation_errors():
+def test_black_set_options_validation_errors() -> None:
     """Validate type checking for option setters raises ValueError."""
     tool = BlackTool()
     with pytest.raises(ValueError):
@@ -24,7 +24,7 @@ def test_black_set_options_validation_errors():
         tool.set_options(diff="maybe")  # type: ignore[arg-type]
 
 
-def test_black_no_files_paths(tmp_path: Path, monkeypatch):
+def test_black_no_files_paths(tmp_path: Path, monkeypatch) -> None:
     """Return success and informative output when no files are discovered.
 
     Args:

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner
 from lintro.cli import cli
 
 
-def test_cli_lists_commands_and_aliases():
+def test_cli_lists_commands_and_aliases() -> None:
     """Ensure help lists primary commands and their common aliases."""
     runner = CliRunner()
     result = runner.invoke(cli, ["--help"])

--- a/tests/unit/test_cli_commands_more.py
+++ b/tests/unit/test_cli_commands_more.py
@@ -10,7 +10,7 @@ from lintro.cli_utils.commands.format import format_code
 from lintro.cli_utils.commands.list_tools import list_tools_command
 
 
-def test_check_invokes_executor(monkeypatch):
+def test_check_invokes_executor(monkeypatch) -> None:
     """Invoke check subcommand and verify executor receives parameters.
 
     Args:
@@ -19,7 +19,7 @@ def test_check_invokes_executor(monkeypatch):
     calls = {}
     import lintro.cli_utils.commands.check as check_mod
 
-    def fake_run(**kwargs):
+    def fake_run(**kwargs) -> int:
         calls.update(kwargs)
         return 0
 
@@ -30,7 +30,7 @@ def test_check_invokes_executor(monkeypatch):
     assert_that(calls.get("action")).is_equal_to("check")
 
 
-def test_format_invokes_executor(monkeypatch):
+def test_format_invokes_executor(monkeypatch) -> None:
     """Invoke format subcommand and verify executor receives parameters.
 
     Args:
@@ -39,7 +39,7 @@ def test_format_invokes_executor(monkeypatch):
     calls = {}
     import lintro.cli_utils.commands.format as format_mod
 
-    def fake_run(**kwargs):
+    def fake_run(**kwargs) -> int:
         calls.update(kwargs)
         return 0
 
@@ -50,7 +50,7 @@ def test_format_invokes_executor(monkeypatch):
     assert_that(calls.get("action")).is_equal_to("fmt")
 
 
-def test_list_tools_outputs(monkeypatch):
+def test_list_tools_outputs(monkeypatch) -> None:
     """Run list-tools command and validate expected text in output.
 
     Args:

--- a/tests/unit/test_cli_programmatic.py
+++ b/tests/unit/test_cli_programmatic.py
@@ -9,7 +9,7 @@ from lintro.cli_utils.commands.check import check as check_prog
 from lintro.cli_utils.commands.format import format_code_legacy
 
 
-def test_check_programmatic_success(monkeypatch):
+def test_check_programmatic_success(monkeypatch) -> None:
     """Programmatic check returns None on success.
 
     Args:
@@ -35,7 +35,7 @@ def test_check_programmatic_success(monkeypatch):
     ).is_none()
 
 
-def test_format_programmatic_success(monkeypatch):
+def test_format_programmatic_success(monkeypatch) -> None:
     """Programmatic format returns None on success.
 
     Args:
@@ -63,7 +63,7 @@ def test_format_programmatic_success(monkeypatch):
     ).is_none()
 
 
-def test_format_programmatic_failure_raises(monkeypatch):
+def test_format_programmatic_failure_raises(monkeypatch) -> None:
     """Programmatic format raises when executor returns non-zero.
 
     Args:

--- a/tests/unit/test_compatibility_ruff_black.py
+++ b/tests/unit/test_compatibility_ruff_black.py
@@ -11,7 +11,7 @@ from lintro.utils.tool_executor import run_lint_tools_simple
 class FakeTool:
     """Simple stub representing a tool with check/fix capability."""
 
-    def __init__(self, name: str, can_fix: bool):
+    def __init__(self, name: str, can_fix: bool) -> None:
         """Initialize stub tool.
 
         Args:
@@ -22,7 +22,7 @@ class FakeTool:
         self.can_fix = can_fix
         self.options = {}
 
-    def set_options(self, **kwargs):
+    def set_options(self, **kwargs) -> None:
         """Record provided options for later assertions.
 
         Args:
@@ -56,11 +56,11 @@ class FakeTool:
 class _EnumLike:
     """Tiny stand-in for enum entries returned by tool discovery."""
 
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         self.name = name
 
 
-def _stub_logger(monkeypatch):
+def _stub_logger(monkeypatch) -> None:
     """Silence console logger for deterministic tests.
 
     Args:
@@ -70,7 +70,7 @@ def _stub_logger(monkeypatch):
 
     class SilentLogger:
         def __getattr__(self, name):
-            def _(*a, **k):
+            def _(*a, **k) -> None:
                 return None
 
             return _
@@ -108,7 +108,7 @@ def _setup_tools(monkeypatch):
     monkeypatch.setattr(te, "_get_tools_to_run", fake_get_tools, raising=True)
     monkeypatch.setattr(te.tool_manager, "get_tool", lambda e: tool_map[e.name.lower()])
 
-    def noop_write_reports_from_results(self, results):
+    def noop_write_reports_from_results(self, results) -> None:
         """No-op writer used to avoid filesystem interaction.
 
         Args:
@@ -129,7 +129,7 @@ def _setup_tools(monkeypatch):
     return ruff, black
 
 
-def test_ruff_formatting_disabled_when_black_present(monkeypatch):
+def test_ruff_formatting_disabled_when_black_present(monkeypatch) -> None:
     """Black present: Ruff formatting should be disabled by default.
 
     Args:
@@ -155,7 +155,7 @@ def test_ruff_formatting_disabled_when_black_present(monkeypatch):
     assert_that(ruff.options.get("format")).is_false()
 
 
-def test_ruff_formatting_respects_cli_override(monkeypatch):
+def test_ruff_formatting_respects_cli_override(monkeypatch) -> None:
     """CLI options should re-enable Ruff format and format_check.
 
     Args:
@@ -182,7 +182,7 @@ def test_ruff_formatting_respects_cli_override(monkeypatch):
     assert_that(ruff.options.get("format_check")).is_true()
 
 
-def test_ruff_format_check_disabled_in_check_when_black_present(monkeypatch):
+def test_ruff_format_check_disabled_in_check_when_black_present(monkeypatch) -> None:
     """Black present: Ruff format_check should be disabled in check.
 
     Args:

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -9,7 +9,7 @@ from assertpy import assert_that
 from lintro.utils.config import load_lintro_tool_config
 
 
-def test_load_lintro_tool_config(tmp_path: Path, monkeypatch):
+def test_load_lintro_tool_config(tmp_path: Path, monkeypatch) -> None:
     """Load tool-specific config sections from pyproject.
 
     Args:
@@ -40,7 +40,7 @@ def test_load_lintro_tool_config(tmp_path: Path, monkeypatch):
 def test_config_loader_handles_missing_and_malformed_pyproject(
     tmp_path: Path,
     monkeypatch,
-):
+) -> None:
     """Validate loaders handle missing and malformed pyproject files.
 
     Args:

--- a/tests/unit/test_config_loader_more.py
+++ b/tests/unit/test_config_loader_more.py
@@ -9,7 +9,7 @@ from assertpy import assert_that
 from lintro.utils.config import load_post_checks_config
 
 
-def test_load_post_checks_config_present(tmp_path: Path, monkeypatch):
+def test_load_post_checks_config_present(tmp_path: Path, monkeypatch) -> None:
     """Load post-checks config from pyproject.
 
     Args:

--- a/tests/unit/test_console_logger.py
+++ b/tests/unit/test_console_logger.py
@@ -10,7 +10,10 @@ from assertpy import assert_that
 from lintro.utils.console_logger import SimpleLintroLogger, create_logger
 
 
-def test_create_logger_and_basic_methods(tmp_path: Path, capsys: pytest.CaptureFixture):
+def test_create_logger_and_basic_methods(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture,
+) -> None:
     """Exercise basic logging methods and ensure files are created.
 
     Args:
@@ -49,7 +52,7 @@ def test_create_logger_and_basic_methods(tmp_path: Path, capsys: pytest.CaptureF
             issues_count: int,
             success: bool,
             output: str = "",
-        ):
+        ) -> None:
             self.name = name
             self.issues_count = issues_count
             self.success = success
@@ -68,7 +71,7 @@ def test_create_logger_and_basic_methods(tmp_path: Path, capsys: pytest.CaptureF
             remaining: int,
             success: bool = True,
             output: str = "",
-        ):
+        ) -> None:
             self.name = name
             self.fixed_issues_count = fixed
             self.remaining_issues_count = remaining
@@ -106,7 +109,7 @@ def test_summary_marks_fail_on_tool_failure(
             issues_count: int,
             success: bool,
             output: str = "",
-        ):
+        ) -> None:
             self.name = name
             self.issues_count = issues_count
             self.success = success

--- a/tests/unit/test_console_logger_more.py
+++ b/tests/unit/test_console_logger_more.py
@@ -9,7 +9,7 @@ from assertpy import assert_that
 from lintro.utils.console_logger import create_logger, get_tool_emoji
 
 
-def test_get_tool_emoji_default():
+def test_get_tool_emoji_default() -> None:
     """Return a default emoji for unknown tools and non-empty string."""
     # Unknown tool should return the default emoji
     emoji = get_tool_emoji("unknown-tool")
@@ -18,7 +18,7 @@ def test_get_tool_emoji_default():
     assert_that(emoji).is_not_equal_to("")
 
 
-def test_console_logger_parsing_messages(tmp_path: Path, capsys):
+def test_console_logger_parsing_messages(tmp_path: Path, capsys) -> None:
     """Parse typical messages and print a concise summary.
 
     Args:

--- a/tests/unit/test_enums_and_normalizers.py
+++ b/tests/unit/test_enums_and_normalizers.py
@@ -18,7 +18,7 @@ from lintro.enums.tool_name import ToolName, normalize_tool_name
 from lintro.enums.yamllint_format import YamllintFormat, normalize_yamllint_format
 
 
-def test_output_format_normalization():
+def test_output_format_normalization() -> None:
     """Normalize output format strings and enum instances consistently."""
     assert_that(normalize_output_format("grid")).is_equal_to(OutputFormat.GRID)
     assert_that(normalize_output_format(OutputFormat.JSON)).is_equal_to(
@@ -27,20 +27,20 @@ def test_output_format_normalization():
     assert_that(normalize_output_format("unknown")).is_equal_to(OutputFormat.GRID)
 
 
-def test_group_by_normalization():
+def test_group_by_normalization() -> None:
     """Normalize group-by strings and enum instances consistently."""
     assert_that(normalize_group_by("file")).is_equal_to(GroupBy.FILE)
     assert_that(normalize_group_by(GroupBy.AUTO)).is_equal_to(GroupBy.AUTO)
     assert_that(normalize_group_by("bad")).is_equal_to(GroupBy.FILE)
 
 
-def test_tool_name_normalization():
+def test_tool_name_normalization() -> None:
     """Normalize tool names from strings and enum instances."""
     assert_that(normalize_tool_name("ruff")).is_equal_to(ToolName.RUFF)
     assert_that(normalize_tool_name(ToolName.PRETTIER)).is_equal_to(ToolName.PRETTIER)
 
 
-def test_yamllint_format_normalization():
+def test_yamllint_format_normalization() -> None:
     """Normalize yamllint format values from strings and enums."""
     assert_that(normalize_yamllint_format("parsable")).is_equal_to(
         YamllintFormat.PARSABLE,
@@ -50,7 +50,7 @@ def test_yamllint_format_normalization():
     )
 
 
-def test_hadolint_normalization():
+def test_hadolint_normalization() -> None:
     """Normalize hadolint format and threshold string values."""
     assert_that(normalize_hadolint_format("json")).is_equal_to(HadolintFormat.JSON)
     assert_that(normalize_hadolint_threshold("warning")).is_equal_to(
@@ -62,7 +62,7 @@ def test_hadolint_normalization():
     )
 
 
-def test_darglint_strictness_normalization():
+def test_darglint_strictness_normalization() -> None:
     """Normalize darglint strictness strings and enum values."""
     assert_that(normalize_darglint_strictness("full")).is_equal_to(
         DarglintStrictness.FULL,

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -11,7 +11,7 @@ from lintro.exceptions.errors import (
 )
 
 
-def test_custom_exceptions_str_and_inheritance():
+def test_custom_exceptions_str_and_inheritance() -> None:
     """Ensure custom exceptions inherit and stringify as expected."""
     base = LintroError("base")
     assert_that(isinstance(base, Exception)).is_true()

--- a/tests/unit/test_formatters_tables.py
+++ b/tests/unit/test_formatters_tables.py
@@ -26,7 +26,7 @@ from lintro.parsers.prettier.prettier_issue import PrettierIssue
 from lintro.parsers.ruff.ruff_issue import RuffFormatIssue, RuffIssue
 
 
-def test_darglint_table_and_formatting(tmp_path):
+def test_darglint_table_and_formatting(tmp_path) -> None:
     """Validate Darglint table layout and grid formatting.
 
     Args:
@@ -43,7 +43,7 @@ def test_darglint_table_and_formatting(tmp_path):
     assert_that(out).contains("D100")
 
 
-def test_prettier_table_and_formatting(tmp_path):
+def test_prettier_table_and_formatting(tmp_path) -> None:
     """Validate Prettier table layout and plain formatting.
 
     Args:
@@ -68,7 +68,7 @@ def test_prettier_table_and_formatting(tmp_path):
     assert_that("Auto-fixable" in out or out).is_true()
 
 
-def test_ruff_table_and_formatting(tmp_path):
+def test_ruff_table_and_formatting(tmp_path) -> None:
     """Validate Ruff table layout and grid formatting for issues.
 
     Args:
@@ -95,7 +95,7 @@ def test_ruff_table_and_formatting(tmp_path):
     assert_that("Auto-fixable" in out or "Not auto-fixable" in out or out).is_true()
 
 
-def test_hadolint_table_and_formatting(tmp_path):
+def test_hadolint_table_and_formatting(tmp_path) -> None:
     """Validate Hadolint table layout and markdown formatting.
 
     Args:

--- a/tests/unit/test_output_manager_reports.py
+++ b/tests/unit/test_output_manager_reports.py
@@ -12,7 +12,7 @@ from lintro.utils.output_manager import OutputManager
 class DummyIssue:
     """Simple container for issue fields used in reports."""
 
-    def __init__(self, file: str, line: int, code: str, message: str):
+    def __init__(self, file: str, line: int, code: str, message: str) -> None:
         """Initialize an issue container.
 
         Args:
@@ -35,7 +35,7 @@ class DummyResult:
         name: str,
         issues_count: int,
         issues: list[DummyIssue] | None = None,
-    ):
+    ) -> None:
         """Initialize a result wrapper.
 
         Args:
@@ -48,7 +48,7 @@ class DummyResult:
         self.issues = issues or []
 
 
-def test_output_manager_writes_reports(tmp_path: Path, monkeypatch):
+def test_output_manager_writes_reports(tmp_path: Path, monkeypatch) -> None:
     """Write multiple report formats and verify artifacts exist.
 
     Args:

--- a/tests/unit/test_parsers_actionlint.py
+++ b/tests/unit/test_parsers_actionlint.py
@@ -9,12 +9,12 @@ from assertpy import assert_that
 from lintro.parsers.actionlint.actionlint_parser import parse_actionlint_output
 
 
-def test_parse_actionlint_empty():
+def test_parse_actionlint_empty() -> None:
     """Return an empty list for empty parser input."""
     assert_that(parse_actionlint_output("")).is_equal_to([])
 
 
-def test_parse_actionlint_lines():
+def test_parse_actionlint_lines() -> None:
     """Parse typical actionlint lines and produce structured issues."""
     out = (
         "workflow.yml:10:5: error: unexpected key [AL100]\n"

--- a/tests/unit/test_ruff_parser_additional.py
+++ b/tests/unit/test_ruff_parser_additional.py
@@ -7,7 +7,7 @@ from assertpy import assert_that
 from lintro.parsers.ruff.ruff_parser import parse_ruff_output
 
 
-def test_parse_ruff_output_plain_json_array():
+def test_parse_ruff_output_plain_json_array() -> None:
     """Parse a simple JSON array output into issues list."""
     output = (
         "[\n"
@@ -20,7 +20,7 @@ def test_parse_ruff_output_plain_json_array():
     assert_that(issues[0].file.endswith("a.py")).is_true()
 
 
-def test_parse_ruff_output_empty_and_malformed_line_skipped():
+def test_parse_ruff_output_empty_and_malformed_line_skipped() -> None:
     """Skip empty and malformed lines in JSONL output gracefully."""
     jl = (
         "\n\n"  # empties ignored

--- a/tests/unit/test_ruff_parser_more.py
+++ b/tests/unit/test_ruff_parser_more.py
@@ -10,7 +10,7 @@ from lintro.parsers.ruff.ruff_parser import (
 )
 
 
-def test_parse_ruff_output_json_lines_and_variants():
+def test_parse_ruff_output_json_lines_and_variants() -> None:
     """Parse JSON lines with variant keys and fix metadata."""
     # Mixed JSON lines with different location key variants and fix metadata
     jl = (
@@ -29,7 +29,7 @@ def test_parse_ruff_output_json_lines_and_variants():
     assert_that(codes).contains("E501", "F401", "E702")
 
 
-def test_parse_ruff_output_trailing_non_json():
+def test_parse_ruff_output_trailing_non_json() -> None:
     """Ignore trailing non-JSON content after a JSON array."""
     # Parser should ignore trailing non-JSON after array
     output = (
@@ -44,7 +44,7 @@ def test_parse_ruff_output_trailing_non_json():
     assert issues[0].file.endswith("x.py")
 
 
-def test_parse_ruff_format_check_output_various_lines():
+def test_parse_ruff_format_check_output_various_lines() -> None:
     """Extract files from various format-check output lines."""
     out = (
         "Would reformat: src/app.py\n"
@@ -56,7 +56,7 @@ def test_parse_ruff_format_check_output_various_lines():
     assert_that(files).contains("src/app.py", "tests/test_app.py")
 
 
-def test_parse_ruff_format_check_output_variants_more():
+def test_parse_ruff_format_check_output_variants_more() -> None:
     """Support alternate wording for 'Would reformat' lines."""
     out = "Would reformat: a.py\nWould reformat b.py\n"
     files = parse_ruff_format_check_output(out)

--- a/tests/unit/test_subprocess_validator.py
+++ b/tests/unit/test_subprocess_validator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Never
+
 import pytest
 
 from lintro.enums.tool_type import ToolType
@@ -20,10 +22,10 @@ class _DummyTool(BaseTool):
         tool_type=ToolType.SECURITY,
     )
 
-    def check(self, paths: list[str]):  # type: ignore[override]
+    def check(self, paths: list[str]) -> Never:  # type: ignore[override]
         raise NotImplementedError
 
-    def fix(self, paths: list[str]):  # type: ignore[override]
+    def fix(self, paths: list[str]) -> Never:  # type: ignore[override]
         raise NotImplementedError
 
 

--- a/tests/unit/test_tool_base_subprocess.py
+++ b/tests/unit/test_tool_base_subprocess.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from typing import Never
 
 import pytest
 
@@ -22,10 +23,10 @@ class _DummyTool(BaseTool):
         tool_type=ToolType.SECURITY,
     )
 
-    def check(self, paths: list[str]):  # type: ignore[override]
+    def check(self, paths: list[str]) -> Never:  # type: ignore[override]
         raise NotImplementedError
 
-    def fix(self, paths: list[str]):  # type: ignore[override]
+    def fix(self, paths: list[str]) -> Never:  # type: ignore[override]
         raise NotImplementedError
 
 
@@ -61,7 +62,7 @@ def test_run_subprocess_timeout(
         monkeypatch: Pytest monkeypatch to stub subprocess.
     """
 
-    def _raise_timeout(*_a, **_k):
+    def _raise_timeout(*_a, **_k) -> Never:
         raise subprocess.TimeoutExpired(cmd=["echo"], timeout=0.01)
 
     monkeypatch.setattr(subprocess, "run", _raise_timeout)
@@ -80,7 +81,7 @@ def test_run_subprocess_called_process_error(
         monkeypatch: Pytest monkeypatch to stub subprocess.
     """
 
-    def _raise_cpe(*_a, **_k):
+    def _raise_cpe(*_a, **_k) -> Never:
         raise subprocess.CalledProcessError(
             returncode=1,
             cmd=["false"],

--- a/tests/unit/test_tool_executor.py
+++ b/tests/unit/test_tool_executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Never
 
 from assertpy import assert_that
 
@@ -14,15 +15,15 @@ from lintro.utils.tool_executor import run_lint_tools_simple
 class FakeLogger:
     """Minimal logger stub capturing method calls for assertions."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the fake logger with call storage and run dir."""
         self.calls: list[tuple[str, tuple, dict]] = []
         self.run_dir = ".lintro/test"
 
-    def _rec(self, name: str, *a, **k):
+    def _rec(self, name: str, *a, **k) -> None:
         self.calls.append((name, a, k))
 
-    def info(self, *a, **k):
+    def info(self, *a, **k) -> None:
         """Record an info call.
 
         Args:
@@ -31,7 +32,7 @@ class FakeLogger:
         """
         self._rec("info", *a, **k)
 
-    def debug(self, *a, **k):
+    def debug(self, *a, **k) -> None:
         """Record a debug call.
 
         Args:
@@ -40,7 +41,7 @@ class FakeLogger:
         """
         self._rec("debug", *a, **k)
 
-    def warning(self, *a, **k):
+    def warning(self, *a, **k) -> None:
         """Record a warning call.
 
         Args:
@@ -49,7 +50,7 @@ class FakeLogger:
         """
         self._rec("warning", *a, **k)
 
-    def error(self, *a, **k):
+    def error(self, *a, **k) -> None:
         """Record an error call.
 
         Args:
@@ -58,7 +59,7 @@ class FakeLogger:
         """
         self._rec("error", *a, **k)
 
-    def success(self, *a, **k):
+    def success(self, *a, **k) -> None:
         """Record a success call.
 
         Args:
@@ -67,7 +68,7 @@ class FakeLogger:
         """
         self._rec("success", *a, **k)
 
-    def console_output(self, *a, **k):
+    def console_output(self, *a, **k) -> None:
         """Record console output.
 
         Args:
@@ -76,7 +77,7 @@ class FakeLogger:
         """
         self._rec("console_output", *a, **k)
 
-    def print_lintro_header(self, *a, **k):
+    def print_lintro_header(self, *a, **k) -> None:
         """Record header printing.
 
         Args:
@@ -85,7 +86,7 @@ class FakeLogger:
         """
         self._rec("print_lintro_header", *a, **k)
 
-    def print_verbose_info(self, *a, **k):
+    def print_verbose_info(self, *a, **k) -> None:
         """Record verbose info printing.
 
         Args:
@@ -94,7 +95,7 @@ class FakeLogger:
         """
         self._rec("print_verbose_info", *a, **k)
 
-    def print_tool_header(self, *a, **k):
+    def print_tool_header(self, *a, **k) -> None:
         """Record tool header printing.
 
         Args:
@@ -103,7 +104,7 @@ class FakeLogger:
         """
         self._rec("print_tool_header", *a, **k)
 
-    def print_tool_result(self, *a, **k):
+    def print_tool_result(self, *a, **k) -> None:
         """Record tool result printing.
 
         Args:
@@ -112,7 +113,7 @@ class FakeLogger:
         """
         self._rec("print_tool_result", *a, **k)
 
-    def print_execution_summary(self, *a, **k):
+    def print_execution_summary(self, *a, **k) -> None:
         """Record execution summary printing.
 
         Args:
@@ -121,7 +122,7 @@ class FakeLogger:
         """
         self._rec("print_execution_summary", *a, **k)
 
-    def save_console_log(self, *a, **k):
+    def save_console_log(self, *a, **k) -> None:
         """Record console log saving.
 
         Args:
@@ -134,7 +135,7 @@ class FakeLogger:
 class FakeTool:
     """Simple tool stub returning a pre-baked ToolResult."""
 
-    def __init__(self, name: str, can_fix: bool, result: ToolResult):
+    def __init__(self, name: str, can_fix: bool, result: ToolResult) -> None:
         """Initialize the fake tool.
 
         Args:
@@ -147,7 +148,7 @@ class FakeTool:
         self._result = result
         self.options = {}
 
-    def set_options(self, **kwargs):
+    def set_options(self, **kwargs) -> None:
         """Record option values provided to the tool stub.
 
         Args:
@@ -181,11 +182,11 @@ class FakeTool:
 class _EnumLike:
     """Tiny enum-like wrapper exposing a `name` attribute."""
 
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         self.name = name
 
 
-def _setup_tool_manager(monkeypatch, tools: dict[str, FakeTool]):
+def _setup_tool_manager(monkeypatch, tools: dict[str, FakeTool]) -> None:
     """Configure tool manager stubs to return provided tools.
 
     Args:
@@ -205,7 +206,7 @@ def _setup_tool_manager(monkeypatch, tools: dict[str, FakeTool]):
 
     monkeypatch.setattr(te.tool_manager, "get_tool", fake_get_tool, raising=True)
 
-    def noop_write_reports_from_results(self, results):
+    def noop_write_reports_from_results(self, results) -> None:
         return None
 
     monkeypatch.setattr(
@@ -216,7 +217,7 @@ def _setup_tool_manager(monkeypatch, tools: dict[str, FakeTool]):
     )
 
 
-def _stub_logger(monkeypatch):
+def _stub_logger(monkeypatch) -> None:
     """Patch create_logger to return a FakeLogger instance.
 
     Args:
@@ -227,7 +228,7 @@ def _stub_logger(monkeypatch):
     monkeypatch.setattr(cl, "create_logger", lambda **k: FakeLogger(), raising=True)
 
 
-def test_executor_check_success(monkeypatch):
+def test_executor_check_success(monkeypatch) -> None:
     """Exit with 0 when check succeeds and has zero issues.
 
     Args:
@@ -254,7 +255,7 @@ def test_executor_check_success(monkeypatch):
     assert_that(code).is_equal_to(0)
 
 
-def test_executor_check_failure(monkeypatch):
+def test_executor_check_failure(monkeypatch) -> None:
     """Exit with 1 when check succeeds but issues are reported.
 
     Args:
@@ -281,7 +282,7 @@ def test_executor_check_failure(monkeypatch):
     assert_that(code).is_equal_to(1)
 
 
-def test_executor_fmt_success_with_counts(monkeypatch):
+def test_executor_fmt_success_with_counts(monkeypatch) -> None:
     """Exit with 0 when format succeeds and counts are populated.
 
     Args:
@@ -315,7 +316,7 @@ def test_executor_fmt_success_with_counts(monkeypatch):
     assert_that(code).is_equal_to(0)
 
 
-def test_executor_json_output(monkeypatch, capsys):
+def test_executor_json_output(monkeypatch, capsys) -> None:
     """Emit JSON output containing action and results when requested.
 
     Args:
@@ -358,7 +359,7 @@ def test_executor_json_output(monkeypatch, capsys):
     assert_that("results" in data and len(data["results"]) >= 2).is_true()
 
 
-def test_executor_handles_tool_failure_with_output(monkeypatch, tmp_path):
+def test_executor_handles_tool_failure_with_output(monkeypatch, tmp_path) -> None:
     """Return non-zero when a tool fails but emits output (coverage branch).
 
     Args:
@@ -386,7 +387,7 @@ def test_executor_handles_tool_failure_with_output(monkeypatch, tmp_path):
     assert_that(code).is_equal_to(1)
 
 
-def test_parse_tool_options_typed_values():
+def test_parse_tool_options_typed_values() -> None:
     """Ensure --tool-options parsing coerces values into proper types.
 
     Supported coercions:
@@ -418,7 +419,7 @@ def test_parse_tool_options_typed_values():
     ).is_true()
 
 
-def test_executor_unknown_tool(monkeypatch):
+def test_executor_unknown_tool(monkeypatch) -> None:
     """Exit with 1 when an unknown tool is requested.
 
     Args:
@@ -427,7 +428,7 @@ def test_executor_unknown_tool(monkeypatch):
     _stub_logger(monkeypatch)
     import lintro.utils.tool_executor as te
 
-    def raise_value_error(tools, action):
+    def raise_value_error(tools, action) -> Never:
         raise ValueError("unknown tool")
 
     monkeypatch.setattr(te, "_get_tools_to_run", raise_value_error, raising=True)

--- a/tests/unit/test_tool_executor_more.py
+++ b/tests/unit/test_tool_executor_more.py
@@ -11,7 +11,7 @@ These tests focus on unhit branches in the simple executor:
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, Never
 
 from assertpy import assert_that
 
@@ -20,16 +20,16 @@ from lintro.utils.tool_executor import run_lint_tools_simple
 
 
 class _EnumLike:
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         self.name = name
 
 
-def _stub_logger(monkeypatch):
+def _stub_logger(monkeypatch) -> None:
     import lintro.utils.console_logger as cl
 
     class SilentLogger:
         def __getattr__(self, name: str):  # noqa: D401 - test stub
-            def _(*a: Any, **k: Any):
+            def _(*a: Any, **k: Any) -> None:
                 return None
 
             return _
@@ -37,7 +37,7 @@ def _stub_logger(monkeypatch):
     monkeypatch.setattr(cl, "create_logger", lambda *a, **k: SilentLogger())
 
 
-def test_get_tools_to_run_unknown_tool_raises(monkeypatch):
+def test_get_tools_to_run_unknown_tool_raises(monkeypatch) -> None:
     """Unknown tool name should raise ValueError.
 
     Args:
@@ -62,7 +62,7 @@ def test_get_tools_to_run_unknown_tool_raises(monkeypatch):
         assert_that(str(e)).contains("Unknown tool")
 
 
-def test_get_tools_to_run_fmt_with_cannot_fix_raises(monkeypatch):
+def test_get_tools_to_run_fmt_with_cannot_fix_raises(monkeypatch) -> None:
     """Selecting a non-fix tool for fmt should raise a validation error.
 
     Args:
@@ -75,7 +75,7 @@ def test_get_tools_to_run_fmt_with_cannot_fix_raises(monkeypatch):
     class NoFixTool:
         can_fix = False
 
-        def set_options(self, **kwargs):  # noqa: D401
+        def set_options(self, **kwargs) -> None:  # noqa: D401
             return None
 
     # Ensure we resolve a tool instance with can_fix False
@@ -94,7 +94,7 @@ def test_get_tools_to_run_fmt_with_cannot_fix_raises(monkeypatch):
         assert_that(str(e)).contains("does not support formatting")
 
 
-def test_main_loop_get_tool_raises_appends_failure(monkeypatch, capsys):
+def test_main_loop_get_tool_raises_appends_failure(monkeypatch, capsys) -> None:
     """If a tool cannot be resolved, a failure result is appended and run continues.
 
     Args:
@@ -155,7 +155,7 @@ def test_main_loop_get_tool_raises_appends_failure(monkeypatch, capsys):
     assert_that(code).is_equal_to(1)
 
 
-def test_write_reports_errors_are_swallowed(monkeypatch):
+def test_write_reports_errors_are_swallowed(monkeypatch) -> None:
     """Errors while saving outputs should not crash or change exit semantics.
 
     Args:
@@ -186,7 +186,7 @@ def test_write_reports_errors_are_swallowed(monkeypatch):
     monkeypatch.setattr(te, "_get_tools_to_run", fake_get_tools, raising=True)
     monkeypatch.setattr(te.tool_manager, "get_tool", lambda e: ruff_tool)
 
-    def boom(self, results):
+    def boom(self, results) -> Never:
         raise RuntimeError("disk full")
 
     monkeypatch.setattr(
@@ -211,7 +211,7 @@ def test_write_reports_errors_are_swallowed(monkeypatch):
     assert_that(code).is_equal_to(0)
 
 
-def test_unknown_post_check_tool_is_skipped(monkeypatch):
+def test_unknown_post_check_tool_is_skipped(monkeypatch) -> None:
     """Unknown post-check tool names should be warned and skipped gracefully.
 
     Args:
@@ -264,7 +264,7 @@ def test_unknown_post_check_tool_is_skipped(monkeypatch):
     assert_that(code).is_equal_to(0)
 
 
-def test_post_checks_early_filter_removes_black_from_main(monkeypatch):
+def test_post_checks_early_filter_removes_black_from_main(monkeypatch) -> None:
     """Black should be excluded from main phase when configured as post-check.
 
     Args:
@@ -273,16 +273,22 @@ def test_post_checks_early_filter_removes_black_from_main(monkeypatch):
     import lintro.utils.tool_executor as te
 
     class LoggerCapture:
-        def __init__(self):
+        def __init__(self) -> None:
             self.tools_list = None
 
         def __getattr__(self, name: str):  # default no-ops
-            def _(*a: Any, **k: Any):
+            def _(*a: Any, **k: Any) -> None:
                 return None
 
             return _
 
-        def print_lintro_header(self, *, action: str, tool_count: int, tools_list: str):
+        def print_lintro_header(
+            self,
+            *,
+            action: str,
+            tool_count: int,
+            tools_list: str,
+        ) -> None:
             self.tools_list = tools_list
             return None
 
@@ -349,7 +355,7 @@ def test_post_checks_early_filter_removes_black_from_main(monkeypatch):
     assert_that("black" in (logger.tools_list or "")).is_false()
 
 
-def test_all_filtered_results_in_no_tools_warning(monkeypatch):
+def test_all_filtered_results_in_no_tools_warning(monkeypatch) -> None:
     """If filtering removes all tools, executor should return failure gracefully.
 
     Args:

--- a/tests/unit/test_tool_executor_post_checks.py
+++ b/tests/unit/test_tool_executor_post_checks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Never
 
 from assertpy import assert_that
 
@@ -13,7 +14,7 @@ from lintro.utils.tool_executor import run_lint_tools_simple
 class FakeTool:
     """Simple tool stub returning a pre-baked ToolResult."""
 
-    def __init__(self, name: str, can_fix: bool, result: ToolResult):
+    def __init__(self, name: str, can_fix: bool, result: ToolResult) -> None:
         """Initialize the fake tool.
 
         Args:
@@ -26,7 +27,7 @@ class FakeTool:
         self._result = result
         self.options: dict[str, object] = {}
 
-    def set_options(self, **kwargs):
+    def set_options(self, **kwargs) -> None:
         """Record option values provided to the tool stub.
 
         Args:
@@ -60,16 +61,16 @@ class FakeTool:
 class _EnumLike:
     """Tiny enum-like wrapper exposing a `name` attribute."""
 
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         self.name = name
 
 
-def _stub_logger(monkeypatch):
+def _stub_logger(monkeypatch) -> None:
     import lintro.utils.console_logger as cl
 
     class SilentLogger:
         def __getattr__(self, name):
-            def _(*a, **k):
+            def _(*a, **k) -> None:
                 return None
 
             return _
@@ -97,7 +98,7 @@ def _setup_main_tool(monkeypatch):
     monkeypatch.setattr(te, "_get_tools_to_run", fake_get_tools, raising=True)
     monkeypatch.setattr(te.tool_manager, "get_tool", lambda e: ruff, raising=True)
 
-    def noop_write_reports_from_results(self, results):
+    def noop_write_reports_from_results(self, results) -> None:
         return None
 
     monkeypatch.setattr(
@@ -110,7 +111,7 @@ def _setup_main_tool(monkeypatch):
     return ruff
 
 
-def test_post_checks_enforce_failure_on_unavailable_tool(monkeypatch):
+def test_post_checks_enforce_failure_on_unavailable_tool(monkeypatch) -> None:
     """When enforce_failure is True, missing post-check yields failure exit.
 
     This exercises the exception path in the post-check loop where resolving the
@@ -156,7 +157,7 @@ def test_post_checks_enforce_failure_on_unavailable_tool(monkeypatch):
     assert_that(code).is_equal_to(1)
 
 
-def test_post_checks_missing_tool_no_enforce_skips(monkeypatch, capsys):
+def test_post_checks_missing_tool_no_enforce_skips(monkeypatch, capsys) -> None:
     """When enforce_failure is False, missing post-check is skipped gracefully.
 
     We validate behavior by inspecting JSON output rather than exit code, to
@@ -179,7 +180,7 @@ def test_post_checks_missing_tool_no_enforce_skips(monkeypatch, capsys):
         raising=True,
     )
 
-    def fail_get_tool(enum_val):
+    def fail_get_tool(enum_val) -> Never:
         raise RuntimeError("black not available")
 
     monkeypatch.setattr(te.tool_manager, "get_tool", fail_get_tool, raising=True)
@@ -203,7 +204,10 @@ def test_post_checks_missing_tool_no_enforce_skips(monkeypatch, capsys):
     assert_that("black" in tools_list).is_false()
 
 
-def test_post_checks_json_mode_enforced_failure_on_missing_tool(monkeypatch, capsys):
+def test_post_checks_json_mode_enforced_failure_on_missing_tool(
+    monkeypatch,
+    capsys,
+) -> None:
     """JSON output mode should still enforce failure on missing post-check.
 
     Args:
@@ -224,7 +228,7 @@ def test_post_checks_json_mode_enforced_failure_on_missing_tool(monkeypatch, cap
     )
 
     # Force resolution failure for the post-check tool
-    def fail_get_tool(enum_val):
+    def fail_get_tool(enum_val) -> Never:
         raise RuntimeError("black not available")
 
     monkeypatch.setattr(te.tool_manager, "get_tool", fail_get_tool, raising=True)

--- a/tests/unit/test_tool_manager.py
+++ b/tests/unit/test_tool_manager.py
@@ -9,7 +9,7 @@ from lintro.tools.core.tool_manager import ToolManager
 from lintro.tools.tool_enum import ToolEnum
 
 
-def test_tool_manager_register_and_get_tools():
+def test_tool_manager_register_and_get_tools() -> None:
     """Register all tools and validate discovery and accessors."""
     tm = ToolManager()
     for enum_member in ToolEnum:
@@ -24,7 +24,7 @@ def test_tool_manager_register_and_get_tools():
     assert_that(set(fix_tools.keys()) <= set(ToolEnum)).is_true()
 
 
-def test_tool_manager_execution_order_and_conflicts(monkeypatch):
+def test_tool_manager_execution_order_and_conflicts(monkeypatch) -> None:
     """Honor conflicts in execution order unless ignore_conflicts is set.
 
     Args:
@@ -57,7 +57,7 @@ def test_tool_manager_execution_order_and_conflicts(monkeypatch):
     )
 
 
-def test_tool_manager_get_tool_missing():
+def test_tool_manager_get_tool_missing() -> None:
     """Raise ValueError when attempting to get an unregistered tool."""
     tm = ToolManager()
     with pytest.raises(ValueError):

--- a/tests/unit/test_tool_utils.py
+++ b/tests/unit/test_tool_utils.py
@@ -12,14 +12,14 @@ from lintro.utils.tool_utils import (
 )
 
 
-def test_should_exclude_path_patterns():
+def test_should_exclude_path_patterns() -> None:
     """Evaluate exclude pattern behavior on file paths."""
     assert_that(should_exclude_path("a/b/.venv/lib.py", [".venv"]) is True).is_true()
     assert_that(should_exclude_path("a/b/c.py", ["*.md"]) is False).is_true()
     assert_that(should_exclude_path("dir/file.md", ["*.md"]) is True).is_true()
 
 
-def test_get_table_columns_and_format_tabulate(monkeypatch):
+def test_get_table_columns_and_format_tabulate(monkeypatch) -> None:
     """Use tabulate when available and validate headers/rows are passed.
 
     Args:
@@ -33,7 +33,7 @@ def test_get_table_columns_and_format_tabulate(monkeypatch):
         tablefmt,
         stralign=None,
         disable_numparse=None,
-    ):
+    ) -> str:
         rows_captured["headers"] = headers
         rows_captured["rows"] = tabular_data
         return "TABLE"
@@ -58,7 +58,7 @@ def test_get_table_columns_and_format_tabulate(monkeypatch):
     assert_that(rows_captured["rows"]).is_true()
 
 
-def test_walk_files_with_excludes(tmp_path):
+def test_walk_files_with_excludes(tmp_path) -> None:
     """Walk files with include/exclude patterns.
 
     Args:
@@ -80,7 +80,7 @@ def test_walk_files_with_excludes(tmp_path):
     assert_that(any(p.endswith("ignore.txt") for p in files)).is_false()
 
 
-def test_is_venv_directory_predicate():
+def test_is_venv_directory_predicate() -> None:
     """Detect typical virtual environment directory names."""
     assert_that(_is_venv_directory(".venv")).is_true()
     assert_that(_is_venv_directory("venv")).is_true()

--- a/tests/unit/test_tool_utils_fallbacks.py
+++ b/tests/unit/test_tool_utils_fallbacks.py
@@ -7,7 +7,7 @@ from assertpy import assert_that
 import lintro.utils.tool_utils as tu
 
 
-def test_format_as_table_fallback_when_no_tabulate():
+def test_format_as_table_fallback_when_no_tabulate() -> None:
     """Fallback to plain text table when tabulate is unavailable."""
     # Force TABULATE_AVAILABLE False
     tu.TABULATE_AVAILABLE = False
@@ -23,7 +23,7 @@ def test_format_as_table_fallback_when_no_tabulate():
     ).is_true()
 
 
-def test_parse_tool_list_error_on_bad_name():
+def test_parse_tool_list_error_on_bad_name() -> None:
     """Raise ValueError when parsing an unknown tool name."""
     try:
         _ = tu.parse_tool_list("notatool")

--- a/tests/unit/test_tool_utils_more.py
+++ b/tests/unit/test_tool_utils_more.py
@@ -8,7 +8,9 @@ from lintro.parsers.ruff.ruff_issue import RuffFormatIssue, RuffIssue
 from lintro.utils.tool_utils import format_tool_output, walk_files_with_excludes
 
 
-def test_format_tool_output_with_parsed_issues_and_fixable_sections(monkeypatch):
+def test_format_tool_output_with_parsed_issues_and_fixable_sections(
+    monkeypatch,
+) -> None:
     """Format tool output, including fixable issues section when present.
 
     Args:
@@ -16,7 +18,13 @@ def test_format_tool_output_with_parsed_issues_and_fixable_sections(monkeypatch)
     """
     import lintro.utils.tool_utils as tu
 
-    def fake_tabulate(tabular_data, headers, tablefmt, stralign, disable_numparse):
+    def fake_tabulate(
+        tabular_data,
+        headers,
+        tablefmt,
+        stralign,
+        disable_numparse,
+    ) -> str:
         return "TABLE"
 
     monkeypatch.setattr(tu, "TABULATE_AVAILABLE", True, raising=True)
@@ -46,7 +54,7 @@ def test_format_tool_output_with_parsed_issues_and_fixable_sections(monkeypatch)
     assert_that("Auto-fixable" in txt or txt == "TABLE").is_true()
 
 
-def test_format_tool_output_parsing_fallbacks(monkeypatch):
+def test_format_tool_output_parsing_fallbacks(monkeypatch) -> None:
     """Fallback to raw output for unknown tools or missing issues.
 
     Args:
@@ -62,7 +70,7 @@ def test_format_tool_output_parsing_fallbacks(monkeypatch):
     assert_that(out).is_equal_to("some raw output")
 
 
-def test_walk_files_excludes_venv(tmp_path):
+def test_walk_files_excludes_venv(tmp_path) -> None:
     """walk_files_with_excludes should omit venv directories by default.
 
     Args:

--- a/tests/utils/test_formatting.py
+++ b/tests/utils/test_formatting.py
@@ -12,7 +12,7 @@ from lintro.utils.formatting import read_ascii_art
 
 
 @pytest.mark.utils
-def test_read_ascii_art():
+def test_read_ascii_art() -> None:
     """Test reading ASCII art from file."""
     mock_content = "line1\nline2\nline3\n"
     with patch("builtins.open", mock_open(read_data=mock_content)):
@@ -22,14 +22,14 @@ def test_read_ascii_art():
 
 
 @pytest.mark.utils
-def test_read_ascii_art_file_not_found():
+def test_read_ascii_art_file_not_found() -> None:
     """Test reading ASCII art when file doesn't exist."""
     result = read_ascii_art("nonexistent.txt")
     assert_that(result).is_equal_to([])
 
 
 @pytest.mark.utils
-def test_read_ascii_art_with_sections():
+def test_read_ascii_art_with_sections() -> None:
     """Test reading ASCII art file with multiple sections."""
     mock_content = "section1_line1\nsection1_line2\n\nsection2_line1\nsection2_line2\n"
     with patch("builtins.open", mock_open(read_data=mock_content)):

--- a/tests/utils/test_output_manager.py
+++ b/tests/utils/test_output_manager.py
@@ -59,7 +59,7 @@ def make_issue(file, line, code, message):
     return SimpleNamespace(file=file, line=line, code=code, message=message)
 
 
-def test_run_dir_creation(temp_output_dir):
+def test_run_dir_creation(temp_output_dir) -> None:
     """Test that OutputManager creates a timestamped run directory.
 
     Args:
@@ -70,7 +70,7 @@ def test_run_dir_creation(temp_output_dir):
     assert_that(om.get_run_dir().parent).is_equal_to(Path(temp_output_dir))
 
 
-def test_write_console_log(temp_output_dir):
+def test_write_console_log(temp_output_dir) -> None:
     """Test writing console.log file.
 
     Args:
@@ -83,7 +83,7 @@ def test_write_console_log(temp_output_dir):
     assert_that(log_path.read_text()).is_equal_to("hello world")
 
 
-def test_write_json(temp_output_dir):
+def test_write_json(temp_output_dir) -> None:
     """Test writing results.json file.
 
     Args:
@@ -99,7 +99,7 @@ def test_write_json(temp_output_dir):
     assert_that(loaded).is_equal_to(data)
 
 
-def test_write_markdown(temp_output_dir):
+def test_write_markdown(temp_output_dir) -> None:
     """Test writing report.md file.
 
     Args:
@@ -112,7 +112,7 @@ def test_write_markdown(temp_output_dir):
     assert_that(md_path.read_text().startswith("# Title")).is_true()
 
 
-def test_write_html(temp_output_dir):
+def test_write_html(temp_output_dir) -> None:
     """Test writing report.html file.
 
     Args:
@@ -125,7 +125,7 @@ def test_write_html(temp_output_dir):
     assert_that(html_path.read_text()).contains("<h1>Title</h1>")
 
 
-def test_write_csv(temp_output_dir):
+def test_write_csv(temp_output_dir) -> None:
     """Test writing summary.csv file.
 
     Args:
@@ -144,7 +144,7 @@ def test_write_csv(temp_output_dir):
     assert_that(reader[2]).is_equal_to(["b", "2"])
 
 
-def test_write_reports_from_results(temp_output_dir):
+def test_write_reports_from_results(temp_output_dir) -> None:
     """Test write_reports_from_results generates all report files with correct content.
 
     Args:

--- a/tests/utils/test_path_utils.py
+++ b/tests/utils/test_path_utils.py
@@ -9,7 +9,7 @@ from lintro.utils.path_utils import normalize_file_path_for_display
 
 
 @pytest.mark.utils
-def test_normalize_file_path_for_display_absolute():
+def test_normalize_file_path_for_display_absolute() -> None:
     """Test normalizing an absolute path."""
     with patch("os.getcwd", return_value="/project/root"):
         with patch("os.path.abspath", return_value="/project/root/src/file.py"):
@@ -19,7 +19,7 @@ def test_normalize_file_path_for_display_absolute():
 
 
 @pytest.mark.utils
-def test_normalize_file_path_for_display_relative():
+def test_normalize_file_path_for_display_relative() -> None:
     """Test normalizing a relative path."""
     with patch("os.getcwd", return_value="/project/root"):
         with patch("os.path.abspath", return_value="/project/root/src/file.py"):
@@ -29,7 +29,7 @@ def test_normalize_file_path_for_display_relative():
 
 
 @pytest.mark.utils
-def test_normalize_file_path_for_display_current_dir():
+def test_normalize_file_path_for_display_current_dir() -> None:
     """Test normalizing a file in current directory."""
     with patch("os.getcwd", return_value="/project/root"):
         with patch("os.path.abspath", return_value="/project/root/file.py"):
@@ -39,7 +39,7 @@ def test_normalize_file_path_for_display_current_dir():
 
 
 @pytest.mark.utils
-def test_normalize_file_path_for_display_parent_dir():
+def test_normalize_file_path_for_display_parent_dir() -> None:
     """Test normalizing a path that goes up directories."""
     with patch("os.getcwd", return_value="/project/root"):
         with patch("os.path.abspath", return_value="/project/file.py"):
@@ -49,7 +49,7 @@ def test_normalize_file_path_for_display_parent_dir():
 
 
 @pytest.mark.utils
-def test_normalize_file_path_for_display_already_relative():
+def test_normalize_file_path_for_display_already_relative() -> None:
     """Test normalizing a path that already starts with './'."""
     with patch("os.getcwd", return_value="/project/root"):
         with patch("os.path.abspath", return_value="/project/root/src/file.py"):
@@ -59,7 +59,7 @@ def test_normalize_file_path_for_display_already_relative():
 
 
 @pytest.mark.utils
-def test_normalize_file_path_for_display_error():
+def test_normalize_file_path_for_display_error() -> None:
     """Test handling errors in path normalization."""
     with patch("os.path.abspath", side_effect=ValueError("Invalid path")):
         result = normalize_file_path_for_display("invalid/path")
@@ -67,7 +67,7 @@ def test_normalize_file_path_for_display_error():
 
 
 @pytest.mark.utils
-def test_normalize_file_path_for_display_os_error():
+def test_normalize_file_path_for_display_os_error() -> None:
     """Test handling OS errors in path normalization."""
     with patch("os.getcwd", side_effect=OSError("Permission denied")):
         result = normalize_file_path_for_display("src/file.py")


### PR DESCRIPTION
## Summary

Adds support for Ruff ANN (flake8-annotations) rules to lintro, following the established pattern from previous commits.

## Changes

- Added ANN to Ruff select rules in pyproject.toml
- ANN rules ignored by default to avoid 700+ violations
- Created test sample with ANN violations
- Added integration tests for ANN rule detection
- Updated documentation with ANN rule category

## ANN Rules Supported

- ANN101: Missing type annotation for self
- ANN102: Missing type annotation for cls  
- ANN201: Missing return type annotation for public functions
- ANN202: Missing return type annotation for private functions
- ANN204: Missing return type annotation for special methods
- ANN205: Missing return type annotation for static methods
- ANN003: Missing type annotation for **kwargs

## Usage



## Testing

- All tests pass
- No linting errors
- Follows pattern from commits 207e2263, c171a4ef, f5dc8376

## Breaking Changes

None - ANN rules are disabled by default.