### PR TITLE
chore: bump internal refs to latest SHA

### DIFF
--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Environment setup
         # yamllint disable-line rule:line-length
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f667c6434aa542152c8698b2096addd9df9fcecc
         with:
           python-version: '3.13'
         env:

--- a/.github/workflows/ci-lintro-analysis.yml
+++ b/.github/workflows/ci-lintro-analysis.yml
@@ -68,7 +68,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f667c6434aa542152c8698b2096addd9df9fcecc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOOTSTRAP_SKIP_SYNC: '1'
@@ -112,7 +112,7 @@ jobs:
 
       - name: Comment PR with Lintro Results (merge-update)
         if: github.event_name == 'pull_request'
-        uses: TurboCoder13/py-lintro/.github/actions/post-pr-comment@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/post-pr-comment@f667c6434aa542152c8698b2096addd9df9fcecc
         with:
           file: pr-comment.txt
           marker: '<!-- lintro-report -->'

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -139,7 +139,7 @@ jobs:
           "Scoped permissions to packages:write via job-level permissions"
 
       - name: Setup Docker (Buildx + login)
-        uses: TurboCoder13/py-lintro/.github/actions/setup-docker@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/setup-docker@f667c6434aa542152c8698b2096addd9df9fcecc
         with:
           login: 'true'
           registry: ghcr.io

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup environment
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f667c6434aa542152c8698b2096addd9df9fcecc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOOTSTRAP_SKIP_SYNC: '1'

--- a/.github/workflows/lintro-report-scheduled.yml
+++ b/.github/workflows/lintro-report-scheduled.yml
@@ -55,7 +55,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f667c6434aa542152c8698b2096addd9df9fcecc
 
       - name: Run Lintro on codebase
         run: ./scripts/ci/lintro-report-generate.sh

--- a/.github/workflows/pages-deploy-coverage.yml
+++ b/.github/workflows/pages-deploy-coverage.yml
@@ -67,6 +67,6 @@ jobs:
         run: ./scripts/ci/pages-deploy.sh --badge-path coverage-badge/coverage-badge.svg
       - name: Deploy coverage to Pages
         id: deployment
-        uses: TurboCoder13/py-lintro/.github/actions/pages-deploy@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/pages-deploy@f667c6434aa542152c8698b2096addd9df9fcecc
         with:
           path: _site

--- a/.github/workflows/pr-comment-cleanup.yml
+++ b/.github/workflows/pr-comment-cleanup.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f667c6434aa542152c8698b2096addd9df9fcecc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -24,20 +24,20 @@ permissions:
 
 jobs:
   quality:
-    uses: TurboCoder13/py-lintro/.github/workflows/reusable-quality.yml@4935c2f2f61c047d851bebae6629d20ed97292d6
+    uses: TurboCoder13/py-lintro/.github/workflows/reusable-quality.yml@f667c6434aa542152c8698b2096addd9df9fcecc
     permissions:
       contents: read
 
   build:
     needs: quality
-    uses: TurboCoder13/py-lintro/.github/workflows/reusable-build.yml@4935c2f2f61c047d851bebae6629d20ed97292d6
+    uses: TurboCoder13/py-lintro/.github/workflows/reusable-build.yml@f667c6434aa542152c8698b2096addd9df9fcecc
     permissions:
       contents: read
 
   sbom:
     name: Generate and verify SBOM
     needs: [build, quality]
-    uses: TurboCoder13/py-lintro/.github/workflows/reusable-sbom.yml@4935c2f2f61c047d851bebae6629d20ed97292d6
+    uses: TurboCoder13/py-lintro/.github/workflows/reusable-sbom.yml@f667c6434aa542152c8698b2096addd9df9fcecc
     permissions:
       contents: read
       actions: read
@@ -77,7 +77,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f667c6434aa542152c8698b2096addd9df9fcecc
         with:
           python-version: '3.13'
       - name: Ensure tag points to a commit on main

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -13,11 +13,11 @@ permissions:
 
 jobs:
   quality:
-    uses: TurboCoder13/py-lintro/.github/workflows/reusable-quality.yml@4935c2f2f61c047d851bebae6629d20ed97292d6
+    uses: TurboCoder13/py-lintro/.github/workflows/reusable-quality.yml@f667c6434aa542152c8698b2096addd9df9fcecc
 
   build:
     needs: quality
-    uses: TurboCoder13/py-lintro/.github/workflows/reusable-build.yml@4935c2f2f61c047d851bebae6629d20ed97292d6
+    uses: TurboCoder13/py-lintro/.github/workflows/reusable-build.yml@f667c6434aa542152c8698b2096addd9df9fcecc
 
   publish:
     name: Upload to TestPyPI

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f667c6434aa542152c8698b2096addd9df9fcecc
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f667c6434aa542152c8698b2096addd9df9fcecc
         with:
           python-version: '3.13'
 

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: TurboCoder13/py-lintro/.github/workflows/reusable-sbom.yml@4935c2f2f61c047d851bebae6629d20ed97292d6
+    uses: TurboCoder13/py-lintro/.github/workflows/reusable-sbom.yml@f667c6434aa542152c8698b2096addd9df9fcecc
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Validate PR title follows Conventional Commits
         id: semantic
-        uses: TurboCoder13/py-lintro/.github/actions/semantic-pr-title-check@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/semantic-pr-title-check@f667c6434aa542152c8698b2096addd9df9fcecc
         with:
           types: |
             chore

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -49,7 +49,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f667c6434aa542152c8698b2096addd9df9fcecc
         with:
           python-version: '3.13'
         env:

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Environment setup
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f667c6434aa542152c8698b2096addd9df9fcecc
       - name: Run comprehensive test suite (with Docker tests)
         run: ./scripts/docker/docker-test.sh
       # (moved) Upload coverage badge artifact happens after badge generation below
@@ -164,7 +164,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Environment setup
         # yamllint disable-line rule:line-length
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f667c6434aa542152c8698b2096addd9df9fcecc
       - name: Download coverage XML artifact (fallback for comment generation)
         if: always()
         continue-on-error: true
@@ -184,7 +184,7 @@ jobs:
           ./scripts/ci/coverage-pr-comment.sh
         # yamllint enable
       - name: Comment PR with coverage info
-        uses: TurboCoder13/py-lintro/.github/actions/post-pr-comment@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/post-pr-comment@f667c6434aa542152c8698b2096addd9df9fcecc
         with:
           file: coverage-pr-comment.txt
           marker: '<!-- coverage-report -->'

--- a/.github/workflows/test-built-package.yml
+++ b/.github/workflows/test-built-package.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Egress audit (allowlist verification)
         # yamllint disable-line rule:line-length
-        uses: TurboCoder13/py-lintro/.github/actions/egress-audit-lite@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/egress-audit-lite@f667c6434aa542152c8698b2096addd9df9fcecc
         with:
           allowed-endpoints: >
             github.com:443
@@ -87,7 +87,7 @@ jobs:
 
       - name: Environment setup
         # yamllint disable-line rule:line-length
-        uses: TurboCoder13/py-lintro/.github/actions/setup-env@4935c2f2f61c047d851bebae6629d20ed97292d6
+        uses: TurboCoder13/py-lintro/.github/actions/setup-env@f667c6434aa542152c8698b2096addd9df9fcecc
         with:
           python-version: '3.13'
         env:


### PR DESCRIPTION
Automated update of internal action/workflow references to the
latest commit SHA to satisfy org policy for pinned refs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow references across CI/CD pipelines to newer, consistent versions.
  * Added an environment flag to speed up workflow setup.
  * Removed a redundant/no-op step to simplify workflows.
  * Toggled a PR comment/update parameter to better handle merge updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->