### PR TITLE
fix: add missing lintro.parsers.pytest module to package

### DIFF
--- a/lintro/parsers/__init__.py
+++ b/lintro/parsers/__init__.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
         darglint,
         hadolint,
         prettier,
+        pytest,
         ruff,
         yamllint,
     )
@@ -23,6 +24,7 @@ __all__ = [
     "darglint",
     "hadolint",
     "prettier",
+    "pytest",
     "ruff",
     "yamllint",
 ]
@@ -34,6 +36,7 @@ _SUBMODULES = {
     "darglint",
     "hadolint",
     "prettier",
+    "pytest",
     "ruff",
     "yamllint",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ Documentation = "https://github.com/TurboCoder13/py-lintro/docs"
 Source = "https://github.com/TurboCoder13/py-lintro"
 
 [tool.setuptools]
-packages = [ "lintro", "lintro.cli_utils", "lintro.cli_utils.commands", "lintro.enums", "lintro.exceptions", "lintro.formatters", "lintro.formatters.core", "lintro.formatters.styles", "lintro.formatters.tools", "lintro.models", "lintro.models.core", "lintro.parsers", "lintro.parsers.actionlint", "lintro.parsers.bandit", "lintro.parsers.black", "lintro.parsers.darglint", "lintro.parsers.hadolint", "lintro.parsers.prettier", "lintro.parsers.ruff", "lintro.parsers.yamllint", "lintro.tools", "lintro.tools.core", "lintro.tools.implementations", "lintro.utils",]
+packages = [ "lintro", "lintro.cli_utils", "lintro.cli_utils.commands", "lintro.enums", "lintro.exceptions", "lintro.formatters", "lintro.formatters.core", "lintro.formatters.styles", "lintro.formatters.tools", "lintro.models", "lintro.models.core", "lintro.parsers", "lintro.parsers.actionlint", "lintro.parsers.bandit", "lintro.parsers.black", "lintro.parsers.darglint", "lintro.parsers.hadolint", "lintro.parsers.prettier", "lintro.parsers.pytest", "lintro.parsers.ruff", "lintro.parsers.yamllint", "lintro.tools", "lintro.tools.core", "lintro.tools.implementations", "lintro.utils",]
 
 [tool.semantic_release]
 branch = "main"


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix: add missing lintro.parsers.pytest module to package`

- Type:
  - [x] fix / perf (patch)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The `lintro.parsers.pytest` module was missing from the setuptools packages list in `pyproject.toml`, causing an import error when using pytest parser functionality in version 0.15.2.

This fix adds:
- `lintro.parsers.pytest` to the setuptools packages list
- `pytest` to the parsers `__init__.py` exports and lazy-load submodules

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (existing tests cover this module)
- [ ] Docs updated if user-facing (not applicable)
- [ ] Local CI passed

## Related Issues

Fixes packaging issue where pytest parser module was missing from distributed package.

## Details

The pytest parser module existed in the codebase but was not included in the package distribution, causing `ModuleNotFoundError` when importing `lintro.parsers.pytest`. Version 0.14.1 worked correctly because the module was included at that time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * pytest submodule is now available in lintro.parsers for on-demand use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->