### PR TITLE
fix(docs): switch release pipeline badge to GitHub native badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ all your code quality needs.
 [![CI](https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/ci-lintro-analysis.yml?label=ci&branch=main&logo=githubactions&logoColor=white)](https://github.com/TurboCoder13/py-lintro/actions/workflows/ci-lintro-analysis.yml?query=branch%3Amain)
 [![Docker](https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/docker-build-publish.yml?label=docker&logo=docker&branch=main)](https://github.com/TurboCoder13/py-lintro/actions/workflows/docker-build-publish.yml?query=branch%3Amain)
 [![SBOM (main)](<https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/sbom-on-main.yml?label=sbom%20(main)&branch=main>)](https://github.com/TurboCoder13/py-lintro/actions/workflows/sbom-on-main.yml?query=branch%3Amain)
-[![Release pipeline (tags)](<https://img.shields.io/github/actions/workflow/status/TurboCoder13/py-lintro/publish-pypi-on-tag.yml?label=release%20pipeline%20(tags)&event=push>)](https://github.com/TurboCoder13/py-lintro/actions/workflows/publish-pypi-on-tag.yml?query=event%3Apush)
+[![Publish - PyPI Production](https://github.com/TurboCoder13/py-lintro/actions/workflows/publish-pypi-on-tag.yml/badge.svg)](https://github.com/TurboCoder13/py-lintro/actions/workflows/publish-pypi-on-tag.yml)
 [![PyPI](https://img.shields.io/pypi/v/lintro?label=pypi)](https://pypi.org/project/lintro/)
 
 [![CodeQL](https://github.com/TurboCoder13/py-lintro/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/TurboCoder13/py-lintro/actions/workflows/codeql.yml?query=branch%3Amain)


### PR DESCRIPTION
## What's Changing

Replaces the shields.io badge for the release pipeline workflow with GitHub's native workflow badge.

### Problem
The shields.io badge was showing "failing" status even though all workflow runs were passing. This was caused by caching issues with shields.io's `event=push` parameter and how it interprets tag-only workflows.

### Solution
Switched to GitHub's native workflow badge which is always in sync with the actual workflow status.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (N/A - docs only)
- [x] Docs updated if user-facing

## Related Issues

N/A - observed issue with badge display

## Details

- The badge label changed from "Release pipeline (tags)" to "Publish - PyPI Production" (the workflow name)
- The link still points to the workflow page
- No functional changes, purely cosmetic/accuracy fix