### PR TITLE
feat(cli): add common CLI aliases (-h, -v, tools)

### DIFF
--- a/lintro/cli.py
+++ b/lintro/cli.py
@@ -96,8 +96,8 @@ class LintroGroup(click.Group):
 
         # Options
         console.print("[bold cyan]Options:[/bold cyan]")
-        console.print("  [yellow]--version[/yellow]  Show the version and exit.")
-        console.print("  [yellow]--help[/yellow]     Show this message and exit.")
+        console.print("  [yellow]-v, --version[/yellow]  Show the version and exit.")
+        console.print("  [yellow]-h, --help[/yellow]     Show this message and exit.")
         console.print()
 
         # Examples
@@ -163,8 +163,12 @@ class LintroGroup(click.Group):
         return int(result) if isinstance(result, int) else 0
 
 
-@click.group(cls=LintroGroup, invoke_without_command=True)
-@click.version_option(version=__version__)
+@click.group(
+    cls=LintroGroup,
+    invoke_without_command=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.version_option(__version__, "-v", "--version")
 def cli() -> None:
     """Lintro: Unified CLI for code formatting, linting, and quality assurance."""
     pass
@@ -189,11 +193,15 @@ cli.add_command(versions_command, name="versions")
 
 # Register aliases
 cli.add_command(check_command, name="chk")
+cli.add_command(check_command, name="lint")
 cli.add_command(config_command, name="cfg")
 cli.add_command(format_command, name="fmt")
+cli.add_command(format_command, name="fix")
 cli.add_command(test_command, name="tst")
 cli.add_command(list_tools_command, name="ls")
+cli.add_command(list_tools_command, name="tools")
 cli.add_command(versions_command, name="ver")
+cli.add_command(versions_command, name="version")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
Add standard CLI aliases for better usability.

### Option aliases
| Short | Long | Action |
|-------|------|--------|
| `-h` | `--help` | Show help |
| `-v` | `--version` | Show version |

### Command aliases
| Alias | Command | Rationale |
|-------|---------|-----------|
| `lint` | `check` | Common linting convention |
| `fix` | `format` | eslint/ruff --fix pattern |
| `tools` | `list-tools` | More discoverable |
| `version` | `versions` | Singular form users expect |

## Before
```
$ lintro -h
Error: No such option: -h

$ lintro lint .
Error: No such command 'lint'.

$ lintro fix .
Error: No such command 'fix'.
```

## After
All of the above work as expected.

## Test plan
- [x] `lintro -h` shows help
- [x] `lintro -v` shows version
- [x] `lintro lint .` runs check
- [x] `lintro fix .` runs format
- [x] `lintro tools` lists tools
- [x] `lintro version` shows tool versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multiple CLI aliases (e.g., lint/check, fix/format, tools/list-tools, version/versions) and shorter shortcuts (chk, fmt, ls, ver) for easier command access.
  * Help output now shows paired short/long flags (-h, --help and -v, --version).
  * CLI help now surfaces canonical command names alongside aliases for clearer discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->