### PR TITLE
fix(ci): use tarball URL to bypass pip index propagation delay

### DIFF
--- a/scripts/ci/homebrew/generate-pypi-formula.sh
+++ b/scripts/ci/homebrew/generate-pypi-formula.sh
@@ -63,8 +63,8 @@ trap 'rm -rf "$ANALYSIS_VENV" "$TMPDIR"' EXIT
 log_info "Creating temporary venv for dependency analysis..."
 python3 -m venv "$ANALYSIS_VENV"
 
-log_info "Installing lintro==${VERSION} in temporary venv..."
-"$ANALYSIS_VENV/bin/pip" install --quiet "lintro==${VERSION}"
+log_info "Installing lintro from tarball (bypasses pip index propagation delay)..."
+"$ANALYSIS_VENV/bin/pip" install --quiet "$TARBALL_URL" --hash "sha256:$TARBALL_SHA"
 
 # Build exclusion list for packages we handle specially
 EXCLUDE_ARGS=()


### PR DESCRIPTION
## Summary
- Fix Homebrew formula generation failing due to PyPI index propagation delay
- Install lintro from tarball URL instead of version specifier to bypass the race condition

## Problem
The `generate-pypi-formula.sh` script was failing because:
1. `wait-for-pypi.sh` checks PyPI JSON API - this passes
2. `fetch_package_info.py` gets tarball URL/SHA from JSON API - this passes  
3. `pip install lintro==${VERSION}` fails because pip index hasn't propagated yet

See failed run: https://github.com/TurboCoder13/py-lintro/actions/runs/21044310604/job/60514992132

## Solution
Use the tarball URL (already fetched from PyPI JSON API) directly with pip install instead of relying on the pip index. This is deterministic and avoids the propagation delay entirely.

## Test plan
- [x] Lint passes
- [x] Tests pass (2650 tests)
- [ ] Verify next release deploys Homebrew formula successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/build process for improved installation reliability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->