### PR TITLE
fix(homebrew): add libyaml dependency and fix style issues

### DIFF
--- a/scripts/ci/homebrew/render_formula.py
+++ b/scripts/ci/homebrew/render_formula.py
@@ -92,10 +92,10 @@ def main() -> None:
                 file=sys.stderr,
             )
 
-    # Read resources
-    poet_resources = read_file_content(args.poet_resources)
-    darglint_resource = read_file_content(args.darglint_resource)
-    pydantic_resource = read_file_content(args.pydantic_resource)
+    # Read resources (strip trailing whitespace to avoid extra blank lines)
+    poet_resources = read_file_content(args.poet_resources).rstrip()
+    darglint_resource = read_file_content(args.darglint_resource).rstrip()
+    pydantic_resource = read_file_content(args.pydantic_resource).rstrip()
 
     # Render template
     rendered = template.replace("{{TARBALL_URL}}", args.tarball_url)

--- a/scripts/ci/homebrew/templates/lintro.rb.template
+++ b/scripts/ci/homebrew/templates/lintro.rb.template
@@ -23,6 +23,7 @@ class Lintro < Formula
   depends_on "bandit"
   depends_on "black"
   depends_on "hadolint"
+  depends_on "libyaml"
   depends_on "mypy"
   depends_on "prettier"
   depends_on "python@3.13"


### PR DESCRIPTION
## Summary

- Add missing `depends_on "libyaml"` to the Homebrew formula template
- Strip trailing whitespace from resource stanzas to prevent extra blank lines

## Problem

The homebrew-tap CI has been failing for releases 0.24.5, 0.25.0, 0.26.0, and 0.27.0 with these errors:

```
Formula/lintro.rb:149:3: FormulaAudit/ResourceRequiresDependencies: Add depends_on lines above for "libyaml".
Formula/lintro.rb:190:1: Layout/EmptyLines: Extra blank line detected.
Formula/lintro.rb:203:1: Layout/EmptyLines: Extra blank line detected.
```

The fix was previously applied directly to homebrew-tap in PR #9, but got overwritten on each new release because the **source template** in this repository was missing the dependency.

## Root Cause

1. **Missing libyaml dependency**: The `pyyaml` resource requires `libyaml` to build from source, but the template didn't declare this dependency
2. **Extra blank lines**: Resource stanzas written to temp files include trailing newlines, which created extra blank lines when substituted into the template

## Changes

1. `scripts/ci/homebrew/templates/lintro.rb.template`: Added `depends_on "libyaml"` in alphabetical order
2. `scripts/ci/homebrew/render_formula.py`: Strip trailing whitespace from resource content before template substitution

## Test plan

- [ ] Merge this PR
- [ ] Create a new release (or manually trigger the homebrew update workflow)
- [ ] Verify homebrew-tap CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure and dependency management for Homebrew formula distribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->