### PR TITLE
fix(ci): remove redundant lintro format from quality checks

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -3,7 +3,7 @@
 ---
 name: Reusable - Quality Gate & Version Export
 # Reusable workflow for quality checks and version extraction.
-# Sets up Python/uv environment, installs external tools, runs lintro format/check,
+# Sets up Python/uv environment, installs external tools, runs lintro check,
 # and exports project version for downstream workflows.
 
 'on':

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -99,12 +99,6 @@ jobs:
           steps.semrel.outputs.next_version != steps.current.outputs.current_version }}
         run: scripts/ci/github/semantic-release-helpers.sh install_external_tools
 
-      - name: Run Lintro format
-        if: >-
-          ${{ steps.semrel.outputs.next_version != '' &&
-          steps.semrel.outputs.next_version != steps.current.outputs.current_version }}
-        run: uv run lintro format . --output-format grid
-
       - name: Run Lintro check
         if: >-
           ${{ steps.semrel.outputs.next_version != '' &&

--- a/scripts/ci/pre-release-quality.sh
+++ b/scripts/ci/pre-release-quality.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 # pre-release-quality.sh
-# Run Lintro format and check with grid output.
+# Run Lintro check with grid output.
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 	cat <<'EOF'
-Run Lintro formatting and checks prior to release.
+Run Lintro checks prior to release.
 
 Usage:
   scripts/ci/pre-release-quality.sh
@@ -14,5 +14,4 @@ EOF
 	exit 0
 fi
 
-uv run lintro format . --output-format grid
 uv run lintro check . --output-format grid

--- a/scripts/ci/testing/reusable-quality-entry.sh
+++ b/scripts/ci/testing/reusable-quality-entry.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 	cat <<'EOF'
-Run quality gate in reusable workflow: install tools, format, check, export version.
+Run quality gate in reusable workflow: install tools, check, export version.
 EOF
 	exit 0
 fi
@@ -11,7 +11,6 @@ fi
 ./scripts/utils/install-tools.sh --local
 echo "$HOME/.local/bin" >>"$GITHUB_PATH"
 
-uv run lintro format . --output-format grid
 uv run lintro check . --output-format grid
 
 python scripts/utils/extract-version.py | tee ver.txt


### PR DESCRIPTION
The `lintro format` command modifies files but doesn't commit them.
Running it before `lintro check` in CI was counterproductive because:
1. Format would fix issues (modifying files)
2. Check would then run on already-fixed files
3. The modifications were discarded when CI finished

Since `lintro check` already runs formatters in check mode (e.g.,
`black --check`, `prettier --check`), it detects formatting issues
without modifying files. The format step was redundant.

The only place `lintro format` belongs in CI is in ci-auto-fix.sh
where changes are actually committed back to the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Removed code formatting automation from continuous integration workflows while maintaining quality checks during release and testing phases.
* Streamlined CI/CD pipeline configuration to optimize workflow execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->