### PR TITLE
fix(ci): add missing egress endpoints to release and report workflows

### DIFF
--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -35,8 +35,23 @@ jobs:
             codeload.github.com:443
             release-assets.githubusercontent.com:443
             objects.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            docker.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            production.cloudflare.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
+            static.rust-lang.org:443
+            bun.sh:443
+            astral.sh:443
+            sh.rustup.rs:443
+            registry.npmjs.org:443
+            crates.io:443
+            static.crates.io:443
+            index.crates.io:443
+            semgrep.dev:443
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:

--- a/.github/workflows/lintro-report-scheduled.yml
+++ b/.github/workflows/lintro-report-scheduled.yml
@@ -48,6 +48,23 @@ jobs:
             codeload.github.com:443
             release-assets.githubusercontent.com:443
             objects.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            docker.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            production.cloudflare.docker.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            static.rust-lang.org:443
+            bun.sh:443
+            astral.sh:443
+            sh.rustup.rs:443
+            registry.npmjs.org:443
+            crates.io:443
+            static.crates.io:443
+            index.crates.io:443
+            semgrep.dev:443
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -38,8 +38,23 @@ jobs:
             codeload.github.com:443
             release-assets.githubusercontent.com:443
             objects.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            docker.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            production.cloudflare.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
+            static.rust-lang.org:443
+            bun.sh:443
+            astral.sh:443
+            sh.rustup.rs:443
+            registry.npmjs.org:443
+            crates.io:443
+            static.crates.io:443
+            index.crates.io:443
+            semgrep.dev:443
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -174,7 +174,6 @@ jobs:
             bun.sh:443
             astral.sh:443
             sh.rustup.rs:443
-            deb.debian.org:80
             registry.npmjs.org:443
             crates.io:443
             static.crates.io:443


### PR DESCRIPTION
## Summary
- Adds comprehensive harden-runner allowed-endpoints to 3 workflows that were failing on main
- Fixes blocked network access to `bun.sh`, `crates.io`, `files.pythonhosted.org`, and other required endpoints

## Affected Workflows
- `lintro-report-scheduled.yml` - Reporting workflow
- `auto-tag-on-main.yml` - Auto-tagging workflow  
- `semantic-release.yml` - Release PR workflow

## Test plan
- [ ] All CI checks pass on this PR
- [ ] Verify the three previously failing workflows now succeed on main after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD runner egress allowlist updated to permit additional package registries and hosts (container registries, language package hosts, and related CDNs), improving artifact fetch and release operations.
  * Removed an outdated debian mirror from the runner allowlist, tightening that specific egress rule.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->