### PR TITLE
fix(ci): add missing egress endpoints to reusable-quality workflow

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -35,12 +35,24 @@ jobs:
             codeload.github.com:443
             release-assets.githubusercontent.com:443
             objects.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            docker.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            production.cloudflare.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
             api.osv.dev:443
+            static.rust-lang.org:443
+            bun.sh:443
+            astral.sh:443
+            sh.rustup.rs:443
+            registry.npmjs.org:443
             crates.io:443
             static.crates.io:443
             index.crates.io:443
+            semgrep.dev:443
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:


### PR DESCRIPTION
## Summary
- Adds missing harden-runner egress endpoints to reusable-quality workflow
- Includes Docker registry, Rust toolchain, JavaScript tooling, and security scanning endpoints
- Fixes PyPI publish workflow failure caused by blocked `bun.sh` access

## Context
The `reusable-quality.yml` workflow was missing egress endpoints required by the `setup-env` action for installing external tools. This caused the PyPI publish workflow to fail when it called `reusable-quality.yml`.

## Test plan
- [ ] Verify PyPI publish workflow succeeds after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to permit additional external network endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->