### PR TITLE
fix(markdownlint): use correct config file suffix for markdownlint-cli2 v0.17+

### DIFF
--- a/lintro/config/tool_config_generator.py
+++ b/lintro/config/tool_config_generator.py
@@ -289,8 +289,18 @@ def _write_defaults_config(
     Raises:
         ImportError: If PyYAML is not installed and YAML format is requested.
     """
-    suffix_map = {ConfigFormat.JSON: ".json", ConfigFormat.YAML: ".yaml"}
-    suffix = suffix_map.get(config_format, ".json")
+    # Tool-specific suffixes required by some tools (e.g., markdownlint-cli2 v0.17+
+    # enforces strict config file naming conventions)
+    tool_suffix_overrides: dict[str, str] = {
+        "markdownlint": ".markdownlint-cli2.jsonc",
+    }
+
+    tool_lower = tool_name.lower()
+    if tool_lower in tool_suffix_overrides:
+        suffix = tool_suffix_overrides[tool_lower]
+    else:
+        suffix_map = {ConfigFormat.JSON: ".json", ConfigFormat.YAML: ".yaml"}
+        suffix = suffix_map.get(config_format, ".json")
 
     temp_fd, temp_path_str = tempfile.mkstemp(
         prefix=f"lintro-{tool_name}-defaults-",

--- a/tests/config/test_tool_config_generator.py
+++ b/tests/config/test_tool_config_generator.py
@@ -6,9 +6,11 @@ from lintro.config.enforce_config import EnforceConfig
 from lintro.config.lintro_config import LintroConfig
 from lintro.config.tool_config_generator import (
     _convert_python_version_for_mypy,
+    _write_defaults_config,
     get_defaults_injection_args,
     get_enforce_cli_args,
 )
+from lintro.enums.config_format import ConfigFormat
 
 
 def test_returns_empty_when_no_enforce_settings() -> None:
@@ -113,3 +115,37 @@ def test_returns_empty_for_none_path() -> None:
     )
 
     assert_that(args).is_empty()
+
+
+def test_markdownlint_config_uses_correct_suffix() -> None:
+    """Should use .markdownlint-cli2.jsonc suffix for markdownlint.
+
+    markdownlint-cli2 v0.17+ requires config files to follow strict naming
+    conventions. The temp config file must end with a recognized suffix.
+    """
+    config_path = _write_defaults_config(
+        defaults={"config": {"MD013": {"line_length": 100}}},
+        tool_name="markdownlint",
+        config_format=ConfigFormat.JSON,
+    )
+
+    try:
+        assert_that(str(config_path)).ends_with(".markdownlint-cli2.jsonc")
+        assert_that(config_path.exists()).is_true()
+    finally:
+        config_path.unlink(missing_ok=True)
+
+
+def test_generic_tool_config_uses_json_suffix() -> None:
+    """Should use .json suffix for tools without special requirements."""
+    config_path = _write_defaults_config(
+        defaults={"some": "config"},
+        tool_name="prettier",
+        config_format=ConfigFormat.JSON,
+    )
+
+    try:
+        assert_that(str(config_path)).ends_with(".json")
+        assert_that(config_path.exists()).is_true()
+    finally:
+        config_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- Fix compatibility with markdownlint-cli2 v0.17+ which enforces strict config file naming conventions
- Temp config files for markdownlint now use `.markdownlint-cli2.jsonc` suffix instead of generic `.json`
- Add tool-specific suffix override mechanism in `_write_defaults_config()` for future extensibility

## Problem

markdownlint-cli2 v0.17.2 introduced strict validation of config file names. It now rejects files that don't match expected patterns like `.markdownlint-cli2.jsonc` or `.markdownlint.json`.

Our temp config files were named like `/tmp/lintro-markdownlint-defaults-xxxxx.json` which caused:
```
error: Configuration file should be one of the supported names (e.g., '.markdownlint-cli2.jsonc')
```

## Test plan

- [x] Unit tests pass (`tests/config/test_tool_config_generator.py`)
- [x] Integration tests pass (`tests/integration/test_markdownlint_integration.py`)
- [x] Full lint check passes (`lintro chk`)
- [x] Full test suite passes (`lintro tst`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration file generation now respects tool-specific naming conventions (e.g., markdownlint gets its special suffix), with sensible fallbacks for common formats.

* **Tests**
  * Added tests confirming generated config filenames follow expected conventions across tools (including markdownlint and JSON-based tools).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->