### PR TITLE
fix(ci): add missing egress endpoints to PyPI publish job

### DIFF
--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -70,7 +70,10 @@ jobs:
             codeload.github.com:443
             release-assets.githubusercontent.com:443
             objects.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
             pypi.org:443
+            upload.pypi.org:443
             files.pythonhosted.org:443
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6


### PR DESCRIPTION
## Summary

Add missing egress endpoints to the PyPI publish job's harden-runner configuration.

## Problem

The publish job was failing with:
```
docker: Error response from daemon: Get "https://ghcr.io/v2/": dial tcp 54.185.253.63:443: connect: connection refused
```

The `pypa/gh-action-pypi-publish` action pulls a Docker image from `ghcr.io`, but this wasn't in the allowed endpoints.

## Solution

Add the required endpoints:
- `ghcr.io:443` - Docker image registry for the publish action
- `pkg-containers.githubusercontent.com:443` - Container blob storage
- `upload.pypi.org:443` - PyPI upload endpoint

## Test plan

- [ ] Verify PyPI publish succeeds on next release