### PR TITLE
fix(ci): add Sigstore endpoints for PyPI attestations

### DIFF
--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -75,6 +75,10 @@ jobs:
             pypi.org:443
             upload.pypi.org:443
             files.pythonhosted.org:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            oauth2.sigstore.dev:443
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:


### PR DESCRIPTION
## Summary

Add Sigstore endpoints required for PyPI package attestations.

## Problem

After fixing the ghcr.io endpoint, the publish job now fails at the attestations step:
```
sigstore.errors.TUFError: Failed to refresh TUF metadata
Failed to establish a new connection: [Errno 111] Connection refused
```

The pypa/gh-action-pypi-publish action generates digital attestations using Sigstore, which requires these endpoints.

## Solution

Add all Sigstore endpoints:
- `fulcio.sigstore.dev:443` - Certificate authority
- `rekor.sigstore.dev:443` - Transparency log  
- `tuf-repo-cdn.sigstore.dev:443` - TUF metadata repository
- `oauth2.sigstore.dev:443` - OIDC authentication

## Test plan

- [ ] Verify PyPI publish succeeds with attestations