### PR TITLE
fix(ci): add pypi.python.org to egress allowlist for skip_existing check

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -64,7 +64,8 @@ All workflows use `step-security/harden-runner` with strict egress policies:
   with:
     egress-policy: 'block'
     allowed-endpoints: >
-      github.com:443 api.github.com:443 pypi.org:443 files.pythonhosted.org:443
+      github.com:443 api.github.com:443 pypi.org:443 pypi.python.org:443
+      upload.pypi.org:443 files.pythonhosted.org:443
 ```
 
 ### Action Pinning

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -73,6 +73,7 @@ jobs:
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
             pypi.org:443
+            pypi.python.org:443
             upload.pypi.org:443
             files.pythonhosted.org:443
             fulcio.sigstore.dev:443


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds `pypi.python.org:443` to the egress allowlist in the PyPI publish workflow.

Twine's `skip_existing` check queries `pypi.python.org/pypi/<package>/json` to verify if a package version already exists before uploading. This legacy domain was missing from the egress policy, causing "Connection refused" errors during PyPI publishing.

Also updates the SECURITY.md example to include `pypi.python.org:443` and `upload.pypi.org:443` for documentation consistency.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (N/A - CI config only)
- [x] Docs updated if user-facing (SECURITY.md updated)
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

Related to previous egress fixes: #395, #397

## Details

The PyPI ecosystem uses multiple domains:
- `pypi.org` - main website/API
- `upload.pypi.org` - upload endpoint
- `pypi.python.org` - legacy domain still used by twine for package existence checks
- `files.pythonhosted.org` - package file downloads

The `skip_existing: true` option in `pypa/gh-action-pypi-publish` triggers twine to check if a version already exists before uploading. This check specifically uses the legacy `pypi.python.org` domain, which was not in our egress allowlist.