### PR TITLE
fix(ci): add uploads.github.com for GitHub release asset uploads

### DIFF
--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -67,6 +67,7 @@ jobs:
           allowed-endpoints: >
             github.com:443
             api.github.com:443
+            uploads.github.com:443
             codeload.github.com:443
             release-assets.githubusercontent.com:443
             objects.githubusercontent.com:443


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds `uploads.github.com:443` to the egress allowlist in the PyPI publish workflow.

The `softprops/action-gh-release` action requires this endpoint to upload release assets. Without it, the GitHub Release creation step fails with `ECONNREFUSED` errors when trying to upload distribution files.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (N/A - CI config only)
- [ ] Docs updated if user-facing (N/A)
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

Related to previous egress fixes: #395, #397, #399

## Details

According to [StepSecurity's action advisor](https://app.stepsecurity.io/action-advisor/softprops/action-gh-release), `softprops/action-gh-release` requires:
- `api.github.com` - for release API calls (already in allowlist)
- `uploads.github.com` - for uploading release assets (was missing)

The error manifested as:
```
Error: connect ECONNREFUSED 54.185.253.63:443
```

This IP resolves to an AWS EC2 instance used by GitHub for uploads, which was blocked by the egress policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance deployment security and reliability for package publishing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->