### PR TITLE
fix(tools): prefer PATH binary for Python tools over python -m

### DIFF
--- a/tests/unit/tools/core/test_command_builders.py
+++ b/tests/unit/tools/core/test_command_builders.py
@@ -72,12 +72,33 @@ def test_python_bundled_builder_prefers_path_binary() -> None:
 def test_python_bundled_builder_falls_back_to_python_module() -> None:
     """PythonBundledBuilder falls back to python -m when tool not in PATH."""
     builder = PythonBundledBuilder()
-    with patch("shutil.which", return_value=None):
+    with (
+        patch("shutil.which", return_value=None),
+        patch(
+            "lintro.tools.core.command_builders._is_compiled_binary",
+            return_value=False,
+        ),
+    ):
         cmd = builder.get_command("ruff", ToolName.RUFF)
         # Should return [python_exe, "-m", "ruff"]
         assert_that(cmd).is_length(3)
         assert_that(cmd[1]).is_equal_to("-m")
         assert_that(cmd[2]).is_equal_to("ruff")
+
+
+def test_python_bundled_builder_skips_python_module_when_compiled() -> None:
+    """PythonBundledBuilder skips python -m fallback when compiled."""
+    builder = PythonBundledBuilder()
+    with (
+        patch("shutil.which", return_value=None),
+        patch(
+            "lintro.tools.core.command_builders._is_compiled_binary",
+            return_value=True,
+        ),
+    ):
+        cmd = builder.get_command("ruff", ToolName.RUFF)
+        # Should return just [tool_name] when compiled
+        assert_that(cmd).is_equal_to(["ruff"])
 
 
 # =============================================================================
@@ -108,12 +129,33 @@ def test_pytest_builder_prefers_path_binary() -> None:
 def test_pytest_builder_falls_back_to_python_module() -> None:
     """PytestBuilder falls back to python -m pytest when not in PATH."""
     builder = PytestBuilder()
-    with patch("shutil.which", return_value=None):
+    with (
+        patch("shutil.which", return_value=None),
+        patch(
+            "lintro.tools.core.command_builders._is_compiled_binary",
+            return_value=False,
+        ),
+    ):
         cmd = builder.get_command("pytest", ToolName.PYTEST)
         # Should return [python_exe, "-m", "pytest"]
         assert_that(cmd).is_length(3)
         assert_that(cmd[1]).is_equal_to("-m")
         assert_that(cmd[2]).is_equal_to("pytest")
+
+
+def test_pytest_builder_skips_python_module_when_compiled() -> None:
+    """PytestBuilder skips python -m fallback when compiled."""
+    builder = PytestBuilder()
+    with (
+        patch("shutil.which", return_value=None),
+        patch(
+            "lintro.tools.core.command_builders._is_compiled_binary",
+            return_value=True,
+        ),
+    ):
+        cmd = builder.get_command("pytest", ToolName.PYTEST)
+        # Should return just ["pytest"] when compiled
+        assert_that(cmd).is_equal_to(["pytest"])
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes issue where Python tools like yamllint fail when lintro is installed via Homebrew or system package managers:
```
/opt/homebrew/Cellar/lintro/0.37.7/libexec/bin/python: No module named yamllint
```

**Root cause**: When lintro is installed via Homebrew, each Python tool (yamllint, ruff, etc.) is installed in its own separate venv. The previous `python -m <tool>` approach fails because the tool isn't in lintro's bundled Python environment.

## Changes

- Modified `PythonBundledBuilder.get_command()` to prefer PATH-based discovery
- Modified `PytestBuilder.get_command()` with the same pattern
- Updated tests to verify new behavior

## New behavior

1. First check if the tool binary exists in PATH using `shutil.which()`
2. If found, use the binary directly (e.g., `/usr/local/bin/yamllint`)
3. Fall back to `python -m <tool>` only if the tool isn't in PATH

## Supported installation methods

This works for all installation methods:
- Homebrew (each tool in its own venv)
- System packages (apt, dnf, etc.)
- pipx / uv tool install
- Traditional pip (binary usually ends up in PATH)

## Test plan

- [x] Unit tests for PATH-first behavior (`test_python_bundled_builder_prefers_path_binary`)
- [x] Unit tests for fallback behavior (`test_python_bundled_builder_falls_back_to_python_module`)
- [x] Same tests for PytestBuilder
- [x] All 30 command builder tests pass
- [x] Manual verification shows tools found in PATH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tool discovery now prefers system PATH binaries and logs decisions; falls back to invoking via Python module when absent and skips fallback when running as a compiled binary.

* **Removed Features**
  * DARGLINT tool support removed.

* **Tests**
  * Tests updated to simulate PATH presence/absence and validate PATH-first, fallback, and compiled-skip behaviors.

* **Documentation**
  * Docstrings updated to reflect PATH-first discovery and fallback behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->