### PR TITLE
fix(ci): add bun bin directory to GitHub Actions PATH

### DIFF
--- a/scripts/utils/bootstrap-env.sh
+++ b/scripts/utils/bootstrap-env.sh
@@ -96,8 +96,9 @@ fi
 # Early exit check for Docker-centric jobs
 if [ "${BOOTSTRAP_SKIP_SYNC:-0}" -eq 1 ] && [ "${BOOTSTRAP_SKIP_INSTALL_TOOLS:-0}" -eq 1 ]; then
 	log_info "Skipping remaining bootstrap steps (both BOOTSTRAP_SKIP_* flags set)"
-	if [ "$DRY_RUN" -eq 0 ] && [ -n "${GITHUB_PATH:-}" ] && [ -d "$HOME/.local/bin" ]; then
-		echo "$HOME/.local/bin" >>"$GITHUB_PATH"
+	if [ "$DRY_RUN" -eq 0 ] && [ -n "${GITHUB_PATH:-}" ]; then
+		[ -d "$HOME/.local/bin" ] && echo "$HOME/.local/bin" >>"$GITHUB_PATH"
+		[ -d "$HOME/.bun/bin" ] && echo "$HOME/.bun/bin" >>"$GITHUB_PATH"
 	fi
 	log_info "Early-exit complete (uv installed)"
 	exit 0
@@ -138,11 +139,18 @@ fi
 
 # Component 5: Ensure PATH persistence
 log_info "Step 5/5: Ensuring PATH persistence"
-if [ "$DRY_RUN" -eq 0 ] && [ -n "${GITHUB_PATH:-}" ] && [ -d "$HOME/.local/bin" ]; then
-	echo "$HOME/.local/bin" >>"$GITHUB_PATH"
-	log_info "Added $HOME/.local/bin to GitHub Actions PATH"
+if [ "$DRY_RUN" -eq 0 ] && [ -n "${GITHUB_PATH:-}" ]; then
+	if [ -d "$HOME/.local/bin" ]; then
+		echo "$HOME/.local/bin" >>"$GITHUB_PATH"
+		log_info "Added $HOME/.local/bin to GitHub Actions PATH"
+	fi
+	# Add bun global bin directory (used by prettier, markdownlint-cli2, biome)
+	if [ -d "$HOME/.bun/bin" ]; then
+		echo "$HOME/.bun/bin" >>"$GITHUB_PATH"
+		log_info "Added $HOME/.bun/bin to GitHub Actions PATH"
+	fi
 elif [ "$DRY_RUN" -eq 1 ]; then
-	log_info "[DRY-RUN] Would add $HOME/.local/bin to PATH"
+	log_info "[DRY-RUN] Would add $HOME/.local/bin and $HOME/.bun/bin to PATH"
 fi
 
 log_info "Environment bootstrap complete ✅"


### PR DESCRIPTION
## Summary

- Adds `$HOME/.bun/bin` to `GITHUB_PATH` in the bootstrap script
- Fixes "Command not found: markdownlint-cli2" error in CI workflows

## Problem

The `install-tools.sh` script installs `markdownlint-cli2`, `prettier`, and `biome` via `bun add -g`, which places them in `$HOME/.bun/bin`. However, `bootstrap-env.sh` only added `$HOME/.local/bin` to `GITHUB_PATH`, causing these tools to be unavailable in subsequent workflow steps.

The tools passed verification during bootstrap (because the bun installer temporarily exports the PATH), but failed when lintro ran in the next step.

**Failed run:** https://github.com/TurboCoder13/py-lintro/actions/runs/21336470223/job/61409131568

## Test plan

- [ ] Verify the `lintro-report-scheduled` workflow passes after merge
- [ ] Confirm `markdownlint-cli2` is found in subsequent workflow steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced PATH management in the bootstrap process to properly handle both local bin and bun binary directories.
  * Improved conditional checks and logging for environment variable persistence during setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->