### PR TITLE
fix(ci): resolve startup_failure in reusable tools-image workflow

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -39,16 +39,7 @@ permissions:
   contents: read
 
 jobs:
-  # Build tools image if tool files changed, otherwise use :latest
-  tools-image:
-    uses: ./.github/workflows/tools-image.yml
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-
   build-and-test:
-    needs: [tools-image]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     defaults:
@@ -60,8 +51,6 @@ jobs:
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.draft == false
-    env:
-      TOOLS_IMAGE: ${{ needs.tools-image.outputs.image-tag }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9
@@ -100,14 +89,6 @@ jobs:
       - name: Set up Docker Buildx
         # yamllint disable-line rule:line-length
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Log tools image tag
-        run: 'echo "Using tools image: $TOOLS_IMAGE"'
       - name: Build Docker image
         # yamllint disable-line rule:line-length
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
@@ -116,8 +97,6 @@ jobs:
           push: false
           load: true
           tags: py-lintro:latest
-          build-args: |
-            TOOLS_IMAGE=${{ env.TOOLS_IMAGE }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false
@@ -128,7 +107,7 @@ jobs:
         run: ./scripts/docker/docker-test.sh
 
   publish:
-    needs: [tools-image, build-and-test]
+    needs: build-and-test
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -138,8 +117,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      TOOLS_IMAGE: ${{ needs.tools-image.outputs.image-tag }}
     if: github.event_name == 'release' || (github.ref == 'refs/heads/main' && github.event_name == 'push') || (github.event_name == 'workflow_dispatch' && inputs.force_publish == 'true') # yamllint disable-line rule:line-length
     concurrency:
       group: docker-publish-${{ github.ref }}
@@ -214,8 +191,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            TOOLS_IMAGE=${{ env.TOOLS_IMAGE }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: true

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -24,16 +24,7 @@ permissions:
   contents: read
 
 jobs:
-  # Build tools image if tool files changed, otherwise use :latest
-  tools-image:
-    uses: ./.github/workflows/tools-image.yml
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-
   run-test-suite:
-    needs: [tools-image]
     permissions:
       contents: read
     runs-on: ubuntu-24.04
@@ -50,7 +41,6 @@ jobs:
     env:
       LINTRO_OUTPUT_DIR: /tmp/lintro
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      TOOLS_IMAGE: ${{ needs.tools-image.outputs.image-tag }}
     outputs:
       coverage-percentage: ${{ steps.coverage.outputs.percentage }}
     steps:
@@ -94,14 +84,6 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
           driver: docker
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Log tools image tag
-        run: 'echo "Using tools image: $TOOLS_IMAGE"'
       - name: Run comprehensive test suite (with Docker tests)
         run: ./scripts/docker/docker-test.sh
       # (moved) Upload coverage badge artifact happens after badge generation below

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -4,7 +4,6 @@
 name: Build - Tools Image
 # Builds and publishes the pre-built tools image used by the main Dockerfile.
 # Runs weekly to pick up base image security updates and on changes to tool configs.
-# Can be called as a reusable workflow by other workflows.
 
 'on':
   schedule:
@@ -17,7 +16,6 @@ name: Build - Tools Image
       - scripts/utils/install-tools.sh
       - scripts/ci/tools-image-*.sh
       - package.json
-      - lintro/_tool_versions.py
       - .github/workflows/tools-image.yml
   pull_request:
     branches: [main]
@@ -26,7 +24,6 @@ name: Build - Tools Image
       - scripts/utils/install-tools.sh
       - scripts/ci/tools-image-*.sh
       - package.json
-      - lintro/_tool_versions.py
       - .github/workflows/tools-image.yml
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
@@ -36,81 +33,27 @@ name: Build - Tools Image
         required: false
         default: 'false'
 
-  # Reusable workflow support
-  workflow_call:
-    inputs:
-      skip_if_unchanged:
-        description: 'Skip build if tool files unchanged (for workflow_call)'
-        type: boolean
-        default: true
-    outputs:
-      image-tag:
-        description: 'The tools image tag to use'
-        value: ${{ jobs.resolve-tag.outputs.tag }}
-
 permissions:
   contents: read
 
 jobs:
-  # Detect if tool files changed (for workflow_call only, path filters don't apply)
-  check-changes:
-    name: Check Tool Changes
-    runs-on: ubuntu-24.04
-    if: github.event_name == 'workflow_call'
-    permissions:
-      contents: read
-    outputs:
-      tools-changed: ${{ steps.filter.outputs.tools }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9
-        with:
-          egress-policy: 'block'
-          allowed-endpoints: >
-            github.com:443
-            api.github.com:443
-
-      - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Check for tool file changes
-        id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        with:
-          filters: |
-            tools:
-              - Dockerfile.tools
-              - scripts/utils/install-tools.sh
-              - scripts/ci/tools-image-*.sh
-              - package.json
-              - lintro/_tool_versions.py
-              - .github/workflows/tools-image.yml
-
   build-tools-image:
     name: Build Tools Image
     runs-on: ubuntu-24.04
-    needs: [check-changes]
-    # Run if: not workflow_call, OR changes detected, OR skip_if_unchanged=false
-    if: >-
-      (github.event_name != 'workflow_call') ||
-      (needs.check-changes.outputs.tools-changed == 'true') ||
-      (inputs.skip_if_unchanged == false)
     permissions:
       contents: read
       packages: write
       id-token: write
     timeout-minutes: 45
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
     defaults:
       run:
         shell: bash
     concurrency:
       group: tools-image-${{ github.ref }}
       cancel-in-progress: true
-    outputs:
-      primary-tag: ${{ steps.tags.outputs.primary_tag }}
 
     steps:
       - name: Harden Runner
@@ -201,26 +144,3 @@ jobs:
           PUSH_LATEST: ${{ steps.tags.outputs.push_latest }}
           PR_TAG: ${{ steps.tags.outputs.pr_tag }}
         run: scripts/ci/tools-image-summary.sh
-
-  # Output the appropriate image tag for callers
-  resolve-tag:
-    name: Resolve Image Tag
-    runs-on: ubuntu-24.04
-    needs: [check-changes, build-tools-image]
-    if: always() && github.event_name == 'workflow_call'
-    permissions:
-      contents: read
-    outputs:
-      tag: ${{ steps.resolve.outputs.tag }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-        with:
-          persist-credentials: false
-
-      - name: Resolve image tag
-        id: resolve
-        env:
-          BUILD_TAG: ${{ needs.build-tools-image.outputs.primary-tag }}
-          BUILD_RESULT: ${{ needs.build-tools-image.result }}
-        run: scripts/ci/tools-image-resolve-tag.sh


### PR DESCRIPTION
## Summary

Fixes the `startup_failure` issue that has been breaking CI for all branches since PR #464 was merged.

**Root Cause**: The `workflow_call` trigger configuration in `tools-image.yml` was causing GitHub Actions to fail at workflow parsing before any jobs could run. Despite passing local validation (actionlint, yamllint), something about the reusable workflow pattern wasn't compatible with GitHub Actions' parser.

**Impact**: All workflow runs for:
- `Testing - Full Suite & Coverage`
- `Build - Docker Image & Registry`  
- `Build - Tools Image`

Were failing with `startup_failure` and not appearing as PR checks at all (silent failure).

## Solution

This PR **reverts PR #464** to restore CI functionality:

- Removes `workflow_call` trigger from `tools-image.yml`
- Removes reusable workflow calls from `test-and-coverage.yml` and `docker-build-publish.yml`
- Restores the original single-job structure in `tools-image.yml`

The reusable workflow feature can be re-implemented later after proper investigation of why the `workflow_call` trigger caused startup failures.

## Test Plan

- [x] CI workflow starts successfully (no `startup_failure`)
- [ ] Tests run and pass
- [ ] Coverage is reported correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline workflows for improved build efficiency and streamlined PR-specific image resolution.
  * Reorganized workflow dependencies to simplify build orchestration and reduce redundant processing steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->