### PR TITLE
fix(clippy): preserve subprocess output when tool fails with no issues

### DIFF
--- a/lintro/tools/definitions/clippy.py
+++ b/lintro/tools/definitions/clippy.py
@@ -368,8 +368,9 @@ class ClippyPlugin(BaseToolPlugin):
         remaining_count = len(remaining_issues)
         fixed_count = max(0, initial_count - remaining_count)
 
-        # Preserve output when fix leaves remaining issues with no parsed output
-        should_show_output = remaining_count > 0 and len(remaining_issues) == 0
+        # Preserve output when command fails but no issues were parsed
+        # This allows users to see error messages like compilation failures
+        should_show_output = not success_after and remaining_count == 0
 
         return ToolResult(
             name=self.definition.name,


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Fixes Clippy showing no diagnostic output when the tool fails.

- Preserves subprocess output in `ToolResult.output` when the command fails but no issues are parsed
- Allows users to see helpful error messages like "cargo clippy not found" or compilation errors
- Adds `# mypy: ignore-errors` directive to work around lintro mypy execution bug (#492)

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

Closes #488

## Details

**Implementation:**
Modified `check()` and `fix()` methods in `clippy.py` to conditionally preserve output:

```python
should_show_output = not success_cmd and issues_count == 0
return ToolResult(
    name=self.definition.name,
    success=bool(success_cmd),
    output=output if should_show_output else None,
    ...
)
```

This ensures that when Clippy fails (e.g., cargo not found, compilation errors) but produces no parsed issues, the raw subprocess output is preserved for debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved output handling in the Clippy tool to preserve and display debugging information when command failures occur or issues cannot be parsed. This enhancement provides better visibility for troubleshooting edge cases and diagnosing unexpected tool behavior while maintaining normal operation in standard scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->