### PR TITLE
fix(ci): resolve build failures and slow Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,8 @@ COPY --from=builder /usr/local/bin/cargo-clippy /usr/local/bin/
 COPY --from=builder /usr/local/bin/uv /usr/local/bin/
 COPY --from=builder /usr/local/bin/bun /usr/local/bin/
 COPY --from=builder /root/.bun/install/global /opt/bun/install/global
-COPY --from=builder /root/.cargo /home/lintro/.cargo
-COPY --from=builder /root/.rustup /home/lintro/.rustup
+COPY --chown=lintro:lintro --from=builder /root/.cargo /home/lintro/.cargo
+COPY --chown=lintro:lintro --from=builder /root/.rustup /home/lintro/.rustup
 
 # Set Rust environment for lintro user and bun global install location
 # RUFF_CACHE_DIR set to /tmp to avoid permission issues with mounted volumes
@@ -118,8 +118,8 @@ COPY scripts/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY scripts/docker/fix-permissions.sh /usr/local/bin/fix-permissions.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/fix-permissions.sh
 
-# Create /code directory for volume mounts and fix Rust directory ownership
-RUN mkdir -p /code && chown -R lintro:lintro /app /code /home/lintro/.cargo /home/lintro/.rustup
+# Create /code directory for volume mounts and set ownership
+RUN mkdir -p /code && chown -R lintro:lintro /app /code
 
 # Health check to verify lintro is working
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \

--- a/scripts/build/build_macos.py
+++ b/scripts/build/build_macos.py
@@ -86,7 +86,6 @@ def build_macos_binary(arch: str = "arm64", verbose: bool = False) -> int:
         "--assume-yes-for-downloads",
         # macOS-specific options
         f"--macos-target-arch={arch}",
-        "--macos-app-mode=console",
         # Include all lintro packages
     ]
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): resolve build failures and slow Docker builds
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Two fixes for CI build issues:

1. **Nuitka build fix**: Remove invalid `--macos-app-mode=console` option from macOS binary build script. This option no longer exists in current Nuitka versions, causing the Build Binary workflow to fail.

2. **Docker build speed fix**: Use `--chown=lintro:lintro` on COPY commands for `.cargo` and `.rustup` directories instead of running a recursive `chown` afterward. The Rust toolchain directories contain thousands of files, and the recursive chown was taking ~10+ minutes.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (N/A - CI config changes)
- [ ] Docs updated if user-facing (N/A - not user-facing)
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #463

## Details

### Nuitka Fix
The `--macos-app-mode` option was removed or changed in recent Nuitka versions. For CLI applications, the default behavior is correct, so we simply remove the option.

### Docker Build Fix
Before:
```dockerfile
COPY --from=builder /root/.cargo /home/lintro/.cargo
COPY --from=builder /root/.rustup /home/lintro/.rustup
# ... later ...
RUN chown -R lintro:lintro /app /code /home/lintro/.cargo /home/lintro/.rustup
```

After:
```dockerfile
COPY --chown=lintro:lintro --from=builder /root/.cargo /home/lintro/.cargo
COPY --chown=lintro:lintro --from=builder /root/.rustup /home/lintro/.rustup
# ... later ...
RUN chown -R lintro:lintro /app /code
```

Using `--chown` on COPY sets ownership during the copy operation (essentially free), avoiding the expensive recursive chown on directories with thousands of Rust toolchain files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to optimize image layer ownership settings.
  * Adjusted macOS build process configuration.

**Note:** These are internal build and infrastructure improvements with no impact on end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->