### PR TITLE
fix(ci): add always() to force build job evaluation

### DIFF
--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -85,11 +85,13 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [check-changes]
     # Run if: check-changes was skipped (non-workflow_call), OR changes detected,
-    # OR skip_if_unchanged=false
+    # OR skip_if_unchanged=false. Use always() to force evaluation when dependency
+    # is skipped.
     if: >-
-      (needs.check-changes.result == 'skipped') ||
+      always() &&
+      ((needs.check-changes.result == 'skipped') ||
       (needs.check-changes.outputs.tools-changed == 'true') ||
-      (inputs.skip_if_unchanged == false)
+      (inputs.skip_if_unchanged == false))
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
- Fix tools-image workflow to run on workflow_dispatch and push events

## Problem
When the `check-changes` job is skipped (due to its `if: github.event_name == 'workflow_call'` condition), GitHub Actions skips dependent jobs **by default before evaluating their `if` conditions**.

This caused the `build-tools-image` job to be skipped even though its condition `needs.check-changes.result == 'skipped'` should have been true.

## Solution
Add `always() &&` to force the build job's `if` condition to be evaluated regardless of dependency status.

## Test plan
- [ ] Verify workflow runs on push to main
- [ ] Verify workflow runs on workflow_dispatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow logic to improve build process reliability and ensure proper job evaluation under all circumstances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->