### PR TITLE
fix: update tools image digest and ensure Python CLI tools in Docker

### DIFF
--- a/.github/actions/resolve-tools-image/action.yml
+++ b/.github/actions/resolve-tools-image/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: Full stable image reference (may differ during migrations)
     required: false
     # yamllint disable-line rule:line-length
-    default: ghcr.io/lgtm-hq/lintro-tools:latest@sha256:b3940578b3fa10215d2ba4accba89250753360ec6f34cebe2dc588694084dad4
+    default: ghcr.io/lgtm-hq/lintro-tools:latest@sha256:e145d4f4942fd3165c4406fabbe34d98edbe02aabb4d99cd71e8db79b0116c8f
 outputs:
   image:
     description: Full tools image reference to use (either fresh pr-N or stable)

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Use the pre-built tools image to avoid rebuilding tools on every CI run.
 # TOOLS_IMAGE can be overridden at build time (e.g., for PR testing with new tools)
 # yamllint disable-line rule:line-length
-ARG TOOLS_IMAGE=ghcr.io/lgtm-hq/lintro-tools:latest@sha256:b3940578b3fa10215d2ba4accba89250753360ec6f34cebe2dc588694084dad4
+ARG TOOLS_IMAGE=ghcr.io/lgtm-hq/lintro-tools:latest@sha256:e145d4f4942fd3165c4406fabbe34d98edbe02aabb4d99cd71e8db79b0116c8f
 # hadolint ignore=DL3006
 FROM ${TOOLS_IMAGE} AS tools
 

--- a/scripts/local/run-tests.sh
+++ b/scripts/local/run-tests.sh
@@ -26,7 +26,7 @@ setup_python_env() {
 		if [ ! -x "/app/.venv/bin/python" ]; then
 			echo -e "${YELLOW}Detected missing /app/.venv; rebuilding venv with uv...${NC}"
 			export UV_LINK_MODE=${UV_LINK_MODE:-copy}
-			uv sync --dev --no-progress
+			uv sync --dev --extra tools --no-progress
 		fi
 	else
 		echo -e "${YELLOW}Running in local environment${NC}"


### PR DESCRIPTION
## Summary
- Update stable-image digest to `e145d4f4` in resolve-tools-image action
- Update TOOLS_IMAGE digest in Dockerfile to match
- Add `--extra tools` to `uv sync` in run-tests.sh for Docker environments

## Problem
After PR #508 merged, CI tests were failing because:
1. The stable-image digest in `resolve-tools-image/action.yml` was outdated (pointing to old tools image missing prettier 3.8.1, oxlint, oxfmt, tsc)
2. When running tests in Docker, if the venv needed to be rebuilt, `run-tests.sh` was missing `--extra tools` which meant semgrep and sqlfluff weren't installed, causing 26 test skips

## Solution
1. Updated the tools image SHA256 digest to `e145d4f4942fd3165c4406fabbe34d98edbe02aabb4d99cd71e8db79b0116c8f` in both:
   - `.github/actions/resolve-tools-image/action.yml`
   - `Dockerfile`
2. Added `--extra tools` flag to the `uv sync` command in `scripts/local/run-tests.sh` so Docker test runs include semgrep and sqlfluff

## Test plan
- [x] Built Docker image locally with fixes
- [x] Ran full test suite in Docker: **3462 passed, 0 failed, 0 skipped**
- [x] Verified all previously skipped tests (semgrep, sqlfluff) now run

Fixes #478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build tools and dependencies to the latest version.
  * Enhanced test environment configuration with additional tooling dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->