### PR TITLE
fix: use package.json as single source of truth for npm tool versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -182,164 +182,156 @@
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
+      "description": "Update hadolint version in _tool_versions.py",
       "customType": "regex",
       "managerFilePatterns": [
         "lintro/_tool_versions\\.py"
       ],
       "matchStrings": [
-        "\"hadolint\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+        "ToolName\\.HADOLINT:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
       ],
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "hadolint/hadolint",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
+      "description": "Update actionlint version in _tool_versions.py",
       "customType": "regex",
       "managerFilePatterns": [
         "lintro/_tool_versions\\.py"
       ],
       "matchStrings": [
-        "\"actionlint\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+        "ToolName\\.ACTIONLINT:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
       ],
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "rhysd/actionlint",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
+      "description": "Update gitleaks version in _tool_versions.py",
       "customType": "regex",
       "managerFilePatterns": [
         "lintro/_tool_versions\\.py"
       ],
       "matchStrings": [
-        "\"prettier\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
-      ],
-      "datasourceTemplate": "npm",
-      "packageNameTemplate": "prettier"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "lintro/_tool_versions\\.py"
-      ],
-      "matchStrings": [
-        "\"oxlint\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
-      ],
-      "datasourceTemplate": "npm",
-      "packageNameTemplate": "oxlint"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "lintro/_tool_versions\\.py"
-      ],
-      "matchStrings": [
-        "\"oxfmt\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
-      ],
-      "datasourceTemplate": "npm",
-      "packageNameTemplate": "oxfmt"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "lintro/_tool_versions\\.py"
-      ],
-      "matchStrings": [
-        "\"markdownlint\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
-      ],
-      "datasourceTemplate": "npm",
-      "packageNameTemplate": "markdownlint-cli2"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "lintro/_tool_versions\\.py"
-      ],
-      "matchStrings": [
-        "\"gitleaks\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+        "ToolName\\.GITLEAKS:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
       ],
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "gitleaks/gitleaks",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
+      "description": "Update shellcheck version in _tool_versions.py",
       "customType": "regex",
       "managerFilePatterns": [
         "lintro/_tool_versions\\.py"
       ],
       "matchStrings": [
-        "\"shellcheck\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+        "ToolName\\.SHELLCHECK:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
       ],
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "koalaman/shellcheck",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
+      "description": "Update shfmt version in _tool_versions.py",
       "customType": "regex",
       "managerFilePatterns": [
         "lintro/_tool_versions\\.py"
       ],
       "matchStrings": [
-        "\"shfmt\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+        "ToolName\\.SHFMT:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
       ],
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "mvdan/sh",
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
+      "description": "Update taplo version in _tool_versions.py",
       "customType": "regex",
       "managerFilePatterns": [
         "lintro/_tool_versions\\.py"
       ],
       "matchStrings": [
-        "\"taplo\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+        "ToolName\\.TAPLO:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
       ],
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "tamasfe/taplo",
       "extractVersionTemplate": "^release-taplo-(?<version>.*)$"
     },
     {
+      "description": "Update semgrep version in _tool_versions.py",
       "customType": "regex",
       "managerFilePatterns": [
         "lintro/_tool_versions\\.py"
       ],
       "matchStrings": [
-        "\"semgrep\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+        "ToolName\\.SEMGREP:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
       ],
       "datasourceTemplate": "pypi",
       "packageNameTemplate": "semgrep"
     },
     {
+      "description": "Update sqlfluff version in _tool_versions.py",
       "customType": "regex",
       "managerFilePatterns": [
         "lintro/_tool_versions\\.py"
       ],
       "matchStrings": [
-        "\"sqlfluff\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+        "ToolName\\.SQLFLUFF:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
       ],
       "datasourceTemplate": "pypi",
       "packageNameTemplate": "sqlfluff"
     },
     {
+      "description": "Update pytest version in _tool_versions.py",
       "customType": "regex",
       "managerFilePatterns": [
         "lintro/_tool_versions\\.py"
       ],
       "matchStrings": [
-        "\"pytest\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+        "ToolName\\.PYTEST:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
       ],
       "datasourceTemplate": "pypi",
       "packageNameTemplate": "pytest"
     },
     {
+      "description": "Update cargo-audit version in _tool_versions.py",
       "customType": "regex",
       "managerFilePatterns": [
         "lintro/_tool_versions\\.py"
       ],
       "matchStrings": [
-        "\"cargo_audit\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+        "ToolName\\.CARGO_AUDIT:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
       ],
       "datasourceTemplate": "crate",
       "packageNameTemplate": "cargo-audit"
+    },
+    {
+      "description": "Update clippy version in _tool_versions.py",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "lintro/_tool_versions\\.py"
+      ],
+      "matchStrings": [
+        "ToolName\\.CLIPPY:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+      ],
+      "datasourceTemplate": "github-tags",
+      "packageNameTemplate": "rust-lang/rust-clippy",
+      "extractVersionTemplate": "^rust-(?<version>.*)$"
+    },
+    {
+      "description": "Update rustfmt version in _tool_versions.py",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "lintro/_tool_versions\\.py"
+      ],
+      "matchStrings": [
+        "ToolName\\.RUSTFMT:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+      ],
+      "datasourceTemplate": "github-tags",
+      "packageNameTemplate": "rust-lang/rustfmt",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "schedule": ["after 22:00", "before 23:00"],

--- a/scripts/ci/verify-tool-version-sync.py
+++ b/scripts/ci/verify-tool-version-sync.py
@@ -1,157 +1,88 @@
 #!/usr/bin/env python3
-"""Verify tool versions are synchronized between package.json and _tool_versions.py.
+"""Verify tool versions are correctly loaded from their sources.
 
-This script ensures that npm packages managed by Renovate in package.json
-have matching versions in lintro/_tool_versions.py.
+This script validates that:
+1. npm tool versions are correctly read from package.json
+2. Non-npm tool versions are defined in _tool_versions.py
+3. All expected tools have versions available
 
 Exit codes:
-    0: All versions are synchronized
-    1: Version mismatch detected or error occurred
+    0: All versions are correctly loaded
+    1: Missing versions or error occurred
 """
 
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
-# Map npm package names to lintro tool names
-# These are tools that exist in both package.json and _tool_versions.py
-NPM_TOOL_MAPPING: dict[str, str] = {
-    "prettier": "prettier",
-    "markdownlint-cli2": "markdownlint",
-    "oxlint": "oxlint",
-    "oxfmt": "oxfmt",
-    "typescript": "tsc",
-}
-
-
-def strip_caret(version: str) -> str:
-    """Strip caret prefix from npm version string."""
-    return version.lstrip("^~")
-
-
-def load_package_json(project_root: Path) -> dict[str, str]:
-    """Load and parse package.json, returning devDependencies versions."""
-    package_json_path = project_root / "package.json"
-    if not package_json_path.exists():
-        print(f"ERROR: package.json not found at {package_json_path}", file=sys.stderr)
-        sys.exit(1)
-
-    with package_json_path.open() as f:
-        data = json.load(f)
-
-    dev_deps = data.get("devDependencies", {})
-    deps = data.get("dependencies", {})
-
-    # Merge, with devDependencies taking precedence
-    all_deps = {**deps, **dev_deps}
-
-    return {pkg: strip_caret(ver) for pkg, ver in all_deps.items()}
-
-
-def load_tool_versions(project_root: Path) -> dict[str, str]:
-    """Load tool versions from _tool_versions.py using get_tool_version."""
-    import runpy
-
-    sys.path.insert(0, str(project_root))
-    tool_versions_path = project_root / "lintro" / "_tool_versions.py"
-
-    if not tool_versions_path.exists():
-        print(
-            f"ERROR: _tool_versions.py not found at {tool_versions_path}",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    mod = runpy.run_path(str(tool_versions_path))
-    get_tool_version = mod["get_tool_version"]
-
-    versions = {}
-    for npm_pkg, tool_name in NPM_TOOL_MAPPING.items():
-        version = get_tool_version(tool_name)
-        if version:
-            versions[npm_pkg] = version
-
-    return versions
-
 
 def main() -> int:
-    """Check for version mismatches between package.json and _tool_versions.py."""
+    """Verify tool versions are correctly loaded."""
     # Find project root (script is in scripts/ci/)
     script_path = Path(__file__).resolve()
     project_root = script_path.parent.parent.parent
 
-    print(f"Checking version sync in: {project_root}")
+    print(f"Checking version loading in: {project_root}")
     print()
 
-    package_versions = load_package_json(project_root)
-    tool_versions = load_tool_versions(project_root)
+    # Add project to path for imports
+    sys.path.insert(0, str(project_root))
 
-    mismatches: list[tuple[str, str, str, str]] = []
-    missing_in_tools: list[str] = []
-    missing_in_package_json: list[str] = []
+    from lintro._tool_versions import (
+        _NPM_PACKAGE_TO_TOOL,
+        TOOL_VERSIONS,
+        get_tool_version,
+        is_npm_managed,
+    )
+    from lintro.enums.tool_name import ToolName
 
-    for npm_pkg, tool_name in NPM_TOOL_MAPPING.items():
-        pkg_version = package_versions.get(npm_pkg)
-        tool_version = tool_versions.get(npm_pkg)
+    errors: list[str] = []
 
-        if pkg_version is None:
-            missing_in_package_json.append(npm_pkg)
-            continue
+    # Check that all npm-managed tools have versions from package.json
+    print("npm-managed tools (from package.json):")
+    for npm_pkg, tool_name in _NPM_PACKAGE_TO_TOOL.items():
+        version = get_tool_version(tool_name)
+        if version:
+            print(f"  ✓ {tool_name.value} ({npm_pkg}): {version}")
+        else:
+            errors.append(f"npm tool '{tool_name.value}' ({npm_pkg}) has no version")
+            print(f"  ✗ {tool_name.value} ({npm_pkg}): MISSING")
 
-        if tool_version is None:
-            missing_in_tools.append(npm_pkg)
-            continue
-
-        if pkg_version != tool_version:
-            mismatches.append((npm_pkg, tool_name, pkg_version, tool_version))
-
-    # Report results
-    if not mismatches and not missing_in_tools and not missing_in_package_json:
-        print("✓ All tool versions are synchronized")
-        print()
-        print("Checked packages:")
-        for npm_pkg, tool_name in NPM_TOOL_MAPPING.items():
-            pkg_version = package_versions.get(npm_pkg)
-            if pkg_version:
-                print(f"  {npm_pkg} ({tool_name}): {pkg_version}")
-        return 0
-
-    print("✗ Version synchronization issues found:")
     print()
 
-    if mismatches:
-        print("Version mismatches:")
-        print("-" * 60)
-        print(f"{'Package':<20} {'package.json':<15} {'_tool_versions.py':<15}")
-        print("-" * 60)
-        for npm_pkg, _tool_name, pkg_ver, tool_ver in mismatches:
-            print(f"{npm_pkg:<20} {pkg_ver:<15} {tool_ver:<15}")
-        print()
+    # Check that all non-npm tools have versions
+    print("Non-npm tools (from _tool_versions.py):")
+    for tool_name_key, version in TOOL_VERSIONS.items():
+        if isinstance(tool_name_key, ToolName):
+            print(f"  ✓ {tool_name_key.value}: {version}")
 
-    if missing_in_tools:
-        print("Missing from _tool_versions.py:")
-        for pkg in missing_in_tools:
-            pkg_version = package_versions.get(pkg, "unknown")
-            print(f"  {pkg}: {pkg_version}")
-        print()
-
-    if missing_in_package_json:
-        print("Missing from package.json (but in NPM_TOOL_MAPPING):")
-        for pkg in missing_in_package_json:
-            tool_version = tool_versions.get(pkg, "unknown")
-            print(f"  {pkg}: {tool_version} (in _tool_versions.py)")
-        print()
-
-    print("To fix:")
-    print("  1. Update lintro/_tool_versions.py to match package.json versions")
-    print("  2. Or update package.json to match _tool_versions.py versions")
-    print("  3. If a package was intentionally removed, update NPM_TOOL_MAPPING")
     print()
-    print("Renovate should keep these in sync, but manual updates may cause drift.")
 
-    return 1
+    # Verify is_npm_managed returns correct values
+    print("Verifying npm-managed detection:")
+    for tool_name in _NPM_PACKAGE_TO_TOOL.values():
+        if not is_npm_managed(tool_name):
+            errors.append(f"is_npm_managed({tool_name}) should be True")
+            print(f"  ✗ {tool_name.value} should be npm-managed")
+        else:
+            print(f"  ✓ {tool_name.value} correctly identified as npm-managed")
+
+    for tool_name_key in TOOL_VERSIONS:
+        if isinstance(tool_name_key, ToolName) and is_npm_managed(tool_name_key):
+            errors.append(f"is_npm_managed({tool_name_key}) should be False")
+            print(f"  ✗ {tool_name_key.value} should NOT be npm-managed")
+
+    print()
+
+    if errors:
+        print("✗ Errors found:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print("✓ All tool versions are correctly loaded from their sources")
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/unit/core/test_version_requirements.py
+++ b/tests/unit/core/test_version_requirements.py
@@ -148,7 +148,7 @@ def test_get_min_version_returns_version_for_registered_tools(
 
 def test_get_min_version_raises_keyerror_for_unknown_tool() -> None:
     """Test that get_min_version raises KeyError for unknown tools."""
-    with pytest.raises(KeyError, match="not found in TOOL_VERSIONS"):
+    with pytest.raises(KeyError, match="not found"):
         get_min_version("nonexistent_tool")  # type: ignore[arg-type]
 
 
@@ -159,8 +159,33 @@ def test_tool_versions_uses_toolname_enum_keys() -> None:
 
 
 def test_all_external_tools_registered_in_tool_versions() -> None:
-    """Test that all expected external tools are in TOOL_VERSIONS."""
-    expected_tools = {
+    """Test that all expected external tools have versions available.
+
+    npm-managed tools (markdownlint, oxfmt, oxlint, prettier, tsc) are
+    read from package.json at runtime. Non-npm tools are in TOOL_VERSIONS.
+    """
+    from lintro._tool_versions import get_all_expected_versions
+
+    # Non-npm tools should be in TOOL_VERSIONS
+    expected_non_npm_tools = {
+        ToolName.ACTIONLINT,
+        ToolName.CARGO_AUDIT,
+        ToolName.CLIPPY,
+        ToolName.GITLEAKS,
+        ToolName.HADOLINT,
+        ToolName.PYTEST,
+        ToolName.RUSTFMT,
+        ToolName.SEMGREP,
+        ToolName.SHELLCHECK,
+        ToolName.SHFMT,
+        ToolName.SQLFLUFF,
+        ToolName.TAPLO,
+    }
+    assert_that(set(TOOL_VERSIONS.keys())).is_equal_to(expected_non_npm_tools)
+
+    # All tools (including npm-managed) should be available via get_all_expected_versions
+    all_versions = get_all_expected_versions()
+    expected_all_tools = {
         ToolName.ACTIONLINT,
         ToolName.CARGO_AUDIT,
         ToolName.CLIPPY,
@@ -179,7 +204,7 @@ def test_all_external_tools_registered_in_tool_versions() -> None:
         ToolName.TAPLO,
         ToolName.TSC,
     }
-    assert_that(set(TOOL_VERSIONS.keys())).is_equal_to(expected_tools)
+    assert_that(set(all_versions.keys())).is_equal_to(expected_all_tools)
 
 
 def test_get_tool_version_returns_version_for_toolname_enum() -> None:


### PR DESCRIPTION
## Summary

This PR fixes the version mismatch issue between `package.json` and `_tool_versions.py` by implementing a single-source-of-truth architecture for tool versions.

### Problem

The CI was failing because `package.json` had typescript at `5.9.3` while `_tool_versions.py` had `5.7.3`. The Renovate custom managers for npm tools in `_tool_versions.py` were also broken - they used regex patterns like `"prettier":\s*"..."` but the actual file format uses `ToolName.PRETTIER: "..."`.

### Solution

- **npm tools** (typescript, prettier, markdownlint-cli2, oxlint, oxfmt): Now read directly from `package.json` at runtime
  - Renovate's native npm manager handles updates automatically
  - No duplication, no sync issues by design
- **Non-npm tools** (hadolint, actionlint, shellcheck, shfmt, gitleaks, taplo, semgrep, sqlfluff, cargo_audit, clippy, rustfmt, pytest): Remain in `TOOL_VERSIONS`
  - Fixed Renovate regex patterns to match actual `ToolName.X: "version"` format
  - Added missing clippy and rustfmt managers

### Changes

- `lintro/_tool_versions.py`: Added `_load_npm_versions()` to read from package.json, removed npm tools from hardcoded dict
- `lintro/tools/core/version_checking.py`: Updated to use new API
- `renovate.json`: Fixed regex patterns for non-npm tools, removed broken npm tool managers
- `scripts/ci/verify-tool-version-sync.py`: Simplified to verify the new architecture
- `tests/unit/core/test_version_requirements.py`: Updated tests to reflect new structure

## Test plan

- [x] `uv run lintro chk` - All linting passes
- [x] `uv run lintro tst` - All 3462 tests pass
- [x] `uv run python scripts/ci/verify-tool-version-sync.py` - Verification passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for npm-managed tool versions loaded from package.json at runtime, alongside traditional hard-coded versions
  * New capability to determine whether a tool's version is managed through npm

* **Improvements**
  * Implemented hybrid tool version resolution supporting both npm-managed and non-npm tools
  * Enhanced version discovery to check multiple sources for improved flexibility in version management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->