### PR TITLE
fix: allow special characters in subprocess arguments with shell=False

### DIFF
--- a/lintro/tools/core/version_checking.py
+++ b/lintro/tools/core/version_checking.py
@@ -56,16 +56,14 @@ def _get_version_timeout() -> int:
         timeout = int(env_value)
     except (TypeError, ValueError):
         logger.warning(
-            "Invalid LINTRO_VERSION_TIMEOUT '%s'; using default %s",
-            env_value,
-            default_timeout,
+            f"Invalid LINTRO_VERSION_TIMEOUT '{env_value}'; "
+            f"using default {default_timeout}",
         )
         return default_timeout
 
     if timeout < 1:
         logger.warning(
-            "LINTRO_VERSION_TIMEOUT must be >= 1; using default %s",
-            default_timeout,
+            f"LINTRO_VERSION_TIMEOUT must be >= 1; using default {default_timeout}",
         )
         return default_timeout
 
@@ -168,8 +166,7 @@ def get_install_hints() -> dict[str, str]:
     missing = set(versions) - set(templates)
     if missing:
         logger.warning(
-            "Missing install hints for tools: %s",
-            ", ".join(sorted(missing)),
+            f"Missing install hints for tools: {', '.join(sorted(missing))}",
         )
 
     return hints

--- a/tests/unit/plugins/base/test_subprocess.py
+++ b/tests/unit/plugins/base/test_subprocess.py
@@ -188,16 +188,33 @@ def test_validate_subprocess_command_non_string_argument(
         fake_tool_plugin._validate_subprocess_command(["ls", 123])  # type: ignore[list-item]
 
 
-def test_validate_subprocess_command_unsafe_characters(
+def test_validate_subprocess_command_unsafe_characters_in_command_name(
     fake_tool_plugin: FakeToolPlugin,
 ) -> None:
-    """Verify command with shell injection characters raises ValueError.
+    """Verify command with shell injection characters in name raises ValueError.
+
+    Only the command name (first element) is validated for unsafe characters.
+    Arguments can contain special characters since shell=False passes them
+    literally to the subprocess.
 
     Args:
         fake_tool_plugin: Fixture providing a FakeToolPlugin instance.
     """
     with pytest.raises(ValueError, match="Unsafe character"):
-        fake_tool_plugin._validate_subprocess_command(["ls", "-la; rm -rf /"])
+        fake_tool_plugin._validate_subprocess_command(["ls;rm", "-la"])
+
+
+def test_validate_subprocess_command_special_chars_allowed_in_args(
+    fake_tool_plugin: FakeToolPlugin,
+) -> None:
+    """Verify special characters in arguments are allowed with shell=False.
+
+    Args:
+        fake_tool_plugin: Fixture providing a FakeToolPlugin instance.
+    """
+    # Should NOT raise - shell=False makes these safe
+    fake_tool_plugin._validate_subprocess_command(["ls", "-la; rm -rf /"])
+    fake_tool_plugin._validate_subprocess_command(["semgrep", "--include", "*.py"])
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Fix logger formatting bug: Changed printf-style `%s` to f-strings in `version_checking.py` (loguru doesn't interpret `%s`, causing literal `"Missing install hints for tools: %s"` output)
- Fix overly restrictive subprocess validation: Allow special characters (`$`, `*`, `{`, `}`, etc.) in command **arguments** while still blocking them in the command **name**

## Problem
When running lintro's Docker image on projects with files containing special characters in paths (e.g., `$var.py`, `{{template}}/`), **all tools** would fail with:
```
Failed to run Semgrep: Unsafe character detected in command argument
```

The validation was designed for shell injection prevention, but since lintro uses `shell=False`, arguments are passed literally without shell interpretation—making these characters safe.

## Changes
| File | Change |
|------|--------|
| `subprocess_executor.py` | Only validate command name (first element), not arguments |
| `version_checking.py` | Fix `%s` → f-string for loguru compatibility |
| `test_subprocess.py` | Update tests for new validation behavior |
| `test_subprocess_injection.py` | Comprehensive tests for command name validation + argument allowance |

## Test plan
- [x] All 3476 tests pass
- [x] Linting passes with 0 issues
- [x] Security tests verify command name is still validated
- [x] New tests confirm special chars in arguments are allowed (glob patterns, template paths, Semgrep metavariables)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined subprocess command validation to properly allow special characters in command arguments while maintaining security protections on command names. This improves execution flexibility for complex commands.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->