### PR TITLE
fix(ci): gate manifest sync check on PRs and align semgrep version

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -85,6 +85,44 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ============================================================================
+  # Stage 1b: Verify manifest/pyproject version sync (lightweight, no Docker)
+  # ============================================================================
+  manifest-sync:
+    name: 📋 Manifest Sync
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            release-assets.githubusercontent.com:443
+            objects.githubusercontent.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            astral.sh:443
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Environment setup
+        uses: ./.github/actions/setup-env
+        with:
+          python-version: '3.13'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOOTSTRAP_SKIP_INSTALL_TOOLS: '1'
+      - name: Verify manifest sync
+        run: python3 scripts/ci/verify-manifest-sync.py
+
+  # ============================================================================
   # Stage 2: Build Docker image ONCE (cached for all subsequent stages)
   # ============================================================================
   docker-build:
@@ -186,7 +224,7 @@ jobs:
   # ============================================================================
   lint:
     name: 🛠️ Lintro Code Quality
-    needs: [resolve-tools, docker-build]
+    needs: [resolve-tools, docker-build, manifest-sync]
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/lintro/tools/manifest.json
+++ b/lintro/tools/manifest.json
@@ -111,7 +111,7 @@
     },
     {
       "name": "semgrep",
-      "version": "1.85.0",
+      "version": "1.151.0",
       "install": { "type": "pip", "package": "semgrep" },
       "tier": "tools"
     },

--- a/tests/unit/parsers/test_semgrep_parser.py
+++ b/tests/unit/parsers/test_semgrep_parser.py
@@ -13,6 +13,7 @@ from assertpy import assert_that
 from lintro.models.core.tool_result import ToolResult
 from lintro.parsers.semgrep.semgrep_parser import parse_semgrep_output
 from lintro.plugins import ToolRegistry
+from lintro.tools.core.version_parsing import get_minimum_versions
 
 
 def test_parse_semgrep_valid_output() -> None:
@@ -379,7 +380,7 @@ def test_semgrep_tool_definition() -> None:
     assert_that(defn.name).is_equal_to("semgrep")
     assert_that(defn.can_fix).is_false()
     assert_that(defn.tool_type).is_equal_to(ToolType.LINTER | ToolType.SECURITY)
-    assert_that(defn.min_version).is_equal_to("1.85.0")
+    assert_that(defn.min_version).is_equal_to(get_minimum_versions()["semgrep"])
     assert_that("*.py" in defn.file_patterns).is_true()
     assert_that("*.js" in defn.file_patterns).is_true()
     assert_that("*.go" in defn.file_patterns).is_true()


### PR DESCRIPTION
## Summary

- **Fixes the v0.44.1 PyPI deploy failure** caused by semgrep version mismatch between `manifest.json` (1.85.0) and `pyproject.toml` (>=1.151.0)
- **Prevents recurrence** by adding `verify-manifest-sync.py` to the CI pipeline so mismatches block PR merges

## Root Cause

PR #548 bumped `pyproject.toml` semgrep from `>=1.85.0` to `>=1.151.0` but did not update `manifest.json`. CI didn't catch it because `verify-manifest-sync.py` only ran in release workflows (`publish-pypi-on-tag.yml`, `publish-testpypi.yml`), not in `ci-pipeline.yml`.

## Changes

- **`manifest.json`** — Update semgrep version from `1.85.0` to `1.151.0`
- **`ci-pipeline.yml`** — Add lightweight `manifest-sync` job (Stage 1b) that runs in parallel with `resolve-tools`/`docker-build` and gates `lint`
- **`test_semgrep_parser.py`** — Replace hardcoded version assertion with dynamic `get_minimum_versions()` lookup to prevent brittle tests

## Test plan

- [x] `uv run lintro fmt` — no changes needed
- [x] `uv run lintro chk` — 0 issues
- [x] Full test suite — 3679/3679 passed
- [x] `verify-manifest-sync.py` passes locally
- [ ] CI pipeline runs the new `manifest-sync` job successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added manifest version synchronization verification in CI pipeline.

* **Chores**
  * Upgraded semgrep tool to version 1.151.0.
  * Updated CI pipeline job dependencies and execution order.

* **Tests**
  * Updated test assertions to use centralized version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->