### PR TITLE
fix(ci): add tool version sync check to quality gate

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Verify manifest sync
         run: python3 scripts/ci/verify-manifest-sync.py
 
+      - name: Verify tool version sync
+        run: python3 scripts/ci/verify-tool-version-sync.py
+
       - name: Sync dependencies
         run: uv sync --dev --no-progress
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `fix(ci): add tool version sync check to quality gate`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Wires the existing `verify-tool-version-sync.py` script into the reusable quality gate workflow. This script validates that fallback npm versions in `_tool_versions.py` match `package.json`, but was never called in CI — allowing the svelte_check version mismatch (4.1.4 vs 4.3.6) to slip through undetected on the last release.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Relates to #544 - feat(tools): add svelte-check for Svelte component type checking

## Details

**Root cause:** Only `verify-manifest-sync.py` was wired into `reusable-quality.yml`. That script checks `manifest.json` against `package.json` and `pyproject.toml`, but does not validate `_FALLBACK_NPM_VERSIONS` in `_tool_versions.py`. The script that does — `verify-tool-version-sync.py` — existed but was never invoked in any workflow.

**Fix:** Add a single step to `reusable-quality.yml` that runs `python3 scripts/ci/verify-tool-version-sync.py` right after the manifest sync check. No new code was written; this just connects the existing validation script to the pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration verification processes to ensure tool synchronization consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->