### PR TITLE
feat(tools): add Astro file support to Prettier plugin

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,15 +5,16 @@
     "": {
       "name": "py-lintro",
       "devDependencies": {
-        "@astrojs/check": "^0.9.4",
-        "astro": "^5.5.3",
-        "markdownlint-cli2": "^0.17.2",
-        "oxfmt": "^0.27.0",
-        "oxlint": "^1.42.0",
-        "prettier": "^3.8.1",
-        "svelte-check": "^4.3.6",
+        "@astrojs/check": "0.9.6",
+        "astro": "5.17.1",
+        "markdownlint-cli2": "0.17.2",
+        "oxfmt": "0.27.0",
+        "oxlint": "1.42.0",
+        "prettier": "3.8.1",
+        "prettier-plugin-astro": "0.14.1",
+        "svelte-check": "4.3.6",
         "typescript": "^5.9.3",
-        "vue-tsc": "^3.2.4",
+        "vue-tsc": "3.2.4",
       },
     },
   },
@@ -746,6 +747,8 @@
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
+    "prettier-plugin-astro": ["prettier-plugin-astro@0.14.1", "", { "dependencies": { "@astrojs/compiler": "^2.9.1", "prettier": "^3.0.0", "sass-formatter": "^0.7.6" } }, "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw=="],
+
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
@@ -804,7 +807,11 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "s.color": ["s.color@0.0.15", "", {}, "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA=="],
+
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
+    "sass-formatter": ["sass-formatter@0.7.9", "", { "dependencies": { "suf-log": "^2.5.3" } }, "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw=="],
 
     "sax": ["sax@1.4.4", "", {}, "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw=="],
 
@@ -829,6 +836,8 @@
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "suf-log": ["suf-log@2.5.3", "", { "dependencies": { "s.color": "0.0.15" } }, "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow=="],
 
     "svelte": ["svelte@5.49.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.2", "esm-env": "^1.2.1", "esrap": "^2.2.2", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-PYLwnngYzyhKzqDlGVlCH4z+NVI8mC0/bTv15vw25CcdOhxENsOHIbQ36oj5DIf3oBazM+STbCAvaskpxtBmWA=="],
 

--- a/lintro/tools/definitions/prettier.py
+++ b/lintro/tools/definitions/prettier.py
@@ -1,7 +1,7 @@
 """Prettier tool definition.
 
 Prettier is an opinionated code formatter for CSS, HTML, JSON, YAML, Markdown,
-and GraphQL. JavaScript/TypeScript files are handled by oxfmt for better
+GraphQL, and Astro. JavaScript/TypeScript files are handled by oxfmt for better
 performance. Prettier enforces a consistent code style by parsing and
 re-printing code.
 """
@@ -46,6 +46,7 @@ PRETTIER_FILE_PATTERNS: list[str] = [
     "*.yml",
     "*.md",
     "*.graphql",
+    "*.astro",
 ]
 
 
@@ -55,7 +56,7 @@ class PrettierPlugin(BaseToolPlugin):
     """Prettier code formatter plugin.
 
     This plugin integrates Prettier with Lintro for formatting CSS, HTML,
-    JSON, YAML, Markdown, and GraphQL files. JS/TS files are handled by oxfmt.
+    JSON, YAML, Markdown, GraphQL, and Astro files. JS/TS files are handled by oxfmt.
     """
 
     @property
@@ -68,8 +69,8 @@ class PrettierPlugin(BaseToolPlugin):
         return ToolDefinition(
             name="prettier",
             description=(
-                "Code formatter for CSS, HTML, JSON, YAML, Markdown, and GraphQL "
-                "(JS/TS handled by oxfmt for better performance)"
+                "Code formatter for CSS, HTML, JSON, YAML, Markdown, GraphQL, "
+                "and Astro (JS/TS handled by oxfmt for better performance)"
             ),
             can_fix=True,
             tool_type=ToolType.FORMATTER,

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "oxfmt": "0.27.0",
     "oxlint": "1.42.0",
     "prettier": "3.8.1",
+    "prettier-plugin-astro": "0.14.1",
     "svelte-check": "4.3.6",
     "typescript": "^5.9.3",
     "vue-tsc": "3.2.4"

--- a/test_samples/tools/web/prettier/prettier_formatted.astro
+++ b/test_samples/tools/web/prettier/prettier_formatted.astro
@@ -1,0 +1,16 @@
+---
+const greeting = "Hello";
+const items = ["apple", "banana", "cherry"];
+---
+
+<html>
+  <head>
+    <title>Test</title>
+  </head>
+  <body>
+    <h1>{greeting}</h1>
+    <ul>
+      {items.map((item) => <li>{item}</li>)}
+    </ul>
+  </body>
+</html>

--- a/test_samples/tools/web/prettier/prettier_unformatted.astro
+++ b/test_samples/tools/web/prettier/prettier_unformatted.astro
@@ -1,0 +1,18 @@
+---
+const greeting = "Hello"
+const   items = ["apple","banana","cherry"]
+---
+
+<html>
+<head>
+<title>Test</title>
+</head>
+<body>
+    <h1>{greeting}</h1>
+<ul>
+{items.map((item) => (
+<li>{item}</li>
+))}
+</ul>
+</body>
+</html>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `feat(tools): add Astro file support to Prettier plugin`

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Add `*.astro` to Prettier's file patterns so lintro can format `.astro` files when users have `prettier-plugin-astro` configured in their `.prettierrc`. This creates parity with oxlint, which already supports `.astro` for linting.

Changes:
- Add `"*.astro"` to `PRETTIER_FILE_PATTERNS` in `prettier.py`
- Update module docstring, class docstring, and `description` field to mention Astro
- Add `prettier-plugin-astro` to `devDependencies` for integration testing
- Add Astro test sample files (`prettier_formatted.astro`, `prettier_unformatted.astro`)
- Add integration tests for check and fix operations on `.astro` files
- Update `test_definition_file_patterns` to assert `*.astro` is in patterns

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` and `uv run pytest`)

## Closes

- Closes #528

## Details

The implementation is purely additive — `*.astro` is appended to the existing `PRETTIER_FILE_PATTERNS` list. Prettier delegates actual Astro parsing to `prettier-plugin-astro`, which users must install and configure in their `.prettierrc`. If the plugin isn't installed, Prettier will produce an error for `.astro` files (expected behavior, same as any missing plugin).

Integration tests symlink the project's `node_modules` into the temp directory so Prettier can resolve the astro plugin during test execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prettier now supports formatting Astro component files alongside existing formats.

* **Chores**
  * Added the Astro Prettier plugin as a development dependency to enable Astro formatting.

* **Tests**
  * Expanded integration tests to verify detection and fixing of Astro file formatting.

* **Documentation**
  * Updated descriptive texts to mention Astro alongside other supported formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->