### PR TITLE
fix(ci): allow PyPI egress in GHCR cleanup workflow

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -47,6 +47,8 @@ jobs:
             codeload.github.com:443
             release-assets.githubusercontent.com:443
             objects.githubusercontent.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): allow PyPI egress in GHCR cleanup workflow
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What's Changing

The weekly GHCR registry cleanup workflow (`ghcr-cleanup.yml`) was failing because the
harden-runner egress policy blocked `pypi.org` and `files.pythonhosted.org`. The prune
step uses `uv run python` which needs to resolve project dependencies (`httpx`, `loguru`)
from PyPI. Added both PyPI domains to the `allowed-endpoints` list.

Failed run: https://github.com/lgtm-hq/py-lintro/actions/runs/21813039937

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Related to https://github.com/lgtm-hq/py-lintro/actions/runs/21813039937

## Details

The harden-runner step in `ghcr-cleanup.yml` uses `egress-policy: block` with an
explicit allowlist. The `uv run python` command in the "Prune untagged GHCR versions"
step needs to resolve Python dependencies from PyPI, which requires egress to
`pypi.org:443` and `files.pythonhosted.org:443`. These were missing from the allowlist,
causing the workflow to fail with "domain not allowed" errors.

The fix adds both domains to `allowed-endpoints`. No test changes needed — this is a
CI-only configuration fix that can be verified by re-running the workflow with
`dry_run: true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow configuration to permit access to Python package repositories, improving the reliability of automated build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->