### PR TITLE
fix(ci): allow scorecard egress to OSV, Fuzz, and Scorecard APIs

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -38,6 +38,9 @@ jobs:
             tuf-repo-cdn.sigstore.dev:443
             ossf.github.io:443
             www.bestpractices.dev:443
+            api.osv.dev:443
+            api.scorecard.dev:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): allow scorecard egress to OSV, Fuzz, and Scorecard APIs
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What's Changing

The OpenSSF Scorecard workflow's harden-runner egress allowlist is missing three endpoints
required by the scorecard-action. This causes the Fuzzing, Vulnerabilities, and
result-publishing checks to fail with `connection refused` errors. The workflow has been
failing on every scheduled run since at least Jan 26.

Adds three endpoints to `scorecards.yml`:
- `api.osv.dev:443` — Vulnerabilities check (OSV database queries)
- `api.scorecard.dev:443` — publishing results to the Scorecard webapp
- `oss-fuzz-build-logs.storage.googleapis.com:443` — Fuzzing check (OSS-Fuzz status)

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated — N/A, YAML-only CI config change
- [ ] Docs updated if user-facing — N/A, no user-facing change
- [ ] Local CI passed (`./scripts/local/run-tests.sh`) — `lintro chk` passed (0 issues)

## Closes

- Relates to #580
- Relates to #583

## Details

No code changes. This is a CI-only fix to the harden-runner egress allowlist in
`.github/workflows/scorecards.yml`. The missing endpoints were identified from the
scorecard run logs showing `dial tcp ... connection refused` for all three hosts.

After merge, trigger a manual `workflow_dispatch` on the scorecard workflow to verify
the Fuzzing, Vulnerabilities, and result-publishing steps pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded CI build pipeline egress allowlist to permit connections to three additional trusted external endpoints, improving access to external services, build log retrieval and vulnerability data; this enhances reliability of pipeline checks and diagnostics without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->