### PR TITLE
fix(plugins): merge CLI --exclude with .lintro-ignore patterns

### DIFF
--- a/lintro/plugins/base.py
+++ b/lintro/plugins/base.py
@@ -182,11 +182,16 @@ class BaseToolPlugin(ABC):
 
         self.options.update(kwargs)
 
-        # Update specific attributes
+        # Update specific attributes — merge CLI patterns with existing
+        # defaults and .lintro-ignore patterns instead of replacing them
         if ToolOptionKey.EXCLUDE_PATTERNS.value in kwargs:
             patterns = kwargs[ToolOptionKey.EXCLUDE_PATTERNS.value]
             if isinstance(patterns, list):
-                self.exclude_patterns = list(patterns)
+                seen = set(self.exclude_patterns)
+                for p in patterns:
+                    if p not in seen:
+                        self.exclude_patterns.append(p)
+                        seen.add(p)
         if ToolOptionKey.INCLUDE_VENV.value in kwargs:
             self.include_venv = bool(kwargs[ToolOptionKey.INCLUDE_VENV.value])
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `fix(plugins): merge CLI --exclude with .lintro-ignore patterns`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

When `--exclude` was passed via CLI, `BaseToolPlugin.set_options()` replaced the entire `exclude_patterns` list (defaults + `.lintro-ignore`) with only the CLI patterns. This caused `.lintro-ignore` entries like `test_samples/` to be silently dropped, leading to 137+ false lint issues in the scheduled report CI workflow.

The fix changes `set_options()` to merge CLI patterns into the existing list instead of replacing it, preserving defaults and `.lintro-ignore` entries while still adding any new CLI-provided patterns.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

Closes #580

## Details

**Root cause:** `lintro/plugins/base.py:189` used assignment (`self.exclude_patterns = list(patterns)`) which overwrote the full pattern list built during `__post_init__` (defaults + `.lintro-ignore`). When `tool_configuration.py` called `set_options(exclude_patterns=cli_list)`, all `.lintro-ignore` entries were silently dropped.

**Fix:** Changed assignment to a merge loop that appends only patterns not already present.

**Tests added:**
- `test_set_options_exclude_patterns_merges_with_existing` — CLI patterns added while defaults preserved
- `test_set_options_exclude_patterns_does_not_duplicate` — already-present patterns not added twice
- `test_set_options_exclude_patterns_preserves_lintro_ignore` — reproduces the #580 scenario end-to-end (`.lintro-ignore` has `test_samples/`, CLI passes different excludes, both must be present)

All 3305 unit tests pass. Bug was latent since PR #324 (plugin architecture redesign) but only surfaced via the scheduled report workflow which passes `--exclude`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI exclude patterns now merge with existing exclude lists (including ignore files and defaults) instead of replacing them; duplicate patterns are prevented and defaults are preserved.

* **Tests**
  * Added and renamed unit tests to verify merging behavior, deduplication, and preservation of ignore-file and default patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->