### PR TITLE
fix(ci): add missing egress endpoints to image drift check

### DIFF
--- a/.github/workflows/image-drift-check.yml
+++ b/.github/workflows/image-drift-check.yml
@@ -32,6 +32,8 @@ jobs:
             docker.io:443
             registry-1.docker.io:443
             auth.docker.io:443
+            registry.npmjs.org:443
+            semgrep.dev:443
 
       - name: Pull tools image
         run: docker pull ghcr.io/lgtm-hq/lintro-tools:latest


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `fix(ci): add missing egress endpoints to image drift check`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Add `registry.npmjs.org:443` and `semgrep.dev:443` to the `allowed-endpoints` in the Image Drift Check workflow.

The `verify-images` job runs `verify-manifest-tools.py` inside the Docker container, which executes version checks for all tools. Two tools need outbound network access that was being blocked:

| Process | Blocked Domain | Impact |
|---------|---------------|--------|
| `python3.14` (semgrep) | `semgrep.dev:443` | `semgrep --version` phones home — timeout (exit 124) |
| `bun` (vue_tsc) | `registry.npmjs.org:443` | bun resolves packages on startup — empty version |

These endpoints are already allowlisted in the `tooling` and `full` presets of `harden-runner-preset` — this workflow just wasn't including them.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

Related https://github.com/lgtm-hq/py-lintro/actions/runs/22050035899

## Details

CI-only change — no tests or docs needed. The fix can be verified by re-running the Image Drift Check workflow via `workflow_dispatch`.