### PR TITLE
fix(ci): grant SBOM callers the permissions reusable-sbom requires

### DIFF
--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -42,8 +42,8 @@ jobs:
     uses: ./.github/workflows/reusable-sbom.yml
     permissions:
       contents: read
-      actions: read
-      packages: read
+      actions: write
+      id-token: write
 
   publish:
     name: Upload to PyPI

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -23,7 +23,8 @@ jobs:
     uses: ./.github/workflows/reusable-sbom.yml
     permissions:
       contents: read
-      actions: read
+      actions: write
+      id-token: write
     with:
       use-release-token: true
     secrets:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `fix(ci): grant SBOM callers the permissions reusable-sbom requires`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

PR #622 moved `reusable-sbom.yml` permissions to job-level, adding `actions: write` and `id-token: write` for cosign attestation. However, both callers (`sbom-on-main.yml` and `publish-pypi-on-tag.yml`) were left with only `actions: read`, causing a `startup_failure` — GitHub rejects reusable workflows that request more permissions than the caller grants.

This PR updates both caller jobs to grant the permissions the reusable workflow actually requires:
- `actions: write` (artifact management)
- `id-token: write` (keyless cosign attestation via Sigstore OIDC)
- Drops unused `packages: read` from the PyPI publish workflow's SBOM job (the reusable workflow doesn't request it)

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated — N/A, CI workflow-only change
- [ ] Docs updated if user-facing — N/A
- [x] Local CI passed (`lintro chk` — actionlint clean)

## Related Issues

Fixes the startup failure in https://github.com/lgtm-hq/py-lintro/actions/runs/22238253814

## Details

The fix is minimal — only the `permissions` blocks on the two caller jobs that invoke `reusable-sbom.yml` are updated. This stays true to PR #622's least-privilege intent: each caller explicitly declares only the permissions the called workflow needs, no more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to enhance security permissions for automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->