### PR TITLE
fix(ci): show NO DATA status when tests didn't run

### DIFF
--- a/scripts/ci/github/coverage-pr-comment.sh
+++ b/scripts/ci/github/coverage-pr-comment.sh
@@ -164,7 +164,9 @@ if [ -f "test-summary.json" ]; then
 	DURATION_STR="${TEST_DURATION}s"
 
 	# Determine test status emoji
-	if [ "${TEST_FAILED:-0}" -gt 0 ] || [ "${TEST_ERRORS:-0}" -gt 0 ]; then
+	if [ "${TEST_TOTAL:-0}" -eq 0 ]; then
+		TEST_STATUS_EMOJI="⚠️ NO DATA"
+	elif [ "${TEST_FAILED:-0}" -gt 0 ] || [ "${TEST_ERRORS:-0}" -gt 0 ]; then
 		TEST_STATUS_EMOJI="❌ FAIL"
 	else
 		TEST_STATUS_EMOJI="✅ PASS"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): show NO DATA status when tests didn't run
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

When a build fails before tests can run, the PR coverage comment currently shows
"✅ PASS" with all-zero counts, which is misleading. This adds a `TEST_TOTAL == 0`
guard that displays "⚠️ NO DATA" instead, making it clear that tests didn't execute.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #486

## Details

Single logic change in `scripts/ci/github/coverage-pr-comment.sh` (lines 167-171).
Added a check for `TEST_TOTAL == 0` before the existing FAIL/PASS logic, producing
three states: NO DATA, FAIL, PASS. The `TEST_TOTAL` variable is already computed
upstream at line 130 via `parse_json_field`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test status reporting logic to accurately reflect scenarios where no test data is available, displaying "NO DATA" status instead of pass/fail results when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->