### PR TITLE
fix(ci): add immutable sha-tagged Docker images

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -886,6 +886,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=sha,prefix=sha-
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -896,6 +897,7 @@ jobs:
         with:
           images: ghcr.io/lgtm-hq/py-lintro
           tags: |
+            type=sha,prefix=sha-,suffix=-base
             type=semver,pattern={{version}},suffix=-base
             type=semver,pattern={{major}}.{{minor}},suffix=-base
             type=semver,pattern={{major}},suffix=-base

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -223,6 +223,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=sha,prefix=sha-
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -233,6 +234,7 @@ jobs:
         with:
           images: ghcr.io/lgtm-hq/py-lintro
           tags: |
+            type=sha,prefix=sha-,suffix=-base
             type=semver,pattern={{version}},suffix=-base
             type=semver,pattern={{major}}.{{minor}},suffix=-base
             type=semver,pattern={{major}},suffix=-base


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): add immutable sha-tagged Docker images
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What's Changing

Consumers pinning `ghcr.io/lgtm-hq/py-lintro` by digest get `manifest unknown` after every push to main because `:latest` and `:main` are the only tags published on non-release builds. The old digest is destroyed when the tag is overwritten.

This PR adds `type=sha,prefix=sha-` to `docker/metadata-action` in both publish workflows so every push to main produces an immutable `sha-<short-sha>` tag (e.g. `sha-876464d`) that won't be garbage-collected when `:latest` is overwritten.

Changes:
- `ci-pipeline.yml`: Add `type=sha,prefix=sha-` to main image metadata and `type=sha,prefix=sha-,suffix=-base` to base image metadata in the publish job
- `docker-build-publish.yml`: Same changes to both metadata blocks in the publish job

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (CI workflow change — no unit tests applicable)
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` — actionlint + yamllint pass)

## Closes

- Closes #633

## Details

The `docker/metadata-action` `type=sha` generates a tag from the short git SHA of the commit being built. With `prefix=sha-`, tags like `sha-876464d` are produced. These are immutable because each commit has a unique SHA — no future push will overwrite them.

This is a registry-only change. Existing `:latest`, `:main`, and semver tag behavior is unaffected. Consumers can continue using `:latest` for floating references or switch to `sha-*` tags for pinned references.