### PR TITLE
fix(ci): pull tools image before Docker compose tests

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -129,6 +129,10 @@ jobs:
       - name: Smoke Test Base Image
         run: docker run --rm py-lintro:base lintro --version
 
+      - name: Pull tools image
+        env:
+          TOOLS_IMAGE: ${{ steps.tools.outputs.image }}
+        run: docker pull "$TOOLS_IMAGE"
       - name: Run pytest suite inside Docker (compose)
         env:
           TOOLS_IMAGE: ${{ steps.tools.outputs.image }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title: `fix(ci): pull tools image before Docker compose tests`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Add an explicit `docker pull` step before running `docker-test.sh` in the `docker-build-publish.yml` workflow, matching the existing pattern in `ci-pipeline.yml` (lines 578-581).

The `docker-publish` job added in #637 calls `docker-build-publish.yml` from the release pipeline. The `docker buildx build` step pulls the tools image internally during the build, but it never lands in the local Docker daemon. When `docker-test.sh` subsequently runs `docker image inspect` to validate the image exists locally, it fails with:

```
Error: TOOLS_IMAGE 'ghcr.io/lgtm-hq/lintro-tools:latest' not found. Build or pull it first.
```

This caused the v0.52.5 release Docker publish to fail: https://github.com/lgtm-hq/py-lintro/actions/runs/22416549957

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (CI-only workflow change; no unit tests applicable)
- [ ] Docs updated if user-facing (not user-facing)
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

Closes #636

## Details

The `ci-pipeline.yml` already has an explicit `docker pull "$TOOLS_IMAGE"` step (line 581) before invoking `docker-test.sh`. The `docker-build-publish.yml` workflow was missing this step, which only surfaced when it was first called from the release path in #637. The fix adds the same pull step to `docker-build-publish.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline efficiency by optimizing Docker image handling in the test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->