### PR TITLE
fix(ci): use native Intel runner for x86_64 Nuitka builds

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -51,7 +51,7 @@ jobs:
   build-macos:
     name: Build macOS Binary
     needs: get-release-info
-    runs-on: macos-latest
+    runs-on: ${{ matrix.arch == 'x86_64' && 'macos-15-intel' || 'macos-latest' }}
     permissions:
       contents: write
     strategy:


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(ci): use native Intel runner for x86_64 Nuitka builds`

- Type:
  - [x] fix / perf (patch)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The x86_64 Nuitka build has **never succeeded** (0/20 runs since Feb 7). It fails because
`uv sync` on an arm64 runner downloads arm64 wheels for native extensions (e.g. `pydantic_core`),
and Nuitka's `--macos-target-arch=x86_64` cannot cross-compile them.

This routes x86_64 matrix jobs to `macos-15-intel` (GitHub's Intel runner, available until
Aug 2027) so each architecture builds natively on matching hardware — no cross-compilation needed.

Single-line change:

```yaml
# Before
runs-on: macos-latest

# After
runs-on: ${{ matrix.arch == 'x86_64' && 'macos-15-intel' || 'macos-latest' }}
```

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated — CI workflow change, no unit tests applicable
- [ ] Docs updated if user-facing — not user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

Closes #584

## Details

**Why native runners?** Python C/Rust extensions ship as pre-built architecture-specific `.so`
files. `uv sync` downloads wheels matching the host arch. Nuitka bundles these `.so` files
but cannot recompile them for a different target. This is a fundamental limitation of Python
packaging, not a Nuitka bug.

**Testing strategy:**
- [ ] Trigger workflow with `arch: x86_64` — confirm Intel runner builds successfully
- [ ] Trigger workflow with `arch: arm64` — confirm no regression
- [ ] Trigger workflow with `arch: universal` — confirm both complete and `lipo` universal binary works

**No changes needed to `build_macos.py`** — the `--macos-target-arch` flag now matches the
native arch of each runner, acting as a no-op confirmation rather than a cross-compile request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build configuration to optimize runner selection based on target architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->