### PR TITLE
fix(homebrew): remove escaped Ruby interpolation in binary formula heredoc

### DIFF
--- a/scripts/ci/homebrew/generate-binary-formula.sh
+++ b/scripts/ci/homebrew/generate-binary-formula.sh
@@ -51,11 +51,11 @@ class LintroBin < Formula
 
   on_macos do
     on_arm do
-      url "\#{RELEASE_BASE}/download/v\#{version}/lintro-macos-arm64"
+      url "#{RELEASE_BASE}/download/v#{version}/lintro-macos-arm64"
       sha256 "${ARM64_SHA}"
     end
     on_intel do
-      url "\#{RELEASE_BASE}/download/v\#{version}/lintro-macos-x86_64"
+      url "#{RELEASE_BASE}/download/v#{version}/lintro-macos-x86_64"
       sha256 "${X86_SHA}"
     end
   end
@@ -82,7 +82,7 @@ class LintroBin < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("\#{bin}/lintro --version")
+    assert_match version.to_s, shell_output("#{bin}/lintro --version")
   end
 end
 EOF


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The `generate-binary-formula.sh` heredoc used `\#{...}` to escape Ruby string
interpolation, but `#{...}` is not bash syntax — bash only expands `${...}`,
`$(...)`, and backticks. The backslash was written literally into the generated
formula, breaking Ruby's `#{}` interpolation. This caused Homebrew to attempt
downloading from a literal URL like `#{RELEASE_BASE}/download/v#{version}/...`
instead of the resolved GitHub release URL.

This has been the root cause of `lintro-bin` homebrew-tap CI failures since
v0.52.5.

- Remove unnecessary `\` escaping before `#` in URL interpolations (lines 54, 58)
- Remove unnecessary `\` escaping before `#` in test block (line 85)

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

_No associated issue._

## Details

The heredoc in `generate-binary-formula.sh` uses `<<EOF` (unquoted), which
enables bash variable expansion for `${VERSION}`, `${ARM64_SHA}`, and
`${X86_SHA}`. The Ruby `#{...}` syntax is not recognized by bash, so it passes
through unchanged — no escaping needed. Removing the `\` before `#` restores
correct Ruby string interpolation in the generated formula.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed Homebrew formula generation script to ensure correct binary path references for macOS ARM64 and Intel architectures.
  * Improved string interpolation in formula test assertions for proper version validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->