### PR TITLE
fix(ci): compact JSON output in backfill-generate-matrix.sh

### DIFF
--- a/scripts/ci/backfill-generate-matrix.sh
+++ b/scripts/ci/backfill-generate-matrix.sh
@@ -50,7 +50,7 @@ for ((i = start; i < end; i++)); do
 	sha=$(git rev-parse "$tag^{}")
 	objects+=("$(jq -n --arg tag "$tag" --arg sha "$sha" '{tag:$tag,sha:$sha}')")
 done
-json=$(printf '%s\n' "${objects[@]}" | jq -s '.')
+json=$(printf '%s\n' "${objects[@]}" | jq -sc '.')
 count=${#objects[@]}
 
 echo "tags=${json}" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): compact JSON output in backfill-generate-matrix.sh
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Fix `backfill-generate-matrix.sh` writing multi-line JSON to `GITHUB_OUTPUT`, which GitHub Actions rejects as an invalid file command. Change `jq -s '.'` to `jq -sc '.'` to produce compact single-line JSON.

All 6 backfill batches triggered for #730 failed at the matrix generation step because the pretty-printed `{` on line 2 of the JSON array was interpreted as an invalid file command.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (N/A — shell script requiring git tags + GITHUB_OUTPUT)
- [x] Docs updated if user-facing (N/A — CI-only change)
- [x] Local CI passed (`uv run lintro chk`)

## Related Issues

- Closes #753 
- Related #730

## Details

One-character fix: `jq -s` → `jq -sc`. After merge, re-trigger `backfill-docker-tags.yml` batches 1–6 to restore semver tags for historical releases.