### PR TITLE
fix(ci): preserve sparse-checkout _ci dir in backfill workflow

### DIFF
--- a/.github/workflows/backfill-docker-tags.yml
+++ b/.github/workflows/backfill-docker-tags.yml
@@ -118,12 +118,14 @@ jobs:
           sparse-checkout: scripts/ci
           path: _ci
 
-      # Checkout the release tag as the build context
+      # Checkout the release tag as the build context.
+      # clean: false preserves the _ci directory from the sparse checkout above.
       - name: Checkout at release tag
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           ref: ${{ matrix.tag }}
           fetch-depth: 1
+          clean: false
 
       # Cannot use ./.github/actions/setup-docker here — it does not
       # exist on old release tags.  Uses same raw actions as the


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): preserve sparse-checkout _ci dir in backfill workflow
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Add `clean: false` to the release tag checkout step in `backfill-docker-tags.yml`. The second `actions/checkout` was cleaning the workspace by default, deleting the `_ci` directory that the first step sparse-checked-out from main. This caused every backfill build to fail with exit code 127 (`_ci/scripts/ci/backfill-compute-tags.sh: No such file or directory`).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (N/A — workflow-only change)
- [x] Docs updated if user-facing (N/A)
- [x] Local CI passed (`uv run lintro chk`)

## Related Issues

- Closes #755 
- Related #730 
- Related #753

## Details

One-line fix: add `clean: false` to the tag checkout step so it preserves the sparse-checked-out CI scripts directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration to preserve critical directories during Docker image creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->