### PR TITLE
fix: remove unused load_pyproject imports after cache migration

### DIFF
--- a/tests/unit/config/test_config_loader.py
+++ b/tests/unit/config/test_config_loader.py
@@ -12,7 +12,6 @@ from lintro.config.config_loader import _load_pyproject_fallback
 from lintro.utils.config import (
     clear_pyproject_cache,
     load_lintro_tool_config,
-    load_pyproject,
 )
 
 

--- a/tests/unit/config/test_config_loaders.py
+++ b/tests/unit/config/test_config_loaders.py
@@ -19,7 +19,6 @@ from lintro.utils.config import (
     load_lintro_global_config,
     load_lintro_tool_config,
     load_post_checks_config,
-    load_pyproject,
     load_pyproject_config,
     load_tool_config_from_pyproject,
 )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title: `fix: remove unused load_pyproject imports after cache migration`

- Type:
  - [x] fix / perf (patch)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Remove unused `load_pyproject` imports from two test files left over after
the `lru_cache` → `clear_pyproject_cache()` migration in #743. These cause
F401 lint failures on main.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` + `uv run pytest tests/`)

## Related Issues

Fixes lint regression introduced by #743

## Details

- `tests/unit/config/test_config_loader.py` — remove unused `load_pyproject` import
- `tests/unit/config/test_config_loaders.py` — remove unused `load_pyproject` import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused test dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->