### PR TITLE
fix(ci): allow osv-scanner API endpoints in semantic-release and reusable-quality

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -45,6 +45,7 @@ jobs:
             pypi.org:443
             files.pythonhosted.org:443
             api.osv.dev:443
+            api.deps.dev:443
             static.rust-lang.org:443
             bun.sh:443
             astral.sh:443

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -56,6 +56,8 @@ jobs:
             index.crates.io:443
             semgrep.dev:443
             metrics.semgrep.dev:443
+            api.osv.dev:443
+            api.deps.dev:443
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): allow osv-scanner API endpoints in semantic-release and reusable-quality
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Add missing `api.osv.dev:443` and `api.deps.dev:443` to harden-runner allowed endpoints in two workflows:

- **`semantic-release.yml`** — missing both endpoints, causing `Failed to parse OSV-Scanner JSON output` errors during release PR creation
- **`reusable-quality.yml`** — had `api.osv.dev` but was missing `api.deps.dev`

Without these endpoints, osv-scanner cannot query vulnerability data during CI runs.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

Related #792

## Details

Follows up on #794 which added these endpoints to `docker-build-publish.yml` and `ci-pipeline.yml`. This PR covers the remaining two workflows that were missed.

No tests needed — this is a workflow configuration change verified by CI passing.