### PR TITLE
fix(ci): harden vuln-suppression workflow against race conditions

### DIFF
--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -11,6 +11,10 @@ name: Vulnerability Suppression Check
 
 permissions: {}
 
+concurrency:
+  group: vuln-suppression-check-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   check-suppressions:
     runs-on: ubuntu-24.04

--- a/scripts/ci/check-vuln-suppressions.sh
+++ b/scripts/ci/check-vuln-suppressions.sh
@@ -174,8 +174,7 @@ if ! git diff --quiet; then
 	git config user.name "github-actions[bot]"
 	git config user.email "github-actions[bot]@users.noreply.github.com"
 	git checkout -b "$BRANCH"
-	git add "$OSV_TOML" 2>/dev/null || true
-	git add -u
+	git add -A -- "$OSV_TOML"
 	git commit -m "$(
 		cat <<EOF
 chore(security): remove stale vulnerability suppressions


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title: `fix(ci): harden vuln-suppression workflow against race conditions`

- Type:
  - [x] fix / perf (patch)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Hardens the vulnerability suppression check workflow against two issues identified in code review:

1. **Race condition** — The workflow can run concurrently (schedule + workflow_dispatch) and create duplicate PRs because the existing open-PR check in the shell script is not atomic with PR creation. Added a `concurrency` block to serialize runs.

2. **Non-deterministic git staging** — `git add "$OSV_TOML" 2>/dev/null || true` followed by `git add -u` silently ignores a deleted `.osv-scanner.toml` and relies on the subsequent `-u` to catch it. Replaced with explicit `git add -A -- "$OSV_TOML"` which handles creates, updates, and deletions deterministically.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed

## Related Issues

Related to CR review feedback

## Details

### Changes

- `.github/workflows/vuln-suppression-check.yml` — Added top-level `concurrency` block with `group: vuln-suppression-check-${{ github.repository }}` and `cancel-in-progress: false` so runs queue rather than overlap
- `scripts/ci/check-vuln-suppressions.sh` — Replaced `git add "$OSV_TOML" 2>/dev/null || true; git add -u` with `git add -A -- "$OSV_TOML"`

### Testing

- All 4230 existing tests pass
- Both files pass lintro checks (actionlint, shellcheck)
- CI-only changes — no runtime code affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to queue vulnerability-suppression checks so new runs don’t cancel in-progress executions, ensuring only one active run per repository group.
  * Adjusted the vulnerability suppression check to reliably include all modifications under the suppression config path when preparing cleanup commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->