### PR TITLE
fix(security): add vulnerability reporting link to SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -12,7 +12,8 @@
 If you discover a security vulnerability in lintro, please report it by:
 
 1. **Do NOT open a public GitHub issue**
-2. Report via [GitHub's private vulnerability reporting](https://github.com/lgtm-hq/py-lintro/security/advisories/new)
+2. Report via
+   [GitHub's private vulnerability reporting](https://github.com/lgtm-hq/py-lintro/security/advisories/new)
 3. Include detailed steps to reproduce the vulnerability
 4. Allow reasonable time for the issue to be addressed before public disclosure
 


### PR DESCRIPTION
## Summary

Add a concrete GitHub private vulnerability reporting link to SECURITY.md. The current file says "email the maintainers directly" without providing an actual address, causing the OpenSSF Scorecard to flag "no linked content" (score 4/10).

## Type

- [x] 🐛 Bug fix (`fix:`)

## Changes Made

- Replace vague "email the maintainers" with direct link to `github.com/lgtm-hq/py-lintro/security/advisories/new`

## Closes

- Closes #824

## Quality Checks

- [x] Linting passes
- [x] Formatting passes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated vulnerability reporting guidance to replace the generic contact step with a dedicated "Report via" instruction that links directly to GitHub’s private vulnerability reporting submission page, clarifying how to securely submit security issues. No other documentation or product behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->