### PR TITLE
fix(ci): use RELEASE_TOKEN for release PR creation

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -137,7 +137,7 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           commit-message: 'chore(release): cut ${{ steps.semrel.outputs.next_version }}'
           title: 'chore(release): prepare ${{ steps.semrel.outputs.next_version }}'
           body: |


### PR DESCRIPTION
## Summary

Use `RELEASE_TOKEN` (with `GITHUB_TOKEN` fallback) in the `create-pull-request` action so CI workflows trigger on release PRs. Currently release PRs are created with `GITHUB_TOKEN`, which means GitHub won't trigger workflows on them (loop prevention), leaving required status checks permanently pending.

Same fix applied to turbo-themes in lgtm-hq/turbo-themes#373.

## Type

- [x] 🐛 Bug fix (`fix:`)

## Changes Made

- `semantic-release.yml`: Change `create-pull-request` token from `secrets.GITHUB_TOKEN` to `secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release automation updated to support an alternative authentication token when present, while falling back to the default token if not set. This enhances flexibility for releases and continuous integration without changing other release step behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->