### PR TITLE
fix(build): remove stale toml package from Nuitka build config

### DIFF
--- a/scripts/build/build_macos.py
+++ b/scripts/build/build_macos.py
@@ -34,7 +34,6 @@ INCLUDE_PACKAGES = [
     "click",
     "loguru",
     "tabulate",
-    "toml",
     "defusedxml",
     "httpx",
 ]


### PR DESCRIPTION
## Summary
- Removed `toml` from `INCLUDE_PACKAGES` in `scripts/build/build_macos.py`
- The project uses `tomllib` (Python 3.11+ stdlib), not the third-party `toml` package
- This stale reference has caused every `lintro-bin` binary build to fail since v0.56.0, with Nuitka erroring: `failed to locate package 'toml'`
- The `lintro-bin` Homebrew formula is stuck at v0.56.0 as a result

## Test plan
- [x] `lintro fmt` — clean
- [x] `lintro chk` — 26 tools passed, zero issues
- [x] `pytest` — 4799 passed, 3 skipped
- [ ] Verify `build-binary.yml` workflow succeeds on next release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated macOS application build configuration — adjusted the set of packages bundled into macOS standalone/universal binaries (the toml package is no longer included), affecting contents of the generated app bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->