### PR TITLE
ci: add merge_group trigger to CI pipeline

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -30,6 +30,7 @@ name: CI Pipeline
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -75,8 +75,8 @@ jobs:
         id: detect
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
         run: scripts/ci/tools-image-detect-changes.sh
 

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -75,8 +75,10 @@ jobs:
         id: detect
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          # yamllint disable rule:line-length
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          # yamllint enable rule:line-length
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
         run: scripts/ci/tools-image-detect-changes.sh
 

--- a/scripts/ci/tools-image-detect-changes.sh
+++ b/scripts/ci/tools-image-detect-changes.sh
@@ -81,12 +81,12 @@ matches_tool_pattern() {
 
 tools_changed="false"
 
-if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-	: "${PR_BASE_SHA:?PR_BASE_SHA is required for pull_request events}"
-	: "${PR_HEAD_SHA:?PR_HEAD_SHA is required for pull_request events}"
+if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
+	: "${PR_BASE_SHA:?PR_BASE_SHA is required for ${GITHUB_EVENT_NAME} events}"
+	: "${PR_HEAD_SHA:?PR_HEAD_SHA is required for ${GITHUB_EVENT_NAME} events}"
 
-	# For PRs, compare base to head
-	echo "Checking for tool file changes in PR..."
+	# For PRs / merge queue, compare base to head
+	echo "Checking for tool file changes in $GITHUB_EVENT_NAME..."
 	changed_files=$(git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" \
 		2>/dev/null || echo "")
 
@@ -124,11 +124,17 @@ echo "tools_changed=${tools_changed}" >>"$GITHUB_OUTPUT"
 echo "Tools changed: ${tools_changed}"
 
 if [[ "$tools_changed" == "true" ]]; then
-	if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+	case "$GITHUB_EVENT_NAME" in
+	pull_request)
 		echo "::notice::Tool files changed — fresh tools image will be built via workflow_call"
-	else
+		;;
+	merge_group)
+		echo "::notice::Tool files changed in merge queue — stable image will be used (PR build already validated)"
+		;;
+	*)
 		echo "::notice::Tool files changed — tools-image.yml will build a fresh image"
-	fi
+		;;
+	esac
 else
 	echo "::notice::No tool file changes detected — stable pinned image will be used"
 fi


### PR DESCRIPTION
## Summary

Adds `merge_group:` trigger to `ci-pipeline.yml` so the full pipeline — including the `security-audit` job — re-runs when a PR enters the merge queue.

## Problem

The security audit only ran on `pull_request` events. A new CVE could be published between when a PR was opened and when it was merged, passing the initial scan but failing the post-merge scan on `main`. This happened in lgtm-hq/turbo-themes with three CVEs that landed in a 4-day window between PR check and merge.

## Why ci-pipeline and not a standalone workflow

py-lintro IS lintro — its security audit uses the freshly built Docker image (`needs: [docker-build]`). Extracting it to a standalone workflow would mean testing against a stale published image, not the current changes. Adding `merge_group` to the existing pipeline is the correct fix.

## Changes

- `.github/workflows/ci-pipeline.yml`: added `merge_group:` trigger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows now run for merge-group events in addition to pull requests.
  * Change-detection treats merge-group like PR events so base/head commit references are provided consistently across triggers.
  * Workflow logging and change-notices now reflect the actual event type and indicate whether a fresh or stable image will be used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->