### PR TITLE
fix(ci): publish minimal image to ghcr.io/py-lintro-base

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -387,9 +387,9 @@ jobs:
           docker tag py-lintro:latest \
             "ghcr.io/lgtm-hq/py-lintro:${CI_TAG}"
           docker tag py-lintro:base \
-            "ghcr.io/lgtm-hq/py-lintro:${CI_TAG}-base"
+            "ghcr.io/lgtm-hq/py-lintro-base:${CI_TAG}"
           docker push "ghcr.io/lgtm-hq/py-lintro:${CI_TAG}"
-          docker push "ghcr.io/lgtm-hq/py-lintro:${CI_TAG}-base"
+          docker push "ghcr.io/lgtm-hq/py-lintro-base:${CI_TAG}"
       - name: Save Docker images to tarball (fork fallback)
         if: steps.fork-check.outputs.is-fork == 'true'
         run: |
@@ -752,8 +752,8 @@ jobs:
         run: |
           docker pull "ghcr.io/lgtm-hq/py-lintro:${CI_TAG}"
           docker tag "ghcr.io/lgtm-hq/py-lintro:${CI_TAG}" py-lintro:latest
-          docker pull "ghcr.io/lgtm-hq/py-lintro:${CI_TAG}-base"
-          docker tag "ghcr.io/lgtm-hq/py-lintro:${CI_TAG}-base" py-lintro:base
+          docker pull "ghcr.io/lgtm-hq/py-lintro-base:${CI_TAG}"
+          docker tag "ghcr.io/lgtm-hq/py-lintro-base:${CI_TAG}" py-lintro:base
       - name: Download Docker images artifact (fork fallback)
         if: needs.docker-build.outputs.is-fork == 'true'
         # Action SHA pin exceeds 88 chars
@@ -1065,17 +1065,21 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
+      # Base image uses a separate GHCR package so digest pins for py-lintro
+      # cannot accidentally resolve to the minimal (no bundled tools) variant.
       - name: Extract metadata (base)
         id: meta-base
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
-          images: ghcr.io/lgtm-hq/py-lintro
+          images: ghcr.io/lgtm-hq/py-lintro-base
           tags: |
-            type=sha,prefix=sha-,suffix=-base,format=long
-            type=semver,pattern={{version}},suffix=-base
-            type=semver,pattern={{major}}.{{minor}},suffix=-base
-            type=semver,pattern={{major}},suffix=-base
-            type=raw,value=base,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix=sha-,format=long
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push Docker image
         env:
           REPO: ghcr.io/lgtm-hq/py-lintro-buildcache
@@ -1150,12 +1154,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI_TAG: ci-${{ github.run_id }}
         run: |
-          for tag_suffix in "" "-base"; do
-            tag="${CI_TAG}${tag_suffix}"
-            echo "Looking up version for tag: ${tag}"
+          delete_ci_tag() {
+            local pkg="$1"
+            local tag="$2"
+            echo "Looking up version for ${pkg}:${tag}"
             api_stderr=$(mktemp)
             version_id=$(gh api \
-              "orgs/lgtm-hq/packages/container/py-lintro/versions" \
+              "orgs/lgtm-hq/packages/container/${pkg}/versions" \
               --paginate \
               --jq ".[] |
                 select(.metadata.container.tags[] == \"${tag}\") |
@@ -1163,18 +1168,20 @@ jobs:
             stderr_text=$(cat "$api_stderr")
             rm -f "$api_stderr"
             if [[ -n "$stderr_text" ]]; then
-              echo "::warning::gh api lookup for tag ${tag}: ${stderr_text}"
+              echo "::warning::gh api lookup for ${pkg}:${tag}: ${stderr_text}"
             fi
             if [[ -n "$version_id" ]]; then
               while IFS= read -r vid; do
                 [[ -z "$vid" ]] && continue
                 gh api --method DELETE \
-                  "orgs/lgtm-hq/packages/container/py-lintro/versions/${vid}" \
+                  "orgs/lgtm-hq/packages/container/${pkg}/versions/${vid}" \
                   2>/dev/null && \
-                  echo "Deleted version ${vid} (tag: ${tag})" || \
+                  echo "Deleted version ${vid} (${pkg}:${tag})" || \
                   echo "::warning::Failed to delete version ${vid}"
               done <<< "$version_id"
             else
-              echo "No version found for tag: ${tag} (may already be cleaned)"
+              echo "No version found for ${pkg}:${tag} (may already be cleaned)"
             fi
-          done
+          }
+          delete_ci_tag py-lintro "${CI_TAG}"
+          delete_ci_tag py-lintro-base "${CI_TAG}"

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -250,6 +250,8 @@ jobs:
       cancel-in-progress: true
     outputs:
       is-fork: ${{ steps.fork-check.outputs.is-fork }}
+    # Non-fork: push from Buildx to GHCR (avoids load ×2 then long docker push).
+    # Fork: load + tarball artifact (cannot push to GHCR).
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
@@ -335,7 +337,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build Docker image (py-lintro:latest)
+      - name: Build Docker image (py-lintro:latest, fork)
+        if: steps.fork-check.outputs.is-fork == 'true'
         env:
           REPO: ghcr.io/lgtm-hq/py-lintro-buildcache
         # Action SHA pin exceeds 88 chars
@@ -360,7 +363,29 @@ jobs:
           # yamllint enable rule:line-length
           provenance: false
 
-      - name: Build Base Docker image (py-lintro:base)
+      - name: Build and push Docker image (py-lintro, GHCR CI tag)
+        if: steps.fork-check.outputs.is-fork != 'true'
+        env:
+          REPO: ghcr.io/lgtm-hq/py-lintro-buildcache
+        # Action SHA pin exceeds 88 chars
+        # yamllint disable-line rule:line-length
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/lgtm-hq/py-lintro:ci-${{ github.run_id }}
+          build-args: |
+            TOOLS_IMAGE=${{ needs.resolve-tools.outputs.image }}
+          # yamllint disable rule:line-length
+          cache-from: |
+            ${{ needs.resolve-tools.outputs.source != 'artifact' && format('type=registry,ref={0}:{1}', env.REPO, env.CACHE_TAG) || '' }}
+            ${{ needs.resolve-tools.outputs.source != 'artifact' && format('type=registry,ref={0}:main', env.REPO) || '' }}
+          cache-to: ${{ steps.fork-check.outputs.is-fork != 'true' && needs.resolve-tools.outputs.source != 'artifact' && format('type=registry,ref={0}:{1},{2}', env.REPO, env.CACHE_TAG, env.CACHE_OPTS) || '' }}
+          # yamllint enable rule:line-length
+          provenance: false
+
+      - name: Build Base Docker image (py-lintro:base, fork)
+        if: steps.fork-check.outputs.is-fork == 'true'
         env:
           REPO: ghcr.io/lgtm-hq/py-lintro-base-buildcache
         # Action SHA pin exceeds 88 chars
@@ -379,17 +404,26 @@ jobs:
           cache-to: ${{ steps.fork-check.outputs.is-fork != 'true' && needs.resolve-tools.outputs.source != 'artifact' && format('type=registry,ref={0}:{1},{2}', env.REPO, env.CACHE_TAG, env.CACHE_OPTS) || '' }}
           # yamllint enable rule:line-length
           provenance: false
-      - name: Push CI images to GHCR
+
+      - name: Build and push Base Docker image (py-lintro-base, GHCR CI tag)
         if: steps.fork-check.outputs.is-fork != 'true'
         env:
-          CI_TAG: ci-${{ github.run_id }}
-        run: |
-          docker tag py-lintro:latest \
-            "ghcr.io/lgtm-hq/py-lintro:${CI_TAG}"
-          docker tag py-lintro:base \
-            "ghcr.io/lgtm-hq/py-lintro-base:${CI_TAG}"
-          docker push "ghcr.io/lgtm-hq/py-lintro:${CI_TAG}"
-          docker push "ghcr.io/lgtm-hq/py-lintro-base:${CI_TAG}"
+          REPO: ghcr.io/lgtm-hq/py-lintro-base-buildcache
+        # Action SHA pin exceeds 88 chars
+        # yamllint disable-line rule:line-length
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Dockerfile.base
+          push: true
+          tags: ghcr.io/lgtm-hq/py-lintro-base:ci-${{ github.run_id }}
+          # yamllint disable rule:line-length
+          cache-from: |
+            ${{ needs.resolve-tools.outputs.source != 'artifact' && format('type=registry,ref={0}:{1}', env.REPO, env.CACHE_TAG) || '' }}
+            ${{ needs.resolve-tools.outputs.source != 'artifact' && format('type=registry,ref={0}:main', env.REPO) || '' }}
+          cache-to: ${{ steps.fork-check.outputs.is-fork != 'true' && needs.resolve-tools.outputs.source != 'artifact' && format('type=registry,ref={0}:{1},{2}', env.REPO, env.CACHE_TAG, env.CACHE_OPTS) || '' }}
+          # yamllint enable rule:line-length
+          provenance: false
       - name: Save Docker images to tarball (fork fallback)
         if: steps.fork-check.outputs.is-fork == 'true'
         run: |

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -248,17 +248,21 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
+      # Base image uses a separate GHCR package so digest pins for py-lintro
+      # cannot accidentally resolve to the minimal (no bundled tools) variant.
       - name: Extract metadata (base)
         id: meta-base
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
-          images: ghcr.io/lgtm-hq/py-lintro
+          images: ghcr.io/lgtm-hq/py-lintro-base
           tags: |
-            type=sha,prefix=sha-,suffix=-base,format=long
-            type=semver,pattern={{version}},suffix=-base
-            type=semver,pattern={{major}}.{{minor}},suffix=-base
-            type=semver,pattern={{major}},suffix=-base
-            type=raw,value=base,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix=sha-,format=long
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push Docker image
         env:
           REPO: ghcr.io/lgtm-hq/py-lintro-buildcache

--- a/.github/workflows/image-drift-check.yml
+++ b/.github/workflows/image-drift-check.yml
@@ -53,7 +53,7 @@ jobs:
         run: docker run --rm ghcr.io/lgtm-hq/py-lintro:latest lintro --version
 
       - name: Pull base image
-        run: docker pull ghcr.io/lgtm-hq/py-lintro:base
+        run: docker pull ghcr.io/lgtm-hq/py-lintro-base:latest
 
       - name: Smoke test base image
-        run: docker run --rm ghcr.io/lgtm-hq/py-lintro:base lintro --version
+        run: docker run --rm ghcr.io/lgtm-hq/py-lintro-base:latest lintro --version

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -21,18 +21,3 @@ reason = "smol-toml@1.6.0 — transitive dev dep via astro, pending upstream upd
 id = "GHSA-48c2-rrv3-qjmp"
 ignoreUntil = 2026-06-25
 reason = "yaml@2.7.1 — transitive dev dep, pending upstream update to 2.8.3"
-
-[[IgnoredVulns]]
-id = "GHSA-4w7w-66w2-5vf9"
-ignoreUntil = 2026-06-25
-reason = "vite@7.3.1 — transitive dev dep via astro, fix requires vite 8 which astro doesn't support yet"
-
-[[IgnoredVulns]]
-id = "GHSA-p9ff-h696-f583"
-ignoreUntil = 2026-06-25
-reason = "vite@7.3.1 — transitive dev dep via astro, fix requires vite 8 which astro doesn't support yet"
-
-[[IgnoredVulns]]
-id = "GHSA-v2wj-q39q-566r"
-ignoreUntil = 2026-06-25
-reason = "vite@7.3.1 — transitive dev dep via astro, fix requires vite 8 which astro doesn't support yet"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,13 @@
 # - Node.js tools via bun (prettier, markdownlint-cli2, tsc, astro, vue-tsc, oxlint, oxfmt)
 # - Python tools (ruff, black, bandit, mypy, semgrep, etc.)
 # - Standalone binaries (hadolint, actionlint, shellcheck, shfmt, taplo, gitleaks)
+#
+# Minimal image (no bundled tools): ghcr.io/lgtm-hq/py-lintro-base (Dockerfile.base).
 # =============================================================================
 
 # TOOLS_IMAGE can be overridden at build time (e.g., for PR testing with new tools)
 # yamllint disable-line rule:line-length
-ARG TOOLS_IMAGE=ghcr.io/lgtm-hq/lintro-tools:latest@sha256:256084f9b02f264f8952b181bd30815a1116abdc2fdd74b40963daa890fd9c5c
+ARG TOOLS_IMAGE=ghcr.io/lgtm-hq/lintro-tools:latest@sha256:d762745f6aac7a3a39af8176ca52c9dba27c727ed2e47ffe26c33dedee22c5b8
 # checkov:skip=CKV_DOCKER_7: Tools image is pinned by digest; tag is for readability.
 # hadolint ignore=DL3006
 FROM ${TOOLS_IMAGE}

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -5,16 +5,20 @@
 # only. It does NOT include external linting tools like shellcheck, gitleaks,
 # or rust toolchain. Use this for lightweight runtimes or when tools are
 # provided by the host environment.
+#
+# Published separately from the full image at ghcr.io/lgtm-hq/py-lintro-base so
+# digest pins for ghcr.io/lgtm-hq/py-lintro always refer to the tools-backed
+# variant only.
 # =============================================================================
 
 FROM python:3.14-slim@sha256:5e59aae31ff0e87511226be8e2b94d78c58f05216efda3b07dbbed938ec8583b
 
-ARG UV_VERSION=0.11.10
+ARG UV_VERSION=0.11.3
 
 # Add Docker labels
 LABEL maintainer="lgtm-hq"
 LABEL org.opencontainers.image.source="https://github.com/lgtm-hq/py-lintro"
-LABEL org.opencontainers.image.description="Lintro base image (no external tools)"
+LABEL org.opencontainers.image.description="Lintro base image (no external tools); GHCR package py-lintro-base"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # Set environment variables

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,7 @@
 
 FROM python:3.14-slim@sha256:5e59aae31ff0e87511226be8e2b94d78c58f05216efda3b07dbbed938ec8583b
 
-ARG UV_VERSION=0.11.3
+ARG UV_VERSION=0.11.10
 
 # Add Docker labels
 LABEL maintainer="lgtm-hq"

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ brew tap lgtm-hq/tap && brew install lintro-bin
 docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro:latest check
 
 # Docker (base image - minimal, no external tools)
-docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro:base check
+docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro-base:latest check
 ```
 
 See [Getting Started](docs/getting-started.md) for detailed installation options.
@@ -333,8 +333,8 @@ docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro:latest check
 # With formatting
 docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro:latest check --output-format grid
 
-# Base image (minimal, no external tools)
-docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro:base check
+# Base image (minimal, no external tools; separate GHCR package)
+docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro-base:latest check
 ```
 
 ## 📚 Documentation

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "py-lintro",
       "devDependencies": {
         "@astrojs/check": "0.9.8",
-        "astro": "6.1.6",
+        "astro": "6.1.10",
         "markdownlint-cli2": "0.22.0",
         "oxfmt": "0.43.0",
         "oxlint": "1.58.0",
@@ -19,6 +19,7 @@
     },
   },
   "overrides": {
+    "fast-uri": "3.1.2",
     "postcss": "^8.5.10",
   },
   "packages": {
@@ -26,15 +27,15 @@
 
     "@astrojs/compiler": ["@astrojs/compiler@3.0.1", "", {}, "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA=="],
 
-    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.8.0", "", { "dependencies": { "picomatch": "^4.0.3" } }, "sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w=="],
+    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.0", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg=="],
 
     "@astrojs/language-server": ["@astrojs/language-server@2.16.6", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.3", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.15", "volar-service-css": "0.0.70", "volar-service-emmet": "0.0.70", "volar-service-html": "0.0.70", "volar-service-prettier": "0.0.70", "volar-service-typescript": "0.0.70", "volar-service-typescript-twoslash-queries": "0.0.70", "volar-service-yaml": "0.0.70", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "bin/nodeServer.js" } }, "sha512-N990lu+HSFiG57owR0XBkr02BYMgiLCshLf+4QG4v6jjSWkBeQGnzqi+E1L08xFPPJ7eEeXnxPXGLaVv5pa4Ug=="],
 
-    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.0", "", { "dependencies": { "@astrojs/internal-helpers": "0.8.0", "@astrojs/prism": "4.0.1", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ=="],
+    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.1", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.0", "@astrojs/prism": "4.0.1", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA=="],
 
     "@astrojs/prism": ["@astrojs/prism@4.0.1", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ=="],
 
-    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.0", "", { "dependencies": { "ci-info": "^4.2.0", "debug": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^3.0.0", "is-wsl": "^3.1.0", "which-pm-runs": "^1.1.0" } }, "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ=="],
+    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.1", "", { "dependencies": { "ci-info": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw=="],
 
     "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.3", "", { "dependencies": { "yaml": "^2.8.2" } }, "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg=="],
 
@@ -402,7 +403,7 @@
 
     "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
 
-    "astro": ["astro@6.1.6", "", { "dependencies": { "@astrojs/compiler": "^3.0.1", "@astrojs/internal-helpers": "0.8.0", "@astrojs/markdown-remark": "7.1.0", "@astrojs/telemetry": "3.3.0", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.3", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.4", "vfile": "^6.0.3", "vite": "^7.3.1", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "bin/astro.mjs" } }, "sha512-pRsz+kYriwCV/AUcY/I9OVKtVHuYFs2DtCszAxprXded/kTE53nMwxfnK0Nf6FPfaX9vcUiLnigcSIhuFoKntA=="],
+    "astro": ["astro@6.1.10", "", { "dependencies": { "@astrojs/compiler": "^3.0.1", "@astrojs/internal-helpers": "0.9.0", "@astrojs/markdown-remark": "7.1.1", "@astrojs/telemetry": "3.3.1", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "bin/astro.mjs" } }, "sha512-jQAIki6c862oxRr7OXXC+h3n4wg1EpmKgCH3vv1FtXM9VFmD2iTjlaxrfb0I6eQCwtUjSBxfJBFBDSXHu7Wing=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -512,7 +513,7 @@
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -576,7 +577,7 @@
 
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
-    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+    "is-docker": ["is-docker@4.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -950,7 +951,7 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+    "vite": ["vite@7.3.3", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA=="],
 
     "vitefu": ["vitefu@1.1.2", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
 
@@ -1025,6 +1026,8 @@
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
+
+    "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -24,7 +24,7 @@ docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro:latest check --tools r
 docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro:latest format
 
 # Base image (minimal, no external tools)
-docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro:base check
+docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro-base:latest check
 ```
 
 ### Development Setup
@@ -63,13 +63,26 @@ Lintro provides a pre-built Docker image available on GitHub Container Registry 
 
 ### Image Details
 
-- **Registry**: `ghcr.io/lgtm-hq/py-lintro`
-- **Tags**:
-  - `latest` - Tools image (recommended; includes external tools)
-  - `main` - Main branch version
-  - `base` - Minimal image (no external tools)
-  - `v1.0.0` - Specific release versions (when available)
-  - `v1.0.0-base` - Base image for that release
+The **tools-backed** image (recommended for CI) is published as
+**`ghcr.io/lgtm-hq/py-lintro`**.
+
+The **minimal** image (lintro only; supply linters from the host or opt-in installs) is
+**`ghcr.io/lgtm-hq/py-lintro-base`**. A separate package avoids digest/tag collisions so
+pins to `py-lintro` never resolve to the minimal variant.
+
+**Full image** (`ghcr.io/lgtm-hq/py-lintro`) tags:
+
+- `latest` — default branch release build with bundled external tools
+- `main` — main branch version
+- `v1.0.0` — semver releases when published
+
+**Base image** (`ghcr.io/lgtm-hq/py-lintro-base`) tags mirror the same semver and
+`sha-*` conventions without a `-base` suffix on the tag (the package name carries that
+distinction).
+
+**Migration:** Older docs referred to `ghcr.io/lgtm-hq/py-lintro:base` or
+`py-lintro:vX.Y.Z-base`. Use `ghcr.io/lgtm-hq/py-lintro-base:latest` or
+`py-lintro-base:vX.Y.Z` instead.
 
 ### Using the Published Image
 
@@ -84,7 +97,7 @@ docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro:latest check
 docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro:main check
 
 # Use the base image (minimal)
-docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro:base check
+docker run --rm -v $(pwd):/code ghcr.io/lgtm-hq/py-lintro-base:latest check
 ```
 
 ### CI/CD Integration
@@ -106,7 +119,7 @@ lintro:
 
 # Base image example (minimal, no external tools)
 lintro_base:
-  image: ghcr.io/lgtm-hq/py-lintro:base
+  image: ghcr.io/lgtm-hq/py-lintro-base:latest
   script:
     - lintro check --output-format grid
 ```

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -85,6 +85,17 @@ If you want to publish the weekly report to Pages, prefer using a dedicated
 - 📦 **GHCR integration** — Full image at `ghcr.io/lgtm-hq/py-lintro`
 - 📦 **GHCR base image** — Minimal image at `ghcr.io/lgtm-hq/py-lintro-base`
 
+The **full** image (`ghcr.io/lgtm-hq/py-lintro`) includes the runtime and optional
+tooling so you can run Lintro out of the box. The **base** image
+(`ghcr.io/lgtm-hq/py-lintro-base`) is a slimmer layer with core dependencies only—use it
+when you want a smaller footprint, CI-only steps, or a foundation for a custom image.
+Add your own packages or layers on top of the base as needed.
+
+```dockerfile
+FROM ghcr.io/lgtm-hq/py-lintro-base
+# Install project-specific tools or copy your app here
+```
+
 ### 7. OpenSSF Allstar (Repository Security Enforcement)
 
 Allstar is an OpenSSF GitHub App that enforces repository security policies org-wide or

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -82,7 +82,8 @@ If you want to publish the weekly report to Pages, prefer using a dedicated
 - 🐳 **Automated Docker image building** and publishing to GHCR
 - 🏷️ **Smart tagging** - Latest, main branch, and semantic versions
 - 🔄 **Release integration** - Images published on releases
-- 📦 **GHCR integration** - Images available at `ghcr.io/lgtm-hq/py-lintro`
+- 📦 **GHCR integration** — Full image at `ghcr.io/lgtm-hq/py-lintro`
+- 📦 **GHCR base image** — Minimal image at `ghcr.io/lgtm-hq/py-lintro-base`
 
 ### 7. OpenSSF Allstar (Repository Security Enforcement)
 

--- a/lintro/_tool_versions.py
+++ b/lintro/_tool_versions.py
@@ -86,7 +86,7 @@ _TOOL_TO_NPM_PACKAGE: dict[ToolName, str] = {
 # Fallback npm tool versions - used when package.json is not found.
 # CI should verify these match package.json to prevent drift.
 _FALLBACK_NPM_VERSIONS: dict[ToolName, str] = {
-    ToolName.ASTRO_CHECK: "6.1.6",
+    ToolName.ASTRO_CHECK: "6.1.10",
     ToolName.SVELTE_CHECK: "4.4.6",
     ToolName.TSC: "5.9.3",
     ToolName.VUE_TSC: "3.2.6",

--- a/lintro/tools/manifest.json
+++ b/lintro/tools/manifest.json
@@ -53,7 +53,7 @@
     },
     {
       "name": "astro_check",
-      "version": "6.1.6",
+      "version": "6.1.10",
       "install": {
         "type": "npm",
         "package": "astro",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "0.9.8",
-    "astro": "6.1.6",
+    "astro": "6.1.10",
     "markdownlint-cli2": "0.22.0",
     "oxfmt": "0.43.0",
     "oxlint": "1.58.0",
@@ -28,6 +28,7 @@
     "vue-tsc": "3.2.6"
   },
   "overrides": {
+    "fast-uri": "3.1.2",
     "postcss": "^8.5.10"
   }
 }

--- a/scripts/ci/backfill-compute-tags.sh
+++ b/scripts/ci/backfill-compute-tags.sh
@@ -8,8 +8,8 @@
 #   GITHUB_REPOSITORY - Owner/repo (e.g. lgtm-hq/py-lintro), used for registry
 #
 # Outputs (via GITHUB_OUTPUT):
-#   main-tags  - Comma-separated GHCR tags for the main image
-#   base-tags  - Comma-separated GHCR tags for the base image (if Dockerfile.base exists)
+#   main-tags  - Comma-separated tags for ghcr.io/<owner>/py-lintro
+#   base-tags  - Comma-separated tags for ghcr.io/<owner>/py-lintro-base (if Dockerfile.base exists)
 #   has-base   - "true" if Dockerfile.base exists, "false" otherwise
 set -euo pipefail
 
@@ -18,7 +18,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Usage: TAG=v0.52.2 SHA=876464d9f1a2b3c4d5e6f7081920a1b2c3d4e5f6 ./scripts/ci/backfill-compute-tags.sh
 
 Computes Docker image tags for a release. Outputs semver tags (X.Y.Z, X.Y, X)
-and sha-prefixed tags for both main and base images.
+and sha-prefixed tags for both packages (py-lintro and py-lintro-base).
 
 Required environment variables:
   TAG                Git tag (e.g. v0.52.2)
@@ -41,9 +41,12 @@ if ! [[ "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
 	exit 1
 fi
 
-# Derive registry from GITHUB_REPOSITORY (lowercase for GHCR compatibility)
+# Derive registry from GITHUB_REPOSITORY (lowercase for GHCR compatibility).
+# Full image: ghcr.io/<owner>/py-lintro — base image: ghcr.io/<owner>/py-lintro-base
 repo="${GITHUB_REPOSITORY:-lgtm-hq/py-lintro}"
-REGISTRY="ghcr.io/${repo,,}"
+owner="${repo%%/*}"
+REGISTRY="ghcr.io/${owner,,}/py-lintro"
+BASE_REGISTRY="ghcr.io/${owner,,}/py-lintro-base"
 
 # Parse semver components (vMAJOR.MINOR.PATCH)
 version="${TAG#v}"
@@ -63,10 +66,10 @@ echo "main-tags=${tags}" >>"$GITHUB_OUTPUT"
 
 # Base image tags (Dockerfile.base exists from v0.42.7+)
 if [[ -f Dockerfile.base ]]; then
-	base_tags="${REGISTRY}:${version}-base"
-	base_tags+=",${REGISTRY}:${major}.${minor}-base"
-	base_tags+=",${REGISTRY}:${major}-base"
-	base_tags+=",${REGISTRY}:sha-${SHA}-base"
+	base_tags="${BASE_REGISTRY}:${version}"
+	base_tags+=",${BASE_REGISTRY}:${major}.${minor}"
+	base_tags+=",${BASE_REGISTRY}:${major}"
+	base_tags+=",${BASE_REGISTRY}:sha-${SHA}"
 	echo "base-tags=${base_tags}" >>"$GITHUB_OUTPUT"
 	echo "has-base=true" >>"$GITHUB_OUTPUT"
 else

--- a/scripts/ci/backfill-compute-tags.sh
+++ b/scripts/ci/backfill-compute-tags.sh
@@ -5,7 +5,7 @@
 # Environment variables:
 #   TAG               - Git tag (e.g. v0.52.2)
 #   SHA               - Full commit SHA
-#   GITHUB_REPOSITORY - Owner/repo (e.g. lgtm-hq/py-lintro), used for registry
+#   GITHUB_REPOSITORY - Owner/repo (e.g. lgtm-hq/py-lintro); owner derives GHCR path
 #
 # Outputs (via GITHUB_OUTPUT):
 #   main-tags  - Comma-separated tags for ghcr.io/<owner>/py-lintro
@@ -41,8 +41,9 @@ if ! [[ "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
 	exit 1
 fi
 
-# Derive registry from GITHUB_REPOSITORY (lowercase for GHCR compatibility).
-# Full image: ghcr.io/<owner>/py-lintro — base image: ghcr.io/<owner>/py-lintro-base
+# Derive owner from GITHUB_REPOSITORY; GHCR packages are fixed names
+# py-lintro / py-lintro-base (split packages). Repo rename requires updating REGISTRY*,
+# BASE_REGISTRY below (legacy single-package code used ghcr.io/<owner>/<repo-lowercase>).
 repo="${GITHUB_REPOSITORY:-lgtm-hq/py-lintro}"
 owner="${repo%%/*}"
 REGISTRY="ghcr.io/${owner,,}/py-lintro"

--- a/scripts/ci/maintenance/ghcr_prune/cli.py
+++ b/scripts/ci/maintenance/ghcr_prune/cli.py
@@ -44,7 +44,7 @@ DEFAULT_MIN_AGE_DAYS = 7
 DEFAULT_BUILDCACHE_PR_AGE_DAYS = 14
 
 # Production image packages — referenced-digest protection applies here.
-_PROD_PACKAGES: tuple[str, ...] = ("py-lintro", "lintro-tools")
+_PROD_PACKAGES: tuple[str, ...] = ("py-lintro", "py-lintro-base", "lintro-tools")
 
 
 def _read_int_env(name: str, default: int) -> int:

--- a/tests/scripts/ghcr_prune/test_buildcache.py
+++ b/tests/scripts/ghcr_prune/test_buildcache.py
@@ -218,6 +218,7 @@ def test_main_iterates_buildcache_packages(
                 return MockOwnerResponse()
             for name in (
                 *BUILDCACHE_PACKAGES,
+                "py-lintro-base",
                 "py-lintro",
                 "lintro-tools",
             ):
@@ -247,6 +248,7 @@ def test_main_iterates_buildcache_packages(
     assert_that(rc).is_equal_to(0)
     for pkg in BUILDCACHE_PACKAGES:
         assert_that(seen).contains(pkg)
+    assert_that(seen).contains("py-lintro-base")
     assert_that(seen).contains("py-lintro")
     assert_that(seen).contains("lintro-tools")
 

--- a/tests/scripts/ghcr_prune/test_main.py
+++ b/tests/scripts/ghcr_prune/test_main.py
@@ -49,7 +49,7 @@ def _patch_httpx(
     mock_client = make_mock_client(
         versions_data=versions_data,
         deleted=deleted,
-        missing_packages=["lintro-tools", *BUILDCACHE_PACKAGES],
+        missing_packages=["lintro-tools", "py-lintro-base", *BUILDCACHE_PACKAGES],
     )
     mock_httpx = type(
         "MockHttpx",

--- a/tests/scripts/ghcr_prune/test_referenced.py
+++ b/tests/scripts/ghcr_prune/test_referenced.py
@@ -360,7 +360,7 @@ def test_main_skips_prune_when_registry_auth_fails(
             if url.startswith("https://ghcr.io/token"):
                 # Auth failure: 401
                 return ManifestResp(payload={}, status_code=401)
-            for pkg in ("lintro-tools", *BUILDCACHE_PACKAGES):
+            for pkg in ("lintro-tools", "py-lintro-base", *BUILDCACHE_PACKAGES):
                 if pkg in url:
                     return make_versions_response(
                         versions_data=[],
@@ -469,7 +469,7 @@ def test_main_protects_slsa_children_end_to_end(
                 if "sha256:tagged-index" in url:
                     return ManifestResp(payload=index_manifest)
                 return ManifestResp(payload={}, status_code=404)
-            for pkg in ("lintro-tools", *BUILDCACHE_PACKAGES):
+            for pkg in ("lintro-tools", "py-lintro-base", *BUILDCACHE_PACKAGES):
                 if pkg in url:
                     return make_versions_response(
                         versions_data=[],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): publish minimal image to ghcr.io/py-lintro-base
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [x] docs
  - [ ] refactor
  - [x] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g., `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What's Changing

The minimal Docker image (lintro without bundled external tools) is published under **`ghcr.io/lgtm-hq/py-lintro-base`** instead of **`py-lintro`** tags such as `:base` or `:vX.Y.Z-base`. The **`py-lintro`** package is reserved for the tools-backed image so digest pins and automated digest bumps cannot accidentally select the minimal variant.

CI and maintenance were updated accordingly: publish metadata, CI ephemeral tags and cleanup for both packages, image drift checks, backfill tag script, GHCR prune production package list, and related tests.

Docs describe the two packages and how to migrate old image references.

**Astro** is bumped to **6.1.10**, **`fast-uri`** is pinned via Bun **overrides** for OSV alignment, and **`lintro/tools/manifest.json`** `astro_check` matches **package.json**.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` and `uv run lintro tst`; `scripts/ci/verify-manifest-sync.py`)

## Related Issues

None tracked for this change.

## Details

- **Consumer migration:** Replace `ghcr.io/lgtm-hq/py-lintro:base` and `ghcr.io/lgtm-hq/py-lintro:v*.*.*-base` with **`ghcr.io/lgtm-hq/py-lintro-base`** using the usual `latest`, semver, or `sha-*` tags on that package.
- **Commits on branch:** `fix(ci): …`, `docs: …`, `chore(deps): …` — squash merge using the PR title above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Minimal "base" Docker image published as a distinct GHCR package (py-lintro-base) for installations without external tools.

* **Documentation**
  * README and docs updated with base-image usage, examples, and migration guidance.

* **Chores**
  * Bumped Astro tooling 6.1.6 → 6.1.10; added an override pin for fast-uri; updated scanner suppressions.

* **Build/CI**
  * CI publishing, tagging and cleanup updated to produce and manage separate base-image tags; build tooling digest pinned.

* **Tests**
  * CI-related tests updated to include the new base-image package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/899)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->