### PR TITLE
ci(pipeline): extend resolve-tools timeout for digest polling

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -137,7 +137,9 @@ jobs:
     permissions:
       contents: read
       packages: read
-    timeout-minutes: 5
+    # Must exceed tools-image-resolve digest polling ((attempts-1)*sleep_seconds)
+    # plus docker pull latency — see scripts/ci/tools-image-resolve.sh push path.
+    timeout-minutes: 15
     # Run when detect-tool-changes AND call-tools-image both succeeded or were skipped.
     # call-tools-image skips for push events or PRs without tool changes.
     # yamllint disable rule:line-length

--- a/scripts/ci/tools-image-resolve.sh
+++ b/scripts/ci/tools-image-resolve.sh
@@ -111,7 +111,9 @@ elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
 	if [[ "$CHANGED" == "true" ]]; then
 		: "${GITHUB_SHA:?GITHUB_SHA is required when TOOLS_CHANGED=true on push}"
 		IMAGE_TAG="${IMAGE_NAME}:sha-${GITHUB_SHA}"
-		IMAGE=$(resolve_image_digest "$IMAGE_TAG" 20 15)
+		# Poll until GHCR serves the commit-scoped tag (tools-image.yml may still
+		# be publishing). Budget ~8.5m sleeps + pulls; ci job timeout must exceed this.
+		IMAGE=$(resolve_image_digest "$IMAGE_TAG" 35 15)
 		SOURCE="registry"
 		echo "Using commit-scoped tools image digest for push: ${IMAGE}"
 	else


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci(pipeline): extend resolve-tools timeout for digest polling
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Pushes to `main` that change tool inputs wait for `ghcr.io/lgtm-hq/lintro-tools:sha-<commit>` while `tools-image.yml` publishes. Digest polling allowed up to ~5 minutes of sleeps (20×15s), which matched the **`resolve-tools` job timeout (5m)** and caused CI to cancel before Docker/lint/test jobs ran (`#899` merge). This raises the job ceiling to **15 minutes** and increases digest poll attempts to **35×15s** so the resolver can outlast a normal tools-image publish.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (not required — CI timeout alignment only)
- [x] Docs updated if user-facing (n/a)
- [x] Local quality gate: `uv run lintro chk .` and `uv run lintro tst tests/`

## Closes

None.

## Details

- `.github/workflows/ci-pipeline.yml`: `resolve-tools` `timeout-minutes: 5` → `15` with comment linking to script.
- `scripts/ci/tools-image-resolve.sh`: `resolve_image_digest` `20 15` → `35 15` on push + tool-changed path; comment notes sleep budget vs job timeout.

**Testing:** `uv run lintro chk .` and `uv run lintro tst tests/` (5123 passed, coverage ~82%).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased CI timeouts and extended polling windows for container image resolution to improve build reliability under network or registry latency.
  * Added inline documentation in CI scripts to clarify expected delays and updated polling/sleep budgets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/902)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->