### PR TITLE
ci: use GitHub App token for homebrew-tap updates

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -24,11 +24,12 @@ documentation of their purposes and security considerations.
 
 ### Required Secrets
 
-| Secret Name          | Purpose                              | Scope              | Rotation     |
-| -------------------- | ------------------------------------ | ------------------ | ------------ |
-| `GITHUB_TOKEN`       | Built-in token for GitHub API access | Automatic          | Per-workflow |
-| `HOMEBREW_TAP_TOKEN` | Push to homebrew-tap repository      | `repo` on tap repo | Annually     |
-| `CODECOV_TOKEN`      | Upload coverage reports              | Codecov org        | As needed    |
+| Secret Name                    | Purpose                                           | Scope                               | Rotation                  |
+| ------------------------------ | ------------------------------------------------- | ----------------------------------- | ------------------------- |
+| `GITHUB_TOKEN`                 | Built-in token for GitHub API access              | Automatic                           | Per-workflow              |
+| `HOMEBREW_TAP_APP_ID`          | GitHub App ID for homebrew-tap formula automation | App registered under org            | If app reset              |
+| `HOMEBREW_TAP_APP_PRIVATE_KEY` | PEM for Homebrew tap GitHub App (see workflow)    | `contents: write` on `homebrew-tap` | On compromise or key roll |
+| `CODECOV_TOKEN`                | Upload coverage reports                           | Codecov org                         | As needed                 |
 
 ### Optional Secrets
 
@@ -46,7 +47,7 @@ documentation of their purposes and security considerations.
    publishing instead of API tokens. This eliminates long-lived credentials.
 
 3. **Token Rotation Schedule**:
-   - `HOMEBREW_TAP_TOKEN`: Rotate annually or immediately if compromised
+   - `HOMEBREW_TAP_APP_PRIVATE_KEY`: Rotate if compromised; regenerate in App settings
    - `CODECOV_TOKEN`: Rotate if Codecov reports suspicious activity
    - `GITHUB_TOKEN`: Automatic, no rotation needed
 

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -270,11 +270,22 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Extracted version: $VERSION from tag: $TAG"
 
+      - name: Create Homebrew tap GitHub App token
+        id: homebrew-app-token
+        # yamllint disable-line rule:line-length
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: lgtm-hq
+          repositories: homebrew-tap
+          permission-contents: write
+
       - name: Checkout homebrew-tap
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: lgtm-hq/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          token: ${{ steps.homebrew-app-token.outputs.token }}
           path: homebrew-tap
 
       - name: Generate formula

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -176,11 +176,25 @@ jobs:
         with:
           python-version: '3.14'
 
+      # GitHub App (e.g. homebrew-tap-release-bot) installed on org with access to
+      # homebrew-tap; must appear in that repo’s ruleset bypass list if main blocks
+      # direct pushes.
+      - name: Create Homebrew tap GitHub App token
+        id: homebrew-app-token
+        # yamllint disable-line rule:line-length
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: lgtm-hq
+          repositories: homebrew-tap
+          permission-contents: write
+
       - name: Checkout homebrew-tap
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: lgtm-hq/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          token: ${{ steps.homebrew-app-token.outputs.token }}
           path: homebrew-tap
 
       - name: Generate Homebrew formula


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci: use GitHub App token for homebrew-tap updates
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

This PR moves Homebrew tap updates off a long-lived `HOMEBREW_TAP_TOKEN` and onto **GitHub App** credentials: `HOMEBREW_TAP_APP_ID` plus `HOMEBREW_TAP_APP_PRIVATE_KEY`. CI uses `actions/create-github-app-token` to mint short-lived installation tokens for checking out and updating the tap. `.github/SECURITY.md` is updated so required secrets, rotation, and compromise handling match the app-based model.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (workflow/docs-only; behavior covered by repo CI on this PR)
- [x] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`) — GitHub Actions are green on this PR; run the script locally before merge if you want parity with CI

## Related Issues

<!-- Replace # with actual issue numbers, e.g., Closes #123, Fixes #456, Related #789 -->

No linked issue — internal CI hardening for Homebrew tap access.

## Details

- **Workflows:** `.github/workflows/build-binary.yml` and `.github/workflows/publish-pypi-on-tag.yml` now create a GitHub App installation token and pass it to the Homebrew tap checkout/update steps instead of a static PAT-style secret.
- **Docs:** `.github/SECURITY.md` documents `HOMEBREW_TAP_APP_ID` / `HOMEBREW_TAP_APP_PRIVATE_KEY`, with rotation and compromise guidance for the app private key.
- **Secrets / ops:** Configure the new secrets in GitHub; decommission the old `HOMEBREW_TAP_TOKEN` usage for these workflows once this is merged and verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use GitHub App–based authentication for Homebrew tap updates instead of a static secret.
* **Documentation**
  * Updated repository security guidance to reflect GitHub App credentials and rotation/compromise procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/903)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
