### PR TITLE
ci: fix tools image validation flow

### DIFF
--- a/.github/actions/resolve-tools-image/action.yml
+++ b/.github/actions/resolve-tools-image/action.yml
@@ -4,12 +4,10 @@
 name: Resolve Tools Image
 description: >-
   Detect tool file changes and resolve the appropriate tools image reference.
-  Returns the stable pinned image for contexts without tool changes. For
-  main-branch pushes with tool changes the resolver produces a commit-scoped
-  sha-${GITHUB_SHA} tag and translates it into a digest-backed image reference.
-  Callers that need a freshly built image for a PR with tool changes should
-  call tools-image.yml via workflow_call and pass the result as BUILT_IMAGE to
-  tools-image-resolve.sh directly (see ci-pipeline.yml).
+  Returns the stable pinned image for contexts that do not provide a freshly
+  built workflow_call image. Callers that need a fresh gate image for PR or
+  merge queue validation should call tools-image.yml via workflow_call and pass
+  the result context to tools-image-resolve.sh directly (see ci-pipeline.yml).
 inputs:
   image-name:
     description: Base image name without tag
@@ -39,8 +37,14 @@ runs:
       shell: bash
       env:
         GITHUB_EVENT_NAME: ${{ github.event_name }}
-        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_BASE_SHA: >-
+          ${{ github.event.pull_request.base.sha ||
+          github.event.merge_group.base_sha ||
+          github.event.merge_group.base_commit_oid }}
+        PR_HEAD_SHA: >-
+          ${{ github.event.pull_request.head.sha ||
+          github.event.merge_group.head_sha ||
+          github.event.merge_group.head_commit_oid }}
         GITHUB_EVENT_BEFORE: ${{ github.event.before }}
       run: scripts/ci/tools-image-detect-changes.sh
 

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -4,7 +4,7 @@
 name: CI Pipeline
 
 # Gated CI:
-#   detect-tool-changes ──→ call-tools-image (PR + tool files changed via workflow_call)
+#   detect-tool-changes ──→ call-tools-image (fresh PR/MQ tools image)
 #                      ╲                    ╲
 # yamllint disable rule:line-length
 #                       ╲──────────────────→ resolve-tools (immutable image ref / artifact fallback) → docker-build ─┬─ lint
@@ -16,11 +16,12 @@ name: CI Pipeline
 # yamllint disable-line rule:line-length
 #                                                            test → deploy-pages (main only)
 #
-# tools-image.yml is called via workflow_call for pull requests that change tool
-# files, and resolve-tools chooses the final tools image source for downstream jobs.
-# Same-repo runs use pinned/immutable image references, while fork PRs fall back to
-# the saved tools-image artifact because they cannot publish to GHCR. Main pushes
-# also resolve immutable tools-image references here before docker-build runs.
+# tools-image.yml is called via workflow_call for PRs and merge queue runs that
+# change tool files. resolve-tools chooses the final tools image source for
+# downstream jobs. Same-repo gate runs use fresh immutable image references, while
+# fork PRs fall back to the saved tools-image artifact because they cannot publish
+# to GHCR. Main push CI uses the stable pinned tools image; the separate
+# Build - Tools Image workflow publishes and validates production tools images.
 # Docker image built ONCE and shared via GHCR (ci-<run_id> tags), with artifact
 # fallback for fork PRs. Smoke test folded into test job.
 
@@ -101,7 +102,7 @@ jobs:
         run: scripts/ci/tools-image-detect-changes.sh
 
   # ============================================================================
-  # Stage 1b: Build fresh tools image (PR events with tool changes)
+  # Stage 1b: Build fresh tools image (PR and merge queue events with tool changes)
   # Delegates to tools-image.yml via workflow_call — no polling required.
   # ============================================================================
   call-tools-image:
@@ -112,8 +113,9 @@ jobs:
     # The tools-changed check moves to skip_if_unchanged (runtime with: expression)
     # so startup validation never sees a needs-output reference in this condition.
     if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.draft == false
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false) ||
+      github.event_name == 'merge_group'
     uses: ./.github/workflows/tools-image.yml
     permissions:
       contents: write
@@ -123,9 +125,10 @@ jobs:
     with:
       # yamllint disable-line rule:line-length
       skip_if_unchanged: ${{ needs.detect-tool-changes.outputs.tools-changed != 'true' }}
-      pr_number: ${{ github.event.pull_request.number }}
       # yamllint disable-line rule:line-length
-      is_fork_pr: ${{ github.event.pull_request.head.repo.fork && 'true' || 'false' }}
+      pr_number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+      # yamllint disable-line rule:line-length
+      is_fork_pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'true' || 'false' }}
 
   # ============================================================================
   # Stage 1c: Resolve final tools image reference
@@ -137,9 +140,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    # Must exceed tools-image-resolve digest polling ((attempts-1)*sleep_seconds)
-    # plus docker pull latency — see scripts/ci/tools-image-resolve.sh push path.
-    timeout-minutes: 15
+    timeout-minutes: 5
     # Run when detect-tool-changes AND call-tools-image both succeeded or were skipped.
     # call-tools-image skips for push events or PRs without tool changes.
     # yamllint disable rule:line-length
@@ -178,8 +179,9 @@ jobs:
           IMAGE_NAME: ghcr.io/lgtm-hq/lintro-tools
           # Use .result (not .outputs) to avoid startup_failure — GitHub rejects
           # workflows where downstream jobs reference .outputs of a conditional
-          # reusable-workflow job. The PR tag is deterministic (pr-<number>), so
-          # we derive it from PR_NUMBER + CALL_RESULT instead of passing the output.
+          # reusable-workflow job. Fresh gate tags are deterministic (pr-<number>
+          # for PRs, sha-<commit> for merge queue), so we derive them from event
+          # context + CALL_RESULT instead of passing the output.
           CALL_RESULT: ${{ needs.call-tools-image.result }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           IS_FORK_PR: ${{ github.event.pull_request.head.repo.fork }}

--- a/scripts/ci/tools-image-detect-changes.sh
+++ b/scripts/ci/tools-image-detect-changes.sh
@@ -6,7 +6,7 @@
 # Used by resolve-tools-image action.
 #
 # Required environment variables:
-#   GITHUB_EVENT_NAME     - "push" or "pull_request"
+#   GITHUB_EVENT_NAME     - "push", "pull_request", or "merge_group"
 #   GITHUB_OUTPUT         - Path to GitHub outputs file
 # Required for pull_request:
 #   PR_BASE_SHA           - Base commit SHA for PR
@@ -24,7 +24,7 @@ Usage:
   scripts/ci/tools-image-detect-changes.sh
 
 Environment Variables (required):
-  GITHUB_EVENT_NAME   GitHub event name (push or pull_request)
+  GITHUB_EVENT_NAME   GitHub event name (push, pull_request, or merge_group)
   GITHUB_OUTPUT       Path to GitHub output file
 
 Environment Variables (for pull_request):
@@ -47,10 +47,10 @@ fi
 : "${GITHUB_EVENT_NAME:?GITHUB_EVENT_NAME is required}"
 : "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
 
-# Define tool-related file patterns that require CI to use a freshly built
+# Define tool-related file patterns that require merge-gating CI to use a fresh
 # tools image. This list must stay aligned with the reusable workflow's
 # workflow_call change detection so resolve-tools picks the same image that the
-# build stage produced.
+# build stage produced for PR and merge queue runs.
 TOOL_PATTERNS=(
 	"Dockerfile.tools"
 	"scripts/utils/install-tools.sh"
@@ -129,10 +129,10 @@ if [[ "$tools_changed" == "true" ]]; then
 		echo "::notice::Tool files changed — fresh tools image will be built via workflow_call"
 		;;
 	merge_group)
-		echo "::notice::Tool files changed in merge queue — stable image will be used (PR build already validated)"
+		echo "::notice::Tool files changed in merge queue — fresh tools image will be built via workflow_call"
 		;;
 	*)
-		echo "::notice::Tool files changed — tools-image.yml will build a fresh image"
+		echo "::notice::Tool files changed — production tools image will be built by Build - Tools Image"
 		;;
 	esac
 else

--- a/scripts/ci/tools-image-resolve.sh
+++ b/scripts/ci/tools-image-resolve.sh
@@ -7,8 +7,8 @@
 #
 # Resolution order:
 #   1. BUILT_IMAGE                    (set when ci-pipeline.yml called tools-image.yml via workflow_call)
-#   2. IMAGE_NAME:sha-${GITHUB_SHA}@digest (push events with tool changes)
-#   3. STABLE_IMAGE                   (PRs without tool changes and pushes without tool changes)
+#   2. IMAGE_NAME:sha-${GITHUB_SHA}   (merge queue with tool changes)
+#   3. STABLE_IMAGE                   (main pushes, PRs without tool changes, and other events)
 #      If STABLE_IMAGE is not provided, reads the pinned value from Dockerfile.
 #
 # Required environment variables:
@@ -18,13 +18,13 @@
 #
 # Optional environment variables:
 #   CALL_RESULT         - Result of the call-tools-image job ("success", "skipped", etc.)
-#                         When "success", TOOLS_CHANGED is true, and PR_NUMBER is set,
-#                         derives the built PR image tag.
+#                         When "success" and TOOLS_CHANGED is true, derives the
+#                         built PR or merge-queue image tag.
 #   PR_NUMBER           - PR number; used with CALL_RESULT to derive the PR image tag.
 #   BUILT_IMAGE         - Pre-built image override (takes priority over CALL_RESULT if set)
 #   STABLE_IMAGE        - Full stable image reference with digest; read from Dockerfile if unset
-#   TOOLS_CHANGED       - "true"/"false" to decide whether a fresh build/image must be used
-#   GITHUB_SHA          - Commit SHA for push/main resolution
+#   TOOLS_CHANGED       - "true"/"false" to decide whether a fresh gate image must be used
+#   GITHUB_SHA          - Commit SHA for merge-queue resolution
 #   IS_FORK_PR          - "true" when the pull request comes from a fork (uses artifact fallback)
 
 set -euo pipefail
@@ -38,8 +38,8 @@ Usage:
 
 Resolution order:
   1. BUILT_IMAGE                 — pre-built image from workflow_call (highest priority)
-  2. IMAGE_NAME:sha-${GITHUB_SHA}@digest — push events with tool changes
-  3. STABLE_IMAGE                — PRs without tool changes (read from Dockerfile if unset)
+  2. IMAGE_NAME:sha-${GITHUB_SHA} — merge queue with tool changes
+  3. STABLE_IMAGE                — main pushes, PRs without tool changes, and other events
 
 Environment Variables (required):
   GITHUB_EVENT_NAME   GitHub event name (push, pull_request, workflow_dispatch, ...)
@@ -49,16 +49,20 @@ Environment Variables (required):
 Environment Variables (optional):
   BUILT_IMAGE         Full image reference from a workflow_call build; if set, used directly
   STABLE_IMAGE        Full stable image reference with digest; read from Dockerfile if unset
-  TOOLS_CHANGED       "true"/"false" — gates BUILT_IMAGE derivation from CALL_RESULT/PR_NUMBER
-                      and chooses between fresh-digest resolution and STABLE_IMAGE on push
+  TOOLS_CHANGED       "true"/"false" — gates BUILT_IMAGE derivation from CALL_RESULT
 
 Outputs (to GITHUB_OUTPUT):
   image               Full image reference to use
   source              Where the image comes from: registry, artifact, or stable
 
-Example (fresh build from workflow_call via CALL_RESULT):
+Example (fresh PR build from workflow_call via CALL_RESULT):
   CALL_RESULT=success PR_NUMBER=123 \
   GITHUB_EVENT_NAME=pull_request IMAGE_NAME=ghcr.io/org/lintro-tools \
+  GITHUB_OUTPUT=/tmp/out ./scripts/ci/tools-image-resolve.sh
+
+Example (fresh merge-queue build from workflow_call via CALL_RESULT):
+  CALL_RESULT=success GITHUB_SHA=abc123... TOOLS_CHANGED=true \
+  GITHUB_EVENT_NAME=merge_group IMAGE_NAME=ghcr.io/org/lintro-tools \
   GITHUB_OUTPUT=/tmp/out ./scripts/ci/tools-image-resolve.sh
 
 Example (stable image for PR without tool changes):
@@ -79,15 +83,16 @@ get_tools_image_from_dockerfile() {
 	grep -E '^ARG TOOLS_IMAGE=' Dockerfile 2>/dev/null | head -n1 | cut -d= -f2 || true
 }
 
-# shellcheck disable=SC1091 # helper path resolved at runtime via $(dirname "$0")
-source "$(dirname "$0")/tools-image-digest-helpers.sh"
-
-# Derive BUILT_IMAGE from CALL_RESULT + PR_NUMBER when not set directly.
+# Derive BUILT_IMAGE from CALL_RESULT + event context when not set directly.
 # This avoids referencing reusable-workflow job outputs (which causes startup_failure
 # when the calling job has a conditional if:).
 if [[ -z "${BUILT_IMAGE:-}" && "${CALL_RESULT:-}" == "success" &&
 	"${TOOLS_CHANGED:-false}" == "true" && -n "${PR_NUMBER:-}" ]]; then
 	BUILT_IMAGE="${IMAGE_NAME}:pr-${PR_NUMBER}"
+elif [[ -z "${BUILT_IMAGE:-}" && "${CALL_RESULT:-}" == "success" &&
+	"${TOOLS_CHANGED:-false}" == "true" && "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
+	: "${GITHUB_SHA:?GITHUB_SHA is required for merge_group fresh tools image resolution}"
+	BUILT_IMAGE="${IMAGE_NAME}:sha-${GITHUB_SHA}"
 fi
 
 # ------------------------------------------------------------------
@@ -104,37 +109,12 @@ if [[ -n "${BUILT_IMAGE:-}" ]]; then
 	fi
 
 # ------------------------------------------------------------------
-# 2. Push to main — require the commit-scoped SHA tag when tool files changed
-# ------------------------------------------------------------------
-elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-	CHANGED="${TOOLS_CHANGED:-false}"
-	if [[ "$CHANGED" == "true" ]]; then
-		: "${GITHUB_SHA:?GITHUB_SHA is required when TOOLS_CHANGED=true on push}"
-		IMAGE_TAG="${IMAGE_NAME}:sha-${GITHUB_SHA}"
-		# Poll until GHCR serves the commit-scoped tag (tools-image.yml may still
-		# be publishing). Budget ~8.5m sleeps + pulls; ci job timeout must exceed this.
-		IMAGE=$(resolve_image_digest "$IMAGE_TAG" 35 15)
-		SOURCE="registry"
-		echo "Using commit-scoped tools image digest for push: ${IMAGE}"
-	else
-		if [[ -z "${STABLE_IMAGE:-}" ]]; then
-			STABLE_IMAGE=$(get_tools_image_from_dockerfile)
-		fi
-		if [[ -z "${STABLE_IMAGE:-}" ]]; then
-			echo "::error::STABLE_IMAGE is unset and could not be read from Dockerfile"
-			exit 1
-		fi
-		IMAGE="${STABLE_IMAGE}"
-		SOURCE="stable"
-		echo "Using stable tools image (no tool changes on push): ${IMAGE}"
-	fi
-
-# ------------------------------------------------------------------
-# 3. Stable pinned image — PRs without tool changes, workflow_dispatch, etc.
+# 2. Stable pinned image — main pushes and runs without fresh gate images
 # ------------------------------------------------------------------
 else
 	if [[ -z "${STABLE_IMAGE:-}" ]]; then
-		# Read the pinned digest directly from Dockerfile — kept current by pin-digest job
+		# Read the pinned digest directly from Dockerfile. The release flow keeps
+		# it current after successful production tools-image builds.
 		STABLE_IMAGE=$(get_tools_image_from_dockerfile)
 	fi
 	if [[ -z "${STABLE_IMAGE:-}" ]]; then
@@ -143,7 +123,11 @@ else
 	fi
 	IMAGE="${STABLE_IMAGE}"
 	SOURCE="stable"
-	echo "Using stable tools image (pinned digest): ${IMAGE}"
+	if [[ "$GITHUB_EVENT_NAME" == "push" && "${TOOLS_CHANGED:-false}" == "true" ]]; then
+		echo "Using stable tools image for main push; Build - Tools Image validates production image: ${IMAGE}"
+	else
+		echo "Using stable tools image (pinned digest): ${IMAGE}"
+	fi
 fi
 
 echo "image=${IMAGE}" >>"$GITHUB_OUTPUT"

--- a/tests/scripts/test_tools_image_detect_changes.py
+++ b/tests/scripts/test_tools_image_detect_changes.py
@@ -84,7 +84,7 @@ def _run_script(
             },
         )
 
-        if event == "pull_request":
+        if event in {"pull_request", "merge_group"}:
             env.update(
                 {
                     "PR_BASE_SHA": "base-sha",
@@ -128,6 +128,34 @@ def test_detect_changes_matches_tools_image_on_push() -> None:
     assert_that(result.returncode).is_equal_to(0)
     assert_that(output_text).contains("tools_changed=true")
     assert_that(result.stdout).contains("scripts/ci/tools-image-*.sh")
+
+
+def test_detect_changes_matches_tools_image_on_merge_group() -> None:
+    """Merge queue events request a fresh tools-image build for tool changes."""
+    result, output_text = _run_script(
+        changed_files="scripts/ci/tools-image-resolve.sh\nREADME.md",
+        event="merge_group",
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(output_text).contains("tools_changed=true")
+    assert_that(result.stdout).contains(
+        "fresh tools image will be built via workflow_call",
+    )
+
+
+def test_detect_changes_on_push_uses_production_tools_image_notice() -> None:
+    """Main pushes leave production image validation to Build - Tools Image."""
+    result, output_text = _run_script(
+        changed_files="scripts/ci/tools-image-resolve.sh\nREADME.md",
+        event="push",
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(output_text).contains("tools_changed=true")
+    assert_that(result.stdout).contains(
+        "production tools image will be built by Build - Tools Image",
+    )
 
 
 def _shell_tool_paths() -> frozenset[str]:

--- a/tests/scripts/test_tools_image_resolve.py
+++ b/tests/scripts/test_tools_image_resolve.py
@@ -1,0 +1,147 @@
+"""Tests for `scripts/ci/tools-image-resolve.sh`."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+from assertpy import assert_that
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "tools-image-resolve.sh"
+IMAGE_NAME = "ghcr.io/example/lintro-tools"
+STABLE_IMAGE = f"{IMAGE_NAME}:latest@sha256:{'a' * 64}"
+MERGE_GROUP_SHA = "1234567890abcdef1234567890abcdef12345678"
+
+
+def _write_fake_docker(bin_dir: Path) -> None:
+    """Write a fake docker executable that fails if the resolver shells out to it.
+
+    Args:
+        bin_dir: Directory that will contain the fake `docker` binary.
+    """
+    fake_docker = bin_dir / "docker"
+    fake_docker.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo 'docker should not be called by this test' >&2\n"
+        "exit 42\n",
+    )
+    fake_docker.chmod(fake_docker.stat().st_mode | stat.S_IXUSR)
+
+
+def _run_resolve(
+    *,
+    event: str,
+    tools_changed: str = "false",
+    call_result: str = "",
+    pr_number: str = "",
+    github_sha: str = MERGE_GROUP_SHA,
+    stable_image: str = STABLE_IMAGE,
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    """Run the tools image resolver with an isolated GitHub output file.
+
+    Args:
+        event: GitHub event name passed to the resolver.
+        tools_changed: Value for TOOLS_CHANGED.
+        call_result: Value for CALL_RESULT.
+        pr_number: Value for PR_NUMBER.
+        github_sha: Value for GITHUB_SHA.
+        stable_image: Value for STABLE_IMAGE.
+
+    Returns:
+        Tuple of subprocess result and output file contents.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        temp_dir = Path(tmpdir)
+        bin_dir = temp_dir / "bin"
+        bin_dir.mkdir()
+        _write_fake_docker(bin_dir=bin_dir)
+
+        output_file = temp_dir / "github-output.txt"
+        env = os.environ.copy()
+        env.update(
+            {
+                "CALL_RESULT": call_result,
+                "GITHUB_EVENT_NAME": event,
+                "GITHUB_OUTPUT": str(output_file),
+                "GITHUB_SHA": github_sha,
+                "IMAGE_NAME": IMAGE_NAME,
+                "PATH": f"{bin_dir}:{env['PATH']}",
+                "PR_NUMBER": pr_number,
+                "STABLE_IMAGE": stable_image,
+                "TOOLS_CHANGED": tools_changed,
+            },
+        )
+
+        result = subprocess.run(
+            [str(SCRIPT_PATH)],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            env=env,
+            check=False,
+        )
+
+        output_text = output_file.read_text() if output_file.exists() else ""
+        return result, output_text
+
+
+def test_pr_workflow_call_success_resolves_pr_image() -> None:
+    """PRs with successful fresh tools-image builds use the PR image tag."""
+    result, output_text = _run_resolve(
+        event="pull_request",
+        tools_changed="true",
+        call_result="success",
+        pr_number="123",
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(output_text).contains(f"image={IMAGE_NAME}:pr-123")
+    assert_that(output_text).contains("source=registry")
+    assert_that(result.stdout).contains("Using pre-built tools image")
+
+
+def test_merge_group_workflow_call_success_resolves_sha_image() -> None:
+    """Merge queue fresh tools-image builds use the merge-group commit tag."""
+    result, output_text = _run_resolve(
+        event="merge_group",
+        tools_changed="true",
+        call_result="success",
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(output_text).contains(f"image={IMAGE_NAME}:sha-{MERGE_GROUP_SHA}")
+    assert_that(output_text).contains("source=registry")
+    assert_that(result.stdout).contains("Using pre-built tools image")
+
+
+def test_main_push_with_tool_changes_uses_stable_image_without_docker_polling() -> None:
+    """Main push CI uses the stable image even when tool files changed."""
+    result, output_text = _run_resolve(
+        event="push",
+        tools_changed="true",
+        call_result="skipped",
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(output_text).contains(f"image={STABLE_IMAGE}")
+    assert_that(output_text).contains("source=stable")
+    assert_that(result.stdout).contains("Build - Tools Image validates")
+    assert_that(result.stderr).does_not_contain("docker should not be called")
+
+
+def test_main_push_without_tool_changes_uses_stable_image() -> None:
+    """Main push CI keeps using the pinned stable image when tools are unchanged."""
+    result, output_text = _run_resolve(
+        event="push",
+        tools_changed="false",
+        call_result="skipped",
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(output_text).contains(f"image={STABLE_IMAGE}")
+    assert_that(output_text).contains("source=stable")
+    assert_that(result.stdout).contains("Using stable tools image")


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci: fix tools image validation flow
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Fixes tools-image CI validation so merge-gating workflows validate fresh tools images without making `main` push CI wait on cross-workflow GHCR digest polling.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk .` and `uv run lintro tst`)

## Related Issues

No linked issue.

## Details

- Removes the push-time GHCR digest polling path from tools-image resolution.
- Keeps PR tools changes on fresh `pr-<number>` images built through `workflow_call`.
- Adds merge queue tools-image validation through `workflow_call` with fresh `sha-<merge-group-sha>` images.
- Makes `push` to `main` resolve the stable pinned Dockerfile image, leaving production image validation and publishing to the separate `Build - Tools Image` workflow.
- Updates resolver/detection comments and tests to document the new contract.

Testing performed:

- `uv run pytest tests/scripts/test_tools_image_detect_changes.py tests/scripts/test_tools_image_resolve.py`
- `uv run lintro chk .`
- `uv run lintro tst`
- `git diff --check`

Review note: local CodeRabbit review could not run because neither `coderabbit` nor `cr` is installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering tool-image detection and resolution for pull requests, merge-queue runs, and production pushes.

* **Chores**
  * CI now treats merge-queue events like PRs for tool-image orchestration.
  * Simplified stable tools-image resolution path and reduced resolve timeout for faster CI feedback.
  * Updated CI documentation and inline guidance around fresh vs. pinned tools images.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/905)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->