### PR TITLE
fix(release): open Homebrew tap PRs

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -280,6 +280,7 @@ jobs:
           owner: lgtm-hq
           repositories: homebrew-tap
           permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout homebrew-tap
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -296,10 +297,19 @@ jobs:
             "${{ steps.checksums.outputs.x86_64_sha256 }}" \
             "homebrew-tap/Formula/lintro-bin.rb"
 
-      - name: Commit and push
+      - name: Create Homebrew tap PR
         env:
+          GH_TOKEN: ${{ steps.homebrew-app-token.outputs.token }}
           WORKING_DIR: homebrew-tap
-        run: |
-          lintro/scripts/ci/git-commit-push.sh \
-            "Formula/lintro-bin.rb" \
-            "Update lintro-bin to ${{ steps.version.outputs.version }}"
+          PR_BRANCH: homebrew/lintro-bin-${{ steps.version.outputs.version }}
+          PR_TITLE: Update lintro-bin to ${{ steps.version.outputs.version }}
+          PR_BODY: |
+            Updates `Formula/lintro-bin.rb` for lintro
+            ${{ steps.version.outputs.version }}.
+
+            Auto-merge is enabled once `validate-formula` passes.
+        run: >-
+          lintro/scripts/ci/homebrew/create-tap-pr.sh
+          "Formula/lintro-bin.rb"
+          "Update lintro-bin to ${{ steps.version.outputs.version }}"
+          --skip-if-empty

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -177,8 +177,7 @@ jobs:
           python-version: '3.14'
 
       # GitHub App (e.g. homebrew-tap-release-bot) installed on org with access to
-      # homebrew-tap; must appear in that repo’s ruleset bypass list if main blocks
-      # direct pushes.
+      # homebrew-tap. It opens a formula PR and enables auto-merge after checks pass.
       - name: Create Homebrew tap GitHub App token
         id: homebrew-app-token
         # yamllint disable-line rule:line-length
@@ -189,6 +188,7 @@ jobs:
           owner: lgtm-hq
           repositories: homebrew-tap
           permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout homebrew-tap
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -203,11 +203,18 @@ jobs:
             "${{ steps.version.outputs.version }}" \
             "homebrew-tap/Formula/lintro.rb"
 
-      - name: Commit and push
+      - name: Create Homebrew tap PR
         env:
+          GH_TOKEN: ${{ steps.homebrew-app-token.outputs.token }}
           WORKING_DIR: homebrew-tap
-        run: |
-          lintro/scripts/ci/git-commit-push.sh \
-            "Formula/lintro.rb" \
-            "Update lintro to ${{ steps.version.outputs.version }}" \
-            --skip-if-empty
+          PR_BRANCH: homebrew/lintro-${{ steps.version.outputs.version }}
+          PR_TITLE: Update lintro to ${{ steps.version.outputs.version }}
+          PR_BODY: |
+            Updates `Formula/lintro.rb` for lintro ${{ steps.version.outputs.version }}.
+
+            Auto-merge is enabled once `validate-formula` passes.
+        run: >-
+          lintro/scripts/ci/homebrew/create-tap-pr.sh
+          "Formula/lintro.rb"
+          "Update lintro to ${{ steps.version.outputs.version }}"
+          --skip-if-empty

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -157,16 +157,17 @@ Scripts for GitHub Actions workflows and continuous integration.
 
 Scripts for generating and updating Homebrew formulas.
 
-| Script                       | Purpose                                            | Usage                                                      |
-| ---------------------------- | -------------------------------------------------- | ---------------------------------------------------------- |
-| `wait-for-pypi.sh`           | Poll PyPI until package version is available       | `./scripts/ci/homebrew/wait-for-pypi.sh lintro 1.0.0`      |
-| `generate-pypi-formula.sh`   | Generate lintro.rb formula from PyPI               | `./scripts/ci/homebrew/generate-pypi-formula.sh 1.0.0 out` |
-| `generate-binary-formula.sh` | Generate lintro-bin.rb formula for binaries        | `./scripts/ci/homebrew/generate-binary-formula.sh ...`     |
-| `pypi_utils.py`              | Shared PyPI API utilities module                   | Imported by other Python scripts                           |
-| `fetch_package_info.py`      | Fetch package tarball info from PyPI               | `python3 fetch_package_info.py lintro 1.0.0`               |
-| `fetch_wheel_info.py`        | Fetch wheel info and generate resource stanzas     | `python3 fetch_wheel_info.py pydoclint --type universal`   |
-| `render_formula.py`          | Render Homebrew formula from template              | `python3 render_formula.py --tarball-url ... -o out.rb`    |
-| `generate_resources.py`      | Generate Homebrew resource stanzas (replaces poet) | `python3 generate_resources.py lintro --exclude pkg1 pkg2` |
+| Script                       | Purpose                                             | Usage                                                                      |
+| ---------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------- |
+| `wait-for-pypi.sh`           | Poll PyPI until package version is available        | `./scripts/ci/homebrew/wait-for-pypi.sh lintro 1.0.0`                      |
+| `create-tap-pr.sh`           | Create/update Homebrew tap PR and enable auto-merge | `./scripts/ci/homebrew/create-tap-pr.sh Formula/lintro.rb "Update lintro"` |
+| `generate-pypi-formula.sh`   | Generate lintro.rb formula from PyPI                | `./scripts/ci/homebrew/generate-pypi-formula.sh 1.0.0 out`                 |
+| `generate-binary-formula.sh` | Generate lintro-bin.rb formula for binaries         | `./scripts/ci/homebrew/generate-binary-formula.sh ...`                     |
+| `pypi_utils.py`              | Shared PyPI API utilities module                    | Imported by other Python scripts                                           |
+| `fetch_package_info.py`      | Fetch package tarball info from PyPI                | `python3 fetch_package_info.py lintro 1.0.0`                               |
+| `fetch_wheel_info.py`        | Fetch wheel info and generate resource stanzas      | `python3 fetch_wheel_info.py pydoclint --type universal`                   |
+| `render_formula.py`          | Render Homebrew formula from template               | `python3 render_formula.py --tarball-url ... -o out.rb`                    |
+| `generate_resources.py`      | Generate Homebrew resource stanzas (replaces poet)  | `python3 generate_resources.py lintro --exclude pkg1 pkg2`                 |
 
 ### 🐳 Docker Scripts (`docker/`)
 

--- a/scripts/ci/homebrew/create-tap-pr.sh
+++ b/scripts/ci/homebrew/create-tap-pr.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Commit Homebrew tap updates to a branch and enable PR auto-merge.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../utils/utils.sh disable=SC1091
+source "$SCRIPT_DIR/../../utils/utils.sh"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Create or update a Homebrew tap PR and enable auto-merge.
+
+Usage: create-tap-pr.sh <file-pattern> <commit-message> [--skip-if-empty]
+
+Environment:
+  WORKING_DIR   Tap checkout directory (default: current directory)
+  PR_BRANCH     Branch to push in the tap repo
+  PR_TITLE      Pull request title
+  PR_BODY       Pull request body
+  PR_BASE       Pull request base branch (default: main)
+  GH_TOKEN      GitHub token with contents and pull-requests write permissions
+EOF
+	exit 0
+fi
+
+FILE_PATTERN="${1:?File pattern is required}"
+COMMIT_MESSAGE="${2:?Commit message is required}"
+SKIP_IF_EMPTY="${3:-}"
+WORKING_DIR="${WORKING_DIR:-.}"
+PR_BASE="${PR_BASE:-main}"
+
+: "${PR_BRANCH:?PR_BRANCH is required}"
+: "${PR_TITLE:?PR_TITLE is required}"
+: "${PR_BODY:?PR_BODY is required}"
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+cd "$WORKING_DIR"
+
+git config user.name "lgtm-homebrew-tap[bot]"
+git config user.email "lgtm-homebrew-tap[bot]@users.noreply.github.com"
+
+log_info "Staging changes: $FILE_PATTERN"
+git add "$FILE_PATTERN"
+
+if git diff --staged --quiet; then
+	if [[ "$SKIP_IF_EMPTY" == "--skip-if-empty" ]]; then
+		log_info "No changes to commit, skipping"
+		exit 0
+	fi
+
+	log_warning "No changes to commit"
+	exit 0
+fi
+
+log_info "Creating update commit"
+git checkout -B "$PR_BRANCH"
+git commit -m "$COMMIT_MESSAGE"
+
+log_info "Pushing branch: $PR_BRANCH"
+git push --force-with-lease origin "HEAD:$PR_BRANCH"
+
+existing_pr="$(
+	gh pr list \
+		--head "$PR_BRANCH" \
+		--base "$PR_BASE" \
+		--state open \
+		--json number \
+		--jq '.[0].number // ""'
+)"
+
+if [[ -n "$existing_pr" ]]; then
+	log_info "Using existing Homebrew tap PR #$existing_pr"
+	pr_number="$existing_pr"
+else
+	log_info "Creating Homebrew tap PR"
+	pr_url="$(
+		gh pr create \
+			--base "$PR_BASE" \
+			--head "$PR_BRANCH" \
+			--title "$PR_TITLE" \
+			--body "$PR_BODY"
+	)"
+	pr_number="${pr_url##*/}"
+fi
+
+log_info "Enabling auto-merge for Homebrew tap PR #$pr_number"
+gh pr merge "$pr_number" --auto --squash --delete-branch
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	echo "pr-number=$pr_number" >>"$GITHUB_OUTPUT"
+	echo "pr-url=${GITHUB_SERVER_URL}/lgtm-hq/homebrew-tap/pull/${pr_number}" >>"$GITHUB_OUTPUT"
+fi
+
+log_success "Homebrew tap PR ready: #$pr_number"

--- a/scripts/ci/homebrew/create-tap-pr.sh
+++ b/scripts/ci/homebrew/create-tap-pr.sh
@@ -14,6 +14,9 @@ Create or update a Homebrew tap PR and enable auto-merge.
 
 Usage: create-tap-pr.sh <file-pattern> <commit-message> [--skip-if-empty]
 
+Options:
+  --skip-if-empty  Exit 0 if there are no changes (default: error)
+
 Environment:
   WORKING_DIR   Tap checkout directory (default: current directory)
   PR_BRANCH     Branch to push in the tap repo
@@ -36,6 +39,11 @@ PR_BASE="${PR_BASE:-main}"
 : "${PR_BODY:?PR_BODY is required}"
 : "${GH_TOKEN:?GH_TOKEN is required}"
 
+if [[ -n "$SKIP_IF_EMPTY" && "$SKIP_IF_EMPTY" != "--skip-if-empty" ]]; then
+	log_error "Unknown option: $SKIP_IF_EMPTY"
+	exit 1
+fi
+
 cd "$WORKING_DIR"
 
 git config user.name "lgtm-homebrew-tap[bot]"
@@ -50,8 +58,8 @@ if git diff --staged --quiet; then
 		exit 0
 	fi
 
-	log_warning "No changes to commit"
-	exit 0
+	log_error "No changes to commit"
+	exit 1
 fi
 
 log_info "Creating update commit"
@@ -89,8 +97,9 @@ log_info "Enabling auto-merge for Homebrew tap PR #$pr_number"
 gh pr merge "$pr_number" --auto --squash --delete-branch
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	tap_repository="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
 	echo "pr-number=$pr_number" >>"$GITHUB_OUTPUT"
-	echo "pr-url=${GITHUB_SERVER_URL}/lgtm-hq/homebrew-tap/pull/${pr_number}" >>"$GITHUB_OUTPUT"
+	echo "pr-url=${GITHUB_SERVER_URL}/${tap_repository}/pull/${pr_number}" >>"$GITHUB_OUTPUT"
 fi
 
 log_success "Homebrew tap PR ready: #$pr_number"


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(release): open Homebrew tap PRs
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `fix(...)` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Routes Homebrew tap formula updates through PRs instead of direct pushes to protected `main`, so the `validate-formula` ruleset can run before auto-merge completes the release automation.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`, `uv run lintro tst`)

## Related Issues

N/A

## Details

- Adds `scripts/ci/homebrew/create-tap-pr.sh` to commit formula updates to a tap branch, create or reuse an open PR, and enable squash auto-merge with branch deletion.
- Updates both PyPI and binary Homebrew formula workflows to request pull request write permission on the Homebrew tap GitHub App token.
- Replaces direct `git push` updates to `homebrew-tap/main` with PR-based updates for `Formula/lintro.rb` and `Formula/lintro-bin.rb`.

Validation:

- `uv run lintro chk`
- `uv run lintro tst`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Homebrew release process now opens pull requests for formula updates instead of committing directly, with updated CI permissions to support PR creation and auto-merge.
* **Documentation**
  * Updated scripts documentation to include the new Homebrew PR helper and adjusted table formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/913)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces direct `git push` updates to the Homebrew tap's `main` branch with a PR-based flow, so the `validate-formula` ruleset can run before auto-merge completes the release.

- Adds `scripts/ci/homebrew/create-tap-pr.sh`: commits formula changes to a versioned branch, creates or reuses an open PR, and enables squash auto-merge with branch deletion. The tap repo is derived dynamically via `gh repo view` rather than hardcoded.
- Updates both `build-binary.yml` and `publish-pypi-on-tag.yml` to request `permission-pull-requests: write` on the App token and call the new script in place of `git-commit-push.sh`.
- `scripts/README.md` adds the new script to the Homebrew table.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the new script is well-structured, correctly derives the tap repo at runtime, and all `gh` commands operate within the tap checkout context.

The logic in `create-tap-pr.sh` is straightforward and the PR-based flow is a strict improvement over direct pushes. All environment variables are validated with `:?` expansions, branch naming is version-scoped, and the `gh repo view` fix for the output URL was correctly applied. The only finding is a cosmetic line-break in the `PR_BODY` of `build-binary.yml`.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/homebrew/create-tap-pr.sh | New script that stages formula changes, creates a versioned branch, force-pushes, creates or reuses an open PR, and enables auto-merge; correctly derives the tap repo via `gh repo view` rather than hardcoding it. |
| .github/workflows/build-binary.yml | Adds `permission-pull-requests: write` to the App token and replaces the direct-push step with `create-tap-pr.sh`; `PR_BODY` wraps the version onto a second line inconsistently with the PyPI workflow. |
| .github/workflows/publish-pypi-on-tag.yml | Mirrors the binary workflow change; updates comment and adds `permission-pull-requests: write`, then routes through the new script. No issues found. |
| scripts/README.md | Adds `create-tap-pr.sh` row to the Homebrew scripts table; purely documentation, no issues. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant WF as GitHub Actions Workflow
    participant Script as create-tap-pr.sh
    participant TapRepo as homebrew-tap (git)
    participant GH as GitHub API (gh CLI)

    WF->>Script: invoke with file-pattern, commit-message, --skip-if-empty
    Script->>TapRepo: git add file-pattern
    Script->>TapRepo: git checkout -B PR_BRANCH
    Script->>TapRepo: git commit -m COMMIT_MESSAGE
    Script->>TapRepo: git push --force-with-lease origin HEAD:PR_BRANCH
    Script->>GH: gh pr list --head PR_BRANCH --state open
    alt Existing PR found
        GH-->>Script: pr_number
        Script->>Script: reuse existing PR
    else No existing PR
        Script->>GH: gh pr create --base PR_BASE --head PR_BRANCH
        GH-->>Script: pr_url
        Script->>Script: "pr_number = pr_url##*/"
    end
    Script->>GH: gh pr merge pr_number --auto --squash --delete-branch
    Script->>GH: gh repo view (derive tap repo name)
    Script->>WF: write pr-number and pr-url to GITHUB_OUTPUT
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fbuild-binary.yml%3A306-308%0AThe%20%60PR_BODY%60%20for%20the%20binary%20formula%20wraps%20the%20version%20onto%20a%20new%20line%2C%20so%20the%20rendered%20body%20reads%20%22Updates%20%60Formula%2Flintro-bin.rb%60%20for%20lintro%0A1.2.3.%22%20%E2%80%94%20with%20the%20version%20on%20its%20own%20line.%20The%20sibling%20step%20in%20%60publish-pypi-on-tag.yml%60%20keeps%20it%20on%20one%20line.%20While%20not%20a%20functional%20bug%2C%20the%20unintended%20line%20break%20makes%20the%20auto-generated%20PR%20description%20look%20broken.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20PR_BODY%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20Updates%20%60Formula%2Flintro-bin.rb%60%20for%20lintro%20%24%7B%7B%20steps.version.outputs.version%20%7D%7D.%0A%60%60%60%0A%0A&pr=913&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fbuild-binary.yml%3A306-308%0AThe%20%60PR_BODY%60%20for%20the%20binary%20formula%20wraps%20the%20version%20onto%20a%20new%20line%2C%20so%20the%20rendered%20body%20reads%20%22Updates%20%60Formula%2Flintro-bin.rb%60%20for%20lintro%0A1.2.3.%22%20%E2%80%94%20with%20the%20version%20on%20its%20own%20line.%20The%20sibling%20step%20in%20%60publish-pypi-on-tag.yml%60%20keeps%20it%20on%20one%20line.%20While%20not%20a%20functional%20bug%2C%20the%20unintended%20line%20break%20makes%20the%20auto-generated%20PR%20description%20look%20broken.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20PR_BODY%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20Updates%20%60Formula%2Flintro-bin.rb%60%20for%20lintro%20%24%7B%7B%20steps.version.outputs.version%20%7D%7D.%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=913&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2Fhomebrew-tap-pr-automation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhomebrew-tap-pr-automation%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fbuild-binary.yml%3A306-308%0AThe%20%60PR_BODY%60%20for%20the%20binary%20formula%20wraps%20the%20version%20onto%20a%20new%20line%2C%20so%20the%20rendered%20body%20reads%20%22Updates%20%60Formula%2Flintro-bin.rb%60%20for%20lintro%0A1.2.3.%22%20%E2%80%94%20with%20the%20version%20on%20its%20own%20line.%20The%20sibling%20step%20in%20%60publish-pypi-on-tag.yml%60%20keeps%20it%20on%20one%20line.%20While%20not%20a%20functional%20bug%2C%20the%20unintended%20line%20break%20makes%20the%20auto-generated%20PR%20description%20look%20broken.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20PR_BODY%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20Updates%20%60Formula%2Flintro-bin.rb%60%20for%20lintro%20%24%7B%7B%20steps.version.outputs.version%20%7D%7D.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(release): fail empty Homebrew tap up..."](https://github.com/lgtm-hq/py-lintro/commit/44975b53af5eed97f54716356d1ab964d50568bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32313091)</sub>

<!-- /greptile_comment -->