### PR TITLE
ci(release): show Homebrew publishing in release workflow

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -2,9 +2,17 @@
 name: Publish - Homebrew Tap
 
 'on':
-  workflow_run:
-    workflows: ['Publish - PyPI Production']
-    types: [completed]
+  workflow_call:
+    inputs:
+      release_tag:
+        description: 'Release tag to publish'
+        required: true
+        type: string
+      arch:
+        description: 'Target architecture'
+        required: false
+        default: universal
+        type: string
   workflow_dispatch:
     inputs:
       arch:
@@ -25,11 +33,10 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    # Only run on workflow_dispatch or successful workflow_run (skip actions-v* tags)
+    # Release workflows call this after PyPI publishes; manual runs use latest release.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       !startsWith(github.event.workflow_run.head_branch, 'actions-v'))
+      github.event_name == 'workflow_call'
     outputs:
       release_tag: ${{ steps.get-tag.outputs.tag }}
       is_prerelease: ${{ steps.get-tag.outputs.is_prerelease }}
@@ -45,7 +52,7 @@ jobs:
         run: scripts/ci/homebrew/get-release-info.sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_CALL_RELEASE_TAG: ${{ inputs.release_tag }}
 
   build-macos:
     name: Build macOS Binary
@@ -57,9 +64,8 @@ jobs:
       matrix:
         arch: >-
           ${{
-            github.event_name == 'workflow_dispatch' &&
-            github.event.inputs.arch != 'universal' &&
-            fromJSON(format('["{0}"]', github.event.inputs.arch)) ||
+            inputs.arch != 'universal' &&
+            fromJSON(format('["{0}"]', inputs.arch)) ||
             fromJSON('["arm64", "x86_64"]')
           }}
 
@@ -143,7 +149,7 @@ jobs:
 
       - name: Upload to release
         if: >-
-          github.event_name == 'workflow_run' &&
+          github.event_name == 'workflow_call' &&
           needs.get-release-info.outputs.release_tag != ''
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
@@ -159,9 +165,8 @@ jobs:
     permissions:
       contents: write
     if: >-
-      github.event_name == 'workflow_run' ||
-      (github.event_name == 'workflow_dispatch' &&
-       github.event.inputs.arch == 'universal')
+      github.event_name == 'workflow_call' ||
+      inputs.arch == 'universal'
 
     steps:
       - name: Harden Runner
@@ -207,7 +212,7 @@ jobs:
 
       - name: Upload to release
         if: >-
-          github.event_name == 'workflow_run' &&
+          github.event_name == 'workflow_call' &&
           needs.get-release-info.outputs.release_tag != ''
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
@@ -225,7 +230,7 @@ jobs:
     if: >-
       always() &&
       !cancelled() &&
-      github.event_name == 'workflow_run' &&
+      github.event_name == 'workflow_call' &&
       needs.get-release-info.result == 'success' &&
       needs.get-release-info.outputs.release_tag != '' &&
       needs.get-release-info.outputs.is_prerelease == 'false'

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -164,9 +164,7 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: write
-    if: >-
-      github.event_name == 'workflow_call' ||
-      inputs.arch == 'universal'
+    if: inputs.arch == 'universal'
 
     steps:
       - name: Harden Runner
@@ -341,7 +339,8 @@ jobs:
             - `Formula/lintro.rb`
             - `Formula/lintro-bin.rb` when macOS binaries are available
 
-            Auto-merge is enabled once `validate-formula` passes.
+            The tap repository merges this PR automatically after `validate-formula`
+            succeeds (release-bot merge workflow).
         run: >-
           lintro/scripts/ci/homebrew/create-lintro-tap-pr.sh
           "${{ steps.version.outputs.version }}"

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -121,6 +121,25 @@ jobs:
           files: |
             dist/*
 
+  homebrew-tap:
+    name: Publish Homebrew Tap
+    needs: publish
+    # Skip for pre-release tags and internal action version tags.
+    if: >-
+      ${{
+        !startsWith(github.ref_name, 'actions-v') &&
+        !contains(github.ref_name, 'a') &&
+        !contains(github.ref_name, 'b') &&
+        !contains(github.ref_name, 'rc')
+      }}
+    uses: ./.github/workflows/build-binary.yml
+    permissions:
+      contents: write
+    with:
+      release_tag: ${{ github.ref_name }}
+      arch: universal
+    secrets: inherit
+
   docker-publish:
     name: Publish Docker Images to GHCR
     needs: publish

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -126,12 +126,10 @@ jobs:
     needs: publish
     # Skip for pre-release tags and internal action version tags.
     if: >-
-      ${{
-        !startsWith(github.ref_name, 'actions-v') &&
-        !contains(github.ref_name, 'a') &&
-        !contains(github.ref_name, 'b') &&
-        !contains(github.ref_name, 'rc')
-      }}
+      !startsWith(github.ref_name, 'actions-v') &&
+      !contains(github.ref_name, 'a') &&
+      !contains(github.ref_name, 'b') &&
+      !contains(github.ref_name, 'rc')
     uses: ./.github/workflows/build-binary.yml
     permissions:
       contents: write

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -157,19 +157,19 @@ Scripts for GitHub Actions workflows and continuous integration.
 
 Scripts for generating and updating Homebrew formulas.
 
-| Script                       | Purpose                                             | Usage                                                                                                          |
-| ---------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `wait-for-pypi.sh`           | Poll PyPI until package version is available        | `./scripts/ci/homebrew/wait-for-pypi.sh lintro 1.0.0`                                                          |
-| `get-release-info.sh`        | Resolve release tag and prerelease metadata         | `GITHUB_EVENT_NAME=workflow_dispatch ./scripts/ci/homebrew/get-release-info.sh`                                |
-| `create-tap-pr.sh`           | Create/update Homebrew tap PR and enable auto-merge | `./scripts/ci/homebrew/create-tap-pr.sh Formula/lintro.rb Formula/lintro-bin.rb "chore(homebrew): update ..."` |
-| `create-lintro-tap-pr.sh`    | Create/update lintro's generated formula PR         | `./scripts/ci/homebrew/create-lintro-tap-pr.sh 1.0.0 --skip-if-empty`                                          |
-| `generate-pypi-formula.sh`   | Generate lintro.rb formula from PyPI                | `./scripts/ci/homebrew/generate-pypi-formula.sh 1.0.0 out`                                                     |
-| `generate-binary-formula.sh` | Generate lintro-bin.rb formula for binaries         | `./scripts/ci/homebrew/generate-binary-formula.sh ...`                                                         |
-| `pypi_utils.py`              | Shared PyPI API utilities module                    | Imported by other Python scripts                                                                               |
-| `fetch_package_info.py`      | Fetch package tarball info from PyPI                | `python3 scripts/ci/homebrew/fetch_package_info.py lintro 1.0.0`                                               |
-| `fetch_wheel_info.py`        | Fetch wheel info and generate resource stanzas      | `python3 scripts/ci/homebrew/fetch_wheel_info.py pydoclint --type universal`                                   |
-| `render_formula.py`          | Render Homebrew formula from template               | `python3 scripts/ci/homebrew/render_formula.py --tarball-url ... -o out.rb`                                    |
-| `generate_resources.py`      | Generate Homebrew resource stanzas (replaces poet)  | `python3 scripts/ci/homebrew/generate_resources.py lintro --exclude pkg1 pkg2`                                 |
+| Script                       | Purpose                                            | Usage                                                                                                          |
+| ---------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `wait-for-pypi.sh`           | Poll PyPI until package version is available       | `./scripts/ci/homebrew/wait-for-pypi.sh lintro 1.0.0`                                                          |
+| `get-release-info.sh`        | Resolve release tag and prerelease metadata        | `GITHUB_EVENT_NAME=workflow_dispatch ./scripts/ci/homebrew/get-release-info.sh`                                |
+| `create-tap-pr.sh`           | Create/update Homebrew tap PR                      | `./scripts/ci/homebrew/create-tap-pr.sh Formula/lintro.rb Formula/lintro-bin.rb "chore(homebrew): update ..."` |
+| `create-lintro-tap-pr.sh`    | Create/update lintro's generated formula PR        | `./scripts/ci/homebrew/create-lintro-tap-pr.sh 1.0.0 --skip-if-empty`                                          |
+| `generate-pypi-formula.sh`   | Generate lintro.rb formula from PyPI               | `./scripts/ci/homebrew/generate-pypi-formula.sh 1.0.0 out`                                                     |
+| `generate-binary-formula.sh` | Generate lintro-bin.rb formula for binaries        | `./scripts/ci/homebrew/generate-binary-formula.sh ...`                                                         |
+| `pypi_utils.py`              | Shared PyPI API utilities module                   | Imported by other Python scripts                                                                               |
+| `fetch_package_info.py`      | Fetch package tarball info from PyPI               | `python3 scripts/ci/homebrew/fetch_package_info.py lintro 1.0.0`                                               |
+| `fetch_wheel_info.py`        | Fetch wheel info and generate resource stanzas     | `python3 scripts/ci/homebrew/fetch_wheel_info.py pydoclint --type universal`                                   |
+| `render_formula.py`          | Render Homebrew formula from template              | `python3 scripts/ci/homebrew/render_formula.py --tarball-url ... -o out.rb`                                    |
+| `generate_resources.py`      | Generate Homebrew resource stanzas (replaces poet) | `python3 scripts/ci/homebrew/generate_resources.py lintro --exclude pkg1 pkg2`                                 |
 
 ### 🐳 Docker Scripts (`docker/`)
 

--- a/scripts/ci/homebrew/create-tap-pr.sh
+++ b/scripts/ci/homebrew/create-tap-pr.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
-# Purpose: Commit Homebrew tap updates to a branch and enable PR auto-merge.
+# Purpose: Commit Homebrew tap updates and open or refresh the tap PR.
 
 set -euo pipefail
 
@@ -10,7 +10,7 @@ source "$SCRIPT_DIR/../../utils/utils.sh"
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 	cat <<'EOF'
-Create or update a Homebrew tap PR and enable auto-merge.
+Create or update a Homebrew tap PR (merge is handled by tap automation).
 
 Usage: create-tap-pr.sh <file-pattern>... <commit-message> [--skip-if-empty]
 
@@ -102,9 +102,6 @@ else
 	)"
 	pr_number="${pr_url##*/}"
 fi
-
-log_info "Enabling auto-merge for Homebrew tap PR #$pr_number"
-gh pr merge "$pr_number" --auto --squash --delete-branch
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
 	tap_repository="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"

--- a/scripts/ci/homebrew/get-release-info.sh
+++ b/scripts/ci/homebrew/get-release-info.sh
@@ -16,6 +16,7 @@ Usage: get-release-info.sh
 
 Environment:
   GITHUB_EVENT_NAME          GitHub Actions event name.
+  WORKFLOW_CALL_RELEASE_TAG  Release tag passed by a reusable workflow caller.
   WORKFLOW_RUN_HEAD_BRANCH   Release tag from the upstream workflow_run event.
   GITHUB_OUTPUT              GitHub Actions output file.
   GH_TOKEN                   GitHub token for workflow_dispatch release lookup.
@@ -29,7 +30,9 @@ fi
 
 EVENT_NAME="${GITHUB_EVENT_NAME:?GITHUB_EVENT_NAME is required}"
 
-if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+if [[ "$EVENT_NAME" == "workflow_call" ]]; then
+	TAG="${WORKFLOW_CALL_RELEASE_TAG:?WORKFLOW_CALL_RELEASE_TAG is required}"
+elif [[ "$EVENT_NAME" == "workflow_run" ]]; then
 	TAG="${WORKFLOW_RUN_HEAD_BRANCH:?WORKFLOW_RUN_HEAD_BRANCH is required}"
 else
 	TAG="$(gh release view --json tagName -q .tagName 2>/dev/null || true)"

--- a/scripts/ci/homebrew/get-release-info.sh
+++ b/scripts/ci/homebrew/get-release-info.sh
@@ -17,7 +17,7 @@ Usage: get-release-info.sh
 Environment:
   GITHUB_EVENT_NAME          GitHub Actions event name.
   WORKFLOW_CALL_RELEASE_TAG  Release tag passed by a reusable workflow caller.
-  WORKFLOW_RUN_HEAD_BRANCH   Release tag from the upstream workflow_run event.
+  WORKFLOW_RUN_HEAD_BRANCH   Release tag from a workflow_run event, kept for reuse.
   GITHUB_OUTPUT              GitHub Actions output file.
   GH_TOKEN                   GitHub token for workflow_dispatch release lookup.
 
@@ -33,6 +33,8 @@ EVENT_NAME="${GITHUB_EVENT_NAME:?GITHUB_EVENT_NAME is required}"
 if [[ "$EVENT_NAME" == "workflow_call" ]]; then
 	TAG="${WORKFLOW_CALL_RELEASE_TAG:?WORKFLOW_CALL_RELEASE_TAG is required}"
 elif [[ "$EVENT_NAME" == "workflow_run" ]]; then
+	# Keep workflow_run support explicit so future callers do not fall back to
+	# the latest release when the triggering branch already identifies the tag.
 	TAG="${WORKFLOW_RUN_HEAD_BRANCH:?WORKFLOW_RUN_HEAD_BRANCH is required}"
 else
 	TAG="$(gh release view --json tagName -q .tagName 2>/dev/null || true)"


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci(release): show Homebrew publishing in release workflow
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Homebrew tap publishing now runs as a visible reusable job from the PyPI release workflow instead of as a separate downstream `workflow_run`. This keeps the macOS binary builds and tap PR creation visible in the release run that operators already monitor.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`, `uv run lintro tst`)

## Related Issues

N/A

## Details

- Converts `Publish - Homebrew Tap` from a hidden `workflow_run` trigger to a reusable `workflow_call` workflow while preserving manual dispatch.
- Calls the Homebrew workflow from `Publish - PyPI Production` after PyPI upload for stable release tags.
- Passes the release tag through `get-release-info.sh` for reusable workflow calls, keeping release metadata handling in scripts.

Validation:

- `uv run lintro chk`
- `uv run lintro tst`
- Smoke-tested `get-release-info.sh` with `GITHUB_EVENT_NAME=workflow_call`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and release automation workflows for greater efficiency
  * Automated Homebrew tap publication integrated into release pipeline
  * Enhanced CI/CD infrastructure flexibility and maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR converts the Homebrew tap publishing from a hidden downstream `workflow_run` trigger into a visible reusable `workflow_call` invoked directly from the PyPI release workflow, so operators can monitor binary builds and tap PR creation in the same run that publishes to PyPI.

- **`build-binary.yml`**: Replaces the `workflow_run` trigger with `workflow_call` (adding a `release_tag` input), drops the upstream-success guard in favour of the caller's gate, and simplifies the `create-universal-binary` guard to `inputs.arch == 'universal'` — fixing the previously-flagged issue where the job would run for any `workflow_call` even with a single-arch input.
- **`publish-pypi-on-tag.yml`**: Adds the `homebrew-tap` reusable-workflow job that gates on stable tags (skipping `actions-v`, alpha/beta/rc) and passes `release_tag` and `arch: universal` after `publish` succeeds.
- **`create-tap-pr.sh` / `get-release-info.sh`**: Removes the inline `gh pr merge --auto` call (tap repo automation now drives merges) and adds a first-class `workflow_call` branch to the tag-resolution script.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the workflow restructuring is logically consistent, the create-universal-binary guard is correctly simplified, and all upload/update steps are properly gated.

The trigger conversion from workflow_run to workflow_call is implemented correctly end-to-end: the release_tag input flows through WORKFLOW_CALL_RELEASE_TAG to the script, the matrix uses inputs.arch uniformly for both dispatch and call events, and the universal-binary job guard was fixed in this PR. No new logic defects were found in the changed code paths.

No files require special attention beyond the items already noted in prior review threads.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-binary.yml | Core change: replaces workflow_run with workflow_call, adds release_tag input, simplifies create-universal-binary guard to inputs.arch == 'universal'. Logic is sound; upload-to-release steps correctly gate on workflow_call. |
| .github/workflows/publish-pypi-on-tag.yml | Adds homebrew-tap reusable-workflow job after publish, gated on stable-tag conditions matching the existing docker-publish pattern. |
| scripts/ci/homebrew/get-release-info.sh | Adds first-class workflow_call branch using WORKFLOW_CALL_RELEASE_TAG; retains workflow_run branch with an explanatory comment. |
| scripts/ci/homebrew/create-tap-pr.sh | Removes inline gh pr merge --auto call; tap repo automation now owns the merge. Change is intentional and correctly reflected in help text and README. |
| scripts/README.md | Column-width alignment cleanup and description updates to match the removed auto-merge behaviour. No functional issues. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): gate universal binary job and d..."](https://github.com/lgtm-hq/py-lintro/commit/a105102178c6477d1880efe4de55355404dc7475) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32491211)</sub>

<!-- /greptile_comment -->