### PR TITLE
fix(ci): allow Renovate post-upgrade script via global allowedCommands

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -56,11 +56,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           configurationFile: renovate.json
         env:
+          # Regex allowlist for post-upgrade commands (global-only).
+          # yamllint disable-line rule:line-length
+          RENOVATE_ALLOWED_COMMANDS: '["^python3 scripts/ci/generate-tool-versions\\.py$"]'
           # yamllint disable-line rule:line-length
           LOG_LEVEL: ${{ github.event_name == 'workflow_dispatch' && 'debug' || 'info' }}
-          # Allow the generator to run as a postUpgradeTask. Anchored regex
-          # rejects any other invocation; bot-level grant is required by
-          # self-hosted Renovate's security model (repos cannot allowlist
-          # their own commands via renovate.json).
-          # yamllint disable-line rule:line-length
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^python3 scripts/ci/generate-tool-versions\\.py$"]'

--- a/renovate.json
+++ b/renovate.json
@@ -106,9 +106,6 @@
     ],
     "executionMode": "branch"
   },
-  "allowedPostUpgradeCommands": [
-    "python3 scripts/ci/generate-tool-versions.py"
-  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): allow Renovate post-upgrade script via global allowedCommands
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## Summary

- Set **`RENOVATE_ALLOWED_COMMANDS`** on the self-hosted Renovate workflow so `postUpgradeTasks` can run `python3 scripts/ci/generate-tool-versions.py` (Renovate only honors global allowlists for these commands).
- Remove invalid repo-level **`allowedPostUpgradeCommands`** from **`renovate.json`** (not applied the way we intended and triggers config warnings).
- Replace deprecated **`RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS`** with the supported **`RENOVATE_ALLOWED_COMMANDS`** env variable in the workflow.

## Changes Made

- **`.github/workflows/renovate.yml`**: Add anchored-regex allowlist via `RENOVATE_ALLOWED_COMMANDS`; drop `RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS`.
- **`renovate.json`**: Drop `allowedPostUpgradeCommands`; keep `postUpgradeTasks` unchanged.

## Closes

No linked issue.

## Details

Self-hosted Renovate compares compiled `postUpgradeTasks.commands` against global **`allowedCommands`** only. Listing commands in **`renovate.json`** does not satisfy that check. Using the correct env name avoids silent skips and clears dependency-dashboard warnings about blocked post-upgrade tasks.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (not applicable — CI/Renovate config only)
- [ ] Docs updated if user-facing (not applicable)
- [x] Local checks passed (`uv run lintro chk`, `uv run lintro tst`)

## Test plan

- [x] `uv run lintro chk` (full suite, zero issues)
- [x] `uv run lintro tst` (5194 passed, 11 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management configuration to streamline operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the self-hosted Renovate post-upgrade task allowlist by replacing the deprecated `RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS` env var with the correct `RENOVATE_ALLOWED_COMMANDS`, and removes the repo-level `allowedPostUpgradeCommands` key from `renovate.json` which Renovate silently ignores for security reasons (global-only enforcement).

- **`.github/workflows/renovate.yml`**: Swaps the deprecated env var for the supported `RENOVATE_ALLOWED_COMMANDS`, preserving the same anchored regex `^python3 scripts/ci/generate-tool-versions\\.py$`.
- **`renovate.json`**: Drops the ineffective `allowedPostUpgradeCommands` array; `postUpgradeTasks` with its `commands` list and `executionMode: branch` remains untouched.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — two-file config change that correctly replaces a deprecated env var and removes a no-op JSON key.

The rename from RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS to RENOVATE_ALLOWED_COMMANDS is the documented current name for this global allowlist. The anchored regex pattern is identical to what was there before. The removed allowedPostUpgradeCommands in renovate.json was provably inert (Renovate enforces the allowlist from the bot/global layer only). The postUpgradeTasks definition that actually schedules the command is untouched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/renovate.yml | Replaces deprecated RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS with the correct RENOVATE_ALLOWED_COMMANDS; same anchored regex retained; yamllint disable comments correctly positioned. |
| renovate.json | Removes the no-op repo-level allowedPostUpgradeCommands array; postUpgradeTasks commands and executionMode: branch remain intact. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant RA as renovate-action (self-hosted)
    participant REN as Renovate Engine
    participant SCR as generate-tool-versions.py

    GHA->>RA: Inject RENOVATE_ALLOWED_COMMANDS env var (anchored regex allowlist)
    RA->>REN: Start Renovate with global allowedCommands
    REN->>REN: Detect dependency update
    REN->>REN: Read postUpgradeTasks.commands from renovate.json
    REN->>REN: Match command against RENOVATE_ALLOWED_COMMANDS regex
    Note over REN: python3 scripts/ci/generate-tool-versions.py matches regex
    REN->>SCR: Execute post-upgrade command
    SCR-->>REN: Update lintro/_generated_versions.py + lintro/tools/manifest.json
    REN-->>GHA: Commit updated files on branch
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): allow Renovate post-upgrade scr..."](https://github.com/lgtm-hq/py-lintro/commit/1862ab00497021bc1c20da1d5955c32b4b3ed109) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32501759)</sub>

<!-- /greptile_comment -->