### PR TITLE
fix(ci): gate Homebrew release jobs on release_tag input

### DIFF
--- a/.github/actions/harden-runner-preset/action.yml
+++ b/.github/actions/harden-runner-preset/action.yml
@@ -48,6 +48,7 @@ runs:
             PRESET_ENDPOINTS+=" ghcr.io:443 docker.io:443"
             PRESET_ENDPOINTS+=" registry-1.docker.io:443 auth.docker.io:443"
             PRESET_ENDPOINTS+=" production.cloudflare.docker.com:443"
+            PRESET_ENDPOINTS+=" production.cloudfront.docker.com:443"
             ;;
           codecov)
             PRESET_ENDPOINTS="pypi.org:443 files.pythonhosted.org:443"
@@ -86,6 +87,7 @@ runs:
             PRESET_ENDPOINTS+=" ghcr.io:443 pkg-containers.githubusercontent.com:443"
             PRESET_ENDPOINTS+=" docker.io:443 registry-1.docker.io:443"
             PRESET_ENDPOINTS+=" auth.docker.io:443 production.cloudflare.docker.com:443"
+            PRESET_ENDPOINTS+=" production.cloudfront.docker.com:443"
             # Codecov
             PRESET_ENDPOINTS+=" codecov.io:443 uploader.codecov.io:443"
             PRESET_ENDPOINTS+=" storage.googleapis.com:443 pings.codecov.com:443"

--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -40,6 +40,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
             static.rust-lang.org:443

--- a/.github/workflows/backfill-docker-tags.yml
+++ b/.github/workflows/backfill-docker-tags.yml
@@ -95,6 +95,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
             static.rust-lang.org:443

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -33,10 +33,11 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    # Release workflows call this after PyPI publishes; manual runs use latest release.
+    # Manual runs use latest release. Tag releases pass inputs.release_tag via
+    # workflow_call; the caller's push event is inherited (not workflow_call).
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call'
+      inputs.release_tag != ''
     outputs:
       release_tag: ${{ steps.get-tag.outputs.tag }}
       is_prerelease: ${{ steps.get-tag.outputs.is_prerelease }}
@@ -148,9 +149,7 @@ jobs:
           retention-days: 7
 
       - name: Upload to release
-        if: >-
-          github.event_name == 'workflow_call' &&
-          needs.get-release-info.outputs.release_tag != ''
+        if: inputs.release_tag != ''
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ${{ needs.get-release-info.outputs.release_tag }}
@@ -209,9 +208,7 @@ jobs:
           retention-days: 7
 
       - name: Upload to release
-        if: >-
-          github.event_name == 'workflow_call' &&
-          needs.get-release-info.outputs.release_tag != ''
+        if: inputs.release_tag != ''
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ${{ needs.get-release-info.outputs.release_tag }}
@@ -228,7 +225,7 @@ jobs:
     if: >-
       always() &&
       !cancelled() &&
-      github.event_name == 'workflow_call' &&
+      inputs.release_tag != '' &&
       needs.get-release-info.result == 'success' &&
       needs.get-release-info.outputs.release_tag != '' &&
       needs.get-release-info.outputs.is_prerelease == 'false'

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -271,6 +271,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
             static.rust-lang.org:443
@@ -473,6 +474,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
             static.rust-lang.org:443
@@ -752,6 +754,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
             codecov.io:443
@@ -1061,6 +1064,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
             static.rust-lang.org:443

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -64,6 +64,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
             static.rust-lang.org:443
@@ -181,6 +182,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
             static.rust-lang.org:443

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -42,6 +42,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
             api.osv.dev:443

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -72,6 +72,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
             static.rust-lang.org:443

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -164,6 +164,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             files.pythonhosted.org:443
             static.rust-lang.org:443

--- a/scripts/ci/homebrew/get-release-info.sh
+++ b/scripts/ci/homebrew/get-release-info.sh
@@ -40,6 +40,11 @@ else
 	TAG="$(gh release view --json tagName -q .tagName 2>/dev/null || true)"
 fi
 
+# Trim surrounding whitespace, then fail fast if the tag is still empty.
+TAG="${TAG#"${TAG%%[![:space:]]*}"}"
+TAG="${TAG%"${TAG##*[![:space:]]}"}"
+: "${TAG:?Release tag is required but was empty or whitespace-only}"
+
 VERSION="${TAG#v}"
 IS_PRERELEASE=false
 if [[ "$VERSION" =~ (a|b|rc)[0-9]+ ]]; then

--- a/scripts/ci/homebrew/get-release-info.sh
+++ b/scripts/ci/homebrew/get-release-info.sh
@@ -30,8 +30,8 @@ fi
 
 EVENT_NAME="${GITHUB_EVENT_NAME:?GITHUB_EVENT_NAME is required}"
 
-if [[ "$EVENT_NAME" == "workflow_call" ]]; then
-	TAG="${WORKFLOW_CALL_RELEASE_TAG:?WORKFLOW_CALL_RELEASE_TAG is required}"
+if [[ -n "${WORKFLOW_CALL_RELEASE_TAG:-}" ]]; then
+	TAG="$WORKFLOW_CALL_RELEASE_TAG"
 elif [[ "$EVENT_NAME" == "workflow_run" ]]; then
 	# Keep workflow_run support explicit so future callers do not fall back to
 	# the latest release when the triggering branch already identifies the tag.


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): gate Homebrew release jobs on release_tag input
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

After #921 inlined Homebrew publishing into `publish-pypi-on-tag.yml` via
`workflow_call`, all `Publish Homebrew Tap` jobs were skipped on v0.63.3 because
reusable workflows inherit the caller’s `push` event — `github.event_name` is never
`workflow_call` in the callee.

Gate release automation on `inputs.release_tag` (the explicit caller contract) and
resolve the tag from `WORKFLOW_CALL_RELEASE_TAG` in `get-release-info.sh` regardless
of event name.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

<!-- No linked issue -->

## Details

**Testing strategy**

- `lintro chk` passed in the worktree.
- Manual smoke test: `GITHUB_EVENT_NAME=push WORKFLOW_CALL_RELEASE_TAG=v0.63.3`
  `get-release-info.sh` emits `tag=v0.63.3`.

**After merge**

Re-run the skipped Homebrew jobs on the
[v0.63.3 publish workflow run](https://github.com/lgtm-hq/py-lintro/actions/runs/26015488314)
to open the homebrew-tap PR for 0.63.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Homebrew publishing automation to honor explicit release tags, simplify trigger conditions, and fail fast on missing/empty tags.
  * Clarified tag resolution and prerelease detection to make releases more reliable and consistent.
  * Expanded runner network allowlist used by CI and release workflows so builds, image tooling, and publishing steps can reach required external Docker distribution endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a CI regression where Homebrew release jobs were silently skipped because reusable workflows inherit the caller's event name (e.g. `push`) rather than `workflow_call`, causing the old `github.event_name == 'workflow_call'` guards to always evaluate false. The fix gates all release-only logic on `inputs.release_tag != ''` instead, and hardens `get-release-info.sh` with whitespace trimming and a fail-fast guard. Several unrelated workflow files also gain `production.cloudfront.docker.com:443` in their egress allowlists.

- **`build-binary.yml`**: All `github.event_name == 'workflow_call'` job/step conditions are replaced with `inputs.release_tag != ''`, so upload and Homebrew steps fire iff the caller explicitly provides a tag.
- **`get-release-info.sh`**: Tag resolution now checks for a non-empty `WORKFLOW_CALL_RELEASE_TAG` env var (event-name-agnostic), strips surrounding whitespace, and hard-fails with a descriptive message when the tag is still empty.
- **Nine workflow files**: `production.cloudfront.docker.com:443` added to harden-runner egress allowlists.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change correctly fixes a silent skip of Homebrew release jobs without introducing new failure modes.

The root-cause fix is precise: replacing event-name checks with inputs.release_tag != '' directly addresses the inherited-event-name problem described in the PR. The shell script hardening (whitespace trim + fail-fast) tightens the existing logic rather than relaxing it. The cloudfront.docker.com endpoint additions are additive and low-risk. No logic regressions are apparent.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/homebrew/get-release-info.sh | Replaces event-name-based tag resolution with WORKFLOW_CALL_RELEASE_TAG presence check; adds POSIX-compliant whitespace trimming and fail-fast guard for empty tags. |
| .github/workflows/build-binary.yml | All release-gating conditions updated from github.event_name == 'workflow_call' to inputs.release_tag != ''; logic is correct for both workflow_dispatch and workflow_call triggers. |
| .github/actions/harden-runner-preset/action.yml | Adds production.cloudfront.docker.com:443 to docker and ci-full presets for Docker registry egress coverage. |
| .github/workflows/ci-pipeline.yml | Adds production.cloudfront.docker.com:443 to four harden-runner egress allowlists; no logic changes. |
| .github/workflows/auto-tag-on-main.yml | Adds production.cloudfront.docker.com:443 to harden-runner egress allowlist; no logic changes. |
| .github/workflows/semantic-release.yml | Adds production.cloudfront.docker.com:443 to harden-runner egress allowlist; no logic changes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as publish-pypi-on-tag.yml<br/>(push event, inputs.release_tag=v0.x.y)
    participant BBW as build-binary.yml<br/>(inherits push event)
    participant GRI as get-release-info job
    participant Script as get-release-info.sh

    Caller->>BBW: "workflow_call(release_tag=v0.x.y)"
    Note over BBW: github.event_name == 'push'<br/>(inherited from caller)
    BBW->>GRI: "if inputs.release_tag != '' → true ✓"
    GRI->>Script: "run with WORKFLOW_CALL_RELEASE_TAG=v0.x.y"
    Script->>Script: "[[ -n WORKFLOW_CALL_RELEASE_TAG ]] → true, TAG = v0.x.y"
    Script->>Script: trim whitespace, fail-fast if empty
    Script-->>GRI: "tag=v0.x.y, is_prerelease=false"
    GRI-->>BBW: "outputs.release_tag=v0.x.y"
    BBW->>BBW: "build-macos Upload to release — inputs.release_tag != '' → true ✓"
    BBW->>BBW: "update-homebrew run — inputs.release_tag != '' → true ✓"
    Note over Caller,Script: OLD (broken): checked github.event_name == 'workflow_call'<br/>which was always 'push' → skipped all release steps
```
</details>

<sub>Reviews (4): Last reviewed commit: ["ci: allow Docker CloudFront CDN in all w..."](https://github.com/lgtm-hq/py-lintro/commit/9a9f9c2b74a93eddf5957f7501cd1e5d2f0d34ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32671398)</sub>

<!-- /greptile_comment -->