### PR TITLE
fix(renovate): trigger post-upgrade generator on canonical sources

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -101,8 +101,12 @@
       "python3 scripts/ci/generate-tool-versions.py"
     ],
     "fileFilters": [
-      "lintro/_generated_versions.py",
-      "lintro/tools/manifest.json"
+      "lintro/_tool_versions.py",
+      "package.json",
+      "pyproject.toml",
+      "Dockerfile",
+      "Dockerfile.tools",
+      "Dockerfile.base"
     ],
     "executionMode": "branch"
   },


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(renovate): trigger post-upgrade generator on canonical sources
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Renovate `postUpgradeTasks.fileFilters` listed generator **outputs**
(`_generated_versions.py`, `manifest.json`), but Renovate only runs the
command when an **upgraded** file matches those globs. Tool bumps usually
change canonical **inputs** (`_tool_versions.py`, `package.json`,
`pyproject.toml`, Dockerfiles), so `generate-tool-versions.py` was skipped,
`renovate/artifacts` failed, and CI Manifest Sync reported drift.

This PR lists the canonical version sources introduced in #896 so the
generator runs after the dependency updates it is meant to follow.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`python3 scripts/ci/generate-tool-versions.py --check`, renovate config test)

## Closes

- Relates to #896

## Details

After merge, re-run Renovate (or rebase open bot PRs) so existing branches
regenerate artifacts. Branches with drift may still need a one-off
`python3 scripts/ci/generate-tool-versions.py` commit until Renovate revisits
them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency upgrade configuration to target additional files during post-upgrade operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The `postUpgradeTasks.fileFilters` in `renovate.json` previously listed generated output files (`_generated_versions.py`, `manifest.json`), which Renovate never modifies directly, so the post-upgrade generator command was silently skipped on every dependency bump. This PR corrects the filters to match the canonical source files that Renovate actually updates.

- **`fileFilters` now points to sources**: `lintro/_tool_versions.py`, `package.json`, `pyproject.toml`, `Dockerfile`, `Dockerfile.tools`, and `Dockerfile.base` — all of which have matching `customManagers` or standard managers in this config that Renovate will modify on a version bump.
- **Generator will now run**: `python3 scripts/ci/generate-tool-versions.py` will execute whenever any of these source files is touched by a Renovate upgrade branch, eliminating the artifact drift that caused CI Manifest Sync failures.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change corrects a misconfiguration that was causing the post-upgrade generator to be silently skipped on every dependency bump.

Every file added to fileFilters has a corresponding customManager or standard manager entry in the same config, confirming Renovate will actually touch them and therefore trigger the generator. The old filters pointed at generated outputs that Renovate never writes, so this is a clear correctness fix with no side effects.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Replaces postUpgradeTasks.fileFilters from generated output files to canonical source files that Renovate actually modifies, so the generator script is now triggered correctly after dependency bumps. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Renovate opens upgrade branch] --> B{Modified file\nmatches fileFilters?}

    subgraph BEFORE ["Before this PR (broken)"]
        B1{Modified file\nmatches filters?} --> C1["Filters: _generated_versions.py\nmanifest.json"]
        C1 -->|"Renovate never writes\ngenerated outputs"| D1["❌ No match → generator skipped\n→ artifact drift → CI fails"]
    end

    subgraph AFTER ["After this PR (fixed)"]
        B2{Modified file\nmatches filters?} --> C2["Filters: _tool_versions.py\npackage.json · pyproject.toml\nDockerfile · Dockerfile.tools\nDockerfile.base"]
        C2 -->|"Renovate writes these\nvia customManagers & std managers"| D2["✅ Match → generator runs\n→ artifacts regenerated → CI passes"]
    end

    A --> B1
    A --> B2
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(renovate): trigger post-upgrade gene..."](https://github.com/lgtm-hq/py-lintro/commit/9bcf095e00d49a292bf27689e9d6aa50c69ab393) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32672679)</sub>

<!-- /greptile_comment -->