### PR TITLE
fix(build): bundle manifest.json in Nuitka onefile binary

### DIFF
--- a/scripts/build/build_macos.py
+++ b/scripts/build/build_macos.py
@@ -43,6 +43,11 @@ INCLUDE_DATA_DIRS = [
     "lintro/assets=lintro/assets",
 ]
 
+# Non-Python data files required at runtime (not included by --include-package)
+INCLUDE_DATA_FILES = [
+    "lintro/tools/manifest.json=lintro/tools/manifest.json",
+]
+
 
 def get_default_arch() -> str:
     """Get the default architecture based on the current system.
@@ -54,6 +59,51 @@ def get_default_arch() -> str:
     if machine in ("arm64", "aarch64"):
         return "arm64"
     return "x86_64"
+
+
+def build_nuitka_command(*, arch: str, verbose: bool = False) -> list[str]:
+    """Build the Nuitka command for a macOS onefile binary.
+
+    Args:
+        arch: Target architecture (arm64, x86_64, or universal).
+        verbose: Enable verbose output during compilation.
+
+    Returns:
+        Nuitka command argv list.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "nuitka",
+        "--standalone",
+        "--onefile",
+        f"--output-dir={OUTPUT_DIR}",
+        "--output-filename=lintro",
+        "--follow-imports",
+        "--assume-yes-for-downloads",
+        f"--macos-target-arch={arch}",
+    ]
+
+    for pkg in INCLUDE_PACKAGES:
+        cmd.append(f"--include-package={pkg}")
+
+    cmd.append("--include-package-data=lintro")
+
+    for data_dir in INCLUDE_DATA_DIRS:
+        data_path = PROJECT_ROOT / data_dir.split("=")[0]
+        if data_path.exists():
+            cmd.append(f"--include-data-dir={data_dir}")
+
+    for data_file in INCLUDE_DATA_FILES:
+        data_path = PROJECT_ROOT / data_file.split("=")[0]
+        if data_path.exists():
+            cmd.append(f"--include-data-files={data_file}")
+
+    if verbose:
+        cmd.append("--verbose")
+
+    cmd.append(str(PROJECT_ROOT / "lintro" / "__main__.py"))
+    return cmd
 
 
 def build_macos_binary(arch: str = "arm64", verbose: bool = False) -> int:
@@ -72,38 +122,7 @@ def build_macos_binary(arch: str = "arm64", verbose: bool = False) -> int:
     # Ensure output directory exists
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Base Nuitka command
-    cmd = [
-        sys.executable,
-        "-m",
-        "nuitka",
-        "--standalone",
-        "--onefile",
-        f"--output-dir={OUTPUT_DIR}",
-        "--output-filename=lintro",
-        "--follow-imports",
-        "--assume-yes-for-downloads",
-        # macOS-specific options
-        f"--macos-target-arch={arch}",
-        # Include all lintro packages
-    ]
-
-    # Add package includes
-    for pkg in INCLUDE_PACKAGES:
-        cmd.append(f"--include-package={pkg}")
-
-    # Add data directories
-    for data_dir in INCLUDE_DATA_DIRS:
-        data_path = PROJECT_ROOT / data_dir.split("=")[0]
-        if data_path.exists():
-            cmd.append(f"--include-data-dir={data_dir}")
-
-    # Add verbose flag if requested
-    if verbose:
-        cmd.append("--verbose")
-
-    # Add the main entry point
-    cmd.append(str(PROJECT_ROOT / "lintro" / "__main__.py"))
+    cmd = build_nuitka_command(arch=arch, verbose=verbose)
 
     print(f"Running: {' '.join(cmd)}")
 
@@ -171,6 +190,25 @@ def verify_binary() -> bool:
             return False
     except subprocess.TimeoutExpired:
         print("Help check timed out", file=sys.stderr)
+        return False
+
+    # Check doctor loads manifest.json (required for tool registry)
+    try:
+        result = subprocess.run(
+            [str(binary_path), "doctor", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if "manifest.json" in result.stderr and "FileNotFoundError" in result.stderr:
+            print(f"Doctor check failed: {result.stderr}", file=sys.stderr)
+            return False
+        if result.returncode not in (0, 1):
+            print(f"Doctor check failed: {result.stderr}", file=sys.stderr)
+            return False
+        print("Doctor command: OK")
+    except subprocess.TimeoutExpired:
+        print("Doctor check timed out", file=sys.stderr)
         return False
 
     # Check file size

--- a/scripts/build/build_macos.py
+++ b/scripts/build/build_macos.py
@@ -16,6 +16,7 @@ Requirements:
 from __future__ import annotations
 
 import argparse
+import json
 import platform
 import shutil
 import subprocess
@@ -96,8 +97,10 @@ def build_nuitka_command(*, arch: str, verbose: bool = False) -> list[str]:
 
     for data_file in INCLUDE_DATA_FILES:
         data_path = PROJECT_ROOT / data_file.split("=")[0]
-        if data_path.exists():
-            cmd.append(f"--include-data-files={data_file}")
+        if not data_path.exists():
+            msg = f"Required runtime data file missing for Nuitka build: {data_path}"
+            raise FileNotFoundError(msg)
+        cmd.append(f"--include-data-files={data_file}")
 
     if verbose:
         cmd.append("--verbose")
@@ -122,7 +125,11 @@ def build_macos_binary(arch: str = "arm64", verbose: bool = False) -> int:
     # Ensure output directory exists
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
-    cmd = build_nuitka_command(arch=arch, verbose=verbose)
+    try:
+        cmd = build_nuitka_command(arch=arch, verbose=verbose)
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
 
     print(f"Running: {' '.join(cmd)}")
 
@@ -142,6 +149,41 @@ def build_macos_binary(arch: str = "arm64", verbose: bool = False) -> int:
             file=sys.stderr,
         )
         return 1
+
+
+def _doctor_check_error(result: subprocess.CompletedProcess[str]) -> str | None:
+    """Validate ``lintro doctor --json`` output from binary verification.
+
+    Args:
+        result: Completed doctor subprocess result.
+
+    Returns:
+        Error message when verification failed, otherwise ``None``.
+    """
+    stderr = result.stderr or ""
+    crash_markers = ("Traceback", "FileNotFoundError", "manifest.json")
+    if any(marker in stderr for marker in crash_markers):
+        return f"Doctor check failed: {stderr}"
+
+    stdout = (result.stdout or "").strip()
+    if not stdout:
+        return "Doctor check failed: JSON output is empty"
+
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        return f"Doctor check failed: invalid JSON ({exc})"
+
+    if not isinstance(data, dict) or not data or "tools" not in data:
+        return "Doctor check failed: JSON output is empty or missing 'tools'"
+
+    if result.returncode not in (0, 1):
+        detail = stderr or stdout[:200]
+        return (
+            f"Doctor check failed with exit code {result.returncode}: {detail}"
+        )
+
+    return None
 
 
 def verify_binary() -> bool:
@@ -200,16 +242,15 @@ def verify_binary() -> bool:
             text=True,
             timeout=60,
         )
-        if "manifest.json" in result.stderr and "FileNotFoundError" in result.stderr:
-            print(f"Doctor check failed: {result.stderr}", file=sys.stderr)
-            return False
-        if result.returncode not in (0, 1):
-            print(f"Doctor check failed: {result.stderr}", file=sys.stderr)
-            return False
-        print("Doctor command: OK")
     except subprocess.TimeoutExpired:
         print("Doctor check timed out", file=sys.stderr)
         return False
+    else:
+        doctor_error = _doctor_check_error(result)
+        if doctor_error is not None:
+            print(doctor_error, file=sys.stderr)
+            return False
+        print("Doctor command: OK")
 
     # Check file size
     size_mb = binary_path.stat().st_size / (1024 * 1024)

--- a/tests/scripts/test_build_macos.py
+++ b/tests/scripts/test_build_macos.py
@@ -1,0 +1,39 @@
+"""Tests for the macOS Nuitka build script."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from assertpy import assert_that
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BUILD_SCRIPT = _REPO_ROOT / "scripts" / "build" / "build_macos.py"
+
+
+def _load_build_macos_module():
+    """Import build_macos without executing its main entry point.
+
+    Returns:
+        Loaded build_macos module.
+    """
+    spec = importlib.util.spec_from_file_location("build_macos", _BUILD_SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["build_macos"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_nuitka_command_includes_manifest_json() -> None:
+    """Nuitka command must bundle manifest.json for onefile runtime."""
+    build_macos = _load_build_macos_module()
+
+    cmd = build_macos.build_nuitka_command(arch="arm64")
+
+    assert_that(cmd).contains("--include-package-data=lintro")
+    assert_that(cmd).contains(
+        "--include-data-files=lintro/tools/manifest.json=lintro/tools/manifest.json",
+    )

--- a/tests/scripts/test_build_macos.py
+++ b/tests/scripts/test_build_macos.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
+import pytest
 from assertpy import assert_that
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -31,9 +33,22 @@ def test_build_nuitka_command_includes_manifest_json() -> None:
     """Nuitka command must bundle manifest.json for onefile runtime."""
     build_macos = _load_build_macos_module()
 
-    cmd = build_macos.build_nuitka_command(arch="arm64")
+    with patch.object(Path, "exists", return_value=True):
+        cmd = build_macos.build_nuitka_command(arch="arm64")
 
     assert_that(cmd).contains("--include-package-data=lintro")
     assert_that(cmd).contains(
         "--include-data-files=lintro/tools/manifest.json=lintro/tools/manifest.json",
     )
+
+
+def test_build_nuitka_command_raises_when_manifest_missing(tmp_path: Path) -> None:
+    """Missing manifest.json must fail the build instead of omitting the flag."""
+    build_macos = _load_build_macos_module()
+    main_entry = tmp_path / "lintro" / "__main__.py"
+    main_entry.parent.mkdir(parents=True)
+    main_entry.write_text("", encoding="utf-8")
+
+    with patch.object(build_macos, "PROJECT_ROOT", tmp_path):
+        with pytest.raises(FileNotFoundError, match="manifest.json"):
+            build_macos.build_nuitka_command(arch="arm64")


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(build): bundle manifest.json in Nuitka onefile binary
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

The Homebrew Nuitka onefile binary omitted `lintro/tools/manifest.json`, causing
`FileNotFoundError` on any command that loads the tool registry (e.g. `lintro doctor`).
This PR adds Nuitka data inclusion flags and a post-build doctor verification step.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` and `uv run lintro tst`)

## Closes

- Closes #934

## Details

- Add `--include-package-data=lintro` so Nuitka respects setuptools package-data
  declared in `pyproject.toml`
- Add explicit `--include-data-files=lintro/tools/manifest.json=lintro/tools/manifest.json`
  as a fallback
- Extract `build_nuitka_command()` for testability
- Extend `verify_binary()` to run `lintro doctor --json` and catch missing manifest
- Add unit test asserting the Nuitka command includes the required data flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized macOS build command generation and ensured configured non-Python runtime files are considered during bundling.

* **Bug Fixes**
  * Improved binary verification with a new runtime "doctor" check that fails on missing required files, timeouts, invalid output, or unexpected exit codes.

* **Tests**
  * Added tests covering macOS build command generation and failure when required runtime data files are missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `FileNotFoundError` in Nuitka onefile binaries caused by `lintro/tools/manifest.json` not being bundled at build time. It refactors the build logic into a testable `build_nuitka_command()` function and extends `verify_binary()` with a `lintro doctor --json` runtime check to catch missing-manifest regressions post-build.

- Adds `--include-package-data=lintro` and an explicit `--include-data-files` flag for `manifest.json`, with a hard `FileNotFoundError` if the source file is absent at build time — preventing silent omission.
- Introduces `_doctor_check_error()` to parse and validate the `doctor --json` output, covering crash markers, empty output, invalid JSON, missing `\"tools\"` key, and unexpected exit codes.
- Adds two unit tests: one asserting the expected Nuitka flags are present (with `Path.exists` mocked), and one asserting `FileNotFoundError` is raised when the manifest is absent.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is limited to the macOS build script and its tests, with no impact on runtime application code.

The fix is straightforward: it adds two complementary Nuitka flags and a post-build verification step. The hard FileNotFoundError on a missing manifest prevents the previous silent-omission failure mode, and both tests are well-isolated. The only issue found is that _doctor_check_error can produce a less-informative 'JSON output is empty' message when the process crashes with an unexpected exit code but produces no stdout — the verification still fails correctly, only the diagnostic is suboptimal.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/build/build_macos.py | Refactors binary build into a testable `build_nuitka_command()`, adds manifest.json bundling via `--include-package-data` and `--include-data-files`, and extends `verify_binary()` with a `lintro doctor --json` runtime check. One minor diagnostic ordering issue in `_doctor_check_error`. |
| tests/scripts/test_build_macos.py | New unit tests for `build_nuitka_command`; one test patches `Path.exists` globally (correctly scoped around the function call), the other patches `PROJECT_ROOT` to a tmp directory and asserts `FileNotFoundError` is raised for a missing manifest. Both tests are well-isolated. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CI as CI / developer
    participant BM as build_macos_binary()
    participant BNC as build_nuitka_command()
    participant Nuitka as Nuitka
    participant VB as verify_binary()
    participant Bin as lintro binary

    CI->>BM: build_macos_binary(arch, verbose)
    BM->>BNC: "build_nuitka_command(arch=arch)"
    BNC-->>BNC: check INCLUDE_DATA_FILES exist
    BNC-->>BM: argv with --include-package-data and --include-data-files
    BM->>Nuitka: subprocess.run(cmd)
    Nuitka-->>BM: returncode
    BM-->>CI: exit code

    CI->>VB: verify_binary()
    VB->>Bin: lintro --version
    Bin-->>VB: stdout / returncode
    VB->>Bin: lintro --help
    Bin-->>VB: stdout / returncode
    VB->>Bin: lintro doctor --json
    Bin-->>VB: stdout (JSON) / stderr / returncode
    VB-->>VB: _doctor_check_error(result)
    VB-->>CI: True (OK) or False (failed)
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fbuild%2Fbuild_macos.py%3A180-184%0A**Returncode%20check%20unreachable%20on%20empty-stdout%20crash**%0A%0AIn%20%60_doctor_check_error%60%2C%20the%20%60returncode%20not%20in%20%280%2C%201%29%60%20guard%20runs%20only%20after%20stdout%20has%20been%20parsed%20as%20valid%20JSON%20with%20a%20%60%22tools%22%60%20key.%20When%20%60lintro%20doctor%20--json%60%20crashes%20with%20an%20unexpected%20exit%20code%20but%20produces%20no%20stdout%20and%20no%20recognised%20crash%20markers%20in%20stderr%20%28e.g.%20a%20segfault%20or%20OOM%20kill%20with%20a%20plain%20numeric%20exit%20code%29%2C%20the%20function%20exits%20early%20at%20the%20%60if%20not%20stdout%60%20branch%20with%20the%20message%20%22JSON%20output%20is%20empty%22%2C%20and%20the%20exit-code%20branch%20is%20never%20reached.%20The%20binary%20verification%20still%20fails%2C%20but%20the%20diagnostic%20message%20hides%20the%20actual%20exit%20code%2C%20making%20the%20failure%20harder%20to%20diagnose%20in%20CI.%0A%0A&pr=935&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fbuild%2Fbuild_macos.py%3A180-184%0A**Returncode%20check%20unreachable%20on%20empty-stdout%20crash**%0A%0AIn%20%60_doctor_check_error%60%2C%20the%20%60returncode%20not%20in%20%280%2C%201%29%60%20guard%20runs%20only%20after%20stdout%20has%20been%20parsed%20as%20valid%20JSON%20with%20a%20%60%22tools%22%60%20key.%20When%20%60lintro%20doctor%20--json%60%20crashes%20with%20an%20unexpected%20exit%20code%20but%20produces%20no%20stdout%20and%20no%20recognised%20crash%20markers%20in%20stderr%20%28e.g.%20a%20segfault%20or%20OOM%20kill%20with%20a%20plain%20numeric%20exit%20code%29%2C%20the%20function%20exits%20early%20at%20the%20%60if%20not%20stdout%60%20branch%20with%20the%20message%20%22JSON%20output%20is%20empty%22%2C%20and%20the%20exit-code%20branch%20is%20never%20reached.%20The%20binary%20verification%20still%20fails%2C%20but%20the%20diagnostic%20message%20hides%20the%20actual%20exit%20code%2C%20making%20the%20failure%20harder%20to%20diagnose%20in%20CI.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=935&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2Fbundle-manifest-json-in-onefile-build%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fbundle-manifest-json-in-onefile-build%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fbuild%2Fbuild_macos.py%3A180-184%0A**Returncode%20check%20unreachable%20on%20empty-stdout%20crash**%0A%0AIn%20%60_doctor_check_error%60%2C%20the%20%60returncode%20not%20in%20%280%2C%201%29%60%20guard%20runs%20only%20after%20stdout%20has%20been%20parsed%20as%20valid%20JSON%20with%20a%20%60%22tools%22%60%20key.%20When%20%60lintro%20doctor%20--json%60%20crashes%20with%20an%20unexpected%20exit%20code%20but%20produces%20no%20stdout%20and%20no%20recognised%20crash%20markers%20in%20stderr%20%28e.g.%20a%20segfault%20or%20OOM%20kill%20with%20a%20plain%20numeric%20exit%20code%29%2C%20the%20function%20exits%20early%20at%20the%20%60if%20not%20stdout%60%20branch%20with%20the%20message%20%22JSON%20output%20is%20empty%22%2C%20and%20the%20exit-code%20branch%20is%20never%20reached.%20The%20binary%20verification%20still%20fails%2C%20but%20the%20diagnostic%20message%20hides%20the%20actual%20exit%20code%2C%20making%20the%20failure%20harder%20to%20diagnose%20in%20CI.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(build): fail fast when manifest.json..."](https://github.com/lgtm-hq/py-lintro/commit/85731761c88227ad9b592534faa5f7cf315ab44a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33218681)</sub>

<!-- /greptile_comment -->