### PR TITLE
fix(ci): merge coverage artifacts, add grype and Docker Hub egress

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,9 +3,11 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`22a7c110415d75843c2c216f95ed47aaeb8e26fc` (**v0.18.1**; includes
+`e42d374f1f89e0ad20d165cd611eb7732462b581` (**v0.18.2**; includes
 [lgtm-ci#206](https://github.com/lgtm-hq/lgtm-ci/pull/206) host-user docker quality and
-`lintro-tool-options` passthrough).
+`lintro-tool-options` passthrough,
+[lgtm-ci#211](https://github.com/lgtm-hq/lgtm-ci/pull/211) per-version coverage artifact
+merge).
 
 ## CI (main branch)
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       languages: python
       build-mode: none

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       fail-on-severity: high
       egress-policy: block

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     permissions:
       contents: read
       packages: write
@@ -52,7 +52,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -86,7 +86,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     permissions:
       contents: read
       packages: write
@@ -115,7 +115,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -469,6 +469,25 @@ jobs:
             api.github.com:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
+            docker.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            deb.debian.org:80
+            pypi.org:443
+            files.pythonhosted.org:443
+            static.rust-lang.org:443
+            bun.sh:443
+            astral.sh:443
+            releases.astral.sh:443
+            sh.rustup.rs:443
+            registry.npmjs.org:443
+            crates.io:443
+            static.crates.io:443
+            index.crates.io:443
+            semgrep.dev:443
+            metrics.semgrep.dev:443
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -210,13 +210,13 @@ jobs:
   dogfooding-quality:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality
       pull-requests: write # reusable-quality post-pr-comment step
     with:
-      tooling-ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
       job-name: '🛠️ Dogfooding Lint'
       post-pr-comment: true
       lintro-tool-options: >-
@@ -345,7 +345,7 @@ jobs:
       - name: Comment PR with security audit results
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@e42d374f1f89e0ad20d165cd611eb7732462b581
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,14 +12,14 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       codeowners-path: .github/CODEOWNERS
       egress-policy: block
       allowed-endpoints: >
         github.com:443
         api.github.com:443
-      tooling-ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -28,10 +28,10 @@ jobs:
   quality:
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       post-pr-comment: false
-      tooling-ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -46,7 +46,7 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       target: .
       target-type: dir
@@ -71,7 +71,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
     permissions:
       contents: read
       security-events: write
@@ -111,7 +111,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+          ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -170,7 +170,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+          ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -64,6 +64,7 @@ jobs:
         anchore.io:443
         get.anchore.io:443
         toolbox-data.anchore.io:443
+        grype.anchore.io:443
         pipelines.actions.githubusercontent.com:443
         fulcio.sigstore.dev:443
         rekor.sigstore.dev:443

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -11,12 +11,12 @@ permissions: {}
 jobs:
   publish:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       test-pypi: true
       update-homebrew: false
       python-version: '3.14'
-      tooling-ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       create-release: false
-      tooling-ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -35,6 +35,7 @@ jobs:
         anchore.io:443
         get.anchore.io:443
         toolbox-data.anchore.io:443
+        grype.anchore.io:443
         pipelines.actions.githubusercontent.com:443
         fulcio.sigstore.dev:443
         rekor.sigstore.dev:443

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       target: .
       target-type: dir
@@ -42,7 +42,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -93,7 +93,6 @@ jobs:
         with:
           name: python-coverage
           pattern: python-coverage-*
-          delete-merged: true
           retention-days: 7
 
   publish-coverage:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       post-pr-comment: true
       python-versions: '3.11,3.14'
@@ -35,7 +35,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -76,40 +76,21 @@ jobs:
             exit 1
           fi
 
-  merge-coverage:
-    name: Merge Coverage Artifacts
+  publish-coverage:
+    name: Publish Coverage to Pages
     needs: test
     if: >-
       github.ref == 'refs/heads/main' &&
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
-    runs-on: ubuntu-24.04
-    permissions:
-      actions: read
-    steps:
-      - name: Merge per-version coverage into single artifact
-        # yamllint disable-line rule:line-length
-        uses: actions/upload-artifact/merge@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: python-coverage
-          pattern: python-coverage-*
-          retention-days: 7
-
-  publish-coverage:
-    name: Publish Coverage to Pages
-    needs: [test, merge-coverage]
-    if: >-
-      github.ref == 'refs/heads/main' &&
-      github.event_name == 'push' &&
-      needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -49,6 +49,7 @@ jobs:
         astral.sh:443
         releases.astral.sh:443
     permissions:
+      actions: write  # aggregate job merges per-version python-coverage artifacts (v0.18.2+)
       contents: read
       pull-requests: write
 

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -76,9 +76,29 @@ jobs:
             exit 1
           fi
 
+  merge-coverage:
+    name: Merge Coverage Artifacts
+    needs: test
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'push' &&
+      needs.test.outputs.passed == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+    steps:
+      - name: Merge per-version coverage into single artifact
+        # yamllint disable-line rule:line-length
+        uses: actions/upload-artifact/merge@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-coverage
+          pattern: python-coverage-*
+          delete-merged: true
+          retention-days: 7
+
   publish-coverage:
     name: Publish Coverage to Pages
-    needs: test
+    needs: [test, merge-coverage]
     if: >-
       github.ref == 'refs/heads/main' &&
       github.event_name == 'push' &&

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -49,7 +49,8 @@ jobs:
         astral.sh:443
         releases.astral.sh:443
     permissions:
-      actions: write  # aggregate job merges per-version python-coverage artifacts (v0.18.2+)
+      # v0.18.2 aggregate job needs actions:write for artifact merge
+      actions: write
       contents: read
       pull-requests: write
 

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@22a7c110415d75843c2c216f95ed47aaeb8e26fc
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
     with:
       egress-policy: block
       allowed-endpoints: >
@@ -30,6 +30,6 @@ jobs:
         codeload.github.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
-      tooling-ref: '22a7c110415d75843c2c216f95ed47aaeb8e26fc'
+      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
     permissions:
       contents: read


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): merge coverage artifacts, add grype and Docker Hub egress
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Fixes three workflows broken on main after the lgtm-ci v0.18.1 migration (#939):

### 1. CI - Tests — coverage pages publish (`test-ci.yml`)

The `reusable-test-python.yml` matrix uploads per-version coverage artifacts (`python-coverage-3.11`, `python-coverage-3.14`), but `reusable-test-python-publish.yml` downloads a single `python-coverage` artifact — causing `Artifact not found`.

**Fix:** Add a `merge-coverage` job that uses `actions/upload-artifact/merge` to combine per-version artifacts into `python-coverage` before the publish step runs. This mirrors the old `ci-pipeline.yml` behavior (single coverage report for Pages) using the standard merge action instead of bespoke scripts. Upstream gap filed as lgtm-ci#210.

### 2. Security - SBOM Generation (`sbom-on-main.yml` + `publish-pypi-on-tag.yml`)

Grype v6 fetches its vulnerability database from `grype.anchore.io:443`, which was missing from the egress allowlists. Harden Runner blocked the connection, causing `failed to load vulnerability db`.

**Fix:** Add `grype.anchore.io:443` to the allowed-endpoints in both SBOM workflows.

### 3. CI - Docker — `📦 Publish to GHCR` (`docker-ci.yml`)

The publish job uses Buildx `driver: docker-container`, which pulls `moby/buildkit:buildx-stable-1` from Docker Hub. The egress allowlist only had GHCR hosts — no Docker Hub or build-time registries. The sibling `docker-build` job already had them.

**Fix:** Align the `publish` job's egress allowlist with `docker-build` — add Docker Hub hosts plus all build-time hosts (apt, PyPI, rustup, npm, crates.io, semgrep).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (CI-only change, no application tests needed)
- [ ] Docs updated if user-facing (not user-facing)
- [x] Local CI passed (`uv run lintro chk`)

## Closes

- Closes #941

## Details

All three failures are egress/artifact regressions from PR #939 (lgtm-ci migration). The coverage artifact mismatch is an impedance between `reusable-test-python.yml` (multi-version matrix → per-version artifacts) and `reusable-test-python-publish.yml` (expects single merged artifact) — filed as [lgtm-ci#210](https://github.com/lgtm-hq/lgtm-ci/issues/210) for upstream fix. The grype and Docker Hub hosts were overlooked when constructing the new egress allowlists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use newer shared reusable workflow revisions across build, publish, test, and release pipelines.
  * Aligned tooling references across workflows for consistency.
  * Expanded allowed network endpoints for publish runs and added action permissions to support coverage aggregation.
  * General workflow maintenance and pin updates to keep automation current.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/942?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bumps the lgtm-ci reusable workflow pin from v0.18.1 (`22a7c110`) to v0.18.2 (`e42d374f`) across all 16 caller workflows and fixes three runtime regressions introduced by the v0.18.1 migration in #939.

- **Coverage artifact merge**: Adds `actions: write` to the `test` job in `test-ci.yml` so the v0.18.2 internal merge step can combine per-version coverage artifacts (`python-coverage-3.11`, `python-coverage-3.14`) into the single `python-coverage` artifact expected by the downstream publish job.
- **Grype egress**: Adds `grype.anchore.io:443` to both `sbom-on-main.yml` and `publish-pypi-on-tag.yml`'s SBOM job so Grype v6 can fetch its vulnerability database.
- **Docker Hub egress**: Aligns the `publish` job in `docker-ci.yml` with the existing `docker-build` job by adding Docker Hub and all build-time registry hosts (apt, PyPI, rustup, npm, crates.io, semgrep) needed when the `docker-container` Buildx driver pulls `moby/buildkit`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three fixes are narrowly scoped CI configuration changes with no application code impact.

The changes are mechanical: a SHA bump of a pinned reusable workflow, two missing Harden Runner egress entries, and one added GitHub Actions permission. Each fix directly matches a documented failure mode. The `actions: write` grant is correctly scoped to only the `test` job, the grype endpoint is correctly added to both SBOM callers, and the Docker Hub egress additions in the publish job are a proper subset of what the sibling docker-build job already allows. No application logic is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/test-ci.yml | Bumps lgtm-ci SHA and adds `actions: write` so the v0.18.2 internal artifact-merge step can run; permission scope is correct — applies to the `test` reusable caller, not the unrelated `publish-coverage` job. |
| .github/workflows/docker-ci.yml | Adds Docker Hub and build-time registry endpoints to the `publish` job's Harden Runner allowlist; list correctly mirrors the `docker-build` job, which already included these hosts. |
| .github/workflows/sbom-on-main.yml | Bumps SHA and adds `grype.anchore.io:443`; consistent with publish-pypi-on-tag.yml fix and required for Grype v6 DB fetch. |
| .github/workflows/publish-pypi-on-tag.yml | Bumps SHA, adds `grype.anchore.io:443` to SBOM job, and bumps internal `ref` checkouts of lgtm-ci tooling scripts; all consistent. |
| .github/workflows/docker-build-publish.yml | SHA bump and tooling-ref update only; no behavioral change. |
| .github/workflows/README.md | Documentation updated to reflect v0.18.2 SHA and list new upstream PRs (#206, #211); accurate. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as test job<br/>(reusable-test-python v0.18.2)
    participant A as GitHub Artifact Store
    participant PC as publish-coverage job<br/>(reusable-test-python-publish v0.18.2)
    participant P as GitHub Pages

    T->>A: upload python-coverage-3.11
    T->>A: upload python-coverage-3.14
    Note over T,A: actions:write now granted
    T->>A: merge to python-coverage
    T->>A: delete python-coverage-3.11
    T->>A: delete python-coverage-3.14
    PC->>A: download python-coverage
    PC->>P: deploy coverage report
```
</details>

<sub>Reviews (6): Last reviewed commit: ["ci: fix yamllint line-length and prettie..."](https://github.com/lgtm-hq/py-lintro/commit/635a171682410da2606eeef709e95923da8d47c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33677204)</sub>

<!-- /greptile_comment -->