### PR TITLE
fix(ci): repin lgtm-ci to v0.18.3 and fix egress allowlists

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,11 +3,9 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`e42d374f1f89e0ad20d165cd611eb7732462b581` (**v0.18.2**; includes
-[lgtm-ci#206](https://github.com/lgtm-hq/lgtm-ci/pull/206) host-user docker quality and
-`lintro-tool-options` passthrough,
-[lgtm-ci#211](https://github.com/lgtm-hq/lgtm-ci/pull/211) per-version coverage artifact
-merge).
+`4c36e28118ecf4f63df55e4a68b850d5e2697975` (**v0.18.3**; includes
+[lgtm-ci#214](https://github.com/lgtm-hq/lgtm-ci/issues/214) checkout order,
+attest-build subject-param, and python `__version__` verification fixes).
 
 ## CI (main branch)
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       languages: python
       build-mode: none

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       fail-on-severity: high
       egress-policy: block

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     permissions:
       contents: read
       packages: write
@@ -52,7 +52,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -86,7 +86,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     permissions:
       contents: read
       packages: write
@@ -115,7 +115,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -210,13 +210,13 @@ jobs:
   dogfooding-quality:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality
       pull-requests: write # reusable-quality post-pr-comment step
     with:
-      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
       job-name: '🛠️ Dogfooding Lint'
       post-pr-comment: true
       lintro-tool-options: >-
@@ -345,7 +345,7 @@ jobs:
       - name: Comment PR with security audit results
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@e42d374f1f89e0ad20d165cd611eb7732462b581
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@4c36e28118ecf4f63df55e4a68b850d5e2697975
         with:
           file: security-audit-comment.txt
           marker: security-audit-report
@@ -467,6 +467,9 @@ jobs:
           allowed-endpoints: >
             github.com:443
             api.github.com:443
+            codeload.github.com:443
+            release-assets.githubusercontent.com:443
+            objects.githubusercontent.com:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
             docker.io:443

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,14 +12,14 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       codeowners-path: .github/CODEOWNERS
       egress-policy: block
       allowed-endpoints: >
         github.com:443
         api.github.com:443
-      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -28,10 +28,10 @@ jobs:
   quality:
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       post-pr-comment: false
-      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -46,7 +46,7 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       target: .
       target-type: dir
@@ -71,7 +71,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
     permissions:
       contents: read
       security-events: write
@@ -111,7 +111,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+          ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -170,7 +170,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+          ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -11,12 +11,12 @@ permissions: {}
 jobs:
   publish:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       test-pypi: true
       update-homebrew: false
       python-version: '3.14'
-      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       create-release: false
-      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       target: .
       target-type: dir
@@ -42,7 +42,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,15 +17,26 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       egress-policy: block
       allowed-endpoints: >
-        github.com:443
+        agent.api.stepsecurity.io:443
+        api.deps.dev:443
         api.github.com:443
+        api.osv.dev:443
+        api.scorecard.dev:443
         codeload.github.com:443
-        release-assets.githubusercontent.com:443
+        fulcio.sigstore.dev:443
+        github.com:443
         objects.githubusercontent.com:443
+        oss-fuzz-build-logs.storage.googleapis.com:443
+        ossf.github.io:443
+        release-assets.githubusercontent.com:443
+        rekor.sigstore.dev:443
+        sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+        www.bestpractices.dev:443
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       post-pr-comment: true
       python-versions: '3.11,3.14'
@@ -35,7 +35,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -86,13 +86,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@e42d374f1f89e0ad20d165cd611eb7732462b581
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
     with:
       egress-policy: block
       allowed-endpoints: >
@@ -30,6 +30,6 @@ jobs:
         codeload.github.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
-      tooling-ref: 'e42d374f1f89e0ad20d165cd611eb7732462b581'
+      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
     permissions:
       contents: read


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): repin lgtm-ci to v0.18.3 and fix egress allowlists
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Repin all lgtm-ci reusable workflow and tooling refs from v0.18.2
(`e42d374f`) to v0.18.3 (`4c36e281`), which includes
[lgtm-hq/lgtm-ci#214](https://github.com/lgtm-hq/lgtm-ci/issues/214) fixes for
main-branch coverage publish, SBOM attestation, and release version PR.

Also expand harden-runner egress allowlists that were blocking two additional
main/scheduled workflows:

- **Publish to GHCR** — allow GitHub release asset hosts for bun downloads inside
  Docker builds (`release-assets.githubusercontent.com`, etc.)
- **OpenSSF Scorecard** — allow Scorecard/Sigstore/deps.dev API endpoints required
  by `ossf/scorecard-action`

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` + `uv run lintro tst`)

## Closes

- Relates to #941

## Details

**lgtm-ci pin:** `4c36e28118ecf4f63df55e4a68b850d5e2697975` (v0.18.3 release
merge commit via `refs/tags/v0.18.3^{}`)

**Files touched:** 16 workflow files + `.github/workflows/README.md` (35 pin
refs updated)

**Post-merge verification (main-only jobs):**

- Publish Coverage to Pages
- Security - SBOM Generation (attestation)
- Release - Version PR
- CI - Docker → Publish to GHCR
- Security - OpenSSF Scorecard Analysis (next scheduled run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD automation workflows to reference newer versions of tooling and dependencies.
  * Enhanced security controls in pipeline configurations by expanding network endpoint allowlists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR repins all `lgtm-ci` reusable workflow references from `e42d374f` (v0.18.2) to `4c36e28118ecf4f63df55e4a68b850d5e2697975` (v0.18.3) across 15 workflow files, and expands harden-runner egress allowlists in two previously-broken workflows.

- **Pin updates**: Every `uses: lgtm-hq/lgtm-ci/...@<sha>` and every `tooling-ref:` value across all 15 caller workflows is consistently updated to the new SHA with no stale references remaining.
- **`docker-ci.yml` (publish job)**: Adds `codeload.github.com`, `release-assets.githubusercontent.com`, and `objects.githubusercontent.com` to the `allowed-endpoints` list to unblock Bun downloads from GitHub release assets during Docker image builds.
- **`scorecards.yml`**: Expands the allowlist with 11 new endpoints covering Scorecard, Sigstore (Fulcio, Rekor, TUF CDN), OSV, deps.dev, OSS-Fuzz, and Best Practices APIs required by `ossf/scorecard-action`.
</details>

<h3>Confidence Score: 5/5</h3>

Mechanical pin bump across all caller workflows with no stale SHA remaining, plus targeted egress additions to unblock two previously-failing jobs.

Every lgtm-ci reference — both uses: workflow pins and tooling-ref: inputs — was updated to the new SHA, and a grep confirms no old hash remains anywhere in .github/. The egress additions in docker-ci.yml match the endpoint set already established in docker-build-publish.yml for an identical Docker-build context. The Scorecard allowlist expansion is comprehensive and aligns with the known network requirements of ossf/scorecard-action.

No files require special attention. The egress additions in docker-ci.yml and scorecards.yml are the only non-mechanical changes and both look correct.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/scorecards.yml | SHA pin updated; egress allowlist expanded with 11 endpoints needed by ossf/scorecard-action (Scorecard API, Sigstore, OSV, deps.dev, OSS-Fuzz, Best Practices). Endpoints are alphabetically sorted and cover all known Scorecard check dependencies. |
| .github/workflows/docker-ci.yml | SHA pin updated in 3 places (reusable-quality, post-pr-comment action, publish job tooling-ref). Publish job gains 3 new egress endpoints matching those already present in docker-build-publish.yml for the same Docker build context. |
| .github/workflows/docker-build-publish.yml | SHA pin updated in 4 places (2 reusable-docker uses, 2 tooling-ref values). Egress allowlist unchanged — already contained the codeload/release-assets/objects endpoints added to docker-ci.yml in this PR. |
| .github/workflows/publish-pypi-on-tag.yml | SHA pin updated in 6 places (reusable-quality, reusable-sbom, 2 tooling-refs, 2 direct checkout refs). No egress changes. |
| .github/workflows/test-ci.yml | SHA pin updated in 4 places (reusable-test-python, reusable-test-python-publish, 2 tooling-refs). No egress changes. |
| .github/workflows/README.md | Documentation updated to reflect new SHA and v0.18.3 release notes (lgtm-ci#214 fixes). |
| .github/workflows/codeql.yml | Single SHA pin update. No other changes. |
| .github/workflows/dependency-review.yml | Single SHA pin update. No other changes. |
| .github/workflows/sbom-on-main.yml | SHA pin updated in 2 places (reusable-sbom uses, tooling-ref). No egress changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Pin["lgtm-ci Pin: e42d374f → 4c36e281 (v0.18.2 → v0.18.3)"]
        direction LR
        OLD["e42d374f\nv0.18.2"] -->|"repin"| NEW["4c36e281\nv0.18.3"]
    end

    subgraph Workflows["15 Caller Workflows Updated"]
        W1[codeql.yml]
        W2[dependency-review.yml]
        W3[docker-build-publish.yml]
        W4[docker-ci.yml]
        W5[pr-auto-assign.yml]
        W6[pr-labeler.yml]
        W7[publish-pypi-on-tag.yml]
        W8[publish-testpypi.yml]
        W9[release-auto-tag.yml]
        W10[release-version-pr.yml]
        W11[sbom-on-main.yml]
        W12[scorecards.yml]
        W13[semantic-pr-title.yml]
        W14[test-ci.yml]
        W15[validate-action-pinning.yml]
    end

    subgraph Egress["Egress Allowlist Expansions"]
        E1["docker-ci.yml publish job\n+ codeload.github.com\n+ release-assets.githubusercontent.com\n+ objects.githubusercontent.com"]
        E2["scorecards.yml\n+ api.scorecard.dev, api.deps.dev\n+ api.osv.dev\n+ fulcio/rekor/tuf-repo-cdn.sigstore.dev\n+ oss-fuzz, bestpractices, ossf.github.io\n+ agent.api.stepsecurity.io"]
    end

    Pin --> Workflows
    W4 --> E1
    W12 --> E2
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): repin lgtm-ci to v0.18.3 and fi..."](https://github.com/lgtm-hq/py-lintro/commit/0f92d4823c8647505eb98578c32ca62dc163b416) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33731093)</sub>

<!-- /greptile_comment -->