### PR TITLE
fix(ci): annotate SHA pins and enable Renovate for lgtm-ci updates

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -72,17 +72,25 @@ All workflows use `step-security/harden-runner` with strict egress policies:
 
 ### Action Pinning
 
-All third-party actions are pinned to full commit SHAs, not version tags:
+LGTM HQ policy ([lgtm-ci#221](https://github.com/lgtm-hq/lgtm-ci/pull/221),
+[.github#12](https://github.com/lgtm-hq/.github/pull/12)): pin third-party and lgtm-ci
+actions to **release commit SHAs** with a trailing Renovate version comment on the same
+line. Tag refs are not allowed.
 
 ```yaml
-# Good - pinned to SHA
-uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+# Good — SHA + version comment (Renovate-discoverable)
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-# Bad - version tag can be moved
+# Bad — movable tag
 uses: actions/checkout@v4
+
+# Bad — bare SHA (Renovate disables; fails validate-action-pinning)
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 ```
 
-The `validate-action-pinning.yml` workflow enforces this policy.
+The same rule applies to `tooling-ref:` and manual lgtm-ci checkout `ref:` fields.
+Enforcement runs via `validate-action-pinning.yml` (lgtm-ci reusable workflow). Renovate
+automation comes from the org preset (`extends: local>lgtm-hq/.github:renovate-config`).
 
 ### Permissions
 

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -10,9 +10,13 @@ inputs in its action.yml.
 versioned separately. When you change a local action, update the workflows that call it
 in the same commit/PR — there is no `@actions-v*` pin to bump.
 
-**External actions** (Marketplace, other repos, or lgtm-ci) must stay pinned to commit
-SHAs in workflow files, per org policy. Breaking changes to those actions are absorbed
-by repinning the SHA in the caller workflow.
+**External actions** (Marketplace, other repos, or lgtm-ci) must stay pinned to
+**release commit SHAs** with a trailing `# vX.Y.Z` comment on the same line, per org
+policy ([lgtm-ci#221](https://github.com/lgtm-hq/lgtm-ci/pull/221),
+[.github#12](https://github.com/lgtm-hq/.github/pull/12)). Breaking changes to those
+actions are absorbed by repinning the SHA and updating the version comment in caller
+workflows. Enforcement is via `validate-action-pinning.yml`; Renovate updates are
+handled by the org preset — not duplicated in this repo’s `renovate.json`.
 
 ## .github/actions/setup-docker
 

--- a/.github/actions/harden-runner-preset/action.yml
+++ b/.github/actions/harden-runner-preset/action.yml
@@ -131,7 +131,8 @@ runs:
       # yamllint enable rule:line-length
 
     - name: Harden Runner
-      uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+      # yamllint disable-line rule:line-length
+      uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
       with:
         egress-policy: ${{ inputs.policy }}
         allowed-endpoints: ${{ steps.endpoints.outputs.endpoints }}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,9 +3,15 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`4c36e28118ecf4f63df55e4a68b850d5e2697975` (**v0.18.3**; includes
-[lgtm-ci#214](https://github.com/lgtm-hq/lgtm-ci/issues/214) checkout order,
-attest-build subject-param, and python `__version__` verification fixes).
+`dfd52172e5ee817cb1b1baf24895209c5e18d5ad` (**v0.19.0** release commit; includes
+[lgtm-ci#221](https://github.com/lgtm-hq/lgtm-ci/pull/221) annotated SHA enforcement and
+[lgtm-ci#218](https://github.com/lgtm-hq/lgtm-ci/pull/218) Pages publish checkout-order
+fix). All workflow SHA pins include trailing `# vX.Y.Z` comments so Renovate can track
+digest updates. Policy is enforced by
+[lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
+`validate-action-pinning.yml`) and automated by the
+[org Renovate preset](https://github.com/lgtm-hq/.github/pull/12)
+(`extends: local>lgtm-hq/.github:renovate-config`).
 
 ## CI (main branch)
 

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -72,7 +72,8 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -167,7 +168,8 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -232,7 +234,8 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       languages: python
       build-mode: none

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       fail-on-severity: high
       egress-policy: block

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     permissions:
       contents: read
       packages: write
@@ -52,7 +52,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -86,7 +86,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     permissions:
       contents: read
       packages: write
@@ -115,7 +115,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -37,7 +37,8 @@ jobs:
       github.event.pull_request.draft == false
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -81,7 +82,8 @@ jobs:
       is-fork: ${{ steps.fork-check.outputs.is-fork }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -210,13 +212,13 @@ jobs:
   dogfooding-quality:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality
       pull-requests: write # reusable-quality post-pr-comment step
     with:
-      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
       job-name: '🛠️ Dogfooding Lint'
       post-pr-comment: true
       lintro-tool-options: >-
@@ -301,7 +303,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -345,7 +348,8 @@ jobs:
       - name: Comment PR with security audit results
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@4c36e28118ecf4f63df55e4a68b850d5e2697975
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
         with:
           file: security-audit-comment.txt
           marker: security-audit-report
@@ -367,7 +371,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -461,7 +466,8 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -573,7 +579,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -41,7 +41,8 @@ jobs:
       packages: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >

--- a/.github/workflows/lintro-report-scheduled.yml
+++ b/.github/workflows/lintro-report-scheduled.yml
@@ -40,7 +40,8 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -79,7 +80,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,14 +12,14 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       codeowners-path: .github/CODEOWNERS
       egress-policy: block
       allowed-endpoints: >
         github.com:443
         api.github.com:443
-      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-comment-cleanup.yml
+++ b/.github/workflows/pr-comment-cleanup.yml
@@ -28,7 +28,8 @@ jobs:
         shell: bash
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -28,10 +28,10 @@ jobs:
   quality:
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       post-pr-comment: false
-      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -46,7 +46,7 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       target: .
       target-type: dir
@@ -71,7 +71,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
     permissions:
       contents: read
       security-events: write
@@ -88,7 +88,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -111,7 +112,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+          ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -152,7 +153,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -170,7 +172,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+          ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -206,7 +208,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -11,12 +11,12 @@ permissions: {}
 jobs:
   publish:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       test-pypi: true
       update-homebrew: false
       python-version: '3.14'
-      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       create-release: false
-      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       target: .
       target-type: dir
@@ -42,7 +42,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/test-built-package.yml
+++ b/.github/workflows/test-built-package.yml
@@ -56,7 +56,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       post-pr-comment: true
       python-versions: '3.11,3.14'
@@ -35,7 +35,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -86,13 +86,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@4c36e28118ecf4f63df55e4a68b850d5e2697975
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
       egress-policy: block
       allowed-endpoints: >
@@ -30,6 +30,6 @@ jobs:
         codeload.github.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
-      tooling-ref: '4c36e28118ecf4f63df55e4a68b850d5e2697975'
+      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
     permissions:
       contents: read

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -27,7 +27,8 @@ jobs:
         shell: bash
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: 'block'
           allowed-endpoints: >


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

One-time py-lintro migration to the org SHA-pinning policy. **Enforcement** ([lgtm-ci#221](https://github.com/lgtm-hq/lgtm-ci/pull/221) → v0.19.0) and **Renovate automation** ([.github#12](https://github.com/lgtm-hq/.github/pull/12)) live upstream — this PR annotates pins, repins tooling, and updates docs only.

## Upstream (not re-implemented here)

| Layer | Repo | Issue | PR |
| --- | --- | --- | --- |
| Enforcement | [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) | [#220](https://github.com/lgtm-hq/lgtm-ci/issues/220) | [#221](https://github.com/lgtm-hq/lgtm-ci/pull/221) → **v0.19.0** |
| Renovate automation | [lgtm-hq/.github](https://github.com/lgtm-hq/.github) | [#11](https://github.com/lgtm-hq/.github/issues/11) | [#12](https://github.com/lgtm-hq/.github/pull/12) |

## What this PR changes (26 files)

- Repins all **lgtm-ci** refs to **v0.19.0** release commit `dfd52172e5ee817cb1b1baf24895209c5e18d5ad`
- Adds `# vX.Y.Z` to **38** bare SHA pins (19× lgtm-ci, 19× harden-runner)
- Repins `validate-action-pinning.yml` to v0.19.0 (runs [lgtm-ci validator](https://github.com/lgtm-hq/lgtm-ci/blob/main/scripts/ci/actions/validate-action-pinning.sh))
- Updates **`.github/SECURITY.md`**, **`.github/workflows/README.md`**, **`.github/actions/README.md`** with org policy + upstream links

## What this PR does not change

- **`renovate.json`** — no lgtm-ci rules added or removed; org preset owns them via `extends: local>lgtm-hq/.github:renovate-config`
- **No pytest/BATS guardrails** — policy tested in lgtm-ci BATS and enforced by `validate-action-pinning.yml`

## Closes

- Closes #945

## Post-merge

- Confirm main **Deploy Coverage to Pages** green
- Confirm Renovate tracks lgtm-ci once [.github#12](https://github.com/lgtm-hq/.github/pull/12) is on main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external CI/CD tooling and security scanning actions to latest stable versions.
  * Applied YAML linting configuration improvements across workflow files.

* **Documentation**
  * Enhanced internal documentation regarding action versioning and pinning best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/946?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates all CI workflow SHA pins to the org's annotated-pin policy, updating every `lgtm-ci` reference from `4c36e28...` (v0.18.3) to `dfd52172...` (v0.19.0) and appending `# vX.Y.Z` comments so Renovate can track digest updates.

- **lgtm-ci bump (v0.18.3 → v0.19.0):** All 19 `uses:` workflow calls and 15 `tooling-ref:` inputs are consistently updated to the new release commit SHA with a trailing `# v0.19.0` annotation.
- **harden-runner annotations:** All 19 `step-security/harden-runner` SHA pins (unchanged SHA `fe104658...`) gain a `# v2.16.1` version comment; `# yamllint disable-line rule:line-length` comments are added where needed to satisfy the linter.
- **Docs update:** `SECURITY.md`, `workflows/README.md`, and `actions/README.md` are updated to describe the annotated-pin policy and link to the upstream enforcement PR and org Renovate preset.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are purely mechanical SHA annotation and a lgtm-ci version bump with no functional code alterations.

Every lgtm-ci reference was updated consistently, all harden-runner pins annotated, no bare SHAs remain, YAML is valid, and no functional logic was modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/validate-action-pinning.yml | Updated lgtm-ci ref and tooling-ref to v0.19.0 SHA with annotation; this is the enforcement workflow itself, so correct pinning here is critical — looks consistent. |
| .github/workflows/docker-ci.yml | All 6 harden-runner and lgtm-ci pins annotated consistently; yamllint disable comments added where needed for newly-extended lines. |
| .github/workflows/publish-pypi-on-tag.yml | All three pin types updated: reusable-workflow uses, tooling-ref inputs, and manual checkout ref fields — all consistently annotated with # v0.19.0. |
| .github/actions/harden-runner-preset/action.yml | harden-runner SHA annotated with # v2.16.1 and yamllint disable-line comment added; change is correct and minimal. |
| .github/SECURITY.md | Policy prose and code examples updated to describe annotated-pin requirement; example SHA matches the one used in actual workflows. |
| .github/workflows/docker-build-publish.yml | Both reusable-docker calls and both tooling-ref inputs updated to v0.19.0 SHA with version annotation. |
| .github/workflows/test-ci.yml | Both reusable-test-python calls and tooling-ref inputs updated consistently to v0.19.0. |
| .github/workflows/README.md | Docs updated with new lgtm-ci SHA, v0.19.0 version, and description of annotated-pin policy and org Renovate preset. |

</details>

</details>

<sub>Reviews (6): Last reviewed commit: ["chore(ci): retrigger CI"](https://github.com/lgtm-hq/py-lintro/commit/57cd658c0378e030927362781b8a7c7143a249be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33790455)</sub>

<!-- /greptile_comment -->