### PR TITLE
fix(ci): repin coverage Pages publish to lgtm-ci v0.19.2

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -38,4 +38,6 @@ jobs:
         api.github.com:443
     permissions:
       contents: read
+      # lgtm-ci reusable-semantic-pr-title → amannn/action-semantic-pull-request:
+      # read PR title/metadata only (read-only; satisfies least-privilege audits).
       pull-requests: read

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -19,6 +19,7 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@77eaaad9c12a3f0199ebb9ed18a4e6c3896d1962 # v0.19.2
     with:
+      tooling-ref: '77eaaad9c12a3f0199ebb9ed18a4e6c3896d1962' # v0.19.2
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -25,3 +25,4 @@ jobs:
         api.github.com:443
     permissions:
       contents: read
+      pull-requests: read

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -19,6 +19,19 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
     with:
+      # action-semantic-pull-request expects newline-delimited types, not CSV
+      types: |
+        feat
+        fix
+        docs
+        style
+        refactor
+        perf
+        test
+        build
+        ci
+        chore
+        revert
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,21 +17,8 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@77eaaad9c12a3f0199ebb9ed18a4e6c3896d1962 # v0.19.2
     with:
-      # action-semantic-pull-request expects newline-delimited types, not CSV
-      types: |
-        feat
-        fix
-        docs
-        style
-        refactor
-        perf
-        test
-        build
-        ci
-        chore
-        revert
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -86,13 +86,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@f2bd33fc7f9af2e3b1862ef0cfb1e365302f09eb # v0.19.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@77eaaad9c12a3f0199ebb9ed18a4e6c3896d1962 # v0.19.2
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: 'f2bd33fc7f9af2e3b1862ef0cfb1e365302f09eb' # v0.19.1
+      tooling-ref: '77eaaad9c12a3f0199ebb9ed18a4e6c3896d1962' # v0.19.2
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -86,13 +86,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@9315d23b1811e9dd93d1c431a1bee9577fdbdd98 # lgtm-ci#223
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@f2bd33fc7f9af2e3b1862ef0cfb1e365302f09eb # v0.19.1
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: '9315d23b1811e9dd93d1c431a1bee9577fdbdd98' # lgtm-ci#223
+      tooling-ref: 'f2bd33fc7f9af2e3b1862ef0cfb1e365302f09eb' # v0.19.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -86,21 +86,22 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@9315d23b1811e9dd93d1c431a1bee9577fdbdd98 # lgtm-ci#223
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
+      tooling-ref: '9315d23b1811e9dd93d1c431a1bee9577fdbdd98' # lgtm-ci#223
       egress-policy: block
       allowed-endpoints: >
         github.com:443
         api.github.com:443
+        actions.githubusercontent.com:443
         codeload.github.com:443
         release-assets.githubusercontent.com:443
         objects.githubusercontent.com:443
     permissions:
-      contents: write
+      contents: read
       pages: write
       id-token: write


### PR DESCRIPTION
## Summary

Repin `reusable-test-python-publish` and `tooling-ref` to lgtm-ci commit that replaces blocked `peaceiris/actions-gh-pages` with official `actions/deploy-pages` flow.

## Closes

- Relates to lgtm-hq/lgtm-ci#223

## Changes

- Pin workflow + tooling to `9315d23b1811e9dd93d1c431a1bee9577fdbdd98` (lgtm-ci#223; tag as v0.19.1 after merge)
- `contents: read` (no gh-pages branch push)
- Allow `actions.githubusercontent.com:443` for OIDC Pages deploy under egress block

## Test plan

- [ ] Merge lgtm-hq/lgtm-ci#223 first (or verify workflow SHA is reachable)
- [ ] Merge this PR
- [ ] Confirm `Deploy Coverage to Pages` succeeds on main push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to a newer pinned reusable workflow and tooling reference.
  * Egress allowlist expanded to include the GitHub Actions endpoint.
  * Repository permissions adjusted: contents permission reduced from write to read; pages and id-token remain write.

Note: No user-facing changes; updates affect internal CI/CD processes only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/947?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Repin CI reusable workflows to lgtm-ci v0.19.2
> Updates both [semantic-pr-title.yml](https://github.com/lgtm-hq/py-lintro/pull/947/files#diff-102229929362be07617740007e2fe727aa2e54f794220d8870f0769d34f31ee7) and [test-ci.yml](https://github.com/lgtm-hq/py-lintro/pull/947/files#diff-6fc0cfc32988f2cc6b9a0f5b8160950c4ca1c13d1159f326bf8a8841676fdca0) to reference lgtm-ci reusable workflow v0.19.2 (commit `77eaaad`), replacing the previous v0.19.0 pin.
>
> - Adds `pull-requests: read` permission to the semantic PR title job.
> - Downgrades `contents` permission from `write` to `read` in the publish-coverage job.
> - Adds `actions.githubusercontent.com:443` to the egress allowlist in the publish-coverage job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05e6f2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR repins the `publish-coverage` and `semantic-title` CI jobs from lgtm-ci v0.19.0 to v0.19.2, which replaces the blocked `peaceiris/actions-gh-pages` action with the official `actions/deploy-pages` flow.

- **`test-ci.yml`**: `publish-coverage` job SHA and `tooling-ref` updated to `77eaaad9c12a3f0199ebb9ed18a4e6c3896d1962`; `contents` permission downgraded from `write` to `read` (least-privilege improvement); `actions.githubusercontent.com:443` added to the egress allowlist for the OIDC-based Pages deploy token exchange.
- **`semantic-pr-title.yml`**: Same SHA bump applied; `tooling-ref` parameter added (was previously absent); `pull-requests: read` permission added with an explanatory comment linking it to the underlying `amannn/action-semantic-pull-request` action's requirements.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are CI-only version pin bumps with corresponding permission tightening and an egress allowlist addition required by the new deploy-pages flow.

Both workflow files consistently use the same v0.19.2 SHA across `uses:` and `tooling-ref`. The `contents: write` → `contents: read` downgrade is correct for `actions/deploy-pages` (which uses OIDC rather than branch push), and the new `actions.githubusercontent.com:443` egress entry is the standard endpoint needed for the OIDC token exchange. No logic regressions are introduced in the changed code paths.

No files require special attention. The intentional split between the `test` job (still v0.19.0) and the `publish-coverage`/`semantic-title` jobs (now v0.19.2) was flagged in a prior review cycle and is a known, pre-existing divergence.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/test-ci.yml | publish-coverage job repinned to v0.19.2 SHA; contents permission downgraded from write to read; actions.githubusercontent.com:443 added for OIDC Pages deploy egress. test job intentionally left on v0.19.0 (already flagged in prior review). |
| .github/workflows/semantic-pr-title.yml | Repinned to v0.19.2 SHA, added tooling-ref parameter (previously absent), and added pull-requests: read permission with an explanatory inline comment. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    push["push to main / PR opened"] --> test["test job\n(reusable-test-python\n@ v0.19.0 / dfd52172)"]
    push --> semantic["semantic-title job\n(reusable-semantic-pr-title\n@ v0.19.2 / 77eaaad9)\npull-requests: read"]

    test -->|passed == true| coverage["publish-coverage job\n(reusable-test-python-publish\n@ v0.19.2 / 77eaaad9)"]
    test --> gating["test-suite-coverage\ngating check"]

    coverage -->|egress allowlist| egress["github.com:443\napi.github.com:443\nactions.githubusercontent.com:443 NEW\ncodeload.github.com:443\nrelease-assets.githubusercontent.com:443\nobjects.githubusercontent.com:443"]

    coverage -->|permissions| perms["contents: read (was write)\npages: write\nid-token: write"]

    coverage --> pages["GitHub Pages\n(actions/deploy-pages)"]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/test-ci.yml`, line 24-38 ([link](https://github.com/lgtm-hq/py-lintro/blob/d8860c29dd7e6809a3fa1a850419230b1c62bf0e/.github/workflows/test-ci.yml#L24-L38)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`test` job still pinned to old SHA (v0.19.0)**

   The `test` job's `uses:` ref (line 24) and `tooling-ref` (line 38) remain at `dfd52172e5ee817cb1b1baf24895209c5e18d5ad` (v0.19.0) while `publish-coverage` now uses `9315d23b1811e9dd93d1c431a1bee9577fdbdd98`. If lgtm-ci#223 touches shared tooling (e.g., runner scripts, harness versions) used by both workflows, the two jobs will run against different tool versions on the same commit. If the divergence is intentional because `reusable-test-python.yml` is unaffected by lgtm-ci#223, a brief inline comment here would make that clear to future reviewers.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Ftest-ci.yml%0ALine%3A%2024-38%0A%0AComment%3A%0A**%60test%60%20job%20still%20pinned%20to%20old%20SHA%20%28v0.19.0%29**%0A%0AThe%20%60test%60%20job's%20%60uses%3A%60%20ref%20%28line%2024%29%20and%20%60tooling-ref%60%20%28line%2038%29%20remain%20at%20%60dfd52172e5ee817cb1b1baf24895209c5e18d5ad%60%20%28v0.19.0%29%20while%20%60publish-coverage%60%20now%20uses%20%609315d23b1811e9dd93d1c431a1bee9577fdbdd98%60.%20If%20lgtm-ci%23223%20touches%20shared%20tooling%20%28e.g.%2C%20runner%20scripts%2C%20harness%20versions%29%20used%20by%20both%20workflows%2C%20the%20two%20jobs%20will%20run%20against%20different%20tool%20versions%20on%20the%20same%20commit.%20If%20the%20divergence%20is%20intentional%20because%20%60reusable-test-python.yml%60%20is%20unaffected%20by%20lgtm-ci%23223%2C%20a%20brief%20inline%20comment%20here%20would%20make%20that%20clear%20to%20future%20reviewers.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=947&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Ftest-ci.yml%0ALine%3A%2024-38%0A%0AComment%3A%0A**%60test%60%20job%20still%20pinned%20to%20old%20SHA%20%28v0.19.0%29**%0A%0AThe%20%60test%60%20job's%20%60uses%3A%60%20ref%20%28line%2024%29%20and%20%60tooling-ref%60%20%28line%2038%29%20remain%20at%20%60dfd52172e5ee817cb1b1baf24895209c5e18d5ad%60%20%28v0.19.0%29%20while%20%60publish-coverage%60%20now%20uses%20%609315d23b1811e9dd93d1c431a1bee9577fdbdd98%60.%20If%20lgtm-ci%23223%20touches%20shared%20tooling%20%28e.g.%2C%20runner%20scripts%2C%20harness%20versions%29%20used%20by%20both%20workflows%2C%20the%20two%20jobs%20will%20run%20against%20different%20tool%20versions%20on%20the%20same%20commit.%20If%20the%20divergence%20is%20intentional%20because%20%60reusable-test-python.yml%60%20is%20unaffected%20by%20lgtm-ci%23223%2C%20a%20brief%20inline%20comment%20here%20would%20make%20that%20clear%20to%20future%20reviewers.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fpy-lintro&pr=947&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2Fpages-repin-lgtm-ci%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpages-repin-lgtm-ci%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Ftest-ci.yml%0ALine%3A%2024-38%0A%0AComment%3A%0A**%60test%60%20job%20still%20pinned%20to%20old%20SHA%20%28v0.19.0%29**%0A%0AThe%20%60test%60%20job's%20%60uses%3A%60%20ref%20%28line%2024%29%20and%20%60tooling-ref%60%20%28line%2038%29%20remain%20at%20%60dfd52172e5ee817cb1b1baf24895209c5e18d5ad%60%20%28v0.19.0%29%20while%20%60publish-coverage%60%20now%20uses%20%609315d23b1811e9dd93d1c431a1bee9577fdbdd98%60.%20If%20lgtm-ci%23223%20touches%20shared%20tooling%20%28e.g.%2C%20runner%20scripts%2C%20harness%20versions%29%20used%20by%20both%20workflows%2C%20the%20two%20jobs%20will%20run%20against%20different%20tool%20versions%20on%20the%20same%20commit.%20If%20the%20divergence%20is%20intentional%20because%20%60reusable-test-python.yml%60%20is%20unaffected%20by%20lgtm-ci%23223%2C%20a%20brief%20inline%20comment%20here%20would%20make%20that%20clear%20to%20future%20reviewers.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["fix(ci): set tooling-ref for semantic PR..."](https://github.com/lgtm-hq/py-lintro/commit/05e6f2d9ee2f755f1566689522d91b4332d8ce3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33883984)</sub>

<!-- /greptile_comment -->