### PR TITLE
fix(ci): grant publish workflow caller permissions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -31,9 +31,12 @@ digest updates. Policy is enforced by
 
 ## Publish
 
-- **publish-pypi-on-tag.yml** — PyPI publish via `reusable-publish-pypi.yml`; bespoke
-  GitHub Release assets, Homebrew (`build-binary.yml`), and Docker
-  (`docker-build-publish.yml`)
+- **publish-pypi-on-tag.yml** — Production tag publish: lgtm-ci `reusable-quality` +
+  `reusable-sbom`, inline build/publish via `publish-pypi.sh`, GitHub Release assets,
+  Homebrew (`build-binary.yml`), Docker (`docker-build-publish.yml`). See
+  [lgtm-hq/lgtm-ci#232](https://github.com/lgtm-hq/lgtm-ci/issues/232) for consolidating
+  on `reusable-publish-pypi.yml`.
+- **publish-testpypi.yml** — TestPyPI via lgtm-ci `reusable-publish-pypi.yml`
 - **docker-build-publish.yml** — Multi-arch GHCR publish via `reusable-docker.yml`
   (full + base images, registry cache at `:cache`, no-cache on version tags)
 

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -29,6 +29,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      security-events: write
     with:
       file: Dockerfile
       target: full
@@ -92,6 +93,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      security-events: write
     with:
       file: Dockerfile
       target: base

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -25,24 +25,67 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Inline lint-only job (not reusable-quality): nested comment job forces
+  # pull-requests: write at parse time even when post-pr-comment is false.
+  # Replace with lgtm-ci reusable-quality-lint after lgtm-hq/lgtm-ci#231.
   quality:
+    name: Lintro Quality Checks
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
-    # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
-    with:
-      post-pr-comment: false
-      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
-      egress-policy: block
-      allowed-endpoints: >
-        github.com:443
-        api.github.com:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: read
-      # reusable-quality comment job declares pull-requests: write (validated even when post-pr-comment: false)
-      pull-requests: write
+    env:
+      # yamllint disable-line rule:line-length
+      LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro@sha256:1ff3db35939283734b859c7c5d95be87fd8fd62734b3434e0437769d50d53578
+    steps:
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
+          sparse-checkout: scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Run lintro quality checks
+        shell: bash
+        env:
+          STEP: check
+          FAIL_ON_ERROR: 'true'
+          MAP_HOST_USER: 'true'
+        # yamllint disable-line rule:line-length
+        run: bash "${{ github.workspace }}/.lgtm-ci-tooling/scripts/ci/quality/run-lintro-docker.sh"
+      - name: Upload linting report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: linting-report
+          path: |
+            .lintro/
+            chk-output.txt
+          retention-days: 7
+          if-no-files-found: ignore
 
   sbom:
     name: Generate and verify SBOM

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -41,6 +41,8 @@ jobs:
     permissions:
       contents: read
       packages: read
+      # reusable-quality comment job declares pull-requests: write (validated even when post-pr-comment: false)
+      pull-requests: write
 
   sbom:
     name: Generate and verify SBOM
@@ -264,3 +266,4 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      security-events: write


### PR DESCRIPTION
## Summary

- Grant `pull-requests: write` on the `quality` job calling lgtm-ci `reusable-quality` (workflow validation requires it even when `post-pr-comment: false`)
- Grant `security-events: write` for `reusable-docker` on tag Docker publish paths
- Correct workflows README: production publish vs TestPyPI

## Closes

- Closes #949

## Relates to

- Relates to lgtm-hq/lgtm-ci#231
- Relates to lgtm-hq/lgtm-ci#232
- Relates to #950
- Relates to #951

## Test plan

- [ ] Merge PR
- [ ] Retag `v0.64.3` to merge commit or cut `0.64.4`
- [ ] Confirm [Publish - PyPI Production](https://github.com/lgtm-hq/py-lintro/actions/workflows/publish-pypi-on-tag.yml) completes: PyPI, GitHub Release, Docker, Homebrew

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Grant `security-events: write` permission to publish workflow callers
> - Adds `security-events: write` permission to the `publish-docker` workflow-call job in [publish-pypi-on-tag.yml](https://github.com/lgtm-hq/py-lintro/pull/952/files#diff-5cf2a1b57dc395ea681b1e3d2132b3e05e48ec5c9768b6930f2a10f7ef3613f2) and to both `docker-base` and `docker-full` jobs in [docker-build-publish.yml](https://github.com/lgtm-hq/py-lintro/pull/952/files#diff-7c332a18c4a688078429fa35fed1d386e5e4dd710e1bdb2e6a7f18c01f81f088).
> - Replaces the reusable-quality workflow invocation in `publish-pypi-on-tag.yml` with an inline job that uses the lintro Docker script, enforces an egress allowlist via `harden-runner`, authenticates to GHCR, and uploads a linting-report artifact.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 405cfa5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CI/CD publish documentation to reflect revised pipelines, added TestPyPI publishing entry, and included a reference to consolidation work.
  * Clarified how publish artifacts (PyPI, Homebrew, Docker, GitHub releases) are produced.

* **Chores**
  * Adjusted publish workflows and GitHub token permissions to enable security event reporting and improved quality-check placement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes missing GitHub token permissions on the production publish workflow and its Docker sub-workflow, and updates the CI documentation. The `quality` job is refactored from a `reusable-quality` caller into an inline lint job to avoid granting `pull-requests: write` on a tag-push workflow; `security-events: write` is added to the Docker jobs to allow Trivy SARIF uploads.

- **`publish-pypi-on-tag.yml`**: `quality` job rewritten as an inline job (checking out the repo + lgtm-ci tooling, pulling a pinned GHCR image, running `run-lintro-docker.sh`). The `docker-publish` caller gains `security-events: write`.
- **`docker-build-publish.yml`**: `security-events: write` added to both `docker-full` and `docker-base` permission blocks so the called `reusable-docker` workflow can upload Trivy SARIF results.
- **`README.md`**: Updated to distinguish `publish-pypi-on-tag.yml` (production) from `publish-testpypi.yml` (TestPyPI), with a reference to the consolidation tracking issue.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are additive permission grants and a well-scoped quality-job refactor with no logic changes to build or publish steps.

All changes are CI workflow permission fixes. The inline quality job is a like-for-like functional replacement of the reusable-quality call, using the same pinned tooling SHA and a digest-pinned GHCR image. The security-events:write additions are necessary for SARIF uploads and are appropriately scoped to the jobs that need them. No application code is affected.

No files require special attention beyond the minor README wording noted in the inline comment.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-pypi-on-tag.yml | Quality job refactored from reusable-quality caller to inline lint job to avoid pull-requests:write; security-events:write added to docker-publish caller |
| .github/workflows/docker-build-publish.yml | security-events:write added to both docker-full and docker-base job permission blocks for reusable-docker Trivy SARIF uploads |
| .github/workflows/README.md | README updated to distinguish production publish from TestPyPI, but still references reusable-quality which is no longer used in publish-pypi-on-tag.yml after this PR |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Tag Push] --> B[quality\ninline lint job\ncontents:read, packages:read]
    A --> C[sbom\nreusable-sbom\nsecurity-events:write]
    B --> D[build-artifacts\ncontents:read]
    C --> D
    D --> E[publish\nPyPI + attest\nid-token:write]
    E --> F[github-release\ncontents:write]
    E --> G[homebrew-tap\nbuild-binary.yml\ncontents:write]
    E --> H[docker-publish\ndocker-build-publish.yml\npackages:write\nsecurity-events:write]
    H --> I[docker-full\nreusable-docker\nsecurity-events:write]
    I --> J[docker-base\nreusable-docker\nsecurity-events:write]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2FREADME.md%3A34-38%0AThe%20description%20still%20says%20%22lgtm-ci%20%60reusable-quality%60%22%20but%20this%20very%20PR%20replaces%20that%20reusable-workflow%20call%20with%20an%20inline%20lint%20job.%20The%20README%20now%20describes%20the%20state%20before%20this%20change%2C%20which%20contradicts%20the%20PR's%20stated%20goal%20of%20correcting%20the%20documentation.%0A%0A%60%60%60suggestion%0A-%20**publish-pypi-on-tag.yml**%20%E2%80%94%20Production%20tag%20publish%3A%20inline%20lint%20%28pending%20lgtm-ci%23231%29%20%2B%0A%20%20%60reusable-sbom%60%2C%20inline%20build%2Fpublish%20via%20%60publish-pypi.sh%60%2C%20GitHub%20Release%20assets%2C%0A%20%20Homebrew%20%28%60build-binary.yml%60%29%2C%20Docker%20%28%60docker-build-publish.yml%60%29.%20See%0A%20%20%5Blgtm-hq%2Flgtm-ci%23232%5D%28https%3A%2F%2Fgithub.com%2Flgtm-hq%2Flgtm-ci%2Fissues%2F232%29%20for%20consolidating%0A%20%20on%20%60reusable-publish-pypi.yml%60.%0A%60%60%60%0A%0A&pr=952&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2FREADME.md%3A34-38%0AThe%20description%20still%20says%20%22lgtm-ci%20%60reusable-quality%60%22%20but%20this%20very%20PR%20replaces%20that%20reusable-workflow%20call%20with%20an%20inline%20lint%20job.%20The%20README%20now%20describes%20the%20state%20before%20this%20change%2C%20which%20contradicts%20the%20PR's%20stated%20goal%20of%20correcting%20the%20documentation.%0A%0A%60%60%60suggestion%0A-%20**publish-pypi-on-tag.yml**%20%E2%80%94%20Production%20tag%20publish%3A%20inline%20lint%20%28pending%20lgtm-ci%23231%29%20%2B%0A%20%20%60reusable-sbom%60%2C%20inline%20build%2Fpublish%20via%20%60publish-pypi.sh%60%2C%20GitHub%20Release%20assets%2C%0A%20%20Homebrew%20%28%60build-binary.yml%60%29%2C%20Docker%20%28%60docker-build-publish.yml%60%29.%20See%0A%20%20%5Blgtm-hq%2Flgtm-ci%23232%5D%28https%3A%2F%2Fgithub.com%2Flgtm-hq%2Flgtm-ci%2Fissues%2F232%29%20for%20consolidating%0A%20%20on%20%60reusable-publish-pypi.yml%60.%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=952&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F949-publish-workflow-permissions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F949-publish-workflow-permissions%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2FREADME.md%3A34-38%0AThe%20description%20still%20says%20%22lgtm-ci%20%60reusable-quality%60%22%20but%20this%20very%20PR%20replaces%20that%20reusable-workflow%20call%20with%20an%20inline%20lint%20job.%20The%20README%20now%20describes%20the%20state%20before%20this%20change%2C%20which%20contradicts%20the%20PR's%20stated%20goal%20of%20correcting%20the%20documentation.%0A%0A%60%60%60suggestion%0A-%20**publish-pypi-on-tag.yml**%20%E2%80%94%20Production%20tag%20publish%3A%20inline%20lint%20%28pending%20lgtm-ci%23231%29%20%2B%0A%20%20%60reusable-sbom%60%2C%20inline%20build%2Fpublish%20via%20%60publish-pypi.sh%60%2C%20GitHub%20Release%20assets%2C%0A%20%20Homebrew%20%28%60build-binary.yml%60%29%2C%20Docker%20%28%60docker-build-publish.yml%60%29.%20See%0A%20%20%5Blgtm-hq%2Flgtm-ci%23232%5D%28https%3A%2F%2Fgithub.com%2Flgtm-hq%2Flgtm-ci%2Fissues%2F232%29%20for%20consolidating%0A%20%20on%20%60reusable-publish-pypi.yml%60.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): inline publish quality lint wit..."](https://github.com/lgtm-hq/py-lintro/commit/405cfa5572921c7c2ddedc864d4e020bfeeb095e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34123776)</sub>

<!-- /greptile_comment -->