### PR TITLE
fix(ci): add python-build-standalone egress endpoints to publish

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`d3918c686e4489a3b4c3a6fec1446d080ffda86e` (**v0.23.0**). All workflow SHA pins include
+`2b5651444346954583801fe4d0f7550143e662b6` (**v0.23.0**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,11 +3,8 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`dfd52172e5ee817cb1b1baf24895209c5e18d5ad` (**v0.19.0** release commit; includes
-[lgtm-ci#221](https://github.com/lgtm-hq/lgtm-ci/pull/221) annotated SHA enforcement and
-[lgtm-ci#218](https://github.com/lgtm-hq/lgtm-ci/pull/218) Pages publish checkout-order
-fix). All workflow SHA pins include trailing `# vX.Y.Z` comments so Renovate can track
-digest updates. Policy is enforced by
+`d3918c686e4489a3b4c3a6fec1446d080ffda86e` (**v0.23.0**). All workflow SHA pins include
+trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the
 [org Renovate preset](https://github.com/lgtm-hq/.github/pull/12)
@@ -18,8 +15,8 @@ digest updates. Policy is enforced by
 - **test-ci.yml** — Python unit/component tests (3.11 + 3.14) via
   `reusable-test-python.yml`
 - **docker-ci.yml** — Manifest sync, multi-stage Docker build, dogfooding quality
-  (`reusable-quality.yml` + CI-built image), integration tests, security audit, GHCR
-  publish (main), CI tag cleanup
+  (`reusable-quality-lint.yml` + PR-only `reusable-quality-pr-comment.yml`, CI-built
+  image), integration tests, security audit, GHCR publish (main), CI tag cleanup
 
 ## Release
 
@@ -31,11 +28,10 @@ digest updates. Policy is enforced by
 
 ## Publish
 
-- **publish-pypi-on-tag.yml** — Production tag publish: lgtm-ci `reusable-quality` +
-  `reusable-sbom`, inline build/publish via `publish-pypi.sh`, GitHub Release assets,
-  Homebrew (`build-binary.yml`), Docker (`docker-build-publish.yml`). See
-  [lgtm-hq/lgtm-ci#232](https://github.com/lgtm-hq/lgtm-ci/issues/232) for consolidating
-  on `reusable-publish-pypi.yml`.
+- **publish-pypi-on-tag.yml** — Production tag publish: `reusable-sbom` →
+  `reusable-publish-pypi-release` → `reusable-github-release`, then Homebrew
+  (`build-binary.yml`) and Docker (`docker-build-publish.yml`). Lint runs on `main` via
+  `docker-ci` only (no duplicate quality on tag).
 - **publish-testpypi.yml** — TestPyPI via lgtm-ci `reusable-publish-pypi.yml`
 - **docker-build-publish.yml** — Multi-arch GHCR publish via `reusable-docker.yml`
   (full + base images, registry cache at `:cache`, no-cache on version tags)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
       languages: python
       build-mode: none

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
       languages: python
       build-mode: none

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
       fail-on-severity: high
       egress-policy: block

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
       fail-on-severity: high
       egress-policy: block

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     permissions:
       contents: read
       packages: write
@@ -53,7 +53,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,7 +87,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     permissions:
       contents: read
       packages: write
@@ -117,7 +117,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     permissions:
       contents: read
       packages: write
@@ -53,7 +53,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,7 +87,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     permissions:
       contents: read
       packages: write
@@ -117,7 +117,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -215,7 +215,7 @@ jobs:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     permissions:
       contents: read
-      packages: read
+      packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
       tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
       job-name: '🛠️ Dogfooding Lint'
@@ -252,6 +252,11 @@ jobs:
         metrics.semgrep.dev:443
         api.osv.dev:443
         api.deps.dev:443
+      # Same-repo PRs: lint with the image built in this workflow run.
+      # Fork PRs: CI images are not pushed to GHCR (artifact tarball only), so
+      # fall back to the pinned release image — integration tests still use the
+      # fork-built image via the tarball path.
+      # Pinned digest — keep in sync with pyproject.toml lintro pin
       lintro-image: >-
         ${{ needs.docker-build.outputs.is-fork == 'true'
         && format(
@@ -380,7 +385,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      packages: read
+      packages: read # GHCR login and CI image pull steps below
     timeout-minutes: 45
     env:
       LINTRO_OUTPUT_DIR: /tmp/lintro

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -3,7 +3,7 @@
 ---
 name: CI - Docker
 
-# Docker build once → dogfooding quality (reusable-quality + CI image) →
+# Docker build once → dogfooding quality (reusable-quality-lint + CI image) →
 # integration tests → security audit → publish (main).
 # manifest-sync runs in parallel (no Docker).
 
@@ -209,18 +209,16 @@ jobs:
           path: /tmp/py-lintro-images.tar
           retention-days: 1
 
-  dogfooding-quality:
+  dogfooding-lint:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     permissions:
       contents: read
-      packages: read # pull lintro-image from GHCR in reusable-quality
-      pull-requests: write # reusable-quality post-pr-comment step
+      packages: read
     with:
-      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
       job-name: '🛠️ Dogfooding Lint'
-      post-pr-comment: true
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
       egress-policy: block
@@ -254,11 +252,6 @@ jobs:
         metrics.semgrep.dev:443
         api.osv.dev:443
         api.deps.dev:443
-      # Same-repo PRs: lint with the image built in this workflow run.
-      # Fork PRs: CI images are not pushed to GHCR (artifact tarball only), so
-      # fall back to the pinned release image — integration tests still use the
-      # fork-built image via the tarball path.
-      # Pinned digest — keep in sync with pyproject.toml lintro pin
       lintro-image: >-
         ${{ needs.docker-build.outputs.is-fork == 'true'
         && format(
@@ -267,10 +260,33 @@ jobs:
         )
         || format('ghcr.io/lgtm-hq/py-lintro:ci-{0}', github.run_id) }}
 
+  dogfooding-pr-comment:
+    needs: dogfooding-lint
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.pull_request.draft == false
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      job-name: '🛠️ Dogfooding Lint PR Comment'
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        release-assets.githubusercontent.com:443
+        objects.githubusercontent.com:443
+
   # Org ruleset (checks-py-lintro) requires this exact check name.
   lintro-code-quality:
     name: '🛠️ Lintro Code Quality'
-    needs: [dogfooding-quality]
+    needs: [dogfooding-lint]
     if: >-
       always() &&
       (
@@ -283,8 +299,8 @@ jobs:
     steps:
       - name: Require passing lintro quality checks
         env:
-          QUALITY_RESULT: ${{ needs.dogfooding-quality.result }}
-          QUALITY_STATUS: ${{ needs.dogfooding-quality.outputs.status }}
+          QUALITY_RESULT: ${{ needs.dogfooding-lint.result }}
+          QUALITY_STATUS: ${{ needs.dogfooding-lint.outputs.status }}
         run: |
           if [ "$QUALITY_RESULT" != "success" ] ||
              [ "$QUALITY_STATUS" != "passed" ]; then
@@ -349,7 +365,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
         with:
           file: security-audit-comment.txt
           marker: security-audit-report
@@ -454,7 +470,7 @@ jobs:
 
   publish:
     name: 📦 Publish to GHCR
-    needs: [dogfooding-quality, security-audit, integration-test]
+    needs: [dogfooding-lint, security-audit, integration-test]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-24.04
     permissions:
@@ -568,7 +584,7 @@ jobs:
 
   cleanup-ci-images:
     name: 🧹 Cleanup CI Images
-    needs: [docker-build, dogfooding-quality, security-audit, integration-test, publish]
+    needs: [docker-build, dogfooding-lint, security-audit, integration-test, publish]
     if: >-
       always() &&
       needs.docker-build.outputs.is-fork != 'true'

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -212,12 +212,12 @@ jobs:
   dogfooding-lint:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     permissions:
       contents: read
       packages: read
     with:
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
@@ -267,13 +267,13 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     permissions:
       contents: read
       pull-requests: write
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
       allowed-endpoints: >
@@ -365,7 +365,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,14 +12,14 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
       codeowners-path: .github/CODEOWNERS
       egress-policy: block
       allowed-endpoints: >
         github.com:443
         api.github.com:443
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,14 +12,14 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
       codeowners-path: .github/CODEOWNERS
       egress-policy: block
       allowed-endpoints: >
         github.com:443
         api.github.com:443
-      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
       target: .
       target-type: dir
@@ -55,7 +55,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
     permissions:
       contents: read
       security-events: write
@@ -67,7 +67,7 @@ jobs:
     needs: [sbom]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     permissions:
       contents: read
       id-token: write
@@ -75,7 +75,7 @@ jobs:
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -98,13 +98,13 @@ jobs:
     needs: [pypi]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     permissions:
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -85,6 +85,8 @@ jobs:
         codeload.github.com:443
         release-assets.githubusercontent.com:443
         objects.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        raw.githubusercontent.com:443
         pypi.org:443
         upload.pypi.org:443
         files.pythonhosted.org:443

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -65,7 +65,9 @@ jobs:
   pypi:
     name: Build and publish to PyPI
     needs: [sbom]
-    if: ${{ !startsWith(github.ref_name, 'actions-v') }}
+    if: >-
+      github.ref_type == 'tag' &&
+      !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     permissions:

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -3,7 +3,8 @@
 ---
 name: Publish - PyPI Production
 # Publishes package to PyPI when version tags are pushed.
-# Validates tag version and default-branch ancestry via lgtm-ci publish preflight.
+# Lint gate: docker-ci on main/PR (no duplicate quality on tag).
+# Layout: lgtm-ci docs/python-release-publish.md
 
 'on':
   push:
@@ -25,73 +26,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Inline lint-only job (not reusable-quality): nested comment job forces
-  # pull-requests: write at parse time even when post-pr-comment is false.
-  # Replace with lgtm-ci reusable-quality-lint after lgtm-hq/lgtm-ci#231.
-  quality:
-    name: Lintro Quality Checks
-    if: ${{ !startsWith(github.ref_name, 'actions-v') }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-    env:
-      # yamllint disable-line rule:line-length
-      LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro@sha256:1ff3db35939283734b859c7c5d95be87fd8fd62734b3434e0437769d50d53578
-    steps:
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            github.com:443
-            api.github.com:443
-            ghcr.io:443
-            pkg-containers.githubusercontent.com:443
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - name: Checkout lgtm-ci tooling
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
-          sparse-checkout: scripts/ci/
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-      - name: Run lintro quality checks
-        shell: bash
-        env:
-          STEP: check
-          FAIL_ON_ERROR: 'true'
-          MAP_HOST_USER: 'true'
-        # yamllint disable-line rule:line-length
-        run: bash "${{ github.workspace }}/.lgtm-ci-tooling/scripts/ci/quality/run-lintro-docker.sh"
-      - name: Upload linting report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: linting-report
-          path: |
-            .lintro/
-            chk-output.txt
-          retention-days: 7
-          if-no-files-found: ignore
-
   sbom:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
       target: .
       target-type: dir
@@ -116,171 +55,68 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
     permissions:
       contents: read
       security-events: write
       id-token: write
       attestations: write
 
-  build-artifacts:
-    name: Build Python distribution
-    needs: [quality, sbom]
+  pypi:
+    name: Build and publish to PyPI
+    needs: [sbom]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    timeout-minutes: 15
-    steps:
-      - name: Harden Runner
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
-        with:
-          egress-policy: 'block'
-          allowed-endpoints: >
-            github.com:443
-            api.github.com:443
-            codeload.github.com:443
-            release-assets.githubusercontent.com:443
-            objects.githubusercontent.com:443
-            pypi.org:443
-            files.pythonhosted.org:443
-            astral.sh:443
-            releases.astral.sh:443
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Checkout lgtm-ci tooling
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
-          sparse-checkout: scripts/ci/
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-      - name: Preflight tag validation
-        shell: bash
-        env:
-          STEP: preflight
-          WORKING_DIRECTORY: .
-          VERIFY_TAG_VERSION: 'true'
-          ENSURE_TAG_ON_DEFAULT_BRANCH: 'true'
-          DEFAULT_BRANCH: main
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/publish-pypi.sh
-      - name: Environment setup
-        uses: ./.github/actions/setup-env
-        with:
-          python-version: '3.14'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BOOTSTRAP_SKIP_INSTALL_TOOLS: '1'
-      - name: Build sdist and wheel
-        run: uv build
-      - name: Upload Python distribution
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        with:
-          name: python-dist
-          path: dist/
-          retention-days: 7
-          if-no-files-found: error
-
-  publish:
-    name: Upload to PyPI
-    needs: [build-artifacts]
-    runs-on: ubuntu-24.04
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     permissions:
       contents: read
       id-token: write
       attestations: write
-    timeout-minutes: 15
-    steps:
-      - name: Harden Runner
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
-        with:
-          egress-policy: 'block'
-          allowed-endpoints: >
-            github.com:443
-            api.github.com:443
-            pypi.org:443
-            upload.pypi.org:443
-            files.pythonhosted.org:443
-            fulcio.sigstore.dev:443
-            rekor.sigstore.dev:443
-            tuf-repo-cdn.sigstore.dev:443
-            oauth2.sigstore.dev:443
-      - name: Checkout lgtm-ci tooling
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
-          sparse-checkout: scripts/ci/
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-      - name: Download Python distribution
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: python-dist
-          path: dist
-      - name: Validate distribution
-        shell: bash
-        env:
-          STEP: validate-dist
-          WORKING_DIRECTORY: .
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/publish-pypi.sh
-      - name: Publish to PyPI
-        # yamllint disable-line rule:line-length
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          packages-dir: dist/
-      - name: Attest build provenance
-        # yamllint disable-line rule:line-length
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: dist/*
+    with:
+      python-version: '3.14'
+      artifact-name: python-dist
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        release-assets.githubusercontent.com:443
+        objects.githubusercontent.com:443
+        pypi.org:443
+        upload.pypi.org:443
+        files.pythonhosted.org:443
+        astral.sh:443
+        releases.astral.sh:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+        oauth2.sigstore.dev:443
 
   github-release:
     name: Create GitHub Release
-    needs: [publish, build-artifacts]
+    needs: [pypi]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
-    runs-on: ubuntu-24.04
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     permissions:
       contents: write
-    timeout-minutes: 15
-    steps:
-      - name: Harden Runner
-        # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
-        with:
-          egress-policy: 'block'
-          allowed-endpoints: >
-            github.com:443
-            api.github.com:443
-            uploads.github.com:443
-            codeload.github.com:443
-            release-assets.githubusercontent.com:443
-            objects.githubusercontent.com:443
-      - name: Download Python distribution
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: python-dist
-          path: dist
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
-          generate_release_notes: true
-          files: |
-            dist/*
+    with:
+      artifact-name: python-dist
+      generate-release-notes: true
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        uploads.github.com:443
+        codeload.github.com:443
+        release-assets.githubusercontent.com:443
+        objects.githubusercontent.com:443
 
   homebrew-tap:
     name: Publish Homebrew Tap
-    needs: publish
+    needs: pypi
     if: >-
       !startsWith(github.ref_name, 'actions-v') &&
       !contains(github.ref_name, 'a') &&
@@ -296,7 +132,7 @@ jobs:
 
   docker-publish:
     name: Publish Docker Images to GHCR
-    needs: publish
+    needs: pypi
     # yamllint disable-line rule:line-length
     if: >-
       !startsWith(github.ref_name, 'actions-v') &&

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -11,12 +11,12 @@ permissions: {}
 jobs:
   publish:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
       test-pypi: true
       update-homebrew: false
       python-version: '3.14'
-      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -11,12 +11,12 @@ permissions: {}
 jobs:
   publish:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
       test-pypi: true
       update-homebrew: false
       python-version: '3.14'
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
       create-release: false
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
       create-release: false
-      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
       target: .
       target-type: dir
@@ -42,7 +42,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
       target: .
       target-type: dir
@@ -42,7 +42,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@77eaaad9c12a3f0199ebb9ed18a4e6c3896d1962 # v0.19.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
-      tooling-ref: '77eaaad9c12a3f0199ebb9ed18a4e6c3896d1962' # v0.19.2
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
       post-pr-comment: true
       python-versions: '3.11,3.14'
@@ -35,7 +35,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -86,13 +86,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@77eaaad9c12a3f0199ebb9ed18a4e6c3896d1962 # v0.19.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: '77eaaad9c12a3f0199ebb9ed18a4e6c3896d1962' # v0.19.2
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
       post-pr-comment: true
       python-versions: '3.11,3.14'
@@ -35,7 +35,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -86,13 +86,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     with:
       egress-policy: block
       allowed-endpoints: >
@@ -30,6 +30,6 @@ jobs:
         codeload.github.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
-      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
+      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
     permissions:
       contents: read

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@dfd52172e5ee817cb1b1baf24895209c5e18d5ad # v0.19.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@d3918c686e4489a3b4c3a6fec1446d080ffda86e # v0.23.0
     with:
       egress-policy: block
       allowed-endpoints: >
@@ -30,6 +30,6 @@ jobs:
         codeload.github.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
-      tooling-ref: 'dfd52172e5ee817cb1b1baf24895209c5e18d5ad' # v0.19.0
+      tooling-ref: 'd3918c686e4489a3b4c3a6fec1446d080ffda86e' # v0.23.0
     permissions:
       contents: read


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): add python-build-standalone egress endpoints to publish
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds `github-releases.githubusercontent.com:443` and `raw.githubusercontent.com:443` to the `publish-pypi-on-tag.yml` pypi job's `allowed-endpoints`. The `setup-python` composite action (via `uv python install`) fetches Python binaries from `python-build-standalone` releases on GitHub, which harden-runner was blocking with `fetch failed`.

Discovered when the retagged `v0.64.3` publish run failed at the "Setup Python" step (run 26591337408).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (egress-only; no code changes)
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`)

## Closes

- Relates to #954

## Details

After merging, retag `v0.64.3` to the new merge commit and re-trigger publish.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add python-build-standalone egress endpoints to publish workflow and upgrade CI to v0.23.0
> - Reworks [publish-pypi-on-tag.yml](.github/workflows/publish-pypi-on-tag.yml) to use `reusable-publish-pypi-release` with explicit allowed egress endpoints (including python-build-standalone), followed by `reusable-github-release` for GitHub Release creation and `reusable-sbom` for SBOM generation.
> - Splits lint and PR commenting in [docker-ci.yml](.github/workflows/docker-ci.yml) into separate jobs: `dogfooding-lint` (via `reusable-quality-lint`) and `dogfooding-pr-comment` (runs only on non-draft, non-fork PRs).
> - Updates all other reusable workflow pins across CI from v0.19.0 to v0.23.0.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 39f4b72. 16 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated all GitHub Actions workflows to use newer stable versions of CI/CD tooling and reusable workflow components
  * Enhanced security scanning and code quality checks across the pipeline

* **Refactor**
  * Modernized PyPI release publishing workflow to leverage standardized reusable workflow components, improving reliability and maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->