### PR TITLE
fix(ci): add python-build-standalone egress endpoints to all workflows

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -229,6 +229,7 @@ jobs:
         release-assets.githubusercontent.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
         ghcr.io:443
         pkg-containers.githubusercontent.com:443
         docker.io:443
@@ -275,7 +276,7 @@ jobs:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
       tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -85,6 +85,8 @@ jobs:
         codeload.github.com:443
         release-assets.githubusercontent.com:443
         objects.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        raw.githubusercontent.com:443
         pypi.org:443
         upload.pypi.org:443
         files.pythonhosted.org:443

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -24,6 +24,10 @@ jobs:
         codeload.github.com:443
         release-assets.githubusercontent.com:443
         objects.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        astral.sh:443
+        releases.astral.sh:443
         pypi.org:443
         files.pythonhosted.org:443
         test.pypi.org:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -44,6 +44,7 @@ jobs:
         release-assets.githubusercontent.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
         pypi.org:443
         files.pythonhosted.org:443
         astral.sh:443


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): add python-build-standalone egress endpoints to all workflows
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

After adopting lgtm-ci v0.23.0 (#955), all workflows using `setup-python` via reusable workflows fetch Python binaries from `python-build-standalone` releases hosted on `github-releases.githubusercontent.com`. With `egress-policy: block`, harden-runner blocks this download, causing `fetch failed` at the "Setup Python" step.

**Affected workflows and fixes:**

| Workflow | Fix |
|---|---|
| `publish-pypi-on-tag.yml` | Add `github-releases.githubusercontent.com:443` + `raw.githubusercontent.com:443` |
| `publish-testpypi.yml` | Add `github-releases.githubusercontent.com:443`, `raw.githubusercontent.com:443`, `astral.sh:443`, `releases.astral.sh:443` |
| `test-ci.yml` | Add `github-releases.githubusercontent.com:443` |
| `docker-ci.yml` | Add `github-releases.githubusercontent.com:443`; document `pull-requests: write` on dogfooding-pr-comment |

Discovered when the retagged `v0.64.3` publish run failed at "Setup Python" (run 26591337408).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (egress-only; no code changes)
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt`, `uv run lintro chk`)

## Closes

- Closes #956

## Details

After merging, retag `v0.64.3` to the merge commit and verify **Publish - PyPI Production** completes end-to-end.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add python-build-standalone egress endpoints to CI workflow hardened-runner configs
> Adds `github-releases.githubusercontent.com:443` to the egress allowlists in all four CI workflows so hardened runners can fetch `python-build-standalone` releases. The [publish-testpypi.yml](.github/workflows/publish-testpypi.yml) workflow also gains `raw.githubusercontent.com:443`, `astral.sh:443`, and `releases.astral.sh:443`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1acffb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and deployment workflow configurations to enable access to additional external services required for automated testing and package publishing processes. These infrastructure-level changes expand the set of permitted network endpoints, allowing CI/CD pipelines to properly communicate with necessary third-party services during build, test, and deployment stages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/957?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR unblocks Python setup in four workflows by adding `github-releases.githubusercontent.com:443` (and, where missing, `raw.githubusercontent.com:443`, `astral.sh:443`, and `releases.astral.sh:443`) to `step-security/harden-runner` egress allowlists. The root cause is that lgtm-ci v0.23.0 reusable workflows now use `python-build-standalone` via `actions/setup-python`, whose binaries are served from `github-releases.githubusercontent.com`, which was previously blocked by `egress-policy: block`.

- `test-ci.yml` and `docker-ci.yml` (`dogfooding-lint`): each needed only `github-releases.githubusercontent.com:443` since `raw.githubusercontent.com:443` was already present.
- `publish-pypi-on-tag.yml` (`pypi` job): added `github-releases.githubusercontent.com:443` and `raw.githubusercontent.com:443`; `astral.sh` endpoints were already present.
- `publish-testpypi.yml`: needed all four new endpoints as it was the most under-provisioned allowlist.
- `docker-ci.yml` also adds a clarifying inline comment to `pull-requests: write` on the `dogfooding-pr-comment` job.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge for the four targeted workflows; a potential gap remains in build-binary.yml which uses actions/setup-python directly for Python 3.14 without the new endpoint in its egress allowlist.

The four changed workflows are correctly fixed and the added endpoints are all legitimate. However, build-binary.yml — invoked as the homebrew-tap job from publish-pypi-on-tag.yml — calls actions/setup-python@v6 with python-version: '3.14' under its own egress-policy: block allowlist that still lacks github-releases.githubusercontent.com:443. If actions/setup-python needs to download Python 3.14 (which is not pre-installed on ubuntu-24.04), that job will hit the same blocked-egress failure on the next stable tag publish.

.github/workflows/build-binary.yml (not changed in this PR) — the Python 3.14 setup-python call at line 289 runs under a harden-runner allowlist that does not include the new endpoint.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/docker-ci.yml | Added github-releases.githubusercontent.com:443 to dogfooding-lint egress allowlist; added clarifying comment to pull-requests:write permission on dogfooding-pr-comment |
| .github/workflows/publish-pypi-on-tag.yml | Added github-releases.githubusercontent.com:443 and raw.githubusercontent.com:443 to the pypi job's egress allowlist to unblock setup-python downloads |
| .github/workflows/publish-testpypi.yml | Added github-releases.githubusercontent.com:443, raw.githubusercontent.com:443, astral.sh:443, and releases.astral.sh:443 — the most endpoints added of any file, as this workflow was missing several that others already had |
| .github/workflows/test-ci.yml | Added github-releases.githubusercontent.com:443 to the reusable-test-python job; raw.githubusercontent.com:443 was already present so no other additions needed |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions Runner
    participant HR as harden-runner (egress-policy:block)
    participant SPY as actions/setup-python (lgtm-ci reusable)
    participant GHR as github-releases.githubusercontent.com
    participant RGH as raw.githubusercontent.com
    participant AST as releases.astral.sh

    GHA->>HR: Job starts, enforce egress allowlist
    GHA->>SPY: Setup Python 3.14 (via lgtm-ci v0.23.0 reusable workflow)
    SPY->>GHR: Fetch python-build-standalone binary
    Note over HR,GHR: BEFORE this PR: blocked → "fetch failed"
    Note over HR,GHR: AFTER this PR: github-releases.githubusercontent.com:443 allowed ✓
    SPY->>RGH: Fetch manifest / metadata
    Note over HR,RGH: raw.githubusercontent.com:443 allowed ✓ (or already was)
    SPY->>AST: Fetch uv-managed Python (publish-testpypi only)
    Note over HR,AST: releases.astral.sh:443 added to publish-testpypi ✓
    SPY-->>GHA: Python 3.14 ready
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.github/workflows/publish-pypi-on-tag.yml`, line 113-119 ([link](https://github.com/lgtm-hq/py-lintro/blob/e1acffb33ada9e98074dbc52cd432f05fec98032/.github/workflows/publish-pypi-on-tag.yml#L113-L119)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`github-release` job may also need `github-releases.githubusercontent.com:443`**

   The `reusable-github-release.yml` job's allowed-endpoints list doesn't include `github-releases.githubusercontent.com:443` or `raw.githubusercontent.com:443`. If the reusable workflow internally runs `actions/setup-python` (e.g. to generate release notes or process the artifact), it would hit the same `fetch failed` error that this PR was introduced to fix. If it doesn't run setup-python, this is fine — worth verifying once the retag run completes.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%0ALine%3A%20113-119%0A%0AComment%3A%0A**%60github-release%60%20job%20may%20also%20need%20%60github-releases.githubusercontent.com%3A443%60**%0A%0AThe%20%60reusable-github-release.yml%60%20job's%20allowed-endpoints%20list%20doesn't%20include%20%60github-releases.githubusercontent.com%3A443%60%20or%20%60raw.githubusercontent.com%3A443%60.%20If%20the%20reusable%20workflow%20internally%20runs%20%60actions%2Fsetup-python%60%20%28e.g.%20to%20generate%20release%20notes%20or%20process%20the%20artifact%29%2C%20it%20would%20hit%20the%20same%20%60fetch%20failed%60%20error%20that%20this%20PR%20was%20introduced%20to%20fix.%20If%20it%20doesn't%20run%20setup-python%2C%20this%20is%20fine%20%E2%80%94%20worth%20verifying%20once%20the%20retag%20run%20completes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=957&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%0ALine%3A%20113-119%0A%0AComment%3A%0A**%60github-release%60%20job%20may%20also%20need%20%60github-releases.githubusercontent.com%3A443%60**%0A%0AThe%20%60reusable-github-release.yml%60%20job's%20allowed-endpoints%20list%20doesn't%20include%20%60github-releases.githubusercontent.com%3A443%60%20or%20%60raw.githubusercontent.com%3A443%60.%20If%20the%20reusable%20workflow%20internally%20runs%20%60actions%2Fsetup-python%60%20%28e.g.%20to%20generate%20release%20notes%20or%20process%20the%20artifact%29%2C%20it%20would%20hit%20the%20same%20%60fetch%20failed%60%20error%20that%20this%20PR%20was%20introduced%20to%20fix.%20If%20it%20doesn't%20run%20setup-python%2C%20this%20is%20fine%20%E2%80%94%20worth%20verifying%20once%20the%20retag%20run%20completes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fpy-lintro&pr=957&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F956-publish-egress%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F956-publish-egress%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%0ALine%3A%20113-119%0A%0AComment%3A%0A**%60github-release%60%20job%20may%20also%20need%20%60github-releases.githubusercontent.com%3A443%60**%0A%0AThe%20%60reusable-github-release.yml%60%20job's%20allowed-endpoints%20list%20doesn't%20include%20%60github-releases.githubusercontent.com%3A443%60%20or%20%60raw.githubusercontent.com%3A443%60.%20If%20the%20reusable%20workflow%20internally%20runs%20%60actions%2Fsetup-python%60%20%28e.g.%20to%20generate%20release%20notes%20or%20process%20the%20artifact%29%2C%20it%20would%20hit%20the%20same%20%60fetch%20failed%60%20error%20that%20this%20PR%20was%20introduced%20to%20fix.%20If%20it%20doesn't%20run%20setup-python%2C%20this%20is%20fine%20%E2%80%94%20worth%20verifying%20once%20the%20retag%20run%20completes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


2. `.github/workflows/publish-pypi-on-tag.yml`, line 129-135 ([link](https://github.com/lgtm-hq/py-lintro/blob/e1acffb33ada9e98074dbc52cd432f05fec98032/.github/workflows/publish-pypi-on-tag.yml#L129-L135)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`build-binary.yml` uses `actions/setup-python` directly without `github-releases.githubusercontent.com:443`**

   The `homebrew-tap` job delegates to `build-binary.yml`, which calls `actions/setup-python@v6` with `python-version: '3.14'` (line 289) under `egress-policy: block`, but its harden-runner allowlist doesn't include `github-releases.githubusercontent.com:443`. If the runner doesn't have Python 3.14 pre-installed and setup-python tries to fetch from python-build-standalone, this step will fail. Python 3.11 (also used in that workflow) is typically pre-installed on `ubuntu-24.04`, so that case may be safe, but 3.14 likely is not.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%0ALine%3A%20129-135%0A%0AComment%3A%0A**%60build-binary.yml%60%20uses%20%60actions%2Fsetup-python%60%20directly%20without%20%60github-releases.githubusercontent.com%3A443%60**%0A%0AThe%20%60homebrew-tap%60%20job%20delegates%20to%20%60build-binary.yml%60%2C%20which%20calls%20%60actions%2Fsetup-python%40v6%60%20with%20%60python-version%3A%20'3.14'%60%20%28line%20289%29%20under%20%60egress-policy%3A%20block%60%2C%20but%20its%20harden-runner%20allowlist%20doesn't%20include%20%60github-releases.githubusercontent.com%3A443%60.%20If%20the%20runner%20doesn't%20have%20Python%203.14%20pre-installed%20and%20setup-python%20tries%20to%20fetch%20from%20python-build-standalone%2C%20this%20step%20will%20fail.%20Python%203.11%20%28also%20used%20in%20that%20workflow%29%20is%20typically%20pre-installed%20on%20%60ubuntu-24.04%60%2C%20so%20that%20case%20may%20be%20safe%2C%20but%203.14%20likely%20is%20not.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=957&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%0ALine%3A%20129-135%0A%0AComment%3A%0A**%60build-binary.yml%60%20uses%20%60actions%2Fsetup-python%60%20directly%20without%20%60github-releases.githubusercontent.com%3A443%60**%0A%0AThe%20%60homebrew-tap%60%20job%20delegates%20to%20%60build-binary.yml%60%2C%20which%20calls%20%60actions%2Fsetup-python%40v6%60%20with%20%60python-version%3A%20'3.14'%60%20%28line%20289%29%20under%20%60egress-policy%3A%20block%60%2C%20but%20its%20harden-runner%20allowlist%20doesn't%20include%20%60github-releases.githubusercontent.com%3A443%60.%20If%20the%20runner%20doesn't%20have%20Python%203.14%20pre-installed%20and%20setup-python%20tries%20to%20fetch%20from%20python-build-standalone%2C%20this%20step%20will%20fail.%20Python%203.11%20%28also%20used%20in%20that%20workflow%29%20is%20typically%20pre-installed%20on%20%60ubuntu-24.04%60%2C%20so%20that%20case%20may%20be%20safe%2C%20but%203.14%20likely%20is%20not.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fpy-lintro&pr=957&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F956-publish-egress%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F956-publish-egress%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%0ALine%3A%20129-135%0A%0AComment%3A%0A**%60build-binary.yml%60%20uses%20%60actions%2Fsetup-python%60%20directly%20without%20%60github-releases.githubusercontent.com%3A443%60**%0A%0AThe%20%60homebrew-tap%60%20job%20delegates%20to%20%60build-binary.yml%60%2C%20which%20calls%20%60actions%2Fsetup-python%40v6%60%20with%20%60python-version%3A%20'3.14'%60%20%28line%20289%29%20under%20%60egress-policy%3A%20block%60%2C%20but%20its%20harden-runner%20allowlist%20doesn't%20include%20%60github-releases.githubusercontent.com%3A443%60.%20If%20the%20runner%20doesn't%20have%20Python%203.14%20pre-installed%20and%20setup-python%20tries%20to%20fetch%20from%20python-build-standalone%2C%20this%20step%20will%20fail.%20Python%203.11%20%28also%20used%20in%20that%20workflow%29%20is%20typically%20pre-installed%20on%20%60ubuntu-24.04%60%2C%20so%20that%20case%20may%20be%20safe%2C%20but%203.14%20likely%20is%20not.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%3A113-119%0A**%60github-release%60%20job%20may%20also%20need%20%60github-releases.githubusercontent.com%3A443%60**%0A%0AThe%20%60reusable-github-release.yml%60%20job's%20allowed-endpoints%20list%20doesn't%20include%20%60github-releases.githubusercontent.com%3A443%60%20or%20%60raw.githubusercontent.com%3A443%60.%20If%20the%20reusable%20workflow%20internally%20runs%20%60actions%2Fsetup-python%60%20%28e.g.%20to%20generate%20release%20notes%20or%20process%20the%20artifact%29%2C%20it%20would%20hit%20the%20same%20%60fetch%20failed%60%20error%20that%20this%20PR%20was%20introduced%20to%20fix.%20If%20it%20doesn't%20run%20setup-python%2C%20this%20is%20fine%20%E2%80%94%20worth%20verifying%20once%20the%20retag%20run%20completes.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%3A129-135%0A**%60build-binary.yml%60%20uses%20%60actions%2Fsetup-python%60%20directly%20without%20%60github-releases.githubusercontent.com%3A443%60**%0A%0AThe%20%60homebrew-tap%60%20job%20delegates%20to%20%60build-binary.yml%60%2C%20which%20calls%20%60actions%2Fsetup-python%40v6%60%20with%20%60python-version%3A%20'3.14'%60%20%28line%20289%29%20under%20%60egress-policy%3A%20block%60%2C%20but%20its%20harden-runner%20allowlist%20doesn't%20include%20%60github-releases.githubusercontent.com%3A443%60.%20If%20the%20runner%20doesn't%20have%20Python%203.14%20pre-installed%20and%20setup-python%20tries%20to%20fetch%20from%20python-build-standalone%2C%20this%20step%20will%20fail.%20Python%203.11%20%28also%20used%20in%20that%20workflow%29%20is%20typically%20pre-installed%20on%20%60ubuntu-24.04%60%2C%20so%20that%20case%20may%20be%20safe%2C%20but%203.14%20likely%20is%20not.%0A%0A&pr=957&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%3A113-119%0A**%60github-release%60%20job%20may%20also%20need%20%60github-releases.githubusercontent.com%3A443%60**%0A%0AThe%20%60reusable-github-release.yml%60%20job's%20allowed-endpoints%20list%20doesn't%20include%20%60github-releases.githubusercontent.com%3A443%60%20or%20%60raw.githubusercontent.com%3A443%60.%20If%20the%20reusable%20workflow%20internally%20runs%20%60actions%2Fsetup-python%60%20%28e.g.%20to%20generate%20release%20notes%20or%20process%20the%20artifact%29%2C%20it%20would%20hit%20the%20same%20%60fetch%20failed%60%20error%20that%20this%20PR%20was%20introduced%20to%20fix.%20If%20it%20doesn't%20run%20setup-python%2C%20this%20is%20fine%20%E2%80%94%20worth%20verifying%20once%20the%20retag%20run%20completes.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%3A129-135%0A**%60build-binary.yml%60%20uses%20%60actions%2Fsetup-python%60%20directly%20without%20%60github-releases.githubusercontent.com%3A443%60**%0A%0AThe%20%60homebrew-tap%60%20job%20delegates%20to%20%60build-binary.yml%60%2C%20which%20calls%20%60actions%2Fsetup-python%40v6%60%20with%20%60python-version%3A%20'3.14'%60%20%28line%20289%29%20under%20%60egress-policy%3A%20block%60%2C%20but%20its%20harden-runner%20allowlist%20doesn't%20include%20%60github-releases.githubusercontent.com%3A443%60.%20If%20the%20runner%20doesn't%20have%20Python%203.14%20pre-installed%20and%20setup-python%20tries%20to%20fetch%20from%20python-build-standalone%2C%20this%20step%20will%20fail.%20Python%203.11%20%28also%20used%20in%20that%20workflow%29%20is%20typically%20pre-installed%20on%20%60ubuntu-24.04%60%2C%20so%20that%20case%20may%20be%20safe%2C%20but%203.14%20likely%20is%20not.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=957&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F956-publish-egress%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F956-publish-egress%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%3A113-119%0A**%60github-release%60%20job%20may%20also%20need%20%60github-releases.githubusercontent.com%3A443%60**%0A%0AThe%20%60reusable-github-release.yml%60%20job's%20allowed-endpoints%20list%20doesn't%20include%20%60github-releases.githubusercontent.com%3A443%60%20or%20%60raw.githubusercontent.com%3A443%60.%20If%20the%20reusable%20workflow%20internally%20runs%20%60actions%2Fsetup-python%60%20%28e.g.%20to%20generate%20release%20notes%20or%20process%20the%20artifact%29%2C%20it%20would%20hit%20the%20same%20%60fetch%20failed%60%20error%20that%20this%20PR%20was%20introduced%20to%20fix.%20If%20it%20doesn't%20run%20setup-python%2C%20this%20is%20fine%20%E2%80%94%20worth%20verifying%20once%20the%20retag%20run%20completes.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%3A129-135%0A**%60build-binary.yml%60%20uses%20%60actions%2Fsetup-python%60%20directly%20without%20%60github-releases.githubusercontent.com%3A443%60**%0A%0AThe%20%60homebrew-tap%60%20job%20delegates%20to%20%60build-binary.yml%60%2C%20which%20calls%20%60actions%2Fsetup-python%40v6%60%20with%20%60python-version%3A%20'3.14'%60%20%28line%20289%29%20under%20%60egress-policy%3A%20block%60%2C%20but%20its%20harden-runner%20allowlist%20doesn't%20include%20%60github-releases.githubusercontent.com%3A443%60.%20If%20the%20runner%20doesn't%20have%20Python%203.14%20pre-installed%20and%20setup-python%20tries%20to%20fetch%20from%20python-build-standalone%2C%20this%20step%20will%20fail.%20Python%203.11%20%28also%20used%20in%20that%20workflow%29%20is%20typically%20pre-installed%20on%20%60ubuntu-24.04%60%2C%20so%20that%20case%20may%20be%20safe%2C%20but%203.14%20likely%20is%20not.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): add python-build-standalone egr..."](https://github.com/lgtm-hq/py-lintro/commit/e1acffb33ada9e98074dbc52cd432f05fec98032) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34417490)</sub>

<!-- /greptile_comment -->