### PR TITLE
fix(ci): pin publish tooling-ref for v0.64.3 PyPI release

### DIFF
--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -77,7 +77,8 @@ jobs:
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      # lgtm-ci#246: validate-dist uses uv run twine (PEP 668 on Ubuntu 24.04)
+      tooling-ref: '4d0cbb3f1421090c5006394a117d8d421ef493fb' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(ci): pin publish tooling-ref for PEP 668 validate-dist`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

PyPI publish on tag failed at `STEP=validate-dist` because lgtm-ci v0.23.0 runs `uv pip install --system twine`, which PEP 668 blocks on Ubuntu 24.04 runners.

This PR pins only the **pypi** job `tooling-ref` to lgtm-hq/lgtm-ci@4d0cbb3 (lgtm-ci#246), which drops that install and uses existing `uv run twine check` in `validate_pypi_package`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` on changed workflow)

## Closes

- Relates to lgtm-hq/lgtm-ci#246

## Details

After merge: move tag `v0.64.3` to the merge commit and re-run **Publish - PyPI Production** to ship 0.64.3 before 0.64.4.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `tooling-ref` commit for v0.64.3 PyPI release
> Updates the `tooling-ref` commit hash in [publish-pypi-on-tag.yml](.github/workflows/publish-pypi-on-tag.yml) from `2b56514` to `4d0cbb3` for the v0.64.3 release.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65f8dd5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal tooling reference for PyPI publishing workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bumps the `tooling-ref` for the `pypi` job in the PyPI publish workflow from `2b5651` (v0.23.0) to `4d0cbb3` (v0.23.1) to resolve a PEP 668 failure on Ubuntu 24.04 runners, where `uv pip install --system twine` is blocked at the `validate-dist` step.

- Only the `pypi` job's `tooling-ref` is updated; the `uses:` workflow ref (line 72) and all other jobs (`sbom`, `github-release`) remain pinned to v0.23.0.
- The fix relies on the v0.23.0 reusable workflow forwarding the `tooling-ref` parameter to the `validate_pypi_package` tooling step; if that forwarding isn't present in v0.23.0's workflow definition, the bump has no effect and the release re-run will fail again.
</details>


<h3>Confidence Score: 3/5</h3>

The fix is narrow and targeted, but its correctness depends on an assumption about the v0.23.0 reusable workflow that should be verified before merging.

The `uses:` ref for the `pypi` job stays at v0.23.0 while `tooling-ref` is bumped to v0.23.1. The entire fix only works if the v0.23.0 workflow definition already forwards `tooling-ref` to the step that calls `validate_pypi_package`. If it does not, the bump is silently ignored and the re-run of the v0.64.3 tag will fail at the same point.

.github/workflows/publish-pypi-on-tag.yml — specifically the interaction between the `uses:` pin (v0.23.0) and the `tooling-ref` (v0.23.1) for the `pypi` job.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/publish-pypi-on-tag.yml | Pins only the `pypi` job's `tooling-ref` from v0.23.0 to v0.23.1 (4d0cbb3) to fix PEP 668 breakage at validate-dist; the `uses:` workflow ref and all other jobs remain on v0.23.0. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/publish-pypi-on-tag.yml`, line 72-81 ([link](https://github.com/lgtm-hq/py-lintro/blob/65f8dd5c571df9bb25b4092d6b091e94bf256369/.github/workflows/publish-pypi-on-tag.yml#L72-L81)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`uses:` ref and `tooling-ref` are now on different versions**

   The `uses:` line (line 72) still resolves the reusable workflow definition at `2b5651` (v0.23.0), while `tooling-ref` is pinned to `4d0cbb3` (v0.23.1). The fix only lands if the v0.23.0 workflow definition actively passes `tooling-ref` down to the step that executes `validate_pypi_package` — i.e., the PEP 668-aware path must already be wired through the `tooling-ref` indirection at v0.23.0. If `validate_pypi_package` is called with a hard-coded internal ref in v0.23.0, the bump here is silently ignored and the tag re-run will fail again. Worth a quick confirmation against lgtm-ci v0.23.0's `reusable-publish-pypi-release.yml` to verify the tooling-ref is forwarded.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%0ALine%3A%2072-81%0A%0AComment%3A%0A**%60uses%3A%60%20ref%20and%20%60tooling-ref%60%20are%20now%20on%20different%20versions**%0A%0AThe%20%60uses%3A%60%20line%20%28line%2072%29%20still%20resolves%20the%20reusable%20workflow%20definition%20at%20%602b5651%60%20%28v0.23.0%29%2C%20while%20%60tooling-ref%60%20is%20pinned%20to%20%604d0cbb3%60%20%28v0.23.1%29.%20The%20fix%20only%20lands%20if%20the%20v0.23.0%20workflow%20definition%20actively%20passes%20%60tooling-ref%60%20down%20to%20the%20step%20that%20executes%20%60validate_pypi_package%60%20%E2%80%94%20i.e.%2C%20the%20PEP%20668-aware%20path%20must%20already%20be%20wired%20through%20the%20%60tooling-ref%60%20indirection%20at%20v0.23.0.%20If%20%60validate_pypi_package%60%20is%20called%20with%20a%20hard-coded%20internal%20ref%20in%20v0.23.0%2C%20the%20bump%20here%20is%20silently%20ignored%20and%20the%20tag%20re-run%20will%20fail%20again.%20Worth%20a%20quick%20confirmation%20against%20lgtm-ci%20v0.23.0's%20%60reusable-publish-pypi-release.yml%60%20to%20verify%20the%20tooling-ref%20is%20forwarded.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=959&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%0ALine%3A%2072-81%0A%0AComment%3A%0A**%60uses%3A%60%20ref%20and%20%60tooling-ref%60%20are%20now%20on%20different%20versions**%0A%0AThe%20%60uses%3A%60%20line%20%28line%2072%29%20still%20resolves%20the%20reusable%20workflow%20definition%20at%20%602b5651%60%20%28v0.23.0%29%2C%20while%20%60tooling-ref%60%20is%20pinned%20to%20%604d0cbb3%60%20%28v0.23.1%29.%20The%20fix%20only%20lands%20if%20the%20v0.23.0%20workflow%20definition%20actively%20passes%20%60tooling-ref%60%20down%20to%20the%20step%20that%20executes%20%60validate_pypi_package%60%20%E2%80%94%20i.e.%2C%20the%20PEP%20668-aware%20path%20must%20already%20be%20wired%20through%20the%20%60tooling-ref%60%20indirection%20at%20v0.23.0.%20If%20%60validate_pypi_package%60%20is%20called%20with%20a%20hard-coded%20internal%20ref%20in%20v0.23.0%2C%20the%20bump%20here%20is%20silently%20ignored%20and%20the%20tag%20re-run%20will%20fail%20again.%20Worth%20a%20quick%20confirmation%20against%20lgtm-ci%20v0.23.0's%20%60reusable-publish-pypi-release.yml%60%20to%20verify%20the%20tooling-ref%20is%20forwarded.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fpy-lintro&pr=959&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2Fpublish-v0643-validate-dist-tooling-ref%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpublish-v0643-validate-dist-tooling-ref%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%0ALine%3A%2072-81%0A%0AComment%3A%0A**%60uses%3A%60%20ref%20and%20%60tooling-ref%60%20are%20now%20on%20different%20versions**%0A%0AThe%20%60uses%3A%60%20line%20%28line%2072%29%20still%20resolves%20the%20reusable%20workflow%20definition%20at%20%602b5651%60%20%28v0.23.0%29%2C%20while%20%60tooling-ref%60%20is%20pinned%20to%20%604d0cbb3%60%20%28v0.23.1%29.%20The%20fix%20only%20lands%20if%20the%20v0.23.0%20workflow%20definition%20actively%20passes%20%60tooling-ref%60%20down%20to%20the%20step%20that%20executes%20%60validate_pypi_package%60%20%E2%80%94%20i.e.%2C%20the%20PEP%20668-aware%20path%20must%20already%20be%20wired%20through%20the%20%60tooling-ref%60%20indirection%20at%20v0.23.0.%20If%20%60validate_pypi_package%60%20is%20called%20with%20a%20hard-coded%20internal%20ref%20in%20v0.23.0%2C%20the%20bump%20here%20is%20silently%20ignored%20and%20the%20tag%20re-run%20will%20fail%20again.%20Worth%20a%20quick%20confirmation%20against%20lgtm-ci%20v0.23.0's%20%60reusable-publish-pypi-release.yml%60%20to%20verify%20the%20tooling-ref%20is%20forwarded.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%3A72-81%0A**%60uses%3A%60%20ref%20and%20%60tooling-ref%60%20are%20now%20on%20different%20versions**%0A%0AThe%20%60uses%3A%60%20line%20%28line%2072%29%20still%20resolves%20the%20reusable%20workflow%20definition%20at%20%602b5651%60%20%28v0.23.0%29%2C%20while%20%60tooling-ref%60%20is%20pinned%20to%20%604d0cbb3%60%20%28v0.23.1%29.%20The%20fix%20only%20lands%20if%20the%20v0.23.0%20workflow%20definition%20actively%20passes%20%60tooling-ref%60%20down%20to%20the%20step%20that%20executes%20%60validate_pypi_package%60%20%E2%80%94%20i.e.%2C%20the%20PEP%20668-aware%20path%20must%20already%20be%20wired%20through%20the%20%60tooling-ref%60%20indirection%20at%20v0.23.0.%20If%20%60validate_pypi_package%60%20is%20called%20with%20a%20hard-coded%20internal%20ref%20in%20v0.23.0%2C%20the%20bump%20here%20is%20silently%20ignored%20and%20the%20tag%20re-run%20will%20fail%20again.%20Worth%20a%20quick%20confirmation%20against%20lgtm-ci%20v0.23.0's%20%60reusable-publish-pypi-release.yml%60%20to%20verify%20the%20tooling-ref%20is%20forwarded.%0A%0A&pr=959&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%3A72-81%0A**%60uses%3A%60%20ref%20and%20%60tooling-ref%60%20are%20now%20on%20different%20versions**%0A%0AThe%20%60uses%3A%60%20line%20%28line%2072%29%20still%20resolves%20the%20reusable%20workflow%20definition%20at%20%602b5651%60%20%28v0.23.0%29%2C%20while%20%60tooling-ref%60%20is%20pinned%20to%20%604d0cbb3%60%20%28v0.23.1%29.%20The%20fix%20only%20lands%20if%20the%20v0.23.0%20workflow%20definition%20actively%20passes%20%60tooling-ref%60%20down%20to%20the%20step%20that%20executes%20%60validate_pypi_package%60%20%E2%80%94%20i.e.%2C%20the%20PEP%20668-aware%20path%20must%20already%20be%20wired%20through%20the%20%60tooling-ref%60%20indirection%20at%20v0.23.0.%20If%20%60validate_pypi_package%60%20is%20called%20with%20a%20hard-coded%20internal%20ref%20in%20v0.23.0%2C%20the%20bump%20here%20is%20silently%20ignored%20and%20the%20tag%20re-run%20will%20fail%20again.%20Worth%20a%20quick%20confirmation%20against%20lgtm-ci%20v0.23.0's%20%60reusable-publish-pypi-release.yml%60%20to%20verify%20the%20tooling-ref%20is%20forwarded.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=959&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2Fpublish-v0643-validate-dist-tooling-ref%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpublish-v0643-validate-dist-tooling-ref%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fpublish-pypi-on-tag.yml%3A72-81%0A**%60uses%3A%60%20ref%20and%20%60tooling-ref%60%20are%20now%20on%20different%20versions**%0A%0AThe%20%60uses%3A%60%20line%20%28line%2072%29%20still%20resolves%20the%20reusable%20workflow%20definition%20at%20%602b5651%60%20%28v0.23.0%29%2C%20while%20%60tooling-ref%60%20is%20pinned%20to%20%604d0cbb3%60%20%28v0.23.1%29.%20The%20fix%20only%20lands%20if%20the%20v0.23.0%20workflow%20definition%20actively%20passes%20%60tooling-ref%60%20down%20to%20the%20step%20that%20executes%20%60validate_pypi_package%60%20%E2%80%94%20i.e.%2C%20the%20PEP%20668-aware%20path%20must%20already%20be%20wired%20through%20the%20%60tooling-ref%60%20indirection%20at%20v0.23.0.%20If%20%60validate_pypi_package%60%20is%20called%20with%20a%20hard-coded%20internal%20ref%20in%20v0.23.0%2C%20the%20bump%20here%20is%20silently%20ignored%20and%20the%20tag%20re-run%20will%20fail%20again.%20Worth%20a%20quick%20confirmation%20against%20lgtm-ci%20v0.23.0's%20%60reusable-publish-pypi-release.yml%60%20to%20verify%20the%20tooling-ref%20is%20forwarded.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): pin publish tooling-ref for PEP..."](https://github.com/lgtm-hq/py-lintro/commit/65f8dd5c571df9bb25b4092d6b091e94bf256369) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34521951)</sub>

<!-- /greptile_comment -->