### PR TITLE
fix(ci): repin lgtm-ci v0.23.1 and complete publish egress for v0.64.3

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`4676e2737994e31cae7c7ef17d10d5106ae1c25a` (**v0.23.1**). All workflow SHA pins include
+`d5fce750002535f59d9675d39575fa382f3427d2` (**v0.23.1**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`d35a6147305691a62ee1dc5d7527b6430c796b27` (**v0.23.1**). All workflow SHA pins include
+`4676e2737994e31cae7c7ef17d10d5106ae1c25a` (**v0.23.1**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`2b5651444346954583801fe4d0f7550143e662b6` (**v0.23.0**). All workflow SHA pins include
+`d35a6147305691a62ee1dc5d7527b6430c796b27` (**v0.23.1**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
       languages: python
       build-mode: none

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
       languages: python
       build-mode: none

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
       languages: python
       build-mode: none

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
       fail-on-severity: high
       egress-policy: block

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
       fail-on-severity: high
       egress-policy: block

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
       fail-on-severity: high
       egress-policy: block

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     permissions:
       contents: read
       packages: write
@@ -53,7 +53,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,7 +87,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     permissions:
       contents: read
       packages: write
@@ -117,7 +117,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     permissions:
       contents: read
       packages: write
@@ -53,7 +53,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,7 +87,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     permissions:
       contents: read
       packages: write
@@ -117,7 +117,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     permissions:
       contents: read
       packages: write
@@ -53,7 +53,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,7 +87,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     permissions:
       contents: read
       packages: write
@@ -117,7 +117,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -212,12 +212,12 @@ jobs:
   dogfooding-lint:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
@@ -273,13 +273,13 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
       allowed-endpoints: >
@@ -371,7 +371,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -212,12 +212,12 @@ jobs:
   dogfooding-lint:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
@@ -273,13 +273,13 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
       allowed-endpoints: >
@@ -371,7 +371,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -212,12 +212,12 @@ jobs:
   dogfooding-lint:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
@@ -273,13 +273,13 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
       allowed-endpoints: >
@@ -371,7 +371,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,14 +12,14 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
       codeowners-path: .github/CODEOWNERS
       egress-policy: block
       allowed-endpoints: >
         github.com:443
         api.github.com:443
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,14 +12,14 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
       codeowners-path: .github/CODEOWNERS
       egress-policy: block
       allowed-endpoints: >
         github.com:443
         api.github.com:443
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,14 +12,14 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
       codeowners-path: .github/CODEOWNERS
       egress-policy: block
       allowed-endpoints: >
         github.com:443
         api.github.com:443
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
       target: .
       target-type: dir
@@ -55,7 +55,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
     permissions:
       contents: read
       security-events: write
@@ -69,7 +69,7 @@ jobs:
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     permissions:
       contents: read
       id-token: write
@@ -78,7 +78,7 @@ jobs:
       python-version: '3.14'
       artifact-name: python-dist
       github-environment: pypi
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
       egress-policy: block
       # lgtm-ci workflow-contract.md § PyPI publish (build + publish jobs)
       allowed-endpoints: >
@@ -107,13 +107,13 @@ jobs:
     needs: [pypi]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     permissions:
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
       target: .
       target-type: dir
@@ -55,7 +55,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
     permissions:
       contents: read
       security-events: write
@@ -68,9 +68,8 @@ jobs:
     if: >-
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
-    environment: pypi
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     permissions:
       contents: read
       id-token: write
@@ -78,7 +77,8 @@ jobs:
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      github-environment: pypi
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
       egress-policy: block
       # lgtm-ci workflow-contract.md § PyPI publish (build + publish jobs)
       allowed-endpoints: >
@@ -107,13 +107,13 @@ jobs:
     needs: [pypi]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     permissions:
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -68,6 +68,7 @@ jobs:
     if: >-
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
+    environment: pypi
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
     permissions:
@@ -80,6 +81,7 @@ jobs:
       # lgtm-ci#246: validate-dist uses uv run twine (PEP 668 on Ubuntu 24.04)
       tooling-ref: '4d0cbb3f1421090c5006394a117d8d421ef493fb' # v0.23.1
       egress-policy: block
+      # Align with v0.64.2 publish job + lgtm-ci setup-python (uv) endpoints
       allowed-endpoints: >
         github.com:443
         api.github.com:443
@@ -88,6 +90,9 @@ jobs:
         objects.githubusercontent.com:443
         github-releases.githubusercontent.com:443
         raw.githubusercontent.com:443
+        uploads.github.com:443
+        ghcr.io:443
+        pkg-containers.githubusercontent.com:443
         pypi.org:443
         upload.pypi.org:443
         files.pythonhosted.org:443
@@ -121,7 +126,7 @@ jobs:
 
   homebrew-tap:
     name: Publish Homebrew Tap
-    needs: pypi
+    needs: [pypi, github-release]
     if: >-
       !startsWith(github.ref_name, 'actions-v') &&
       !contains(github.ref_name, 'a') &&

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -4,7 +4,7 @@
 name: Publish - PyPI Production
 # Publishes package to PyPI when version tags are pushed.
 # Lint gate: docker-ci on main/PR (no duplicate quality on tag).
-# Layout: lgtm-ci docs/python-release-publish.md
+# Layout: lgtm-ci docs/python-release-publish.md (requires lgtm-ci v0.23.1+)
 
 'on':
   push:
@@ -30,7 +30,7 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
       target: .
       target-type: dir
@@ -55,7 +55,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
     permissions:
       contents: read
       security-events: write
@@ -70,7 +70,7 @@ jobs:
       !startsWith(github.ref_name, 'actions-v')
     environment: pypi
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     permissions:
       contents: read
       id-token: write
@@ -78,10 +78,9 @@ jobs:
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      # lgtm-ci#246: validate-dist uses uv run twine (PEP 668 on Ubuntu 24.04)
-      tooling-ref: '4d0cbb3f1421090c5006394a117d8d421ef493fb' # v0.23.1
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
       egress-policy: block
-      # Align with v0.64.2 publish job + lgtm-ci setup-python (uv) endpoints
+      # lgtm-ci workflow-contract.md § PyPI publish (build + publish jobs)
       allowed-endpoints: >
         github.com:443
         api.github.com:443
@@ -108,13 +107,13 @@ jobs:
     needs: [pypi]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     permissions:
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -11,12 +11,12 @@ permissions: {}
 jobs:
   publish:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
       test-pypi: true
       update-homebrew: false
       python-version: '3.14'
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -11,12 +11,12 @@ permissions: {}
 jobs:
   publish:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
       test-pypi: true
       update-homebrew: false
       python-version: '3.14'
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -11,12 +11,12 @@ permissions: {}
 jobs:
   publish:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
       test-pypi: true
       update-homebrew: false
       python-version: '3.14'
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -26,12 +26,19 @@ jobs:
         objects.githubusercontent.com:443
         github-releases.githubusercontent.com:443
         raw.githubusercontent.com:443
+        uploads.github.com:443
+        ghcr.io:443
+        pkg-containers.githubusercontent.com:443
         astral.sh:443
         releases.astral.sh:443
         pypi.org:443
         files.pythonhosted.org:443
         test.pypi.org:443
         upload.test.pypi.org:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+        oauth2.sigstore.dev:443
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
       create-release: false
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
       create-release: false
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
       create-release: false
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
       target: .
       target-type: dir
@@ -42,7 +42,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
       target: .
       target-type: dir
@@ -42,7 +42,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
       target: .
       target-type: dir
@@ -42,7 +42,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
       post-pr-comment: true
       python-versions: '3.11,3.14'
@@ -35,7 +35,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,13 +87,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
       post-pr-comment: true
       python-versions: '3.11,3.14'
@@ -35,7 +35,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,13 +87,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
       post-pr-comment: true
       python-versions: '3.11,3.14'
@@ -35,7 +35,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,13 +87,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@2b5651444346954583801fe4d0f7550143e662b6 # v0.23.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
     with:
       egress-policy: block
       allowed-endpoints: >
@@ -30,6 +30,6 @@ jobs:
         codeload.github.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
-      tooling-ref: '2b5651444346954583801fe4d0f7550143e662b6' # v0.23.0
+      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
     permissions:
       contents: read

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
     with:
       egress-policy: block
       allowed-endpoints: >
@@ -30,6 +30,6 @@ jobs:
         codeload.github.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
-      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
+      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
     permissions:
       contents: read

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@d35a6147305691a62ee1dc5d7527b6430c796b27 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@4676e2737994e31cae7c7ef17d10d5106ae1c25a # v0.23.1
     with:
       egress-policy: block
       allowed-endpoints: >
@@ -30,6 +30,6 @@ jobs:
         codeload.github.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
-      tooling-ref: 'd35a6147305691a62ee1dc5d7527b6430c796b27' # v0.23.1
+      tooling-ref: '4676e2737994e31cae7c7ef17d10d5106ae1c25a' # v0.23.1
     permissions:
       contents: read


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(ci): repin lgtm-ci v0.23.1 and complete publish egress for v0.64.3`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

## What's Changing

**Upstream:** [lgtm-ci v0.23.1](https://github.com/lgtm-hq/lgtm-ci/releases/tag/v0.23.1) is released; pins use `git rev-parse v0.23.1^{}` → `d5fce750002535f59d9675d39575fa382f3427d2`.

All `uses:` / `tooling-ref` pins match **`d5fce750002535f59d9675d39575fa382f3427d2`** (lgtm-ci tag `v0.23.1`, release commit from #247).

### lgtm-ci v0.23.1 (upstream — #246)

- `validate-dist` uses `validate_pypi_package` (twine, or `uv run --with twine`; skips if neither tool is present)
- Documented canonical PyPI publish egress + caller `environment: pypi`

### py-lintro (this PR)

- **Repin** all `uses:` / `tooling-ref` / `post-pr-comment` from v0.23.0 → **v0.23.1** (`d5fce75`)
- **`publish-pypi-on-tag.yml`**: `environment: pypi`; full egress (`ghcr.io`, `pkg-containers`, setup-python hosts, PyPI, Sigstore); unified tooling-ref (drops #959 branch-only pin)
- **`publish-testpypi.yml`**: same PyPI egress pattern for Docker publish action
- **`homebrew-tap`**: `needs: [pypi, github-release]`
- **`.github/workflows/README.md`**: v0.23.1 pin note

Replaces partial fixes in #959 (tooling-ref-only); superseded by full v0.23.1 repin here.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` on changed workflows)

## Closes

- Relates to lgtm-hq/lgtm-ci#246

## After merge (manual)

1. Merge this PR; wait for `main` CI green
2. Retag **`v0.64.3`** → merge commit; confirm Publish workflow green end-to-end

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Repin all CI workflows to lgtm-ci v0.23.1 and expand publish egress allowlist
> - Updates all reusable workflow references and `tooling-ref` pins across CI from lgtm-ci v0.23.0 to v0.23.1.
> - Expands allowed network endpoints in the PyPI and TestPyPI publish workflows to include `uploads.github.com`, `ghcr.io`, `pkg-containers.githubusercontent.com`, and Sigstore endpoints required by v0.23.1.
> - The homebrew-tap job in [publish-pypi-on-tag.yml](.github/workflows/publish-pypi-on-tag.yml) now waits for both the `pypi` and `github-release` jobs before running.
> - Adds `github-environment: pypi` to the PyPI release job caller.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 571e4c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
- Bumped CI/CD reusable tooling pin to v0.23.1 across workflows to standardize tooling versions.
- Expanded egress allowlists to permit additional artifact upload, container registry, and signing service endpoints for publishing.
- Reordered release job dependencies so package publishing and GitHub release steps complete before homebrew/tap publication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR repins all 16 CI workflow files from lgtm-ci v0.23.0 (`2b5651...`) to v0.23.1 (`d5fce75...`), with the SHA consistent across every `uses:` ref, `tooling-ref`, and the README. The two substantive changes beyond the version bump are in the publish workflows.

- **`publish-pypi-on-tag.yml`**: Adds `github-environment: pypi` to the production publish job (enabling environment protection rules and scoped secrets), expands egress to cover `uploads.github.com`, `ghcr.io`, `pkg-containers.githubusercontent.com`, and Sigstore signing endpoints, and fixes the `homebrew-tap` job to depend on `github-release` in addition to `pypi`.
- **`publish-testpypi.yml`**: Receives the same extended egress set (GHCR, GitHub uploads, Sigstore signing endpoints) to match what `reusable-publish-pypi.yml` requires under v0.23.1.
- All remaining workflow files are mechanical one-line repin updates.
</details>

<h3>Confidence Score: 5/5</h3>

All workflow files are consistently pinned to the same v0.23.1 commit SHA; the substantive publish-workflow changes are well-scoped and correct.

Every uses: ref and tooling-ref across all 16 files resolves to the same SHA (d5fce750002535f59d9675d39575fa382f3427d2), which matches the README and the PR description. The github-environment: pypi addition follows GitHub best practice for protected publish environments. The homebrew-tap dependency fix is correct and prevents a race where the tap could be bumped before the GitHub release artifact existed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-pypi-on-tag.yml | Repin to v0.23.1, add github-environment: pypi, expand egress for GHCR/uploads/Sigstore, and fix homebrew-tap dependency to include github-release. |
| .github/workflows/publish-testpypi.yml | Repin to v0.23.1; adds GHCR, github uploads, and Sigstore signing endpoints to match the production publish egress pattern. |
| .github/workflows/docker-ci.yml | Repin all reusable workflow refs and tooling-refs from v0.23.0 to v0.23.1; no logic changes. |
| .github/workflows/docker-build-publish.yml | Repin both docker job uses/tooling-refs from v0.23.0 to v0.23.1; no logic changes. |
| .github/workflows/test-ci.yml | Repin test and publish jobs from v0.23.0 to v0.23.1; no logic changes. |
| .github/workflows/README.md | Updates pinned SHA reference in documentation from v0.23.0 to v0.23.1 (d5fce75); consistent with all workflow files. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): repin lgtm-ci to v0.23.1 releas..."](https://github.com/lgtm-hq/py-lintro/commit/571e4c0c8c1c726b0e5042b9a1e7edab7ed89a47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34532756)</sub>

<!-- /greptile_comment -->