### PR TITLE
fix(ci): adopt lgtm-ci PyPI OIDC upload split (#961)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`ca8f9a6c00b561e9457104d4e67be11cb30eb5b1` (**v0.24.0**). All workflow SHA pins include
+`f96f88353ccf669dacb7c9e2bd3b5d4410d859fd` (**v0.24.0**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the
@@ -31,9 +31,8 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 - **publish-pypi-on-tag.yml** — Production tag publish: `reusable-sbom` →
   `reusable-build-python-dist` → caller `pypi-upload` job (`upload-pypi-oidc`) →
   `reusable-github-release`, then Homebrew (`build-binary.yml`) and Docker
-  (`docker-build-publish.yml`). OIDC upload runs in this workflow file (not in
-  lgtm-ci reusables). Lint runs on `main` via `docker-ci` only (no duplicate quality on
-  tag).
+  (`docker-build-publish.yml`). OIDC upload runs in this workflow file (not in lgtm-ci
+  reusables). Lint runs on `main` via `docker-ci` only (no duplicate quality on tag).
 - **publish-testpypi.yml** — TestPyPI: `reusable-build-python-dist` + caller upload job
   (`upload-pypi-oidc` with `test-pypi: true`)
 - **docker-build-publish.yml** — Multi-arch GHCR publish via `reusable-docker.yml`

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`d5fce750002535f59d9675d39575fa382f3427d2` (**v0.23.1**). All workflow SHA pins include
+`ca8f9a6c00b561e9457104d4e67be11cb30eb5b1` (**v0.24.0**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the
@@ -29,10 +29,13 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 ## Publish
 
 - **publish-pypi-on-tag.yml** — Production tag publish: `reusable-sbom` →
-  `reusable-publish-pypi-release` → `reusable-github-release`, then Homebrew
-  (`build-binary.yml`) and Docker (`docker-build-publish.yml`). Lint runs on `main` via
-  `docker-ci` only (no duplicate quality on tag).
-- **publish-testpypi.yml** — TestPyPI via lgtm-ci `reusable-publish-pypi.yml`
+  `reusable-build-python-dist` → caller `pypi-upload` job (`upload-pypi-oidc`) →
+  `reusable-github-release`, then Homebrew (`build-binary.yml`) and Docker
+  (`docker-build-publish.yml`). OIDC upload runs in this workflow file (not in
+  lgtm-ci reusables). Lint runs on `main` via `docker-ci` only (no duplicate quality on
+  tag).
+- **publish-testpypi.yml** — TestPyPI: `reusable-build-python-dist` + caller upload job
+  (`upload-pypi-oidc` with `test-pypi: true`)
 - **docker-build-publish.yml** — Multi-arch GHCR publish via `reusable-docker.yml`
   (full + base images, registry cache at `:cache`, no-cache on version tags)
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     with:
       languages: python
       build-mode: none

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     with:
       languages: python
       build-mode: none

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     with:
       fail-on-severity: high
       egress-policy: block

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     with:
       fail-on-severity: high
       egress-policy: block

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     permissions:
       contents: read
       packages: write
@@ -53,7 +53,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,7 +87,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     permissions:
       contents: read
       packages: write
@@ -117,7 +117,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     permissions:
       contents: read
       packages: write
@@ -53,7 +53,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,7 +87,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     permissions:
       contents: read
       packages: write
@@ -117,7 +117,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -212,12 +212,12 @@ jobs:
   dogfooding-lint:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
@@ -273,13 +273,13 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
       allowed-endpoints: >
@@ -371,7 +371,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -212,12 +212,12 @@ jobs:
   dogfooding-lint:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
@@ -273,13 +273,13 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
       allowed-endpoints: >
@@ -371,7 +371,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,14 +12,14 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     with:
       codeowners-path: .github/CODEOWNERS
       egress-policy: block
       allowed-endpoints: >
         github.com:443
         api.github.com:443
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,14 +12,14 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     with:
       codeowners-path: .github/CODEOWNERS
       egress-policy: block
       allowed-endpoints: >
         github.com:443
         api.github.com:443
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     with:
       target: .
       target-type: dir
@@ -55,7 +55,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
     permissions:
       # read: checkout repo for SBOM generation
       contents: read
@@ -73,14 +73,14 @@ jobs:
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       egress-policy: block
       # lgtm-ci workflow-contract.md § PyPI build
       allowed-endpoints: >
@@ -130,25 +130,25 @@ jobs:
             oauth2.sigstore.dev:443
       - name: Upload to PyPI (OIDC)
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+          tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
 
   github-release:
     name: Create GitHub Release
     needs: [pypi-upload]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     permissions:
       # write: create GitHub Release and upload dist assets
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -4,7 +4,7 @@
 name: Publish - PyPI Production
 # Publishes package to PyPI when version tags are pushed.
 # Lint gate: docker-ci on main/PR (no duplicate quality on tag).
-# Layout: lgtm-ci docs/python-release-publish.md (requires lgtm-ci v0.23.1+)
+# Layout: lgtm-ci docs/python-release-publish.md (requires lgtm-ci v0.24.0+)
 
 'on':
   push:
@@ -30,7 +30,7 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     with:
       target: .
       target-type: dir
@@ -55,32 +55,29 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
     permissions:
       contents: read
       security-events: write
       id-token: write
       attestations: write
 
-  pypi:
-    name: Build and publish to PyPI
+  pypi-build:
+    name: Build Python distribution
     needs: [sbom]
     if: >-
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     permissions:
       contents: read
-      id-token: write
-      attestations: write
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      github-environment: pypi
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
       egress-policy: block
-      # lgtm-ci workflow-contract.md § PyPI publish (build + publish jobs)
+      # lgtm-ci workflow-contract.md § PyPI build
       allowed-endpoints: >
         github.com:443
         api.github.com:443
@@ -89,31 +86,59 @@ jobs:
         objects.githubusercontent.com:443
         github-releases.githubusercontent.com:443
         raw.githubusercontent.com:443
-        uploads.github.com:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        pypi.org:443
-        upload.pypi.org:443
-        files.pythonhosted.org:443
         astral.sh:443
         releases.astral.sh:443
-        fulcio.sigstore.dev:443
-        rekor.sigstore.dev:443
-        tuf-repo-cdn.sigstore.dev:443
-        oauth2.sigstore.dev:443
+
+  pypi-upload:
+    name: Upload to PyPI
+    needs: [pypi-build]
+    if: >-
+      github.ref_type == 'tag' &&
+      !startsWith(github.ref_name, 'actions-v')
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: block
+          # lgtm-ci workflow-contract.md § PyPI upload (OIDC)
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            pypi.org:443
+            upload.pypi.org:443
+            files.pythonhosted.org:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            oauth2.sigstore.dev:443
+      - name: Upload to PyPI (OIDC)
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+        with:
+          artifact-name: python-dist
+          python-version: '3.14'
+          tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
 
   github-release:
     name: Create GitHub Release
-    needs: [pypi]
+    needs: [pypi-upload]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     permissions:
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -125,7 +150,7 @@ jobs:
 
   homebrew-tap:
     name: Publish Homebrew Tap
-    needs: [pypi, github-release]
+    needs: [pypi-upload, github-release]
     if: >-
       !startsWith(github.ref_name, 'actions-v') &&
       !contains(github.ref_name, 'a') &&
@@ -141,7 +166,7 @@ jobs:
 
   docker-publish:
     name: Publish Docker Images to GHCR
-    needs: pypi
+    needs: [pypi-upload]
     # yamllint disable-line rule:line-length
     if: >-
       !startsWith(github.ref_name, 'actions-v') &&

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -57,9 +57,13 @@ jobs:
         sigstore-tuf-root.storage.googleapis.com:443
       tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
     permissions:
+      # read: checkout repo for SBOM generation
       contents: read
+      # write: upload vulnerability findings to GitHub Security tab
       security-events: write
+      # write: OIDC for SBOM attestation signing
       id-token: write
+      # write: publish SBOM / build attestations
       attestations: write
 
   pypi-build:
@@ -71,6 +75,7 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     permissions:
+      # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
     with:
       python-version: '3.14'
@@ -98,11 +103,15 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      # read: download python-dist workflow artifact
       contents: read
+      # write: OIDC JWT for PyPI trusted publishing (this workflow file)
       id-token: write
+      # write: Sigstore provenance attestation after upload (best-effort)
       attestations: write
     steps:
       - name: Harden runner
+        # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: block
@@ -134,6 +143,7 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     permissions:
+      # write: create GitHub Release and upload dist assets
       contents: write
     with:
       artifact-name: python-dist
@@ -158,6 +168,7 @@ jobs:
       !contains(github.ref_name, 'rc')
     uses: ./.github/workflows/build-binary.yml
     permissions:
+      # write: push formula updates to Homebrew tap repository
       contents: write
     with:
       release_tag: ${{ github.ref_name }}
@@ -175,8 +186,13 @@ jobs:
       !contains(github.ref_name, 'rc')
     uses: ./.github/workflows/docker-build-publish.yml
     permissions:
+      # read: checkout for Docker build context
       contents: read
+      # write: push images to ghcr.io
       packages: write
+      # write: OIDC for container image signing / provenance
       id-token: write
+      # write: publish image attestations
       attestations: write
+      # write: upload container scan results to Security tab
       security-events: write

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -3,21 +3,28 @@
 ---
 name: Publish - TestPyPI Staging
 
+# Layout: lgtm-ci docs/python-release-publish.md (v0.24.0+)
+
 'on':
   workflow_dispatch:
 
 permissions: {}
 
 jobs:
-  publish:
+  pypi-build:
+    name: Build Python distribution
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    permissions:
+      contents: read
     with:
-      test-pypi: true
-      update-homebrew: false
       python-version: '3.14'
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      verify-tag-version: false
+      ensure-tag-on-default-branch: false
+      artifact-name: python-dist
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
       egress-policy: block
+      # lgtm-ci workflow-contract.md § PyPI build
       allowed-endpoints: >
         github.com:443
         api.github.com:443
@@ -26,20 +33,42 @@ jobs:
         objects.githubusercontent.com:443
         github-releases.githubusercontent.com:443
         raw.githubusercontent.com:443
-        uploads.github.com:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
         astral.sh:443
         releases.astral.sh:443
-        pypi.org:443
-        files.pythonhosted.org:443
-        test.pypi.org:443
-        upload.test.pypi.org:443
-        fulcio.sigstore.dev:443
-        rekor.sigstore.dev:443
-        tuf-repo-cdn.sigstore.dev:443
-        oauth2.sigstore.dev:443
+
+  pypi-upload:
+    name: Upload to TestPyPI
+    needs: [pypi-build]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
       attestations: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: block
+          # lgtm-ci workflow-contract.md § PyPI upload (OIDC)
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            pypi.org:443
+            upload.pypi.org:443
+            files.pythonhosted.org:443
+            test.pypi.org:443
+            upload.test.pypi.org:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            oauth2.sigstore.dev:443
+      - name: Upload to TestPyPI (OIDC)
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+        with:
+          artifact-name: python-dist
+          test-pypi: true
+          python-version: '3.14'
+          tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -10,12 +10,17 @@ name: Publish - TestPyPI Staging
 
 permissions: {}
 
+concurrency:
+  group: publish-testpypi-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pypi-build:
     name: Build Python distribution
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     permissions:
+      # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
     with:
       python-version: '3.14'
@@ -40,12 +45,19 @@ jobs:
     name: Upload to TestPyPI
     needs: [pypi-build]
     runs-on: ubuntu-latest
+    # Must match TestPyPI trusted publisher environment (same pattern as production
+    # `environment: pypi`). Auto-created in GitHub if missing.
+    environment: testpypi
     permissions:
+      # read: download python-dist workflow artifact
       contents: read
+      # write: OIDC JWT for TestPyPI trusted publishing (this workflow file)
       id-token: write
+      # write: Sigstore provenance attestation after upload (best-effort)
       attestations: write
     steps:
       - name: Harden runner
+        # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: block

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -18,7 +18,7 @@ jobs:
   pypi-build:
     name: Build Python distribution
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
@@ -27,7 +27,7 @@ jobs:
       verify-tag-version: false
       ensure-tag-on-default-branch: false
       artifact-name: python-dist
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       egress-policy: block
       # lgtm-ci workflow-contract.md § PyPI build
       allowed-endpoints: >
@@ -78,9 +78,9 @@ jobs:
             oauth2.sigstore.dev:443
       - name: Upload to TestPyPI (OIDC)
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
         with:
           artifact-name: python-dist
           test-pypi: true
           python-version: '3.14'
-          tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+          tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     with:
       create-release: false
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     with:
       create-release: false
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     with:
       target: .
       target-type: dir
@@ -42,7 +42,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     with:
       target: .
       target-type: dir
@@ -42,7 +42,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     with:
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     with:
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     with:
       post-pr-comment: true
       python-versions: '3.11,3.14'
@@ -35,7 +35,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,13 +87,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     with:
       post-pr-comment: true
       python-versions: '3.11,3.14'
@@ -35,7 +35,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,13 +87,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@d5fce750002535f59d9675d39575fa382f3427d2 # v0.23.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
     with:
       egress-policy: block
       allowed-endpoints: >
@@ -30,6 +30,6 @@ jobs:
         codeload.github.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
-      tooling-ref: 'd5fce750002535f59d9675d39575fa382f3427d2' # v0.23.1
+      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
     permissions:
       contents: read

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@ca8f9a6c00b561e9457104d4e67be11cb30eb5b1 # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
     with:
       egress-policy: block
       allowed-endpoints: >
@@ -30,6 +30,6 @@ jobs:
         codeload.github.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
-      tooling-ref: 'ca8f9a6c00b561e9457104d4e67be11cb30eb5b1' # v0.24.0
+      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
     permissions:
       contents: read


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(ci): adopt lgtm-ci PyPI OIDC upload split (#961)`
- Type:
  - [x] fix / perf (patch)
  - [x] chore / ci / style
- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

PyPI trusted publishing requires the OIDC upload step to run in `publish-pypi-on-tag.yml`, not inside a cross-repo lgtm-ci reusable. This PR repins all lgtm-ci workflow refs to **v0.24.0** (`ca8f9a6`) and splits publish into build (reusable) + upload (caller job with `upload-pypi-oidc`).

Depends on lgtm-hq/lgtm-ci#248 / release **v0.24.0** (merged).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #961

## Details

### Workflow changes

| Workflow | Before | After |
| --- | --- | --- |
| `publish-pypi-on-tag.yml` | `reusable-publish-pypi-release` | `reusable-build-python-dist` + `pypi-upload` (`environment: pypi`) |
| `publish-testpypi.yml` | `reusable-publish-pypi` | `reusable-build-python-dist` + upload job (`test-pypi: true`) |
| All other workflows | lgtm-ci v0.23.1 | lgtm-ci v0.24.0 |

- `github-release`, `homebrew-tap`, and `docker-publish` now `needs: pypi-upload`.
- Egress split per lgtm-ci `workflow-contract.md` (build vs upload).
- Removed `github-environment` on reusable `with:` (environment on caller upload job only).

### Test plan (post-merge, human)

- [ ] Merge PR
- [ ] Retag `v0.64.3` or publish next patch (explicit approval before retag)
- [ ] Confirm **Publish - PyPI Production** completes and PyPI shows the release
- [ ] Optional: `workflow_dispatch` **Publish - TestPyPI Staging**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split PyPI OIDC upload into a separate caller-side job in publish workflows
> - Replaces the single reusable `publish` job in [publish-pypi-on-tag.yml](https://github.com/lgtm-hq/py-lintro/pull/962/files#diff-5cf2a1b57dc395ea681b1e3d2132b3e05e48ec5c9768b6930f2a10f7ef3613f2) and [publish-testpypi.yml](https://github.com/lgtm-hq/py-lintro/pull/962/files#diff-300b085d7483ad9987af81e1ffc77b5b989917ed56dba37ff61d59770bce0e0b) with a two-stage approach: a `pypi-build` job using the reusable `reusable-build-python-dist` workflow, followed by a `pypi-upload` job that runs directly in this repo using the `upload-pypi-oidc` action.
> - The upload job runs with an explicit environment (`pypi` or `testpypi`), OIDC `id-token: write` permission, and a `harden-runner` step, matching Trusted Publishing requirements.
> - Downstream jobs (`github-release`, `homebrew-tap`, `docker-publish`) now depend on `pypi-upload` instead of the old single `pypi` job.
> - All other CI workflows are bumped from lgtm-ci `v0.23.1` to `v0.24.0` as part of this upgrade.
> - `publish-testpypi.yml` also gains a concurrency group to serialize runs on the same workflow ref.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4283e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow tooling to the latest version across all automated processes including testing, code quality checks, security scanning, dependency review, Docker builds, and PyPI publishing pipelines.
  * Restructured internal publishing workflow dependencies for improved build reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adopts the lgtm-ci v0.24.0 OIDC trusted-publishing pattern by splitting the monolithic `reusable-publish-pypi-release` call into a two-phase approach across the publish workflows, and bumps all lgtm-ci reusable workflow SHA pins from v0.23.1 to v0.24.0.

- **`publish-pypi-on-tag.yml`**: `pypi` job replaced with `pypi-build` (calls `reusable-build-python-dist`) + inline `pypi-upload` job that runs in the `pypi` GitHub environment and performs the OIDC token exchange directly in this workflow file; downstream jobs (`github-release`, `homebrew-tap`, `docker-publish`) updated to `needs: [pypi-upload]`.
- **`publish-testpypi.yml`**: Same two-phase split with `environment: testpypi` on the upload job and `verify-tag-version: false` / `ensure-tag-on-default-branch: false` for staging; concurrency group added to cancel in-progress staging runs.
- **All other CI workflows**: Routine SHA bump of every `uses:` and `tooling-ref:` reference from `d5fce750` (v0.23.1) to `f96f88353ccf` (v0.24.0).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The OIDC split is correctly implemented — environment declarations are present on both upload jobs, harden-runner egress blocks are in place, and all downstream dependency edges have been updated to point at pypi-upload.

All 16 files are CI/CD configuration only with no source code changes. The two-phase publish split follows the expected PyPI trusted publishing pattern: the build reusable has only contents: read, and the inline upload job is the one that holds id-token: write inside a named GitHub environment. SHA pins are consistent across all files and match the README.

No files require special attention. The two publish workflows are the most structurally significant changes and both look correct.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-pypi-on-tag.yml | Restructured from a single reusable-publish-pypi-release job into pypi-build (reusable) + pypi-upload (inline caller job with environment: pypi and OIDC); downstream job dependencies correctly updated to needs: [pypi-upload]. |
| .github/workflows/publish-testpypi.yml | Restructured from a single reusable call into pypi-build + pypi-upload with environment: testpypi; added concurrency group. TestPyPI egress allow-list on pypi-upload includes upload.pypi.org:443 which is the production endpoint and is not needed for TestPyPI uploads. |
| .github/workflows/README.md | Updated SHA comment from v0.23.1 to v0.24.0 and documentation for the new two-phase publish layout; internally consistent with the workflow files. |
| .github/workflows/docker-ci.yml | Routine version bump of all lgtm-ci reusable workflow and action refs from v0.23.1 to v0.24.0. |
| .github/workflows/docker-build-publish.yml | Routine version bump of reusable-docker.yml refs and tooling-ref values from v0.23.1 to v0.24.0. |
| .github/workflows/test-ci.yml | Routine version bump of reusable-test-python.yml and reusable-test-python-publish.yml refs and tooling-ref values. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["push: version tag\nor workflow_dispatch"] --> B

    subgraph publish-pypi-on-tag.yml
        B["sbom\n(reusable-sbom @ v0.24.0)"]
        B --> C["pypi-build\n(reusable-build-python-dist @ v0.24.0)\npermissions: contents: read only"]
        C --> D["pypi-upload\n(upload-pypi-oidc action)\nenvironment: pypi\npermissions: id-token: write"]
        D --> E["github-release\n(reusable-github-release @ v0.24.0)"]
        D --> F["homebrew-tap\n(build-binary.yml)\nneeds: pypi-upload + github-release"]
        D --> G["docker-publish\n(docker-build-publish.yml)"]
        E --> F
    end

    subgraph publish-testpypi.yml
        H["workflow_dispatch"] --> I["pypi-build\n(reusable-build-python-dist @ v0.24.0)"]
        I --> J["pypi-upload\n(upload-pypi-oidc action)\nenvironment: testpypi\ntest-pypi: true"]
    end
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fpublish-testpypi.yml%3A70-74%0AThe%20TestPyPI%20upload%20job's%20egress%20allow-list%20includes%20%60upload.pypi.org%3A443%60%2C%20which%20is%20the%20**production**%20PyPI%20upload%20endpoint.%20Since%20this%20job%20passes%20%60test-pypi%3A%20true%60%20and%20targets%20%60upload.test.pypi.org%60%2C%20the%20production%20endpoint%20is%20not%20needed%20and%20unnecessarily%20widens%20the%20egress%20boundary%20for%20a%20staging%20run.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20pypi.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20files.pythonhosted.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20test.pypi.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20upload.test.pypi.org%3A443%0A%60%60%60%0A%0A&pr=962&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fpublish-testpypi.yml%3A70-74%0AThe%20TestPyPI%20upload%20job's%20egress%20allow-list%20includes%20%60upload.pypi.org%3A443%60%2C%20which%20is%20the%20**production**%20PyPI%20upload%20endpoint.%20Since%20this%20job%20passes%20%60test-pypi%3A%20true%60%20and%20targets%20%60upload.test.pypi.org%60%2C%20the%20production%20endpoint%20is%20not%20needed%20and%20unnecessarily%20widens%20the%20egress%20boundary%20for%20a%20staging%20run.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20pypi.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20files.pythonhosted.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20test.pypi.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20upload.test.pypi.org%3A443%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=962&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F961-pypi-oidc-upload-job%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F961-pypi-oidc-upload-job%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fpublish-testpypi.yml%3A70-74%0AThe%20TestPyPI%20upload%20job's%20egress%20allow-list%20includes%20%60upload.pypi.org%3A443%60%2C%20which%20is%20the%20**production**%20PyPI%20upload%20endpoint.%20Since%20this%20job%20passes%20%60test-pypi%3A%20true%60%20and%20targets%20%60upload.test.pypi.org%60%2C%20the%20production%20endpoint%20is%20not%20needed%20and%20unnecessarily%20widens%20the%20egress%20boundary%20for%20a%20staging%20run.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20pypi.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20files.pythonhosted.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20test.pypi.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20upload.test.pypi.org%3A443%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): pin lgtm-ci v0.24.0 commit SHA ..."](https://github.com/lgtm-hq/py-lintro/commit/b4283e3f143b87f60038f0758607afd6d5a9c103) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34569188)</sub>

<!-- /greptile_comment -->