### PR TITLE
fix(ci): allow PyPI index egress in publish build job

### DIFF
--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -82,7 +82,7 @@ jobs:
       artifact-name: python-dist
       tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       egress-policy: block
-      # lgtm-ci workflow-contract.md § PyPI build
+      # PyPI build egress (uv python install fetches wheels from the index)
       allowed-endpoints: >
         github.com:443
         api.github.com:443
@@ -93,6 +93,8 @@ jobs:
         raw.githubusercontent.com:443
         astral.sh:443
         releases.astral.sh:443
+        pypi.org:443
+        files.pythonhosted.org:443
 
   pypi-upload:
     name: Upload to PyPI

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -29,7 +29,7 @@ jobs:
       artifact-name: python-dist
       tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
       egress-policy: block
-      # lgtm-ci workflow-contract.md § PyPI build
+      # PyPI build egress (uv python install fetches wheels from the index)
       allowed-endpoints: >
         github.com:443
         api.github.com:443
@@ -40,6 +40,8 @@ jobs:
         raw.githubusercontent.com:443
         astral.sh:443
         releases.astral.sh:443
+        pypi.org:443
+        files.pythonhosted.org:443
 
   pypi-upload:
     name: Upload to TestPyPI


### PR DESCRIPTION
## Summary

- Restores `pypi.org` and `files.pythonhosted.org` on the `pypi-build` job in production and TestPyPI publish workflows.
- Fixes v0.64.3 publish failure after #962 split build/upload: `Setup Python` runs `uv python install`, which fetches `zstandard` from PyPI while egress is blocked.

## Root cause

Run https://github.com/lgtm-hq/py-lintro/actions/runs/26641735933 failed in **Build Python distribution → Setup Python** with:

```
Failed to fetch: `https://pypi.org/simple/zstandard/`
Connection refused (os error 111)
```

OIDC/upload never ran. The old combined `pypi` job included PyPI index endpoints; the new build job copied only the lgtm-ci “PyPI build” contract (GitHub + Astral), which omits the index.

## Test plan

- [ ] Merge to `main`
- [ ] Move tag `v0.64.3` to new `main` HEAD and push tag (or re-run publish after retag)
- [ ] Confirm **Publish - PyPI Production** completes through **Upload to PyPI**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow PyPI index egress in publish build jobs
> Adds `pypi.org:443` and `files.pythonhosted.org:443` to the egress allowlist in the `pypi-build` job for both [publish-pypi-on-tag.yml](https://github.com/lgtm-hq/py-lintro/pull/963/files#diff-5cf2a1b57dc395ea681b1e3d2132b3e05e48ec5c9768b6930f2a10f7ef3613f2) and [publish-testpypi.yml](https://github.com/lgtm-hq/py-lintro/pull/963/files#diff-300b085d7483ad9987af81e1ffc77b5b989917ed56dba37ff61d59770bce0e0b). This fixes build failures caused by blocked outbound connections to PyPI when the egress policy is set to block.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 02948b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PyPI production and test deployment workflows to extend allowed network access, ensuring reliable package installation from PyPI repositories during build processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/py-lintro/pull/963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a publish failure introduced by a previous build/upload job split (#962) by restoring `pypi.org:443` and `files.pythonhosted.org:443` to the `pypi-build` job's egress allowlist in both the production and TestPyPI publish workflows. Without these endpoints the hardened runner blocks `uv python install`, which fetches the `zstandard` wheel from the PyPI index during the **Setup Python** step.

- Adds `pypi.org:443` and `files.pythonhosted.org:443` to `allowed-endpoints` in the `pypi-build` job of both `publish-pypi-on-tag.yml` and `publish-testpypi.yml`.
- Updates the inline comment on the allowlist to explain the reason (`uv python install fetches wheels from the index`) rather than referencing the now-stale contract section header.
- Upload-only endpoints (`upload.pypi.org`, `upload.test.pypi.org`) remain correctly scoped to the `pypi-upload` job, so the separation of build and upload privileges is preserved.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted fix that restores two well-known PyPI CDN endpoints to the build job's egress allowlist.

Both workflows receive identical, symmetrical changes. The added endpoints (pypi.org and files.pythonhosted.org) are the standard PyPI index and file-hosting CDN; they are already present in the pypi-upload job, so their addition to the build job follows established precedent in the same files. Upload-only endpoints (upload.pypi.org, upload.test.pypi.org) remain exclusively in the upload job, preserving the intended privilege separation between build and upload phases.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-pypi-on-tag.yml | Adds pypi.org:443 and files.pythonhosted.org:443 to the pypi-build job's egress allowlist; upload endpoints remain scoped to pypi-upload only. |
| .github/workflows/publish-testpypi.yml | Same two endpoints added to pypi-build job; test.pypi.org and upload.test.pypi.org remain correctly confined to the pypi-upload job. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Build as pypi-build job
    participant PyPI as pypi.org:443
    participant Files as files.pythonhosted.org:443
    participant Upload as pypi-upload job
    participant UPyPI as upload.pypi.org:443

    GH->>Build: trigger (tag push)
    Build->>PyPI: uv python install - fetch zstandard index (NEW)
    PyPI-->>Build: package metadata
    Build->>Files: download zstandard wheel (NEW)
    Files-->>Build: wheel artifact
    Build->>Build: build sdist / wheel
    Build-->>GH: upload python-dist artifact

    GH->>Upload: trigger (needs pypi-build)
    Upload->>PyPI: resolve / verify (already allowed)
    Upload->>UPyPI: publish (already allowed)
    UPyPI-->>Upload: upload OK
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(ci): retrigger checks"](https://github.com/lgtm-hq/py-lintro/commit/02948b5d31c1495ae20f9e0074c53122b7fe20c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34580153)</sub>

<!-- /greptile_comment -->