### PR TITLE
fix(ci): pin upload-pypi-oidc composite fix for v0.64.3 publish

### DIFF
--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -121,22 +121,25 @@ jobs:
           allowed-endpoints: >
             github.com:443
             api.github.com:443
+            codeload.github.com:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
             pypi.org:443
             upload.pypi.org:443
             files.pythonhosted.org:443
+            astral.sh:443
+            releases.astral.sh:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
             oauth2.sigstore.dev:443
       - name: Upload to PyPI (OIDC)
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@29e82f5b128ba8fd5bd6a9ebbff749db6676f011
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+          tooling-ref: '29e82f5b128ba8fd5bd6a9ebbff749db6676f011'
 
   github-release:
     name: Create GitHub Release

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -124,7 +124,7 @@ jobs:
             codeload.github.com:443
             objects.githubusercontent.com:443
             actions.githubusercontent.com:443
-            blob.core.windows.net:443
+            *.blob.core.windows.net:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
             pypi.org:443

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -138,11 +138,11 @@ jobs:
             oauth2.sigstore.dev:443
       - name: Upload to PyPI (OIDC)
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@6e8989c47b255de12cd49c387190a898f59666fb # v0.24.1 (lgtm-ci#252)
+        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@6e8989c47b255de12cd49c387190a898f59666fb # v0.24.1
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '6e8989c47b255de12cd49c387190a898f59666fb' # v0.24.1 (lgtm-ci#252)
+          tooling-ref: '6e8989c47b255de12cd49c387190a898f59666fb' # v0.24.1
 
   github-release:
     name: Create GitHub Release

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -122,6 +122,9 @@ jobs:
             github.com:443
             api.github.com:443
             codeload.github.com:443
+            objects.githubusercontent.com:443
+            actions.githubusercontent.com:443
+            blob.core.windows.net:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
             pypi.org:443
@@ -135,11 +138,11 @@ jobs:
             oauth2.sigstore.dev:443
       - name: Upload to PyPI (OIDC)
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@29e82f5b128ba8fd5bd6a9ebbff749db6676f011
+        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@6e8989c47b255de12cd49c387190a898f59666fb # v0.24.1 (lgtm-ci#252)
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '29e82f5b128ba8fd5bd6a9ebbff749db6676f011'
+          tooling-ref: '6e8989c47b255de12cd49c387190a898f59666fb' # v0.24.1 (lgtm-ci#252)
 
   github-release:
     name: Create GitHub Release

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -70,7 +70,7 @@ jobs:
             codeload.github.com:443
             objects.githubusercontent.com:443
             actions.githubusercontent.com:443
-            blob.core.windows.net:443
+            *.blob.core.windows.net:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
             pypi.org:443

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -67,6 +67,7 @@ jobs:
           allowed-endpoints: >
             github.com:443
             api.github.com:443
+            codeload.github.com:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
             pypi.org:443
@@ -74,15 +75,17 @@ jobs:
             files.pythonhosted.org:443
             test.pypi.org:443
             upload.test.pypi.org:443
+            astral.sh:443
+            releases.astral.sh:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
             oauth2.sigstore.dev:443
       - name: Upload to TestPyPI (OIDC)
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@29e82f5b128ba8fd5bd6a9ebbff749db6676f011
         with:
           artifact-name: python-dist
           test-pypi: true
           python-version: '3.14'
-          tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+          tooling-ref: '29e82f5b128ba8fd5bd6a9ebbff749db6676f011'

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -68,6 +68,9 @@ jobs:
             github.com:443
             api.github.com:443
             codeload.github.com:443
+            objects.githubusercontent.com:443
+            actions.githubusercontent.com:443
+            blob.core.windows.net:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
             pypi.org:443
@@ -83,9 +86,9 @@ jobs:
             oauth2.sigstore.dev:443
       - name: Upload to TestPyPI (OIDC)
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@29e82f5b128ba8fd5bd6a9ebbff749db6676f011
+        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@6e8989c47b255de12cd49c387190a898f59666fb # v0.24.1 (lgtm-ci#252)
         with:
           artifact-name: python-dist
           test-pypi: true
           python-version: '3.14'
-          tooling-ref: '29e82f5b128ba8fd5bd6a9ebbff749db6676f011'
+          tooling-ref: '6e8989c47b255de12cd49c387190a898f59666fb' # v0.24.1 (lgtm-ci#252)

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -86,9 +86,9 @@ jobs:
             oauth2.sigstore.dev:443
       - name: Upload to TestPyPI (OIDC)
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@6e8989c47b255de12cd49c387190a898f59666fb # v0.24.1 (lgtm-ci#252)
+        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@6e8989c47b255de12cd49c387190a898f59666fb # v0.24.1
         with:
           artifact-name: python-dist
           test-pypi: true
           python-version: '3.14'
-          tooling-ref: '6e8989c47b255de12cd49c387190a898f59666fb' # v0.24.1 (lgtm-ci#252)
+          tooling-ref: '6e8989c47b255de12cd49c387190a898f59666fb' # v0.24.1


### PR DESCRIPTION
## Summary

- Pins `upload-pypi-oidc` to [lgtm-ci@29e82f5](https://github.com/lgtm-hq/lgtm-ci/pull/252) (fixes composite `inputs` in nested `uses:` ref).
- Adds `codeload.github.com`, `astral.sh`, and `releases.astral.sh` to the upload job egress allowlist for tooling checkout and `uv python install`.

## Failure context

[Publish v0.64.3 run 26652363045](https://github.com/lgtm-hq/py-lintro/actions/runs/26652363045): build succeeded after #963; **Upload to PyPI** failed at job setup:

```
Unrecognized named-value: 'inputs' in upload-pypi-oidc setup-python uses: ref
```

## Test plan

- [ ] Merge [lgtm-ci#252](https://github.com/lgtm-hq/lgtm-ci/pull/252) (or confirm pin to branch commit is acceptable)
- [ ] Merge this PR
- [ ] Retag `v0.64.3` on `main` and confirm publish completes through **Upload to PyPI**

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `upload-pypi-oidc` action to v0.24.1 in PyPI publish workflows
> Updates both [publish-pypi-on-tag.yml](.github/workflows/publish-pypi-on-tag.yml) and [publish-testpypi.yml](.github/workflows/publish-testpypi.yml) to reference `lgtm-ci` `upload-pypi-oidc` action at v0.24.1 (commit `6e8989c`) instead of v0.24.0. Also expands the harden-runner egress allowlist in both workflows to permit connections to `codeload.github.com`, `objects.githubusercontent.com`, `actions.githubusercontent.com`, `*.blob.core.windows.net`, `astral.sh`, and `releases.astral.sh`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1868528.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Hardened publishing workflows: expanded runner egress allowlist to additional upload and verification endpoints to improve publishing resilience and security.
  * CI action updates: bumped the publishing OIDC action and aligned its tooling reference across TestPyPI and PyPI workflows to ensure consistent, reliable package uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the failing PyPI publish step for v0.64.3 by bumping the `upload-pypi-oidc` composite action from `v0.24.0` to `v0.24.1` in both the production and TestPyPI upload jobs, and expanding the harden-runner egress allowlist with the endpoints needed by the updated composite action's setup steps.

- Both `uses:` SHA pins and the corresponding `tooling-ref` inputs are updated consistently to `6e8989c47b255de12cd49c387190a898f59666fb` (`# v0.24.1`) across both workflow files.
- New egress entries (`codeload.github.com`, `objects.githubusercontent.com`, `actions.githubusercontent.com`, `*.blob.core.windows.net`, `astral.sh`, `releases.astral.sh`) are added only to the runner-hardened `pypi-upload` job in each workflow, keeping other jobs at their existing allowlists.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a well-scoped CI fix that consistently updates one composite action and its required network allowlist across both affected workflows.

Both workflows are updated in lockstep: the uses: SHA and the tooling-ref input match in every instance, the new egress entries are confined to the jobs that actually run the updated composite action, and the rest of the pipeline remains pinned to the previously-stable v0.24.0 refs.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-pypi-on-tag.yml | Upgrades upload-pypi-oidc to v0.24.1 (SHA + tooling-ref) and adds 6 egress endpoints to the pypi-upload job's harden-runner step; all other jobs remain at v0.24.0. |
| .github/workflows/publish-testpypi.yml | Same targeted fix as the production workflow — upgrades upload-pypi-oidc to v0.24.1 and expands the TestPyPI upload job's egress allowlist identically. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): allow Azure artifact subdomains..."](https://github.com/lgtm-hq/py-lintro/commit/1868528c25c2519afdb922848e3aa0c168a5742f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34617137)</sub>

<!-- /greptile_comment -->