### PR TITLE
fix(ci): migrate PyPI publish to prepare-pypi-upload (lgtm-ci v0.29.1)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,9 +32,10 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
   `reusable-build-python-dist` → caller `pypi-upload` job (`prepare-pypi-upload` →
   `pypa/gh-action-pypi-publish` → `attest-build-provenance`) →
   `reusable-github-release`, then Homebrew (`build-binary.yml`) and Docker
-  (`docker-build-publish.yml`). OIDC upload runs in this workflow file (not in lgtm-ci
-  reusables). Publish pipeline pins lgtm-ci at **v0.29.1**. Lint runs on `main` via
-  `docker-ci` only (no duplicate quality on tag).
+  (`docker-build-publish.yml`). Upload via `pypa/gh-action-pypi-publish` (OIDC trusted
+  publishing) runs in this workflow file, not in lgtm-ci reusables. Publish pipeline
+  pins lgtm-ci at **v0.29.1**. Lint runs on `main` via `docker-ci` only (no duplicate
+  quality on tag).
 - **publish-testpypi.yml** — TestPyPI: `reusable-build-python-dist` + caller upload job
   (same three-step pattern with `repository-url: https://test.pypi.org/legacy/`)
 - **docker-build-publish.yml** — Multi-arch GHCR publish via `reusable-docker.yml`

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,11 +1,9 @@
 # Workflows overview
 
 This repository uses GitHub Actions for quality gates, release automation, and
-publishing. Most shared workflows are thin callers to
+publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`f96f88353ccf669dacb7c9e2bd3b5d4410d859fd` (**v0.24.0**). PyPI publish workflows
-(`publish-pypi-on-tag.yml`, `publish-testpypi.yml`) pin their lgtm-ci reusables at
-**v0.29.1** (`32022b3d920ec123790873ab194638e5db2bcd86`). All workflow SHA pins include
+`32022b3d920ec123790873ab194638e5db2bcd86` (**v0.29.1**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the
@@ -37,11 +35,10 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
   (`docker-build-publish.yml`). Upload via `pypa/gh-action-pypi-publish` (OIDC trusted
   publishing) runs in this workflow file, not in lgtm-ci reusables. Lint runs on `main`
   via `docker-ci` only (no duplicate quality on tag).
-- **publish-testpypi.yml** — TestPyPI: `reusable-build-python-dist` (v0.29.1) + caller
-  upload job (same three-step pattern with
-  `repository-url: https://test.pypi.org/legacy/`)
+- **publish-testpypi.yml** — TestPyPI: `reusable-build-python-dist` + caller upload job
+  (same three-step pattern with `repository-url: https://test.pypi.org/legacy/`)
 - **docker-build-publish.yml** — Multi-arch GHCR publish via `reusable-docker.yml`
-  (v0.24.0; full + base images, registry cache at `:cache`, no-cache on version tags)
+  (full + base images, registry cache at `:cache`, no-cache on version tags)
 
 ## Security & maintenance (bespoke)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,9 +1,11 @@
 # Workflows overview
 
 This repository uses GitHub Actions for quality gates, release automation, and
-publishing. Shared workflows are thin callers to
+publishing. Most shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`f96f88353ccf669dacb7c9e2bd3b5d4410d859fd` (**v0.24.0**). All workflow SHA pins include
+`f96f88353ccf669dacb7c9e2bd3b5d4410d859fd` (**v0.24.0**). PyPI publish workflows
+(`publish-pypi-on-tag.yml`, `publish-testpypi.yml`) pin their lgtm-ci reusables at
+**v0.29.1** (`32022b3d920ec123790873ab194638e5db2bcd86`). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the
@@ -33,13 +35,13 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
   `pypa/gh-action-pypi-publish` → `attest-build-provenance`) →
   `reusable-github-release`, then Homebrew (`build-binary.yml`) and Docker
   (`docker-build-publish.yml`). Upload via `pypa/gh-action-pypi-publish` (OIDC trusted
-  publishing) runs in this workflow file, not in lgtm-ci reusables. Publish pipeline
-  pins lgtm-ci at **v0.29.1**. Lint runs on `main` via `docker-ci` only (no duplicate
-  quality on tag).
-- **publish-testpypi.yml** — TestPyPI: `reusable-build-python-dist` + caller upload job
-  (same three-step pattern with `repository-url: https://test.pypi.org/legacy/`)
+  publishing) runs in this workflow file, not in lgtm-ci reusables. Lint runs on `main`
+  via `docker-ci` only (no duplicate quality on tag).
+- **publish-testpypi.yml** — TestPyPI: `reusable-build-python-dist` (v0.29.1) + caller
+  upload job (same three-step pattern with
+  `repository-url: https://test.pypi.org/legacy/`)
 - **docker-build-publish.yml** — Multi-arch GHCR publish via `reusable-docker.yml`
-  (full + base images, registry cache at `:cache`, no-cache on version tags)
+  (v0.24.0; full + base images, registry cache at `:cache`, no-cache on version tags)
 
 ## Security & maintenance (bespoke)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`32022b3d920ec123790873ab194638e5db2bcd86` (**v0.29.1**). All workflow SHA pins include
+`51c056cf62302e367c272f5ca8c49922709b2716` (**v0.29.1**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -29,12 +29,14 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
 ## Publish
 
 - **publish-pypi-on-tag.yml** — Production tag publish: `reusable-sbom` →
-  `reusable-build-python-dist` → caller `pypi-upload` job (`upload-pypi-oidc`) →
+  `reusable-build-python-dist` → caller `pypi-upload` job (`prepare-pypi-upload` →
+  `pypa/gh-action-pypi-publish` → `attest-build-provenance`) →
   `reusable-github-release`, then Homebrew (`build-binary.yml`) and Docker
   (`docker-build-publish.yml`). OIDC upload runs in this workflow file (not in lgtm-ci
-  reusables). Lint runs on `main` via `docker-ci` only (no duplicate quality on tag).
+  reusables). Publish pipeline pins lgtm-ci at **v0.29.1**. Lint runs on `main` via
+  `docker-ci` only (no duplicate quality on tag).
 - **publish-testpypi.yml** — TestPyPI: `reusable-build-python-dist` + caller upload job
-  (`upload-pypi-oidc` with `test-pypi: true`)
+  (same three-step pattern with `repository-url: https://test.pypi.org/legacy/`)
 - **docker-build-publish.yml** — Multi-arch GHCR publish via `reusable-docker.yml`
   (full + base images, registry cache at `:cache`, no-cache on version tags)
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     with:
       languages: python
       build-mode: none

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     with:
       languages: python
       build-mode: none

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     with:
       fail-on-severity: high
       egress-policy: block

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     with:
       fail-on-severity: high
       egress-policy: block

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     permissions:
       contents: read
       packages: write
@@ -53,7 +53,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,7 +87,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     permissions:
       contents: read
       packages: write
@@ -117,7 +117,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     permissions:
       contents: read
       packages: write
@@ -53,7 +53,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,7 +87,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     permissions:
       contents: read
       packages: write
@@ -117,7 +117,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -212,12 +212,12 @@ jobs:
   dogfooding-lint:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
@@ -273,13 +273,13 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
       allowed-endpoints: >
@@ -371,7 +371,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -212,12 +212,12 @@ jobs:
   dogfooding-lint:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
@@ -273,13 +273,13 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-pr-comment.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
       allowed-endpoints: >
@@ -371,7 +371,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,14 +12,14 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     with:
       codeowners-path: .github/CODEOWNERS
       egress-policy: block
       allowed-endpoints: >
         github.com:443
         api.github.com:443
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,14 +12,14 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     with:
       codeowners-path: .github/CODEOWNERS
       egress-policy: block
       allowed-endpoints: >
         github.com:443
         api.github.com:443
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -4,7 +4,7 @@
 name: Publish - PyPI Production
 # Publishes package to PyPI when version tags are pushed.
 # Lint gate: docker-ci on main/PR (no duplicate quality on tag).
-# Layout: lgtm-ci docs/python-release-publish.md (requires lgtm-ci v0.24.0+)
+# Layout: lgtm-ci docs/python-release-publish.md (requires lgtm-ci v0.29.1+)
 
 'on':
   push:
@@ -30,7 +30,7 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     with:
       target: .
       target-type: dir
@@ -55,7 +55,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
     permissions:
       # read: checkout repo for SBOM generation
       contents: read
@@ -73,14 +73,14 @@ jobs:
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
       egress-policy: block
       # PyPI build egress (uv python install fetches wheels from the index)
       allowed-endpoints: >
@@ -136,27 +136,40 @@ jobs:
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
             oauth2.sigstore.dev:443
-      - name: Upload to PyPI (OIDC)
+      - name: Prepare PyPI upload
+        id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@6e8989c47b255de12cd49c387190a898f59666fb # v0.24.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '6e8989c47b255de12cd49c387190a898f59666fb' # v0.24.1
+          tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      - name: Upload to PyPI
+        # yamllint disable-line rule:line-length
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://upload.pypi.org/legacy/
+          packages-dir: ${{ steps.prepare.outputs.dist-path }}
+      - name: Attest build provenance
+        continue-on-error: true
+        # yamllint disable-line rule:line-length
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: ${{ steps.prepare.outputs.dist-path }}/*
 
   github-release:
     name: Create GitHub Release
     needs: [pypi-upload]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     permissions:
       # write: create GitHub Release and upload dist assets
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     with:
       target: .
       target-type: dir
@@ -55,7 +55,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
     permissions:
       # read: checkout repo for SBOM generation
       contents: read
@@ -73,14 +73,14 @@ jobs:
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       egress-policy: block
       # PyPI build egress (uv python install fetches wheels from the index)
       allowed-endpoints: >
@@ -139,11 +139,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+          tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       - name: Upload to PyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
@@ -162,14 +162,14 @@ jobs:
     needs: [pypi-upload]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     permissions:
       # write: create GitHub Release and upload dist assets
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -18,7 +18,7 @@ jobs:
   pypi-build:
     name: Build Python distribution
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
@@ -27,7 +27,7 @@ jobs:
       verify-tag-version: false
       ensure-tag-on-default-branch: false
       artifact-name: python-dist
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       egress-policy: block
       # PyPI build egress (uv python install fetches wheels from the index)
       allowed-endpoints: >
@@ -87,11 +87,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+          tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       - name: Upload to TestPyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -3,7 +3,7 @@
 ---
 name: Publish - TestPyPI Staging
 
-# Layout: lgtm-ci docs/python-release-publish.md (v0.24.0+)
+# Layout: lgtm-ci docs/python-release-publish.md (v0.29.1+)
 
 'on':
   workflow_dispatch:
@@ -18,7 +18,7 @@ jobs:
   pypi-build:
     name: Build Python distribution
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
@@ -27,7 +27,7 @@ jobs:
       verify-tag-version: false
       ensure-tag-on-default-branch: false
       artifact-name: python-dist
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
       egress-policy: block
       # PyPI build egress (uv python install fetches wheels from the index)
       allowed-endpoints: >
@@ -84,11 +84,23 @@ jobs:
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
             oauth2.sigstore.dev:443
-      - name: Upload to TestPyPI (OIDC)
+      - name: Prepare PyPI upload
+        id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@6e8989c47b255de12cd49c387190a898f59666fb # v0.24.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
         with:
           artifact-name: python-dist
-          test-pypi: true
           python-version: '3.14'
-          tooling-ref: '6e8989c47b255de12cd49c387190a898f59666fb' # v0.24.1
+          tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      - name: Upload to TestPyPI
+        # yamllint disable-line rule:line-length
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: ${{ steps.prepare.outputs.dist-path }}
+      - name: Attest build provenance
+        continue-on-error: true
+        # yamllint disable-line rule:line-length
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: ${{ steps.prepare.outputs.dist-path }}/*

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     with:
       create-release: false
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     with:
       create-release: false
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     with:
       target: .
       target-type: dir
@@ -42,7 +42,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     with:
       target: .
       target-type: dir
@@ -42,7 +42,7 @@ jobs:
         timestamp.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         sigstore-tuf-root.storage.googleapis.com:443
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     with:
       egress-policy: block
       allowed-endpoints: >

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     with:
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     with:
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     with:
       post-pr-comment: true
       python-versions: '3.11,3.14'
@@ -35,7 +35,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,13 +87,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     with:
       post-pr-comment: true
       python-versions: '3.11,3.14'
@@ -35,7 +35,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -87,13 +87,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
       egress-policy: block
       allowed-endpoints: >
         github.com:443

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@f96f88353ccf669dacb7c9e2bd3b5d4410d859fd # v0.24.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
     with:
       egress-policy: block
       allowed-endpoints: >
@@ -30,6 +30,6 @@ jobs:
         codeload.github.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
-      tooling-ref: 'f96f88353ccf669dacb7c9e2bd3b5d4410d859fd' # v0.24.0
+      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
     permissions:
       contents: read

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@32022b3d920ec123790873ab194638e5db2bcd86 # v0.29.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@51c056cf62302e367c272f5ca8c49922709b2716 # v0.29.1
     with:
       egress-policy: block
       allowed-endpoints: >
@@ -30,6 +30,6 @@ jobs:
         codeload.github.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443
-      tooling-ref: '32022b3d920ec123790873ab194638e5db2bcd86' # v0.29.1
+      tooling-ref: '51c056cf62302e367c272f5ca8c49922709b2716' # v0.29.1
     permissions:
       contents: read


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): migrate PyPI publish to prepare-pypi-upload (lgtm-ci v0.29.1)
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Migrates production and TestPyPI publish workflows off the removed
`upload-pypi-oidc` composite to the lgtm-ci v0.29.1 caller pattern:
`prepare-pypi-upload` → `pypa/gh-action-pypi-publish` →
`attest-build-provenance`. This fixes nested composite OIDC resolution
(`github.action_repository` resolving to `lgtm-hq/lgtm-ci`) that blocked the
v0.64.3 PyPI upload.

Publish pipeline lgtm-ci reusables are repinned to **v0.29.1**
(`32022b3d920ec123790873ab194638e5db2bcd86`).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` + `uv run lintro tst`)

## Closes

- Closes #966
- Relates to lgtm-hq/lgtm-ci#269
- Relates to lgtm-hq/lgtm-ci#270

## Details

### Changes

- **publish-pypi-on-tag.yml** — Repin `reusable-sbom`, `reusable-build-python-dist`,
  and `reusable-github-release` to v0.29.1; replace upload step with three-step
  caller pattern (prod `repository-url`).
- **publish-testpypi.yml** — Repin build reusable; same upload pattern with TestPyPI
  `repository-url`.
- **.github/workflows/README.md** — Document new upload flow; remove
  `upload-pypi-oidc` references.

### CodeRabbit review

- Applied README clarification for `pypa/gh-action-pypi-publish` OIDC wording.
- Skipped `dist-path` output concern — `prepare-pypi-upload@32022b3` defines
  `outputs.dist-path` in lgtm-ci v0.29.1.
- Kept `pypa/gh-action-pypi-publish@cef22109…` pin matching lgtm-ci v0.29.1
  canonical example.

### Post-merge

Retag **v0.64.3** on green `main` and verify full publish pipeline (PyPI + GitHub
Release).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate PyPI publish workflow to use `prepare-pypi-upload` and attest build provenance
> - Updates all reusable workflow references from lgtm-ci v0.24.0 (`f96f883`) to v0.29.1 (`51c056c`) across all CI workflows.
> - Replaces the single-step OIDC upload in [publish-pypi-on-tag.yml](https://github.com/lgtm-hq/py-lintro/pull/967/files#diff-5cf2a1b57dc395ea681b1e3d2132b3e05e48ec5c9768b6930f2a10f7ef3613f2) and [publish-testpypi.yml](https://github.com/lgtm-hq/py-lintro/pull/967/files#diff-300b085d7483ad9987af81e1ffc77b5b989917ed56dba37ff61d59770bce0e0b) with a three-step sequence: `prepare-pypi-upload` to resolve the dist path, `pypa/gh-action-pypi-publish` to upload, and `actions/attest-build-provenance` to generate provenance attestations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93f75d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped CI/CD workflow tooling to a newer pinned version (v0.29.1) across publishing, CI, Docker, SBOM, and support workflows.
  * Revised PyPI/TestPyPI publishing flow to a multi-step pipeline and added provenance attestation for stricter package integrity.
* **Documentation**
  * Updated workflow documentation to reflect the revised publish process and tooling pins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates the PyPI publish pipeline off the removed `upload-pypi-oidc` composite action to the lgtm-ci v0.29.1 caller pattern, and simultaneously bumps all other lgtm-ci reusable refs from v0.24.0 to v0.29.1 across every workflow file.

- **Core publish change** (`publish-pypi-on-tag.yml`, `publish-testpypi.yml`): The single `upload-pypi-oidc` step is replaced with three explicit steps — `prepare-pypi-upload` (downloads and stages the artifact), `pypa/gh-action-pypi-publish@v1.14.0` (OIDC trusted publish), and `actions/attest-build-provenance@v4.1.0` (best-effort supply-chain attestation with `continue-on-error: true`). Both production and TestPyPI paths follow the same pattern, differentiated only by `repository-url`.
- **Broad version bump**: All 14 remaining workflow files have their lgtm-ci SHA pins and `tooling-ref` values updated from `f96f88353ccf…` (v0.24.0) to `51c056cf6230…` (v0.29.1), consistently matching the SHA documented in the README.
- **Minor documentation note**: The PR description body references SHA `32022b3d920ec123790873ab194638e5db2bcd86` as v0.29.1, but all file changes and the README consistently use `51c056cf62302e367c272f5ca8c49922709b2716`. This inconsistency is in the PR description only and does not affect deployed workflows.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the publish pipeline changes are mechanically straightforward and the broad version bump is consistent across all workflow files.

The core change correctly decomposes the removed composite into its three constituent steps with proper OIDC permissions, matching `repository-url` values, and a best-effort `continue-on-error` attestation step. All 16 files consistently use the same lgtm-ci SHA (`51c056cf`), the README matches, and no logic regressions are introduced in any of the non-publish workflows.

No files require special attention beyond the pre-existing `upload.pypi.org:443` entry in the TestPyPI egress allowlist that was already flagged in a prior review.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/publish-pypi-on-tag.yml | Migrates production PyPI publish from `upload-pypi-oidc` composite to three-step caller pattern (`prepare-pypi-upload` → `gh-action-pypi-publish` → `attest-build-provenance`); all lgtm-ci refs bumped to v0.29.1; OIDC and attestation permissions correctly declared. |
| .github/workflows/publish-testpypi.yml | Mirrors production three-step upload pattern for TestPyPI; `repository-url` correctly set to `https://test.pypi.org/legacy/`; `upload.pypi.org:443` remains in egress allowlist (unnecessary for TestPyPI, flagged in prior review). |
| .github/workflows/README.md | Documentation updated to reflect the new three-step upload flow and v0.29.1 pins; SHA in the intro (`51c056cf`) matches the code consistently. |
| .github/workflows/docker-ci.yml | Bulk SHA and tooling-ref update from v0.24.0 to v0.29.1; no functional changes beyond the version bump. |
| .github/workflows/test-ci.yml | Version-only update of lgtm-ci reusable pins and tooling-ref from v0.24.0 to v0.29.1; no logic changes. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Tag as git push tag
    participant SBOM as sbom job
    participant Build as pypi-build job
    participant Upload as pypi-upload job
    participant Prepare as prepare-pypi-upload@v0.29.1
    participant PyPI as pypa/gh-action-pypi-publish@v1.14.0
    participant Attest as attest-build-provenance@v4.1.0
    participant Release as github-release job

    Tag->>SBOM: trigger
    SBOM->>Build: needs: [sbom]
    Build->>Upload: needs: [pypi-build]
    Upload->>Prepare: step 1 — download artifact, stage dist
    Prepare-->>Upload: outputs.dist-path
    Upload->>PyPI: step 2 — OIDC trusted publish
    PyPI-->>Upload: package live on PyPI
    Upload->>Attest: step 3 — attest-build-provenance (continue-on-error)
    Upload->>Release: needs: [pypi-upload]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/publish-testpypi.yml`, line 76-80 ([link](https://github.com/lgtm-hq/py-lintro/blob/b512c2e7ec3184d2e8fa89c497fcce0b3b0a587f/.github/workflows/publish-testpypi.yml#L76-L80)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `upload.pypi.org:443` endpoint is unnecessary in the TestPyPI upload job — all traffic goes to `test.pypi.org` and `upload.test.pypi.org`. Leaving it in the allowlist widens the permitted egress beyond what the job actually needs, reducing the value of the `egress-policy: block` hardening.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish-testpypi.yml%0ALine%3A%2076-80%0A%0AComment%3A%0AThe%20%60upload.pypi.org%3A443%60%20endpoint%20is%20unnecessary%20in%20the%20TestPyPI%20upload%20job%20%E2%80%94%20all%20traffic%20goes%20to%20%60test.pypi.org%60%20and%20%60upload.test.pypi.org%60.%20Leaving%20it%20in%20the%20allowlist%20widens%20the%20permitted%20egress%20beyond%20what%20the%20job%20actually%20needs%2C%20reducing%20the%20value%20of%20the%20%60egress-policy%3A%20block%60%20hardening.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20pypi.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20files.pythonhosted.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20test.pypi.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20upload.test.pypi.org%3A443%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=967&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish-testpypi.yml%0ALine%3A%2076-80%0A%0AComment%3A%0AThe%20%60upload.pypi.org%3A443%60%20endpoint%20is%20unnecessary%20in%20the%20TestPyPI%20upload%20job%20%E2%80%94%20all%20traffic%20goes%20to%20%60test.pypi.org%60%20and%20%60upload.test.pypi.org%60.%20Leaving%20it%20in%20the%20allowlist%20widens%20the%20permitted%20egress%20beyond%20what%20the%20job%20actually%20needs%2C%20reducing%20the%20value%20of%20the%20%60egress-policy%3A%20block%60%20hardening.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20pypi.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20files.pythonhosted.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20test.pypi.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20upload.test.pypi.org%3A443%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fpy-lintro&pr=967&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F966-migrate-prepare-pypi-upload-lgtm-ci-v0-29-1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F966-migrate-prepare-pypi-upload-lgtm-ci-v0-29-1%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish-testpypi.yml%0ALine%3A%2076-80%0A%0AComment%3A%0AThe%20%60upload.pypi.org%3A443%60%20endpoint%20is%20unnecessary%20in%20the%20TestPyPI%20upload%20job%20%E2%80%94%20all%20traffic%20goes%20to%20%60test.pypi.org%60%20and%20%60upload.test.pypi.org%60.%20Leaving%20it%20in%20the%20allowlist%20widens%20the%20permitted%20egress%20beyond%20what%20the%20job%20actually%20needs%2C%20reducing%20the%20value%20of%20the%20%60egress-policy%3A%20block%60%20hardening.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20pypi.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20files.pythonhosted.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20test.pypi.org%3A443%0A%20%20%20%20%20%20%20%20%20%20%20%20upload.test.pypi.org%3A443%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix(ci): use v0.29.1 commit SHA instead ..."](https://github.com/lgtm-hq/py-lintro/commit/93f75d007fccf46b7356dea9c5f52f8282cecbd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34780769)</sub>

<!-- /greptile_comment -->