### PR TITLE
fix(renovate): scope postUpgradeTasks to regex managers only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -69,6 +69,26 @@
         "vue-tsc"
       ],
       "automerge": false
+    },
+    {
+      "description": "Regenerate _tool_versions.py when tool version sources change",
+      "matchManagers": ["regex"],
+      "matchFileNames": [
+        "Dockerfile",
+        "lintro/_tool_versions.py"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "python3 scripts/ci/generate-tool-versions.py"
+        ],
+        "fileFilters": [
+          "lintro/_tool_versions.py",
+          "package.json",
+          "pyproject.toml",
+          "Dockerfile"
+        ],
+        "executionMode": "branch"
+      }
     }
   ],
   "pip_requirements": {
@@ -79,18 +99,6 @@
   "lockFileMaintenance": {
     "schedule": ["before 5am on monday"],
     "commitMessageAction": "update lockfile"
-  },
-  "postUpgradeTasks": {
-    "commands": [
-      "python3 scripts/ci/generate-tool-versions.py"
-    ],
-    "fileFilters": [
-      "lintro/_tool_versions.py",
-      "package.json",
-      "pyproject.toml",
-      "Dockerfile"
-    ],
-    "executionMode": "branch"
   },
   "customManagers": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -72,7 +72,7 @@
     },
     {
       "description": "Regenerate _tool_versions.py when tool version sources change",
-      "matchManagers": ["regex"],
+      "matchManagers": ["custom.regex"],
       "matchFileNames": [
         "Dockerfile",
         "lintro/_tool_versions.py"


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Moves `postUpgradeTasks` from the top-level Renovate config into a `packageRules`
entry scoped to `custom.regex` managers targeting `Dockerfile` and
`lintro/_tool_versions.py`. This prevents `generate-tool-versions.py` from running
for unrelated dependency updates (e.g. `lgtm-ci` workflow SHA pins), which was
causing "Post-upgrade task did not match any on allowedCommands list" warnings on the
Mend hosted Renovate app.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Relates to #4

## Details

The Mend hosted Renovate app does not have access to the `RENOVATE_ALLOWED_COMMANDS`
env var configured in the self-hosted `renovate.yml` workflow. When `postUpgradeTasks`
was defined at the top level, it applied to all dependency updates — including
`lgtm-ci` workflow pins managed by the org preset's custom managers. Since the Mend
app has no allowlist for `python3 scripts/ci/generate-tool-versions.py`, it blocked
execution and errored the update.

By scoping the rule to `custom.regex` managers and specific file patterns, the task
only runs when actual tool versions change (Dockerfile ARGs, `_tool_versions.py`
entries) where regeneration is needed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope Renovate `postUpgradeTasks` to regex manager package rule only
> Moves the `postUpgradeTasks` block (running `scripts/ci/generate-tool-versions.py`) from the global Renovate config into a dedicated package rule targeting the `custom.regex` manager and the `Dockerfile`/`lintro/_tool_versions.py` files. Previously, the script ran for all Renovate upgrades; now it only runs when those specific files are updated by the regex manager.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acc6ffd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management automation configuration to improve tool version handling during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR scopes `postUpgradeTasks` to only run `generate-tool-versions.py` when `custom.regex` managers update `Dockerfile` ARG pins or `lintro/_tool_versions.py` entries, rather than on every Renovate update. This eliminates the "Post-upgrade task did not match any on allowedCommands list" warnings from the Mend hosted Renovate app, which has no allowlist for the script.

- The `postUpgradeTasks` block is removed from the top level and added as a `packageRules` entry combining `matchManagers: [\"custom.regex\"]` with `matchFileNames: [\"Dockerfile\", \"lintro/_tool_versions.py\"]`, so the script runs only where version regeneration is actually needed.
- The `.github/workflows/sbom-on-main.yml` custom manager (bomctl) is intentionally excluded since that file does not feed into `_tool_versions.py`; `executionMode`, `commands`, and `fileFilters` are otherwise unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change correctly narrows when the post-upgrade script fires and makes no modifications to the script itself or any other workflow logic.

The restructuring is straightforward: the same command, fileFilters, and executionMode are preserved verbatim; only the matching conditions change. All existing custom.regex managers that target Dockerfile or _tool_versions.py remain covered, while the bomctl workflow manager is correctly left out since it has no need to regenerate that file. No regressions are expected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Moves postUpgradeTasks from top-level config into a scoped packageRules entry matching only custom.regex managers on Dockerfile and lintro/_tool_versions.py; bomctl workflow manager is correctly excluded. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(renovate): use custom.regex manager ..."](https://github.com/lgtm-hq/py-lintro/commit/acc6ffd41df1f51941cf82bb346b6aa9111a56b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35190643)</sub>

<!-- /greptile_comment -->