### PR TITLE
chore(ci): bump lgtm-ci from v0.32.3 to v0.45.2

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`f469f4d5c187f0700ccec4c023152fb68ee3dc89` (**v0.32.3**). All workflow SHA pins include
+`96a42109637efd4c019d176e0902e3be23295716` (**v0.45.1**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`a8b6e50f095c8eb1a49d60f4df71a552c460b211` (**v0.45.1**). All workflow SHA pins include
+`deb53fdb15a630cc60e6e5f35ecb9a8b58966690` (**v0.45.2**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`96a42109637efd4c019d176e0902e3be23295716` (**v0.45.1**). All workflow SHA pins include
+`a8b6e50f095c8eb1a49d60f4df71a552c460b211` (**v0.45.1**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,13 +24,13 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
       languages: python
       build-mode: none
       config-file: .github/codeql/codeql-config.yml
       category: '/language:all'
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,13 +24,13 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
       languages: python
       build-mode: none
       config-file: .github/codeql/codeql-config.yml
       category: '/language:all'
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,13 +24,13 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       languages: python
       build-mode: none
       config-file: .github/codeql/codeql-config.yml
       category: '/language:all'
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
       fail-on-severity: high
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       fail-on-severity: high
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
       fail-on-severity: high
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read
       packages: write
@@ -53,7 +53,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: docker
       allowed-endpoints-mode: append
@@ -65,7 +65,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read
       packages: write
@@ -95,7 +95,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: docker
       allowed-endpoints-mode: append

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     permissions:
       contents: read
       packages: write
@@ -53,7 +53,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: docker
       allowed-endpoints-mode: append
@@ -65,7 +65,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     permissions:
       contents: read
       packages: write
@@ -95,7 +95,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: docker
       allowed-endpoints-mode: append

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     permissions:
       contents: read
       packages: write
@@ -53,7 +53,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: docker
       allowed-endpoints-mode: append
@@ -65,7 +65,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     permissions:
       contents: read
       packages: write
@@ -95,7 +95,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: docker
       allowed-endpoints-mode: append

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -212,12 +212,12 @@ jobs:
   dogfooding-lint:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
@@ -242,13 +242,13 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
 
@@ -262,11 +262,11 @@ jobs:
         github.event.pull_request.draft == false
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     permissions:
       contents: read
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       job-name: '🛠️ Lintro Code Quality'
       runner-image: ubuntu-24.04
       upstream-result: ${{ needs.dogfooding-lint.result }}
@@ -332,7 +332,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -212,12 +212,12 @@ jobs:
   dogfooding-lint:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
@@ -242,13 +242,13 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
 
@@ -262,11 +262,11 @@ jobs:
         github.event.pull_request.draft == false
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     permissions:
       contents: read
     with:
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       job-name: '🛠️ Lintro Code Quality'
       runner-image: ubuntu-24.04
       upstream-result: ${{ needs.dogfooding-lint.result }}
@@ -332,7 +332,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -212,12 +212,12 @@ jobs:
   dogfooding-lint:
     needs: [docker-build, manifest-sync]
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
@@ -242,13 +242,13 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
 
@@ -262,11 +262,11 @@ jobs:
         github.event.pull_request.draft == false
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read
     with:
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: '🛠️ Lintro Code Quality'
       runner-image: ubuntu-24.04
       upstream-result: ${{ needs.dogfooding-lint.result }}
@@ -332,7 +332,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,10 +12,10 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,10 +12,10 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,10 +12,10 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,11 +12,11 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,11 +12,11 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,11 +12,11 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -30,14 +30,14 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
       target: .
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: sbom
     permissions:
@@ -57,14 +57,14 @@ jobs:
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -116,11 +116,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+          tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       - name: Upload to PyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
@@ -139,14 +139,14 @@ jobs:
     needs: [pypi-upload]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     permissions:
       # write: create GitHub Release and upload dist assets
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -30,14 +30,14 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
       target: .
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: sbom
     permissions:
@@ -57,14 +57,14 @@ jobs:
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -116,11 +116,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+          tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       - name: Upload to PyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
@@ -139,14 +139,14 @@ jobs:
     needs: [pypi-upload]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     permissions:
       # write: create GitHub Release and upload dist assets
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -4,7 +4,7 @@
 name: Publish - PyPI Production
 # Publishes package to PyPI when version tags are pushed.
 # Lint gate: docker-ci on main/PR (no duplicate quality on tag).
-# Layout: lgtm-ci docs/python-release-publish.md (requires lgtm-ci v0.32.3+)
+# Layout: lgtm-ci docs/python-release-publish.md (requires lgtm-ci v0.45.1+)
 
 'on':
   push:
@@ -30,14 +30,14 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       target: .
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: sbom
     permissions:
@@ -57,14 +57,14 @@ jobs:
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -116,11 +116,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+          tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       - name: Upload to PyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
@@ -139,14 +139,14 @@ jobs:
     needs: [pypi-upload]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       # write: create GitHub Release and upload dist assets
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -18,7 +18,7 @@ jobs:
   pypi-build:
     name: Build Python distribution
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
@@ -27,7 +27,7 @@ jobs:
       verify-tag-version: false
       ensure-tag-on-default-branch: false
       artifact-name: python-dist
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -80,11 +80,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+          tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       - name: Upload to TestPyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -3,7 +3,7 @@
 ---
 name: Publish - TestPyPI Staging
 
-# Layout: lgtm-ci docs/python-release-publish.md (v0.32.3+)
+# Layout: lgtm-ci docs/python-release-publish.md (v0.45.1+)
 
 'on':
   workflow_dispatch:
@@ -18,7 +18,7 @@ jobs:
   pypi-build:
     name: Build Python distribution
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
@@ -27,7 +27,7 @@ jobs:
       verify-tag-version: false
       ensure-tag-on-default-branch: false
       artifact-name: python-dist
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -80,11 +80,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+          tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       - name: Upload to TestPyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -18,7 +18,7 @@ jobs:
   pypi-build:
     name: Build Python distribution
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
@@ -27,7 +27,7 @@ jobs:
       verify-tag-version: false
       ensure-tag-on-default-branch: false
       artifact-name: python-dist
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -80,11 +80,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+          tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       - name: Upload to TestPyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       create-release: false
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
     secrets:

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
       create-release: false
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
     secrets:

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
       create-release: false
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: github-tooling
     secrets:

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: pypi
     secrets:

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: pypi
     secrets:

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: pypi
     secrets:

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,14 +17,14 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
       target: .
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: sbom
     permissions:

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,14 +17,14 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       target: .
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: sbom
     permissions:

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,14 +17,14 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
       target: .
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: sbom
     permissions:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -44,6 +44,7 @@ jobs:
       # multi-version matrix requires actions:write for artifact aggregation
       actions: write
       contents: read
+      pull-requests: write
 
   # Coverage mode: single runtime with coverage reporting
   test-coverage:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -22,7 +22,7 @@ jobs:
   # Compat mode: multi-runtime matrix, no coverage or PR comments
   test-compat:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
       publish-test-summary: false
       python-versions: '3.11,3.14'
@@ -33,7 +33,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -49,7 +49,7 @@ jobs:
   # Coverage mode: single runtime with coverage reporting
   test-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
       publish-test-summary: true
       python-version: '3.14'
@@ -57,13 +57,12 @@ jobs:
       extras: 'full'
       extra-args: '-x --ignore=tests/integration'
       coverage: true
-      coverage-format: xml
       coverage-threshold: 80
       upload-coverage: true
       draft-pr-skip: true
       job-name: Python Coverage
       runner-image: ubuntu-24.04
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -112,11 +111,11 @@ jobs:
     needs: test-gate
     if: always()
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     permissions:
       contents: read
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       job-name: '🧪 Test Suite & Coverage'
       runner-image: ubuntu-24.04
       upstream-result: ${{ needs.test-gate.outputs.result }}
@@ -132,13 +131,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test-coverage.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
       coverage-percent: ${{ needs.test-coverage.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: github-pages
     permissions:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   test:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       publish-test-summary: false
       python-versions: '3.11,3.14'
@@ -35,7 +35,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -58,11 +58,11 @@ jobs:
         github.event.pull_request.draft == false
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
       contents: read
     with:
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: '🧪 Test Suite & Coverage'
       runner-image: ubuntu-24.04
       upstream-result: ${{ needs.test.result }}
@@ -78,13 +78,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
       coverage-percent: ${{ needs.test.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-pages
     permissions:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -116,7 +116,7 @@ jobs:
       tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: '🧪 Test Suite & Coverage'
       runner-image: ubuntu-24.04
-      upstream-result: ${{ needs.test-gate.result }}
+      upstream-result: ${{ needs.test-gate.outputs.result }}
       passed-output: ${{ needs.test-gate.outputs.passed }}
       egress-policy: block
       egress-preset: github-tooling

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -76,6 +76,7 @@ jobs:
 
   # Evaluate both upstream jobs into a single result for the required-check gate
   test-gate:
+    name: Test Gate
     needs: [test-compat, test-coverage]
     if: always()
     runs-on: ubuntu-24.04
@@ -89,6 +90,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: scripts/ci/evaluate-test-gate.sh
+          sparse-checkout-cone-mode: false
           persist-credentials: false
       - name: Evaluate upstream results
         id: gate

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -19,7 +19,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  test:
+  # Compat mode: multi-runtime matrix, no coverage or PR comments
+  test-compat:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
@@ -28,10 +29,7 @@ jobs:
       test-path: tests
       extras: 'full'
       extra-args: '-x --ignore=tests/integration'
-      coverage: true
-      coverage-format: xml
-      coverage-threshold: 80
-      upload-coverage: true
+      coverage: false
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
@@ -43,20 +41,73 @@ jobs:
         astral.sh:443
         releases.astral.sh:443
     permissions:
-      # v0.18.2 aggregate job needs actions:write for artifact merge
+      # multi-version matrix requires actions:write for artifact aggregation
+      actions: write
+      contents: read
+
+  # Coverage mode: single runtime with coverage reporting
+  test-coverage:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    with:
+      publish-test-summary: true
+      python-version: '3.14'
+      test-path: tests
+      extras: 'full'
+      extra-args: '-x --ignore=tests/integration'
+      coverage: true
+      coverage-format: xml
+      coverage-threshold: 80
+      upload-coverage: true
+      draft-pr-skip: true
+      job-name: Python Coverage
+      runner-image: ubuntu-24.04
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      egress-policy: block
+      egress-preset: pypi
+      allowed-endpoints-mode: append
+      allowed-endpoints: >
+        astral.sh:443
+        releases.astral.sh:443
+    permissions:
       actions: write
       contents: read
       pull-requests: write
 
+  # Evaluate both upstream jobs into a single result for the required-check gate
+  test-gate:
+    needs: [test-compat, test-coverage]
+    if: always()
+    runs-on: ubuntu-24.04
+    permissions: {}
+    outputs:
+      result: ${{ steps.gate.outputs.result }}
+      passed: ${{ steps.gate.outputs.passed }}
+    steps:
+      - name: Checkout gate script
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: scripts/ci/evaluate-test-gate.sh
+          persist-credentials: false
+      - name: Evaluate upstream results
+        id: gate
+        env:
+          COMPAT_RESULT: ${{ needs.test-compat.result }}
+          COVERAGE_RESULT: ${{ needs.test-coverage.result }}
+        run: |
+          if bash scripts/ci/evaluate-test-gate.sh; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+            echo "passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # Org ruleset (checks-py-lintro): test-suite-coverage / 🧪 Test Suite & Coverage
   test-suite-coverage:
-    needs: test
-    if: >-
-      always() &&
-      (
-        github.event_name != 'pull_request' ||
-        github.event.pull_request.draft == false
-      )
+    needs: test-gate
+    if: always()
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     permissions:
@@ -65,22 +116,22 @@ jobs:
       tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       job-name: '🧪 Test Suite & Coverage'
       runner-image: ubuntu-24.04
-      upstream-result: ${{ needs.test.result }}
-      passed-output: ${{ needs.test.outputs.passed }}
+      upstream-result: ${{ needs.test-gate.result }}
+      passed-output: ${{ needs.test-gate.outputs.passed }}
       egress-policy: block
       egress-preset: github-tooling
 
   publish-coverage:
     name: Publish Coverage to Pages
-    needs: test
+    needs: test-coverage
     if: >-
       github.ref == 'refs/heads/main' &&
       github.event_name == 'push' &&
-      needs.test.outputs.passed == 'true'
+      needs.test-coverage.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
-      coverage-percent: ${{ needs.test.outputs.coverage-percent }}
+      coverage-percent: ${{ needs.test-coverage.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -22,7 +22,7 @@ jobs:
   # Compat mode: multi-runtime matrix, no coverage or PR comments
   test-compat:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
       publish-test-summary: false
       python-versions: '3.11,3.14'
@@ -33,7 +33,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -49,7 +49,7 @@ jobs:
   # Coverage mode: single runtime with coverage reporting
   test-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
       publish-test-summary: true
       python-version: '3.14'
@@ -62,7 +62,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Coverage
       runner-image: ubuntu-24.04
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -111,11 +111,11 @@ jobs:
     needs: test-gate
     if: always()
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     permissions:
       contents: read
     with:
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       job-name: '🧪 Test Suite & Coverage'
       runner-image: ubuntu-24.04
       upstream-result: ${{ needs.test-gate.outputs.result }}
@@ -131,13 +131,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test-coverage.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
       coverage-percent: ${{ needs.test-coverage.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: github-pages
     permissions:

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,9 +21,9 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
     with:
-      tooling-ref: 'f469f4d5c187f0700ccec4c023152fb68ee3dc89' # v0.32.3
+      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,9 +21,9 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@96a42109637efd4c019d176e0902e3be23295716 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
     with:
-      tooling-ref: '96a42109637efd4c019d176e0902e3be23295716' # v0.45.1
+      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -21,9 +21,9 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@a8b6e50f095c8eb1a49d60f4df71a552c460b211 # v0.45.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@deb53fdb15a630cc60e6e5f35ecb9a8b58966690 # v0.45.2
     with:
-      tooling-ref: 'a8b6e50f095c8eb1a49d60f4df71a552c460b211' # v0.45.1
+      tooling-ref: 'deb53fdb15a630cc60e6e5f35ecb9a8b58966690' # v0.45.2
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -13,11 +13,6 @@ ignoreUntil = 2026-06-25
 reason = "defu@6.1.4 — transitive dev dep via h3→astro, fix in 6.1.5 pending upstream h3 update"
 
 [[IgnoredVulns]]
-id = "GHSA-v3rj-xjv7-4jmq"
-ignoreUntil = 2026-06-25
-reason = "smol-toml@1.6.0 — transitive dev dep via astro, pending upstream update"
-
-[[IgnoredVulns]]
 id = "GHSA-48c2-rrv3-qjmp"
 ignoreUntil = 2026-06-25
 reason = "yaml@2.7.1 — transitive dev dep, pending upstream update to 2.8.3"

--- a/bun.lock
+++ b/bun.lock
@@ -6,8 +6,8 @@
       "name": "py-lintro",
       "devDependencies": {
         "@astrojs/check": "0.9.8",
-        "astro": "6.1.10",
-        "markdownlint-cli2": "0.22.0",
+        "astro": "6.4.8",
+        "markdownlint-cli2": "0.22.1",
         "oxfmt": "0.43.0",
         "oxlint": "1.58.0",
         "prettier": "3.8.1",
@@ -21,23 +21,27 @@
   },
   "overrides": {
     "devalue": "5.8.1",
+    "esbuild": "^0.28.1",
     "fast-uri": "3.1.2",
+    "js-yaml": "^4.2.0",
+    "markdown-it": "^14.2.0",
     "postcss": "^8.5.10",
+    "vite": "^8.0.16",
   },
   "packages": {
     "@astrojs/check": ["@astrojs/check@0.9.8", "", { "dependencies": { "@astrojs/language-server": "^2.16.5", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw=="],
 
-    "@astrojs/compiler": ["@astrojs/compiler@3.0.1", "", {}, "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA=="],
+    "@astrojs/compiler": ["@astrojs/compiler@4.0.0", "", {}, "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA=="],
 
-    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.0", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg=="],
+    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.0", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.1.1", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw=="],
 
     "@astrojs/language-server": ["@astrojs/language-server@2.16.6", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.3", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.15", "volar-service-css": "0.0.70", "volar-service-emmet": "0.0.70", "volar-service-html": "0.0.70", "volar-service-prettier": "0.0.70", "volar-service-typescript": "0.0.70", "volar-service-typescript-twoslash-queries": "0.0.70", "volar-service-yaml": "0.0.70", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "bin/nodeServer.js" } }, "sha512-N990lu+HSFiG57owR0XBkr02BYMgiLCshLf+4QG4v6jjSWkBeQGnzqi+E1L08xFPPJ7eEeXnxPXGLaVv5pa4Ug=="],
 
-    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.1", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.0", "@astrojs/prism": "4.0.1", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA=="],
+    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.2.0", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.0", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw=="],
 
-    "@astrojs/prism": ["@astrojs/prism@4.0.1", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ=="],
+    "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
 
-    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.1", "", { "dependencies": { "ci-info": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw=="],
+    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.2", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ=="],
 
     "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.3", "", { "dependencies": { "yaml": "^2.8.2" } }, "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg=="],
 
@@ -69,59 +73,63 @@
 
     "@emmetio/stream-reader-utils": ["@emmetio/stream-reader-utils@0.1.0", "", {}, "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A=="],
 
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
     "@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.4", "", { "os": "android", "cpu": "arm64" }, "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.4", "", { "os": "android", "cpu": "x64" }, "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.4", "", { "os": "linux", "cpu": "arm" }, "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.4", "", { "os": "linux", "cpu": "x64" }, "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.4", "", { "os": "none", "cpu": "x64" }, "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.4", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -183,6 +191,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -190,6 +200,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.43.0", "", { "os": "android", "cpu": "arm" }, "sha512-CgU2s+/9hHZgo0IxVxrbMPrMj+tJ6VM3mD7Mr/4oiz4FNTISLoCvRmB5nk4wAAle045RtRjd86m673jwPyb1OQ=="],
 
@@ -267,6 +279,38 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.58.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bCn5rbiz5My+Bj7M09sDcnqW0QJyINRVxdZ65x1/Y2tGrMwherwK/lpk+HRQCKvXa8pcaQdF5KY5j54VGZLwNg=="],
 
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.3", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.1", "", { "os": "android", "cpu": "arm" }, "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA=="],
@@ -339,6 +383,8 @@
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.9", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA=="],
 
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -405,7 +451,7 @@
 
     "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
 
-    "astro": ["astro@6.1.10", "", { "dependencies": { "@astrojs/compiler": "^3.0.1", "@astrojs/internal-helpers": "0.9.0", "@astrojs/markdown-remark": "7.1.1", "@astrojs/telemetry": "3.3.1", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "bin/astro.mjs" } }, "sha512-jQAIki6c862oxRr7OXXC+h3n4wg1EpmKgCH3vv1FtXM9VFmD2iTjlaxrfb0I6eQCwtUjSBxfJBFBDSXHu7Wing=="],
+    "astro": ["astro@6.4.8", "", { "dependencies": { "@astrojs/compiler": "^4.0.0", "@astrojs/internal-helpers": "0.10.0", "@astrojs/markdown-remark": "7.2.0", "@astrojs/telemetry": "3.3.2", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "./bin/astro.mjs" } }, "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -475,8 +521,6 @@
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
-    "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
-
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
@@ -495,7 +539,7 @@
 
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
-    "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -535,11 +579,13 @@
 
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
+    "get-tsconfig": ["get-tsconfig@5.0.0-beta.4", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ=="],
+
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "globby": ["globby@16.1.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "fast-glob": "^3.3.3", "ignore": "^7.0.5", "is-path-inside": "^4.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.4.0" } }, "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg=="],
+    "globby": ["globby@16.2.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "fast-glob": "^3.3.3", "ignore": "^7.0.5", "is-path-inside": "^4.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.4.0" } }, "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q=="],
 
     "h3": ["h3@1.15.10", "", { "dependencies": { "cookie-es": "^1.2.2", "crossws": "^0.3.5", "defu": "^6.1.4", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg=="],
 
@@ -601,7 +647,7 @@
 
     "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -613,7 +659,31 @@
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
-    "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "linkify-it": ["linkify-it@5.0.1", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg=="],
 
     "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
@@ -625,13 +695,13 @@
 
     "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
 
-    "markdown-it": ["markdown-it@14.1.1", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA=="],
+    "markdown-it": ["markdown-it@14.2.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.1", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
     "markdownlint": ["markdownlint@0.40.0", "", { "dependencies": { "micromark": "4.0.2", "micromark-core-commonmark": "2.0.3", "micromark-extension-directive": "4.0.0", "micromark-extension-gfm-autolink-literal": "2.1.0", "micromark-extension-gfm-footnote": "2.1.0", "micromark-extension-gfm-table": "2.1.1", "micromark-extension-math": "3.1.0", "micromark-util-types": "2.0.2", "string-width": "8.1.0" } }, "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg=="],
 
-    "markdownlint-cli2": ["markdownlint-cli2@0.22.0", "", { "dependencies": { "globby": "16.1.1", "js-yaml": "4.1.1", "jsonc-parser": "3.3.1", "jsonpointer": "5.0.1", "markdown-it": "14.1.1", "markdownlint": "0.40.0", "markdownlint-cli2-formatter-default": "0.0.6", "micromatch": "4.0.8", "smol-toml": "1.6.0" }, "bin": { "markdownlint-cli2": "markdownlint-cli2-bin.mjs" } }, "sha512-mOC9BY/XGtdX3M9n3AgERd79F0+S7w18yBBTNIQ453sI87etZfp1z4eajqSMV70CYjbxKe5ktKvT2HCpvcWx9w=="],
+    "markdownlint-cli2": ["markdownlint-cli2@0.22.1", "", { "dependencies": { "globby": "16.2.0", "js-yaml": "4.1.1", "jsonc-parser": "3.3.1", "jsonpointer": "5.0.1", "markdown-it": "14.1.1", "markdownlint": "0.40.0", "markdownlint-cli2-formatter-default": "0.0.6", "micromatch": "4.0.8", "smol-toml": "1.6.1" }, "bin": { "markdownlint-cli2": "markdownlint-cli2-bin.mjs" } }, "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw=="],
 
     "markdownlint-cli2-formatter-default": ["markdownlint-cli2-formatter-default@0.0.6", "", { "peerDependencies": { "markdownlint-cli2": ">=0.0.4" } }, "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ=="],
 
@@ -835,6 +905,8 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
     "retext": ["retext@9.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "retext-latin": "^4.0.0", "retext-stringify": "^4.0.0", "unified": "^11.0.0" } }, "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA=="],
 
     "retext-latin": ["retext-latin@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "parse-latin": "^7.0.0", "unified": "^11.0.0" } }, "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA=="],
@@ -844,6 +916,8 @@
     "retext-stringify": ["retext-stringify@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unified": "^11.0.0" } }, "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
 
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
@@ -903,8 +977,6 @@
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
-    "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typesafe-path": ["typesafe-path@0.2.2", "", {}, "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="],
@@ -953,7 +1025,7 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@7.3.3", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA=="],
+    "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
 
     "vitefu": ["vitefu@1.1.2", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
 
@@ -1021,6 +1093,8 @@
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
+    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
     "@vscode/emmet-helper/jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
 
     "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
@@ -1035,8 +1109,6 @@
 
     "markdownlint/string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
 
-    "markdownlint-cli2/smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
-
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
@@ -1048,6 +1120,8 @@
     "svelte/aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "yaml-language-server/request-light": ["request-light@0.5.8", "", {}, "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="],
 

--- a/lintro/_generated_versions.py
+++ b/lintro/_generated_versions.py
@@ -10,8 +10,8 @@ Sources:
 
 NPM_VERSIONS: dict[str, str] = {
     "@astrojs/check": "0.9.8",
-    "astro": "6.1.10",
-    "markdownlint-cli2": "0.22.0",
+    "astro": "6.4.8",
+    "markdownlint-cli2": "0.22.1",
     "oxfmt": "0.43.0",
     "oxlint": "1.58.0",
     "prettier": "3.8.1",

--- a/lintro/tools/manifest.json
+++ b/lintro/tools/manifest.json
@@ -65,7 +65,7 @@
     },
     {
       "name": "astro_check",
-      "version": "6.1.10",
+      "version": "6.4.8",
       "install": {
         "type": "npm",
         "package": "astro",
@@ -168,7 +168,7 @@
     },
     {
       "name": "markdownlint",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "install": {
         "type": "npm",
         "package": "markdownlint-cli2"

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "devDependencies": {
     "@astrojs/check": "0.9.8",
-    "astro": "6.1.10",
-    "markdownlint-cli2": "0.22.0",
+    "astro": "6.4.8",
+    "markdownlint-cli2": "0.22.1",
     "oxfmt": "0.43.0",
     "oxlint": "1.58.0",
     "prettier": "3.8.1",
@@ -30,7 +30,11 @@
   },
   "overrides": {
     "devalue": "5.8.1",
+    "esbuild": "^0.28.1",
     "fast-uri": "3.1.2",
-    "postcss": "^8.5.10"
+    "js-yaml": "^4.2.0",
+    "markdown-it": "^14.2.0",
+    "postcss": "^8.5.10",
+    "vite": "^8.0.16"
   }
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -69,46 +69,47 @@ below). Release automation writes `Formula/lintro.rb` (binary) and
 
 Scripts for GitHub Actions workflows and continuous integration.
 
-| Script                                | Purpose                                                               | Usage                                                            |
-| ------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `coverage-manager.sh`                 | Unified coverage ops (extract/badge/comment/threshold)                | `./scripts/utils/coverage-manager.sh --help`                     |
-| `ci-log.sh`                           | Generic CI logging utility for workflow status messages               | `./scripts/ci/ci-log.sh <message>`                               |
-| `ci-post-pr-comment.sh`               | Post comments to PRs using GitHub API                                 | `./scripts/ci/ci-post-pr-comment.sh [file]`                      |
-| `post-pr-delete-previous.sh`          | Delete previous PR comments by marker                                 | `./scripts/ci/post-pr-delete-previous.sh --help`                 |
-| `lintro-report-generate.sh`           | Generate comprehensive Lintro reports                                 | `./scripts/ci/lintro-report-generate.sh`                         |
-| `pull-lintro-image.sh`                | Pull lintro Docker image from GHCR and log digest                     | `./scripts/ci/testing/pull-lintro-image.sh`                      |
-| `maintenance/delete-ci-ghcr-tags.sh`  | Delete ephemeral CI GHCR tags after PR merge or close                 | `./scripts/ci/maintenance/delete-ci-ghcr-tags.sh`                |
-| `maintenance/ghcr_prune_untagged.py`  | Prune untagged GHCR package versions (CLI entry shim)                 | `uv run python scripts/ci/maintenance/ghcr_prune_untagged.py`    |
-| `maintenance/ghcr_prune/api.py`       | GhcrVersion list/delete/owner-type GitHub API helpers                 | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`      |
-| `maintenance/ghcr_prune/cli.py`       | Entry-point and env-var handling for the prune CLI                    | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`      |
-| `maintenance/ghcr_prune/dates.py`     | ISO-8601 parsing and `min_age_days` comparison                        | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`      |
-| `maintenance/ghcr_prune/protocols.py` | `GhcrClient` HTTP protocol used by tests and prod                     | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`      |
-| `maintenance/ghcr_prune/prune.py`     | `prune_package` and `prune_buildcache_package` per-package logic      | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`      |
-| `maintenance/ghcr_prune/registry.py`  | OCI manifest + Referrers walk; SLSA / cosign protection set           | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`      |
-| `maintenance/ghcr_prune/tags.py`      | Cache tag constants and ephemeral-tag detection                       | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`      |
-| `maintenance/ghcr_prune/version.py`   | `GhcrVersion` dataclass                                               | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`      |
-| `coverage-badge-update.sh`            | Generate and update coverage badge                                    | `./scripts/ci/coverage-badge-update.sh --help`                   |
-| `sbom-generate.sh`                    | Generate and export SBOMs via bomctl                                  | `./scripts/ci/sbom-generate.sh --help`                           |
-| `egress-audit-lite.sh`                | Audit reachability of allowed endpoints                               | `./scripts/ci/egress-audit-lite.sh --help`                       |
-| `detect-changes.sh`                   | Detect repo diffs and set has_changes output                          | `./scripts/ci/detect-changes.sh --help`                          |
-| `detect-fork-pr.sh`                   | Detect fork PRs and set `is-fork` output for conditional steps        | `EVENT_NAME=pull_request ./scripts/ci/detect-fork-pr.sh`         |
-| `fail-on-security-audit.sh`           | Fail CI when security audit finds vulnerabilities                     | `./scripts/ci/fail-on-security-audit.sh`                         |
-| `free-disk-space.sh`                  | Free disk space on CI runner for Docker builds                        | `./scripts/ci/free-disk-space.sh`                                |
-| `security-comment.sh`                 | Run osv-scanner via lintro in Docker and generate security PR comment | `./scripts/ci/security-comment.sh --help`                        |
-| `classify-suppressions.py`            | Classify vulnerability suppressions as active, stale, or expired      | `osv-scanner ... \| python3 scripts/ci/classify-suppressions.py` |
-| `format-security-comment.py`          | Format lintro osv_scanner JSON as security PR comment markdown        | `python3 scripts/ci/format-security-comment.py osv-results.json` |
-| `check-vuln-suppressions.sh`          | Detect stale/expired vulnerability suppressions and open cleanup PR   | `./scripts/ci/check-vuln-suppressions.sh --help`                 |
-| `test-install-package.sh`             | Install and verify built package in isolated venv                     | `./scripts/ci/test-install-package.sh wheel`                     |
-| `test-built-package-integration.sh`   | Run integration tests for built package in isolated venv              | `./scripts/ci/test-built-package-integration.sh`                 |
-| `test-venv-setup.sh`                  | Create isolated Python 3.13 virtual environment                       | `./scripts/ci/test-venv-setup.sh`                                |
-| `test-verify-cli.sh`                  | Verify lintro CLI entry points in installed package                   | `./scripts/ci/test-verify-cli.sh`                                |
-| `test-verify-imports.sh`              | Verify critical package imports in installed lintro                   | `./scripts/ci/test-verify-imports.sh wheel`                      |
-| `extract-test-summary.sh`             | Extract pytest test summary to JSON for PR comments                   | `./scripts/ci/testing/extract-test-summary.sh <log> <out.json>`  |
-| `load-ci-docker-images.sh`            | Load Docker images from CI tarball artifact                           | `./scripts/ci/testing/load-ci-docker-images.sh`                  |
-| `pull-ci-docker-images.sh`            | Pull CI Docker images from GHCR for testing                           | `./scripts/ci/testing/pull-ci-docker-images.sh`                  |
-| `resolve-vue-tsc-version.sh`          | Read installed vue-tsc version from bun's global install root         | `./scripts/ci/resolve-vue-tsc-version.sh --help`                 |
-| `verify-manifest-tools.py`            | Verify tools in image match manifest versions                         | `python scripts/ci/verify-manifest-tools.py --help`              |
-| `generate-tool-versions.py`           | Generate `_generated_versions.py` and sync `manifest.json` versions   | `python scripts/ci/generate-tool-versions.py [--check]`          |
+| Script                                | Purpose                                                               | Usage                                                                              |
+| ------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `coverage-manager.sh`                 | Unified coverage ops (extract/badge/comment/threshold)                | `./scripts/utils/coverage-manager.sh --help`                                       |
+| `ci-log.sh`                           | Generic CI logging utility for workflow status messages               | `./scripts/ci/ci-log.sh <message>`                                                 |
+| `ci-post-pr-comment.sh`               | Post comments to PRs using GitHub API                                 | `./scripts/ci/ci-post-pr-comment.sh [file]`                                        |
+| `post-pr-delete-previous.sh`          | Delete previous PR comments by marker                                 | `./scripts/ci/post-pr-delete-previous.sh --help`                                   |
+| `lintro-report-generate.sh`           | Generate comprehensive Lintro reports                                 | `./scripts/ci/lintro-report-generate.sh`                                           |
+| `pull-lintro-image.sh`                | Pull lintro Docker image from GHCR and log digest                     | `./scripts/ci/testing/pull-lintro-image.sh`                                        |
+| `maintenance/delete-ci-ghcr-tags.sh`  | Delete ephemeral CI GHCR tags after PR merge or close                 | `./scripts/ci/maintenance/delete-ci-ghcr-tags.sh`                                  |
+| `maintenance/ghcr_prune_untagged.py`  | Prune untagged GHCR package versions (CLI entry shim)                 | `uv run python scripts/ci/maintenance/ghcr_prune_untagged.py`                      |
+| `maintenance/ghcr_prune/api.py`       | GhcrVersion list/delete/owner-type GitHub API helpers                 | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`                        |
+| `maintenance/ghcr_prune/cli.py`       | Entry-point and env-var handling for the prune CLI                    | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`                        |
+| `maintenance/ghcr_prune/dates.py`     | ISO-8601 parsing and `min_age_days` comparison                        | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`                        |
+| `maintenance/ghcr_prune/protocols.py` | `GhcrClient` HTTP protocol used by tests and prod                     | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`                        |
+| `maintenance/ghcr_prune/prune.py`     | `prune_package` and `prune_buildcache_package` per-package logic      | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`                        |
+| `maintenance/ghcr_prune/registry.py`  | OCI manifest + Referrers walk; SLSA / cosign protection set           | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`                        |
+| `maintenance/ghcr_prune/tags.py`      | Cache tag constants and ephemeral-tag detection                       | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`                        |
+| `maintenance/ghcr_prune/version.py`   | `GhcrVersion` dataclass                                               | imported by `scripts/ci/maintenance/ghcr_prune_untagged.py`                        |
+| `coverage-badge-update.sh`            | Generate and update coverage badge                                    | `./scripts/ci/coverage-badge-update.sh --help`                                     |
+| `sbom-generate.sh`                    | Generate and export SBOMs via bomctl                                  | `./scripts/ci/sbom-generate.sh --help`                                             |
+| `egress-audit-lite.sh`                | Audit reachability of allowed endpoints                               | `./scripts/ci/egress-audit-lite.sh --help`                                         |
+| `detect-changes.sh`                   | Detect repo diffs and set has_changes output                          | `./scripts/ci/detect-changes.sh --help`                                            |
+| `detect-fork-pr.sh`                   | Detect fork PRs and set `is-fork` output for conditional steps        | `EVENT_NAME=pull_request ./scripts/ci/detect-fork-pr.sh`                           |
+| `evaluate-test-gate.sh`               | Evaluate upstream compat/coverage results for required-check gate     | `COMPAT_RESULT=success COVERAGE_RESULT=success ./scripts/ci/evaluate-test-gate.sh` |
+| `fail-on-security-audit.sh`           | Fail CI when security audit finds vulnerabilities                     | `./scripts/ci/fail-on-security-audit.sh`                                           |
+| `free-disk-space.sh`                  | Free disk space on CI runner for Docker builds                        | `./scripts/ci/free-disk-space.sh`                                                  |
+| `security-comment.sh`                 | Run osv-scanner via lintro in Docker and generate security PR comment | `./scripts/ci/security-comment.sh --help`                                          |
+| `classify-suppressions.py`            | Classify vulnerability suppressions as active, stale, or expired      | `osv-scanner ... \| python3 scripts/ci/classify-suppressions.py`                   |
+| `format-security-comment.py`          | Format lintro osv_scanner JSON as security PR comment markdown        | `python3 scripts/ci/format-security-comment.py osv-results.json`                   |
+| `check-vuln-suppressions.sh`          | Detect stale/expired vulnerability suppressions and open cleanup PR   | `./scripts/ci/check-vuln-suppressions.sh --help`                                   |
+| `test-install-package.sh`             | Install and verify built package in isolated venv                     | `./scripts/ci/test-install-package.sh wheel`                                       |
+| `test-built-package-integration.sh`   | Run integration tests for built package in isolated venv              | `./scripts/ci/test-built-package-integration.sh`                                   |
+| `test-venv-setup.sh`                  | Create isolated Python 3.13 virtual environment                       | `./scripts/ci/test-venv-setup.sh`                                                  |
+| `test-verify-cli.sh`                  | Verify lintro CLI entry points in installed package                   | `./scripts/ci/test-verify-cli.sh`                                                  |
+| `test-verify-imports.sh`              | Verify critical package imports in installed lintro                   | `./scripts/ci/test-verify-imports.sh wheel`                                        |
+| `extract-test-summary.sh`             | Extract pytest test summary to JSON for PR comments                   | `./scripts/ci/testing/extract-test-summary.sh <log> <out.json>`                    |
+| `load-ci-docker-images.sh`            | Load Docker images from CI tarball artifact                           | `./scripts/ci/testing/load-ci-docker-images.sh`                                    |
+| `pull-ci-docker-images.sh`            | Pull CI Docker images from GHCR for testing                           | `./scripts/ci/testing/pull-ci-docker-images.sh`                                    |
+| `resolve-vue-tsc-version.sh`          | Read installed vue-tsc version from bun's global install root         | `./scripts/ci/resolve-vue-tsc-version.sh --help`                                   |
+| `verify-manifest-tools.py`            | Verify tools in image match manifest versions                         | `python scripts/ci/verify-manifest-tools.py --help`                                |
+| `generate-tool-versions.py`           | Generate `_generated_versions.py` and sync `manifest.json` versions   | `python scripts/ci/generate-tool-versions.py [--check]`                            |
 
 #### Homebrew Scripts (`ci/homebrew/`)
 

--- a/scripts/ci/evaluate-test-gate.sh
+++ b/scripts/ci/evaluate-test-gate.sh
@@ -10,6 +10,23 @@
 
 set -euo pipefail
 
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Evaluate upstream test job results for the required org-ruleset gate.
+
+Fails when any upstream job reports "failure" or "cancelled"; treats
+"skipped" (draft PRs) as acceptable.
+
+Usage:
+  COMPAT_RESULT=success COVERAGE_RESULT=success scripts/ci/evaluate-test-gate.sh
+
+Required environment variables:
+  COMPAT_RESULT   needs.test-compat.result
+  COVERAGE_RESULT needs.test-coverage.result
+EOF
+	exit 0
+fi
+
 : "${COMPAT_RESULT:?}"
 : "${COVERAGE_RESULT:?}"
 

--- a/scripts/ci/evaluate-test-gate.sh
+++ b/scripts/ci/evaluate-test-gate.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Evaluate upstream test job results for the required org-ruleset gate.
+# Fails when any upstream job reports "failure" or "cancelled"; treats
+# "skipped" (draft PRs) as acceptable.
+#
+# Required environment variables:
+#   COMPAT_RESULT  - needs.test-compat.result
+#   COVERAGE_RESULT - needs.test-coverage.result
+
+set -euo pipefail
+
+: "${COMPAT_RESULT:?}"
+: "${COVERAGE_RESULT:?}"
+
+echo "test-compat:  ${COMPAT_RESULT}"
+echo "test-coverage: ${COVERAGE_RESULT}"
+
+failed=()
+for job in "test-compat:${COMPAT_RESULT}" "test-coverage:${COVERAGE_RESULT}"; do
+	name="${job%%:*}"
+	result="${job##*:}"
+	if [[ "${result}" == "failure" || "${result}" == "cancelled" ]]; then
+		failed+=("${name} (${result})")
+	fi
+done
+
+if ((${#failed[@]} > 0)); then
+	printf '::error::Upstream test jobs failed: %s\n' "${failed[*]}"
+	exit 1
+fi
+
+echo "All upstream test jobs passed or were skipped"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(ci): bump lgtm-ci from v0.32.3 to v0.45.1
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Bump all lgtm-ci reusable workflow and composite action references from **v0.32.3** (`f469f4d5`) to **v0.45.1** (`96a42109`) across 16 workflow files. This aligns py-lintro with Rustume's current lgtm-ci pin and picks up 13 minor versions of upstream improvements, including the likely fix for the scorecard `results_file` failure on main.

No workflow logic, permissions, or secrets were changed — this is a pure SHA pin update.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #977
- Closes #978

## Details

**Files changed:** 16 workflow files + workflows README

All occurrences of the old SHA (`f469f4d5c187f0700ccec4c023152fb68ee3dc89`) replaced with the new SHA (`96a42109637efd4c019d176e0902e3be23295716`), including both `uses:` references and `tooling-ref:` input values. Version comments updated from `# v0.32.3` to `# v0.45.1`.

**Review:** Passed both Greptile (5/5 confidence, 0 comments) and CodeRabbit (0 findings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated pinned GitHub Actions reusable workflows/actions to **v0.45.1** across CI/CD, quality checks, security scanning, Docker build/publish, SBOM generation, and release/PR automation.
- **Tests**
  - Split CI into separate compatibility and coverage runs.
  - Added a CI “test gate” aggregator and rewired required checks and coverage publishing to use its results.
- **Dependencies**
  - Updated **astro** and **markdownlint-cli2** versions and refreshed tool/build override pins.
- **Security**
  - Updated the OSV scanner suppression to a new advisory.
- **Documentation**
  - Reformatted and regenerated the CI/CD scripts documentation table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bumps all lgtm-ci reusable workflow and composite action references from v0.32.3 to v0.45.2 across 16 workflow files, and restructures `test-ci.yml` to split the single test job into separate compatibility (multi-Python matrix) and coverage (single runtime) jobs behind a new `test-gate` aggregator. It also updates frontend dev-dependencies (`astro`, `markdownlint-cli2`, `vite`, `esbuild`) and removes a now-fixed OSV suppression.

- **lgtm-ci pin bump**: All `uses:` references and `tooling-ref:` inputs updated from SHA `f469f4d5` (v0.32.3) to `deb53fdb` (v0.45.2); no workflow logic, permissions, or secrets changed.
- **test-ci restructure**: New `test-compat` + `test-coverage` split with `evaluate-test-gate.sh` aggregating results into a single `test-gate` output consumed by the required-check gate; the gate script correctly exits non-zero on failure/cancelled and treats skipped as passing.
- **Dependency updates**: `astro` 6.1.10→6.4.8, `vite` 7→8, `esbuild` 0.27→0.28 with matching overrides; `smol-toml` OSV suppression removed as it is fixed in `markdownlint-cli2@0.22.1`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all workflow references are consistently updated to the same pinned SHA and the test-gate logic is correct.

Every workflow file uses the same new SHA (deb53fdb) with matching # v0.45.2 comments; no permissions, secrets, or business logic changed. The evaluate-test-gate.sh script properly propagates failure status. The only discrepancy is between the PR description text (which names a different SHA and version) and the actual code, which is a documentation issue rather than a code defect.

The PR description body documents SHA 96a42109 (v0.45.1) but the actual code pins deb53fdb (v0.45.2) — worth confirming the intended target before merge for audit clarity.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/test-ci.yml | Splits the single `test` job into `test-compat` (multi-Python matrix) and `test-coverage` (single runtime), adds a `test-gate` aggregator that runs `evaluate-test-gate.sh`, and rewires `test-suite-coverage` and `publish-coverage` to consume gate outputs. Logic is sound. |
| scripts/ci/evaluate-test-gate.sh | New script that reads COMPAT_RESULT/COVERAGE_RESULT env vars and exits non-zero when either job reports failure or cancelled; skipped is treated as passing. Logic is correct and well-guarded with `set -euo pipefail`. |
| .github/workflows/README.md | Updated SHA reference to `deb53fdb` (v0.45.2) in the README, which is consistent with all workflow files; however this contradicts the PR description body that documents SHA `96a42109` (v0.45.1). |
| .osv-scanner.toml | Removes the GHSA-v3rj-xjv7-4jmq (smol-toml 1.6.0) suppression; fix confirmed in bun.lock where markdownlint-cli2@0.22.1 now pins smol-toml 1.6.1. Correct cleanup. |
| package.json | Bumps astro 6.1.10→6.4.8, markdownlint-cli2 0.22.0→0.22.1, and adds overrides for esbuild ^0.28.1, js-yaml ^4.2.0, markdown-it ^14.2.0, vite ^8.0.16 to lock transitive deps at audited versions. |
| lintro/_generated_versions.py | Auto-generated file updated to reflect new astro (6.4.8) and markdownlint-cli2 (0.22.1) versions, in sync with package.json. |
| lintro/tools/manifest.json | Tool manifest versions updated to match new astro_check (6.4.8) and markdownlint (0.22.1) package versions. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[test-compat\nmulti-Python matrix\nno coverage] --> G
    B[test-coverage\nPython 3.14\nwith coverage] --> G
    G[test-gate\nevaluate-test-gate.sh\nif failure/cancelled → exit 1] --> H
    G --> I
    B --> I[publish-coverage\nmain branch only]
    H[test-suite-coverage\nreusable-required-check.yml\norg ruleset gate]
    style H fill:#f9f,stroke:#333
    style I fill:#bbf,stroke:#333
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[test-compat\nmulti-Python matrix\nno coverage] --> G
    B[test-coverage\nPython 3.14\nwith coverage] --> G
    G[test-gate\nevaluate-test-gate.sh\nif failure/cancelled → exit 1] --> H
    G --> I
    B --> I[publish-coverage\nmain branch only]
    H[test-suite-coverage\nreusable-required-check.yml\norg ruleset gate]
    style H fill:#f9f,stroke:#333
    style I fill:#bbf,stroke:#333
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2FREADME.md%3A4%0A**PR%20description%20documents%20a%20different%20SHA%20than%20what%20was%20actually%20pinned**%0A%0AThe%20PR%20description%20body%20explicitly%20states%20the%20new%20SHA%20is%20%6096a42109637efd4c019d176e0902e3be23295716%60%20%28v0.45.1%29%2C%20but%20every%20workflow%20file%20and%20the%20README%20use%20%60deb53fdb15a630cc60e6e5f35ecb9a8b58966690%60%20%28v0.45.2%29.%20The%20commit%20summary%20in%20the%20description%20also%20says%20%22v0.45.1%22%20while%20the%20PR%20title%20says%20%22v0.45.2%22.%20Anyone%20performing%20a%20security%20audit%20of%20this%20bump%20would%20be%20looking%20at%20the%20wrong%20SHA.%20Could%20you%20confirm%20%60deb53fdb%60%20is%20the%20intended%20pin%20and%20update%20the%20description%20accordingly%3F%0A%0A&pr=986&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2FREADME.md%3A4%0A**PR%20description%20documents%20a%20different%20SHA%20than%20what%20was%20actually%20pinned**%0A%0AThe%20PR%20description%20body%20explicitly%20states%20the%20new%20SHA%20is%20%6096a42109637efd4c019d176e0902e3be23295716%60%20%28v0.45.1%29%2C%20but%20every%20workflow%20file%20and%20the%20README%20use%20%60deb53fdb15a630cc60e6e5f35ecb9a8b58966690%60%20%28v0.45.2%29.%20The%20commit%20summary%20in%20the%20description%20also%20says%20%22v0.45.1%22%20while%20the%20PR%20title%20says%20%22v0.45.2%22.%20Anyone%20performing%20a%20security%20audit%20of%20this%20bump%20would%20be%20looking%20at%20the%20wrong%20SHA.%20Could%20you%20confirm%20%60deb53fdb%60%20is%20the%20intended%20pin%20and%20update%20the%20description%20accordingly%3F%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=986&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22chore%2F977-bump-lgtm-ci-v0.45.1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F977-bump-lgtm-ci-v0.45.1%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2FREADME.md%3A4%0A**PR%20description%20documents%20a%20different%20SHA%20than%20what%20was%20actually%20pinned**%0A%0AThe%20PR%20description%20body%20explicitly%20states%20the%20new%20SHA%20is%20%6096a42109637efd4c019d176e0902e3be23295716%60%20%28v0.45.1%29%2C%20but%20every%20workflow%20file%20and%20the%20README%20use%20%60deb53fdb15a630cc60e6e5f35ecb9a8b58966690%60%20%28v0.45.2%29.%20The%20commit%20summary%20in%20the%20description%20also%20says%20%22v0.45.1%22%20while%20the%20PR%20title%20says%20%22v0.45.2%22.%20Anyone%20performing%20a%20security%20audit%20of%20this%20bump%20would%20be%20looking%20at%20the%20wrong%20SHA.%20Could%20you%20confirm%20%60deb53fdb%60%20is%20the%20intended%20pin%20and%20update%20the%20description%20accordingly%3F%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=986&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (8): Last reviewed commit: ["chore(ci): bump lgtm-ci from v0.45.1 to ..."](https://github.com/lgtm-hq/py-lintro/commit/47dadff63731dcf02a2fe57f2fe9e57234842c1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38618933)</sub>

<!-- /greptile_comment -->