### PR TITLE
fix(ci): grant missing permissions for lgtm-ci v0.45.2 reusable workflows

### DIFF
--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -27,4 +27,6 @@ jobs:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
     permissions:
+      actions: read # report-release-failure reads workflow/job metadata
       contents: write
+      issues: write # report-release-failure opens deduplicated failure issues

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -29,5 +29,7 @@ jobs:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
     permissions:
+      actions: read # report-release-failure reads workflow/job metadata
       contents: write
+      issues: write # report-release-failure opens deduplicated failure issues
       pull-requests: write

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -24,6 +24,5 @@ jobs:
       egress-preset: github-tooling
     permissions:
       contents: read
-      # lgtm-ci reusable-semantic-pr-title → amannn/action-semantic-pull-request:
-      # read PR title/metadata only (read-only; satisfies least-privilege audits).
-      pull-requests: read
+      # post-failure-comment (default: true) upserts failure comments on the PR
+      pull-requests: write


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title: `fix(ci): grant missing permissions for lgtm-ci v0.45.2 reusable workflows`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

After merging the lgtm-ci v0.32.3 → v0.45.2 bump (#986), three workflows fail on
main due to missing caller permissions. The reusable workflows in lgtm-ci v0.45.x
added internal jobs that require permissions not previously granted:

- **release-version-pr.yml**: Add `actions: read` + `issues: write` for
  `report-release-failure` internal job
- **release-auto-tag.yml**: Same — add `actions: read` + `issues: write`
- **semantic-pr-title.yml**: Change `pull-requests: read` → `write` for
  `post-failure-comment` (default: true) which upserts failure comments on PRs

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (N/A — CI workflow permissions only)
- [ ] Docs updated if user-facing (N/A)
- [x] Local CI passed (actionlint + yamllint)

## Closes

- Closes #987

## Details

GitHub validates reusable workflow permissions at parse time, not runtime. Even if
an internal job's logic is gated by an input (e.g., `post-failure-comment: false`),
the permission declaration is still checked against the caller's grants. This causes
`startup_failure` with zero logs when insufficient permissions are provided.

Permission rationale matches Rustume's equivalent workflows (`auto-tag-on-main.yml`,
`semantic-release.yml`).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes three GitHub Actions caller workflows that were failing at startup after the lgtm-ci v0.32.3 → v0.45.2 bump, by granting the permissions required by newly introduced internal jobs in the reusable workflows.

- **`release-auto-tag.yml` / `release-version-pr.yml`**: Add `actions: read` (so the `report-release-failure` job can read workflow/job metadata) and `issues: write` (so it can open deduplicated failure issues).
- **`semantic-pr-title.yml`**: Promotes `pull-requests` from `read` to `write`, required by the `post-failure-comment` job (enabled by default) that upserts failure comments on PRs.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are minimal, well-scoped permission declarations with accurate inline comments matching the reusable workflow's requirements.

All three files receive exactly the permissions documented by lgtm-ci v0.45.2 for the internal jobs they add. The grants are least-privilege (read where read suffices, write only where the job explicitly needs to create or update a GitHub resource). The top-level permissions: {} default is preserved on each workflow, so no unintended escalation occurs. The pull-requests: write added to semantic-pr-title.yml is correctly scoped to the PR event and will be automatically downgraded by GitHub to read-only for fork-sourced pull requests, which is expected behavior.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-auto-tag.yml | Adds `actions: read` and `issues: write` for the `report-release-failure` internal job in the lgtm-ci v0.45.2 reusable workflow; no logic changes. |
| .github/workflows/release-version-pr.yml | Adds the same `actions: read` + `issues: write` pair as release-auto-tag.yml; existing `contents: write` and `pull-requests: write` are unchanged. |
| .github/workflows/semantic-pr-title.yml | Upgrades `pull-requests` from `read` to `write` to support the `post-failure-comment` feature (default: true) in the reusable workflow; old comment explaining read-only rationale is replaced with new one. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Callers["Caller Workflows (this repo)"]
        RAT[".github/workflows/release-auto-tag.yml\nactions: read\ncontents: write\nissues: write"]
        RVP[".github/workflows/release-version-pr.yml\nactions: read\ncontents: write\nissues: write\npull-requests: write"]
        SPT[".github/workflows/semantic-pr-title.yml\ncontents: read\npull-requests: write"]
    end

    subgraph Reusables["lgtm-ci Reusable Workflows @ v0.45.2"]
        RW1["reusable-release-auto-tag.yml"]
        RW2["reusable-release-version-pr.yml"]
        RW3["reusable-semantic-pr-title.yml"]
    end

    subgraph InternalJobs["Internal Jobs (v0.45.x new)"]
        RRF1["report-release-failure\n→ reads workflow metadata (actions: read)\n→ opens failure issues (issues: write)"]
        RRF2["report-release-failure\n→ reads workflow metadata (actions: read)\n→ opens failure issues (issues: write)"]
        PFC["post-failure-comment\n→ upserts PR comment (pull-requests: write)"]
    end

    RAT -->|calls| RW1
    RVP -->|calls| RW2
    SPT -->|calls| RW3

    RW1 --> RRF1
    RW2 --> RRF2
    RW3 --> PFC
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Callers["Caller Workflows (this repo)"]
        RAT[".github/workflows/release-auto-tag.yml\nactions: read\ncontents: write\nissues: write"]
        RVP[".github/workflows/release-version-pr.yml\nactions: read\ncontents: write\nissues: write\npull-requests: write"]
        SPT[".github/workflows/semantic-pr-title.yml\ncontents: read\npull-requests: write"]
    end

    subgraph Reusables["lgtm-ci Reusable Workflows @ v0.45.2"]
        RW1["reusable-release-auto-tag.yml"]
        RW2["reusable-release-version-pr.yml"]
        RW3["reusable-semantic-pr-title.yml"]
    end

    subgraph InternalJobs["Internal Jobs (v0.45.x new)"]
        RRF1["report-release-failure\n→ reads workflow metadata (actions: read)\n→ opens failure issues (issues: write)"]
        RRF2["report-release-failure\n→ reads workflow metadata (actions: read)\n→ opens failure issues (issues: write)"]
        PFC["post-failure-comment\n→ upserts PR comment (pull-requests: write)"]
    end

    RAT -->|calls| RW1
    RVP -->|calls| RW2
    SPT -->|calls| RW3

    RW1 --> RRF1
    RW2 --> RRF2
    RW3 --> PFC
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): grant missing permissions for l..."](https://github.com/lgtm-hq/py-lintro/commit/f642874bb1bc681670e2d038421e786c24724775) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38712858)</sub>

<!-- /greptile_comment -->