### PR TITLE
feat(ai/review): add review prompt templates

### DIFF
--- a/lintro/ai/prompts/__init__.py
+++ b/lintro/ai/prompts/__init__.py
@@ -11,6 +11,18 @@ from lintro.ai.prompts.fix import (
     REFINEMENT_PROMPT_TEMPLATE,
 )
 from lintro.ai.prompts.post_fix import POST_FIX_SUMMARY_PROMPT_TEMPLATE
+from lintro.ai.prompts.review import (
+    REVIEW_ADVERSARIAL_SWEEP_TEMPLATE,
+    REVIEW_GENERATE_QUESTIONS_TEMPLATE,
+    REVIEW_OUTPUT_SCHEMA,
+    REVIEW_SYSTEM,
+    REVIEW_USER_PROMPT_TEMPLATE,
+    format_changed_files_for_prompt,
+    format_checklist_table_for_prompt,
+    format_deferred_scope_section,
+    format_external_review_section,
+    format_lint_results_section,
+)
 from lintro.ai.prompts.summary import SUMMARY_PROMPT_TEMPLATE, SUMMARY_SYSTEM
 
 __all__ = [
@@ -19,6 +31,16 @@ __all__ = [
     "FIX_SYSTEM",
     "POST_FIX_SUMMARY_PROMPT_TEMPLATE",
     "REFINEMENT_PROMPT_TEMPLATE",
+    "REVIEW_ADVERSARIAL_SWEEP_TEMPLATE",
+    "REVIEW_GENERATE_QUESTIONS_TEMPLATE",
+    "REVIEW_OUTPUT_SCHEMA",
+    "REVIEW_SYSTEM",
+    "REVIEW_USER_PROMPT_TEMPLATE",
     "SUMMARY_PROMPT_TEMPLATE",
     "SUMMARY_SYSTEM",
+    "format_changed_files_for_prompt",
+    "format_checklist_table_for_prompt",
+    "format_deferred_scope_section",
+    "format_external_review_section",
+    "format_lint_results_section",
 ]

--- a/lintro/ai/prompts/review.py
+++ b/lintro/ai/prompts/review.py
@@ -232,9 +232,7 @@ def format_external_review_section(*, flags: list[str] | None) -> str:
     if not flags:
         return ""
     joined = ", ".join(flags)
-    return (
-        f"**External tools flagged:** {joined} — verify against current code."
-    )
+    return f"**External tools flagged:** {joined} — verify against current code."
 
 
 def format_lint_results_section(*, digest: str | None) -> str:

--- a/lintro/ai/prompts/review.py
+++ b/lintro/ai/prompts/review.py
@@ -1,0 +1,251 @@
+"""Prompt templates for AI diff-based code review."""
+
+from __future__ import annotations
+
+from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.checklist_item import ChecklistItem
+
+__all__ = [
+    "REVIEW_ADVERSARIAL_SWEEP_TEMPLATE",
+    "REVIEW_GENERATE_QUESTIONS_TEMPLATE",
+    "REVIEW_OUTPUT_SCHEMA",
+    "REVIEW_SYSTEM",
+    "REVIEW_USER_PROMPT_TEMPLATE",
+    "format_changed_files_for_prompt",
+    "format_checklist_table_for_prompt",
+    "format_deferred_scope_section",
+    "format_external_review_section",
+    "format_lint_results_section",
+]
+
+REVIEW_SYSTEM = """\
+You are a senior staff engineer performing a pre-merge code review. Your job is to find logic bugs, integration gaps, silent failure modes, and test contract weaknesses — the kinds of issues that pass linters and unit tests but fail in production.
+
+You review code diffs across languages and domains: shell scripts, GitHub Actions, Python, Rust, TypeScript/JavaScript, API contracts, middleware, tests, and documentation. You trace execution paths mentally: follow conditionals, default values, HTTP status codes, exit codes, and cross-file wiring (workflow inputs → env vars → script behavior → server routes → middleware → DB → client parsing → UI).
+
+**Review method (follow in order):**
+
+1. Read the diff and changed-file list.
+2. Trace every interaction path provided in the user prompt.
+3. Cross-check OpenAPI/docs against new routes, presets, and error shapes when applicable.
+4. Complete every checklist item — answer yes/no with file:line evidence.
+5. Report every checklist **yes** as a finding (merge related items that share a root cause).
+6. Scan for additional issues not covered by the checklist.
+7. Output JSON only.
+
+**Focus on:**
+
+1. **LOGIC BUGS** — wrong precedence, inverted conditions, off-by-one, wrong variable
+2. **SILENT FAILURES** — exit 0 / HTTP 200 when work was skipped or security checks should fail; fail-open when fail-closed is required
+3. **DEFAULT INTERACTIONS** — new defaults breaking callers; feature A blocking feature B; grace-period vs expired vs active
+4. **TIMESTAMP/DATA HANDLING** — empty strings, null coalescing order, sort key vs filter key mismatch (jq/shell/API fields)
+5. **CI INTEGRATION** — egress policies, permissions, env wiring, URL encoding for API paths, action SHA pinning
+6. **TEST GAPS** — incomplete migration tests; implicit setup() dependencies; visibility-only assertions; mock internals not behavior
+7. **DOC/CONTRACT DRIFT** — documented behavior ≠ implementation; docs claiming hosts/presets the code does not provide
+8. **DATA SEMANTICS** — jq coalescing (`//` vs `// empty`); empty timestamp comparisons; server prose errors vs client substring matching
+9. **CONTROL-FLOW ORDER** — what happens BEFORE early returns; can independent work proceed when an optional step fails?
+10. **SECURITY EXIT SEMANTICS** — trace security-sensitive branches to exit 0 vs exit 1 / HTTP 403 vs 200
+11. **TEST DEFAULTS vs PRODUCTION DEFAULTS** — compare test setup/fixture defaults to workflow/script/production defaults
+12. **BREAKING DEFAULT CHANGES** — intentional default changes without migration guidance or caller updates
+
+**Do NOT report:**
+
+- Style/formatting issues linters would catch
+- Missing docstrings unless they hide a behavioral contract
+- Deferred scope explicitly listed in the PR summary (if provided)
+- Suggestions to refactor unrelated code
+- Issues already fixed in later commits (review the final merged state)
+
+**Severity (fixed scale — not configurable):**
+
+- **P1:** Production bug, security bypass, or silent data loss — must fix before merge
+- **P2:** Incorrect edge-case behavior, contract drift, or incomplete test coverage
+- **P3:** Breaking default needing migration notes, UX wording, minor inaccuracy, or test isolation nit
+
+Respond ONLY with valid JSON. No markdown fences."""
+
+REVIEW_USER_PROMPT_TEMPLATE = """\
+Review this code change for actionable findings.
+
+**PR:** {pr_title}
+
+**Base → Head:** `{base_ref}`...`{head_ref}`
+
+**Summary:**
+
+{pr_summary}
+
+{deferred_scope_section}
+
+{external_review_section}
+
+**Changed files ({changed_file_count}):**
+
+{changed_files}
+
+---
+
+### Interaction paths (trace each explicitly)
+
+{interaction_paths}
+
+---
+
+### Mandatory checklist (complete all {checklist_count} before finalizing)
+
+Answer every item. Any **yes** → add a finding. Any **no** → record in `checklist` with brief evidence (file:line).
+
+{checklist}
+
+---
+
+<pull_request_diff>
+{diff}
+</pull_request_diff>
+
+{lint_results_section}
+
+---
+
+### Required JSON output
+
+{output_schema}
+
+**Rules:**
+
+- Include all **{checklist_count}** checklist entries in `checklist` (even if answer is "no").
+- Every checklist **yes** must have a corresponding finding (link via `checklist_ids`).
+- Do not duplicate findings — merge related checklist items when they share a root cause.
+- Prioritize cross-file integration bugs over isolated nits."""
+
+REVIEW_OUTPUT_SCHEMA = """\
+{
+  "summary": "2-3 sentence assessment (safe to merge / merge with fixes / needs rework)",
+  "checklist": [
+    {
+      "id": 1,
+      "answer": "yes|no",
+      "evidence": "One sentence — file:line or logic trace"
+    }
+  ],
+  "findings": [
+    {
+      "severity": "P1|P2|P3",
+      "category": "logic-bug|silent-failure|integration|test-gap|contract-drift|security|breaking-change",
+      "file": "path/to/file",
+      "line": 123,
+      "title": "Short title (5-8 words)",
+      "description": "What is wrong and why it matters in production",
+      "cause": "Root cause — trace the code path",
+      "fix": "Concise fix suggestion",
+      "confidence": "high|medium|low",
+      "checklist_ids": [1, 2]
+    }
+  ]
+}"""
+
+REVIEW_GENERATE_QUESTIONS_TEMPLATE = """\
+You are generating domain-specific review questions for a code diff.
+
+Read the diff and changed files. Generate 5-10 additional yes/no checklist questions tailored to THIS specific change.
+
+Output JSON only:
+{{"generated_questions": [{{"id": "G1", "question": "...", "rationale": "..."}}]}}
+
+Diff:
+{diff}
+Changed files:
+{changed_files}"""
+
+REVIEW_ADVERSARIAL_SWEEP_TEMPLATE = """\
+You previously reviewed this diff. Perform adversarial "what did I miss?" sweep.
+
+Prior findings (do not duplicate):
+{prior_findings_json}
+
+Diff:
+{diff}
+
+Output JSON: {{"findings": [...]}} — NEW findings only. Empty array if nothing new."""
+
+
+def format_checklist_table_for_prompt(*, items: list[ChecklistItem]) -> str:
+    """Format checklist items as a numbered markdown table.
+
+    Args:
+        items: Selected checklist items sorted by id.
+
+    Returns:
+        Markdown table with prompt row numbers and questions.
+    """
+    lines = [
+        "| # | Category | Question |",
+        "|---|----------|----------|",
+    ]
+    for prompt_id, item in enumerate(items, start=1):
+        lines.append(
+            f"| {prompt_id} | {item.category.value} | {item.question} |",
+        )
+    return "\n".join(lines)
+
+
+def format_changed_files_for_prompt(*, files: list[ChangedFile]) -> str:
+    """Format changed files as a bullet list with status.
+
+    Args:
+        files: Changed files from review context.
+
+    Returns:
+        Bullet list suitable for prompt injection.
+    """
+    if not files:
+        return "- (no changed files)"
+    return "\n".join(
+        f"- `{file.path}` ({file.status}, +{file.additions}/-{file.deletions})"
+        for file in files
+    )
+
+
+def format_deferred_scope_section(*, text: str | None) -> str:
+    """Format optional deferred scope block for the review prompt.
+
+    Args:
+        text: Deferred scope description from PR summary, if any.
+
+    Returns:
+        Markdown block or empty string when no deferred scope.
+    """
+    if not text or not text.strip():
+        return ""
+    return f"**Deferred:** {text.strip()}"
+
+
+def format_external_review_section(*, flags: list[str] | None) -> str:
+    """Format optional external review tool flags section.
+
+    Args:
+        flags: External tool flags to verify against current code.
+
+    Returns:
+        Markdown block or empty string when no flags provided.
+    """
+    if not flags:
+        return ""
+    joined = ", ".join(flags)
+    return (
+        f"**External tools flagged:** {joined} — verify against current code."
+    )
+
+
+def format_lint_results_section(*, digest: str | None) -> str:
+    """Format lint digest for prompt injection.
+
+    Args:
+        digest: Compact lint results digest, if any.
+
+    Returns:
+        XML-wrapped digest or empty string when no lint results.
+    """
+    if not digest or not digest.strip():
+        return ""
+    return f"<lint_results>\n{digest.strip()}\n</lint_results>"

--- a/lintro/ai/prompts/review.py
+++ b/lintro/ai/prompts/review.py
@@ -18,6 +18,9 @@ __all__ = [
     "format_lint_results_section",
 ]
 
+# Production prompt strings below are copied verbatim from the v3.1 spec.
+# ruff: noqa: E501
+
 REVIEW_SYSTEM = """\
 You are a senior staff engineer performing a pre-merge code review. Your job is to find logic bugs, integration gaps, silent failure modes, and test contract weaknesses — the kinds of issues that pass linters and unit tests but fail in production.
 

--- a/lintro/ai/prompts/review.py
+++ b/lintro/ai/prompts/review.py
@@ -185,9 +185,9 @@ def format_checklist_table_for_prompt(*, items: list[ChecklistItem]) -> str:
         "| # | Category | Question |",
         "|---|----------|----------|",
     ]
-    for prompt_id, item in enumerate(items, start=1):
+    for item in items:
         lines.append(
-            f"| {prompt_id} | {item.category.value} | {item.question} |",
+            f"| {item.id} | {item.category.value} | {item.question} |",
         )
     return "\n".join(lines)
 

--- a/lintro/ai/review/__init__.py
+++ b/lintro/ai/review/__init__.py
@@ -50,7 +50,12 @@ if TYPE_CHECKING:
     from lintro.ai.review.context import (
         split_unified_diff_by_file as split_unified_diff_by_file,
     )
-    from lintro.ai.review.pipeline import prepare_review_chunks as prepare_review_chunks
+    from lintro.ai.review.pipeline import (
+        prepare_review_chunks as prepare_review_chunks,
+    )
+    from lintro.ai.review.pipeline import (
+        prepare_review_user_prompt as prepare_review_user_prompt,
+    )
 
 _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "chunk_review_context": (
@@ -70,6 +75,10 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
         "parse_changed_files",
     ),
     "prepare_review_chunks": ("lintro.ai.review.pipeline", "prepare_review_chunks"),
+    "prepare_review_user_prompt": (
+        "lintro.ai.review.pipeline",
+        "prepare_review_user_prompt",
+    ),
     "resolve_default_base_branch": (
         "lintro.ai.review.context.collection",
         "resolve_default_base_branch",
@@ -106,6 +115,7 @@ __all__ = [
     "get_all_checklist_items",
     "parse_changed_files",
     "prepare_review_chunks",
+    "prepare_review_user_prompt",
     "resolve_default_base_branch",
     "select_checklist_items",
     "split_unified_diff_by_file",

--- a/lintro/ai/review/paths_registry.py
+++ b/lintro/ai/review/paths_registry.py
@@ -10,9 +10,7 @@ from lintro.ai.review.models.file_classification import FileClassification
 
 __all__ = ["generate_interaction_paths"]
 
-_PATH_BUILDERS: list[
-    tuple[frozenset[str], Callable[[list[str]], str]]
-] = [
+_PATH_BUILDERS: list[tuple[frozenset[str], Callable[[list[str]], str]]] = [
     (
         frozenset({FileDomain.CI.value, FileDomain.SHELL.value}),
         lambda files: (

--- a/lintro/ai/review/paths_registry.py
+++ b/lintro/ai/review/paths_registry.py
@@ -4,101 +4,128 @@ from __future__ import annotations
 
 from collections import Counter
 from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
 
 from lintro.ai.review.enums.file_domain import FileDomain
+from lintro.ai.review.file_language import languages_for_path
 from lintro.ai.review.models.file_classification import FileClassification
 
 __all__ = ["generate_interaction_paths"]
 
-_PATH_BUILDERS: list[tuple[frozenset[FileDomain], Callable[[list[str]], str]]] = [
-    (
-        frozenset({FileDomain.CI, FileDomain.SHELL}),
-        lambda files: (
+_MAX_PATHS = 7
+_REPETITIVE_THRESHOLD = 34
+
+
+@dataclass(frozen=True)
+class _PathSpec:
+    """Domain and optional language requirements for an interaction path."""
+
+    required_domains: frozenset[FileDomain]
+    required_languages: frozenset[str]
+    builder: Callable[[list[str]], str]
+    skip_when_domains: frozenset[FileDomain] = frozenset()
+
+
+_PATH_BUILDERS: list[_PathSpec] = [
+    _PathSpec(
+        required_domains=frozenset({FileDomain.CI, FileDomain.SHELL}),
+        required_languages=frozenset(),
+        builder=lambda files: (
             "**Path A — CI + shell:** Trace workflow inputs → env vars → "
             f"sourced script behavior → exit codes. Changed: {', '.join(files[:5])}"
         ),
     ),
-    (
-        frozenset({FileDomain.SHELL}),
-        lambda files: (
+    _PathSpec(
+        required_domains=frozenset({FileDomain.SHELL}),
+        required_languages=frozenset(),
+        skip_when_domains=frozenset({FileDomain.CI}),
+        builder=lambda files: (
             "**Path A — Shell exit semantics:** Trace exit codes for ALL branches "
             "where error/removal ID vars are non-empty. "
             f"Changed: {', '.join(files[:5])}"
         ),
     ),
-    (
-        frozenset({FileDomain.CI, FileDomain.DOCS}),
-        lambda files: (
+    _PathSpec(
+        required_domains=frozenset({FileDomain.CI, FileDomain.DOCS}),
+        required_languages=frozenset(),
+        builder=lambda files: (
             "**Path B — CI docs vs presets:** Cross-check workflow docs/presets vs "
             f"script defaults. Changed: {', '.join(files[:5])}"
         ),
     ),
-    (
-        frozenset({FileDomain.TEST}),
-        lambda files: (
+    _PathSpec(
+        required_domains=frozenset({FileDomain.TEST}),
+        required_languages=frozenset(),
+        builder=lambda files: (
             "**Path C — Test vs production defaults:** Compare test setup/fixture "
             f"defaults vs production/workflow defaults. Changed: {', '.join(files[:5])}"
         ),
     ),
-    (
-        frozenset({FileDomain.DOCS}),
-        lambda files: (
+    _PathSpec(
+        required_domains=frozenset({FileDomain.DOCS}),
+        required_languages=frozenset(),
+        builder=lambda files: (
             "**Path D — Docs vs code:** Cross-check documented behavior vs "
             f"implementation. Changed: {', '.join(files[:5])}"
         ),
     ),
-    (
-        frozenset({FileDomain.SECURITY}),
-        lambda files: (
+    _PathSpec(
+        required_domains=frozenset({FileDomain.SECURITY}),
+        required_languages=frozenset(),
+        builder=lambda files: (
             "**Path E — Security exit semantics:** Trace security-sensitive branches "
             f"to exit 0 vs exit 1 / HTTP 403 vs 200. Changed: {', '.join(files[:5])}"
         ),
     ),
-    (
-        frozenset({FileDomain.RUST, FileDomain.TYPESCRIPT}),
-        lambda files: (
+    _PathSpec(
+        required_domains=frozenset({FileDomain.SOURCE}),
+        required_languages=frozenset({"rust", "ts"}),
+        builder=lambda files: (
             "**Path F — Server ↔ client:** Trace server route → middleware → DB → "
             f"client API parse → UI component. Changed: {', '.join(files[:5])}"
         ),
     ),
-    (
-        frozenset({FileDomain.RUST, FileDomain.API}),
-        lambda files: (
+    _PathSpec(
+        required_domains=frozenset({FileDomain.SOURCE, FileDomain.API}),
+        required_languages=frozenset({"rust"}),
+        builder=lambda files: (
             "**Path G — OpenAPI vs routes:** Cross-check OpenAPI registration vs "
             f"route handlers vs error response shapes. Changed: {', '.join(files[:5])}"
         ),
     ),
-    (
-        frozenset({FileDomain.TYPESCRIPT, FileDomain.API}),
-        lambda files: (
+    _PathSpec(
+        required_domains=frozenset({FileDomain.SOURCE, FileDomain.API}),
+        required_languages=frozenset({"ts"}),
+        builder=lambda files: (
             "**Path H — Auth/API → UI:** Trace auth/API payload parsing → UI "
             f"copy/state; runtime validation vs casts. Changed: {', '.join(files[:5])}"
         ),
     ),
-    (
-        frozenset({FileDomain.PYTHON, FileDomain.TEST}),
-        lambda files: (
+    _PathSpec(
+        required_domains=frozenset({FileDomain.SOURCE, FileDomain.TEST}),
+        required_languages=frozenset(),
+        builder=lambda files: (
             "**Path I — Pytest vs production:** Compare pytest fixtures/defaults vs "
             f"production config defaults. Changed: {', '.join(files[:5])}"
         ),
     ),
-    (
-        frozenset({FileDomain.PYTHON, FileDomain.SECURITY}),
-        lambda files: (
+    _PathSpec(
+        required_domains=frozenset({FileDomain.SOURCE, FileDomain.SECURITY}),
+        required_languages=frozenset(),
+        builder=lambda files: (
             "**Path J — Auth guards:** Trace auth decorators/guards on all new/"
             f"changed routes. Changed: {', '.join(files[:5])}"
         ),
     ),
 ]
 
-_MAX_PATHS = 7
-_REPETITIVE_THRESHOLD = 34
-
 
 def generate_interaction_paths(
     *,
     classifications: list[FileClassification],
     changed_files: list[str],
+    repo_root: Path | str | None = None,
 ) -> str:
     """Generate domain-triggered interaction paths for the review prompt.
 
@@ -108,6 +135,7 @@ def generate_interaction_paths(
     Args:
         classifications: Domain classifications for changed files.
         changed_files: Repository-relative changed file paths.
+        repo_root: Optional repository root for extensionless script language tags.
 
     Returns:
         Formatted interaction path block for prompt injection.
@@ -116,25 +144,31 @@ def generate_interaction_paths(
         return "No interaction paths — no changed files."
 
     domain_set = _collect_domains(classifications=classifications)
+    language_set = _collect_languages(
+        classifications=classifications,
+        repo_root=repo_root,
+    )
     paths: list[str] = []
     used_labels: set[str] = set()
 
-    for required_domains, builder in _PATH_BUILDERS:
-        if not required_domains.issubset(domain_set):
-            continue
-        if (
-            required_domains == frozenset({FileDomain.SHELL})
-            and FileDomain.CI in domain_set
+    for spec in _PATH_BUILDERS:
+        if not _spec_matches(
+            spec=spec,
+            domain_set=domain_set,
+            language_set=language_set,
         ):
             continue
-        matching_files = _files_for_domains(
+        if spec.skip_when_domains.intersection(domain_set):
+            continue
+        matching_files = _files_for_spec(
             classifications=classifications,
-            domains=required_domains,
+            spec=spec,
             changed_files=changed_files,
+            repo_root=repo_root,
         )
         if not matching_files:
             matching_files = changed_files
-        path_text = builder(matching_files)
+        path_text = spec.builder(matching_files)
         label = path_text.split(":", maxsplit=1)[0]
         if label in used_labels:
             continue
@@ -160,6 +194,20 @@ def generate_interaction_paths(
     return "\n\n".join(paths)
 
 
+def _spec_matches(
+    *,
+    spec: _PathSpec,
+    domain_set: set[FileDomain],
+    language_set: set[str],
+) -> bool:
+    """Return True when a path spec matches the diff domains and languages."""
+    if not spec.required_domains.issubset(domain_set):
+        return False
+    if not spec.required_languages:
+        return True
+    return spec.required_languages.issubset(language_set)
+
+
 def _collect_domains(*, classifications: list[FileClassification]) -> set[FileDomain]:
     """Collect unique domain labels from classifications."""
     domains: set[FileDomain] = set()
@@ -168,21 +216,42 @@ def _collect_domains(*, classifications: list[FileClassification]) -> set[FileDo
     return domains
 
 
-def _files_for_domains(
+def _collect_languages(
     *,
     classifications: list[FileClassification],
-    domains: frozenset[FileDomain],
+    repo_root: Path | str | None,
+) -> set[str]:
+    """Collect unique identify language tags from classified paths."""
+    languages: set[str] = set()
+    for classification in classifications:
+        languages |= languages_for_path(
+            path=classification.path,
+            repo_root=repo_root,
+        )
+    return languages
+
+
+def _files_for_spec(
+    *,
+    classifications: list[FileClassification],
+    spec: _PathSpec,
     changed_files: list[str],
+    repo_root: Path | str | None,
 ) -> list[str]:
-    """Return changed files whose classification includes any required domain."""
+    """Return changed files matching a path spec's domain and language axes."""
     classification_map = {item.path: item for item in classifications}
     matched: list[str] = []
     for path in changed_files:
         classification = classification_map.get(path)
         if classification is None:
             continue
-        if domains.intersection(classification.domains):
-            matched.append(path)
+        if not spec.required_domains.intersection(classification.domains):
+            continue
+        if spec.required_languages:
+            path_languages = languages_for_path(path=path, repo_root=repo_root)
+            if not spec.required_languages.intersection(path_languages):
+                continue
+        matched.append(path)
     return matched
 
 

--- a/lintro/ai/review/paths_registry.py
+++ b/lintro/ai/review/paths_registry.py
@@ -1,0 +1,219 @@
+"""Interaction path generation for AI diff review prompts."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable
+
+from lintro.ai.review.enums.file_domain import FileDomain
+from lintro.ai.review.models.file_classification import FileClassification
+
+__all__ = ["generate_interaction_paths"]
+
+_PATH_BUILDERS: list[
+    tuple[frozenset[str], Callable[[list[str]], str]]
+] = [
+    (
+        frozenset({FileDomain.CI.value, FileDomain.SHELL.value}),
+        lambda files: (
+            "**Path A — CI + shell:** Trace workflow inputs → env vars → "
+            f"sourced script behavior → exit codes. Changed: {', '.join(files[:5])}"
+        ),
+    ),
+    (
+        frozenset({FileDomain.SHELL.value}),
+        lambda files: (
+            "**Path A — Shell exit semantics:** Trace exit codes for ALL branches "
+            f"where error/removal ID vars are non-empty. Changed: {', '.join(files[:5])}"
+        ),
+    ),
+    (
+        frozenset({FileDomain.CI.value, FileDomain.DOCS.value}),
+        lambda files: (
+            "**Path B — CI docs vs presets:** Cross-check workflow docs/presets vs "
+            f"script defaults. Changed: {', '.join(files[:5])}"
+        ),
+    ),
+    (
+        frozenset({FileDomain.TEST.value}),
+        lambda files: (
+            "**Path C — Test vs production defaults:** Compare test setup/fixture "
+            f"defaults vs production/workflow defaults. Changed: {', '.join(files[:5])}"
+        ),
+    ),
+    (
+        frozenset({FileDomain.DOCS.value}),
+        lambda files: (
+            "**Path D — Docs vs code:** Cross-check documented behavior vs "
+            f"implementation. Changed: {', '.join(files[:5])}"
+        ),
+    ),
+    (
+        frozenset({FileDomain.SECURITY.value}),
+        lambda files: (
+            "**Path E — Security exit semantics:** Trace security-sensitive branches "
+            f"to exit 0 vs exit 1 / HTTP 403 vs 200. Changed: {', '.join(files[:5])}"
+        ),
+    ),
+    (
+        frozenset({FileDomain.RUST.value, FileDomain.TYPESCRIPT.value}),
+        lambda files: (
+            "**Path F — Server ↔ client:** Trace server route → middleware → DB → "
+            f"client API parse → UI component. Changed: {', '.join(files[:5])}"
+        ),
+    ),
+    (
+        frozenset({FileDomain.RUST.value, FileDomain.API.value}),
+        lambda files: (
+            "**Path G — OpenAPI vs routes:** Cross-check OpenAPI registration vs "
+            f"route handlers vs error response shapes. Changed: {', '.join(files[:5])}"
+        ),
+    ),
+    (
+        frozenset({FileDomain.TYPESCRIPT.value, FileDomain.API.value}),
+        lambda files: (
+            "**Path H — Auth/API → UI:** Trace auth/API payload parsing → UI "
+            f"copy/state; runtime validation vs casts. Changed: {', '.join(files[:5])}"
+        ),
+    ),
+    (
+        frozenset({FileDomain.PYTHON.value, FileDomain.TEST.value}),
+        lambda files: (
+            "**Path I — Pytest vs production:** Compare pytest fixtures/defaults vs "
+            f"production config defaults. Changed: {', '.join(files[:5])}"
+        ),
+    ),
+    (
+        frozenset({FileDomain.PYTHON.value, FileDomain.SECURITY.value}),
+        lambda files: (
+            "**Path J — Auth guards:** Trace auth decorators/guards on all new/"
+            f"changed routes. Changed: {', '.join(files[:5])}"
+        ),
+    ),
+]
+
+_MAX_PATHS = 7
+_REPETITIVE_THRESHOLD = 34
+
+
+def generate_interaction_paths(
+    *,
+    classifications: list[FileClassification],
+    changed_files: list[str],
+) -> str:
+    """Generate domain-triggered interaction paths for the review prompt.
+
+    Selects up to seven path templates matching detected file domains and
+    emits explicit trace instructions referencing changed file names.
+
+    Args:
+        classifications: Domain classifications for changed files.
+        changed_files: Repository-relative changed file paths.
+
+    Returns:
+        Formatted interaction path block for prompt injection.
+    """
+    if not changed_files:
+        return "No interaction paths — no changed files."
+
+    domain_set = _collect_domains(classifications=classifications)
+    paths: list[str] = []
+    used_labels: set[str] = set()
+
+    for required_domains, builder in _PATH_BUILDERS:
+        if not required_domains.issubset(domain_set):
+            continue
+        matching_files = _files_for_domains(
+            classifications=classifications,
+            domains=required_domains,
+            changed_files=changed_files,
+        )
+        if not matching_files:
+            matching_files = changed_files
+        path_text = builder(matching_files)
+        label = path_text.split(":", maxsplit=1)[0]
+        if label in used_labels:
+            continue
+        used_labels.add(label)
+        paths.append(path_text)
+        if len(paths) >= _MAX_PATHS:
+            break
+
+    repetitive_note = _repetitive_bulk_path(
+        changed_files=changed_files,
+        classifications=classifications,
+    )
+    if repetitive_note and len(paths) < _MAX_PATHS:
+        paths.append(repetitive_note)
+
+    if not paths:
+        sample = ", ".join(changed_files[:5])
+        paths.append(
+            f"**Path A — General integration:** Trace cross-file wiring for "
+            f"changed files: {sample}",
+        )
+
+    return "\n\n".join(paths)
+
+
+def _collect_domains(*, classifications: list[FileClassification]) -> set[str]:
+    """Collect unique domain labels from classifications."""
+    domains: set[str] = set()
+    for classification in classifications:
+        domains.update(classification.domains)
+    return domains
+
+
+def _files_for_domains(
+    *,
+    classifications: list[FileClassification],
+    domains: frozenset[str],
+    changed_files: list[str],
+) -> list[str]:
+    """Return changed files whose classification includes any required domain."""
+    classification_map = {item.path: item for item in classifications}
+    matched: list[str] = []
+    for path in changed_files:
+        classification = classification_map.get(path)
+        if classification is None:
+            continue
+        if domains.intersection(classification.domains):
+            matched.append(path)
+    return matched
+
+
+def _repetitive_bulk_path(
+    *,
+    changed_files: list[str],
+    classifications: list[FileClassification],
+) -> str | None:
+    """Emit a sampling path when many identical-pattern files changed."""
+    if len(changed_files) < _REPETITIVE_THRESHOLD:
+        return None
+
+    domain_counts = Counter(
+        domain
+        for classification in classifications
+        for domain in classification.domains
+        if domain not in {FileDomain.TEST.value, FileDomain.DOCS.value}
+    )
+    if not domain_counts:
+        return None
+
+    dominant_domain = domain_counts.most_common(1)[0][0]
+    domain_files = [
+        path
+        for path in changed_files
+        if any(
+            dominant_domain in classification.domains
+            for classification in classifications
+            if classification.path == path
+        )
+    ]
+    sample = domain_files[:3] if domain_files else changed_files[:3]
+    sample_text = ", ".join(f"`{path}`" for path in sample)
+    return (
+        f"**Path — Bulk repetitive changes:** {len(changed_files)} files with "
+        f"similar {dominant_domain} patterns — sample {sample_text} and verify "
+        "the pattern holds across all instances."
+    )

--- a/lintro/ai/review/paths_registry.py
+++ b/lintro/ai/review/paths_registry.py
@@ -274,14 +274,12 @@ def _repetitive_bulk_path(
         return None
 
     dominant_domain = domain_counts.most_common(1)[0][0]
+    classification_map = {item.path: item for item in classifications}
     domain_files = [
         path
         for path in changed_files
-        if any(
-            dominant_domain in classification.domains
-            for classification in classifications
-            if classification.path == path
-        )
+        if (classification := classification_map.get(path)) is not None
+        and dominant_domain in classification.domains
     ]
     sample = domain_files[:3] if domain_files else changed_files[:3]
     sample_text = ", ".join(f"`{path}`" for path in sample)

--- a/lintro/ai/review/paths_registry.py
+++ b/lintro/ai/review/paths_registry.py
@@ -122,6 +122,11 @@ def generate_interaction_paths(
     for required_domains, builder in _PATH_BUILDERS:
         if not required_domains.issubset(domain_set):
             continue
+        if (
+            required_domains == frozenset({FileDomain.SHELL.value})
+            and FileDomain.CI.value in domain_set
+        ):
+            continue
         matching_files = _files_for_domains(
             classifications=classifications,
             domains=required_domains,

--- a/lintro/ai/review/paths_registry.py
+++ b/lintro/ai/review/paths_registry.py
@@ -22,7 +22,8 @@ _PATH_BUILDERS: list[tuple[frozenset[str], Callable[[list[str]], str]]] = [
         frozenset({FileDomain.SHELL.value}),
         lambda files: (
             "**Path A — Shell exit semantics:** Trace exit codes for ALL branches "
-            f"where error/removal ID vars are non-empty. Changed: {', '.join(files[:5])}"
+            "where error/removal ID vars are non-empty. "
+            f"Changed: {', '.join(files[:5])}"
         ),
     ),
     (

--- a/lintro/ai/review/paths_registry.py
+++ b/lintro/ai/review/paths_registry.py
@@ -10,16 +10,16 @@ from lintro.ai.review.models.file_classification import FileClassification
 
 __all__ = ["generate_interaction_paths"]
 
-_PATH_BUILDERS: list[tuple[frozenset[str], Callable[[list[str]], str]]] = [
+_PATH_BUILDERS: list[tuple[frozenset[FileDomain], Callable[[list[str]], str]]] = [
     (
-        frozenset({FileDomain.CI.value, FileDomain.SHELL.value}),
+        frozenset({FileDomain.CI, FileDomain.SHELL}),
         lambda files: (
             "**Path A — CI + shell:** Trace workflow inputs → env vars → "
             f"sourced script behavior → exit codes. Changed: {', '.join(files[:5])}"
         ),
     ),
     (
-        frozenset({FileDomain.SHELL.value}),
+        frozenset({FileDomain.SHELL}),
         lambda files: (
             "**Path A — Shell exit semantics:** Trace exit codes for ALL branches "
             "where error/removal ID vars are non-empty. "
@@ -27,63 +27,63 @@ _PATH_BUILDERS: list[tuple[frozenset[str], Callable[[list[str]], str]]] = [
         ),
     ),
     (
-        frozenset({FileDomain.CI.value, FileDomain.DOCS.value}),
+        frozenset({FileDomain.CI, FileDomain.DOCS}),
         lambda files: (
             "**Path B — CI docs vs presets:** Cross-check workflow docs/presets vs "
             f"script defaults. Changed: {', '.join(files[:5])}"
         ),
     ),
     (
-        frozenset({FileDomain.TEST.value}),
+        frozenset({FileDomain.TEST}),
         lambda files: (
             "**Path C — Test vs production defaults:** Compare test setup/fixture "
             f"defaults vs production/workflow defaults. Changed: {', '.join(files[:5])}"
         ),
     ),
     (
-        frozenset({FileDomain.DOCS.value}),
+        frozenset({FileDomain.DOCS}),
         lambda files: (
             "**Path D — Docs vs code:** Cross-check documented behavior vs "
             f"implementation. Changed: {', '.join(files[:5])}"
         ),
     ),
     (
-        frozenset({FileDomain.SECURITY.value}),
+        frozenset({FileDomain.SECURITY}),
         lambda files: (
             "**Path E — Security exit semantics:** Trace security-sensitive branches "
             f"to exit 0 vs exit 1 / HTTP 403 vs 200. Changed: {', '.join(files[:5])}"
         ),
     ),
     (
-        frozenset({FileDomain.RUST.value, FileDomain.TYPESCRIPT.value}),
+        frozenset({FileDomain.RUST, FileDomain.TYPESCRIPT}),
         lambda files: (
             "**Path F — Server ↔ client:** Trace server route → middleware → DB → "
             f"client API parse → UI component. Changed: {', '.join(files[:5])}"
         ),
     ),
     (
-        frozenset({FileDomain.RUST.value, FileDomain.API.value}),
+        frozenset({FileDomain.RUST, FileDomain.API}),
         lambda files: (
             "**Path G — OpenAPI vs routes:** Cross-check OpenAPI registration vs "
             f"route handlers vs error response shapes. Changed: {', '.join(files[:5])}"
         ),
     ),
     (
-        frozenset({FileDomain.TYPESCRIPT.value, FileDomain.API.value}),
+        frozenset({FileDomain.TYPESCRIPT, FileDomain.API}),
         lambda files: (
             "**Path H — Auth/API → UI:** Trace auth/API payload parsing → UI "
             f"copy/state; runtime validation vs casts. Changed: {', '.join(files[:5])}"
         ),
     ),
     (
-        frozenset({FileDomain.PYTHON.value, FileDomain.TEST.value}),
+        frozenset({FileDomain.PYTHON, FileDomain.TEST}),
         lambda files: (
             "**Path I — Pytest vs production:** Compare pytest fixtures/defaults vs "
             f"production config defaults. Changed: {', '.join(files[:5])}"
         ),
     ),
     (
-        frozenset({FileDomain.PYTHON.value, FileDomain.SECURITY.value}),
+        frozenset({FileDomain.PYTHON, FileDomain.SECURITY}),
         lambda files: (
             "**Path J — Auth guards:** Trace auth decorators/guards on all new/"
             f"changed routes. Changed: {', '.join(files[:5])}"
@@ -123,8 +123,8 @@ def generate_interaction_paths(
         if not required_domains.issubset(domain_set):
             continue
         if (
-            required_domains == frozenset({FileDomain.SHELL.value})
-            and FileDomain.CI.value in domain_set
+            required_domains == frozenset({FileDomain.SHELL})
+            and FileDomain.CI in domain_set
         ):
             continue
         matching_files = _files_for_domains(
@@ -160,9 +160,9 @@ def generate_interaction_paths(
     return "\n\n".join(paths)
 
 
-def _collect_domains(*, classifications: list[FileClassification]) -> set[str]:
+def _collect_domains(*, classifications: list[FileClassification]) -> set[FileDomain]:
     """Collect unique domain labels from classifications."""
-    domains: set[str] = set()
+    domains: set[FileDomain] = set()
     for classification in classifications:
         domains.update(classification.domains)
     return domains
@@ -171,7 +171,7 @@ def _collect_domains(*, classifications: list[FileClassification]) -> set[str]:
 def _files_for_domains(
     *,
     classifications: list[FileClassification],
-    domains: frozenset[str],
+    domains: frozenset[FileDomain],
     changed_files: list[str],
 ) -> list[str]:
     """Return changed files whose classification includes any required domain."""
@@ -199,7 +199,7 @@ def _repetitive_bulk_path(
         domain
         for classification in classifications
         for domain in classification.domains
-        if domain not in {FileDomain.TEST.value, FileDomain.DOCS.value}
+        if domain not in {FileDomain.TEST, FileDomain.DOCS}
     )
     if not domain_counts:
         return None
@@ -218,6 +218,6 @@ def _repetitive_bulk_path(
     sample_text = ", ".join(f"`{path}`" for path in sample)
     return (
         f"**Path — Bulk repetitive changes:** {len(changed_files)} files with "
-        f"similar {dominant_domain} patterns — sample {sample_text} and verify "
+        f"similar {dominant_domain.value} patterns — sample {sample_text} and verify "
         "the pattern holds across all instances."
     )

--- a/lintro/ai/review/pipeline.py
+++ b/lintro/ai/review/pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from lintro.ai.review import prompt_builder
 from lintro.ai.review.chunker import chunk_review_context
 from lintro.ai.review.classifier import classify_changed_files
 from lintro.ai.review.context import validate_review_context_diff
@@ -11,7 +12,6 @@ from lintro.ai.review.models.checklist_item import ChecklistItem
 from lintro.ai.review.models.chunking_result import ChunkingResult
 from lintro.ai.review.models.file_classification import FileClassification
 from lintro.ai.review.models.review_context import ReviewContext
-from lintro.ai.review.prompt_builder import build_review_user_prompt
 
 __all__ = [
     "prepare_review_chunks",
@@ -73,7 +73,7 @@ def prepare_review_user_prompt(
     """
     validate_review_context_diff(context=context)
     classifications = classify_changed_files(files=context.changed_files)
-    prompt, prompt_mapping = build_review_user_prompt(
+    prompt, prompt_mapping = prompt_builder.build_review_user_prompt(
         context=context,
         classifications=classifications,
         checklist_items=checklist_items,

--- a/lintro/ai/review/pipeline.py
+++ b/lintro/ai/review/pipeline.py
@@ -2,11 +2,21 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from lintro.ai.review.chunker import chunk_review_context
 from lintro.ai.review.classifier import classify_changed_files
 from lintro.ai.review.context import validate_review_context_diff
+from lintro.ai.review.models.checklist_item import ChecklistItem
 from lintro.ai.review.models.chunking_result import ChunkingResult
+from lintro.ai.review.models.file_classification import FileClassification
 from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.prompt_builder import build_review_user_prompt
+
+__all__ = [
+    "prepare_review_chunks",
+    "prepare_review_user_prompt",
+]
 
 
 def prepare_review_chunks(
@@ -35,3 +45,42 @@ def prepare_review_chunks(
         classifications=classifications,
         allow_omitted_files=allow_omitted_files,
     )
+
+
+def prepare_review_user_prompt(
+    *,
+    context: ReviewContext,
+    checklist_items: list[ChecklistItem],
+    diff: str | None = None,
+    lint_digest: str | None = None,
+    deferred_scope: str | None = None,
+    external_flags: list[str] | None = None,
+    repo_root: Path | str | None = None,
+) -> tuple[str, list[FileClassification], dict[int, int]]:
+    """Classify changed files and build the review user prompt.
+
+    Args:
+        context: Collected review diff context.
+        checklist_items: Selected checklist items for this review.
+        diff: Unified diff text to embed. Defaults to ``context.unified_diff``.
+        lint_digest: Optional compact lint digest from ``--with-lint``.
+        deferred_scope: Optional deferred-scope note from the PR summary.
+        external_flags: Optional external review tool flags to verify.
+        repo_root: Optional repository root for language tagging.
+
+    Returns:
+        Tuple of rendered prompt, file classifications, and prompt-id mapping.
+    """
+    validate_review_context_diff(context=context)
+    classifications = classify_changed_files(files=context.changed_files)
+    prompt, prompt_mapping = build_review_user_prompt(
+        context=context,
+        classifications=classifications,
+        checklist_items=checklist_items,
+        diff=diff,
+        lint_digest=lint_digest,
+        deferred_scope=deferred_scope,
+        external_flags=external_flags,
+        repo_root=repo_root,
+    )
+    return prompt, classifications, prompt_mapping

--- a/lintro/ai/review/prompt_builder.py
+++ b/lintro/ai/review/prompt_builder.py
@@ -1,0 +1,81 @@
+"""Review user prompt construction for AI diff review."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lintro.ai.prompts.review import (
+    REVIEW_OUTPUT_SCHEMA,
+    REVIEW_USER_PROMPT_TEMPLATE,
+    format_changed_files_for_prompt,
+    format_deferred_scope_section,
+    format_external_review_section,
+    format_lint_results_section,
+)
+from lintro.ai.review.checklist_selector import format_checklist_for_prompt
+from lintro.ai.review.models.checklist_item import ChecklistItem
+from lintro.ai.review.models.file_classification import FileClassification
+from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.paths_registry import generate_interaction_paths
+
+__all__ = ["build_review_user_prompt"]
+
+
+def build_review_user_prompt(
+    *,
+    context: ReviewContext,
+    classifications: list[FileClassification],
+    checklist_items: list[ChecklistItem],
+    diff: str | None = None,
+    lint_digest: str | None = None,
+    deferred_scope: str | None = None,
+    external_flags: list[str] | None = None,
+    repo_root: Path | str | None = None,
+) -> tuple[str, dict[int, int]]:
+    """Build the review user prompt with interaction paths and checklist.
+
+    Args:
+        context: Collected review diff context.
+        classifications: Per-file domain classifications for changed files.
+        checklist_items: Selected checklist items for this review.
+        diff: Unified diff text to embed. Defaults to ``context.unified_diff``.
+        lint_digest: Optional compact lint digest from ``--with-lint``.
+        deferred_scope: Optional deferred-scope note from the PR summary.
+        external_flags: Optional external review tool flags to verify.
+        repo_root: Optional repository root for language tagging.
+
+    Returns:
+        Tuple of rendered user prompt and prompt-id to checklist-id mapping.
+    """
+    changed_paths = [file.path for file in context.changed_files]
+    interaction_paths = generate_interaction_paths(
+        classifications=classifications,
+        changed_files=changed_paths,
+        repo_root=repo_root,
+    )
+    checklist_text, prompt_mapping = format_checklist_for_prompt(
+        items=checklist_items,
+    )
+    pr_title = (
+        context.pr_metadata.title
+        if context.pr_metadata is not None
+        else f"{context.base_ref}...{context.head_ref}"
+    )
+    pr_summary = context.pr_metadata.body if context.pr_metadata is not None else ""
+    prompt = REVIEW_USER_PROMPT_TEMPLATE.format(
+        pr_title=pr_title,
+        base_ref=context.base_ref,
+        head_ref=context.head_ref,
+        pr_summary=pr_summary,
+        deferred_scope_section=format_deferred_scope_section(text=deferred_scope),
+        external_review_section=format_external_review_section(flags=external_flags),
+        changed_file_count=len(context.changed_files),
+        changed_files=format_changed_files_for_prompt(files=context.changed_files),
+        interaction_paths=interaction_paths,
+        checklist_count=len(checklist_items),
+        checklist=checklist_text,
+        diff=diff if diff is not None else context.unified_diff,
+        lint_results_section=format_lint_results_section(digest=lint_digest),
+        output_schema=REVIEW_OUTPUT_SCHEMA,
+    )
+    return prompt, prompt_mapping

--- a/tests/unit/ai/prompts/test_review_prompts.py
+++ b/tests/unit/ai/prompts/test_review_prompts.py
@@ -1,0 +1,119 @@
+"""Tests for review prompt templates."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.ai.prompts.review import (
+    REVIEW_ADVERSARIAL_SWEEP_TEMPLATE,
+    REVIEW_GENERATE_QUESTIONS_TEMPLATE,
+    REVIEW_OUTPUT_SCHEMA,
+    REVIEW_SYSTEM,
+    REVIEW_USER_PROMPT_TEMPLATE,
+    format_changed_files_for_prompt,
+    format_checklist_table_for_prompt,
+    format_deferred_scope_section,
+    format_external_review_section,
+    format_lint_results_section,
+)
+from lintro.ai.review.enums.review_category import ReviewCategory
+from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.checklist_item import ChecklistItem
+
+
+def test_review_user_prompt_template_renders_all_placeholders() -> None:
+    """User prompt template renders without KeyError for all placeholders."""
+    rendered = REVIEW_USER_PROMPT_TEMPLATE.format(
+        pr_title="Test PR",
+        base_ref="main",
+        head_ref="feature",
+        pr_summary="Summary text",
+        deferred_scope_section="",
+        external_review_section="",
+        changed_file_count=1,
+        changed_files="- `src/main.py` (modified, +1/-0)",
+        interaction_paths="**Path A:** trace wiring",
+        checklist_count=1,
+        checklist="1. [logic-bug] Example question?",
+        diff="diff --git a/src/main.py",
+        lint_results_section="",
+        output_schema=REVIEW_OUTPUT_SCHEMA,
+    )
+
+    assert_that(rendered).contains("Test PR")
+    assert_that(rendered).contains("main")
+    assert_that(rendered).contains("feature")
+
+
+def test_format_checklist_table_for_prompt_produces_markdown_table() -> None:
+    """Checklist table formatter produces valid markdown table headers."""
+    items = [
+        ChecklistItem(
+            id=1,
+            question="Does any early return skip required cleanup?",
+            triggers=[],
+            category=ReviewCategory.LOGIC_BUG,
+            tier=1,
+        ),
+    ]
+    table = format_checklist_table_for_prompt(items=items)
+
+    assert_that(table).contains("| # | Category | Question |")
+    assert_that(table).contains("| 1 | logic-bug |")
+
+
+def test_format_changed_files_for_prompt_lists_files_with_status() -> None:
+    """Changed files formatter includes path and status."""
+    files = [
+        ChangedFile(
+            path="src/main.py",
+            status="modified",
+            additions=3,
+            deletions=1,
+        ),
+    ]
+    rendered = format_changed_files_for_prompt(files=files)
+
+    assert_that(rendered).contains("src/main.py")
+    assert_that(rendered).contains("modified")
+
+
+def test_format_lint_results_section_empty_when_no_digest() -> None:
+    """Empty lint digest renders as empty string."""
+    assert_that(format_lint_results_section(digest=None)).is_empty()
+    assert_that(format_lint_results_section(digest="")).is_empty()
+
+
+def test_format_lint_results_section_wraps_digest() -> None:
+    """Non-empty lint digest is wrapped in lint_results tags."""
+    rendered = format_lint_results_section(digest="ruff: 2 issues")
+
+    assert_that(rendered).starts_with("<lint_results>")
+    assert_that(rendered).contains("ruff: 2 issues")
+
+
+def test_depth_templates_render_without_key_error() -> None:
+    """Depth 2 and 3 templates render with required placeholders."""
+    questions = REVIEW_GENERATE_QUESTIONS_TEMPLATE.format(
+        diff="sample diff",
+        changed_files="- src/main.py",
+    )
+    adversarial = REVIEW_ADVERSARIAL_SWEEP_TEMPLATE.format(
+        prior_findings_json="[]",
+        diff="sample diff",
+    )
+
+    assert_that(questions).contains("sample diff")
+    assert_that(adversarial).contains("[]")
+
+
+def test_optional_sections_render_empty_by_default() -> None:
+    """Optional prompt sections default to empty strings."""
+    assert_that(format_deferred_scope_section(text=None)).is_empty()
+    assert_that(format_external_review_section(flags=None)).is_empty()
+
+
+def test_review_system_is_nonempty() -> None:
+    """System prompt contains review method instructions."""
+    assert_that(REVIEW_SYSTEM).contains("Review method")
+    assert_that(REVIEW_SYSTEM).contains("P1")

--- a/tests/unit/ai/prompts/test_review_prompts.py
+++ b/tests/unit/ai/prompts/test_review_prompts.py
@@ -49,7 +49,7 @@ def test_format_checklist_table_for_prompt_produces_markdown_table() -> None:
     """Checklist table formatter produces valid markdown table headers."""
     items = [
         ChecklistItem(
-            id=1,
+            id=42,
             question="Does any early return skip required cleanup?",
             domains=(),
             languages=(),
@@ -60,7 +60,7 @@ def test_format_checklist_table_for_prompt_produces_markdown_table() -> None:
     table = format_checklist_table_for_prompt(items=items)
 
     assert_that(table).contains("| # | Category | Question |")
-    assert_that(table).contains("| 1 | logic-bug |")
+    assert_that(table).contains("| 42 | logic-bug |")
 
 
 def test_format_changed_files_for_prompt_lists_files_with_status() -> None:
@@ -112,6 +112,22 @@ def test_optional_sections_render_empty_by_default() -> None:
     """Optional prompt sections default to empty strings."""
     assert_that(format_deferred_scope_section(text=None)).is_empty()
     assert_that(format_external_review_section(flags=None)).is_empty()
+
+
+def test_deferred_scope_section_renders_trimmed_text() -> None:
+    """Deferred scope section includes the prefix and trimmed body."""
+    rendered = format_deferred_scope_section(text="  follow-up in #995  ")
+
+    assert_that(rendered).is_equal_to("**Deferred:** follow-up in #995")
+
+
+def test_external_review_section_renders_joined_flags() -> None:
+    """External review section joins flags with the expected prefix."""
+    rendered = format_external_review_section(flags=["semgrep", "codeql"])
+
+    assert_that(rendered).is_equal_to(
+        "**External tools flagged:** semgrep, codeql — verify against current code.",
+    )
 
 
 def test_review_system_is_nonempty() -> None:

--- a/tests/unit/ai/prompts/test_review_prompts.py
+++ b/tests/unit/ai/prompts/test_review_prompts.py
@@ -51,7 +51,8 @@ def test_format_checklist_table_for_prompt_produces_markdown_table() -> None:
         ChecklistItem(
             id=1,
             question="Does any early return skip required cleanup?",
-            triggers=[],
+            domains=(),
+            languages=(),
             category=ReviewCategory.LOGIC_BUG,
             tier=1,
         ),

--- a/tests/unit/ai/review/test_paths_registry.py
+++ b/tests/unit/ai/review/test_paths_registry.py
@@ -8,6 +8,8 @@ from lintro.ai.review.enums.file_domain import FileDomain
 from lintro.ai.review.models.file_classification import FileClassification
 from lintro.ai.review.paths_registry import generate_interaction_paths
 
+_REPETITIVE_THRESHOLD = 34
+
 
 def test_generate_interaction_paths_emits_ci_shell_path() -> None:
     """CI and shell domains produce workflow-to-script trace path."""
@@ -30,6 +32,29 @@ def test_generate_interaction_paths_emits_ci_shell_path() -> None:
 
     assert_that(paths.lower()).contains("workflow")
     assert_that(paths.lower()).contains("script")
+    assert_that(paths.count("**Path A —")).is_equal_to(1)
+
+
+def test_generate_interaction_paths_skips_shell_only_when_ci_present() -> None:
+    """Shell-only path is omitted when CI+shell combined path already matches."""
+    classifications = [
+        FileClassification(
+            path=".github/workflows/ci.yml",
+            domains=[FileDomain.CI.value],
+        ),
+        FileClassification(
+            path="scripts/ci/run.sh",
+            domains=[FileDomain.SHELL.value],
+        ),
+    ]
+
+    paths = generate_interaction_paths(
+        classifications=classifications,
+        changed_files=[".github/workflows/ci.yml", "scripts/ci/run.sh"],
+    )
+
+    assert_that(paths).contains("**Path A — CI + shell:**")
+    assert_that(paths).does_not_contain("**Path A — Shell exit semantics:**")
 
 
 def test_generate_interaction_paths_emits_test_vs_production_path() -> None:
@@ -83,3 +108,71 @@ def test_generate_interaction_paths_handles_empty_changed_files() -> None:
     )
 
     assert_that(paths).contains("No interaction paths")
+
+
+def test_generate_interaction_paths_emits_bulk_repetitive_path() -> None:
+    """Large diffs emit a bulk repetitive sampling path."""
+    changed_files = [f"src/module_{index}.py" for index in range(_REPETITIVE_THRESHOLD)]
+    classifications = [
+        FileClassification(path=path, domains=[FileDomain.PYTHON.value])
+        for path in changed_files
+    ]
+
+    paths = generate_interaction_paths(
+        classifications=classifications,
+        changed_files=changed_files,
+    )
+
+    assert_that(paths).contains("Bulk repetitive changes")
+    assert_that(paths).contains("34 files")
+
+
+def test_generate_interaction_paths_caps_at_seven_paths() -> None:
+    """At most seven interaction paths are emitted."""
+    changed_files = [
+        ".github/workflows/ci.yml",
+        "scripts/ci/run.sh",
+        "docs/guide.md",
+        "tests/test_main.py",
+        "src/main.py",
+        "src/auth.rs",
+        "src/api.ts",
+        "openapi.yaml",
+        "src/security.py",
+    ]
+    classifications = [
+        FileClassification(
+            path=".github/workflows/ci.yml",
+            domains=[FileDomain.CI.value, FileDomain.DOCS.value],
+        ),
+        FileClassification(
+            path="scripts/ci/run.sh",
+            domains=[FileDomain.SHELL.value, FileDomain.SECURITY.value],
+        ),
+        FileClassification(path="docs/guide.md", domains=[FileDomain.DOCS.value]),
+        FileClassification(
+            path="tests/test_main.py",
+            domains=[FileDomain.PYTHON.value, FileDomain.TEST.value],
+        ),
+        FileClassification(path="src/main.py", domains=[FileDomain.PYTHON.value]),
+        FileClassification(
+            path="src/auth.rs",
+            domains=[FileDomain.RUST.value, FileDomain.SECURITY.value],
+        ),
+        FileClassification(
+            path="src/api.ts",
+            domains=[FileDomain.TYPESCRIPT.value, FileDomain.API.value],
+        ),
+        FileClassification(path="openapi.yaml", domains=[FileDomain.API.value]),
+        FileClassification(
+            path="src/security.py",
+            domains=[FileDomain.PYTHON.value, FileDomain.SECURITY.value],
+        ),
+    ]
+
+    paths = generate_interaction_paths(
+        classifications=classifications,
+        changed_files=changed_files,
+    )
+
+    assert_that(paths.count("**Path ")).is_less_than_or_equal_to(7)

--- a/tests/unit/ai/review/test_paths_registry.py
+++ b/tests/unit/ai/review/test_paths_registry.py
@@ -62,11 +62,11 @@ def test_generate_interaction_paths_emits_test_vs_production_path() -> None:
     classifications = [
         FileClassification(
             path="tests/test_main.py",
-            domains=[FileDomain.PYTHON, FileDomain.TEST],
+            domains=[FileDomain.SOURCE, FileDomain.TEST],
         ),
         FileClassification(
             path="src/main.py",
-            domains=[FileDomain.PYTHON],
+            domains=[FileDomain.SOURCE],
         ),
     ]
 
@@ -85,7 +85,7 @@ def test_generate_interaction_paths_includes_security_path() -> None:
         FileClassification(
             path="scripts/security/auth.py",
             domains=[
-                FileDomain.PYTHON,
+                FileDomain.SOURCE,
                 FileDomain.SHELL,
                 FileDomain.SECURITY,
             ],
@@ -114,7 +114,7 @@ def test_generate_interaction_paths_emits_bulk_repetitive_path() -> None:
     """Large diffs emit a bulk repetitive sampling path."""
     changed_files = [f"src/module_{index}.py" for index in range(_REPETITIVE_THRESHOLD)]
     classifications = [
-        FileClassification(path=path, domains=[FileDomain.PYTHON])
+        FileClassification(path=path, domains=[FileDomain.SOURCE])
         for path in changed_files
     ]
 
@@ -125,6 +125,27 @@ def test_generate_interaction_paths_emits_bulk_repetitive_path() -> None:
 
     assert_that(paths).contains("Bulk repetitive changes")
     assert_that(paths).contains("34 files")
+
+
+def test_generate_interaction_paths_emits_server_client_path() -> None:
+    """Rust and TypeScript source files trigger server-client interaction path."""
+    classifications = [
+        FileClassification(
+            path="src/auth.rs",
+            domains=[FileDomain.SOURCE, FileDomain.SECURITY],
+        ),
+        FileClassification(
+            path="src/api.ts",
+            domains=[FileDomain.SOURCE, FileDomain.API],
+        ),
+    ]
+
+    paths = generate_interaction_paths(
+        classifications=classifications,
+        changed_files=["src/auth.rs", "src/api.ts"],
+    )
+
+    assert_that(paths).contains("Server ↔ client")
 
 
 def test_generate_interaction_paths_caps_at_seven_paths() -> None:
@@ -152,21 +173,21 @@ def test_generate_interaction_paths_caps_at_seven_paths() -> None:
         FileClassification(path="docs/guide.md", domains=[FileDomain.DOCS]),
         FileClassification(
             path="tests/test_main.py",
-            domains=[FileDomain.PYTHON, FileDomain.TEST],
+            domains=[FileDomain.SOURCE, FileDomain.TEST],
         ),
-        FileClassification(path="src/main.py", domains=[FileDomain.PYTHON]),
+        FileClassification(path="src/main.py", domains=[FileDomain.SOURCE]),
         FileClassification(
             path="src/auth.rs",
-            domains=[FileDomain.RUST, FileDomain.SECURITY],
+            domains=[FileDomain.SOURCE, FileDomain.SECURITY],
         ),
         FileClassification(
             path="src/api.ts",
-            domains=[FileDomain.TYPESCRIPT, FileDomain.API],
+            domains=[FileDomain.SOURCE, FileDomain.API],
         ),
         FileClassification(path="openapi.yaml", domains=[FileDomain.API]),
         FileClassification(
             path="src/security.py",
-            domains=[FileDomain.PYTHON, FileDomain.SECURITY],
+            domains=[FileDomain.SOURCE, FileDomain.SECURITY],
         ),
     ]
 

--- a/tests/unit/ai/review/test_paths_registry.py
+++ b/tests/unit/ai/review/test_paths_registry.py
@@ -1,0 +1,85 @@
+"""Tests for review interaction path generation."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.ai.review.enums.file_domain import FileDomain
+from lintro.ai.review.models.file_classification import FileClassification
+from lintro.ai.review.paths_registry import generate_interaction_paths
+
+
+def test_generate_interaction_paths_emits_ci_shell_path() -> None:
+    """CI and shell domains produce workflow-to-script trace path."""
+    classifications = [
+        FileClassification(
+            path=".github/workflows/ci.yml",
+            domains=[FileDomain.CI.value],
+        ),
+        FileClassification(
+            path="scripts/ci/run.sh",
+            domains=[FileDomain.SHELL.value, FileDomain.SECURITY.value],
+        ),
+    ]
+    changed_files = [".github/workflows/ci.yml", "scripts/ci/run.sh"]
+
+    paths = generate_interaction_paths(
+        classifications=classifications,
+        changed_files=changed_files,
+    )
+
+    assert_that(paths.lower()).contains("workflow")
+    assert_that(paths.lower()).contains("script")
+
+
+def test_generate_interaction_paths_emits_test_vs_production_path() -> None:
+    """Test domain triggers test-vs-production default comparison path."""
+    classifications = [
+        FileClassification(
+            path="tests/test_main.py",
+            domains=[FileDomain.PYTHON.value, FileDomain.TEST.value],
+        ),
+        FileClassification(
+            path="src/main.py",
+            domains=[FileDomain.PYTHON.value],
+        ),
+    ]
+
+    paths = generate_interaction_paths(
+        classifications=classifications,
+        changed_files=["tests/test_main.py", "src/main.py"],
+    )
+
+    assert_that(paths.lower()).contains("test")
+    assert_that(paths.lower()).contains("production")
+
+
+def test_generate_interaction_paths_includes_security_path() -> None:
+    """Security domain triggers security exit semantics path."""
+    classifications = [
+        FileClassification(
+            path="scripts/security/auth.py",
+            domains=[
+                FileDomain.PYTHON.value,
+                FileDomain.SHELL.value,
+                FileDomain.SECURITY.value,
+            ],
+        ),
+    ]
+
+    paths = generate_interaction_paths(
+        classifications=classifications,
+        changed_files=["scripts/security/auth.py"],
+    )
+
+    assert_that(paths.lower()).contains("security")
+
+
+def test_generate_interaction_paths_handles_empty_changed_files() -> None:
+    """Empty changed file list returns a placeholder message."""
+    paths = generate_interaction_paths(
+        classifications=[],
+        changed_files=[],
+    )
+
+    assert_that(paths).contains("No interaction paths")

--- a/tests/unit/ai/review/test_paths_registry.py
+++ b/tests/unit/ai/review/test_paths_registry.py
@@ -197,3 +197,4 @@ def test_generate_interaction_paths_caps_at_seven_paths() -> None:
     )
 
     assert_that(paths.count("**Path ")).is_less_than_or_equal_to(7)
+    assert_that(paths).contains("OpenAPI vs routes")

--- a/tests/unit/ai/review/test_paths_registry.py
+++ b/tests/unit/ai/review/test_paths_registry.py
@@ -16,11 +16,11 @@ def test_generate_interaction_paths_emits_ci_shell_path() -> None:
     classifications = [
         FileClassification(
             path=".github/workflows/ci.yml",
-            domains=[FileDomain.CI.value],
+            domains=[FileDomain.CI],
         ),
         FileClassification(
             path="scripts/ci/run.sh",
-            domains=[FileDomain.SHELL.value, FileDomain.SECURITY.value],
+            domains=[FileDomain.SHELL, FileDomain.SECURITY],
         ),
     ]
     changed_files = [".github/workflows/ci.yml", "scripts/ci/run.sh"]
@@ -40,11 +40,11 @@ def test_generate_interaction_paths_skips_shell_only_when_ci_present() -> None:
     classifications = [
         FileClassification(
             path=".github/workflows/ci.yml",
-            domains=[FileDomain.CI.value],
+            domains=[FileDomain.CI],
         ),
         FileClassification(
             path="scripts/ci/run.sh",
-            domains=[FileDomain.SHELL.value],
+            domains=[FileDomain.SHELL],
         ),
     ]
 
@@ -62,11 +62,11 @@ def test_generate_interaction_paths_emits_test_vs_production_path() -> None:
     classifications = [
         FileClassification(
             path="tests/test_main.py",
-            domains=[FileDomain.PYTHON.value, FileDomain.TEST.value],
+            domains=[FileDomain.PYTHON, FileDomain.TEST],
         ),
         FileClassification(
             path="src/main.py",
-            domains=[FileDomain.PYTHON.value],
+            domains=[FileDomain.PYTHON],
         ),
     ]
 
@@ -85,9 +85,9 @@ def test_generate_interaction_paths_includes_security_path() -> None:
         FileClassification(
             path="scripts/security/auth.py",
             domains=[
-                FileDomain.PYTHON.value,
-                FileDomain.SHELL.value,
-                FileDomain.SECURITY.value,
+                FileDomain.PYTHON,
+                FileDomain.SHELL,
+                FileDomain.SECURITY,
             ],
         ),
     ]
@@ -114,7 +114,7 @@ def test_generate_interaction_paths_emits_bulk_repetitive_path() -> None:
     """Large diffs emit a bulk repetitive sampling path."""
     changed_files = [f"src/module_{index}.py" for index in range(_REPETITIVE_THRESHOLD)]
     classifications = [
-        FileClassification(path=path, domains=[FileDomain.PYTHON.value])
+        FileClassification(path=path, domains=[FileDomain.PYTHON])
         for path in changed_files
     ]
 
@@ -143,30 +143,30 @@ def test_generate_interaction_paths_caps_at_seven_paths() -> None:
     classifications = [
         FileClassification(
             path=".github/workflows/ci.yml",
-            domains=[FileDomain.CI.value, FileDomain.DOCS.value],
+            domains=[FileDomain.CI, FileDomain.DOCS],
         ),
         FileClassification(
             path="scripts/ci/run.sh",
-            domains=[FileDomain.SHELL.value, FileDomain.SECURITY.value],
+            domains=[FileDomain.SHELL, FileDomain.SECURITY],
         ),
-        FileClassification(path="docs/guide.md", domains=[FileDomain.DOCS.value]),
+        FileClassification(path="docs/guide.md", domains=[FileDomain.DOCS]),
         FileClassification(
             path="tests/test_main.py",
-            domains=[FileDomain.PYTHON.value, FileDomain.TEST.value],
+            domains=[FileDomain.PYTHON, FileDomain.TEST],
         ),
-        FileClassification(path="src/main.py", domains=[FileDomain.PYTHON.value]),
+        FileClassification(path="src/main.py", domains=[FileDomain.PYTHON]),
         FileClassification(
             path="src/auth.rs",
-            domains=[FileDomain.RUST.value, FileDomain.SECURITY.value],
+            domains=[FileDomain.RUST, FileDomain.SECURITY],
         ),
         FileClassification(
             path="src/api.ts",
-            domains=[FileDomain.TYPESCRIPT.value, FileDomain.API.value],
+            domains=[FileDomain.TYPESCRIPT, FileDomain.API],
         ),
-        FileClassification(path="openapi.yaml", domains=[FileDomain.API.value]),
+        FileClassification(path="openapi.yaml", domains=[FileDomain.API]),
         FileClassification(
             path="src/security.py",
-            domains=[FileDomain.PYTHON.value, FileDomain.SECURITY.value],
+            domains=[FileDomain.PYTHON, FileDomain.SECURITY],
         ),
     ]
 

--- a/tests/unit/ai/review/test_prompt_builder.py
+++ b/tests/unit/ai/review/test_prompt_builder.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
 from unittest.mock import patch
 
 from assertpy import assert_that
@@ -10,6 +9,7 @@ from assertpy import assert_that
 from lintro.ai.review.checklist_registry import get_all_checklist_items
 from lintro.ai.review.checklist_selector import select_checklist_items
 from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.pipeline import prepare_review_user_prompt
 from lintro.ai.review.prompt_builder import build_review_user_prompt
 
 
@@ -47,25 +47,18 @@ def test_prepare_review_user_prompt_wires_paths_registry(
     sample_review_context: ReviewContext,
 ) -> None:
     """Pipeline prompt preparation calls the interaction path registry."""
-    import lintro.ai.review.pipeline as pipeline_module
-
-    importlib.reload(pipeline_module)
-
     checklist_items = select_checklist_items(
         classifications=[],
         items=get_all_checklist_items()[:1],
     )
 
-    with patch.object(
-        pipeline_module.prompt_builder,
-        "build_review_user_prompt",
+    with patch(
+        "lintro.ai.review.pipeline.prompt_builder.build_review_user_prompt",
         wraps=build_review_user_prompt,
     ) as build_mock:
-        prompt, classifications, prompt_mapping = (
-            pipeline_module.prepare_review_user_prompt(
-                context=sample_review_context,
-                checklist_items=checklist_items,
-            )
+        prompt, classifications, prompt_mapping = prepare_review_user_prompt(
+            context=sample_review_context,
+            checklist_items=checklist_items,
         )
 
     build_mock.assert_called_once()

--- a/tests/unit/ai/review/test_prompt_builder.py
+++ b/tests/unit/ai/review/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 from unittest.mock import patch
 
 from assertpy import assert_that
@@ -9,7 +10,6 @@ from assertpy import assert_that
 from lintro.ai.review.checklist_registry import get_all_checklist_items
 from lintro.ai.review.checklist_selector import select_checklist_items
 from lintro.ai.review.models.review_context import ReviewContext
-from lintro.ai.review.pipeline import prepare_review_user_prompt
 from lintro.ai.review.prompt_builder import build_review_user_prompt
 
 
@@ -47,18 +47,25 @@ def test_prepare_review_user_prompt_wires_paths_registry(
     sample_review_context: ReviewContext,
 ) -> None:
     """Pipeline prompt preparation calls the interaction path registry."""
+    import lintro.ai.review.pipeline as pipeline_module
+
+    importlib.reload(pipeline_module)
+
     checklist_items = select_checklist_items(
         classifications=[],
         items=get_all_checklist_items()[:1],
     )
 
-    with patch(
-        "lintro.ai.review.pipeline.build_review_user_prompt",
+    with patch.object(
+        pipeline_module.prompt_builder,
+        "build_review_user_prompt",
         wraps=build_review_user_prompt,
     ) as build_mock:
-        prompt, classifications, prompt_mapping = prepare_review_user_prompt(
-            context=sample_review_context,
-            checklist_items=checklist_items,
+        prompt, classifications, prompt_mapping = (
+            pipeline_module.prepare_review_user_prompt(
+                context=sample_review_context,
+                checklist_items=checklist_items,
+            )
         )
 
     build_mock.assert_called_once()

--- a/tests/unit/ai/review/test_prompt_builder.py
+++ b/tests/unit/ai/review/test_prompt_builder.py
@@ -1,0 +1,68 @@
+"""Tests for review user prompt construction."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from assertpy import assert_that
+
+from lintro.ai.review.checklist_registry import get_all_checklist_items
+from lintro.ai.review.checklist_selector import select_checklist_items
+from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.pipeline import prepare_review_user_prompt
+from lintro.ai.review.prompt_builder import build_review_user_prompt
+
+
+def test_build_review_user_prompt_includes_interaction_paths(
+    sample_review_context: ReviewContext,
+) -> None:
+    """Prompt builder injects generated interaction paths into the user prompt."""
+    from lintro.ai.review.classifier import classify_changed_files
+
+    classifications = classify_changed_files(
+        files=sample_review_context.changed_files,
+    )
+    checklist_items = select_checklist_items(
+        classifications=classifications,
+        items=get_all_checklist_items(),
+    )
+
+    with patch(
+        "lintro.ai.review.prompt_builder.generate_interaction_paths",
+        return_value="**Path A — CI + shell:** trace wiring",
+    ) as generate_mock:
+        prompt, prompt_mapping = build_review_user_prompt(
+            context=sample_review_context,
+            classifications=classifications,
+            checklist_items=checklist_items,
+        )
+
+    generate_mock.assert_called_once()
+    assert_that(prompt).contains("**Path A — CI + shell:** trace wiring")
+    assert_that(prompt).contains("Interaction paths")
+    assert_that(prompt_mapping).is_not_empty()
+
+
+def test_prepare_review_user_prompt_wires_paths_registry(
+    sample_review_context: ReviewContext,
+) -> None:
+    """Pipeline prompt preparation calls the interaction path registry."""
+    checklist_items = select_checklist_items(
+        classifications=[],
+        items=get_all_checklist_items()[:1],
+    )
+
+    with patch(
+        "lintro.ai.review.pipeline.build_review_user_prompt",
+        wraps=build_review_user_prompt,
+    ) as build_mock:
+        prompt, classifications, prompt_mapping = prepare_review_user_prompt(
+            context=sample_review_context,
+            checklist_items=checklist_items,
+        )
+
+    build_mock.assert_called_once()
+    assert_that(classifications).is_not_empty()
+    assert_that(prompt).contains("Interaction paths")
+    assert_that(prompt.lower()).contains("workflow")
+    assert_that(prompt_mapping).is_not_empty()


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai/review): add review prompt templates
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Phase 3 of #991 — encodes the v3.1 production review prompt templates and domain-triggered interaction path generation for the AI diff review pipeline.

- `lintro/ai/prompts/review.py` — `REVIEW_SYSTEM`, user prompt template, output schema, depth templates, and formatting helpers
- `lintro/ai/review/paths_registry.py` — domain/language-matched interaction paths with bulk-repetitive sampling and 7-path cap; skips redundant shell-only Path A when CI+shell already matches
- `lintro/ai/review/prompt_builder.py` + `prepare_review_user_prompt` — wires `generate_interaction_paths` into `REVIEW_USER_PROMPT_TEMPLATE` at runtime

Rebased onto `main` after #1003 merge; paths registry updated for the collapsed `FileDomain.SOURCE` model and `identify` language tags from #1000.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt`, `uv run lintro chk`, `uv run lintro tst`)

## Related Issues

Closes #994

Related #991

## Details

**Rebase note:** The original 22-commit stacked branch duplicated #992–#993 already on `main`. This PR is now 8 commits on top of `main` (phase-#994 delta only).

**Testing:** Unit tests cover prompt rendering, path selection (including SOURCE + language gates), and pipeline prompt wiring via `prepare_review_user_prompt`.

**Follow-ups (separate issues):** #995 orchestrator, #1031 externalize checklist corpus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI diff-based review prompt generation, including checklist formatting and interaction-path summaries for changed files.
  * Exposed a new review prompt preparation entrypoint that returns the rendered prompt plus related classifications and prompt mapping.
  * Expanded prompt section support for optional diff, lint results, deferred scope, and external review notes.

* **Tests**
  * Added unit coverage for prompt template rendering, optional section formatting, interaction-path selection, and end-to-end prompt construction wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR (phase 3 of #991) adds the production v3.1 AI diff-review prompt layer: system and user prompt templates, a JSON output schema, depth/adversarial sweep templates, five formatting helpers, a domain-triggered interaction-path registry, and a `prompt_builder` that wires everything together via `prepare_review_user_prompt`.

- `lintro/ai/prompts/review.py` encodes the full prompt corpus; all `str.format()` placeholder names are supplied correctly, and the `{{...}}` escapes in `REVIEW_GENERATE_QUESTIONS_TEMPLATE` are handled properly.
- `paths_registry.py` selects up to seven domain-matched interaction paths, with correct `skip_when_domains` deduplication for the dual Path A specs and a bulk-repetitive fallback at 34+ files.
- `prompt_builder.py` and `pipeline.py` integrate cleanly; `format_checklist_table_for_prompt` is exported but has no call-site inside the pipeline (the prompt uses the numbered-list format from `format_checklist_for_prompt` instead).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are additive prompt templates and a path-selection registry with no mutations to existing review logic.

All template placeholders are correctly named and supplied, the skip_when_domains guard prevents duplicate Path A entries, the 7-path cap is enforced before the bulk-repetitive fallback is appended, and PRMetadata.body is typed str so there is no None-injection risk.

No files require special attention for merge safety.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/prompts/review.py | New file — defines REVIEW_SYSTEM, REVIEW_USER_PROMPT_TEMPLATE, output schema, depth templates, and five formatting helpers; all placeholders and escape sequences are correct. |
| lintro/ai/review/paths_registry.py | New file — domain-triggered interaction path generation; 7-path cap, skip_when_domains deduplication, and bulk-repetitive fallback all behave as intended. |
| lintro/ai/review/prompt_builder.py | New file — wires generate_interaction_paths and format_checklist_for_prompt into REVIEW_USER_PROMPT_TEMPLATE; all template keys are supplied correctly. |
| lintro/ai/review/pipeline.py | Adds prepare_review_user_prompt delegating to prompt_builder after classify_changed_files; validate_review_context_diff guard preserved. |
| lintro/ai/prompts/__init__.py | Adds review prompt symbols to the lazy-export registry and __all__; format_checklist_table_for_prompt is exported here but has no callers inside the pipeline. |
| lintro/ai/review/__init__.py | Registers prepare_review_user_prompt in the lazy module export map; TYPE_CHECKING guard and __all__ updated consistently. |
| tests/unit/ai/prompts/test_review_prompts.py | Good coverage of all prompt helpers and template placeholders; tests are clear and well-scoped. |
| tests/unit/ai/review/test_paths_registry.py | Covers CI+shell, skip deduplication, security, bulk-repetitive, server-client, 7-path cap, and empty-file cases. |
| tests/unit/ai/review/test_prompt_builder.py | Tests that generate_interaction_paths is called and wired into the prompt, and that prepare_review_user_prompt delegates to the builder correctly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant pipeline as pipeline.prepare_review_user_prompt
    participant classifier as classifier.classify_changed_files
    participant builder as prompt_builder.build_review_user_prompt
    participant paths as paths_registry.generate_interaction_paths
    participant checklist as checklist_selector.format_checklist_for_prompt
    participant template as REVIEW_USER_PROMPT_TEMPLATE

    Caller->>pipeline: context, checklist_items, diff?, lint_digest?, ...
    pipeline->>pipeline: validate_review_context_diff(context)
    pipeline->>classifier: "files=context.changed_files"
    classifier-->>pipeline: classifications
    pipeline->>builder: context, classifications, checklist_items, ...
    builder->>paths: classifications, changed_files, repo_root
    paths-->>builder: interaction_paths (up to 7)
    builder->>checklist: "items=checklist_items"
    checklist-->>builder: checklist_text, prompt_mapping
    builder->>template: .format(pr_title, base_ref, head_ref, pr_summary, interaction_paths, checklist, diff, ...)
    template-->>builder: rendered prompt
    builder-->>pipeline: (prompt, prompt_mapping)
    pipeline-->>Caller: (prompt, classifications, prompt_mapping)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant pipeline as pipeline.prepare_review_user_prompt
    participant classifier as classifier.classify_changed_files
    participant builder as prompt_builder.build_review_user_prompt
    participant paths as paths_registry.generate_interaction_paths
    participant checklist as checklist_selector.format_checklist_for_prompt
    participant template as REVIEW_USER_PROMPT_TEMPLATE

    Caller->>pipeline: context, checklist_items, diff?, lint_digest?, ...
    pipeline->>pipeline: validate_review_context_diff(context)
    pipeline->>classifier: "files=context.changed_files"
    classifier-->>pipeline: classifications
    pipeline->>builder: context, classifications, checklist_items, ...
    builder->>paths: classifications, changed_files, repo_root
    paths-->>builder: interaction_paths (up to 7)
    builder->>checklist: "items=checklist_items"
    checklist-->>builder: checklist_text, prompt_mapping
    builder->>template: .format(pr_title, base_ref, head_ref, pr_summary, interaction_paths, checklist, diff, ...)
    template-->>builder: rendered prompt
    builder-->>pipeline: (prompt, prompt_mapping)
    pipeline-->>Caller: (prompt, classifications, prompt_mapping)
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(test): patch pipeline prompt\_builder..."](https://github.com/lgtm-hq/py-lintro/commit/a1c34754d4cff986f4cf7f74128a3f82817cdaf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39919611)</sub>

<!-- /greptile_comment -->