### PR TITLE
feat(ai): add Cursor provider via agent CLI

### DIFF
--- a/lintro/ai/model_pricing.py
+++ b/lintro/ai/model_pricing.py
@@ -28,6 +28,7 @@ MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     "gpt-4o-mini": 128_000,
     "gpt-4-turbo": 128_000,
     "o1": 200_000,
+    "auto": 200_000,
     "o1-mini": 128_000,
 }
 

--- a/lintro/ai/provider_enum.py
+++ b/lintro/ai/provider_enum.py
@@ -16,3 +16,4 @@ class AIProvider(StrEnum):
 
     ANTHROPIC = auto()
     OPENAI = auto()
+    CURSOR = auto()

--- a/lintro/ai/providers/__init__.py
+++ b/lintro/ai/providers/__init__.py
@@ -54,6 +54,10 @@ def get_provider(config: AIConfig) -> BaseAIProvider:
             "lintro.ai.providers.openai",
             "OpenAIProvider",
         ),
+        AIProvider.CURSOR: (
+            "lintro.ai.providers.cursor",
+            "CursorProvider",
+        ),
     }
 
     entry = provider_classes.get(provider_enum)
@@ -73,6 +77,10 @@ def get_provider(config: AIConfig) -> BaseAIProvider:
         from lintro.ai.providers.openai import OpenAIProvider
 
         provider_cls = OpenAIProvider
+    elif provider_enum is AIProvider.CURSOR:
+        from lintro.ai.providers.cursor import CursorProvider
+
+        provider_cls = CursorProvider
     return provider_cls(
         model=config.model,
         api_key_env=config.api_key_env,

--- a/lintro/ai/providers/base.py
+++ b/lintro/ai/providers/base.py
@@ -103,6 +103,9 @@ class BaseAIProvider(ABC):
                 f"environment variable.",
             )
 
+        if not api_key and self._base_url:
+            api_key = "not-needed"
+
         self._client = self._create_client(api_key=api_key)
         return self._client
 

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -126,7 +126,7 @@ class CursorProvider(BaseAIProvider):
         if system:
             combined_prompt = f"{system}\n\n---\n\n{prompt}"
         combined_prompt = (
-            f"{combined_prompt}\n\n" f"[Respond in at most {effective_max} tokens.]"
+            f"{combined_prompt}\n\n[Respond in at most {effective_max} tokens.]"
         )
 
         cmd = [

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -1,0 +1,234 @@
+"""Cursor AI provider implementation.
+
+Shells out to the ``agent`` CLI (Cursor's headless agent) to access
+any model available on the user's Cursor subscription. No SDK
+dependency -- requires only the ``agent`` binary on ``PATH``.
+
+Authentication is handled by the CLI itself: either ``agent login``
+(interactive, stores credentials in the macOS Keychain) or the
+``CURSOR_API_KEY`` environment variable.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from typing import Any
+
+from loguru import logger
+
+from lintro.ai.exceptions import (
+    AIAuthenticationError,
+    AINotAvailableError,
+    AIProviderError,
+)
+from lintro.ai.providers.base import AIResponse, BaseAIProvider
+from lintro.ai.providers.constants import (
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_PER_CALL_MAX_TOKENS,
+    DEFAULT_TIMEOUT,
+)
+from lintro.ai.registry import AIProvider
+
+_AGENT_BIN = "agent"
+_DEFAULT_MODEL = "auto"
+_DEFAULT_API_KEY_ENV = "CURSOR_API_KEY"
+
+
+def _find_agent() -> str | None:
+    """Return the full path to the ``agent`` binary, or None."""
+    return shutil.which(_AGENT_BIN)
+
+
+class CursorProvider(BaseAIProvider):
+    """Cursor provider via the ``agent`` CLI.
+
+    Unlike the Anthropic and OpenAI providers, this does **not** use a
+    Python SDK. Instead it invokes ``agent --print --output-format json``
+    as a subprocess and parses the structured output.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        api_key_env: str | None = None,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        base_url: str | None = None,
+    ) -> None:
+        agent_path = _find_agent()
+        if not agent_path:
+            raise AINotAvailableError(
+                "Cursor provider requires the 'agent' CLI. "
+                "Install with: curl https://cursor.com/install -fsS | bash",
+            )
+
+        # BaseAIProvider checks has_sdk; we always pass True since there
+        # is no Python package to import -- only the CLI binary.
+        super().__init__(
+            provider_name=AIProvider.CURSOR,
+            has_sdk=True,
+            sdk_package="agent CLI",
+            default_model=_DEFAULT_MODEL,
+            default_api_key_env=_DEFAULT_API_KEY_ENV,
+            model=model,
+            api_key_env=api_key_env,
+            max_tokens=max_tokens,
+            base_url=base_url,
+        )
+        self._agent_path = agent_path
+
+    # -- BaseAIProvider contract -------------------------------------------
+
+    def _create_client(self, *, api_key: str) -> Any:
+        """No persistent client -- each call spawns a subprocess."""
+        return None
+
+    def _get_client(self) -> Any:
+        """Override: skip API-key validation (the CLI handles auth)."""
+        return None
+
+    def is_available(self) -> bool:
+        return _find_agent() is not None
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        system: str | None = None,
+        max_tokens: int = DEFAULT_PER_CALL_MAX_TOKENS,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> AIResponse:
+        """Run a completion via ``agent --print``.
+
+        The system prompt is prepended to the user prompt since the
+        CLI does not have a dedicated system-prompt flag.
+        """
+        combined_prompt = prompt
+        if system:
+            combined_prompt = f"{system}\n\n---\n\n{prompt}"
+
+        cmd = [
+            self._agent_path,
+            "--print",
+            "--output-format", "json",
+            "--trust",
+            "--mode", "ask",
+            "--model", self._model,
+        ]
+
+        logger.debug(
+            f"Cursor CLI request: model={self._model}, "
+            f"prompt_len={len(combined_prompt)}",
+        )
+
+        # Pipe via stdin to avoid OS argument-length limits on large prompts.
+        try:
+            result = subprocess.run(
+                cmd,
+                input=combined_prompt,
+                capture_output=True,
+                text=True,
+                timeout=max(timeout, 300.0),
+                check=False,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise AIProviderError(
+                f"Cursor CLI timed out after {timeout}s",
+            ) from e
+        except FileNotFoundError as e:
+            raise AINotAvailableError(
+                "Cursor 'agent' CLI not found on PATH. "
+                "Install with: curl https://cursor.com/install -fsS | bash",
+            ) from e
+
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            if "Authentication required" in stderr or "login" in stderr:
+                raise AIAuthenticationError(
+                    "Cursor CLI authentication required. "
+                    "Run 'agent login' or set CURSOR_API_KEY.",
+                )
+            raise AIProviderError(
+                f"Cursor CLI exited with code {result.returncode}: {stderr}",
+            )
+
+        return self._parse_json_output(result.stdout)
+
+    @staticmethod
+    def _extract_json_object(text: str) -> str:
+        """Extract the outermost JSON object ``{...}`` from text.
+
+        The ``agent`` CLI sometimes prepends prose before JSON output.
+        This finds the first ``{`` and matches its closing ``}`` using
+        brace counting, returning the substring. Falls back to the
+        original text if no balanced object is found.
+        """
+        start = text.find("{")
+        if start == -1:
+            return text
+
+        depth = 0
+        in_string = False
+        escape_next = False
+        for i in range(start, len(text)):
+            c = text[i]
+            if escape_next:
+                escape_next = False
+                continue
+            if c == "\\":
+                if in_string:
+                    escape_next = True
+                continue
+            if c == '"':
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start : i + 1]
+        return text
+
+    def _parse_json_output(self, stdout: str) -> AIResponse:
+        """Parse the JSON envelope from ``agent --output-format json``."""
+        try:
+            data = json.loads(stdout.strip())
+        except json.JSONDecodeError as e:
+            raise AIProviderError(
+                f"Cursor CLI returned invalid JSON: {e}\n"
+                f"Raw output: {stdout[:500]}",
+            ) from e
+
+        if data.get("is_error") or data.get("subtype") == "error":
+            raise AIProviderError(
+                f"Cursor CLI reported error: {data.get('result', stdout[:500])}",
+            )
+
+        content = data.get("result", "")
+        if not content:
+            logger.warning(
+                f"Cursor CLI returned empty result. "
+                f"Full response: {json.dumps(data)[:1000]}",
+            )
+
+        # The agent CLI may prefix the JSON with prose. Extract the
+        # outermost JSON object so downstream parsers don't choke.
+        content = self._extract_json_object(content)
+
+        usage = data.get("usage", {})
+        input_tokens = usage.get("inputTokens", 0)
+        output_tokens = usage.get("outputTokens", 0)
+
+        return AIResponse(
+            content=content,
+            model=self._model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_estimate=0.0,
+            provider=AIProvider.CURSOR,
+        )

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -240,9 +240,13 @@ class CursorProvider(BaseAIProvider):
                 f"Full response: {json.dumps(data)[:1000]}",
             )
 
-        # The agent CLI may prefix the JSON with prose. Extract the
-        # outermost JSON object so downstream parsers don't choke.
-        content = self._extract_json_object(content)
+        # The agent CLI may prefix JSON with prose. Only extract when the
+        # result is not already valid JSON, so plain-text answers with
+        # incidental braces are not silently truncated.
+        try:
+            json.loads(content)
+        except json.JSONDecodeError:
+            content = self._extract_json_object(content)
 
         usage = data.get("usage", {})
         # agent --output-format json does not expose token counts; default to 0.

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -112,10 +112,13 @@ class CursorProvider(BaseAIProvider):
         cmd = [
             self._agent_path,
             "--print",
-            "--output-format", "json",
+            "--output-format",
+            "json",
             "--trust",
-            "--mode", "ask",
-            "--model", self._model,
+            "--mode",
+            "ask",
+            "--model",
+            self._model,
         ]
 
         logger.debug(

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -121,9 +121,13 @@ class CursorProvider(BaseAIProvider):
         The system prompt is prepended to the user prompt since the
         CLI does not have a dedicated system-prompt flag.
         """
+        effective_max = min(max_tokens, self._max_tokens)
         combined_prompt = prompt
         if system:
             combined_prompt = f"{system}\n\n---\n\n{prompt}"
+        combined_prompt = (
+            f"{combined_prompt}\n\n" f"[Respond in at most {effective_max} tokens.]"
+        )
 
         cmd = [
             self._agent_path,
@@ -139,6 +143,7 @@ class CursorProvider(BaseAIProvider):
 
         logger.debug(
             f"Cursor CLI request: model={self._model}, "
+            f"max_tokens={effective_max}, "
             f"prompt_len={len(combined_prompt)}",
         )
 
@@ -149,7 +154,7 @@ class CursorProvider(BaseAIProvider):
                 input=combined_prompt,
                 capture_output=True,
                 text=True,
-                timeout=max(timeout, 300.0),
+                timeout=timeout,
                 check=False,
             )
         except subprocess.TimeoutExpired as e:
@@ -240,6 +245,7 @@ class CursorProvider(BaseAIProvider):
         content = self._extract_json_object(content)
 
         usage = data.get("usage", {})
+        # agent --output-format json does not expose token counts; default to 0.
         input_tokens = usage.get("inputTokens", 0)
         output_tokens = usage.get("outputTokens", 0)
 

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -57,6 +57,17 @@ class CursorProvider(BaseAIProvider):
         max_tokens: int = DEFAULT_MAX_TOKENS,
         base_url: str | None = None,
     ) -> None:
+        """Initialize the Cursor provider.
+
+        Args:
+            model: Model identifier override.
+            api_key_env: Environment variable for the API key override.
+            max_tokens: Provider-level cap on generated tokens.
+            base_url: Custom API base URL (unused for CLI).
+
+        Raises:
+            AINotAvailableError: If the ``agent`` CLI is not on PATH.
+        """
         agent_path = _find_agent()
         if not agent_path:
             raise AINotAvailableError(
@@ -90,6 +101,11 @@ class CursorProvider(BaseAIProvider):
         return None
 
     def is_available(self) -> bool:
+        """Check if the ``agent`` CLI is on PATH.
+
+        Returns:
+            True when the ``agent`` binary is discoverable.
+        """
         return _find_agent() is not None
 
     def complete(

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -240,13 +240,20 @@ class CursorProvider(BaseAIProvider):
                 f"Full response: {json.dumps(data)[:1000]}",
             )
 
-        # The agent CLI may prefix JSON with prose. Only extract when the
-        # result is not already valid JSON, so plain-text answers with
-        # incidental braces are not silently truncated.
+        # The agent CLI may prefix JSON with prose. Only substitute extracted
+        # content when it parses as JSON; otherwise keep plain-text answers
+        # with incidental braces intact.
         try:
             json.loads(content)
         except json.JSONDecodeError:
-            content = self._extract_json_object(content)
+            extracted = self._extract_json_object(content)
+            if extracted != content:
+                try:
+                    json.loads(extracted)
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    content = extracted
 
         usage = data.get("usage", {})
         # agent --output-format json does not expose token counts; default to 0.

--- a/lintro/ai/registry.py
+++ b/lintro/ai/registry.py
@@ -41,6 +41,7 @@ class AIProviderRegistry:
 
     anthropic: ProviderInfo
     openai: ProviderInfo
+    cursor: ProviderInfo
     _cached_model_pricing: dict[str, ModelPricing] = field(
         default_factory=dict,
         init=False,
@@ -109,6 +110,13 @@ PROVIDERS = AIProviderRegistry(
             "gpt-4-turbo": ModelPricing(10.00, 30.00),
             "o1": ModelPricing(15.00, 60.00),
             "o1-mini": ModelPricing(1.10, 4.40),
+        },
+    ),
+    cursor=ProviderInfo(
+        default_model="auto",
+        default_api_key_env="CURSOR_API_KEY",
+        models={
+            "auto": ModelPricing(0.0, 0.0),
         },
     ),
 )

--- a/tests/unit/ai/test_cost.py
+++ b/tests/unit/ai/test_cost.py
@@ -65,9 +65,13 @@ def test_cost_large_token_count():
 
 @pytest.mark.parametrize("model", list(PROVIDERS.model_pricing.keys()))
 def test_cost_all_known_models_have_pricing(model):
-    """Verify every registered model produces a positive cost estimate."""
+    """Verify every registered model produces a known cost estimate."""
+    pricing = PROVIDERS.model_pricing[model]
     cost = estimate_cost(model, 1000, 1000)
-    assert_that(cost).is_greater_than(0)
+    if pricing.input_per_million == 0 and pricing.output_per_million == 0:
+        assert_that(cost).is_equal_to(0.0)
+    else:
+        assert_that(cost).is_greater_than(0)
 
 
 def test_cost_format_small():

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -55,224 +55,240 @@ def _cli_json(
     )
 
 
-class TestFindAgent:
-    """Tests for agent binary discovery."""
-
-    def test_found(self):
-        """Return agent path when binary is on PATH."""
-        with patch("shutil.which", return_value="/usr/local/bin/agent"):
-            assert_that(_find_agent()).is_equal_to("/usr/local/bin/agent")
-
-    def test_not_found(self):
-        """Return None when agent binary is missing."""
-        with patch("shutil.which", return_value=None):
-            assert_that(_find_agent()).is_none()
+# -- _find_agent -----------------------------------------------------------
 
 
-class TestCursorProviderInit:
-    """Tests for CursorProvider initialization."""
-
-    def test_raises_when_agent_missing(self):
-        """Raise AINotAvailableError when agent CLI is missing."""
-        with (
-            patch(
-                "lintro.ai.providers.cursor._find_agent",
-                return_value=None,
-            ),
-            pytest.raises(AINotAvailableError, match="agent"),
-        ):
-            CursorProvider()
-
-    def test_default_model(self, provider):
-        """Use auto as the default model."""
-        assert_that(provider.model_name).is_equal_to("auto")
-
-    def test_custom_model(self, _mock_agent_on_path):
-        """Accept a custom model override."""
-        p = CursorProvider(model="claude-opus-4-8-thinking-high")
-        assert_that(p.model_name).is_equal_to("claude-opus-4-8-thinking-high")
-
-    def test_is_available(self, provider):
-        """Report available when agent binary is present."""
-        assert_that(provider.is_available()).is_true()
+def test_find_agent_returns_path_when_on_path():
+    """Return agent path when binary is on PATH."""
+    with patch("shutil.which", return_value="/usr/local/bin/agent"):
+        assert_that(_find_agent()).is_equal_to("/usr/local/bin/agent")
 
 
-class TestComplete:
-    """Tests for CursorProvider.complete()."""
+def test_find_agent_returns_none_when_missing():
+    """Return None when agent binary is missing."""
+    with patch("shutil.which", return_value=None):
+        assert_that(_find_agent()).is_none()
 
-    def test_success(self, provider):
-        """Parse successful CLI JSON into AIResponse."""
-        stdout = _cli_json(result="review output")
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[],
-                returncode=0,
-                stdout=stdout,
-                stderr="",
-            )
-            resp = provider.complete("Hello")
-        assert_that(resp.content).is_equal_to("review output")
-        assert_that(resp.provider).is_equal_to(AIProvider.CURSOR)
-        assert_that(resp.input_tokens).is_equal_to(100)
-        assert_that(resp.output_tokens).is_equal_to(50)
 
-    def test_system_prompt_prepended(self, provider):
-        """Prepend system prompt to user message via stdin."""
-        stdout = _cli_json(result="ok")
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[],
-                returncode=0,
-                stdout=stdout,
-                stderr="",
-            )
-            provider.complete("user msg", system="sys prompt")
-            call_kwargs = mock_run.call_args
-            input_text = call_kwargs.kwargs.get("input", "")
-            assert_that(input_text).contains("sys prompt")
-            assert_that(input_text).contains("user msg")
+# -- CursorProvider.__init__ -----------------------------------------------
 
-    def test_timeout_raises(self, provider):
-        """Raise AIProviderError when CLI times out."""
-        with (
-            patch(
-                "subprocess.run",
-                side_effect=subprocess.TimeoutExpired(cmd="agent", timeout=60),
-            ),
-            pytest.raises(AIProviderError, match="timed out"),
-        ):
+
+def test_cursor_provider_raises_when_agent_missing():
+    """Raise AINotAvailableError when agent CLI is missing."""
+    with (
+        patch(
+            "lintro.ai.providers.cursor._find_agent",
+            return_value=None,
+        ),
+        pytest.raises(AINotAvailableError, match="agent"),
+    ):
+        CursorProvider()
+
+
+def test_cursor_provider_default_model(provider):
+    """Use auto as the default model."""
+    assert_that(provider.model_name).is_equal_to("auto")
+
+
+def test_cursor_provider_custom_model(_mock_agent_on_path):
+    """Accept a custom model override."""
+    p = CursorProvider(model="claude-opus-4-8-thinking-high")
+    assert_that(p.model_name).is_equal_to("claude-opus-4-8-thinking-high")
+
+
+def test_cursor_provider_is_available(provider):
+    """Report available when agent binary is present."""
+    assert_that(provider.is_available()).is_true()
+
+
+# -- CursorProvider.complete() ---------------------------------------------
+
+
+def test_complete_parses_successful_cli_json(provider):
+    """Parse successful CLI JSON into AIResponse."""
+    stdout = _cli_json(result="review output")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+        resp = provider.complete("Hello")
+    assert_that(resp.content).is_equal_to("review output")
+    assert_that(resp.provider).is_equal_to(AIProvider.CURSOR)
+    assert_that(resp.input_tokens).is_equal_to(100)
+    assert_that(resp.output_tokens).is_equal_to(50)
+
+
+def test_complete_prepends_system_prompt_via_stdin(provider):
+    """Prepend system prompt to user message via stdin."""
+    stdout = _cli_json(result="ok")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+        provider.complete("user msg", system="sys prompt")
+        call_kwargs = mock_run.call_args
+        input_text = call_kwargs.kwargs.get("input", "")
+        assert_that(input_text).contains("sys prompt")
+        assert_that(input_text).contains("user msg")
+
+
+def test_complete_raises_on_subprocess_timeout(provider):
+    """Raise AIProviderError when CLI times out."""
+    with patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="agent", timeout=60),
+    ):
+        with pytest.raises(AIProviderError, match="timed out"):
             provider.complete("Hello")
 
-    def test_auth_error(self, provider):
-        """Raise AIAuthenticationError on auth failure stderr."""
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[],
-                returncode=1,
-                stdout="",
-                stderr="Authentication required. Run 'agent login' first.",
-            )
-            with pytest.raises(AIAuthenticationError, match="login"):
-                provider.complete("Hello")
 
-    def test_nonzero_exit(self, provider):
-        """Raise AIProviderError on non-zero CLI exit code."""
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[],
-                returncode=2,
-                stdout="",
-                stderr="something broke",
-            )
-            with pytest.raises(AIProviderError, match="exited with code 2"):
-                provider.complete("Hello")
-
-    def test_invalid_json_stdout(self, provider):
-        """Raise AIProviderError when stdout is not valid JSON."""
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[],
-                returncode=0,
-                stdout="not json at all",
-                stderr="",
-            )
-            with pytest.raises(AIProviderError, match="invalid JSON"):
-                provider.complete("Hello")
-
-    def test_cli_error_in_response(self, provider):
-        """Raise AIProviderError when JSON reports is_error."""
-        stdout = _cli_json(
-            result="something failed",
-            is_error=True,
-            subtype="error",
+def test_complete_raises_auth_error(provider):
+    """Raise AIAuthenticationError on auth failure stderr."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="Authentication required. Run 'agent login' first.",
         )
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[],
-                returncode=0,
-                stdout=stdout,
-                stderr="",
-            )
-            with pytest.raises(AIProviderError, match="reported error"):
-                provider.complete("Hello")
-
-    def test_max_tokens_appended_to_prompt(self, provider):
-        """Append token budget constraint to the CLI stdin prompt."""
-        stdout = _cli_json(result="ok")
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[],
-                returncode=0,
-                stdout=stdout,
-                stderr="",
-            )
-            provider.complete("Hello", max_tokens=512)
-            input_text = mock_run.call_args.kwargs.get("input", "")
-            assert_that(input_text).contains("Respond in at most 512 tokens")
-
-    def test_timeout_passed_to_subprocess(self, provider):
-        """Pass caller timeout directly to subprocess.run."""
-        stdout = _cli_json(result="ok")
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[],
-                returncode=0,
-                stdout=stdout,
-                stderr="",
-            )
-            provider.complete("Hello", timeout=45.0)
-            assert_that(mock_run.call_args.kwargs.get("timeout")).is_equal_to(45.0)
-
-    def test_cost_estimate_zero(self, provider):
-        """Cursor subscription — per-token cost is always zero."""
-        stdout = _cli_json(result="ok", input_tokens=5000, output_tokens=2000)
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[],
-                returncode=0,
-                stdout=stdout,
-                stderr="",
-            )
-            resp = provider.complete("Hello")
-        assert_that(resp.cost_estimate).is_equal_to(0.0)
+        with pytest.raises(AIAuthenticationError, match="login"):
+            provider.complete("Hello")
 
 
-class TestExtractJsonObject:
-    """Tests for the JSON extraction helper."""
+def test_complete_raises_on_nonzero_exit(provider):
+    """Raise AIProviderError on non-zero CLI exit code."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=2,
+            stdout="",
+            stderr="something broke",
+        )
+        with pytest.raises(AIProviderError, match="exited with code 2"):
+            provider.complete("Hello")
 
-    def test_clean_json(self):
-        """Return clean JSON unchanged."""
-        obj = '{"a": 1}'
-        assert_that(CursorProvider._extract_json_object(obj)).is_equal_to(obj)
 
-    def test_prose_before_json(self):
-        """Extract JSON object after leading prose."""
-        text = 'Some preamble text.\n{"summary": "ok", "findings": []}'
-        assert_that(
-            CursorProvider._extract_json_object(text),
-        ).is_equal_to('{"summary": "ok", "findings": []}')
+def test_complete_raises_on_invalid_json_stdout(provider):
+    """Raise AIProviderError when stdout is not valid JSON."""
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="not json at all",
+            stderr="",
+        )
+        with pytest.raises(AIProviderError, match="invalid JSON"):
+            provider.complete("Hello")
 
-    def test_nested_braces(self):
-        """Handle nested JSON objects correctly."""
-        text = 'Preamble\n{"a": {"b": 1}, "c": 2}'
-        assert_that(
-            CursorProvider._extract_json_object(text),
-        ).is_equal_to('{"a": {"b": 1}, "c": 2}')
 
-    def test_braces_in_strings(self):
-        """Ignore braces inside JSON string values."""
-        text = '{"key": "value with { brace }"}'
-        assert_that(
-            CursorProvider._extract_json_object(text),
-        ).is_equal_to(text)
+def test_complete_raises_on_cli_error_in_response(provider):
+    """Raise AIProviderError when JSON reports is_error."""
+    stdout = _cli_json(
+        result="something failed",
+        is_error=True,
+        subtype="error",
+    )
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+        with pytest.raises(AIProviderError, match="reported error"):
+            provider.complete("Hello")
 
-    def test_no_json(self):
-        """Return original text when no JSON is present."""
-        text = "no json here"
-        assert_that(
-            CursorProvider._extract_json_object(text),
-        ).is_equal_to(text)
 
-    def test_empty_string(self):
-        """Return empty string unchanged."""
-        assert_that(CursorProvider._extract_json_object("")).is_equal_to("")
+def test_complete_appends_max_tokens_to_prompt(provider):
+    """Append token budget constraint to the CLI stdin prompt."""
+    stdout = _cli_json(result="ok")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+        provider.complete("Hello", max_tokens=512)
+        input_text = mock_run.call_args.kwargs.get("input", "")
+        assert_that(input_text).contains("Respond in at most 512 tokens")
+
+
+def test_complete_passes_timeout_to_subprocess(provider):
+    """Pass caller timeout directly to subprocess.run."""
+    stdout = _cli_json(result="ok")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+        provider.complete("Hello", timeout=45.0)
+        assert_that(mock_run.call_args.kwargs.get("timeout")).is_equal_to(45.0)
+
+
+def test_complete_cost_estimate_is_zero(provider):
+    """Cursor subscription — per-token cost is always zero."""
+    stdout = _cli_json(result="ok", input_tokens=5000, output_tokens=2000)
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+        resp = provider.complete("Hello")
+    assert_that(resp.cost_estimate).is_equal_to(0.0)
+
+
+# -- CursorProvider._extract_json_object() ---------------------------------
+
+
+def test_extract_json_object_returns_clean_json_unchanged():
+    """Return clean JSON unchanged."""
+    obj = '{"a": 1}'
+    assert_that(CursorProvider._extract_json_object(obj)).is_equal_to(obj)
+
+
+def test_extract_json_object_strips_leading_prose():
+    """Extract JSON object after leading prose."""
+    text = 'Some preamble text.\n{"summary": "ok", "findings": []}'
+    assert_that(
+        CursorProvider._extract_json_object(text),
+    ).is_equal_to('{"summary": "ok", "findings": []}')
+
+
+def test_extract_json_object_handles_nested_braces():
+    """Handle nested JSON objects correctly."""
+    text = 'Preamble\n{"a": {"b": 1}, "c": 2}'
+    assert_that(
+        CursorProvider._extract_json_object(text),
+    ).is_equal_to('{"a": {"b": 1}, "c": 2}')
+
+
+def test_extract_json_object_ignores_braces_in_strings():
+    """Ignore braces inside JSON string values."""
+    text = '{"key": "value with { brace }"}'
+    assert_that(
+        CursorProvider._extract_json_object(text),
+    ).is_equal_to(text)
+
+
+def test_extract_json_object_returns_original_when_no_json():
+    """Return original text when no JSON is present."""
+    text = "no json here"
+    assert_that(
+        CursorProvider._extract_json_object(text),
+    ).is_equal_to(text)
+
+
+def test_extract_json_object_returns_empty_string_unchanged():
+    """Return empty string unchanged."""
+    assert_that(CursorProvider._extract_json_object("")).is_equal_to("")

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -145,45 +145,39 @@ class TestComplete:
 
     def test_auth_error(self, provider):
         """Raise AIAuthenticationError on auth failure stderr."""
-        with (
-            patch("subprocess.run") as mock_run,
-            pytest.raises(AIAuthenticationError, match="login"),
-        ):
+        with patch("subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=[],
                 returncode=1,
                 stdout="",
                 stderr="Authentication required. Run 'agent login' first.",
             )
-            provider.complete("Hello")
+            with pytest.raises(AIAuthenticationError, match="login"):
+                provider.complete("Hello")
 
     def test_nonzero_exit(self, provider):
         """Raise AIProviderError on non-zero CLI exit code."""
-        with (
-            patch("subprocess.run") as mock_run,
-            pytest.raises(AIProviderError, match="exited with code 2"),
-        ):
+        with patch("subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=[],
                 returncode=2,
                 stdout="",
                 stderr="something broke",
             )
-            provider.complete("Hello")
+            with pytest.raises(AIProviderError, match="exited with code 2"):
+                provider.complete("Hello")
 
     def test_invalid_json_stdout(self, provider):
         """Raise AIProviderError when stdout is not valid JSON."""
-        with (
-            patch("subprocess.run") as mock_run,
-            pytest.raises(AIProviderError, match="invalid JSON"),
-        ):
+        with patch("subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=[],
                 returncode=0,
                 stdout="not json at all",
                 stderr="",
             )
-            provider.complete("Hello")
+            with pytest.raises(AIProviderError, match="invalid JSON"):
+                provider.complete("Hello")
 
     def test_cli_error_in_response(self, provider):
         """Raise AIProviderError when JSON reports is_error."""
@@ -192,17 +186,42 @@ class TestComplete:
             is_error=True,
             subtype="error",
         )
-        with (
-            patch("subprocess.run") as mock_run,
-            pytest.raises(AIProviderError, match="reported error"),
-        ):
+        with patch("subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=[],
                 returncode=0,
                 stdout=stdout,
                 stderr="",
             )
-            provider.complete("Hello")
+            with pytest.raises(AIProviderError, match="reported error"):
+                provider.complete("Hello")
+
+    def test_max_tokens_appended_to_prompt(self, provider):
+        """Append token budget constraint to the CLI stdin prompt."""
+        stdout = _cli_json(result="ok")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=stdout,
+                stderr="",
+            )
+            provider.complete("Hello", max_tokens=512)
+            input_text = mock_run.call_args.kwargs.get("input", "")
+            assert_that(input_text).contains("Respond in at most 512 tokens")
+
+    def test_timeout_passed_to_subprocess(self, provider):
+        """Pass caller timeout directly to subprocess.run."""
+        stdout = _cli_json(result="ok")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=stdout,
+                stderr="",
+            )
+            provider.complete("Hello", timeout=45.0)
+            assert_that(mock_run.call_args.kwargs.get("timeout")).is_equal_to(45.0)
 
     def test_cost_estimate_zero(self, provider):
         """Cursor subscription — per-token cost is always zero."""

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -51,7 +51,7 @@ def _cli_json(
                 "inputTokens": input_tokens,
                 "outputTokens": output_tokens,
             },
-        }
+        },
     )
 
 
@@ -59,10 +59,12 @@ class TestFindAgent:
     """Tests for agent binary discovery."""
 
     def test_found(self):
+        """Return agent path when binary is on PATH."""
         with patch("shutil.which", return_value="/usr/local/bin/agent"):
             assert_that(_find_agent()).is_equal_to("/usr/local/bin/agent")
 
     def test_not_found(self):
+        """Return None when agent binary is missing."""
         with patch("shutil.which", return_value=None):
             assert_that(_find_agent()).is_none()
 
@@ -71,6 +73,7 @@ class TestCursorProviderInit:
     """Tests for CursorProvider initialization."""
 
     def test_raises_when_agent_missing(self):
+        """Raise AINotAvailableError when agent CLI is missing."""
         with (
             patch(
                 "lintro.ai.providers.cursor._find_agent",
@@ -81,13 +84,16 @@ class TestCursorProviderInit:
             CursorProvider()
 
     def test_default_model(self, provider):
+        """Use auto as the default model."""
         assert_that(provider.model_name).is_equal_to("auto")
 
     def test_custom_model(self, _mock_agent_on_path):
+        """Accept a custom model override."""
         p = CursorProvider(model="claude-opus-4-8-thinking-high")
         assert_that(p.model_name).is_equal_to("claude-opus-4-8-thinking-high")
 
     def test_is_available(self, provider):
+        """Report available when agent binary is present."""
         assert_that(provider.is_available()).is_true()
 
 
@@ -95,6 +101,7 @@ class TestComplete:
     """Tests for CursorProvider.complete()."""
 
     def test_success(self, provider):
+        """Parse successful CLI JSON into AIResponse."""
         stdout = _cli_json(result="review output")
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
@@ -110,6 +117,7 @@ class TestComplete:
         assert_that(resp.output_tokens).is_equal_to(50)
 
     def test_system_prompt_prepended(self, provider):
+        """Prepend system prompt to user message via stdin."""
         stdout = _cli_json(result="ok")
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
@@ -125,6 +133,7 @@ class TestComplete:
             assert_that(input_text).contains("user msg")
 
     def test_timeout_raises(self, provider):
+        """Raise AIProviderError when CLI times out."""
         with (
             patch(
                 "subprocess.run",
@@ -135,6 +144,7 @@ class TestComplete:
             provider.complete("Hello")
 
     def test_auth_error(self, provider):
+        """Raise AIAuthenticationError on auth failure stderr."""
         with (
             patch("subprocess.run") as mock_run,
             pytest.raises(AIAuthenticationError, match="login"),
@@ -148,6 +158,7 @@ class TestComplete:
             provider.complete("Hello")
 
     def test_nonzero_exit(self, provider):
+        """Raise AIProviderError on non-zero CLI exit code."""
         with (
             patch("subprocess.run") as mock_run,
             pytest.raises(AIProviderError, match="exited with code 2"),
@@ -161,6 +172,7 @@ class TestComplete:
             provider.complete("Hello")
 
     def test_invalid_json_stdout(self, provider):
+        """Raise AIProviderError when stdout is not valid JSON."""
         with (
             patch("subprocess.run") as mock_run,
             pytest.raises(AIProviderError, match="invalid JSON"),
@@ -174,6 +186,7 @@ class TestComplete:
             provider.complete("Hello")
 
     def test_cli_error_in_response(self, provider):
+        """Raise AIProviderError when JSON reports is_error."""
         stdout = _cli_json(
             result="something failed",
             is_error=True,
@@ -209,32 +222,38 @@ class TestExtractJsonObject:
     """Tests for the JSON extraction helper."""
 
     def test_clean_json(self):
+        """Return clean JSON unchanged."""
         obj = '{"a": 1}'
         assert_that(CursorProvider._extract_json_object(obj)).is_equal_to(obj)
 
     def test_prose_before_json(self):
+        """Extract JSON object after leading prose."""
         text = 'Some preamble text.\n{"summary": "ok", "findings": []}'
         assert_that(
             CursorProvider._extract_json_object(text),
         ).is_equal_to('{"summary": "ok", "findings": []}')
 
     def test_nested_braces(self):
+        """Handle nested JSON objects correctly."""
         text = 'Preamble\n{"a": {"b": 1}, "c": 2}'
         assert_that(
             CursorProvider._extract_json_object(text),
         ).is_equal_to('{"a": {"b": 1}, "c": 2}')
 
     def test_braces_in_strings(self):
+        """Ignore braces inside JSON string values."""
         text = '{"key": "value with { brace }"}'
         assert_that(
             CursorProvider._extract_json_object(text),
         ).is_equal_to(text)
 
     def test_no_json(self):
+        """Return original text when no JSON is present."""
         text = "no json here"
         assert_that(
             CursorProvider._extract_json_object(text),
         ).is_equal_to(text)
 
     def test_empty_string(self):
+        """Return empty string unchanged."""
         assert_that(CursorProvider._extract_json_object("")).is_equal_to("")

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -90,7 +90,8 @@ def test_cursor_provider_default_model(provider):
     assert_that(provider.model_name).is_equal_to("auto")
 
 
-def test_cursor_provider_custom_model(_mock_agent_on_path):
+@pytest.mark.usefixtures("_mock_agent_on_path")
+def test_cursor_provider_custom_model():
     """Accept a custom model override."""
     p = CursorProvider(model="claude-opus-4-8-thinking-high")
     assert_that(p.model_name).is_equal_to("claude-opus-4-8-thinking-high")
@@ -140,12 +141,14 @@ def test_complete_prepends_system_prompt_via_stdin(provider):
 
 def test_complete_raises_on_subprocess_timeout(provider):
     """Raise AIProviderError when CLI times out."""
-    with patch(
-        "subprocess.run",
-        side_effect=subprocess.TimeoutExpired(cmd="agent", timeout=60),
+    with (
+        patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="agent", timeout=60),
+        ),
+        pytest.raises(AIProviderError, match="timed out"),
     ):
-        with pytest.raises(AIProviderError, match="timed out"):
-            provider.complete("Hello")
+        provider.complete("Hello")
 
 
 def test_complete_raises_auth_error(provider):

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -292,3 +292,18 @@ def test_extract_json_object_returns_original_when_no_json():
 def test_extract_json_object_returns_empty_string_unchanged():
     """Return empty string unchanged."""
     assert_that(CursorProvider._extract_json_object("")).is_equal_to("")
+
+
+def test_complete_preserves_plain_text_with_braces(provider):
+    """Do not truncate plain-text answers that contain balanced braces."""
+    result_text = "Use destructuring like { userId } in your handler."
+    stdout = _cli_json(result=result_text)
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+        resp = provider.complete("Hello")
+    assert_that(resp.content).is_equal_to(result_text)

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -1,0 +1,238 @@
+"""Tests for the Cursor AI provider (agent CLI wrapper)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.exceptions import (
+    AIAuthenticationError,
+    AINotAvailableError,
+    AIProviderError,
+)
+from lintro.ai.providers.cursor import CursorProvider, _find_agent
+from lintro.ai.registry import AIProvider
+
+
+@pytest.fixture()
+def _mock_agent_on_path():
+    """Patch shutil.which to report ``agent`` as available."""
+    with patch(
+        "lintro.ai.providers.cursor._find_agent",
+        return_value="/usr/local/bin/agent",
+    ):
+        yield
+
+
+@pytest.fixture()
+def provider(_mock_agent_on_path):
+    """Create a CursorProvider with a mocked agent binary."""
+    return CursorProvider()
+
+
+def _cli_json(
+    result: str = "hello",
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    is_error: bool = False,
+    subtype: str = "success",
+) -> str:
+    return json.dumps({
+        "type": "result",
+        "subtype": subtype,
+        "is_error": is_error,
+        "result": result,
+        "usage": {
+            "inputTokens": input_tokens,
+            "outputTokens": output_tokens,
+        },
+    })
+
+
+class TestFindAgent:
+    """Tests for agent binary discovery."""
+
+    def test_found(self):
+        with patch("shutil.which", return_value="/usr/local/bin/agent"):
+            assert_that(_find_agent()).is_equal_to("/usr/local/bin/agent")
+
+    def test_not_found(self):
+        with patch("shutil.which", return_value=None):
+            assert_that(_find_agent()).is_none()
+
+
+class TestCursorProviderInit:
+    """Tests for CursorProvider initialization."""
+
+    def test_raises_when_agent_missing(self):
+        with (
+            patch(
+                "lintro.ai.providers.cursor._find_agent",
+                return_value=None,
+            ),
+            pytest.raises(AINotAvailableError, match="agent"),
+        ):
+            CursorProvider()
+
+    def test_default_model(self, provider):
+        assert_that(provider.model_name).is_equal_to("auto")
+
+    def test_custom_model(self, _mock_agent_on_path):
+        p = CursorProvider(model="claude-opus-4-8-thinking-high")
+        assert_that(p.model_name).is_equal_to("claude-opus-4-8-thinking-high")
+
+    def test_is_available(self, provider):
+        assert_that(provider.is_available()).is_true()
+
+
+class TestComplete:
+    """Tests for CursorProvider.complete()."""
+
+    def test_success(self, provider):
+        stdout = _cli_json(result="review output")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=stdout,
+                stderr="",
+            )
+            resp = provider.complete("Hello")
+        assert_that(resp.content).is_equal_to("review output")
+        assert_that(resp.provider).is_equal_to(AIProvider.CURSOR)
+        assert_that(resp.input_tokens).is_equal_to(100)
+        assert_that(resp.output_tokens).is_equal_to(50)
+
+    def test_system_prompt_prepended(self, provider):
+        stdout = _cli_json(result="ok")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=stdout,
+                stderr="",
+            )
+            provider.complete("user msg", system="sys prompt")
+            call_kwargs = mock_run.call_args
+            input_text = call_kwargs.kwargs.get("input", "")
+            assert_that(input_text).contains("sys prompt")
+            assert_that(input_text).contains("user msg")
+
+    def test_timeout_raises(self, provider):
+        with (
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="agent", timeout=60),
+            ),
+            pytest.raises(AIProviderError, match="timed out"),
+        ):
+            provider.complete("Hello")
+
+    def test_auth_error(self, provider):
+        with (
+            patch("subprocess.run") as mock_run,
+            pytest.raises(AIAuthenticationError, match="login"),
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr="Authentication required. Run 'agent login' first.",
+            )
+            provider.complete("Hello")
+
+    def test_nonzero_exit(self, provider):
+        with (
+            patch("subprocess.run") as mock_run,
+            pytest.raises(AIProviderError, match="exited with code 2"),
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=2,
+                stdout="",
+                stderr="something broke",
+            )
+            provider.complete("Hello")
+
+    def test_invalid_json_stdout(self, provider):
+        with (
+            patch("subprocess.run") as mock_run,
+            pytest.raises(AIProviderError, match="invalid JSON"),
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="not json at all",
+                stderr="",
+            )
+            provider.complete("Hello")
+
+    def test_cli_error_in_response(self, provider):
+        stdout = _cli_json(
+            result="something failed",
+            is_error=True,
+            subtype="error",
+        )
+        with (
+            patch("subprocess.run") as mock_run,
+            pytest.raises(AIProviderError, match="reported error"),
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=stdout,
+                stderr="",
+            )
+            provider.complete("Hello")
+
+    def test_cost_estimate_zero(self, provider):
+        """Cursor subscription — per-token cost is always zero."""
+        stdout = _cli_json(result="ok", input_tokens=5000, output_tokens=2000)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=stdout,
+                stderr="",
+            )
+            resp = provider.complete("Hello")
+        assert_that(resp.cost_estimate).is_equal_to(0.0)
+
+
+class TestExtractJsonObject:
+    """Tests for the JSON extraction helper."""
+
+    def test_clean_json(self):
+        obj = '{"a": 1}'
+        assert_that(CursorProvider._extract_json_object(obj)).is_equal_to(obj)
+
+    def test_prose_before_json(self):
+        text = 'Some preamble text.\n{"summary": "ok", "findings": []}'
+        assert_that(
+            CursorProvider._extract_json_object(text),
+        ).is_equal_to('{"summary": "ok", "findings": []}')
+
+    def test_nested_braces(self):
+        text = 'Preamble\n{"a": {"b": 1}, "c": 2}'
+        assert_that(
+            CursorProvider._extract_json_object(text),
+        ).is_equal_to('{"a": {"b": 1}, "c": 2}')
+
+    def test_braces_in_strings(self):
+        text = '{"key": "value with { brace }"}'
+        assert_that(
+            CursorProvider._extract_json_object(text),
+        ).is_equal_to(text)
+
+    def test_no_json(self):
+        text = "no json here"
+        assert_that(
+            CursorProvider._extract_json_object(text),
+        ).is_equal_to(text)
+
+    def test_empty_string(self):
+        assert_that(CursorProvider._extract_json_object("")).is_equal_to("")

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -41,16 +41,18 @@ def _cli_json(
     is_error: bool = False,
     subtype: str = "success",
 ) -> str:
-    return json.dumps({
-        "type": "result",
-        "subtype": subtype,
-        "is_error": is_error,
-        "result": result,
-        "usage": {
-            "inputTokens": input_tokens,
-            "outputTokens": output_tokens,
-        },
-    })
+    return json.dumps(
+        {
+            "type": "result",
+            "subtype": subtype,
+            "is_error": is_error,
+            "result": result,
+            "usage": {
+                "inputTokens": input_tokens,
+                "outputTokens": output_tokens,
+            },
+        }
+    )
 
 
 class TestFindAgent:


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai): add Cursor provider via agent CLI
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds a `CursorProvider` that shells out to the Cursor `agent` CLI so users can run AI features on a Cursor subscription without Anthropic/OpenAI API keys. Registers `AIProvider.CURSOR` in the enum, factory, registry, and model pricing (zero-cost `auto` model).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt && uv run lintro chk && uv run lintro tst`)

## Closes

- Closes #1004

## Details

- **`lintro/ai/providers/cursor.py`**: invokes `agent --print --output-format json`, parses the JSON envelope, maps auth/timeout/exit errors to shared exceptions, honors caller `timeout` and `max_tokens` (via prompt constraint).
- **Registry wiring**: `AIProvider.CURSOR`, `ProviderInfo`, factory map, and `"auto"` context-window entry.
- **`base.py`**: allow missing API key when `base_url` is set (CLI auth path).
- **Tests**: `tests/unit/ai/test_cursor_provider.py` (flat pytest functions) and `test_cost.py` zero-pricing coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new Cursor-based AI provider option.
  * Expanded model context handling so the automatic model uses a 200,000-token context window.
* **Bug Fixes**
  * Improved API-key handling when a base URL is provided (avoids requiring an API key in that scenario).
  * Updated cost estimation expectations so providers with zero pricing correctly report zero cost.
* **Tests**
  * Added a comprehensive Cursor provider test suite, including response parsing, prompt handling, timeouts, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `CursorProvider` that shells out to the Cursor `agent` CLI so users can leverage their Cursor subscription without Anthropic or OpenAI API keys. It wires `AIProvider.CURSOR` through the enum, factory, registry, and model pricing, and includes solid test coverage.

- **`cursor.py`**: Spawns `agent --print --output-format json`, pipes the prompt via stdin, and maps auth/timeout/exit errors to shared exceptions. The `_extract_json_object` fallback (only triggered when `json.loads` fails) and zero-cost `AIResponse` are both correctly implemented.
- **`base.py`**: Adds a fallback that substitutes `\"not-needed\"` when `base_url` is set but no API key is present — a path unused by `CursorProvider` itself (which overrides `_get_client` to return `None`), but it changes error behavior for SDK-based providers configured with a custom `base_url`.
- **Tests**: Good coverage including timeout, auth failure, non-zero exit, invalid JSON, the `is_error` envelope field, and the plain-text-with-braces regression case from the prior review round.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the Cursor provider is cleanly isolated and previous review issues are resolved.

The new provider is well-contained: it overrides `_get_client` to avoid touching SDK auth, maps every subprocess failure mode to a typed exception, and the `_extract_json_object` fix from the prior round is correctly implemented with a regression test. The two remaining observations — the generic `agent` binary name and the `base.py` dummy-key fallback affecting SDK providers — are both quality concerns rather than broken behavior on the changed path.

`lintro/ai/providers/base.py` — the new `base_url`-without-key branch changes error behavior for Anthropic and OpenAI providers and is worth a second look before it unexpectedly surfaces in those code paths.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/providers/cursor.py | New CursorProvider implementation using subprocess to call the Cursor `agent` CLI. Error handling, JSON parsing, and prompt construction are well-structured. The `agent` binary name is generic enough that it could resolve to a non-Cursor binary on some machines, and the `--trust` flag is hardcoded with no opt-out. Previous review issues (timeout floor, token cap, `_extract_json_object` truncation) are addressed. |
| lintro/ai/providers/base.py | Adds a `base_url`-without-key fallback that inserts a dummy `"not-needed"` API key. Logically sound for local-proxy use cases but silently changes error behavior for Anthropic/OpenAI providers; `CursorProvider` does not actually use this path since it overrides `_get_client()` entirely. |
| lintro/ai/registry.py | Adds `cursor: ProviderInfo` field and singleton entry with `"auto"` model priced at zero. Consistent with the existing pattern for Anthropic and OpenAI entries. |
| lintro/ai/providers/__init__.py | Registers `CursorProvider` in both the `provider_classes` lookup dict and the `if/elif` dispatch chain. The dual-representation pattern is pre-existing; the Cursor entries are consistent with Anthropic and OpenAI. |
| tests/unit/ai/test_cursor_provider.py | Good coverage of the happy path, error cases (timeout, auth, non-zero exit, invalid JSON, `is_error` flag), and the `_extract_json_object` edge cases including the regression test for plain-text answers with incidental braces. |
| tests/unit/ai/test_cost.py | Updates parametrized cost test to handle zero-cost models correctly; the branched assertion cleanly covers both free and paid models. |
| lintro/ai/model_pricing.py | Adds `"auto": 200_000` to `MODEL_CONTEXT_WINDOWS`. Correct value for a generic large-context model; no naming collision with existing entries. |
| lintro/ai/provider_enum.py | Adds `CURSOR = auto()` to `AIProvider` StrEnum. Minimal, correct change. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant CursorProvider
    participant shutil
    participant agent as agent CLI (subprocess)

    Caller->>CursorProvider: __init__()
    CursorProvider->>shutil: which("agent")
    shutil-->>CursorProvider: /usr/local/bin/agent (or None → AINotAvailableError)

    Caller->>CursorProvider: complete(prompt, system, max_tokens, timeout)
    CursorProvider->>CursorProvider: build combined_prompt (system + prompt + token hint)
    CursorProvider->>agent: "subprocess.run([agent, --print, --output-format, json, --trust, --mode, ask, --model, auto], stdin=combined_prompt, timeout=timeout)"
    alt timeout exceeded
        agent-->>CursorProvider: TimeoutExpired
        CursorProvider-->>Caller: AIProviderError("timed out")
    else "returncode != 0"
        agent-->>CursorProvider: stderr with error
        alt "Authentication required" in stderr
            CursorProvider-->>Caller: AIAuthenticationError
        else
            CursorProvider-->>Caller: AIProviderError(returncode + stderr)
        end
    else "returncode == 0"
        agent-->>CursorProvider: stdout JSON envelope
        CursorProvider->>CursorProvider: _parse_json_output(stdout)
        alt "is_error or subtype=="error""
            CursorProvider-->>Caller: AIProviderError
        else valid result
            CursorProvider-->>Caller: "AIResponse(content, tokens, cost=0.0)"
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant CursorProvider
    participant shutil
    participant agent as agent CLI (subprocess)

    Caller->>CursorProvider: __init__()
    CursorProvider->>shutil: which("agent")
    shutil-->>CursorProvider: /usr/local/bin/agent (or None → AINotAvailableError)

    Caller->>CursorProvider: complete(prompt, system, max_tokens, timeout)
    CursorProvider->>CursorProvider: build combined_prompt (system + prompt + token hint)
    CursorProvider->>agent: "subprocess.run([agent, --print, --output-format, json, --trust, --mode, ask, --model, auto], stdin=combined_prompt, timeout=timeout)"
    alt timeout exceeded
        agent-->>CursorProvider: TimeoutExpired
        CursorProvider-->>Caller: AIProviderError("timed out")
    else "returncode != 0"
        agent-->>CursorProvider: stderr with error
        alt "Authentication required" in stderr
            CursorProvider-->>Caller: AIAuthenticationError
        else
            CursorProvider-->>Caller: AIProviderError(returncode + stderr)
        end
    else "returncode == 0"
        agent-->>CursorProvider: stdout JSON envelope
        CursorProvider->>CursorProvider: _parse_json_output(stdout)
        alt "is_error or subtype=="error""
            CursorProvider-->>Caller: AIProviderError
        else valid result
            CursorProvider-->>Caller: "AIResponse(content, tokens, cost=0.0)"
        end
    end
```

</a>
</details>

<sub>Reviews (10): Last reviewed commit: ["style(test): address CodeRabbit PT019 an..."](https://github.com/lgtm-hq/py-lintro/commit/b6d6ed70c143547e67877bd4053bb0ccb429ed79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39939256)</sub>

<!-- /greptile_comment -->