### PR TITLE
feat(ai/review): add live progress bar for review operations

### DIFF
--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -151,34 +151,41 @@ def run_review(
     )
 
     tracker.on_start(total_chunks=len(chunks), depth=depth)
+    total_findings = 0
+    completed = False
+    try:
+        for chunk_index, chunk in enumerate(chunks):
+            budget.check()
+            tracker.on_chunk_start(
+                chunk_index=chunk_index,
+                files=list(chunk.files),
+            )
+            partial, next_generated_checklist_id = _review_chunk(
+                chunk=chunk,
+                context=context,
+                provider=provider,
+                ai_config=ai_config,
+                depth=depth,
+                checklist_text=checklist_text,
+                checklist_count=len(checklist_items),
+                next_generated_checklist_id=next_generated_checklist_id,
+                classifications=classifications,
+                lint_results=lint_results,
+                budget=budget,
+                progress=tracker,
+                chunk_index=chunk_index,
+            )
+            partials.append(partial)
+            tracker.on_chunk_done(chunk_index=chunk_index)
 
-    for chunk_index, chunk in enumerate(chunks):
-        budget.check()
-        tracker.on_chunk_start(
-            chunk_index=chunk_index,
-            files=list(chunk.files),
-        )
-        partial, next_generated_checklist_id = _review_chunk(
-            chunk=chunk,
-            context=context,
-            provider=provider,
-            ai_config=ai_config,
-            depth=depth,
-            checklist_text=checklist_text,
-            checklist_count=len(checklist_items),
-            next_generated_checklist_id=next_generated_checklist_id,
-            classifications=classifications,
-            lint_results=lint_results,
-            budget=budget,
-            progress=tracker,
-            chunk_index=chunk_index,
-        )
-        partials.append(partial)
-        tracker.on_chunk_done(chunk_index=chunk_index)
-
-    merged = merge_review_results(partials=partials)
-    total_findings = len(merged.findings) if hasattr(merged, "findings") else 0
-    tracker.on_complete(total_findings=total_findings)
+        merged = merge_review_results(partials=partials)
+        total_findings = len(merged.findings) if hasattr(merged, "findings") else 0
+        completed = True
+    finally:
+        if completed:
+            tracker.on_complete(total_findings=total_findings)
+        else:
+            tracker.on_abort()
     total_input = sum(partial.input_tokens for partial in partials)
     total_output = sum(partial.output_tokens for partial in partials)
     total_cost = sum(partial.cost_estimate for partial in partials)

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -33,9 +33,8 @@ from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.paths_registry import generate_interaction_paths
-from lintro.ai.token_budget import estimate_tokens
-
 from lintro.ai.review.progress import NullReviewProgress, ReviewProgressCallback
+from lintro.ai.token_budget import estimate_tokens
 
 if TYPE_CHECKING:
     from lintro.ai.config import AIConfig

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+from contextlib import suppress
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -182,10 +183,11 @@ def run_review(
         total_findings = len(merged.findings)
         completed = True
     finally:
-        if completed:
-            tracker.on_complete(total_findings=total_findings)
-        else:
-            tracker.on_abort()
+        with suppress(Exception):
+            if completed:
+                tracker.on_complete(total_findings=total_findings)
+            else:
+                tracker.on_abort()
     total_input = sum(partial.input_tokens for partial in partials)
     total_output = sum(partial.output_tokens for partial in partials)
     total_cost = sum(partial.cost_estimate for partial in partials)

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -35,6 +35,8 @@ from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.paths_registry import generate_interaction_paths
 from lintro.ai.token_budget import estimate_tokens
 
+from lintro.ai.review.progress import NullReviewProgress, ReviewProgressCallback
+
 if TYPE_CHECKING:
     from lintro.ai.config import AIConfig
     from lintro.ai.providers.base import AIResponse, BaseAIProvider
@@ -82,6 +84,7 @@ def run_review(
     classifications: list[FileClassification],
     context_window_override: int | None = None,
     lint_results: str | None = None,
+    progress: ReviewProgressCallback | None = None,
 ) -> ReviewResult:
     """Execute an AI diff review with depth-controlled passes.
 
@@ -95,6 +98,7 @@ def run_review(
         classifications: Domain classifications for changed files.
         context_window_override: Optional explicit context window override.
         lint_results: Optional lint digest for ``--with-lint`` integration.
+        progress: Optional progress callback for live status updates.
 
     Returns:
         Complete review result with metadata, checklist, and findings.
@@ -137,6 +141,7 @@ def run_review(
         _single_chunk_from_context(context=context),
     ]
 
+    tracker = progress or NullReviewProgress()
     budget = CostBudget(max_cost_usd=ai_config.max_cost_usd)
     partials: list[_ChunkReviewPartial] = []
     next_generated_checklist_id = (
@@ -146,8 +151,14 @@ def run_review(
         + 1
     )
 
-    for chunk in chunks:
+    tracker.on_start(total_chunks=len(chunks), depth=depth)
+
+    for chunk_index, chunk in enumerate(chunks):
         budget.check()
+        tracker.on_chunk_start(
+            chunk_index=chunk_index,
+            files=list(chunk.files),
+        )
         partial, next_generated_checklist_id = _review_chunk(
             chunk=chunk,
             context=context,
@@ -160,10 +171,15 @@ def run_review(
             classifications=classifications,
             lint_results=lint_results,
             budget=budget,
+            progress=tracker,
+            chunk_index=chunk_index,
         )
         partials.append(partial)
+        tracker.on_chunk_done(chunk_index=chunk_index)
 
     merged = merge_review_results(partials=partials)
+    total_findings = len(merged.findings) if hasattr(merged, "findings") else 0
+    tracker.on_complete(total_findings=total_findings)
     total_input = sum(partial.input_tokens for partial in partials)
     total_output = sum(partial.output_tokens for partial in partials)
     total_cost = sum(partial.cost_estimate for partial in partials)
@@ -392,8 +408,11 @@ def _review_chunk(
     classifications: list[FileClassification],
     lint_results: str | None,
     budget: CostBudget,
+    progress: ReviewProgressCallback | None = None,
+    chunk_index: int = 0,
 ) -> tuple[_ChunkReviewPartial, int]:
     """Run depth-controlled review for a single chunk."""
+    tracker = progress or NullReviewProgress()
     interaction_paths = generate_interaction_paths(
         classifications=classifications,
         changed_files=chunk.files,
@@ -401,6 +420,7 @@ def _review_chunk(
     extra_checklist = ""
     extra_checklist_usage: _ChunkReviewPartial | None = None
     if depth >= 2:
+        tracker.on_step(chunk_index=chunk_index, step="generating questions")
         (
             extra_checklist,
             next_generated_checklist_id,
@@ -414,6 +434,7 @@ def _review_chunk(
             next_generated_checklist_id=next_generated_checklist_id,
         )
 
+    tracker.on_step(chunk_index=chunk_index, step="reviewing")
     system_prompt, user_prompt = build_review_prompt(
         chunk=chunk,
         context=context,
@@ -442,6 +463,7 @@ def _review_chunk(
         )
 
     if depth >= 3:
+        tracker.on_step(chunk_index=chunk_index, step="adversarial sweep")
         adversarial = _run_adversarial_pass(
             chunk=chunk,
             provider=provider,

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -179,7 +179,7 @@ def run_review(
             tracker.on_chunk_done(chunk_index=chunk_index)
 
         merged = merge_review_results(partials=partials)
-        total_findings = len(merged.findings) if hasattr(merged, "findings") else 0
+        total_findings = len(merged.findings)
         completed = True
     finally:
         if completed:

--- a/lintro/ai/review/progress.py
+++ b/lintro/ai/review/progress.py
@@ -78,19 +78,19 @@ class NullReviewProgress:
     """No-op progress tracker (silent)."""
 
     def on_start(self, *, total_chunks: int, depth: int) -> None:
-        pass
+        """Ignore review start notification."""
 
     def on_chunk_start(self, *, chunk_index: int, files: list[str]) -> None:
-        pass
+        """Ignore chunk start notification."""
 
     def on_step(self, *, chunk_index: int, step: str) -> None:
-        pass
+        """Ignore step notification."""
 
     def on_chunk_done(self, *, chunk_index: int) -> None:
-        pass
+        """Ignore chunk completion notification."""
 
     def on_complete(self, *, total_findings: int) -> None:
-        pass
+        """Ignore review completion notification."""
 
 
 class RichReviewProgress:
@@ -104,6 +104,11 @@ class RichReviewProgress:
     """
 
     def __init__(self, *, console: Console | None = None) -> None:
+        """Initialize the Rich progress display.
+
+        Args:
+            console: Optional Rich console; defaults to stdout.
+        """
         self._console = console or Console()
         self._progress: Progress | None = None
         self._task_id: TaskID | None = None
@@ -111,10 +116,12 @@ class RichReviewProgress:
         self._depth = 1
 
     def on_start(self, *, total_chunks: int, depth: int) -> None:
+        """Start the live progress bar for the review run."""
         passes = _passes_per_chunk(depth)
         depth_label = {1: "standard", 2: "thorough", 3: "deep"}.get(depth, "")
         self._total_chunks = total_chunks
         self._depth = depth
+        pass_word = "passes" if passes > 1 else "pass"
 
         self._progress = Progress(
             SpinnerColumn(),
@@ -127,12 +134,13 @@ class RichReviewProgress:
             transient=True,
         )
         self._task_id = self._progress.add_task(
-            f"Reviewing ({depth_label}, {passes} pass{'es' if passes > 1 else ''}/chunk)",
+            f"Reviewing ({depth_label}, {passes} {pass_word}/chunk)",
             total=total_chunks,
         )
         self._progress.start()
 
     def on_chunk_start(self, *, chunk_index: int, files: list[str]) -> None:
+        """Update the bar description for a new chunk."""
         if self._progress is None or self._task_id is None:
             return
         file_count = len(files)
@@ -143,6 +151,7 @@ class RichReviewProgress:
         )
 
     def on_step(self, *, chunk_index: int, step: str) -> None:
+        """Update the bar description for an in-chunk step."""
         if self._progress is None or self._task_id is None:
             return
         self._progress.update(
@@ -151,11 +160,13 @@ class RichReviewProgress:
         )
 
     def on_chunk_done(self, *, chunk_index: int) -> None:
+        """Advance the bar after a chunk completes."""
         if self._progress is None or self._task_id is None:
             return
         self._progress.update(self._task_id, advance=1)
 
     def on_complete(self, *, total_findings: int) -> None:
+        """Stop the bar and print the completion summary."""
         if self._progress is not None:
             self._progress.stop()
             self._progress = None

--- a/lintro/ai/review/progress.py
+++ b/lintro/ai/review/progress.py
@@ -147,9 +147,7 @@ class RichReviewProgress:
             return
         self._progress.update(
             self._task_id,
-            description=(
-                f"Chunk {chunk_index + 1}/{self._total_chunks}: {step}"
-            ),
+            description=(f"Chunk {chunk_index + 1}/{self._total_chunks}: {step}"),
         )
 
     def on_chunk_done(self, *, chunk_index: int) -> None:
@@ -163,8 +161,7 @@ class RichReviewProgress:
             self._progress = None
         noun = "finding" if total_findings == 1 else "findings"
         self._console.print(
-            f"[bold green]✓[/bold green] Review complete — "
-            f"{total_findings} {noun}",
+            f"[bold green]✓[/bold green] Review complete — " f"{total_findings} {noun}",
         )
 
 
@@ -174,4 +171,4 @@ def _passes_per_chunk(depth: int) -> int:
         return 3  # questions + review + adversarial
     if depth >= 2:
         return 2  # questions + review
-    return 1      # review only
+    return 1  # review only

--- a/lintro/ai/review/progress.py
+++ b/lintro/ai/review/progress.py
@@ -1,0 +1,177 @@
+"""Progress tracking for AI review operations.
+
+Provides a protocol for progress callbacks and a Rich terminal
+implementation with a live progress bar, elapsed timer, and
+per-step status updates.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TaskID,
+    TextColumn,
+    TimeElapsedColumn,
+)
+
+
+class ReviewProgressCallback(Protocol):
+    """Protocol for review progress reporting.
+
+    Implementors receive lifecycle calls from the orchestrator to
+    update a progress display. The default no-op implementation
+    (``NullReviewProgress``) silently ignores all calls.
+    """
+
+    def on_start(self, *, total_chunks: int, depth: int) -> None:
+        """Called once when the review begins.
+
+        Args:
+            total_chunks: Number of semantic chunks to review.
+            depth: Review depth level (1-3).
+        """
+        ...
+
+    def on_chunk_start(self, *, chunk_index: int, files: list[str]) -> None:
+        """Called when a chunk begins processing.
+
+        Args:
+            chunk_index: Zero-based chunk index.
+            files: List of file paths in this chunk.
+        """
+        ...
+
+    def on_step(self, *, chunk_index: int, step: str) -> None:
+        """Called when a sub-step begins within a chunk.
+
+        Args:
+            chunk_index: Zero-based chunk index.
+            step: Human-readable step name (e.g. "reviewing",
+                "generating questions", "adversarial sweep").
+        """
+        ...
+
+    def on_chunk_done(self, *, chunk_index: int) -> None:
+        """Called when a chunk finishes processing.
+
+        Args:
+            chunk_index: Zero-based chunk index.
+        """
+        ...
+
+    def on_complete(self, *, total_findings: int) -> None:
+        """Called when the entire review is finished.
+
+        Args:
+            total_findings: Number of findings produced.
+        """
+        ...
+
+
+class NullReviewProgress:
+    """No-op progress tracker (silent)."""
+
+    def on_start(self, *, total_chunks: int, depth: int) -> None:
+        pass
+
+    def on_chunk_start(self, *, chunk_index: int, files: list[str]) -> None:
+        pass
+
+    def on_step(self, *, chunk_index: int, step: str) -> None:
+        pass
+
+    def on_chunk_done(self, *, chunk_index: int) -> None:
+        pass
+
+    def on_complete(self, *, total_findings: int) -> None:
+        pass
+
+
+class RichReviewProgress:
+    """Rich-based live progress bar for terminal output.
+
+    Displays a progress bar with:
+    - Spinner animation
+    - Current step description
+    - Chunk progress (e.g. 2/3)
+    - Elapsed time
+    """
+
+    def __init__(self, *, console: Console | None = None) -> None:
+        self._console = console or Console()
+        self._progress: Progress | None = None
+        self._task_id: TaskID | None = None
+        self._total_chunks = 0
+        self._depth = 1
+
+    def on_start(self, *, total_chunks: int, depth: int) -> None:
+        passes = _passes_per_chunk(depth)
+        depth_label = {1: "standard", 2: "thorough", 3: "deep"}.get(depth, "")
+        self._total_chunks = total_chunks
+        self._depth = depth
+
+        self._progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[bold cyan]{task.description}"),
+            BarColumn(bar_width=30),
+            MofNCompleteColumn(),
+            TextColumn("[dim]chunks[/dim]"),
+            TimeElapsedColumn(),
+            console=self._console,
+            transient=True,
+        )
+        self._task_id = self._progress.add_task(
+            f"Reviewing ({depth_label}, {passes} pass{'es' if passes > 1 else ''}/chunk)",
+            total=total_chunks,
+        )
+        self._progress.start()
+
+    def on_chunk_start(self, *, chunk_index: int, files: list[str]) -> None:
+        if self._progress is None or self._task_id is None:
+            return
+        file_count = len(files)
+        label = files[0] if file_count == 1 else f"{file_count} files"
+        self._progress.update(
+            self._task_id,
+            description=f"Chunk {chunk_index + 1}/{self._total_chunks}: {label}",
+        )
+
+    def on_step(self, *, chunk_index: int, step: str) -> None:
+        if self._progress is None or self._task_id is None:
+            return
+        self._progress.update(
+            self._task_id,
+            description=(
+                f"Chunk {chunk_index + 1}/{self._total_chunks}: {step}"
+            ),
+        )
+
+    def on_chunk_done(self, *, chunk_index: int) -> None:
+        if self._progress is None or self._task_id is None:
+            return
+        self._progress.update(self._task_id, advance=1)
+
+    def on_complete(self, *, total_findings: int) -> None:
+        if self._progress is not None:
+            self._progress.stop()
+            self._progress = None
+        noun = "finding" if total_findings == 1 else "findings"
+        self._console.print(
+            f"[bold green]✓[/bold green] Review complete — "
+            f"{total_findings} {noun}",
+        )
+
+
+def _passes_per_chunk(depth: int) -> int:
+    """Calculate the number of AI calls per chunk at the given depth."""
+    if depth >= 3:
+        return 3  # questions + review + adversarial
+    if depth >= 2:
+        return 2  # questions + review
+    return 1      # review only

--- a/lintro/ai/review/progress.py
+++ b/lintro/ai/review/progress.py
@@ -73,6 +73,10 @@ class ReviewProgressCallback(Protocol):
         """
         ...
 
+    def on_abort(self) -> None:
+        """Called when the review stops before completing successfully."""
+        ...
+
 
 class NullReviewProgress:
     """No-op progress tracker (silent)."""
@@ -91,6 +95,9 @@ class NullReviewProgress:
 
     def on_complete(self, *, total_findings: int) -> None:
         """Ignore review completion notification."""
+
+    def on_abort(self) -> None:
+        """Ignore review abort notification."""
 
 
 class RichReviewProgress:
@@ -159,7 +166,7 @@ class RichReviewProgress:
             description=(f"Chunk {chunk_index + 1}/{self._total_chunks}: {step}"),
         )
 
-    def on_chunk_done(self, *, chunk_index: int) -> None:
+    def on_chunk_done(self, *, chunk_index: int) -> None:  # noqa: ARG002
         """Advance the bar after a chunk completes."""
         if self._progress is None or self._task_id is None:
             return
@@ -167,13 +174,21 @@ class RichReviewProgress:
 
     def on_complete(self, *, total_findings: int) -> None:
         """Stop the bar and print the completion summary."""
+        self._stop_progress()
+        noun = "finding" if total_findings == 1 else "findings"
+        self._console.print(
+            f"[bold green]✓[/bold green] Review complete — {total_findings} {noun}",
+        )
+
+    def on_abort(self) -> None:
+        """Stop the bar without printing a completion summary."""
+        self._stop_progress()
+
+    def _stop_progress(self) -> None:
+        """Stop the live progress display if it is running."""
         if self._progress is not None:
             self._progress.stop()
             self._progress = None
-        noun = "finding" if total_findings == 1 else "findings"
-        self._console.print(
-            f"[bold green]✓[/bold green] Review complete — " f"{total_findings} {noun}",
-        )
 
 
 def _passes_per_chunk(depth: int) -> int:

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -168,6 +168,13 @@ def review_command(
             )
 
     provider = get_provider(lintro_config.ai)
+
+    progress_tracker = None
+    if output_format == "terminal":
+        from lintro.ai.review.progress import RichReviewProgress
+
+        progress_tracker = RichReviewProgress()
+
     result = run_review(
         context,
         provider=provider,
@@ -178,6 +185,7 @@ def review_command(
         classifications=classifications,
         context_window_override=context_window,
         lint_results=lint_digest,
+        progress=progress_tracker,
     )
 
     output = render_review_output(result=result, output_format=output_format)

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
@@ -18,6 +19,7 @@ from lintro.ai.review.orchestrator import (
     run_review,
     strip_json_fences,
 )
+from lintro.ai.review.progress import ReviewProgressCallback
 
 
 def _sample_response_json(*, include_finding: bool = True) -> str:
@@ -235,25 +237,25 @@ def test_run_review_aborts_progress_when_chunk_review_fails() -> None:
         pr_metadata=None,
     )
     provider = _mock_provider(content=_sample_response_json())
-    progress = MagicMock()
+    progress = MagicMock(spec=ReviewProgressCallback)
 
-    with patch(
-        "lintro.ai.review.orchestrator.complete_with_fallback",
-        side_effect=RuntimeError("provider failed"),
+    with (
+        patch(
+            "lintro.ai.review.orchestrator.complete_with_fallback",
+            side_effect=RuntimeError("provider failed"),
+        ),
+        pytest.raises(RuntimeError, match="provider failed"),
     ):
-        try:
-            run_review(
-                context,
-                provider=provider,
-                ai_config=AIConfig(enabled=True),
-                depth=1,
-                checklist_items=[],
-                checklist_text="1. [logic-bug] Example?",
-                classifications=[],
-                progress=progress,
-            )
-        except RuntimeError:
-            pass
+        run_review(
+            context,
+            provider=provider,
+            ai_config=AIConfig(enabled=True),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+            progress=progress,
+        )
 
     progress.on_start.assert_called_once()
     progress.on_abort.assert_called_once()

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -216,3 +216,45 @@ def test_run_review_depth2_calls_provider_twice() -> None:
     assert_that(result.metadata.token_usage["prompt"]).is_equal_to(150)
     assert_that(result.metadata.token_usage["completion"]).is_equal_to(70)
     assert_that(result.metadata.cost_estimate_usd).is_equal_to(0.015)
+
+
+def test_run_review_aborts_progress_when_chunk_review_fails() -> None:
+    """Progress tracker receives on_abort when a chunk review raises."""
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(
+                path="src/main.py",
+                status="modified",
+                additions=1,
+                deletions=0,
+            ),
+        ],
+        unified_diff="diff --git a/src/main.py b/src/main.py\n+change",
+        pr_metadata=None,
+    )
+    provider = _mock_provider(content=_sample_response_json())
+    progress = MagicMock()
+
+    with patch(
+        "lintro.ai.review.orchestrator.complete_with_fallback",
+        side_effect=RuntimeError("provider failed"),
+    ):
+        try:
+            run_review(
+                context,
+                provider=provider,
+                ai_config=AIConfig(enabled=True),
+                depth=1,
+                checklist_items=[],
+                checklist_text="1. [logic-bug] Example?",
+                classifications=[],
+                progress=progress,
+            )
+        except RuntimeError:
+            pass
+
+    progress.on_start.assert_called_once()
+    progress.on_abort.assert_called_once()
+    progress.on_complete.assert_not_called()

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -262,6 +262,49 @@ def test_run_review_aborts_progress_when_chunk_review_fails() -> None:
     progress.on_complete.assert_not_called()
 
 
+def test_run_review_propagates_chunk_error_when_progress_abort_raises() -> None:
+    """Progress cleanup errors must not mask the original chunk review failure."""
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(
+                path="src/main.py",
+                status="modified",
+                additions=1,
+                deletions=0,
+            ),
+        ],
+        unified_diff="diff --git a/src/main.py b/src/main.py\n+change",
+        pr_metadata=None,
+    )
+    provider = _mock_provider(content=_sample_response_json())
+    progress = MagicMock(spec=ReviewProgressCallback)
+    progress.on_abort.side_effect = BrokenPipeError()
+
+    with (
+        patch(
+            "lintro.ai.review.orchestrator.complete_with_fallback",
+            side_effect=RuntimeError("provider failed"),
+        ),
+        pytest.raises(RuntimeError, match="provider failed"),
+    ):
+        run_review(
+            context,
+            provider=provider,
+            ai_config=AIConfig(enabled=True),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+            progress=progress,
+        )
+
+    progress.on_start.assert_called_once()
+    progress.on_abort.assert_called_once()
+    progress.on_complete.assert_not_called()
+
+
 def test_run_review_returns_result_when_progress_complete_raises() -> None:
     """Progress cleanup errors must not discard a successful review result."""
     context = ReviewContext(

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -260,3 +260,57 @@ def test_run_review_aborts_progress_when_chunk_review_fails() -> None:
     progress.on_start.assert_called_once()
     progress.on_abort.assert_called_once()
     progress.on_complete.assert_not_called()
+
+
+def test_run_review_returns_result_when_progress_complete_raises() -> None:
+    """Progress cleanup errors must not discard a successful review result."""
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(
+                path="src/main.py",
+                status="modified",
+                additions=1,
+                deletions=0,
+            ),
+        ],
+        unified_diff="diff --git a/src/main.py b/src/main.py\n+change",
+        pr_metadata=None,
+    )
+    checklist_items = [
+        ChecklistItem(
+            id=1,
+            question="Example?",
+            domains=(),
+            languages=(),
+            category=ReviewCategory.LOGIC_BUG,
+            tier=1,
+        ),
+    ]
+    provider = _mock_provider(content=_sample_response_json())
+    progress = MagicMock(spec=ReviewProgressCallback)
+    progress.on_complete.side_effect = BrokenPipeError()
+
+    with patch(
+        "lintro.ai.review.orchestrator.complete_with_fallback",
+        side_effect=lambda _provider, _prompt, **kwargs: _provider.complete(
+            _prompt,
+            system=kwargs.get("system"),
+            max_tokens=kwargs.get("max_tokens", 1024),
+            timeout=kwargs.get("timeout", 60.0),
+        ),
+    ):
+        result = run_review(
+            context,
+            provider=provider,
+            ai_config=AIConfig(enabled=True),
+            depth=1,
+            checklist_items=checklist_items,
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+            progress=progress,
+        )
+
+    assert_that(result.summary).contains("Merge")
+    progress.on_complete.assert_called_once_with(total_findings=1)

--- a/tests/unit/ai/test_review_progress.py
+++ b/tests/unit/ai/test_review_progress.py
@@ -2,108 +2,118 @@
 
 from __future__ import annotations
 
+from io import StringIO
+
 from assertpy import assert_that
+from rich.console import Console
 
 from lintro.ai.review.progress import (
     NullReviewProgress,
     RichReviewProgress,
     _passes_per_chunk,
 )
+from lintro.parsers.base_parser import strip_ansi_codes
+
+# -- _passes_per_chunk -----------------------------------------------------
 
 
-class TestPassesPerChunk:
-    """Tests for the _passes_per_chunk helper."""
-
-    def test_depth_1_single_pass(self) -> None:
-        """Depth 1 runs one AI pass per chunk."""
-        assert_that(_passes_per_chunk(1)).is_equal_to(1)
-
-    def test_depth_2_two_passes(self) -> None:
-        """Depth 2 runs two AI passes per chunk."""
-        assert_that(_passes_per_chunk(2)).is_equal_to(2)
-
-    def test_depth_3_three_passes(self) -> None:
-        """Depth 3 runs three AI passes per chunk."""
-        assert_that(_passes_per_chunk(3)).is_equal_to(3)
+def test_passes_per_chunk_depth_1_single_pass() -> None:
+    """Depth 1 runs one AI pass per chunk."""
+    assert_that(_passes_per_chunk(1)).is_equal_to(1)
 
 
-class TestNullReviewProgress:
-    """NullReviewProgress silently accepts all calls."""
-
-    def test_full_lifecycle(self) -> None:
-        """All lifecycle hooks are safe no-ops."""
-        p = NullReviewProgress()
-        p.on_start(total_chunks=3, depth=2)
-        p.on_chunk_start(chunk_index=0, files=["a.py"])
-        p.on_step(chunk_index=0, step="reviewing")
-        p.on_chunk_done(chunk_index=0)
-        p.on_complete(total_findings=5)
+def test_passes_per_chunk_depth_2_two_passes() -> None:
+    """Depth 2 runs two AI passes per chunk."""
+    assert_that(_passes_per_chunk(2)).is_equal_to(2)
 
 
-class TestRichReviewProgress:
-    """RichReviewProgress lifecycle without a live terminal."""
+def test_passes_per_chunk_depth_3_three_passes() -> None:
+    """Depth 3 runs three AI passes per chunk."""
+    assert_that(_passes_per_chunk(3)).is_equal_to(3)
 
-    def test_full_lifecycle_does_not_crash(self) -> None:
-        """Exercise the full progress lifecycle without raising."""
-        from rich.console import Console
 
-        console = Console(file=None, force_terminal=False)
-        p = RichReviewProgress(console=console)
-        p.on_start(total_chunks=2, depth=1)
-        p.on_chunk_start(chunk_index=0, files=["a.py", "b.py"])
-        p.on_step(chunk_index=0, step="reviewing")
-        p.on_chunk_done(chunk_index=0)
-        p.on_chunk_start(chunk_index=1, files=["c.py"])
-        p.on_step(chunk_index=1, step="reviewing")
-        p.on_chunk_done(chunk_index=1)
-        p.on_complete(total_findings=3)
+# -- NullReviewProgress ----------------------------------------------------
 
-    def test_calls_before_start_are_safe(self) -> None:
-        """Chunk callbacks before on_start do not raise."""
-        from rich.console import Console
 
-        console = Console(file=None, force_terminal=False)
-        p = RichReviewProgress(console=console)
-        p.on_chunk_start(chunk_index=0, files=["a.py"])
-        p.on_step(chunk_index=0, step="reviewing")
-        p.on_chunk_done(chunk_index=0)
+def test_null_review_progress_full_lifecycle() -> None:
+    """All lifecycle hooks are safe no-ops."""
+    progress = NullReviewProgress()
+    progress.on_start(total_chunks=3, depth=2)
+    progress.on_chunk_start(chunk_index=0, files=["a.py"])
+    progress.on_step(chunk_index=0, step="reviewing")
+    progress.on_chunk_done(chunk_index=0)
+    progress.on_complete(total_findings=5)
+    progress.on_abort()
 
-    def test_complete_without_start_is_safe(self) -> None:
-        """on_complete before on_start does not raise."""
-        from rich.console import Console
 
-        console = Console(file=None, force_terminal=False)
-        p = RichReviewProgress(console=console)
-        p.on_complete(total_findings=0)
+# -- RichReviewProgress ----------------------------------------------------
 
-    def test_single_file_shows_filename(self) -> None:
-        """Single-file chunks render the plural findings label."""
-        from io import StringIO
 
-        from rich.console import Console
+def test_rich_review_progress_full_lifecycle_does_not_crash() -> None:
+    """Exercise the full progress lifecycle without raising."""
+    console = Console(file=None, force_terminal=False)
+    progress = RichReviewProgress(console=console)
+    progress.on_start(total_chunks=2, depth=1)
+    progress.on_chunk_start(chunk_index=0, files=["a.py", "b.py"])
+    progress.on_step(chunk_index=0, step="reviewing")
+    progress.on_chunk_done(chunk_index=0)
+    progress.on_chunk_start(chunk_index=1, files=["c.py"])
+    progress.on_step(chunk_index=1, step="reviewing")
+    progress.on_chunk_done(chunk_index=1)
+    progress.on_complete(total_findings=3)
 
-        buf = StringIO()
-        console = Console(file=buf, force_terminal=True, width=120)
-        p = RichReviewProgress(console=console)
-        p.on_start(total_chunks=1, depth=1)
-        p.on_chunk_start(chunk_index=0, files=["src/main.py"])
-        p.on_chunk_done(chunk_index=0)
-        p.on_complete(total_findings=0)
-        output = buf.getvalue()
-        assert_that(output).contains("0 findings")
 
-    def test_singular_finding_label(self) -> None:
-        """Exactly one finding uses the singular noun."""
-        from io import StringIO
+def test_rich_review_progress_calls_before_start_are_safe() -> None:
+    """Chunk callbacks before on_start do not raise."""
+    console = Console(file=None, force_terminal=False)
+    progress = RichReviewProgress(console=console)
+    progress.on_chunk_start(chunk_index=0, files=["a.py"])
+    progress.on_step(chunk_index=0, step="reviewing")
+    progress.on_chunk_done(chunk_index=0)
 
-        from rich.console import Console
 
-        buf = StringIO()
-        console = Console(file=buf, force_terminal=True, width=120)
-        p = RichReviewProgress(console=console)
-        p.on_start(total_chunks=1, depth=1)
-        p.on_chunk_done(chunk_index=0)
-        p.on_complete(total_findings=1)
-        output = buf.getvalue()
-        assert_that(output).contains("1 finding")
-        assert_that(output).does_not_contain("1 findings")
+def test_rich_review_progress_complete_without_start_is_safe() -> None:
+    """on_complete before on_start does not raise."""
+    console = Console(file=None, force_terminal=False)
+    progress = RichReviewProgress(console=console)
+    progress.on_complete(total_findings=0)
+
+
+def test_rich_review_progress_abort_stops_without_completion_message() -> None:
+    """on_abort stops the bar without printing the success summary."""
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=True, width=120)
+    progress = RichReviewProgress(console=console)
+    progress.on_start(total_chunks=1, depth=1)
+    progress.on_abort()
+    output = strip_ansi_codes(buf.getvalue())
+
+    assert_that(output).does_not_contain("Review complete")
+
+
+def test_rich_review_progress_single_file_shows_filename() -> None:
+    """Single-file chunks render the plural findings label."""
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=True, width=120)
+    progress = RichReviewProgress(console=console)
+    progress.on_start(total_chunks=1, depth=1)
+    progress.on_chunk_start(chunk_index=0, files=["src/main.py"])
+    progress.on_chunk_done(chunk_index=0)
+    progress.on_complete(total_findings=0)
+    output = strip_ansi_codes(buf.getvalue())
+
+    assert_that(output).contains("0 findings")
+
+
+def test_rich_review_progress_singular_finding_label() -> None:
+    """Exactly one finding uses the singular noun."""
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=True, width=120)
+    progress = RichReviewProgress(console=console)
+    progress.on_start(total_chunks=1, depth=1)
+    progress.on_chunk_done(chunk_index=0)
+    progress.on_complete(total_findings=1)
+    output = strip_ansi_codes(buf.getvalue())
+
+    assert_that(output).contains("1 finding")
+    assert_that(output).does_not_contain("1 findings")

--- a/tests/unit/ai/test_review_progress.py
+++ b/tests/unit/ai/test_review_progress.py
@@ -1,0 +1,100 @@
+"""Tests for review progress tracking."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.ai.review.progress import (
+    NullReviewProgress,
+    RichReviewProgress,
+    _passes_per_chunk,
+)
+
+
+class TestPassesPerChunk:
+    """Tests for the _passes_per_chunk helper."""
+
+    def test_depth_1_single_pass(self):
+        assert_that(_passes_per_chunk(1)).is_equal_to(1)
+
+    def test_depth_2_two_passes(self):
+        assert_that(_passes_per_chunk(2)).is_equal_to(2)
+
+    def test_depth_3_three_passes(self):
+        assert_that(_passes_per_chunk(3)).is_equal_to(3)
+
+
+class TestNullReviewProgress:
+    """NullReviewProgress silently accepts all calls."""
+
+    def test_full_lifecycle(self):
+        p = NullReviewProgress()
+        p.on_start(total_chunks=3, depth=2)
+        p.on_chunk_start(chunk_index=0, files=["a.py"])
+        p.on_step(chunk_index=0, step="reviewing")
+        p.on_chunk_done(chunk_index=0)
+        p.on_complete(total_findings=5)
+
+
+class TestRichReviewProgress:
+    """RichReviewProgress lifecycle without a live terminal."""
+
+    def test_full_lifecycle_does_not_crash(self):
+        from rich.console import Console
+
+        console = Console(file=None, force_terminal=False)
+        p = RichReviewProgress(console=console)
+        p.on_start(total_chunks=2, depth=1)
+        p.on_chunk_start(chunk_index=0, files=["a.py", "b.py"])
+        p.on_step(chunk_index=0, step="reviewing")
+        p.on_chunk_done(chunk_index=0)
+        p.on_chunk_start(chunk_index=1, files=["c.py"])
+        p.on_step(chunk_index=1, step="reviewing")
+        p.on_chunk_done(chunk_index=1)
+        p.on_complete(total_findings=3)
+
+    def test_calls_before_start_are_safe(self):
+        from rich.console import Console
+
+        console = Console(file=None, force_terminal=False)
+        p = RichReviewProgress(console=console)
+        p.on_chunk_start(chunk_index=0, files=["a.py"])
+        p.on_step(chunk_index=0, step="reviewing")
+        p.on_chunk_done(chunk_index=0)
+
+    def test_complete_without_start_is_safe(self):
+        from rich.console import Console
+
+        console = Console(file=None, force_terminal=False)
+        p = RichReviewProgress(console=console)
+        p.on_complete(total_findings=0)
+
+    def test_single_file_shows_filename(self):
+        from io import StringIO
+
+        from rich.console import Console
+
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True, width=120)
+        p = RichReviewProgress(console=console)
+        p.on_start(total_chunks=1, depth=1)
+        p.on_chunk_start(chunk_index=0, files=["src/main.py"])
+        p.on_chunk_done(chunk_index=0)
+        p.on_complete(total_findings=0)
+        output = buf.getvalue()
+        assert_that(output).contains("0 findings")
+
+    def test_singular_finding_label(self):
+        from io import StringIO
+
+        from rich.console import Console
+
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True, width=120)
+        p = RichReviewProgress(console=console)
+        p.on_start(total_chunks=1, depth=1)
+        p.on_chunk_done(chunk_index=0)
+        p.on_complete(total_findings=1)
+        output = buf.getvalue()
+        assert_that(output).contains("1 finding")
+        assert_that(output).does_not_contain("1 findings")

--- a/tests/unit/ai/test_review_progress.py
+++ b/tests/unit/ai/test_review_progress.py
@@ -14,20 +14,24 @@ from lintro.ai.review.progress import (
 class TestPassesPerChunk:
     """Tests for the _passes_per_chunk helper."""
 
-    def test_depth_1_single_pass(self):
+    def test_depth_1_single_pass(self) -> None:
+        """Depth 1 runs one AI pass per chunk."""
         assert_that(_passes_per_chunk(1)).is_equal_to(1)
 
-    def test_depth_2_two_passes(self):
+    def test_depth_2_two_passes(self) -> None:
+        """Depth 2 runs two AI passes per chunk."""
         assert_that(_passes_per_chunk(2)).is_equal_to(2)
 
-    def test_depth_3_three_passes(self):
+    def test_depth_3_three_passes(self) -> None:
+        """Depth 3 runs three AI passes per chunk."""
         assert_that(_passes_per_chunk(3)).is_equal_to(3)
 
 
 class TestNullReviewProgress:
     """NullReviewProgress silently accepts all calls."""
 
-    def test_full_lifecycle(self):
+    def test_full_lifecycle(self) -> None:
+        """All lifecycle hooks are safe no-ops."""
         p = NullReviewProgress()
         p.on_start(total_chunks=3, depth=2)
         p.on_chunk_start(chunk_index=0, files=["a.py"])
@@ -39,7 +43,8 @@ class TestNullReviewProgress:
 class TestRichReviewProgress:
     """RichReviewProgress lifecycle without a live terminal."""
 
-    def test_full_lifecycle_does_not_crash(self):
+    def test_full_lifecycle_does_not_crash(self) -> None:
+        """Exercise the full progress lifecycle without raising."""
         from rich.console import Console
 
         console = Console(file=None, force_terminal=False)
@@ -53,7 +58,8 @@ class TestRichReviewProgress:
         p.on_chunk_done(chunk_index=1)
         p.on_complete(total_findings=3)
 
-    def test_calls_before_start_are_safe(self):
+    def test_calls_before_start_are_safe(self) -> None:
+        """Chunk callbacks before on_start do not raise."""
         from rich.console import Console
 
         console = Console(file=None, force_terminal=False)
@@ -62,14 +68,16 @@ class TestRichReviewProgress:
         p.on_step(chunk_index=0, step="reviewing")
         p.on_chunk_done(chunk_index=0)
 
-    def test_complete_without_start_is_safe(self):
+    def test_complete_without_start_is_safe(self) -> None:
+        """on_complete before on_start does not raise."""
         from rich.console import Console
 
         console = Console(file=None, force_terminal=False)
         p = RichReviewProgress(console=console)
         p.on_complete(total_findings=0)
 
-    def test_single_file_shows_filename(self):
+    def test_single_file_shows_filename(self) -> None:
+        """Single-file chunks render the plural findings label."""
         from io import StringIO
 
         from rich.console import Console
@@ -84,7 +92,8 @@ class TestRichReviewProgress:
         output = buf.getvalue()
         assert_that(output).contains("0 findings")
 
-    def test_singular_finding_label(self):
+    def test_singular_finding_label(self) -> None:
+        """Exactly one finding uses the singular noun."""
         from io import StringIO
 
         from rich.console import Console

--- a/tests/unit/ai/test_review_progress.py
+++ b/tests/unit/ai/test_review_progress.py
@@ -91,8 +91,8 @@ def test_rich_review_progress_abort_stops_without_completion_message() -> None:
     assert_that(output).does_not_contain("Review complete")
 
 
-def test_rich_review_progress_single_file_shows_filename() -> None:
-    """Single-file chunks render the plural findings label."""
+def test_rich_review_progress_zero_findings_plural_label() -> None:
+    """Completion summary uses the plural findings label for zero findings."""
     buf = StringIO()
     console = Console(file=buf, force_terminal=True, width=120)
     progress = RichReviewProgress(console=console)


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai/review): add live progress bar for review operations
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds live progress reporting during multi-chunk AI reviews: spinner, chunk counter, elapsed time, and per-step status (collecting → chunking → reviewing → merging).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed

## Closes

- Closes #1005

## Details

- **`lintro/ai/review/progress.py`**: `ReviewProgressCallback` protocol, no-op default, and `RichReviewProgress` terminal implementation.
- **`orchestrator.py`**: emits chunk/step lifecycle callbacks during review runs.
- **CLI**: enables Rich progress for terminal output only.
- **Tests**: progress pass counting and lifecycle behavior in `tests/unit/ai/review/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a review-progress callback API with lifecycle hooks (start, per-chunk/step updates, completion, abort).
  * Added a terminal live progress UI with chunk/step updates and a completion summary.
  * Integrated progress reporting into the review flow and enabled it for terminal output.
* **Bug Fixes**
  * Ensures progress completion is only emitted on successful reviews; emits abort on chunk failures.
* **Tests**
  * Added unit tests for no-op safety, abort/completion behavior (including when completion itself errors), and correct output wording/pluralization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds live progress reporting to multi-chunk AI reviews via a `ReviewProgressCallback` protocol, a no-op `NullReviewProgress` default, and a `RichReviewProgress` terminal implementation backed by Rich. The orchestrator emits lifecycle callbacks (`on_start`, `on_chunk_start`, `on_step`, `on_chunk_done`, `on_complete`/`on_abort`) and the CLI enables the Rich display only for terminal output format.

- **`progress.py`**: New file defines the Protocol, the no-op null tracker, and the Rich terminal implementation with a transient spinner/bar, chunk counter, step label, and elapsed timer.
- **`orchestrator.py`**: Wraps the chunk loop in `try/finally` with `suppress(Exception)` so progress teardown errors (e.g. `BrokenPipeError` from piped output) can never mask a successful review result or re-raise over a genuine chunk failure.
- **Tests**: Three new orchestrator tests lock the `suppress` contract; eight new progress tests cover no-op safety, pre-start guards, pluralisation, and abort-vs-complete output.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the progress layer is purely additive, isolated behind a Protocol, and guarded so teardown errors never affect review output.

The change adds an opt-in progress layer that the existing review path can ignore entirely via NullReviewProgress. The only footgun — progress teardown raising over a successful result — is addressed with suppress(Exception) and locked by a dedicated test. No logic changes to chunking, merging, or result construction.

No files require special attention. The two style notes in progress.py are cosmetic and do not affect correctness.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/review/progress.py | New file introducing ReviewProgressCallback Protocol, NullReviewProgress no-op, and RichReviewProgress terminal implementation. Minor: _depth field stored in on_start but never read elsewhere in the class. |
| lintro/ai/review/orchestrator.py | Integrates progress callbacks into run_review and _review_chunk; uses suppress(Exception) in finally to prevent progress teardown errors from masking review results. Clean lifecycle management. |
| lintro/cli_utils/commands/review.py | Conditionally instantiates RichReviewProgress only for terminal output format and passes it to run_review. Lazy import avoids loading Rich for non-terminal output paths. |
| tests/unit/ai/review/test_orchestrator.py | Adds three orchestrator tests covering: abort on chunk failure, abort when on_abort itself raises (BrokenPipeError), and successful result return when on_complete raises. Good coverage of the suppress(Exception) contract. |
| tests/unit/ai/test_review_progress.py | Unit tests for NullReviewProgress no-op safety, RichReviewProgress lifecycle, pre-start guard, pluralisation of findings noun, and abort vs complete terminal output. Solid coverage. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as review_command
    participant ORC as run_review (orchestrator)
    participant CHK as _review_chunk
    participant TRK as ReviewProgressCallback

    CLI->>ORC: "run_review(..., progress=RichReviewProgress())"
    ORC->>TRK: "on_start(total_chunks=N, depth=D)"
    Note over TRK: Progress bar starts

    loop for each chunk
        ORC->>TRK: on_chunk_start(chunk_index, files)
        ORC->>CHK: "_review_chunk(..., progress=tracker)"
        alt "depth >= 2"
            CHK->>TRK: on_step("generating questions")
        end
        CHK->>TRK: on_step("reviewing")
        alt "depth >= 3"
            CHK->>TRK: on_step("adversarial sweep")
        end
        CHK-->>ORC: partial result
        ORC->>TRK: on_chunk_done(chunk_index)
    end

    ORC->>ORC: merge_review_results(partials)
    Note over ORC: completed = True

    alt success path (finally)
        ORC->>TRK: "on_complete(total_findings=N)"
        Note over TRK: Prints "✓ Review complete — N findings"
    else failure path (finally)
        ORC->>TRK: on_abort()
        Note over TRK: Stops bar silently
    end
    Note over ORC,TRK: Both wrapped in suppress(Exception)
    ORC-->>CLI: ReviewResult
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as review_command
    participant ORC as run_review (orchestrator)
    participant CHK as _review_chunk
    participant TRK as ReviewProgressCallback

    CLI->>ORC: "run_review(..., progress=RichReviewProgress())"
    ORC->>TRK: "on_start(total_chunks=N, depth=D)"
    Note over TRK: Progress bar starts

    loop for each chunk
        ORC->>TRK: on_chunk_start(chunk_index, files)
        ORC->>CHK: "_review_chunk(..., progress=tracker)"
        alt "depth >= 2"
            CHK->>TRK: on_step("generating questions")
        end
        CHK->>TRK: on_step("reviewing")
        alt "depth >= 3"
            CHK->>TRK: on_step("adversarial sweep")
        end
        CHK-->>ORC: partial result
        ORC->>TRK: on_chunk_done(chunk_index)
    end

    ORC->>ORC: merge_review_results(partials)
    Note over ORC: completed = True

    alt success path (finally)
        ORC->>TRK: "on_complete(total_findings=N)"
        Note over TRK: Prints "✓ Review complete — N findings"
    else failure path (finally)
        ORC->>TRK: on_abort()
        Note over TRK: Stops bar silently
    end
    Note over ORC,TRK: Both wrapped in suppress(Exception)
    ORC-->>CLI: ReviewResult
```

</a>
</details>

<sub>Reviews (8): Last reviewed commit: ["test: cover on\_abort cleanup error maski..."](https://github.com/lgtm-hq/py-lintro/commit/f08a5a8f030ed933960e053096b26a4d08ca8eb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39940257)</sub>

<!-- /greptile_comment -->