### PR TITLE
feat(ai/review): finding-centric checklist display

### DIFF
--- a/lintro/ai/review/checklist_display.py
+++ b/lintro/ai/review/checklist_display.py
@@ -1,0 +1,168 @@
+"""Helpers for resolving and rendering checklist display."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
+from lintro.ai.review.models.checklist_answer import ChecklistAnswer
+from lintro.ai.review.models.checklist_item import ChecklistItem
+from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_result import ReviewResult
+
+__all__ = [
+    "build_prompt_question_map",
+    "cleared_answers",
+    "enrich_review_result",
+    "format_review_questions_markdown",
+    "orphan_concerns",
+    "questions_for_finding",
+    "resolve_checklist_display",
+]
+
+
+def resolve_checklist_display(
+    *,
+    cli_value: str | None,
+    config_value: ChecklistDisplay,
+) -> ChecklistDisplay:
+    """Resolve effective checklist display mode from CLI and config.
+
+    Args:
+        cli_value: Optional ``--show-checklist`` value (``linked`` or ``all``).
+        config_value: Default from ``review.checklist_display``.
+
+    Returns:
+        Effective display mode.
+    """
+    if cli_value is not None:
+        return ChecklistDisplay(cli_value.lower())
+    return config_value
+
+
+def build_prompt_question_map(
+    *,
+    items: list[ChecklistItem],
+) -> dict[int, str]:
+    """Map prompt checklist ids (1..N) to question text.
+
+    Args:
+        items: Selected checklist items in prompt order.
+
+    Returns:
+        Mapping from prompt id to question string.
+    """
+    return {
+        prompt_id: item.question
+        for prompt_id, item in enumerate(items, start=1)
+    }
+
+
+def enrich_review_result(
+    *,
+    result: ReviewResult,
+    question_map: dict[int, str],
+) -> ReviewResult:
+    """Attach question text to checklist answers on a review result.
+
+    Args:
+        result: Raw review result from the orchestrator.
+        question_map: Prompt id to question mapping.
+
+    Returns:
+        Review result with enriched checklist answers.
+    """
+    enriched = tuple(
+        ChecklistAnswer(
+            id=answer.id,
+            answer=answer.answer,
+            evidence=answer.evidence,
+            question=question_map.get(answer.id, ""),
+        )
+        for answer in result.checklist
+    )
+    return replace(result, checklist=enriched)
+
+
+def questions_for_finding(
+    *,
+    finding: ReviewFinding,
+    question_map: dict[int, str],
+) -> tuple[str, ...]:
+    """Return linked review question text for a finding.
+
+    Args:
+        finding: Review finding with optional checklist_ids.
+        question_map: Prompt id to question mapping.
+
+    Returns:
+        Question strings in checklist_ids order, skipping unknown ids.
+    """
+    questions: list[str] = []
+    for checklist_id in finding.checklist_ids:
+        question = question_map.get(checklist_id, "").strip()
+        if question:
+            questions.append(question)
+    return tuple(questions)
+
+
+def cleared_answers(
+    *,
+    answers: tuple[ChecklistAnswer, ...],
+) -> tuple[ChecklistAnswer, ...]:
+    """Return checklist answers marked as cleared (no concern).
+
+    Args:
+        answers: Enriched checklist answers.
+
+    Returns:
+        Answers where the model responded ``no``.
+    """
+    return tuple(
+        answer for answer in answers if answer.answer.lower() == "no"
+    )
+
+
+def orphan_concerns(
+    *,
+    answers: tuple[ChecklistAnswer, ...],
+    findings: tuple[ReviewFinding, ...],
+) -> tuple[ChecklistAnswer, ...]:
+    """Return yes answers not linked from any finding.
+
+    Args:
+        answers: Enriched checklist answers.
+        findings: Review findings.
+
+    Returns:
+        Checklist yes answers whose prompt id is absent from all findings.
+    """
+    linked_ids = {
+        checklist_id
+        for finding in findings
+        for checklist_id in finding.checklist_ids
+    }
+    return tuple(
+        answer
+        for answer in answers
+        if answer.answer.lower() == "yes" and answer.id not in linked_ids
+    )
+
+
+def format_review_questions_markdown(
+    *,
+    questions: tuple[str, ...],
+) -> str:
+    """Format linked review questions as markdown bullets.
+
+    Args:
+        questions: Question strings to render.
+
+    Returns:
+        Markdown block or empty string when no questions.
+    """
+    if not questions:
+        return ""
+    lines = ["", "**Review questions:**"]
+    lines.extend(f"- {question}" for question in questions)
+    return "\n".join(lines)

--- a/lintro/ai/review/checklist_display.py
+++ b/lintro/ai/review/checklist_display.py
@@ -29,7 +29,8 @@ def resolve_checklist_display(
     """Resolve effective checklist display mode from CLI and config.
 
     Args:
-        cli_value: Optional ``--show-checklist`` value (``linked`` or ``all``).
+        cli_value: Optional ``--show-checklist`` value (``off``, ``linked``,
+            or ``all``).
         config_value: Default from ``review.checklist_display``.
 
     Returns:

--- a/lintro/ai/review/checklist_display.py
+++ b/lintro/ai/review/checklist_display.py
@@ -52,10 +52,7 @@ def build_prompt_question_map(
     Returns:
         Mapping from prompt id to question string.
     """
-    return {
-        prompt_id: item.question
-        for prompt_id, item in enumerate(items, start=1)
-    }
+    return {prompt_id: item.question for prompt_id, item in enumerate(items, start=1)}
 
 
 def enrich_review_result(
@@ -118,9 +115,7 @@ def cleared_answers(
     Returns:
         Answers where the model responded ``no``.
     """
-    return tuple(
-        answer for answer in answers if answer.answer.lower() == "no"
-    )
+    return tuple(answer for answer in answers if answer.answer.lower() == "no")
 
 
 def orphan_concerns(
@@ -138,9 +133,7 @@ def orphan_concerns(
         Checklist yes answers whose prompt id is absent from all findings.
     """
     linked_ids = {
-        checklist_id
-        for finding in findings
-        for checklist_id in finding.checklist_ids
+        checklist_id for finding in findings for checklist_id in finding.checklist_ids
     }
     return tuple(
         answer

--- a/lintro/ai/review/display.py
+++ b/lintro/ai/review/display.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 from rich.console import Console
 from rich.panel import Panel
-from rich.table import Table
 from rich.text import Text
 
 from lintro.ai.cost import format_cost
 from lintro.ai.display.shared import cost_str, print_section_header
+from lintro.ai.review.checklist_display import (
+    cleared_answers,
+    orphan_concerns,
+    questions_for_finding,
+)
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_result import ReviewResult
 
@@ -26,22 +31,27 @@ def render_review_terminal(
     *,
     result: ReviewResult,
     console: Console | None = None,
+    checklist_display: ChecklistDisplay = ChecklistDisplay.OFF,
+    question_map: dict[int, str] | None = None,
 ) -> None:
     """Render review result to the terminal with Rich formatting.
 
     Args:
         result: Review result to display.
         console: Optional Rich console instance.
+        checklist_display: Structured checklist visibility mode.
+        question_map: Prompt id to question text for linked display.
     """
     output = console or Console()
     metadata = result.metadata
+    prompt_questions = question_map or {}
 
     header_detail = (
         f"Model: {metadata.model} | Context: {metadata.context_window:,} | "
         f"Depth: {metadata.depth} | Strictness: {metadata.strictness} | Chunks: "
         f"{metadata.chunks_current}/{metadata.chunks_total} | "
         f"Files: {metadata.files_reviewed}/{metadata.files_total} | "
-        f"Checklist: {metadata.checklist_items} items"
+        f"Structured checks: {metadata.checklist_items}"
     )
     token_info = cost_str(
         metadata.token_usage.get("prompt", 0),
@@ -69,35 +79,25 @@ def render_review_terminal(
         ),
     )
 
-    _render_checklist_table(result=result, console=output)
-    _render_findings(result=result, console=output)
+    show_linked = checklist_display in {ChecklistDisplay.LINKED, ChecklistDisplay.ALL}
+    _render_findings(
+        result=result,
+        console=output,
+        show_linked_questions=show_linked,
+        question_map=prompt_questions,
+    )
+
+    if checklist_display == ChecklistDisplay.ALL:
+        _render_checklist_appendix(result=result, console=output)
 
 
-def _render_checklist_table(*, result: ReviewResult, console: Console) -> None:
-    """Render checklist answers as a Rich table."""
-    if not result.checklist:
-        return
-
-    table = Table(title="Checklist", show_header=True, header_style="bold cyan")
-    table.add_column("ID", justify="right", style="cyan", no_wrap=True)
-    table.add_column("Answer", no_wrap=True)
-    table.add_column("Evidence")
-
-    for answer in result.checklist:
-        answer_style = "red" if answer.answer.lower() == "yes" else "green"
-        evidence = answer.evidence
-        if len(evidence) > 120:
-            evidence = f"{evidence[:117]}..."
-        table.add_row(
-            str(answer.id),
-            Text(answer.answer, style=answer_style),
-            evidence,
-        )
-
-    console.print(table)
-
-
-def _render_findings(*, result: ReviewResult, console: Console) -> None:
+def _render_findings(
+    *,
+    result: ReviewResult,
+    console: Console,
+    show_linked_questions: bool,
+    question_map: dict[int, str],
+) -> None:
     """Render findings grouped by severity."""
     if not result.findings:
         console.print("[dim]No findings.[/dim]")
@@ -121,6 +121,8 @@ def _render_findings(*, result: ReviewResult, console: Console) -> None:
             index=index,
             total=len(sorted_findings),
             console=console,
+            show_linked_questions=show_linked_questions,
+            question_map=question_map,
         )
 
 
@@ -130,6 +132,8 @@ def _render_finding_panel(
     index: int,
     total: int,
     console: Console,
+    show_linked_questions: bool,
+    question_map: dict[int, str],
 ) -> None:
     """Render a single finding as a Rich panel."""
     severity_style = _SEVERITY_STYLES.get(finding.severity, "white")
@@ -147,6 +151,17 @@ def _render_finding_panel(
     body.append("Fix: ", style="bold")
     body.append(finding.fix)
 
+    if show_linked_questions:
+        linked_questions = questions_for_finding(
+            finding=finding,
+            question_map=question_map,
+        )
+        if linked_questions:
+            body.append("\n\n")
+            body.append("Review questions:\n", style="bold")
+            for question in linked_questions:
+                body.append(f"  • {question}\n")
+
     console.print(
         Panel(
             body,
@@ -156,3 +171,37 @@ def _render_finding_panel(
             padding=(0, 1),
         ),
     )
+
+
+def _render_checklist_appendix(*, result: ReviewResult, console: Console) -> None:
+    """Render cleared and orphan checklist sections for audit mode."""
+    cleared = cleared_answers(answers=result.checklist)
+    orphans = orphan_concerns(
+        answers=result.checklist,
+        findings=result.findings,
+    )
+
+    console.print()
+    console.print(f"[bold cyan]Cleared checks ({len(cleared)})[/bold cyan]")
+    if cleared:
+        for answer in cleared:
+            question = answer.question or f"(checklist item {answer.id})"
+            console.print(f"  [green]✓[/green] {question}")
+    else:
+        console.print("[dim]  (none)[/dim]")
+
+    console.print()
+    console.print(
+        f"[bold cyan]Checklist concerns without findings ({len(orphans)})[/bold cyan]",
+    )
+    if orphans:
+        for answer in orphans:
+            question = answer.question or f"(checklist item {answer.id})"
+            console.print(f"  [yellow]•[/yellow] {question}")
+            if answer.evidence.strip():
+                evidence = answer.evidence
+                if len(evidence) > 120:
+                    evidence = f"{evidence[:117]}..."
+                console.print(f"    [dim]{evidence}[/dim]")
+    else:
+        console.print("[dim]  (none — good)[/dim]")

--- a/lintro/ai/review/enums/checklist_display.py
+++ b/lintro/ai/review/enums/checklist_display.py
@@ -1,0 +1,22 @@
+"""Checklist visibility modes for review output."""
+
+from __future__ import annotations
+
+from enum import auto
+
+from lintro.enums.hyphenated_str_enum import HyphenatedStrEnum
+
+__all__ = ["ChecklistDisplay"]
+
+
+class ChecklistDisplay(HyphenatedStrEnum):
+    """How structured checklist results appear in human-facing output.
+
+    * **off** — findings only (default).
+    * **linked** — review questions under findings with checklist_ids.
+    * **all** — linked plus cleared-check and orphan appendices.
+    """
+
+    OFF = auto()
+    LINKED = auto()
+    ALL = auto()

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -7,6 +7,13 @@ from typing import Any
 from loguru import logger
 
 from lintro.ai.integrations.github_pr import GitHubPRReporter
+from lintro.ai.review.checklist_display import (
+    cleared_answers,
+    format_review_questions_markdown,
+    orphan_concerns,
+    questions_for_finding,
+)
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_result import ReviewResult
 
@@ -23,6 +30,8 @@ def post_review_to_github(
     pr_number: int | None = None,
     repo: str | None = None,
     reporter: GitHubPRReporter | None = None,
+    checklist_display: ChecklistDisplay = ChecklistDisplay.OFF,
+    question_map: dict[int, str] | None = None,
 ) -> bool:
     """Post review findings as GitHub PR comments.
 
@@ -31,6 +40,8 @@ def post_review_to_github(
         pr_number: Optional PR number override.
         repo: Optional repository override (owner/name).
         reporter: Optional preconfigured GitHub reporter.
+        checklist_display: Structured checklist visibility mode.
+        question_map: Prompt id to question text for linked display.
 
     Returns:
         True when posting succeeded; False on failure or when GitHub context is
@@ -41,7 +52,12 @@ def post_review_to_github(
         logger.warning("GitHub PR context not available — skipping review posting")
         return False
 
-    summary_body = format_review_summary(result=result)
+    prompt_questions = question_map or {}
+    summary_body = format_review_summary(
+        result=result,
+        checklist_display=checklist_display,
+        question_map=prompt_questions,
+    )
     inline_findings, fallback_findings = _partition_findings(
         result=result,
         reporter=gh_reporter,
@@ -54,11 +70,17 @@ def post_review_to_github(
     if inline_findings and not _post_inline_findings(
         reporter=gh_reporter,
         findings=inline_findings,
+        checklist_display=checklist_display,
+        question_map=prompt_questions,
     ):
         success = False
 
     for finding in fallback_findings:
-        body = format_finding_comment(finding=finding)
+        body = format_finding_comment(
+            finding=finding,
+            checklist_display=checklist_display,
+            question_map=prompt_questions,
+        )
         location = _format_fallback_location(finding=finding)
         comment = f"{location}\n\n{body}" if location else body
         if not gh_reporter._post_issue_comment(comment):
@@ -67,16 +89,24 @@ def post_review_to_github(
     return success
 
 
-def format_finding_comment(*, finding: ReviewFinding) -> str:
+def format_finding_comment(
+    *,
+    finding: ReviewFinding,
+    checklist_display: ChecklistDisplay = ChecklistDisplay.OFF,
+    question_map: dict[int, str] | None = None,
+) -> str:
     """Format a review finding as a GitHub markdown comment.
 
     Args:
         finding: Review finding to format.
+        checklist_display: Structured checklist visibility mode.
+        question_map: Prompt id to question text for linked display.
 
     Returns:
         Markdown comment body.
     """
-    return (
+    prompt_questions = question_map or {}
+    body = (
         f"**{finding.severity}** | {finding.category} | "
         f"{finding.confidence} confidence\n\n"
         f"### {finding.title}\n\n"
@@ -84,13 +114,27 @@ def format_finding_comment(*, finding: ReviewFinding) -> str:
         f"**Cause:** {finding.cause}\n\n"
         f"**Fix:** {finding.fix}"
     )
+    if checklist_display in {ChecklistDisplay.LINKED, ChecklistDisplay.ALL}:
+        linked = questions_for_finding(
+            finding=finding,
+            question_map=prompt_questions,
+        )
+        body += format_review_questions_markdown(questions=linked)
+    return body
 
 
-def format_review_summary(*, result: ReviewResult) -> str:
+def format_review_summary(
+    *,
+    result: ReviewResult,
+    checklist_display: ChecklistDisplay = ChecklistDisplay.OFF,
+    question_map: dict[int, str] | None = None,
+) -> str:
     """Format the top-level review summary comment.
 
     Args:
         result: Review result to summarize.
+        checklist_display: Structured checklist visibility mode.
+        question_map: Prompt id to question text (unused except for appendix).
 
     Returns:
         Markdown summary comment body.
@@ -102,24 +146,23 @@ def format_review_summary(*, result: ReviewResult) -> str:
         (
             f"**Model:** {metadata.model} | **Depth:** {metadata.depth} | "
             f"**Files:** {metadata.files_reviewed}/{metadata.files_total} | "
-            f"**Checklist:** {metadata.checklist_items} items"
+            f"**Structured checks:** {metadata.checklist_items}"
         ),
         "",
         "### Summary",
         result.summary or "(no summary)",
     ]
 
-    if result.checklist:
-        lines.extend(
-            ["", "### Checklist", "| ID | Answer | Evidence |", "|---|---|---|"],
-        )
-        for answer in result.checklist:
-            evidence = (
-                answer.evidence.replace("|", "\\|")
-                .replace("\n", " ")
-                .replace("\r", " ")
-            )
-            lines.append(f"| {answer.id} | {answer.answer} | {evidence} |")
+    outside_diff = [
+        finding for finding in result.findings if not finding.file or finding.line <= 0
+    ]
+    if outside_diff:
+        lines.extend(["", "### Findings outside diff"])
+        for finding in outside_diff:
+            lines.append(f"- **{finding.severity}** {finding.title} ({finding.file})")
+
+    if checklist_display == ChecklistDisplay.ALL:
+        lines.extend(_format_checklist_appendix_markdown(result=result))
 
     return "\n".join(lines)
 
@@ -131,6 +174,34 @@ def _format_fallback_location(*, finding: ReviewFinding) -> str:
     if finding.line > 0:
         return f"`{finding.file}:{finding.line}`"
     return f"`{finding.file}`"
+
+
+def _format_checklist_appendix_markdown(*, result: ReviewResult) -> list[str]:
+    """Build cleared/orphan checklist appendix lines for markdown."""
+    cleared = cleared_answers(answers=result.checklist)
+    orphans = orphan_concerns(
+        answers=result.checklist,
+        findings=result.findings,
+    )
+    lines = ["", f"### Cleared checks ({len(cleared)})"]
+    if cleared:
+        for answer in cleared:
+            question = answer.question or f"(checklist item {answer.id})"
+            lines.append(f"- ✓ {question}")
+    else:
+        lines.append("- (none)")
+
+    lines.extend(["", f"### Checklist concerns without findings ({len(orphans)})"])
+    if orphans:
+        for answer in orphans:
+            question = answer.question or f"(checklist item {answer.id})"
+            evidence = answer.evidence.replace("|", "\\|")
+            lines.append(f"- {question}")
+            if evidence.strip():
+                lines.append(f"  - {evidence}")
+    else:
+        lines.append("- (none — good)")
+    return lines
 
 
 def _partition_findings(
@@ -162,6 +233,8 @@ def _post_inline_findings(
     *,
     reporter: GitHubPRReporter,
     findings: list[ReviewFinding],
+    checklist_display: ChecklistDisplay,
+    question_map: dict[int, str],
 ) -> bool:
     """Post inline PR review comments for mappable findings."""
     comments: list[dict[str, Any]] = []
@@ -170,7 +243,11 @@ def _post_inline_findings(
         comments.append(
             {
                 "path": rel,
-                "body": format_finding_comment(finding=finding),
+                "body": format_finding_comment(
+                    finding=finding,
+                    checklist_display=checklist_display,
+                    question_map=question_map,
+                ),
                 "line": finding.line,
                 "side": "RIGHT",
             },

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -198,7 +198,8 @@ def _format_checklist_appendix_markdown(*, result: ReviewResult) -> list[str]:
             evidence = answer.evidence.replace("|", "\\|")
             lines.append(f"- {question}")
             if evidence.strip():
-                lines.append(f"  - {evidence}")
+                truncated = evidence if len(evidence) <= 120 else f"{evidence[:117]}..."
+                lines.append(f"  - {truncated}")
     else:
         lines.append("- (none — good)")
     return lines

--- a/lintro/ai/review/models/checklist_answer.py
+++ b/lintro/ai/review/models/checklist_answer.py
@@ -13,8 +13,10 @@ class ChecklistAnswer:
         id: Prompt checklist item id (1..N in the review pass).
         answer: ``yes`` or ``no``.
         evidence: Brief file:line or logic trace supporting the answer.
+        question: Full checklist question text (populated for JSON output).
     """
 
     id: int
     answer: str
     evidence: str
+    question: str = ""

--- a/lintro/ai/review/output.py
+++ b/lintro/ai/review/output.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import asdict
 from typing import Any
 
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.models.review_result import ReviewResult
 
 __all__ = [
@@ -62,12 +63,16 @@ def render_review_output(
     *,
     result: ReviewResult,
     output_format: str = "terminal",
+    checklist_display: ChecklistDisplay = ChecklistDisplay.OFF,
+    question_map: dict[int, str] | None = None,
 ) -> str | None:
     """Dispatch review output rendering by format.
 
     Args:
         result: Review result to render.
         output_format: ``terminal`` or ``json``.
+        checklist_display: Structured checklist visibility for terminal output.
+        question_map: Prompt id to question text for linked terminal display.
 
     Returns:
         JSON string when ``output_format`` is ``json``; otherwise ``None``.
@@ -77,5 +82,9 @@ def render_review_output(
 
     from lintro.ai.review.display import render_review_terminal
 
-    render_review_terminal(result=result)
+    render_review_terminal(
+        result=result,
+        checklist_display=checklist_display,
+        question_map=question_map,
+    )
     return None

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -86,11 +86,11 @@ from lintro.config.config_loader import get_config
 )
 @click.option(
     "--show-checklist",
-    type=click.Choice(["linked", "all"], case_sensitive=False),
+    type=click.Choice(["off", "linked", "all"], case_sensitive=False),
     default=None,
     help=(
-        "Show structured checklist in output: linked (under findings) or "
-        "all (linked plus cleared/orphan appendices)."
+        "Show structured checklist in output: linked (under findings), "
+        "all (linked plus cleared/orphan appendices), or off to disable."
     ),
 )
 @click.option(

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -259,12 +259,14 @@ def review_command(
 
     result = enrich_review_result(result=result, question_map=question_map)
 
-    render_review_output(
+    output = render_review_output(
         result=result,
         output_format=output_format,
         checklist_display=checklist_display,
         question_map=question_map,
     )
+    if output is not None:
+        click.echo(output)
 
     if post:
         from lintro.ai.review.github import post_review_to_github

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -24,8 +24,8 @@ from lintro.ai.review.checklist_display import (
     resolve_checklist_display,
 )
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
-from lintro.ai.review.exceptions import ReviewContextError
 from lintro.ai.review.error_display import render_review_error
+from lintro.ai.review.exceptions import ReviewContextError
 from lintro.ai.review.orchestrator import run_review
 from lintro.ai.review.output import render_review_output
 from lintro.ai.review.sensitivity import resolve_sensitivity_policy

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -18,9 +18,14 @@ from lintro.ai.review import (
     get_all_checklist_items,
     select_checklist_items,
 )
+from lintro.ai.review.checklist_display import (
+    build_prompt_question_map,
+    enrich_review_result,
+    resolve_checklist_display,
+)
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
-from lintro.ai.review.error_display import render_review_error
 from lintro.ai.review.exceptions import ReviewContextError
+from lintro.ai.review.error_display import render_review_error
 from lintro.ai.review.orchestrator import run_review
 from lintro.ai.review.output import render_review_output
 from lintro.ai.review.sensitivity import resolve_sensitivity_policy
@@ -80,6 +85,15 @@ from lintro.config.config_loader import get_config
     ),
 )
 @click.option(
+    "--show-checklist",
+    type=click.Choice(["linked", "all"], case_sensitive=False),
+    default=None,
+    help=(
+        "Show structured checklist in output: linked (under findings) or "
+        "all (linked plus cleared/orphan appendices)."
+    ),
+)
+@click.option(
     "--post",
     is_flag=True,
     help="Post findings to GitHub as PR review comments.",
@@ -118,6 +132,7 @@ def review_command(
     depth: int | None,
     strictness: str | None,
     semantic_chunks: bool,
+    show_checklist: str | None,
     post: bool,
     output_format: str,
     with_lint: bool,
@@ -174,6 +189,11 @@ def review_command(
     )
     checklist_text, _prompt_mapping = format_checklist_for_prompt(
         items=selected_items,
+    )
+    question_map = build_prompt_question_map(items=selected_items)
+    checklist_display = resolve_checklist_display(
+        cli_value=show_checklist,
+        config_value=lintro_config.review.checklist_display,
     )
 
     lint_digest: str | None = None
@@ -237,9 +257,14 @@ def review_command(
         render_review_error(error=exc, console=console)
         raise SystemExit(1) from exc
 
-    output = render_review_output(result=result, output_format=output_format)
-    if output is not None:
-        click.echo(output)
+    result = enrich_review_result(result=result, question_map=question_map)
+
+    render_review_output(
+        result=result,
+        output_format=output_format,
+        checklist_display=checklist_display,
+        question_map=question_map,
+    )
 
     if post:
         from lintro.ai.review.github import post_review_to_github
@@ -248,6 +273,8 @@ def review_command(
             result=result,
             pr_number=resolved_pr,
             repo=effective_repo,
+            checklist_display=checklist_display,
+            question_map=question_map,
         )
         if not posted:
             logger.warning("GitHub review posting skipped or failed")

--- a/lintro/config/review_config.py
+++ b/lintro/config/review_config.py
@@ -21,6 +21,7 @@ from identify.identify import ALL_TAGS
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from lintro.ai.review.constants import CUSTOM_CHECKLIST_ID_START
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.enums.file_domain import FileDomain
 from lintro.ai.review.enums.review_category import ReviewCategory
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
@@ -124,6 +125,13 @@ class ReviewConfig(BaseModel):
     model_config = ConfigDict(frozen=False, extra="forbid")
 
     checklist: ReviewChecklistConfig = Field(default_factory=ReviewChecklistConfig)
+    checklist_display: ChecklistDisplay = Field(
+        default=ChecklistDisplay.OFF,
+        description=(
+            "Structured checklist visibility: off, linked (under findings), "
+            "or all (linked plus cleared/orphan appendices)."
+        ),
+    )
     strictness: ReviewStrictness = Field(
         default=ReviewStrictness.BALANCED,
         description=("Review sensitivity preset: focused, balanced, or thorough."),

--- a/tests/unit/ai/review/conftest.py
+++ b/tests/unit/ai/review/conftest.py
@@ -12,6 +12,7 @@ import pytest
 
 from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
 from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
 from lintro.ai.review.models.review_context import ReviewContext
 from lintro.ai.review.models.review_finding import ReviewFinding
@@ -245,7 +246,7 @@ def sample_review_result() -> ReviewResult:
             chunks_current=2,
             files_reviewed=3,
             files_total=3,
-            checklist_items=2,
+            checklist_items=3,
             token_usage={"prompt": 1000, "completion": 200, "total": 1200},
             cost_estimate_usd=0.05,
             base_ref="main",
@@ -254,8 +255,24 @@ def sample_review_result() -> ReviewResult:
         ),
         summary="Merge with fixes.",
         checklist=(
-            ChecklistAnswer(id=1, answer="yes", evidence="src/main.py:10"),
-            ChecklistAnswer(id=2, answer="no", evidence="none"),
+            ChecklistAnswer(
+                id=1,
+                answer="yes",
+                evidence="src/main.py:10",
+                question="Does unknown status fail closed?",
+            ),
+            ChecklistAnswer(
+                id=2,
+                answer="no",
+                evidence="none",
+                question="Are access paths covered by tests?",
+            ),
+            ChecklistAnswer(
+                id=3,
+                answer="yes",
+                evidence="docs/README.md:1",
+                question="Is migration documented?",
+            ),
         ),
         findings=(
             ReviewFinding(

--- a/tests/unit/ai/review/conftest.py
+++ b/tests/unit/ai/review/conftest.py
@@ -12,7 +12,6 @@ import pytest
 
 from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
 from lintro.ai.review.models.changed_file import ChangedFile
-from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
 from lintro.ai.review.models.review_context import ReviewContext
 from lintro.ai.review.models.review_finding import ReviewFinding

--- a/tests/unit/ai/review/test_checklist_display.py
+++ b/tests/unit/ai/review/test_checklist_display.py
@@ -27,14 +27,16 @@ def test_build_prompt_question_map_uses_prompt_order() -> None:
         ChecklistItem(
             id=100,
             question="First question?",
-            triggers=[],
+            domains=(),
+            languages=(),
             category=ReviewCategory.SECURITY,
             tier=1,
         ),
         ChecklistItem(
             id=200,
             question="Second question?",
-            triggers=[],
+            domains=(),
+            languages=(),
             category=ReviewCategory.TEST_GAP,
             tier=1,
         ),

--- a/tests/unit/ai/review/test_checklist_display.py
+++ b/tests/unit/ai/review/test_checklist_display.py
@@ -27,14 +27,14 @@ def test_build_prompt_question_map_uses_prompt_order() -> None:
         ChecklistItem(
             id=100,
             question="First question?",
-            triggers=(),
+            triggers=[],
             category=ReviewCategory.SECURITY,
             tier=1,
         ),
         ChecklistItem(
             id=200,
             question="Second question?",
-            triggers=(),
+            triggers=[],
             category=ReviewCategory.TEST_GAP,
             tier=1,
         ),

--- a/tests/unit/ai/review/test_checklist_display.py
+++ b/tests/unit/ai/review/test_checklist_display.py
@@ -1,0 +1,147 @@
+"""Tests for checklist display helpers."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.ai.review.checklist_display import (
+    build_prompt_question_map,
+    cleared_answers,
+    enrich_review_result,
+    orphan_concerns,
+    questions_for_finding,
+    resolve_checklist_display,
+)
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
+from lintro.ai.review.enums.review_category import ReviewCategory
+from lintro.ai.review.models.checklist_answer import ChecklistAnswer
+from lintro.ai.review.models.checklist_item import ChecklistItem
+from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_metadata import ReviewMetadata
+from lintro.ai.review.models.review_result import ReviewResult
+
+
+def test_build_prompt_question_map_uses_prompt_order() -> None:
+    """Prompt ids follow enumerate order starting at 1."""
+    items = [
+        ChecklistItem(
+            id=100,
+            question="First question?",
+            triggers=(),
+            category=ReviewCategory.SECURITY,
+            tier=1,
+        ),
+        ChecklistItem(
+            id=200,
+            question="Second question?",
+            triggers=(),
+            category=ReviewCategory.TEST_GAP,
+            tier=1,
+        ),
+    ]
+
+    question_map = build_prompt_question_map(items=items)
+
+    assert_that(question_map).is_equal_to(
+        {1: "First question?", 2: "Second question?"},
+    )
+
+
+def test_resolve_checklist_display_prefers_cli() -> None:
+    """CLI flag overrides config default."""
+    resolved = resolve_checklist_display(
+        cli_value="all",
+        config_value=ChecklistDisplay.OFF,
+    )
+
+    assert_that(resolved).is_equal_to(ChecklistDisplay.ALL)
+
+
+def test_enrich_review_result_attaches_questions() -> None:
+    """Checklist answers receive question text from the prompt map."""
+    result = ReviewResult(
+        metadata=ReviewMetadata(
+            model="gpt-4o",
+            provider="openai",
+            context_window=128_000,
+            depth=1,
+            chunks_total=1,
+            chunks_current=1,
+            files_reviewed=1,
+            files_total=1,
+            checklist_items=1,
+        ),
+        summary="ok",
+        checklist=(ChecklistAnswer(id=1, answer="yes", evidence="a.py:1"),),
+        findings=(),
+    )
+
+    enriched = enrich_review_result(
+        result=result,
+        question_map={1: "Is auth enforced?"},
+    )
+
+    assert_that(enriched.checklist[0].question).is_equal_to("Is auth enforced?")
+
+
+def test_questions_for_finding_returns_linked_prompt_questions() -> None:
+    """Finding checklist_ids resolve to question strings in order."""
+    finding = ReviewFinding(
+        severity="P1",
+        category="security",
+        file="a.py",
+        line=1,
+        title="Issue",
+        description="desc",
+        cause="cause",
+        fix="fix",
+        confidence="high",
+        checklist_ids=(2, 99),
+    )
+
+    questions = questions_for_finding(
+        finding=finding,
+        question_map={1: "One", 2: "Two"},
+    )
+
+    assert_that(questions).is_equal_to(("Two",))
+
+
+def test_cleared_answers_returns_no_rows() -> None:
+    """Cleared answers are checklist rows answered no."""
+    answers = (
+        ChecklistAnswer(id=1, answer="yes", evidence="a"),
+        ChecklistAnswer(id=2, answer="no", evidence="b", question="Cleared?"),
+    )
+
+    cleared = cleared_answers(answers=answers)
+
+    assert_that(cleared).is_length(1)
+    assert_that(cleared[0].question).is_equal_to("Cleared?")
+
+
+def test_orphan_concerns_returns_unlinked_yes_rows() -> None:
+    """Orphan concerns are yes answers not referenced by findings."""
+    answers = (
+        ChecklistAnswer(id=1, answer="yes", evidence="linked"),
+        ChecklistAnswer(id=2, answer="yes", evidence="orphan"),
+        ChecklistAnswer(id=3, answer="no", evidence="cleared"),
+    )
+    findings = (
+        ReviewFinding(
+            severity="P1",
+            category="security",
+            file="a.py",
+            line=1,
+            title="Issue",
+            description="desc",
+            cause="cause",
+            fix="fix",
+            confidence="high",
+            checklist_ids=(1,),
+        ),
+    )
+
+    orphans = orphan_concerns(answers=answers, findings=findings)
+
+    assert_that([answer.id for answer in orphans]).is_equal_to([2])

--- a/tests/unit/ai/review/test_display.py
+++ b/tests/unit/ai/review/test_display.py
@@ -6,6 +6,7 @@ from assertpy import assert_that
 from rich.console import Console
 
 from lintro.ai.review.display import render_review_terminal
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 
@@ -43,3 +44,65 @@ def test_render_review_terminal_orders_p1_before_p2(
     text = console.export_text()
 
     assert_that(text.index("P1")).is_less_than(text.index("P2"))
+
+
+def test_render_review_terminal_default_hides_checklist_table(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Default output omits the legacy checklist table."""
+    console = Console(record=True)
+    render_review_terminal(result=sample_review_result, console=console)
+    text = console.export_text()
+
+    assert_that(text).contains("Structured checks: 3")
+    assert_that(text).does_not_contain("Checklist")
+    assert_that(text).does_not_contain("ID | Answer | Evidence")
+    assert_that(text).does_not_contain("Review questions:")
+
+
+def test_render_review_terminal_linked_shows_questions_under_findings(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Linked mode shows review questions under findings."""
+    console = Console(record=True)
+    question_map = {
+        1: "Does unknown status fail closed?",
+        2: "Are access paths covered by tests?",
+        3: "Is migration documented?",
+    }
+    render_review_terminal(
+        result=sample_review_result,
+        console=console,
+        checklist_display=ChecklistDisplay.LINKED,
+        question_map=question_map,
+    )
+    text = console.export_text()
+
+    assert_that(text).contains("Review questions:")
+    assert_that(text).contains("Does unknown status fail closed?")
+    assert_that(text).does_not_contain("Cleared checks")
+
+
+def test_render_review_terminal_all_shows_appendix(
+    sample_review_result: ReviewResult,
+) -> None:
+    """All mode includes cleared and orphan checklist appendices."""
+    console = Console(record=True)
+    question_map = {
+        1: "Does unknown status fail closed?",
+        2: "Are access paths covered by tests?",
+        3: "Is migration documented?",
+    }
+    render_review_terminal(
+        result=sample_review_result,
+        console=console,
+        checklist_display=ChecklistDisplay.ALL,
+        question_map=question_map,
+    )
+    text = console.export_text()
+
+    assert_that(text).contains("Cleared checks (1)")
+    assert_that(text).contains("Are access paths covered by tests?")
+    assert_that(text).contains("Checklist concerns without findings (1)")
+    assert_that(text).contains("Is migration documented?")
+    assert_that(text).does_not_contain("(none — good)")

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from assertpy import assert_that
 
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.github import (
     format_finding_comment,
     format_review_summary,
@@ -26,15 +27,45 @@ def test_format_finding_comment_includes_severity_and_fix(
     assert_that(comment).contains("Default to Expired")
 
 
-def test_format_review_summary_includes_checklist_table(
+def test_format_finding_comment_linked_includes_review_questions(
     sample_review_result: ReviewResult,
 ) -> None:
-    """Summary comment includes checklist table rows."""
+    """Linked mode appends review question bullets to finding comments."""
+    finding = sample_review_result.findings[0]
+    comment = format_finding_comment(
+        finding=finding,
+        checklist_display=ChecklistDisplay.LINKED,
+        question_map={1: "Does unknown status fail closed?"},
+    )
+
+    assert_that(comment).contains("**Review questions:**")
+    assert_that(comment).contains("Does unknown status fail closed?")
+
+
+def test_format_review_summary_uses_structured_checks_header(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Summary comment uses structured checks header without checklist table."""
     summary = format_review_summary(result=sample_review_result)
 
     assert_that(summary).contains("## Lintro Review")
-    assert_that(summary).contains("| 1 | yes |")
-    assert_that(summary).does_not_contain("Findings outside diff")
+    assert_that(summary).contains("**Structured checks:** 3")
+    assert_that(summary).does_not_contain("| 1 | yes |")
+
+
+def test_format_review_summary_all_includes_appendix(
+    sample_review_result: ReviewResult,
+) -> None:
+    """All mode appends cleared and orphan sections to the summary."""
+    summary = format_review_summary(
+        result=sample_review_result,
+        checklist_display=ChecklistDisplay.ALL,
+    )
+
+    assert_that(summary).contains("### Cleared checks (1)")
+    assert_that(summary).contains("Are access paths covered by tests?")
+    assert_that(summary).contains("### Checklist concerns without findings (1)")
+    assert_that(summary).contains("Is migration documented?")
 
 
 def test_post_review_to_github_posts_fallback_without_line_number(
@@ -112,6 +143,8 @@ def test_post_review_to_github_posts_summary_and_inline(
         posted = post_review_to_github(
             result=sample_review_result,
             reporter=reporter,
+            checklist_display=ChecklistDisplay.LINKED,
+            question_map={1: "Does unknown status fail closed?"},
         )
 
     assert_that(posted).is_true()

--- a/tests/unit/ai/review/test_output.py
+++ b/tests/unit/ai/review/test_output.py
@@ -24,8 +24,9 @@ def test_review_result_to_dict_includes_metadata_fields(
     assert_that(payload["metadata"]).contains_key("context_window")
     assert_that(payload["metadata"]).contains_key("timestamp")
     assert_that(payload["summary"]).is_equal_to("Merge with fixes.")
-    assert_that(payload["checklist"]).is_length(2)
+    assert_that(payload["checklist"]).is_length(3)
     assert_that(payload["findings"]).is_length(2)
+    assert_that(payload["checklist"][0]).contains_key("question")
 
 
 def test_render_review_json_is_valid_json(

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -7,8 +7,9 @@ from unittest.mock import MagicMock, patch
 from assertpy import assert_that
 from click.testing import CliRunner
 
-from lintro.ai.review.enums.review_strictness import ReviewStrictness
 from lintro.ai.review.exceptions import ReviewExecutionError
+from lintro.ai.review.enums.review_strictness import ReviewStrictness
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.cli import cli
@@ -42,6 +43,7 @@ def test_review_help_shows_flags() -> None:
     assert_that(result.output).contains("--base")
     assert_that(result.output).contains("--with-lint")
     assert_that(result.output).contains("--depth")
+    assert_that(result.output).contains("--show-checklist")
 
 
 def test_review_alias_rev_works() -> None:
@@ -74,6 +76,7 @@ def test_review_exits_zero_without_p1_findings() -> None:
     mock_config.review.strictness = ReviewStrictness.BALANCED
     mock_config.review.sensitivity = MagicMock()
     mock_config.review.force_semantic_chunking = False
+    mock_config.review.checklist_display = ChecklistDisplay.OFF
 
     with patch("lintro.cli_utils.commands.review.require_ai"):
         with patch(
@@ -113,10 +116,13 @@ def test_review_exits_zero_without_p1_findings() -> None:
                                     ):
                                         with patch(
                                             "lintro.cli_utils.commands.review.render_review_output",
-                                        ):
+                                        ) as mock_render:
                                             result = runner.invoke(cli, ["review"])
 
     assert_that(result.exit_code).is_equal_to(0)
+    assert_that(mock_render.call_args.kwargs).contains_key(
+        "checklist_display",
+    )
 
 
 def test_review_failure_renders_friendly_error_without_traceback() -> None:
@@ -139,6 +145,7 @@ def test_review_failure_renders_friendly_error_without_traceback() -> None:
     mock_config.review.strictness = ReviewStrictness.BALANCED
     mock_config.review.sensitivity = MagicMock()
     mock_config.review.force_semantic_chunking = False
+    mock_config.review.checklist_display = ChecklistDisplay.OFF
 
     with patch("lintro.cli_utils.commands.review.require_ai"):
         with patch(

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -65,6 +65,71 @@ def test_review_requires_ai_packages() -> None:
     assert_that(result.exit_code).is_not_equal_to(0)
 
 
+def test_review_json_output_echoes_payload() -> None:
+    """Review command echoes JSON when --output json is used."""
+    runner = CliRunner()
+    mock_context = MagicMock()
+    mock_context.changed_files = []
+    mock_context.unified_diff = ""
+    mock_config = MagicMock(ai=MagicMock(enabled=True))
+    mock_config.review.depth = 1
+    mock_config.review.strictness = ReviewStrictness.BALANCED
+    mock_config.review.sensitivity = MagicMock()
+    mock_config.review.force_semantic_chunking = False
+    mock_config.review.checklist_display = ChecklistDisplay.OFF
+
+    with patch("lintro.cli_utils.commands.review.require_ai"):
+        with patch(
+            "lintro.cli_utils.commands.review.get_config",
+            return_value=mock_config,
+        ):
+            with patch(
+                "lintro.cli_utils.commands.review.collect_review_context",
+                return_value=mock_context,
+            ):
+                with patch(
+                    "lintro.cli_utils.commands.review.classify_changed_files",
+                    return_value=[],
+                ):
+                    with patch(
+                        "lintro.cli_utils.commands.review.get_all_checklist_items",
+                        return_value=[],
+                    ):
+                        with patch(
+                            "lintro.cli_utils.commands.review.select_checklist_items",
+                            return_value=[],
+                        ):
+                            with patch(
+                                "lintro.cli_utils.commands.review.format_checklist_for_prompt",
+                                return_value=("", {}),
+                            ):
+                                with patch(
+                                    "lintro.cli_utils.commands.review.get_provider",
+                                    return_value=MagicMock(
+                                        model_name="gpt-4o",
+                                        name="openai",
+                                    ),
+                                ):
+                                    with patch(
+                                        "lintro.cli_utils.commands.review.run_review",
+                                        return_value=_empty_result(),
+                                    ):
+                                        with patch(
+                                            "lintro.cli_utils.commands.review.render_review_output",
+                                            return_value='{"summary": "ok"}',
+                                        ) as mock_render:
+                                            result = runner.invoke(
+                                                cli,
+                                                ["review", "--output", "json"],
+                                            )
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains('"summary": "ok"')
+    assert_that(mock_render.call_args.kwargs).contains_key(
+        "checklist_display",
+    )
+
+
 def test_review_exits_zero_without_p1_findings() -> None:
     """Review command exits 0 when no P1 findings exist."""
     runner = CliRunner()

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -7,9 +7,9 @@ from unittest.mock import MagicMock, patch
 from assertpy import assert_that
 from click.testing import CliRunner
 
-from lintro.ai.review.exceptions import ReviewExecutionError
-from lintro.ai.review.enums.review_strictness import ReviewStrictness
 from lintro.ai.review.enums.checklist_display import ChecklistDisplay
+from lintro.ai.review.enums.review_strictness import ReviewStrictness
+from lintro.ai.review.exceptions import ReviewExecutionError
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.cli import cli

--- a/tests/unit/config/test_review_config.py
+++ b/tests/unit/config/test_review_config.py
@@ -9,10 +9,10 @@ import pytest
 from assertpy import assert_that
 
 from lintro.ai.review.constants import CUSTOM_CHECKLIST_ID_START
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.enums.file_domain import FileDomain
 from lintro.ai.review.enums.review_category import ReviewCategory
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
-from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.config.config_loader import clear_config_cache, load_config
 from lintro.config.review_config import (
     ReviewChecklistItemConfig,

--- a/tests/unit/config/test_review_config.py
+++ b/tests/unit/config/test_review_config.py
@@ -12,6 +12,7 @@ from lintro.ai.review.constants import CUSTOM_CHECKLIST_ID_START
 from lintro.ai.review.enums.file_domain import FileDomain
 from lintro.ai.review.enums.review_category import ReviewCategory
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.config.config_loader import clear_config_cache, load_config
 from lintro.config.review_config import (
     ReviewChecklistItemConfig,
@@ -108,6 +109,26 @@ def test_load_config_parses_review_depth_and_semantic_chunking(
 
     assert_that(config.review.depth).is_equal_to(2)
     assert_that(config.review.force_semantic_chunking).is_true()
+
+
+def test_load_config_parses_checklist_display(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """YAML review.checklist_display is loaded."""
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text(
+        "review:\n  checklist_display: linked\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    config = load_config(config_path=config_file)
+
+    assert_that(config.review.checklist_display).is_equal_to(
+        ChecklistDisplay.LINKED,
+    )
 
 
 def test_review_config_rejects_invalid_depth() -> None:

--- a/tests/unit/config/test_review_config.py
+++ b/tests/unit/config/test_review_config.py
@@ -131,6 +131,26 @@ def test_load_config_parses_checklist_display(
     )
 
 
+def test_load_config_parses_quoted_off_checklist_display(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """YAML review.checklist_display: 'off' (quoted) is loaded correctly."""
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text(
+        "review:\n  checklist_display: 'off'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    config = load_config(config_path=config_file)
+
+    assert_that(config.review.checklist_display).is_equal_to(
+        ChecklistDisplay.OFF,
+    )
+
+
 def test_review_config_rejects_invalid_depth() -> None:
     """Review depth must be between 1 and 3."""
     from lintro.config.review_config import ReviewConfig


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai/review): finding-centric checklist display
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Replaces the opaque checklist table in terminal and GitHub review output with finding-linked questions. Configurable via `checklist_display: off | linked | all` (quote `'off'` in YAML).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed

## Closes

- Closes #1007

## Details

- **`lintro/ai/review/checklist_display.py`** and **`enums/checklist_display.py`**: display modes and rendering helpers.
- **Terminal (`display.py`)** and **GitHub (`github.py`)**: linked questions under findings; cleared-check and orphan-concern appendices in `all` mode.
- **JSON output**: checklist answers enriched with question text.
- **CLI/config**: `--show-checklist` flag and `review.checklist_display` setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured checklist display options for review output, including showing linked review questions or a full checklist appendix.
  * Review comments and terminal output now include clearer checklist-related summaries and question links when enabled.
  * Added a new CLI option to control checklist visibility in review results.

* **Bug Fixes**
  * Review summaries now handle findings outside the diff more clearly.
  * Checklist items without matching findings are surfaced separately when full checklist display is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the opaque checklist table in terminal and GitHub review output with finding-linked checklist questions, controlled by a new `checklist_display: off | linked | all` setting configurable via CLI (`--show-checklist`) or config (`review.checklist_display`).

- **New `checklist_display.py` module**: contains helpers that power the new rendering pipeline across terminal and GitHub outputs.
- **Terminal (`display.py`) and GitHub (`github.py`)**: the legacy checklist table is removed; linked questions now appear under each finding; `all` mode adds cleared-check and orphan-concern appendices.
- **Config and CLI**: `ReviewConfig` gains a `checklist_display` field defaulting to `OFF`, and `review_command` gains `--show-checklist`; `ChecklistAnswer` model is extended with an optional `question` field populated via `enrich_review_result`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the feature is well-structured and the two flagged items are cosmetic.

The core logic is clean: question_map is correctly used for linked-question rendering in both terminal and GitHub finding comments, the enrichment step happens before any rendering, and the CLI/config wiring follows existing patterns. The two issues in github.py are cosmetic — a dead parameter on format_review_summary and an empty-string file producing trailing () in the outside-diff summary. Neither affects correctness of the primary feature paths.

lintro/ai/review/github.py — dead question_map parameter on format_review_summary and empty-file edge case in the outside-diff formatter.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/review/checklist_display.py | New module with well-tested, pure helpers for resolving display mode, building the question map, enriching results, and computing cleared/orphan answers. |
| lintro/ai/review/github.py | Replaces legacy checklist table in summary with findings-outside-diff section and optional appendix. Two issues: question_map parameter in format_review_summary is silently unused, and empty finding.file renders as trailing () in outside-diff entries. |
| lintro/ai/review/display.py | Removes legacy checklist table; correctly uses question_map for linked questions and enriched answer.question for the appendix. |
| lintro/cli_utils/commands/review.py | Adds --show-checklist CLI option; correctly calls build_prompt_question_map, resolve_checklist_display, enrich_review_result in the right order. |
| lintro/config/review_config.py | Adds checklist_display: ChecklistDisplay = OFF to ReviewConfig; Pydantic handles enum parsing from YAML strings correctly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as review_command
    participant CD as checklist_display
    participant OUT as render_review_output
    participant TERM as render_review_terminal
    participant GH as post_review_to_github
    participant SUM as format_review_summary
    participant FC as format_finding_comment

    CLI->>CD: build_prompt_question_map(items)
    CD-->>CLI: question_map
    CLI->>CD: resolve_checklist_display(cli_value, config_value)
    CD-->>CLI: ChecklistDisplay
    CLI->>CD: enrich_review_result(result, question_map)
    CD-->>CLI: result with answer.question populated

    CLI->>OUT: render_review_output(result, checklist_display, question_map)
    OUT->>TERM: render_review_terminal(result, checklist_display, question_map)
    TERM->>CD: questions_for_finding(finding, question_map)
    TERM->>CD: cleared_answers and orphan_concerns

    CLI->>GH: post_review_to_github(result, checklist_display, question_map)
    GH->>SUM: format_review_summary(result, checklist_display, question_map)
    Note over SUM: question_map is accepted but never used
    GH->>FC: format_finding_comment(finding, checklist_display, question_map)
    FC->>CD: questions_for_finding(finding, question_map)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as review_command
    participant CD as checklist_display
    participant OUT as render_review_output
    participant TERM as render_review_terminal
    participant GH as post_review_to_github
    participant SUM as format_review_summary
    participant FC as format_finding_comment

    CLI->>CD: build_prompt_question_map(items)
    CD-->>CLI: question_map
    CLI->>CD: resolve_checklist_display(cli_value, config_value)
    CD-->>CLI: ChecklistDisplay
    CLI->>CD: enrich_review_result(result, question_map)
    CD-->>CLI: result with answer.question populated

    CLI->>OUT: render_review_output(result, checklist_display, question_map)
    OUT->>TERM: render_review_terminal(result, checklist_display, question_map)
    TERM->>CD: questions_for_finding(finding, question_map)
    TERM->>CD: cleared_answers and orphan_concerns

    CLI->>GH: post_review_to_github(result, checklist_display, question_map)
    GH->>SUM: format_review_summary(result, checklist_display, question_map)
    Note over SUM: question_map is accepted but never used
    GH->>FC: format_finding_comment(finding, checklist_display, question_map)
    FC->>CD: questions_for_finding(finding, question_map)
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(review): address CodeRabbit checklis..."](https://github.com/lgtm-hq/py-lintro/commit/d93407801714f03e8336416df21e7071e6e744e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39941542)</sub>

<!-- /greptile_comment -->