### PR TITLE
fix(ai/review): Cursor review timeout reliability

### DIFF
--- a/lintro/ai/prompts/review.py
+++ b/lintro/ai/prompts/review.py
@@ -8,6 +8,8 @@ from lintro.ai.review.models.checklist_item import ChecklistItem
 __all__ = [
     "REVIEW_ADVERSARIAL_SWEEP_TEMPLATE",
     "REVIEW_GENERATE_QUESTIONS_TEMPLATE",
+    "REVIEW_GIT_NATIVE_DIFF_GIT_COMMAND",
+    "REVIEW_GIT_NATIVE_DIFF_INLINE",
     "REVIEW_GIT_NATIVE_USER_PROMPT_TEMPLATE",
     "REVIEW_OUTPUT_SCHEMA",
     "REVIEW_SYSTEM",
@@ -159,9 +161,9 @@ Answer every item. Any **yes** → add a finding. Any **no** → record in `chec
 
 ---
 
-<pull_request_diff>
-{diff}
-</pull_request_diff>
+### Diff to review
+
+{diff_section}
 
 {lint_results_section}
 
@@ -179,6 +181,20 @@ Answer every item. Any **yes** → add a finding. Any **no** → record in `chec
 - Every checklist **yes** must have a corresponding finding (link via `checklist_ids`).
 - Do not duplicate findings — merge related checklist items when they share a root cause.
 - Prioritize cross-file integration bugs over isolated nits."""
+
+REVIEW_GIT_NATIVE_DIFF_INLINE = """\
+The diff is included below — review it directly (do not run git commands):
+
+<pull_request_diff>
+{diff}
+</pull_request_diff>"""
+
+REVIEW_GIT_NATIVE_DIFF_GIT_COMMAND = """\
+Run this command in the repository root and review the output:
+
+```
+git diff {base_ref}...{head_ref} -- {git_diff_paths}
+```"""
 
 REVIEW_OUTPUT_SCHEMA = """\
 {

--- a/lintro/ai/prompts/review.py
+++ b/lintro/ai/prompts/review.py
@@ -10,6 +10,7 @@ __all__ = [
     "REVIEW_GENERATE_QUESTIONS_TEMPLATE",
     "REVIEW_GIT_NATIVE_DIFF_GIT_COMMAND",
     "REVIEW_GIT_NATIVE_DIFF_INLINE",
+    "REVIEW_GIT_NATIVE_DIFF_WORKTREE_COMMAND",
     "REVIEW_GIT_NATIVE_USER_PROMPT_TEMPLATE",
     "REVIEW_OUTPUT_SCHEMA",
     "REVIEW_SYSTEM",
@@ -194,6 +195,13 @@ Run this command in the repository root and review the output:
 
 ```
 git diff {base_ref}...{head_ref} -- {git_diff_paths}
+```"""
+
+REVIEW_GIT_NATIVE_DIFF_WORKTREE_COMMAND = """\
+Run this command in the repository root and review the output:
+
+```
+git diff {base_ref} -- {git_diff_paths}
 ```"""
 
 REVIEW_OUTPUT_SCHEMA = """\

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -30,6 +30,8 @@ from lintro.ai.providers.constants import (
 )
 from lintro.ai.registry import PROVIDERS, AIProvider
 
+CURSOR_MIN_TIMEOUT = 600.0
+
 _AGENT_BIN = "agent"
 DEFAULT_MODEL = PROVIDERS.cursor.default_model
 DEFAULT_API_KEY_ENV = PROVIDERS.cursor.default_api_key_env
@@ -131,7 +133,7 @@ class CursorProvider(BaseAIProvider):
             prompt: User prompt text.
             system: Optional system prompt prepended to the user prompt.
             max_tokens: Unused; kept for provider API parity.
-            timeout: Subprocess timeout in seconds (minimum 300 for agent).
+            timeout: Subprocess timeout in seconds (minimum 600 for agent).
             repo_root: Git repository root for ``--workspace``.
             use_one_shot: When True, do not resume an existing CLI session.
             model: Optional per-call model override.
@@ -184,7 +186,7 @@ class CursorProvider(BaseAIProvider):
             f"prompt_len={len(combined_prompt)}",
         )
 
-        effective_timeout = max(timeout, 300.0)
+        effective_timeout = max(timeout, CURSOR_MIN_TIMEOUT)
         env = os.environ.copy()
         api_key = os.environ.get(self._api_key_env)
         if api_key:

--- a/lintro/ai/review/error_display.py
+++ b/lintro/ai/review/error_display.py
@@ -122,7 +122,8 @@ def _format_execution_error(error: ReviewExecutionError) -> tuple[str, str, list
     hints = _provider_hints(error.cause_message or error.message)
     if "timed out" in body.lower():
         hints = [
-            "Increase ai.api_timeout in .lintro-config.yaml (e.g. 600.0)",
+            "Increase ai.api_timeout in .lintro-config.yaml (e.g. 600.0) or use --timeout",
+            "Small diffs embed inline automatically; large diffs use agentic git — allow 600s+",
             "Narrow scope with --path for large diffs",
             "Switch to anthropic/openai for faster direct API calls",
             *hints,

--- a/lintro/ai/review/error_display.py
+++ b/lintro/ai/review/error_display.py
@@ -122,8 +122,14 @@ def _format_execution_error(error: ReviewExecutionError) -> tuple[str, str, list
     hints = _provider_hints(error.cause_message or error.message)
     if "timed out" in body.lower():
         hints = [
-            "Increase ai.api_timeout in .lintro-config.yaml (e.g. 600.0) or use --timeout",
-            "Small diffs embed inline automatically; large diffs use agentic git — allow 600s+",
+            (
+                "Increase ai.api_timeout in .lintro-config.yaml "
+                "(e.g. 600.0) or use --timeout"
+            ),
+            (
+                "Small diffs embed inline automatically; large diffs use "
+                "agentic git — allow 600s+"
+            ),
             "Narrow scope with --path for large diffs",
             "Switch to anthropic/openai for faster direct API calls",
             *hints,

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import suppress
 from dataclasses import dataclass, replace
@@ -14,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from lintro.ai.budget import CostBudget
+from lintro.ai.token_budget import estimate_tokens
 from lintro.ai.fallback import complete_with_fallback
 from lintro.ai.model_pricing import (
     calculate_available_diff_tokens,
@@ -22,6 +24,8 @@ from lintro.ai.model_pricing import (
 from lintro.ai.prompts.review import (
     REVIEW_ADVERSARIAL_SWEEP_TEMPLATE,
     REVIEW_GENERATE_QUESTIONS_TEMPLATE,
+    REVIEW_GIT_NATIVE_DIFF_GIT_COMMAND,
+    REVIEW_GIT_NATIVE_DIFF_INLINE,
     REVIEW_GIT_NATIVE_USER_PROMPT_TEMPLATE,
     REVIEW_OUTPUT_SCHEMA,
     REVIEW_SYSTEM,
@@ -50,7 +54,6 @@ from lintro.ai.review.sensitivity import (
     filter_findings_by_policy,
     format_strictness_prompt_section,
 )
-from lintro.ai.token_budget import estimate_tokens
 
 if TYPE_CHECKING:
     from lintro.ai.config import AIConfig
@@ -143,6 +146,7 @@ def _review_all_chunks(
     max_parallel_calls: int,
     strictness_section: str,
     next_generated_checklist_id: int = 1,
+    diff_budget: int,
 ) -> list[_ChunkReviewPartial]:
     """Review all chunks sequentially or in parallel."""
     if len(chunks) <= 1:
@@ -165,6 +169,7 @@ def _review_all_chunks(
                 use_one_shot=use_one_shot,
                 strictness_section=strictness_section,
                 next_generated_checklist_id=next_generated_checklist_id,
+                diff_budget=diff_budget,
             ),
         ]
 
@@ -195,6 +200,7 @@ def _review_all_chunks(
                     repo_root=repo_root,
                     use_one_shot=use_one_shot,
                     strictness_section=strictness_section,
+                    diff_budget=diff_budget,
                 )
             except Exception as exc:
                 progress.on_error(
@@ -241,6 +247,7 @@ def _review_all_chunks(
                 repo_root=repo_root,
                 use_one_shot=use_one_shot,
                 strictness_section=strictness_section,
+                diff_budget=diff_budget,
             ): chunk_index
             for chunk_index, chunk in enumerate(chunks)
         }
@@ -294,6 +301,7 @@ def _review_chunk_with_progress(
     use_one_shot: bool,
     strictness_section: str = "",
     next_generated_checklist_id: int = 1,
+    diff_budget: int = 0,
 ) -> _ChunkReviewPartial:
     """Review one chunk with progress tracking and error wrapping."""
     budget.check()
@@ -316,6 +324,7 @@ def _review_chunk_with_progress(
             repo_root=repo_root,
             use_one_shot=use_one_shot,
             strictness_section=strictness_section,
+            diff_budget=diff_budget,
         )
     except Exception as exc:
         step_tracker = progress if isinstance(progress, StepTrackingProgress) else None
@@ -353,6 +362,7 @@ def run_review(
     progress: ReviewProgressCallback | None = None,
     sensitivity: ReviewSensitivityPolicy | None = None,
     force_semantic_chunking: bool = False,
+    timeout: float | None = None,
 ) -> ReviewResult:
     """Execute an AI diff review with depth-controlled passes.
 
@@ -417,6 +427,11 @@ def run_review(
         force_semantic_chunking=force_semantic_chunking,
     )
 
+    effective_ai_config = (
+        replace(ai_config, api_timeout=timeout)
+        if timeout is not None
+        else ai_config
+    )
     tracker = progress or NullReviewProgress()
     budget = CostBudget(max_cost_usd=ai_config.max_cost_usd)
     use_cursor_durable = (
@@ -441,7 +456,7 @@ def run_review(
             chunks=chunks,
             context=context,
             provider=provider,
-            ai_config=ai_config,
+            ai_config=effective_ai_config,
             depth=depth,
             checklist_items=checklist_items,
             checklist_text=checklist_text,
@@ -456,6 +471,7 @@ def run_review(
             next_generated_checklist_id=(
                 _max_checklist_id(checklist_items=checklist_items) + 1
             ),
+            diff_budget=diff_budget,
         )
         merged = merge_review_results(partials=partials)
         filtered_findings = filter_findings_by_policy(
@@ -572,6 +588,7 @@ def build_git_native_review_prompt(
     lint_results: str | None = None,
     extra_checklist: str = "",
     strictness_section: str = "",
+    embed_diff: bool = False,
 ) -> tuple[str, str]:
     """Build git-native prompts for Cursor local agent review.
 
@@ -584,6 +601,7 @@ def build_git_native_review_prompt(
         lint_results: Optional lint digest for prompt injection.
         extra_checklist: Additional generated checklist rows for depth 2.
         strictness_section: Sensitivity instructions for the review pass.
+        embed_diff: When True, inline the diff instead of agentic git commands.
 
     Returns:
         Tuple of (system_prompt, user_prompt).
@@ -598,6 +616,15 @@ def build_git_native_review_prompt(
             1 if extra_checklist.strip() else 0
         )
 
+    git_diff_paths = " ".join(shlex.quote(path) for path in chunk.files)
+    if embed_diff:
+        diff_section = REVIEW_GIT_NATIVE_DIFF_INLINE.format(diff=chunk.diff)
+    else:
+        diff_section = REVIEW_GIT_NATIVE_DIFF_GIT_COMMAND.format(
+            base_ref=context.base_ref,
+            head_ref=context.head_ref,
+            git_diff_paths=git_diff_paths,
+        )
     user_prompt = REVIEW_GIT_NATIVE_USER_PROMPT_TEMPLATE.format(
         pr_title=pr_title,
         base_ref=context.base_ref,
@@ -610,7 +637,7 @@ def build_git_native_review_prompt(
         interaction_paths=interaction_paths,
         checklist_count=checklist_count,
         checklist=combined_checklist,
-        diff=chunk.diff,
+        diff_section=diff_section,
         lint_results_section=format_lint_results_section(digest=lint_results),
         strictness_section=strictness_section,
         output_schema=REVIEW_OUTPUT_SCHEMA,
@@ -765,6 +792,7 @@ def _review_chunk(
     repo_root: str = "",
     use_one_shot: bool = False,
     strictness_section: str = "",
+    diff_budget: int = 0,
 ) -> tuple[_ChunkReviewPartial, int]:
     """Run depth-controlled review for a single chunk."""
     tracker = progress or NullReviewProgress()
@@ -792,21 +820,30 @@ def _review_chunk(
         )
 
     tracker.on_step(chunk_index=chunk_index, step="reviewing")
-    prompt_builder = (
-        build_git_native_review_prompt
-        if provider.name == AIProvider.CURSOR
-        else build_review_prompt
-    )
-    system_prompt, user_prompt = prompt_builder(
-        chunk=chunk,
-        context=context,
-        checklist_text=checklist_text,
-        checklist_count=checklist_count,
-        interaction_paths=interaction_paths,
-        lint_results=lint_results,
-        extra_checklist=extra_checklist,
-        strictness_section=strictness_section,
-    )
+    if provider.name == AIProvider.CURSOR:
+        embed_diff = estimate_tokens(chunk.diff) <= max(diff_budget, 1)
+        system_prompt, user_prompt = build_git_native_review_prompt(
+            chunk=chunk,
+            context=context,
+            checklist_text=checklist_text,
+            checklist_count=checklist_count,
+            interaction_paths=interaction_paths,
+            lint_results=lint_results,
+            extra_checklist=extra_checklist,
+            strictness_section=strictness_section,
+            embed_diff=embed_diff,
+        )
+    else:
+        system_prompt, user_prompt = build_review_prompt(
+            chunk=chunk,
+            context=context,
+            checklist_text=checklist_text,
+            checklist_count=checklist_count,
+            interaction_paths=interaction_paths,
+            lint_results=lint_results,
+            extra_checklist=extra_checklist,
+            strictness_section=strictness_section,
+        )
     response = _call_provider(
         provider=provider,
         ai_config=ai_config,

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -25,6 +25,7 @@ from lintro.ai.prompts.review import (
     REVIEW_GENERATE_QUESTIONS_TEMPLATE,
     REVIEW_GIT_NATIVE_DIFF_GIT_COMMAND,
     REVIEW_GIT_NATIVE_DIFF_INLINE,
+    REVIEW_GIT_NATIVE_DIFF_WORKTREE_COMMAND,
     REVIEW_GIT_NATIVE_USER_PROMPT_TEMPLATE,
     REVIEW_OUTPUT_SCHEMA,
     REVIEW_SYSTEM,
@@ -429,7 +430,9 @@ def run_review(
     )
 
     effective_ai_config = (
-        replace(ai_config, api_timeout=timeout) if timeout is not None else ai_config
+        ai_config.model_copy(update={"api_timeout": timeout})
+        if timeout is not None
+        else ai_config
     )
     tracker = progress or NullReviewProgress()
     budget = CostBudget(max_cost_usd=ai_config.max_cost_usd)
@@ -618,6 +621,11 @@ def build_git_native_review_prompt(
     git_diff_paths = " ".join(shlex.quote(path) for path in chunk.files)
     if embed_diff:
         diff_section = REVIEW_GIT_NATIVE_DIFF_INLINE.format(diff=chunk.diff)
+    elif context.head_ref == "WORKTREE":
+        diff_section = REVIEW_GIT_NATIVE_DIFF_WORKTREE_COMMAND.format(
+            base_ref=context.base_ref,
+            git_diff_paths=git_diff_paths,
+        )
     else:
         diff_section = REVIEW_GIT_NATIVE_DIFF_GIT_COMMAND.format(
             base_ref=context.base_ref,

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from lintro.ai.budget import CostBudget
-from lintro.ai.token_budget import estimate_tokens
 from lintro.ai.fallback import complete_with_fallback
 from lintro.ai.model_pricing import (
     calculate_available_diff_tokens,
@@ -428,9 +427,7 @@ def run_review(
     )
 
     effective_ai_config = (
-        replace(ai_config, api_timeout=timeout)
-        if timeout is not None
-        else ai_config
+        replace(ai_config, api_timeout=timeout) if timeout is not None else ai_config
     )
     tracker = progress or NullReviewProgress()
     budget = CostBudget(max_cost_usd=ai_config.max_cost_usd)

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -53,6 +53,7 @@ from lintro.ai.review.sensitivity import (
     filter_findings_by_policy,
     format_strictness_prompt_section,
 )
+from lintro.ai.token_budget import estimate_tokens
 
 if TYPE_CHECKING:
     from lintro.ai.config import AIConfig

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -378,6 +378,7 @@ def run_review(
         progress: Optional progress callback for live status updates.
         sensitivity: Sensitivity preset controlling prompts and finding filters.
         force_semantic_chunking: When True, skip the single-chunk fast path.
+        timeout: Optional per-call timeout override in seconds.
 
     Returns:
         Complete review result with metadata, checklist, and findings.

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -118,6 +118,12 @@ from lintro.config.config_loader import get_config
     help="Override model context window size in tokens.",
 )
 @click.option(
+    "--timeout",
+    type=float,
+    default=None,
+    help="Override ai.api_timeout for this review (seconds).",
+)
+@click.option(
     "--path",
     "path_filter",
     multiple=True,
@@ -137,6 +143,7 @@ def review_command(
     output_format: str,
     with_lint: bool,
     context_window: int | None,
+    timeout: float | None,
     path_filter: tuple[str, ...],
 ) -> None:
     """Run AI-powered diff-based code review."""
@@ -250,6 +257,7 @@ def review_command(
             progress=progress_tracker,
             sensitivity=sensitivity,
             force_semantic_chunking=force_semantic_chunking,
+            timeout=timeout,
         )
     except (AIError, ValueError) as exc:
         if output_format == "json":

--- a/tests/unit/ai/review/test_error_display.py
+++ b/tests/unit/ai/review/test_error_display.py
@@ -32,6 +32,7 @@ def test_render_timeout_includes_actionable_hints() -> None:
     assert_that(output).contains("chunk 6/6")
     assert_that(output).contains("5 chunks completed")
     assert_that(output).contains("api_timeout")
+    assert_that(output).contains("inline")
     assert_that(output).does_not_contain("Traceback")
 
 

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -20,6 +20,7 @@ from lintro.ai.review.models.checklist_item import ChecklistItem
 from lintro.ai.review.models.review_chunk import ReviewChunk
 from lintro.ai.review.models.review_context import ReviewContext
 from lintro.ai.review.orchestrator import (
+    build_git_native_review_prompt,
     parse_review_response,
     resolve_review_chunks,
     run_review,
@@ -471,3 +472,54 @@ def test_run_review_returns_result_when_progress_complete_raises() -> None:
 
     assert_that(result.summary).contains("Merge")
     progress.on_complete.assert_called_once_with(total_findings=1)
+
+
+def test_build_git_native_review_prompt_embeds_diff_when_requested(
+    sample_review_context: ReviewContext,
+) -> None:
+    """Git-native prompts can inline the diff for budget-fitting chunks."""
+    chunk = ReviewChunk(
+        id=1,
+        files=["src/lib/math.py"],
+        diff="diff --git a/src/lib/math.py b/src/lib/math.py\n+1\n",
+        relationship="single-file",
+        metadata_note=None,
+    )
+
+    _, user_prompt = build_git_native_review_prompt(
+        chunk=chunk,
+        context=sample_review_context,
+        checklist_text="1. [logic-bug] Example?",
+        checklist_count=1,
+        interaction_paths="(none)",
+        embed_diff=True,
+    )
+
+    assert_that(user_prompt).contains("<pull_request_diff>")
+    assert_that(user_prompt).contains("src/lib/math.py")
+    assert_that(user_prompt).does_not_contain("git diff")
+
+
+def test_build_git_native_review_prompt_uses_git_command_when_not_embedded(
+    sample_review_context: ReviewContext,
+) -> None:
+    """Large diffs keep agentic git diff instructions."""
+    chunk = ReviewChunk(
+        id=1,
+        files=["src/lib/math.py"],
+        diff="diff --git a/src/lib/math.py b/src/lib/math.py\n+1\n",
+        relationship="single-file",
+        metadata_note=None,
+    )
+
+    _, user_prompt = build_git_native_review_prompt(
+        chunk=chunk,
+        context=sample_review_context,
+        checklist_text="1. [logic-bug] Example?",
+        checklist_count=1,
+        interaction_paths="(none)",
+        embed_diff=False,
+    )
+
+    assert_that(user_prompt).contains("git diff")
+    assert_that(user_prompt).does_not_contain("<pull_request_diff>")

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -290,7 +290,9 @@ def test_complete_uses_minimum_timeout_for_agent(provider):
             stderr="",
         )
         provider.complete("Hello", timeout=45.0)
-        assert_that(mock_run.call_args.kwargs.get("timeout")).is_equal_to(300.0)
+        assert_that(mock_run.call_args.kwargs.get("timeout")).is_equal_to(
+            CURSOR_MIN_TIMEOUT,
+        )
 
 
 def test_complete_cost_estimate_is_zero(provider):

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -163,6 +163,7 @@ def test_complete_one_shot_skips_resume(provider):
         assert_that(cmd).does_not_contain("--resume")
 
     def test_timeout_floor_is_six_hundred_seconds(self, provider):
+        """Enforce Cursor CLI minimum timeout of 600 seconds."""
         stdout = _cli_json(result="ok")
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -14,7 +14,7 @@ from lintro.ai.exceptions import (
     AINotAvailableError,
     AIProviderError,
 )
-from lintro.ai.providers.cursor import CursorProvider, _find_agent
+from lintro.ai.providers.cursor import CURSOR_MIN_TIMEOUT, CursorProvider, _find_agent
 from lintro.ai.registry import AIProvider
 
 
@@ -161,6 +161,20 @@ def test_complete_one_shot_skips_resume(provider):
         )
         cmd = mock_run.call_args.args[0]
         assert_that(cmd).does_not_contain("--resume")
+
+    def test_timeout_floor_is_six_hundred_seconds(self, provider):
+        stdout = _cli_json(result="ok")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=stdout,
+                stderr="",
+            )
+            provider.complete("Hello", timeout=120.0, repo_root="/tmp/repo")
+        assert_that(mock_run.call_args.kwargs["timeout"]).is_equal_to(
+            CURSOR_MIN_TIMEOUT,
+        )
 
 
 def test_complete_prepends_system_prompt_via_stdin(provider):

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -162,20 +162,21 @@ def test_complete_one_shot_skips_resume(provider):
         cmd = mock_run.call_args.args[0]
         assert_that(cmd).does_not_contain("--resume")
 
-    def test_timeout_floor_is_six_hundred_seconds(self, provider):
-        """Enforce Cursor CLI minimum timeout of 600 seconds."""
-        stdout = _cli_json(result="ok")
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[],
-                returncode=0,
-                stdout=stdout,
-                stderr="",
-            )
-            provider.complete("Hello", timeout=120.0, repo_root="/tmp/repo")
-        assert_that(mock_run.call_args.kwargs["timeout"]).is_equal_to(
-            CURSOR_MIN_TIMEOUT,
+
+def test_timeout_floor_is_six_hundred_seconds(provider):
+    """Enforce Cursor CLI minimum timeout of 600 seconds."""
+    stdout = _cli_json(result="ok")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
         )
+        provider.complete("Hello", timeout=120.0, repo_root="/tmp/repo")
+    assert_that(mock_run.call_args.kwargs["timeout"]).is_equal_to(
+        CURSOR_MIN_TIMEOUT,
+    )
 
 
 def test_complete_prepends_system_prompt_via_stdin(provider):

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -44,6 +44,7 @@ def test_review_help_shows_flags() -> None:
     assert_that(result.output).contains("--with-lint")
     assert_that(result.output).contains("--depth")
     assert_that(result.output).contains("--show-checklist")
+    assert_that(result.output).contains("--timeout")
 
 
 def test_review_alias_rev_works() -> None:


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ai/review): Cursor review timeout reliability
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Fixes Cursor single-chunk review timeouts by embedding diffs inline when they fit the token budget and raising the minimum subprocess timeout floor to 600 s. Adds a `--timeout` CLI override.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed

## Closes

- Closes #1008

## Details

- **`CURSOR_MIN_TIMEOUT`**: raised from 300 s to 600 s.
- **`embed_diff` in `_review_chunk`**: inline diff in prompt when chunk fits `diff_budget`; git-command template as fallback.
- **Prompt templates**: split into `REVIEW_GIT_NATIVE_DIFF_INLINE` and `REVIEW_GIT_NATIVE_DIFF_GIT_COMMAND`.
- **CLI**: `--timeout` flag flows into `run_review` via effective AI config.
- **Tests**: timeout floor, inline vs git prompt paths, error display hints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--timeout` option to the `review` command to override the configured AI review runtime per run.
  * Enhanced AI review prompting with Cursor “git-native” diff handling that embeds diffs when they fit the token budget, otherwise uses git-command-based review instructions.

* **Bug Fixes**
  * Increased the minimum timeout for Cursor-based agent runs to reduce premature timeouts.
  * Improved timeout error guidance with clearer suggestions for increasing time and using agentic git for larger diffs.

* **Tests**
  * Updated/added unit tests covering `--timeout`, Cursor timeout flooring, and diff embedding vs git-command prompt construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR addresses Cursor review timeouts through two targeted changes: raising `CURSOR_MIN_TIMEOUT` from 300 s to 600 s, and embedding the diff inline in the prompt (rather than issuing an agentic `git diff` command) when the chunk fits the token budget. A `--timeout` CLI flag is also added as a per-invocation override, flowing through `run_review` via `ai_config.model_copy(update={"api_timeout": timeout})`.

- `CURSOR_MIN_TIMEOUT` is now 600 s; the constant is exported so tests can assert against it without magic numbers.
- `build_git_native_review_prompt` gains an `embed_diff` parameter that selects between an inline `<pull_request_diff>` block and one of two git-command templates (regular or worktree), with `_review_chunk` making the decision by comparing `estimate_tokens(chunk.diff)` against the same `diff_budget` used by the chunker.
- Three new prompt-template constants (`REVIEW_GIT_NATIVE_DIFF_INLINE`, `REVIEW_GIT_NATIVE_DIFF_GIT_COMMAND`, `REVIEW_GIT_NATIVE_DIFF_WORKTREE_COMMAND`) are introduced and tested.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the timeout floor increase and inline-diff embedding are mechanical improvements, and the model_copy approach for propagating the CLI timeout override is correct.

All the wiring is correct: model_copy properly propagates the timeout, diff_budget is threaded through every call site, and CURSOR_MIN_TIMEOUT is consistently applied. The one notable observation is that embed_diff will always be True in practice because the chunker and the embed condition share the same threshold — the git-command templates become unreachable for normal operation — but this is a design clarity issue rather than a runtime defect.

The embed_diff decision in orchestrator.py line 831 and the associated error hint in error_display.py deserve a second look to confirm whether the git-command templates are intentionally reserved for degenerate edge cases or were meant to be a live fallback for large multi-chunk reviews.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/review/orchestrator.py | Adds embed_diff decision for Cursor reviews (inline vs git-command), threads diff_budget through the call chain, and wires timeout override via model_copy. The embed_diff condition uses the same threshold as the chunker, so the git-command fallback is unreachable in normal operation. |
| lintro/ai/providers/cursor.py | Raises CURSOR_MIN_TIMEOUT constant from 300 s to 600 s and exposes it for tests. Straightforward change with no correctness issues. |
| lintro/ai/prompts/review.py | Adds three new template constants for diff sections (inline, git-command, worktree-command) and replaces the hardcoded {diff} block in the user-prompt template with {diff_section}. Clean change. |
| lintro/ai/review/error_display.py | Adds two new timeout hints describing inline embedding behaviour and the --timeout CLI flag. Straightforward hint expansion. |
| lintro/cli_utils/commands/review.py | Adds --timeout Click option and threads it through to run_review. Clean, minimal change. |
| tests/unit/ai/review/test_orchestrator.py | Adds two new tests for build_git_native_review_prompt covering inline-embed and git-command paths. Tests call the function directly with explicit embed_diff flags rather than exercising the decision logic in _review_chunk. |
| tests/unit/ai/test_cursor_provider.py | Updates the timeout-floor assertion from 300 s to 600 s and adds a dedicated test using the exported CURSOR_MIN_TIMEOUT constant. Correct and thorough. |
| tests/unit/ai/review/test_error_display.py | Adds an assertion that the timeout error output contains 'inline', covering the new hint string. Minimal but appropriate. |
| tests/unit/cli/test_review_command.py | Adds assertion that --timeout appears in the CLI help output. Correct. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as review_command (CLI)
    participant Orch as run_review (orchestrator)
    participant Chunks as resolve_review_chunks
    participant AllChunks as _review_all_chunks
    participant ChunkFn as _review_chunk
    participant PromptB as build_git_native_review_prompt
    participant Provider as CursorProvider

    CLI->>Orch: "run_review(timeout=T, ...)"
    Orch->>Orch: "effective_ai_config = ai_config.model_copy(api_timeout=T)"
    Orch->>Orch: "diff_budget = calculate_available_diff_tokens(...)"
    Orch->>Chunks: resolve_review_chunks(diff_budget)
    Chunks-->>Orch: "chunks (each <= max(diff_budget,1) tokens)"
    Orch->>AllChunks: _review_all_chunks(effective_ai_config, diff_budget)
    loop per chunk
        AllChunks->>ChunkFn: "_review_chunk(ai_config=effective, diff_budget)"
        ChunkFn->>ChunkFn: "embed_diff = estimate_tokens(chunk.diff) <= max(diff_budget,1)"
        alt "embed_diff == True (normal case)"
            ChunkFn->>PromptB: "build_git_native_review_prompt(embed_diff=True)"
            PromptB-->>ChunkFn: prompt with inline diff
        else "embed_diff == False (diff_budget~0 edge case)"
            ChunkFn->>PromptB: "build_git_native_review_prompt(embed_diff=False)"
            PromptB-->>ChunkFn: prompt with git-diff command
        end
        ChunkFn->>Provider: "complete(timeout=effective_ai_config.api_timeout)"
        Provider->>Provider: "effective_timeout = max(timeout, CURSOR_MIN_TIMEOUT=600s)"
        Provider-->>ChunkFn: response
    end
    Orch-->>CLI: ReviewResult
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as review_command (CLI)
    participant Orch as run_review (orchestrator)
    participant Chunks as resolve_review_chunks
    participant AllChunks as _review_all_chunks
    participant ChunkFn as _review_chunk
    participant PromptB as build_git_native_review_prompt
    participant Provider as CursorProvider

    CLI->>Orch: "run_review(timeout=T, ...)"
    Orch->>Orch: "effective_ai_config = ai_config.model_copy(api_timeout=T)"
    Orch->>Orch: "diff_budget = calculate_available_diff_tokens(...)"
    Orch->>Chunks: resolve_review_chunks(diff_budget)
    Chunks-->>Orch: "chunks (each <= max(diff_budget,1) tokens)"
    Orch->>AllChunks: _review_all_chunks(effective_ai_config, diff_budget)
    loop per chunk
        AllChunks->>ChunkFn: "_review_chunk(ai_config=effective, diff_budget)"
        ChunkFn->>ChunkFn: "embed_diff = estimate_tokens(chunk.diff) <= max(diff_budget,1)"
        alt "embed_diff == True (normal case)"
            ChunkFn->>PromptB: "build_git_native_review_prompt(embed_diff=True)"
            PromptB-->>ChunkFn: prompt with inline diff
        else "embed_diff == False (diff_budget~0 edge case)"
            ChunkFn->>PromptB: "build_git_native_review_prompt(embed_diff=False)"
            PromptB-->>ChunkFn: prompt with git-diff command
        end
        ChunkFn->>Provider: "complete(timeout=effective_ai_config.api_timeout)"
        Provider->>Provider: "effective_timeout = max(timeout, CURSOR_MIN_TIMEOUT=600s)"
        Provider-->>ChunkFn: response
    end
    Orch-->>CLI: ReviewResult
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(ai/review): address CodeRabbit revie..."](https://github.com/lgtm-hq/py-lintro/commit/ddfa63042e209d9d20523cb69b30987f85d0066c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39942207)</sub>

<!-- /greptile_comment -->