### PR TITLE
feat(ai): unified AI transport foundation

### DIFF
--- a/lintro/ai/availability.py
+++ b/lintro/ai/availability.py
@@ -1,98 +1,129 @@
-"""Graceful degradation for AI dependencies.
-
-Checks whether the required AI provider packages are installed and
-provides clear error messages when they are not.
-"""
+"""Transport-aware AI availability checks."""
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import click
 
+from lintro.ai.enums import AITransport
+from lintro.ai.registry import AIProvider
+
 if TYPE_CHECKING:
-    from lintro.ai.registry import AIProvider
+    pass
 
 _AI_AVAILABLE: bool | None = None
+
+_CLI_BINARIES: dict[tuple[AIProvider, AITransport], str] = {
+    (AIProvider.ANTHROPIC, AITransport.CLI): "claude",
+    (AIProvider.OPENAI, AITransport.CLI): "codex",
+    (AIProvider.CURSOR, AITransport.CLI): "agent",
+}
+
+
+def _resolve_provider(provider: AIProvider | str) -> AIProvider | None:
+    if isinstance(provider, AIProvider):
+        return provider
+    try:
+        return AIProvider(str(provider).lower())
+    except ValueError:
+        return None
+
+
+def _resolve_transport(transport: AITransport | str | None) -> AITransport | None:
+    if transport is None:
+        return None
+    if isinstance(transport, AITransport):
+        return transport
+    try:
+        return AITransport(str(transport).lower())
+    except ValueError:
+        return None
+
+
+def _api_provider_available(provider: AIProvider) -> bool:
+    if provider == AIProvider.CURSOR:
+        return False
+    try:
+        if provider == AIProvider.ANTHROPIC:
+            import anthropic  # noqa: F401
+
+            return True
+        if provider == AIProvider.OPENAI:
+            import openai  # noqa: F401
+
+            return True
+    except ImportError:
+        return False
+    return False
+
+
+def _cli_binary_available(provider: AIProvider) -> bool:
+    import shutil
+
+    binary = _CLI_BINARIES.get((provider, AITransport.CLI))
+    if binary is None:
+        return False
+    return shutil.which(binary) is not None
+
+
+def is_provider_available(
+    provider: AIProvider | str,
+    *,
+    transport: AITransport | str | None = None,
+) -> bool:
+    """Check if a provider is usable for the given transport.
+
+    Args:
+        provider: Provider name or enum member.
+        transport: Optional transport filter. When ``None``, either API or CLI
+            availability satisfies the check.
+
+    Returns:
+        bool: True when the provider can serve requests.
+    """
+    from loguru import logger
+
+    provider_enum = _resolve_provider(provider)
+    if provider_enum is None:
+        supported = ", ".join(p.value for p in AIProvider)
+        logger.warning(
+            "Unknown AI provider {!r}; supported providers: {}",
+            provider,
+            supported,
+        )
+        return False
+
+    transport_enum = _resolve_transport(transport)
+    if transport_enum == AITransport.API:
+        return _api_provider_available(provider_enum)
+    if transport_enum == AITransport.CLI:
+        return _cli_binary_available(provider_enum)
+
+    return _api_provider_available(provider_enum) or _cli_binary_available(
+        provider_enum,
+    )
 
 
 def is_ai_available() -> bool:
     """Check if at least one AI provider is usable.
 
     Returns:
-        bool: True if anthropic, openai, or the Cursor agent CLI is available.
+        bool: True when any provider is available via API or CLI.
     """
     global _AI_AVAILABLE
 
     if _AI_AVAILABLE is not None:
         return _AI_AVAILABLE
 
-    if is_provider_available("cursor"):
-        _AI_AVAILABLE = True
-        return True
-
-    try:
-        import anthropic  # noqa: F401 -- import-only availability check
-
-        _AI_AVAILABLE = True
-        return True
-    except ImportError:
-        pass
-
-    try:
-        import openai  # noqa: F401 -- import-only availability check
-
-        _AI_AVAILABLE = True
-        return True
-    except ImportError:
-        pass
+    for provider in AIProvider:
+        if is_provider_available(provider):
+            _AI_AVAILABLE = True
+            return True
 
     _AI_AVAILABLE = False
-    return False
-
-
-def is_provider_available(provider: AIProvider | str) -> bool:
-    """Check if a specific provider package is installed.
-
-    Args:
-        provider: Provider name ("anthropic" or "openai").
-
-    Returns:
-        bool: True if the provider's package is importable.
-    """
-    from lintro.ai.registry import AIProvider
-
-    if isinstance(provider, AIProvider):
-        provider_value = provider.value
-    else:
-        provider_value = str(provider).lower()
-
-    if provider_value not in {p.value for p in AIProvider}:
-        from loguru import logger
-
-        supported = ", ".join(p.value for p in AIProvider)
-        logger.warning(
-            "Unknown AI provider {!r}; supported providers: {}",
-            provider_value,
-            supported,
-        )
-        return False
-
-    try:
-        if provider_value == AIProvider.ANTHROPIC.value:
-            import anthropic  # noqa: F401 -- import-only availability check
-
-            return True
-        if provider_value == AIProvider.OPENAI.value:
-            import openai  # noqa: F401 -- import-only availability check
-
-            return True
-        if provider_value == AIProvider.CURSOR.value:
-            from lintro.ai.providers.cursor import _find_agent
-
-            return _find_agent() is not None
-    except ImportError:
-        pass
     return False
 
 
@@ -117,3 +148,22 @@ def reset_availability_cache() -> None:
     """
     global _AI_AVAILABLE
     _AI_AVAILABLE = None
+
+
+def provider_api_key_env(provider: AIProvider) -> str:
+    """Return the default API key environment variable for a provider."""
+    from lintro.ai.registry import PROVIDERS
+
+    return PROVIDERS.get(provider).default_api_key_env
+
+
+def provider_cli_binary(provider: AIProvider) -> str | None:
+    """Return the CLI binary name for a provider, if any."""
+    return _CLI_BINARIES.get((provider, AITransport.CLI))
+
+
+def codex_auth_configured() -> bool:
+    """Return True when Codex CLI auth is likely configured."""
+    if os.environ.get("CODEX_API_KEY"):
+        return True
+    return (Path.home() / ".codex" / "auth.json").is_file()

--- a/lintro/ai/budget.py
+++ b/lintro/ai/budget.py
@@ -66,6 +66,4 @@ class CostBudget:
                 self._raise_exceeded()
             result = fn()
             self._spent += cost_of(result)
-            if self.max_cost_usd is not None and self._spent >= self.max_cost_usd:
-                self._raise_exceeded()
             return result

--- a/lintro/ai/budget.py
+++ b/lintro/ai/budget.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import TypeVar
+
+_T = TypeVar("_T")
 
 
 @dataclass
@@ -43,10 +47,25 @@ class CostBudget:
 
     def check(self) -> None:
         """Raise AIError if the budget has been exceeded."""
-        if self.max_cost_usd is not None and self.spent >= self.max_cost_usd:
-            from lintro.ai.exceptions import AIError
+        with self._lock:
+            if self.max_cost_usd is not None and self._spent >= self.max_cost_usd:
+                self._raise_exceeded()
 
-            raise AIError(
-                f"AI cost budget exceeded: ${self.spent:.4f} spent, "
-                f"limit is ${self.max_cost_usd:.2f}",
-            )
+    def _raise_exceeded(self) -> None:
+        from lintro.ai.exceptions import AIError
+
+        raise AIError(
+            f"AI cost budget exceeded: ${self._spent:.4f} spent, "
+            f"limit is ${self.max_cost_usd:.2f}",
+        )
+
+    def execute(self, fn: Callable[[], _T], *, cost_of: Callable[[_T], float]) -> _T:
+        """Run ``fn`` under the budget lock to prevent parallel overspend."""
+        with self._lock:
+            if self.max_cost_usd is not None and self._spent >= self.max_cost_usd:
+                self._raise_exceeded()
+            result = fn()
+            self._spent += cost_of(result)
+            if self.max_cost_usd is not None and self._spent >= self.max_cost_usd:
+                self._raise_exceeded()
+            return result

--- a/lintro/ai/cache.py
+++ b/lintro/ai/cache.py
@@ -74,11 +74,13 @@ def get_cached_suggestion(
     if isinstance(suggestion, dict):
         # Touch the file to update its access/modification time for LRU tracking
         cache_file.touch()
-        return AIFixSuggestion(**{
-            k: v
-            for k, v in suggestion.items()
-            if k in {f.name for f in dataclasses.fields(AIFixSuggestion)}
-        })
+        return AIFixSuggestion(
+            **{
+                k: v
+                for k, v in suggestion.items()
+                if k in {f.name for f in dataclasses.fields(AIFixSuggestion)}
+            }
+        )
     return None
 
 

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -164,17 +164,6 @@ class AIConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_transport_and_retries(self) -> AIConfig:
-        if (
-            self.enabled
-            and self.transport == AITransport.API
-            and self.provider == AIProvider.CURSOR
-        ):
-            msg = (
-                "cursor provider only supports transport: cli "
-                "(the Cursor agent CLI; API transport is invalid)"
-            )
-            raise ValueError(msg)
-
         if self.retry_max_delay < self.retry_base_delay:
             msg = (
                 f"retry_max_delay ({self.retry_max_delay}) must be >= "

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -168,10 +168,7 @@ class AIConfig(BaseModel):
             msg = "ai.transport is required when ai.enabled is true (api or cli)"
             raise ValueError(msg)
 
-        if (
-            self.transport == AITransport.API
-            and self.provider == AIProvider.CURSOR
-        ):
+        if self.transport == AITransport.API and self.provider == AIProvider.CURSOR:
             msg = (
                 "cursor provider only supports transport: cli "
                 "(the Cursor agent CLI; API transport is invalid)"

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from lintro.ai.config_views import AIBudgetConfig, AIOutputConfig, AIProviderConfig
-from lintro.ai.enums import ConfidenceLevel, SanitizeMode
+from lintro.ai.enums import AITransport, ConfidenceLevel, SanitizeMode
 from lintro.ai.registry import AIProvider
 
 __all__ = [
@@ -42,6 +42,13 @@ class AIConfig(BaseModel):
 
     enabled: bool = False
     provider: AIProvider = AIProvider.ANTHROPIC
+    transport: AITransport | None = Field(
+        default=None,
+        description=(
+            "Required when ai.enabled is true. "
+            "How to invoke the provider: 'api' (SDK) or 'cli' (local binary)."
+        ),
+    )
     model: str | None = None
     api_key_env: str | None = None
     api_base_url: str | None = Field(
@@ -156,7 +163,21 @@ class AIConfig(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _check_retry_delays(self) -> AIConfig:
+    def _validate_transport_and_retries(self) -> AIConfig:
+        if self.enabled and self.transport is None:
+            msg = "ai.transport is required when ai.enabled is true (api or cli)"
+            raise ValueError(msg)
+
+        if (
+            self.transport == AITransport.API
+            and self.provider == AIProvider.CURSOR
+        ):
+            msg = (
+                "cursor provider only supports transport: cli "
+                "(the Cursor agent CLI; API transport is invalid)"
+            )
+            raise ValueError(msg)
+
         if self.retry_max_delay < self.retry_base_delay:
             msg = (
                 f"retry_max_delay ({self.retry_max_delay}) must be >= "
@@ -172,6 +193,7 @@ class AIConfig(BaseModel):
         """Return a frozen snapshot of provider-related settings."""
         return AIProviderConfig(
             provider=self.provider,
+            transport=self.transport,
             model=self.model,
             api_key_env=self.api_key_env,
             api_base_url=self.api_base_url,

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -164,7 +164,11 @@ class AIConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_transport_and_retries(self) -> AIConfig:
-        if self.transport == AITransport.API and self.provider == AIProvider.CURSOR:
+        if (
+            self.enabled
+            and self.transport == AITransport.API
+            and self.provider == AIProvider.CURSOR
+        ):
             msg = (
                 "cursor provider only supports transport: cli "
                 "(the Cursor agent CLI; API transport is invalid)"

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -164,10 +164,6 @@ class AIConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_transport_and_retries(self) -> AIConfig:
-        if self.enabled and self.transport is None:
-            msg = "ai.transport is required when ai.enabled is true (api or cli)"
-            raise ValueError(msg)
-
         if self.transport == AITransport.API and self.provider == AIProvider.CURSOR:
             msg = (
                 "cursor provider only supports transport: cli "

--- a/lintro/ai/config_views.py
+++ b/lintro/ai/config_views.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from lintro.ai.enums import ConfidenceLevel, SanitizeMode
+from lintro.ai.enums import AITransport, ConfidenceLevel, SanitizeMode
 from lintro.ai.registry import AIProvider
 
 
@@ -19,6 +19,7 @@ class AIProviderConfig:
     """Read-only view of provider-related AI settings."""
 
     provider: AIProvider
+    transport: AITransport | None
     model: str | None
     api_key_env: str | None
     api_base_url: str | None

--- a/lintro/ai/doctor_checks.py
+++ b/lintro/ai/doctor_checks.py
@@ -122,7 +122,10 @@ def check_ai_configuration(config: AIConfig) -> list[AICheckResult]:
                 name=f"ai.api.{key_env}",
                 status=ToolStatus.MISSING,
                 message=f"Environment variable {key_env} is not set",
-                hint=f"Export {key_env} or set ai.api_base_url for a compatible endpoint",
+                hint=(
+                    f"Export {key_env} or set ai.api_base_url "
+                    "for a compatible endpoint"
+                ),
             ),
         )
 

--- a/lintro/ai/doctor_checks.py
+++ b/lintro/ai/doctor_checks.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 from lintro.ai.availability import (
     codex_auth_configured,
+    is_provider_available,
     provider_api_key_env,
     provider_cli_binary,
 )
@@ -107,6 +108,19 @@ def check_ai_configuration(config: AIConfig) -> list[AICheckResult]:
         return results
 
     # API transport
+    if not is_provider_available(provider, transport=AITransport.API):
+        results.append(
+            AICheckResult(
+                name=f"ai.api.sdk.{provider.value}",
+                status=ToolStatus.MISSING,
+                message=(
+                    f"Provider SDK for {provider.value} API transport is not installed"
+                ),
+                hint="Install with: uv pip install 'lintro[ai]'",
+            ),
+        )
+        return results
+
     key_env = config.api_key_env or provider_api_key_env(provider)
     if config.api_base_url or os.environ.get(key_env):
         results.append(

--- a/lintro/ai/doctor_checks.py
+++ b/lintro/ai/doctor_checks.py
@@ -1,0 +1,194 @@
+"""Transport-aware AI configuration checks for ``lintro doctor``."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+
+from lintro.ai.availability import (
+    codex_auth_configured,
+    provider_api_key_env,
+    provider_cli_binary,
+)
+from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
+from lintro.ai.registry import AIProvider
+from lintro.enums.tool_status import ToolStatus
+
+__all__ = ["AICheckResult", "check_ai_configuration"]
+
+
+@dataclass(frozen=True)
+class AICheckResult:
+    """Result of a single AI configuration or dependency check."""
+
+    name: str
+    status: ToolStatus
+    message: str
+    hint: str = ""
+
+
+def check_ai_configuration(config: AIConfig) -> list[AICheckResult]:
+    """Run transport-aware AI checks when AI features are enabled.
+
+    Args:
+        config: Parsed AI configuration.
+
+    Returns:
+        List of check results (empty when ``ai.enabled`` is false).
+    """
+    if not config.enabled:
+        return []
+
+    results: list[AICheckResult] = []
+
+    if config.transport is None:
+        results.append(
+            AICheckResult(
+                name="ai.transport",
+                status=ToolStatus.INCOMPATIBLE,
+                message="ai.transport is required when ai.enabled is true",
+                hint="Add `transport: api` or `transport: cli` under `ai:` in config",
+            ),
+        )
+        return results
+
+    if (
+        config.provider == AIProvider.CURSOR
+        and config.transport == AITransport.API
+    ):
+        results.append(
+            AICheckResult(
+                name="ai.provider+transport",
+                status=ToolStatus.INCOMPATIBLE,
+                message="cursor provider only supports transport: cli",
+                hint="Set `transport: cli` and install the Cursor agent CLI",
+            ),
+        )
+        return results
+
+    transport = config.transport
+    provider = config.provider
+
+    if transport == AITransport.CLI:
+        binary = provider_cli_binary(provider)
+        if binary is None:
+            results.append(
+                AICheckResult(
+                    name="ai.cli",
+                    status=ToolStatus.INCOMPATIBLE,
+                    message=f"No CLI transport for provider {provider.value}",
+                    hint="Use `transport: api` or choose a different provider",
+                ),
+            )
+            return results
+
+        path = shutil.which(binary)
+        if path is None:
+            hint = _cli_install_hint(provider=provider)
+            results.append(
+                AICheckResult(
+                    name=f"ai.cli.{binary}",
+                    status=ToolStatus.MISSING,
+                    message=f"CLI binary '{binary}' not found on PATH",
+                    hint=hint,
+                ),
+            )
+        else:
+            results.append(
+                AICheckResult(
+                    name=f"ai.cli.{binary}",
+                    status=ToolStatus.OK,
+                    message=f"CLI binary '{binary}' found at {path}",
+                ),
+            )
+
+        auth_result = _check_cli_auth(provider=provider, config=config)
+        if auth_result is not None:
+            results.append(auth_result)
+        return results
+
+    # API transport
+    key_env = config.api_key_env or provider_api_key_env(provider)
+    if config.api_base_url or os.environ.get(key_env):
+        results.append(
+            AICheckResult(
+                name=f"ai.api.{key_env}",
+                status=ToolStatus.OK,
+                message=f"API credentials configured via {key_env} or api_base_url",
+            ),
+        )
+    else:
+        results.append(
+            AICheckResult(
+                name=f"ai.api.{key_env}",
+                status=ToolStatus.MISSING,
+                message=f"Environment variable {key_env} is not set",
+                hint=f"Export {key_env} or set ai.api_base_url for a compatible endpoint",
+            ),
+        )
+
+    return results
+
+
+def _cli_install_hint(*, provider: AIProvider) -> str:
+    if provider == AIProvider.CURSOR:
+        return "Install agent CLI: curl https://cursor.com/install -fsS | bash"
+    if provider == AIProvider.ANTHROPIC:
+        return "Install Claude Code: https://code.claude.com/docs/en/setup"
+    if provider == AIProvider.OPENAI:
+        return "Install Codex CLI: https://developers.openai.com/codex/cli"
+    return "Install the provider CLI and ensure it is on PATH"
+
+
+def _check_cli_auth(
+    *,
+    provider: AIProvider,
+    config: AIConfig,
+) -> AICheckResult | None:
+    if provider == AIProvider.CURSOR:
+        key_env = config.api_key_env or provider_api_key_env(provider)
+        if os.environ.get(key_env):
+            return AICheckResult(
+                name="ai.cli.auth",
+                status=ToolStatus.OK,
+                message=f"{key_env} is set",
+            )
+        return AICheckResult(
+            name="ai.cli.auth",
+            status=ToolStatus.UNKNOWN,
+            message="Cursor CLI auth not verified",
+            hint="Run `agent login` or set CURSOR_API_KEY",
+        )
+
+    if provider == AIProvider.ANTHROPIC:
+        key_env = config.api_key_env or provider_api_key_env(provider)
+        if os.environ.get(key_env):
+            return AICheckResult(
+                name="ai.cli.auth",
+                status=ToolStatus.OK,
+                message=f"{key_env} set (API billing overrides subscription)",
+            )
+        return AICheckResult(
+            name="ai.cli.auth",
+            status=ToolStatus.UNKNOWN,
+            message="Claude CLI auth not verified",
+            hint="Run `claude login` or set ANTHROPIC_API_KEY",
+        )
+
+    if provider == AIProvider.OPENAI:
+        if codex_auth_configured():
+            return AICheckResult(
+                name="ai.cli.auth",
+                status=ToolStatus.OK,
+                message="Codex auth configured (CODEX_API_KEY or ~/.codex/auth.json)",
+            )
+        return AICheckResult(
+            name="ai.cli.auth",
+            status=ToolStatus.UNKNOWN,
+            message="Codex CLI auth not verified",
+            hint="Run `codex login` or set CODEX_API_KEY",
+        )
+
+    return None

--- a/lintro/ai/doctor_checks.py
+++ b/lintro/ai/doctor_checks.py
@@ -54,10 +54,7 @@ def check_ai_configuration(config: AIConfig) -> list[AICheckResult]:
         )
         return results
 
-    if (
-        config.provider == AIProvider.CURSOR
-        and config.transport == AITransport.API
-    ):
+    if config.provider == AIProvider.CURSOR and config.transport == AITransport.API:
         results.append(
             AICheckResult(
                 name="ai.provider+transport",

--- a/lintro/ai/enums/__init__.py
+++ b/lintro/ai/enums/__init__.py
@@ -1,7 +1,8 @@
 """AI-specific enumerations for confidence levels and risk classifications."""
 
+from lintro.ai.enums.ai_transport import AITransport
 from lintro.ai.enums.confidence_level import ConfidenceLevel
 from lintro.ai.enums.risk_level import RiskLevel
 from lintro.ai.enums.sanitize_mode import SanitizeMode
 
-__all__ = ["ConfidenceLevel", "RiskLevel", "SanitizeMode"]
+__all__ = ["AITransport", "ConfidenceLevel", "RiskLevel", "SanitizeMode"]

--- a/lintro/ai/enums/ai_transport.py
+++ b/lintro/ai/enums/ai_transport.py
@@ -1,0 +1,16 @@
+"""AI transport enumeration for API vs CLI invocation."""
+
+from __future__ import annotations
+
+from enum import auto
+
+from lintro.enums.hyphenated_str_enum import HyphenatedStrEnum
+
+__all__ = ["AITransport"]
+
+
+class AITransport(HyphenatedStrEnum):
+    """How lintro invokes the configured AI provider."""
+
+    API = auto()
+    CLI = auto()

--- a/lintro/ai/invoke.py
+++ b/lintro/ai/invoke.py
@@ -5,12 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 from lintro.ai.budget import CostBudget
-from lintro.ai.exceptions import (
-    AIAuthenticationError,
-    AIError,
-    AIProviderError,
-    AIRateLimitError,
-)
 from lintro.ai.fallback import complete_with_fallback
 from lintro.ai.providers.response import AIResponse
 from lintro.ai.retry import with_retry
@@ -22,7 +16,7 @@ if TYPE_CHECKING:
 __all__ = ["call_ai"]
 
 
-def call_ai(
+def call_ai(  # noqa: DOC502
     *,
     provider: BaseAIProvider,
     ai_config: AIConfig,
@@ -68,38 +62,22 @@ def call_ai(
             use_one_shot=use_one_shot,
         )
 
-    if budget is not None:
-
-        @with_retry(
-            max_retries=ai_config.max_retries,
-            base_delay=ai_config.retry_base_delay,
-            max_delay=ai_config.retry_max_delay,
-            backoff_factor=ai_config.retry_backoff_factor,
-        )
-        def _call() -> AIResponse:
+    def _budgeted_call() -> AIResponse:
+        if budget is not None and budget.max_cost_usd is not None:
             return budget.execute(
                 _call_once,
                 cost_of=lambda response: response.cost_estimate,
             )
+        response = _call_once()
+        if budget is not None:
+            budget.record(response.cost_estimate)
+        return response
 
-    else:
+    call_with_retry = with_retry(
+        max_retries=ai_config.max_retries,
+        base_delay=ai_config.retry_base_delay,
+        max_delay=ai_config.retry_max_delay,
+        backoff_factor=ai_config.retry_backoff_factor,
+    )(_budgeted_call)
 
-        @with_retry(
-            max_retries=ai_config.max_retries,
-            base_delay=ai_config.retry_base_delay,
-            max_delay=ai_config.retry_max_delay,
-            backoff_factor=ai_config.retry_backoff_factor,
-        )
-        def _call() -> AIResponse:
-            return _call_once()
-
-    try:
-        return cast(AIResponse, _call())
-    except AIAuthenticationError:
-        raise
-    except AIRateLimitError:
-        raise
-    except AIProviderError:
-        raise
-    except AIError:
-        raise
+    return cast(AIResponse, call_with_retry())

--- a/lintro/ai/invoke.py
+++ b/lintro/ai/invoke.py
@@ -56,13 +56,7 @@ def call_ai(
     """
     tokens = max_tokens if max_tokens is not None else ai_config.max_tokens
 
-    @with_retry(
-        max_retries=ai_config.max_retries,
-        base_delay=ai_config.retry_base_delay,
-        max_delay=ai_config.retry_max_delay,
-        backoff_factor=ai_config.retry_backoff_factor,
-    )
-    def _call() -> AIResponse:
+    def _call_once() -> AIResponse:
         return complete_with_fallback(
             provider,
             user_prompt,
@@ -74,15 +68,32 @@ def call_ai(
             use_one_shot=use_one_shot,
         )
 
-    try:
-        if budget is not None:
-            return cast(
-                AIResponse,
-                budget.execute(
-                    _call,
-                    cost_of=lambda response: response.cost_estimate,
-                ),
+    if budget is not None:
+
+        @with_retry(
+            max_retries=ai_config.max_retries,
+            base_delay=ai_config.retry_base_delay,
+            max_delay=ai_config.retry_max_delay,
+            backoff_factor=ai_config.retry_backoff_factor,
+        )
+        def _call() -> AIResponse:
+            return budget.execute(
+                _call_once,
+                cost_of=lambda response: response.cost_estimate,
             )
+
+    else:
+
+        @with_retry(
+            max_retries=ai_config.max_retries,
+            base_delay=ai_config.retry_base_delay,
+            max_delay=ai_config.retry_max_delay,
+            backoff_factor=ai_config.retry_backoff_factor,
+        )
+        def _call() -> AIResponse:
+            return _call_once()
+
+    try:
         return cast(AIResponse, _call())
     except AIAuthenticationError:
         raise

--- a/lintro/ai/invoke.py
+++ b/lintro/ai/invoke.py
@@ -74,26 +74,21 @@ def call_ai(
             use_one_shot=use_one_shot,
         )
 
-    if budget is not None:
-        try:
-            budget.check()
-        except AIError:
-            raise
-
     try:
-        response = cast(AIResponse, _call())
+        if budget is not None:
+            return cast(
+                AIResponse,
+                budget.execute(
+                    _call,
+                    cost_of=lambda response: response.cost_estimate,
+                ),
+            )
+        return cast(AIResponse, _call())
     except AIAuthenticationError:
         raise
     except AIRateLimitError:
         raise
     except AIProviderError:
         raise
-
-    if budget is not None:
-        budget.record(response.cost_estimate)
-        try:
-            budget.check()
-        except AIError:
-            raise
-
-    return response
+    except AIError:
+        raise

--- a/lintro/ai/invoke.py
+++ b/lintro/ai/invoke.py
@@ -1,0 +1,80 @@
+"""Unified AI invocation with retry, fallback, and budget tracking."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from lintro.ai.budget import CostBudget
+from lintro.ai.fallback import complete_with_fallback
+from lintro.ai.providers.response import AIResponse
+from lintro.ai.retry import with_retry
+
+if TYPE_CHECKING:
+    from lintro.ai.config import AIConfig
+    from lintro.ai.providers.base import BaseAIProvider
+
+__all__ = ["call_ai"]
+
+
+def call_ai(
+    *,
+    provider: BaseAIProvider,
+    ai_config: AIConfig,
+    user_prompt: str,
+    system_prompt: str | None,
+    budget: CostBudget | None,
+    max_tokens: int | None = None,
+    repo_root: str | None = None,
+    use_one_shot: bool = False,
+) -> AIResponse:
+    """Retry, fallback, and budget tracking for all AI products.
+
+    Args:
+        provider: Configured AI provider instance.
+        ai_config: AI configuration (retry, timeout, fallback models).
+        user_prompt: User-facing prompt text.
+        system_prompt: Optional system prompt.
+        budget: Optional session cost budget to record against.
+        max_tokens: Per-call token cap; defaults to ``ai_config.max_tokens``.
+        repo_root: Optional repository root for CLI providers.
+        use_one_shot: When True, avoid durable CLI sessions.
+
+    Returns:
+        The provider response with usage metadata.
+
+    Raises:
+        AIAuthenticationError: On permanent auth failure (not retried).
+        AIProviderError: When all retries and fallbacks are exhausted.
+        AIRateLimitError: When rate limits persist after retries.
+        AIError: When the cost budget is exceeded.
+    """
+    tokens = max_tokens if max_tokens is not None else ai_config.max_tokens
+
+    @with_retry(
+        max_retries=ai_config.max_retries,
+        base_delay=ai_config.retry_base_delay,
+        max_delay=ai_config.retry_max_delay,
+        backoff_factor=ai_config.retry_backoff_factor,
+    )
+    def _call() -> AIResponse:
+        return complete_with_fallback(
+            provider,
+            user_prompt,
+            fallback_models=list(ai_config.fallback_models),
+            system=system_prompt,
+            max_tokens=tokens,
+            timeout=ai_config.api_timeout,
+            repo_root=repo_root,
+            use_one_shot=use_one_shot,
+        )
+
+    if budget is not None:
+        budget.check()
+
+    response = _call()
+
+    if budget is not None:
+        budget.record(response.cost_estimate)
+        budget.check()
+
+    return response

--- a/lintro/ai/invoke.py
+++ b/lintro/ai/invoke.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from lintro.ai.budget import CostBudget
+from lintro.ai.exceptions import (
+    AIAuthenticationError,
+    AIError,
+    AIProviderError,
+    AIRateLimitError,
+)
 from lintro.ai.fallback import complete_with_fallback
 from lintro.ai.providers.response import AIResponse
 from lintro.ai.retry import with_retry
@@ -69,12 +75,25 @@ def call_ai(
         )
 
     if budget is not None:
-        budget.check()
+        try:
+            budget.check()
+        except AIError:
+            raise
 
-    response = _call()
+    try:
+        response = cast(AIResponse, _call())
+    except AIAuthenticationError:
+        raise
+    except AIRateLimitError:
+        raise
+    except AIProviderError:
+        raise
 
     if budget is not None:
         budget.record(response.cost_estimate)
-        budget.check()
+        try:
+            budget.check()
+        except AIError:
+            raise
 
     return response

--- a/lintro/ai/invoke.py
+++ b/lintro/ai/invoke.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 __all__ = ["call_ai"]
 
 
-def call_ai(  # noqa: DOC502
+def call_ai(
     *,
     provider: BaseAIProvider,
     ai_config: AIConfig,
@@ -41,12 +41,6 @@ def call_ai(  # noqa: DOC502
 
     Returns:
         The provider response with usage metadata.
-
-    Raises:
-        AIAuthenticationError: On permanent auth failure (not retried).
-        AIProviderError: When all retries and fallbacks are exhausted.
-        AIRateLimitError: When rate limits persist after retries.
-        AIError: When the cost budget is exceeded.
     """
     tokens = max_tokens if max_tokens is not None else ai_config.max_tokens
 

--- a/lintro/ai/json_response.py
+++ b/lintro/ai/json_response.py
@@ -1,0 +1,72 @@
+"""Shared JSON response parsing for AI products."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "CliSchemaRequest",
+    "load_json_object",
+    "strip_json_fences",
+]
+
+_JSON_FENCE_PATTERN = re.compile(
+    r"```(?:json)?\s*\n?(.*?)\n?```",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class CliSchemaRequest:
+    """Native CLI schema arguments for structured output (Phase 14).
+
+    Attributes:
+        schema: JSON Schema object passed to provider-native flags.
+        schema_name: Optional provider-specific schema identifier.
+    """
+
+    schema: dict[str, Any]
+    schema_name: str | None = None
+
+
+def strip_json_fences(*, content: str) -> str:
+    """Strip markdown JSON code fences from model output.
+
+    Args:
+        content: Raw model response text.
+
+    Returns:
+        JSON string suitable for ``json.loads``.
+    """
+    stripped = content.strip()
+    match = _JSON_FENCE_PATTERN.search(stripped)
+    if match is not None:
+        return match.group(1).strip()
+    return stripped
+
+
+def load_json_object(*, content: str) -> dict[str, Any]:
+    """Parse fenced or raw JSON into an object with clear errors.
+
+    Args:
+        content: Raw or fenced JSON model response.
+
+    Returns:
+        Parsed JSON object.
+
+    Raises:
+        ValueError: When JSON is invalid or not an object.
+    """
+    json_text = strip_json_fences(content=content)
+    try:
+        payload = json.loads(json_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError("JSON response must be an object")
+
+    return payload

--- a/lintro/ai/providers/__init__.py
+++ b/lintro/ai/providers/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from lintro.ai.exceptions import AINotAvailableError  # noqa: F401 -- public re-export
+from lintro.ai.enums import AITransport
 from lintro.ai.registry import PROVIDERS, AIProvider
 
 if TYPE_CHECKING:
@@ -86,6 +87,7 @@ def get_provider(config: AIConfig) -> BaseAIProvider:
         api_key_env=config.api_key_env,
         max_tokens=config.max_tokens,
         base_url=config.api_base_url,
+        transport=config.transport or AITransport.API,
     )
 
 

--- a/lintro/ai/providers/__init__.py
+++ b/lintro/ai/providers/__init__.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from lintro.ai.exceptions import AINotAvailableError  # noqa: F401 -- public re-export
 from lintro.ai.enums import AITransport
+from lintro.ai.exceptions import AINotAvailableError  # noqa: F401 -- public re-export
 from lintro.ai.registry import PROVIDERS, AIProvider
 
 if TYPE_CHECKING:

--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -164,7 +164,6 @@ class AnthropicProvider(BaseAIProvider):
         """
         self._transport = transport
         self._cli: _AnthropicCliTransport | None = None
-        self._session_id: str | None = None
 
         if transport == AITransport.CLI:
             claude_path = _find_claude()
@@ -234,6 +233,7 @@ class AnthropicProvider(BaseAIProvider):
         use_one_shot: bool,
         model: str | None = None,
     ) -> AIResponse:
+        del use_one_shot
         if self._cli is None:
             raise AINotAvailableError("Claude CLI transport is not initialized")
 
@@ -252,12 +252,9 @@ class AnthropicProvider(BaseAIProvider):
         ]
         if system:
             cmd.extend(["--append-system-prompt", system])
-        if not use_one_shot and self._session_id is not None:
-            cmd.extend(["--resume", self._session_id])
 
         logger.debug(
             f"Claude CLI request: model={effective_model}, "
-            f"resume={self._session_id is not None and not use_one_shot}, "
             f"prompt_len={len(prompt)}",
         )
 
@@ -276,14 +273,6 @@ class AnthropicProvider(BaseAIProvider):
         )
 
         response = self._cli.parse_stdout(result.stdout)
-        session_id = None
-        try:
-            envelope = json.loads(result.stdout.strip())
-            session_id = envelope.get("session_id")
-        except json.JSONDecodeError:
-            session_id = None
-        if not use_one_shot and isinstance(session_id, str) and session_id.strip():
-            self._session_id = session_id.strip()
         return response
 
     def complete(
@@ -305,7 +294,7 @@ class AnthropicProvider(BaseAIProvider):
             max_tokens: Maximum tokens to generate (API only).
             timeout: Request timeout in seconds.
             repo_root: Working directory for CLI transport.
-            use_one_shot: When True, avoid resuming CLI sessions.
+            use_one_shot: Ignored for CLI transport; each call is independent.
             model: Optional per-call model override.
 
         Returns:

--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -232,10 +232,12 @@ class AnthropicProvider(BaseAIProvider):
         timeout: float,
         repo_root: str | None,
         use_one_shot: bool,
+        model: str | None = None,
     ) -> AIResponse:
         if self._cli is None:
             raise AINotAvailableError("Claude CLI transport is not initialized")
 
+        effective_model = model or self._model
         cmd = [
             self._cli._binary_path,
             "--bare",
@@ -245,6 +247,8 @@ class AnthropicProvider(BaseAIProvider):
             "json",
             "--permission-mode",
             "dontAsk",
+            "--model",
+            effective_model,
         ]
         if system:
             cmd.extend(["--append-system-prompt", system])
@@ -252,7 +256,7 @@ class AnthropicProvider(BaseAIProvider):
             cmd.extend(["--resume", self._session_id])
 
         logger.debug(
-            f"Claude CLI request: model={self._model}, "
+            f"Claude CLI request: model={effective_model}, "
             f"resume={self._session_id is not None and not use_one_shot}, "
             f"prompt_len={len(prompt)}",
         )
@@ -315,6 +319,7 @@ class AnthropicProvider(BaseAIProvider):
                 timeout=timeout,
                 repo_root=repo_root,
                 use_one_shot=use_one_shot,
+                model=model,
             )
 
         del repo_root, use_one_shot

--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -29,7 +29,7 @@ from lintro.ai.providers.constants import (
     DEFAULT_PER_CALL_MAX_TOKENS,
     DEFAULT_TIMEOUT,
 )
-from lintro.ai.registry import AIProvider, PROVIDERS
+from lintro.ai.registry import PROVIDERS, AIProvider
 
 _has_anthropic = False
 try:
@@ -243,10 +243,7 @@ class AnthropicProvider(BaseAIProvider):
         ]
         if system:
             cmd.extend(["--append-system-prompt", system])
-        if (
-            not use_one_shot
-            and self._session_id is not None
-        ):
+        if not use_one_shot and self._session_id is not None:
             cmd.extend(["--resume", self._session_id])
 
         logger.debug(
@@ -276,11 +273,7 @@ class AnthropicProvider(BaseAIProvider):
             session_id = envelope.get("session_id")
         except json.JSONDecodeError:
             session_id = None
-        if (
-            not use_one_shot
-            and isinstance(session_id, str)
-            and session_id.strip()
-        ):
+        if not use_one_shot and isinstance(session_id, str) and session_id.strip():
             self._session_id = session_id.strip()
         return response
 

--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -267,8 +267,8 @@ class AnthropicProvider(BaseAIProvider):
             result,
             auth_patterns=("authentication", "login", "not logged in"),
             auth_hint=(
-                "Run 'claude login' or set ANTHROPIC_API_KEY "
-                "(API key billing overrides subscription credits)."
+                "Set ANTHROPIC_API_KEY or configure apiKeyHelper "
+                "(--bare mode does not use OAuth login)."
             ),
         )
 

--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -157,6 +157,10 @@ class AnthropicProvider(BaseAIProvider):
             base_url: Custom API base URL for Anthropic-compatible
                 endpoints (proxies, self-hosted, etc.).
             transport: ``api`` for SDK or ``cli`` for ``claude -p``.
+
+        Raises:
+            AINotAvailableError: When CLI transport is selected but the
+                ``claude`` binary is not on PATH.
         """
         self._transport = transport
         self._cli: _AnthropicCliTransport | None = None
@@ -215,6 +219,7 @@ class AnthropicProvider(BaseAIProvider):
         return anthropic.Anthropic(**kwargs)
 
     def is_available(self) -> bool:
+        """Return True when the configured transport is usable."""
         if self._transport == AITransport.CLI:
             return _find_claude() is not None
         return super().is_available()

--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -1,11 +1,13 @@
 """Anthropic AI provider implementation.
 
-Uses the Anthropic Python SDK to communicate with Claude models.
-Requires the ``anthropic`` package (installed via ``lintro[ai]``).
+Uses the Anthropic Python SDK for ``transport: api`` and the ``claude`` CLI
+for ``transport: cli``.
 """
 
 from __future__ import annotations
 
+import json
+import os
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
@@ -13,18 +15,21 @@ from typing import Any
 from loguru import logger
 
 from lintro.ai.cost import estimate_cost
+from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import (
     AIAuthenticationError,
+    AINotAvailableError,
     AIProviderError,
     AIRateLimitError,
 )
 from lintro.ai.providers.base import AIResponse, AIStreamResult, BaseAIProvider
+from lintro.ai.providers.cli_transport import CliTransport
 from lintro.ai.providers.constants import (
     DEFAULT_MAX_TOKENS,
     DEFAULT_PER_CALL_MAX_TOKENS,
     DEFAULT_TIMEOUT,
 )
-from lintro.ai.registry import PROVIDERS, AIProvider
+from lintro.ai.registry import AIProvider, PROVIDERS
 
 _has_anthropic = False
 try:
@@ -36,6 +41,73 @@ except ImportError:
 
 DEFAULT_MODEL = PROVIDERS.anthropic.default_model
 DEFAULT_API_KEY_ENV = PROVIDERS.anthropic.default_api_key_env
+_CLAUDE_BIN = "claude"
+
+
+def _find_claude() -> str | None:
+    """Return the full path to the ``claude`` binary, or None."""
+    return CliTransport.find_binary(_CLAUDE_BIN)
+
+
+class _AnthropicCliTransport(CliTransport):
+    """Anthropic ``claude -p`` subprocess transport."""
+
+    def __init__(
+        self,
+        *,
+        binary_path: str,
+        model: str,
+    ) -> None:
+        super().__init__(
+            binary_path=binary_path,
+            binary_name="Claude",
+            install_hint="Install Claude Code: https://code.claude.com/docs/en/setup",
+            api_key_env=DEFAULT_API_KEY_ENV,
+        )
+        self._model = model
+
+    def parse_stdout(self, stdout: str) -> AIResponse:
+        """Parse JSON envelope from ``claude --output-format json``."""
+        try:
+            data = json.loads(stdout.strip())
+        except json.JSONDecodeError as exc:
+            raise AIProviderError(
+                f"Claude CLI returned invalid JSON: {exc}\n"
+                f"Raw output: {stdout[:500]}",
+            ) from exc
+
+        if data.get("is_error") or data.get("subtype") == "error":
+            raise AIProviderError(
+                f"Claude CLI reported error: {data.get('result', stdout[:500])}",
+            )
+
+        content = data.get("result", "")
+        if isinstance(content, dict):
+            content = json.dumps(content)
+        elif not isinstance(content, str):
+            content = str(content)
+
+        usage = data.get("usage", {})
+        input_tokens = int(
+            usage.get("input_tokens", usage.get("inputTokens", 0)),
+        )
+        output_tokens = int(
+            usage.get("output_tokens", usage.get("outputTokens", 0)),
+        )
+        cost = data.get("total_cost_usd")
+        if cost is None:
+            cost = estimate_cost(self._model, input_tokens, output_tokens)
+        else:
+            cost = float(cost)
+
+        return AIResponse(
+            content=self.extract_json_object(content),
+            model=self._model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_estimate=cost,
+            provider=AIProvider.ANTHROPIC,
+        )
 
 
 class AnthropicProvider(BaseAIProvider):
@@ -73,6 +145,7 @@ class AnthropicProvider(BaseAIProvider):
         api_key_env: str | None = None,
         max_tokens: int = DEFAULT_MAX_TOKENS,
         base_url: str | None = None,
+        transport: AITransport = AITransport.API,
     ) -> None:
         """Initialize the Anthropic provider.
 
@@ -83,7 +156,37 @@ class AnthropicProvider(BaseAIProvider):
             max_tokens: Default max tokens for completions.
             base_url: Custom API base URL for Anthropic-compatible
                 endpoints (proxies, self-hosted, etc.).
+            transport: ``api`` for SDK or ``cli`` for ``claude -p``.
         """
+        self._transport = transport
+        self._cli: _AnthropicCliTransport | None = None
+        self._session_id: str | None = None
+
+        if transport == AITransport.CLI:
+            claude_path = _find_claude()
+            if not claude_path:
+                raise AINotAvailableError(
+                    "Anthropic CLI transport requires the 'claude' binary. "
+                    "Install Claude Code: https://code.claude.com/docs/en/setup",
+                )
+            super().__init__(
+                provider_name=AIProvider.ANTHROPIC,
+                has_sdk=True,
+                sdk_package="claude CLI",
+                default_model=DEFAULT_MODEL,
+                default_api_key_env=DEFAULT_API_KEY_ENV,
+                model=model,
+                api_key_env=api_key_env,
+                max_tokens=max_tokens,
+                base_url=base_url,
+                transport=transport,
+            )
+            self._cli = _AnthropicCliTransport(
+                binary_path=claude_path,
+                model=self._model,
+            )
+            return
+
         super().__init__(
             provider_name=AIProvider.ANTHROPIC,
             has_sdk=_has_anthropic,
@@ -94,6 +197,7 @@ class AnthropicProvider(BaseAIProvider):
             api_key_env=api_key_env,
             max_tokens=max_tokens,
             base_url=base_url,
+            transport=transport,
         )
 
     def _create_client(self, *, api_key: str) -> Any:
@@ -110,6 +214,76 @@ class AnthropicProvider(BaseAIProvider):
             kwargs["base_url"] = self._base_url
         return anthropic.Anthropic(**kwargs)
 
+    def is_available(self) -> bool:
+        if self._transport == AITransport.CLI:
+            return _find_claude() is not None
+        return super().is_available()
+
+    def _complete_cli(
+        self,
+        prompt: str,
+        *,
+        system: str | None,
+        timeout: float,
+        repo_root: str | None,
+        use_one_shot: bool,
+    ) -> AIResponse:
+        if self._cli is None:
+            raise AINotAvailableError("Claude CLI transport is not initialized")
+
+        cmd = [
+            self._cli._binary_path,
+            "--bare",
+            "-p",
+            prompt,
+            "--output-format",
+            "json",
+            "--permission-mode",
+            "dontAsk",
+        ]
+        if system:
+            cmd.extend(["--append-system-prompt", system])
+        if (
+            not use_one_shot
+            and self._session_id is not None
+        ):
+            cmd.extend(["--resume", self._session_id])
+
+        logger.debug(
+            f"Claude CLI request: model={self._model}, "
+            f"resume={self._session_id is not None and not use_one_shot}, "
+            f"prompt_len={len(prompt)}",
+        )
+
+        result = self._cli.run(
+            cmd,
+            timeout=timeout,
+            cwd=repo_root or os.getcwd(),
+        )
+        self._cli.check_exit_code(
+            result,
+            auth_patterns=("authentication", "login", "not logged in"),
+            auth_hint=(
+                "Run 'claude login' or set ANTHROPIC_API_KEY "
+                "(API key billing overrides subscription credits)."
+            ),
+        )
+
+        response = self._cli.parse_stdout(result.stdout)
+        session_id = None
+        try:
+            envelope = json.loads(result.stdout.strip())
+            session_id = envelope.get("session_id")
+        except json.JSONDecodeError:
+            session_id = None
+        if (
+            not use_one_shot
+            and isinstance(session_id, str)
+            and session_id.strip()
+        ):
+            self._session_id = session_id.strip()
+        return response
+
     def complete(
         self,
         prompt: str,
@@ -121,20 +295,30 @@ class AnthropicProvider(BaseAIProvider):
         use_one_shot: bool = False,
         model: str | None = None,
     ) -> AIResponse:
-        """Generate a completion using Claude.
+        """Generate a completion using Claude (API or CLI).
 
         Args:
             prompt: The user prompt.
             system: Optional system prompt.
-            max_tokens: Maximum tokens to generate.
+            max_tokens: Maximum tokens to generate (API only).
             timeout: Request timeout in seconds.
-            repo_root: Unused; accepted for provider API parity.
-            use_one_shot: Unused; accepted for provider API parity.
+            repo_root: Working directory for CLI transport.
+            use_one_shot: When True, avoid resuming CLI sessions.
             model: Optional per-call model override.
 
         Returns:
             AIResponse: The model's response with usage metadata.
         """
+        if self._transport == AITransport.CLI:
+            del max_tokens
+            return self._complete_cli(
+                prompt,
+                system=system,
+                timeout=timeout,
+                repo_root=repo_root,
+                use_one_shot=use_one_shot,
+            )
+
         del repo_root, use_one_shot
         client = self._get_client()
         effective_model = model or self._model
@@ -193,6 +377,14 @@ class AnthropicProvider(BaseAIProvider):
         Returns:
             An AIStreamResult wrapping the token stream.
         """
+        if self._transport == AITransport.CLI:
+            return super().stream_complete(
+                prompt,
+                system=system,
+                max_tokens=max_tokens,
+                timeout=timeout,
+            )
+
         client = self._get_client()
         effective_max = min(max_tokens, self._max_tokens)
         effective_model = model or self._model
@@ -214,10 +406,6 @@ class AnthropicProvider(BaseAIProvider):
         final_response: list[AIResponse] = []
 
         def _generate() -> Iterator[str]:
-            # Note: mid-stream errors surface as exceptions during
-            # iteration and are NOT retried because partial content has
-            # already been yielded to the caller. Only setup failures
-            # (before the first token) are caught by the fallback chain.
             with self._map_errors():
                 with client.messages.stream(**kwargs) as stream:
                     yield from stream.text_stream

--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -101,7 +101,7 @@ class _AnthropicCliTransport(CliTransport):
             cost = float(cost)
 
         return AIResponse(
-            content=self.extract_json_object(content),
+            content=self.substitute_parsed_json(content),
             model=self._model,
             input_tokens=input_tokens,
             output_tokens=output_tokens,

--- a/lintro/ai/providers/base.py
+++ b/lintro/ai/providers/base.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lintro.ai.exceptions import AIAuthenticationError, AINotAvailableError
 from lintro.ai.providers.constants import (
@@ -19,6 +19,9 @@ from lintro.ai.providers.constants import (
 )
 from lintro.ai.providers.response import AIResponse  # noqa: F401
 from lintro.ai.providers.stream_result import AIStreamResult  # noqa: F401
+
+if TYPE_CHECKING:
+    from lintro.ai.enums import AITransport
 
 __all__ = ["AIResponse", "AIStreamResult", "BaseAIProvider"]
 
@@ -47,6 +50,7 @@ class BaseAIProvider(ABC):
         api_key_env: str | None = None,
         max_tokens: int = DEFAULT_MAX_TOKENS,
         base_url: str | None = None,
+        transport: AITransport | None = None,
     ) -> None:
         """Initialise the provider with shared parameters.
 
@@ -63,6 +67,7 @@ class BaseAIProvider(ABC):
                 ``AIAuthenticationError`` on first API call.
             max_tokens: Provider-level cap on generated tokens.
             base_url: Custom API base URL.
+            transport: Optional transport label for availability checks.
 
         Raises:
             AINotAvailableError: If the SDK is not installed.
@@ -80,6 +85,7 @@ class BaseAIProvider(ABC):
         self._api_key_env = api_key_env or default_api_key_env
         self._max_tokens = max_tokens
         self._base_url = base_url
+        self._transport = transport
         self._client: Any = None
 
     # -- Client management -------------------------------------------------

--- a/lintro/ai/providers/cli_transport.py
+++ b/lintro/ai/providers/cli_transport.py
@@ -10,7 +10,11 @@ from typing import Any
 
 from loguru import logger
 
-from lintro.ai.exceptions import AIAuthenticationError, AINotAvailableError, AIProviderError
+from lintro.ai.exceptions import (
+    AIAuthenticationError,
+    AINotAvailableError,
+    AIProviderError,
+)
 
 __all__ = ["CliTransport"]
 

--- a/lintro/ai/providers/cli_transport.py
+++ b/lintro/ai/providers/cli_transport.py
@@ -1,0 +1,190 @@
+"""Shared CLI subprocess transport for AI providers."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from abc import ABC, abstractmethod
+from typing import Any
+
+from loguru import logger
+
+from lintro.ai.exceptions import AIAuthenticationError, AINotAvailableError, AIProviderError
+
+__all__ = ["CliTransport"]
+
+
+class CliTransport(ABC):
+    """Base subprocess runner for CLI-backed AI providers."""
+
+    def __init__(
+        self,
+        *,
+        binary_path: str,
+        binary_name: str,
+        install_hint: str,
+        api_key_env: str | None = None,
+    ) -> None:
+        """Initialize CLI transport metadata.
+
+        Args:
+            binary_path: Absolute path to the CLI executable.
+            binary_name: Human-readable binary name for error messages.
+            install_hint: Installation guidance shown when the binary is missing.
+            api_key_env: Optional environment variable forwarded to subprocesses.
+        """
+        self._binary_path = binary_path
+        self._binary_name = binary_name
+        self._install_hint = install_hint
+        self._api_key_env = api_key_env
+
+    @staticmethod
+    def find_binary(name: str) -> str | None:
+        """Return the full path to *name* on ``PATH``, if present.
+
+        Args:
+            name: Executable name to locate.
+
+        Returns:
+            Absolute path, or ``None`` when not found.
+        """
+        return shutil.which(name)
+
+    def run(
+        self,
+        cmd: list[str],
+        *,
+        input_text: str | None = None,
+        timeout: float,
+        cwd: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """Execute a CLI command with timeout and env forwarding.
+
+        Args:
+            cmd: Full argv including the binary path.
+            input_text: Optional stdin payload.
+            timeout: Subprocess timeout in seconds.
+            cwd: Optional working directory.
+
+        Returns:
+            Completed subprocess result.
+
+        Raises:
+            AIProviderError: On timeout.
+            AINotAvailableError: When the binary disappears from ``PATH``.
+        """
+        env = os.environ.copy()
+        if self._api_key_env:
+            api_key = os.environ.get(self._api_key_env)
+            if api_key:
+                env[self._api_key_env] = api_key
+
+        logger.debug(
+            f"{self._binary_name} CLI: cmd={' '.join(cmd[:4])}..., "
+            f"timeout={timeout:.0f}s, cwd={cwd}",
+        )
+
+        try:
+            return subprocess.run(
+                cmd,
+                input=input_text,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+                env=env,
+                cwd=cwd,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise AIProviderError(
+                f"{self._binary_name} CLI timed out after {timeout:.0f}s",
+            ) from exc
+        except FileNotFoundError as exc:
+            raise AINotAvailableError(
+                f"{self._binary_name} CLI not found on PATH. {self._install_hint}",
+            ) from exc
+
+    def check_exit_code(
+        self,
+        result: subprocess.CompletedProcess[str],
+        *,
+        auth_patterns: tuple[str, ...] = ("authentication", "login"),
+        auth_hint: str = "",
+    ) -> None:
+        """Raise mapped AI exceptions when a CLI exits non-zero.
+
+        Args:
+            result: Completed subprocess result.
+            auth_patterns: Substrings in stderr that indicate auth failure.
+            auth_hint: Guidance appended to authentication errors.
+
+        Raises:
+            AIAuthenticationError: When stderr matches auth patterns.
+            AIProviderError: For other non-zero exits.
+        """
+        if result.returncode == 0:
+            return
+
+        stderr = result.stderr.strip()
+        lowered = stderr.lower()
+        for pattern in auth_patterns:
+            if pattern in lowered:
+                message = f"{self._binary_name} CLI authentication required."
+                if auth_hint:
+                    message = f"{message} {auth_hint}"
+                raise AIAuthenticationError(message)
+
+        raise AIProviderError(
+            f"{self._binary_name} CLI exited with code {result.returncode}: {stderr}",
+        )
+
+    @staticmethod
+    def extract_json_object(text: str) -> str:
+        """Extract the outermost JSON object ``{...}`` from text.
+
+        Args:
+            text: Raw stdout that may contain prose before JSON.
+
+        Returns:
+            Extracted JSON substring, or the original text when none found.
+        """
+        start = text.find("{")
+        if start == -1:
+            return text
+
+        depth = 0
+        in_string = False
+        escape_next = False
+        for index, char in enumerate(text[start:], start=start):
+            if escape_next:
+                escape_next = False
+                continue
+            if char == "\\":
+                if in_string:
+                    escape_next = True
+                continue
+            if char == '"':
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start : index + 1]
+        return text
+
+    @abstractmethod
+    def parse_stdout(self, stdout: str) -> Any:
+        """Parse provider-specific stdout into a transport payload.
+
+        Args:
+            stdout: Raw stdout from the CLI.
+
+        Returns:
+            Provider-specific parsed payload.
+        """
+        ...

--- a/lintro/ai/providers/cli_transport.py
+++ b/lintro/ai/providers/cli_transport.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -180,6 +181,22 @@ class CliTransport(ABC):
                 if depth == 0:
                     return text[start : index + 1]
         return text
+
+    @classmethod
+    def substitute_parsed_json(cls, content: str) -> str:
+        """Return extracted JSON only when it parses; else keep original text."""
+        try:
+            json.loads(content)
+        except json.JSONDecodeError:
+            extracted = cls.extract_json_object(content)
+            if extracted != content:
+                try:
+                    json.loads(extracted)
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    return extracted
+        return content
 
     @abstractmethod
     def parse_stdout(self, stdout: str) -> Any:

--- a/lintro/ai/providers/cli_transport.py
+++ b/lintro/ai/providers/cli_transport.py
@@ -80,10 +80,6 @@ class CliTransport(ABC):
             AINotAvailableError: When the binary disappears from ``PATH``.
         """
         env = os.environ.copy()
-        if self._api_key_env:
-            api_key = os.environ.get(self._api_key_env)
-            if api_key:
-                env[self._api_key_env] = api_key
 
         logger.debug(
             f"{self._binary_name} CLI: cmd={' '.join(cmd[:4])}..., "

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -67,7 +67,21 @@ class _CursorCliTransport(CliTransport):
                 f"Full response: {json.dumps(data)[:1000]}",
             )
 
-        content = self.extract_json_object(content)
+        # The agent CLI may prefix JSON with prose. Only substitute extracted
+        # content when it parses as JSON; otherwise keep plain-text answers
+        # with incidental braces intact.
+        try:
+            json.loads(content)
+        except json.JSONDecodeError:
+            extracted = self.extract_json_object(content)
+            if extracted != content:
+                try:
+                    json.loads(extracted)
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    content = extracted
+
         usage = data.get("usage", {})
         session_id = data.get("session_id")
         if isinstance(session_id, str) and session_id.strip():

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -201,7 +201,7 @@ class CursorProvider(BaseAIProvider):
         self._session_id = None
         self._durable_repo_root = None
 
-    def complete(  # noqa: DOC502
+    def complete(
         self,
         prompt: str,
         *,
@@ -225,11 +225,6 @@ class CursorProvider(BaseAIProvider):
 
         Returns:
             Parsed model response with usage metadata.
-
-        Raises:
-            AIAuthenticationError: When the CLI reports an auth failure.
-            AIProviderError: When the CLI exits with an error or returns
-                invalid JSON.
         """
         effective_model = model or self._model
         effective_max = min(max_tokens, self._max_tokens)

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -17,6 +17,7 @@ from loguru import logger
 
 from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import (
+    AIAuthenticationError,
     AINotAvailableError,
     AIProviderError,
 )
@@ -213,9 +214,9 @@ class CursorProvider(BaseAIProvider):
             Parsed model response with usage metadata.
 
         Raises:
-            AIProviderError: If the CLI times out, exits non-zero, or returns
-                invalid output.
-            AIAuthenticationError: If the CLI reports missing authentication.
+            AIAuthenticationError: When the CLI reports an auth failure.
+            AIProviderError: When the CLI exits with an error or returns
+                invalid JSON.
             AINotAvailableError: If the ``agent`` binary is not on PATH.
         """
         effective_model = model or self._model
@@ -258,18 +259,23 @@ class CursorProvider(BaseAIProvider):
         )
 
         effective_timeout = max(timeout, CURSOR_MIN_TIMEOUT)
-        result = self._cli.run(
-            cmd,
-            input_text=combined_prompt,
-            timeout=effective_timeout,
-        )
-        self._cli.check_exit_code(
-            result,
-            auth_patterns=("authentication required", "login"),
-            auth_hint="Run 'agent login' or set CURSOR_API_KEY.",
-        )
+        try:
+            result = self._cli.run(
+                cmd,
+                input_text=combined_prompt,
+                timeout=effective_timeout,
+            )
+            self._cli.check_exit_code(
+                result,
+                auth_patterns=("authentication required", "login"),
+                auth_hint="Run 'agent login' or set CURSOR_API_KEY.",
+            )
+            response, session_id = self._cli.parse_stdout(result.stdout)
+        except AIAuthenticationError:
+            raise
+        except AIProviderError:
+            raise
 
-        response, session_id = self._cli.parse_stdout(result.stdout)
         if not use_one_shot and self._durable_repo_root is not None and session_id:
             self._session_id = session_id
         return response

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -17,7 +17,6 @@ from loguru import logger
 
 from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import (
-    AIAuthenticationError,
     AINotAvailableError,
     AIProviderError,
 )
@@ -202,7 +201,7 @@ class CursorProvider(BaseAIProvider):
         self._session_id = None
         self._durable_repo_root = None
 
-    def complete(
+    def complete(  # noqa: DOC502
         self,
         prompt: str,
         *,
@@ -272,22 +271,17 @@ class CursorProvider(BaseAIProvider):
         )
 
         effective_timeout = max(timeout, CURSOR_MIN_TIMEOUT)
-        try:
-            result = self._cli.run(
-                cmd,
-                input_text=combined_prompt,
-                timeout=effective_timeout,
-            )
-            self._cli.check_exit_code(
-                result,
-                auth_patterns=("authentication required", "login"),
-                auth_hint="Run 'agent login' or set CURSOR_API_KEY.",
-            )
-            response, session_id = self._cli.parse_stdout(result.stdout)
-        except AIAuthenticationError:
-            raise
-        except AIProviderError:
-            raise
+        result = self._cli.run(
+            cmd,
+            input_text=combined_prompt,
+            timeout=effective_timeout,
+        )
+        self._cli.check_exit_code(
+            result,
+            auth_patterns=("authentication required", "login"),
+            auth_hint="Run 'agent login' or set CURSOR_API_KEY.",
+        )
+        response, session_id = self._cli.parse_stdout(result.stdout)
 
         if not use_one_shot and self._durable_repo_root is not None and session_id:
             self._session_id = session_id

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -17,7 +17,6 @@ from loguru import logger
 
 from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import (
-    AIAuthenticationError,
     AINotAvailableError,
     AIProviderError,
 )
@@ -28,7 +27,7 @@ from lintro.ai.providers.constants import (
     DEFAULT_PER_CALL_MAX_TOKENS,
     DEFAULT_TIMEOUT,
 )
-from lintro.ai.registry import AIProvider, PROVIDERS
+from lintro.ai.registry import PROVIDERS, AIProvider
 
 CURSOR_MIN_TIMEOUT = 600.0
 
@@ -271,11 +270,7 @@ class CursorProvider(BaseAIProvider):
         )
 
         response, session_id = self._cli.parse_stdout(result.stdout)
-        if (
-            not use_one_shot
-            and self._durable_repo_root is not None
-            and session_id
-        ):
+        if not use_one_shot and self._durable_repo_root is not None and session_id:
             self._session_id = session_id
         return response
 

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -1,7 +1,7 @@
 """Cursor AI provider implementation.
 
 Invokes the ``agent`` CLI (Cursor's headless agent) for completions. The
-``cursor-sdk`` CreateAgent API is not used because it currently returns
+Cursor CreateAgent HTTP API is not used because it currently returns
 internal errors in environments where the ``agent`` binary works reliably.
 
 Authentication is handled by the CLI: ``CURSOR_API_KEY`` or ``agent login``.
@@ -11,24 +11,24 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
-import subprocess
 from typing import Any
 
 from loguru import logger
 
+from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import (
     AIAuthenticationError,
     AINotAvailableError,
     AIProviderError,
 )
 from lintro.ai.providers.base import AIResponse, BaseAIProvider
+from lintro.ai.providers.cli_transport import CliTransport
 from lintro.ai.providers.constants import (
     DEFAULT_MAX_TOKENS,
     DEFAULT_PER_CALL_MAX_TOKENS,
     DEFAULT_TIMEOUT,
 )
-from lintro.ai.registry import PROVIDERS, AIProvider
+from lintro.ai.registry import AIProvider, PROVIDERS
 
 CURSOR_MIN_TIMEOUT = 600.0
 
@@ -39,7 +39,67 @@ DEFAULT_API_KEY_ENV = PROVIDERS.cursor.default_api_key_env
 
 def _find_agent() -> str | None:
     """Return the full path to the ``agent`` binary, or None."""
-    return shutil.which(_AGENT_BIN)
+    return CliTransport.find_binary(_AGENT_BIN)
+
+
+class _CursorCliTransport(CliTransport):
+    """Cursor ``agent --print`` subprocess transport."""
+
+    def parse_stdout(self, stdout: str) -> tuple[AIResponse, str | None]:
+        """Parse the JSON envelope from ``agent --output-format json``."""
+        try:
+            data = json.loads(stdout.strip())
+        except json.JSONDecodeError as exc:
+            raise AIProviderError(
+                f"Cursor CLI returned invalid JSON: {exc}\n"
+                f"Raw output: {stdout[:500]}",
+            ) from exc
+
+        if data.get("is_error") or data.get("subtype") == "error":
+            raise AIProviderError(
+                f"Cursor CLI reported error: {data.get('result', stdout[:500])}",
+            )
+
+        content = data.get("result", "")
+        if not content:
+            logger.warning(
+                f"Cursor CLI returned empty result. "
+                f"Full response: {json.dumps(data)[:1000]}",
+            )
+
+        content = self.extract_json_object(content)
+        usage = data.get("usage", {})
+        session_id = data.get("session_id")
+        if isinstance(session_id, str) and session_id.strip():
+            session_id = session_id.strip()
+        else:
+            session_id = None
+
+        return (
+            AIResponse(
+                content=content,
+                model=self._model,
+                input_tokens=usage.get("inputTokens", 0),
+                output_tokens=usage.get("outputTokens", 0),
+                cost_estimate=0.0,
+                provider=AIProvider.CURSOR,
+            ),
+            session_id,
+        )
+
+    def __init__(
+        self,
+        *,
+        binary_path: str,
+        model: str,
+    ) -> None:
+        super().__init__(
+            binary_path=binary_path,
+            binary_name="Cursor agent",
+            install_hint="Install with: curl https://cursor.com/install -fsS | bash",
+            api_key_env=DEFAULT_API_KEY_ENV,
+        )
+        self._model = model
 
 
 class CursorProvider(BaseAIProvider):
@@ -52,18 +112,25 @@ class CursorProvider(BaseAIProvider):
         api_key_env: str | None = None,
         max_tokens: int = DEFAULT_MAX_TOKENS,
         base_url: str | None = None,
+        transport: AITransport = AITransport.CLI,
     ) -> None:
         """Initialize the Cursor provider.
 
         Args:
-            model: Model identifier override.
-            api_key_env: Environment variable for the API key override.
-            max_tokens: Provider-level cap on generated tokens.
-            base_url: Custom API base URL (unused for CLI).
+            model: Optional model override (defaults to provider config).
+            api_key_env: Environment variable name for the API key.
+            max_tokens: Default max tokens for provider configuration.
+            base_url: Unused; kept for provider API parity.
+            transport: AI transport mode (CLI only for Cursor).
 
         Raises:
-            AINotAvailableError: If the ``agent`` CLI is not on PATH.
+            AINotAvailableError: When transport is not CLI or the ``agent``
+                binary is not on PATH.
         """
+        if transport != AITransport.CLI:
+            msg = "cursor provider only supports transport: cli"
+            raise AINotAvailableError(msg)
+
         agent_path = _find_agent()
         if not agent_path:
             raise AINotAvailableError(
@@ -81,13 +148,18 @@ class CursorProvider(BaseAIProvider):
             api_key_env=api_key_env,
             max_tokens=max_tokens,
             base_url=base_url,
+            transport=transport,
         )
-        self._agent_path = agent_path
+        self._cli = _CursorCliTransport(
+            binary_path=agent_path,
+            model=self._model,
+        )
         self._session_id: str | None = None
         self._durable_repo_root: str | None = None
 
     def _create_client(self, *, api_key: str) -> Any:
         """No persistent client -- each call spawns a subprocess."""
+        del api_key
         return None
 
     def _get_client(self) -> Any:
@@ -164,7 +236,7 @@ class CursorProvider(BaseAIProvider):
         )
 
         cmd = [
-            self._agent_path,
+            self._cli._binary_path,
             "--print",
             "--output-format",
             "json",
@@ -187,130 +259,27 @@ class CursorProvider(BaseAIProvider):
         )
 
         effective_timeout = max(timeout, CURSOR_MIN_TIMEOUT)
-        env = os.environ.copy()
-        api_key = os.environ.get(self._api_key_env)
-        if api_key:
-            env[self._api_key_env] = api_key
+        result = self._cli.run(
+            cmd,
+            input_text=combined_prompt,
+            timeout=effective_timeout,
+        )
+        self._cli.check_exit_code(
+            result,
+            auth_patterns=("authentication required", "login"),
+            auth_hint="Run 'agent login' or set CURSOR_API_KEY.",
+        )
 
-        try:
-            result = subprocess.run(
-                cmd,
-                input=combined_prompt,
-                capture_output=True,
-                text=True,
-                timeout=effective_timeout,
-                check=False,
-                env=env,
-            )
-        except subprocess.TimeoutExpired as exc:
-            raise AIProviderError(
-                f"Cursor CLI timed out after {effective_timeout:.0f}s",
-            ) from exc
-        except FileNotFoundError as exc:
-            raise AINotAvailableError(
-                "Cursor 'agent' CLI not found on PATH. "
-                "Install with: curl https://cursor.com/install -fsS | bash",
-            ) from exc
-
-        if result.returncode != 0:
-            stderr = result.stderr.strip()
-            if "Authentication required" in stderr or "login" in stderr.lower():
-                raise AIAuthenticationError(
-                    "Cursor CLI authentication required. "
-                    "Run 'agent login' or set CURSOR_API_KEY.",
-                )
-            raise AIProviderError(
-                f"Cursor CLI exited with code {result.returncode}: {stderr}",
-            )
-
-        response, session_id = self._parse_json_output(result.stdout)
-        if not use_one_shot and self._durable_repo_root is not None and session_id:
+        response, session_id = self._cli.parse_stdout(result.stdout)
+        if (
+            not use_one_shot
+            and self._durable_repo_root is not None
+            and session_id
+        ):
             self._session_id = session_id
         return response
 
     @staticmethod
     def _extract_json_object(text: str) -> str:
         """Extract the outermost JSON object ``{...}`` from text."""
-        start = text.find("{")
-        if start == -1:
-            return text
-
-        depth = 0
-        in_string = False
-        escape_next = False
-        for index, char in enumerate(text[start:], start=start):
-            if escape_next:
-                escape_next = False
-                continue
-            if char == "\\":
-                if in_string:
-                    escape_next = True
-                continue
-            if char == '"':
-                in_string = not in_string
-                continue
-            if in_string:
-                continue
-            if char == "{":
-                depth += 1
-            elif char == "}":
-                depth -= 1
-                if depth == 0:
-                    return text[start : index + 1]
-        return text
-
-    def _parse_json_output(self, stdout: str) -> tuple[AIResponse, str | None]:
-        """Parse the JSON envelope from ``agent --output-format json``."""
-        try:
-            data = json.loads(stdout.strip())
-        except json.JSONDecodeError as exc:
-            raise AIProviderError(
-                f"Cursor CLI returned invalid JSON: {exc}\n"
-                f"Raw output: {stdout[:500]}",
-            ) from exc
-
-        if data.get("is_error") or data.get("subtype") == "error":
-            raise AIProviderError(
-                f"Cursor CLI reported error: {data.get('result', stdout[:500])}",
-            )
-
-        content = data.get("result", "")
-        if not content:
-            logger.warning(
-                f"Cursor CLI returned empty result. "
-                f"Full response: {json.dumps(data)[:1000]}",
-            )
-
-        # The agent CLI may prefix JSON with prose. Only substitute extracted
-        # content when it parses as JSON; otherwise keep plain-text answers
-        # with incidental braces intact.
-        try:
-            json.loads(content)
-        except json.JSONDecodeError:
-            extracted = self._extract_json_object(content)
-            if extracted != content:
-                try:
-                    json.loads(extracted)
-                except json.JSONDecodeError:
-                    pass
-                else:
-                    content = extracted
-
-        usage = data.get("usage", {})
-        session_id = data.get("session_id")
-        if isinstance(session_id, str) and session_id.strip():
-            session_id = session_id.strip()
-        else:
-            session_id = None
-
-        return (
-            AIResponse(
-                content=content,
-                model=self._model,
-                input_tokens=usage.get("inputTokens", 0),
-                output_tokens=usage.get("outputTokens", 0),
-                cost_estimate=0.0,
-                provider=AIProvider.CURSOR,
-            ),
-            session_id,
-        )
+        return CliTransport.extract_json_object(text)

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -217,7 +217,6 @@ class CursorProvider(BaseAIProvider):
             AIAuthenticationError: When the CLI reports an auth failure.
             AIProviderError: When the CLI exits with an error or returns
                 invalid JSON.
-            AINotAvailableError: If the ``agent`` binary is not on PATH.
         """
         effective_model = model or self._model
         effective_max = min(max_tokens, self._max_tokens)

--- a/lintro/ai/providers/openai.py
+++ b/lintro/ai/providers/openai.py
@@ -1,30 +1,36 @@
 """OpenAI AI provider implementation.
 
-Uses the OpenAI Python SDK to communicate with GPT models.
-Requires the ``openai`` package (installed via ``lintro[ai]``).
+Uses the OpenAI Python SDK for ``transport: api`` and ``codex exec`` for
+``transport: cli``.
 """
 
 from __future__ import annotations
 
+import json
+import os
 from collections.abc import Iterator
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any
 
 from loguru import logger
 
 from lintro.ai.cost import estimate_cost
+from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import (
     AIAuthenticationError,
+    AINotAvailableError,
     AIProviderError,
     AIRateLimitError,
 )
 from lintro.ai.providers.base import AIResponse, AIStreamResult, BaseAIProvider
+from lintro.ai.providers.cli_transport import CliTransport
 from lintro.ai.providers.constants import (
     DEFAULT_MAX_TOKENS,
     DEFAULT_PER_CALL_MAX_TOKENS,
     DEFAULT_TIMEOUT,
 )
-from lintro.ai.registry import PROVIDERS, AIProvider
+from lintro.ai.registry import AIProvider, PROVIDERS
 
 _has_openai = False
 try:
@@ -36,6 +42,91 @@ except ImportError:
 
 DEFAULT_MODEL = PROVIDERS.openai.default_model
 DEFAULT_API_KEY_ENV = PROVIDERS.openai.default_api_key_env
+_CODEX_BIN = "codex"
+_CODEX_AUTH_PATH = Path.home() / ".codex" / "auth.json"
+
+
+def _find_codex() -> str | None:
+    """Return the full path to the ``codex`` binary, or None."""
+    return CliTransport.find_binary(_CODEX_BIN)
+
+
+def _codex_authenticated() -> bool:
+    """Return True when Codex CLI auth is likely configured."""
+    if os.environ.get("CODEX_API_KEY"):
+        return True
+    return _CODEX_AUTH_PATH.is_file()
+
+
+class _CodexCliTransport(CliTransport):
+    """OpenAI Codex ``codex exec`` subprocess transport."""
+
+    def __init__(
+        self,
+        *,
+        binary_path: str,
+        model: str,
+    ) -> None:
+        super().__init__(
+            binary_path=binary_path,
+            binary_name="Codex",
+            install_hint="Install Codex CLI: https://developers.openai.com/codex/cli",
+            api_key_env="CODEX_API_KEY",
+        )
+        self._model = model
+
+    def parse_stdout(self, stdout: str) -> AIResponse:
+        """Parse JSONL stdout and extract the final agent message."""
+        final_text = ""
+        input_tokens = 0
+        output_tokens = 0
+
+        for line in stdout.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                event = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+            if event_type == "item.completed":
+                item = event.get("item", {})
+                if item.get("type") == "agent_message":
+                    final_text = item.get("text", final_text)
+            elif event_type == "turn.completed":
+                usage = event.get("usage", {})
+                input_tokens = int(usage.get("input_tokens", input_tokens))
+                output_tokens = int(usage.get("output_tokens", output_tokens))
+            elif event_type == "error":
+                raise AIProviderError(
+                    f"Codex CLI reported error: {event.get('message', stripped)}",
+                )
+
+        if not final_text:
+            # Fallback: single JSON object envelope
+            try:
+                data = json.loads(stdout.strip())
+                final_text = data.get("result", data.get("output", ""))
+                usage = data.get("usage", {})
+                input_tokens = int(usage.get("input_tokens", input_tokens))
+                output_tokens = int(usage.get("output_tokens", output_tokens))
+            except json.JSONDecodeError as exc:
+                raise AIProviderError(
+                    f"Codex CLI returned unparsable output: {exc}\n"
+                    f"Raw output: {stdout[:500]}",
+                ) from exc
+
+        cost = estimate_cost(self._model, input_tokens, output_tokens)
+        return AIResponse(
+            content=self.extract_json_object(final_text),
+            model=self._model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_estimate=cost,
+            provider=AIProvider.OPENAI,
+        )
 
 
 class OpenAIProvider(BaseAIProvider):
@@ -73,6 +164,7 @@ class OpenAIProvider(BaseAIProvider):
         api_key_env: str | None = None,
         max_tokens: int = DEFAULT_MAX_TOKENS,
         base_url: str | None = None,
+        transport: AITransport = AITransport.API,
     ) -> None:
         """Initialize the OpenAI provider.
 
@@ -83,7 +175,36 @@ class OpenAIProvider(BaseAIProvider):
             max_tokens: Default max tokens for completions.
             base_url: Custom API base URL for OpenAI-compatible
                 endpoints (Ollama, vLLM, Azure OpenAI, etc.).
+            transport: ``api`` for SDK or ``cli`` for ``codex exec``.
         """
+        self._transport = transport
+        self._cli: _CodexCliTransport | None = None
+
+        if transport == AITransport.CLI:
+            codex_path = _find_codex()
+            if not codex_path:
+                raise AINotAvailableError(
+                    "OpenAI CLI transport requires the 'codex' binary. "
+                    "Install Codex CLI: https://developers.openai.com/codex/cli",
+                )
+            super().__init__(
+                provider_name=AIProvider.OPENAI,
+                has_sdk=True,
+                sdk_package="codex CLI",
+                default_model=DEFAULT_MODEL,
+                default_api_key_env=DEFAULT_API_KEY_ENV,
+                model=model,
+                api_key_env=api_key_env,
+                max_tokens=max_tokens,
+                base_url=base_url,
+                transport=transport,
+            )
+            self._cli = _CodexCliTransport(
+                binary_path=codex_path,
+                model=self._model,
+            )
+            return
+
         super().__init__(
             provider_name=AIProvider.OPENAI,
             has_sdk=_has_openai,
@@ -94,6 +215,7 @@ class OpenAIProvider(BaseAIProvider):
             api_key_env=api_key_env,
             max_tokens=max_tokens,
             base_url=base_url,
+            transport=transport,
         )
 
     def _create_client(self, *, api_key: str) -> Any:
@@ -110,6 +232,46 @@ class OpenAIProvider(BaseAIProvider):
             kwargs["base_url"] = self._base_url
         return openai.OpenAI(**kwargs)
 
+    def is_available(self) -> bool:
+        if self._transport == AITransport.CLI:
+            return _find_codex() is not None
+        return super().is_available()
+
+    def _complete_cli(
+        self,
+        prompt: str,
+        *,
+        timeout: float,
+        repo_root: str | None,
+    ) -> AIResponse:
+        if self._cli is None:
+            raise AINotAvailableError("Codex CLI transport is not initialized")
+
+        cmd = [
+            self._cli._binary_path,
+            "exec",
+            "--json",
+            "--sandbox",
+            "read-only",
+            prompt,
+        ]
+
+        logger.debug(
+            f"Codex CLI request: model={self._model}, prompt_len={len(prompt)}",
+        )
+
+        result = self._cli.run(
+            cmd,
+            timeout=timeout,
+            cwd=repo_root or os.getcwd(),
+        )
+        self._cli.check_exit_code(
+            result,
+            auth_patterns=("authentication", "login", "not authenticated"),
+            auth_hint="Run 'codex login' or set CODEX_API_KEY.",
+        )
+        return self._cli.parse_stdout(result.stdout)
+
     def complete(
         self,
         prompt: str,
@@ -121,20 +283,31 @@ class OpenAIProvider(BaseAIProvider):
         use_one_shot: bool = False,
         model: str | None = None,
     ) -> AIResponse:
-        """Generate a completion using GPT.
+        """Generate a completion using GPT (API or Codex CLI).
 
         Args:
             prompt: The user prompt.
             system: Optional system prompt.
-            max_tokens: Maximum tokens to generate.
+            max_tokens: Maximum tokens to generate (API only).
             timeout: Request timeout in seconds.
-            repo_root: Unused; accepted for provider API parity.
-            use_one_shot: Unused; accepted for provider API parity.
+            repo_root: Working directory for CLI transport (git repo).
+            use_one_shot: Unused for Codex; accepted for API parity.
             model: Optional per-call model override.
 
         Returns:
             AIResponse: The model's response with usage metadata.
         """
+        if self._transport == AITransport.CLI:
+            del max_tokens, use_one_shot
+            combined = prompt
+            if system:
+                combined = f"{system}\n\n---\n\n{prompt}"
+            return self._complete_cli(
+                combined,
+                timeout=timeout,
+                repo_root=repo_root,
+            )
+
         del repo_root, use_one_shot
         client = self._get_client()
         effective_model = model or self._model
@@ -195,6 +368,14 @@ class OpenAIProvider(BaseAIProvider):
         Returns:
             An AIStreamResult wrapping the token stream.
         """
+        if self._transport == AITransport.CLI:
+            return super().stream_complete(
+                prompt,
+                system=system,
+                max_tokens=max_tokens,
+                timeout=timeout,
+            )
+
         client = self._get_client()
         effective_max = min(max_tokens, self._max_tokens)
         effective_model = model or self._model

--- a/lintro/ai/providers/openai.py
+++ b/lintro/ai/providers/openai.py
@@ -30,7 +30,7 @@ from lintro.ai.providers.constants import (
     DEFAULT_PER_CALL_MAX_TOKENS,
     DEFAULT_TIMEOUT,
 )
-from lintro.ai.registry import AIProvider, PROVIDERS
+from lintro.ai.registry import PROVIDERS, AIProvider
 
 _has_openai = False
 try:

--- a/lintro/ai/providers/openai.py
+++ b/lintro/ai/providers/openai.py
@@ -176,6 +176,10 @@ class OpenAIProvider(BaseAIProvider):
             base_url: Custom API base URL for OpenAI-compatible
                 endpoints (Ollama, vLLM, Azure OpenAI, etc.).
             transport: ``api`` for SDK or ``cli`` for ``codex exec``.
+
+        Raises:
+            AINotAvailableError: When CLI transport is selected but the
+                ``codex`` binary is not on PATH.
         """
         self._transport = transport
         self._cli: _CodexCliTransport | None = None
@@ -233,6 +237,7 @@ class OpenAIProvider(BaseAIProvider):
         return openai.OpenAI(**kwargs)
 
     def is_available(self) -> bool:
+        """Return True when the configured transport is usable."""
         if self._transport == AITransport.CLI:
             return _find_codex() is not None
         return super().is_available()

--- a/lintro/ai/providers/openai.py
+++ b/lintro/ai/providers/openai.py
@@ -248,21 +248,25 @@ class OpenAIProvider(BaseAIProvider):
         *,
         timeout: float,
         repo_root: str | None,
+        model: str | None = None,
     ) -> AIResponse:
         if self._cli is None:
             raise AINotAvailableError("Codex CLI transport is not initialized")
 
+        effective_model = model or self._model
         cmd = [
             self._cli._binary_path,
             "exec",
             "--json",
             "--sandbox",
             "read-only",
+            "--model",
+            effective_model,
             prompt,
         ]
 
         logger.debug(
-            f"Codex CLI request: model={self._model}, prompt_len={len(prompt)}",
+            f"Codex CLI request: model={effective_model}, prompt_len={len(prompt)}",
         )
 
         result = self._cli.run(
@@ -311,6 +315,7 @@ class OpenAIProvider(BaseAIProvider):
                 combined,
                 timeout=timeout,
                 repo_root=repo_root,
+                model=model,
             )
 
         del repo_root, use_one_shot

--- a/lintro/ai/providers/openai.py
+++ b/lintro/ai/providers/openai.py
@@ -120,7 +120,7 @@ class _CodexCliTransport(CliTransport):
 
         cost = estimate_cost(self._model, input_tokens, output_tokens)
         return AIResponse(
-            content=self.extract_json_object(final_text),
+            content=self.substitute_parsed_json(final_text),
             model=self._model,
             input_tokens=input_tokens,
             output_tokens=output_tokens,

--- a/lintro/ai/providers/openai.py
+++ b/lintro/ai/providers/openai.py
@@ -109,6 +109,10 @@ class _CodexCliTransport(CliTransport):
             try:
                 data = json.loads(stdout.strip())
                 final_text = data.get("result", data.get("output", ""))
+                if isinstance(final_text, dict):
+                    final_text = json.dumps(final_text)
+                elif not isinstance(final_text, str):
+                    final_text = str(final_text)
                 usage = data.get("usage", {})
                 input_tokens = int(usage.get("input_tokens", input_tokens))
                 output_tokens = int(usage.get("output_tokens", output_tokens))

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -111,7 +111,8 @@ def resolve_review_chunks(
         Ordered list of review chunks to process.
     """
     if not force_semantic_chunking and estimate_tokens(context.unified_diff) <= max(
-        diff_budget, 1
+        diff_budget,
+        1,
     ):
         return [_single_chunk_from_context(context=context)]
 

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -437,7 +437,7 @@ def run_review(
         and hasattr(provider, "begin_durable_session")
     )
     repo_root = context.repo_root or os.getcwd()
-    use_one_shot = provider.name == AIProvider.CURSOR and len(chunks) > 1
+    use_one_shot = len(chunks) > 1
 
     if use_cursor_durable:
         provider.begin_durable_session(repo_root=repo_root)

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import shlex
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import suppress
@@ -36,6 +35,8 @@ from lintro.ai.prompts.review import (
 )
 from lintro.ai.registry import AIProvider
 from lintro.ai.review.chunker import chunk_review_context
+from lintro.ai.review.enums.review_strictness import ReviewStrictness
+from lintro.ai.review.exceptions import ReviewExecutionError
 from lintro.ai.review.group_labels import REL_DIRECTORY_PREFIX, REL_SINGLE_FILE
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
 from lintro.ai.review.models.review_chunk import ReviewChunk
@@ -43,20 +44,17 @@ from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.paths_registry import generate_interaction_paths
-from lintro.ai.review.enums.review_strictness import ReviewStrictness
+from lintro.ai.review.progress import (
+    NullReviewProgress,
+    ReviewProgressCallback,
+    StepTrackingProgress,
+)
 from lintro.ai.review.sensitivity import (
     ReviewSensitivityPolicy,
     filter_findings_by_policy,
     format_strictness_prompt_section,
 )
 from lintro.ai.token_budget import estimate_tokens
-
-from lintro.ai.review.exceptions import ReviewExecutionError
-from lintro.ai.review.progress import (
-    NullReviewProgress,
-    ReviewProgressCallback,
-    StepTrackingProgress,
-)
 
 if TYPE_CHECKING:
     from lintro.ai.config import AIConfig
@@ -112,9 +110,8 @@ def resolve_review_chunks(
     Returns:
         Ordered list of review chunks to process.
     """
-    if (
-        not force_semantic_chunking
-        and estimate_tokens(context.unified_diff) <= max(diff_budget, 1)
+    if not force_semantic_chunking and estimate_tokens(context.unified_diff) <= max(
+        diff_budget, 1
     ):
         return [_single_chunk_from_context(context=context)]
 
@@ -427,9 +424,13 @@ def run_review(
     )
 
     effective_ai_config = (
+<<<<<<< HEAD
         ai_config.model_copy(update={"api_timeout": timeout})
         if timeout is not None
         else ai_config
+=======
+        replace(ai_config, api_timeout=timeout) if timeout is not None else ai_config
+>>>>>>> 6b71e3da (style: apply lintro fmt fixes for #1009)
     )
     tracker = progress or NullReviewProgress()
     budget = CostBudget(max_cost_usd=ai_config.max_cost_usd)

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -15,7 +15,8 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from lintro.ai.budget import CostBudget
-from lintro.ai.fallback import complete_with_fallback
+from lintro.ai.invoke import call_ai
+from lintro.ai.json_response import strip_json_fences
 from lintro.ai.model_pricing import (
     calculate_available_diff_tokens,
     get_context_window,
@@ -35,8 +36,6 @@ from lintro.ai.prompts.review import (
 )
 from lintro.ai.registry import AIProvider
 from lintro.ai.review.chunker import chunk_review_context
-from lintro.ai.review.enums.review_strictness import ReviewStrictness
-from lintro.ai.review.exceptions import ReviewExecutionError
 from lintro.ai.review.group_labels import REL_DIRECTORY_PREFIX, REL_SINGLE_FILE
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
 from lintro.ai.review.models.review_chunk import ReviewChunk
@@ -44,17 +43,20 @@ from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.paths_registry import generate_interaction_paths
-from lintro.ai.review.progress import (
-    NullReviewProgress,
-    ReviewProgressCallback,
-    StepTrackingProgress,
-)
+from lintro.ai.review.enums.review_strictness import ReviewStrictness
 from lintro.ai.review.sensitivity import (
     ReviewSensitivityPolicy,
     filter_findings_by_policy,
     format_strictness_prompt_section,
 )
 from lintro.ai.token_budget import estimate_tokens
+
+from lintro.ai.review.exceptions import ReviewExecutionError
+from lintro.ai.review.progress import (
+    NullReviewProgress,
+    ReviewProgressCallback,
+    StepTrackingProgress,
+)
 
 if TYPE_CHECKING:
     from lintro.ai.config import AIConfig
@@ -74,11 +76,6 @@ __all__ = [
     "run_review",
     "strip_json_fences",
 ]
-
-_JSON_FENCE_PATTERN = re.compile(
-    r"```(?:json)?\s*\n?(.*?)\n?```",
-    re.DOTALL | re.IGNORECASE,
-)
 _PROMPT_OVERHEAD_TOKENS = 12_000
 
 
@@ -115,9 +112,9 @@ def resolve_review_chunks(
     Returns:
         Ordered list of review chunks to process.
     """
-    if not force_semantic_chunking and estimate_tokens(context.unified_diff) <= max(
-        diff_budget,
-        1,
+    if (
+        not force_semantic_chunking
+        and estimate_tokens(context.unified_diff) <= max(diff_budget, 1)
     ):
         return [_single_chunk_from_context(context=context)]
 
@@ -652,22 +649,6 @@ def build_git_native_review_prompt(
     return REVIEW_SYSTEM, user_prompt
 
 
-def strip_json_fences(*, content: str) -> str:
-    """Strip markdown JSON code fences from model output.
-
-    Args:
-        content: Raw model response text.
-
-    Returns:
-        JSON string suitable for ``json.loads``.
-    """
-    stripped = content.strip()
-    match = _JSON_FENCE_PATTERN.search(stripped)
-    if match is not None:
-        return match.group(1).strip()
-    return stripped
-
-
 def parse_review_response(*, content: str) -> dict[str, Any]:
     """Parse and validate AI review JSON response.
 
@@ -851,13 +832,13 @@ def _review_chunk(
             extra_checklist=extra_checklist,
             strictness_section=strictness_section,
         )
-    response = _call_provider(
+    response = call_ai(
         provider=provider,
         ai_config=ai_config,
         system_prompt=system_prompt,
         user_prompt=user_prompt,
         budget=budget,
-        repo_root=repo_root,
+        repo_root=repo_root or None,
         use_one_shot=use_one_shot,
     )
     payload = parse_review_response(content=response.content)
@@ -914,14 +895,14 @@ def _generate_extra_checklist(
         diff=chunk.diff,
         changed_files=changed_files,
     )
-    response = _call_provider(
+    response = call_ai(
         provider=provider,
         ai_config=ai_config,
         system_prompt="You generate review checklist questions.",
         user_prompt=prompt,
         budget=budget,
         max_tokens=1024,
-        repo_root=repo_root,
+        repo_root=repo_root or None,
         use_one_shot=use_one_shot,
     )
     usage = _ChunkReviewPartial(
@@ -984,13 +965,13 @@ def _run_adversarial_pass(
         prior_findings_json=prior_json,
         diff=chunk.diff,
     )
-    response = _call_provider(
+    response = call_ai(
         provider=provider,
         ai_config=ai_config,
         system_prompt=REVIEW_SYSTEM,
         user_prompt=prompt,
         budget=budget,
-        repo_root=repo_root,
+        repo_root=repo_root or None,
         use_one_shot=use_one_shot,
     )
     try:
@@ -1027,33 +1008,6 @@ def _run_adversarial_pass(
         output_tokens=response.output_tokens,
         cost_estimate=response.cost_estimate,
     )
-
-
-def _call_provider(
-    *,
-    provider: BaseAIProvider,
-    ai_config: AIConfig,
-    system_prompt: str,
-    user_prompt: str,
-    budget: CostBudget,
-    max_tokens: int | None = None,
-    repo_root: str = "",
-    use_one_shot: bool = False,
-) -> AIResponse:
-    """Call the AI provider with retry/fallback and budget tracking."""
-    tokens = max_tokens if max_tokens is not None else ai_config.max_tokens
-    response = complete_with_fallback(
-        provider,
-        user_prompt,
-        fallback_models=list(ai_config.fallback_models),
-        system=system_prompt,
-        max_tokens=tokens,
-        timeout=ai_config.api_timeout,
-        repo_root=repo_root or None,
-        use_one_shot=use_one_shot,
-    )
-    budget.record(response.cost_estimate)
-    return response
 
 
 def _payload_to_partial(

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -425,13 +425,9 @@ def run_review(
     )
 
     effective_ai_config = (
-<<<<<<< HEAD
         ai_config.model_copy(update={"api_timeout": timeout})
         if timeout is not None
         else ai_config
-=======
-        replace(ai_config, api_timeout=timeout) if timeout is not None else ai_config
->>>>>>> 6b71e3da (style: apply lintro fmt fixes for #1009)
     )
     tracker = progress or NullReviewProgress()
     budget = CostBudget(max_cost_usd=ai_config.max_cost_usd)

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -16,6 +16,7 @@ import click
 from rich.console import Console
 from rich.text import Text
 
+from lintro.ai.doctor_checks import AICheckResult, check_ai_configuration
 from lintro.enums.tool_status import ToolStatus
 from lintro.tools.core.install_context import RuntimeContext
 from lintro.tools.core.install_strategies import get_strategy
@@ -296,6 +297,47 @@ def _render_tool_line(
             console.print(f"         [dim]{r.details}[/dim]")
 
 
+def _ai_check_is_failure(check: AICheckResult) -> bool:
+    return check.status in (
+        ToolStatus.MISSING,
+        ToolStatus.INCOMPATIBLE,
+    )
+
+
+def _render_ai_checks(console: Console, checks: list[AICheckResult]) -> None:
+    """Render AI configuration checks."""
+    if not checks:
+        return
+
+    ok_count = sum(1 for check in checks if check.status == ToolStatus.OK)
+    console.print()
+    header = Text("  AI transport ", style="bold")
+    header.append(f"({ok_count}/{len(checks)} OK)", style="dim")
+    console.print(header)
+
+    for check in checks:
+        line = Text("    ")
+        if check.status == ToolStatus.OK:
+            line.append("[OK] ", style="green")
+            line.append(f"{check.name:<20}", style="cyan")
+            line.append(check.message, style="dim")
+        elif check.status == ToolStatus.INCOMPATIBLE:
+            line.append("[!!] ", style="red bold")
+            line.append(f"{check.name:<20}", style="cyan")
+            line.append(check.message, style="red")
+        elif check.status == ToolStatus.MISSING:
+            line.append("[!!] ", style="red bold")
+            line.append(f"{check.name:<20}", style="cyan")
+            line.append(check.message, style="red")
+        else:
+            line.append("[??] ", style="yellow")
+            line.append(f"{check.name:<20}", style="cyan")
+            line.append(check.message, style="dim")
+        console.print(line)
+        if check.hint:
+            console.print(f"         [dim]{check.hint}[/dim]")
+
+
 def _generate_markdown_report(
     env: EnvironmentReport,
     context: RuntimeContext,
@@ -437,6 +479,8 @@ def doctor_command(
     from lintro.config.config_loader import get_config
 
     config = get_config()
+    ai_checks = check_ai_configuration(config.ai)
+    ai_failure_count = sum(1 for check in ai_checks if _ai_check_is_failure(check))
 
     # Determine which tools to check
     if tools:
@@ -524,6 +568,7 @@ def doctor_command(
             or outdated_count > 0
             or incompatible_count > 0
             or unknown_count > 0
+            or ai_failure_count > 0
         ):
             sys.exit(1)
         return
@@ -539,12 +584,14 @@ def doctor_command(
             outdated_count,
             incompatible_count,
             unknown_count,
+            ai_checks=ai_checks,
         )
         if (
             missing_count > 0
             or outdated_count > 0
             or incompatible_count > 0
             or unknown_count > 0
+            or ai_failure_count > 0
         ):
             sys.exit(1)
         return
@@ -586,6 +633,8 @@ def doctor_command(
             disabled_prod,
             verbose=verbose,
         )
+
+    _render_ai_checks(display_console, ai_checks)
 
     # Summary
     display_console.print()
@@ -644,6 +693,7 @@ def doctor_command(
         or outdated_count > 0
         or incompatible_count > 0
         or unknown_count > 0
+        or ai_failure_count > 0
     ):
         raise SystemExit(1)
 
@@ -657,6 +707,8 @@ def _output_json(
     outdated_count: int,
     incompatible_count: int,
     unknown_count: int,
+    *,
+    ai_checks: list[AICheckResult] | None = None,
 ) -> None:
     """Output doctor results as JSON."""
     disabled_count = sum(
@@ -722,6 +774,27 @@ def _output_json(
                 },
             )
 
+    for check in ai_checks or []:
+        if _ai_check_is_failure(check):
+            issues.append(
+                {
+                    "tool": check.name,
+                    "severity": "error",
+                    "message": check.message,
+                    "install_hint": check.hint,
+                },
+            )
+
+    ai_json = [
+        {
+            "name": check.name,
+            "status": check.status.value,
+            "message": check.message,
+            "hint": check.hint,
+        }
+        for check in (ai_checks or [])
+    ]
+
     output: dict[str, object] = {
         "context": {
             "install_method": context.install_context.value,
@@ -730,6 +803,7 @@ def _output_json(
         },
         "tools": tools_json,
         "issues": issues,
+        "ai": ai_json,
         "summary": {
             "total": (
                 ok_count

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -321,11 +321,10 @@ def _render_ai_checks(console: Console, checks: list[AICheckResult]) -> None:
             line.append("[OK] ", style="green")
             line.append(f"{check.name:<20}", style="cyan")
             line.append(check.message, style="dim")
-        elif check.status == ToolStatus.INCOMPATIBLE:
-            line.append("[!!] ", style="red bold")
-            line.append(f"{check.name:<20}", style="cyan")
-            line.append(check.message, style="red")
-        elif check.status == ToolStatus.MISSING:
+        elif (
+            check.status == ToolStatus.INCOMPATIBLE
+            or check.status == ToolStatus.MISSING
+        ):
             line.append("[!!] ", style="red bold")
             line.append(f"{check.name:<20}", style="cyan")
             line.append(check.message, style="red")

--- a/tests/unit/ai/conftest.py
+++ b/tests/unit/ai/conftest.py
@@ -106,7 +106,11 @@ def mock_provider() -> MockAIProvider:
 @pytest.fixture
 def ai_config() -> AIConfig:
     """Create a default AI config for testing."""
-    return AIConfig(enabled=True, provider="anthropic")  # type: ignore[arg-type]  # Pydantic coerces str
+    return AIConfig(
+        enabled=True,
+        provider="anthropic",  # type: ignore[arg-type]
+        transport="api",  # type: ignore[arg-type]
+    )
 
 
 @pytest.fixture

--- a/tests/unit/ai/conftest.py
+++ b/tests/unit/ai/conftest.py
@@ -9,8 +9,10 @@ from typing import Any
 import pytest
 
 from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
 from lintro.ai.models import AIFixSuggestion
 from lintro.ai.providers.base import AIResponse, BaseAIProvider
+from lintro.ai.registry import AIProvider
 from lintro.parsers.base_issue import BaseIssue
 
 
@@ -108,8 +110,8 @@ def ai_config() -> AIConfig:
     """Create a default AI config for testing."""
     return AIConfig(
         enabled=True,
-        provider="anthropic",  # type: ignore[arg-type]
-        transport="api",  # type: ignore[arg-type]
+        provider=AIProvider.ANTHROPIC,
+        transport=AITransport.API,
     )
 
 

--- a/tests/unit/ai/review/test_context_parse.py
+++ b/tests/unit/ai/review/test_context_parse.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 from assertpy import assert_that
 
@@ -404,7 +406,7 @@ def test_review_context_error_coerces_string_code() -> None:
 def test_review_context_error_rejects_invalid_code_type() -> None:
     """Non-string, non-enum codes raise TypeError."""
     with pytest.raises(TypeError, match="ReviewContextErrorCode"):
-        ReviewContextError("bad code", code=123)  # type: ignore[arg-type]
+        ReviewContextError("bad code", code=cast(Any, 123))
 
 
 def test_parse_changed_files_supports_newlines_in_numstat_z_paths() -> None:

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -356,7 +356,7 @@ def test_run_review_aborts_progress_when_chunk_review_fails() -> None:
 
     with (
         patch(
-            "lintro.ai.review.orchestrator.complete_with_fallback",
+            "lintro.ai.review.orchestrator.call_ai",
             side_effect=RuntimeError("provider failed"),
         ),
         pytest.raises(ReviewExecutionError),
@@ -364,7 +364,7 @@ def test_run_review_aborts_progress_when_chunk_review_fails() -> None:
         run_review(
             context,
             provider=provider,
-            ai_config=AIConfig(enabled=True),
+            ai_config=AIConfig(enabled=True, transport="api"),  # type: ignore[arg-type]
             depth=1,
             checklist_items=[],
             checklist_text="1. [logic-bug] Example?",
@@ -400,7 +400,7 @@ def test_run_review_propagates_chunk_error_when_progress_abort_raises() -> None:
 
     with (
         patch(
-            "lintro.ai.review.orchestrator.complete_with_fallback",
+            "lintro.ai.review.orchestrator.call_ai",
             side_effect=RuntimeError("provider failed"),
         ),
         pytest.raises(ReviewExecutionError) as exc_info,
@@ -408,7 +408,7 @@ def test_run_review_propagates_chunk_error_when_progress_abort_raises() -> None:
         run_review(
             context,
             provider=provider,
-            ai_config=AIConfig(enabled=True),
+            ai_config=AIConfig(enabled=True, transport="api"),  # type: ignore[arg-type]
             depth=1,
             checklist_items=[],
             checklist_text="1. [logic-bug] Example?",
@@ -453,10 +453,10 @@ def test_run_review_returns_result_when_progress_complete_raises() -> None:
     progress.on_complete.side_effect = BrokenPipeError()
 
     with patch(
-        "lintro.ai.review.orchestrator.complete_with_fallback",
-        side_effect=lambda _provider, _prompt, **kwargs: _provider.complete(
-            _prompt,
-            system=kwargs.get("system"),
+        "lintro.ai.review.orchestrator.call_ai",
+        side_effect=lambda *, provider, user_prompt, **kwargs: provider.complete(
+            user_prompt,
+            system=kwargs.get("system_prompt"),
             max_tokens=kwargs.get("max_tokens", 1024),
             timeout=kwargs.get("timeout", 60.0),
         ),
@@ -464,7 +464,7 @@ def test_run_review_returns_result_when_progress_complete_raises() -> None:
         result = run_review(
             context,
             provider=provider,
-            ai_config=AIConfig(enabled=True),
+            ai_config=AIConfig(enabled=True, transport="api"),  # type: ignore[arg-type]
             depth=1,
             checklist_items=checklist_items,
             checklist_text="1. [logic-bug] Example?",

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -116,12 +116,11 @@ def test_run_review_depth1_returns_review_result() -> None:
     provider = _mock_provider(content=_sample_response_json())
 
     with patch(
-        "lintro.ai.review.orchestrator.complete_with_fallback",
-        side_effect=lambda _provider, _prompt, **kwargs: _provider.complete(
-            _prompt,
-            system=kwargs.get("system"),
+        "lintro.ai.review.orchestrator.call_ai",
+        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: provider.complete(
+            user_prompt,
+            system=system_prompt,
             max_tokens=kwargs.get("max_tokens", 1024),
-            timeout=kwargs.get("timeout", 60.0),
         ),
     ):
         result = run_review(
@@ -203,12 +202,11 @@ def test_run_review_depth2_calls_provider_twice() -> None:
     ]
 
     with patch(
-        "lintro.ai.review.orchestrator.complete_with_fallback",
-        side_effect=lambda _provider, _prompt, **kwargs: _provider.complete(
-            _prompt,
-            system=kwargs.get("system"),
+        "lintro.ai.review.orchestrator.call_ai",
+        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: provider.complete(
+            user_prompt,
+            system=system_prompt,
             max_tokens=kwargs.get("max_tokens", 1024),
-            timeout=kwargs.get("timeout", 60.0),
         ),
     ):
         result = run_review(
@@ -301,9 +299,8 @@ def test_run_review_parallelizes_multiple_chunks(tmp_path: Path) -> None:
     lock = threading.Lock()
     active = 0
     max_active = 0
-    response = provider.complete.return_value
-
-    def _track_concurrency(*_args, **_kwargs):
+    def _track_concurrency(*, provider, user_prompt, **kwargs):
+        del user_prompt, kwargs
         nonlocal active, max_active
         with lock:
             active += 1
@@ -311,13 +308,17 @@ def test_run_review_parallelizes_multiple_chunks(tmp_path: Path) -> None:
         time.sleep(0.05)
         with lock:
             active -= 1
-        return response
+        return provider.complete("prompt")
 
-    provider.complete.side_effect = _track_concurrency
-
-    with patch(
-        "lintro.ai.review.orchestrator.resolve_review_chunks",
-        return_value=chunks,
+    with (
+        patch(
+            "lintro.ai.review.orchestrator.resolve_review_chunks",
+            return_value=chunks,
+        ),
+        patch(
+            "lintro.ai.review.orchestrator.call_ai",
+            side_effect=_track_concurrency,
+        ),
     ):
         run_review(
             context,

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -12,6 +12,7 @@ import pytest
 from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
 from lintro.ai.providers.response import AIResponse
 from lintro.ai.review.enums.review_category import ReviewCategory
 from lintro.ai.review.exceptions import ReviewExecutionError
@@ -126,7 +127,7 @@ def test_run_review_depth1_returns_review_result() -> None:
         result = run_review(
             context,
             provider=provider,
-            ai_config=AIConfig(enabled=True, transport="api"),  # type: ignore[arg-type]
+            ai_config=AIConfig(enabled=True, transport=AITransport.API),
             depth=1,
             checklist_items=checklist_items,
             checklist_text="1. [logic-bug] Example?",
@@ -152,7 +153,7 @@ def test_run_review_empty_diff_returns_empty_result() -> None:
     result = run_review(
         context,
         provider=provider,
-        ai_config=AIConfig(enabled=True, transport="api"),  # type: ignore[arg-type]
+        ai_config=AIConfig(enabled=True, transport=AITransport.API),
         depth=1,
         checklist_items=[],
         checklist_text="",
@@ -212,7 +213,7 @@ def test_run_review_depth2_calls_provider_twice() -> None:
         result = run_review(
             context,
             provider=provider,
-            ai_config=AIConfig(enabled=True, transport="api"),  # type: ignore[arg-type]
+            ai_config=AIConfig(enabled=True, transport=AITransport.API),
             depth=2,
             checklist_items=[],
             checklist_text="1. [logic-bug] Example?",
@@ -324,7 +325,11 @@ def test_run_review_parallelizes_multiple_chunks(tmp_path: Path) -> None:
         run_review(
             context,
             provider=provider,
-            ai_config=AIConfig(enabled=True, transport="api", max_parallel_calls=4),  # type: ignore[arg-type]
+            ai_config=AIConfig(
+                enabled=True,
+                transport=AITransport.API,
+                max_parallel_calls=4,
+            ),
             depth=1,
             checklist_items=[],
             checklist_text="1. [logic-bug] Example?",
@@ -364,7 +369,7 @@ def test_run_review_aborts_progress_when_chunk_review_fails() -> None:
         run_review(
             context,
             provider=provider,
-            ai_config=AIConfig(enabled=True, transport="api"),  # type: ignore[arg-type]
+            ai_config=AIConfig(enabled=True, transport=AITransport.API),
             depth=1,
             checklist_items=[],
             checklist_text="1. [logic-bug] Example?",
@@ -408,7 +413,7 @@ def test_run_review_propagates_chunk_error_when_progress_abort_raises() -> None:
         run_review(
             context,
             provider=provider,
-            ai_config=AIConfig(enabled=True, transport="api"),  # type: ignore[arg-type]
+            ai_config=AIConfig(enabled=True, transport=AITransport.API),
             depth=1,
             checklist_items=[],
             checklist_text="1. [logic-bug] Example?",
@@ -464,7 +469,7 @@ def test_run_review_returns_result_when_progress_complete_raises() -> None:
         result = run_review(
             context,
             provider=provider,
-            ai_config=AIConfig(enabled=True, transport="api"),  # type: ignore[arg-type]
+            ai_config=AIConfig(enabled=True, transport=AITransport.API),
             depth=1,
             checklist_items=checklist_items,
             checklist_text="1. [logic-bug] Example?",

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -127,7 +127,7 @@ def test_run_review_depth1_returns_review_result() -> None:
         result = run_review(
             context,
             provider=provider,
-            ai_config=AIConfig(enabled=True),
+            ai_config=AIConfig(enabled=True, transport="api"),  # type: ignore[arg-type]
             depth=1,
             checklist_items=checklist_items,
             checklist_text="1. [logic-bug] Example?",
@@ -153,7 +153,7 @@ def test_run_review_empty_diff_returns_empty_result() -> None:
     result = run_review(
         context,
         provider=provider,
-        ai_config=AIConfig(enabled=True),
+        ai_config=AIConfig(enabled=True, transport="api"),  # type: ignore[arg-type]
         depth=1,
         checklist_items=[],
         checklist_text="",
@@ -214,7 +214,7 @@ def test_run_review_depth2_calls_provider_twice() -> None:
         result = run_review(
             context,
             provider=provider,
-            ai_config=AIConfig(enabled=True),
+            ai_config=AIConfig(enabled=True, transport="api"),  # type: ignore[arg-type]
             depth=2,
             checklist_items=[],
             checklist_text="1. [logic-bug] Example?",
@@ -322,7 +322,7 @@ def test_run_review_parallelizes_multiple_chunks(tmp_path: Path) -> None:
         run_review(
             context,
             provider=provider,
-            ai_config=AIConfig(enabled=True, max_parallel_calls=4),
+            ai_config=AIConfig(enabled=True, transport="api", max_parallel_calls=4),  # type: ignore[arg-type]
             depth=1,
             checklist_items=[],
             checklist_text="1. [logic-bug] Example?",

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -299,6 +299,7 @@ def test_run_review_parallelizes_multiple_chunks(tmp_path: Path) -> None:
     lock = threading.Lock()
     active = 0
     max_active = 0
+
     def _track_concurrency(*, provider, user_prompt, **kwargs):
         del user_prompt, kwargs
         nonlocal active, max_active

--- a/tests/unit/ai/test_budget.py
+++ b/tests/unit/ai/test_budget.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 
 import pytest
 from assertpy import assert_that
@@ -117,3 +118,32 @@ def test_thread_safety_concurrent_records() -> None:
 
     expected = num_threads * increments_per_thread * cost_per_increment
     assert_that(budget.spent).is_close_to(expected, tolerance=1e-9)
+
+
+def test_execute_serializes_budgeted_calls() -> None:
+    """execute() holds the budget lock for the full call to avoid races."""
+    budget = CostBudget(max_cost_usd=10.0)
+    active_lock = threading.Lock()
+    active = 0
+    max_active = 0
+
+    def tracked_call() -> float:
+        nonlocal active, max_active
+        with active_lock:
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.05)
+        with active_lock:
+            active -= 1
+        return 0.01
+
+    def worker() -> None:
+        budget.execute(tracked_call, cost_of=lambda cost: cost)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert_that(max_active).is_equal_to(1)

--- a/tests/unit/ai/test_cache.py
+++ b/tests/unit/ai/test_cache.py
@@ -18,17 +18,24 @@ from lintro.ai.cache import (
 from lintro.ai.models import AIFixSuggestion
 
 
-def _make_suggestion(**kwargs: object) -> AIFixSuggestion:
+def _make_suggestion(
+    *,
+    file: str = "test.py",
+    line: int = 1,
+    code: str = "E001",
+    original_code: str = "x",
+    suggested_code: str = "y",
+    **kwargs: str | int | float,
+) -> AIFixSuggestion:
     """Create a minimal AIFixSuggestion for tests."""
-    defaults = {
-        "file": "test.py",
-        "line": 1,
-        "code": "E001",
-        "original_code": "x",
-        "suggested_code": "y",
-    }
-    defaults.update(kwargs)
-    return AIFixSuggestion(**defaults)  # type: ignore[arg-type]
+    return AIFixSuggestion(
+        file=file,
+        line=line,
+        code=code,
+        original_code=original_code,
+        suggested_code=suggested_code,
+        **kwargs,
+    )
 
 
 # -- _cache_key --------------------------------------------------------------

--- a/tests/unit/ai/test_cache.py
+++ b/tests/unit/ai/test_cache.py
@@ -170,7 +170,13 @@ def test_cache_suggestion_evicts_when_over_max(tmp_path: Path) -> None:
     # Adding one more entry should evict the oldest (old_entry_0)
     suggestion = _make_suggestion(code="E999")
     cache_suggestion(
-        root, "new", "E999", 1, "new msg", suggestion, max_entries=max_entries,
+        root,
+        "new",
+        "E999",
+        1,
+        "new msg",
+        suggestion,
+        max_entries=max_entries,
     )
 
     remaining = sorted(p.name for p in cache_dir.glob("*.json"))

--- a/tests/unit/ai/test_claude_cli_provider.py
+++ b/tests/unit/ai/test_claude_cli_provider.py
@@ -67,7 +67,10 @@ class TestClaudeCliComplete:
 
     def test_success(self, _mock_claude_on_path: None) -> None:
         """Parse JSON output from a successful claude -p invocation."""
-        provider = AnthropicProvider(transport=AITransport.CLI)
+        provider = AnthropicProvider(
+            model="claude-sonnet-4-6",
+            transport=AITransport.CLI,
+        )
         stdout = _cli_json(result='{"summary": "ok"}')
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
@@ -83,6 +86,7 @@ class TestClaudeCliComplete:
         cmd = mock_run.call_args.args[0]
         assert_that(cmd).contains("--bare", "-p", "--output-format", "json")
         assert_that(cmd).contains("--append-system-prompt", "Be concise")
+        assert_that(cmd).contains("--model", "claude-sonnet-4-6")
 
     def test_auth_error(self, _mock_claude_on_path: None) -> None:
         """Surface authentication failures from claude stderr."""

--- a/tests/unit/ai/test_claude_cli_provider.py
+++ b/tests/unit/ai/test_claude_cli_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from collections.abc import Iterator
 from unittest.mock import patch
 
 import pytest
@@ -16,7 +17,8 @@ from lintro.ai.registry import AIProvider
 
 
 @pytest.fixture()
-def _mock_claude_on_path():
+def _mock_claude_on_path() -> Iterator[None]:
+    """Patch claude binary discovery for CLI transport tests."""
     with patch(
         "lintro.ai.providers.anthropic._find_claude",
         return_value="/usr/local/bin/claude",
@@ -39,7 +41,7 @@ def _cli_json(
                 "output_tokens": output_tokens,
             },
             "total_cost_usd": total_cost_usd,
-        }
+        },
     )
 
 
@@ -47,13 +49,15 @@ class TestClaudeCliInit:
     """Tests for CLI transport initialization."""
 
     def test_raises_when_claude_missing(self) -> None:
+        """Raise when the claude binary is not on PATH."""
         with (
             patch("lintro.ai.providers.anthropic._find_claude", return_value=None),
             pytest.raises(AINotAvailableError, match="claude"),
         ):
             AnthropicProvider(transport=AITransport.CLI)
 
-    def test_cli_transport_available(self, _mock_claude_on_path) -> None:
+    def test_cli_transport_available(self, _mock_claude_on_path: None) -> None:
+        """Report availability when the claude binary is discoverable."""
         provider = AnthropicProvider(transport=AITransport.CLI)
         assert_that(provider.is_available()).is_true()
 
@@ -61,7 +65,8 @@ class TestClaudeCliInit:
 class TestClaudeCliComplete:
     """Tests for claude -p completions."""
 
-    def test_success(self, _mock_claude_on_path) -> None:
+    def test_success(self, _mock_claude_on_path: None) -> None:
+        """Parse JSON output from a successful claude -p invocation."""
         provider = AnthropicProvider(transport=AITransport.CLI)
         stdout = _cli_json(result='{"summary": "ok"}')
         with patch("subprocess.run") as mock_run:
@@ -79,7 +84,8 @@ class TestClaudeCliComplete:
         assert_that(cmd).contains("--bare", "-p", "--output-format", "json")
         assert_that(cmd).contains("--append-system-prompt", "Be concise")
 
-    def test_auth_error(self, _mock_claude_on_path) -> None:
+    def test_auth_error(self, _mock_claude_on_path: None) -> None:
+        """Surface authentication failures from claude stderr."""
         provider = AnthropicProvider(transport=AITransport.CLI)
         with (
             patch("subprocess.run") as mock_run,
@@ -98,5 +104,6 @@ class TestFindClaude:
     """Tests for claude binary discovery."""
 
     def test_found(self) -> None:
+        """Return the claude path when shutil.which finds it."""
         with patch("shutil.which", return_value="/usr/local/bin/claude"):
             assert_that(_find_claude()).is_equal_to("/usr/local/bin/claude")

--- a/tests/unit/ai/test_claude_cli_provider.py
+++ b/tests/unit/ai/test_claude_cli_provider.py
@@ -1,0 +1,100 @@
+"""Tests for Anthropic Claude CLI provider backend."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.enums import AITransport
+from lintro.ai.exceptions import AIAuthenticationError, AINotAvailableError
+from lintro.ai.providers.anthropic import AnthropicProvider, _find_claude
+from lintro.ai.registry import AIProvider
+
+
+@pytest.fixture()
+def _mock_claude_on_path():
+    with patch(
+        "lintro.ai.providers.anthropic._find_claude",
+        return_value="/usr/local/bin/claude",
+    ):
+        yield
+
+
+def _cli_json(
+    *,
+    result: str = "hello",
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    total_cost_usd: float = 0.01,
+) -> str:
+    return json.dumps({
+        "result": result,
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        },
+        "total_cost_usd": total_cost_usd,
+    })
+
+
+class TestClaudeCliInit:
+    """Tests for CLI transport initialization."""
+
+    def test_raises_when_claude_missing(self) -> None:
+        with (
+            patch("lintro.ai.providers.anthropic._find_claude", return_value=None),
+            pytest.raises(AINotAvailableError, match="claude"),
+        ):
+            AnthropicProvider(transport=AITransport.CLI)
+
+    def test_cli_transport_available(self, _mock_claude_on_path) -> None:
+        provider = AnthropicProvider(transport=AITransport.CLI)
+        assert_that(provider.is_available()).is_true()
+
+
+class TestClaudeCliComplete:
+    """Tests for claude -p completions."""
+
+    def test_success(self, _mock_claude_on_path) -> None:
+        provider = AnthropicProvider(transport=AITransport.CLI)
+        stdout = _cli_json(result='{"summary": "ok"}')
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=stdout,
+                stderr="",
+            )
+            response = provider.complete("Review this diff", system="Be concise")
+
+        assert_that(response.content).contains("summary")
+        assert_that(response.provider).is_equal_to(AIProvider.ANTHROPIC)
+        cmd = mock_run.call_args.args[0]
+        assert_that(cmd).contains("--bare", "-p", "--output-format", "json")
+        assert_that(cmd).contains("--append-system-prompt", "Be concise")
+
+    def test_auth_error(self, _mock_claude_on_path) -> None:
+        provider = AnthropicProvider(transport=AITransport.CLI)
+        with (
+            patch("subprocess.run") as mock_run,
+            pytest.raises(AIAuthenticationError, match="login"),
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr="Authentication required. Please login.",
+            )
+            provider.complete("hello")
+
+
+class TestFindClaude:
+    """Tests for claude binary discovery."""
+
+    def test_found(self) -> None:
+        with patch("shutil.which", return_value="/usr/local/bin/claude"):
+            assert_that(_find_claude()).is_equal_to("/usr/local/bin/claude")

--- a/tests/unit/ai/test_claude_cli_provider.py
+++ b/tests/unit/ai/test_claude_cli_provider.py
@@ -31,14 +31,16 @@ def _cli_json(
     output_tokens: int = 50,
     total_cost_usd: float = 0.01,
 ) -> str:
-    return json.dumps({
-        "result": result,
-        "usage": {
-            "input_tokens": input_tokens,
-            "output_tokens": output_tokens,
-        },
-        "total_cost_usd": total_cost_usd,
-    })
+    return json.dumps(
+        {
+            "result": result,
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            },
+            "total_cost_usd": total_cost_usd,
+        }
+    )
 
 
 class TestClaudeCliInit:

--- a/tests/unit/ai/test_codex_cli_provider.py
+++ b/tests/unit/ai/test_codex_cli_provider.py
@@ -1,0 +1,96 @@
+"""Tests for OpenAI Codex CLI provider backend."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.enums import AITransport
+from lintro.ai.exceptions import AIAuthenticationError, AINotAvailableError
+from lintro.ai.providers.openai import OpenAIProvider, _find_codex
+from lintro.ai.registry import AIProvider
+
+
+@pytest.fixture()
+def _mock_codex_on_path():
+    with patch(
+        "lintro.ai.providers.openai._find_codex",
+        return_value="/usr/local/bin/codex",
+    ):
+        yield
+
+
+def _jsonl_response(*, text: str = '{"summary": "ok"}') -> str:
+    lines = [
+        json.dumps({
+            "type": "item.completed",
+            "item": {"type": "agent_message", "text": text},
+        }),
+        json.dumps({
+            "type": "turn.completed",
+            "usage": {"input_tokens": 120, "output_tokens": 40},
+        }),
+    ]
+    return "\n".join(lines)
+
+
+class TestCodexCliInit:
+    """Tests for Codex CLI transport initialization."""
+
+    def test_raises_when_codex_missing(self) -> None:
+        with (
+            patch("lintro.ai.providers.openai._find_codex", return_value=None),
+            pytest.raises(AINotAvailableError, match="codex"),
+        ):
+            OpenAIProvider(transport=AITransport.CLI)
+
+    def test_cli_transport_available(self, _mock_codex_on_path) -> None:
+        provider = OpenAIProvider(transport=AITransport.CLI)
+        assert_that(provider.is_available()).is_true()
+
+
+class TestCodexCliComplete:
+    """Tests for codex exec completions."""
+
+    def test_success(self, _mock_codex_on_path) -> None:
+        provider = OpenAIProvider(transport=AITransport.CLI)
+        stdout = _jsonl_response()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=stdout,
+                stderr="",
+            )
+            response = provider.complete("Review this diff", repo_root="/tmp/repo")
+
+        assert_that(response.content).contains("summary")
+        assert_that(response.provider).is_equal_to(AIProvider.OPENAI)
+        cmd = mock_run.call_args.args[0]
+        assert_that(cmd).contains("exec", "--json", "--sandbox", "read-only")
+
+    def test_auth_error(self, _mock_codex_on_path) -> None:
+        provider = OpenAIProvider(transport=AITransport.CLI)
+        with (
+            patch("subprocess.run") as mock_run,
+            pytest.raises(AIAuthenticationError, match="login"),
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr="Not authenticated. Run codex login.",
+            )
+            provider.complete("hello", repo_root="/tmp/repo")
+
+
+class TestFindCodex:
+    """Tests for codex binary discovery."""
+
+    def test_found(self) -> None:
+        with patch("shutil.which", return_value="/usr/local/bin/codex"):
+            assert_that(_find_codex()).is_equal_to("/usr/local/bin/codex")

--- a/tests/unit/ai/test_codex_cli_provider.py
+++ b/tests/unit/ai/test_codex_cli_provider.py
@@ -66,7 +66,7 @@ class TestCodexCliComplete:
 
     def test_success(self, _mock_codex_on_path: None) -> None:
         """Parse JSONL output from a successful codex exec invocation."""
-        provider = OpenAIProvider(transport=AITransport.CLI)
+        provider = OpenAIProvider(model="gpt-5.2-codex", transport=AITransport.CLI)
         stdout = _jsonl_response()
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
@@ -81,6 +81,7 @@ class TestCodexCliComplete:
         assert_that(response.provider).is_equal_to(AIProvider.OPENAI)
         cmd = mock_run.call_args.args[0]
         assert_that(cmd).contains("exec", "--json", "--sandbox", "read-only")
+        assert_that(cmd).contains("--model", "gpt-5.2-codex")
 
     def test_auth_error(self, _mock_codex_on_path: None) -> None:
         """Surface authentication failures from codex stderr."""

--- a/tests/unit/ai/test_codex_cli_provider.py
+++ b/tests/unit/ai/test_codex_cli_provider.py
@@ -26,14 +26,18 @@ def _mock_codex_on_path():
 
 def _jsonl_response(*, text: str = '{"summary": "ok"}') -> str:
     lines = [
-        json.dumps({
-            "type": "item.completed",
-            "item": {"type": "agent_message", "text": text},
-        }),
-        json.dumps({
-            "type": "turn.completed",
-            "usage": {"input_tokens": 120, "output_tokens": 40},
-        }),
+        json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": text},
+            }
+        ),
+        json.dumps(
+            {
+                "type": "turn.completed",
+                "usage": {"input_tokens": 120, "output_tokens": 40},
+            }
+        ),
     ]
     return "\n".join(lines)
 

--- a/tests/unit/ai/test_codex_cli_provider.py
+++ b/tests/unit/ai/test_codex_cli_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from collections.abc import Iterator
 from unittest.mock import patch
 
 import pytest
@@ -16,7 +17,8 @@ from lintro.ai.registry import AIProvider
 
 
 @pytest.fixture()
-def _mock_codex_on_path():
+def _mock_codex_on_path() -> Iterator[None]:
+    """Patch codex binary discovery for CLI transport tests."""
     with patch(
         "lintro.ai.providers.openai._find_codex",
         return_value="/usr/local/bin/codex",
@@ -30,13 +32,13 @@ def _jsonl_response(*, text: str = '{"summary": "ok"}') -> str:
             {
                 "type": "item.completed",
                 "item": {"type": "agent_message", "text": text},
-            }
+            },
         ),
         json.dumps(
             {
                 "type": "turn.completed",
                 "usage": {"input_tokens": 120, "output_tokens": 40},
-            }
+            },
         ),
     ]
     return "\n".join(lines)
@@ -46,13 +48,15 @@ class TestCodexCliInit:
     """Tests for Codex CLI transport initialization."""
 
     def test_raises_when_codex_missing(self) -> None:
+        """Raise when the codex binary is not on PATH."""
         with (
             patch("lintro.ai.providers.openai._find_codex", return_value=None),
             pytest.raises(AINotAvailableError, match="codex"),
         ):
             OpenAIProvider(transport=AITransport.CLI)
 
-    def test_cli_transport_available(self, _mock_codex_on_path) -> None:
+    def test_cli_transport_available(self, _mock_codex_on_path: None) -> None:
+        """Report availability when the codex binary is discoverable."""
         provider = OpenAIProvider(transport=AITransport.CLI)
         assert_that(provider.is_available()).is_true()
 
@@ -60,7 +64,8 @@ class TestCodexCliInit:
 class TestCodexCliComplete:
     """Tests for codex exec completions."""
 
-    def test_success(self, _mock_codex_on_path) -> None:
+    def test_success(self, _mock_codex_on_path: None) -> None:
+        """Parse JSONL output from a successful codex exec invocation."""
         provider = OpenAIProvider(transport=AITransport.CLI)
         stdout = _jsonl_response()
         with patch("subprocess.run") as mock_run:
@@ -77,7 +82,8 @@ class TestCodexCliComplete:
         cmd = mock_run.call_args.args[0]
         assert_that(cmd).contains("exec", "--json", "--sandbox", "read-only")
 
-    def test_auth_error(self, _mock_codex_on_path) -> None:
+    def test_auth_error(self, _mock_codex_on_path: None) -> None:
+        """Surface authentication failures from codex stderr."""
         provider = OpenAIProvider(transport=AITransport.CLI)
         with (
             patch("subprocess.run") as mock_run,
@@ -96,5 +102,6 @@ class TestFindCodex:
     """Tests for codex binary discovery."""
 
     def test_found(self) -> None:
+        """Return the codex path when shutil.which finds it."""
         with patch("shutil.which", return_value="/usr/local/bin/codex"):
             assert_that(_find_codex()).is_equal_to("/usr/local/bin/codex")

--- a/tests/unit/ai/test_config.py
+++ b/tests/unit/ai/test_config.py
@@ -7,6 +7,8 @@ from assertpy import assert_that
 from pydantic import ValidationError
 
 from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
+from lintro.ai.registry import AIProvider
 
 # -- Defaults --------------------------------------------------------------
 
@@ -50,20 +52,20 @@ def test_default_config_numeric_fields() -> None:
 
 def test_provider_anthropic() -> None:
     """Provider 'anthropic' is accepted (Pydantic coerces str to AIProvider)."""
-    config = AIConfig(provider="anthropic")  # type: ignore[arg-type]  # tests YAML-style str coercion
-    assert_that(config.provider).is_equal_to("anthropic")
+    config = AIConfig.model_validate({"provider": "anthropic"})
+    assert_that(config.provider).is_equal_to(AIProvider.ANTHROPIC)
 
 
 def test_provider_openai() -> None:
     """Provider 'openai' is accepted (Pydantic coerces str to AIProvider)."""
-    config = AIConfig(provider="openai")  # type: ignore[arg-type]  # tests YAML-style str coercion
-    assert_that(config.provider).is_equal_to("openai")
+    config = AIConfig.model_validate({"provider": "openai"})
+    assert_that(config.provider).is_equal_to(AIProvider.OPENAI)
 
 
 def test_provider_invalid_rejected() -> None:
     """An invalid provider string is rejected by validation."""
     with pytest.raises(ValidationError):
-        AIConfig(provider="gemini")  # type: ignore[arg-type]  # intentionally invalid
+        AIConfig.model_validate({"provider": "gemini"})
 
 
 # -- Boolean overrides -----------------------------------------------------
@@ -71,7 +73,7 @@ def test_provider_invalid_rejected() -> None:
 
 def test_enabled_override() -> None:
     """Enabled can be set to True with required transport."""
-    config = AIConfig(enabled=True, transport="api")  # type: ignore[arg-type]
+    config = AIConfig(enabled=True, transport=AITransport.API)
     assert_that(config.enabled).is_true()
 
 
@@ -160,7 +162,7 @@ def test_numeric_field_accepts_valid_value(
     expected: int | float,
 ) -> None:
     """Numeric field {field_name} accepts value {valid_value}."""
-    config = AIConfig(**{field_name: valid_value})  # type: ignore[arg-type]  # dynamic field name
+    config = AIConfig.model_validate({field_name: valid_value})
     assert_that(getattr(config, field_name)).is_equal_to(expected)
 
 
@@ -203,7 +205,7 @@ def test_numeric_field_rejects_invalid_value(
 ) -> None:
     """Numeric field {field_name} rejects invalid value {invalid_value}."""
     with pytest.raises(ValidationError):
-        AIConfig(**{field_name: invalid_value})  # type: ignore[arg-type]  # dynamic field name
+        AIConfig.model_validate({field_name: invalid_value})
 
 
 # -- Cross-field validators ------------------------------------------------

--- a/tests/unit/ai/test_config.py
+++ b/tests/unit/ai/test_config.py
@@ -70,8 +70,8 @@ def test_provider_invalid_rejected() -> None:
 
 
 def test_enabled_override() -> None:
-    """Enabled can be set to True."""
-    config = AIConfig(enabled=True)
+    """Enabled can be set to True with required transport."""
+    config = AIConfig(enabled=True, transport="api")  # type: ignore[arg-type]
     assert_that(config.enabled).is_true()
 
 

--- a/tests/unit/ai/test_config_wiring.py
+++ b/tests/unit/ai/test_config_wiring.py
@@ -71,7 +71,7 @@ def test_context_lines_flows_to_generate_fixes(
     fix_issues, _result, _issue = _make_fix_issues()
     mock_generate_fixes.return_value = []
 
-    ai_config = AIConfig(enabled=True, context_lines=42)
+    ai_config = AIConfig(enabled=True, transport="api", context_lines=42)  # type: ignore[arg-type]
 
     run_fix_pipeline(
         fix_issues=fix_issues,
@@ -114,6 +114,7 @@ def test_fix_search_radius_flows_to_apply_fixes(
 
     ai_config = AIConfig(
         enabled=True,
+        transport="api",  # type: ignore[arg-type]
         auto_apply=True,
         fix_search_radius=25,
     )
@@ -156,6 +157,7 @@ def test_retry_delays_flow_to_generate_fixes(
 
     ai_config = AIConfig(
         enabled=True,
+        transport="api",  # type: ignore[arg-type]
         retry_base_delay=0.5,
         retry_max_delay=10.0,
         retry_backoff_factor=3.0,
@@ -210,6 +212,7 @@ def test_timeout_and_retries_flow_to_post_fix_summary(
 
     ai_config = AIConfig(
         enabled=True,
+        transport="api",  # type: ignore[arg-type]
         auto_apply=True,
         api_timeout=120.0,
         max_retries=5,
@@ -259,6 +262,7 @@ def test_timeout_and_retries_flow_to_generate_summary(
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
+            transport="api",  # type: ignore[arg-type]
             api_timeout=90.0,
             max_retries=4,
             retry_base_delay=1.5,

--- a/tests/unit/ai/test_config_wiring.py
+++ b/tests/unit/ai/test_config_wiring.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
 from lintro.ai.models import AIFixSuggestion
 from lintro.ai.pipeline import run_fix_pipeline
 from lintro.ai.validation import ValidationResult
@@ -71,7 +72,7 @@ def test_context_lines_flows_to_generate_fixes(
     fix_issues, _result, _issue = _make_fix_issues()
     mock_generate_fixes.return_value = []
 
-    ai_config = AIConfig(enabled=True, transport="api", context_lines=42)  # type: ignore[arg-type]
+    ai_config = AIConfig(enabled=True, transport=AITransport.API, context_lines=42)
 
     run_fix_pipeline(
         fix_issues=fix_issues,
@@ -114,7 +115,7 @@ def test_fix_search_radius_flows_to_apply_fixes(
 
     ai_config = AIConfig(
         enabled=True,
-        transport="api",  # type: ignore[arg-type]
+        transport=AITransport.API,
         auto_apply=True,
         fix_search_radius=25,
     )
@@ -157,7 +158,7 @@ def test_retry_delays_flow_to_generate_fixes(
 
     ai_config = AIConfig(
         enabled=True,
-        transport="api",  # type: ignore[arg-type]
+        transport=AITransport.API,
         retry_base_delay=0.5,
         retry_max_delay=10.0,
         retry_backoff_factor=3.0,
@@ -212,7 +213,7 @@ def test_timeout_and_retries_flow_to_post_fix_summary(
 
     ai_config = AIConfig(
         enabled=True,
-        transport="api",  # type: ignore[arg-type]
+        transport=AITransport.API,
         auto_apply=True,
         api_timeout=120.0,
         max_retries=5,
@@ -262,7 +263,7 @@ def test_timeout_and_retries_flow_to_generate_summary(
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
-            transport="api",  # type: ignore[arg-type]
+            transport=AITransport.API,
             api_timeout=90.0,
             max_retries=4,
             retry_base_delay=1.5,

--- a/tests/unit/ai/test_hook.py
+++ b/tests/unit/ai/test_hook.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
 from lintro.ai.hook import AIPostExecutionHook
 from lintro.config.lintro_config import LintroConfig
 from lintro.enums.action import Action
@@ -20,7 +21,7 @@ from tests.unit.ai.conftest import MockIssue
 
 def test_should_run_returns_true_for_check_when_enabled():
     """Verify should_run returns True for CHECK action when AI is enabled."""
-    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
+    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
     hook = AIPostExecutionHook(config)
 
     result = hook.should_run(Action.CHECK)
@@ -30,7 +31,7 @@ def test_should_run_returns_true_for_check_when_enabled():
 
 def test_should_run_returns_true_for_fix_when_enabled():
     """Verify should_run returns True for FIX action when AI is enabled."""
-    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
+    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
     hook = AIPostExecutionHook(config)
 
     result = hook.should_run(Action.FIX)
@@ -40,7 +41,7 @@ def test_should_run_returns_true_for_fix_when_enabled():
 
 def test_should_run_returns_false_for_test_action():
     """Verify should_run returns False for TEST action even when AI is enabled."""
-    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
+    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
     hook = AIPostExecutionHook(config)
 
     result = hook.should_run(Action.TEST)
@@ -66,7 +67,7 @@ def test_should_run_returns_false_when_disabled():
 @patch("lintro.ai.orchestrator.run_ai_enhancement")
 def test_execute_calls_run_ai_enhancement(mock_run_ai_enhancement):
     """Verify execute delegates to run_ai_enhancement with correct arguments."""
-    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
+    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
     hook = AIPostExecutionHook(config, ai_fix=True)
     console_logger = MagicMock()
     results = [
@@ -106,7 +107,7 @@ def test_execute_calls_run_ai_enhancement(mock_run_ai_enhancement):
 def test_execute_catches_exceptions_and_logs_warning(mock_run_ai_enhancement):
     """Exceptions don't propagate; warning is logged."""
     mock_run_ai_enhancement.side_effect = RuntimeError("provider exploded")
-    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
+    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
     hook = AIPostExecutionHook(config)
     console_logger = MagicMock()
     results = [
@@ -139,7 +140,7 @@ def test_execute_catches_exceptions_and_logs_warning(mock_run_ai_enhancement):
 
 def test_execute_handles_import_failure():
     """Verify graceful handling when the lazy import of run_ai_enhancement fails."""
-    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
+    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
     hook = AIPostExecutionHook(config)
     console_logger = MagicMock()
     results = [

--- a/tests/unit/ai/test_hook.py
+++ b/tests/unit/ai/test_hook.py
@@ -20,7 +20,7 @@ from tests.unit.ai.conftest import MockIssue
 
 def test_should_run_returns_true_for_check_when_enabled():
     """Verify should_run returns True for CHECK action when AI is enabled."""
-    config = LintroConfig(ai=AIConfig(enabled=True))
+    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
     hook = AIPostExecutionHook(config)
 
     result = hook.should_run(Action.CHECK)
@@ -30,7 +30,7 @@ def test_should_run_returns_true_for_check_when_enabled():
 
 def test_should_run_returns_true_for_fix_when_enabled():
     """Verify should_run returns True for FIX action when AI is enabled."""
-    config = LintroConfig(ai=AIConfig(enabled=True))
+    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
     hook = AIPostExecutionHook(config)
 
     result = hook.should_run(Action.FIX)
@@ -40,7 +40,7 @@ def test_should_run_returns_true_for_fix_when_enabled():
 
 def test_should_run_returns_false_for_test_action():
     """Verify should_run returns False for TEST action even when AI is enabled."""
-    config = LintroConfig(ai=AIConfig(enabled=True))
+    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
     hook = AIPostExecutionHook(config)
 
     result = hook.should_run(Action.TEST)
@@ -66,7 +66,7 @@ def test_should_run_returns_false_when_disabled():
 @patch("lintro.ai.orchestrator.run_ai_enhancement")
 def test_execute_calls_run_ai_enhancement(mock_run_ai_enhancement):
     """Verify execute delegates to run_ai_enhancement with correct arguments."""
-    config = LintroConfig(ai=AIConfig(enabled=True))
+    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
     hook = AIPostExecutionHook(config, ai_fix=True)
     console_logger = MagicMock()
     results = [
@@ -106,7 +106,7 @@ def test_execute_calls_run_ai_enhancement(mock_run_ai_enhancement):
 def test_execute_catches_exceptions_and_logs_warning(mock_run_ai_enhancement):
     """Exceptions don't propagate; warning is logged."""
     mock_run_ai_enhancement.side_effect = RuntimeError("provider exploded")
-    config = LintroConfig(ai=AIConfig(enabled=True))
+    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
     hook = AIPostExecutionHook(config)
     console_logger = MagicMock()
     results = [
@@ -139,7 +139,7 @@ def test_execute_catches_exceptions_and_logs_warning(mock_run_ai_enhancement):
 
 def test_execute_handles_import_failure():
     """Verify graceful handling when the lazy import of run_ai_enhancement fails."""
-    config = LintroConfig(ai=AIConfig(enabled=True))
+    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
     hook = AIPostExecutionHook(config)
     console_logger = MagicMock()
     results = [

--- a/tests/unit/ai/test_invoke.py
+++ b/tests/unit/ai/test_invoke.py
@@ -9,6 +9,7 @@ from assertpy import assert_that
 
 from lintro.ai.budget import CostBudget
 from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import AIError, AIProviderError
 from lintro.ai.invoke import call_ai
 from lintro.ai.providers.response import AIResponse
@@ -31,7 +32,7 @@ def test_call_ai_returns_response_and_records_budget() -> None:
     provider.complete.return_value = _response(cost=0.02)
     config = AIConfig(
         enabled=True,
-        transport="api",  # type: ignore[arg-type]
+        transport=AITransport.API,
         max_retries=0,
     )
     budget = CostBudget(max_cost_usd=1.0)
@@ -57,7 +58,7 @@ def test_call_ai_retries_on_provider_error() -> None:
     ]
     config = AIConfig(
         enabled=True,
-        transport="api",  # type: ignore[arg-type]
+        transport=AITransport.API,
         max_retries=1,
         retry_base_delay=0.1,
         retry_max_delay=1.0,
@@ -82,7 +83,7 @@ def test_call_ai_returns_response_when_single_call_exceeds_budget() -> None:
     provider.complete.return_value = _response(cost=0.50)
     config = AIConfig(
         enabled=True,
-        transport="api",  # type: ignore[arg-type]
+        transport=AITransport.API,
         max_retries=0,
     )
     budget = CostBudget(max_cost_usd=0.10)
@@ -105,7 +106,7 @@ def test_call_ai_raises_when_budget_already_exceeded() -> None:
     provider.complete.return_value = _response(cost=0.50)
     config = AIConfig(
         enabled=True,
-        transport="api",  # type: ignore[arg-type]
+        transport=AITransport.API,
         max_retries=0,
     )
     budget = CostBudget(max_cost_usd=0.10)

--- a/tests/unit/ai/test_invoke.py
+++ b/tests/unit/ai/test_invoke.py
@@ -76,8 +76,8 @@ def test_call_ai_retries_on_provider_error() -> None:
     assert_that(provider.complete.call_count).is_equal_to(2)
 
 
-def test_call_ai_raises_when_budget_exceeded() -> None:
-    """Budget check runs before and after the provider call."""
+def test_call_ai_returns_response_when_single_call_exceeds_budget() -> None:
+    """A completed call is returned even when it pushes spent over the limit."""
     provider = MagicMock()
     provider.complete.return_value = _response(cost=0.50)
     config = AIConfig(
@@ -86,6 +86,30 @@ def test_call_ai_raises_when_budget_exceeded() -> None:
         max_retries=0,
     )
     budget = CostBudget(max_cost_usd=0.10)
+
+    response = call_ai(
+        provider=provider,
+        ai_config=config,
+        user_prompt="hello",
+        system_prompt=None,
+        budget=budget,
+    )
+
+    assert_that(response.cost_estimate).is_equal_to(0.50)
+    assert_that(budget.spent).is_equal_to(0.50)
+
+
+def test_call_ai_raises_when_budget_already_exceeded() -> None:
+    """Subsequent calls fail once the budget ceiling has been reached."""
+    provider = MagicMock()
+    provider.complete.return_value = _response(cost=0.50)
+    config = AIConfig(
+        enabled=True,
+        transport="api",  # type: ignore[arg-type]
+        max_retries=0,
+    )
+    budget = CostBudget(max_cost_usd=0.10)
+    budget.record(0.10)
 
     with pytest.raises(AIError, match="budget exceeded"):
         call_ai(

--- a/tests/unit/ai/test_invoke.py
+++ b/tests/unit/ai/test_invoke.py
@@ -1,0 +1,97 @@
+"""Tests for call_ai unified invocation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.budget import CostBudget
+from lintro.ai.config import AIConfig
+from lintro.ai.exceptions import AIError, AIProviderError
+from lintro.ai.invoke import call_ai
+from lintro.ai.providers.response import AIResponse
+
+
+def _response(*, cost: float = 0.01) -> AIResponse:
+    return AIResponse(
+        content='{"ok": true}',
+        model="test-model",
+        input_tokens=10,
+        output_tokens=5,
+        cost_estimate=cost,
+        provider="anthropic",
+    )
+
+
+def test_call_ai_returns_response_and_records_budget() -> None:
+    """call_ai records cost against the session budget."""
+    provider = MagicMock()
+    provider.complete.return_value = _response(cost=0.02)
+    config = AIConfig(
+        enabled=True,
+        transport="api",  # type: ignore[arg-type]
+        max_retries=0,
+    )
+    budget = CostBudget(max_cost_usd=1.0)
+
+    response = call_ai(
+        provider=provider,
+        ai_config=config,
+        user_prompt="hello",
+        system_prompt="system",
+        budget=budget,
+    )
+
+    assert_that(response.cost_estimate).is_equal_to(0.02)
+    assert_that(budget.spent).is_equal_to(0.02)
+
+
+def test_call_ai_retries_on_provider_error() -> None:
+    """Transient provider errors are retried according to config."""
+    provider = MagicMock()
+    provider.complete.side_effect = [
+        AIProviderError("temporary"),
+        _response(),
+    ]
+    config = AIConfig(
+        enabled=True,
+        transport="api",  # type: ignore[arg-type]
+        max_retries=1,
+        retry_base_delay=0.1,
+        retry_max_delay=1.0,
+    )
+
+    with patch("lintro.ai.retry.time.sleep"):
+        response = call_ai(
+            provider=provider,
+            ai_config=config,
+            user_prompt="hello",
+            system_prompt=None,
+            budget=None,
+        )
+
+    assert_that(response.content).contains("ok")
+    assert_that(provider.complete.call_count).is_equal_to(2)
+
+
+def test_call_ai_raises_when_budget_exceeded() -> None:
+    """Budget check runs before and after the provider call."""
+    provider = MagicMock()
+    provider.complete.return_value = _response(cost=0.50)
+    config = AIConfig(
+        enabled=True,
+        transport="api",  # type: ignore[arg-type]
+        max_retries=0,
+    )
+    budget = CostBudget(max_cost_usd=0.10)
+
+    with pytest.raises(AIError, match="budget exceeded"):
+        call_ai(
+            provider=provider,
+            ai_config=config,
+            user_prompt="hello",
+            system_prompt=None,
+            budget=budget,
+        )

--- a/tests/unit/ai/test_json_response.py
+++ b/tests/unit/ai/test_json_response.py
@@ -1,0 +1,38 @@
+"""Tests for JSON response parsing helpers."""
+
+from __future__ import annotations
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.json_response import load_json_object, strip_json_fences
+
+
+def test_strip_json_fences_removes_markdown_wrapper() -> None:
+    """Fence stripper extracts JSON from markdown code blocks."""
+    content = '```json\n{"summary": "ok"}\n```'
+    assert_that(strip_json_fences(content=content)).is_equal_to('{"summary": "ok"}')
+
+
+def test_strip_json_fences_passthrough_without_fences() -> None:
+    """Plain JSON passes through unchanged."""
+    content = '{"summary": "ok"}'
+    assert_that(strip_json_fences(content=content)).is_equal_to(content)
+
+
+def test_load_json_object_parses_fenced_payload() -> None:
+    """load_json_object strips fences and parses objects."""
+    payload = load_json_object(content='```json\n{"a": 1}\n```')
+    assert_that(payload).is_equal_to({"a": 1})
+
+
+def test_load_json_object_rejects_invalid_json() -> None:
+    """Invalid JSON raises ValueError with a clear message."""
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        load_json_object(content="not json")
+
+
+def test_load_json_object_rejects_non_object() -> None:
+    """Array JSON raises ValueError."""
+    with pytest.raises(ValueError, match="must be an object"):
+        load_json_object(content="[1, 2, 3]")

--- a/tests/unit/ai/test_orchestrator_check.py
+++ b/tests/unit/ai/test_orchestrator_check.py
@@ -47,7 +47,7 @@ def single_issue_result():
 @pytest.fixture
 def check_config():
     """LintroConfig with AI enabled and max_fix_attempts=5."""
-    return LintroConfig(ai=AIConfig(enabled=True, max_fix_attempts=5))
+    return LintroConfig(ai=AIConfig(enabled=True, transport="api", max_fix_attempts=5))  # type: ignore[arg-type]
 
 
 @pytest.fixture
@@ -156,7 +156,7 @@ def test_summary_attachment_summary_attached_to_all_results_with_issues(
             ),
         ],
     )
-    config = LintroConfig(ai=AIConfig(enabled=True))
+    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
     logger = MagicMock()
 
     mock_get_provider.return_value = MockAIProvider()
@@ -269,7 +269,7 @@ def test_integration_orchestrator_end_to_end_check_with_real_summary_generation(
     )
 
     mock_get_provider.return_value = MockAIProvider(responses=[summary_response])
-    config = LintroConfig(ai=AIConfig(enabled=True))
+    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
     logger = MagicMock()
 
     run_ai_enhancement(

--- a/tests/unit/ai/test_orchestrator_check.py
+++ b/tests/unit/ai/test_orchestrator_check.py
@@ -10,6 +10,7 @@ import pytest
 from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
 from lintro.ai.models import AIFixSuggestion, AISummary
 from lintro.ai.orchestrator import (
     _log_fix_limit_message,
@@ -47,7 +48,9 @@ def single_issue_result():
 @pytest.fixture
 def check_config():
     """LintroConfig with AI enabled and max_fix_attempts=5."""
-    return LintroConfig(ai=AIConfig(enabled=True, transport="api", max_fix_attempts=5))  # type: ignore[arg-type]
+    return LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API, max_fix_attempts=5),
+    )
 
 
 @pytest.fixture
@@ -156,7 +159,7 @@ def test_summary_attachment_summary_attached_to_all_results_with_issues(
             ),
         ],
     )
-    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
+    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
     logger = MagicMock()
 
     mock_get_provider.return_value = MockAIProvider()
@@ -269,7 +272,7 @@ def test_integration_orchestrator_end_to_end_check_with_real_summary_generation(
     )
 
     mock_get_provider.return_value = MockAIProvider(responses=[summary_response])
-    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
+    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
     logger = MagicMock()
 
     run_ai_enhancement(

--- a/tests/unit/ai/test_orchestrator_edge.py
+++ b/tests/unit/ai/test_orchestrator_edge.py
@@ -9,6 +9,7 @@ import pytest
 from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
 from lintro.ai.models import AIFixSuggestion, AIResult, AISummary
 from lintro.ai.orchestrator import run_ai_enhancement
 from lintro.ai.validation import ValidationResult
@@ -44,7 +45,7 @@ def test_ai_result_default_no_error(
             ),
         ],
     )
-    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
+    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
     logger = MagicMock()
 
     mock_get_provider.return_value = MockAIProvider()
@@ -96,7 +97,7 @@ def test_ai_result_unfixed_issues_when_fixes_fail(
         ],
     )
     config = LintroConfig(
-        ai=AIConfig(enabled=True, transport="api", fail_on_unfixed=True),  # type: ignore[arg-type]
+        ai=AIConfig(enabled=True, transport=AITransport.API, fail_on_unfixed=True),
     )
     logger = MagicMock()
 
@@ -120,7 +121,7 @@ def test_ai_result_unfixed_issues_when_fixes_fail(
 
 def test_ai_result_error_on_exception():
     """AIResult.error is True when AI enhancement raises an exception."""
-    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
+    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
     logger = MagicMock()
 
     with patch(
@@ -141,7 +142,9 @@ def test_ai_result_error_on_exception():
 
 def test_ai_result_error_propagates_when_fail_on_ai_error():
     """Exceptions propagate when fail_on_ai_error=True."""
-    config = LintroConfig(ai=AIConfig(enabled=True, transport="api", fail_on_ai_error=True))  # type: ignore[arg-type]
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API, fail_on_ai_error=True),
+    )
     logger = MagicMock()
 
     with (
@@ -213,7 +216,7 @@ def test_ai_result_tracks_applied_fixes(
         tool_name="ruff",
     )
     config = LintroConfig(
-        ai=AIConfig(enabled=True, transport="api", auto_apply=True),  # type: ignore[arg-type]
+        ai=AIConfig(enabled=True, transport=AITransport.API, auto_apply=True),
     )
     logger = MagicMock()
 

--- a/tests/unit/ai/test_orchestrator_edge.py
+++ b/tests/unit/ai/test_orchestrator_edge.py
@@ -44,7 +44,7 @@ def test_ai_result_default_no_error(
             ),
         ],
     )
-    config = LintroConfig(ai=AIConfig(enabled=True))
+    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
     logger = MagicMock()
 
     mock_get_provider.return_value = MockAIProvider()
@@ -96,7 +96,7 @@ def test_ai_result_unfixed_issues_when_fixes_fail(
         ],
     )
     config = LintroConfig(
-        ai=AIConfig(enabled=True, max_fix_attempts=5, fail_on_unfixed=True),
+        ai=AIConfig(enabled=True, transport="api", fail_on_unfixed=True),  # type: ignore[arg-type]
     )
     logger = MagicMock()
 
@@ -120,7 +120,7 @@ def test_ai_result_unfixed_issues_when_fixes_fail(
 
 def test_ai_result_error_on_exception():
     """AIResult.error is True when AI enhancement raises an exception."""
-    config = LintroConfig(ai=AIConfig(enabled=True))
+    config = LintroConfig(ai=AIConfig(enabled=True, transport="api"))  # type: ignore[arg-type]
     logger = MagicMock()
 
     with patch(
@@ -141,7 +141,7 @@ def test_ai_result_error_on_exception():
 
 def test_ai_result_error_propagates_when_fail_on_ai_error():
     """Exceptions propagate when fail_on_ai_error=True."""
-    config = LintroConfig(ai=AIConfig(enabled=True, fail_on_ai_error=True))
+    config = LintroConfig(ai=AIConfig(enabled=True, transport="api", fail_on_ai_error=True))  # type: ignore[arg-type]
     logger = MagicMock()
 
     with (
@@ -213,7 +213,7 @@ def test_ai_result_tracks_applied_fixes(
         tool_name="ruff",
     )
     config = LintroConfig(
-        ai=AIConfig(enabled=True, auto_apply=True),
+        ai=AIConfig(enabled=True, transport="api", auto_apply=True),  # type: ignore[arg-type]
     )
     logger = MagicMock()
 

--- a/tests/unit/ai/test_orchestrator_fix.py
+++ b/tests/unit/ai/test_orchestrator_fix.py
@@ -55,6 +55,7 @@ def test_run_ai_enhancement_fix_action_generates_fix_metadata(
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
+            transport="api",  # type: ignore[arg-type]
             max_fix_attempts=5,
             auto_apply=True,
         ),
@@ -131,6 +132,7 @@ def test_run_ai_enhancement_fix_action_passes_validate_mode_to_interactive_revie
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
+            transport="api",  # type: ignore[arg-type]
             max_fix_attempts=5,
             validate_after_group=True,
         ),
@@ -194,7 +196,7 @@ def test_run_ai_enhancement_fix_action_uses_only_remaining_issue_tail(
         issues=[fixed_issue, remaining_issue],
         remaining_issues_count=1,
     )
-    config = LintroConfig(ai=AIConfig(enabled=True, max_fix_attempts=5))
+    config = LintroConfig(ai=AIConfig(enabled=True, transport="api", max_fix_attempts=5))  # type: ignore[arg-type]
     logger = MagicMock()
 
     mock_get_provider.return_value = MockAIProvider()
@@ -240,7 +242,7 @@ def test_run_ai_enhancement_fix_action_skips_tools_with_zero_remaining_issues(
         ],
         remaining_issues_count=0,
     )
-    config = LintroConfig(ai=AIConfig(enabled=True, max_fix_attempts=5))
+    config = LintroConfig(ai=AIConfig(enabled=True, transport="api", max_fix_attempts=5))  # type: ignore[arg-type]
     logger = MagicMock()
 
     mock_get_provider.return_value = MockAIProvider()

--- a/tests/unit/ai/test_orchestrator_fix.py
+++ b/tests/unit/ai/test_orchestrator_fix.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
 from lintro.ai.models import AIFixSuggestion
 from lintro.ai.orchestrator import run_ai_enhancement
 from lintro.ai.validation import ValidationResult
@@ -55,7 +56,7 @@ def test_run_ai_enhancement_fix_action_generates_fix_metadata(
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
-            transport="api",  # type: ignore[arg-type]
+            transport=AITransport.API,
             max_fix_attempts=5,
             auto_apply=True,
         ),
@@ -132,7 +133,7 @@ def test_run_ai_enhancement_fix_action_passes_validate_mode_to_interactive_revie
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
-            transport="api",  # type: ignore[arg-type]
+            transport=AITransport.API,
             max_fix_attempts=5,
             validate_after_group=True,
         ),
@@ -196,7 +197,9 @@ def test_run_ai_enhancement_fix_action_uses_only_remaining_issue_tail(
         issues=[fixed_issue, remaining_issue],
         remaining_issues_count=1,
     )
-    config = LintroConfig(ai=AIConfig(enabled=True, transport="api", max_fix_attempts=5))  # type: ignore[arg-type]
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API, max_fix_attempts=5),
+    )
     logger = MagicMock()
 
     mock_get_provider.return_value = MockAIProvider()
@@ -242,7 +245,9 @@ def test_run_ai_enhancement_fix_action_skips_tools_with_zero_remaining_issues(
         ],
         remaining_issues_count=0,
     )
-    config = LintroConfig(ai=AIConfig(enabled=True, transport="api", max_fix_attempts=5))  # type: ignore[arg-type]
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API, max_fix_attempts=5),
+    )
     logger = MagicMock()
 
     mock_get_provider.return_value = MockAIProvider()
@@ -301,7 +306,7 @@ def test_run_ai_enhancement_fix_action_uses_fresh_rerun_results_for_post_summary
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
-            transport="api",  # type: ignore[arg-type]
+            transport=AITransport.API,
             auto_apply=True,
         ),
     )

--- a/tests/unit/ai/test_orchestrator_fix.py
+++ b/tests/unit/ai/test_orchestrator_fix.py
@@ -301,6 +301,7 @@ def test_run_ai_enhancement_fix_action_uses_fresh_rerun_results_for_post_summary
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
+            transport="api",  # type: ignore[arg-type]
             auto_apply=True,
         ),
     )

--- a/tests/unit/ai/test_orchestrator_multi.py
+++ b/tests/unit/ai/test_orchestrator_multi.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
 from lintro.ai.models import AIFixSuggestion
 from lintro.ai.orchestrator import run_ai_enhancement
 from lintro.ai.rerun import _rerun_cwd_lock, paths_for_context, rerun_tools
@@ -16,6 +17,7 @@ from lintro.ai.validation import ValidationResult
 from lintro.config.lintro_config import LintroConfig
 from lintro.enums.action import Action
 from lintro.models.core.tool_result import ToolResult
+from lintro.parsers.base_issue import BaseIssue
 from tests.unit.ai.conftest import MockAIProvider, MockIssue
 
 # ---------------------------------------------------------------------------
@@ -65,7 +67,7 @@ def test_run_ai_enhancement_fix_action_noninteractive_applies_safe_then_reviews_
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
-            transport="api",  # type: ignore[arg-type]
+            transport=AITransport.API,
             auto_apply=False,
             auto_apply_safe_fixes=True,
         ),
@@ -153,7 +155,7 @@ def test_run_ai_enhancement_fix_action_json_auto_applies_safe_style_suggestions(
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
-            transport="api",  # type: ignore[arg-type]
+            transport=AITransport.API,
             max_fix_attempts=5,
             auto_apply=False,
             auto_apply_safe_fixes=True,
@@ -243,7 +245,7 @@ def test_run_ai_enhancement_fix_action_json_uses_fresh_rerun_results(
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
-            transport="api",  # type: ignore[arg-type]
+            transport=AITransport.API,
             auto_apply=True,
         ),
     )
@@ -317,7 +319,9 @@ def test_rerun_context_rerun_uses_original_tool_cwd(mock_get_tool, tmp_path):
         remaining_issues_count=1,
         cwd=str(tool_cwd),
     )
-    by_tool = {"ruff": (original_result, [issue])}
+    by_tool: dict[str, tuple[ToolResult, list[BaseIssue]]] = {
+        "ruff": (original_result, [issue]),
+    }
 
     captured: dict[str, object] = {}
 
@@ -335,7 +339,7 @@ def test_rerun_context_rerun_uses_original_tool_cwd(mock_get_tool, tmp_path):
             )
 
     mock_get_tool.return_value = _FakeTool()
-    rerun_results = rerun_tools(by_tool)  # type: ignore[arg-type]  # test uses simplified mock data
+    rerun_results = rerun_tools(by_tool)
 
     assert_that(rerun_results).is_length(1)
     assert_that(captured.get("cwd")).is_equal_to(str(tool_cwd))
@@ -396,11 +400,11 @@ def test_rerun_context_rerun_continues_on_tool_failure(mock_get_tool, tmp_path):
 
     mock_get_tool.side_effect = _side_effect
 
-    by_tool = {
+    by_tool: dict[str, tuple[ToolResult, list[BaseIssue]]] = {
         "failing-tool": (result_a, [issue_a]),
         "passing-tool": (result_b, [issue_b]),
     }
-    rerun_results = rerun_tools(by_tool)  # type: ignore[arg-type]  # test uses simplified mock data
+    rerun_results = rerun_tools(by_tool)
 
     assert_that(call_count["failing"]).is_equal_to(1)
     assert_that(call_count["passing"]).is_equal_to(1)

--- a/tests/unit/ai/test_orchestrator_multi.py
+++ b/tests/unit/ai/test_orchestrator_multi.py
@@ -65,6 +65,7 @@ def test_run_ai_enhancement_fix_action_noninteractive_applies_safe_then_reviews_
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
+            transport="api",  # type: ignore[arg-type]
             auto_apply=False,
             auto_apply_safe_fixes=True,
         ),
@@ -152,6 +153,7 @@ def test_run_ai_enhancement_fix_action_json_auto_applies_safe_style_suggestions(
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
+            transport="api",  # type: ignore[arg-type]
             max_fix_attempts=5,
             auto_apply=False,
             auto_apply_safe_fixes=True,
@@ -241,6 +243,7 @@ def test_run_ai_enhancement_fix_action_json_uses_fresh_rerun_results(
     config = LintroConfig(
         ai=AIConfig(
             enabled=True,
+            transport="api",  # type: ignore[arg-type]
             auto_apply=True,
         ),
     )

--- a/tests/unit/ai/test_pipeline.py
+++ b/tests/unit/ai/test_pipeline.py
@@ -47,6 +47,7 @@ def _make_suggestion(
 def _default_ai_config(**overrides: object) -> AIConfig:
     defaults: dict[str, object] = {
         "enabled": True,
+        "transport": "api",
         "max_fix_attempts": 20,
     }
     defaults.update(overrides)

--- a/tests/unit/ai/test_pipeline.py
+++ b/tests/unit/ai/test_pipeline.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
 from lintro.ai.models import AIFixSuggestion
 from lintro.ai.pipeline import run_fix_pipeline
 from lintro.ai.validation import ValidationResult
@@ -47,11 +48,11 @@ def _make_suggestion(
 def _default_ai_config(**overrides: object) -> AIConfig:
     defaults: dict[str, object] = {
         "enabled": True,
-        "transport": "api",
+        "transport": AITransport.API,
         "max_fix_attempts": 20,
     }
     defaults.update(overrides)
-    return AIConfig(**defaults)  # type: ignore[arg-type]
+    return AIConfig.model_validate(defaults)
 
 
 def _make_result(name: str, issues: list[MockIssue]) -> ToolResult:

--- a/tests/unit/ai/test_transport_config.py
+++ b/tests/unit/ai/test_transport_config.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pytest
 from assertpy import assert_that
-from pydantic import ValidationError
 
 from lintro.ai.config import AIConfig
 from lintro.ai.doctor_checks import check_ai_configuration
@@ -33,14 +32,18 @@ def test_doctor_reports_missing_transport_when_ai_enabled() -> None:
     assert_that(results[0].status).is_equal_to(ToolStatus.INCOMPATIBLE)
 
 
-def test_cursor_api_combo_rejected_when_enabled() -> None:
-    """Cursor + api is invalid when AI is enabled."""
-    with pytest.raises(ValidationError, match="cursor provider only supports"):
+def test_doctor_reports_cursor_api_combo_when_enabled() -> None:
+    """Doctor surfaces invalid cursor+api instead of raw config validation."""
+    results = check_ai_configuration(
         AIConfig(
             enabled=True,
             provider=AIProvider.CURSOR,
             transport=AITransport.API,
-        )
+        ),
+    )
+    assert_that(results).is_length(1)
+    assert_that(results[0].name).is_equal_to("ai.provider+transport")
+    assert_that(results[0].status).is_equal_to(ToolStatus.INCOMPATIBLE)
 
 
 def test_cursor_api_combo_allowed_when_disabled() -> None:

--- a/tests/unit/ai/test_transport_config.py
+++ b/tests/unit/ai/test_transport_config.py
@@ -23,7 +23,7 @@ def test_transport_required_when_ai_enabled() -> None:
 
 
 def test_cursor_api_combo_rejected() -> None:
-    """cursor + api is an invalid provider/transport combination."""
+    """Cursor + api is an invalid provider/transport combination."""
     with pytest.raises(ValidationError, match="cursor provider only supports"):
         AIConfig(
             enabled=True,

--- a/tests/unit/ai/test_transport_config.py
+++ b/tests/unit/ai/test_transport_config.py
@@ -1,0 +1,64 @@
+"""Tests for AI transport configuration validation."""
+
+from __future__ import annotations
+
+import pytest
+from assertpy import assert_that
+from pydantic import ValidationError
+
+from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
+
+
+def test_transport_optional_when_ai_disabled() -> None:
+    """Disabled AI config does not require transport."""
+    config = AIConfig(enabled=False)
+    assert_that(config.transport).is_none()
+
+
+def test_transport_required_when_ai_enabled() -> None:
+    """Enabled AI config requires explicit transport."""
+    with pytest.raises(ValidationError, match="ai.transport is required"):
+        AIConfig(enabled=True)
+
+
+def test_cursor_api_combo_rejected() -> None:
+    """cursor + api is an invalid provider/transport combination."""
+    with pytest.raises(ValidationError, match="cursor provider only supports"):
+        AIConfig(
+            enabled=True,
+            provider="cursor",  # type: ignore[arg-type]
+            transport=AITransport.API,
+        )
+
+
+@pytest.mark.parametrize(
+    ("provider", "transport"),
+    [
+        ("anthropic", AITransport.API),
+        ("anthropic", AITransport.CLI),
+        ("openai", AITransport.API),
+        ("openai", AITransport.CLI),
+        ("cursor", AITransport.CLI),
+    ],
+)
+def test_valid_provider_transport_matrix(
+    provider: str,
+    transport: AITransport,
+) -> None:
+    """Valid provider and transport pairs are accepted."""
+    config = AIConfig(
+        enabled=True,
+        provider=provider,  # type: ignore[arg-type]
+        transport=transport,
+    )
+    assert_that(config.transport).is_equal_to(transport)
+
+
+def test_transport_yaml_string_coercion() -> None:
+    """Transport accepts hyphenated string values from YAML."""
+    config = AIConfig(
+        enabled=True,
+        transport="cli",  # type: ignore[arg-type]
+    )
+    assert_that(config.transport).is_equal_to(AITransport.CLI)

--- a/tests/unit/ai/test_transport_config.py
+++ b/tests/unit/ai/test_transport_config.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from lintro.ai.config import AIConfig
 from lintro.ai.doctor_checks import check_ai_configuration
 from lintro.ai.enums import AITransport
+from lintro.ai.registry import AIProvider
 from lintro.enums.tool_status import ToolStatus
 
 
@@ -32,34 +33,44 @@ def test_doctor_reports_missing_transport_when_ai_enabled() -> None:
     assert_that(results[0].status).is_equal_to(ToolStatus.INCOMPATIBLE)
 
 
-def test_cursor_api_combo_rejected() -> None:
-    """Cursor + api is an invalid provider/transport combination."""
+def test_cursor_api_combo_rejected_when_enabled() -> None:
+    """Cursor + api is invalid when AI is enabled."""
     with pytest.raises(ValidationError, match="cursor provider only supports"):
         AIConfig(
             enabled=True,
-            provider="cursor",  # type: ignore[arg-type]
+            provider=AIProvider.CURSOR,
             transport=AITransport.API,
         )
+
+
+def test_cursor_api_combo_allowed_when_disabled() -> None:
+    """Disabled configs may keep stale cursor/api settings for doctor."""
+    config = AIConfig(
+        enabled=False,
+        provider=AIProvider.CURSOR,
+        transport=AITransport.API,
+    )
+    assert_that(config.transport).is_equal_to(AITransport.API)
 
 
 @pytest.mark.parametrize(
     ("provider", "transport"),
     [
-        ("anthropic", AITransport.API),
-        ("anthropic", AITransport.CLI),
-        ("openai", AITransport.API),
-        ("openai", AITransport.CLI),
-        ("cursor", AITransport.CLI),
+        (AIProvider.ANTHROPIC, AITransport.API),
+        (AIProvider.ANTHROPIC, AITransport.CLI),
+        (AIProvider.OPENAI, AITransport.API),
+        (AIProvider.OPENAI, AITransport.CLI),
+        (AIProvider.CURSOR, AITransport.CLI),
     ],
 )
 def test_valid_provider_transport_matrix(
-    provider: str,
+    provider: AIProvider,
     transport: AITransport,
 ) -> None:
     """Valid provider and transport pairs are accepted."""
     config = AIConfig(
         enabled=True,
-        provider=provider,  # type: ignore[arg-type]
+        provider=provider,
         transport=transport,
     )
     assert_that(config.transport).is_equal_to(transport)
@@ -67,8 +78,5 @@ def test_valid_provider_transport_matrix(
 
 def test_transport_yaml_string_coercion() -> None:
     """Transport accepts hyphenated string values from YAML."""
-    config = AIConfig(
-        enabled=True,
-        transport="cli",  # type: ignore[arg-type]
-    )
+    config = AIConfig.model_validate({"enabled": True, "transport": "cli"})
     assert_that(config.transport).is_equal_to(AITransport.CLI)

--- a/tests/unit/ai/test_transport_config.py
+++ b/tests/unit/ai/test_transport_config.py
@@ -7,7 +7,9 @@ from assertpy import assert_that
 from pydantic import ValidationError
 
 from lintro.ai.config import AIConfig
+from lintro.ai.doctor_checks import check_ai_configuration
 from lintro.ai.enums import AITransport
+from lintro.enums.tool_status import ToolStatus
 
 
 def test_transport_optional_when_ai_disabled() -> None:
@@ -16,10 +18,18 @@ def test_transport_optional_when_ai_disabled() -> None:
     assert_that(config.transport).is_none()
 
 
-def test_transport_required_when_ai_enabled() -> None:
-    """Enabled AI config requires explicit transport."""
-    with pytest.raises(ValidationError, match="ai.transport is required"):
-        AIConfig(enabled=True)
+def test_transport_deferred_to_doctor_when_ai_enabled() -> None:
+    """Enabled AI config may omit transport until doctor validates it."""
+    config = AIConfig(enabled=True)
+    assert_that(config.transport).is_none()
+
+
+def test_doctor_reports_missing_transport_when_ai_enabled() -> None:
+    """Doctor surfaces missing transport instead of raw config validation."""
+    results = check_ai_configuration(AIConfig(enabled=True))
+    assert_that(results).is_length(1)
+    assert_that(results[0].name).is_equal_to("ai.transport")
+    assert_that(results[0].status).is_equal_to(ToolStatus.INCOMPATIBLE)
 
 
 def test_cursor_api_combo_rejected() -> None:

--- a/tests/unit/utils/console/test_pre_execution_summary.py
+++ b/tests/unit/utils/console/test_pre_execution_summary.py
@@ -9,6 +9,8 @@ from assertpy import assert_that
 from rich.console import Console
 
 from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
+from lintro.ai.registry import AIProvider
 from lintro.utils.console.pre_execution_summary import print_pre_execution_summary
 
 
@@ -36,7 +38,7 @@ def test_pre_execution_summary_shows_ai_when_disabled() -> None:
     output = _render_summary(
         AIConfig(
             enabled=False,
-            provider="openai",  # type: ignore[arg-type]  # Pydantic coerces str
+            provider=AIProvider.OPENAI,
             max_parallel_calls=7,
         ),
     )
@@ -61,8 +63,8 @@ def test_pre_execution_summary_shows_ai_when_enabled(
     output = _render_summary(
         AIConfig(
             enabled=True,
-            transport="api",  # type: ignore[arg-type]
-            provider="anthropic",  # type: ignore[arg-type]  # Pydantic coerces str
+            transport=AITransport.API,
+            provider=AIProvider.ANTHROPIC,
             max_parallel_calls=3,
         ),
     )

--- a/tests/unit/utils/console/test_pre_execution_summary.py
+++ b/tests/unit/utils/console/test_pre_execution_summary.py
@@ -61,6 +61,7 @@ def test_pre_execution_summary_shows_ai_when_enabled(
     output = _render_summary(
         AIConfig(
             enabled=True,
+            transport="api",  # type: ignore[arg-type]
             provider="anthropic",  # type: ignore[arg-type]  # Pydantic coerces str
             max_parallel_calls=3,
         ),

--- a/tests/unit/utils/output/conftest.py
+++ b/tests/unit/utils/output/conftest.py
@@ -1,22 +1,21 @@
-"""Shared fixtures and test data for file writer tests.
-
-Provides MockIssue and MockToolResult dataclasses along with factories
-for creating test data across multiple file writer test modules.
-"""
+"""Shared fixtures and test data for file writer tests."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import pytest
+
+from lintro.models.core.tool_result import ToolResult
+from lintro.parsers.base_issue import BaseIssue
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 
 @dataclass
-class MockIssue:
+class MockIssue(BaseIssue):
     """Mock issue for testing file writer functionality."""
 
     file: str = "src/main.py"
@@ -25,40 +24,19 @@ class MockIssue:
     message: str = "Test error"
 
 
-@dataclass
-class MockToolResult:
-    """Mock tool result for testing file writer functionality."""
-
-    name: str = "test-tool"
-    success: bool = True
-    issues_count: int = 0
-    output: str = ""
-    issues: list[MockIssue] = field(default_factory=list)
-    initial_issues: list[MockIssue] | None = None
-    parse_failures_count: int | None = None
-
-
 @pytest.fixture
-def mock_tool_result_factory() -> Callable[..., MockToolResult]:
-    """Provide a factory for creating MockToolResult instances with custom attributes.
+def mock_tool_result_factory() -> Callable[..., ToolResult]:
+    """Provide a factory for creating ToolResult instances."""
 
-    Returns:
-        Factory function that creates MockToolResult instances.
-    """
-
-    def _create(**kwargs: Any) -> MockToolResult:
-        return MockToolResult(**kwargs)
+    def _create(**kwargs: Any) -> ToolResult:
+        return ToolResult(**kwargs)
 
     return _create
 
 
 @pytest.fixture
 def mock_issue_factory() -> Callable[..., MockIssue]:
-    """Provide a factory for creating MockIssue instances with custom attributes.
-
-    Returns:
-        Factory function that creates MockIssue instances.
-    """
+    """Provide a factory for creating MockIssue instances."""
 
     def _create(**kwargs: Any) -> MockIssue:
         return MockIssue(**kwargs)
@@ -68,18 +46,10 @@ def mock_issue_factory() -> Callable[..., MockIssue]:
 
 @pytest.fixture
 def sample_results_with_issues(
-    mock_tool_result_factory: Callable[..., MockToolResult],
+    mock_tool_result_factory: Callable[..., ToolResult],
     mock_issue_factory: Callable[..., MockIssue],
-) -> list[MockToolResult]:
-    """Provide sample tool results with issues for testing output formats.
-
-    Args:
-        mock_tool_result_factory: Factory for creating mock tool results.
-        mock_issue_factory: Factory for creating mock issues.
-
-    Returns:
-        List containing a single MockToolResult with one issue.
-    """
+) -> list[ToolResult]:
+    """Sample tool results with one issue."""
     return [
         mock_tool_result_factory(
             name="ruff",
@@ -91,14 +61,7 @@ def sample_results_with_issues(
 
 @pytest.fixture
 def sample_results_empty(
-    mock_tool_result_factory: Callable[..., MockToolResult],
-) -> list[MockToolResult]:
-    """Provide sample tool results with no issues for testing output formats.
-
-    Args:
-        mock_tool_result_factory: Factory for creating mock tool results.
-
-    Returns:
-        List containing a single MockToolResult with zero issues.
-    """
+    mock_tool_result_factory: Callable[..., ToolResult],
+) -> list[ToolResult]:
+    """Sample tool results with no issues."""
     return [mock_tool_result_factory(name="ruff", issues_count=0)]

--- a/tests/unit/utils/output/test_file_writer_common.py
+++ b/tests/unit/utils/output/test_file_writer_common.py
@@ -17,12 +17,12 @@ from lintro.utils.output.file_writer import write_output_file
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from .conftest import MockToolResult
+    from lintro.models.core.tool_result import ToolResult
 
 
 def test_write_output_file_creates_parent_directories(
     tmp_path: Path,
-    mock_tool_result_factory: Callable[..., MockToolResult],
+    mock_tool_result_factory: Callable[..., ToolResult],
 ) -> None:
     """Verify parent directories are created when they don't exist.
 
@@ -36,7 +36,7 @@ def test_write_output_file_creates_parent_directories(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.PLAIN,
-        all_results=results,  # type: ignore[arg-type]
+        all_results=results,
         action=Action.CHECK,
         total_issues=0,
         total_fixed=0,

--- a/tests/unit/utils/output/test_file_writer_csv.py
+++ b/tests/unit/utils/output/test_file_writer_csv.py
@@ -15,12 +15,12 @@ from lintro.enums.output_format import OutputFormat
 from lintro.utils.output.file_writer import write_output_file
 
 if TYPE_CHECKING:
-    from .conftest import MockToolResult
+    from lintro.models.core.tool_result import ToolResult
 
 
 def test_write_csv_file_creates_valid_file_with_headers(
     tmp_path: Path,
-    sample_results_empty: list[MockToolResult],
+    sample_results_empty: list[ToolResult],
 ) -> None:
     """Verify CSV file contains proper header row with all required columns.
 
@@ -33,7 +33,7 @@ def test_write_csv_file_creates_valid_file_with_headers(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.CSV,
-        all_results=sample_results_empty,  # type: ignore[arg-type]
+        all_results=sample_results_empty,
         action=Action.CHECK,
         total_issues=0,
         total_fixed=0,
@@ -55,7 +55,7 @@ def test_write_csv_file_creates_valid_file_with_headers(
 
 def test_write_csv_file_includes_issue_data(
     tmp_path: Path,
-    sample_results_with_issues: list[MockToolResult],
+    sample_results_with_issues: list[ToolResult],
 ) -> None:
     """Verify CSV output includes issue details in data rows.
 
@@ -68,7 +68,7 @@ def test_write_csv_file_includes_issue_data(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.CSV,
-        all_results=sample_results_with_issues,  # type: ignore[arg-type]
+        all_results=sample_results_with_issues,
         action=Action.CHECK,
         total_issues=1,
         total_fixed=0,

--- a/tests/unit/utils/output/test_file_writer_html.py
+++ b/tests/unit/utils/output/test_file_writer_html.py
@@ -17,12 +17,14 @@ from lintro.utils.output.file_writer import write_output_file
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from .conftest import MockIssue, MockToolResult
+    from lintro.models.core.tool_result import ToolResult
+
+    from .conftest import MockIssue
 
 
 def test_write_html_file_creates_valid_structure(
     tmp_path: Path,
-    sample_results_empty: list[MockToolResult],
+    sample_results_empty: list[ToolResult],
 ) -> None:
     """Verify HTML file contains proper document structure with headers and tables.
 
@@ -35,7 +37,7 @@ def test_write_html_file_creates_valid_structure(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.HTML,
-        all_results=sample_results_empty,  # type: ignore[arg-type]
+        all_results=sample_results_empty,
         action=Action.CHECK,
         total_issues=0,
         total_fixed=0,
@@ -53,7 +55,7 @@ def test_write_html_file_creates_valid_structure(
 
 def test_write_html_file_includes_issue_table(
     tmp_path: Path,
-    sample_results_with_issues: list[MockToolResult],
+    sample_results_with_issues: list[ToolResult],
 ) -> None:
     """Verify HTML output includes issues in table cells with proper structure.
 
@@ -66,7 +68,7 @@ def test_write_html_file_includes_issue_table(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.HTML,
-        all_results=sample_results_with_issues,  # type: ignore[arg-type]
+        all_results=sample_results_with_issues,
         action=Action.CHECK,
         total_issues=1,
         total_fixed=0,
@@ -82,7 +84,7 @@ def test_write_html_file_includes_issue_table(
 
 def test_write_html_file_escapes_xss_characters(
     tmp_path: Path,
-    mock_tool_result_factory: Callable[..., MockToolResult],
+    mock_tool_result_factory: Callable[..., ToolResult],
     mock_issue_factory: Callable[..., MockIssue],
 ) -> None:
     """Verify HTML special characters are escaped to prevent XSS vulnerabilities.
@@ -104,7 +106,7 @@ def test_write_html_file_escapes_xss_characters(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.HTML,
-        all_results=results,  # type: ignore[arg-type]
+        all_results=results,
         action=Action.CHECK,
         total_issues=1,
         total_fixed=0,
@@ -120,7 +122,7 @@ def test_write_html_file_escapes_xss_characters(
 
 def test_write_html_fix_mode_shows_detected_and_remaining(
     tmp_path: Path,
-    mock_tool_result_factory: Callable[..., MockToolResult],
+    mock_tool_result_factory: Callable[..., ToolResult],
     mock_issue_factory: Callable[..., MockIssue],
 ) -> None:
     """Fix-mode HTML output renders Detected and Remaining tables.
@@ -146,7 +148,7 @@ def test_write_html_fix_mode_shows_detected_and_remaining(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.HTML,
-        all_results=results,  # type: ignore[arg-type]
+        all_results=results,
         action=Action.FIX,
         total_issues=1,
         total_fixed=1,
@@ -161,7 +163,7 @@ def test_write_html_fix_mode_shows_detected_and_remaining(
 
 def test_write_html_fix_mode_all_fixed(
     tmp_path: Path,
-    mock_tool_result_factory: Callable[..., MockToolResult],
+    mock_tool_result_factory: Callable[..., ToolResult],
     mock_issue_factory: Callable[..., MockIssue],
 ) -> None:
     """When all issues were fixed, HTML shows 'All issues were auto-fixed'.
@@ -184,7 +186,7 @@ def test_write_html_fix_mode_all_fixed(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.HTML,
-        all_results=results,  # type: ignore[arg-type]
+        all_results=results,
         action=Action.FIX,
         total_issues=0,
         total_fixed=1,

--- a/tests/unit/utils/output/test_file_writer_json.py
+++ b/tests/unit/utils/output/test_file_writer_json.py
@@ -18,12 +18,14 @@ from lintro.utils.output.file_writer import write_output_file
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from .conftest import MockIssue, MockToolResult
+    from lintro.models.core.tool_result import ToolResult
+
+    from .conftest import MockIssue
 
 
 def test_write_json_file_creates_valid_file(
     tmp_path: Path,
-    mock_tool_result_factory: Callable[..., MockToolResult],
+    mock_tool_result_factory: Callable[..., ToolResult],
 ) -> None:
     """Verify JSON file is created with correct structure and metadata.
 
@@ -46,7 +48,7 @@ def test_write_json_file_creates_valid_file(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.JSON,
-        all_results=results,  # type: ignore[arg-type]
+        all_results=results,
         action=Action.CHECK,
         total_issues=2,
         total_fixed=0,
@@ -67,7 +69,7 @@ def test_write_json_file_creates_valid_file(
 
 def test_write_json_file_omits_parse_failures_count_when_unset(
     tmp_path: Path,
-    mock_tool_result_factory: Callable[..., MockToolResult],
+    mock_tool_result_factory: Callable[..., ToolResult],
 ) -> None:
     """JSON output omits parse_failures_count unless the tool sets it."""
     output_path = tmp_path / "report.json"
@@ -78,7 +80,7 @@ def test_write_json_file_omits_parse_failures_count_when_unset(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.JSON,
-        all_results=results,  # type: ignore[arg-type]
+        all_results=results,
         action=Action.CHECK,
         total_issues=0,
         total_fixed=0,
@@ -90,7 +92,7 @@ def test_write_json_file_omits_parse_failures_count_when_unset(
 
 def test_write_json_file_includes_parsed_issues(
     tmp_path: Path,
-    sample_results_with_issues: list[MockToolResult],
+    sample_results_with_issues: list[ToolResult],
 ) -> None:
     """Verify parsed issues are properly serialized in JSON output with all fields.
 
@@ -105,7 +107,7 @@ def test_write_json_file_includes_parsed_issues(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.JSON,
-        all_results=sample_results_with_issues,  # type: ignore[arg-type]
+        all_results=sample_results_with_issues,
         action=Action.CHECK,
         total_issues=1,
         total_fixed=0,
@@ -123,7 +125,7 @@ def test_write_json_file_includes_parsed_issues(
 
 def test_write_json_file_merges_fix_mode_issues(
     tmp_path: Path,
-    mock_tool_result_factory: Callable[..., MockToolResult],
+    mock_tool_result_factory: Callable[..., ToolResult],
     mock_issue_factory: Callable[..., MockIssue],
 ) -> None:
     """JSON output merges pre-fix and remaining issues with deduplication.
@@ -160,7 +162,7 @@ def test_write_json_file_merges_fix_mode_issues(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.JSON,
-        all_results=results,  # type: ignore[arg-type]
+        all_results=results,
         action=Action.FIX,
         total_issues=1,
         total_fixed=1,

--- a/tests/unit/utils/output/test_file_writer_markdown.py
+++ b/tests/unit/utils/output/test_file_writer_markdown.py
@@ -17,12 +17,14 @@ from lintro.utils.output.file_writer import write_output_file
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from .conftest import MockIssue, MockToolResult
+    from lintro.models.core.tool_result import ToolResult
+
+    from .conftest import MockIssue
 
 
 def test_write_markdown_file_creates_valid_structure(
     tmp_path: Path,
-    sample_results_empty: list[MockToolResult],
+    sample_results_empty: list[ToolResult],
 ) -> None:
     """Verify Markdown file contains proper heading structure and summary table.
 
@@ -35,7 +37,7 @@ def test_write_markdown_file_creates_valid_structure(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.MARKDOWN,
-        all_results=sample_results_empty,  # type: ignore[arg-type]
+        all_results=sample_results_empty,
         action=Action.CHECK,
         total_issues=0,
         total_fixed=0,
@@ -52,7 +54,7 @@ def test_write_markdown_file_creates_valid_structure(
 
 def test_write_markdown_file_includes_issue_table(
     tmp_path: Path,
-    sample_results_with_issues: list[MockToolResult],
+    sample_results_with_issues: list[ToolResult],
 ) -> None:
     """Verify Markdown output includes issues in table format with proper headers.
 
@@ -65,7 +67,7 @@ def test_write_markdown_file_includes_issue_table(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.MARKDOWN,
-        all_results=sample_results_with_issues,  # type: ignore[arg-type]
+        all_results=sample_results_with_issues,
         action=Action.CHECK,
         total_issues=1,
         total_fixed=0,
@@ -82,7 +84,7 @@ def test_write_markdown_file_includes_issue_table(
 
 def test_write_markdown_file_escapes_pipe_characters(
     tmp_path: Path,
-    mock_tool_result_factory: Callable[..., MockToolResult],
+    mock_tool_result_factory: Callable[..., ToolResult],
     mock_issue_factory: Callable[..., MockIssue],
 ) -> None:
     """Verify pipe characters in messages are escaped to preserve table formatting.
@@ -104,7 +106,7 @@ def test_write_markdown_file_escapes_pipe_characters(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.MARKDOWN,
-        all_results=results,  # type: ignore[arg-type]
+        all_results=results,
         action=Action.CHECK,
         total_issues=1,
         total_fixed=0,
@@ -117,7 +119,7 @@ def test_write_markdown_file_escapes_pipe_characters(
 
 def test_write_markdown_fix_mode_shows_detected_and_remaining(
     tmp_path: Path,
-    mock_tool_result_factory: Callable[..., MockToolResult],
+    mock_tool_result_factory: Callable[..., ToolResult],
     mock_issue_factory: Callable[..., MockIssue],
 ) -> None:
     """Fix-mode markdown output renders Detected and Remaining tables.
@@ -143,7 +145,7 @@ def test_write_markdown_fix_mode_shows_detected_and_remaining(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.MARKDOWN,
-        all_results=results,  # type: ignore[arg-type]
+        all_results=results,
         action=Action.FIX,
         total_issues=1,
         total_fixed=1,
@@ -158,7 +160,7 @@ def test_write_markdown_fix_mode_shows_detected_and_remaining(
 
 def test_write_markdown_fix_mode_all_fixed(
     tmp_path: Path,
-    mock_tool_result_factory: Callable[..., MockToolResult],
+    mock_tool_result_factory: Callable[..., ToolResult],
     mock_issue_factory: Callable[..., MockIssue],
 ) -> None:
     """When all issues were fixed, shows 'All issues were auto-fixed'.
@@ -181,7 +183,7 @@ def test_write_markdown_fix_mode_all_fixed(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.MARKDOWN,
-        all_results=results,  # type: ignore[arg-type]
+        all_results=results,
         action=Action.FIX,
         total_issues=0,
         total_fixed=1,

--- a/tests/unit/utils/output/test_file_writer_plain.py
+++ b/tests/unit/utils/output/test_file_writer_plain.py
@@ -17,12 +17,12 @@ from lintro.utils.output.file_writer import write_output_file
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from .conftest import MockToolResult
+    from lintro.models.core.tool_result import ToolResult
 
 
 def test_write_plain_file_creates_valid_structure(
     tmp_path: Path,
-    mock_tool_result_factory: Callable[..., MockToolResult],
+    mock_tool_result_factory: Callable[..., ToolResult],
 ) -> None:
     """Verify plain text file contains report header and summary totals.
 
@@ -36,7 +36,7 @@ def test_write_plain_file_creates_valid_structure(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.PLAIN,
-        all_results=results,  # type: ignore[arg-type]
+        all_results=results,
         action=Action.CHECK,
         total_issues=5,
         total_fixed=0,
@@ -53,7 +53,7 @@ def test_write_plain_file_creates_valid_structure(
 
 def test_write_plain_file_shows_fixed_count_for_fix_action(
     tmp_path: Path,
-    sample_results_empty: list[MockToolResult],
+    sample_results_empty: list[ToolResult],
 ) -> None:
     """Verify fix action report includes 'Total Fixed' instead of just issues.
 
@@ -66,7 +66,7 @@ def test_write_plain_file_shows_fixed_count_for_fix_action(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.PLAIN,
-        all_results=sample_results_empty,  # type: ignore[arg-type]
+        all_results=sample_results_empty,
         action=Action.FIX,
         total_issues=0,
         total_fixed=5,
@@ -80,7 +80,7 @@ def test_write_plain_file_shows_fixed_count_for_fix_action(
 
 def test_write_plain_fix_mode_shows_detected_and_remaining(
     tmp_path: Path,
-    mock_tool_result_factory: Callable[..., MockToolResult],
+    mock_tool_result_factory: Callable[..., ToolResult],
 ) -> None:
     """Fix-mode plain output renders Detected and Remaining tables.
 
@@ -130,7 +130,7 @@ def test_write_plain_fix_mode_shows_detected_and_remaining(
     write_output_file(
         output_path=str(output_path),
         output_format=OutputFormat.PLAIN,
-        all_results=results,  # type: ignore[arg-type]
+        all_results=results,
         action=Action.FIX,
         total_issues=1,
         total_fixed=1,

--- a/tests/unit/utils/test_tool_executor_ai.py
+++ b/tests/unit/utils/test_tool_executor_ai.py
@@ -131,6 +131,7 @@ def test_fix_recomputes_totals_after_ai_changes(monkeypatch, fake_logger):
         execution=ExecutionConfig(parallel=False),
         ai=AIConfig(
             enabled=True,
+            transport="api",  # type: ignore[arg-type]
             auto_apply=True,
         ),
     )

--- a/tests/unit/utils/test_tool_executor_ai.py
+++ b/tests/unit/utils/test_tool_executor_ai.py
@@ -9,6 +9,7 @@ from assertpy import assert_that
 
 import lintro.utils.tool_executor as te
 from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
 from lintro.config.execution_config import ExecutionConfig
 from lintro.config.lintro_config import LintroConfig
 from lintro.enums.action import Action
@@ -131,7 +132,7 @@ def test_fix_recomputes_totals_after_ai_changes(monkeypatch, fake_logger):
         execution=ExecutionConfig(parallel=False),
         ai=AIConfig(
             enabled=True,
-            transport="api",  # type: ignore[arg-type]
+            transport=AITransport.API,
             auto_apply=True,
         ),
     )


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai): unified AI transport foundation
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Unifies AI invocation across check, fix, and review with explicit `ai.transport: api | cli`. Adds shared CLI subprocess transport for Cursor, Claude, and Codex providers plus a central `call_ai()` entry point.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed

## Closes

- Closes #1009

## Details

- **`ai.transport` config**: explicit API vs CLI selection.
- **`CliTransport`**: shared subprocess wrapper; Cursor refactored onto it; Claude (`claude -p`) and Codex (`codex exec`) CLI backends added.
- **`call_ai()`**: unified invocation with retry, fallback, and budget tracking; review orchestration wired in.
- **`lintro doctor`**: transport-aware availability checks.
- Removes unused `cursor-sdk` dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transport-aware AI support (API vs CLI) with transport reflected in configuration and provider wiring.
  * Expanded **doctor** diagnostics to validate AI transport/provider compatibility, binary/SDK availability, and authentication, with richer terminal/JSON output.
  * Added reliable JSON parsing helpers for fenced/invalid AI outputs.
  * Introduced a unified AI invocation entrypoint with optional cost-budget tracking.
* **Bug Fixes**
  * Improved cost-budget enforcement to be lock-safe and consistently raise “budget exceeded” errors.
* **Tests**
  * Updated/added coverage for transport selection, CLI provider flows, invoke/budget behavior, and budget concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a unified AI transport layer (`api` | `cli`) across all providers, wires a shared `CliTransport` subprocess base into Cursor (refactor), Anthropic (`claude -p`), and OpenAI (`codex exec`), and centralises invocation through a new `call_ai()` entrypoint with retry, fallback, and lock-safe budget tracking.

- **`CliTransport` + three provider transports**: shared subprocess runner with timeout, exit-code mapping, and a guarded `substitute_parsed_json` helper; Anthropic and Codex transports are new, Cursor is refactored cleanly onto the base.
- **`call_ai()` + `CostBudget.execute()`**: replaces the old inline `_call_provider` / manual `budget.record()` pattern with a lock-protected execute path that prevents parallel overspend; `use_one_shot` is now set for all providers on multi-chunk reviews.
- **`lintro doctor` transport checks**: new `check_ai_configuration()` produces transport-aware diagnostics; rendered in terminal and JSON output, but the `--report` (markdown) path exits non-zero on AI failures without including the AI check details in the report content.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge with one known gap: `lintro doctor --report` exits non-zero on AI config failures but the markdown output contains no mention of those failures.

The core transport abstraction, budget locking, and `call_ai()` path are well-structured and the many previous review rounds addressed the major correctness issues. The one remaining defect is in `doctor_command`: the `--report` path now exits 1 when AI checks fail but `_generate_markdown_report` is never given the `ai_checks` list, so the report body gives the caller no indication of what went wrong. CI pipelines using `lintro doctor --report` to gate on configuration health would see an unexplained failure.

lintro/cli_utils/commands/doctor.py — the `--report` branch passes `ai_checks` to the exit condition but not to `_generate_markdown_report`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/cli_utils/commands/doctor.py | Adds AI transport checks and rendering; `--report` (markdown) mode exits 1 for AI failures but `_generate_markdown_report` receives no `ai_checks` so the report content never explains the failure. |
| lintro/ai/providers/cli_transport.py | New shared `CliTransport` base with `run()`, `check_exit_code()`, `extract_json_object()`, and the guarded `substitute_parsed_json()` classmethod; well-structured abstraction. |
| lintro/ai/invoke.py | New unified `call_ai()` entrypoint wiring retry, fallback, and budget; logic is clean and correctly threads budget through `execute()` when a ceiling is set. |
| lintro/ai/budget.py | Adds lock-protected `execute()` to prevent parallel overspend; `record()` and `check()` also acquire the lock; implementation is correct. |
| lintro/ai/providers/anthropic.py | Adds CLI transport via `_AnthropicCliTransport`; uses `substitute_parsed_json` correctly; minor: `_complete_cli` accesses `self._cli._binary_path` (protected member) directly. |
| lintro/ai/providers/openai.py | Adds Codex CLI transport via `_CodexCliTransport` with JSONL parsing and single-envelope fallback; `substitute_parsed_json` guarded correctly; accesses `_binary_path` directly. |
| lintro/ai/providers/cursor.py | Refactored onto `CliTransport`; `parse_stdout` duplicates `substitute_parsed_json` logic inline instead of calling the classmethod; otherwise clean delegation. |
| lintro/ai/doctor_checks.py | New transport-aware AI config checks for `lintro doctor`; covers missing transport, cursor+API, CLI binary discovery, and auth heuristics; logic is thorough. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant O as Orchestrator
    participant CI as call_ai()
    participant B as CostBudget
    participant F as complete_with_fallback
    participant P as Provider (API or CLI)

    O->>CI: call_ai(provider, ai_config, budget, ...)
    CI->>CI: wrap _budgeted_call with with_retry()
    CI->>B: budget.execute(_call_once) [if max_cost_usd set]
    activate B
    B->>B: "acquire lock, check _spent >= limit"
    B->>F: _call_once() → complete_with_fallback()
    F->>P: provider.complete(prompt, ...)
    alt "transport == API"
        P-->>F: AIResponse (SDK)
    else "transport == CLI"
        P->>P: CliTransport.run(cmd)
        P->>P: parse_stdout / substitute_parsed_json
        P-->>F: AIResponse (subprocess)
    end
    F-->>B: AIResponse
    B->>B: "_spent += cost_estimate, release lock"
    deactivate B
    B-->>CI: AIResponse
    CI-->>O: AIResponse
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant O as Orchestrator
    participant CI as call_ai()
    participant B as CostBudget
    participant F as complete_with_fallback
    participant P as Provider (API or CLI)

    O->>CI: call_ai(provider, ai_config, budget, ...)
    CI->>CI: wrap _budgeted_call with with_retry()
    CI->>B: budget.execute(_call_once) [if max_cost_usd set]
    activate B
    B->>B: "acquire lock, check _spent >= limit"
    B->>F: _call_once() → complete_with_fallback()
    F->>P: provider.complete(prompt, ...)
    alt "transport == API"
        P-->>F: AIResponse (SDK)
    else "transport == CLI"
        P->>P: CliTransport.run(cmd)
        P->>P: parse_stdout / substitute_parsed_json
        P-->>F: AIResponse (subprocess)
    end
    F-->>B: AIResponse
    B->>B: "_spent += cost_estimate, release lock"
    deactivate B
    B-->>CI: AIResponse
    CI-->>O: AIResponse
```

</a>
</details>

<sub>Reviews (13): Last reviewed commit: ["fix(ai): defer cursor+api validation to ..."](https://github.com/lgtm-hq/py-lintro/commit/85fc29d967b4994d232d79ef31086673d1e02498) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39943079)</sub>

<!-- /greptile_comment -->