### PR TITLE
feat(ai/review): add review orchestrator with depth and chunking

### DIFF
--- a/lintro/ai/model_pricing.py
+++ b/lintro/ai/model_pricing.py
@@ -68,6 +68,10 @@ def calculate_available_diff_tokens(
 
     Returns:
         Remaining token budget for diff content (minimum zero).
+
+    Raises:
+        ValueError: If ``context_window`` is not positive or ``prompt_overhead``
+            is negative.
     """
     if context_window <= 0:
         raise ValueError(f"context_window must be positive, got {context_window}")

--- a/lintro/ai/model_pricing.py
+++ b/lintro/ai/model_pricing.py
@@ -1,12 +1,35 @@
-"""Per-model pricing dataclass.
+"""Per-model pricing dataclass and context window registry.
 
 Defines the :class:`ModelPricing` frozen dataclass used by provider
-metadata to track input/output costs per million tokens.
+metadata to track input/output costs per million tokens, plus context
+window sizes for review token budgeting.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+
+__all__ = [
+    "DEFAULT_CONTEXT_WINDOW",
+    "MODEL_CONTEXT_WINDOWS",
+    "ModelPricing",
+    "calculate_available_diff_tokens",
+    "get_context_window",
+]
+
+DEFAULT_CONTEXT_WINDOW = 128_000
+
+MODEL_CONTEXT_WINDOWS: dict[str, int] = {
+    "claude-sonnet-4-6": 200_000,
+    "claude-sonnet-4-20250514": 200_000,
+    "claude-haiku-4-5-20251001": 200_000,
+    "claude-opus-4-20250514": 200_000,
+    "gpt-4o": 128_000,
+    "gpt-4o-mini": 128_000,
+    "gpt-4-turbo": 128_000,
+    "o1": 200_000,
+    "o1-mini": 128_000,
+}
 
 
 @dataclass(frozen=True)
@@ -15,3 +38,39 @@ class ModelPricing:
 
     input_per_million: float
     output_per_million: float
+
+
+def get_context_window(*, model: str, override: int | None = None) -> int:
+    """Return the context window size for a model.
+
+    Args:
+        model: Model identifier.
+        override: Optional explicit override from CLI/config.
+
+    Returns:
+        Context window size in tokens.
+    """
+    if override is not None and override > 0:
+        return override
+    return MODEL_CONTEXT_WINDOWS.get(model, DEFAULT_CONTEXT_WINDOW)
+
+
+def calculate_available_diff_tokens(
+    *,
+    context_window: int,
+    prompt_overhead: int,
+) -> int:
+    """Calculate token budget available for diff content.
+
+    Args:
+        context_window: Total model context window.
+        prompt_overhead: Estimated tokens for system/user prompt overhead.
+
+    Returns:
+        Remaining token budget for diff content (minimum zero).
+    """
+    if context_window <= 0:
+        raise ValueError(f"context_window must be positive, got {context_window}")
+    if prompt_overhead < 0:
+        raise ValueError(f"prompt_overhead must be non-negative, got {prompt_overhead}")
+    return max(context_window - prompt_overhead, 0)

--- a/lintro/ai/review/models/__init__.py
+++ b/lintro/ai/review/models/__init__.py
@@ -3,19 +3,27 @@
 from __future__ import annotations
 
 from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.checklist_answer import ChecklistAnswer
 from lintro.ai.review.models.checklist_item import ChecklistItem
 from lintro.ai.review.models.chunking_result import ChunkingResult
 from lintro.ai.review.models.file_classification import FileClassification
 from lintro.ai.review.models.pr_metadata import PRMetadata
 from lintro.ai.review.models.review_chunk import ReviewChunk
 from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_metadata import ReviewMetadata
+from lintro.ai.review.models.review_result import ReviewResult
 
 __all__ = [
     "ChangedFile",
+    "ChecklistAnswer",
     "ChecklistItem",
     "ChunkingResult",
     "FileClassification",
     "PRMetadata",
     "ReviewChunk",
     "ReviewContext",
+    "ReviewFinding",
+    "ReviewMetadata",
+    "ReviewResult",
 ]

--- a/lintro/ai/review/models/checklist_answer.py
+++ b/lintro/ai/review/models/checklist_answer.py
@@ -1,0 +1,20 @@
+"""Checklist answer from AI review output."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ChecklistAnswer:
+    """A yes/no answer for a checklist item in a review result.
+
+    Attributes:
+        id: Prompt checklist item id (1..N in the review pass).
+        answer: ``yes`` or ``no``.
+        evidence: Brief file:line or logic trace supporting the answer.
+    """
+
+    id: int
+    answer: str
+    evidence: str

--- a/lintro/ai/review/models/review_finding.py
+++ b/lintro/ai/review/models/review_finding.py
@@ -1,0 +1,34 @@
+"""Review finding from AI diff review."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewFinding:
+    """An actionable finding from AI diff review.
+
+    Attributes:
+        severity: Finding severity (P1, P2, or P3).
+        category: Finding category label.
+        file: Repository-relative file path.
+        line: Line number in the file.
+        title: Short finding title.
+        description: What is wrong and why it matters.
+        cause: Root cause explanation.
+        fix: Concise fix suggestion.
+        confidence: Model confidence (high, medium, low).
+        checklist_ids: Prompt checklist ids linked to this finding.
+    """
+
+    severity: str
+    category: str
+    file: str
+    line: int
+    title: str
+    description: str
+    cause: str
+    fix: str
+    confidence: str
+    checklist_ids: tuple[int, ...] = field(default_factory=tuple)

--- a/lintro/ai/review/models/review_metadata.py
+++ b/lintro/ai/review/models/review_metadata.py
@@ -1,0 +1,42 @@
+"""Review run metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewMetadata:
+    """Metadata describing an AI review run.
+
+    Attributes:
+        model: Model identifier used for the review.
+        provider: Provider name (anthropic, openai, etc.).
+        context_window: Model context window in tokens.
+        depth: Review depth level (1-3).
+        chunks_total: Total semantic chunks processed.
+        chunks_current: Chunks included in this result view.
+        files_reviewed: Number of changed files included in review.
+        files_total: Total changed files in the diff.
+        checklist_items: Number of checklist items in the prompt.
+        token_usage: Aggregated token usage counters.
+        cost_estimate_usd: Estimated cost in USD.
+        base_ref: Base git ref for the diff.
+        head_ref: Head git ref for the diff.
+        timestamp: ISO 8601 UTC timestamp of the review run.
+    """
+
+    model: str
+    provider: str
+    context_window: int
+    depth: int
+    chunks_total: int
+    chunks_current: int
+    files_reviewed: int
+    files_total: int
+    checklist_items: int
+    token_usage: dict[str, int] = field(default_factory=dict)
+    cost_estimate_usd: float = 0.0
+    base_ref: str = ""
+    head_ref: str = ""
+    timestamp: str = ""

--- a/lintro/ai/review/models/review_result.py
+++ b/lintro/ai/review/models/review_result.py
@@ -1,0 +1,31 @@
+"""Complete AI review result."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from lintro.ai.review.models.checklist_answer import ChecklistAnswer
+from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_metadata import ReviewMetadata
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewResult:
+    """Complete result from an AI diff review run.
+
+    Attributes:
+        metadata: Run metadata (model, tokens, cost, etc.).
+        summary: High-level review summary text.
+        checklist: Checklist yes/no answers with evidence.
+        findings: Actionable findings from the review.
+    """
+
+    metadata: ReviewMetadata
+    summary: str
+    checklist: tuple[ChecklistAnswer, ...] = field(default_factory=tuple)
+    findings: tuple[ReviewFinding, ...] = field(default_factory=tuple)
+
+    @property
+    def has_p1_findings(self) -> bool:
+        """Return True when any P1 finding exists."""
+        return any(finding.severity == "P1" for finding in self.findings)

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -26,7 +26,9 @@ from lintro.ai.prompts.review import (
     format_lint_results_section,
 )
 from lintro.ai.review.chunker import chunk_review_context
+from lintro.ai.review.group_labels import REL_DIRECTORY_PREFIX, REL_SINGLE_FILE
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
+from lintro.ai.review.models.review_chunk import ReviewChunk
 from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
@@ -38,7 +40,6 @@ if TYPE_CHECKING:
     from lintro.ai.providers.base import AIResponse, BaseAIProvider
     from lintro.ai.review.models.checklist_item import ChecklistItem
     from lintro.ai.review.models.file_classification import FileClassification
-    from lintro.ai.review.models.review_chunk import ReviewChunk
     from lintro.ai.review.models.review_context import ReviewContext
 
 __all__ = [
@@ -329,8 +330,10 @@ def merge_checklist_answers(
             if existing is None:
                 by_id[answer.id] = answer
                 continue
-            if answer.answer.lower() == "yes" or existing.answer.lower() != "yes":
-                by_id[answer.id] = answer
+            by_id[answer.id] = _pick_preferred_checklist_answer(
+                candidate=answer,
+                existing=existing,
+            )
     return tuple(sorted(by_id.values(), key=lambda item: item.id))
 
 
@@ -355,7 +358,7 @@ def merge_review_results(
         )
 
     summaries = [partial.summary for partial in partials if partial.summary.strip()]
-    summary = summaries[0] if len(summaries) == 1 else "\n\n".join(summaries[:3])
+    summary = summaries[0] if len(summaries) == 1 else "\n\n".join(summaries)
 
     return ReviewResult(
         metadata=_placeholder_metadata(),
@@ -467,6 +470,10 @@ def _generate_extra_checklist(
         logger.warning("Failed to parse generated questions; skipping depth-2 extras")
         return ""
 
+    if not isinstance(payload, dict):
+        logger.warning("Generated questions payload was not an object; skipping extras")
+        return ""
+
     questions = payload.get("generated_questions", [])
     if not isinstance(questions, list):
         return ""
@@ -477,7 +484,7 @@ def _generate_extra_checklist(
             continue
         question = item.get("question")
         if isinstance(question, str) and question.strip():
-            lines.append(f"G{index}. [generated] {question.strip()}")
+            lines.append(f"{-index}. [generated] {question.strip()}")
     return "\n".join(lines)
 
 
@@ -516,6 +523,17 @@ def _run_adversarial_pass(
         payload = json.loads(strip_json_fences(content=response.content))
     except (json.JSONDecodeError, ValueError):
         logger.warning("Failed to parse adversarial sweep response")
+        return _ChunkReviewPartial(
+            summary="",
+            checklist=(),
+            findings=(),
+            input_tokens=response.input_tokens,
+            output_tokens=response.output_tokens,
+            cost_estimate=response.cost_estimate,
+        )
+
+    if not isinstance(payload, dict):
+        logger.warning("Adversarial sweep payload was not an object")
         return _ChunkReviewPartial(
             summary="",
             checklist=(),
@@ -603,8 +621,8 @@ def _parse_checklist(*, raw_checklist: object) -> tuple[ChecklistAnswer, ...]:
         answers.append(
             ChecklistAnswer(
                 id=answer_id,
-                answer=answer.lower(),
-                evidence=evidence,
+                answer=_normalize_checklist_answer_value(answer=answer),
+                evidence=evidence.strip(),
             ),
         )
     return tuple(answers)
@@ -674,13 +692,47 @@ def _estimate_prompt_overhead(
     return max(estimated, _PROMPT_OVERHEAD_TOKENS)
 
 
+def _normalize_checklist_answer_value(*, answer: str) -> str:
+    """Normalize checklist answers to the yes/no contract."""
+    normalized = answer.strip().lower()
+    if normalized not in {"yes", "no"}:
+        return "no"
+    return normalized
+
+
+def _pick_preferred_checklist_answer(
+    *,
+    candidate: ChecklistAnswer,
+    existing: ChecklistAnswer,
+) -> ChecklistAnswer:
+    """Pick the stronger checklist answer when merging chunk results."""
+    candidate_answer = candidate.answer
+    existing_answer = existing.answer
+    candidate_has_evidence = bool(candidate.evidence.strip())
+    existing_has_evidence = bool(existing.evidence.strip())
+
+    if candidate_answer == "yes" and candidate_has_evidence:
+        return candidate
+    if existing_answer == "yes" and existing_has_evidence:
+        return existing
+    if candidate_answer == "yes" and existing_answer == "no" and existing_has_evidence:
+        return existing
+    if candidate_answer == "yes":
+        return candidate
+    if existing_answer == "yes":
+        return existing
+    return candidate
+
+
 def _single_chunk_from_context(*, context: ReviewContext) -> ReviewChunk:
     """Build a single chunk when chunker returns no groups."""
+    files = [file.path for file in context.changed_files]
+    relationship = REL_SINGLE_FILE if len(files) == 1 else REL_DIRECTORY_PREFIX
     return ReviewChunk(
         id=1,
-        files=[file.path for file in context.changed_files],
+        files=files,
         diff=context.unified_diff,
-        relationship="full-diff",
+        relationship=relationship,
     )
 
 

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -700,28 +700,25 @@ def _normalize_checklist_answer_value(*, answer: str) -> str:
     return normalized
 
 
+def _checklist_answer_strength(*, answer: ChecklistAnswer) -> int:
+    """Score checklist answers for merge precedence."""
+    has_evidence = bool(answer.evidence.strip())
+    if answer.answer == "yes":
+        return 4 if has_evidence else 2
+    return 3 if has_evidence else 1
+
+
 def _pick_preferred_checklist_answer(
     *,
     candidate: ChecklistAnswer,
     existing: ChecklistAnswer,
 ) -> ChecklistAnswer:
     """Pick the stronger checklist answer when merging chunk results."""
-    candidate_answer = candidate.answer
-    existing_answer = existing.answer
-    candidate_has_evidence = bool(candidate.evidence.strip())
-    existing_has_evidence = bool(existing.evidence.strip())
-
-    if candidate_answer == "yes" and candidate_has_evidence:
+    candidate_strength = _checklist_answer_strength(answer=candidate)
+    existing_strength = _checklist_answer_strength(answer=existing)
+    if candidate_strength >= existing_strength:
         return candidate
-    if existing_answer == "yes" and existing_has_evidence:
-        return existing
-    if candidate_answer == "yes" and existing_answer == "no" and existing_has_evidence:
-        return existing
-    if candidate_answer == "yes":
-        return candidate
-    if existing_answer == "yes":
-        return existing
-    return candidate
+    return existing
 
 
 def _single_chunk_from_context(*, context: ReviewContext) -> ReviewChunk:

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -1,0 +1,739 @@
+"""Review orchestrator for AI diff-based code review."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from lintro.ai.budget import CostBudget
+from lintro.ai.fallback import complete_with_fallback
+from lintro.ai.model_pricing import (
+    calculate_available_diff_tokens,
+    get_context_window,
+)
+from lintro.ai.prompts.review import (
+    REVIEW_ADVERSARIAL_SWEEP_TEMPLATE,
+    REVIEW_GENERATE_QUESTIONS_TEMPLATE,
+    REVIEW_OUTPUT_SCHEMA,
+    REVIEW_SYSTEM,
+    REVIEW_USER_PROMPT_TEMPLATE,
+    format_changed_files_for_prompt,
+    format_lint_results_section,
+)
+from lintro.ai.review.chunker import chunk_review_context
+from lintro.ai.review.models.checklist_answer import ChecklistAnswer
+from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_metadata import ReviewMetadata
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.paths_registry import generate_interaction_paths
+from lintro.ai.token_budget import estimate_tokens
+
+if TYPE_CHECKING:
+    from lintro.ai.config import AIConfig
+    from lintro.ai.providers.base import BaseAIProvider, AIResponse
+    from lintro.ai.review.models.checklist_item import ChecklistItem
+    from lintro.ai.review.models.file_classification import FileClassification
+    from lintro.ai.review.models.review_chunk import ReviewChunk
+    from lintro.ai.review.models.review_context import ReviewContext
+
+__all__ = [
+    "build_review_prompt",
+    "merge_checklist_answers",
+    "merge_findings",
+    "merge_review_results",
+    "parse_review_response",
+    "run_review",
+    "strip_json_fences",
+]
+
+_JSON_FENCE_PATTERN = re.compile(
+    r"```(?:json)?\s*\n?(.*?)\n?```",
+    re.DOTALL | re.IGNORECASE,
+)
+_PROMPT_OVERHEAD_TOKENS = 12_000
+
+
+@dataclass(frozen=True, slots=True)
+class _ChunkReviewPartial:
+    """Intermediate review result for one chunk."""
+
+    summary: str
+    checklist: tuple[ChecklistAnswer, ...]
+    findings: tuple[ReviewFinding, ...]
+    input_tokens: int
+    output_tokens: int
+    cost_estimate: float
+
+
+def run_review(
+    context: ReviewContext,
+    *,
+    provider: BaseAIProvider,
+    ai_config: AIConfig,
+    depth: int = 1,
+    checklist_items: list[ChecklistItem],
+    checklist_text: str,
+    classifications: list[FileClassification],
+    context_window_override: int | None = None,
+    lint_results: str | None = None,
+) -> ReviewResult:
+    """Execute an AI diff review with depth-controlled passes.
+
+    Args:
+        context: Collected review diff context.
+        provider: Configured AI provider instance.
+        ai_config: AI configuration for retries, budget, and fallbacks.
+        depth: Review depth level (1-3).
+        checklist_items: Selected checklist items for the review.
+        checklist_text: Pre-formatted checklist prompt text.
+        classifications: Domain classifications for changed files.
+        context_window_override: Optional explicit context window override.
+        lint_results: Optional lint digest for ``--with-lint`` integration.
+
+    Returns:
+        Complete review result with metadata, checklist, and findings.
+    """
+    if depth < 1 or depth > 3:
+        raise ValueError(f"depth must be between 1 and 3, got {depth}")
+
+    if not context.changed_files and not context.unified_diff.strip():
+        return _empty_review_result(
+            context=context,
+            provider=provider,
+            depth=depth,
+            checklist_items=checklist_items,
+            context_window_override=context_window_override,
+        )
+
+    context_window = get_context_window(
+        model=provider.model_name,
+        override=context_window_override,
+    )
+    prompt_overhead = _estimate_prompt_overhead(
+        context=context,
+        checklist_text=checklist_text,
+        classifications=classifications,
+        lint_results=lint_results,
+    )
+    diff_budget = calculate_available_diff_tokens(
+        context_window=context_window,
+        prompt_overhead=prompt_overhead,
+    )
+    chunking = chunk_review_context(
+        context=context,
+        max_tokens=max(diff_budget, 1),
+        classifications=classifications,
+    )
+    chunks = chunking.chunks or [
+        _single_chunk_from_context(context=context),
+    ]
+
+    budget = CostBudget(max_cost_usd=ai_config.max_cost_usd)
+    partials: list[_ChunkReviewPartial] = []
+
+    for chunk in chunks:
+        budget.check()
+        partial = _review_chunk(
+            chunk=chunk,
+            context=context,
+            provider=provider,
+            ai_config=ai_config,
+            depth=depth,
+            checklist_text=checklist_text,
+            checklist_count=len(checklist_items),
+            classifications=classifications,
+            lint_results=lint_results,
+            budget=budget,
+        )
+        partials.append(partial)
+
+    merged = merge_review_results(partials=partials)
+    total_input = sum(partial.input_tokens for partial in partials)
+    total_output = sum(partial.output_tokens for partial in partials)
+    total_cost = sum(partial.cost_estimate for partial in partials)
+
+    metadata = ReviewMetadata(
+        model=provider.model_name,
+        provider=provider.name,
+        context_window=context_window,
+        depth=depth,
+        chunks_total=len(chunks),
+        chunks_current=len(chunks),
+        files_reviewed=len(context.changed_files),
+        files_total=len(context.changed_files),
+        checklist_items=len(checklist_items),
+        token_usage={
+            "prompt": total_input,
+            "completion": total_output,
+            "total": total_input + total_output,
+        },
+        cost_estimate_usd=total_cost,
+        base_ref=context.base_ref,
+        head_ref=context.head_ref,
+        timestamp=datetime.now(tz=UTC).isoformat(),
+    )
+
+    return ReviewResult(
+        metadata=metadata,
+        summary=merged.summary,
+        checklist=merged.checklist,
+        findings=merged.findings,
+    )
+
+
+def build_review_prompt(
+    *,
+    chunk: ReviewChunk,
+    context: ReviewContext,
+    checklist_text: str,
+    checklist_count: int,
+    interaction_paths: str,
+    lint_results: str | None = None,
+    extra_checklist: str = "",
+) -> tuple[str, str]:
+    """Build system and user prompts for a review chunk.
+
+    Args:
+        chunk: Semantic diff chunk to review.
+        context: Full review context for PR metadata and file list.
+        checklist_text: Formatted checklist for the prompt.
+        checklist_count: Number of checklist items in the prompt.
+        interaction_paths: Domain-triggered interaction path text.
+        lint_results: Optional lint digest for prompt injection.
+        extra_checklist: Additional generated checklist rows for depth 2.
+
+    Returns:
+        Tuple of (system_prompt, user_prompt).
+    """
+    pr_title = context.pr_metadata.title if context.pr_metadata else "Local changes"
+    pr_summary = context.pr_metadata.body if context.pr_metadata else "(no PR summary)"
+    changed_files = [
+        file
+        for file in context.changed_files
+        if file.path in chunk.files
+    ]
+    combined_checklist = checklist_text
+    if extra_checklist.strip():
+        combined_checklist = f"{checklist_text}\n\n{extra_checklist.strip()}"
+        checklist_count += extra_checklist.strip().count("\n") + (
+            1 if extra_checklist.strip() else 0
+        )
+
+    user_prompt = REVIEW_USER_PROMPT_TEMPLATE.format(
+        pr_title=pr_title,
+        base_ref=context.base_ref,
+        head_ref=context.head_ref,
+        pr_summary=pr_summary,
+        deferred_scope_section="",
+        external_review_section="",
+        changed_file_count=len(changed_files),
+        changed_files=format_changed_files_for_prompt(files=changed_files),
+        interaction_paths=interaction_paths,
+        checklist_count=checklist_count,
+        checklist=combined_checklist,
+        diff=chunk.diff,
+        lint_results_section=format_lint_results_section(digest=lint_results),
+        output_schema=REVIEW_OUTPUT_SCHEMA,
+    )
+    return REVIEW_SYSTEM, user_prompt
+
+
+def strip_json_fences(*, content: str) -> str:
+    """Strip markdown JSON code fences from model output.
+
+    Args:
+        content: Raw model response text.
+
+    Returns:
+        JSON string suitable for ``json.loads``.
+    """
+    stripped = content.strip()
+    match = _JSON_FENCE_PATTERN.search(stripped)
+    if match is not None:
+        return match.group(1).strip()
+    return stripped
+
+
+def parse_review_response(*, content: str) -> dict[str, Any]:
+    """Parse and validate AI review JSON response.
+
+    Args:
+        content: Raw or fenced JSON model response.
+
+    Returns:
+        Parsed review response dictionary.
+
+    Raises:
+        ValueError: When JSON is invalid or missing required keys.
+    """
+    json_text = strip_json_fences(content=content)
+    try:
+        payload = json.loads(json_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid review JSON: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError("Review response must be a JSON object")
+
+    for key in ("summary", "checklist", "findings"):
+        if key not in payload:
+            raise ValueError(f"Review response missing required key: {key}")
+
+    return payload
+
+
+def merge_findings(
+    *,
+    findings_groups: list[tuple[ReviewFinding, ...]],
+) -> tuple[ReviewFinding, ...]:
+    """Merge findings from multiple chunks, deduplicating by location.
+
+    Args:
+        findings_groups: Finding tuples from each chunk/pass.
+
+    Returns:
+        Deduplicated findings preserving first-seen order.
+    """
+    merged: list[ReviewFinding] = []
+    seen: set[tuple[str, int, str]] = set()
+    for group in findings_groups:
+        for finding in group:
+            key = (finding.file, finding.line, finding.title)
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(finding)
+    return tuple(merged)
+
+
+def merge_checklist_answers(
+    *,
+    checklist_groups: list[tuple[ChecklistAnswer, ...]],
+) -> tuple[ChecklistAnswer, ...]:
+    """Merge checklist answers with yes winning over no.
+
+    Args:
+        checklist_groups: Checklist answer tuples from each chunk/pass.
+
+    Returns:
+        Merged checklist answers keyed by checklist id.
+    """
+    by_id: dict[int, ChecklistAnswer] = {}
+    for group in checklist_groups:
+        for answer in group:
+            existing = by_id.get(answer.id)
+            if existing is None:
+                by_id[answer.id] = answer
+                continue
+            if answer.answer.lower() == "yes":
+                by_id[answer.id] = answer
+            elif existing.answer.lower() != "yes":
+                by_id[answer.id] = answer
+    return tuple(sorted(by_id.values(), key=lambda item: item.id))
+
+
+def merge_review_results(
+    *,
+    partials: list[_ChunkReviewPartial],
+) -> ReviewResult:
+    """Merge partial chunk results into a single review result shell.
+
+    Args:
+        partials: Partial results from each chunk.
+
+    Returns:
+        Review result without metadata (caller attaches metadata).
+    """
+    if not partials:
+        return ReviewResult(
+            metadata=_placeholder_metadata(),
+            summary="No review output.",
+            checklist=(),
+            findings=(),
+        )
+
+    summaries = [partial.summary for partial in partials if partial.summary.strip()]
+    summary = summaries[0] if len(summaries) == 1 else " ".join(summaries[:3])
+
+    return ReviewResult(
+        metadata=_placeholder_metadata(),
+        summary=summary,
+        checklist=merge_checklist_answers(
+            checklist_groups=[partial.checklist for partial in partials],
+        ),
+        findings=merge_findings(
+            findings_groups=[partial.findings for partial in partials],
+        ),
+    )
+
+
+def _review_chunk(
+    *,
+    chunk: ReviewChunk,
+    context: ReviewContext,
+    provider: BaseAIProvider,
+    ai_config: AIConfig,
+    depth: int,
+    checklist_text: str,
+    checklist_count: int,
+    classifications: list[FileClassification],
+    lint_results: str | None,
+    budget: CostBudget,
+) -> _ChunkReviewPartial:
+    """Run depth-controlled review for a single chunk."""
+    interaction_paths = generate_interaction_paths(
+        classifications=classifications,
+        changed_files=chunk.files,
+    )
+    extra_checklist = ""
+    if depth >= 2:
+        extra_checklist = _generate_extra_checklist(
+            chunk=chunk,
+            context=context,
+            provider=provider,
+            ai_config=ai_config,
+            budget=budget,
+        )
+
+    system_prompt, user_prompt = build_review_prompt(
+        chunk=chunk,
+        context=context,
+        checklist_text=checklist_text,
+        checklist_count=checklist_count,
+        interaction_paths=interaction_paths,
+        lint_results=lint_results,
+        extra_checklist=extra_checklist,
+    )
+    response = _call_provider(
+        provider=provider,
+        ai_config=ai_config,
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        budget=budget,
+    )
+    payload = parse_review_response(content=response.content)
+    partial = _payload_to_partial(response=response, payload=payload)
+
+    if depth >= 3:
+        adversarial = _run_adversarial_pass(
+            chunk=chunk,
+            provider=provider,
+            ai_config=ai_config,
+            prior_findings=partial.findings,
+            budget=budget,
+        )
+        partial = replace(
+            partial,
+            findings=merge_findings(
+                findings_groups=[partial.findings, adversarial.findings],
+            ),
+            input_tokens=partial.input_tokens + adversarial.input_tokens,
+            output_tokens=partial.output_tokens + adversarial.output_tokens,
+            cost_estimate=partial.cost_estimate + adversarial.cost_estimate,
+        )
+
+    return partial
+
+
+def _generate_extra_checklist(
+    *,
+    chunk: ReviewChunk,
+    context: ReviewContext,
+    provider: BaseAIProvider,
+    ai_config: AIConfig,
+    budget: CostBudget,
+) -> str:
+    """Generate depth-2 domain-specific checklist questions."""
+    changed_files = format_changed_files_for_prompt(
+        files=[file for file in context.changed_files if file.path in chunk.files],
+    )
+    prompt = REVIEW_GENERATE_QUESTIONS_TEMPLATE.format(
+        diff=chunk.diff,
+        changed_files=changed_files,
+    )
+    response = _call_provider(
+        provider=provider,
+        ai_config=ai_config,
+        system_prompt="You generate review checklist questions.",
+        user_prompt=prompt,
+        budget=budget,
+        max_tokens=1024,
+    )
+    try:
+        payload = json.loads(strip_json_fences(content=response.content))
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("Failed to parse generated questions; skipping depth-2 extras")
+        return ""
+
+    questions = payload.get("generated_questions", [])
+    if not isinstance(questions, list):
+        return ""
+
+    lines: list[str] = []
+    for index, item in enumerate(questions, start=1):
+        if not isinstance(item, dict):
+            continue
+        question = item.get("question")
+        if isinstance(question, str) and question.strip():
+            lines.append(f"G{index}. [generated] {question.strip()}")
+    return "\n".join(lines)
+
+
+def _run_adversarial_pass(
+    *,
+    chunk: ReviewChunk,
+    provider: BaseAIProvider,
+    ai_config: AIConfig,
+    prior_findings: tuple[ReviewFinding, ...],
+    budget: CostBudget,
+) -> _ChunkReviewPartial:
+    """Run depth-3 adversarial sweep for missed findings."""
+    prior_json = json.dumps(
+        [
+            {
+                "severity": finding.severity,
+                "file": finding.file,
+                "line": finding.line,
+                "title": finding.title,
+            }
+            for finding in prior_findings
+        ],
+    )
+    prompt = REVIEW_ADVERSARIAL_SWEEP_TEMPLATE.format(
+        prior_findings_json=prior_json,
+        diff=chunk.diff,
+    )
+    response = _call_provider(
+        provider=provider,
+        ai_config=ai_config,
+        system_prompt=REVIEW_SYSTEM,
+        user_prompt=prompt,
+        budget=budget,
+    )
+    try:
+        payload = json.loads(strip_json_fences(content=response.content))
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("Failed to parse adversarial sweep response")
+        return _ChunkReviewPartial(
+            summary="",
+            checklist=(),
+            findings=(),
+            input_tokens=response.input_tokens,
+            output_tokens=response.output_tokens,
+            cost_estimate=response.cost_estimate,
+        )
+
+    findings_raw = payload.get("findings", [])
+    findings = _parse_findings(raw_findings=findings_raw)
+    return _ChunkReviewPartial(
+        summary="",
+        checklist=(),
+        findings=findings,
+        input_tokens=response.input_tokens,
+        output_tokens=response.output_tokens,
+        cost_estimate=response.cost_estimate,
+    )
+
+
+def _call_provider(
+    *,
+    provider: BaseAIProvider,
+    ai_config: AIConfig,
+    system_prompt: str,
+    user_prompt: str,
+    budget: CostBudget,
+    max_tokens: int | None = None,
+) -> AIResponse:
+    """Call the AI provider with retry/fallback and budget tracking."""
+    tokens = max_tokens if max_tokens is not None else ai_config.max_tokens
+    response = complete_with_fallback(
+        provider,
+        user_prompt,
+        fallback_models=list(ai_config.fallback_models),
+        system=system_prompt,
+        max_tokens=tokens,
+        timeout=ai_config.api_timeout,
+    )
+    budget.record(response.cost_estimate)
+    return response
+
+
+def _payload_to_partial(
+    *,
+    response: AIResponse,
+    payload: dict[str, Any],
+) -> _ChunkReviewPartial:
+    """Convert parsed JSON payload to a chunk partial result."""
+    summary = payload.get("summary", "")
+    if not isinstance(summary, str):
+        summary = str(summary)
+
+    checklist = _parse_checklist(raw_checklist=payload.get("checklist", []))
+    findings = _parse_findings(raw_findings=payload.get("findings", []))
+
+    return _ChunkReviewPartial(
+        summary=summary,
+        checklist=checklist,
+        findings=findings,
+        input_tokens=response.input_tokens,
+        output_tokens=response.output_tokens,
+        cost_estimate=response.cost_estimate,
+    )
+
+
+def _parse_checklist(*, raw_checklist: object) -> tuple[ChecklistAnswer, ...]:
+    """Parse checklist answers from AI JSON."""
+    if not isinstance(raw_checklist, list):
+        return ()
+    answers: list[ChecklistAnswer] = []
+    for item in raw_checklist:
+        if not isinstance(item, dict):
+            continue
+        answer_id = item.get("id")
+        answer = item.get("answer", "no")
+        evidence = item.get("evidence", "")
+        if not isinstance(answer_id, int):
+            continue
+        if not isinstance(answer, str):
+            answer = str(answer)
+        if not isinstance(evidence, str):
+            evidence = str(evidence)
+        answers.append(
+            ChecklistAnswer(
+                id=answer_id,
+                answer=answer.lower(),
+                evidence=evidence,
+            ),
+        )
+    return tuple(answers)
+
+
+def _parse_findings(*, raw_findings: object) -> tuple[ReviewFinding, ...]:
+    """Parse findings from AI JSON."""
+    if not isinstance(raw_findings, list):
+        return ()
+    findings: list[ReviewFinding] = []
+    for item in raw_findings:
+        if not isinstance(item, dict):
+            continue
+        line = item.get("line", 0)
+        if not isinstance(line, int):
+            try:
+                line = int(line)
+            except (TypeError, ValueError):
+                line = 0
+        checklist_ids_raw = item.get("checklist_ids", [])
+        checklist_ids: tuple[int, ...] = ()
+        if isinstance(checklist_ids_raw, list):
+            checklist_ids = tuple(
+                checklist_id
+                for checklist_id in checklist_ids_raw
+                if isinstance(checklist_id, int)
+            )
+        findings.append(
+            ReviewFinding(
+                severity=str(item.get("severity", "P3")),
+                category=str(item.get("category", "logic-bug")),
+                file=str(item.get("file", "")),
+                line=line,
+                title=str(item.get("title", "")),
+                description=str(item.get("description", "")),
+                cause=str(item.get("cause", "")),
+                fix=str(item.get("fix", "")),
+                confidence=str(item.get("confidence", "medium")),
+                checklist_ids=checklist_ids,
+            ),
+        )
+    return tuple(findings)
+
+
+def _estimate_prompt_overhead(
+    *,
+    context: ReviewContext,
+    checklist_text: str,
+    classifications: list[FileClassification],
+    lint_results: str | None,
+) -> int:
+    """Estimate non-diff prompt token overhead."""
+    paths = generate_interaction_paths(
+        classifications=classifications,
+        changed_files=[file.path for file in context.changed_files],
+    )
+    overhead_text = "\n".join(
+        [
+            REVIEW_SYSTEM,
+            checklist_text,
+            paths,
+            context.pr_metadata.body if context.pr_metadata else "",
+            lint_results or "",
+        ],
+    )
+    estimated = estimate_tokens(overhead_text)
+    return max(estimated, _PROMPT_OVERHEAD_TOKENS)
+
+
+def _single_chunk_from_context(*, context: ReviewContext) -> ReviewChunk:
+    """Build a single chunk when chunker returns no groups."""
+    return ReviewChunk(
+        id=1,
+        files=[file.path for file in context.changed_files],
+        diff=context.unified_diff,
+        relationship="full-diff",
+    )
+
+
+def _empty_review_result(
+    *,
+    context: ReviewContext,
+    provider: BaseAIProvider,
+    depth: int,
+    checklist_items: list[ChecklistItem],
+    context_window_override: int | None,
+) -> ReviewResult:
+    """Return an empty result when no changes are present."""
+    context_window = get_context_window(
+        model=provider.model_name,
+        override=context_window_override,
+    )
+    metadata = ReviewMetadata(
+        model=provider.model_name,
+        provider=provider.name,
+        context_window=context_window,
+        depth=depth,
+        chunks_total=0,
+        chunks_current=0,
+        files_reviewed=0,
+        files_total=0,
+        checklist_items=len(checklist_items),
+        token_usage={"prompt": 0, "completion": 0, "total": 0},
+        cost_estimate_usd=0.0,
+        base_ref=context.base_ref,
+        head_ref=context.head_ref,
+        timestamp=datetime.now(tz=UTC).isoformat(),
+    )
+    return ReviewResult(
+        metadata=metadata,
+        summary="No changes found to review.",
+        checklist=(),
+        findings=(),
+    )
+
+
+def _placeholder_metadata() -> ReviewMetadata:
+    """Return placeholder metadata for merge-only results."""
+    return ReviewMetadata(
+        model="",
+        provider="",
+        context_window=0,
+        depth=0,
+        chunks_total=0,
+        chunks_current=0,
+        files_reviewed=0,
+        files_total=0,
+        checklist_items=0,
+    )

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -35,7 +35,7 @@ from lintro.ai.token_budget import estimate_tokens
 
 if TYPE_CHECKING:
     from lintro.ai.config import AIConfig
-    from lintro.ai.providers.base import BaseAIProvider, AIResponse
+    from lintro.ai.providers.base import AIResponse, BaseAIProvider
     from lintro.ai.review.models.checklist_item import ChecklistItem
     from lintro.ai.review.models.file_classification import FileClassification
     from lintro.ai.review.models.review_chunk import ReviewChunk
@@ -212,11 +212,7 @@ def build_review_prompt(
     """
     pr_title = context.pr_metadata.title if context.pr_metadata else "Local changes"
     pr_summary = context.pr_metadata.body if context.pr_metadata else "(no PR summary)"
-    changed_files = [
-        file
-        for file in context.changed_files
-        if file.path in chunk.files
-    ]
+    changed_files = [file for file in context.changed_files if file.path in chunk.files]
     combined_checklist = checklist_text
     if extra_checklist.strip():
         combined_checklist = f"{checklist_text}\n\n{extra_checklist.strip()}"
@@ -330,9 +326,7 @@ def merge_checklist_answers(
             if existing is None:
                 by_id[answer.id] = answer
                 continue
-            if answer.answer.lower() == "yes":
-                by_id[answer.id] = answer
-            elif existing.answer.lower() != "yes":
+            if answer.answer.lower() == "yes" or existing.answer.lower() != "yes":
                 by_id[answer.id] = answer
     return tuple(sorted(by_id.values(), key=lambda item: item.id))
 

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -352,7 +352,7 @@ def merge_review_results(
         )
 
     summaries = [partial.summary for partial in partials if partial.summary.strip()]
-    summary = summaries[0] if len(summaries) == 1 else " ".join(summaries[:3])
+    summary = summaries[0] if len(summaries) == 1 else "\n\n".join(summaries[:3])
 
     return ReviewResult(
         metadata=_placeholder_metadata(),

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -97,6 +97,9 @@ def run_review(
 
     Returns:
         Complete review result with metadata, checklist, and findings.
+
+    Raises:
+        ValueError: If ``depth`` is outside the allowed range 1-3.
     """
     if depth < 1 or depth > 3:
         raise ValueError(f"depth must be between 1 and 3, got {depth}")

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -150,6 +150,9 @@ def run_review(
             depth=depth,
             checklist_text=checklist_text,
             checklist_count=len(checklist_items),
+            generated_checklist_base_id=_max_checklist_id(
+                checklist_items=checklist_items,
+            ),
             classifications=classifications,
             lint_results=lint_results,
             budget=budget,
@@ -381,6 +384,7 @@ def _review_chunk(
     depth: int,
     checklist_text: str,
     checklist_count: int,
+    generated_checklist_base_id: int,
     classifications: list[FileClassification],
     lint_results: str | None,
     budget: CostBudget,
@@ -398,6 +402,7 @@ def _review_chunk(
             provider=provider,
             ai_config=ai_config,
             budget=budget,
+            generated_checklist_base_id=generated_checklist_base_id,
         )
 
     system_prompt, user_prompt = build_review_prompt(
@@ -447,6 +452,7 @@ def _generate_extra_checklist(
     provider: BaseAIProvider,
     ai_config: AIConfig,
     budget: CostBudget,
+    generated_checklist_base_id: int,
 ) -> str:
     """Generate depth-2 domain-specific checklist questions."""
     changed_files = format_changed_files_for_prompt(
@@ -484,7 +490,8 @@ def _generate_extra_checklist(
             continue
         question = item.get("question")
         if isinstance(question, str) and question.strip():
-            lines.append(f"{-index}. [generated] {question.strip()}")
+            generated_id = generated_checklist_base_id + index
+            lines.append(f"{generated_id}. [generated] {question.strip()}")
     return "\n".join(lines)
 
 
@@ -689,7 +696,14 @@ def _estimate_prompt_overhead(
         ],
     )
     estimated = estimate_tokens(overhead_text)
-    return max(estimated, _PROMPT_OVERHEAD_TOKENS)
+    return int(max(estimated, _PROMPT_OVERHEAD_TOKENS))
+
+
+def _max_checklist_id(*, checklist_items: list[ChecklistItem]) -> int:
+    """Return the highest checklist item id in the selected set."""
+    if not checklist_items:
+        return 0
+    return int(max(item.id for item in checklist_items))
 
 
 def _normalize_checklist_answer_value(*, answer: str) -> str:

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -623,13 +623,17 @@ def _parse_checklist(*, raw_checklist: object) -> tuple[ChecklistAnswer, ...]:
             continue
         answer_id = item.get("id")
         answer = item.get("answer", "no")
-        evidence = item.get("evidence", "")
+        evidence_raw = item.get("evidence", "")
         if not isinstance(answer_id, int):
             continue
         if not isinstance(answer, str):
             answer = str(answer)
-        if not isinstance(evidence, str):
-            evidence = str(evidence)
+        if evidence_raw is None:
+            evidence = ""
+        elif isinstance(evidence_raw, str):
+            evidence = evidence_raw
+        else:
+            evidence = str(evidence_raw)
         answers.append(
             ChecklistAnswer(
                 id=answer_id,

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -139,10 +139,16 @@ def run_review(
 
     budget = CostBudget(max_cost_usd=ai_config.max_cost_usd)
     partials: list[_ChunkReviewPartial] = []
+    next_generated_checklist_id = (
+        _max_checklist_id(
+            checklist_items=checklist_items,
+        )
+        + 1
+    )
 
     for chunk in chunks:
         budget.check()
-        partial = _review_chunk(
+        partial, next_generated_checklist_id = _review_chunk(
             chunk=chunk,
             context=context,
             provider=provider,
@@ -150,9 +156,7 @@ def run_review(
             depth=depth,
             checklist_text=checklist_text,
             checklist_count=len(checklist_items),
-            generated_checklist_base_id=_max_checklist_id(
-                checklist_items=checklist_items,
-            ),
+            next_generated_checklist_id=next_generated_checklist_id,
             classifications=classifications,
             lint_results=lint_results,
             budget=budget,
@@ -384,11 +388,11 @@ def _review_chunk(
     depth: int,
     checklist_text: str,
     checklist_count: int,
-    generated_checklist_base_id: int,
+    next_generated_checklist_id: int,
     classifications: list[FileClassification],
     lint_results: str | None,
     budget: CostBudget,
-) -> _ChunkReviewPartial:
+) -> tuple[_ChunkReviewPartial, int]:
     """Run depth-controlled review for a single chunk."""
     interaction_paths = generate_interaction_paths(
         classifications=classifications,
@@ -396,13 +400,13 @@ def _review_chunk(
     )
     extra_checklist = ""
     if depth >= 2:
-        extra_checklist = _generate_extra_checklist(
+        extra_checklist, next_generated_checklist_id = _generate_extra_checklist(
             chunk=chunk,
             context=context,
             provider=provider,
             ai_config=ai_config,
             budget=budget,
-            generated_checklist_base_id=generated_checklist_base_id,
+            next_generated_checklist_id=next_generated_checklist_id,
         )
 
     system_prompt, user_prompt = build_review_prompt(
@@ -442,7 +446,7 @@ def _review_chunk(
             cost_estimate=partial.cost_estimate + adversarial.cost_estimate,
         )
 
-    return partial
+    return partial, next_generated_checklist_id
 
 
 def _generate_extra_checklist(
@@ -452,8 +456,8 @@ def _generate_extra_checklist(
     provider: BaseAIProvider,
     ai_config: AIConfig,
     budget: CostBudget,
-    generated_checklist_base_id: int,
-) -> str:
+    next_generated_checklist_id: int,
+) -> tuple[str, int]:
     """Generate depth-2 domain-specific checklist questions."""
     changed_files = format_changed_files_for_prompt(
         files=[file for file in context.changed_files if file.path in chunk.files],
@@ -474,25 +478,26 @@ def _generate_extra_checklist(
         payload = json.loads(strip_json_fences(content=response.content))
     except (json.JSONDecodeError, ValueError):
         logger.warning("Failed to parse generated questions; skipping depth-2 extras")
-        return ""
+        return "", next_generated_checklist_id
 
     if not isinstance(payload, dict):
         logger.warning("Generated questions payload was not an object; skipping extras")
-        return ""
+        return "", next_generated_checklist_id
 
     questions = payload.get("generated_questions", [])
     if not isinstance(questions, list):
-        return ""
+        return "", next_generated_checklist_id
 
     lines: list[str] = []
-    for index, item in enumerate(questions, start=1):
+    next_id = next_generated_checklist_id
+    for item in questions:
         if not isinstance(item, dict):
             continue
         question = item.get("question")
         if isinstance(question, str) and question.strip():
-            generated_id = generated_checklist_base_id + index
-            lines.append(f"{generated_id}. [generated] {question.strip()}")
-    return "\n".join(lines)
+            lines.append(f"{next_id}. [generated] {question.strip()}")
+            next_id += 1
+    return "\n".join(lines), next_id
 
 
 def _run_adversarial_pass(

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -399,8 +399,13 @@ def _review_chunk(
         changed_files=chunk.files,
     )
     extra_checklist = ""
+    extra_checklist_usage: _ChunkReviewPartial | None = None
     if depth >= 2:
-        extra_checklist, next_generated_checklist_id = _generate_extra_checklist(
+        (
+            extra_checklist,
+            next_generated_checklist_id,
+            extra_checklist_usage,
+        ) = _generate_extra_checklist(
             chunk=chunk,
             context=context,
             provider=provider,
@@ -427,6 +432,14 @@ def _review_chunk(
     )
     payload = parse_review_response(content=response.content)
     partial = _payload_to_partial(response=response, payload=payload)
+
+    if extra_checklist_usage is not None:
+        partial = replace(
+            partial,
+            input_tokens=partial.input_tokens + extra_checklist_usage.input_tokens,
+            output_tokens=partial.output_tokens + extra_checklist_usage.output_tokens,
+            cost_estimate=partial.cost_estimate + extra_checklist_usage.cost_estimate,
+        )
 
     if depth >= 3:
         adversarial = _run_adversarial_pass(
@@ -457,7 +470,7 @@ def _generate_extra_checklist(
     ai_config: AIConfig,
     budget: CostBudget,
     next_generated_checklist_id: int,
-) -> tuple[str, int]:
+) -> tuple[str, int, _ChunkReviewPartial]:
     """Generate depth-2 domain-specific checklist questions."""
     changed_files = format_changed_files_for_prompt(
         files=[file for file in context.changed_files if file.path in chunk.files],
@@ -474,19 +487,27 @@ def _generate_extra_checklist(
         budget=budget,
         max_tokens=1024,
     )
+    usage = _ChunkReviewPartial(
+        summary="",
+        checklist=(),
+        findings=(),
+        input_tokens=response.input_tokens,
+        output_tokens=response.output_tokens,
+        cost_estimate=response.cost_estimate,
+    )
     try:
         payload = json.loads(strip_json_fences(content=response.content))
     except (json.JSONDecodeError, ValueError):
         logger.warning("Failed to parse generated questions; skipping depth-2 extras")
-        return "", next_generated_checklist_id
+        return "", next_generated_checklist_id, usage
 
     if not isinstance(payload, dict):
         logger.warning("Generated questions payload was not an object; skipping extras")
-        return "", next_generated_checklist_id
+        return "", next_generated_checklist_id, usage
 
     questions = payload.get("generated_questions", [])
     if not isinstance(questions, list):
-        return "", next_generated_checklist_id
+        return "", next_generated_checklist_id, usage
 
     lines: list[str] = []
     next_id = next_generated_checklist_id
@@ -497,7 +518,7 @@ def _generate_extra_checklist(
         if isinstance(question, str) and question.strip():
             lines.append(f"{next_id}. [generated] {question.strip()}")
             next_id += 1
-    return "\n".join(lines), next_id
+    return "\n".join(lines), next_id, usage
 
 
 def _run_adversarial_pass(

--- a/tests/unit/ai/review/test_merge.py
+++ b/tests/unit/ai/review/test_merge.py
@@ -56,3 +56,17 @@ def test_merge_checklist_answers_requires_evidence_for_yes() -> None:
     assert_that(merged).is_length(1)
     assert_that(merged[0].answer).is_equal_to("no")
     assert_that(merged[0].evidence).contains("src/main.py")
+
+
+def test_merge_checklist_answers_keeps_evidence_backed_no() -> None:
+    """Evidence-backed no answers beat unsupported yes regardless of order."""
+    unsupported_yes = ChecklistAnswer(id=1, answer="yes", evidence="")
+    supported_no = ChecklistAnswer(id=1, answer="no", evidence="src/main.py:10")
+
+    merged = merge_checklist_answers(
+        checklist_groups=[(unsupported_yes,), (supported_no,)],
+    )
+
+    assert_that(merged).is_length(1)
+    assert_that(merged[0].answer).is_equal_to("no")
+    assert_that(merged[0].evidence).contains("src/main.py")

--- a/tests/unit/ai/review/test_merge.py
+++ b/tests/unit/ai/review/test_merge.py
@@ -6,7 +6,11 @@ from assertpy import assert_that
 
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
 from lintro.ai.review.models.review_finding import ReviewFinding
-from lintro.ai.review.orchestrator import merge_checklist_answers, merge_findings
+from lintro.ai.review.orchestrator import (
+    _parse_checklist,
+    merge_checklist_answers,
+    merge_findings,
+)
 
 
 def test_merge_findings_deduplicates_by_file_line_title() -> None:
@@ -70,3 +74,28 @@ def test_merge_checklist_answers_keeps_evidence_backed_no() -> None:
     assert_that(merged).is_length(1)
     assert_that(merged[0].answer).is_equal_to("no")
     assert_that(merged[0].evidence).contains("src/main.py")
+
+
+def test_parse_checklist_treats_null_evidence_as_empty() -> None:
+    """JSON null evidence must not become the literal string 'None'."""
+    answers = _parse_checklist(
+        raw_checklist=[{"id": 1, "answer": "yes", "evidence": None}],
+    )
+
+    assert_that(answers).is_length(1)
+    assert_that(answers[0].evidence).is_empty()
+
+
+def test_merge_checklist_answers_rejects_null_evidence_yes() -> None:
+    """Null-evidence yes answers parsed from JSON do not beat evidence-backed no."""
+    null_evidence_yes = _parse_checklist(
+        raw_checklist=[{"id": 1, "answer": "yes", "evidence": None}],
+    )[0]
+    supported_no = ChecklistAnswer(id=1, answer="no", evidence="src/main.py:10")
+
+    merged = merge_checklist_answers(
+        checklist_groups=[(supported_no,), (null_evidence_yes,)],
+    )
+
+    assert_that(merged).is_length(1)
+    assert_that(merged[0].answer).is_equal_to("no")

--- a/tests/unit/ai/review/test_merge.py
+++ b/tests/unit/ai/review/test_merge.py
@@ -1,0 +1,44 @@
+"""Tests for review result merge helpers."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.ai.review.models.checklist_answer import ChecklistAnswer
+from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.orchestrator import merge_checklist_answers, merge_findings
+
+
+def test_merge_findings_deduplicates_by_file_line_title() -> None:
+    """Duplicate findings with same file, line, and title are merged once."""
+    finding = ReviewFinding(
+        severity="P2",
+        category="logic-bug",
+        file="src/main.py",
+        line=10,
+        title="Duplicate title",
+        description="desc",
+        cause="cause",
+        fix="fix",
+        confidence="high",
+        checklist_ids=(1,),
+    )
+    merged = merge_findings(
+        findings_groups=[(finding,), (finding,)],
+    )
+
+    assert_that(merged).is_length(1)
+
+
+def test_merge_checklist_answers_prefers_yes_over_no() -> None:
+    """Checklist merge keeps yes answers when conflicting answers exist."""
+    no_answer = ChecklistAnswer(id=1, answer="no", evidence="none")
+    yes_answer = ChecklistAnswer(id=1, answer="yes", evidence="src/main.py:10")
+
+    merged = merge_checklist_answers(
+        checklist_groups=[(no_answer,), (yes_answer,)],
+    )
+
+    assert_that(merged).is_length(1)
+    assert_that(merged[0].answer).is_equal_to("yes")
+    assert_that(merged[0].evidence).contains("src/main.py")

--- a/tests/unit/ai/review/test_merge.py
+++ b/tests/unit/ai/review/test_merge.py
@@ -42,3 +42,17 @@ def test_merge_checklist_answers_prefers_yes_over_no() -> None:
     assert_that(merged).is_length(1)
     assert_that(merged[0].answer).is_equal_to("yes")
     assert_that(merged[0].evidence).contains("src/main.py")
+
+
+def test_merge_checklist_answers_requires_evidence_for_yes() -> None:
+    """Unsupported yes answers do not override evidence-backed no answers."""
+    supported_no = ChecklistAnswer(id=1, answer="no", evidence="src/main.py:10")
+    unsupported_yes = ChecklistAnswer(id=1, answer="yes", evidence="")
+
+    merged = merge_checklist_answers(
+        checklist_groups=[(supported_no,), (unsupported_yes,)],
+    )
+
+    assert_that(merged).is_length(1)
+    assert_that(merged[0].answer).is_equal_to("no")
+    assert_that(merged[0].evidence).contains("src/main.py")

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -9,10 +9,10 @@ from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
 from lintro.ai.providers.response import AIResponse
+from lintro.ai.review.enums.review_category import ReviewCategory
 from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.checklist_item import ChecklistItem
 from lintro.ai.review.models.review_context import ReviewContext
-from lintro.ai.review.enums.review_category import ReviewCategory
 from lintro.ai.review.orchestrator import (
     parse_review_response,
     run_review,

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -98,7 +98,8 @@ def test_run_review_depth1_returns_review_result() -> None:
         ChecklistItem(
             id=1,
             question="Example?",
-            triggers=[],
+            domains=(),
+            languages=(),
             category=ReviewCategory.LOGIC_BUG,
             tier=1,
         ),

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -1,0 +1,214 @@
+"""Tests for review orchestrator."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from assertpy import assert_that
+
+from lintro.ai.config import AIConfig
+from lintro.ai.providers.response import AIResponse
+from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.checklist_item import ChecklistItem
+from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.enums.review_category import ReviewCategory
+from lintro.ai.review.orchestrator import (
+    parse_review_response,
+    run_review,
+    strip_json_fences,
+)
+
+
+def _sample_response_json(*, include_finding: bool = True) -> str:
+    finding = (
+        {
+            "severity": "P1",
+            "category": "security",
+            "file": "src/main.py",
+            "line": 12,
+            "title": "Fail-open default",
+            "description": "Unknown status grants access",
+            "cause": "else branch returns Active",
+            "fix": "Default to Expired",
+            "confidence": "high",
+            "checklist_ids": [1],
+        }
+        if include_finding
+        else None
+    )
+    payload = {
+        "summary": "Merge with fixes.",
+        "checklist": [
+            {"id": 1, "answer": "yes", "evidence": "src/main.py:12"},
+        ],
+        "findings": [finding] if finding is not None else [],
+    }
+    return json.dumps(payload)
+
+
+def _mock_provider(*, content: str) -> MagicMock:
+    provider = MagicMock()
+    provider.model_name = "claude-sonnet-4-20250514"
+    provider.name = "anthropic"
+    provider.complete.return_value = AIResponse(
+        content=content,
+        model="claude-sonnet-4-20250514",
+        input_tokens=100,
+        output_tokens=50,
+        cost_estimate=0.01,
+        provider="anthropic",
+    )
+    return provider
+
+
+def test_strip_json_fences_removes_markdown_wrapper() -> None:
+    """Fence stripper extracts JSON from markdown code blocks."""
+    content = '```json\n{"summary": "ok"}\n```'
+    stripped = strip_json_fences(content=content)
+
+    assert_that(stripped).is_equal_to('{"summary": "ok"}')
+
+
+def test_parse_review_response_validates_required_keys() -> None:
+    """Parser accepts valid review JSON payloads."""
+    payload = parse_review_response(content=_sample_response_json())
+
+    assert_that(payload["summary"]).contains("Merge")
+    assert_that(payload["checklist"]).is_length(1)
+
+
+def test_run_review_depth1_returns_review_result() -> None:
+    """Depth 1 review produces findings from mocked provider response."""
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(
+                path="src/main.py",
+                status="modified",
+                additions=1,
+                deletions=0,
+            ),
+        ],
+        unified_diff="diff --git a/src/main.py b/src/main.py\n+change",
+        pr_metadata=None,
+    )
+    checklist_items = [
+        ChecklistItem(
+            id=1,
+            question="Example?",
+            triggers=[],
+            category=ReviewCategory.LOGIC_BUG,
+            tier=1,
+        ),
+    ]
+    provider = _mock_provider(content=_sample_response_json())
+
+    with patch(
+        "lintro.ai.review.orchestrator.complete_with_fallback",
+        side_effect=lambda _provider, _prompt, **kwargs: _provider.complete(
+            _prompt,
+            system=kwargs.get("system"),
+            max_tokens=kwargs.get("max_tokens", 1024),
+            timeout=kwargs.get("timeout", 60.0),
+        ),
+    ):
+        result = run_review(
+            context,
+            provider=provider,
+            ai_config=AIConfig(enabled=True),
+            depth=1,
+            checklist_items=checklist_items,
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+        )
+
+    assert_that(result.summary).contains("Merge")
+    assert_that(result.findings).is_not_empty()
+    assert_that(result.has_p1_findings).is_true()
+
+
+def test_run_review_empty_diff_returns_empty_result() -> None:
+    """Empty diff returns graceful empty review result."""
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[],
+        unified_diff="",
+        pr_metadata=None,
+    )
+    provider = _mock_provider(content="{}")
+
+    result = run_review(
+        context,
+        provider=provider,
+        ai_config=AIConfig(enabled=True),
+        depth=1,
+        checklist_items=[],
+        checklist_text="",
+        classifications=[],
+    )
+
+    assert_that(result.summary).contains("No changes")
+    assert_that(result.findings).is_empty()
+
+
+def test_run_review_depth2_calls_provider_twice() -> None:
+    """Depth 2 runs question generation before the main review pass."""
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(
+                path="src/main.py",
+                status="modified",
+                additions=1,
+                deletions=0,
+            ),
+        ],
+        unified_diff="diff --git a/src/main.py b/src/main.py\n+change",
+        pr_metadata=None,
+    )
+    provider = _mock_provider(
+        content='{"generated_questions": [{"id": "G1", "question": "Extra?"}]}',
+    )
+    provider.complete.side_effect = [
+        AIResponse(
+            content='{"generated_questions": [{"id": "G1", "question": "Extra?"}]}',
+            model="claude-sonnet-4-20250514",
+            input_tokens=50,
+            output_tokens=20,
+            cost_estimate=0.005,
+            provider="anthropic",
+        ),
+        AIResponse(
+            content=_sample_response_json(include_finding=False),
+            model="claude-sonnet-4-20250514",
+            input_tokens=100,
+            output_tokens=50,
+            cost_estimate=0.01,
+            provider="anthropic",
+        ),
+    ]
+
+    with patch(
+        "lintro.ai.review.orchestrator.complete_with_fallback",
+        side_effect=lambda _provider, _prompt, **kwargs: _provider.complete(
+            _prompt,
+            system=kwargs.get("system"),
+            max_tokens=kwargs.get("max_tokens", 1024),
+            timeout=kwargs.get("timeout", 60.0),
+        ),
+    ):
+        run_review(
+            context,
+            provider=provider,
+            ai_config=AIConfig(enabled=True),
+            depth=2,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+        )
+
+    assert_that(provider.complete.call_count).is_equal_to(2)

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -202,7 +202,7 @@ def test_run_review_depth2_calls_provider_twice() -> None:
             timeout=kwargs.get("timeout", 60.0),
         ),
     ):
-        run_review(
+        result = run_review(
             context,
             provider=provider,
             ai_config=AIConfig(enabled=True),
@@ -213,3 +213,6 @@ def test_run_review_depth2_calls_provider_twice() -> None:
         )
 
     assert_that(provider.complete.call_count).is_equal_to(2)
+    assert_that(result.metadata.token_usage["prompt"]).is_equal_to(150)
+    assert_that(result.metadata.token_usage["completion"]).is_equal_to(70)
+    assert_that(result.metadata.cost_estimate_usd).is_equal_to(0.015)

--- a/tests/unit/ai/test_model_pricing.py
+++ b/tests/unit/ai/test_model_pricing.py
@@ -1,0 +1,42 @@
+"""Tests for model context window helpers."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.ai.model_pricing import (
+    DEFAULT_CONTEXT_WINDOW,
+    calculate_available_diff_tokens,
+    get_context_window,
+)
+
+
+def test_get_context_window_returns_known_model_size() -> None:
+    """Known models return configured context window sizes."""
+    assert_that(
+        get_context_window(model="claude-sonnet-4-20250514"),
+    ).is_equal_to(200_000)
+
+
+def test_get_context_window_uses_override_when_provided() -> None:
+    """Explicit override takes precedence over model defaults."""
+    assert_that(
+        get_context_window(model="unknown-model", override=64_000),
+    ).is_equal_to(64_000)
+
+
+def test_get_context_window_falls_back_to_default() -> None:
+    """Unknown models fall back to default context window."""
+    assert_that(
+        get_context_window(model="unknown-model"),
+    ).is_equal_to(DEFAULT_CONTEXT_WINDOW)
+
+
+def test_calculate_available_diff_tokens_subtracts_overhead() -> None:
+    """Available diff tokens subtract prompt overhead from context window."""
+    available = calculate_available_diff_tokens(
+        context_window=200_000,
+        prompt_overhead=20_000,
+    )
+
+    assert_that(available).is_equal_to(180_000)


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai/review): add review orchestrator with depth and chunking
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Phase 4 of #991 — adds the review orchestrator that ties diff context, checklist selection, and prompt templates into depth-controlled AI passes with semantic chunking and merged results.

- `lintro/ai/review/orchestrator.py` — `run_review()` with depth 1–3 flows, chunk execution, JSON parsing, and finding merge
- New models: `ReviewFinding`, `ChecklistAnswer`, `ReviewMetadata`, `ReviewResult`
- Extended `model_pricing.py` with context-window registry and available-diff token calculation
- Tests for orchestrator, merge logic, and model pricing

Rebased onto `main` after #1011 merge; branch is 6 commits (orchestrator delta only). Adapted orchestrator tests for the #1003 checklist domain/language model.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt`, `uv run lintro chk`, orchestrator tests)

## Closes

- Closes #995

- Relates to #991

## Details

**Rebase note:** Straight rebase duplicated #992–#994 commits already on `main`. Reset to `origin/main` and cherry-picked the 5 orchestrator commits plus a test fix for `ChecklistItem.domains`/`languages`.

**Testing:** `tests/unit/ai/review/test_orchestrator.py`, `test_merge.py`, `tests/unit/ai/test_model_pricing.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured AI diff review outputs, including review metadata, checklist answers, and typed findings.
  * Introduced depth-based multi-pass review with optional extra checklist generation and adversarial sweeps.
  * Improved model context handling with per-model context sizing and token budget calculation.

* **Bug Fixes**
  * More robust handling of AI responses returned with markdown-wrapped JSON.
  * Review consolidation now deduplicates findings and resolves checklist answer conflicts deterministically.

* **Tests**
  * Added unit tests covering merge behavior, JSON parsing, model context utilities, and depth-dependent review calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds the review orchestrator (Phase 4 of #991), wiring together diff context, checklist selection, and prompt templates into depth-controlled AI passes with semantic chunking and merged results. Four new model classes (`ReviewFinding`, `ChecklistAnswer`, `ReviewMetadata`, `ReviewResult`) and a context-window registry in `model_pricing.py` support the orchestrator.

- **`orchestrator.py`** implements `run_review()` with depth 1–3 flows: depth-1 is a single-pass review, depth-2 adds a question-generation pre-pass, and depth-3 appends an adversarial sweep; chunk results are merged via evidence-strength scoring.
- **`model_pricing.py`** gains `MODEL_CONTEXT_WINDOWS`, `get_context_window`, and `calculate_available_diff_tokens` for per-model token budgeting.
- Tests cover merge logic, JSON parsing, model context utilities, and depth-1/2 orchestrator flows; depth-3 adversarial pass is not yet tested.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all previously identified runtime crashes have been resolved and the orchestrator logic is correct end-to-end.

The three blocking issues from earlier rounds (ReviewChunk under TYPE_CHECKING, invalid RelationshipLabel value, negative generated-question IDs) are all fixed. The evidence-strength merge for checklist answers is correctly order-independent. The remaining observations are design-level: merge_review_results exposes placeholder metadata through a public return type, and ReviewMetadata's token_usage dict is mutable inside a frozen dataclass. Neither causes incorrect behavior in the current calling code.

orchestrator.py (merge_review_results public contract) and review_metadata.py (mutable dict in frozen dataclass)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/review/orchestrator.py | Core orchestrator — depth 1/2/3 pass logic, chunking, merge, and JSON parsing. Previously flagged runtime crashes (ReviewChunk under TYPE_CHECKING, full-diff RelationshipLabel, negative IDs, order-dependent merge) are all resolved. Remaining issues are design-level: merge_review_results returns an invalid-metadata ReviewResult as public API, and a redundant boolean expression in checklist_count computation. |
| lintro/ai/model_pricing.py | Adds MODEL_CONTEXT_WINDOWS registry and get_context_window / calculate_available_diff_tokens helpers. Previously flagged claude-sonnet-4-6 alias was confirmed intentional by the team. Logic is correct; calculate_available_diff_tokens properly clamps to zero. |
| lintro/ai/review/models/review_metadata.py | New ReviewMetadata frozen dataclass. The token_usage dict field is mutable despite the frozen class, which breaks the immutability guarantee for callers that mutate the dict in-place. All other fields are immutable primitives. |
| lintro/ai/review/models/review_finding.py | New ReviewFinding frozen dataclass; default_factory=tuple for checklist_ids correctly produces an empty tuple. Clean. |
| lintro/ai/review/models/review_result.py | New ReviewResult frozen dataclass with has_p1_findings property. Uses tuple fields for immutable checklist/findings. Clean. |
| lintro/ai/review/models/checklist_answer.py | New ChecklistAnswer frozen dataclass. Straightforward; no issues. |
| tests/unit/ai/review/test_merge.py | Tests for merge_findings, merge_checklist_answers, and _parse_checklist. Covers both ordering directions for the evidence-backed no vs. unsupported yes case after the 9f13a0a2 fix. |
| tests/unit/ai/review/test_orchestrator.py | Tests for depth-1 and depth-2 flows plus strip/parse utilities. Depth-3 adversarial pass has no test coverage. |
| tests/unit/ai/test_model_pricing.py | Tests for get_context_window (known model, override, fallback) and calculate_available_diff_tokens. Clean and thorough. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Caller
    participant O as run_review()
    participant CK as chunk_review_context()
    participant R as _review_chunk()
    participant P as AI Provider

    C->>O: context, depth, checklist_items
    O->>CK: unified_diff, max_tokens
    CK-->>O: ChunkingResult (chunks[])
    loop each chunk
        O->>R: chunk, depth, next_id
        alt "depth >= 2"
            R->>P: REVIEW_GENERATE_QUESTIONS_TEMPLATE
            P-->>R: generated_questions JSON
        end
        R->>P: REVIEW_USER_PROMPT_TEMPLATE
        P-->>R: review JSON (summary, checklist, findings)
        alt "depth >= 3"
            R->>P: REVIEW_ADVERSARIAL_SWEEP_TEMPLATE
            P-->>R: additional findings JSON
        end
        R-->>O: _ChunkReviewPartial, next_id
    end
    O->>O: merge_review_results(partials)
    O-->>C: ReviewResult(metadata, summary, checklist, findings)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Caller
    participant O as run_review()
    participant CK as chunk_review_context()
    participant R as _review_chunk()
    participant P as AI Provider

    C->>O: context, depth, checklist_items
    O->>CK: unified_diff, max_tokens
    CK-->>O: ChunkingResult (chunks[])
    loop each chunk
        O->>R: chunk, depth, next_id
        alt "depth >= 2"
            R->>P: REVIEW_GENERATE_QUESTIONS_TEMPLATE
            P-->>R: generated_questions JSON
        end
        R->>P: REVIEW_USER_PROMPT_TEMPLATE
        P-->>R: review JSON (summary, checklist, findings)
        alt "depth >= 3"
            R->>P: REVIEW_ADVERSARIAL_SWEEP_TEMPLATE
            P-->>R: additional findings JSON
        end
        R-->>O: _ChunkReviewPartial, next_id
    end
    O->>O: merge_review_results(partials)
    O-->>C: ReviewResult(metadata, summary, checklist, findings)
```

</a>
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(ai/review): include depth-2 question..."](https://github.com/lgtm-hq/py-lintro/commit/f4bdddaf795a5057333f9605a0fdf8bc548b6e19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41284555)</sub>

<!-- /greptile_comment -->