### PR TITLE
feat(cli): add lintro review command

### DIFF
--- a/lintro/ai/review/display.py
+++ b/lintro/ai/review/display.py
@@ -1,0 +1,158 @@
+"""Rich terminal rendering for AI review results."""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from lintro.ai.cost import format_cost
+from lintro.ai.display.shared import cost_str, print_section_header
+from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_result import ReviewResult
+
+__all__ = ["render_review_terminal"]
+
+_SEVERITY_ORDER = {"P1": 0, "P2": 1, "P3": 2}
+_SEVERITY_STYLES = {
+    "P1": "bold red",
+    "P2": "bold yellow",
+    "P3": "bold blue",
+}
+
+
+def render_review_terminal(
+    *,
+    result: ReviewResult,
+    console: Console | None = None,
+) -> None:
+    """Render review result to the terminal with Rich formatting.
+
+    Args:
+        result: Review result to display.
+        console: Optional Rich console instance.
+    """
+    output = console or Console()
+    metadata = result.metadata
+
+    header_detail = (
+        f"Model: {metadata.model} | Context: {metadata.context_window:,} | "
+        f"Depth: {metadata.depth} | Chunks: "
+        f"{metadata.chunks_current}/{metadata.chunks_total} | "
+        f"Files: {metadata.files_reviewed}/{metadata.files_total} | "
+        f"Checklist: {metadata.checklist_items} items"
+    )
+    token_info = cost_str(
+        metadata.token_usage.get("prompt", 0),
+        metadata.token_usage.get("completion", 0),
+        metadata.cost_estimate_usd,
+    )
+    print_section_header(
+        output,
+        "🔍",
+        "Lintro Review",
+        header_detail,
+        cost_info=token_info or f"   est. {format_cost(metadata.cost_estimate_usd)}",
+    )
+
+    if metadata.chunks_total > 1:
+        output.print(
+            f"[dim]Reviewed in {metadata.chunks_total} semantic chunks[/dim]",
+        )
+
+    output.print(
+        Panel(
+            result.summary or "(no summary)",
+            title="Summary",
+            border_style="cyan",
+        ),
+    )
+
+    _render_checklist_table(result=result, console=output)
+    _render_findings(result=result, console=output)
+
+
+def _render_checklist_table(*, result: ReviewResult, console: Console) -> None:
+    """Render checklist answers as a Rich table."""
+    if not result.checklist:
+        return
+
+    table = Table(title="Checklist", show_header=True, header_style="bold cyan")
+    table.add_column("ID", justify="right", style="cyan", no_wrap=True)
+    table.add_column("Answer", no_wrap=True)
+    table.add_column("Evidence")
+
+    for answer in result.checklist:
+        answer_style = "red" if answer.answer.lower() == "yes" else "green"
+        evidence = answer.evidence
+        if len(evidence) > 120:
+            evidence = f"{evidence[:117]}..."
+        table.add_row(
+            str(answer.id),
+            Text(answer.answer, style=answer_style),
+            evidence,
+        )
+
+    console.print(table)
+
+
+def _render_findings(*, result: ReviewResult, console: Console) -> None:
+    """Render findings grouped by severity."""
+    if not result.findings:
+        console.print("[dim]No findings.[/dim]")
+        return
+
+    sorted_findings = sorted(
+        result.findings,
+        key=lambda finding: (
+            _SEVERITY_ORDER.get(finding.severity, 99),
+            finding.file,
+            finding.line,
+        ),
+    )
+
+    console.print()
+    console.print(f"[bold cyan]Findings ({len(sorted_findings)})[/bold cyan]")
+
+    for index, finding in enumerate(sorted_findings, start=1):
+        _render_finding_panel(
+            finding=finding,
+            index=index,
+            total=len(sorted_findings),
+            console=console,
+        )
+
+
+def _render_finding_panel(
+    *,
+    finding: ReviewFinding,
+    index: int,
+    total: int,
+    console: Console,
+) -> None:
+    """Render a single finding as a Rich panel."""
+    severity_style = _SEVERITY_STYLES.get(finding.severity, "white")
+    title = (
+        f"[{severity_style}]{finding.severity}[/{severity_style}]  "
+        f"{finding.category}  "
+        f"{finding.file}:{finding.line}  "
+        f"[dim]({finding.confidence})[/dim]"
+    )
+    body = Text()
+    body.append(f"{finding.title}\n\n", style="bold")
+    body.append(f"{finding.description}\n\n")
+    body.append("Cause: ", style="bold")
+    body.append(f"{finding.cause}\n\n")
+    body.append("Fix: ", style="bold")
+    body.append(finding.fix)
+
+    console.print(
+        Panel(
+            body,
+            title=f"[bold cyan][{index}/{total}][/bold cyan] {title}",
+            title_align="left",
+            border_style="cyan",
+            padding=(0, 1),
+        ),
+    )

--- a/lintro/ai/review/output.py
+++ b/lintro/ai/review/output.py
@@ -9,7 +9,6 @@ from typing import Any
 from lintro.ai.review.models.review_result import ReviewResult
 
 __all__ = [
-    "render_review_json",
     "render_review_output",
     "review_result_to_dict",
     "review_result_to_json",
@@ -46,18 +45,6 @@ def review_result_to_json(*, result: ReviewResult) -> str:
     return json.dumps(review_result_to_dict(result=result), indent=2)
 
 
-def render_review_json(*, result: ReviewResult) -> str:
-    """Render review result as JSON text.
-
-    Args:
-        result: Review result to render.
-
-    Returns:
-        Pretty-printed JSON string.
-    """
-    return review_result_to_json(result=result)
-
-
 def render_review_output(
     *,
     result: ReviewResult,
@@ -73,7 +60,7 @@ def render_review_output(
         JSON string when ``output_format`` is ``json``; otherwise ``None``.
     """
     if output_format.lower() == "json":
-        return render_review_json(result=result)
+        return review_result_to_json(result=result)
 
     from lintro.ai.review.display import render_review_terminal
 

--- a/lintro/ai/review/output.py
+++ b/lintro/ai/review/output.py
@@ -1,0 +1,81 @@
+"""JSON serialization for AI review results."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import Any
+
+from lintro.ai.review.models.review_result import ReviewResult
+
+__all__ = [
+    "render_review_json",
+    "render_review_output",
+    "review_result_to_dict",
+    "review_result_to_json",
+]
+
+
+def review_result_to_dict(*, result: ReviewResult) -> dict[str, Any]:
+    """Convert a review result to a JSON-serializable dictionary.
+
+    Args:
+        result: Review result to serialize.
+
+    Returns:
+        Dictionary representation suitable for JSON encoding.
+    """
+    metadata = asdict(result.metadata)
+    return {
+        "metadata": metadata,
+        "summary": result.summary,
+        "checklist": [asdict(answer) for answer in result.checklist],
+        "findings": [asdict(finding) for finding in result.findings],
+    }
+
+
+def review_result_to_json(*, result: ReviewResult) -> str:
+    """Serialize a review result to pretty-printed JSON.
+
+    Args:
+        result: Review result to serialize.
+
+    Returns:
+        JSON string with two-space indentation.
+    """
+    return json.dumps(review_result_to_dict(result=result), indent=2)
+
+
+def render_review_json(*, result: ReviewResult) -> str:
+    """Render review result as JSON text.
+
+    Args:
+        result: Review result to render.
+
+    Returns:
+        Pretty-printed JSON string.
+    """
+    return review_result_to_json(result=result)
+
+
+def render_review_output(
+    *,
+    result: ReviewResult,
+    output_format: str = "terminal",
+) -> str | None:
+    """Dispatch review output rendering by format.
+
+    Args:
+        result: Review result to render.
+        output_format: ``terminal`` or ``json``.
+
+    Returns:
+        JSON string when ``output_format`` is ``json``; otherwise ``None``.
+    """
+    if output_format.lower() == "json":
+        return render_review_json(result=result)
+
+    from lintro.ai.review.display import render_review_terminal
+
+    render_review_terminal(result=result)
+    return None

--- a/lintro/cli.py
+++ b/lintro/cli.py
@@ -26,6 +26,7 @@ from lintro.cli_utils.commands.format import format_command  # noqa: E402
 from lintro.cli_utils.commands.init import init_command  # noqa: E402
 from lintro.cli_utils.commands.install import install_command  # noqa: E402
 from lintro.cli_utils.commands.list_tools import list_tools_command  # noqa: E402
+from lintro.cli_utils.commands.review import review_command  # noqa: E402
 from lintro.cli_utils.commands.setup import setup_command  # noqa: E402
 from lintro.cli_utils.commands.test import test_command  # noqa: E402
 from lintro.cli_utils.commands.versions import versions_command  # noqa: E402
@@ -197,6 +198,7 @@ cast(Any, install_command)._canonical_name = "install"
 cast(Any, setup_command)._canonical_name = "setup"
 cast(Any, test_command)._canonical_name = "test"
 cast(Any, list_tools_command)._canonical_name = "list-tools"
+cast(Any, review_command)._canonical_name = "review"
 cast(Any, versions_command)._canonical_name = "versions"
 
 cli.add_command(check_command, name="check")
@@ -208,6 +210,7 @@ cli.add_command(install_command, name="install")
 cli.add_command(setup_command, name="setup")
 cli.add_command(test_command, name="test")
 cli.add_command(list_tools_command, name="list-tools")
+cli.add_command(review_command, name="review")
 cli.add_command(versions_command, name="versions")
 
 # Register aliases
@@ -221,6 +224,7 @@ cli.add_command(list_tools_command, name="ls")
 cli.add_command(list_tools_command, name="tools")
 cli.add_command(install_command, name="ins")
 cli.add_command(setup_command, name="su")
+cli.add_command(review_command, name="rev")
 cli.add_command(versions_command, name="ver")
 cli.add_command(versions_command, name="version")
 

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -135,7 +135,7 @@ def review_command(
     classifications = classify_changed_files(context.changed_files)
     checklist_items = get_all_checklist_items(config=lintro_config)
     selected_items = select_checklist_items(
-        changed_files=[file.path for file in context.changed_files],
+        classifications=classifications,
         items=checklist_items,
     )
     checklist_text, _prompt_mapping = format_checklist_for_prompt(

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -113,6 +113,7 @@ def review_command(
         raise click.UsageError(
             "--pr and --uncommitted cannot be used together.",
         )
+    resolved_pr: int | None = None
     if post:
         resolved_pr = pr or _detect_pr_number_from_env()
         if resolved_pr is None:
@@ -184,7 +185,7 @@ def review_command(
 
         posted = post_review_to_github(
             result=result,
-            pr_number=pr or _detect_pr_number_from_env(),
+            pr_number=resolved_pr,
             repo=effective_repo,
         )
         if not posted:

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -109,6 +109,16 @@ def review_command(
         raise click.UsageError(
             "--pr requires --repo or GITHUB_REPOSITORY environment variable.",
         )
+    if pr is not None and uncommitted:
+        raise click.UsageError(
+            "--pr and --uncommitted cannot be used together.",
+        )
+    if post:
+        resolved_pr = pr or _detect_pr_number_from_env()
+        if resolved_pr is None:
+            raise click.UsageError(
+                "--post requires --pr or a CI pull-request environment.",
+            )
 
     paths = list(path_filter) if path_filter else None
     try:
@@ -165,7 +175,9 @@ def review_command(
         lint_results=lint_digest,
     )
 
-    render_review_output(result=result, output_format=output_format)
+    output = render_review_output(result=result, output_format=output_format)
+    if output is not None:
+        click.echo(output)
 
     if post:
         from lintro.ai.review.github import post_review_to_github

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -1,0 +1,203 @@
+"""CLI command for AI diff-based code review."""
+
+from __future__ import annotations
+
+import os
+
+import click
+from loguru import logger
+
+from lintro.ai.availability import require_ai
+from lintro.ai.providers import get_provider
+from lintro.ai.review import (
+    classify_changed_files,
+    collect_review_context,
+    format_checklist_for_prompt,
+    get_all_checklist_items,
+    select_checklist_items,
+)
+from lintro.ai.review.exceptions import ReviewContextError
+from lintro.ai.review.orchestrator import run_review
+from lintro.ai.review.output import render_review_output
+from lintro.config.config_loader import get_config
+
+
+@click.command("review")
+@click.option(
+    "--base",
+    default="main",
+    show_default=True,
+    help="Base branch for diff comparison.",
+)
+@click.option(
+    "--uncommitted",
+    is_flag=True,
+    help="Review staged and unstaged working tree changes.",
+)
+@click.option(
+    "--pr",
+    type=int,
+    default=None,
+    help="GitHub pull request number to review.",
+)
+@click.option(
+    "--repo",
+    default=None,
+    help="GitHub repository (owner/name) when using --pr.",
+)
+@click.option(
+    "--depth",
+    type=click.IntRange(1, 3),
+    default=1,
+    show_default=True,
+    help="Review depth (1=checklist, 2=+generated questions, 3=+adversarial).",
+)
+@click.option(
+    "--post",
+    is_flag=True,
+    help="Post findings to GitHub as PR review comments.",
+)
+@click.option(
+    "--output",
+    "output_format",
+    type=click.Choice(["terminal", "json"]),
+    default="terminal",
+    show_default=True,
+    help="Output format for review results.",
+)
+@click.option(
+    "--with-lint",
+    is_flag=True,
+    help="Run lintro tools on changed files and include results in review.",
+)
+@click.option(
+    "--context-window",
+    type=int,
+    default=None,
+    help="Override model context window size in tokens.",
+)
+@click.option(
+    "--path",
+    "path_filter",
+    multiple=True,
+    help="Limit review to specific path prefixes.",
+)
+def review_command(
+    *,
+    base: str,
+    uncommitted: bool,
+    pr: int | None,
+    repo: str | None,
+    depth: int,
+    post: bool,
+    output_format: str,
+    with_lint: bool,
+    context_window: int | None,
+    path_filter: tuple[str, ...],
+) -> None:
+    """Run AI-powered diff-based code review."""
+    require_ai()
+    lintro_config = get_config()
+    if not lintro_config.ai.enabled:
+        raise click.UsageError(
+            "AI is disabled in configuration. Set ai.enabled: true in "
+            ".lintro-config.yaml",
+        )
+
+    effective_repo = repo or os.environ.get("GITHUB_REPOSITORY")
+    if pr is not None and not effective_repo:
+        raise click.UsageError(
+            "--pr requires --repo or GITHUB_REPOSITORY environment variable.",
+        )
+
+    paths = list(path_filter) if path_filter else None
+    try:
+        context = collect_review_context(
+            base=base,
+            uncommitted=uncommitted,
+            pr_number=pr,
+            repo=effective_repo,
+            paths=paths,
+        )
+    except ReviewContextError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    classifications = classify_changed_files(context.changed_files)
+    checklist_items = get_all_checklist_items(config=lintro_config)
+    selected_items = select_checklist_items(
+        changed_files=[file.path for file in context.changed_files],
+        items=checklist_items,
+    )
+    checklist_text, _prompt_mapping = format_checklist_for_prompt(
+        items=selected_items,
+    )
+
+    lint_digest: str | None = None
+    if with_lint:
+        from lintro.ai.review.lint_bridge import (
+            format_lint_results_for_prompt,
+            run_lint_on_changed_files,
+        )
+
+        lint_results = run_lint_on_changed_files(
+            changed_files=[file.path for file in context.changed_files],
+            lintro_config=lintro_config,
+        )
+        lint_digest = format_lint_results_for_prompt(results=lint_results)
+        if lint_digest and output_format == "terminal":
+            issue_count = sum(result.issues_count or 0 for result in lint_results)
+            logger.info(
+                "Ran lint on changed files: {} tools, {} issues",
+                len(lint_results),
+                issue_count,
+            )
+
+    provider = get_provider(lintro_config.ai)
+    result = run_review(
+        context,
+        provider=provider,
+        ai_config=lintro_config.ai,
+        depth=depth,
+        checklist_items=selected_items,
+        checklist_text=checklist_text,
+        classifications=classifications,
+        context_window_override=context_window,
+        lint_results=lint_digest,
+    )
+
+    render_review_output(result=result, output_format=output_format)
+
+    if post:
+        from lintro.ai.review.github import post_review_to_github
+
+        posted = post_review_to_github(
+            result=result,
+            pr_number=pr or _detect_pr_number_from_env(),
+            repo=effective_repo,
+        )
+        if not posted:
+            logger.warning("GitHub review posting skipped or failed")
+
+    exit_code = 1 if result.has_p1_findings else 0
+    raise SystemExit(exit_code)
+
+
+def _detect_pr_number_from_env() -> int | None:
+    """Detect PR number from common CI environment variables."""
+    github_ref = os.environ.get("GITHUB_REF", "")
+    if github_ref.startswith("refs/pull/"):
+        parts = github_ref.split("/")
+        if len(parts) >= 3 and parts[2].isdigit():
+            return int(parts[2])
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return None
+    try:
+        import json
+        from pathlib import Path
+
+        payload = json.loads(Path(event_path).read_text(encoding="utf-8"))
+        number = payload.get("pull_request", {}).get("number")
+        return int(number) if isinstance(number, int) else None
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return None

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -120,6 +120,10 @@ def review_command(
             raise click.UsageError(
                 "--post requires --pr or a CI pull-request environment.",
             )
+        if not effective_repo:
+            raise click.UsageError(
+                "--post requires --repo or GITHUB_REPOSITORY environment variable.",
+            )
 
     paths = list(path_filter) if path_filter else None
     try:

--- a/tests/unit/ai/review/test_display.py
+++ b/tests/unit/ai/review/test_display.py
@@ -6,6 +6,8 @@ from assertpy import assert_that
 from rich.console import Console
 
 from lintro.ai.review.display import render_review_terminal
+from lintro.ai.review.models.checklist_answer import ChecklistAnswer
+from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 
@@ -34,12 +36,59 @@ def test_render_review_terminal_with_empty_findings() -> None:
     assert_that(console.export_text()).contains("Safe to merge")
 
 
-def test_render_review_terminal_orders_p1_before_p2(
-    sample_review_result: ReviewResult,
-) -> None:
+def test_render_review_terminal_orders_p1_before_p2() -> None:
     """P1 findings appear before P2 findings in terminal output."""
+    result = ReviewResult(
+        metadata=ReviewMetadata(
+            model="claude-sonnet-4-20250514",
+            provider="anthropic",
+            context_window=200_000,
+            depth=2,
+            chunks_total=2,
+            chunks_current=2,
+            files_reviewed=3,
+            files_total=3,
+            checklist_items=2,
+            token_usage={"prompt": 1000, "completion": 200, "total": 1200},
+            cost_estimate_usd=0.05,
+            base_ref="main",
+            head_ref="feature",
+            timestamp="2026-06-24T10:00:00+00:00",
+        ),
+        summary="Merge with fixes.",
+        checklist=(
+            ChecklistAnswer(id=1, answer="yes", evidence="src/main.py:10"),
+            ChecklistAnswer(id=2, answer="no", evidence="none"),
+        ),
+        findings=(
+            ReviewFinding(
+                severity="P1",
+                category="security",
+                file="src/main.py",
+                line=10,
+                title="Fail-open default",
+                description="Unknown status grants access",
+                cause="else branch returns Active",
+                fix="Default to Expired",
+                confidence="high",
+                checklist_ids=(1,),
+            ),
+            ReviewFinding(
+                severity="P2",
+                category="test-gap",
+                file="tests/test_main.py",
+                line=5,
+                title="Missing access test",
+                description="No test for unknown status",
+                cause="Test gap",
+                fix="Add unit test",
+                confidence="medium",
+                checklist_ids=(2,),
+            ),
+        ),
+    )
     console = Console(record=True)
-    render_review_terminal(result=sample_review_result, console=console)
+    render_review_terminal(result=result, console=console)
     text = console.export_text()
 
     assert_that(text.index("P1")).is_less_than(text.index("P2"))

--- a/tests/unit/ai/review/test_display.py
+++ b/tests/unit/ai/review/test_display.py
@@ -1,0 +1,45 @@
+"""Tests for review terminal display."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+from rich.console import Console
+
+from lintro.ai.review.display import render_review_terminal
+from lintro.ai.review.models.review_metadata import ReviewMetadata
+from lintro.ai.review.models.review_result import ReviewResult
+
+
+def test_render_review_terminal_with_empty_findings() -> None:
+    """Terminal rendering succeeds when no findings are present."""
+    result = ReviewResult(
+        metadata=ReviewMetadata(
+            model="gpt-4o",
+            provider="openai",
+            context_window=128_000,
+            depth=1,
+            chunks_total=1,
+            chunks_current=1,
+            files_reviewed=1,
+            files_total=1,
+            checklist_items=0,
+        ),
+        summary="Safe to merge.",
+        checklist=(),
+        findings=(),
+    )
+    console = Console(record=True)
+    render_review_terminal(result=result, console=console)
+
+    assert_that(console.export_text()).contains("Safe to merge")
+
+
+def test_render_review_terminal_orders_p1_before_p2(
+    sample_review_result: ReviewResult,
+) -> None:
+    """P1 findings appear before P2 findings in terminal output."""
+    console = Console(record=True)
+    render_review_terminal(result=sample_review_result, console=console)
+    text = console.export_text()
+
+    assert_that(text.index("P1")).is_less_than(text.index("P2"))

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -1,0 +1,112 @@
+"""Tests for lintro review CLI command."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from assertpy import assert_that
+from click.testing import CliRunner
+
+from lintro.ai.review.models.review_metadata import ReviewMetadata
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.cli import cli
+
+
+def _empty_result() -> ReviewResult:
+    return ReviewResult(
+        metadata=ReviewMetadata(
+            model="gpt-4o",
+            provider="openai",
+            context_window=128_000,
+            depth=1,
+            chunks_total=1,
+            chunks_current=1,
+            files_reviewed=0,
+            files_total=0,
+            checklist_items=0,
+        ),
+        summary="No changes found to review.",
+        checklist=(),
+        findings=(),
+    )
+
+
+def test_review_help_shows_flags() -> None:
+    """Review command help lists primary flags."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["review", "--help"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains("--base")
+    assert_that(result.output).contains("--with-lint")
+    assert_that(result.output).contains("--depth")
+
+
+def test_review_alias_rev_works() -> None:
+    """Alias rev resolves to the review command help."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["rev", "--help"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains("AI-powered diff-based code review")
+
+
+def test_review_requires_ai_packages() -> None:
+    """Missing AI packages produce a usage error."""
+    runner = CliRunner()
+    with patch("lintro.cli_utils.commands.review.require_ai") as mock_require:
+        mock_require.side_effect = Exception("AI packages not installed")
+        result = runner.invoke(cli, ["review"])
+
+    assert_that(result.exit_code).is_not_equal_to(0)
+
+
+def test_review_exits_zero_without_p1_findings() -> None:
+    """Review command exits 0 when no P1 findings exist."""
+    runner = CliRunner()
+    mock_context = MagicMock()
+    mock_context.changed_files = []
+    mock_context.unified_diff = ""
+
+    with patch("lintro.cli_utils.commands.review.require_ai"):
+        with patch(
+            "lintro.cli_utils.commands.review.get_config",
+            return_value=MagicMock(ai=MagicMock(enabled=True)),
+        ):
+            with patch(
+                "lintro.cli_utils.commands.review.collect_review_context",
+                return_value=mock_context,
+            ):
+                with patch(
+                    "lintro.cli_utils.commands.review.classify_changed_files",
+                    return_value=[],
+                ):
+                    with patch(
+                        "lintro.cli_utils.commands.review.get_all_checklist_items",
+                        return_value=[],
+                    ):
+                        with patch(
+                            "lintro.cli_utils.commands.review.select_checklist_items",
+                            return_value=[],
+                        ):
+                            with patch(
+                                "lintro.cli_utils.commands.review.format_checklist_for_prompt",
+                                return_value=("", {}),
+                            ):
+                                with patch(
+                                    "lintro.cli_utils.commands.review.get_provider",
+                                    return_value=MagicMock(
+                                        model_name="gpt-4o",
+                                        name="openai",
+                                    ),
+                                ):
+                                    with patch(
+                                        "lintro.cli_utils.commands.review.run_review",
+                                        return_value=_empty_result(),
+                                    ):
+                                        with patch(
+                                            "lintro.cli_utils.commands.review.render_review_output",
+                                        ):
+                                            result = runner.invoke(cli, ["review"])
+
+    assert_that(result.exit_code).is_equal_to(0)


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(cli): add lintro review command
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Adds the `lintro review` CLI command — the user-facing entry point for the AI review engine (phases 1–4 now on main via #1000–#1034).

Rebased onto `main` after #1034 merge; cherry-picked the three CLI commits and fixed `select_checklist_items` to use `classifications` per the current API.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt/chk/tst`)

## Closes

- Closes #996
- Relates to #991

## Details

- `lintro/cli_utils/commands/review.py` — review command with flags (depth, format, `--with-lint`, `--post`, etc.)
- `lintro/ai/review/output.py` — terminal/JSON output helpers
- `tests/unit/cli/test_review_command.py` — unit tests
- Rebase note: branch reset to `origin/main` + cherry-pick (stack phases already merged); not a blind rebase replay.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces the `lintro review` CLI command — the user-facing entry point for the AI diff-based code review engine. It wires together context collection, checklist selection, AI orchestration, and output rendering (terminal via Rich, or JSON) that were merged in earlier phases.

- **`lintro/cli_utils/commands/review.py`**: New Click command with flags for base branch, uncommitted changes, PR number, depth, GitHub posting, output format, lint integration, and path filtering; includes CI environment auto-detection for PR numbers.
- **`lintro/ai/review/display.py`** and **`output.py`**: Rich terminal renderer and a format dispatcher that lazily imports the terminal renderer to avoid hard-importing Rich when only JSON output is used.
- **`lintro/cli.py`**: Command and `rev` alias registered alongside existing commands.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after the missing --post + --uncommitted guard is added; all other paths are well-structured and covered by tests.

The validation block intentionally prevents --pr + --uncommitted but has no equivalent guard for --post + --uncommitted. A user or CI job supplying both flags would auto-detect a PR number from GITHUB_REF and post a review of local uncommitted changes to that PR, silently presenting incorrect findings to reviewers. The fix is a straightforward three-line addition.

lintro/cli_utils/commands/review.py — missing flag-combination guard in the validation section

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/cli_utils/commands/review.py | New review CLI command with full flag set; missing guard for --post + --uncommitted combination allows posting local changes to a GitHub PR |
| lintro/ai/review/display.py | New Rich terminal renderer; checklist answer fallback color defaults to green for non-"yes" values including partial/n/a |
| lintro/ai/review/output.py | Clean JSON/terminal output dispatcher; lazy import of display module and consistent return-type contract look correct |
| lintro/cli.py | Registers review_command and rev alias; straightforward one-liner additions consistent with existing command wiring |
| tests/unit/ai/review/test_display.py | Two focused tests; both construct ReviewResult inline so the previous fixture-missing issue is resolved; ordering and empty-state paths are covered |
| tests/unit/cli/test_review_command.py | Covers help output, alias, AI-not-available, and exit-0 path; no test for --post or --post + --uncommitted guard |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(cli): require repo when posting with..."](https://github.com/lgtm-hq/py-lintro/commit/9660f36aca494c632c169e20a866d5404cd662be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41342630)</sub>

<!-- /greptile_comment -->