### PR TITLE
feat(ai/review): add terminal and JSON output formatters

### DIFF
--- a/lintro/ai/review/output.py
+++ b/lintro/ai/review/output.py
@@ -9,6 +9,7 @@ from typing import Any
 from lintro.ai.review.models.review_result import ReviewResult
 
 __all__ = [
+    "render_review_json",
     "render_review_output",
     "review_result_to_dict",
     "review_result_to_json",
@@ -45,6 +46,18 @@ def review_result_to_json(*, result: ReviewResult) -> str:
     return json.dumps(review_result_to_dict(result=result), indent=2)
 
 
+def render_review_json(*, result: ReviewResult) -> str:
+    """Render review result as JSON text.
+
+    Args:
+        result: Review result to render.
+
+    Returns:
+        Pretty-printed JSON string.
+    """
+    return review_result_to_json(result=result)
+
+
 def render_review_output(
     *,
     result: ReviewResult,
@@ -60,7 +73,7 @@ def render_review_output(
         JSON string when ``output_format`` is ``json``; otherwise ``None``.
     """
     if output_format.lower() == "json":
-        return review_result_to_json(result=result)
+        return render_review_json(result=result)
 
     from lintro.ai.review.display import render_review_terminal
 

--- a/tests/unit/ai/review/conftest.py
+++ b/tests/unit/ai/review/conftest.py
@@ -12,7 +12,11 @@ import pytest
 
 from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
 from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.checklist_answer import ChecklistAnswer
 from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_metadata import ReviewMetadata
+from lintro.ai.review.models.review_result import ReviewResult
 from tests.unit.ai.review.review_fixtures import load_review_fixture
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -219,3 +223,57 @@ index 1111111..2222222 100644
 +value = 2
 """
     return "".join(hunk.format(idx=index) for index in range(6))
+
+
+@pytest.fixture
+def sample_review_result() -> ReviewResult:
+    """Build a representative review result for display/output tests."""
+    return ReviewResult(
+        metadata=ReviewMetadata(
+            model="claude-sonnet-4-20250514",
+            provider="anthropic",
+            context_window=200_000,
+            depth=2,
+            chunks_total=2,
+            chunks_current=2,
+            files_reviewed=3,
+            files_total=3,
+            checklist_items=2,
+            token_usage={"prompt": 1000, "completion": 200, "total": 1200},
+            cost_estimate_usd=0.05,
+            base_ref="main",
+            head_ref="feature",
+            timestamp="2026-06-24T10:00:00+00:00",
+        ),
+        summary="Merge with fixes.",
+        checklist=(
+            ChecklistAnswer(id=1, answer="yes", evidence="src/main.py:10"),
+            ChecklistAnswer(id=2, answer="no", evidence="none"),
+        ),
+        findings=(
+            ReviewFinding(
+                severity="P1",
+                category="security",
+                file="src/main.py",
+                line=10,
+                title="Fail-open default",
+                description="Unknown status grants access",
+                cause="else branch returns Active",
+                fix="Default to Expired",
+                confidence="high",
+                checklist_ids=(1,),
+            ),
+            ReviewFinding(
+                severity="P2",
+                category="test-gap",
+                file="tests/test_main.py",
+                line=5,
+                title="Missing access test",
+                description="No test for unknown status",
+                cause="Test gap",
+                fix="Add unit test",
+                confidence="medium",
+                checklist_ids=(2,),
+            ),
+        ),
+    )

--- a/tests/unit/ai/review/test_display.py
+++ b/tests/unit/ai/review/test_display.py
@@ -6,8 +6,6 @@ from assertpy import assert_that
 from rich.console import Console
 
 from lintro.ai.review.display import render_review_terminal
-from lintro.ai.review.models.checklist_answer import ChecklistAnswer
-from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 
@@ -36,59 +34,12 @@ def test_render_review_terminal_with_empty_findings() -> None:
     assert_that(console.export_text()).contains("Safe to merge")
 
 
-def test_render_review_terminal_orders_p1_before_p2() -> None:
+def test_render_review_terminal_orders_p1_before_p2(
+    sample_review_result: ReviewResult,
+) -> None:
     """P1 findings appear before P2 findings in terminal output."""
-    result = ReviewResult(
-        metadata=ReviewMetadata(
-            model="claude-sonnet-4-20250514",
-            provider="anthropic",
-            context_window=200_000,
-            depth=2,
-            chunks_total=2,
-            chunks_current=2,
-            files_reviewed=3,
-            files_total=3,
-            checklist_items=2,
-            token_usage={"prompt": 1000, "completion": 200, "total": 1200},
-            cost_estimate_usd=0.05,
-            base_ref="main",
-            head_ref="feature",
-            timestamp="2026-06-24T10:00:00+00:00",
-        ),
-        summary="Merge with fixes.",
-        checklist=(
-            ChecklistAnswer(id=1, answer="yes", evidence="src/main.py:10"),
-            ChecklistAnswer(id=2, answer="no", evidence="none"),
-        ),
-        findings=(
-            ReviewFinding(
-                severity="P1",
-                category="security",
-                file="src/main.py",
-                line=10,
-                title="Fail-open default",
-                description="Unknown status grants access",
-                cause="else branch returns Active",
-                fix="Default to Expired",
-                confidence="high",
-                checklist_ids=(1,),
-            ),
-            ReviewFinding(
-                severity="P2",
-                category="test-gap",
-                file="tests/test_main.py",
-                line=5,
-                title="Missing access test",
-                description="No test for unknown status",
-                cause="Test gap",
-                fix="Add unit test",
-                confidence="medium",
-                checklist_ids=(2,),
-            ),
-        ),
-    )
     console = Console(record=True)
-    render_review_terminal(result=result, console=console)
+    render_review_terminal(result=sample_review_result, console=console)
     text = console.export_text()
 
     assert_that(text.index("P1")).is_less_than(text.index("P2"))

--- a/tests/unit/ai/review/test_output.py
+++ b/tests/unit/ai/review/test_output.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import json
+
 from assertpy import assert_that
 
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.output import (
     render_review_json,
+    render_review_output,
     review_result_to_dict,
 )
 
@@ -29,9 +32,20 @@ def test_render_review_json_is_valid_json(
     sample_review_result: ReviewResult,
 ) -> None:
     """Rendered JSON can be parsed back into a dictionary."""
-    import json
-
     rendered = render_review_json(result=sample_review_result)
     payload = json.loads(rendered)
 
-    assert_that(payload["findings"][0]["severity"]).is_equal_to("P1")
+    assert_that(payload["summary"]).is_equal_to("Merge with fixes.")
+    assert_that(payload["findings"]).is_length(2)
+    severities = {finding["severity"] for finding in payload["findings"]}
+    assert_that(severities).is_equal_to({"P1", "P2"})
+
+
+def test_render_review_output_json_dispatches_to_render_review_json(
+    sample_review_result: ReviewResult,
+) -> None:
+    """JSON output format routes through render_review_json."""
+    output = render_review_output(result=sample_review_result, output_format="json")
+    expected = render_review_json(result=sample_review_result)
+
+    assert_that(output).is_equal_to(expected)

--- a/tests/unit/ai/review/test_output.py
+++ b/tests/unit/ai/review/test_output.py
@@ -1,0 +1,37 @@
+"""Tests for review JSON output."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.output import (
+    render_review_json,
+    review_result_to_dict,
+)
+
+
+def test_review_result_to_dict_includes_metadata_fields(
+    sample_review_result: ReviewResult,
+) -> None:
+    """JSON dict includes all metadata fields."""
+    payload = review_result_to_dict(result=sample_review_result)
+
+    assert_that(payload["metadata"]).contains_key("model")
+    assert_that(payload["metadata"]).contains_key("context_window")
+    assert_that(payload["metadata"]).contains_key("timestamp")
+    assert_that(payload["summary"]).is_equal_to("Merge with fixes.")
+    assert_that(payload["checklist"]).is_length(2)
+    assert_that(payload["findings"]).is_length(2)
+
+
+def test_render_review_json_is_valid_json(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Rendered JSON can be parsed back into a dictionary."""
+    import json
+
+    rendered = render_review_json(result=sample_review_result)
+    payload = json.loads(rendered)
+
+    assert_that(payload["findings"][0]["severity"]).is_equal_to("P1")


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai/review): add terminal and JSON output formatters
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Phase 6 of the AI review stack (#991): completes JSON output formatting and
test coverage on top of the terminal display that landed via #1035.

- Adds `render_review_json()` alias and routes JSON output through it in
  `render_review_output()`
- Introduces shared `sample_review_result` fixture for display/output tests
- Adds JSON serialization unit tests and refactors display ordering test to
  reuse the shared fixture

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt`, `uv run lintro chk`, targeted pytest)

## Closes

- Closes #997
- Relates to #991

## Details

Terminal rendering (`display.py`) was already merged in #1035 during the #996
babysit. This PR carries the remaining Phase 6 scope: JSON formatter polish,
shared fixtures, and output tests rebased onto current `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new way to render AI review results as pretty-printed JSON.
  * JSON output now uses the new rendering helper for consistent formatting.

* **Tests**
  * Added coverage for review JSON output and key metadata fields.
  * Updated existing review display tests to use shared sample review data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR completes Phase 6 of the AI review stack by adding `render_review_json` as a named rendering entrypoint and routing the JSON path in `render_review_output` through it, while also introducing a shared `sample_review_result` fixture and new output tests.

- `render_review_json` is a thin alias for `review_result_to_json`; `render_review_output` now calls it for the JSON path, and three new tests cover dict conversion, JSON round-trip, and the dispatch routing.
- The shared fixture in `conftest.py` eliminates the duplicated inline `ReviewResult` construction from `test_display.py`, and the severity check in the JSON test correctly uses a set comparison, avoiding the ordering fragility noted in a prior review cycle.
- No production logic changes beyond the routing indirection; the change is low-risk.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is a one-line routing indirection backed by new tests that cover the dispatch, JSON round-trip, and metadata fields.

The production change is minimal — swapping a direct call to review_result_to_json for a call to render_review_json, which is a single-line passthrough. The new test file directly exercises the dispatch path, the dict conversion, and JSON validity, and the shared fixture reduces duplication without altering test logic. No edge cases are left unhandled in the changed paths.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lintro/ai/review/output.py | Adds render_review_json as a thin alias for review_result_to_json and routes the JSON path in render_review_output through it; logic is correct and tests cover the dispatch. |
| tests/unit/ai/review/conftest.py | Adds shared sample_review_result fixture with two findings (P1 + P2) used across display and output tests; fixture data is internally consistent. |
| tests/unit/ai/review/test_display.py | Removes inline fixture construction and delegates to shared sample_review_result; test logic is unchanged and remains correct. |
| tests/unit/ai/review/test_output.py | New test file covering dict conversion, JSON round-trip, and render_review_output dispatch; uses set comparison for severity checks, avoiding the fragile ordering issue noted in a prior review. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["render_review_output(result, output_format)"] -->|json| B["render_review_json(result)"]
    A -->|terminal| C["render_review_terminal(result)"]
    B --> D["review_result_to_json(result)"]
    D --> E["review_result_to_dict(result)"]
    E --> F["json.dumps with indent=2"]
    C --> G["Rich console output, returns None"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["render_review_output(result, output_format)"] -->|json| B["render_review_json(result)"]
    A -->|terminal| C["render_review_terminal(result)"]
    B --> D["review_result_to_json(result)"]
    D --> E["review_result_to_dict(result)"]
    E --> F["json.dumps with indent=2"]
    C --> G["Rich console output, returns None"]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lintro/ai/review/output.py`, line 11-16 ([link](https://github.com/lgtm-hq/py-lintro/blob/426773d49b1e9cee550fffc58284600a81c15c63/lintro/ai/review/output.py#L11-L16)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Duplicate public API surface**

   Both `render_review_json` and `review_result_to_json` are exported in `__all__` and do exactly the same thing — `render_review_json` is a one-line passthrough. Publishing both names risks confusion for callers about which to prefer, and the module docstring ("JSON serialization for AI review results") doesn't hint that the `render_*` variant exists. If `render_review_json` is intended as the stable, user-facing entrypoint, consider deprecating or un-exporting `review_result_to_json`, or at least documenting the distinction.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lintro%2Fai%2Freview%2Foutput.py%0ALine%3A%2011-16%0A%0AComment%3A%0A**Duplicate%20public%20API%20surface**%0A%0ABoth%20%60render_review_json%60%20and%20%60review_result_to_json%60%20are%20exported%20in%20%60__all__%60%20and%20do%20exactly%20the%20same%20thing%20%E2%80%94%20%60render_review_json%60%20is%20a%20one-line%20passthrough.%20Publishing%20both%20names%20risks%20confusion%20for%20callers%20about%20which%20to%20prefer%2C%20and%20the%20module%20docstring%20%28%22JSON%20serialization%20for%20AI%20review%20results%22%29%20doesn't%20hint%20that%20the%20%60render_*%60%20variant%20exists.%20If%20%60render_review_json%60%20is%20intended%20as%20the%20stable%2C%20user-facing%20entrypoint%2C%20consider%20deprecating%20or%20un-exporting%20%60review_result_to_json%60%2C%20or%20at%20least%20documenting%20the%20distinction.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=1036&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lintro%2Fai%2Freview%2Foutput.py%0ALine%3A%2011-16%0A%0AComment%3A%0A**Duplicate%20public%20API%20surface**%0A%0ABoth%20%60render_review_json%60%20and%20%60review_result_to_json%60%20are%20exported%20in%20%60__all__%60%20and%20do%20exactly%20the%20same%20thing%20%E2%80%94%20%60render_review_json%60%20is%20a%20one-line%20passthrough.%20Publishing%20both%20names%20risks%20confusion%20for%20callers%20about%20which%20to%20prefer%2C%20and%20the%20module%20docstring%20%28%22JSON%20serialization%20for%20AI%20review%20results%22%29%20doesn't%20hint%20that%20the%20%60render_*%60%20variant%20exists.%20If%20%60render_review_json%60%20is%20intended%20as%20the%20stable%2C%20user-facing%20entrypoint%2C%20consider%20deprecating%20or%20un-exporting%20%60review_result_to_json%60%2C%20or%20at%20least%20documenting%20the%20distinction.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fpy-lintro&pr=1036&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22feat%2F997-add-terminal-and-json-output-formatters%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F997-add-terminal-and-json-output-formatters%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20lintro%2Fai%2Freview%2Foutput.py%0ALine%3A%2011-16%0A%0AComment%3A%0A**Duplicate%20public%20API%20surface**%0A%0ABoth%20%60render_review_json%60%20and%20%60review_result_to_json%60%20are%20exported%20in%20%60__all__%60%20and%20do%20exactly%20the%20same%20thing%20%E2%80%94%20%60render_review_json%60%20is%20a%20one-line%20passthrough.%20Publishing%20both%20names%20risks%20confusion%20for%20callers%20about%20which%20to%20prefer%2C%20and%20the%20module%20docstring%20%28%22JSON%20serialization%20for%20AI%20review%20results%22%29%20doesn't%20hint%20that%20the%20%60render_*%60%20variant%20exists.%20If%20%60render_review_json%60%20is%20intended%20as%20the%20stable%2C%20user-facing%20entrypoint%2C%20consider%20deprecating%20or%20un-exporting%20%60review_result_to_json%60%2C%20or%20at%20least%20documenting%20the%20distinction.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fpy-lintro&pr=1036&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(tests): address review feedback on o..."](https://github.com/lgtm-hq/py-lintro/commit/f59a16f13e161c07a018e050e1c2fb8a70dbe586) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41372019)</sub>

<!-- /greptile_comment -->