### PR TITLE
feat(ai/review): add GitHub PR review posting

### DIFF
--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -1,0 +1,184 @@
+"""GitHub PR posting adapter for AI review results."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from lintro.ai.integrations.github_pr import GitHubPRReporter
+from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_result import ReviewResult
+
+__all__ = [
+    "format_finding_comment",
+    "format_review_summary",
+    "post_review_to_github",
+]
+
+
+def post_review_to_github(
+    *,
+    result: ReviewResult,
+    pr_number: int | None = None,
+    repo: str | None = None,
+    reporter: GitHubPRReporter | None = None,
+) -> bool:
+    """Post review findings as GitHub PR comments.
+
+    Args:
+        result: Review result to post.
+        pr_number: Optional PR number override.
+        repo: Optional repository override (owner/name).
+        reporter: Optional preconfigured GitHub reporter.
+
+    Returns:
+        True when posting succeeded or was skipped cleanly; False on failure.
+    """
+    gh_reporter = reporter or GitHubPRReporter(pr_number=pr_number, repo=repo)
+    if not gh_reporter.is_available():
+        logger.warning("GitHub PR context not available — skipping review posting")
+        return False
+
+    summary_body = format_review_summary(result=result)
+    inline_findings, fallback_findings = _partition_findings(
+        result=result,
+        reporter=gh_reporter,
+    )
+
+    success = True
+    if summary_body and not gh_reporter._post_issue_comment(summary_body):
+        success = False
+
+    if inline_findings and not _post_inline_findings(
+        reporter=gh_reporter,
+        findings=inline_findings,
+    ):
+        success = False
+
+    for finding in fallback_findings:
+        body = format_finding_comment(finding=finding)
+        location = f"`{finding.file}:{finding.line}`"
+        if not gh_reporter._post_issue_comment(f"{location}\n\n{body}"):
+            success = False
+
+    return success
+
+
+def format_finding_comment(*, finding: ReviewFinding) -> str:
+    """Format a review finding as a GitHub markdown comment.
+
+    Args:
+        finding: Review finding to format.
+
+    Returns:
+        Markdown comment body.
+    """
+    return (
+        f"**{finding.severity}** | {finding.category} | "
+        f"{finding.confidence} confidence\n\n"
+        f"### {finding.title}\n\n"
+        f"{finding.description}\n\n"
+        f"**Cause:** {finding.cause}\n\n"
+        f"**Fix:** {finding.fix}"
+    )
+
+
+def format_review_summary(*, result: ReviewResult) -> str:
+    """Format the top-level review summary comment.
+
+    Args:
+        result: Review result to summarize.
+
+    Returns:
+        Markdown summary comment body.
+    """
+    metadata = result.metadata
+    lines = [
+        "## Lintro Review",
+        "",
+        (
+            f"**Model:** {metadata.model} | **Depth:** {metadata.depth} | "
+            f"**Files:** {metadata.files_reviewed}/{metadata.files_total} | "
+            f"**Checklist:** {metadata.checklist_items} items"
+        ),
+        "",
+        "### Summary",
+        result.summary or "(no summary)",
+    ]
+
+    if result.checklist:
+        lines.extend(
+            ["", "### Checklist", "| ID | Answer | Evidence |", "|---|---|---|"],
+        )
+        for answer in result.checklist:
+            evidence = answer.evidence.replace("|", "\\|")
+            lines.append(f"| {answer.id} | {answer.answer} | {evidence} |")
+
+    outside_diff = [
+        finding for finding in result.findings if not finding.file or finding.line <= 0
+    ]
+    if outside_diff:
+        lines.extend(["", "### Findings outside diff"])
+        for finding in outside_diff:
+            lines.append(f"- **{finding.severity}** {finding.title} ({finding.file})")
+
+    return "\n".join(lines)
+
+
+def _partition_findings(
+    *,
+    result: ReviewResult,
+    reporter: GitHubPRReporter,
+) -> tuple[list[ReviewFinding], list[ReviewFinding]]:
+    """Split findings into inline-capable and fallback groups."""
+    diff_lines = reporter._fetch_pr_diff_lines()
+    inline: list[ReviewFinding] = []
+    fallback: list[ReviewFinding] = []
+
+    for finding in result.findings:
+        rel = finding.file.removeprefix("./").replace("\\", "/")
+        if (
+            not rel
+            or finding.line <= 0
+            or diff_lines is None
+            or finding.line not in diff_lines.get(rel, set())
+        ):
+            fallback.append(finding)
+        else:
+            inline.append(finding)
+
+    return inline, fallback
+
+
+def _post_inline_findings(
+    *,
+    reporter: GitHubPRReporter,
+    findings: list[ReviewFinding],
+) -> bool:
+    """Post inline PR review comments for mappable findings."""
+    comments: list[dict[str, Any]] = []
+    for finding in findings:
+        rel = finding.file.removeprefix("./").replace("\\", "/")
+        comments.append(
+            {
+                "path": rel,
+                "body": format_finding_comment(finding=finding),
+                "line": finding.line,
+                "side": "RIGHT",
+            },
+        )
+
+    if not comments:
+        return True
+
+    payload = {
+        "event": "COMMENT",
+        "body": "Lintro review findings",
+        "comments": comments,
+    }
+    url = (
+        f"{reporter.api_base}/repos/{reporter.repo}/pulls/"
+        f"{reporter.pr_number}/reviews"
+    )
+    return reporter._api_request("POST", url, payload)

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -33,7 +33,8 @@ def post_review_to_github(
         reporter: Optional preconfigured GitHub reporter.
 
     Returns:
-        True when posting succeeded or was skipped cleanly; False on failure.
+        True when posting succeeded; False on failure or when GitHub context is
+        unavailable.
     """
     gh_reporter = reporter or GitHubPRReporter(pr_number=pr_number, repo=repo)
     if not gh_reporter.is_available():
@@ -58,8 +59,9 @@ def post_review_to_github(
 
     for finding in fallback_findings:
         body = format_finding_comment(finding=finding)
-        location = f"`{finding.file}:{finding.line}`"
-        if not gh_reporter._post_issue_comment(f"{location}\n\n{body}"):
+        location = _format_fallback_location(finding=finding)
+        comment = f"{location}\n\n{body}" if location else body
+        if not gh_reporter._post_issue_comment(comment):
             success = False
 
     return success
@@ -112,18 +114,23 @@ def format_review_summary(*, result: ReviewResult) -> str:
             ["", "### Checklist", "| ID | Answer | Evidence |", "|---|---|---|"],
         )
         for answer in result.checklist:
-            evidence = answer.evidence.replace("|", "\\|")
+            evidence = (
+                answer.evidence.replace("|", "\\|")
+                .replace("\n", " ")
+                .replace("\r", " ")
+            )
             lines.append(f"| {answer.id} | {answer.answer} | {evidence} |")
 
-    outside_diff = [
-        finding for finding in result.findings if not finding.file or finding.line <= 0
-    ]
-    if outside_diff:
-        lines.extend(["", "### Findings outside diff"])
-        for finding in outside_diff:
-            lines.append(f"- **{finding.severity}** {finding.title} ({finding.file})")
-
     return "\n".join(lines)
+
+
+def _format_fallback_location(*, finding: ReviewFinding) -> str:
+    """Format the location header for a fallback issue comment."""
+    if not finding.file:
+        return ""
+    if finding.line > 0:
+        return f"`{finding.file}:{finding.line}`"
+    return f"`{finding.file}`"
 
 
 def _partition_findings(

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -11,6 +11,7 @@ from lintro.ai.review.github import (
     format_review_summary,
     post_review_to_github,
 )
+from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_result import ReviewResult
 
 
@@ -33,6 +34,49 @@ def test_format_review_summary_includes_checklist_table(
 
     assert_that(summary).contains("## Lintro Review")
     assert_that(summary).contains("| 1 | yes |")
+    assert_that(summary).does_not_contain("Findings outside diff")
+
+
+def test_post_review_to_github_posts_fallback_without_line_number(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Fallback comments omit invalid line numbers from the location header."""
+    outside_diff_finding = ReviewFinding(
+        severity="P2",
+        category="architecture",
+        file="docs/design.md",
+        line=0,
+        title="Missing ADR",
+        description="No architecture decision record",
+        cause="Process gap",
+        fix="Add ADR",
+        confidence="medium",
+        checklist_ids=(),
+    )
+    result = ReviewResult(
+        metadata=sample_review_result.metadata,
+        summary=sample_review_result.summary,
+        checklist=sample_review_result.checklist,
+        findings=(*sample_review_result.findings, outside_diff_finding),
+    )
+    reporter = MagicMock()
+    reporter.is_available.return_value = True
+    reporter._fetch_pr_diff_lines.return_value = {"src/main.py": {10}}
+    reporter._post_issue_comment.return_value = True
+
+    with patch(
+        "lintro.ai.review.github._post_inline_findings",
+        return_value=True,
+    ):
+        post_review_to_github(result=result, reporter=reporter)
+
+    fallback_calls = [
+        call.args[0]
+        for call in reporter._post_issue_comment.call_args_list
+        if call.args[0].startswith("`docs/design.md`")
+    ]
+    assert_that(fallback_calls).is_length(1)
+    assert_that(fallback_calls[0]).does_not_contain(":0")
 
 
 def test_post_review_to_github_returns_false_when_unavailable(
@@ -48,6 +92,7 @@ def test_post_review_to_github_returns_false_when_unavailable(
     )
 
     assert_that(posted).is_false()
+    reporter._post_issue_comment.assert_not_called()
 
 
 def test_post_review_to_github_posts_summary_and_inline(

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -1,0 +1,74 @@
+"""Tests for GitHub review posting adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from assertpy import assert_that
+
+from lintro.ai.review.github import (
+    format_finding_comment,
+    format_review_summary,
+    post_review_to_github,
+)
+from lintro.ai.review.models.review_result import ReviewResult
+
+
+def test_format_finding_comment_includes_severity_and_fix(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Finding comment includes severity badge and fix suggestion."""
+    finding = sample_review_result.findings[0]
+    comment = format_finding_comment(finding=finding)
+
+    assert_that(comment).contains("P1")
+    assert_that(comment).contains("Default to Expired")
+
+
+def test_format_review_summary_includes_checklist_table(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Summary comment includes checklist table rows."""
+    summary = format_review_summary(result=sample_review_result)
+
+    assert_that(summary).contains("## Lintro Review")
+    assert_that(summary).contains("| 1 | yes |")
+
+
+def test_post_review_to_github_returns_false_when_unavailable(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Posting is skipped cleanly when GitHub context is unavailable."""
+    reporter = MagicMock()
+    reporter.is_available.return_value = False
+
+    posted = post_review_to_github(
+        result=sample_review_result,
+        reporter=reporter,
+    )
+
+    assert_that(posted).is_false()
+
+
+def test_post_review_to_github_posts_summary_and_inline(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Available reporter posts summary and inline review comments."""
+    reporter = MagicMock()
+    reporter.is_available.return_value = True
+    reporter._fetch_pr_diff_lines.return_value = {"src/main.py": {10}}
+    reporter._post_issue_comment.return_value = True
+    reporter._api_request.return_value = True
+
+    with patch(
+        "lintro.ai.review.github._post_inline_findings",
+        return_value=True,
+    ) as mock_inline:
+        posted = post_review_to_github(
+            result=sample_review_result,
+            reporter=reporter,
+        )
+
+    assert_that(posted).is_true()
+    assert_that(reporter._post_issue_comment.called).is_true()
+    assert_that(mock_inline.called).is_true()


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai/review): add GitHub PR review posting
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Phase 7 of the AI review stack (#991): adds GitHub PR review posting so
`lintro review --post` can publish inline findings and a summary comment via
the GitHub API.

- New `lintro/ai/review/github.py` with `post_review_to_github()`
- Unit tests for comment formatting and posting flow
- CLI `--post` wiring already landed in #1035; this PR supplies the backend

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt`, `uv run lintro chk`, targeted pytest)

## Closes

- Closes #998
- Relates to #991

## Details

Rebased onto current `main` (post-#1036) with a minimal delta: only
`github.py` and `test_github.py`. Prior stacked branch history was not
cherry-picked wholesale to avoid regressions in review infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub PR review posting for AI-generated findings, including a top-level review summary and inline comments when possible.
  * Review summaries now include key metadata and a “Findings outside diff” section for items that can’t be placed inline.

* **Bug Fixes**
  * Improved posting behavior so reviews cleanly skip when GitHub context is unavailable, and fall back to issue-style comments when inline placement isn’t possible.

* **Tests**
  * Added coverage for comment formatting, summary output, and successful/skip review posting flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `lintro/ai/review/github.py`, the GitHub posting backend for `lintro review --post`, along with four unit tests. The new module wires `ReviewResult` → summary comment + inline GitHub review comments + fallback issue comments for unmappable findings.

- `post_review_to_github` orchestrates three posting paths: a top-level summary, a batched inline review via `/pulls/{pr}/reviews`, and per-finding fallback issue comments for findings not mapped to the diff.
- `_partition_findings` correctly gates inline placement on diff membership (line > 0, present in `_fetch_pr_diff_lines` output), sending all other findings to fallback.
- Previously flagged issues (double-posting, invalid `line=0` in location headers, docstring contradiction) are resolved in the current code.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the posting logic is self-contained, all three comment paths are exercised by tests, and the previously flagged issues are resolved in the current code.

The diff introduces a clean, well-scoped posting adapter with no shared mutable state. Partition logic is correct, fallback location formatting is correct, the docstring now accurately describes the return value, and the Findings outside diff duplication is absent. Remaining observations are style-level concerns that do not affect runtime behavior.

No files require special attention. lintro/ai/review/github.py is worth a second glance if GitHubPRReporter is ever refactored, since _post_inline_findings reaches into its protected interface.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/review/github.py | New GitHub PR posting adapter: posts a summary comment, inline review comments for in-diff findings, and fallback issue comments for unmappable findings. Logic is sound; _post_inline_findings reaches into GitHubPRReporter protected members across module boundaries, and the top-level summary omits the finding count entirely. |
| tests/unit/ai/review/test_github.py | Four focused unit tests covering comment formatting, fallback location rendering, unavailable-reporter short-circuit, and the happy path. Coverage is appropriate for the surface area introduced. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant post_review_to_github
    participant GitHubPRReporter
    participant GitHub_API

    Caller->>post_review_to_github: result, reporter?
    post_review_to_github->>GitHubPRReporter: is_available()
    alt not available
        post_review_to_github-->>Caller: False
    end
    post_review_to_github->>post_review_to_github: format_review_summary(result)
    post_review_to_github->>GitHubPRReporter: _fetch_pr_diff_lines()
    GitHubPRReporter->>GitHub_API: "GET /pulls/{pr}/files"
    GitHub_API-->>GitHubPRReporter: diff line map
    post_review_to_github->>post_review_to_github: _partition_findings(result, diff_lines)
    note over post_review_to_github: inline: in-diff and line>0, fallback: everything else
    post_review_to_github->>GitHubPRReporter: _post_issue_comment(summary)
    GitHubPRReporter->>GitHub_API: "POST /issues/{pr}/comments"
    opt inline_findings non-empty
        post_review_to_github->>post_review_to_github: _post_inline_findings(reporter, inline)
        post_review_to_github->>GitHub_API: "POST /pulls/{pr}/reviews"
    end
    loop each fallback finding
        post_review_to_github->>GitHubPRReporter: _post_issue_comment(location + body)
        GitHubPRReporter->>GitHub_API: "POST /issues/{pr}/comments"
    end
    post_review_to_github-->>Caller: success bool
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant post_review_to_github
    participant GitHubPRReporter
    participant GitHub_API

    Caller->>post_review_to_github: result, reporter?
    post_review_to_github->>GitHubPRReporter: is_available()
    alt not available
        post_review_to_github-->>Caller: False
    end
    post_review_to_github->>post_review_to_github: format_review_summary(result)
    post_review_to_github->>GitHubPRReporter: _fetch_pr_diff_lines()
    GitHubPRReporter->>GitHub_API: "GET /pulls/{pr}/files"
    GitHub_API-->>GitHubPRReporter: diff line map
    post_review_to_github->>post_review_to_github: _partition_findings(result, diff_lines)
    note over post_review_to_github: inline: in-diff and line>0, fallback: everything else
    post_review_to_github->>GitHubPRReporter: _post_issue_comment(summary)
    GitHubPRReporter->>GitHub_API: "POST /issues/{pr}/comments"
    opt inline_findings non-empty
        post_review_to_github->>post_review_to_github: _post_inline_findings(reporter, inline)
        post_review_to_github->>GitHub_API: "POST /pulls/{pr}/reviews"
    end
    loop each fallback finding
        post_review_to_github->>GitHubPRReporter: _post_issue_comment(location + body)
        GitHubPRReporter->>GitHub_API: "POST /issues/{pr}/comments"
    end
    post_review_to_github-->>Caller: success bool
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ai/review): avoid duplicate fallback..."](https://github.com/lgtm-hq/py-lintro/commit/fff2aa32d4430cae6f775f7ce0e754c4ff6eac66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41394494)</sub>

<!-- /greptile_comment -->