### PR TITLE
feat(ai/review): add --with-lint to feed tool results into review

### DIFF
--- a/lintro/ai/review/lint_bridge.py
+++ b/lintro/ai/review/lint_bridge.py
@@ -59,20 +59,20 @@ def run_lint_on_changed_files(
         except (KeyError, ValueError):
             continue
 
-        configure_tool_for_execution(
-            tool=tool,
-            tool_name=tool_name,
-            config_manager=config_manager,
-            tool_option_dict={},
-            exclude=None,
-            include_venv=False,
-            incremental=False,
-            action=Action.CHECK,
-            post_tools=set(),
-            auto_install=False,
-            lintro_config=lintro_config,
-        )
         try:
+            configure_tool_for_execution(
+                tool=tool,
+                tool_name=tool_name,
+                config_manager=config_manager,
+                tool_option_dict={},
+                exclude=None,
+                include_venv=False,
+                incremental=False,
+                action=Action.CHECK,
+                post_tools=set(),
+                auto_install=False,
+                lintro_config=lintro_config,
+            )
             result = tool.check(paths=changed_files, options={})
         except (
             Exception

--- a/lintro/ai/review/lint_bridge.py
+++ b/lintro/ai/review/lint_bridge.py
@@ -1,0 +1,114 @@
+"""Lint integration bridge for AI diff review."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from lintro.ai.prompts.review import format_lint_results_section
+from lintro.enums.action import Action
+from lintro.models.core.tool_result import ToolResult
+from lintro.tools import tool_manager
+from lintro.utils.execution.tool_configuration import (
+    configure_tool_for_execution,
+    get_tools_to_run,
+)
+from lintro.utils.unified_config import UnifiedConfigManager
+
+if TYPE_CHECKING:
+    from lintro.config.lintro_config import LintroConfig
+
+__all__ = [
+    "format_lint_results_for_prompt",
+    "run_lint_on_changed_files",
+]
+
+
+def run_lint_on_changed_files(
+    *,
+    changed_files: list[str],
+    lintro_config: LintroConfig,
+) -> list[ToolResult]:
+    """Run lintro check tools scoped to changed files without AI enhancement.
+
+    Args:
+        changed_files: Repository-relative changed file paths.
+        lintro_config: Loaded Lintro configuration.
+
+    Returns:
+        Raw tool results from applicable linters.
+    """
+    del lintro_config  # Config is read via get_tools_to_run/get_config internally.
+    if not changed_files:
+        return []
+
+    selection = get_tools_to_run(tools="all", action=Action.CHECK)
+    if not selection.to_run:
+        return []
+
+    config_manager = UnifiedConfigManager()
+    results: list[ToolResult] = []
+
+    for tool_name in selection.to_run:
+        try:
+            tool = tool_manager.get_tool(tool_name)
+        except (KeyError, ValueError):
+            continue
+
+        configure_tool_for_execution(
+            tool=tool,
+            tool_name=tool_name,
+            config_manager=config_manager,
+            tool_option_dict={},
+            exclude=None,
+            include_venv=False,
+            incremental=False,
+            action=Action.CHECK,
+            post_tools=set(),
+            auto_install=False,
+        )
+        result = tool.check(paths=changed_files, options={})
+        results.append(result)
+
+    return results
+
+
+def format_lint_results_for_prompt(
+    *,
+    results: list[ToolResult],
+    max_entries: int = 200,
+) -> str:
+    """Format lint tool results as a compact prompt digest.
+
+    Args:
+        results: Tool results from ``run_lint_on_changed_files``.
+        max_entries: Maximum number of issue lines to include.
+
+    Returns:
+        Lint digest wrapped in ``<lint_results>`` tags, or empty string.
+    """
+    lines: list[str] = []
+    for result in results:
+        if not result.issues:
+            continue
+        for issue in result.issues:
+            if len(lines) >= max_entries:
+                break
+            code = getattr(issue, "code", "") or "unknown"
+            message = getattr(issue, "message", "") or ""
+            file_path = getattr(issue, "file", "") or ""
+            line_no = getattr(issue, "line", None)
+            line_suffix = f" | line: {line_no}" if line_no else ""
+            lines.append(
+                f"Tool: {result.name} | file: {file_path}{line_suffix}\n"
+                f"Code: {code} | Message: {message}",
+            )
+        if len(lines) >= max_entries:
+            break
+
+    if not lines:
+        return ""
+
+    digest = "\n\n".join(lines)
+    if len(lines) >= max_entries:
+        digest += "\n\n(truncated lint digest)"
+    return format_lint_results_section(digest=digest)

--- a/lintro/ai/review/lint_bridge.py
+++ b/lintro/ai/review/lint_bridge.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from loguru import logger
+
 from lintro.ai.prompts.review import format_lint_results_section
 from lintro.enums.action import Action
 from lintro.models.core.tool_result import ToolResult
@@ -37,11 +39,14 @@ def run_lint_on_changed_files(
     Returns:
         Raw tool results from applicable linters.
     """
-    del lintro_config  # Config is read via get_tools_to_run/get_config internally.
     if not changed_files:
         return []
 
-    selection = get_tools_to_run(tools="all", action=Action.CHECK)
+    selection = get_tools_to_run(
+        tools="all",
+        action=Action.CHECK,
+        lintro_config=lintro_config,
+    )
     if not selection.to_run:
         return []
 
@@ -65,8 +70,17 @@ def run_lint_on_changed_files(
             action=Action.CHECK,
             post_tools=set(),
             auto_install=False,
+            lintro_config=lintro_config,
         )
-        result = tool.check(paths=changed_files, options={})
+        try:
+            result = tool.check(paths=changed_files, options={})
+        except Exception:
+            logger.warning(
+                "Lint bridge skipped {} after check failure",
+                tool_name,
+                exc_info=True,
+            )
+            continue
         results.append(result)
 
     return results
@@ -81,7 +95,7 @@ def format_lint_results_for_prompt(
 
     Args:
         results: Tool results from ``run_lint_on_changed_files``.
-        max_entries: Maximum number of issue lines to include.
+        max_entries: Maximum number of issue entries to include.
 
     Returns:
         Lint digest wrapped in ``<lint_results>`` tags, or empty string.

--- a/lintro/ai/review/lint_bridge.py
+++ b/lintro/ai/review/lint_bridge.py
@@ -74,7 +74,9 @@ def run_lint_on_changed_files(
         )
         try:
             result = tool.check(paths=changed_files, options={})
-        except Exception:
+        except (
+            Exception
+        ):  # noqa: BLE001 - one tool failure must not abort scoped lint run
             logger.warning(
                 "Lint bridge skipped {} after check failure",
                 tool_name,

--- a/lintro/utils/execution/tool_configuration.py
+++ b/lintro/utils/execution/tool_configuration.py
@@ -211,6 +211,7 @@ def get_tools_to_run(
     action: str | Action,
     *,
     ignore_conflicts: bool = False,
+    lintro_config: LintroConfig | None = None,
 ) -> ToolsToRunResult:
     """Get the list of tools to run based on the tools string and action.
 
@@ -218,6 +219,7 @@ def get_tools_to_run(
         tools: Comma-separated tool names, "all", or None.
         action: "check", "fmt", or "test".
         ignore_conflicts: If True, skip conflict checking between tools.
+        lintro_config: Optional config override; uses global config when omitted.
 
     Returns:
         ToolsToRunResult with tools to run and skipped tools with reasons.
@@ -240,16 +242,16 @@ def get_tools_to_run(
         if not tool_manager.is_tool_registered("pytest"):
             raise ValueError("pytest tool is not available")
         # Respect enabled/disabled config for pytest
-        lintro_config = get_config()
-        if not lintro_config.is_tool_enabled("pytest"):
-            reason = _get_disabled_reason(lintro_config, "pytest")
+        config = lintro_config or get_config()
+        if not config.is_tool_enabled("pytest"):
+            reason = _get_disabled_reason(config, "pytest")
             return ToolsToRunResult(
                 skipped=[SkippedTool(name="pytest", reason=reason)],
             )
         return ToolsToRunResult(to_run=["pytest"])
 
     # Get lintro config for enabled/disabled tool checking
-    lintro_config = get_config()
+    config = lintro_config or get_config()
 
     if (
         tools is None
@@ -267,8 +269,8 @@ def get_tools_to_run(
         for name in available_tools:
             if name.lower() == "pytest":
                 continue
-            if not lintro_config.is_tool_enabled(name):
-                reason = _get_disabled_reason(lintro_config, name)
+            if not config.is_tool_enabled(name):
+                reason = _get_disabled_reason(config, name)
                 skipped.append(SkippedTool(name=name, reason=reason))
             else:
                 to_run.append(name)
@@ -302,8 +304,8 @@ def get_tools_to_run(
                 f"Unknown tool '{name}'. Available tools: {available_names}",
             )
         # Track disabled tools with reason
-        if not lintro_config.is_tool_enabled(name):
-            reason = _get_disabled_reason(lintro_config, name)
+        if not config.is_tool_enabled(name):
+            reason = _get_disabled_reason(config, name)
             skipped.append(SkippedTool(name=name, reason=reason))
             continue
         # Verify the tool supports the requested action

--- a/tests/unit/ai/review/test_lint_bridge.py
+++ b/tests/unit/ai/review/test_lint_bridge.py
@@ -1,0 +1,79 @@
+"""Tests for lint bridge integration."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from assertpy import assert_that
+
+from lintro.ai.review.lint_bridge import (
+    format_lint_results_for_prompt,
+    run_lint_on_changed_files,
+)
+from lintro.config.lintro_config import LintroConfig
+from lintro.models.core.tool_result import ToolResult
+
+
+def test_run_lint_on_changed_files_returns_empty_for_no_paths() -> None:
+    """No changed files yields an empty lint result list."""
+    results = run_lint_on_changed_files(
+        changed_files=[],
+        lintro_config=LintroConfig(),
+    )
+
+    assert_that(results).is_empty()
+
+
+def test_format_lint_results_for_prompt_returns_empty_without_issues() -> None:
+    """Empty lint results produce an empty prompt section."""
+    digest = format_lint_results_for_prompt(
+        results=[ToolResult(name="ruff", success=True, issues_count=0, issues=[])],
+    )
+
+    assert_that(digest).is_empty()
+
+
+def test_format_lint_results_for_prompt_wraps_issue_lines() -> None:
+    """Lint issues are formatted as compact digest lines."""
+    issue = MagicMock()
+    issue.code = "E501"
+    issue.message = "Line too long"
+    issue.file = "src/main.py"
+    issue.line = 10
+
+    digest = format_lint_results_for_prompt(
+        results=[
+            ToolResult(
+                name="ruff",
+                success=False,
+                issues_count=1,
+                issues=[issue],
+            ),
+        ],
+    )
+
+    assert_that(digest).contains("<lint_results>")
+    assert_that(digest).contains("Tool: ruff")
+    assert_that(digest).contains("E501")
+
+
+def test_run_lint_on_changed_files_invokes_tool_check() -> None:
+    """Lint bridge runs configured tools against changed file paths."""
+    mock_tool = MagicMock()
+    mock_tool.check.return_value = ToolResult(name="ruff", success=True, issues_count=0)
+
+    with patch(
+        "lintro.ai.review.lint_bridge.get_tools_to_run",
+    ) as mock_get_tools:
+        mock_get_tools.return_value.to_run = ["ruff"]
+        with patch(
+            "lintro.ai.review.lint_bridge.tool_manager.get_tool",
+            return_value=mock_tool,
+        ):
+            results = run_lint_on_changed_files(
+                changed_files=["src/main.py"],
+                lintro_config=LintroConfig(),
+            )
+
+    assert_that(results).is_length(1)
+    mock_tool.check.assert_called_once()

--- a/tests/unit/ai/review/test_lint_bridge.py
+++ b/tests/unit/ai/review/test_lint_bridge.py
@@ -66,9 +66,14 @@ def test_run_lint_on_changed_files_invokes_tool_check() -> None:
         "lintro.ai.review.lint_bridge.get_tools_to_run",
     ) as mock_get_tools:
         mock_get_tools.return_value.to_run = ["ruff"]
-        with patch(
-            "lintro.ai.review.lint_bridge.tool_manager.get_tool",
-            return_value=mock_tool,
+        with (
+            patch(
+                "lintro.ai.review.lint_bridge.tool_manager.get_tool",
+                return_value=mock_tool,
+            ),
+            patch(
+                "lintro.ai.review.lint_bridge.configure_tool_for_execution",
+            ),
         ):
             results = run_lint_on_changed_files(
                 changed_files=["src/main.py"],


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai/review): add --with-lint to feed tool results into review
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Phase 8 of the AI review stack (#991): adds the lint bridge so
`lintro review --with-lint` runs scoped lintro checks on changed files and
injects formatted results into the review prompt.

- New `lintro/ai/review/lint_bridge.py` with `run_lint_on_changed_files()` and
  `format_lint_results_for_prompt()`
- Unit tests for bridge formatting and tool invocation
- CLI `--with-lint` wiring and `format_lint_results_section()` already on `main`

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt`, `uv run lintro chk`, targeted pytest)

## Closes

- Closes #999
- Relates to #991

## Details

Rebased onto current `main` (post-#1037) with a minimal delta. Supersedes
stacked draft [#1016](https://github.com/lgtm-hq/py-lintro/pull/1016), which
targeted `feat/998` and was closed during the unstack-to-main workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run lint checks only on changed files to focus review feedback on relevant paths.
  * Summarize lint findings into a compact, scan-friendly digest for prompts.

* **Bug Fixes**
  * Return clean, empty output when there are no changed files, no configured lint tools, or no lint issues.

* **Tests**
  * Added unit coverage for changed-file lint execution, tool invocation behavior, and digest formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds the lint bridge for Phase 8 of the AI review stack: `run_lint_on_changed_files()` runs scoped lintro checks on PR-changed paths, and `format_lint_results_for_prompt()` packages the results into a `<lint_results>` digest that is injected into the AI review prompt. The `get_tools_to_run` utility also receives a new optional `lintro_config` parameter so the caller's loaded config propagates cleanly instead of falling back to a global `get_config()` call.

- `lint_bridge.py` correctly passes `lintro_config` through to both `get_tools_to_run` and `configure_tool_for_execution`, and the per-tool `try/except` guard now wraps both configuration and execution — all four issues from prior review rounds appear resolved.
- `format_lint_results_for_prompt` has two small logic gaps: `line_no` is tested for truthiness rather than `is not None` (silently drops line 0), and the `(truncated lint digest)` sentinel fires when `len(lines) == max_entries` exactly, even when no issues were actually omitted.
- `tool_configuration.py` changes are clean and backward-compatible.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the bridge introduces no blocking failures — all four concerns from prior review rounds are resolved and the remaining gaps are cosmetic formatting edge cases in the prompt digest.

All previously flagged issues (config pass-through, try/except scope, docstring wording, un-mocked configure_tool_for_execution in tests) are addressed in this revision. The two remaining findings are limited to the AI prompt digest: a line-0 location omission and a false truncation notice when issue count equals the cap exactly. Neither causes incorrect lint execution or data loss.

lintro/ai/review/lint_bridge.py — specifically the truncation logic and line-number truthiness check in format_lint_results_for_prompt

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/review/lint_bridge.py | New bridge module running scoped lint checks and formatting results for AI prompts; previously-flagged issues (config pass-through, try/except scope, docstring wording) are all resolved in this revision. Minor logic issue: line number 0 is silently dropped as falsy, and the truncation sentinel fires when issue count equals max_entries exactly (no actual overflow). |
| lintro/utils/execution/tool_configuration.py | Backward-compatible addition of lintro_config parameter to get_tools_to_run(); local variable renamed from lintro_config to config to avoid shadowing — clean refactor with no behavioural regression. |
| tests/unit/ai/review/test_lint_bridge.py | Four focused unit tests covering empty paths, empty issues, digest formatting, and tool invocation; configure_tool_for_execution is now correctly mocked. Tool check call arguments (paths, options) are not asserted, leaving a gap in coverage. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as lintro CLI (--with-lint)
    participant Bridge as lint_bridge.py
    participant Config as tool_configuration.py
    participant TM as tool_manager
    participant Tool as BaseToolPlugin
    participant Prompt as ai/prompts/review.py

    CLI->>Bridge: run_lint_on_changed_files(changed_files, lintro_config)
    Bridge->>Config: get_tools_to_run("all", CHECK, lintro_config)
    Config-->>Bridge: "ToolsToRunResult(to_run=[...])"
    loop for each tool_name
        Bridge->>TM: get_tool(tool_name)
        TM-->>Bridge: tool instance
        Bridge->>Config: configure_tool_for_execution(tool, ..., lintro_config)
        Bridge->>Tool: "check(paths=changed_files, options={})"
        Tool-->>Bridge: ToolResult
    end
    Bridge-->>CLI: list[ToolResult]
    CLI->>Bridge: "format_lint_results_for_prompt(results, max_entries=200)"
    Bridge->>Prompt: format_lint_results_section(digest)
    Prompt-->>Bridge: "<lint_results>...</lint_results>"
    Bridge-->>CLI: prompt section string
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as lintro CLI (--with-lint)
    participant Bridge as lint_bridge.py
    participant Config as tool_configuration.py
    participant TM as tool_manager
    participant Tool as BaseToolPlugin
    participant Prompt as ai/prompts/review.py

    CLI->>Bridge: run_lint_on_changed_files(changed_files, lintro_config)
    Bridge->>Config: get_tools_to_run("all", CHECK, lintro_config)
    Config-->>Bridge: "ToolsToRunResult(to_run=[...])"
    loop for each tool_name
        Bridge->>TM: get_tool(tool_name)
        TM-->>Bridge: tool instance
        Bridge->>Config: configure_tool_for_execution(tool, ..., lintro_config)
        Bridge->>Tool: "check(paths=changed_files, options={})"
        Tool-->>Bridge: ToolResult
    end
    Bridge-->>CLI: list[ToolResult]
    CLI->>Bridge: "format_lint_results_for_prompt(results, max_entries=200)"
    Bridge->>Prompt: format_lint_results_section(digest)
    Prompt-->>Bridge: "<lint_results>...</lint_results>"
    Bridge-->>CLI: prompt section string
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ai/review): guard configure\_tool\_for..."](https://github.com/lgtm-hq/py-lintro/commit/6b1c1c3b8a0d924fe37ef7d1d4b7241d8550df65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41422275)</sub>

<!-- /greptile_comment -->