### PR TITLE
fix(ai/review): CLI mode wiring broken — --uncommitted, --pr, and CI runs always fail

### DIFF
--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -174,6 +174,8 @@ def review_command(
         raise click.UsageError(
             "--pr and --uncommitted cannot be used together.",
         )
+    if pr is None and repo is not None:
+        raise click.UsageError("--repo can only be used with --pr.")
     resolved_pr: int | None = None
     if post:
         resolved_pr = pr or _detect_pr_number_from_env()

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -36,9 +36,11 @@ from lintro.config.config_loader import get_config
 @click.command("review")
 @click.option(
     "--base",
-    default="main",
-    show_default=True,
-    help="Base branch for diff comparison.",
+    default=None,
+    help=(
+        "Base branch for diff comparison. When omitted, uses the repository "
+        "default branch (origin/HEAD)."
+    ),
 )
 @click.option(
     "--uncommitted",
@@ -138,7 +140,7 @@ from lintro.config.config_loader import get_config
 )
 def review_command(
     *,
-    base: str,
+    base: str | None,
     uncommitted: bool,
     pr: int | None,
     repo: str | None,
@@ -185,12 +187,13 @@ def review_command(
             )
 
     paths = list(path_filter) if path_filter else None
+    context_repo = effective_repo if pr is not None else None
     try:
         context = collect_review_context(
             base=base,
             uncommitted=uncommitted,
             pr_number=pr,
-            repo=effective_repo,
+            repo=context_repo,
             paths=paths,
         )
     except ReviewContextError as exc:

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -174,7 +174,7 @@ def review_command(
         raise click.UsageError(
             "--pr and --uncommitted cannot be used together.",
         )
-    if pr is None and repo is not None:
+    if pr is None and repo is not None and not post:
         raise click.UsageError("--repo can only be used with --pr.")
     resolved_pr: int | None = None
     if post:

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -189,12 +189,13 @@ def review_command(
             )
 
     paths = list(path_filter) if path_filter else None
-    context_repo = effective_repo if pr is not None else None
+    context_pr = resolved_pr if post else pr
+    context_repo = effective_repo if context_pr is not None else None
     try:
         context = collect_review_context(
             base=base,
             uncommitted=uncommitted,
-            pr_number=pr,
+            pr_number=context_pr,
             repo=context_repo,
             paths=paths,
         )

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -488,6 +488,39 @@ def test_review_repo_without_pr_fails() -> None:
     assert_that(result.output).contains("--repo can only be used with --pr.")
 
 
+def test_review_post_with_repo_without_pr() -> None:
+    """--post with explicit --repo does not require a redundant --pr flag."""
+    runner = CliRunner()
+    mock_collect = MagicMock(
+        return_value=MagicMock(changed_files=[], unified_diff=""),
+    )
+    patches = _mock_review_pipeline(mock_collect=mock_collect)
+
+    with (
+        patches["require_ai"],
+        patches["get_config"],
+        patches["collect_review_context"],
+        patches["classify_changed_files"],
+        patches["get_all_checklist_items"],
+        patches["select_checklist_items"],
+        patches["format_checklist_for_prompt"],
+        patches["get_provider"],
+        patches["run_review"],
+        patches["render_review_output"],
+        patch(
+            "lintro.cli_utils.commands.review._detect_pr_number_from_env",
+            return_value=42,
+        ),
+        patch("lintro.ai.review.github.post_review_to_github", return_value=True),
+    ):
+        result = runner.invoke(cli, ["review", "--post", "--repo", "owner/repo"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).does_not_contain(
+        "--repo can only be used with --pr.",
+    )
+
+
 def test_review_failure_renders_friendly_error_without_traceback() -> None:
     """Mid-review failures show a Rich panel instead of a traceback."""
     runner = CliRunner()

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from assertpy import assert_that
@@ -260,6 +261,214 @@ def test_review_exits_zero_without_p1_findings() -> None:
     assert_that(mock_render.call_args.kwargs).contains_key(
         "checklist_display",
     )
+
+
+def _mock_review_pipeline(
+    *,
+    mock_collect: MagicMock | None = None,
+) -> dict[str, Any]:
+    """Return patched review dependencies for CliRunner mode wiring tests."""
+    mock_context = MagicMock()
+    mock_context.changed_files = []
+    mock_context.unified_diff = ""
+    mock_config = MagicMock(ai=MagicMock(enabled=True))
+    mock_config.review.depth = 1
+    mock_config.review.strictness = ReviewStrictness.BALANCED
+    mock_config.review.sensitivity = MagicMock()
+    mock_config.review.force_semantic_chunking = False
+    mock_config.review.checklist_display = ChecklistDisplay.OFF
+
+    collect_patch = (
+        patch(
+            "lintro.cli_utils.commands.review.collect_review_context",
+            mock_collect,
+        )
+        if mock_collect is not None
+        else patch(
+            "lintro.cli_utils.commands.review.collect_review_context",
+            return_value=mock_context,
+        )
+    )
+
+    patches = {
+        "require_ai": patch("lintro.cli_utils.commands.review.require_ai"),
+        "get_config": patch(
+            "lintro.cli_utils.commands.review.get_config",
+            return_value=mock_config,
+        ),
+        "collect_review_context": collect_patch,
+        "classify_changed_files": patch(
+            "lintro.cli_utils.commands.review.classify_changed_files",
+            return_value=[],
+        ),
+        "get_all_checklist_items": patch(
+            "lintro.cli_utils.commands.review.get_all_checklist_items",
+            return_value=[],
+        ),
+        "select_checklist_items": patch(
+            "lintro.cli_utils.commands.review.select_checklist_items",
+            return_value=[],
+        ),
+        "format_checklist_for_prompt": patch(
+            "lintro.cli_utils.commands.review.format_checklist_for_prompt",
+            return_value=("", {}),
+        ),
+        "get_provider": patch(
+            "lintro.cli_utils.commands.review.get_provider",
+            return_value=MagicMock(
+                model_name="gpt-4o",
+                name="openai",
+            ),
+        ),
+        "run_review": patch(
+            "lintro.cli_utils.commands.review.run_review",
+            return_value=_empty_result(),
+        ),
+        "render_review_output": patch(
+            "lintro.cli_utils.commands.review.render_review_output",
+        ),
+    }
+    return patches
+
+
+def test_review_uncommitted_mode() -> None:
+    """Uncommitted mode does not pass an explicit base branch to collection."""
+    runner = CliRunner()
+    mock_collect = MagicMock(
+        return_value=MagicMock(changed_files=[], unified_diff=""),
+    )
+    patches = _mock_review_pipeline(mock_collect=mock_collect)
+
+    with (
+        patches["require_ai"],
+        patches["get_config"],
+        patches["collect_review_context"],
+        patches["classify_changed_files"],
+        patches["get_all_checklist_items"],
+        patches["select_checklist_items"],
+        patches["format_checklist_for_prompt"],
+        patches["get_provider"],
+        patches["run_review"],
+        patches["render_review_output"],
+    ):
+        result = runner.invoke(cli, ["review", "--uncommitted"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).does_not_contain("Cannot combine")
+    assert_that(mock_collect.call_args.kwargs).is_equal_to(
+        {
+            "base": None,
+            "uncommitted": True,
+            "pr_number": None,
+            "repo": None,
+            "paths": None,
+        },
+    )
+
+
+def test_review_pr_mode() -> None:
+    """PR mode forwards repo without an explicit base branch."""
+    runner = CliRunner()
+    mock_collect = MagicMock(
+        return_value=MagicMock(changed_files=[], unified_diff=""),
+    )
+    patches = _mock_review_pipeline(mock_collect=mock_collect)
+
+    with (
+        patches["require_ai"],
+        patches["get_config"],
+        patches["collect_review_context"],
+        patches["classify_changed_files"],
+        patches["get_all_checklist_items"],
+        patches["select_checklist_items"],
+        patches["format_checklist_for_prompt"],
+        patches["get_provider"],
+        patches["run_review"],
+        patches["render_review_output"],
+    ):
+        result = runner.invoke(
+            cli,
+            ["review", "--pr", "5", "--repo", "owner/repo"],
+        )
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).does_not_contain("explicit base branch")
+    assert_that(mock_collect.call_args.kwargs).is_equal_to(
+        {
+            "base": None,
+            "uncommitted": False,
+            "pr_number": 5,
+            "repo": "owner/repo",
+            "paths": None,
+        },
+    )
+
+
+def test_review_plain_mode() -> None:
+    """Default branch mode succeeds without CI repository env vars."""
+    runner = CliRunner()
+    mock_collect = MagicMock(
+        return_value=MagicMock(changed_files=[], unified_diff=""),
+    )
+    patches = _mock_review_pipeline(mock_collect=mock_collect)
+
+    with (
+        patches["require_ai"],
+        patches["get_config"],
+        patches["collect_review_context"],
+        patches["classify_changed_files"],
+        patches["get_all_checklist_items"],
+        patches["select_checklist_items"],
+        patches["format_checklist_for_prompt"],
+        patches["get_provider"],
+        patches["run_review"],
+        patches["render_review_output"],
+    ):
+        result = runner.invoke(cli, ["review"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(mock_collect.call_args.kwargs).is_equal_to(
+        {
+            "base": None,
+            "uncommitted": False,
+            "pr_number": None,
+            "repo": None,
+            "paths": None,
+        },
+    )
+
+
+def test_review_plain_with_github_repository_env() -> None:
+    """CI GITHUB_REPOSITORY env does not leak into non-PR collection."""
+    runner = CliRunner()
+    mock_collect = MagicMock(
+        return_value=MagicMock(changed_files=[], unified_diff=""),
+    )
+    patches = _mock_review_pipeline(mock_collect=mock_collect)
+
+    with (
+        patches["require_ai"],
+        patches["get_config"],
+        patches["collect_review_context"],
+        patches["classify_changed_files"],
+        patches["get_all_checklist_items"],
+        patches["select_checklist_items"],
+        patches["format_checklist_for_prompt"],
+        patches["get_provider"],
+        patches["run_review"],
+        patches["render_review_output"],
+    ):
+        result = runner.invoke(
+            cli,
+            ["review"],
+            env={"GITHUB_REPOSITORY": "owner/repo"},
+        )
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).does_not_contain(
+        "Cannot provide repo without pr_number",
+    )
+    assert_that(mock_collect.call_args.kwargs["repo"]).is_none()
 
 
 def test_review_failure_renders_friendly_error_without_traceback() -> None:

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -519,6 +519,15 @@ def test_review_post_with_repo_without_pr() -> None:
     assert_that(result.output).does_not_contain(
         "--repo can only be used with --pr.",
     )
+    assert_that(mock_collect.call_args.kwargs).is_equal_to(
+        {
+            "base": None,
+            "uncommitted": False,
+            "pr_number": 42,
+            "repo": "owner/repo",
+            "paths": None,
+        },
+    )
 
 
 def test_review_failure_renders_friendly_error_without_traceback() -> None:

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -290,7 +290,7 @@ def _mock_review_pipeline(
         )
     )
 
-    patches = {
+    return {
         "require_ai": patch("lintro.cli_utils.commands.review.require_ai"),
         "get_config": patch(
             "lintro.cli_utils.commands.review.get_config",
@@ -328,7 +328,6 @@ def _mock_review_pipeline(
             "lintro.cli_utils.commands.review.render_review_output",
         ),
     }
-    return patches
 
 
 def test_review_uncommitted_mode() -> None:
@@ -469,6 +468,24 @@ def test_review_plain_with_github_repository_env() -> None:
         "Cannot provide repo without pr_number",
     )
     assert_that(mock_collect.call_args.kwargs["repo"]).is_none()
+
+
+def test_review_repo_without_pr_fails() -> None:
+    """Explicit --repo without --pr fails fast instead of reviewing locally."""
+    runner = CliRunner()
+    mock_config = MagicMock(ai=MagicMock(enabled=True))
+
+    with (
+        patch("lintro.cli_utils.commands.review.require_ai"),
+        patch(
+            "lintro.cli_utils.commands.review.get_config",
+            return_value=mock_config,
+        ),
+    ):
+        result = runner.invoke(cli, ["review", "--repo", "owner/repo"])
+
+    assert_that(result.exit_code).is_not_equal_to(0)
+    assert_that(result.output).contains("--repo can only be used with --pr.")
 
 
 def test_review_failure_renders_friendly_error_without_traceback() -> None:


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ai/review): allow --uncommitted and --pr without conflicting --base default
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The `lintro review` CLI command had broken mode wiring that caused three common invocation paths to fail:

1. **`--uncommitted`** — Click defaulted `--base` to `"main"`, which conflicted with uncommitted mode inside `collect_review_context`.
2. **`--pr`** — Same implicit `"main"` base was forwarded, breaking PR diff collection.
3. **Plain `lintro review` in CI** — `GITHUB_REPOSITORY` was always forwarded as `repo`, even when not in PR mode, causing context collection to fail outside GitHub Actions PR contexts.

**Fix:**
- Change `--base` default from `"main"` to `None` so mode flags control base resolution.
- Only pass `repo` to `collect_review_context` when `--pr` is explicitly set (`context_repo = effective_repo if pr is not None else None`).

Added four CliRunner regression tests covering uncommitted, PR, plain, and plain-with-`GITHUB_REPOSITORY` modes.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

Closes #1039

## Details

### Root cause

`--base` defaulted to `"main"` at the Click layer. When `--uncommitted` or `--pr` was used, that explicit base was still forwarded to `collect_review_context`, which rejects incompatible combinations. Separately, `GITHUB_REPOSITORY` was always passed as `repo`, which is only valid for PR mode.

### Testing strategy

- Unit tests in `tests/unit/cli/test_review_command.py` mock the review pipeline and assert `collect_review_context` receives the correct kwargs for each mode.
- Verified locally: `uv run pytest tests/unit/cli/test_review_command.py -v` (11 passed), `uv run lintro fmt`, `uv run lintro chk`.

## Test plan

- [x] `uv run pytest tests/unit/cli/test_review_command.py -v` — all 11 tests pass
- [x] `uv run lintro fmt && uv run lintro chk` — zero issues
- [ ] CI green on PR
- [ ] CodeRabbit / Greptile review clean

## Closes

- Closes #1039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `review` command so omitting `--base` now follows the repository’s default branch automatically.
  * Added stricter argument validation: `--repo` is rejected unless used with `--pr` (with the documented exception when posting).
  * Improved review context handling so repo resolution is applied only when it applies to the selected mode.

* **Tests**
  * Expanded unit test coverage for `review` across uncommitted, PR, default, and `GITHUB_REPOSITORY` scenarios, plus new validation/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes mode wiring for the `lintro review` command. The main changes are:

- `--base` now defaults to no explicit branch.
- Non-PR runs no longer pass `GITHUB_REPOSITORY` into context collection.
- Post mode now forwards the detected PR and repo into context collection.
- Tests cover the affected CLI invocation modes.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/cli_utils/commands/review.py | Updates review command argument handling so base, repo, and PR values match the selected mode. |
| tests/unit/cli/test_review_command.py | Adds tests for uncommitted, PR, plain, repo-env, explicit repo, and post-mode review command flows. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(ai/review): use detected PR for --po..."](https://github.com/lgtm-hq/py-lintro/commit/28d64074da69a0baa0df2b4ec0d7a0c746ade9b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41819620)</sub>

<!-- /greptile_comment -->