### PR TITLE
fix(ci): unblock Renovate PRs blocked by mypy and artifact updates

### DIFF
--- a/lintro/utils/path_filtering.py
+++ b/lintro/utils/path_filtering.py
@@ -162,7 +162,7 @@ def walk_files_with_excludes(
 
 def _should_exclude_with_spec(
     path: str,
-    spec: pathspec.PathSpec | None,
+    spec: pathspec.GitIgnoreSpec | None,
 ) -> bool:
     """Check if a path should be excluded using a pre-compiled PathSpec.
 

--- a/renovate.json
+++ b/renovate.json
@@ -86,6 +86,8 @@
         ],
         "fileFilters": [
           "lintro/_tool_versions.py",
+          "lintro/_generated_versions.py",
+          "lintro/tools/manifest.json",
           "package.json",
           "pyproject.toml",
           "Dockerfile"

--- a/renovate.json
+++ b/renovate.json
@@ -78,7 +78,8 @@
       "matchManagers": ["custom.regex"],
       "matchFileNames": [
         "Dockerfile",
-        "lintro/_tool_versions.py"
+        "lintro/_tool_versions.py",
+        "lintro/tools/manifest.json"
       ],
       "postUpgradeTasks": {
         "commands": [

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "local>lgtm-hq/.github:renovate-config"
   ],
+  "allowedCommands": [
+    "python3 scripts/ci/generate-tool-versions.py"
+  ],
   "packageRules": [
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
## Summary

Fix two CI blockers affecting multiple open Renovate PRs: a mypy `PathSpec` typing regression triggered by lockfile maintenance, and Renovate artifact updates failing because `generate-tool-versions.py` was not in `allowedCommands`.

## Type

- [x] fix

## Changes Made

- Annotate `_should_exclude_with_spec` with `pathspec.GitIgnoreSpec | None` instead of bare `PathSpec`
- Add `allowedCommands` entry for `python3 scripts/ci/generate-tool-versions.py` in `renovate.json`

## Testing

- [x] Verified root cause from failing Renovate PR CI logs

## Quality Checks

- [x] Linting/formatting passes locally

## Checklist

- [x] Changes are focused on CI/Renovate unblockers
- [x] No secrets or credentials included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository automation settings to allow an additional maintenance command for version-generation workflows.
  * Refined internal type annotations for path filtering helpers, with no change in app behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes CI blockers for Renovate updates.

- Narrows the path filtering spec annotation to `pathspec.GitIgnoreSpec | None`.
- Allows the tool-version generator command in Renovate configuration.
- Expands the Renovate post-upgrade rule to include manifest-triggered generation and generated artifacts.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/utils/path_filtering.py | Updates the internal pathspec helper annotation to match the GitIgnoreSpec object produced by the helper flow. |
| renovate.json | Adds Renovate command allowance and expands the post-upgrade generation rule to cover the manifest and generated outputs. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(ci): run generator when manifest.jso..."](https://github.com/lgtm-hq/py-lintro/commit/7e3ab51abd818c71f8ba83f945051ecf12444cc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41826782)</sub>

<!-- /greptile_comment -->