### PR TITLE
ci: pin merge_group activity type to checks_requested

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ name: Security - CodeQL Code Scanning
     branches: [main]
     paths: ['**.py', 'pyproject.toml', '.github/**']
   merge_group:
+    types: [checks_requested]
   schedule:
     - cron: '0 5 * * 1'
   workflow_dispatch:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,6 +7,7 @@ name: Security - Dependency Review
   pull_request:
     branches: [main]
   merge_group:
+    types: [checks_requested]
 
 permissions: {}
 

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -14,6 +14,7 @@ name: CI - Docker
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -7,6 +7,7 @@ name: Quality Check - PR Title Validation
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
   merge_group:
+    types: [checks_requested]
 
 permissions: {}
 

--- a/.github/workflows/test-built-package.yml
+++ b/.github/workflows/test-built-package.yml
@@ -23,6 +23,7 @@ name: Testing - Built Package Validation
       - MANIFEST.in
       - scripts/ci/test-*.sh
   merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -10,6 +10,7 @@ name: CI - Tests
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -10,6 +10,7 @@ name: Quality Check - Action Pinning Validation
       - '.github/workflows/**'
       - '.github/actions/**'
   merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Summary

Pins the `merge_group` trigger to `types: [checks_requested]` across every workflow that uses it, making the merge-queue contract explicit and consistent with other lgtm-hq repos. `checks_requested` is currently the only activity type `merge_group` emits, so this change is behavior-preserving and cannot affect releases.

Issue #889 originally targeted `.github/workflows/ci-pipeline.yml`, but that file was split into thin reusable-workflow files in #939. The `merge_group` triggers now live across 7 workflows, none of which pinned the activity type. This PR pins all of them for consistency:

- `test-ci.yml`
- `codeql.yml`
- `dependency-review.yml`
- `semantic-pr-title.yml`
- `docker-ci.yml`
- `validate-action-pinning.yml`
- `test-built-package.yml`

## Validation

- All 7 workflow YAML files parse and pass yamllint (`uv run lintro chk`).
- `uv run lintro fmt` clean.
- Full test suite green: 5719 passed, 11 skipped.

## Deferred: #844 (vuln-suppression expiry)

**Not addressed here — needs clarification / belongs upstream.**

Issue #844's fix targets `scripts/ci/check-vuln-suppressions.sh`, but that script no longer exists in this repo. In #990 the vuln-suppression check was migrated to the shared `lgtm-hq/lgtm-ci` reusable workflow (`reusable-vuln-suppression-check.yml@v0.46.0`); py-lintro now only calls it via `.github/workflows/vuln-suppression-check.yml`. The three-part logic fix (stale-only removal, non-zero exit on expired entries, `.[0].number // empty`) must be applied in `lgtm-hq/lgtm-ci` (matching how it was done in `lgtm-hq/Rustume#136`), not here. Left #844 open.

- Closes #889

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several automated checks so they run for the `checks_requested` event on pull requests and merge groups.
  * This helps keep security, dependency, CI, and validation workflows in sync with the latest review activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the merge queue trigger explicit in the CI workflows. The main changes are:

- Adds `types: [checks_requested]` to the CodeQL workflow.
- Adds the same merge queue type pin to dependency review, Docker CI, PR title validation, built-package testing, test CI, and action pinning validation.
- Keeps the existing workflow jobs and filters unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/codeql.yml | Pins the existing merge queue trigger to `checks_requested`. |
| .github/workflows/dependency-review.yml | Pins the existing merge queue trigger to `checks_requested`. |
| .github/workflows/docker-ci.yml | Pins the existing merge queue trigger to `checks_requested`. |
| .github/workflows/semantic-pr-title.yml | Pins the existing merge queue trigger to `checks_requested`. |
| .github/workflows/test-built-package.yml | Pins the existing merge queue trigger to `checks_requested`. |
| .github/workflows/test-ci.yml | Pins the existing merge queue trigger to `checks_requested`. |
| .github/workflows/validate-action-pinning.yml | Pins the existing merge queue trigger to `checks_requested`. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: pin merge\_group activity type to che..."](https://github.com/lgtm-hq/py-lintro/commit/75bce12b0e1e0e32cde03f736e82a96e52ef0d9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41846740)</sub>

<!-- /greptile_comment -->