### PR TITLE
fix(output): unify report counts and clean JSON stdout

### DIFF
--- a/lintro/utils/console/__init__.py
+++ b/lintro/utils/console/__init__.py
@@ -24,18 +24,22 @@ from lintro.utils.console.logger import ThreadSafeConsoleLogger
 
 def create_logger(
     run_dir: Path | None = None,
+    *,
+    route_stderr: bool = False,
     **kwargs: Any,
 ) -> ThreadSafeConsoleLogger:
     """Create a new ThreadSafeConsoleLogger instance.
 
     Args:
         run_dir: Optional run directory path for output location display.
+        route_stderr: When True, decorative console output is routed to stderr
+            so stdout carries only the final machine-readable document.
         **kwargs: Additional arguments (ignored for backward compatibility).
 
     Returns:
         ThreadSafeConsoleLogger: A new instance of ThreadSafeConsoleLogger.
     """
-    return ThreadSafeConsoleLogger(run_dir=run_dir)
+    return ThreadSafeConsoleLogger(run_dir=run_dir, route_stderr=route_stderr)
 
 
 __all__ = [

--- a/lintro/utils/console/logger.py
+++ b/lintro/utils/console/logger.py
@@ -39,13 +39,23 @@ class ThreadSafeConsoleLogger:
     thread synchronization for parallel tool execution.
     """
 
-    def __init__(self, run_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        run_dir: Path | None = None,
+        *,
+        route_stderr: bool = False,
+    ) -> None:
         """Initialize the ThreadSafeConsoleLogger.
 
         Args:
             run_dir: Optional run directory path for output location display.
+            route_stderr: When True, all decorative console output is written
+                to stderr instead of stdout. Used for machine-readable output
+                formats (JSON/SARIF) so stdout carries only the final
+                parseable document.
         """
         self.run_dir = run_dir
+        self.route_stderr = route_stderr
         self._messages: list[str] = []
         self._lock = threading.Lock()
 
@@ -54,14 +64,17 @@ class ThreadSafeConsoleLogger:
 
         Thread-safe: Uses lock when appending to message list.
 
+        When ``route_stderr`` is set the text is written to stderr so stdout
+        stays a single parseable document for machine-readable formats.
+
         Args:
             text: Text to display.
             color: Optional color for the text.
         """
         if color:
-            click.echo(click.style(text, fg=color))
+            click.echo(click.style(text, fg=color), err=self.route_stderr)
         else:
-            click.echo(text)
+            click.echo(text, err=self.route_stderr)
 
         # Track for console.log (thread-safe)
         with self._lock:
@@ -114,7 +127,10 @@ class ThreadSafeConsoleLogger:
             **kwargs: Additional keyword arguments for logger formatting.
         """
         error_text = f"ERROR: {message}"
-        click.echo(click.style(error_text, fg="red", bold=True))
+        click.echo(
+            click.style(error_text, fg="red", bold=True),
+            err=self.route_stderr,
+        )
         with self._lock:
             self._messages.append(error_text)
         logger.error(message, **kwargs)

--- a/lintro/utils/execution/exit_codes.py
+++ b/lintro/utils/execution/exit_codes.py
@@ -71,7 +71,9 @@ def aggregate_tool_results(
         action: The action performed (determines which counts to aggregate).
 
     Returns:
-        Tuple of (total_issues, total_fixed, total_remaining).
+        Tuple of (total_issues, total_fixed, total_remaining). In CHECK/TEST
+        mode nothing is fixed, so ``total_remaining`` mirrors ``total_issues``
+        rather than the misleading constant 0.
     """
     total_issues = 0
     total_fixed = 0
@@ -88,5 +90,11 @@ def aggregate_tool_results(
             total_fixed += fixed if fixed is not None else 0
             remaining = getattr(result, "remaining_issues_count", None)
             total_remaining += remaining if remaining is not None else 0
+
+    # Outside FIX mode nothing is fixed; the remaining count is simply the
+    # total issues found. Mirroring it here keeps the check-mode JSON summary
+    # from reporting "total_remaining": 0 alongside a nonzero "total_issues".
+    if action != Action.FIX:
+        total_remaining = total_issues
 
     return total_issues, total_fixed, total_remaining

--- a/lintro/utils/json_output.py
+++ b/lintro/utils/json_output.py
@@ -88,8 +88,10 @@ def serialize_tool_result(
     if result.parse_failures_count is not None:
         data["parse_failures_count"] = result.parse_failures_count
     if action == Action.FIX:
-        data["fixed"] = getattr(result, "fixed_issues_count", 0)
-        data["remaining"] = getattr(result, "remaining_issues_count", 0)
+        fixed = getattr(result, "fixed_issues_count", None)
+        remaining = getattr(result, "remaining_issues_count", None)
+        data["fixed"] = fixed if fixed is not None else 0
+        data["remaining"] = remaining if remaining is not None else 0
     ai_metadata = getattr(result, "ai_metadata", None)
     if isinstance(ai_metadata, dict) and ai_metadata:
         normalized_ai_metadata = normalize_ai_metadata(ai_metadata)

--- a/lintro/utils/json_output.py
+++ b/lintro/utils/json_output.py
@@ -1,13 +1,103 @@
 """JSON output utilities for Lintro.
 
 This module provides functionality for creating JSON output from tool results.
+
+It exposes a single source of truth for the per-tool JSON object shared by
+both serialization paths:
+
+- ``create_json_output`` renders the ``--output-format json`` stdout payload.
+- ``lintro.utils.output.file_writer.write_output_file`` renders the
+  ``--output <file>`` artifact.
+
+Both build each per-tool object via :func:`serialize_tool_result` so their
+schemas cannot silently drift.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lintro.ai.metadata import normalize_ai_metadata
 from lintro.enums.action import Action, normalize_action
+from lintro.formatters.formatter import merge_detected_and_remaining
 from lintro.models.core.tool_result import ToolResult
+
+if TYPE_CHECKING:
+    from lintro.parsers.base_issue import BaseIssue
+
+
+def serialize_issue(issue: "BaseIssue") -> dict[str, Any]:
+    """Serialize a ``BaseIssue`` to a JSON-safe dictionary.
+
+    Args:
+        issue: The issue to serialize.
+
+    Returns:
+        Serialized issue data with ``file``, ``line``, ``code`` and
+        ``message`` always present and ``doc_url`` included when set.
+    """
+    data: dict[str, Any] = {
+        "file": getattr(issue, "file", "") or "",
+        "line": getattr(issue, "line", None) or 0,
+        "code": getattr(issue, "code", "") or "",
+        "message": getattr(issue, "message", "") or "",
+    }
+    doc_url = getattr(issue, "doc_url", "") or ""
+    if doc_url:
+        data["doc_url"] = doc_url
+    return data
+
+
+def serialize_tool_result(
+    result: ToolResult,
+    *,
+    action: Action,
+) -> dict[str, Any]:
+    """Serialize a single ``ToolResult`` into the shared per-tool JSON object.
+
+    This is the single source of truth for the per-tool schema emitted by both
+    the stdout payload (:func:`create_json_output`) and the file artifact
+    (``write_output_file``). Keeping both callers on this helper prevents the
+    two serializers from drifting.
+
+    The ``issues_count`` is derived from the deduplicated merge of pre-fix and
+    remaining issues (``len(merged_issues)``) so it stays consistent with the
+    ``issues`` array in fix mode, where ``merge_detected_and_remaining``
+    collapses duplicate detected/remaining entries.
+
+    Args:
+        result: The tool result to serialize.
+        action: The action being performed (check, fmt, test).
+
+    Returns:
+        The per-tool JSON object: always ``tool``, ``success``,
+        ``issues_count``, ``skipped``, ``skip_reason`` and ``output``; plus
+        ``parse_failures_count`` when set, ``fixed``/``remaining`` in FIX mode,
+        normalized ``ai_metadata`` when present, and ``issues`` when any exist.
+    """
+    merged_issues = merge_detected_and_remaining(
+        getattr(result, "initial_issues", None),
+        getattr(result, "issues", None),
+    )
+    data: dict[str, Any] = {
+        "tool": result.name,
+        "success": getattr(result, "success", True),
+        "issues_count": len(merged_issues),
+        "skipped": getattr(result, "skipped", False),
+        "skip_reason": getattr(result, "skip_reason", None),
+        "output": getattr(result, "output", ""),
+    }
+    if result.parse_failures_count is not None:
+        data["parse_failures_count"] = result.parse_failures_count
+    if action == Action.FIX:
+        data["fixed"] = getattr(result, "fixed_issues_count", 0)
+        data["remaining"] = getattr(result, "remaining_issues_count", 0)
+    ai_metadata = getattr(result, "ai_metadata", None)
+    if isinstance(ai_metadata, dict) and ai_metadata:
+        normalized_ai_metadata = normalize_ai_metadata(ai_metadata)
+        if normalized_ai_metadata:
+            data["ai_metadata"] = normalized_ai_metadata
+    if merged_issues:
+        data["issues"] = [serialize_issue(issue) for issue in merged_issues]
+    return data
 
 
 def create_json_output(
@@ -25,7 +115,9 @@ def create_json_output(
         results: List of tool result objects.
         total_issues: Total number of issues found.
         total_fixed: Total number of issues fixed (only for FIX action).
-        total_remaining: Total number of issues remaining (only for FIX action).
+        total_remaining: Total number of issues remaining. In FIX mode this is
+            the post-fix remaining count; in CHECK/TEST mode nothing is fixed,
+            so it mirrors ``total_issues``.
         exit_code: Exit code for the run.
 
     Returns:
@@ -39,39 +131,23 @@ def create_json_output(
         "summary": {
             "total_issues": total_issues,
             "total_fixed": total_fixed if action_enum == Action.FIX else 0,
-            "total_remaining": total_remaining if action_enum == Action.FIX else 0,
+            # In CHECK/TEST mode nothing is fixed, so remaining mirrors the
+            # total issues rather than the misleading constant 0.
+            "total_remaining": (
+                total_remaining if action_enum == Action.FIX else total_issues
+            ),
         },
     }
     for result in results:
-        result_data: dict[str, Any] = {
-            "tool": result.name,
-            "success": getattr(result, "success", True),
-            "issues_count": getattr(result, "issues_count", 0),
-            "skipped": getattr(result, "skipped", False),
-            "skip_reason": getattr(result, "skip_reason", None),
-        }
-        if result.parse_failures_count is not None:
-            result_data["parse_failures_count"] = result.parse_failures_count
-        if action_enum == Action.FIX:
-            result_data["fixed"] = getattr(result, "fixed_issues_count", 0)
-            result_data["remaining"] = getattr(
-                result,
-                "remaining_issues_count",
-                0,
-            )
-        # Include AI metadata when present
-        ai_metadata = getattr(result, "ai_metadata", None)
-        if isinstance(ai_metadata, dict):
-            normalized_ai_metadata = normalize_ai_metadata(ai_metadata)
-            if normalized_ai_metadata:
-                result_data["ai_metadata"] = normalized_ai_metadata
-                # Extract AI summary from the first result that has one
-                if (
-                    "summary" in normalized_ai_metadata
-                    and "ai_summary" not in json_data
-                ):
-                    json_data["ai_summary"] = normalized_ai_metadata["summary"]
-
+        result_data = serialize_tool_result(result, action=action_enum)
+        # Extract AI summary from the first result that has one.
+        ai_metadata = result_data.get("ai_metadata")
+        if (
+            isinstance(ai_metadata, dict)
+            and "summary" in ai_metadata
+            and "ai_summary" not in json_data
+        ):
+            json_data["ai_summary"] = ai_metadata["summary"]
         json_data["results"].append(result_data)
 
     return json_data

--- a/lintro/utils/output/file_writer.py
+++ b/lintro/utils/output/file_writer.py
@@ -148,13 +148,28 @@ _HTML_ISSUES_HEADER = (
 )
 
 
-def _merged_issue_count(result: ToolResult) -> int:
-    """Return the deduplicated issue count for a result.
+def _merged_issues(result: ToolResult) -> list[BaseIssue]:
+    """Return the deduplicated issue list for a result.
 
-    Uses ``len(merge_detected_and_remaining(...))`` so every output format
-    reports the same count the JSON writer does. In check mode
+    Uses ``merge_detected_and_remaining(...)`` so every output format
+    reports the same issues the JSON writer does. In check mode
     ``initial_issues`` is None and the merged list equals ``result.issues``;
     in fix mode the merge deduplicates pre-fix and remaining issues.
+
+    Args:
+        result: Tool result to collect issues for.
+
+    Returns:
+        The merged/deduplicated issue list.
+    """
+    return merge_detected_and_remaining(
+        getattr(result, "initial_issues", None),
+        getattr(result, "issues", None),
+    )
+
+
+def _merged_issue_count(result: ToolResult) -> int:
+    """Return the deduplicated issue count for a result.
 
     Args:
         result: Tool result to count issues for.
@@ -162,11 +177,7 @@ def _merged_issue_count(result: ToolResult) -> int:
     Returns:
         The merged/deduplicated issue count.
     """
-    merged_issues = merge_detected_and_remaining(
-        getattr(result, "initial_issues", None),
-        getattr(result, "issues", None),
-    )
-    return len(merged_issues)
+    return len(_merged_issues(result))
 
 
 def write_output_file(
@@ -227,9 +238,10 @@ def write_output_file(
             "doc_url",
         ]
         for result in all_results:
-            merged_count = _merged_issue_count(result)
-            if hasattr(result, "issues") and result.issues:
-                for issue in result.issues:
+            merged_issues = _merged_issues(result)
+            merged_count = len(merged_issues)
+            if merged_issues:
+                for issue in merged_issues:
                     rows.append(
                         [
                             sanitize_csv_value(result.name),

--- a/lintro/utils/output/file_writer.py
+++ b/lintro/utils/output/file_writer.py
@@ -29,6 +29,7 @@ from lintro.formatters.formatter import (
     merge_detected_and_remaining,
 )
 from lintro.parsers.base_issue import BaseIssue
+from lintro.utils.json_output import serialize_tool_result
 from lintro.utils.output.helpers import sanitize_csv_value
 from lintro.utils.output.parser_registration import ParserError
 from lintro.utils.output.parser_registry import ParserRegistry
@@ -147,25 +148,25 @@ _HTML_ISSUES_HEADER = (
 )
 
 
-def _serialize_issue(issue: BaseIssue) -> dict[str, Any]:
-    """Serialize a BaseIssue to a JSON-safe dictionary.
+def _merged_issue_count(result: ToolResult) -> int:
+    """Return the deduplicated issue count for a result.
+
+    Uses ``len(merge_detected_and_remaining(...))`` so every output format
+    reports the same count the JSON writer does. In check mode
+    ``initial_issues`` is None and the merged list equals ``result.issues``;
+    in fix mode the merge deduplicates pre-fix and remaining issues.
 
     Args:
-        issue: BaseIssue: The issue to serialize.
+        result: Tool result to count issues for.
 
     Returns:
-        dict[str, Any]: Serialized issue data.
+        The merged/deduplicated issue count.
     """
-    data: dict[str, Any] = {
-        "file": getattr(issue, "file", "") or "",
-        "line": getattr(issue, "line", None) or 0,
-        "code": getattr(issue, "code", "") or "",
-        "message": getattr(issue, "message", "") or "",
-    }
-    doc_url = getattr(issue, "doc_url", "") or ""
-    if doc_url:
-        data["doc_url"] = doc_url
-    return data
+    merged_issues = merge_detected_and_remaining(
+        getattr(result, "initial_issues", None),
+        getattr(result, "issues", None),
+    )
+    return len(merged_issues)
 
 
 def write_output_file(
@@ -203,36 +204,11 @@ def write_output_file(
             "results": [],
         }
         for result in all_results:
-            # Merge pre-fix and remaining issues (deduped) so fix-mode
-            # JSON matches the CLI JSON output from format_fix_results.
-            # For check mode, initial_issues is None and the merged list
-            # equals result.issues.
-            merged_issues = merge_detected_and_remaining(
-                getattr(result, "initial_issues", None),
-                getattr(result, "issues", None),
+            # Build each per-tool object via the shared serializer so the
+            # file artifact and the stdout payload cannot drift.
+            json_data["results"].append(
+                serialize_tool_result(result, action=action),
             )
-            result_data = {
-                "tool": result.name,
-                "success": getattr(result, "success", True),
-                "issues_count": len(merged_issues),
-                "skipped": getattr(result, "skipped", False),
-                "skip_reason": getattr(result, "skip_reason", None),
-                "output": getattr(result, "output", ""),
-            }
-            if result.parse_failures_count is not None:
-                result_data["parse_failures_count"] = result.parse_failures_count
-            ai_metadata = getattr(result, "ai_metadata", None)
-            if isinstance(ai_metadata, dict) and ai_metadata:
-                from lintro.ai.metadata import normalize_ai_metadata
-
-                normalized = normalize_ai_metadata(ai_metadata)
-                if normalized:
-                    result_data["ai_metadata"] = normalized
-            if merged_issues:
-                result_data["issues"] = [
-                    _serialize_issue(issue) for issue in merged_issues
-                ]
-            json_data["results"].append(result_data)
         output_file.write_text(
             json.dumps(json_data, indent=2, ensure_ascii=False),
             encoding="utf-8",
@@ -251,13 +227,14 @@ def write_output_file(
             "doc_url",
         ]
         for result in all_results:
+            merged_count = _merged_issue_count(result)
             if hasattr(result, "issues") and result.issues:
                 for issue in result.issues:
                     rows.append(
                         [
                             sanitize_csv_value(result.name),
                             sanitize_csv_value(
-                                str(getattr(result, "issues_count", 0)),
+                                str(merged_count),
                             ),
                             sanitize_csv_value(str(getattr(issue, "file", "") or "")),
                             sanitize_csv_value(
@@ -276,7 +253,7 @@ def write_output_file(
                 rows.append(
                     [
                         sanitize_csv_value(result.name),
-                        sanitize_csv_value(str(getattr(result, "issues_count", 0))),
+                        sanitize_csv_value(str(merged_count)),
                         "",
                         "",
                         "",
@@ -296,10 +273,10 @@ def write_output_file(
         lines.append("| Tool | Issues |")
         lines.append("|------|--------|")
         for result in all_results:
-            lines.append(f"| {result.name} | {getattr(result, 'issues_count', 0)} |")
+            lines.append(f"| {result.name} | {_merged_issue_count(result)} |")
         lines.append("")
         for result in all_results:
-            issues_count = getattr(result, "issues_count", 0)
+            issues_count = _merged_issue_count(result)
             lines.append(f"### {result.name} ({issues_count} issues)")
             if _result_has_fix_split(result, action):
                 initial = list(result.initial_issues or [])
@@ -343,11 +320,11 @@ def write_output_file(
             safe_name = html.escape(result.name)
             html_lines.append(
                 f"<tr><td>{safe_name}</td>"
-                f"<td>{getattr(result, 'issues_count', 0)}</td></tr>",
+                f"<td>{_merged_issue_count(result)}</td></tr>",
             )
         html_lines.append("</table>")
         for result in all_results:
-            issues_count = getattr(result, "issues_count", 0)
+            issues_count = _merged_issue_count(result)
             html_lines.append(
                 f"<h3>{html.escape(result.name)} ({issues_count} issues)</h3>",
             )
@@ -403,7 +380,7 @@ def write_output_file(
 
         lines = [f"Lintro {action.value.capitalize()} Report", "=" * 40, ""]
         for result in all_results:
-            issues_count = getattr(result, "issues_count", 0)
+            issues_count = _merged_issue_count(result)
             lines.append(f"{result.name}: {issues_count} issues")
             if _result_has_fix_split(result, action):
                 split_output = format_fix_results(

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -459,10 +459,16 @@ def run_lint_tools_simple(
 
     setup_execution_logging(output_manager.run_dir, debug=debug)
 
-    # Create simplified logger with rich formatting
+    # Create simplified logger with rich formatting. For machine-readable
+    # output (JSON/SARIF) route all decorative console output to stderr so
+    # stdout carries only the final parseable document.
     from lintro.utils.console import create_logger
 
-    logger = create_logger(run_dir=output_manager.run_dir)
+    machine_readable_output = output_format.lower() in ("json", "sarif")
+    logger = create_logger(
+        run_dir=output_manager.run_dir,
+        route_stderr=machine_readable_output,
+    )
 
     # Get tools to run (now returns ToolsToRunResult with skip info)
     try:

--- a/tests/unit/tools/executor/test_tool_executor.py
+++ b/tests/unit/tools/executor/test_tool_executor.py
@@ -309,6 +309,53 @@ def test_executor_json_output(
     assert_that("summary" in data).is_true()
 
 
+def test_executor_json_stdout_is_clean_and_banners_go_to_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Route decorative banners to stderr so stdout is a single JSON document.
+
+    Regression test for #1045: with ``--output-format json`` the real console
+    logger must emit banners/progress to stderr, leaving stdout parseable.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        capsys: Pytest capture fixture for stdout/stderr.
+    """
+    # Intentionally do NOT stub the logger so real banner routing is exercised.
+    result = ToolResult(name="ruff", success=False, output="raw", issues_count=2)
+    _setup_tool_manager(
+        monkeypatch,
+        {"ruff": FakeTool("ruff", can_fix=True, result=result)},
+    )
+    code = run_lint_tools_simple(
+        action="check",
+        paths=["."],
+        tools="all",
+        tool_options=None,
+        exclude=None,
+        include_venv=False,
+        group_by="auto",
+        output_format="json",
+        verbose=False,
+        raw_output=False,
+    )
+    assert_that(code).is_equal_to(1)
+
+    captured = capsys.readouterr()
+    # stdout must be a single parseable JSON document.
+    data = json.loads(captured.out)
+    assert_that(data).contains_key("results")
+    assert_that(data).contains_key("summary")
+    # Check-mode remaining mirrors total_issues rather than a constant 0.
+    assert_that(data["summary"]["total_remaining"]).is_equal_to(
+        data["summary"]["total_issues"],
+    )
+    # The banner must not pollute stdout, but must appear on stderr.
+    assert_that(captured.out).does_not_contain("[LINTRO]")
+    assert_that(captured.err).contains("[LINTRO]")
+
+
 def test_executor_handles_tool_failure_with_output(
     monkeypatch: pytest.MonkeyPatch,
     fake_logger: Any,

--- a/tests/unit/utils/console/test_logger_levels.py
+++ b/tests/unit/utils/console/test_logger_levels.py
@@ -73,7 +73,7 @@ def test_error_outputs_red_text(logger: ThreadSafeConsoleLogger) -> None:
         mock_style.return_value = "styled"
         logger.error("error message")
         mock_style.assert_called_once_with("ERROR: error message", fg="red", bold=True)
-        mock_echo.assert_called_once_with("styled")
+        mock_echo.assert_called_once_with("styled", err=False)
         assert_that(logger._messages).contains("ERROR: error message")
 
 

--- a/tests/unit/utils/console/test_logger_output_methods.py
+++ b/tests/unit/utils/console/test_logger_output_methods.py
@@ -30,7 +30,7 @@ def test_console_output_no_color(logger: ThreadSafeConsoleLogger) -> None:
     """
     with patch("click.echo") as mock_echo:
         logger.console_output("test message")
-        mock_echo.assert_called_once_with("test message")
+        mock_echo.assert_called_once_with("test message", err=False)
 
 
 def test_console_output_with_color(logger: ThreadSafeConsoleLogger) -> None:
@@ -48,7 +48,19 @@ def test_console_output_with_color(logger: ThreadSafeConsoleLogger) -> None:
     ):
         logger.console_output("test message", color="red")
         mock_style.assert_called_once_with("test message", fg="red")
-        mock_echo.assert_called_once_with("styled text")
+        mock_echo.assert_called_once_with("styled text", err=False)
+
+
+def test_console_output_routes_to_stderr_when_enabled() -> None:
+    """Verify console_output writes to stderr when route_stderr is enabled.
+
+    Regression test for #1045: machine-readable formats route decorative
+    output to stderr so stdout stays a single parseable document.
+    """
+    stderr_logger = ThreadSafeConsoleLogger(route_stderr=True)
+    with patch("click.echo") as mock_echo:
+        stderr_logger.console_output("banner text")
+        mock_echo.assert_called_once_with("banner text", err=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/utils/output/test_file_writer_csv.py
+++ b/tests/unit/utils/output/test_file_writer_csv.py
@@ -127,7 +127,11 @@ def test_write_csv_uses_merged_issue_count_not_stale_value(
     )
 
     content = output_path.read_text()
+    lines = content.strip().split("\n")
     # Merged/deduped count is 2 (detected [E001, E002] + remaining [E002]).
     assert_that(content).does_not_contain("99")
-    data_row = content.strip().split("\n")[1]
-    assert_that(data_row.split(",")[1]).is_equal_to("2")
+    assert_that(lines).is_length(3)  # header + 2 merged issue rows
+    assert_that(content).contains("E001")
+    assert_that(content).contains("E002")
+    for data_row in lines[1:]:
+        assert_that(data_row.split(",")[1]).is_equal_to("2")

--- a/tests/unit/utils/output/test_file_writer_csv.py
+++ b/tests/unit/utils/output/test_file_writer_csv.py
@@ -15,7 +15,11 @@ from lintro.enums.output_format import OutputFormat
 from lintro.utils.output.file_writer import write_output_file
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from lintro.models.core.tool_result import ToolResult
+
+    from .conftest import MockIssue
 
 
 def test_write_csv_file_creates_valid_file_with_headers(
@@ -81,3 +85,49 @@ def test_write_csv_file_includes_issue_data(
     assert_that(content).contains("src/main.py")
     assert_that(content).contains("E001")
     assert_that(content).contains("ruff")
+
+
+def test_write_csv_uses_merged_issue_count_not_stale_value(
+    tmp_path: Path,
+    mock_tool_result_factory: Callable[..., ToolResult],
+    mock_issue_factory: Callable[..., MockIssue],
+) -> None:
+    """CSV issues_count reflects merged/deduped count, not stale ToolResult value.
+
+    Regression test for #856: fix-mode results carry a pre-merge
+    ``issues_count`` that can diverge from ``len(merged_issues)``. The CSV
+    writer must report the merged count so it agrees with the JSON writer.
+
+    Args:
+        tmp_path: Temporary directory path for test output.
+        mock_tool_result_factory: Factory for creating ToolResult objects.
+        mock_issue_factory: Factory for creating MockIssue objects.
+    """
+    detected = mock_issue_factory(code="E001")
+    remaining = mock_issue_factory(code="E002")
+    result = mock_tool_result_factory(
+        name="ruff",
+        # Deliberately stale/wrong pre-merge count.
+        issues_count=99,
+        issues=[remaining],
+        initial_issues=[detected, remaining],
+        initial_issues_count=2,
+        fixed_issues_count=1,
+        remaining_issues_count=1,
+    )
+
+    output_path = tmp_path / "report.csv"
+    write_output_file(
+        output_path=str(output_path),
+        output_format=OutputFormat.CSV,
+        all_results=[result],
+        action=Action.FIX,
+        total_issues=2,
+        total_fixed=1,
+    )
+
+    content = output_path.read_text()
+    # Merged/deduped count is 2 (detected [E001, E002] + remaining [E002]).
+    assert_that(content).does_not_contain("99")
+    data_row = content.strip().split("\n")[1]
+    assert_that(data_row.split(",")[1]).is_equal_to("2")

--- a/tests/unit/utils/output/test_file_writer_plain.py
+++ b/tests/unit/utils/output/test_file_writer_plain.py
@@ -19,19 +19,35 @@ if TYPE_CHECKING:
 
     from lintro.models.core.tool_result import ToolResult
 
+    from .conftest import MockIssue
+
 
 def test_write_plain_file_creates_valid_structure(
     tmp_path: Path,
     mock_tool_result_factory: Callable[..., ToolResult],
+    mock_issue_factory: Callable[..., MockIssue],
 ) -> None:
     """Verify plain text file contains report header and summary totals.
+
+    The per-tool count is derived from the merged/deduped issue list (as the
+    JSON writer does) so every format agrees; the result therefore carries
+    matching issue objects.
 
     Args:
         tmp_path: Temporary directory path for test output.
         mock_tool_result_factory: Factory for creating mock tool results.
+        mock_issue_factory: Factory for creating mock issue objects.
     """
     output_path = tmp_path / "report.txt"
-    results = [mock_tool_result_factory(name="ruff", issues_count=5, output="5 issues")]
+    issues = [mock_issue_factory(line=n) for n in range(1, 6)]
+    results = [
+        mock_tool_result_factory(
+            name="ruff",
+            issues_count=5,
+            output="5 issues",
+            issues=issues,
+        ),
+    ]
 
     write_output_file(
         output_path=str(output_path),

--- a/tests/unit/utils/test_console_output_writer.py
+++ b/tests/unit/utils/test_console_output_writer.py
@@ -39,7 +39,7 @@ def test_console_output_no_color(logger: ThreadSafeConsoleLogger) -> None:
     with patch("lintro.utils.console.logger.click.echo") as mock_echo:
         logger.console_output("Test message")
 
-        mock_echo.assert_called_once_with("Test message")
+        mock_echo.assert_called_once_with("Test message", err=False)
         assert_that(logger._messages).contains("Test message")
 
 
@@ -57,7 +57,7 @@ def test_console_output_with_color(logger: ThreadSafeConsoleLogger) -> None:
         logger.console_output("Test message", color="green")
 
         mock_style.assert_called_once_with("Test message", fg="green")
-        mock_echo.assert_called_once_with("styled text")
+        mock_echo.assert_called_once_with("styled text", err=False)
         assert_that(logger._messages).contains("Test message")
 
 
@@ -73,7 +73,7 @@ def test_info(logger: ThreadSafeConsoleLogger) -> None:
     ):
         logger.info("Info message")
 
-        mock_echo.assert_called_once_with("Info message")
+        mock_echo.assert_called_once_with("Info message", err=False)
         mock_logger.info.assert_called_once()
         assert_that(logger._messages).contains("Info message")
 
@@ -93,7 +93,7 @@ def test_info_blue(logger: ThreadSafeConsoleLogger) -> None:
         logger.info_blue("Blue message")
 
         mock_style.assert_called_once_with("Blue message", fg="cyan")
-        mock_echo.assert_called_once_with("styled")
+        mock_echo.assert_called_once_with("styled", err=False)
         mock_logger.info.assert_called_once()
         assert_that(logger._messages).contains("Blue message")
 

--- a/tests/unit/utils/test_exit_codes.py
+++ b/tests/unit/utils/test_exit_codes.py
@@ -1,0 +1,70 @@
+"""Tests for result aggregation in ``lintro.utils.execution.exit_codes``."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.enums.action import Action
+from lintro.models.core.tool_result import ToolResult
+from lintro.utils.execution.exit_codes import aggregate_tool_results
+
+
+def test_aggregate_check_mode_remaining_mirrors_total_issues() -> None:
+    """In check mode ``total_remaining`` mirrors ``total_issues``.
+
+    Regression test for #1045: nothing is fixed in check mode, so reporting
+    ``total_remaining`` as a constant 0 alongside a nonzero ``total_issues``
+    is misleading.
+    """
+    results = [
+        ToolResult(name="ruff", success=False, issues_count=3),
+        ToolResult(name="black", success=False, issues_count=2),
+    ]
+
+    total_issues, total_fixed, total_remaining = aggregate_tool_results(
+        results,
+        Action.CHECK,
+    )
+
+    assert_that(total_issues).is_equal_to(5)
+    assert_that(total_fixed).is_equal_to(0)
+    assert_that(total_remaining).is_equal_to(5)
+
+
+def test_aggregate_fix_mode_remaining_uses_remaining_counts() -> None:
+    """In fix mode ``total_remaining`` sums per-tool remaining counts."""
+    results = [
+        ToolResult(
+            name="ruff",
+            success=True,
+            issues_count=1,
+            initial_issues_count=3,
+            fixed_issues_count=2,
+            remaining_issues_count=1,
+        ),
+    ]
+
+    total_issues, total_fixed, total_remaining = aggregate_tool_results(
+        results,
+        Action.FIX,
+    )
+
+    assert_that(total_issues).is_equal_to(1)
+    assert_that(total_fixed).is_equal_to(2)
+    assert_that(total_remaining).is_equal_to(1)
+
+
+def test_aggregate_excludes_skipped_tools() -> None:
+    """Skipped tools contribute nothing to any total."""
+    results = [
+        ToolResult(name="ruff", success=False, issues_count=4),
+        ToolResult(name="black", skipped=True, skip_reason="missing", issues_count=0),
+    ]
+
+    total_issues, total_fixed, total_remaining = aggregate_tool_results(
+        results,
+        Action.CHECK,
+    )
+
+    assert_that(total_issues).is_equal_to(4)
+    assert_that(total_remaining).is_equal_to(4)

--- a/tests/unit/utils/test_exit_codes.py
+++ b/tests/unit/utils/test_exit_codes.py
@@ -61,7 +61,7 @@ def test_aggregate_excludes_skipped_tools() -> None:
         ToolResult(name="black", skipped=True, skip_reason="missing", issues_count=0),
     ]
 
-    total_issues, total_fixed, total_remaining = aggregate_tool_results(
+    total_issues, _total_fixed, total_remaining = aggregate_tool_results(
         results,
         Action.CHECK,
     )

--- a/tests/unit/utils/test_json_output.py
+++ b/tests/unit/utils/test_json_output.py
@@ -59,6 +59,22 @@ def fix_result_with_split() -> ToolResult:
     )
 
 
+def test_serialize_tool_result_fix_mode_defaults_unset_counts_to_zero() -> None:
+    """FIX serialization emits integers when split counts are unset."""
+    result = ToolResult(
+        name="ruff",
+        success=False,
+        issues_count=1,
+        output="ruff raw output",
+        issues=[_StubIssue()],
+    )
+
+    data = serialize_tool_result(result, action=Action.FIX)
+
+    assert_that(data["fixed"]).is_equal_to(0)
+    assert_that(data["remaining"]).is_equal_to(0)
+
+
 def test_serialize_tool_result_includes_output_and_issues(
     check_result_with_issue: ToolResult,
 ) -> None:

--- a/tests/unit/utils/test_json_output.py
+++ b/tests/unit/utils/test_json_output.py
@@ -2,11 +2,156 @@
 
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
 from assertpy import assert_that
 
 from lintro.enums.action import Action
+from lintro.enums.output_format import OutputFormat
 from lintro.models.core.tool_result import ToolResult
-from lintro.utils.json_output import create_json_output
+from lintro.parsers.base_issue import BaseIssue
+from lintro.utils.json_output import create_json_output, serialize_tool_result
+from lintro.utils.output.file_writer import write_output_file
+
+
+@dataclass
+class _StubIssue(BaseIssue):
+    """Minimal issue used to exercise JSON serialization."""
+
+    file: str = "src/main.py"
+    line: int = 3
+    code: str = "E001"
+    message: str = "boom"
+
+
+@pytest.fixture
+def check_result_with_issue() -> ToolResult:
+    """Return a check-mode ToolResult carrying a single issue."""
+    return ToolResult(
+        name="ruff",
+        success=False,
+        issues_count=1,
+        output="ruff raw output",
+        issues=[_StubIssue()],
+        parse_failures_count=0,
+    )
+
+
+@pytest.fixture
+def fix_result_with_split() -> ToolResult:
+    """Return a fix-mode ToolResult with pre-fix and remaining issues."""
+    detected = _StubIssue()
+    remaining = _StubIssue(code="E002", message="still here")
+    return ToolResult(
+        name="prettier",
+        success=False,
+        issues_count=1,
+        output="prettier raw output",
+        issues=[remaining],
+        initial_issues=[detected, remaining],
+        initial_issues_count=2,
+        fixed_issues_count=1,
+        remaining_issues_count=1,
+        parse_failures_count=0,
+    )
+
+
+def test_serialize_tool_result_includes_output_and_issues(
+    check_result_with_issue: ToolResult,
+) -> None:
+    """The shared serializer includes raw output and the issues array."""
+    data = serialize_tool_result(check_result_with_issue, action=Action.CHECK)
+
+    assert_that(data).contains_key("output")
+    assert_that(data["output"]).is_equal_to("ruff raw output")
+    assert_that(data["issues_count"]).is_equal_to(1)
+    assert_that(data).contains_key("issues")
+    assert_that(data["issues"]).is_length(1)
+    assert_that(data["parse_failures_count"]).is_equal_to(0)
+
+
+def test_file_and_stdout_serializers_produce_same_per_tool_object(
+    tmp_path: Path,
+    check_result_with_issue: ToolResult,
+) -> None:
+    """Both serialization paths emit an identical per-tool object (check)."""
+    stdout_payload = create_json_output(
+        action=Action.CHECK,
+        results=[check_result_with_issue],
+        total_issues=1,
+        total_fixed=0,
+        total_remaining=1,
+        exit_code=1,
+    )
+    stdout_result = stdout_payload["results"][0]
+
+    output_path = tmp_path / "report.json"
+    write_output_file(
+        output_path=str(output_path),
+        output_format=OutputFormat.JSON,
+        all_results=[check_result_with_issue],
+        action=Action.CHECK,
+        total_issues=1,
+        total_fixed=0,
+    )
+    file_result = json.loads(output_path.read_text())["results"][0]
+
+    assert_that(file_result).is_equal_to(stdout_result)
+    assert_that(stdout_result).contains_key("output")
+    assert_that(stdout_result).contains_key("issues")
+
+
+def test_file_and_stdout_serializers_parity_fix_mode(
+    tmp_path: Path,
+    fix_result_with_split: ToolResult,
+) -> None:
+    """Both serialization paths agree in fix mode, including merged counts."""
+    stdout_payload = create_json_output(
+        action=Action.FIX,
+        results=[fix_result_with_split],
+        total_issues=2,
+        total_fixed=1,
+        total_remaining=1,
+        exit_code=1,
+    )
+    stdout_result = stdout_payload["results"][0]
+
+    output_path = tmp_path / "report.json"
+    write_output_file(
+        output_path=str(output_path),
+        output_format=OutputFormat.JSON,
+        all_results=[fix_result_with_split],
+        action=Action.FIX,
+        total_issues=2,
+        total_fixed=1,
+    )
+    file_result = json.loads(output_path.read_text())["results"][0]
+
+    assert_that(file_result).is_equal_to(stdout_result)
+    # Merged/deduped count: detected [E001, E002] + remaining [E002] -> 2
+    assert_that(stdout_result["issues_count"]).is_equal_to(2)
+    assert_that(stdout_result["fixed"]).is_equal_to(1)
+    assert_that(stdout_result["remaining"]).is_equal_to(1)
+
+
+def test_check_mode_total_remaining_mirrors_total_issues(
+    check_result_with_issue: ToolResult,
+) -> None:
+    """Check-mode summary mirrors total_issues instead of a constant 0."""
+    data = create_json_output(
+        action=Action.CHECK,
+        results=[check_result_with_issue],
+        total_issues=5,
+        total_fixed=0,
+        total_remaining=0,
+        exit_code=1,
+    )
+
+    assert_that(data["summary"]["total_remaining"]).is_equal_to(5)
+    assert_that(data["summary"]["total_issues"]).is_equal_to(5)
 
 
 def test_create_json_output_includes_summary_and_fix_suggestions_together() -> None:


### PR DESCRIPTION
## Summary

Fixes three related output-layer consistency bugs in one pass (same subsystem: `lintro/utils/output/` + `exit_codes.py`).

### #856 — Stale `issues_count` in CSV/Markdown/HTML/plain reports
The JSON writer computed `issues_count` from `len(merged_issues)` (deduped detected+remaining), but CSV, Markdown, HTML, and plain-text writers used the raw pre-merge `ToolResult.issues_count`, which can diverge in fix mode. Added `_merged_issue_count()` and use it across every format so all writers agree.

### #1025 — Divergent per-tool JSON schema across serializers
The `--output <file>` artifact and the `--output-format json` stdout payload were two hand-maintained serializers that had already drifted (stdout dropped the raw `output` field). Introduced a single source of truth, `serialize_tool_result(result, *, action)` in `lintro/utils/json_output.py`, used by both `create_json_output` and `write_output_file`. Stdout now also carries `output` and `issues`, and the two paths cannot silently diverge. Each path keeps its distinct top-level wrapper.

### #1045 — Banners mixed with JSON on stdout + misleading `total_remaining`
`--output-format json` printed decorative banners/progress headers to stdout before the JSON document, breaking `| jq`. Added a `route_stderr` flag to `ThreadSafeConsoleLogger`; in machine-readable modes (JSON/SARIF) all decorative console output goes to stderr, leaving stdout a single parseable JSON document. Also fixed check-mode summaries that reported `total_remaining: 0` alongside a nonzero `total_issues` — nothing is fixed in check/test mode, so `total_remaining` now mirrors `total_issues` (both in `aggregate_tool_results` and `create_json_output`).

## Tests
- File vs. stdout serializer parity (check and fix modes), including `output` and `issues`
- Merged-count CSV regression (stale count no longer emitted)
- CLI JSON stdout is valid JSON with banners routed to stderr
- `route_stderr` routing unit test
- Check-mode `total_remaining` aggregation
- Updated existing `click.echo` call-signature assertions for the new `err=` kwarg

## Gates
- `uv run lintro fmt` — clean
- `uv run lintro chk` — 0 issues
- `uv run pytest` — 5729 passed, 11 skipped

- Closes #856
- Closes #1025
- Closes #1045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JSON/SARIF output now keeps console banners and progress messages out of standard output, making machine-readable output cleaner.
  * Reported issue counts are now consistent across on-screen, file, and JSON outputs.

* **Bug Fixes**
  * Fixed summary totals so “remaining” matches “issues” in check/test modes.
  * Improved error and status message routing so styled console output appears in the correct stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR cleans up output reporting across JSON, files, and console streams. The main changes are:

- Shared per-tool JSON serialization for stdout and file output.
- Merged issue counts used across report formats.
- CSV rows updated to match the merged issue count.
- JSON and SARIF console banners routed to stderr.
- Check-mode remaining totals aligned with total issues.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/utils/output/file_writer.py | Updates report writers so merged issue data drives JSON and CSV output consistently. |
| lintro/utils/json_output.py | Adds the shared per-tool serializer used by both JSON output paths. |
| lintro/utils/console/logger.py | Adds stderr routing support while keeping default console behavior unchanged. |
| lintro/utils/tool_executor.py | Enables stderr routing for machine-readable output formats. |
| lintro/utils/execution/exit_codes.py | Updates non-fix aggregation so remaining totals match reported issues. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(output): address review feedback on ..."](https://github.com/lgtm-hq/py-lintro/commit/66481cf7815f98e9ff7293dd49af0f9ef9747166) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41876751)</sub>

<!-- /greptile_comment -->