### PR TITLE
refactor(plugins): separate stdout/stderr from subprocess and harden parsers

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -98,12 +98,12 @@ Workflows follow the principle of least privilege:
 
 ```yaml
 permissions:
-  contents: read  # Default: read-only
+  contents: read # Default: read-only
 
 # Only escalate when necessary
 permissions:
-  contents: write  # For releases
-  id-token: write  # For OIDC
+  contents: write # For releases
+  id-token: write # For OIDC
 ```
 
 ## Permission Scopes by Workflow

--- a/docs/tool-analysis/README.md
+++ b/docs/tool-analysis/README.md
@@ -80,6 +80,7 @@ implementations with the core tools themselves.
   scanning
 - ⚠️ **Limited**: Runtime rule customization, Docker Compose support, auto-fixing
 - 🚀 **Enhanced**: Issue normalization, Python integration, error parsing
+
 <!-- markdownlint-enable MD036 -->
 
 ### [Black Analysis](./black-analysis.md)

--- a/lintro/ai/review/context/collection.py
+++ b/lintro/ai/review/context/collection.py
@@ -12,7 +12,6 @@ from lintro.ai.review.context.diff_parse import (
     unified_diff_preamble,
 )
 from lintro.ai.review.context.git_ops import (
-    _ensure_bash,
     _ensure_git_repo,
     _git_diff_triple_snapshot,
     _run_gh,
@@ -64,7 +63,6 @@ def collect_review_context(
         repo=repo,
     )
     if pr_number is None:
-        _ensure_bash()
         _ensure_git_repo()
         repo_root = _run_git(args=["rev-parse", "--show-toplevel"]).stdout.strip()
     else:

--- a/lintro/ai/review/context/git_ops.py
+++ b/lintro/ai/review/context/git_ops.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import secrets
-import shlex
 import shutil
 import subprocess
 
@@ -11,6 +9,24 @@ from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorC
 from lintro.ai.review.exceptions import ReviewContextError
 
 _GIT_GH_TIMEOUT_SECONDS = 120.0
+
+# Shared ``git`` configuration and ``diff`` flags used for the three diff
+# snapshot variants. Kept identical across variants so the unified diff,
+# name-status, and numstat views share the same normalized formatting.
+_DIFF_SNAPSHOT_CONFIG_ARGS: list[str] = [
+    "-c",
+    "diff.mnemonicPrefix=false",
+    "-c",
+    "diff.noprefix=false",
+    "-c",
+    "color.ui=false",
+]
+_DIFF_SNAPSHOT_FLAGS: list[str] = [
+    "-M",
+    "--no-color",
+    "--no-ext-diff",
+    "--no-textconv",
+]
 
 
 def _ensure_git_repo() -> None:
@@ -30,15 +46,6 @@ def _ensure_git_repo() -> None:
             "Not a git repository — lintro review requires a git checkout.",
             code=ReviewContextErrorCode.NOT_GIT_REPO,
         )
-
-
-def _ensure_bash() -> None:
-    """Verify bash is available for combined git diff collection."""
-    _resolve_executable(
-        command="bash",
-        code=ReviewContextErrorCode.BASH_UNAVAILABLE,
-        message="bash is not installed or not on PATH — required for lintro review.",
-    )
 
 
 def _resolve_executable(
@@ -107,62 +114,16 @@ def _run_git(
     return result
 
 
-def _run_bash(*, script: str) -> subprocess.CompletedProcess[str]:
-    """Run a bash script and return captured output.
-
-    Args:
-        script: Shell script executed via ``bash -c`` with quoted internal args.
-
-    Returns:
-        Completed process with stdout/stderr captured as text.
-
-    Raises:
-        ReviewContextError: When bash execution fails or is unavailable.
-    """
-    bash_bin = _resolve_executable(
-        command="bash",
-        code=ReviewContextErrorCode.BASH_UNAVAILABLE,
-        message="bash is not installed or not on PATH — required for lintro review.",
-    )
-    try:
-        result = subprocess.run(  # nosec B603 - argv is [resolved bash, "-c", script]; script body uses shlex-quoted git refs from _git_diff_triple_snapshot, not caller shell input
-            [bash_bin, "-c", script],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="surrogateescape",
-            check=False,
-            timeout=_GIT_GH_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise ReviewContextError(
-            f"bash snapshot timed out after {_GIT_GH_TIMEOUT_SECONDS}s",
-            code=ReviewContextErrorCode.GIT_COMMAND_FAILED,
-        ) from exc
-    except OSError as exc:
-        raise ReviewContextError(
-            f"Failed to run bash snapshot: {exc}",
-            code=ReviewContextErrorCode.GIT_COMMAND_FAILED,
-        ) from exc
-
-    if result.returncode != 0:
-        stderr = result.stderr.strip() or result.stdout.strip() or "unknown bash error"
-        raise ReviewContextError(
-            f"git diff snapshot failed: {stderr}",
-            code=ReviewContextErrorCode.GIT_COMMAND_FAILED,
-        )
-
-    return result
-
-
 def _git_diff_triple_snapshot(*, diff_args: list[str]) -> tuple[str, str, str]:
-    """Collect unified diff, name-status, and numstat in one subprocess.
+    """Collect unified diff, name-status, and numstat via three git calls.
 
-    The three ``git diff`` variants run inside a single shell script to avoid
-    process setup drift while preserving each view's native git formatting.
-    Output sections are separated by a random nonce delimiter; if diff content
-    ever contained that exact sentinel the snapshot would raise
-    ``GIT_OUTPUT_PARSE_FAILED``.
+    Each ``git diff`` variant runs as its own plain ``subprocess.run`` (via
+    :func:`_run_git`). This replaces the previous ``bash -c`` snapshot, dropping
+    the hard ``bash`` dependency, the nonce-delimiter collision failure mode,
+    and the Windows portability gap in ``lintro review``.
+
+    Each ``git diff`` runs via :func:`_run_git`, which raises
+    ``ReviewContextError`` on failure.
 
     Args:
         diff_args: Arguments passed to ``git diff`` (for example ``HEAD`` or
@@ -170,41 +131,16 @@ def _git_diff_triple_snapshot(*, diff_args: list[str]) -> tuple[str, str, str]:
 
     Returns:
         Tuple of ``(unified_diff, name_status, numstat)`` raw stdout payloads.
-
-    Raises:
-        ReviewContextError: When the snapshot command fails or returns malformed
-            output.
     """
-    ref = " ".join(shlex.quote(part) for part in diff_args)
-    git_bin = shlex.quote(
-        _resolve_executable(
-            command="git",
-            code=ReviewContextErrorCode.GIT_UNAVAILABLE,
-            message="git is not installed or not on PATH — required for lintro review.",
-        ),
-    )
-    delimiter = f"\n---LINTRO_DIFF_SNAP_{secrets.token_hex(16)}---\n"
-    delim_shell = delimiter.replace("'", "'\"'\"'")
-    git_diff_cfg = (
-        "-c diff.mnemonicPrefix=false -c diff.noprefix=false " "-c color.ui=false"
-    )
-    diff_flags = "-M --no-color --no-ext-diff --no-textconv"
-    script = (
-        f"set -euo pipefail; "
-        f"{git_bin} {git_diff_cfg} diff {diff_flags} {ref}; "
-        f"printf '%s' '{delim_shell}'; "
-        f"{git_bin} {git_diff_cfg} diff {diff_flags} --name-status -z {ref}; "
-        f"printf '%s' '{delim_shell}'; "
-        f"{git_bin} {git_diff_cfg} diff {diff_flags} --numstat -z {ref}"
-    )
-    result = _run_bash(script=script)
-    parts = result.stdout.split(delimiter)
-    if len(parts) != 3:
-        raise ReviewContextError(
-            "Failed to parse combined git diff output.",
-            code=ReviewContextErrorCode.GIT_OUTPUT_PARSE_FAILED,
-        )
-    return parts[0], parts[1], parts[2]
+    base_args = [*_DIFF_SNAPSHOT_CONFIG_ARGS, "diff", *_DIFF_SNAPSHOT_FLAGS]
+    unified_diff = _run_git(args=[*base_args, *diff_args]).stdout
+    name_status = _run_git(
+        args=[*base_args, "--name-status", "-z", *diff_args],
+    ).stdout
+    numstat = _run_git(
+        args=[*base_args, "--numstat", "-z", *diff_args],
+    ).stdout
+    return unified_diff, name_status, numstat
 
 
 def _run_gh(*, args: list[str]) -> subprocess.CompletedProcess[str]:

--- a/lintro/ai/review/context/git_ops.py
+++ b/lintro/ai/review/context/git_ops.py
@@ -125,6 +125,10 @@ def _git_diff_triple_snapshot(*, diff_args: list[str]) -> tuple[str, str, str]:
     Each ``git diff`` runs via :func:`_run_git`, which raises
     ``ReviewContextError`` on failure.
 
+    The three calls run back-to-back without yielding; callers must not
+    mutate the worktree concurrently during collection (same assumption as the
+    prior single-shell snapshot this replaced).
+
     Args:
         diff_args: Arguments passed to ``git diff`` (for example ``HEAD`` or
             ``merge-base...HEAD``).

--- a/lintro/parsers/cargo_audit/cargo_audit_parser.py
+++ b/lintro/parsers/cargo_audit/cargo_audit_parser.py
@@ -111,16 +111,19 @@ def _normalize_severity(severity: str | None) -> str:
 
 def parse_cargo_audit_output(
     output: str | None,
+    data: dict[str, Any] | None = None,
 ) -> list[CargoAuditIssue]:
     """Parse cargo-audit JSON output into CargoAuditIssue objects.
 
     Args:
         output: Raw JSON output from cargo-audit --json command.
+        data: Pre-parsed JSON payload when already extracted from ``output``.
 
     Returns:
         List of parsed security vulnerability issues.
     """
-    data = extract_cargo_audit_payload(output)
+    if data is None:
+        data = extract_cargo_audit_payload(output)
     if data is None:
         return []
 

--- a/lintro/parsers/cargo_audit/cargo_audit_parser.py
+++ b/lintro/parsers/cargo_audit/cargo_audit_parser.py
@@ -51,6 +51,34 @@ def _extract_cargo_audit_json(raw_text: str) -> dict[str, Any]:
     return parsed
 
 
+def extract_cargo_audit_payload(output: str | None) -> dict[str, Any] | None:
+    """Extract the parsed JSON object from cargo-audit output.
+
+    Args:
+        output: Raw stdout from ``cargo audit --json``.
+
+    Returns:
+        The parsed JSON object, or ``None`` when the output is empty or cannot
+        be parsed as a JSON object. A ``None`` result on non-empty output
+        indicates a parse failure that security callers must treat as a
+        non-clean scan (see #1044).
+    """
+    if not output or not output.strip():
+        return None
+
+    try:
+        data = _extract_cargo_audit_json(output)
+    except (json.JSONDecodeError, ValueError) as e:
+        logger.warning(f"Failed to parse cargo-audit JSON output: {e}")
+        return None
+
+    if not isinstance(data, dict):
+        logger.warning("cargo-audit output is not a dictionary")
+        return None
+
+    return data
+
+
 def _normalize_severity(severity: str | None) -> str:
     """Normalize severity level to uppercase standard format.
 
@@ -92,17 +120,8 @@ def parse_cargo_audit_output(
     Returns:
         List of parsed security vulnerability issues.
     """
-    if not output:
-        return []
-
-    try:
-        data = _extract_cargo_audit_json(output)
-    except (json.JSONDecodeError, ValueError) as e:
-        logger.warning(f"Failed to parse cargo-audit JSON output: {e}")
-        return []
-
-    if not isinstance(data, dict):
-        logger.warning("cargo-audit output is not a dictionary")
+    data = extract_cargo_audit_payload(output)
+    if data is None:
         return []
 
     # Extract vulnerabilities from the nested structure

--- a/lintro/plugins/base.py
+++ b/lintro/plugins/base.py
@@ -52,6 +52,7 @@ from lintro.plugins.file_discovery import (
 )
 from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.subprocess_executor import (
+    SubprocessResult,
     run_subprocess,
     run_subprocess_streaming,
     validate_subprocess_command,
@@ -289,6 +290,31 @@ class BaseToolPlugin(ABC):
             show_progress=show_progress,
         )
 
+    def _run_subprocess_result(
+        self,
+        cmd: list[str],
+        timeout: int | float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> SubprocessResult:
+        """Run a subprocess command, returning separated output streams.
+
+        Prefer this over :meth:`_run_subprocess` when the tool needs to parse
+        stdout independently of stderr (e.g. JSON output that must not be
+        corrupted by stderr warnings). See issue #1043.
+
+        Args:
+            cmd: Command and arguments to run.
+            timeout: Timeout in seconds (defaults to tool's timeout).
+            cwd: Working directory for command execution.
+            env: Environment variables for the subprocess.
+
+        Returns:
+            SubprocessResult with the return code and separated stdout/stderr.
+        """
+        effective_timeout = self._get_effective_timeout(timeout)
+        return run_subprocess(cmd, effective_timeout, cwd, env)
+
     def _run_subprocess(
         self,
         cmd: list[str],
@@ -297,6 +323,10 @@ class BaseToolPlugin(ABC):
         env: dict[str, str] | None = None,
     ) -> tuple[bool, str]:
         """Run a subprocess command safely.
+
+        Backward-compatible wrapper around :meth:`_run_subprocess_result` that
+        returns the legacy ``(success, output)`` tuple with the combined
+        display output.
 
         Args:
             cmd: Command and arguments to run.
@@ -307,8 +337,30 @@ class BaseToolPlugin(ABC):
         Returns:
             Tuple of (success, output) where success indicates return code 0.
         """
+        return self._run_subprocess_result(cmd, timeout, cwd, env).as_tuple()
+
+    def _run_subprocess_streaming_result(
+        self,
+        cmd: list[str],
+        timeout: int | float | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        line_handler: Callable[[str], None] | None = None,
+    ) -> SubprocessResult:
+        """Run a streaming subprocess, returning the full result object.
+
+        Args:
+            cmd: Command and arguments to run.
+            timeout: Timeout in seconds (defaults to tool's timeout).
+            cwd: Working directory for command execution.
+            env: Environment variables for the subprocess.
+            line_handler: Optional callback called for each line of output.
+
+        Returns:
+            SubprocessResult with the return code and captured output.
+        """
         effective_timeout = self._get_effective_timeout(timeout)
-        return run_subprocess(cmd, effective_timeout, cwd, env)
+        return run_subprocess_streaming(cmd, effective_timeout, cwd, env, line_handler)
 
     def _run_subprocess_streaming(
         self,
@@ -320,8 +372,9 @@ class BaseToolPlugin(ABC):
     ) -> tuple[bool, str]:
         """Run a subprocess command with optional line-by-line streaming.
 
-        This method allows real-time output processing by calling the line_handler
-        callback for each line of output as it is produced by the subprocess.
+        Backward-compatible wrapper around
+        :meth:`_run_subprocess_streaming_result` returning the legacy
+        ``(success, output)`` tuple.
 
         Args:
             cmd: Command and arguments to run.
@@ -333,8 +386,13 @@ class BaseToolPlugin(ABC):
         Returns:
             Tuple of (success, output) where success indicates return code 0.
         """
-        effective_timeout = self._get_effective_timeout(timeout)
-        return run_subprocess_streaming(cmd, effective_timeout, cwd, env, line_handler)
+        return self._run_subprocess_streaming_result(
+            cmd,
+            timeout,
+            cwd,
+            env,
+            line_handler,
+        ).as_tuple()
 
     def _get_effective_timeout(self, timeout: int | float | None = None) -> float:
         """Get the effective timeout value.

--- a/lintro/plugins/subprocess_executor.py
+++ b/lintro/plugins/subprocess_executor.py
@@ -10,6 +10,7 @@ import os
 import subprocess  # nosec B404 - subprocess used safely with shell=False
 import sys
 import threading
+import time
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -295,7 +296,12 @@ def run_subprocess_streaming(
                     if line_handler:
                         line_handler(stripped)
 
-        # Use a thread to read output so we can enforce timeout
+        # Use a thread to read output so we can enforce timeout.
+        # Track elapsed wall time so the reader join and the subsequent
+        # process.wait() share a single timeout budget rather than each
+        # receiving the full timeout (which could allow ~2x the configured
+        # limit). See issue #1047.
+        start_time = time.monotonic()
         reader_thread = threading.Thread(target=read_output, daemon=True)
         reader_thread.start()
         reader_thread.join(timeout=timeout)
@@ -315,9 +321,12 @@ def run_subprocess_streaming(
                 output="\n".join(output_lines),
             )
 
-        # Reading completed, now wait for process to finish
+        # Reading completed, now wait for process to finish using only the
+        # remaining slice of the timeout budget.
+        elapsed = time.monotonic() - start_time
+        remaining_timeout = max(0.0, timeout - elapsed)
         try:
-            returncode = process.wait(timeout=timeout)
+            returncode = process.wait(timeout=remaining_timeout)
         except subprocess.TimeoutExpired as e:
             logger.warning(
                 f"Subprocess {cmd[0]} timed out after {timeout}s (during wait)",

--- a/lintro/plugins/subprocess_executor.py
+++ b/lintro/plugins/subprocess_executor.py
@@ -11,6 +11,7 @@ import subprocess  # nosec B404 - subprocess used safely with shell=False
 import sys
 import threading
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -22,6 +23,51 @@ if TYPE_CHECKING:
 
 # Cache for compiled binary detection
 _IS_COMPILED_BINARY: bool | None = None
+
+
+@dataclass(frozen=True)
+class SubprocessResult:
+    """Result of a subprocess execution with separated output streams.
+
+    Historically the subprocess runners concatenated stdout and stderr into a
+    single string, which forced every JSON parser to hand-roll recovery from a
+    mixed blob (a single stderr warning line could break parsing). This result
+    object keeps the streams separated so tool definitions can parse stdout
+    only and log stderr independently. See issue #1043.
+
+    Attributes:
+        returncode: The subprocess exit code.
+        stdout: Captured standard output. For streaming execution (which merges
+            the child's stderr into stdout for real-time line handling) this
+            holds the combined stream and ``stderr`` is empty.
+        stderr: Captured standard error (empty for streaming execution).
+        output: Backward-compatible display string. Normally ``stdout`` and
+            ``stderr`` concatenated, or a formatted failure message when the
+            command failed without emitting any output.
+    """
+
+    returncode: int
+    stdout: str
+    stderr: str
+    output: str
+
+    @property
+    def success(self) -> bool:
+        """Whether the subprocess exited successfully.
+
+        Returns:
+            True when the return code is zero.
+        """
+        return self.returncode == 0
+
+    def as_tuple(self) -> tuple[bool, str]:
+        """Return the legacy ``(success, output)`` representation.
+
+        Returns:
+            Tuple of the success flag and the combined/display output, matching
+            the pre-#1043 return contract used by most tool definitions.
+        """
+        return self.success, self.output
 
 
 def is_compiled_binary() -> bool:
@@ -138,7 +184,7 @@ def run_subprocess(
     timeout: float,
     cwd: str | None = None,
     env: dict[str, str] | None = None,
-) -> tuple[bool, str]:
+) -> SubprocessResult:
     """Run a subprocess command safely.
 
     Args:
@@ -149,7 +195,8 @@ def run_subprocess(
             os.environ to preserve PATH and other essential variables.
 
     Returns:
-        Tuple of (success, output) where success indicates return code 0.
+        SubprocessResult with the return code and separated stdout/stderr
+        streams (plus a combined ``output`` display string for compatibility).
 
     Raises:
         subprocess.TimeoutExpired: If command times out.
@@ -196,7 +243,12 @@ def run_subprocess(
                 )
                 logger.warning(combined)
 
-        return result.returncode == 0, combined
+        return SubprocessResult(
+            returncode=result.returncode,
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+            output=combined,
+        )
     except subprocess.TimeoutExpired as e:
         logger.warning(f"Subprocess {cmd[0]} timed out after {timeout}s")
         # Preserve partial output from the original exception
@@ -235,7 +287,7 @@ def run_subprocess_streaming(
     cwd: str | None = None,
     env: dict[str, str] | None = None,
     line_handler: Callable[[str], None] | None = None,
-) -> tuple[bool, str]:
+) -> SubprocessResult:
     """Run a subprocess command with optional line-by-line streaming.
 
     This function allows real-time output processing by calling the line_handler
@@ -243,6 +295,10 @@ def run_subprocess_streaming(
 
     The timeout is enforced during both output reading and process completion,
     preventing indefinite blocking on slow or hanging processes.
+
+    Streaming execution merges the child's stderr into stdout so the line
+    handler observes a single ordered stream; the returned ``stderr`` field is
+    therefore empty and ``stdout`` carries the combined stream.
 
     Args:
         cmd: Command and arguments to run.
@@ -253,7 +309,8 @@ def run_subprocess_streaming(
         line_handler: Optional callback called for each line of output.
 
     Returns:
-        Tuple of (success, output) where success indicates return code 0.
+        SubprocessResult with the return code and captured output. ``stdout``
+        holds the merged stream, ``stderr`` is empty.
 
     Raises:
         subprocess.TimeoutExpired: If command times out.
@@ -339,7 +396,8 @@ def run_subprocess_streaming(
                 output="\n".join(output_lines),
             ) from e
 
-        output = "\n".join(output_lines)
+        raw_output = "\n".join(output_lines)
+        output = raw_output
         if returncode != 0:
             output_preview = output[:500]
             if output_preview:
@@ -357,7 +415,12 @@ def run_subprocess_streaming(
                 )
                 logger.warning(output)
 
-        return returncode == 0, output
+        return SubprocessResult(
+            returncode=returncode,
+            stdout=raw_output,
+            stderr="",
+            output=output,
+        )
 
     except FileNotFoundError as e:
         logger.warning(

--- a/lintro/tools/definitions/bandit.py
+++ b/lintro/tools/definitions/bandit.py
@@ -468,15 +468,19 @@ class BanditPlugin(BaseToolPlugin):
                 output=output if execution_failure else None,
                 issues_count=issues_count,
                 issues=issues,
+                parse_failures_count=0,
             )
 
         except (json.JSONDecodeError, ValueError) as e:
+            # Bandit is a security scanner: unparseable output must never be
+            # reported as a clean pass (see #1044).
             logger.error(f"Failed to parse bandit output: {e}")
             return ToolResult(
                 name=self.definition.name,
                 success=False,
                 output=(output or f"Failed to parse bandit output: {str(e)}"),
                 issues_count=0,
+                parse_failures_count=1,
             )
 
     def fix(self, paths: list[str], options: dict[str, object]) -> ToolResult:

--- a/lintro/tools/definitions/bandit.py
+++ b/lintro/tools/definitions/bandit.py
@@ -478,7 +478,7 @@ class BanditPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=False,
-                output=(output or f"Failed to parse bandit output: {str(e)}"),
+                output=(output or f"Failed to parse bandit output: {e!s}"),
                 issues_count=0,
                 parse_failures_count=1,
             )

--- a/lintro/tools/definitions/cargo_audit.py
+++ b/lintro/tools/definitions/cargo_audit.py
@@ -172,7 +172,7 @@ class CargoAuditPlugin(BaseToolPlugin):
         # (combined) is retained for display.
         output = proc.output
         payload = extract_cargo_audit_payload(proc.stdout)
-        issues = parse_cargo_audit_output(proc.stdout)
+        issues = parse_cargo_audit_output(proc.stdout, data=payload)
 
         # Fail closed on unparseable output. cargo-audit is a security scanner,
         # so a payload we cannot parse (yet non-empty stdout) must never be

--- a/lintro/tools/definitions/cargo_audit.py
+++ b/lintro/tools/definitions/cargo_audit.py
@@ -17,7 +17,10 @@ from lintro.enums.doc_url_template import DocUrlTemplate
 from lintro.enums.tool_name import ToolName
 from lintro.enums.tool_type import ToolType
 from lintro.models.core.tool_result import ToolResult
-from lintro.parsers.cargo_audit.cargo_audit_parser import parse_cargo_audit_output
+from lintro.parsers.cargo_audit.cargo_audit_parser import (
+    extract_cargo_audit_payload,
+    parse_cargo_audit_output,
+)
 from lintro.plugins.base import BaseToolPlugin
 from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.registry import register_tool
@@ -168,7 +171,16 @@ class CargoAuditPlugin(BaseToolPlugin):
         # stderr warning cannot corrupt parsing (see #1043). ``output``
         # (combined) is retained for display.
         output = proc.output
+        payload = extract_cargo_audit_payload(proc.stdout)
         issues = parse_cargo_audit_output(proc.stdout)
+
+        # Fail closed on unparseable output. cargo-audit is a security scanner,
+        # so a payload we cannot parse (yet non-empty stdout) must never be
+        # reported as a clean pass (see #1044).
+        parse_failure = payload is None and bool(proc.stdout.strip())
+        if parse_failure:
+            success = False
+        parse_failures_count = 1 if parse_failure else 0
 
         # Determine overall success: subprocess must succeed AND no issues found.
         # cargo-audit returns non-zero if vulnerabilities found, but also if
@@ -186,6 +198,7 @@ class CargoAuditPlugin(BaseToolPlugin):
             output=output if should_show_output else None,
             issues_count=len(issues),
             issues=issues if issues else None,
+            parse_failures_count=parse_failures_count,
         )
 
     def fix(self, paths: list[str], options: dict[str, object]) -> ToolResult:

--- a/lintro/tools/definitions/cargo_audit.py
+++ b/lintro/tools/definitions/cargo_audit.py
@@ -150,7 +150,7 @@ class CargoAuditPlugin(BaseToolPlugin):
 
         cmd = self._build_command()
         try:
-            success, output = self._run_subprocess(
+            proc = self._run_subprocess_result(
                 cmd,
                 timeout=ctx.timeout,
                 cwd=str(cargo_root),
@@ -163,7 +163,12 @@ class CargoAuditPlugin(BaseToolPlugin):
                 issues_count=0,
             )
 
-        issues = parse_cargo_audit_output(output)
+        success = proc.success
+        # cargo-audit writes its JSON report to stdout; parse stdout only so a
+        # stderr warning cannot corrupt parsing (see #1043). ``output``
+        # (combined) is retained for display.
+        output = proc.output
+        issues = parse_cargo_audit_output(proc.stdout)
 
         # Determine overall success: subprocess must succeed AND no issues found.
         # cargo-audit returns non-zero if vulnerabilities found, but also if

--- a/lintro/tools/definitions/gitleaks.py
+++ b/lintro/tools/definitions/gitleaks.py
@@ -261,12 +261,14 @@ class GitleaksPlugin(BaseToolPlugin):
             issues = parse_gitleaks_output(output=output)
             issues_count = len(issues)
 
-            # Check for parsing failures: if we have output that's not empty/[] but
-            # got no issues, verify the output is valid JSON. This catches cases
-            # where the report file contains invalid data.
+            # Check for parsing failures: if we have output that's not empty/[]
+            # but got no issues, verify the output is a valid JSON array. This
+            # catches cases where the report file contains invalid or unexpected
+            # data. Gitleaks is a security scanner, so an unparseable report must
+            # never be reported as a clean pass (see #1044).
             if issues_count == 0 and output and output.strip() not in ("", "[]"):
                 try:
-                    json.loads(output)
+                    data = json.loads(output)
                 except json.JSONDecodeError as e:
                     logger.error(f"Failed to parse gitleaks output: {e}")
                     return ToolResult(
@@ -274,6 +276,22 @@ class GitleaksPlugin(BaseToolPlugin):
                         success=False,
                         output=f"Failed to parse gitleaks output: {e}",
                         issues_count=0,
+                        parse_failures_count=1,
+                    )
+                if not isinstance(data, list):
+                    logger.error(
+                        "Gitleaks output was not a JSON array (got %s).",
+                        type(data).__name__,
+                    )
+                    return ToolResult(
+                        name=self.definition.name,
+                        success=False,
+                        output=(
+                            "Gitleaks output was not a JSON array; "
+                            "treating as a parse failure."
+                        ),
+                        issues_count=0,
+                        parse_failures_count=1,
                     )
 
             return ToolResult(
@@ -282,6 +300,7 @@ class GitleaksPlugin(BaseToolPlugin):
                 output=None,
                 issues_count=issues_count,
                 issues=issues,
+                parse_failures_count=0,
             )
         finally:
             # Clean up the temporary report file

--- a/lintro/tools/definitions/gitleaks.py
+++ b/lintro/tools/definitions/gitleaks.py
@@ -261,12 +261,24 @@ class GitleaksPlugin(BaseToolPlugin):
             issues = parse_gitleaks_output(output=output)
             issues_count = len(issues)
 
-            # Check for parsing failures: if we have output that's not empty/[]
-            # but got no issues, verify the output is a valid JSON array. This
-            # catches cases where the report file contains invalid or unexpected
-            # data. Gitleaks is a security scanner, so an unparseable report must
-            # never be reported as a clean pass (see #1044).
-            if issues_count == 0 and output and output.strip() not in ("", "[]"):
+            # Check for parsing failures. Gitleaks is a security scanner, so an
+            # empty or unparseable report must never be reported as a clean pass
+            # (see #1044).
+            stripped = output.strip()
+            if issues_count == 0 and not stripped:
+                logger.error("Gitleaks report file was empty")
+                return ToolResult(
+                    name=self.definition.name,
+                    success=False,
+                    output=(
+                        "Gitleaks report file was empty; "
+                        "treating as a parse failure."
+                    ),
+                    issues_count=0,
+                    parse_failures_count=1,
+                )
+
+            if issues_count == 0 and stripped != "[]":
                 try:
                     data = json.loads(output)
                 except json.JSONDecodeError as e:

--- a/lintro/tools/definitions/osv_scanner.py
+++ b/lintro/tools/definitions/osv_scanner.py
@@ -294,6 +294,17 @@ class OsvScannerPlugin(BaseToolPlugin):
         ):
             success = True
 
+        # Fail closed on unparseable output. If osv-scanner produced stdout that
+        # we could not parse as JSON — and it is not a recognized no-op — the
+        # scan result is unknown. For a security scanner an unknown result must
+        # never be reported as a clean pass (see #1044).
+        parse_failure = (
+            payload is None and bool(proc.stdout.strip()) and not no_op_success
+        )
+        if parse_failure:
+            success = False
+            parse_failures_count = 1
+
         # Determine overall success: subprocess must succeed AND no issues
         # found. A non-zero exit with 0 parsed issues indicates an execution
         # error (e.g. network failure), not a clean scan.

--- a/lintro/tools/definitions/osv_scanner.py
+++ b/lintro/tools/definitions/osv_scanner.py
@@ -248,7 +248,7 @@ class OsvScannerPlugin(BaseToolPlugin):
 
         try:
             # osv-scanner returns non-zero when vulnerabilities exist
-            success, output = self._run_subprocess(
+            proc = self._run_subprocess_result(
                 cmd,
                 timeout=timeout,
                 cwd=str(scan_root),
@@ -261,8 +261,13 @@ class OsvScannerPlugin(BaseToolPlugin):
                 issues_count=0,
             )
 
-        issues = parse_osv_scanner_output(output)
-        payload = extract_osv_scanner_payload(output)
+        success = proc.success
+        # Parse the JSON report from stdout only; stderr may carry human-readable
+        # log lines that must not corrupt JSON parsing (see #1043). ``output``
+        # (combined) is retained for display and plain-text signal detection.
+        output = proc.output
+        issues = parse_osv_scanner_output(proc.stdout)
+        payload = extract_osv_scanner_payload(proc.stdout)
         parse_failures_count = 0 if payload is not None else None
         no_op_success = False
 
@@ -355,7 +360,7 @@ class OsvScannerPlugin(BaseToolPlugin):
         # Run osv-scanner without suppressions to see all vulnerabilities
         probe_cmd = self._build_probe_command(scan_root)
         try:
-            _probe_success, probe_output = self._run_subprocess(
+            probe = self._run_subprocess_result(
                 probe_cmd,
                 timeout=timeout,
                 cwd=str(scan_root),
@@ -364,11 +369,11 @@ class OsvScannerPlugin(BaseToolPlugin):
             logger.debug("[osv-scanner] Probe scan timed out, skipping staleness check")
             return None
 
-        probe_issues = parse_osv_scanner_output(probe_output)
+        probe_issues = parse_osv_scanner_output(probe.stdout)
 
         # If probe failed and returned no parseable issues, skip classification
         # to avoid incorrectly marking all suppressions as stale.
-        if not _probe_success and not probe_issues:
+        if not probe.success and not probe_issues:
             logger.debug(
                 "[osv-scanner] Probe scan failed with no parseable output, "
                 "skipping staleness check",

--- a/tests/unit/ai/review/conftest.py
+++ b/tests/unit/ai/review/conftest.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import re
-import shlex
 from collections import defaultdict
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -20,35 +18,24 @@ from lintro.ai.review.models.review_result import ReviewResult
 from tests.unit.ai.review.review_fixtures import load_review_fixture
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
-_SNAPSHOT_DELIM_RE = re.compile(r"---LINTRO_DIFF_SNAP_([a-f0-9]+)---")
 
-
-def _diff_ref_from_bash_snapshot_script(*, script: str) -> str:
-    """Extract the full ``git diff`` argument signature from a snapshot script."""
-    for command in script.split(";"):
-        tokens = shlex.split(command)
-        if (
-            not any(Path(token).name == "git" for token in tokens)
-            or "diff" not in tokens
-        ):
-            continue
-        diff_index = tokens.index("diff")
-        index = diff_index + 1
-        while index < len(tokens) and tokens[index].startswith("-"):
-            index += 1
-        if index >= len(tokens):
-            continue
-        args: list[str] = []
-        while index < len(tokens):
-            token = tokens[index]
-            if token in {"--name-status", "--numstat"}:
-                break
-            args.append(token)
-            index += 1
-        if args:
-            return " ".join(args)
-    msg = f"could not parse git diff target from script: {script!r}"
-    raise AssertionError(msg)
+# Shared ``git diff`` config/flags mirroring
+# lintro.ai.review.context.git_ops._git_diff_triple_snapshot so mocked argv
+# matches the real invocation exactly.
+_DIFF_SNAPSHOT_BASE_ARGV: list[str] = [
+    "git",
+    "-c",
+    "diff.mnemonicPrefix=false",
+    "-c",
+    "diff.noprefix=false",
+    "-c",
+    "color.ui=false",
+    "diff",
+    "-M",
+    "--no-color",
+    "--no-ext-diff",
+    "--no-textconv",
+]
 
 
 def _assert_review_subprocess_kwargs(*, kwargs: dict[str, object]) -> None:
@@ -77,7 +64,6 @@ class SubprocessMock:
         self._queues: dict[tuple[str, ...], list[CompletedProcess[str]]] = defaultdict(
             list,
         )
-        self._bash_snapshots: list[tuple[str, str, str, str]] = []
 
     def queue(
         self,
@@ -97,17 +83,6 @@ class SubprocessMock:
             ),
         )
 
-    def queue_bash_snapshot(
-        self,
-        *,
-        diff_ref: str,
-        unified: str = "",
-        name_status: str = "",
-        numstat: str = "",
-    ) -> None:
-        """Register stdout for the next combined ``bash -c`` diff collection."""
-        self._bash_snapshots.append((diff_ref, unified, name_status, numstat))
-
     def __call__(
         self,
         args: list[str],
@@ -116,27 +91,6 @@ class SubprocessMock:
         """Return the next queued response for ``args``."""
         _assert_review_subprocess_kwargs(kwargs=kwargs)
         normalized_args = [Path(args[0]).name, *args[1:]]
-        if len(normalized_args) >= 3 and normalized_args[:2] == ["bash", "-c"]:
-            script = args[2]
-            requested_ref = _diff_ref_from_bash_snapshot_script(script=script)
-            for index, (diff_ref, unified, name_status, numstat) in enumerate(
-                self._bash_snapshots,
-            ):
-                if diff_ref == requested_ref:
-                    del self._bash_snapshots[index]
-                    match = _SNAPSHOT_DELIM_RE.search(script)
-                    if match is None:
-                        msg = f"could not parse snapshot delimiter from script: {script!r}"
-                        raise AssertionError(msg)
-                    delimiter = f"\n---LINTRO_DIFF_SNAP_{match.group(1)}---\n"
-                    stdout = unified + delimiter + name_status + delimiter + numstat
-                    return CompletedProcess(
-                        args=["bash", "-c", script],
-                        returncode=0,
-                        stdout=stdout,
-                        stderr="",
-                    )
-
         key = tuple(normalized_args)
         if not self._queues[key]:
             if key == ("git", "rev-parse", "--show-toplevel"):
@@ -159,12 +113,27 @@ def queue_diff_snapshot(
     name_status: str = "",
     numstat: str = "",
 ) -> None:
-    """Register the combined stdout for a ``git diff`` collection."""
-    dispatcher.queue_bash_snapshot(
-        diff_ref=diff_ref,
-        unified=unified,
-        name_status=name_status,
-        numstat=numstat,
+    """Register responses for the three ``git diff`` snapshot invocations.
+
+    Mirrors ``_git_diff_triple_snapshot`` which now issues three separate git
+    calls (unified diff, name-status, numstat) instead of one bash script.
+
+    Args:
+        dispatcher: The subprocess mock to register responses on.
+        diff_ref: The diff target (for example ``base...head`` or ``HEAD``).
+        unified: Stdout for the unified diff call.
+        name_status: Stdout for the ``--name-status -z`` call.
+        numstat: Stdout for the ``--numstat -z`` call.
+    """
+    ref_args = diff_ref.split(" ")
+    dispatcher.queue([*_DIFF_SNAPSHOT_BASE_ARGV, *ref_args], stdout=unified)
+    dispatcher.queue(
+        [*_DIFF_SNAPSHOT_BASE_ARGV, "--name-status", "-z", *ref_args],
+        stdout=name_status,
+    )
+    dispatcher.queue(
+        [*_DIFF_SNAPSHOT_BASE_ARGV, "--numstat", "-z", *ref_args],
+        stdout=numstat,
     )
 
 

--- a/tests/unit/ai/review/test_context_collect.py
+++ b/tests/unit/ai/review/test_context_collect.py
@@ -153,13 +153,15 @@ def test_collect_branch_context_uses_merge_base(
             deletions=0,
         ),
     )
-    bash_calls = [
+    diff_calls = [
         call.args[0]
         for call in mock_run.call_args_list
-        if [Path(call.args[0][0]).name, *call.args[0][1:2]] == ["bash", "-c"]
+        if Path(call.args[0][0]).name == "git" and "diff" in call.args[0]
     ]
-    assert_that(bash_calls).is_length(1)
-    assert_that(bash_calls[0][2]).contains("base123...head456")
+    # Three separate git diff variants: unified, name-status, numstat.
+    assert_that(diff_calls).is_length(3)
+    for diff_call in diff_calls:
+        assert_that(diff_call).contains("base123...head456")
 
 
 @patch("lintro.ai.review.context.git_ops.subprocess.run")
@@ -171,7 +173,7 @@ def test_collect_uncommitted_context_merges_staged_and_unstaged(
     _mock_which: MagicMock,
     mock_run: MagicMock,
 ) -> None:
-    """Uncommitted mode uses a single git diff HEAD for index and working tree."""
+    """Uncommitted mode diffs HEAD for the index and working tree."""
     dispatcher = SubprocessMock()
     dispatcher.queue(["git", "rev-parse", "--git-dir"], stdout=".git\n")
     dispatcher.queue(["git", "ls-files", "--others", "--exclude-standard"], stdout="")
@@ -196,13 +198,15 @@ def test_collect_uncommitted_context_merges_staged_and_unstaged(
     assert_that({file.path for file in context.changed_files}).is_equal_to(
         {"unstaged.py", "staged.py"},
     )
-    bash_calls = [
+    diff_calls = [
         call.args[0]
         for call in mock_run.call_args_list
-        if [Path(call.args[0][0]).name, *call.args[0][1:2]] == ["bash", "-c"]
+        if Path(call.args[0][0]).name == "git" and "diff" in call.args[0]
     ]
-    assert_that(bash_calls).is_length(1)
-    assert_that(bash_calls[0][2]).contains("head456")
+    # Three separate git diff variants: unified, name-status, numstat.
+    assert_that(diff_calls).is_length(3)
+    for diff_call in diff_calls:
+        assert_that(diff_call).contains("head456")
 
 
 @patch("lintro.ai.review.context.git_ops.subprocess.run")
@@ -374,24 +378,6 @@ def test_collect_review_context_rejects_repo_without_pr_number() -> None:
     assert_that(exc_info.value.code).is_equal_to(
         ReviewContextErrorCode.INVALID_REVIEW_MODE,
     )
-
-
-@patch("lintro.ai.review.context.git_ops.subprocess.run")
-@patch(
-    "lintro.ai.review.context.git_ops.shutil.which",
-    side_effect=lambda cmd: None if cmd == "bash" else "/usr/bin/git",
-)
-def test_collect_review_context_requires_bash_for_git_modes(
-    _mock_which: MagicMock,
-    mock_run: MagicMock,
-) -> None:
-    """Branch and uncommitted collection require bash for combined diff output."""
-    with pytest.raises(ReviewContextError) as exc_info:
-        collect_review_context(base="main")
-    assert_that(exc_info.value.code).is_equal_to(
-        ReviewContextErrorCode.BASH_UNAVAILABLE,
-    )
-    mock_run.assert_not_called()
 
 
 @patch("lintro.ai.review.context.git_ops.subprocess.run")

--- a/tests/unit/plugins/base/test_subprocess_result.py
+++ b/tests/unit/plugins/base/test_subprocess_result.py
@@ -1,0 +1,84 @@
+"""Unit tests for the SubprocessResult contract (issue #1043).
+
+These tests verify that ``run_subprocess`` returns stdout and stderr as
+separate streams so tool definitions can parse stdout only, without a stderr
+warning line corrupting JSON parsing.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from assertpy import assert_that
+
+from lintro.plugins.subprocess_executor import SubprocessResult, run_subprocess
+
+
+def test_run_subprocess_returns_separate_streams() -> None:
+    """run_subprocess keeps stdout and stderr as distinct fields."""
+    script = "import sys; sys.stdout.write('OUT'); sys.stderr.write('ERR')"
+    result = run_subprocess([sys.executable, "-c", script], timeout=30)
+
+    assert_that(result).is_instance_of(SubprocessResult)
+    assert_that(result.stdout).is_equal_to("OUT")
+    assert_that(result.stderr).is_equal_to("ERR")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.success).is_true()
+
+
+def test_run_subprocess_output_field_combines_streams() -> None:
+    """The compatibility ``output`` field concatenates stdout and stderr."""
+    script = "import sys; sys.stdout.write('OUT'); sys.stderr.write('ERR')"
+    result = run_subprocess([sys.executable, "-c", script], timeout=30)
+
+    assert_that(result.output).contains("OUT")
+    assert_that(result.output).contains("ERR")
+
+
+def test_run_subprocess_stdout_stays_clean_json_despite_stderr_noise() -> None:
+    """A stderr warning does not corrupt JSON parsing of stdout.
+
+    This is the core motivation for #1043: parsers can now consume stdout only.
+    """
+    script = (
+        "import sys; "
+        "sys.stderr.write('WARNING: deprecated flag\\n'); "
+        "sys.stdout.write('{\"issues\": 1}')"
+    )
+    result = run_subprocess([sys.executable, "-c", script], timeout=30)
+
+    parsed = json.loads(result.stdout)
+    assert_that(parsed).is_equal_to({"issues": 1})
+    assert_that(result.stderr).contains("WARNING")
+
+
+def test_run_subprocess_reports_failure_returncode() -> None:
+    """A non-zero exit is reflected in returncode and success."""
+    result = run_subprocess(
+        [sys.executable, "-c", "import sys; sys.exit(3)"],
+        timeout=30,
+    )
+
+    assert_that(result.returncode).is_equal_to(3)
+    assert_that(result.success).is_false()
+
+
+def test_subprocess_result_as_tuple_matches_legacy_contract() -> None:
+    """as_tuple() yields the legacy ``(success, output)`` pair."""
+    result = SubprocessResult(returncode=0, stdout="a", stderr="b", output="ab")
+
+    success, output = result.as_tuple()
+
+    assert_that(success).is_true()
+    assert_that(output).is_equal_to("ab")
+
+
+def test_subprocess_result_as_tuple_reports_failure() -> None:
+    """as_tuple() reports failure for a non-zero return code."""
+    result = SubprocessResult(returncode=1, stdout="", stderr="boom", output="boom")
+
+    success, output = result.as_tuple()
+
+    assert_that(success).is_false()
+    assert_that(output).is_equal_to("boom")

--- a/tests/unit/plugins/base/test_subprocess_streaming.py
+++ b/tests/unit/plugins/base/test_subprocess_streaming.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import subprocess
+import sys
+import time
+from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -89,6 +92,56 @@ def test_streaming_timeout_during_read() -> None:
             run_subprocess_streaming(["long", "cmd"], timeout=1)
 
         mock_process.kill.assert_called_once()
+
+
+def test_streaming_wait_receives_remaining_timeout_budget() -> None:
+    """process.wait() gets the remaining budget, not the full timeout.
+
+    Regression test for issue #1047: previously the reader-thread join and
+    the subsequent ``process.wait()`` each received the full timeout,
+    allowing a tool to run for up to ~2x its configured limit.
+    """
+    read_delay = 0.4
+    timeout = 2.0
+
+    def slow_stdout() -> Iterator[str]:
+        """Yield no lines but block the reader thread for ``read_delay``."""
+        time.sleep(read_delay)
+        return
+        yield  # pragma: no cover - makes this a generator
+
+    with patch("lintro.plugins.subprocess_executor.subprocess.Popen") as mock_popen:
+        mock_process = MagicMock()
+        mock_process.stdout = slow_stdout()
+        mock_process.wait.return_value = 0
+        mock_popen.return_value = mock_process
+
+        run_subprocess_streaming(["slow", "cmd"], timeout=timeout)
+
+        wait_timeout = mock_process.wait.call_args.kwargs["timeout"]
+        # The wait budget must be strictly less than the full timeout since
+        # the reader already consumed part of it.
+        assert_that(wait_timeout).is_less_than(timeout)
+        assert_that(wait_timeout).is_less_than_or_equal_to(timeout - read_delay + 0.25)
+        assert_that(wait_timeout).is_greater_than_or_equal_to(0.0)
+
+
+def test_streaming_total_walltime_stays_within_budget_on_hang() -> None:
+    """A hanging process is bounded by the configured timeout plus epsilon.
+
+    Runs a real child process that sleeps far beyond the timeout and produces
+    no output, then asserts the total wall time stays within ``timeout`` plus
+    a small epsilon rather than a multiple of it.
+    """
+    timeout = 1.0
+    start = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired):
+        run_subprocess_streaming(
+            [sys.executable, "-c", "import time; time.sleep(10)"],
+            timeout=timeout,
+        )
+    elapsed = time.monotonic() - start
+    assert_that(elapsed).is_less_than(timeout + 1.5)
 
 
 def test_streaming_timeout_during_wait() -> None:

--- a/tests/unit/plugins/base/test_subprocess_streaming.py
+++ b/tests/unit/plugins/base/test_subprocess_streaming.py
@@ -26,11 +26,11 @@ def test_streaming_successful_command() -> None:
         mock_process.wait.return_value = 0
         mock_popen.return_value = mock_process
 
-        success, output = run_subprocess_streaming(["echo", "hello"], timeout=30)
+        result = run_subprocess_streaming(["echo", "hello"], timeout=30)
 
-        assert_that(success).is_true()
-        assert_that(output).contains("line1")
-        assert_that(output).contains("line2")
+        assert_that(result.success).is_true()
+        assert_that(result.output).contains("line1")
+        assert_that(result.output).contains("line2")
 
 
 def test_streaming_failed_command_nonzero_exit() -> None:
@@ -41,10 +41,10 @@ def test_streaming_failed_command_nonzero_exit() -> None:
         mock_process.wait.return_value = 1
         mock_popen.return_value = mock_process
 
-        success, output = run_subprocess_streaming(["false"], timeout=30)
+        result = run_subprocess_streaming(["false"], timeout=30)
 
-        assert_that(success).is_false()
-        assert_that(output).contains("error output")
+        assert_that(result.success).is_false()
+        assert_that(result.output).contains("error output")
 
 
 def test_streaming_with_line_handler() -> None:
@@ -188,10 +188,10 @@ def test_streaming_empty_output() -> None:
         mock_process.wait.return_value = 0
         mock_popen.return_value = mock_process
 
-        success, output = run_subprocess_streaming(["true"], timeout=30)
+        result = run_subprocess_streaming(["true"], timeout=30)
 
-        assert_that(success).is_true()
-        assert_that(output).is_equal_to("")
+        assert_that(result.success).is_true()
+        assert_that(result.output).is_equal_to("")
 
 
 def test_streaming_with_cwd_and_env() -> None:

--- a/tests/unit/plugins/base/test_subprocess_streaming.py
+++ b/tests/unit/plugins/base/test_subprocess_streaming.py
@@ -141,7 +141,7 @@ def test_streaming_total_walltime_stays_within_budget_on_hang() -> None:
             timeout=timeout,
         )
     elapsed = time.monotonic() - start
-    assert_that(elapsed).is_less_than(timeout + 1.5)
+    assert_that(elapsed).is_less_than(timeout + 2.0)
 
 
 def test_streaming_timeout_during_wait() -> None:

--- a/tests/unit/tools/bandit/__init__.py
+++ b/tests/unit/tools/bandit/__init__.py
@@ -1,0 +1,1 @@
+"""Bandit plugin tests."""

--- a/tests/unit/tools/bandit/test_bandit_parse_failure.py
+++ b/tests/unit/tools/bandit/test_bandit_parse_failure.py
@@ -1,0 +1,79 @@
+"""Unit tests for Bandit fail-closed parsing on unparseable output (#1044)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+from assertpy import assert_that
+
+from lintro.tools.definitions.bandit import BanditPlugin
+
+
+def test_check_garbage_stdout_with_zero_exit_is_not_clean(tmp_path: Path) -> None:
+    """Unparseable bandit stdout with a zero exit must not report a clean pass.
+
+    Args:
+        tmp_path: Temporary directory path for the target Python file.
+    """
+    py_file = tmp_path / "mod.py"
+    py_file.write_text("x = 1\n")
+    plugin = BanditPlugin()
+
+    completed: CompletedProcess[str] = CompletedProcess(
+        args=["bandit"],
+        returncode=0,
+        stdout="this is not valid json at all",
+        stderr="",
+    )
+
+    with (
+        patch(
+            "lintro.plugins.execution_preparation.verify_tool_version",
+            return_value=None,
+        ),
+        patch(
+            "lintro.tools.definitions.bandit.subprocess.run",
+            return_value=completed,
+        ),
+    ):
+        result = plugin.check([str(py_file)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.parse_failures_count).is_equal_to(1)
+
+
+def test_check_valid_json_reports_no_parse_failures(tmp_path: Path) -> None:
+    """A clean bandit run reports zero parse failures.
+
+    Args:
+        tmp_path: Temporary directory path for the target Python file.
+    """
+    py_file = tmp_path / "mod.py"
+    py_file.write_text("x = 1\n")
+    plugin = BanditPlugin()
+
+    completed: CompletedProcess[str] = CompletedProcess(
+        args=["bandit"],
+        returncode=0,
+        stdout='{"results": [], "errors": []}',
+        stderr="",
+    )
+
+    with (
+        patch(
+            "lintro.plugins.execution_preparation.verify_tool_version",
+            return_value=None,
+        ),
+        patch(
+            "lintro.tools.definitions.bandit.subprocess.run",
+            return_value=completed,
+        ),
+    ):
+        result = plugin.check([str(py_file)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.parse_failures_count).is_equal_to(0)

--- a/tests/unit/tools/cargo_audit/test_cargo_audit_plugin.py
+++ b/tests/unit/tools/cargo_audit/test_cargo_audit_plugin.py
@@ -10,10 +10,29 @@ import pytest
 from assertpy import assert_that
 
 from lintro.enums.tool_type import ToolType
+from lintro.plugins.subprocess_executor import SubprocessResult
 from lintro.tools.definitions.cargo_audit import (
     CARGO_AUDIT_DEFAULT_TIMEOUT,
     CargoAuditPlugin,
 )
+
+
+def _proc(*, success: bool, stdout: str = "") -> SubprocessResult:
+    """Build a SubprocessResult for mocking ``_run_subprocess_result``.
+
+    Args:
+        success: Whether the subprocess succeeded (return code 0).
+        stdout: Captured standard output (the JSON report stream).
+
+    Returns:
+        SubprocessResult with the JSON payload on stdout.
+    """
+    return SubprocessResult(
+        returncode=0 if success else 1,
+        stdout=stdout,
+        stderr="",
+        output=stdout,
+    )
 
 
 @pytest.fixture
@@ -198,8 +217,8 @@ def test_check_no_vulnerabilities(
     ):
         with patch.object(
             cargo_audit_plugin,
-            "_run_subprocess",
-            return_value=(True, mock_output),
+            "_run_subprocess_result",
+            return_value=_proc(success=True, stdout=mock_output),
         ):
             result = cargo_audit_plugin.check([str(cargo_lock)], {})
 
@@ -245,8 +264,8 @@ def test_check_with_vulnerabilities(
     ):
         with patch.object(
             cargo_audit_plugin,
-            "_run_subprocess",
-            return_value=(False, mock_output),
+            "_run_subprocess_result",
+            return_value=_proc(success=False, stdout=mock_output),
         ):
             result = cargo_audit_plugin.check([str(cargo_lock)], {})
 
@@ -273,7 +292,7 @@ def test_check_timeout(
     ):
         with patch.object(
             cargo_audit_plugin,
-            "_run_subprocess",
+            "_run_subprocess_result",
             side_effect=TimeoutExpired(
                 cmd=["cargo", "audit"],
                 timeout=120,

--- a/tests/unit/tools/cargo_audit/test_cargo_audit_plugin.py
+++ b/tests/unit/tools/cargo_audit/test_cargo_audit_plugin.py
@@ -314,16 +314,18 @@ def test_check_garbage_output_with_zero_exit_is_not_clean(
 
     garbage = "this is not json {["
 
-    with patch(
-        "lintro.plugins.execution_preparation.verify_tool_version",
-        return_value=None,
-    ):
-        with patch.object(
+    with (
+        patch(
+            "lintro.plugins.execution_preparation.verify_tool_version",
+            return_value=None,
+        ),
+        patch.object(
             cargo_audit_plugin,
             "_run_subprocess_result",
             return_value=_proc(success=True, stdout=garbage),
-        ):
-            result = cargo_audit_plugin.check([str(cargo_lock)], {})
+        ),
+    ):
+        result = cargo_audit_plugin.check([str(cargo_lock)], {})
 
     assert_that(result.success).is_false()
     assert_that(result.issues_count).is_equal_to(0)

--- a/tests/unit/tools/cargo_audit/test_cargo_audit_plugin.py
+++ b/tests/unit/tools/cargo_audit/test_cargo_audit_plugin.py
@@ -302,3 +302,29 @@ def test_check_timeout(
 
     assert_that(result.success).is_false()
     assert_that(result.output).contains("timed out")
+
+
+def test_check_garbage_output_with_zero_exit_is_not_clean(
+    cargo_audit_plugin: CargoAuditPlugin,
+    tmp_path: Path,
+) -> None:
+    """Unparseable output with a zero exit must not report a clean scan (#1044)."""
+    cargo_lock = tmp_path / "Cargo.lock"
+    cargo_lock.write_text('[[package]]\nname = "test"\nversion = "1.0.0"')
+
+    garbage = "this is not json {["
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            cargo_audit_plugin,
+            "_run_subprocess_result",
+            return_value=_proc(success=True, stdout=garbage),
+        ):
+            result = cargo_audit_plugin.check([str(cargo_lock)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.parse_failures_count).is_equal_to(1)

--- a/tests/unit/tools/gitleaks/test_execution.py
+++ b/tests/unit/tools/gitleaks/test_execution.py
@@ -112,6 +112,31 @@ def test_check_with_mocked_subprocess_secrets_found(
     assert_that(result.issues).is_length(1)
 
 
+def test_check_empty_report_with_zero_exit_is_not_clean(
+    gitleaks_plugin: GitleaksPlugin,
+    tmp_path: Path,
+) -> None:
+    """An empty report with a zero exit must not report a clean scan (#1044).
+
+    Args:
+        gitleaks_plugin: The GitleaksPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    test_file = tmp_path / "test_module.py"
+    test_file.write_text('"""Module."""\n')
+
+    with patch.object(
+        gitleaks_plugin,
+        "_run_subprocess",
+        side_effect=_mock_subprocess_factory(""),
+    ):
+        result = gitleaks_plugin.check([str(test_file)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.parse_failures_count).is_equal_to(1)
+
+
 def test_check_garbage_report_with_zero_exit_is_not_clean(
     gitleaks_plugin: GitleaksPlugin,
     tmp_path: Path,

--- a/tests/unit/tools/gitleaks/test_execution.py
+++ b/tests/unit/tools/gitleaks/test_execution.py
@@ -110,3 +110,55 @@ def test_check_with_mocked_subprocess_secrets_found(
     assert_that(result.issues_count).is_equal_to(1)
     assert_that(result.issues).is_not_none()
     assert_that(result.issues).is_length(1)
+
+
+def test_check_garbage_report_with_zero_exit_is_not_clean(
+    gitleaks_plugin: GitleaksPlugin,
+    tmp_path: Path,
+) -> None:
+    """An unparseable report with a zero exit must not report a clean scan (#1044).
+
+    Args:
+        gitleaks_plugin: The GitleaksPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    test_file = tmp_path / "test_module.py"
+    test_file.write_text('"""Module."""\n')
+
+    garbage = "}{ not valid json report"
+
+    with patch.object(
+        gitleaks_plugin,
+        "_run_subprocess",
+        side_effect=_mock_subprocess_factory(garbage),
+    ):
+        result = gitleaks_plugin.check([str(test_file)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.parse_failures_count).is_equal_to(1)
+
+
+def test_check_non_array_report_with_zero_exit_is_not_clean(
+    gitleaks_plugin: GitleaksPlugin,
+    tmp_path: Path,
+) -> None:
+    """Valid JSON that is not an array must not report a clean scan (#1044).
+
+    Args:
+        gitleaks_plugin: The GitleaksPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    test_file = tmp_path / "test_module.py"
+    test_file.write_text('"""Module."""\n')
+
+    with patch.object(
+        gitleaks_plugin,
+        "_run_subprocess",
+        side_effect=_mock_subprocess_factory('{"unexpected": "object"}'),
+    ):
+        result = gitleaks_plugin.check([str(test_file)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.parse_failures_count).is_equal_to(1)

--- a/tests/unit/tools/osv_scanner/test_osv_scanner_plugin.py
+++ b/tests/unit/tools/osv_scanner/test_osv_scanner_plugin.py
@@ -15,10 +15,38 @@ from assertpy import assert_that
 from lintro.enums.severity_level import SeverityLevel
 from lintro.enums.tool_type import ToolType
 from lintro.parsers.osv_scanner.osv_scanner_issue import OsvScannerIssue
+from lintro.plugins.subprocess_executor import SubprocessResult
 from lintro.tools.definitions.osv_scanner import (
     OSV_SCANNER_DEFAULT_TIMEOUT,
     OsvScannerPlugin,
 )
+
+
+def _proc(
+    *,
+    success: bool,
+    stdout: str = "",
+    stderr: str = "",
+    output: str | None = None,
+) -> SubprocessResult:
+    """Build a SubprocessResult for mocking ``_run_subprocess_result``.
+
+    Args:
+        success: Whether the subprocess succeeded (return code 0).
+        stdout: Captured standard output (the JSON report stream).
+        stderr: Captured standard error (human-readable log lines).
+        output: Combined display output; defaults to ``stdout`` when omitted.
+
+    Returns:
+        SubprocessResult with the requested streams.
+    """
+    return SubprocessResult(
+        returncode=0 if success else 1,
+        stdout=stdout,
+        stderr=stderr,
+        output=stdout if output is None else output,
+    )
+
 
 # =============================================================================
 # Tests for definition
@@ -104,8 +132,8 @@ def test_check_no_vulnerabilities(
 
     with patch.object(
         osv_scanner_plugin,
-        "_run_subprocess",
-        return_value=(True, ""),
+        "_run_subprocess_result",
+        return_value=_proc(success=True),
     ):
         result = osv_scanner_plugin.check([str(lockfile)], {})
 
@@ -128,8 +156,8 @@ def test_check_clean_scan_with_log_prefix_and_nonzero_exit(
 
     with patch.object(
         osv_scanner_plugin,
-        "_run_subprocess",
-        return_value=(False, osv_output),
+        "_run_subprocess_result",
+        return_value=_proc(success=False, stdout=osv_output),
     ):
         result = osv_scanner_plugin.check([str(lockfile)], {})
 
@@ -151,8 +179,8 @@ def test_check_no_package_sources_sets_parse_failures_count(
 
     with patch.object(
         osv_scanner_plugin,
-        "_run_subprocess",
-        return_value=(False, osv_output),
+        "_run_subprocess_result",
+        return_value=_proc(success=False, stderr=osv_output, output=osv_output),
     ):
         result = osv_scanner_plugin.check([str(lockfile)], {})
 
@@ -173,8 +201,8 @@ def test_check_zero_packages_without_no_sources_is_not_success(
 
     with patch.object(
         osv_scanner_plugin,
-        "_run_subprocess",
-        return_value=(False, osv_output),
+        "_run_subprocess_result",
+        return_value=_proc(success=False, stderr=osv_output, output=osv_output),
     ):
         result = osv_scanner_plugin.check([str(lockfile)], {})
 
@@ -194,8 +222,8 @@ def test_check_error_payload_without_results_is_not_success(
 
     with patch.object(
         osv_scanner_plugin,
-        "_run_subprocess",
-        return_value=(False, osv_output),
+        "_run_subprocess_result",
+        return_value=_proc(success=False, stdout=osv_output),
     ):
         result = osv_scanner_plugin.check([str(lockfile)], {})
 
@@ -266,8 +294,8 @@ def test_check_with_vulnerabilities(
 
     with patch.object(
         osv_scanner_plugin,
-        "_run_subprocess",
-        return_value=(False, osv_output),
+        "_run_subprocess_result",
+        return_value=_proc(success=False, stdout=osv_output),
     ):
         result = osv_scanner_plugin.check([str(lockfile)], {})
 
@@ -296,7 +324,7 @@ def test_check_timeout(
 
     with patch.object(
         osv_scanner_plugin,
-        "_run_subprocess",
+        "_run_subprocess_result",
         side_effect=subprocess.TimeoutExpired(
             cmd=["osv-scanner"],
             timeout=120,
@@ -379,10 +407,10 @@ def test_check_with_suppressions_detects_stale(
     # Probe scan: also no issues (vuln was fixed upstream → stale)
     with patch.object(
         osv_scanner_plugin,
-        "_run_subprocess",
+        "_run_subprocess_result",
         side_effect=[
-            (True, ""),  # gating scan
-            (True, ""),  # probe scan
+            _proc(success=True),  # gating scan
+            _proc(success=True),  # probe scan
         ],
     ):
         result = osv_scanner_plugin.check([str(lockfile)], {})
@@ -406,8 +434,8 @@ def test_check_without_config_no_metadata(
 
     with patch.object(
         osv_scanner_plugin,
-        "_run_subprocess",
-        return_value=(True, ""),
+        "_run_subprocess_result",
+        return_value=_proc(success=True),
     ):
         result = osv_scanner_plugin.check([str(lockfile)], {})
 
@@ -433,8 +461,8 @@ def test_check_suppressions_disabled(
 
     with patch.object(
         osv_scanner_plugin,
-        "_run_subprocess",
-        return_value=(True, ""),
+        "_run_subprocess_result",
+        return_value=_proc(success=True),
     ) as mock_run:
         result = osv_scanner_plugin.check(
             [str(lockfile)],
@@ -464,9 +492,9 @@ def test_check_suppressions_probe_timeout(
 
     with patch.object(
         osv_scanner_plugin,
-        "_run_subprocess",
+        "_run_subprocess_result",
         side_effect=[
-            (True, ""),  # gating scan succeeds
+            _proc(success=True),  # gating scan succeeds
             subprocess.TimeoutExpired(cmd=["osv-scanner"], timeout=120),  # probe
         ],
     ):

--- a/tests/unit/tools/osv_scanner/test_osv_scanner_plugin.py
+++ b/tests/unit/tools/osv_scanner/test_osv_scanner_plugin.py
@@ -210,6 +210,28 @@ def test_check_zero_packages_without_no_sources_is_not_success(
     assert_that(result.issues_count).is_equal_to(0)
 
 
+def test_check_garbage_stdout_with_zero_exit_is_not_clean(
+    osv_scanner_plugin: OsvScannerPlugin,
+    tmp_path: Path,
+) -> None:
+    """Unparseable stdout with a zero exit must not report a clean scan (#1044)."""
+    lockfile = tmp_path / "requirements.txt"
+    lockfile.write_text("requests==2.32.3\n")
+
+    garbage = "}{ this is not valid json at all"
+
+    with patch.object(
+        osv_scanner_plugin,
+        "_run_subprocess_result",
+        return_value=_proc(success=True, stdout=garbage),
+    ):
+        result = osv_scanner_plugin.check([str(lockfile)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.parse_failures_count).is_equal_to(1)
+
+
 def test_check_error_payload_without_results_is_not_success(
     osv_scanner_plugin: OsvScannerPlugin,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

This PR separates a subprocess's stdout and stderr end-to-end so parsers can
consume clean stdout, hardens the timeout accounting of the streaming runner,
and makes security scanners fail closed when their output cannot be parsed. It
lands three sequenced, file-coupled issues as three commits.

### 1. Streaming timeout budget (`Closes #1047`)
`run_subprocess_streaming` previously handed the full timeout to *both* the
reader-thread join and the subsequent `process.wait()`, so a tool could run for
up to ~2x its configured limit. Elapsed wall time is now tracked with
`time.monotonic()` after the reader join and only the remaining budget
(`max(0, timeout - elapsed)`) is passed to `process.wait()`.

### 2. Separate stdout/stderr contract (`Closes #1043`)
`run_subprocess` and `run_subprocess_streaming` now return a `SubprocessResult`
dataclass (`returncode`, `stdout`, `stderr`, plus a combined `output` display
string and `.success` / `.as_tuple()`). Previously they concatenated
stdout+stderr into one blob, which forced JSON parsers to recover their payload
from mixed output where a single stderr warning line could break parsing.

- **Compatibility shim:** `BaseToolPlugin._run_subprocess` /
  `_run_subprocess_streaming` keep returning the legacy `(success, output)`
  tuple, so all ~30 tool definitions are untouched and behavior is preserved.
  New `_run_subprocess_result` / `_run_subprocess_streaming_result` accessors
  expose the separated streams.
- **Migration:** `osv_scanner` and `cargo_audit` (the security JSON tools most
  affected) now parse stdout only, retaining combined output for display.
- **Ride-along:** the bash-based `_git_diff_triple_snapshot` in `lintro review`
  is replaced with three plain `subprocess.run` git calls, dropping the hard
  `bash` dependency, the nonce-delimiter collision failure mode, and the Windows
  portability gap.

### 3. Security parsers fail closed (`Closes #1044`)
Security scanners previously reported a clean pass when their JSON payload could
not be parsed — a corrupted or truncated exit-0 payload became "no issues
found". Each security tool now surfaces an unparseable, non-empty payload as
`success=False` with `parse_failures_count=1`:

- **osv_scanner:** unparseable stdout that is not a recognized no-op now fails.
- **cargo_audit:** new `extract_cargo_audit_payload`; a `None` payload on
  non-empty stdout fails instead of returning `[]`.
- **gitleaks:** a report that is invalid JSON or not a JSON array now fails.
- **bandit:** the existing fail-closed path is annotated with
  `parse_failures_count`.

Lint-only `sqlfluff` intentionally keeps returning `[]` on parse errors.

## Testing
Behavior preservation is the whole point of this refactor — the existing suite
is the safety net. Full suite green (`uv run pytest`: 5733 passed, 10 skipped),
`uv run lintro chk` clean, `uv run lintro fmt` applied. New tests:
- streaming `process.wait()` receives the reduced budget; a hanging child stays
  within `timeout + epsilon`.
- `run_subprocess` returns separated streams and clean JSON stdout despite
  stderr noise.
- each security tool surfaces a parse failure as `success=False` on garbage +
  exit 0.

- Closes #1047
- Closes #1043
- Closes #1044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool scan results now include clearer parse-failure tracking, helping distinguish clean scans from unreadable output.
  * Subprocess handling now returns richer result details, improving reliability across command-driven checks.

* **Bug Fixes**
  * Improved handling of malformed or unexpected scan output for security tools, reducing false “clean” results.
  * Streaming commands now respect timeout limits more accurately.
  * Review context collection no longer depends on shell-based diff execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors subprocess output handling and tightens security scanner parsing. The main changes are:

- Separate stdout and stderr through `SubprocessResult`.
- Keep legacy subprocess tuple wrappers for existing plugins.
- Parse security scanner JSON from stdout only.
- Fail closed on malformed scanner reports.
- Share one timeout budget in streaming subprocess execution.
- Replace the bash-based git diff snapshot with direct git calls.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/definitions/gitleaks.py | Adds fail-closed handling for empty, malformed, and non-array gitleaks reports. |
| lintro/plugins/subprocess_executor.py | Adds separated subprocess result streams and updates streaming timeout accounting. |
| lintro/tools/definitions/osv_scanner.py | Parses OSV scanner JSON from stdout and reports non-empty unparseable stdout as a parse failure. |
| lintro/tools/definitions/cargo_audit.py | Parses cargo-audit JSON from stdout and reports non-empty unparseable stdout as a parse failure. |
| lintro/parsers/cargo_audit/cargo_audit_parser.py | Adds reusable cargo-audit payload extraction and supports pre-parsed payloads. |
| lintro/ai/review/context/git_ops.py | Collects diff snapshots with three direct git calls instead of a bash script. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(plugins): fail closed on empty gitle..."](https://github.com/lgtm-hq/py-lintro/commit/1801309c7e31ba70651a55300e84239d165f4a24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41878517)</sub>

<!-- /greptile_comment -->