### PR TITLE
fix(ai/review): correct patch line mapping and head-repo fallback

### DIFF
--- a/lintro/ai/integrations/github_pr.py
+++ b/lintro/ai/integrations/github_pr.py
@@ -354,6 +354,10 @@ def _parse_patch_lines(patch: str) -> set[int]:
         if hunk_match:
             current_line = int(hunk_match.group(1))
             continue
+        if raw_line.startswith("\\"):
+            # "\ No newline at end of file" marker — not a real line, so it
+            # must not advance the right-side counter.
+            continue
         if raw_line.startswith("-"):
             # Deleted line — doesn't advance right-side counter
             continue

--- a/lintro/ai/review/context/pr_metadata.py
+++ b/lintro/ai/review/context/pr_metadata.py
@@ -105,10 +105,13 @@ def _parse_pr_view_json(
                 "'headRepository'.",
                 code=ReviewContextErrorCode.GH_METADATA_INVALID,
             )
-        raise ReviewContextError(
-            "Could not determine repository for pull request review.",
-            code=ReviewContextErrorCode.GH_METADATA_INVALID,
-        )
+        if parsed_head_repo is not None:
+            repo_name = parsed_head_repo
+        else:
+            raise ReviewContextError(
+                "Could not determine repository for pull request review.",
+                code=ReviewContextErrorCode.GH_METADATA_INVALID,
+            )
 
     body = data.get("body")
     body_text = body if isinstance(body, str) else ""

--- a/tests/unit/ai/review/test_context_parse.py
+++ b/tests/unit/ai/review/test_context_parse.py
@@ -13,7 +13,10 @@ from lintro.ai.review.context import (
     unified_diff_preamble,
     validate_review_context_diff,
 )
-from lintro.ai.review.context.pr_metadata import _parse_changed_files_from_diff
+from lintro.ai.review.context.pr_metadata import (
+    _parse_changed_files_from_diff,
+    _parse_pr_view_json,
+)
 from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
 from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
 from lintro.ai.review.exceptions import ReviewContextError
@@ -417,3 +420,34 @@ def test_parse_changed_files_supports_newlines_in_numstat_z_paths() -> None:
     changed_files = parse_changed_files(name_status=name_status, numstat=numstat)
     assert_that(changed_files).is_length(1)
     assert_that(changed_files[0].path).is_equal_to(path)
+
+
+def test_pr_metadata_missing_base_uses_head_repo() -> None:
+    """Resolve the repository from head when baseRepository is absent.
+
+    When ``baseRepository`` is missing but ``headRepository`` carries a valid
+    ``nameWithOwner``, the parsed head repository must be used as the fallback
+    instead of raising "Could not determine repository".
+    """
+    import json
+
+    payload = json.dumps(
+        {
+            "number": 42,
+            "title": "Example PR",
+            "baseRefOid": "a" * 40,
+            "headRefOid": "b" * 40,
+            "headRepository": {"nameWithOwner": "octo/head-fork"},
+            "body": "Body text",
+        },
+    )
+
+    metadata, base_ref, head_ref = _parse_pr_view_json(
+        payload=payload,
+        repo_override=None,
+    )
+
+    assert_that(metadata.repo).is_equal_to("octo/head-fork")
+    assert_that(metadata.head_repo).is_equal_to("octo/head-fork")
+    assert_that(base_ref).is_equal_to("a" * 40)
+    assert_that(head_ref).is_equal_to("b" * 40)

--- a/tests/unit/ai/test_github_pr.py
+++ b/tests/unit/ai/test_github_pr.py
@@ -14,6 +14,7 @@ from lintro.ai.integrations.github_pr import (
     _detect_pr_number,
     _format_inline_comment,
     _format_summary_comment,
+    _parse_patch_lines,
 )
 from lintro.ai.models import AIFixSuggestion, AISummary
 
@@ -405,3 +406,52 @@ def test_post_review_skips_out_of_workspace_suggestions(test_token: str) -> None
         reporter._post_review(suggestions)
         # Out-of-workspace suggestion should be filtered; no API call made
         mock_api.assert_not_called()
+
+
+def test_parse_patch_lines_skips_no_newline_marker() -> None:
+    r"""Ensure the "\\ No newline at end of file" marker does not shift lines.
+
+    The marker begins with a backslash rather than ``+``/``-`` and must not
+    advance the right-side line counter; otherwise added lines after it map
+    one line off.
+    """
+    patch = "\n".join(
+        [
+            "@@ -1,2 +1,3 @@",
+            " context1",
+            "-removed old",
+            "\\ No newline at end of file",
+            "+added new",
+            "+added final",
+        ],
+    )
+
+    result = _parse_patch_lines(patch)
+
+    assert_that(sorted(result)).is_equal_to([2, 3])
+
+
+def test_parse_patch_lines_no_newline_comment_mapping() -> None:
+    """Ensure a line targeted after a no-newline marker maps correctly.
+
+    A right-side line following the marker must retain its true position so
+    inline comments are not demoted to fallback issue comments.
+    """
+    patch = "\n".join(
+        [
+            "@@ -1,3 +1,4 @@",
+            " context1",
+            " context2",
+            "-old third",
+            "\\ No newline at end of file",
+            "+new third",
+            "+new fourth",
+        ],
+    )
+
+    result = _parse_patch_lines(patch)
+
+    # The added lines occupy right-side positions 3 and 4; the off-by-one
+    # positions 4 and 5 must not appear.
+    assert_that(sorted(result)).is_equal_to([3, 4])
+    assert_that(result).does_not_contain(5)


### PR DESCRIPTION
## Summary

Two minor correctness fixes in AI PR review posting.

### Problem A — patch line mapping off-by-one
`_parse_patch_lines` in `lintro/ai/integrations/github_pr.py` advanced the right-side line counter on `\ No newline at end of file` markers. These markers start with `\` (not `+`/`-`) and previously fell through to the counter increment, so any added line following such a marker mapped one line off and its inline comment got demoted to a fallback issue comment. Fixed by skipping lines starting with `\` before the increment.

### Problem B — dead head-repo fallback
`_parse_pr_view_json` in `lintro/ai/review/context/pr_metadata.py` raised "Could not determine repository" when `baseRepository` was absent, even though a valid `parsed_head_repo` had already been computed from `headRepository`. Fixed by using `parsed_head_repo` as the final fallback for `repo_name` before raising.

## Tests
- `test_parse_patch_lines_skips_no_newline_marker` — patch with a no-newline marker maps subsequent lines correctly (`{2, 3}`, not off-by-one).
- `test_parse_patch_lines_no_newline_comment_mapping` — a line targeted after the marker retains its true position.
- `test_pr_metadata_missing_base_uses_head_repo` — metadata with `baseRepository` absent but `headRepository` present resolves the repo via the head fallback.

## Gates
- `uv run lintro fmt` — clean
- `uv run lintro chk` — clean (exit 0)
- `uv run pytest` — 5748 passed, 10 skipped

Closes #1046

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two AI review posting edge cases. The main changes are:

- Skips unified-diff no-newline marker rows when mapping patch lines.
- Falls back to the parsed head repository when base repository metadata is missing.
- Adds tests for patch line mapping and repository fallback parsing.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/integrations/github_pr.py | Skips no-newline marker rows so patch line mapping keeps the correct right-side line numbers. |
| lintro/ai/review/context/pr_metadata.py | Uses the parsed head repository as the final repository fallback when base metadata is unavailable. |
| tests/unit/ai/review/test_context_parse.py | Adds test coverage for PR metadata parsing with missing base repository data. |
| tests/unit/ai/test_github_pr.py | Adds test coverage for no-newline marker handling in patch line mapping. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/lgtm-hq/py-lintro/commit/33ad84fd362f6f61da5a8a436f90751c7f774c65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41898960)</sub>

<!-- /greptile_comment -->