### PR TITLE
fix(ai): Cursor provider cost accounting and opt-in --trust

### DIFF
--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -161,6 +161,18 @@ class AIConfig(BaseModel):
             "'off' disables detection."
         ),
     )
+    cursor_trust_workspace: bool = Field(
+        default=False,
+        description=(
+            "Pass '--trust' to the Cursor 'agent' CLI, granting it workspace "
+            "trust. Security risk: the Cursor provider is fed untrusted, "
+            "prompt-injectable content (e.g. 'lintro review --pr N' embeds "
+            "diffs from arbitrary fork PRs). Combining workspace trust with "
+            "such input could let an injected diff drive an agent operating "
+            "with full workspace trust, so this defaults to False and should "
+            "only be enabled for fully trusted local workspaces."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_transport_and_retries(self) -> AIConfig:

--- a/lintro/ai/cost.py
+++ b/lintro/ai/cost.py
@@ -62,7 +62,7 @@ def estimate_cost_with_floor(
     """
     pricing = PROVIDERS.model_pricing.get(model)
     if pricing is None or (
-        pricing.input_per_million == 0.0 and pricing.output_per_million == 0.0
+        pricing.input_per_million == 0.0 or pricing.output_per_million == 0.0
     ):
         pricing = DEFAULT_PRICING
 

--- a/lintro/ai/cost.py
+++ b/lintro/ai/cost.py
@@ -37,6 +37,41 @@ def estimate_cost(
     return input_cost + output_cost
 
 
+def estimate_cost_with_floor(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+) -> float:
+    """Estimate cost, using default pricing when a model is unpriced.
+
+    Some providers (notably Cursor via its subscription ``agent`` CLI) do
+    not expose per-token pricing, so their registry entries carry zero
+    rates. Pricing such calls at zero would let them accrue nothing against
+    :class:`~lintro.ai.budget.CostBudget`, turning ``ai.max_cost_usd`` into
+    a no-op and allowing deep reviews to run unbounded API calls. To keep
+    the budget a meaningful safety cap, fall back to :data:`DEFAULT_PRICING`
+    whenever the model is unknown or priced at zero.
+
+    Args:
+        model: Model identifier (e.g., "auto", "composer-2.5").
+        input_tokens: Number of input tokens.
+        output_tokens: Number of output tokens.
+
+    Returns:
+        float: Estimated cost in USD, always using a non-zero rate.
+    """
+    pricing = PROVIDERS.model_pricing.get(model)
+    if pricing is None or (
+        pricing.input_per_million == 0.0 and pricing.output_per_million == 0.0
+    ):
+        pricing = DEFAULT_PRICING
+
+    input_cost = (input_tokens / 1_000_000) * pricing.input_per_million
+    output_cost = (output_tokens / 1_000_000) * pricing.output_per_million
+
+    return input_cost + output_cost
+
+
 def format_cost(cost: float) -> str:
     """Format a cost value for display.
 

--- a/lintro/ai/providers/__init__.py
+++ b/lintro/ai/providers/__init__.py
@@ -82,6 +82,14 @@ def get_provider(config: AIConfig) -> BaseAIProvider:
         from lintro.ai.providers.cursor import CursorProvider
 
         provider_cls = CursorProvider
+        return provider_cls(
+            model=config.model,
+            api_key_env=config.api_key_env,
+            max_tokens=config.max_tokens,
+            base_url=config.api_base_url,
+            transport=config.transport or AITransport.API,
+            cursor_trust_workspace=config.cursor_trust_workspace,
+        )
     return provider_cls(
         model=config.model,
         api_key_env=config.api_key_env,

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import replace
 from typing import Any
 
 from loguru import logger
 
+from lintro.ai.cost import estimate_cost_with_floor
 from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import (
     AINotAvailableError,
@@ -29,6 +31,7 @@ from lintro.ai.providers.constants import (
     DEFAULT_TIMEOUT,
 )
 from lintro.ai.registry import PROVIDERS, AIProvider
+from lintro.ai.token_budget import estimate_tokens
 
 CURSOR_MIN_TIMEOUT = 600.0
 
@@ -127,6 +130,7 @@ class CursorProvider(BaseAIProvider):
         max_tokens: int = DEFAULT_MAX_TOKENS,
         base_url: str | None = None,
         transport: AITransport = AITransport.CLI,
+        cursor_trust_workspace: bool = False,
     ) -> None:
         """Initialize the Cursor provider.
 
@@ -136,6 +140,13 @@ class CursorProvider(BaseAIProvider):
             max_tokens: Default max tokens for provider configuration.
             base_url: Unused; kept for provider API parity.
             transport: AI transport mode (CLI only for Cursor).
+            cursor_trust_workspace: When True, pass ``--trust`` to the
+                ``agent`` CLI, granting Cursor workspace trust. Defaults to
+                False. Enabling it is a security risk: the provider is fed
+                untrusted, prompt-injectable content (``lintro review --pr N``
+                embeds diffs from arbitrary fork PRs), so combining workspace
+                trust with such input could let an injected diff drive an
+                agent operating with full workspace trust.
 
         Raises:
             AINotAvailableError: When transport is not CLI or the ``agent``
@@ -168,6 +179,7 @@ class CursorProvider(BaseAIProvider):
             binary_path=agent_path,
             model=self._model,
         )
+        self._trust_workspace = cursor_trust_workspace
         self._session_id: str | None = None
         self._durable_repo_root: str | None = None
 
@@ -251,14 +263,19 @@ class CursorProvider(BaseAIProvider):
             "--print",
             "--output-format",
             "json",
-            "--trust",
-            "--mode",
-            "ask",
-            "--model",
-            effective_model,
-            "--workspace",
-            effective_root,
         ]
+        if self._trust_workspace:
+            cmd.append("--trust")
+        cmd.extend(
+            [
+                "--mode",
+                "ask",
+                "--model",
+                effective_model,
+                "--workspace",
+                effective_root,
+            ],
+        )
         if resume_session and self._session_id is not None:
             cmd.extend(["--resume", self._session_id])
 
@@ -281,10 +298,50 @@ class CursorProvider(BaseAIProvider):
             auth_hint="Run 'agent login' or set CURSOR_API_KEY.",
         )
         response, session_id = self._cli.parse_stdout(result.stdout)
+        response = self._estimate_usage(
+            prompt=combined_prompt,
+            model=effective_model,
+            response=response,
+        )
 
         if not use_one_shot and self._durable_repo_root is not None and session_id:
             self._session_id = session_id
         return response
+
+    @staticmethod
+    def _estimate_usage(
+        *,
+        prompt: str,
+        model: str,
+        response: AIResponse,
+    ) -> AIResponse:
+        """Fill in local token estimates and a budget-safe cost estimate.
+
+        The Cursor ``agent`` CLI does not reliably expose token usage, and
+        its subscription pricing is zero in the model registry, so every
+        call would otherwise record zero cost and bypass the session budget.
+        This estimates tokens from the prompt and response text (when the CLI
+        omits them) and prices them with a non-zero floor so
+        :class:`~lintro.ai.budget.CostBudget` accrues a meaningful figure and
+        ``ai.max_cost_usd`` acts as a real safety cap.
+
+        Args:
+            prompt: The combined prompt sent to the CLI (system + user).
+            model: The effective model identifier used for the call.
+            response: The parsed provider response to augment.
+
+        Returns:
+            AIResponse: A copy with non-zero token counts and cost estimate.
+        """
+        input_tokens = response.input_tokens or estimate_tokens(prompt)
+        output_tokens = response.output_tokens or estimate_tokens(response.content)
+        cost = estimate_cost_with_floor(model, input_tokens, output_tokens)
+        return replace(
+            response,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_estimate=cost,
+        )
 
     @staticmethod
     def _extract_json_object(text: str) -> str:

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -798,6 +798,9 @@ def _review_chunk(
         )
 
     tracker.on_step(chunk_index=chunk_index, step="reviewing")
+    # Gate before the main provider call so intra-chunk (depth-2/3) work
+    # cannot overshoot the budget between the per-chunk checks.
+    budget.check()
     use_git_native = ai_config.transport == AITransport.CLI
     if use_git_native:
         embed_diff = estimate_tokens(chunk.diff) <= max(diff_budget, 1)
@@ -887,6 +890,7 @@ def _generate_extra_checklist(
         diff=chunk.diff,
         changed_files=changed_files,
     )
+    budget.check()
     response = call_ai(
         provider=provider,
         ai_config=ai_config,
@@ -957,6 +961,7 @@ def _run_adversarial_pass(
         prior_findings_json=prior_json,
         diff=chunk.diff,
     )
+    budget.check()
     response = call_ai(
         provider=provider,
         ai_config=ai_config,

--- a/tests/unit/ai/providers/test_factory.py
+++ b/tests/unit/ai/providers/test_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -62,3 +63,42 @@ def test_get_provider_passes_model():
         assert_that(provider.model_name).is_equal_to(
             "claude-opus-4-20250514",
         )
+
+
+def test_get_provider_cursor_trust_defaults_off():
+    """Cursor provider does not trust the workspace unless opted in."""
+    from lintro.ai.enums import AITransport
+    from lintro.ai.providers.cursor import CursorProvider
+
+    config = AIConfig(
+        provider="cursor",  # type: ignore[arg-type]  # Pydantic coerces str
+        transport=AITransport.CLI,
+    )
+    with patch(
+        "lintro.ai.providers.cursor._find_agent",
+        return_value="/usr/local/bin/agent",
+    ):
+        provider = get_provider(config)
+    assert_that(isinstance(provider, CursorProvider)).is_true()
+    cursor = cast(CursorProvider, provider)
+    assert_that(cursor._trust_workspace).is_false()
+
+
+def test_get_provider_cursor_trust_threaded_when_enabled():
+    """get_provider threads cursor_trust_workspace into the provider."""
+    from lintro.ai.enums import AITransport
+    from lintro.ai.providers.cursor import CursorProvider
+
+    config = AIConfig(
+        provider="cursor",  # type: ignore[arg-type]  # Pydantic coerces str
+        transport=AITransport.CLI,
+        cursor_trust_workspace=True,
+    )
+    with patch(
+        "lintro.ai.providers.cursor._find_agent",
+        return_value="/usr/local/bin/agent",
+    ):
+        provider = get_provider(config)
+    assert_that(isinstance(provider, CursorProvider)).is_true()
+    cursor = cast(CursorProvider, provider)
+    assert_that(cursor._trust_workspace).is_true()

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -11,16 +11,20 @@ from unittest.mock import MagicMock, patch
 import pytest
 from assertpy import assert_that
 
+from lintro.ai.budget import CostBudget
 from lintro.ai.config import AIConfig
 from lintro.ai.enums import AITransport
+from lintro.ai.exceptions import AIError
 from lintro.ai.providers.response import AIResponse
 from lintro.ai.review.enums.review_category import ReviewCategory
 from lintro.ai.review.exceptions import ReviewExecutionError
+from lintro.ai.review.group_labels import REL_SINGLE_FILE
 from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.checklist_item import ChecklistItem
 from lintro.ai.review.models.review_chunk import ReviewChunk
 from lintro.ai.review.models.review_context import ReviewContext
 from lintro.ai.review.orchestrator import (
+    _review_chunk,
     build_git_native_review_prompt,
     parse_review_response,
     resolve_review_chunks,
@@ -224,6 +228,128 @@ def test_run_review_depth2_calls_provider_twice() -> None:
     assert_that(result.metadata.token_usage["prompt"]).is_equal_to(150)
     assert_that(result.metadata.token_usage["completion"]).is_equal_to(70)
     assert_that(result.metadata.cost_estimate_usd).is_equal_to(0.015)
+
+
+def _single_chunk() -> ReviewChunk:
+    """Build a one-file review chunk for direct ``_review_chunk`` tests."""
+    return ReviewChunk(
+        id=1,
+        files=["src/main.py"],
+        diff="diff --git a/src/main.py b/src/main.py\n+change",
+        relationship=REL_SINGLE_FILE,
+    )
+
+
+def _single_file_context() -> ReviewContext:
+    """Build a minimal review context for direct ``_review_chunk`` tests."""
+    return ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(
+                path="src/main.py",
+                status="modified",
+                additions=1,
+                deletions=0,
+            ),
+        ],
+        unified_diff="diff --git a/src/main.py b/src/main.py\n+change",
+        pr_metadata=None,
+    )
+
+
+def test_review_chunk_checks_budget_before_each_provider_call() -> None:
+    """Depth-3 review checks the budget before every intra-chunk call."""
+    events: list[str] = []
+    budget = CostBudget(max_cost_usd=None)
+    original_check = budget.check
+
+    def _record_check() -> None:
+        events.append("check")
+        original_check()
+
+    def _fake_call_ai(*, budget: CostBudget, **kwargs: object) -> AIResponse:
+        del budget, kwargs
+        events.append("call")
+        return AIResponse(
+            content=_sample_response_json(include_finding=False),
+            model="auto",
+            input_tokens=100,
+            output_tokens=50,
+            cost_estimate=0.01,
+            provider="cursor",
+        )
+
+    with (
+        patch.object(budget, "check", side_effect=_record_check),
+        patch(
+            "lintro.ai.review.orchestrator.call_ai",
+            side_effect=_fake_call_ai,
+        ),
+    ):
+        _review_chunk(
+            chunk=_single_chunk(),
+            context=_single_file_context(),
+            provider=MagicMock(),
+            ai_config=AIConfig(enabled=True, transport=AITransport.API),
+            depth=3,
+            checklist_text="1. [logic-bug] Example?",
+            checklist_count=1,
+            next_generated_checklist_id=100,
+            classifications=[],
+            lint_results=None,
+            budget=budget,
+        )
+
+    # Three provider calls (extra checklist, main review, adversarial), each
+    # preceded by a budget check.
+    assert_that(events.count("call")).is_equal_to(3)
+    for index, event in enumerate(events):
+        if event == "call":
+            assert_that(events[index - 1]).is_equal_to("check")
+
+
+def test_review_chunk_budget_stops_runaway_calls() -> None:
+    """An exhausted budget halts the chunk before overspending on more calls."""
+    calls: list[str] = []
+    budget = CostBudget(max_cost_usd=0.01)
+
+    def _fake_call_ai(*, budget: CostBudget, **kwargs: object) -> AIResponse:
+        del kwargs
+        calls.append("call")
+        response = AIResponse(
+            content=_sample_response_json(include_finding=False),
+            model="auto",
+            input_tokens=100,
+            output_tokens=50,
+            cost_estimate=0.02,
+            provider="cursor",
+        )
+        budget.record(response.cost_estimate)
+        return response
+
+    with patch(
+        "lintro.ai.review.orchestrator.call_ai",
+        side_effect=_fake_call_ai,
+    ):
+        with pytest.raises(AIError):
+            _review_chunk(
+                chunk=_single_chunk(),
+                context=_single_file_context(),
+                provider=MagicMock(),
+                ai_config=AIConfig(enabled=True, transport=AITransport.API),
+                depth=3,
+                checklist_text="1. [logic-bug] Example?",
+                checklist_count=1,
+                next_generated_checklist_id=100,
+                classifications=[],
+                lint_results=None,
+                budget=budget,
+            )
+
+    # The first depth-2 call overspends the $0.01 cap; the budget check gates
+    # the next call before a runaway depth-3 sweep can fire.
+    assert_that(len(calls)).is_less_than(3)
 
 
 def test_resolve_review_chunks_uses_fast_path_for_small_diff(

--- a/tests/unit/ai/test_config.py
+++ b/tests/unit/ai/test_config.py
@@ -32,6 +32,18 @@ def test_default_config_optional_fields() -> None:
     assert_that(config.api_key_env).is_none()
 
 
+def test_cursor_trust_workspace_defaults_false() -> None:
+    """Cursor workspace trust is opt-in and disabled by default."""
+    config = AIConfig()
+    assert_that(config.cursor_trust_workspace).is_false()
+
+
+def test_cursor_trust_workspace_opt_in() -> None:
+    """Cursor workspace trust can be explicitly enabled via config."""
+    config = AIConfig(cursor_trust_workspace=True)
+    assert_that(config.cursor_trust_workspace).is_true()
+
+
 def test_default_config_numeric_fields() -> None:
     """All numeric fields have correct defaults."""
     config = AIConfig()

--- a/tests/unit/ai/test_cost.py
+++ b/tests/unit/ai/test_cost.py
@@ -9,10 +9,11 @@ from assertpy import assert_that
 
 from lintro.ai.cost import (
     estimate_cost,
+    estimate_cost_with_floor,
     format_cost,
     format_token_count,
 )
-from lintro.ai.registry import DEFAULT_PRICING, PROVIDERS
+from lintro.ai.registry import DEFAULT_PRICING, PROVIDERS, ModelPricing
 
 
 def test_cost_known_model():
@@ -22,6 +23,15 @@ def test_cost_known_model():
     expected = (1000 / 1_000_000) * pricing.input_per_million + (
         500 / 1_000_000
     ) * pricing.output_per_million
+    assert_that(cost).is_close_to(expected, 1e-10)
+
+
+def test_estimate_cost_with_floor_partial_zero_uses_default():
+    """Verify partial zero pricing falls back to default rates."""
+    partial_zero = ModelPricing(input_per_million=3.0, output_per_million=0.0)
+    with patch.dict(PROVIDERS.model_pricing, {"partial-zero": partial_zero}):
+        cost = estimate_cost_with_floor("partial-zero", 1_000_000, 1_000_000)
+    expected = DEFAULT_PRICING.input_per_million + DEFAULT_PRICING.output_per_million
     assert_that(cost).is_close_to(expected, 1e-10)
 
 

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 from assertpy import assert_that
 
+from lintro.ai.budget import CostBudget
 from lintro.ai.exceptions import (
     AIAuthenticationError,
     AINotAvailableError,
@@ -296,8 +297,8 @@ def test_complete_uses_minimum_timeout_for_agent(provider):
         )
 
 
-def test_complete_cost_estimate_is_zero(provider):
-    """Cursor subscription — per-token cost is always zero."""
+def test_complete_estimates_nonzero_cost_from_cli_usage(provider):
+    """Cursor prices reported usage with a non-zero floor for the budget."""
     stdout = _cli_json(result="ok", input_tokens=5000, output_tokens=2000)
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
@@ -307,7 +308,76 @@ def test_complete_cost_estimate_is_zero(provider):
             stderr="",
         )
         resp = provider.complete("Hello")
-    assert_that(resp.cost_estimate).is_equal_to(0.0)
+    assert_that(resp.input_tokens).is_equal_to(5000)
+    assert_that(resp.output_tokens).is_equal_to(2000)
+    assert_that(resp.cost_estimate).is_greater_than(0.0)
+
+
+def test_complete_estimates_tokens_when_cli_omits_usage(provider):
+    """When the CLI omits usage, tokens are estimated locally from text."""
+    stdout = _cli_json(
+        result="a fairly long review answer",
+        input_tokens=0,
+        output_tokens=0,
+    )
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+        resp = provider.complete("Hello there, please review this code carefully")
+    assert_that(resp.input_tokens).is_greater_than(0)
+    assert_that(resp.output_tokens).is_greater_than(0)
+    assert_that(resp.cost_estimate).is_greater_than(0.0)
+
+
+def test_cursor_cost_accrues_into_budget(provider):
+    """A Cursor response's estimated cost is recorded by CostBudget."""
+    stdout = _cli_json(result="ok", input_tokens=5000, output_tokens=2000)
+    budget = CostBudget(max_cost_usd=1.0)
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+        resp = provider.complete("Hello")
+    budget.record(resp.cost_estimate)
+    assert_that(budget.spent).is_greater_than(0.0)
+
+
+def test_complete_omits_trust_flag_by_default(provider):
+    """The '--trust' flag is absent unless workspace trust is opted in."""
+    stdout = _cli_json(result="ok")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+        provider.complete("Hello", repo_root="/tmp/repo")
+    cmd = mock_run.call_args.args[0]
+    assert_that(cmd).does_not_contain("--trust")
+
+
+def test_complete_includes_trust_flag_when_opted_in(_mock_agent_on_path):
+    """The '--trust' flag is present only when the opt-in is set."""
+    trusting = CursorProvider(cursor_trust_workspace=True)
+    stdout = _cli_json(result="ok")
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+        trusting.complete("Hello", repo_root="/tmp/repo")
+    cmd = mock_run.call_args.args[0]
+    assert_that(cmd).contains("--trust")
 
 
 # -- CursorProvider._extract_json_object() ---------------------------------


### PR DESCRIPTION
## Summary

Two related hardening fixes for the Cursor AI provider, delivered as one PR.

### Cursor cost accounting — Closes #1042

The Cursor `agent` CLI does not reliably expose token usage, and Cursor's
subscription models are priced at `0.0` in the registry, so every call
recorded `cost_estimate=0.0` and zero tokens. `CostBudget` accrued nothing,
making `ai.max_cost_usd` a no-op and letting deep reviews run unbounded calls.

- `CursorProvider.complete()` now estimates tokens locally (`estimate_tokens`
  on the combined prompt and the response) when the CLI omits usage.
- New `estimate_cost_with_floor()` in `lintro/ai/cost.py` prices those tokens,
  falling back to `DEFAULT_PRICING` whenever a model is unknown or priced at
  zero, so the session budget accrues a meaningful (approximate) figure and
  `max_cost_usd` acts as a real safety cap.
- The review orchestrator now calls `budget.check()` before **each** provider
  call — the main review pass, the depth-2 question generation, and the
  depth-3 adversarial sweep — not just between chunks, so intra-chunk calls
  cannot overshoot the budget.

### Opt-in `--trust` — Closes #1049

`--trust` was hardcoded on every `agent` CLI invocation, granting workspace
trust unconditionally even though the provider is fed untrusted,
prompt-injectable content (`lintro review --pr N` embeds arbitrary fork-PR
diffs).

- Removed `--trust` from the default argv.
- Added `AIConfig.cursor_trust_workspace` (default `False`) with a docstring
  documenting the risk, threaded through the `CursorProvider` constructor via
  the provider factory. `--trust` is appended only when the opt-in is set.
- No other provider's default behavior changes.

## Spec drift (post-transport)

Both issues referenced `cursor.py:137` / `cursor.py:268` from before the
`#1009/#1010` unified transport merge. On current main the `--trust` argv and
the `cost_estimate=0.0` assignment live in `CursorProvider.complete()` and
`_CursorCliTransport.parse_stdout()` respectively; changes were adapted to
those locations. `call_ai` (the unified invocation path) already gates via
`budget.execute` when a budget is set; the added explicit `budget.check()`
calls make per-call gating robust and cover the `_generate_extra_checklist`
and `_run_adversarial_pass` paths.

## Tests

- Cursor response yields non-zero estimated cost/tokens and accrues into
  `CostBudget`; tokens estimated when the CLI omits usage.
- `--trust` absent by default, present only when `cursor_trust_workspace=True`;
  config defaults to `False`; factory threads the option.
- Orchestrator checks the budget before every intra-chunk provider call and an
  exhausted budget halts a depth-3 chunk before a runaway sweep.

Gates: `uv run lintro fmt`, `uv run lintro chk` (clean), `uv run pytest`
(5755 passed, 10 skipped) all green.

- Closes #1042
- Closes #1049

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the Cursor provider cost and trust behavior. The main changes are:

- Local token estimation when Cursor omits usage.
- Floor-based cost accounting for zero-priced Cursor models.
- Per-call budget checks in the review flow.
- Opt-in Cursor workspace trust through config.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The partial-zero pricing fix now falls back when either token rate is zero.
- Cursor responses now flow through the floor-based cost path before budget recording.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/cost.py | Adds floor-based cost estimation and handles zero pricing on either token side. |
| lintro/ai/providers/cursor.py | Estimates missing Cursor usage, records non-zero cost, and makes workspace trust opt-in. |
| lintro/ai/review/orchestrator.py | Checks the budget before each review provider call. |
| lintro/ai/config.py | Adds the Cursor workspace trust opt-in setting. |
| lintro/ai/providers/__init__.py | Threads the Cursor workspace trust setting into the provider factory. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ai): apply DEFAULT\_PRICING when eith..."](https://github.com/lgtm-hq/py-lintro/commit/e2a69e2f86959239d088fd3df43cd07c02073405) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41900118)</sub>

<!-- /greptile_comment -->