### PR TITLE
fix(ai/review): harden review AI — secret redaction, severity normalization, response robustness

### DIFF
--- a/lintro/ai/integrations/github_pr.py
+++ b/lintro/ai/integrations/github_pr.py
@@ -11,6 +11,7 @@ import os
 import urllib.error
 import urllib.parse
 import urllib.request
+import warnings
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -103,7 +104,7 @@ class GitHubPRReporter:
 
         if summary and summary.overview:
             body = _format_summary_comment(summary)
-            if not self._post_issue_comment(body):
+            if not self.post_issue_comment(body):
                 success = False
 
         if suggestions and not self._post_review(suggestions):
@@ -126,7 +127,7 @@ class GitHubPRReporter:
         Returns:
             True if all comments were posted successfully.
         """
-        diff_lines = self._fetch_pr_diff_lines()
+        diff_lines = self.fetch_pr_diff_lines()
         comments: list[dict[str, Any]] = []
         fallback_suggestions: list[AIFixSuggestion] = []
 
@@ -172,19 +173,19 @@ class GitHubPRReporter:
                 "comments": comments,
             }
             url = f"{self.api_base}/repos/{self.repo}/pulls/{self.pr_number}/reviews"
-            if not self._api_request("POST", url, payload):
+            if not self.api_request("POST", url, payload):
                 success = False
 
         # Post unmappable suggestions as standalone issue comments
         for s in fallback_suggestions:
             body = _format_inline_comment(s)
             location = f"`{s.file}:{s.line}`" if s.line else f"`{s.file}`"
-            if not self._post_issue_comment(f"{location}\n\n{body}"):
+            if not self.post_issue_comment(f"{location}\n\n{body}"):
                 success = False
 
         return success
 
-    def _fetch_pr_diff_lines(self) -> dict[str, set[int]] | None:
+    def fetch_pr_diff_lines(self) -> dict[str, set[int]] | None:
         """Fetch changed lines per file from the PR diff.
 
         Paginates through all pages of the ``GET /pulls/{pr}/files``
@@ -240,7 +241,7 @@ class GitHubPRReporter:
             result[filename] = _parse_patch_lines(patch)
         return result
 
-    def _post_issue_comment(self, body: str) -> bool:
+    def post_issue_comment(self, body: str) -> bool:
         """Post a top-level issue comment on the PR.
 
         Args:
@@ -250,9 +251,9 @@ class GitHubPRReporter:
             True if posted successfully.
         """
         url = f"{self.api_base}/repos/{self.repo}/issues/{self.pr_number}/comments"
-        return self._api_request("POST", url, {"body": body})
+        return self.api_request("POST", url, {"body": body})
 
-    def _api_request(
+    def api_request(
         self,
         method: str,
         url: str,
@@ -308,6 +309,60 @@ class GitHubPRReporter:
         except urllib.error.URLError as e:
             logger.warning("GitHub API request error: {}", e.reason)
             return False
+
+    def _fetch_pr_diff_lines(self) -> dict[str, set[int]] | None:
+        """Deprecated alias for :meth:`fetch_pr_diff_lines`.
+
+        Returns:
+            Result of :meth:`fetch_pr_diff_lines`.
+        """
+        warnings.warn(
+            "GitHubPRReporter._fetch_pr_diff_lines is deprecated; "
+            "use fetch_pr_diff_lines.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.fetch_pr_diff_lines()
+
+    def _post_issue_comment(self, body: str) -> bool:
+        """Deprecated alias for :meth:`post_issue_comment`.
+
+        Args:
+            body: Comment body in Markdown.
+
+        Returns:
+            Result of :meth:`post_issue_comment`.
+        """
+        warnings.warn(
+            "GitHubPRReporter._post_issue_comment is deprecated; "
+            "use post_issue_comment.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.post_issue_comment(body)
+
+    def _api_request(
+        self,
+        method: str,
+        url: str,
+        payload: dict[str, Any],
+    ) -> bool:
+        """Deprecated alias for :meth:`api_request`.
+
+        Args:
+            method: HTTP method.
+            url: Full API URL.
+            payload: JSON payload.
+
+        Returns:
+            Result of :meth:`api_request`.
+        """
+        warnings.warn(
+            "GitHubPRReporter._api_request is deprecated; use api_request.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.api_request(method, url, payload)
 
 
 def _detect_repo_root() -> Path | None:

--- a/lintro/ai/json_response.py
+++ b/lintro/ai/json_response.py
@@ -35,8 +35,83 @@ class CliSchemaRequest:
     schema_name: str | None = None
 
 
+def _is_parseable_json(text: str) -> bool:
+    """Return True when ``text`` parses as JSON.
+
+    Args:
+        text: Candidate JSON string.
+
+    Returns:
+        True if ``json.loads`` succeeds, else False.
+    """
+    try:
+        json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    return True
+
+
+def _extract_json_span(text: str) -> str | None:
+    """Extract the outermost balanced JSON object or array span from text.
+
+    Mirrors the brace-matching approach used by the CLI transport: finds the
+    earliest ``{`` or ``[``, then scans for its matching close bracket while
+    respecting string literals and escapes.
+
+    Args:
+        text: Raw text that may embed a JSON object or array in prose.
+
+    Returns:
+        The extracted JSON substring, or ``None`` when no balanced span is
+        found.
+    """
+    open_to_close = {"{": "}", "[": "]"}
+    start = -1
+    opener = ""
+    for index, char in enumerate(text):
+        if char in open_to_close:
+            start = index
+            opener = char
+            break
+    if start == -1:
+        return None
+
+    closer = open_to_close[opener]
+    depth = 0
+    in_string = False
+    escape_next = False
+    for index in range(start, len(text)):
+        char = text[index]
+        if escape_next:
+            escape_next = False
+            continue
+        if char == "\\":
+            if in_string:
+                escape_next = True
+            continue
+        if char == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if char == opener:
+            depth += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return text[start : index + 1]
+    return None
+
+
 def strip_json_fences(*, content: str) -> str:
     """Strip markdown JSON code fences from model output.
+
+    Robust against responses that prepend prose containing a decoy fenced
+    block before the real JSON payload: all fenced blocks are considered and
+    the last one that parses as valid JSON wins (models place their final
+    answer last). When no fenced block parses, the last fenced block is
+    returned. When there are no fences at all, falls back to brace/bracket
+    matched extraction before returning the raw stripped content.
 
     Args:
         content: Raw model response text.
@@ -45,9 +120,18 @@ def strip_json_fences(*, content: str) -> str:
         JSON string suitable for ``json.loads``.
     """
     stripped = content.strip()
-    match = _JSON_FENCE_PATTERN.search(stripped)
-    if match is not None:
-        return match.group(1).strip()
+    blocks: list[str] = _JSON_FENCE_PATTERN.findall(stripped)
+    if blocks:
+        for block in reversed(blocks):
+            candidate = block.strip()
+            if _is_parseable_json(candidate):
+                return candidate
+        return blocks[-1].strip()
+
+    if not _is_parseable_json(stripped):
+        extracted = _extract_json_span(stripped)
+        if extracted is not None and _is_parseable_json(extracted):
+            return extracted
     return stripped
 
 

--- a/lintro/ai/json_response.py
+++ b/lintro/ai/json_response.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -51,59 +52,111 @@ def _is_parseable_json(text: str) -> bool:
     return True
 
 
-def _extract_json_span(text: str) -> str | None:
-    """Extract the outermost balanced JSON object or array span from text.
+def _parses_as_object(text: str) -> bool:
+    """Return True when ``text`` parses as a JSON object (``dict``).
 
-    Mirrors the brace-matching approach used by the CLI transport: finds the
-    earliest ``{`` or ``[``, then scans for its matching close bracket while
-    respecting string literals and escapes.
+    Args:
+        text: Candidate JSON string.
+
+    Returns:
+        True if ``json.loads`` yields a ``dict``, else False.
+    """
+    try:
+        return isinstance(json.loads(text), dict)
+    except (json.JSONDecodeError, ValueError):
+        return False
+
+
+def _iter_balanced_json_spans(text: str) -> Iterator[str]:
+    """Yield each top-level balanced JSON object/array span found in text.
+
+    Scans left to right and, for every ``{`` or ``[`` encountered at the top
+    level, emits the substring through its matching close bracket while
+    respecting string literals and escapes. After a span closes, scanning
+    resumes just past it, so a response with a decoy span (for example
+    ``Checklist [1]``) followed by the real payload yields both spans in order.
+
+    Args:
+        text: Raw text that may embed one or more JSON spans in prose.
+
+    Yields:
+        str: Each balanced JSON substring, in the order it appears.
+    """
+    open_to_close = {"{": "}", "[": "]"}
+    length = len(text)
+    index = 0
+    while index < length:
+        opener = text[index]
+        if opener not in open_to_close:
+            index += 1
+            continue
+        closer = open_to_close[opener]
+        depth = 0
+        in_string = False
+        escape_next = False
+        end = -1
+        for scan in range(index, length):
+            char = text[scan]
+            if escape_next:
+                escape_next = False
+                continue
+            if char == "\\":
+                if in_string:
+                    escape_next = True
+                continue
+            if char == '"':
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if char == opener:
+                depth += 1
+            elif char == closer:
+                depth -= 1
+                if depth == 0:
+                    end = scan
+                    break
+        if end == -1:
+            # Unbalanced from here on; no further complete spans possible.
+            return
+        yield text[index : end + 1]
+        index = end + 1
+
+
+def _extract_json_span(text: str, *, expect_object: bool = False) -> str | None:
+    """Extract a balanced JSON object or array span embedded in prose.
+
+    Iterates every top-level balanced span in ``text``. When ``expect_object``
+    is set, the last span that parses as a JSON object wins, so an earlier
+    decoy array or scalar span (for example ``[1]`` before the real
+    ``{...}``) can never shadow the intended object payload. When no object is
+    found (or ``expect_object`` is unset), the last span that parses as any
+    JSON value is returned, falling back to the first balanced span.
 
     Args:
         text: Raw text that may embed a JSON object or array in prose.
+        expect_object: When True, bias extraction toward a JSON object span.
 
     Returns:
         The extracted JSON substring, or ``None`` when no balanced span is
         found.
     """
-    open_to_close = {"{": "}", "[": "]"}
-    start = -1
-    opener = ""
-    for index, char in enumerate(text):
-        if char in open_to_close:
-            start = index
-            opener = char
-            break
-    if start == -1:
+    spans = list(_iter_balanced_json_spans(text))
+    if not spans:
         return None
 
-    closer = open_to_close[opener]
-    depth = 0
-    in_string = False
-    escape_next = False
-    for index in range(start, len(text)):
-        char = text[index]
-        if escape_next:
-            escape_next = False
-            continue
-        if char == "\\":
-            if in_string:
-                escape_next = True
-            continue
-        if char == '"':
-            in_string = not in_string
-            continue
-        if in_string:
-            continue
-        if char == opener:
-            depth += 1
-        elif char == closer:
-            depth -= 1
-            if depth == 0:
-                return text[start : index + 1]
-    return None
+    if expect_object:
+        for span in reversed(spans):
+            if _parses_as_object(span):
+                return span
+
+    for span in reversed(spans):
+        if _is_parseable_json(span):
+            return span
+    return spans[0]
 
 
-def strip_json_fences(*, content: str) -> str:
+def strip_json_fences(*, content: str, expect_object: bool = False) -> str:
     """Strip markdown JSON code fences from model output.
 
     Robust against responses that prepend prose containing a decoy fenced
@@ -113,8 +166,14 @@ def strip_json_fences(*, content: str) -> str:
     returned. When there are no fences at all, falls back to brace/bracket
     matched extraction before returning the raw stripped content.
 
+    When ``expect_object`` is set, extraction is biased toward a JSON object
+    so an earlier decoy array or scalar span (for example ``[1]`` in prose
+    before the real ``{...}``) cannot shadow the intended object payload.
+
     Args:
         content: Raw model response text.
+        expect_object: When True, prefer a JSON object over an earlier array
+            or scalar when isolating the payload.
 
     Returns:
         JSON string suitable for ``json.loads``.
@@ -122,11 +181,23 @@ def strip_json_fences(*, content: str) -> str:
     stripped = content.strip()
     blocks: list[str] = _JSON_FENCE_PATTERN.findall(stripped)
     if blocks:
-        for block in reversed(blocks):
-            candidate = block.strip()
+        candidates = [block.strip() for block in blocks]
+        if expect_object:
+            for candidate in reversed(candidates):
+                if _parses_as_object(candidate):
+                    return candidate
+        for candidate in reversed(candidates):
             if _is_parseable_json(candidate):
                 return candidate
-        return blocks[-1].strip()
+        return candidates[-1]
+
+    if expect_object:
+        if _parses_as_object(stripped):
+            return stripped
+        extracted = _extract_json_span(stripped, expect_object=True)
+        if extracted is not None and _is_parseable_json(extracted):
+            return extracted
+        return stripped
 
     if not _is_parseable_json(stripped):
         extracted = _extract_json_span(stripped)
@@ -147,7 +218,7 @@ def load_json_object(*, content: str) -> dict[str, Any]:
     Raises:
         ValueError: When JSON is invalid or not an object.
     """
-    json_text = strip_json_fences(content=content)
+    json_text = strip_json_fences(content=content, expect_object=True)
     try:
         payload = json.loads(json_text)
     except json.JSONDecodeError as exc:

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -64,7 +64,7 @@ def post_review_to_github(
     )
 
     success = True
-    if summary_body and not gh_reporter._post_issue_comment(summary_body):
+    if summary_body and not gh_reporter.post_issue_comment(summary_body):
         success = False
 
     if inline_findings and not _post_inline_findings(
@@ -83,7 +83,7 @@ def post_review_to_github(
         )
         location = _format_fallback_location(finding=finding)
         comment = f"{location}\n\n{body}" if location else body
-        if not gh_reporter._post_issue_comment(comment):
+        if not gh_reporter.post_issue_comment(comment):
             success = False
 
     return success
@@ -211,7 +211,7 @@ def _partition_findings(
     reporter: GitHubPRReporter,
 ) -> tuple[list[ReviewFinding], list[ReviewFinding]]:
     """Split findings into inline-capable and fallback groups."""
-    diff_lines = reporter._fetch_pr_diff_lines()
+    diff_lines = reporter.fetch_pr_diff_lines()
     inline: list[ReviewFinding] = []
     fallback: list[ReviewFinding] = []
 
@@ -266,4 +266,4 @@ def _post_inline_findings(
         f"{reporter.api_base}/repos/{reporter.repo}/pulls/"
         f"{reporter.pr_number}/reviews"
     )
-    return reporter._api_request("POST", url, payload)
+    return reporter.api_request("POST", url, payload)

--- a/lintro/ai/review/models/__init__.py
+++ b/lintro/ai/review/models/__init__.py
@@ -10,7 +10,7 @@ from lintro.ai.review.models.file_classification import FileClassification
 from lintro.ai.review.models.pr_metadata import PRMetadata
 from lintro.ai.review.models.review_chunk import ReviewChunk
 from lintro.ai.review.models.review_context import ReviewContext
-from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 
@@ -26,4 +26,5 @@ __all__ = [
     "ReviewFinding",
     "ReviewMetadata",
     "ReviewResult",
+    "Severity",
 ]

--- a/lintro/ai/review/models/review_finding.py
+++ b/lintro/ai/review/models/review_finding.py
@@ -3,6 +3,28 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
+
+__all__ = ["ReviewFinding", "Severity"]
+
+
+class Severity(StrEnum):
+    """Canonical severity levels for review findings.
+
+    Members carry the uppercase labels emitted in review output and used by
+    the P1 exit gate. Explicit ``P*`` values are used (instead of
+    ``auto()``) because the canonical labels are uppercase and are compared
+    and displayed verbatim across the review pipeline.
+
+    Attributes:
+        P1: Blocking severity that fails the review exit gate.
+        P2: Important but non-blocking severity.
+        P3: Minor or informational severity.
+    """
+
+    P1 = "P1"
+    P2 = "P2"
+    P3 = "P3"
 
 
 @dataclass(frozen=True, slots=True)
@@ -22,7 +44,7 @@ class ReviewFinding:
         checklist_ids: Prompt checklist ids linked to this finding.
     """
 
-    severity: str
+    severity: Severity
     category: str
     file: str
     line: int

--- a/lintro/ai/review/models/review_result.py
+++ b/lintro/ai/review/models/review_result.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
-from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 
 
@@ -28,4 +28,4 @@ class ReviewResult:
     @property
     def has_p1_findings(self) -> bool:
         """Return True when any P1 finding exists."""
-        return any(finding.severity == "P1" for finding in self.findings)
+        return any(finding.severity == Severity.P1 for finding in self.findings)

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -575,6 +575,7 @@ def build_review_prompt(
         Tuple of (system_prompt, user_prompt).
     """
     pr_title = context.pr_metadata.title if context.pr_metadata else "Local changes"
+    pr_title = _redact_prompt_text(text=pr_title, source="PR title")
     pr_summary = context.pr_metadata.body if context.pr_metadata else "(no PR summary)"
     pr_summary = _redact_prompt_text(text=pr_summary, source="PR metadata")
     redacted_diff = _redact_prompt_text(text=chunk.diff, source="diff")
@@ -635,6 +636,7 @@ def build_git_native_review_prompt(
         Tuple of (system_prompt, user_prompt).
     """
     pr_title = context.pr_metadata.title if context.pr_metadata else "Local changes"
+    pr_title = _redact_prompt_text(text=pr_title, source="PR title")
     pr_summary = context.pr_metadata.body if context.pr_metadata else "(no PR summary)"
     pr_summary = _redact_prompt_text(text=pr_summary, source="PR metadata")
     changed_files = [file for file in context.changed_files if file.path in chunk.files]
@@ -1159,29 +1161,64 @@ def _max_checklist_id(*, checklist_items: list[ChecklistItem]) -> int:
     return int(max(item.id for item in checklist_items))
 
 
+_SEVERITY_SYNONYMS: dict[str, Severity] = {
+    "CRITICAL": Severity.P1,
+    "BLOCKER": Severity.P1,
+    "BLOCKING": Severity.P1,
+    "HIGH": Severity.P1,
+    "SEVERE": Severity.P1,
+    "ERROR": Severity.P1,
+    "MAJOR": Severity.P2,
+    "MEDIUM": Severity.P2,
+    "MODERATE": Severity.P2,
+    "WARNING": Severity.P2,
+    "WARN": Severity.P2,
+    "MINOR": Severity.P3,
+    "LOW": Severity.P3,
+    "TRIVIAL": Severity.P3,
+    "INFO": Severity.P3,
+    "NOTE": Severity.P3,
+}
+
+
 def _normalize_severity(*, raw: object) -> Severity:
     """Normalize an unvalidated model severity value to a ``Severity`` member.
 
     Strips surrounding whitespace and uppercases the value before matching
-    against the canonical ``P1``/``P2``/``P3`` labels. Any unrecognized value
-    (case variants aside) is mapped to ``Severity.P3`` and logged so a
-    malformed severity can never silently bypass the P1 exit gate.
+    against the canonical ``P1``/``P2``/``P3`` labels. When the value is not a
+    canonical label, it is matched against a table of common synonyms so that
+    blocking words like ``critical`` map to ``P1`` rather than being downgraded.
+    A truly unknown value defaults to ``Severity.P2`` (not ``P3``) and is logged,
+    so an unrecognized-but-possibly-serious label is never silently dropped
+    below the visible, blocking threshold.
+
+    Synonym mapping:
+        P1: critical, blocker, blocking, high, severe, error.
+        P2: major, medium, moderate, warning, warn.
+        P3: minor, low, trivial, info, note.
 
     Args:
         raw: Raw severity value from a parsed model response.
 
     Returns:
-        The matching ``Severity`` member, or ``Severity.P3`` when unknown.
+        The matching ``Severity`` member, a synonym-mapped member, or
+        ``Severity.P2`` when the value is unrecognized.
     """
     normalized = str(raw).strip().upper()
     try:
         return Severity(normalized)
     except ValueError:
-        logger.warning(
-            "Unknown finding severity {raw!r}; defaulting to P3.",
-            raw=raw,
-        )
-        return Severity.P3
+        pass
+
+    synonym = _SEVERITY_SYNONYMS.get(normalized)
+    if synonym is not None:
+        return synonym
+
+    logger.warning(
+        "Unknown finding severity {raw!r}; defaulting to P2.",
+        raw=raw,
+    )
+    return Severity.P2
 
 
 def _normalize_checklist_answer_value(*, answer: str) -> str:

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -42,7 +42,7 @@ from lintro.ai.review.exceptions import ReviewExecutionError
 from lintro.ai.review.group_labels import REL_DIRECTORY_PREFIX, REL_SINGLE_FILE
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
 from lintro.ai.review.models.review_chunk import ReviewChunk
-from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.paths_registry import generate_interaction_paths
@@ -56,6 +56,7 @@ from lintro.ai.review.sensitivity import (
     filter_findings_by_policy,
     format_strictness_prompt_section,
 )
+from lintro.ai.secrets import redact_secrets, scan_for_secrets
 from lintro.ai.token_budget import estimate_tokens
 
 if TYPE_CHECKING:
@@ -77,6 +78,32 @@ __all__ = [
     "strip_json_fences",
 ]
 _PROMPT_OVERHEAD_TOKENS = 12_000
+
+
+def _redact_prompt_text(*, text: str, source: str) -> str:
+    """Redact detected secrets from prompt text before provider dispatch.
+
+    This is the single redaction choke point for every review prompt path
+    (base review, git-native, depth-2 question generation, and depth-3
+    adversarial sweep). Any diff or PR metadata destined for an external AI
+    provider must pass through here so credentials never leave the machine.
+
+    Args:
+        text: Raw text destined for an AI provider prompt.
+        source: Human-readable label for the text origin, used in log lines.
+
+    Returns:
+        The text with any detected secrets replaced by ``[REDACTED]``.
+    """
+    detected = scan_for_secrets(text)
+    if detected:
+        logger.warning(
+            "Redacted {count} potential secret(s) from review {source} "
+            "before sending to the AI provider.",
+            count=len(detected),
+            source=source,
+        )
+    return redact_secrets(text)
 
 
 @dataclass(frozen=True, slots=True)
@@ -549,6 +576,8 @@ def build_review_prompt(
     """
     pr_title = context.pr_metadata.title if context.pr_metadata else "Local changes"
     pr_summary = context.pr_metadata.body if context.pr_metadata else "(no PR summary)"
+    pr_summary = _redact_prompt_text(text=pr_summary, source="PR metadata")
+    redacted_diff = _redact_prompt_text(text=chunk.diff, source="diff")
     changed_files = [file for file in context.changed_files if file.path in chunk.files]
     combined_checklist = checklist_text
     if extra_checklist.strip():
@@ -569,7 +598,7 @@ def build_review_prompt(
         interaction_paths=interaction_paths,
         checklist_count=checklist_count,
         checklist=combined_checklist,
-        diff=chunk.diff,
+        diff=redacted_diff,
         lint_results_section=format_lint_results_section(digest=lint_results),
         strictness_section=strictness_section,
         output_schema=REVIEW_OUTPUT_SCHEMA,
@@ -607,6 +636,7 @@ def build_git_native_review_prompt(
     """
     pr_title = context.pr_metadata.title if context.pr_metadata else "Local changes"
     pr_summary = context.pr_metadata.body if context.pr_metadata else "(no PR summary)"
+    pr_summary = _redact_prompt_text(text=pr_summary, source="PR metadata")
     changed_files = [file for file in context.changed_files if file.path in chunk.files]
     combined_checklist = checklist_text
     if extra_checklist.strip():
@@ -617,7 +647,9 @@ def build_git_native_review_prompt(
 
     git_diff_paths = " ".join(shlex.quote(path) for path in chunk.files)
     if embed_diff:
-        diff_section = REVIEW_GIT_NATIVE_DIFF_INLINE.format(diff=chunk.diff)
+        diff_section = REVIEW_GIT_NATIVE_DIFF_INLINE.format(
+            diff=_redact_prompt_text(text=chunk.diff, source="diff"),
+        )
     elif context.head_ref == "WORKTREE":
         diff_section = REVIEW_GIT_NATIVE_DIFF_WORKTREE_COMMAND.format(
             base_ref=context.base_ref,
@@ -884,7 +916,7 @@ def _generate_extra_checklist(
         files=[file for file in context.changed_files if file.path in chunk.files],
     )
     prompt = REVIEW_GENERATE_QUESTIONS_TEMPLATE.format(
-        diff=chunk.diff,
+        diff=_redact_prompt_text(text=chunk.diff, source="diff"),
         changed_files=changed_files,
     )
     response = call_ai(
@@ -955,7 +987,7 @@ def _run_adversarial_pass(
     )
     prompt = REVIEW_ADVERSARIAL_SWEEP_TEMPLATE.format(
         prior_findings_json=prior_json,
-        diff=chunk.diff,
+        diff=_redact_prompt_text(text=chunk.diff, source="diff"),
     )
     response = call_ai(
         provider=provider,
@@ -1080,7 +1112,7 @@ def _parse_findings(*, raw_findings: object) -> tuple[ReviewFinding, ...]:
             )
         findings.append(
             ReviewFinding(
-                severity=str(item.get("severity", "P3")),
+                severity=_normalize_severity(raw=item.get("severity", "P3")),
                 category=str(item.get("category", "logic-bug")),
                 file=str(item.get("file", "")),
                 line=line,
@@ -1127,6 +1159,31 @@ def _max_checklist_id(*, checklist_items: list[ChecklistItem]) -> int:
     return int(max(item.id for item in checklist_items))
 
 
+def _normalize_severity(*, raw: object) -> Severity:
+    """Normalize an unvalidated model severity value to a ``Severity`` member.
+
+    Strips surrounding whitespace and uppercases the value before matching
+    against the canonical ``P1``/``P2``/``P3`` labels. Any unrecognized value
+    (case variants aside) is mapped to ``Severity.P3`` and logged so a
+    malformed severity can never silently bypass the P1 exit gate.
+
+    Args:
+        raw: Raw severity value from a parsed model response.
+
+    Returns:
+        The matching ``Severity`` member, or ``Severity.P3`` when unknown.
+    """
+    normalized = str(raw).strip().upper()
+    try:
+        return Severity(normalized)
+    except ValueError:
+        logger.warning(
+            "Unknown finding severity {raw!r}; defaulting to P3.",
+            raw=raw,
+        )
+        return Severity.P3
+
+
 def _normalize_checklist_answer_value(*, answer: str) -> str:
     """Normalize checklist answers to the yes/no contract."""
     normalized = answer.strip().lower()
@@ -1136,11 +1193,24 @@ def _normalize_checklist_answer_value(*, answer: str) -> str:
 
 
 def _checklist_answer_strength(*, answer: ChecklistAnswer) -> int:
-    """Score checklist answers for merge precedence."""
+    """Score checklist answers for merge precedence.
+
+    Per epic #991's v3.1 contract, every ``yes`` must map to a finding, so a
+    ``yes`` from any chunk strictly wins over a ``no`` regardless of evidence.
+    Evidence only breaks ties between two answers of the same polarity. This
+    prevents an evidence-backed ``no`` from one chunk silently overturning a
+    bare ``yes`` from another and dropping the finding non-deterministically.
+
+    Args:
+        answer: Checklist answer to score.
+
+    Returns:
+        Strength score: yes-with-evidence 4, yes 3, no-with-evidence 2, no 1.
+    """
     has_evidence = bool(answer.evidence.strip())
     if answer.answer == "yes":
-        return 4 if has_evidence else 2
-    return 3 if has_evidence else 1
+        return 4 if has_evidence else 3
+    return 2 if has_evidence else 1
 
 
 def _pick_preferred_checklist_answer(

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -1188,9 +1188,11 @@ def _normalize_severity(*, raw: object) -> Severity:
     against the canonical ``P1``/``P2``/``P3`` labels. When the value is not a
     canonical label, it is matched against a table of common synonyms so that
     blocking words like ``critical`` map to ``P1`` rather than being downgraded.
-    A truly unknown value defaults to ``Severity.P2`` (not ``P3``) and is logged,
-    so an unrecognized-but-possibly-serious label is never silently dropped
-    below the visible, blocking threshold.
+    A truly unknown value fails closed to ``Severity.P1`` and is logged: since
+    the exit gate only trips on ``P1``, an unrecognized label (e.g. ``fatal``)
+    must be treated as blocking so malformed model output can never silently
+    pass the gate. The synonym table already captures the benign labels, so the
+    fallback is deliberately conservative.
 
     Synonym mapping:
         P1: critical, blocker, blocking, high, severe, error.
@@ -1202,7 +1204,7 @@ def _normalize_severity(*, raw: object) -> Severity:
 
     Returns:
         The matching ``Severity`` member, a synonym-mapped member, or
-        ``Severity.P2`` when the value is unrecognized.
+        ``Severity.P1`` (fail-closed) when the value is unrecognized.
     """
     normalized = str(raw).strip().upper()
     try:
@@ -1215,10 +1217,10 @@ def _normalize_severity(*, raw: object) -> Severity:
         return synonym
 
     logger.warning(
-        "Unknown finding severity {raw!r}; defaulting to P2.",
+        "Unknown finding severity {raw!r}; failing closed to P1.",
         raw=raw,
     )
-    return Severity.P2
+    return Severity.P1
 
 
 def _normalize_checklist_answer_value(*, answer: str) -> str:

--- a/tests/unit/ai/review/conftest.py
+++ b/tests/unit/ai/review/conftest.py
@@ -12,7 +12,7 @@ from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
 from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
 from lintro.ai.review.models.review_context import ReviewContext
-from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 from tests.unit.ai.review.review_fixtures import load_review_fixture
@@ -244,7 +244,7 @@ def sample_review_result() -> ReviewResult:
         ),
         findings=(
             ReviewFinding(
-                severity="P1",
+                severity=Severity.P1,
                 category="security",
                 file="src/main.py",
                 line=10,
@@ -256,7 +256,7 @@ def sample_review_result() -> ReviewResult:
                 checklist_ids=(1,),
             ),
             ReviewFinding(
-                severity="P2",
+                severity=Severity.P2,
                 category="test-gap",
                 file="tests/test_main.py",
                 line=5,

--- a/tests/unit/ai/review/test_checklist_display.py
+++ b/tests/unit/ai/review/test_checklist_display.py
@@ -16,7 +16,7 @@ from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.enums.review_category import ReviewCategory
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
 from lintro.ai.review.models.checklist_item import ChecklistItem
-from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 
@@ -89,7 +89,7 @@ def test_enrich_review_result_attaches_questions() -> None:
 def test_questions_for_finding_returns_linked_prompt_questions() -> None:
     """Finding checklist_ids resolve to question strings in order."""
     finding = ReviewFinding(
-        severity="P1",
+        severity=Severity.P1,
         category="security",
         file="a.py",
         line=1,
@@ -131,7 +131,7 @@ def test_orphan_concerns_returns_unlinked_yes_rows() -> None:
     )
     findings = (
         ReviewFinding(
-            severity="P1",
+            severity=Severity.P1,
             category="security",
             file="a.py",
             line=1,

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -12,7 +12,7 @@ from lintro.ai.review.github import (
     format_review_summary,
     post_review_to_github,
 )
-from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_result import ReviewResult
 
 
@@ -73,7 +73,7 @@ def test_post_review_to_github_posts_fallback_without_line_number(
 ) -> None:
     """Fallback comments omit invalid line numbers from the location header."""
     outside_diff_finding = ReviewFinding(
-        severity="P2",
+        severity=Severity.P2,
         category="architecture",
         file="docs/design.md",
         line=0,
@@ -92,8 +92,8 @@ def test_post_review_to_github_posts_fallback_without_line_number(
     )
     reporter = MagicMock()
     reporter.is_available.return_value = True
-    reporter._fetch_pr_diff_lines.return_value = {"src/main.py": {10}}
-    reporter._post_issue_comment.return_value = True
+    reporter.fetch_pr_diff_lines.return_value = {"src/main.py": {10}}
+    reporter.post_issue_comment.return_value = True
 
     with patch(
         "lintro.ai.review.github._post_inline_findings",
@@ -103,7 +103,7 @@ def test_post_review_to_github_posts_fallback_without_line_number(
 
     fallback_calls = [
         call.args[0]
-        for call in reporter._post_issue_comment.call_args_list
+        for call in reporter.post_issue_comment.call_args_list
         if call.args[0].startswith("`docs/design.md`")
     ]
     assert_that(fallback_calls).is_length(1)
@@ -123,7 +123,7 @@ def test_post_review_to_github_returns_false_when_unavailable(
     )
 
     assert_that(posted).is_false()
-    reporter._post_issue_comment.assert_not_called()
+    reporter.post_issue_comment.assert_not_called()
 
 
 def test_post_review_to_github_posts_summary_and_inline(
@@ -132,9 +132,9 @@ def test_post_review_to_github_posts_summary_and_inline(
     """Available reporter posts summary and inline review comments."""
     reporter = MagicMock()
     reporter.is_available.return_value = True
-    reporter._fetch_pr_diff_lines.return_value = {"src/main.py": {10}}
-    reporter._post_issue_comment.return_value = True
-    reporter._api_request.return_value = True
+    reporter.fetch_pr_diff_lines.return_value = {"src/main.py": {10}}
+    reporter.post_issue_comment.return_value = True
+    reporter.api_request.return_value = True
 
     with patch(
         "lintro.ai.review.github._post_inline_findings",
@@ -148,5 +148,5 @@ def test_post_review_to_github_posts_summary_and_inline(
         )
 
     assert_that(posted).is_true()
-    assert_that(reporter._post_issue_comment.called).is_true()
+    assert_that(reporter.post_issue_comment.called).is_true()
     assert_that(mock_inline.called).is_true()

--- a/tests/unit/ai/review/test_merge.py
+++ b/tests/unit/ai/review/test_merge.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from assertpy import assert_that
 
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
-from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.orchestrator import (
     _parse_checklist,
     merge_checklist_answers,
@@ -16,7 +16,7 @@ from lintro.ai.review.orchestrator import (
 def test_merge_findings_deduplicates_by_file_line_title() -> None:
     """Duplicate findings with same file, line, and title are merged once."""
     finding = ReviewFinding(
-        severity="P2",
+        severity=Severity.P2,
         category="logic-bug",
         file="src/main.py",
         line=10,
@@ -48,8 +48,8 @@ def test_merge_checklist_answers_prefers_yes_over_no() -> None:
     assert_that(merged[0].evidence).contains("src/main.py")
 
 
-def test_merge_checklist_answers_requires_evidence_for_yes() -> None:
-    """Unsupported yes answers do not override evidence-backed no answers."""
+def test_merge_checklist_answers_bare_yes_beats_evidence_backed_no() -> None:
+    """A bare yes strictly wins over an evidence-backed no (epic #991 v3.1)."""
     supported_no = ChecklistAnswer(id=1, answer="no", evidence="src/main.py:10")
     unsupported_yes = ChecklistAnswer(id=1, answer="yes", evidence="")
 
@@ -58,12 +58,11 @@ def test_merge_checklist_answers_requires_evidence_for_yes() -> None:
     )
 
     assert_that(merged).is_length(1)
-    assert_that(merged[0].answer).is_equal_to("no")
-    assert_that(merged[0].evidence).contains("src/main.py")
+    assert_that(merged[0].answer).is_equal_to("yes")
 
 
-def test_merge_checklist_answers_keeps_evidence_backed_no() -> None:
-    """Evidence-backed no answers beat unsupported yes regardless of order."""
+def test_merge_checklist_answers_yes_wins_regardless_of_order() -> None:
+    """Yes strictly wins over an evidence-backed no regardless of order."""
     unsupported_yes = ChecklistAnswer(id=1, answer="yes", evidence="")
     supported_no = ChecklistAnswer(id=1, answer="no", evidence="src/main.py:10")
 
@@ -72,8 +71,7 @@ def test_merge_checklist_answers_keeps_evidence_backed_no() -> None:
     )
 
     assert_that(merged).is_length(1)
-    assert_that(merged[0].answer).is_equal_to("no")
-    assert_that(merged[0].evidence).contains("src/main.py")
+    assert_that(merged[0].answer).is_equal_to("yes")
 
 
 def test_parse_checklist_treats_null_evidence_as_empty() -> None:
@@ -86,8 +84,8 @@ def test_parse_checklist_treats_null_evidence_as_empty() -> None:
     assert_that(answers[0].evidence).is_empty()
 
 
-def test_merge_checklist_answers_rejects_null_evidence_yes() -> None:
-    """Null-evidence yes answers parsed from JSON do not beat evidence-backed no."""
+def test_merge_checklist_answers_null_evidence_yes_still_wins() -> None:
+    """Null-evidence yes answers parsed from JSON still beat evidence-backed no."""
     null_evidence_yes = _parse_checklist(
         raw_checklist=[{"id": 1, "answer": "yes", "evidence": None}],
     )[0]
@@ -98,4 +96,4 @@ def test_merge_checklist_answers_rejects_null_evidence_yes() -> None:
     )
 
     assert_that(merged).is_length(1)
-    assert_that(merged[0].answer).is_equal_to("no")
+    assert_that(merged[0].answer).is_equal_to("yes")

--- a/tests/unit/ai/review/test_orchestrator_hardening.py
+++ b/tests/unit/ai/review/test_orchestrator_hardening.py
@@ -1,0 +1,210 @@
+"""Tests for review orchestrator hardening: redaction and severity handling.
+
+Covers issue #1040 (secret redaction reaches the provider payload) and
+issue #1041 (severity normalization for the P1 exit gate).
+"""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+from loguru import logger
+
+from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.pr_metadata import PRMetadata
+from lintro.ai.review.models.review_chunk import ReviewChunk
+from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.review_finding import Severity
+from lintro.ai.review.models.review_metadata import ReviewMetadata
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.orchestrator import (
+    _parse_findings,
+    build_review_prompt,
+)
+
+_LEAKED_KEY = "sk-abcdefghijklmnopqrstuvwxyz0123456789"
+
+
+def _placeholder_metadata() -> ReviewMetadata:
+    """Return placeholder review metadata for result construction.
+
+    Returns:
+        A zeroed ``ReviewMetadata`` suitable for result-only assertions.
+    """
+    return ReviewMetadata(
+        model="",
+        provider="",
+        context_window=0,
+        depth=0,
+        chunks_total=0,
+        chunks_current=0,
+        files_reviewed=0,
+        files_total=0,
+        checklist_items=0,
+    )
+
+
+def _make_context(*, body: str) -> ReviewContext:
+    """Build a minimal review context with a PR body.
+
+    Args:
+        body: PR metadata body text.
+
+    Returns:
+        A review context wrapping a single changed file.
+    """
+    return ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(
+                path="src/main.py",
+                status="modified",
+                additions=1,
+                deletions=0,
+            ),
+        ],
+        unified_diff="diff",
+        pr_metadata=PRMetadata(
+            title="Rotate keys",
+            body=body,
+            number=7,
+            repo="owner/repo",
+        ),
+    )
+
+
+def _make_chunk(*, diff: str) -> ReviewChunk:
+    """Build a single-file review chunk with the given diff.
+
+    Args:
+        diff: Diff content for the chunk.
+
+    Returns:
+        A review chunk covering ``src/main.py``.
+    """
+    return ReviewChunk(
+        id=1,
+        files=["src/main.py"],
+        diff=diff,
+        relationship="single-file",
+    )
+
+
+def test_build_review_prompt_redacts_secrets_in_diff() -> None:
+    """An API key embedded in the diff is redacted in the rendered prompt."""
+    chunk = _make_chunk(diff=f"+api_key = '{_LEAKED_KEY}'\n")
+    context = _make_context(body="Routine change.")
+
+    _system, user_prompt = build_review_prompt(
+        chunk=chunk,
+        context=context,
+        checklist_text="1. [logic-bug] Example?",
+        checklist_count=1,
+        interaction_paths="(none)",
+    )
+
+    assert_that(user_prompt).does_not_contain(_LEAKED_KEY)
+    assert_that(user_prompt).contains("[REDACTED]")
+
+
+def test_build_review_prompt_redacts_secrets_in_pr_body() -> None:
+    """A secret in PR metadata body is redacted before reaching the prompt."""
+    chunk = _make_chunk(diff="+harmless change\n")
+    context = _make_context(body=f"Deploy token: {_LEAKED_KEY}")
+
+    _system, user_prompt = build_review_prompt(
+        chunk=chunk,
+        context=context,
+        checklist_text="1. [logic-bug] Example?",
+        checklist_count=1,
+        interaction_paths="(none)",
+    )
+
+    assert_that(user_prompt).does_not_contain(_LEAKED_KEY)
+    assert_that(user_prompt).contains("[REDACTED]")
+
+
+def test_build_review_prompt_logs_secret_warning() -> None:
+    """Detected secrets emit a warning before the prompt is dispatched."""
+    chunk = _make_chunk(diff=f"+token = {_LEAKED_KEY}\n")
+    context = _make_context(body="Routine change.")
+
+    messages: list[str] = []
+    handler_id = logger.add(
+        lambda message: messages.append(str(message)),
+        level="WARNING",
+    )
+    try:
+        build_review_prompt(
+            chunk=chunk,
+            context=context,
+            checklist_text="1. [logic-bug] Example?",
+            checklist_count=1,
+            interaction_paths="(none)",
+        )
+    finally:
+        logger.remove(handler_id)
+
+    joined = "".join(messages)
+    assert_that(joined).contains("Redacted")
+    assert_that(joined).contains("secret")
+
+
+def test_severity_normalization_lowercase() -> None:
+    """A lowercase 'p1' severity normalizes to Severity.P1."""
+    findings = _parse_findings(
+        raw_findings=[{"severity": "p1", "title": "Bug"}],
+    )
+
+    assert_that(findings).is_length(1)
+    assert_that(findings[0].severity).is_equal_to(Severity.P1)
+
+
+def test_severity_normalization_whitespace() -> None:
+    """A trailing-space 'P1 ' severity normalizes to Severity.P1."""
+    findings = _parse_findings(
+        raw_findings=[{"severity": "P1 ", "title": "Bug"}],
+    )
+
+    assert_that(findings).is_length(1)
+    assert_that(findings[0].severity).is_equal_to(Severity.P1)
+
+
+def test_severity_unknown_maps_to_p3() -> None:
+    """An unknown severity like 'critical' maps to Severity.P3."""
+    findings = _parse_findings(
+        raw_findings=[{"severity": "critical", "title": "Bug"}],
+    )
+
+    assert_that(findings).is_length(1)
+    assert_that(findings[0].severity).is_equal_to(Severity.P3)
+
+
+def test_has_p1_findings_after_lowercase_normalization() -> None:
+    """The exit gate fires when a lowercase 'p1' finding is normalized."""
+    findings = _parse_findings(
+        raw_findings=[{"severity": "p1", "title": "Bug", "file": "a.py", "line": 1}],
+    )
+    result = ReviewResult(
+        metadata=_placeholder_metadata(),
+        summary="s",
+        checklist=(),
+        findings=findings,
+    )
+
+    assert_that(result.has_p1_findings).is_true()
+
+
+def test_has_p1_findings_false_for_unknown_severity() -> None:
+    """An unknown severity does not trip the P1 exit gate (maps to P3)."""
+    findings = _parse_findings(
+        raw_findings=[{"severity": "blocker", "title": "Bug"}],
+    )
+    result = ReviewResult(
+        metadata=_placeholder_metadata(),
+        summary="s",
+        checklist=(),
+        findings=findings,
+    )
+
+    assert_that(result.has_p1_findings).is_false()

--- a/tests/unit/ai/review/test_orchestrator_hardening.py
+++ b/tests/unit/ai/review/test_orchestrator_hardening.py
@@ -223,9 +223,9 @@ def test_normalize_severity_critical_maps_to_p1() -> None:
     assert_that(_normalize_severity(raw="critical")).is_equal_to(Severity.P1)
 
 
-def test_normalize_severity_gibberish_maps_to_p2() -> None:
-    """A truly unknown label defaults to Severity.P2, never below the gate."""
-    assert_that(_normalize_severity(raw="banana")).is_equal_to(Severity.P2)
+def test_normalize_severity_gibberish_fails_closed_to_p1() -> None:
+    """A truly unknown label fails closed to Severity.P1 so it can't bypass the gate."""
+    assert_that(_normalize_severity(raw="banana")).is_equal_to(Severity.P1)
 
 
 def test_normalize_severity_warning_maps_to_p2() -> None:
@@ -270,8 +270,8 @@ def test_has_p1_findings_true_for_blocking_synonym() -> None:
     assert_that(result.has_p1_findings).is_true()
 
 
-def test_has_p1_findings_false_for_gibberish_severity() -> None:
-    """A truly unknown severity defaults to P2 and does not trip the gate."""
+def test_has_p1_findings_true_for_gibberish_severity() -> None:
+    """A truly unknown severity fails closed to P1 and trips the exit gate."""
     findings = _parse_findings(
         raw_findings=[{"severity": "banana", "title": "Bug"}],
     )
@@ -282,4 +282,4 @@ def test_has_p1_findings_false_for_gibberish_severity() -> None:
         findings=findings,
     )
 
-    assert_that(result.has_p1_findings).is_false()
+    assert_that(result.has_p1_findings).is_true()

--- a/tests/unit/ai/review/test_orchestrator_hardening.py
+++ b/tests/unit/ai/review/test_orchestrator_hardening.py
@@ -17,7 +17,9 @@ from lintro.ai.review.models.review_finding import Severity
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.orchestrator import (
+    _normalize_severity,
     _parse_findings,
+    build_git_native_review_prompt,
     build_review_prompt,
 )
 
@@ -43,11 +45,12 @@ def _placeholder_metadata() -> ReviewMetadata:
     )
 
 
-def _make_context(*, body: str) -> ReviewContext:
+def _make_context(*, body: str, title: str = "Rotate keys") -> ReviewContext:
     """Build a minimal review context with a PR body.
 
     Args:
         body: PR metadata body text.
+        title: PR metadata title text.
 
     Returns:
         A review context wrapping a single changed file.
@@ -65,7 +68,7 @@ def _make_context(*, body: str) -> ReviewContext:
         ],
         unified_diff="diff",
         pr_metadata=PRMetadata(
-            title="Rotate keys",
+            title=title,
             body=body,
             number=7,
             repo="owner/repo",
@@ -124,6 +127,41 @@ def test_build_review_prompt_redacts_secrets_in_pr_body() -> None:
     assert_that(user_prompt).contains("[REDACTED]")
 
 
+def test_build_review_prompt_redacts_secrets_in_pr_title() -> None:
+    """A secret in the PR title is redacted before reaching the prompt."""
+    chunk = _make_chunk(diff="+harmless change\n")
+    context = _make_context(body="Routine change.", title=f"Add {_LEAKED_KEY}")
+
+    _system, user_prompt = build_review_prompt(
+        chunk=chunk,
+        context=context,
+        checklist_text="1. [logic-bug] Example?",
+        checklist_count=1,
+        interaction_paths="(none)",
+    )
+
+    assert_that(user_prompt).does_not_contain(_LEAKED_KEY)
+    assert_that(user_prompt).contains("[REDACTED]")
+
+
+def test_build_git_native_review_prompt_redacts_secrets_in_pr_title() -> None:
+    """The git-native builder redacts a secret embedded in the PR title."""
+    chunk = _make_chunk(diff="+harmless change\n")
+    context = _make_context(body="Routine change.", title=f"Add {_LEAKED_KEY}")
+
+    _system, user_prompt = build_git_native_review_prompt(
+        chunk=chunk,
+        context=context,
+        checklist_text="1. [logic-bug] Example?",
+        checklist_count=1,
+        interaction_paths="(none)",
+        embed_diff=True,
+    )
+
+    assert_that(user_prompt).does_not_contain(_LEAKED_KEY)
+    assert_that(user_prompt).contains("[REDACTED]")
+
+
 def test_build_review_prompt_logs_secret_warning() -> None:
     """Detected secrets emit a warning before the prompt is dispatched."""
     chunk = _make_chunk(diff=f"+token = {_LEAKED_KEY}\n")
@@ -170,14 +208,34 @@ def test_severity_normalization_whitespace() -> None:
     assert_that(findings[0].severity).is_equal_to(Severity.P1)
 
 
-def test_severity_unknown_maps_to_p3() -> None:
-    """An unknown severity like 'critical' maps to Severity.P3."""
+def test_severity_synonym_critical_maps_to_p1() -> None:
+    """A blocking synonym like 'critical' maps to Severity.P1."""
     findings = _parse_findings(
         raw_findings=[{"severity": "critical", "title": "Bug"}],
     )
 
     assert_that(findings).is_length(1)
-    assert_that(findings[0].severity).is_equal_to(Severity.P3)
+    assert_that(findings[0].severity).is_equal_to(Severity.P1)
+
+
+def test_normalize_severity_critical_maps_to_p1() -> None:
+    """A blocking synonym like 'critical' maps directly to Severity.P1."""
+    assert_that(_normalize_severity(raw="critical")).is_equal_to(Severity.P1)
+
+
+def test_normalize_severity_gibberish_maps_to_p2() -> None:
+    """A truly unknown label defaults to Severity.P2, never below the gate."""
+    assert_that(_normalize_severity(raw="banana")).is_equal_to(Severity.P2)
+
+
+def test_normalize_severity_warning_maps_to_p2() -> None:
+    """A P2 synonym like 'warning' maps to Severity.P2."""
+    assert_that(_normalize_severity(raw="warning")).is_equal_to(Severity.P2)
+
+
+def test_normalize_severity_minor_maps_to_p3() -> None:
+    """A P3 synonym like 'minor' maps to Severity.P3."""
+    assert_that(_normalize_severity(raw="minor")).is_equal_to(Severity.P3)
 
 
 def test_has_p1_findings_after_lowercase_normalization() -> None:
@@ -195,10 +253,27 @@ def test_has_p1_findings_after_lowercase_normalization() -> None:
     assert_that(result.has_p1_findings).is_true()
 
 
-def test_has_p1_findings_false_for_unknown_severity() -> None:
-    """An unknown severity does not trip the P1 exit gate (maps to P3)."""
+def test_has_p1_findings_true_for_blocking_synonym() -> None:
+    """A blocking synonym like 'blocker' trips the P1 exit gate."""
     findings = _parse_findings(
-        raw_findings=[{"severity": "blocker", "title": "Bug"}],
+        raw_findings=[
+            {"severity": "blocker", "title": "Bug", "file": "a.py", "line": 1},
+        ],
+    )
+    result = ReviewResult(
+        metadata=_placeholder_metadata(),
+        summary="s",
+        checklist=(),
+        findings=findings,
+    )
+
+    assert_that(result.has_p1_findings).is_true()
+
+
+def test_has_p1_findings_false_for_gibberish_severity() -> None:
+    """A truly unknown severity defaults to P2 and does not trip the gate."""
+    findings = _parse_findings(
+        raw_findings=[{"severity": "banana", "title": "Bug"}],
     )
     result = ReviewResult(
         metadata=_placeholder_metadata(),

--- a/tests/unit/ai/review/test_sensitivity.py
+++ b/tests/unit/ai/review/test_sensitivity.py
@@ -6,7 +6,7 @@ from assertpy import assert_that
 
 from lintro.ai.review.enums.review_category import ReviewCategory
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
-from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.sensitivity import (
     filter_findings_by_policy,
     format_strictness_prompt_section,
@@ -17,7 +17,7 @@ from lintro.config.review_config import ReviewSensitivityOverrides
 
 def _finding(
     *,
-    severity: str = "P3",
+    severity: Severity = Severity.P3,
     category: str = ReviewCategory.BREAKING_CHANGE.value,
     file: str = "docs/architecture.md",
     title: str = "No CI script migration note",
@@ -93,7 +93,7 @@ def test_filter_findings_focused_keeps_p2_integration() -> None:
     policy = resolve_sensitivity_policy(strictness=ReviewStrictness.FOCUSED)
     findings = (
         _finding(
-            severity="P2",
+            severity=Severity.P2,
             category=ReviewCategory.INTEGRATION.value,
             file=".github/workflows/test-core.yml",
             title="CI runs auth-setup twice",

--- a/tests/unit/ai/test_github_pr.py
+++ b/tests/unit/ai/test_github_pr.py
@@ -161,7 +161,7 @@ def test_post_review_comments_posts_summary(test_token: str) -> None:
     )
     summary = AISummary(overview="Test overview", key_patterns=["pattern1"])
 
-    with patch.object(reporter, "_post_issue_comment", return_value=True) as mock:
+    with patch.object(reporter, "post_issue_comment", return_value=True) as mock:
         result = reporter.post_review_comments([], summary=summary)
         assert_that(result).is_true()
         mock.assert_called_once()
@@ -208,7 +208,7 @@ def test_api_request_constructs_correct_request(test_token: str) -> None:
     mock_response.__exit__ = MagicMock(return_value=False)
 
     with patch("urllib.request.urlopen", return_value=mock_response) as mock_open:
-        result = reporter._api_request(
+        result = reporter.api_request(
             "POST",
             "https://api.github.com/test",
             {"key": "value"},
@@ -367,8 +367,8 @@ def test_post_review_uses_workspace_relative_paths(test_token: str) -> None:
 
     diff = {"src/main.py": {10}}
     with (
-        patch.object(reporter, "_fetch_pr_diff_lines", return_value=diff),
-        patch.object(reporter, "_api_request", return_value=True) as mock_api,
+        patch.object(reporter, "fetch_pr_diff_lines", return_value=diff),
+        patch.object(reporter, "api_request", return_value=True) as mock_api,
     ):
         reporter._post_review(suggestions)
         payload = mock_api.call_args[0][2]
@@ -399,9 +399,67 @@ def test_post_review_skips_out_of_workspace_suggestions(test_token: str) -> None
 
     diff = {"some/other/file.py": {1, 2, 3}}
     with (
-        patch.object(reporter, "_fetch_pr_diff_lines", return_value=diff),
-        patch.object(reporter, "_api_request", return_value=True) as mock_api,
+        patch.object(reporter, "fetch_pr_diff_lines", return_value=diff),
+        patch.object(reporter, "api_request", return_value=True) as mock_api,
     ):
         reporter._post_review(suggestions)
         # Out-of-workspace suggestion should be filtered; no API call made
         mock_api.assert_not_called()
+
+
+# -- Deprecation aliases: public API promotion (#1050C). ---------------------
+
+
+def test_deprecated_post_issue_comment_alias_delegates(test_token: str) -> None:
+    """The private _post_issue_comment alias delegates to the public method."""
+    reporter = GitHubPRReporter(
+        token=test_token,
+        repo="owner/repo",
+        pr_number=5,
+    )
+
+    with (
+        patch.object(reporter, "post_issue_comment", return_value=True) as mock,
+        pytest.warns(DeprecationWarning),
+    ):
+        result = reporter._post_issue_comment("body")
+
+    assert_that(result).is_true()
+    mock.assert_called_once_with("body")
+
+
+def test_deprecated_fetch_pr_diff_lines_alias_delegates(test_token: str) -> None:
+    """The private _fetch_pr_diff_lines alias delegates to the public method."""
+    reporter = GitHubPRReporter(
+        token=test_token,
+        repo="owner/repo",
+        pr_number=5,
+    )
+    diff = {"src/main.py": {10}}
+
+    with (
+        patch.object(reporter, "fetch_pr_diff_lines", return_value=diff) as mock,
+        pytest.warns(DeprecationWarning),
+    ):
+        result = reporter._fetch_pr_diff_lines()
+
+    assert_that(result).is_equal_to(diff)
+    mock.assert_called_once_with()
+
+
+def test_deprecated_api_request_alias_delegates(test_token: str) -> None:
+    """The private _api_request alias delegates to the public method."""
+    reporter = GitHubPRReporter(
+        token=test_token,
+        repo="owner/repo",
+        pr_number=5,
+    )
+
+    with (
+        patch.object(reporter, "api_request", return_value=True) as mock,
+        pytest.warns(DeprecationWarning),
+    ):
+        result = reporter._api_request("POST", "https://api.github.com/x", {"a": 1})
+
+    assert_that(result).is_true()
+    mock.assert_called_once_with("POST", "https://api.github.com/x", {"a": 1})

--- a/tests/unit/ai/test_json_response.py
+++ b/tests/unit/ai/test_json_response.py
@@ -36,3 +36,56 @@ def test_load_json_object_rejects_non_object() -> None:
     """Array JSON raises ValueError."""
     with pytest.raises(ValueError, match="must be an object"):
         load_json_object(content="[1, 2, 3]")
+
+
+def test_strip_json_fences_prefers_last_parseable_block() -> None:
+    """Prose with a decoy fenced block before real JSON extracts the payload."""
+    content = (
+        "Here is an example of the shape:\n"
+        "```json\n"
+        '{"summary": "decoy"}\n'
+        "```\n"
+        "And here is my actual review:\n"
+        "```json\n"
+        '{"summary": "real", "findings": []}\n'
+        "```\n"
+    )
+
+    stripped = strip_json_fences(content=content)
+
+    assert_that(stripped).is_equal_to('{"summary": "real", "findings": []}')
+
+
+def test_strip_json_fences_skips_non_json_decoy_fence() -> None:
+    """A non-JSON fenced snippet before the payload is ignored."""
+    content = (
+        "First run this:\n"
+        "```bash\n"
+        "git diff HEAD~1\n"
+        "```\n"
+        "```json\n"
+        '{"summary": "ok"}\n'
+        "```\n"
+    )
+
+    stripped = strip_json_fences(content=content)
+
+    assert_that(stripped).is_equal_to('{"summary": "ok"}')
+
+
+def test_strip_json_fences_falls_back_to_brace_matching() -> None:
+    """Unfenced prose wrapping a JSON object extracts via brace matching."""
+    content = 'Sure! Here is the result: {"summary": "ok", "findings": []} Done.'
+
+    stripped = strip_json_fences(content=content)
+
+    assert_that(stripped).is_equal_to('{"summary": "ok", "findings": []}')
+
+
+def test_strip_json_fences_brace_matching_ignores_braces_in_strings() -> None:
+    """Brace matching respects braces embedded in string literals."""
+    content = 'prefix {"text": "a } b", "n": 1} suffix'
+
+    stripped = strip_json_fences(content=content)
+
+    assert_that(stripped).is_equal_to('{"text": "a } b", "n": 1}')

--- a/tests/unit/ai/test_json_response.py
+++ b/tests/unit/ai/test_json_response.py
@@ -89,3 +89,21 @@ def test_strip_json_fences_brace_matching_ignores_braces_in_strings() -> None:
     stripped = strip_json_fences(content=content)
 
     assert_that(stripped).is_equal_to('{"text": "a } b", "n": 1}')
+
+
+def test_strip_json_fences_skips_decoy_array_before_object() -> None:
+    """A decoy array span before the real object is not returned as payload."""
+    content = 'Checklist [1]\n{"summary": "real", "findings": []}'
+
+    stripped = strip_json_fences(content=content, expect_object=True)
+
+    assert_that(stripped).is_equal_to('{"summary": "real", "findings": []}')
+
+
+def test_load_json_object_skips_decoy_array_before_object() -> None:
+    """load_json_object recovers the real object past an earlier decoy array."""
+    payload = load_json_object(
+        content='Checklist [1]\n{"summary": "real", "findings": []}',
+    )
+
+    assert_that(payload).is_equal_to({"summary": "real", "findings": []})


### PR DESCRIPTION
## Summary

Hardens the AI review pipeline across three issues. All work landed as one PR because it touches the same orchestrator/response-handling surface.

### #1040 — Secret redaction on review prompts (P1 security)
Review mode previously shipped raw diffs and PR metadata to external providers with zero redaction, while every other AI flow (fix/summary/refinement) already redacts. Added a single redaction choke point, `_redact_prompt_text`, that runs `redact_secrets()` and logs a `scan_for_secrets` warning. It is applied to:
- `build_review_prompt` — chunk diff + PR metadata body
- `build_git_native_review_prompt` — inlined (embedded) diff + PR body
- `_generate_extra_checklist` — depth-2 question generation
- `_run_adversarial_pass` — depth-3 adversarial sweep

**Post-transport note (#1009/#1010):** since the issues were written, `strip_json_fences` and the review-response parser moved into `lintro/ai/json_response.py`; the fixes were adapted to the current locations.

### #1041 — Case-insensitive severity + P1 exit gate
- New `Severity` StrEnum (`P1`/`P2`/`P3`) in `review_finding.py`; `ReviewFinding.severity` is now typed to it (explicit uppercase values are used instead of `auto()` because the canonical labels are uppercase and compared/displayed verbatim).
- `_parse_findings` normalizes unvalidated model output: strips whitespace, uppercases, and maps unknown values (e.g. `"critical"`) to `Severity.P3` with a logged warning — so malformed severities can no longer silently bypass the exit gate.
- `ReviewResult.has_p1_findings` compares against `Severity.P1`.

### #1050 — Response-handling robustness
- **(A) Checklist merge contract — chose "yes strictly wins".** `_checklist_answer_strength` now scores yes-with-evidence 4, yes 3, no-with-evidence 2, no 1, so a bare `yes` from one chunk always beats an evidence-backed `no` from another, matching epic #991's v3.1 contract (every `yes` maps to a finding). The three existing merge tests that encoded the old no-with-evidence-beats-yes behavior were updated to the new contract.
- **(B) JSON fence extraction.** `strip_json_fences` now considers all fenced blocks and returns the last one that parses as JSON (models place the final answer last), defeating decoy fenced snippets in prose. With no fences it falls back to brace/bracket-matched extraction (mirrors `CliTransport.extract_json_object`, string/escape aware).
- **(C) Reporter public API.** Promoted `GitHubPRReporter._post_issue_comment` / `_fetch_pr_diff_lines` / `_api_request` to `post_issue_comment` / `fetch_pr_diff_lines` / `api_request`, kept the private names as deprecated aliases (emit `DeprecationWarning`), and updated the review github adapter call sites.

## Tests
- Redaction reaches the provider payload (diff + PR body) and logs a warning.
- Severity `"p1"` / `"P1 "` / `"critical"` handled correctly by the exit gate.
- Last-fence JSON extraction, non-JSON decoy skipping, and brace-matching fallback.
- Yes-wins checklist merge.
- Public reporter methods plus deprecated-alias delegation.

Gates: `uv run lintro fmt`, `uv run lintro chk` (clean), `uv run pytest` (5760 passed, 10 skipped) all green.

Closes #1040
Closes #1041
Closes #1050

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the AI review pipeline around prompt safety, response parsing, and reporting APIs. The main changes are:

- Redacts PR title, PR body, and embedded diff text before provider prompts.
- Normalizes review finding labels through a shared `Severity` enum.
- Makes unknown finding labels fail closed in the review exit gate.
- Extracts the final parseable JSON response from fenced or prose-wrapped model output.
- Promotes GitHub reporter helper methods to public APIs with deprecated aliases.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/review/orchestrator.py | Adds prompt redaction and label normalization for the review flow. |
| lintro/ai/json_response.py | Improves JSON extraction from fenced and prose-wrapped model responses. |
| lintro/ai/review/models/review_finding.py | Adds the shared `Severity` enum for review findings. |
| lintro/ai/review/models/review_result.py | Updates the review exit check to use the shared severity type. |
| lintro/ai/integrations/github_pr.py | Promotes reporter methods to public names while keeping deprecated aliases. |
| lintro/ai/review/github.py | Updates GitHub review posting to call the public reporter methods. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/1040-review..."](https://github.com/lgtm-hq/py-lintro/commit/004ec71041f4e6b693864388098145052c517211) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41900156)</sub>

<!-- /greptile_comment -->