### PR TITLE
feat(ci): dogfood lintro review on py-lintro pull requests

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: AI Review - Dogfood
+
+# Dogfood `lintro review` on py-lintro's own pull requests.
+#
+# Informational only: the review runs with continue-on-error and the script
+# always exits 0, so it can never fail a PR. When the ANTHROPIC_API_KEY secret
+# is absent (not configured yet, or a fork PR that cannot read secrets) the
+# script skips gracefully. This is intentionally NOT a required check.
+
+'on':
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'lintro/**'
+
+permissions: {}
+
+concurrency:
+  group: ai-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ai-review:
+    name: AI Review
+    runs-on: ubuntu-24.04
+    # Skip draft PRs; only review PRs that are ready.
+    if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      pull-requests: read
+    timeout-minutes: 15
+
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            api.anthropic.com:443
+            astral.sh:443
+            releases.astral.sh:443
+            pypi.org:443
+            files.pythonhosted.org:443
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: 'latest'
+
+      - name: Install dependencies
+        run: uv sync --extra ai
+
+      - name: Run AI review (informational, non-blocking)
+        continue-on-error: true
+        run: scripts/ci/run-ai-review.sh
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AI_REVIEW_MAX_COST_USD: '0.50'

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -36,8 +36,8 @@ jobs:
     # SECURITY: even for same-repo PRs, this job checks out and installs PR
     # code with the ANTHROPIC_API_KEY secret in scope, so PR authors with write
     # access could exfiltrate it. This residual same-repo risk is tracked in a
-    # follow-up issue (trusted-install re-architecture); see follow-up issue.
-    # The ANTHROPIC_API_KEY secret MUST NOT be enabled until that lands.
+    # follow-up issue (trusted-install re-architecture); see #1073.
+    # The ANTHROPIC_API_KEY secret MUST NOT be enabled until #1073 lands.
     if: >-
       github.event.pull_request.draft == false
       && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -26,8 +26,21 @@ jobs:
   ai-review:
     name: AI Review
     runs-on: ubuntu-24.04
-    # Skip draft PRs; only review PRs that are ready.
-    if: github.event.pull_request.draft == false
+    # Fully informational: any failure (setup, egress, checkout, or the review
+    # step itself) is non-blocking and never fails the PR.
+    continue-on-error: true
+    # Skip draft PRs and never run for fork PRs. Fork PRs already cannot read
+    # secrets, but requiring head.repo == the base repo makes it explicit that
+    # the keyed job only runs for same-repository pull requests.
+    #
+    # SECURITY: even for same-repo PRs, this job checks out and installs PR
+    # code with the ANTHROPIC_API_KEY secret in scope, so PR authors with write
+    # access could exfiltrate it. This residual same-repo risk is tracked in a
+    # follow-up issue (trusted-install re-architecture); see follow-up issue.
+    # The ANTHROPIC_API_KEY secret MUST NOT be enabled until that lands.
+    if: >-
+      github.event.pull_request.draft == false
+      && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: read

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -48,6 +48,29 @@ docker-ci).
 If you want to publish the weekly report to Pages, prefer using a dedicated
 `deploy-pages` job gated on the report workflow.
 
+### 4b. AI Review (Dogfood) Workflow
+
+**File:** `.github/workflows/ai-review.yml`
+
+py-lintro dogfoods its own `lintro review` command on pull requests that touch
+`lintro/**`. The workflow runs an AI diff review and prints the JSON result to the job
+log.
+
+**Features:**
+
+- 🤖 **AI diff review** via `lintro review --pr <n> --depth 1 --output json`
+- 🔑 **Bring-your-own key** — reads the `ANTHROPIC_API_KEY` repository secret
+- 💸 **Bounded spend** — caps cost via `ai.max_cost_usd`
+- 🟢 **Non-blocking / informational** — runs with `continue-on-error` and always exits
+  0, so it can never fail a pull request. It is intentionally not a required check.
+- ⏭️ **Graceful skip** — when `ANTHROPIC_API_KEY` is absent (secret not configured yet,
+  or a fork PR that cannot read secrets) and for draft PRs, the review is skipped
+  without error.
+
+To activate it, add an `ANTHROPIC_API_KEY` secret to the repository (**Settings →
+Secrets and variables → Actions**). Until that secret exists the workflow runs but skips
+gracefully, so merging it never breaks CI.
+
 ### 5. Docker Image Publishing
 
 **File:** `.github/workflows/docker-build-publish.yml`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -87,6 +87,8 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `fail-on-security-audit.sh`          | Fail CI when security audit finds vulnerabilities                     | `./scripts/ci/fail-on-security-audit.sh`                                           |
 | `free-disk-space.sh`                 | Free disk space on CI runner for Docker builds                        | `./scripts/ci/free-disk-space.sh`                                                  |
 | `security-comment.sh`                | Run osv-scanner via lintro in Docker and generate security PR comment | `./scripts/ci/security-comment.sh --help`                                          |
+| `run-ai-review.sh`                   | Dogfood `lintro review` on a PR (informational, non-blocking)         | `PR_NUMBER=123 ./scripts/ci/run-ai-review.sh`                                      |
+| `enable_review_config.py`            | Enable AI review + cost cap in `.lintro-config.yaml` for a CI run     | `python3 scripts/ci/enable_review_config.py --help`                                |
 | `classify-osv-results.py`            | Classify osv_scanner JSON as ok, vulns, or error for CI status        | `python3 scripts/ci/classify-osv-results.py osv-results.json`                      |
 | `format-security-comment.py`         | Format lintro osv_scanner JSON as security PR comment markdown        | `python3 scripts/ci/format-security-comment.py osv-results.json`                   |
 | `test-install-package.sh`            | Install and verify built package in isolated venv                     | `./scripts/ci/test-install-package.sh wheel`                                       |

--- a/scripts/ci/enable_review_config.py
+++ b/scripts/ci/enable_review_config.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Enable AI review in ``.lintro-config.yaml`` for a single CI invocation.
+
+``lintro review`` reads its configuration from ``.lintro-config.yaml`` and
+exposes no CLI flag or environment override for ``ai.enabled`` or
+``ai.max_cost_usd``. The dogfood workflow therefore patches the checked-out
+(ephemeral) config in place before invoking the review command: it turns AI on,
+pins the API transport and the Anthropic provider, and bounds spend with
+``ai.max_cost_usd``.
+
+Only ``ai.enabled``, ``ai.transport``, ``ai.provider``, and ``ai.max_cost_usd``
+are touched; every other configured value is preserved. This script never edits
+a committed file in normal use — it runs against the throwaway CI checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_CONFIG_FILENAME = ".lintro-config.yaml"
+DEFAULT_MAX_COST_USD = 0.50
+MAX_COST_ENV_VAR = "AI_REVIEW_MAX_COST_USD"
+
+
+def resolve_max_cost_usd(*, raw_value: str | None) -> float:
+    """Resolve the review cost cap from a raw string value.
+
+    Args:
+        raw_value: Raw value from the environment, or ``None`` when unset.
+
+    Returns:
+        The resolved cost cap in USD.
+
+    Raises:
+        ValueError: When ``raw_value`` is set but not a non-negative float.
+    """
+    if raw_value is None or raw_value.strip() == "":
+        return DEFAULT_MAX_COST_USD
+    parsed = float(raw_value)
+    if parsed < 0:
+        msg = f"{MAX_COST_ENV_VAR} must be non-negative, got {parsed}"
+        raise ValueError(msg)
+    return parsed
+
+
+def patch_config(*, data: dict[str, Any], max_cost_usd: float) -> dict[str, Any]:
+    """Return config data with AI review enabled and cost-bounded.
+
+    Args:
+        data: Parsed ``.lintro-config.yaml`` contents.
+        max_cost_usd: Maximum total spend in USD for the review session.
+
+    Returns:
+        The mutated configuration mapping (mutated in place and returned).
+    """
+    ai_section = data.get("ai")
+    if not isinstance(ai_section, dict):
+        ai_section = {}
+        data["ai"] = ai_section
+
+    ai_section["enabled"] = True
+    ai_section["transport"] = "api"
+    ai_section["provider"] = "anthropic"
+    ai_section["max_cost_usd"] = max_cost_usd
+    return data
+
+
+def _load_config(*, config_path: Path) -> dict[str, Any]:
+    """Load a YAML config file into a mapping.
+
+    Args:
+        config_path: Path to the ``.lintro-config.yaml`` file.
+
+    Returns:
+        Parsed configuration mapping (empty when the file has no content).
+    """
+    with config_path.open(encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle)
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _write_config(*, config_path: Path, data: dict[str, Any]) -> None:
+    """Write a config mapping back to disk as YAML.
+
+    Args:
+        config_path: Destination path for the config file.
+        data: Configuration mapping to serialize.
+    """
+    with config_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(data, handle, sort_keys=False, default_flow_style=False)
+
+
+def main(*, argv: list[str] | None = None) -> int:
+    """Patch the config file and report the effective settings.
+
+    Args:
+        argv: Optional argument vector (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Process exit code (``0`` on success).
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG_FILENAME,
+        help="Path to the .lintro-config.yaml file to patch.",
+    )
+    args = parser.parse_args(argv)
+
+    config_path = Path(args.config)
+    if not config_path.exists():
+        print(f"Config file not found: {config_path}", file=sys.stderr)
+        return 1
+
+    max_cost_usd = resolve_max_cost_usd(raw_value=os.environ.get(MAX_COST_ENV_VAR))
+    data = _load_config(config_path=config_path)
+    patch_config(data=data, max_cost_usd=max_cost_usd)
+    _write_config(config_path=config_path, data=data)
+
+    print(
+        "Enabled AI review: ai.enabled=true, ai.transport=api, "
+        f"ai.provider=anthropic, ai.max_cost_usd={max_cost_usd}",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# run-ai-review.sh
+#
+# Dogfood `lintro review` on py-lintro's own pull requests. Runs an AI diff
+# review over the PR and prints the JSON result to the log. Informational only:
+# this script always exits 0 so it can never fail a pull request check.
+#
+# It gracefully skips (logs a message and exits 0) when ANTHROPIC_API_KEY is
+# empty. That covers both "the repo secret is not configured yet" and fork PRs
+# (which cannot access repository secrets), so merging the workflow never
+# breaks CI.
+#
+# Usage:
+#   PR_NUMBER=<n> ANTHROPIC_API_KEY=<key> GH_TOKEN=<token> \
+#     scripts/ci/run-ai-review.sh
+#   scripts/ci/run-ai-review.sh <pr-number>
+#
+# Environment:
+#   ANTHROPIC_API_KEY       Anthropic API key. Empty => graceful skip.
+#   PR_NUMBER               Pull request number (alternative to the argument).
+#   GH_TOKEN                Token used by `gh` to fetch the PR diff.
+#   GITHUB_REPOSITORY       owner/name; supplies --repo for `lintro review`.
+#   AI_REVIEW_MAX_COST_USD  Optional spend cap (defaults handled downstream).
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Dogfood `lintro review` on a pull request (informational, non-blocking).
+
+Usage:
+  PR_NUMBER=<n> scripts/ci/run-ai-review.sh
+  scripts/ci/run-ai-review.sh <pr-number>
+
+Skips gracefully (exit 0) when ANTHROPIC_API_KEY is empty.
+EOF
+	exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pr_number="${1:-${PR_NUMBER:-}}"
+
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+	echo "ANTHROPIC_API_KEY is not set — skipping AI review (informational only)."
+	echo "Add the ANTHROPIC_API_KEY repository secret to activate AI review on PRs."
+	exit 0
+fi
+
+if [[ -z "$pr_number" ]]; then
+	echo "No PR number provided (set PR_NUMBER or pass it as an argument)." >&2
+	echo "Skipping AI review — nothing to review." >&2
+	exit 0
+fi
+
+echo "Running AI review on PR #${pr_number} (informational, non-blocking)..."
+
+# Enable AI review in the ephemeral CI checkout's config. `lintro review` reads
+# ai.enabled and ai.max_cost_usd only from .lintro-config.yaml, so patch it here
+# rather than passing non-existent flags. Transport/provider are pinned too.
+uv run python "${script_dir}/enable_review_config.py"
+
+# Never let a P1 finding (exit 1) or any review error fail the PR check.
+set +e
+review_output="$(uv run lintro review --pr "${pr_number}" --depth 1 --output json 2>&1)"
+review_status=$?
+set -e
+
+printf '%s\n' "$review_output"
+
+if [[ "$review_status" -ne 0 ]]; then
+	echo "lintro review exited with status ${review_status} " \
+		"(findings or error) — informational only, not failing the PR."
+fi
+
+exit 0

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -201,6 +201,34 @@ def test_workflow_yaml_parses() -> None:
     assert_that(trigger).contains_key("pull_request")
 
 
+def test_workflow_job_is_non_blocking() -> None:
+    """The review job is non-blocking at the job level.
+
+    Job-level ``continue-on-error`` keeps setup failures (uv sync, egress,
+    checkout) from turning the PR check red, matching the informational intent.
+    """
+    loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+    job = loaded["jobs"]["ai-review"]
+    assert_that(job).contains_key("continue-on-error")
+    assert_that(job["continue-on-error"]).is_true()
+
+
+def test_workflow_job_is_same_repo_only() -> None:
+    """The keyed job only runs for same-repository (non-fork) PRs.
+
+    The job ``if`` guard combines the draft check with a head-repo equality
+    check so fork PRs never attempt the job that has the secret in scope.
+    """
+    loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+    guard = loaded["jobs"]["ai-review"]["if"]
+    assert_that(guard).contains("github.event.pull_request.draft == false")
+    assert_that(guard).contains(
+        "github.event.pull_request.head.repo.full_name == github.repository",
+    )
+
+
 @pytest.mark.parametrize(
     "action_ref",
     [

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -1,0 +1,220 @@
+"""Tests for the dogfood AI review CI helpers.
+
+Covers the ``enable_review_config.py`` config patcher, the graceful-skip
+behaviour of ``run-ai-review.sh``, the review CLI flags the script relies on,
+and that the ``ai-review.yml`` workflow parses as valid YAML.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import yaml
+from assertpy import assert_that
+from click.testing import CliRunner
+
+from lintro.cli import cli
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_SCRIPT = REPO_ROOT / "scripts" / "ci" / "enable_review_config.py"
+SHELL_SCRIPT = REPO_ROOT / "scripts" / "ci" / "run-ai-review.sh"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ai-review.yml"
+
+
+def _load_config_module() -> ModuleType:
+    """Load enable_review_config.py as an importable module.
+
+    Returns:
+        The loaded module exposing its public helpers.
+
+    Raises:
+        RuntimeError: When the module spec cannot be created.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "enable_review_config",
+        CONFIG_SCRIPT,
+    )
+    if spec is None or spec.loader is None:
+        msg = f"Unable to load module from {CONFIG_SCRIPT}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["enable_review_config"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_shell(
+    *,
+    args: list[str],
+    env_overrides: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Run the shell helper with a controlled environment.
+
+    Args:
+        args: Positional arguments passed to the script.
+        env_overrides: Environment variables layered onto a minimal base.
+
+    Returns:
+        The completed subprocess result.
+    """
+    env = {"PATH": os.environ.get("PATH", "")}
+    env.update(env_overrides)
+    return subprocess.run(
+        [str(SHELL_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_resolve_max_cost_defaults_when_unset() -> None:
+    """An unset or blank cost value falls back to the default cap."""
+    module = _load_config_module()
+
+    assert_that(module.resolve_max_cost_usd(raw_value=None)).is_equal_to(
+        module.DEFAULT_MAX_COST_USD,
+    )
+    assert_that(module.resolve_max_cost_usd(raw_value="  ")).is_equal_to(
+        module.DEFAULT_MAX_COST_USD,
+    )
+
+
+def test_resolve_max_cost_parses_value() -> None:
+    """A valid numeric string parses into a float cap."""
+    module = _load_config_module()
+
+    assert_that(module.resolve_max_cost_usd(raw_value="1.25")).is_equal_to(1.25)
+
+
+def test_resolve_max_cost_rejects_negative() -> None:
+    """A negative cost value raises ValueError."""
+    module = _load_config_module()
+
+    assert_that(module.resolve_max_cost_usd).raises(ValueError).when_called_with(
+        raw_value="-1",
+    )
+
+
+def test_patch_config_enables_ai_and_bounds_cost() -> None:
+    """Patching enables AI, pins transport/provider, and sets the cost cap."""
+    module = _load_config_module()
+
+    data = {"ai": {"enabled": False, "model": "keep-me"}, "review": {"depth": 1}}
+    patched = module.patch_config(data=data, max_cost_usd=0.5)
+
+    assert_that(patched["ai"]["enabled"]).is_true()
+    assert_that(patched["ai"]["transport"]).is_equal_to("api")
+    assert_that(patched["ai"]["provider"]).is_equal_to("anthropic")
+    assert_that(patched["ai"]["max_cost_usd"]).is_equal_to(0.5)
+    # Unrelated values are preserved.
+    assert_that(patched["ai"]["model"]).is_equal_to("keep-me")
+    assert_that(patched["review"]["depth"]).is_equal_to(1)
+
+
+def test_patch_config_creates_ai_section_when_missing() -> None:
+    """A missing ai section is created rather than raising."""
+    module = _load_config_module()
+
+    patched = module.patch_config(data={}, max_cost_usd=0.25)
+
+    assert_that(patched["ai"]["enabled"]).is_true()
+    assert_that(patched["ai"]["max_cost_usd"]).is_equal_to(0.25)
+
+
+def test_main_patches_config_file(tmp_path: Path) -> None:
+    """main() writes the enabled AI settings back to the target file."""
+    module = _load_config_module()
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text("ai:\n  enabled: false\n", encoding="utf-8")
+
+    exit_code = module.main(argv=["--config", str(config_file)])
+
+    assert_that(exit_code).is_equal_to(0)
+    reloaded = yaml.safe_load(config_file.read_text(encoding="utf-8"))
+    assert_that(reloaded["ai"]["enabled"]).is_true()
+    assert_that(reloaded["ai"]["transport"]).is_equal_to("api")
+
+
+def test_main_returns_error_when_config_missing(tmp_path: Path) -> None:
+    """main() returns a non-zero code when the config file is absent."""
+    module = _load_config_module()
+
+    exit_code = module.main(argv=["--config", str(tmp_path / "missing.yaml")])
+
+    assert_that(exit_code).is_equal_to(1)
+
+
+def test_shell_help_exits_zero() -> None:
+    """The --help flag prints usage and exits 0."""
+    result = _run_shell(args=["--help"], env_overrides={})
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("Usage:")
+
+
+def test_shell_skips_without_api_key() -> None:
+    """An empty ANTHROPIC_API_KEY skips gracefully with exit 0."""
+    result = _run_shell(
+        args=[],
+        env_overrides={"ANTHROPIC_API_KEY": "", "PR_NUMBER": "123"},
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("skipping AI review")
+
+
+def test_shell_skips_without_pr_number() -> None:
+    """A configured key but no PR number skips gracefully with exit 0."""
+    result = _run_shell(
+        args=[],
+        env_overrides={"ANTHROPIC_API_KEY": "dummy-key", "PR_NUMBER": ""},
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+
+
+def test_review_cli_accepts_script_flags() -> None:
+    """The review command exposes the flags the script invokes."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["review", "--help"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains("--pr")
+    assert_that(result.output).contains("--depth")
+    assert_that(result.output).contains("--output")
+    assert_that(result.output).contains("json")
+
+
+def test_workflow_yaml_parses() -> None:
+    """The ai-review workflow is valid YAML with the expected trigger."""
+    loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+    assert_that(loaded).contains_key("jobs")
+    assert_that(loaded["jobs"]).contains_key("ai-review")
+    trigger = loaded[True] if True in loaded else loaded["on"]
+    assert_that(trigger).contains_key("pull_request")
+
+
+@pytest.mark.parametrize(
+    "action_ref",
+    [
+        "step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411",
+        "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+        "astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78",
+    ],
+)
+def test_workflow_pins_actions_to_sha(*, action_ref: str) -> None:
+    """Third-party actions are pinned to full commit SHAs.
+
+    Args:
+        action_ref: The ``owner/repo@sha`` reference expected in the workflow.
+    """
+    content = WORKFLOW.read_text(encoding="utf-8")
+
+    assert_that(content).contains(action_ref)


### PR DESCRIPTION
## Summary

Dogfoods `lintro review` on py-lintro's own pull requests via a new,
informational-only CI workflow.

### Workflow: `.github/workflows/ai-review.yml`
- Triggers on `pull_request` (opened/synchronize/reopened/ready_for_review)
  scoped to `paths: ['lintro/**']`.
- Skips draft PRs (`if: github.event.pull_request.draft == false`).
- **Non-blocking**: the run step uses `continue-on-error: true` and the script
  always exits 0, so it can never fail a PR. Not a required check.
- Minimal permissions: `contents: read`, `pull-requests: read` (read-only; no
  `--post` in v1).
- All third-party actions pinned to full commit SHAs (harden-runner, checkout,
  setup-python, setup-uv) with `# vX.Y.Z` comments, matching repo convention.
- Passes `ANTHROPIC_API_KEY` and `GH_TOKEN` to the script as env.

### Script: `scripts/ci/run-ai-review.sh`
- **Graceful skip (exit 0) when `ANTHROPIC_API_KEY` is empty** — covers both
  "secret not configured yet" and fork PRs (which cannot read secrets), so
  merging this never breaks CI even before a key is added.
- Otherwise runs `uv run lintro review --pr <n> --depth 1 --output json`, prints
  the JSON to the log, and exits 0 regardless of findings (surfacing a non-zero
  review status as an informational log line).

### Enabling AI + cost cap
`lintro review` reads `ai.enabled` and `ai.max_cost_usd` only from
`.lintro-config.yaml` (no CLI flag or env override exists for them). The helper
`scripts/ci/enable_review_config.py` patches the ephemeral CI checkout's config
to set `ai.enabled: true`, `ai.transport: api`, `ai.provider: anthropic`, and
`ai.max_cost_usd` (default 0.50, overridable via `AI_REVIEW_MAX_COST_USD`).
Depth is capped at 1 via the real `--depth 1` flag.

### Tests & docs
- `tests/scripts/test_run_ai_review.py`: config-patch logic, graceful-skip
  behaviour, review CLI flag acceptance, workflow YAML validity, and SHA pinning.
- Documented in `docs/github-integration.md` and `scripts/README.md`: setting
  the `ANTHROPIC_API_KEY` repo secret activates AI review; it is
  informational/non-blocking.

### Gates
- `uv run lintro fmt` / `uv run lintro chk`: clean (0 issues).
- `uv run pytest`: 5798 passed, 10 skipped.

Closes #1051

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a dogfood AI review workflow for py-lintro pull requests. The main changes are:

- A new GitHub Actions workflow for informational `lintro review` runs.
- CI helpers to enable AI review settings and run the review command.
- Tests for the workflow, helper scripts, and CLI flags.
- Documentation for enabling and using the workflow.
</details>

<h3>Confidence Score: 4/5</h3>

This is close, but the activation guidance should be fixed before merging.

- The workflow records that the API key should stay disabled until the trusted-install work lands.
- The docs tell maintainers to add the key without that warning.
- Following the docs can expose the key to same-repo PR code.

docs/github-integration.md

<details open><summary><h3>Security Review</h3></summary>

The documentation currently tells maintainers to add `ANTHROPIC_API_KEY` even though the workflow still runs same-repo PR code with that secret available.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ai-review.yml | Adds the dogfood review workflow with same-repo gating, read-only permissions, pinned actions, and non-blocking job behavior. |
| scripts/ci/run-ai-review.sh | Adds the wrapper that skips without an API key, patches review config, runs `lintro review`, prints output, and exits successfully. |
| scripts/ci/enable_review_config.py | Adds the config patcher that enables API-backed Anthropic review and sets the review cost cap. |
| docs/github-integration.md | Documents the AI review workflow and activation steps, including the API key setup path that needs the workflow blocker warning. |
| scripts/README.md | Adds the new AI review helper scripts to the scripts reference table. |
| tests/scripts/test_run_ai_review.py | Adds tests for config patching, script skip behavior, workflow parsing, same-repo gating, non-blocking behavior, and pinned actions. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fgithub-integration.md%3A70-72%0A**Secret%20Activation%20Bypasses%20Blocker**%0A%0AThe%20workflow%20comment%20says%20%60ANTHROPIC_API_KEY%60%20must%20not%20be%20enabled%20until%20the%20trusted-install%20work%20lands%2C%20because%20same-repo%20pull%20requests%20still%20run%20checked-out%20code%20with%20the%20secret%20available.%20This%20new%20setup%20text%20tells%20maintainers%20to%20add%20the%20secret%20now%2C%20so%20following%20the%20docs%20can%20make%20the%20key%20available%20to%20PR-controlled%20code%20on%20the%20next%20same-repo%20PR.%20Please%20carry%20the%20same%20blocker%20into%20this%20activation%20guidance%2C%20or%20remove%20the%20activation%20step%20until%20the%20workflow%20no%20longer%20runs%20PR%20code%20with%20the%20key%20in%20scope.%0A%0A&pr=1072&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fgithub-integration.md%3A70-72%0A**Secret%20Activation%20Bypasses%20Blocker**%0A%0AThe%20workflow%20comment%20says%20%60ANTHROPIC_API_KEY%60%20must%20not%20be%20enabled%20until%20the%20trusted-install%20work%20lands%2C%20because%20same-repo%20pull%20requests%20still%20run%20checked-out%20code%20with%20the%20secret%20available.%20This%20new%20setup%20text%20tells%20maintainers%20to%20add%20the%20secret%20now%2C%20so%20following%20the%20docs%20can%20make%20the%20key%20available%20to%20PR-controlled%20code%20on%20the%20next%20same-repo%20PR.%20Please%20carry%20the%20same%20blocker%20into%20this%20activation%20guidance%2C%20or%20remove%20the%20activation%20step%20until%20the%20workflow%20no%20longer%20runs%20PR%20code%20with%20the%20key%20in%20scope.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1072&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22feat%2F1051-dogfood-ai-review%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F1051-dogfood-ai-review%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fgithub-integration.md%3A70-72%0A**Secret%20Activation%20Bypasses%20Blocker**%0A%0AThe%20workflow%20comment%20says%20%60ANTHROPIC_API_KEY%60%20must%20not%20be%20enabled%20until%20the%20trusted-install%20work%20lands%2C%20because%20same-repo%20pull%20requests%20still%20run%20checked-out%20code%20with%20the%20secret%20available.%20This%20new%20setup%20text%20tells%20maintainers%20to%20add%20the%20secret%20now%2C%20so%20following%20the%20docs%20can%20make%20the%20key%20available%20to%20PR-controlled%20code%20on%20the%20next%20same-repo%20PR.%20Please%20carry%20the%20same%20blocker%20into%20this%20activation%20guidance%2C%20or%20remove%20the%20activation%20step%20until%20the%20workflow%20no%20longer%20runs%20PR%20code%20with%20the%20key%20in%20scope.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1072&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["docs(ci): reference follow-up #1073 in a..."](https://github.com/lgtm-hq/py-lintro/commit/4762450e5052fcf2c96e453dac146c1ee3766473) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41915094)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->