### PR TITLE
fix(ai/review): guarantee secret redaction in git-native review mode

### DIFF
--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -174,6 +174,22 @@ class AIConfig(BaseModel):
         ),
     )
 
+    review_allow_unredacted_git_native: bool = Field(
+        default=False,
+        description=(
+            "Allow the git-native (CLI transport) review path to delegate "
+            "diff retrieval to the provider by emitting a 'git diff' command "
+            "instead of embedding the diff. Security risk: a delegated diff "
+            "is produced by the provider itself and never passes through "
+            "lintro's secret-redaction choke point, so secrets present in "
+            "the diff can reach the provider's backend unredacted. Defaults "
+            "to False so redaction always wins: lintro embeds the redacted "
+            "diff in the prompt even for large diffs. Only enable this for "
+            "trusted diffs with no secrets concern when the efficiency of "
+            "delegated git retrieval on very large diffs is required."
+        ),
+    )
+
     @model_validator(mode="after")
     def _validate_transport_and_retries(self) -> AIConfig:
         if self.retry_max_delay < self.retry_base_delay:

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -618,8 +618,16 @@ def build_git_native_review_prompt(
     extra_checklist: str = "",
     strictness_section: str = "",
     embed_diff: bool = False,
+    allow_unredacted_git_native: bool = False,
 ) -> tuple[str, str]:
     """Build git-native prompts for CLI-backed review (all providers).
+
+    Redaction is a security invariant and wins by default. When ``embed_diff``
+    is False the builder would normally emit a delegated ``git diff`` command,
+    which lets the provider produce the diff itself and thus bypasses lintro's
+    secret-redaction choke point. Unless ``allow_unredacted_git_native`` is
+    explicitly True, the builder instead falls back to embedding the redacted
+    diff so no unredacted diff can reach the provider.
 
     Args:
         chunk: Semantic diff chunk to review.
@@ -631,10 +639,18 @@ def build_git_native_review_prompt(
         extra_checklist: Additional generated checklist rows for depth 2.
         strictness_section: Sensitivity instructions for the review pass.
         embed_diff: When True, inline the diff instead of agentic git commands.
+        allow_unredacted_git_native: Explicit opt-out permitting the delegated
+            ``git diff`` command path (which bypasses secret redaction) when
+            ``embed_diff`` is False. Defaults to False so redaction always
+            wins and the diff is embedded and redacted instead.
 
     Returns:
         Tuple of (system_prompt, user_prompt).
     """
+    # Redaction wins by default: never delegate diff retrieval to the provider
+    # unless the caller has explicitly opted out of the redaction guarantee.
+    if not embed_diff and not allow_unredacted_git_native:
+        embed_diff = True
     pr_title = context.pr_metadata.title if context.pr_metadata else "Local changes"
     pr_title = _redact_prompt_text(text=pr_title, source="PR title")
     pr_summary = context.pr_metadata.body if context.pr_metadata else "(no PR summary)"
@@ -848,6 +864,7 @@ def _review_chunk(
             extra_checklist=extra_checklist,
             strictness_section=strictness_section,
             embed_diff=embed_diff,
+            allow_unredacted_git_native=ai_config.review_allow_unredacted_git_native,
         )
     else:
         system_prompt, user_prompt = build_review_prompt(

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -676,7 +676,12 @@ def test_build_git_native_review_prompt_embeds_diff_when_requested(
 def test_build_git_native_review_prompt_uses_git_command_when_not_embedded(
     sample_review_context: ReviewContext,
 ) -> None:
-    """Large diffs keep agentic git diff instructions."""
+    """Large diffs keep agentic git diff instructions under the opt-out.
+
+    The delegated ``git diff`` command bypasses secret redaction, so it is
+    only emitted when the caller explicitly opts out of the redaction
+    guarantee via ``allow_unredacted_git_native``.
+    """
     chunk = ReviewChunk(
         id=1,
         files=["src/lib/math.py"],
@@ -692,6 +697,7 @@ def test_build_git_native_review_prompt_uses_git_command_when_not_embedded(
         checklist_count=1,
         interaction_paths="(none)",
         embed_diff=False,
+        allow_unredacted_git_native=True,
     )
 
     assert_that(user_prompt).contains("git diff")

--- a/tests/unit/ai/review/test_orchestrator_hardening.py
+++ b/tests/unit/ai/review/test_orchestrator_hardening.py
@@ -162,6 +162,56 @@ def test_build_git_native_review_prompt_redacts_secrets_in_pr_title() -> None:
     assert_that(user_prompt).contains("[REDACTED]")
 
 
+def test_git_native_default_embeds_redacted_diff_not_git_command() -> None:
+    """By default the git-native builder embeds the redacted diff.
+
+    When ``embed_diff`` is False and the redaction opt-out is not set, the
+    builder must fall back to embedding the redacted diff rather than emitting
+    a delegated ``git diff`` command that would bypass secret redaction.
+    """
+    chunk = _make_chunk(diff=f"+api_key = '{_LEAKED_KEY}'\n")
+    context = _make_context(body="Routine change.")
+
+    _system, user_prompt = build_git_native_review_prompt(
+        chunk=chunk,
+        context=context,
+        checklist_text="1. [logic-bug] Example?",
+        checklist_count=1,
+        interaction_paths="(none)",
+        embed_diff=False,
+    )
+
+    assert_that(user_prompt).does_not_contain(_LEAKED_KEY)
+    assert_that(user_prompt).contains("[REDACTED]")
+    assert_that(user_prompt).does_not_contain("git diff")
+    assert_that(user_prompt).contains("<pull_request_diff>")
+
+
+def test_git_native_opt_out_uses_delegated_git_command() -> None:
+    """With the explicit opt-out enabled the delegated git command is emitted.
+
+    A user who knowingly accepts the loss of redaction for efficiency on very
+    large diffs can opt out; then the builder emits the delegated ``git diff``
+    command and does not embed the diff.
+    """
+    chunk = _make_chunk(diff=f"+api_key = '{_LEAKED_KEY}'\n")
+    context = _make_context(body="Routine change.")
+
+    _system, user_prompt = build_git_native_review_prompt(
+        chunk=chunk,
+        context=context,
+        checklist_text="1. [logic-bug] Example?",
+        checklist_count=1,
+        interaction_paths="(none)",
+        embed_diff=False,
+        allow_unredacted_git_native=True,
+    )
+
+    assert_that(user_prompt).contains("git diff")
+    assert_that(user_prompt).does_not_contain("<pull_request_diff>")
+    assert_that(user_prompt).does_not_contain(_LEAKED_KEY)
+
+
 def test_build_review_prompt_logs_secret_warning() -> None:
     """Detected secrets emit a warning before the prompt is dispatched."""
     chunk = _make_chunk(diff=f"+token = {_LEAKED_KEY}\n")


### PR DESCRIPTION
## Summary

Closes the secret-redaction gap in git-native (CLI transport) review mode reported in #1070. Previously, when `embed_diff=False` the git-native prompt builder emitted a delegated `git diff` command (`REVIEW_GIT_NATIVE_DIFF_WORKTREE_COMMAND` / `REVIEW_GIT_NATIVE_DIFF_GIT_COMMAND`) instructing the provider to produce the diff itself. That diff never passed through lintro's `_redact_prompt_text` choke point (added in #1040 / #1069), so a secret in the diff could reach the provider's backend unredacted.

## Change: redaction wins by default

Secret redaction is treated as a security invariant that wins by default.

- `build_git_native_review_prompt` now forces the embedded, redacted diff whenever the non-embed delegated-git path would otherwise bypass redaction. Concretely: if `embed_diff` is False and the explicit opt-out is not set, `embed_diff` is flipped to True so the diff is embedded via `REVIEW_GIT_NATIVE_DIFF_INLINE` after passing through `_redact_prompt_text`. The default path can never instruct the provider to produce an unredacted diff.
- New explicit opt-out `ai.review_allow_unredacted_git_native` (default `False`) in `AIConfig` (`lintro/ai/config.py`). Its docstring documents the security risk: the delegated diff is produced by the provider and never passes through lintro's redaction, so secrets in the diff can reach the provider unredacted. Only when this is explicitly `True` may the builder emit the delegated `git diff` command — for users who knowingly want delegated git retrieval (efficiency on very large diffs, no secrets concern).
- The option is threaded from `AIConfig.review_allow_unredacted_git_native` through the call site in `_run_chunk_review` into `build_git_native_review_prompt` via a new keyword-only `allow_unredacted_git_native` parameter. The `embed_diff` size heuristic is unchanged; the redaction guarantee sits underneath it as the final gate.

## Risk / trade-off

The opt-out re-enables the exact path #1070 flags: a delegated diff cannot be redacted at the prompt layer. It defaults off so redaction always applies; large-diff efficiency via delegated git is available only by explicit, documented opt-in.

## Tests

- Default git-native builder embeds the redacted diff: a planted secret is redacted (`[REDACTED]`), no `git diff` command is emitted, and `<pull_request_diff>` is present.
- With `allow_unredacted_git_native=True`, the delegated `git diff` command path is used and the diff is not embedded.
- Updated the pre-existing "uses git command when not embedded" test to pass the explicit opt-out, matching the new default-safe behavior.

Gates: `uv run lintro fmt`, `uv run lintro chk` (0 issues), `uv run pytest` (5802 passed, 10 skipped) all green.

Closes #1070

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes git-native review prompts redact diffs by default. The main changes are:

- Added a config opt-out for unredacted delegated git diffs.
- Forced git-native prompt building to embed the redacted diff unless the opt-out is enabled.
- Passed the new config value through the review chunk path.
- Added tests for the default redacted path and the explicit opt-out path.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/config.py | Adds the `review_allow_unredacted_git_native` config flag with a default of `False`. |
| lintro/ai/review/orchestrator.py | Forces git-native review prompts onto the redacted inline diff path unless the new opt-out is enabled. |
| tests/unit/ai/review/test_orchestrator.py | Updates the delegated git diff test to require the explicit opt-out. |
| tests/unit/ai/review/test_orchestrator_hardening.py | Adds coverage for the default redacted git-native path and the explicit delegated-git opt-out. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/1070-git-na..."](https://github.com/lgtm-hq/py-lintro/commit/463142e906718c1bc89a6a6a2c832767f1cba0e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41922330)</sub>

<!-- /greptile_comment -->