### PR TITLE
refactor(tools): replace repetitive tool-option type validation with schema-based checks

### DIFF
--- a/lintro/tools/core/option_validators.py
+++ b/lintro/tools/core/option_validators.py
@@ -4,7 +4,89 @@ This module provides common validation functions to reduce boilerplate
 in tool set_options() methods.
 """
 
+from collections.abc import Mapping
 from typing import Any
+
+# Human-friendly labels used when reporting an option's expected type.
+# These keep error messages consistent with the historical wording
+# (e.g. "must be a boolean" rather than "must be a bool").
+_TYPE_LABELS: dict[type, str] = {
+    bool: "boolean",
+    str: "string",
+    int: "integer",
+    float: "number",
+    list: "list",
+}
+
+# A single option's expected type. Either a bare ``type`` (whose label is
+# looked up in ``_TYPE_LABELS``) or a ``(type, label)`` tuple that overrides
+# the label used in the error message (e.g. ``(str, "string path")``).
+OptionType = type | tuple[type, str]
+
+# Mapping of option name to its expected type specification.
+OptionSchema = Mapping[str, OptionType]
+
+
+def _resolve_option_type(spec: OptionType) -> tuple[type, str]:
+    """Resolve an option type specification into a type and its label.
+
+    Args:
+        spec: Either a bare ``type`` or a ``(type, label)`` tuple.
+
+    Returns:
+        tuple[type, str]: The expected type and its human-friendly label.
+    """
+    if isinstance(spec, tuple):
+        expected_type, label = spec
+        return expected_type, label
+    return spec, _TYPE_LABELS.get(spec, spec.__name__)
+
+
+def _type_error_message(name: str, label: str) -> str:
+    """Build a type-mismatch error message with a grammatical article.
+
+    Args:
+        name: The option name.
+        label: The human-friendly type label (e.g. "boolean", "integer").
+
+    Returns:
+        str: An error message such as "name must be a boolean" or
+        "name must be an integer".
+    """
+    article = "an" if label[:1].lower() in "aeiou" else "a"
+    return f"{name} must be {article} {label}"
+
+
+def validate_option_types(
+    options: Mapping[str, Any],
+    schema: OptionSchema,
+) -> None:
+    """Validate option values against a declarative type schema.
+
+    Iterates over the schema and checks each present (non-``None``) option
+    against its expected type, raising a ``ValueError`` naming the offending
+    option on the first mismatch. Options absent from ``options`` or set to
+    ``None`` are skipped, and options not present in the schema are ignored
+    (pass-through), preserving the historical per-option validation behavior.
+
+    Args:
+        options: Mapping of option name to provided value.
+        schema: Mapping of option name to its expected type specification.
+
+    Raises:
+        ValueError: If a present option's value is not of its expected type.
+    """
+    for name, spec in schema.items():
+        value = options.get(name)
+        if value is None:
+            continue
+        expected_type, label = _resolve_option_type(spec)
+        # ``bool`` is a subclass of ``int``; reject booleans where an integer
+        # is required so numeric options do not silently accept True/False.
+        if expected_type is int and isinstance(value, bool):
+            raise ValueError(_type_error_message(name, label))
+        if not isinstance(value, expected_type):
+            raise ValueError(_type_error_message(name, label))
 
 
 def validate_bool(value: Any, name: str) -> None:

--- a/lintro/tools/definitions/astro_check.py
+++ b/lintro/tools/definitions/astro_check.py
@@ -99,9 +99,6 @@ class AstroCheckPlugin(BaseToolPlugin):
         Args:
             root: Root directory for the Astro project.
             **kwargs: Other tool options.
-
-        Raises:
-            ValueError: If any provided option is of an unexpected type.
         """
         options: dict[str, object] = {"root": root}
         validate_option_types(options, ASTRO_CHECK_OPTION_TYPES)

--- a/lintro/tools/definitions/astro_check.py
+++ b/lintro/tools/definitions/astro_check.py
@@ -32,6 +32,10 @@ from lintro.parsers.base_parser import strip_ansi_codes
 from lintro.plugins.base import BaseToolPlugin
 from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.registry import register_tool
+from lintro.tools.core.option_validators import (
+    OptionSchema,
+    validate_option_types,
+)
 from lintro.tools.core.timeout_utils import create_timeout_result
 
 # Constants for Astro check configuration
@@ -44,6 +48,11 @@ _ASTRO_CONFIG_NAMES: tuple[str, ...] = (
     "astro.config.js",
     "astro.config.cjs",
 )
+
+# Expected types for astro-check-specific options, validated in set_options().
+ASTRO_CHECK_OPTION_TYPES: OptionSchema = {
+    "root": (str, "string path"),
+}
 
 
 @register_tool
@@ -94,10 +103,8 @@ class AstroCheckPlugin(BaseToolPlugin):
         Raises:
             ValueError: If any provided option is of an unexpected type.
         """
-        if root is not None and not isinstance(root, str):
-            raise ValueError("root must be a string path")
-
         options: dict[str, object] = {"root": root}
+        validate_option_types(options, ASTRO_CHECK_OPTION_TYPES)
         options = {k: v for k, v in options.items() if v is not None}
         super().set_options(**options, **kwargs)
 

--- a/lintro/tools/definitions/mypy.py
+++ b/lintro/tools/definitions/mypy.py
@@ -22,6 +22,10 @@ from lintro.parsers.mypy.mypy_parser import parse_mypy_output
 from lintro.plugins.base import BaseToolPlugin
 from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.registry import register_tool
+from lintro.tools.core.option_validators import (
+    OptionSchema,
+    validate_option_types,
+)
 from lintro.tools.core.timeout_utils import create_timeout_result
 from lintro.utils.config import load_mypy_config
 
@@ -39,6 +43,15 @@ MYPY_DEFAULT_EXCLUDE_PATTERNS: list[str] = [
     "dist/**",
     "build/**",
 ]
+
+# Expected types for mypy-specific options, validated in set_options().
+MYPY_OPTION_TYPES: OptionSchema = {
+    "strict": bool,
+    "ignore_missing_imports": bool,
+    "python_version": str,
+    "config_file": (str, "string path"),
+    "cache_dir": (str, "string path"),
+}
 
 
 def _split_config_values(raw_value: str) -> list[str]:
@@ -143,20 +156,6 @@ class MypyPlugin(BaseToolPlugin):
         Raises:
             ValueError: If any provided option is of an unexpected type.
         """
-        if strict is not None and not isinstance(strict, bool):
-            raise ValueError("strict must be a boolean")
-        if ignore_missing_imports is not None and not isinstance(
-            ignore_missing_imports,
-            bool,
-        ):
-            raise ValueError("ignore_missing_imports must be a boolean")
-        if python_version is not None and not isinstance(python_version, str):
-            raise ValueError("python_version must be a string")
-        if config_file is not None and not isinstance(config_file, str):
-            raise ValueError("config_file must be a string path")
-        if cache_dir is not None and not isinstance(cache_dir, str):
-            raise ValueError("cache_dir must be a string path")
-
         options: dict[str, object] = {
             "strict": strict,
             "ignore_missing_imports": ignore_missing_imports,
@@ -164,6 +163,7 @@ class MypyPlugin(BaseToolPlugin):
             "config_file": config_file,
             "cache_dir": cache_dir,
         }
+        validate_option_types(options, MYPY_OPTION_TYPES)
         options = {k: v for k, v in options.items() if v is not None}
         super().set_options(**options, **kwargs)
 

--- a/lintro/tools/definitions/mypy.py
+++ b/lintro/tools/definitions/mypy.py
@@ -152,9 +152,6 @@ class MypyPlugin(BaseToolPlugin):
             config_file: Path to mypy config file.
             cache_dir: Path to mypy cache directory.
             **kwargs: Other tool options.
-
-        Raises:
-            ValueError: If any provided option is of an unexpected type.
         """
         options: dict[str, object] = {
             "strict": strict,

--- a/lintro/tools/definitions/tsc.py
+++ b/lintro/tools/definitions/tsc.py
@@ -144,9 +144,6 @@ class TscPlugin(BaseToolPlugin):
                 instead of lintro's file targeting. Default is False, meaning lintro
                 respects your file selection even when tsconfig.json exists.
             **kwargs: Other tool options.
-
-        Raises:
-            ValueError: If any provided option is of an unexpected type.
         """
         options: dict[str, object] = {
             "project": project,

--- a/lintro/tools/definitions/tsc.py
+++ b/lintro/tools/definitions/tsc.py
@@ -44,6 +44,10 @@ from lintro.parsers.tsc.tsc_parser import (
 from lintro.plugins.base import BaseToolPlugin, ExecutionContext
 from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.registry import register_tool
+from lintro.tools.core.option_validators import (
+    OptionSchema,
+    validate_option_types,
+)
 from lintro.tools.core.timeout_utils import create_timeout_result
 from lintro.utils.tsconfig import (
     create_temp_tsconfig,
@@ -74,6 +78,14 @@ FRAMEWORK_CONFIGS: dict[str, tuple[str, list[str]]] = {
         "svelte-check",
         ["svelte.config.js", "svelte.config.ts"],
     ),
+}
+
+# Expected types for tsc-specific options, validated in set_options().
+TSC_OPTION_TYPES: OptionSchema = {
+    "project": (str, "string path"),
+    "strict": bool,
+    "skip_lib_check": bool,
+    "use_project_files": bool,
 }
 
 
@@ -136,21 +148,13 @@ class TscPlugin(BaseToolPlugin):
         Raises:
             ValueError: If any provided option is of an unexpected type.
         """
-        if project is not None and not isinstance(project, str):
-            raise ValueError("project must be a string path")
-        if strict is not None and not isinstance(strict, bool):
-            raise ValueError("strict must be a boolean")
-        if skip_lib_check is not None and not isinstance(skip_lib_check, bool):
-            raise ValueError("skip_lib_check must be a boolean")
-        if use_project_files is not None and not isinstance(use_project_files, bool):
-            raise ValueError("use_project_files must be a boolean")
-
         options: dict[str, object] = {
             "project": project,
             "strict": strict,
             "skip_lib_check": skip_lib_check,
             "use_project_files": use_project_files,
         }
+        validate_option_types(options, TSC_OPTION_TYPES)
         options = {k: v for k, v in options.items() if v is not None}
         super().set_options(**options, **kwargs)
 

--- a/lintro/tools/definitions/vue_tsc.py
+++ b/lintro/tools/definitions/vue_tsc.py
@@ -119,9 +119,6 @@ class VueTscPlugin(BaseToolPlugin):
             use_project_files: When True, use tsconfig.json's include/files patterns
                 instead of lintro's file targeting. Default is False.
             **kwargs: Other tool options.
-
-        Raises:
-            ValueError: If any provided option is of an unexpected type.
         """
         options: dict[str, object] = {
             "project": project,

--- a/lintro/tools/definitions/vue_tsc.py
+++ b/lintro/tools/definitions/vue_tsc.py
@@ -38,6 +38,10 @@ from lintro.parsers.vue_tsc.vue_tsc_parser import (
 from lintro.plugins.base import BaseToolPlugin, ExecutionContext
 from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.registry import register_tool
+from lintro.tools.core.option_validators import (
+    OptionSchema,
+    validate_option_types,
+)
 from lintro.tools.core.timeout_utils import create_timeout_result
 from lintro.utils.tsconfig import (
     create_temp_tsconfig,
@@ -51,6 +55,14 @@ from lintro.utils.tsconfig import (
 VUE_TSC_DEFAULT_TIMEOUT: int = 120
 VUE_TSC_DEFAULT_PRIORITY: int = 83  # After tsc (82)
 VUE_TSC_FILE_PATTERNS: list[str] = ["*.vue"]
+
+# Expected types for vue-tsc-specific options, validated in set_options().
+VUE_TSC_OPTION_TYPES: OptionSchema = {
+    "project": (str, "string path"),
+    "strict": bool,
+    "skip_lib_check": bool,
+    "use_project_files": bool,
+}
 
 
 @register_tool
@@ -111,21 +123,13 @@ class VueTscPlugin(BaseToolPlugin):
         Raises:
             ValueError: If any provided option is of an unexpected type.
         """
-        if project is not None and not isinstance(project, str):
-            raise ValueError("project must be a string path")
-        if strict is not None and not isinstance(strict, bool):
-            raise ValueError("strict must be a boolean")
-        if skip_lib_check is not None and not isinstance(skip_lib_check, bool):
-            raise ValueError("skip_lib_check must be a boolean")
-        if use_project_files is not None and not isinstance(use_project_files, bool):
-            raise ValueError("use_project_files must be a boolean")
-
         options: dict[str, object] = {
             "project": project,
             "strict": strict,
             "skip_lib_check": skip_lib_check,
             "use_project_files": use_project_files,
         }
+        validate_option_types(options, VUE_TSC_OPTION_TYPES)
         options = {k: v for k, v in options.items() if v is not None}
         super().set_options(**options, **kwargs)
 

--- a/tests/unit/tools/core/test_option_validators.py
+++ b/tests/unit/tools/core/test_option_validators.py
@@ -8,11 +8,13 @@ import pytest
 from assertpy import assert_that
 
 from lintro.tools.core.option_validators import (
+    OptionSchema,
     filter_none_options,
     normalize_str_or_list,
     validate_bool,
     validate_int,
     validate_list,
+    validate_option_types,
     validate_positive_int,
     validate_str,
 )
@@ -346,3 +348,94 @@ def test_filter_none_options_preserves_falsy_values() -> None:
     """Preserve False, 0, empty string (not None)."""
     result = filter_none_options(a=False, b=0, c="", d=None)
     assert_that(result).is_equal_to({"a": False, "b": 0, "c": ""})
+
+
+# =============================================================================
+# validate_option_types tests
+# =============================================================================
+
+_SCHEMA: OptionSchema = {
+    "strict": bool,
+    "python_version": str,
+    "config_file": (str, "string path"),
+    "jobs": int,
+}
+
+
+def test_validate_option_types_accepts_valid_values() -> None:
+    """Accept values that match their declared types."""
+    validate_option_types(
+        {
+            "strict": True,
+            "python_version": "3.11",
+            "config_file": "mypy.ini",
+            "jobs": 4,
+        },
+        _SCHEMA,
+    )
+
+
+def test_validate_option_types_skips_none_values() -> None:
+    """Skip options whose value is None."""
+    validate_option_types(
+        {"strict": None, "python_version": None},
+        _SCHEMA,
+    )
+
+
+def test_validate_option_types_skips_absent_options() -> None:
+    """Accept an empty mapping without raising."""
+    validate_option_types({}, _SCHEMA)
+
+
+def test_validate_option_types_ignores_options_outside_schema() -> None:
+    """Pass through options not declared in the schema without raising."""
+    validate_option_types(
+        {"strict": True, "unknown_option": object()},
+        _SCHEMA,
+    )
+
+
+@pytest.mark.parametrize(
+    ("option", "value", "message"),
+    [
+        pytest.param("strict", "yes", "strict must be a boolean", id="bool"),
+        pytest.param(
+            "python_version",
+            310,
+            "python_version must be a string",
+            id="str",
+        ),
+        pytest.param(
+            "config_file",
+            123,
+            "config_file must be a string path",
+            id="str-custom-label",
+        ),
+        pytest.param("jobs", "four", "jobs must be an integer", id="int"),
+        pytest.param("jobs", True, "jobs must be an integer", id="int-rejects-bool"),
+    ],
+)
+def test_validate_option_types_rejects_wrong_type(
+    option: str,
+    value: Any,
+    message: str,
+) -> None:
+    """Raise ValueError naming the option when its type is wrong.
+
+    Args:
+        option: The option name being validated.
+        value: The invalid value supplied for the option.
+        message: The exact error message expected.
+    """
+    with pytest.raises(ValueError, match=message):
+        validate_option_types({option: value}, _SCHEMA)
+
+
+def test_validate_option_types_reports_first_mismatch() -> None:
+    """Raise for the offending option even when others are valid."""
+    with pytest.raises(ValueError, match="python_version must be a string"):
+        validate_option_types(
+            {"strict": True, "python_version": 3.11},
+            _SCHEMA,
+        )


### PR DESCRIPTION
## Summary

Replaces the repetitive per-option `if x is not None and not isinstance(x, T): raise ValueError(...)` blocks in tool `set_options()` methods with a shared, schema-driven validation helper.

## What changed

New helper `validate_option_types(options, schema)` in `lintro/tools/core/option_validators.py`:

- Takes an `OptionSchema` (`Mapping[str, type | tuple[type, str]]`) and validates each present (non-`None`) option against its declared type.
- Skips `None`/absent values and ignores options outside the schema (pass-through), preserving the historical per-option behavior.
- Emits messages with a grammatical article (`must be a boolean`, `must be an integer`) consistent with the existing `validate_*` helpers, and supports a per-option label override (e.g. `(str, "string path")`) to preserve exact wording asserted by tests.
- Rejects `bool` where an `int` is expected (since `bool` subclasses `int`).

## Tool definitions migrated

Only tools whose validation was a near-literal `isinstance`-then-`raise` match were migrated, each now declaring a module-level schema constant:

- `lintro/tools/definitions/mypy.py` — `MYPY_OPTION_TYPES` (strict, ignore_missing_imports, python_version, config_file, cache_dir)
- `lintro/tools/definitions/astro_check.py` — `ASTRO_CHECK_OPTION_TYPES` (root)
- `lintro/tools/definitions/vue_tsc.py` — `VUE_TSC_OPTION_TYPES` (project, strict, skip_lib_check, use_project_files)
- `lintro/tools/definitions/tsc.py` — `TSC_OPTION_TYPES` (project, strict, skip_lib_check, use_project_files)

Left intentionally untouched (more complex validation, per the issue's "don't force-fit" guidance): `svelte_check` (enum threshold check), `semgrep`/`bandit`/`shfmt`/`cargo_audit` (range/enum/number validation), and `lintro/plugins/base.py`'s `set_options()` (out of scope).

## Tests

Added `validate_option_types` tests in `tests/unit/tools/core/test_option_validators.py`: valid values pass, `None`/absent are skipped, out-of-schema options pass through, and wrong types raise `ValueError` naming the option (including the custom `string path` label and int-rejects-bool). Existing per-tool option-validation tests (including exact error-message assertions) remain green.

## Gates

- `uv run lintro fmt` — applied
- `uv run lintro chk` — clean (exit 0)
- `uv run pytest` — 5810 passed, 10 skipped

Closes #1064

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces repeated tool option type checks with a shared schema helper. The main changes are:

- Added `validate_option_types` in `lintro/tools/core/option_validators.py`.
- Added schema constants for Astro, mypy, tsc, and vue-tsc options.
- Updated those tools to validate options through the shared helper.
- Added unit tests for valid values, skipped `None` values, unknown options, and error messages.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/core/option_validators.py | Adds the shared schema-based option type validator and supporting type-label helpers. |
| lintro/tools/definitions/astro_check.py | Moves the Astro `root` option type check into a module-level schema. |
| lintro/tools/definitions/mypy.py | Moves mypy option type checks into a module-level schema. |
| lintro/tools/definitions/tsc.py | Moves tsc option type checks into a module-level schema. |
| lintro/tools/definitions/vue_tsc.py | Moves vue-tsc option type checks into a module-level schema. |
| tests/unit/tools/core/test_option_validators.py | Adds tests for the shared option type validator. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(tools): drop stale Raises sections ..."](https://github.com/lgtm-hq/py-lintro/commit/524858553d60a49c595b53acc36b84cf5858eb7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41925319)</sub>

<!-- /greptile_comment -->