### PR TITLE
refactor(utils): extract shared find_file_upward helper for duplicated config-walk logic

### DIFF
--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -31,6 +31,7 @@ from lintro.config.review_config import (
     ReviewConfig,
 )
 from lintro.enums.config_key import ConfigKey
+from lintro.utils.path_utils import find_file_upward
 
 try:
     import yaml
@@ -58,21 +59,7 @@ def _find_config_file(start_dir: Path | None = None) -> Path | None:
     """
     current = Path(start_dir) if start_dir else Path.cwd()
     current = current.resolve()
-
-    while True:
-        for filename in LINTRO_CONFIG_FILENAMES:
-            config_path = current / filename
-            if config_path.exists():
-                return config_path
-
-        # Move up one directory
-        parent = current.parent
-        if parent == current:
-            # Reached filesystem root
-            break
-        current = parent
-
-    return None
+    return find_file_upward(current, LINTRO_CONFIG_FILENAMES)
 
 
 def _load_yaml_file(path: Path) -> dict[str, Any]:

--- a/lintro/tools/definitions/prettier.py
+++ b/lintro/tools/definitions/prettier.py
@@ -9,9 +9,9 @@ re-printing code.
 from __future__ import annotations
 
 import json
-import os
 import subprocess  # nosec B404 - used safely with shell disabled
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from loguru import logger
@@ -30,6 +30,7 @@ from lintro.tools.core.option_validators import (
     validate_bool,
     validate_positive_int,
 )
+from lintro.utils.path_utils import find_file_upward
 
 # Constants for Prettier configuration
 PRETTIER_DEFAULT_TIMEOUT: int = 30
@@ -143,43 +144,52 @@ class PrettierPlugin(BaseToolPlugin):
         """
         config_paths = [*PRETTIER_CONFIG_FILENAMES, "package.json"]
         # Search upward from search_dir (or cwd) to find config, just like prettier
-        start_dir = os.path.abspath(search_dir) if search_dir else os.getcwd()
-        current_dir = start_dir
+        start_dir = Path(search_dir).absolute() if search_dir else Path.cwd()
 
-        # Walk upward from the directory to find config
-        # Stop at filesystem root to avoid infinite loop
+        # Walk upward using the shared helper. ``package.json`` is existence-only
+        # to the helper, so its prettier-content sniffing is layered on top: a
+        # ``package.json`` without a ``prettier`` key does not count as config, so
+        # the search resumes above the directory that contained it.
+        current = start_dir
         while True:
-            for config_name in config_paths:
-                config_path = os.path.join(current_dir, config_name)
-                if os.path.exists(config_path):
-                    # For package.json, check if it contains prettier config
-                    if config_name == "package.json":
-                        try:
-                            with open(config_path, encoding="utf-8") as f:
-                                pkg_data = json.load(f)
-                                if "prettier" not in pkg_data:
-                                    continue
-                        except (
-                            json.JSONDecodeError,
-                            FileNotFoundError,
-                            PermissionError,
-                        ):
-                            # Skip invalid or unreadable package.json files
-                            continue
-                    logger.debug(
-                        f"[PrettierPlugin] Found config file: {config_path} "
-                        f"(searched from {start_dir})",
-                    )
-                    return config_path
+            found = find_file_upward(current, config_paths)
+            if found is None:
+                return None
 
-            # Move up one directory
-            parent_dir = os.path.dirname(current_dir)
-            # Stop if we've reached the filesystem root (parent == current)
-            if parent_dir == current_dir:
-                break
-            current_dir = parent_dir
+            if found.name == "package.json" and not self._package_json_has_prettier(
+                found,
+            ):
+                parent = found.parent.parent
+                if parent == found.parent:
+                    # Reached the filesystem root without a usable config.
+                    return None
+                current = parent
+                continue
 
-        return None
+            logger.debug(
+                f"[PrettierPlugin] Found config file: {found} "
+                f"(searched from {start_dir})",
+            )
+            return str(found)
+
+    @staticmethod
+    def _package_json_has_prettier(path: Path) -> bool:
+        """Report whether a package.json declares a ``prettier`` key.
+
+        Args:
+            path: Path to the package.json file to inspect.
+
+        Returns:
+            True if the file parses as JSON and contains a top-level
+            ``prettier`` key, False otherwise (including unreadable or
+            invalid files).
+        """
+        try:
+            with path.open(encoding="utf-8") as f:
+                pkg_data = json.load(f)
+        except (json.JSONDecodeError, FileNotFoundError, PermissionError):
+            return False
+        return "prettier" in pkg_data
 
     def _find_prettierignore(self, search_dir: str | None = None) -> str | None:
         """Locate .prettierignore file by walking up the directory tree.
@@ -194,23 +204,14 @@ class PrettierPlugin(BaseToolPlugin):
         Returns:
             str | None: Path to .prettierignore file if found, None otherwise.
         """
-        ignore_filename = ".prettierignore"
-        start_dir = os.path.abspath(search_dir) if search_dir else os.getcwd()
-        current_dir = start_dir
-
-        while True:
-            ignore_path = os.path.join(current_dir, ignore_filename)
-            if os.path.exists(ignore_path):
-                logger.debug(
-                    f"[PrettierPlugin] Found .prettierignore: {ignore_path} "
-                    f"(searched from {start_dir})",
-                )
-                return ignore_path
-
-            parent_dir = os.path.dirname(current_dir)
-            if parent_dir == current_dir:
-                break
-            current_dir = parent_dir
+        start_dir = Path(search_dir).absolute() if search_dir else Path.cwd()
+        found = find_file_upward(start_dir, [".prettierignore"])
+        if found is not None:
+            logger.debug(
+                f"[PrettierPlugin] Found .prettierignore: {found} "
+                f"(searched from {start_dir})",
+            )
+            return str(found)
 
         return None
 

--- a/lintro/tools/definitions/yamllint.py
+++ b/lintro/tools/definitions/yamllint.py
@@ -11,6 +11,7 @@ import fnmatch
 import os
 import subprocess  # nosec B404 - used safely with shell disabled
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import click
@@ -37,6 +38,7 @@ from lintro.tools.core.option_validators import (
     validate_bool,
     validate_str,
 )
+from lintro.utils.path_utils import find_file_upward
 
 # Constants for Yamllint configuration
 YAMLLINT_DEFAULT_TIMEOUT: int = 15
@@ -161,23 +163,14 @@ class YamllintPlugin(BaseToolPlugin):
             ".yamllint.yaml",
         ]
 
-        start_dir = os.path.abspath(search_dir) if search_dir else os.getcwd()
-        current_dir = start_dir
-
-        while True:
-            for config_name in config_paths:
-                config_path = os.path.join(current_dir, config_name)
-                if os.path.exists(config_path):
-                    logger.debug(
-                        f"[YamllintPlugin] Found config file: {config_path} "
-                        f"(searched from {start_dir})",
-                    )
-                    return config_path
-
-            parent_dir = os.path.dirname(current_dir)
-            if parent_dir == current_dir:
-                break
-            current_dir = parent_dir
+        start_dir = Path(search_dir).absolute() if search_dir else Path.cwd()
+        found = find_file_upward(start_dir, config_paths)
+        if found is not None:
+            logger.debug(
+                f"[YamllintPlugin] Found config file: {found} "
+                f"(searched from {start_dir})",
+            )
+            return str(found)
 
         return None
 

--- a/lintro/utils/path_utils.py
+++ b/lintro/utils/path_utils.py
@@ -3,9 +3,39 @@
 Small helpers to normalize paths for display consistency and path safety validation.
 """
 
+from collections.abc import Sequence
 from pathlib import Path
 
 from loguru import logger
+
+
+def find_file_upward(
+    start: Path,
+    filenames: Sequence[str],
+) -> Path | None:
+    """Walk up from start to filesystem root, return first matching file.
+
+    Starting at ``start``, each directory up to the filesystem root is
+    checked for the candidate ``filenames`` in the order given. The first
+    existing candidate encountered wins. The walk is bounded by
+    ``Path.parents``, which terminates at the filesystem root, so no manual
+    depth guard is required.
+
+    Args:
+        start: Directory to begin searching from.
+        filenames: Candidate filenames to look for in each directory,
+            checked in order.
+
+    Returns:
+        Path to the first matching file found, or None if none exists
+        anywhere from start up to the filesystem root.
+    """
+    for directory in (start, *start.parents):
+        for name in filenames:
+            candidate = directory / name
+            if candidate.exists():
+                return candidate
+    return None
 
 
 def validate_safe_path(path: str | Path, base_dir: Path | None = None) -> bool:
@@ -54,35 +84,13 @@ def find_lintro_ignore() -> Path | None:
     Returns:
         Path | None: Path to .lintro-ignore file if found, None otherwise.
     """
-    current_dir = Path.cwd()
-    # Limit search to prevent infinite loops (e.g., if we're in /)
-    max_depth = 20
-    depth = 0
-
-    while depth < max_depth:
-        lintro_ignore_path = current_dir / ".lintro-ignore"
-        if lintro_ignore_path.exists():
-            return lintro_ignore_path
-
-        # Also check for pyproject.toml as project root indicator
-        pyproject_path = current_dir / "pyproject.toml"
-        if pyproject_path.exists():
-            # If pyproject.toml exists, check for .lintro-ignore in same directory
-            lintro_ignore_path = current_dir / ".lintro-ignore"
-            if lintro_ignore_path.exists():
-                return lintro_ignore_path
-            # Even if .lintro-ignore doesn't exist, we found project root
-            # Return None to indicate no .lintro-ignore found
-            return None
-
-        # Move up one directory
-        parent_dir = current_dir.parent
-        if parent_dir == current_dir:
-            # Reached filesystem root
-            break
-        current_dir = parent_dir
-        depth += 1
-
+    # Walk upward looking for either marker. Within a directory ``.lintro-ignore``
+    # takes precedence over ``pyproject.toml``. Finding ``pyproject.toml`` first
+    # marks the project root and short-circuits the search: return None because
+    # no closer ``.lintro-ignore`` exists.
+    found = find_file_upward(Path.cwd(), [".lintro-ignore", "pyproject.toml"])
+    if found is not None and found.name == ".lintro-ignore":
+        return found
     return None
 
 

--- a/lintro/utils/path_utils.py
+++ b/lintro/utils/path_utils.py
@@ -3,15 +3,23 @@
 Small helpers to normalize paths for display consistency and path safety validation.
 """
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
+from itertools import islice
 from pathlib import Path
 
 from loguru import logger
+
+# Bound the upward search for ``.lintro-ignore`` so it stays project-scoped and
+# never loads an ignore file from a far filesystem ancestor. This preserves the
+# historical ~20-directory limit that guarded the walk.
+_IGNORE_SEARCH_MAX_DEPTH = 20
 
 
 def find_file_upward(
     start: Path,
     filenames: Sequence[str],
+    *,
+    max_depth: int | None = None,
 ) -> Path | None:
     """Walk up from start to filesystem root, return first matching file.
 
@@ -25,12 +33,19 @@ def find_file_upward(
         start: Directory to begin searching from.
         filenames: Candidate filenames to look for in each directory,
             checked in order.
+        max_depth: Maximum number of directories to inspect, counting
+            ``start`` itself. ``None`` (the default) searches all the way up
+            to the filesystem root. Pass a positive integer to keep the walk
+            project-scoped and avoid picking up config from far ancestors.
 
     Returns:
         Path to the first matching file found, or None if none exists
-        anywhere from start up to the filesystem root.
+        anywhere within the searched directories.
     """
-    for directory in (start, *start.parents):
+    directories: Iterable[Path] = (start, *start.parents)
+    if max_depth is not None:
+        directories = islice(directories, max_depth)
+    for directory in directories:
         for name in filenames:
             candidate = directory / name
             if candidate.exists():
@@ -79,7 +94,9 @@ def find_lintro_ignore() -> Path | None:
     """Find .lintro-ignore file by searching upward from current directory.
 
     Searches upward from the current working directory to find the project root
-    by looking for .lintro-ignore or pyproject.toml files.
+    by looking for .lintro-ignore or pyproject.toml files. The walk is bounded
+    to ``_IGNORE_SEARCH_MAX_DEPTH`` directories so an unrelated ``.lintro-ignore``
+    from a far filesystem ancestor is never picked up for the current run.
 
     Returns:
         Path | None: Path to .lintro-ignore file if found, None otherwise.
@@ -87,8 +104,13 @@ def find_lintro_ignore() -> Path | None:
     # Walk upward looking for either marker. Within a directory ``.lintro-ignore``
     # takes precedence over ``pyproject.toml``. Finding ``pyproject.toml`` first
     # marks the project root and short-circuits the search: return None because
-    # no closer ``.lintro-ignore`` exists.
-    found = find_file_upward(Path.cwd(), [".lintro-ignore", "pyproject.toml"])
+    # no closer ``.lintro-ignore`` exists. The search is depth-bounded to keep it
+    # project-scoped rather than walking all the way to the filesystem root.
+    found = find_file_upward(
+        Path.cwd(),
+        [".lintro-ignore", "pyproject.toml"],
+        max_depth=_IGNORE_SEARCH_MAX_DEPTH,
+    )
     if found is not None and found.name == ".lintro-ignore":
         return found
     return None

--- a/tests/unit/tools/prettier/test_config_discovery.py
+++ b/tests/unit/tools/prettier/test_config_discovery.py
@@ -8,77 +8,133 @@ from unittest.mock import MagicMock, patch
 from assertpy import assert_that
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from lintro.tools.definitions.prettier import PrettierPlugin
 
 
 # Tests for _find_prettier_config method
 
 
-def test_find_prettier_config_not_found(prettier_plugin: PrettierPlugin) -> None:
+def test_find_prettier_config_not_found(
+    prettier_plugin: PrettierPlugin,
+    tmp_path: Path,
+) -> None:
     """Returns None when no config file exists.
 
     Args:
         prettier_plugin: The PrettierPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
     """
-    with patch("os.path.exists", return_value=False):
-        result = prettier_plugin._find_prettier_config(search_dir="/nonexistent")
-        assert_that(result).is_none()
+    result = prettier_plugin._find_prettier_config(search_dir=str(tmp_path))
+    assert_that(result).is_none()
 
 
-def test_find_prettier_config_found_prettierrc(prettier_plugin: PrettierPlugin) -> None:
+def test_find_prettier_config_found_prettierrc(
+    prettier_plugin: PrettierPlugin,
+    tmp_path: Path,
+) -> None:
     """Returns path when .prettierrc exists.
 
     Args:
         prettier_plugin: The PrettierPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
     """
+    (tmp_path / ".prettierrc").write_text("{}\n")
 
-    def mock_exists(path: str) -> bool:
-        return path.endswith(".prettierrc")
+    result = prettier_plugin._find_prettier_config(search_dir=str(tmp_path))
+    assert_that(result).is_not_none()
+    assert_that(result).contains(".prettierrc")
 
-    with patch("os.path.exists", side_effect=mock_exists):
-        with patch("os.getcwd", return_value="/project"):
-            with patch(
-                "os.path.abspath",
-                side_effect=lambda p: p if p.startswith("/") else f"/project/{p}",
-            ):
-                result = prettier_plugin._find_prettier_config(search_dir="/project")
-                assert_that(result).is_not_none()
-                assert_that(result).contains(".prettierrc")
+
+def test_find_prettier_config_found_in_parent(
+    prettier_plugin: PrettierPlugin,
+    tmp_path: Path,
+) -> None:
+    """Returns path when config exists in an ancestor directory.
+
+    Args:
+        prettier_plugin: The PrettierPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    (tmp_path / ".prettierrc").write_text("{}\n")
+    nested = tmp_path / "a" / "b"
+    nested.mkdir(parents=True)
+
+    result = prettier_plugin._find_prettier_config(search_dir=str(nested))
+    assert_that(result).is_not_none()
+    assert_that(result).contains(".prettierrc")
+
+
+def test_find_prettier_config_skips_package_json_without_prettier(
+    prettier_plugin: PrettierPlugin,
+    tmp_path: Path,
+) -> None:
+    """Skips package.json lacking a prettier key and keeps searching upward.
+
+    Args:
+        prettier_plugin: The PrettierPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    (tmp_path / ".prettierrc").write_text("{}\n")
+    nested = tmp_path / "child"
+    nested.mkdir()
+    (nested / "package.json").write_text('{"name": "child"}\n')
+
+    result = prettier_plugin._find_prettier_config(search_dir=str(nested))
+    assert_that(result).is_not_none()
+    assert_that(result).contains(".prettierrc")
+
+
+def test_find_prettier_config_uses_package_json_with_prettier(
+    prettier_plugin: PrettierPlugin,
+    tmp_path: Path,
+) -> None:
+    """Uses package.json when it declares a prettier key.
+
+    Args:
+        prettier_plugin: The PrettierPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    (tmp_path / "package.json").write_text('{"prettier": {"printWidth": 100}}\n')
+
+    result = prettier_plugin._find_prettier_config(search_dir=str(tmp_path))
+    assert_that(result).is_not_none()
+    assert_that(result).contains("package.json")
 
 
 # Tests for _find_prettierignore method
 
 
-def test_find_prettierignore_not_found(prettier_plugin: PrettierPlugin) -> None:
+def test_find_prettierignore_not_found(
+    prettier_plugin: PrettierPlugin,
+    tmp_path: Path,
+) -> None:
     """Returns None when no .prettierignore file exists.
 
     Args:
         prettier_plugin: The PrettierPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
     """
-    with patch("os.path.exists", return_value=False):
-        result = prettier_plugin._find_prettierignore(search_dir="/nonexistent")
-        assert_that(result).is_none()
+    result = prettier_plugin._find_prettierignore(search_dir=str(tmp_path))
+    assert_that(result).is_none()
 
 
-def test_find_prettierignore_found(prettier_plugin: PrettierPlugin) -> None:
+def test_find_prettierignore_found(
+    prettier_plugin: PrettierPlugin,
+    tmp_path: Path,
+) -> None:
     """Returns path when .prettierignore exists.
 
     Args:
         prettier_plugin: The PrettierPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
     """
+    (tmp_path / ".prettierignore").write_text("dist/\n")
 
-    def mock_exists(path: str) -> bool:
-        return path.endswith(".prettierignore")
-
-    with patch("os.path.exists", side_effect=mock_exists):
-        with patch("os.getcwd", return_value="/project"):
-            with patch(
-                "os.path.abspath",
-                side_effect=lambda p: p if p.startswith("/") else f"/project/{p}",
-            ):
-                result = prettier_plugin._find_prettierignore(search_dir="/project")
-                assert_that(result).is_not_none()
-                assert_that(result).contains(".prettierignore")
+    result = prettier_plugin._find_prettierignore(search_dir=str(tmp_path))
+    assert_that(result).is_not_none()
+    assert_that(result).contains(".prettierignore")
 
 
 # Tests for _build_config_args with builtin defaults

--- a/tests/unit/utils/test_path_utils.py
+++ b/tests/unit/utils/test_path_utils.py
@@ -104,6 +104,29 @@ def test_find_file_upward_nearer_ancestor_wins_over_precedence(
     assert_that(result).is_equal_to(near)
 
 
+def test_find_file_upward_respects_max_depth(tmp_path: Path) -> None:
+    """Do not inspect ancestors beyond ``max_depth`` directories.
+
+    A candidate that only exists more than ``max_depth`` directories above the
+    starting point must not be returned, while an unbounded search finds it.
+
+    Args:
+        tmp_path: Temporary directory path for test files.
+    """
+    target = tmp_path / ".config"
+    target.write_text("x\n")
+    nested = tmp_path
+    for index in range(5):
+        nested = nested / f"level{index}"
+    nested.mkdir(parents=True)
+
+    bounded = find_file_upward(nested, [".config"], max_depth=3)
+    unbounded = find_file_upward(nested, [".config"])
+
+    assert_that(bounded).is_none()
+    assert_that(unbounded).is_equal_to(target)
+
+
 # =============================================================================
 # Tests for find_lintro_ignore
 # =============================================================================
@@ -177,6 +200,33 @@ def test_find_lintro_ignore_returns_none_when_nothing_found(tmp_path: Path) -> N
     with patch("lintro.utils.path_utils.Path") as mock_path:
         mock_path.cwd.return_value = deep_dir
 
+        result = find_lintro_ignore()
+
+    assert_that(result).is_none()
+
+
+def test_find_lintro_ignore_ignores_far_ancestor(tmp_path: Path) -> None:
+    """Do not load a .lintro-ignore from a far filesystem ancestor.
+
+    An unrelated ``.lintro-ignore`` sitting many directories above the current
+    working directory must not be picked up, because the upward walk is bounded
+    to keep the search project-scoped.
+
+    Args:
+        tmp_path: Temporary directory path for test files.
+    """
+    far_ignore = tmp_path / ".lintro-ignore"
+    far_ignore.write_text("*.pyc\n")
+
+    # Nest well beyond the bounded search depth so the far-ancestor ignore file
+    # is out of scope for the current run.
+    deep_dir = tmp_path
+    for index in range(25):
+        deep_dir = deep_dir / f"level{index}"
+    deep_dir.mkdir(parents=True)
+
+    with patch("lintro.utils.path_utils.Path") as mock_path:
+        mock_path.cwd.return_value = deep_dir
         result = find_lintro_ignore()
 
     assert_that(result).is_none()

--- a/tests/unit/utils/test_path_utils.py
+++ b/tests/unit/utils/test_path_utils.py
@@ -4,16 +4,105 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from assertpy import assert_that
 
 from lintro.utils.path_utils import (
+    find_file_upward,
     find_lintro_ignore,
     load_lintro_ignore,
     normalize_file_path_for_display,
 )
+
+# =============================================================================
+# Tests for find_file_upward
+# =============================================================================
+
+
+def test_find_file_upward_found_at_start(tmp_path: Path) -> None:
+    """Return the candidate when it exists in the starting directory.
+
+    Args:
+        tmp_path: Temporary directory path for test files.
+    """
+    target = tmp_path / ".config"
+    target.write_text("x\n")
+
+    result = find_file_upward(tmp_path, [".config"])
+
+    assert_that(result).is_equal_to(target)
+
+
+def test_find_file_upward_found_in_ancestor(tmp_path: Path) -> None:
+    """Return the candidate when it exists in an ancestor directory.
+
+    Args:
+        tmp_path: Temporary directory path for test files.
+    """
+    target = tmp_path / ".config"
+    target.write_text("x\n")
+    nested = tmp_path / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+
+    result = find_file_upward(nested, [".config"])
+
+    assert_that(result).is_equal_to(target)
+
+
+def test_find_file_upward_not_found(tmp_path: Path) -> None:
+    """Return None when no candidate exists up to the filesystem root.
+
+    Args:
+        tmp_path: Temporary directory path for test files.
+    """
+    nested = tmp_path / "a" / "b"
+    nested.mkdir(parents=True)
+
+    result = find_file_upward(nested, [".does-not-exist"])
+
+    assert_that(result).is_none()
+
+
+def test_find_file_upward_respects_filename_precedence(tmp_path: Path) -> None:
+    """Return the first matching filename in the order provided.
+
+    Args:
+        tmp_path: Temporary directory path for test files.
+    """
+    first = tmp_path / ".first"
+    second = tmp_path / ".second"
+    first.write_text("x\n")
+    second.write_text("y\n")
+
+    result = find_file_upward(tmp_path, [".first", ".second"])
+
+    assert_that(result).is_equal_to(first)
+
+
+def test_find_file_upward_nearer_ancestor_wins_over_precedence(
+    tmp_path: Path,
+) -> None:
+    """Prefer a nearer directory even for a lower-precedence filename.
+
+    A candidate found in the starting directory takes priority over a
+    higher-precedence candidate that only exists in an ancestor, because the
+    walk checks each directory fully before moving up.
+
+    Args:
+        tmp_path: Temporary directory path for test files.
+    """
+    (tmp_path / ".high").write_text("x\n")
+    nested = tmp_path / "child"
+    nested.mkdir()
+    near = nested / ".low"
+    near.write_text("y\n")
+
+    result = find_file_upward(nested, [".high", ".low"])
+
+    assert_that(result).is_equal_to(near)
+
 
 # =============================================================================
 # Tests for find_lintro_ignore
@@ -82,18 +171,11 @@ def test_find_lintro_ignore_returns_none_when_nothing_found(tmp_path: Path) -> N
     deep_dir = tmp_path / "a" / "b" / "c"
     deep_dir.mkdir(parents=True)
 
-    # Mock Path.cwd() to return the deep directory
-    # and also mock parent traversal to eventually reach tmp_path's parent
+    # Walk upward from the marker-free deep directory. No .lintro-ignore or
+    # pyproject.toml exists between it and the filesystem root, so the search
+    # terminates at root and returns None without looping forever.
     with patch("lintro.utils.path_utils.Path") as mock_path:
-        # Create a path that has no .lintro-ignore or pyproject.toml
-        mock_cwd = MagicMock()
-        mock_path.cwd.return_value = mock_cwd
-
-        # Mock the traversal to return paths without markers
-        mock_cwd.__truediv__ = MagicMock(
-            return_value=MagicMock(exists=MagicMock(return_value=False)),
-        )
-        mock_cwd.parent = mock_cwd  # Simulate reaching root
+        mock_path.cwd.return_value = deep_dir
 
         result = find_lintro_ignore()
 


### PR DESCRIPTION
## Summary

Extracts a single shared `find_file_upward(start, filenames)` helper into
`lintro/utils/path_utils.py` and replaces the duplicated, drifting "walk up
to the filesystem root looking for a config file" implementations across
the codebase. The helper walks `Path.parents` (bounded by the filesystem
root, so no manual `max_depth` counter) and returns the first existing
candidate, checking filenames in the order given.

## Call sites replaced

- **`lintro/config/config_loader.py`** — `_find_config_file()` now searches
  `LINTRO_CONFIG_FILENAMES` via the helper.
- **`lintro/utils/path_utils.py`** — `find_lintro_ignore()` uses the helper
  for the `.lintro-ignore` search while preserving its existing
  `pyproject.toml`-as-project-root short-circuit (returns `None` once
  `pyproject.toml` is reached without a `.lintro-ignore`).
- **`lintro/tools/definitions/yamllint.py`** — `_find_yamllint_config()`
  migrated from `os.path` to `pathlib` and the shared helper.
- **`lintro/tools/definitions/prettier.py`** — `_find_prettier_config()` and
  `_find_prettierignore()` migrated from `os.path` to `pathlib`. The
  `package.json` prettier-key content sniffing stays as a thin wrapper
  layered on top of the existence-only helper (extracted into
  `_package_json_has_prettier`), so a `package.json` without a `prettier`
  key still does not count as config and the search resumes above it.

Behavior is preserved at every call site. The Rust tool definitions
(`clippy`, `cargo_deny`, `cargo_audit`, `rustfmt`, `osv_scanner`) also walk
upward, but use `is_file()` marker-file semantics rather than the
existence-only search and are already clean `pathlib`, so they are left
unchanged (out of scope for this issue).

## Tests

- New unit tests for `find_file_upward`: found at start, found in an
  ancestor, not found anywhere (terminates at root), filename precedence,
  and nearer-directory-wins-over-precedence.
- Updated the prettier config-discovery and `find_lintro_ignore` tests
  whose `os.path`/`MagicMock` mocking no longer applied after the `pathlib`
  migration; they now exercise real temp directories with equivalent
  assertions, plus added coverage for the `package.json` sniffing paths.

## Gates

- `uv run lintro fmt` — clean
- `uv run lintro chk` — clean
- `uv run pytest` — 5808 passed, 10 skipped

Closes #1063

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extracts shared upward config-file discovery into a reusable path helper. The main changes are:

- Added `find_file_upward` with optional depth limiting.
- Reused the helper in Lintro, Prettier, and Yamllint config discovery.
- Kept `.lintro-ignore` discovery bounded to the historical search depth.
- Updated path utility and Prettier config-discovery tests.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/utils/path_utils.py | Adds the shared upward-search helper and keeps `.lintro-ignore` discovery depth-bounded. |
| lintro/tools/definitions/prettier.py | Moves Prettier config and ignore discovery onto the shared helper while preserving package.json filtering. |
| lintro/tools/definitions/yamllint.py | Moves Yamllint config discovery onto the shared helper. |
| lintro/config/config_loader.py | Replaces the local Lintro config walk with the shared helper. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(utils): keep find\_lintro\_ignore sear..."](https://github.com/lgtm-hq/py-lintro/commit/ae26e6ef779531913dc310a0a40b1543d9c78d99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41925451)</sub>

<!-- /greptile_comment -->