### PR TITLE
chore(config): enforce module size limit via lint gate

### DIFF
--- a/lintro/utils/config.py
+++ b/lintro/utils/config.py
@@ -28,6 +28,7 @@ __all__ = [
     "load_lintro_tool_config",
     "get_tool_order_config",
     "load_post_checks_config",
+    "load_module_size_config",
     # Tool-specific loaders
     "load_ruff_config",
     "load_bandit_config",
@@ -171,6 +172,7 @@ def load_lintro_global_config() -> dict[str, Any]:
         "pydoclint",
         "tsc",
         "post_checks",
+        "module_size",
         "versions",
     }
 
@@ -220,6 +222,26 @@ def load_post_checks_config() -> dict[str, Any]:
     """
     cfg = _get_lintro_section()
     section = cfg.get("post_checks", {})
+    if isinstance(section, dict):
+        return section
+    return {}
+
+
+def load_module_size_config() -> dict[str, Any]:
+    """Load module-size gate configuration from pyproject.
+
+    Reads the ``[tool.lintro.module_size]`` table. See
+    ``lintro/utils/module_size.py`` for the ratchet-down plan.
+
+    Returns:
+        Dict with keys like:
+            - enabled: bool
+            - threshold: int
+            - baseline: list[str]
+            - exclude: list[str]
+    """
+    cfg = _get_lintro_section()
+    section = cfg.get("module_size", {})
     if isinstance(section, dict):
         return section
     return {}

--- a/lintro/utils/module_size.py
+++ b/lintro/utils/module_size.py
@@ -1,0 +1,181 @@
+"""Module-size gate for Lintro's own source tree.
+
+This module implements a lightweight, warn-level guard against the
+oversized-module pattern that has repeatedly recurred in Lintro's codebase
+(see issue #1052). Ruff does not ship a file-length rule, so this check is
+wired into the existing post-check pipeline (``lintro/utils/post_checks.py``)
+rather than a dedicated linter.
+
+Behaviour:
+    * Counts physical lines per Python module under the scanned paths.
+    * Emits a warning for any module whose line count exceeds the configured
+      threshold and is not present in the baseline allowlist.
+    * Never fails the build. The gate is warn-level only so it can land green
+      while the historical violators are burned down.
+
+Ratchet-down plan:
+    The threshold starts at ``DEFAULT_MODULE_SIZE_THRESHOLD`` (800 lines) with
+    the modules in ``DEFAULT_MODULE_SIZE_BASELINE`` grandfathered in. As those
+    modules are refactored below the threshold, remove them from the baseline
+    (in ``[tool.lintro.module_size]`` in ``pyproject.toml``). Once the baseline
+    is empty, lower the threshold in steps (e.g. 800 -> 700 -> 600), tightening
+    the gate over time. A possible future enhancement is to promote module-size
+    enforcement to a first-class Lintro tool with fail-level support; that is
+    intentionally out of scope here.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from lintro.utils.path_filtering import walk_files_with_excludes
+
+# Warn-level threshold in physical lines. Ratchet this down over time (see the
+# module docstring) once the baseline has been burned down.
+DEFAULT_MODULE_SIZE_THRESHOLD: int = 800
+
+# Paths that are never subject to the module-size gate. These are intentionally
+# large or generated: deliberate lint fixtures and vendored/virtual-env trees.
+DEFAULT_MODULE_SIZE_EXCLUDES: tuple[str, ...] = (
+    "test_samples/",
+    "node_modules/",
+    ".venv/",
+    "venv/",
+    "dist/",
+    "build/",
+    "__pycache__/",
+    ".lintro/",
+)
+
+# Historical violators grandfathered in at the time of implementation (issue
+# #1052). Remove entries here as the modules are refactored below the
+# threshold. Paths are matched against each discovered file's path suffix, so
+# repo-relative POSIX paths are used.
+DEFAULT_MODULE_SIZE_BASELINE: tuple[str, ...] = (
+    "lintro/ai/review/orchestrator.py",
+    "lintro/utils/tool_executor.py",
+    "lintro/ai/review/chunker/workflow_scripts.py",
+    "lintro/cli_utils/commands/doctor.py",
+    "lintro/tools/definitions/tsc.py",
+    "lintro/ai/review/checklist_builtin.py",
+)
+
+
+@dataclass(frozen=True)
+class OversizedModule:
+    """A Python module that exceeds the module-size threshold.
+
+    Attributes:
+        path: Path to the offending module as discovered on disk.
+        line_count: Number of physical lines in the module.
+    """
+
+    path: str
+    line_count: int
+
+
+def count_module_lines(
+    *,
+    file_path: str,
+) -> int:
+    """Count the physical lines in a file.
+
+    Args:
+        file_path: Path to the file to measure.
+
+    Returns:
+        int: Number of physical lines in the file. Returns 0 when the file
+        cannot be read.
+    """
+    try:
+        with open(file_path, encoding="utf-8", errors="replace") as handle:
+            return sum(1 for _ in handle)
+    except OSError:
+        return 0
+
+
+def _normalize(path: str) -> str:
+    """Normalize a path to a POSIX-style string for suffix matching.
+
+    Args:
+        path: Path to normalize.
+
+    Returns:
+        str: The path with backslashes converted to forward slashes.
+    """
+    return path.replace("\\", "/")
+
+
+def _is_baselined(
+    *,
+    file_path: str,
+    baseline: frozenset[str],
+) -> bool:
+    """Return whether a discovered file is in the baseline allowlist.
+
+    A file matches when its normalized path equals a baseline entry or ends
+    with ``/<entry>``. This lets baseline entries be repo-relative POSIX paths
+    regardless of whether the scanner yields absolute or relative paths.
+
+    Args:
+        file_path: Discovered file path.
+        baseline: Set of normalized baseline entries.
+
+    Returns:
+        bool: True when the file is baselined and should be skipped.
+    """
+    normalized = _normalize(file_path)
+    for entry in baseline:
+        if normalized == entry or normalized.endswith(f"/{entry}"):
+            return True
+    return False
+
+
+def find_oversized_modules(
+    *,
+    paths: list[str],
+    threshold: int = DEFAULT_MODULE_SIZE_THRESHOLD,
+    baseline: tuple[str, ...] = DEFAULT_MODULE_SIZE_BASELINE,
+    exclude_patterns: tuple[str, ...] = DEFAULT_MODULE_SIZE_EXCLUDES,
+    include_venv: bool = False,
+) -> list[OversizedModule]:
+    """Find Python modules that exceed the module-size threshold.
+
+    Baselined modules are skipped even when they exceed the threshold, so the
+    gate can land green while historical violators are burned down.
+
+    Args:
+        paths: Files or directories to scan for Python modules.
+        threshold: Maximum allowed physical line count. Modules with strictly
+            more lines than this are reported.
+        baseline: Grandfathered module paths to skip. Matched by path suffix.
+        exclude_patterns: Gitignore-style patterns of paths to skip entirely.
+        include_venv: Whether to descend into virtual-environment directories.
+
+    Returns:
+        list[OversizedModule]: Offending modules sorted by descending line
+        count, then path. Empty when nothing exceeds the threshold.
+    """
+    baseline_set = frozenset(_normalize(entry) for entry in baseline)
+
+    files = walk_files_with_excludes(
+        paths=paths,
+        file_patterns=["*.py"],
+        exclude_patterns=list(exclude_patterns),
+        include_venv=include_venv,
+    )
+
+    violations: list[OversizedModule] = []
+    for file_path in files:
+        if _is_baselined(file_path=file_path, baseline=baseline_set):
+            continue
+        line_count = count_module_lines(file_path=file_path)
+        if line_count > threshold:
+            display_path = _normalize(os.path.relpath(file_path))
+            violations.append(
+                OversizedModule(path=display_path, line_count=line_count),
+            )
+
+    violations.sort(key=lambda module: (-module.line_count, module.path))
+    return violations

--- a/lintro/utils/module_size.py
+++ b/lintro/utils/module_size.py
@@ -27,6 +27,7 @@ Ratchet-down plan:
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 from lintro.utils.path_filtering import walk_files_with_excludes
@@ -60,6 +61,85 @@ DEFAULT_MODULE_SIZE_BASELINE: tuple[str, ...] = (
     "lintro/tools/definitions/tsc.py",
     "lintro/ai/review/checklist_builtin.py",
 )
+
+
+def _coerce_threshold(
+    *,
+    value: object,
+) -> int:
+    """Coerce a raw ``threshold`` config value into a positive integer.
+
+    Booleans are rejected (``True``/``False`` are not meaningful line counts)
+    and non-numeric values fall back to the default rather than raising.
+
+    Args:
+        value: Raw ``threshold`` value from configuration.
+
+    Returns:
+        int: The parsed threshold, or ``DEFAULT_MODULE_SIZE_THRESHOLD`` when the
+        value is missing, non-numeric, or not strictly positive.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        return DEFAULT_MODULE_SIZE_THRESHOLD
+    try:
+        threshold = int(value)
+    except (TypeError, ValueError):
+        return DEFAULT_MODULE_SIZE_THRESHOLD
+    return threshold if threshold > 0 else DEFAULT_MODULE_SIZE_THRESHOLD
+
+
+def _coerce_str_tuple(
+    *,
+    value: object,
+    default: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Coerce a raw config value into a tuple of strings.
+
+    Scalar strings are intentionally rejected (rather than iterated into
+    individual characters) so a mistyped ``baseline``/``exclude`` value falls
+    back to the provided default instead of silently misbehaving.
+
+    Args:
+        value: Raw config value, expected to be a list or tuple of strings.
+        default: Fallback tuple used when ``value`` is not a valid sequence.
+
+    Returns:
+        tuple[str, ...]: The coerced string tuple, or ``default`` when the
+        value is missing or not a list/tuple.
+    """
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item) for item in value)
+    return default
+
+
+def resolve_module_size_settings(
+    *,
+    config: Mapping[str, object],
+) -> tuple[int, tuple[str, ...], tuple[str, ...]]:
+    """Resolve raw module-size config into validated settings.
+
+    Coerces the optional ``[tool.lintro.module_size]`` values into concrete
+    types, falling back to the module defaults for any missing or malformed
+    entry. This keeps a mistyped config (e.g. a non-numeric ``threshold`` or a
+    scalar ``baseline``/``exclude``) from crashing the warn-level gate.
+
+    Args:
+        config: Raw module-size configuration mapping.
+
+    Returns:
+        tuple[int, tuple[str, ...], tuple[str, ...]]: The resolved
+        ``(threshold, baseline, exclude_patterns)``.
+    """
+    threshold = _coerce_threshold(value=config.get("threshold"))
+    baseline = _coerce_str_tuple(
+        value=config.get("baseline"),
+        default=DEFAULT_MODULE_SIZE_BASELINE,
+    )
+    exclude_patterns = _coerce_str_tuple(
+        value=config.get("exclude"),
+        default=DEFAULT_MODULE_SIZE_EXCLUDES,
+    )
+    return threshold, baseline, exclude_patterns
 
 
 @dataclass(frozen=True)

--- a/lintro/utils/post_checks.py
+++ b/lintro/utils/post_checks.py
@@ -14,10 +14,8 @@ from lintro.plugins.registry import ToolRegistry
 from lintro.tools import tool_manager
 from lintro.utils.config import load_module_size_config, load_post_checks_config
 from lintro.utils.module_size import (
-    DEFAULT_MODULE_SIZE_BASELINE,
-    DEFAULT_MODULE_SIZE_EXCLUDES,
-    DEFAULT_MODULE_SIZE_THRESHOLD,
     find_oversized_modules,
+    resolve_module_size_settings,
 )
 from lintro.utils.output import format_tool_output
 from lintro.utils.unified_config import UnifiedConfigManager
@@ -52,11 +50,8 @@ def _run_module_size_gate(
     if not bool(cfg.get("enabled", True)):
         return
 
-    threshold = int(cfg.get("threshold", DEFAULT_MODULE_SIZE_THRESHOLD))
-    baseline = tuple(cfg.get("baseline", DEFAULT_MODULE_SIZE_BASELINE))
-    exclude_patterns: list[str] = list(
-        cfg.get("exclude", DEFAULT_MODULE_SIZE_EXCLUDES),
-    )
+    threshold, baseline, base_excludes = resolve_module_size_settings(config=cfg)
+    exclude_patterns: list[str] = list(base_excludes)
     if exclude:
         exclude_patterns.extend(p.strip() for p in exclude.split(",") if p.strip())
 

--- a/lintro/utils/post_checks.py
+++ b/lintro/utils/post_checks.py
@@ -12,13 +12,78 @@ from lintro.enums.group_by import normalize_group_by
 from lintro.enums.output_format import OutputFormat, normalize_output_format
 from lintro.plugins.registry import ToolRegistry
 from lintro.tools import tool_manager
-from lintro.utils.config import load_post_checks_config
+from lintro.utils.config import load_module_size_config, load_post_checks_config
+from lintro.utils.module_size import (
+    DEFAULT_MODULE_SIZE_BASELINE,
+    DEFAULT_MODULE_SIZE_EXCLUDES,
+    DEFAULT_MODULE_SIZE_THRESHOLD,
+    find_oversized_modules,
+)
 from lintro.utils.output import format_tool_output
 from lintro.utils.unified_config import UnifiedConfigManager
 
 if TYPE_CHECKING:
     from lintro.models.core.tool_result import ToolResult
     from lintro.utils.console import ThreadSafeConsoleLogger
+
+
+def _run_module_size_gate(
+    *,
+    paths: list[str],
+    exclude: str | None,
+    include_venv: bool,
+    json_output_mode: bool,
+    logger: ThreadSafeConsoleLogger,
+) -> None:
+    """Run the warn-level module-size gate over the scanned paths.
+
+    This gate never fails the build. It emits a warning for any Python module
+    that exceeds the configured threshold and is not baselined. See
+    ``lintro/utils/module_size.py`` for the ratchet-down plan.
+
+    Args:
+        paths: Paths being linted.
+        exclude: Additional comma-separated exclude patterns from the CLI.
+        include_venv: Whether virtual-environment directories are included.
+        json_output_mode: Whether output is JSON (suppresses console warnings).
+        logger: Logger instance for console output.
+    """
+    cfg = load_module_size_config()
+    if not bool(cfg.get("enabled", True)):
+        return
+
+    threshold = int(cfg.get("threshold", DEFAULT_MODULE_SIZE_THRESHOLD))
+    baseline = tuple(cfg.get("baseline", DEFAULT_MODULE_SIZE_BASELINE))
+    exclude_patterns: list[str] = list(
+        cfg.get("exclude", DEFAULT_MODULE_SIZE_EXCLUDES),
+    )
+    if exclude:
+        exclude_patterns.extend(p.strip() for p in exclude.split(",") if p.strip())
+
+    violations = find_oversized_modules(
+        paths=paths,
+        threshold=threshold,
+        baseline=baseline,
+        exclude_patterns=tuple(exclude_patterns),
+        include_venv=include_venv,
+    )
+
+    if not violations or json_output_mode:
+        return
+
+    logger.console_output(
+        text=(
+            f"Warning: {len(violations)} module(s) exceed the "
+            f"{threshold}-line size limit (warn-level, non-blocking):"
+        ),
+        color="yellow",
+    )
+    for module in violations:
+        logger.console_output(
+            text=f"  {module.path} ({module.line_count} lines)",
+            color="yellow",
+        )
+    logger.console_output(text="")
 
 
 def execute_post_checks(
@@ -208,5 +273,15 @@ def execute_post_checks(
                             issues_count=1,
                         ),
                     )
+
+    # Warn-level module-size gate (issue #1052). Runs independently of the
+    # configured post-check tools and never contributes to failure counts.
+    _run_module_size_gate(
+        paths=paths,
+        exclude=exclude,
+        include_venv=include_venv,
+        json_output_mode=json_output_mode,
+        logger=logger,
+    )
 
     return total_issues, total_fixed, total_remaining

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,34 @@ enabled = true
 tools = ["black"]
 enforce_failure = true
 
+# Warn-level module-size gate (issue #1052). Guards against the recurring
+# oversized-module pattern. Non-blocking today: existing violators are
+# baselined so the gate is green on merge. Ratchet plan: refactor the baselined
+# modules below the threshold, remove them from `baseline`, then lower
+# `threshold` in steps (800 -> 700 -> 600). See lintro/utils/module_size.py.
+[tool.lintro.module_size]
+enabled = true
+threshold = 800
+baseline = [
+  "lintro/ai/review/orchestrator.py",
+  "lintro/utils/tool_executor.py",
+  "lintro/ai/review/chunker/workflow_scripts.py",
+  "lintro/cli_utils/commands/doctor.py",
+  "lintro/tools/definitions/tsc.py",
+  "lintro/ai/review/checklist_builtin.py",
+]
+exclude = [
+  "test_samples/",
+  "node_modules/",
+  ".venv/",
+  "venv/",
+  "dist/",
+  "build/",
+  "__pycache__/",
+  ".lintro/",
+  "tests/",
+]
+
 [tool.lintro.ruff]
 
 [tool.mypy]

--- a/tests/unit/utils/test_module_size.py
+++ b/tests/unit/utils/test_module_size.py
@@ -7,10 +7,13 @@ from pathlib import Path
 from assertpy import assert_that
 
 from lintro.utils.module_size import (
+    DEFAULT_MODULE_SIZE_BASELINE,
+    DEFAULT_MODULE_SIZE_EXCLUDES,
     DEFAULT_MODULE_SIZE_THRESHOLD,
     OversizedModule,
     count_module_lines,
     find_oversized_modules,
+    resolve_module_size_settings,
 )
 
 
@@ -171,3 +174,48 @@ def test_excluded_paths_are_skipped(
 def test_default_threshold_is_eight_hundred() -> None:
     """The default warn-level threshold is 800 lines."""
     assert_that(DEFAULT_MODULE_SIZE_THRESHOLD).is_equal_to(800)
+
+
+def test_resolve_settings_returns_defaults_for_empty_config() -> None:
+    """An empty config resolves to the module defaults."""
+    threshold, baseline, exclude = resolve_module_size_settings(config={})
+
+    assert_that(threshold).is_equal_to(DEFAULT_MODULE_SIZE_THRESHOLD)
+    assert_that(baseline).is_equal_to(DEFAULT_MODULE_SIZE_BASELINE)
+    assert_that(exclude).is_equal_to(DEFAULT_MODULE_SIZE_EXCLUDES)
+
+
+def test_resolve_settings_parses_valid_overrides() -> None:
+    """Valid overrides are coerced into concrete types."""
+    threshold, baseline, exclude = resolve_module_size_settings(
+        config={
+            "threshold": "600",
+            "baseline": ["pkg/legacy.py"],
+            "exclude": ["custom/"],
+        },
+    )
+
+    assert_that(threshold).is_equal_to(600)
+    assert_that(baseline).is_equal_to(("pkg/legacy.py",))
+    assert_that(exclude).is_equal_to(("custom/",))
+
+
+def test_resolve_settings_falls_back_on_invalid_threshold() -> None:
+    """A non-numeric or non-positive threshold falls back to the default."""
+    for bad_value in ("not-a-number", -5, 0, True, None):
+        threshold, _, _ = resolve_module_size_settings(
+            config={"threshold": bad_value},
+        )
+
+        assert_that(threshold).is_equal_to(DEFAULT_MODULE_SIZE_THRESHOLD)
+
+
+def test_resolve_settings_rejects_scalar_sequences() -> None:
+    """A scalar string baseline/exclude falls back instead of char-splitting."""
+    threshold, baseline, exclude = resolve_module_size_settings(
+        config={"baseline": "pkg/legacy.py", "exclude": "custom/"},
+    )
+
+    assert_that(threshold).is_equal_to(DEFAULT_MODULE_SIZE_THRESHOLD)
+    assert_that(baseline).is_equal_to(DEFAULT_MODULE_SIZE_BASELINE)
+    assert_that(exclude).is_equal_to(DEFAULT_MODULE_SIZE_EXCLUDES)

--- a/tests/unit/utils/test_module_size.py
+++ b/tests/unit/utils/test_module_size.py
@@ -1,0 +1,173 @@
+"""Unit tests for the warn-level module-size gate (issue #1052)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from assertpy import assert_that
+
+from lintro.utils.module_size import (
+    DEFAULT_MODULE_SIZE_THRESHOLD,
+    OversizedModule,
+    count_module_lines,
+    find_oversized_modules,
+)
+
+
+def _write_module(
+    *,
+    directory: Path,
+    name: str,
+    line_count: int,
+) -> Path:
+    """Create a Python module with a given number of lines.
+
+    Args:
+        directory: Directory in which to create the module.
+        name: File name for the module.
+        line_count: Number of lines to write.
+
+    Returns:
+        Path: Path to the created module.
+    """
+    path = directory / name
+    path.write_text(
+        "\n".join(f"x = {index}" for index in range(line_count)) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_count_module_lines_counts_physical_lines(
+    *,
+    tmp_path: Path,
+) -> None:
+    """A module's physical line count is measured accurately.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    module = _write_module(directory=tmp_path, name="counted.py", line_count=42)
+
+    assert_that(count_module_lines(file_path=str(module))).is_equal_to(42)
+
+
+def test_small_module_produces_no_warning(
+    *,
+    tmp_path: Path,
+) -> None:
+    """A module under the threshold yields no violations.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    _write_module(directory=tmp_path, name="small.py", line_count=100)
+
+    violations = find_oversized_modules(
+        paths=[str(tmp_path)],
+        threshold=800,
+        baseline=(),
+    )
+
+    assert_that(violations).is_empty()
+
+
+def test_oversized_module_is_flagged(
+    *,
+    tmp_path: Path,
+) -> None:
+    """A module over the threshold and not baselined is flagged.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    _write_module(directory=tmp_path, name="huge.py", line_count=900)
+
+    violations = find_oversized_modules(
+        paths=[str(tmp_path)],
+        threshold=800,
+        baseline=(),
+    )
+
+    flagged = [module.path for module in violations]
+    assert_that(flagged).is_length(1)
+    assert_that(flagged[0]).contains("huge.py")
+    assert_that(violations[0]).is_instance_of(OversizedModule)
+    assert_that(violations[0].line_count).is_equal_to(900)
+
+
+def test_baselined_module_is_skipped(
+    *,
+    tmp_path: Path,
+) -> None:
+    """A baselined module over the threshold is not flagged.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    package = tmp_path / "pkg"
+    package.mkdir()
+    _write_module(directory=package, name="legacy.py", line_count=900)
+
+    violations = find_oversized_modules(
+        paths=[str(tmp_path)],
+        threshold=800,
+        baseline=("pkg/legacy.py",),
+    )
+
+    assert_that(violations).is_empty()
+
+
+def test_threshold_is_configurable(
+    *,
+    tmp_path: Path,
+) -> None:
+    """Lowering the threshold flags a previously-passing module.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    _write_module(directory=tmp_path, name="medium.py", line_count=500)
+
+    passing = find_oversized_modules(
+        paths=[str(tmp_path)],
+        threshold=800,
+        baseline=(),
+    )
+    flagged = find_oversized_modules(
+        paths=[str(tmp_path)],
+        threshold=400,
+        baseline=(),
+    )
+
+    assert_that(passing).is_empty()
+    assert_that(flagged).is_not_empty()
+    assert_that(flagged[0].path).contains("medium.py")
+
+
+def test_excluded_paths_are_skipped(
+    *,
+    tmp_path: Path,
+) -> None:
+    """Modules under excluded paths are not scanned.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    samples = tmp_path / "test_samples"
+    samples.mkdir()
+    _write_module(directory=samples, name="fixture.py", line_count=900)
+
+    violations = find_oversized_modules(
+        paths=[str(tmp_path)],
+        threshold=800,
+        baseline=(),
+        exclude_patterns=("test_samples/",),
+    )
+
+    assert_that(violations).is_empty()
+
+
+def test_default_threshold_is_eight_hundred() -> None:
+    """The default warn-level threshold is 800 lines."""
+    assert_that(DEFAULT_MODULE_SIZE_THRESHOLD).is_equal_to(800)


### PR DESCRIPTION
## Summary

Enforces a warn-level module-size gate so Lintro's recurring oversized-module
pattern (issue #1052, spawning #1024/#1027/#1031/#1033) cannot silently recur.
Ruff has no file-length rule, so this is implemented as option (a): a
self-contained check wired into the existing post-check pipeline
(`lintro/utils/post_checks.py`), with the logic housed in a dedicated module
(`lintro/utils/module_size.py`).

## How it works

- After primary linting, `execute_post_checks` runs the module-size gate over
  the scanned paths.
- Any Python module exceeding the threshold (default **800 lines**) that is not
  baselined emits a yellow warning.
- **Warn-level only** — it never contributes to failure counts or the exit
  code, so it can land green while the historical violators are burned down.
- Fully configurable via `[tool.lintro.module_size]` in `pyproject.toml`
  (`enabled`, `threshold`, `baseline`, `exclude`).

## Baseline (green on merge)

Current violators are grandfathered in so `lintro chk` stays clean today:

| Module | Lines |
| --- | --- |
| `lintro/ai/review/orchestrator.py` | 1334 |
| `lintro/utils/tool_executor.py` | 988 |
| `lintro/ai/review/chunker/workflow_scripts.py` | 923 |
| `lintro/cli_utils/commands/doctor.py` | 879 |
| `lintro/tools/definitions/tsc.py` | 873 |
| `lintro/ai/review/checklist_builtin.py` | 809 |

`test_samples/` and `tests/` are excluded (deliberate fixtures / test scaffolding).

## Ratchet-down plan

Documented in `lintro/utils/module_size.py` and the `pyproject.toml` comment:
refactor each baselined module below the threshold, remove it from `baseline`,
then lower `threshold` in steps (800 -> 700 -> 600). Once the baseline is empty
and the threshold has tightened, promoting module-size enforcement to a
first-class fail-level Lintro tool is a possible future enhancement (out of
scope here).

## Tests

`tests/unit/utils/test_module_size.py` (pytest-style, assertpy, keyword-only
helpers): under-threshold passes; over-threshold is flagged; baselined module is
skipped; excluded paths are skipped; threshold is configurable; line counting is
accurate.

## Gates

- `uv run lintro fmt` — clean
- `uv run lintro chk` — 0 issues (gate green with baseline)
- `uv run pytest` — 5807 passed, 10 skipped

Closes #1052

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a warn-level module-size gate to the existing lint post-check flow. The main changes are:

- New module-size scanner with threshold, baseline, and exclude handling.
- New `[tool.lintro.module_size]` config loader and default project settings.
- Post-check integration that prints warnings without changing lint results.
- Unit tests for line counting, baselines, excludes, thresholds, and malformed config fallback.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/utils/module_size.py | Adds module-size scanning and defensive config coercion for threshold, baseline, and exclude settings. |
| lintro/utils/post_checks.py | Runs the module-size gate after post-check tools without changing failure counts. |
| lintro/utils/config.py | Adds loading for the module-size config table. |
| pyproject.toml | Defines the default module-size gate settings, baseline, and excludes. |
| tests/unit/utils/test_module_size.py | Covers module-size counting, filtering, config overrides, and malformed config fallback. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(config): harden module-size gate aga..."](https://github.com/lgtm-hq/py-lintro/commit/dc3cf0211bc90eca9f26e2fd45915f6ed28307a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41925454)</sub>

<!-- /greptile_comment -->