### PR TITLE
refactor(output): SARIF output should emit standard lint results, not only AI metadata

### DIFF
--- a/lintro/ai/output/sarif.py
+++ b/lintro/ai/output/sarif.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from lintro.ai.enums import ConfidenceLevel, RiskLevel
 from lintro.ai.models import AIFixSuggestion, AISummary
+from lintro.enums.severity_level import SeverityLevel
 
 SARIF_SCHEMA = (
     "https://raw.githubusercontent.com/oasis-tcs/sarif-spec"
@@ -28,6 +30,53 @@ _CONFIDENCE_SCORE = {
     ConfidenceLevel.MEDIUM: 0.6,
     ConfidenceLevel.LOW: 0.3,
 }
+
+_SEVERITY_TO_SARIF_LEVEL = {
+    SeverityLevel.ERROR: "error",
+    SeverityLevel.WARNING: "warning",
+    SeverityLevel.INFO: "note",
+}
+
+
+@dataclass
+class StandardIssue:
+    """Normalized lint issue for SARIF standard-mode emission.
+
+    Represents a single lint finding independent of any AI enrichment,
+    carrying the minimal fields required to build a SARIF result and its
+    rule descriptor.
+
+    Attributes:
+        tool_name: Name of the tool that produced the issue.
+        file: File path where the issue was found.
+        line: Line number (1-based, 0 means unknown).
+        column: Column number (1-based, 0 means unknown).
+        code: Rule code/identifier for the issue.
+        message: Human-readable description of the issue.
+        severity: Normalized severity level for the issue.
+        doc_url: Documentation URL for the rule (empty when unavailable).
+    """
+
+    tool_name: str = field(default="")
+    file: str = field(default="")
+    line: int = field(default=0)
+    column: int = field(default=0)
+    code: str = field(default="")
+    message: str = field(default="")
+    severity: SeverityLevel = field(default=SeverityLevel.WARNING)
+    doc_url: str = field(default="")
+
+
+def _severity_to_sarif_level(severity: SeverityLevel) -> str:
+    """Map a normalized severity level to a SARIF result level.
+
+    Args:
+        severity: Normalized severity enum value.
+
+    Returns:
+        One of ``"error"``, ``"warning"``, or ``"note"``.
+    """
+    return _SEVERITY_TO_SARIF_LEVEL.get(severity, "warning")
 
 
 def _risk_to_sarif_level(risk_level: RiskLevel | str) -> str:
@@ -69,6 +118,74 @@ def _confidence_to_score(confidence: ConfidenceLevel | str) -> float:
         return 0.5
 
 
+def _add_standard_issues(
+    standard_issues: Sequence[StandardIssue],
+    *,
+    rules_map: dict[str, dict[str, Any]],
+    results: list[dict[str, Any]],
+    doc_urls: dict[str, str] | None,
+) -> None:
+    """Append standard lint issues as SARIF rules and results in place.
+
+    Emits one SARIF result per issue with its physical location, rule
+    descriptor, severity level, and ``helpUri`` (from the issue's own
+    ``doc_url`` or the ``doc_urls`` map). Runs independently of AI
+    enrichment so SARIF output is populated without AI features.
+
+    Args:
+        standard_issues: Normalized lint issues to emit.
+        rules_map: Shared rule descriptor map, updated in place.
+        results: Shared results list, appended to in place.
+        doc_urls: Optional mapping of rule codes to documentation URLs.
+    """
+    for issue in standard_issues:
+        if issue.tool_name and issue.code:
+            rule_id = f"{issue.tool_name}/{issue.code}"
+        else:
+            rule_id = issue.tool_name or issue.code or "unknown"
+
+        if rule_id not in rules_map:
+            rule: dict[str, Any] = {"id": rule_id}
+            rule["shortDescription"] = {"text": issue.code or "lint finding"}
+            help_uri = issue.doc_url
+            if not help_uri and doc_urls:
+                help_uri = doc_urls.get(issue.code, "") or doc_urls.get(rule_id, "")
+            if help_uri:
+                rule["helpUri"] = help_uri
+            if issue.tool_name:
+                rule["properties"] = {"tool": issue.tool_name}
+            rules_map[rule_id] = rule
+
+        result: dict[str, Any] = {
+            "ruleId": rule_id,
+            "level": _severity_to_sarif_level(issue.severity),
+            "message": {"text": issue.message or issue.code or "lint finding"},
+        }
+
+        if issue.file:
+            location: dict[str, Any] = {
+                "physicalLocation": {
+                    "artifactLocation": {"uri": issue.file},
+                },
+            }
+            if issue.line > 0:
+                region: dict[str, int] = {"startLine": issue.line}
+                if issue.column > 0:
+                    region["startColumn"] = issue.column
+                location["physicalLocation"]["region"] = region
+            result["locations"] = [location]
+
+        props: dict[str, Any] = {}
+        if issue.tool_name:
+            props["tool"] = issue.tool_name
+        if issue.code:
+            props["code"] = issue.code
+        if props:
+            result["properties"] = props
+
+        results.append(result)
+
+
 def to_sarif(
     suggestions: Sequence[AIFixSuggestion],
     summary: AISummary | None = None,
@@ -76,8 +193,13 @@ def to_sarif(
     tool_name: str = "lintro-ai",
     tool_version: str = "",
     doc_urls: dict[str, str] | None = None,
+    standard_issues: Sequence[StandardIssue] | None = None,
 ) -> dict[str, Any]:
-    """Convert AI findings to a SARIF v2.1.0 document.
+    """Convert lint and AI findings to a SARIF v2.1.0 document.
+
+    Standard lint issues are emitted directly from ``standard_issues`` so
+    SARIF output is populated even without AI features. AI fix suggestions
+    are added additively on top.
 
     Args:
         suggestions: AI fix suggestions to include as results.
@@ -86,12 +208,22 @@ def to_sarif(
         tool_version: Version string for the tool driver.
         doc_urls: Optional mapping of rule codes to documentation URLs.
             When provided, matching rules get a ``helpUri`` property.
+        standard_issues: Normalized lint issues to emit as standard SARIF
+            results, independent of any AI enrichment.
 
     Returns:
         SARIF document as a dictionary.
     """
     rules_map: dict[str, dict[str, Any]] = {}
     results: list[dict[str, Any]] = []
+
+    if standard_issues:
+        _add_standard_issues(
+            standard_issues,
+            rules_map=rules_map,
+            results=results,
+            doc_urls=doc_urls,
+        )
 
     for s in suggestions:
         if s.tool_name and s.code:
@@ -217,14 +349,18 @@ def render_fixes_sarif(
     *,
     tool_name: str = "lintro-ai",
     tool_version: str = "",
+    doc_urls: dict[str, str] | None = None,
+    standard_issues: Sequence[StandardIssue] | None = None,
 ) -> str:
-    """Render AI findings as a SARIF JSON string.
+    """Render lint and AI findings as a SARIF JSON string.
 
     Args:
         suggestions: AI fix suggestions.
         summary: Optional AI summary.
         tool_name: Name for the SARIF tool driver.
         tool_version: Version string for the tool driver.
+        doc_urls: Optional mapping of rule codes to documentation URLs.
+        standard_issues: Normalized lint issues to emit as standard results.
 
     Returns:
         Pretty-printed SARIF JSON string.
@@ -234,6 +370,8 @@ def render_fixes_sarif(
         summary,
         tool_name=tool_name,
         tool_version=tool_version,
+        doc_urls=doc_urls,
+        standard_issues=standard_issues,
     )
     return json.dumps(sarif, indent=2)
 
@@ -246,8 +384,9 @@ def write_sarif(
     tool_name: str = "lintro-ai",
     tool_version: str = "",
     doc_urls: dict[str, str] | None = None,
+    standard_issues: Sequence[StandardIssue] | None = None,
 ) -> None:
-    """Write AI findings as a SARIF file.
+    """Write lint and AI findings as a SARIF file.
 
     Args:
         suggestions: AI fix suggestions.
@@ -256,6 +395,7 @@ def write_sarif(
         tool_name: Name for the SARIF tool driver.
         tool_version: Version string for the tool driver.
         doc_urls: Optional mapping of rule codes to documentation URLs.
+        standard_issues: Normalized lint issues to emit as standard results.
     """
     sarif = to_sarif(
         suggestions,
@@ -263,6 +403,7 @@ def write_sarif(
         tool_name=tool_name,
         tool_version=tool_version,
         doc_urls=doc_urls,
+        standard_issues=standard_issues,
     )
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(

--- a/lintro/ai/output/sarif_bridge.py
+++ b/lintro/ai/output/sarif_bridge.py
@@ -74,7 +74,9 @@ def _to_standard_issue(
         code=str(row.get("code", "") or ""),
         message=str(row.get("message", "") or ""),
         severity=severity,
-        doc_url=str(getattr(issue, "doc_url", "") or ""),
+        doc_url=str(
+            getattr(issue, "doc_url", "") or getattr(issue, "url", "") or "",
+        ),
     )
 
 

--- a/lintro/ai/output/sarif_bridge.py
+++ b/lintro/ai/output/sarif_bridge.py
@@ -11,9 +11,71 @@ from typing import TYPE_CHECKING, Any
 
 from lintro.ai.enums import ConfidenceLevel
 from lintro.ai.models import AIFixSuggestion, AISummary
+from lintro.ai.output.sarif import StandardIssue
+from lintro.enums.severity_level import SeverityLevel
 
 if TYPE_CHECKING:
     from lintro.models.core.tool_result import ToolResult
+    from lintro.parsers.base_issue import BaseIssue
+
+
+def standard_issues_from_results(
+    all_results: list[ToolResult],
+) -> list[StandardIssue]:
+    """Extract normalized standard lint issues from ToolResults.
+
+    Reads ``result.issues`` directly (independent of AI metadata) and
+    normalizes each ``BaseIssue`` into a ``StandardIssue`` carrying the
+    fields required for SARIF standard-mode emission.
+
+    Args:
+        all_results: List of tool results carrying parsed lint issues.
+
+    Returns:
+        List of normalized standard issues across all results.
+    """
+    standard_issues: list[StandardIssue] = []
+    for result in all_results:
+        issues = getattr(result, "issues", None)
+        if not issues:
+            continue
+        tool_name = str(getattr(result, "name", "") or "")
+        for issue in issues:
+            standard_issues.append(
+                _to_standard_issue(issue, tool_name=tool_name),
+            )
+    return standard_issues
+
+
+def _to_standard_issue(
+    issue: BaseIssue,
+    *,
+    tool_name: str,
+) -> StandardIssue:
+    """Normalize a single ``BaseIssue`` into a ``StandardIssue``.
+
+    Args:
+        issue: Parsed lint issue to normalize.
+        tool_name: Name of the tool that produced the issue.
+
+    Returns:
+        Normalized standard issue.
+    """
+    row = issue.to_display_row()
+    try:
+        severity = issue.get_severity()
+    except (ValueError, AttributeError):
+        severity = SeverityLevel.WARNING
+    return StandardIssue(
+        tool_name=tool_name,
+        file=str(getattr(issue, "file", "") or ""),
+        line=int(getattr(issue, "line", 0) or 0),
+        column=int(getattr(issue, "column", 0) or 0),
+        code=str(row.get("code", "") or ""),
+        message=str(row.get("message", "") or ""),
+        severity=severity,
+        doc_url=str(getattr(issue, "doc_url", "") or ""),
+    )
 
 
 def _coerce_confidence(value: object) -> ConfidenceLevel:

--- a/lintro/utils/output/file_writer.py
+++ b/lintro/utils/output/file_writer.py
@@ -372,18 +372,21 @@ def write_output_file(
     elif output_format == OutputFormat.SARIF:
         from lintro.ai.output.sarif import write_sarif
         from lintro.ai.output.sarif_bridge import (
+            standard_issues_from_results,
             suggestions_from_results,
             summary_from_results,
         )
 
         suggestions = suggestions_from_results(all_results)
         summary = summary_from_results(all_results)
+        standard_issues = standard_issues_from_results(all_results)
 
         write_sarif(
             suggestions,
             summary,
             output_path=output_file,
             doc_urls=build_doc_url_map(all_results) or None,
+            standard_issues=standard_issues,
         )
 
     else:

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -878,13 +878,21 @@ def run_lint_tools_simple(
         elif output_format.lower() == "sarif":
             from lintro.ai.output.sarif import render_fixes_sarif
             from lintro.ai.output.sarif_bridge import (
+                standard_issues_from_results,
                 suggestions_from_results,
                 summary_from_results,
             )
+            from lintro.utils.output.file_writer import build_doc_url_map
 
             suggestions = suggestions_from_results(all_results)
             summary = summary_from_results(all_results)
-            sarif_json = render_fixes_sarif(suggestions, summary)
+            standard_issues = standard_issues_from_results(all_results)
+            sarif_json = render_fixes_sarif(
+                suggestions,
+                summary,
+                doc_urls=build_doc_url_map(all_results) or None,
+                standard_issues=standard_issues,
+            )
             print(sarif_json)
         else:
             logger.print_execution_summary(action, all_results)
@@ -942,6 +950,7 @@ def run_lint_tools_simple(
 
                     from lintro.ai.output.sarif import write_sarif
                     from lintro.ai.output.sarif_bridge import (
+                        standard_issues_from_results,
                         suggestions_from_results,
                         summary_from_results,
                     )
@@ -949,11 +958,13 @@ def run_lint_tools_simple(
 
                     suggestions = suggestions_from_results(all_results)
                     summary = summary_from_results(all_results)
+                    standard_issues = standard_issues_from_results(all_results)
                     write_sarif(
                         suggestions,
                         summary,
                         output_path=Path(output_file),
                         doc_urls=build_doc_url_map(all_results) or None,
+                        standard_issues=standard_issues,
                     )
                 else:
                     write_output_file(

--- a/tests/unit/ai/test_sarif_bridge.py
+++ b/tests/unit/ai/test_sarif_bridge.py
@@ -7,11 +7,15 @@ import json
 from assertpy import assert_that
 
 from lintro.ai.models import AISummary
+from lintro.ai.output.sarif import StandardIssue, to_sarif
 from lintro.ai.output.sarif_bridge import (
+    standard_issues_from_results,
     suggestions_from_results,
     summary_from_results,
 )
+from lintro.enums.severity_level import SeverityLevel
 from lintro.models.core.tool_result import ToolResult
+from lintro.parsers.ruff.ruff_issue import RuffIssue
 
 
 def test_suggestions_from_results_with_metadata() -> None:
@@ -186,3 +190,168 @@ def test_sarif_format_end_to_end() -> None:
     assert_that(run["properties"]["aiSummary"]["overview"]).is_equal_to(
         "Found 1 issue.",
     )
+
+
+def test_standard_issues_from_results_extracts_fields() -> None:
+    """Normalize BaseIssue objects from result.issues without AI metadata."""
+    result = ToolResult(
+        name="ruff",
+        success=False,
+        issues=[
+            RuffIssue(
+                file="src/main.py",
+                line=10,
+                column=5,
+                code="F401",
+                message="imported but unused",
+                doc_url="https://docs.astral.sh/ruff/rules/F401",
+            ),
+        ],
+    )
+
+    standard = standard_issues_from_results([result])
+
+    assert_that(standard).is_length(1)
+    issue = standard[0]
+    assert_that(issue).is_instance_of(StandardIssue)
+    assert_that(issue.tool_name).is_equal_to("ruff")
+    assert_that(issue.file).is_equal_to("src/main.py")
+    assert_that(issue.line).is_equal_to(10)
+    assert_that(issue.column).is_equal_to(5)
+    assert_that(issue.code).is_equal_to("F401")
+    assert_that(issue.message).is_equal_to("imported but unused")
+    assert_that(issue.doc_url).is_equal_to("https://docs.astral.sh/ruff/rules/F401")
+
+
+def test_standard_issues_from_results_no_issues() -> None:
+    """Return empty list when results carry no issues."""
+    result = ToolResult(name="ruff", success=True, issues=[])
+
+    assert_that(standard_issues_from_results([result])).is_empty()
+
+
+def test_standard_sarif_without_ai_has_result_per_issue() -> None:
+    """SARIF emits a standard result per issue with no AI metadata present."""
+    result = ToolResult(
+        name="ruff",
+        success=False,
+        issues=[
+            RuffIssue(
+                file="a.py",
+                line=3,
+                column=1,
+                code="E501",
+                message="line too long",
+                doc_url="https://docs.astral.sh/ruff/rules/E501",
+            ),
+            RuffIssue(
+                file="b.py",
+                line=7,
+                column=0,
+                code="F811",
+                message="redefinition",
+            ),
+        ],
+    )
+
+    standard = standard_issues_from_results([result])
+    sarif = to_sarif([], None, standard_issues=standard)
+
+    assert_that(sarif["version"]).is_equal_to("2.1.0")
+    assert_that(sarif).contains_key("$schema")
+    assert_that(sarif["runs"]).is_length(1)
+
+    run = sarif["runs"][0]
+    results = run["results"]
+    assert_that(results).is_length(2)
+
+    first = results[0]
+    assert_that(first["ruleId"]).is_equal_to("ruff/E501")
+    assert_that(first["message"]["text"]).is_equal_to("line too long")
+    location = first["locations"][0]["physicalLocation"]
+    assert_that(location["artifactLocation"]["uri"]).is_equal_to("a.py")
+    assert_that(location["region"]["startLine"]).is_equal_to(3)
+    assert_that(location["region"]["startColumn"]).is_equal_to(1)
+
+    second = results[1]
+    assert_that(second["ruleId"]).is_equal_to("ruff/F811")
+    assert_that(
+        second["locations"][0]["physicalLocation"]["artifactLocation"]["uri"],
+    ).is_equal_to("b.py")
+
+    rules = run["tool"]["driver"]["rules"]
+    rule_ids = [r["id"] for r in rules]
+    assert_that(rule_ids).contains("ruff/E501", "ruff/F811")
+    e501_rule = next(r for r in rules if r["id"] == "ruff/E501")
+    assert_that(e501_rule["helpUri"]).is_equal_to(
+        "https://docs.astral.sh/ruff/rules/E501",
+    )
+
+
+def test_standard_and_ai_results_are_additive() -> None:
+    """Standard issues and AI suggestions coexist in the same SARIF run."""
+    result = ToolResult(
+        name="ruff",
+        success=False,
+        issues=[
+            RuffIssue(file="a.py", line=1, code="F401", message="unused"),
+        ],
+        ai_metadata={
+            "fix_suggestions": [
+                {
+                    "file": "a.py",
+                    "line": 1,
+                    "code": "F401",
+                    "tool_name": "ruff",
+                    "suggested_code": "",
+                    "explanation": "Remove import",
+                    "confidence": "high",
+                    "risk_level": "safe-style",
+                },
+            ],
+        },
+    )
+
+    suggestions = suggestions_from_results([result])
+    standard = standard_issues_from_results([result])
+    sarif = to_sarif(suggestions, None, standard_issues=standard)
+
+    results = sarif["runs"][0]["results"]
+    assert_that(results).is_length(2)
+    messages = [r["message"]["text"] for r in results]
+    assert_that(messages).contains("unused", "Remove import")
+
+
+def test_standard_issue_severity_maps_to_sarif_level() -> None:
+    """Severity levels map to SARIF error/warning/note levels."""
+    issues = [
+        StandardIssue(
+            tool_name="t",
+            file="x.py",
+            line=1,
+            code="A",
+            message="err",
+            severity=SeverityLevel.ERROR,
+        ),
+        StandardIssue(
+            tool_name="t",
+            file="x.py",
+            line=2,
+            code="B",
+            message="warn",
+            severity=SeverityLevel.WARNING,
+        ),
+        StandardIssue(
+            tool_name="t",
+            file="x.py",
+            line=3,
+            code="C",
+            message="info",
+            severity=SeverityLevel.INFO,
+        ),
+    ]
+
+    sarif = to_sarif([], None, standard_issues=issues)
+    levels = [r["level"] for r in sarif["runs"][0]["results"]]
+
+    assert_that(levels).is_equal_to(["error", "warning", "note"])

--- a/tests/unit/ai/test_sarif_bridge.py
+++ b/tests/unit/ai/test_sarif_bridge.py
@@ -223,6 +223,31 @@ def test_standard_issues_from_results_extracts_fields() -> None:
     assert_that(issue.doc_url).is_equal_to("https://docs.astral.sh/ruff/rules/F401")
 
 
+def test_standard_issues_from_results_falls_back_to_url() -> None:
+    """Use the issue ``url`` field for ``doc_url`` when ``doc_url`` is empty."""
+    result = ToolResult(
+        name="ruff",
+        success=False,
+        issues=[
+            RuffIssue(
+                file="src/main.py",
+                line=10,
+                column=5,
+                code="F401",
+                message="imported but unused",
+                url="https://docs.astral.sh/ruff/rules/F401",
+            ),
+        ],
+    )
+
+    standard = standard_issues_from_results([result])
+
+    assert_that(standard).is_length(1)
+    assert_that(standard[0].doc_url).is_equal_to(
+        "https://docs.astral.sh/ruff/rules/F401",
+    )
+
+
 def test_standard_issues_from_results_no_issues() -> None:
     """Return empty list when results carry no issues."""
     result = ToolResult(name="ruff", success=True, issues=[])


### PR DESCRIPTION
## Summary

Previously the SARIF output path (`lintro/ai/output/sarif.py` via `sarif_bridge.py`) only emitted results reconstructed from `ToolResult.ai_metadata` (AI fix suggestions). Without AI features enabled, SARIF output contained **no results** — standard lint findings were never read from `result.issues`.

This makes `--output-format sarif` useful without AI features, enabling native IDE/GitHub Code Scanning integrations to consume lintro output.

## Changes

- **`lintro/ai/output/sarif.py`**: Added a `StandardIssue` dataclass and a `_add_standard_issues(...)` helper. `to_sarif(...)`, `render_fixes_sarif(...)`, and `write_sarif(...)` gained a `standard_issues` keyword arg. Standard issues become SARIF results with proper `physicalLocation` (file/line/column), rule descriptors, severity `level` (ERROR→error, WARNING→warning, INFO→note), and `helpUri` from each issue's `doc_url` (falling back to the `doc_urls` map). Severity maps via `SeverityLevel`.
- **`lintro/ai/output/sarif_bridge.py`**: Added `standard_issues_from_results(...)` that reads `result.issues` directly and normalizes each `BaseIssue` into a `StandardIssue`.
- **`lintro/utils/output/file_writer.py`** and **`lintro/utils/tool_executor.py`**: All three SARIF paths (stdout, `--output` file, and GHA artifact via `write_output_file`) now pass standard issues through. AI-metadata enrichment remains fully additive — standard results and AI fix suggestions coexist in the same run.

## Tests

Added tests in `tests/unit/ai/test_sarif_bridge.py` (pytest-style, assertpy):
- Extraction of `StandardIssue` fields from `result.issues` with no AI metadata
- Empty results yield no standard issues
- SARIF (no AI) contains one result per issue with correct file/line/column/ruleId/message and valid SARIF structure + `helpUri`
- Standard results and AI suggestions are additive in the same run
- Severity → SARIF level mapping (error/warning/note)

## Gates

- `uv run lintro fmt` — clean
- `uv run lintro chk` — 0 issues
- `uv run pytest` — 5805 passed, 10 skipped

Closes #816

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes SARIF output include normal lint findings as well as AI metadata. The main changes are:

- Adds a normalized standard issue model for SARIF emission.
- Converts `result.issues` into SARIF results with locations, levels, rules, and help links.
- Threads standard issues through stdout, file, and artifact SARIF output paths.
- Adds tests for standard SARIF output, help links, mixed AI results, and level mapping.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/output/sarif.py | Adds standard lint issue SARIF emission alongside existing AI suggestion results. |
| lintro/ai/output/sarif_bridge.py | Normalizes tool results into standard SARIF issues and preserves rule documentation links from issue URL fields. |
| lintro/utils/output/file_writer.py | Passes standard lint issues into SARIF file output generation. |
| lintro/utils/tool_executor.py | Passes standard lint issues into stdout and explicit output-file SARIF generation. |
| tests/unit/ai/test_sarif_bridge.py | Adds coverage for standard issue extraction, SARIF result generation, documentation links, mixed AI output, and level mapping. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ai/output): fall back to issue url f..."](https://github.com/lgtm-hq/py-lintro/commit/9fd95e70d3ee4760bb0794722aff32d171e04e88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41925462)</sub>

<!-- /greptile_comment -->