### PR TITLE
fix(osv_scanner): treat malformed exit-0 payload as scan error, not clean

### DIFF
--- a/lintro/tools/definitions/osv_scanner.py
+++ b/lintro/tools/definitions/osv_scanner.py
@@ -149,6 +149,27 @@ class OsvScannerPlugin(BaseToolPlugin):
         ]
 
     @staticmethod
+    def _payload_has_valid_results(payload: dict[str, Any]) -> bool:
+        """Return whether an osv-scanner payload is a valid scan report.
+
+        A well-formed osv-scanner JSON report is an object whose ``results``
+        key holds a list (possibly empty). Error-shaped payloads such as
+        ``{"error": ...}`` — or payloads whose ``results`` is missing or not a
+        list — are not valid scan reports. For a security gate such a payload
+        must be treated as a scan failure rather than a clean pass (see #1028).
+
+        Args:
+            payload: Parsed JSON object extracted from osv-scanner stdout.
+
+        Returns:
+            True when ``payload`` is a dict whose ``results`` value is a list.
+        """
+        return isinstance(payload, dict) and isinstance(
+            payload.get("results"),
+            list,
+        )
+
+    @staticmethod
     def _find_config_file(scan_root: Path) -> Path | None:
         """Find .osv-scanner.toml by walking up from the scan root.
 
@@ -288,8 +309,7 @@ class OsvScannerPlugin(BaseToolPlugin):
             not success
             and len(issues) == 0
             and payload is not None
-            and "results" in payload
-            and isinstance(payload["results"], list)
+            and self._payload_has_valid_results(payload)
             and len(payload["results"]) == 0
         ):
             success = True
@@ -302,6 +322,15 @@ class OsvScannerPlugin(BaseToolPlugin):
             payload is None and bool(proc.stdout.strip()) and not no_op_success
         )
         if parse_failure:
+            success = False
+            parse_failures_count = 1
+
+        # Fail closed on malformed exit-0 payloads. osv-scanner may exit 0 while
+        # emitting an error-shaped object (``{"error": ...}``) or a payload whose
+        # ``results`` key is missing or not a list. Such a payload parses as JSON
+        # but is not a real scan report, so its true result is unknown. A security
+        # gate must treat this as a failure, never a clean pass (see #1028).
+        if payload is not None and not self._payload_has_valid_results(payload):
             success = False
             parse_failures_count = 1
 

--- a/tests/scripts/test_classify_osv_results.py
+++ b/tests/scripts/test_classify_osv_results.py
@@ -333,3 +333,45 @@ def test_script_prints_error_for_invalid_json(
 
     assert_that(completed.returncode).is_equal_to(0)
     assert_that(completed.stdout.strip()).is_equal_to("error")
+
+
+def test_classify_error_for_malformed_exit_zero_payload() -> None:
+    """A fail-closed exit-0 malformed payload result classifies as error (#1028).
+
+    This mirrors the ToolResult the osv_scanner plugin emits when osv-scanner
+    exits 0 but returns an error-shaped or non-list ``results`` payload.
+    """
+    module = _load_classify_module()
+    payload = {
+        "results": [
+            {
+                "tool": "osv_scanner",
+                "success": False,
+                "issues_count": 0,
+                "parse_failures_count": 1,
+            },
+        ],
+    }
+
+    assert_that(module.classify_osv_results(payload=payload)).is_equal_to(
+        module.OsvResultClass.ERROR,
+    )
+
+
+def test_classify_ok_for_empty_results_scan() -> None:
+    """A clean exit-0 empty-results scan still classifies as ok (#1028)."""
+    module = _load_classify_module()
+    payload = {
+        "results": [
+            {
+                "tool": "osv_scanner",
+                "success": True,
+                "issues_count": 0,
+                "parse_failures_count": 0,
+            },
+        ],
+    }
+
+    assert_that(module.classify_osv_results(payload=payload)).is_equal_to(
+        module.OsvResultClass.OK,
+    )

--- a/tests/unit/tools/osv_scanner/test_osv_scanner_plugin.py
+++ b/tests/unit/tools/osv_scanner/test_osv_scanner_plugin.py
@@ -253,6 +253,106 @@ def test_check_error_payload_without_results_is_not_success(
     assert_that(result.issues_count).is_equal_to(0)
 
 
+def test_check_exit_zero_error_payload_fails_closed(
+    osv_scanner_plugin: OsvScannerPlugin,
+    tmp_path: Path,
+) -> None:
+    """Exit-0 with an error-shaped payload is a scan failure, not a clean pass.
+
+    osv-scanner can exit 0 while emitting ``{"error": ...}``. Reporting that as
+    a clean scan would be a silent false-negative in a security gate (#1028).
+
+    Args:
+        osv_scanner_plugin: The OsvScannerPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    lockfile = tmp_path / "requirements.txt"
+    lockfile.write_text("setuptools==80.9.0\n")
+
+    osv_output = '{"error": "failed to load config"}\n'
+
+    with patch.object(
+        osv_scanner_plugin,
+        "_run_subprocess_result",
+        return_value=_proc(success=True, stdout=osv_output),
+    ):
+        result = osv_scanner_plugin.check([str(lockfile)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.parse_failures_count).is_equal_to(1)
+
+
+def test_check_exit_zero_results_not_a_list_fails_closed(
+    osv_scanner_plugin: OsvScannerPlugin,
+    tmp_path: Path,
+) -> None:
+    """Exit-0 with a non-list ``results`` value fails closed (#1028).
+
+    Args:
+        osv_scanner_plugin: The OsvScannerPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    lockfile = tmp_path / "requirements.txt"
+    lockfile.write_text("setuptools==80.9.0\n")
+
+    osv_output = '{"results": "not-a-list"}\n'
+
+    with patch.object(
+        osv_scanner_plugin,
+        "_run_subprocess_result",
+        return_value=_proc(success=True, stdout=osv_output),
+    ):
+        result = osv_scanner_plugin.check([str(lockfile)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.parse_failures_count).is_equal_to(1)
+
+
+def test_check_exit_zero_empty_results_is_clean(
+    osv_scanner_plugin: OsvScannerPlugin,
+    tmp_path: Path,
+) -> None:
+    """Exit-0 with an empty results list is a legitimate clean scan (#1028).
+
+    Args:
+        osv_scanner_plugin: The OsvScannerPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    lockfile = tmp_path / "requirements.txt"
+    lockfile.write_text("setuptools==80.9.0\n")
+
+    osv_output = '{"results": []}\n'
+
+    with patch.object(
+        osv_scanner_plugin,
+        "_run_subprocess_result",
+        return_value=_proc(success=True, stdout=osv_output),
+    ):
+        result = osv_scanner_plugin.check([str(lockfile)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.parse_failures_count).is_equal_to(0)
+
+
+def test_payload_has_valid_results_discriminates_shapes() -> None:
+    """The results-shape guard accepts only dicts with a list ``results``."""
+    assert_that(
+        OsvScannerPlugin._payload_has_valid_results({"results": []}),
+    ).is_true()
+    assert_that(
+        OsvScannerPlugin._payload_has_valid_results({"results": [{"x": 1}]}),
+    ).is_true()
+    assert_that(
+        OsvScannerPlugin._payload_has_valid_results({"error": "boom"}),
+    ).is_false()
+    assert_that(
+        OsvScannerPlugin._payload_has_valid_results({"results": "nope"}),
+    ).is_false()
+
+
 def test_check_with_vulnerabilities(
     osv_scanner_plugin: OsvScannerPlugin,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

`OsvScannerPlugin.check()` treated any parsed JSON object as a clean parse. When osv-scanner exits 0 but emits an error-shaped payload (`{"error": ...}`) or a payload whose `results` is missing or not a list, the tool reported `success=True` / `issues_count=0` / `parse_failures_count=0`, and `scripts/ci/classify-osv-results.py` published `ok` — a silent false-negative in a security gate.

This fails closed:

- Adds `OsvScannerPlugin._payload_has_valid_results(payload)` → `True` only when the payload is a dict **and** `payload.get("results")` is a list.
- When the payload is present but malformed, forces overall success `False` and sets `parse_failures_count` positive, so the classifier returns `error`.
- Reuses the same guard in the existing non-zero→success flip for consistent shape validation.
- Legitimate paths are preserved: `{"results": []}` clean scans and the `no package sources found` no-op (payload is `None`, `parse_failures_count` 0) still classify as `ok`.

## Acceptance criteria coverage

Plugin tests (`tests/unit/tools/osv_scanner/test_osv_scanner_plugin.py`):

- exit-0 + `{"error": ...}` → `success=False`, `parse_failures_count=1` (classifier `error`)
- exit-0 + `{"results": "not-a-list"}` → `success=False`, `parse_failures_count=1` (classifier `error`)
- exit-0 + `{"results": []}` → `success=True`, `parse_failures_count=0` (classifier `ok`)
- no-package-sources no-op → still `ok` (unchanged, covered by existing test)
- `_payload_has_valid_results` shape discrimination unit test

Classifier tests (`tests/scripts/test_classify_osv_results.py`):

- fail-closed malformed exit-0 result shape → `error`
- empty-results clean result shape → `ok`

## Gates

- `uv run lintro fmt` applied
- `uv run lintro chk` → 0 issues (Total Issues: 0)
- `uv run pytest` → 5810 passed, 10 skipped

Closes #1028

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes malformed OSV scanner output fail closed. The main changes are:

- Adds a helper that accepts only dict payloads with list-valued `results`.
- Reuses that helper when converting empty non-zero scans to success.
- Marks parsed but malformed payloads as failed scans with a parse failure.
- Adds plugin and classifier tests for malformed and empty-result scans.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/definitions/osv_scanner.py | Adds payload shape validation and fails closed when parsed OSV output is not a real scan report. |
| tests/unit/tools/osv_scanner/test_osv_scanner_plugin.py | Adds coverage for malformed exit-zero payloads, non-list results, clean empty results, and the new validation helper. |
| tests/scripts/test_classify_osv_results.py | Adds classifier coverage for error and ok outcomes from the OSV scanner result shape. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/1028-osv-fa..."](https://github.com/lgtm-hq/py-lintro/commit/65635e704bf84edf3132ee28eb8c6164b4528bd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41956985)</sub>

<!-- /greptile_comment -->