### PR TITLE
docs(changelog): wrap release-note lines to satisfy lint gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,26 +44,33 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- **site**: add honest comparison page vs trunk, MegaLinter, pre-commit, qlty (#1058) (9eab1b3)
+- **site**: add honest comparison page vs trunk, MegaLinter, pre-commit, qlty (#1058)
+  (9eab1b3)
 - **config**: enforce module size limit via lint gate (#1078) (276929e)
-- **output**: SARIF output should emit standard lint results, not only AI metadata (#1079) (4a423f1)
-- **utils**: extract shared find_file_upward helper for duplicated config-walk logic (#1077) (8d983ca)
+- **output**: SARIF output should emit standard lint results, not only AI metadata
+  (#1079) (4a423f1)
+- **utils**: extract shared find_file_upward helper for duplicated config-walk logic
+  (#1077) (8d983ca)
 - pin merge_group activity type to checks_requested (#1059) (5f8edcd)
-- **plugins**: separate stdout/stderr from subprocess and harden parsers (#1061) (23f6f09)
+- **plugins**: separate stdout/stderr from subprocess and harden parsers (#1061)
+  (23f6f09)
 - **deps**: update actions/attest-build-provenance to v4.1.1 (#874) (d839d3d)
 - **deps**: update python digest (#968) (eb2de3f)
 - **deps**: update svelte to 5.56.4 (minor) (#969) (70d9001)
 
 ### Fixed
 
-- **ai/review**: lintro review --pr crashes on invalid gh baseRepository field (#1084) (819040f)
+- **ai/review**: lintro review --pr crashes on invalid gh baseRepository field (#1084)
+  (819040f)
 - **ai/review**: guarantee secret redaction in git-native review mode (#1075) (a92fd93)
 - **ci**: run dogfood review with trusted base-ref lintro, not PR code (#1074) (488c9b1)
 - **ai/review**: correct patch line mapping and head-repo fallback (#1067) (6a07761)
-- **ai/review**: harden review AI — secret redaction, severity normalization, response robustness (#1069) (7b0afe0)
+- **ai/review**: harden review AI — secret redaction, severity normalization, response
+  robustness (#1069) (7b0afe0)
 - **ai**: Cursor provider cost accounting and opt-in --trust (#1068) (0a3af28)
 - **output**: unify report counts and clean JSON stdout (#1060) (5111d6c)
-- **ai/review**: CLI mode wiring broken — --uncommitted, --pr, and CI runs always fail (#1056) (4d0ccce)
+- **ai/review**: CLI mode wiring broken — --uncommitted, --pr, and CI runs always fail
+  (#1056) (4d0ccce)
 - **ci**: unblock Renovate PRs blocked by mypy and artifact updates (#1057) (9159290)
 - **deps**: update sqlfluff to 4.2.0 (minor) (#927) (efe3ea2)
 - **ai/review**: Cursor review timeout reliability (#1021) (4cd3c7c)


### PR DESCRIPTION
## Summary

Main's dogfooding-lint went red after the v0.65.0 release merge: the release automation wrote CHANGELOG.md entries exceeding the 88-column limit (4x MD013 + 1 prettier FORMAT finding, all in CHANGELOG.md). This wraps those lines via lintro fmt; no content changes.

## Gates

- uv run lintro fmt applied; uv run lintro chk: 0 issues
- uv run pytest: 5840 passed, 10 skipped

Repairs main lint health (dogfooding-lint red since the v0.65.0 release commit); no linked issue.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wraps long changelog release-note lines.

- Wrapped several v0.65.0 `Changed` entries in `CHANGELOG.md`.
- Wrapped several v0.65.0 `Fixed` entries in `CHANGELOG.md`.
- Preserved the release-note text, issue numbers, and commit hashes.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Long release-note bullets were wrapped with valid markdown continuation indentation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): wrap release-note lines..."](https://github.com/lgtm-hq/py-lintro/commit/d0207916c95e9479a70855cefaee4b1115f64736) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41993715)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog entry for version 0.65.0.
  * Reformatted several listed items and wrapped longer entries for improved readability, with no change to the recorded content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->