### PR TITLE
fix(mypy): treat no Python files as a clean skip

### DIFF
--- a/lintro/tools/definitions/mypy.py
+++ b/lintro/tools/definitions/mypy.py
@@ -34,6 +34,13 @@ MYPY_DEFAULT_TIMEOUT: int = 60
 MYPY_DEFAULT_PRIORITY: int = 82
 MYPY_FILE_PATTERNS: list[str] = ["*.py", "*.pyi"]
 
+# mypy prints this diagnostic (to stderr, not as JSON) and exits non-zero when
+# the resolved scope contains no Python sources, e.g. running the full tool set
+# against a non-Python repository. It surfaces in every execution path, both the
+# local CLI and the Docker image used by lgtm-ci reusable workflows, so we detect
+# it and skip cleanly like other language tools do on an empty scope.
+MYPY_NO_FILES_MARKER: str = "no .py[i] files"
+
 MYPY_DEFAULT_EXCLUDE_PATTERNS: list[str] = [
     "test_samples/*",
     "test_samples/**",
@@ -70,6 +77,19 @@ def _split_config_values(raw_value: str) -> list[str]:
         if value:
             entries.append(value)
     return entries
+
+
+def _has_no_python_files_error(output: str) -> bool:
+    """Detect mypy's "no Python files in scope" diagnostic.
+
+    Args:
+        output: Combined stdout/stderr captured from the mypy subprocess.
+
+    Returns:
+        bool: True when mypy reported that no ``.py``/``.pyi`` files were found
+        in the resolved scope, meaning there is nothing to type-check.
+    """
+    return MYPY_NO_FILES_MARKER in output.lower()
 
 
 def _regex_to_glob(pattern: str) -> str:
@@ -467,6 +487,21 @@ class MypyPlugin(BaseToolPlugin):
                 name=self.definition.name,
                 success=False,
                 output=f"mypy execution failed: {e}",
+                issues_count=0,
+            )
+
+        # Defensive secondary guard: when mypy resolves a scope with no Python
+        # sources it errors out (exit 2) with a non-JSON "no .py[i] files"
+        # diagnostic. This path is reached when mypy performs its own directory
+        # discovery (e.g. the Docker/reusable-workflow path), where lintro's
+        # pre-flight file discovery cannot pre-empt it. Treat it as a clean skip
+        # so non-Python repositories pass like they do for other language tools.
+        if _has_no_python_files_error(output):
+            logger.debug("[mypy] No .py/.pyi files in scope; skipping cleanly")
+            return ToolResult(
+                name=self.definition.name,
+                success=True,
+                output="No .py/.pyi files found to check.",
                 issues_count=0,
             )
 

--- a/lintro/tools/definitions/mypy.py
+++ b/lintro/tools/definitions/mypy.py
@@ -490,13 +490,18 @@ class MypyPlugin(BaseToolPlugin):
                 issues_count=0,
             )
 
+        issues = parse_mypy_output(output=output)
+        issues_count = len(issues)
+
         # Defensive secondary guard: when mypy resolves a scope with no Python
         # sources it errors out (exit 2) with a non-JSON "no .py[i] files"
         # diagnostic. This path is reached when mypy performs its own directory
         # discovery (e.g. the Docker/reusable-workflow path), where lintro's
         # pre-flight file discovery cannot pre-empt it. Treat it as a clean skip
         # so non-Python repositories pass like they do for other language tools.
-        if _has_no_python_files_error(output):
+        # Only skip when no structured issues were parsed, so a run that both
+        # reports type errors and mentions the marker still surfaces the errors.
+        if issues_count == 0 and _has_no_python_files_error(output):
             logger.debug("[mypy] No .py/.pyi files in scope; skipping cleanly")
             return ToolResult(
                 name=self.definition.name,
@@ -504,9 +509,6 @@ class MypyPlugin(BaseToolPlugin):
                 output="No .py/.pyi files found to check.",
                 issues_count=0,
             )
-
-        issues = parse_mypy_output(output=output)
-        issues_count = len(issues)
 
         if not success and issues_count == 0:
             # Execution failed but no structured issues were parsed; surface diagnostics

--- a/tests/unit/tools/mypy/test_mypy_no_python_files.py
+++ b/tests/unit/tools/mypy/test_mypy_no_python_files.py
@@ -1,0 +1,190 @@
+"""Tests for mypy skipping cleanly when no Python files are in scope.
+
+Covers issues #1071 and #930: running mypy against a repository or scope with
+zero ``.py``/``.pyi`` files must no-op like other language tools rather than
+hard-erroring with ``There are no .py[i] files in directory '.'``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.tools.definitions.mypy import (
+    MypyPlugin,
+    _has_no_python_files_error,
+)
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("There are no .py[i] files in directory '.'", True),
+        ("There are no .py[i] files in directory 'src'", True),
+        ("mypy: error: There are no .py[i] files in directory '.'\n", True),
+        ("NO .PY[I] FILES", True),
+        ("", False),
+        ("[]", False),
+        ('[{"path": "a.py", "line": 1, "message": "x"}]', False),
+    ],
+    ids=[
+        "current_dir",
+        "named_dir",
+        "with_prefix",
+        "case_insensitive",
+        "empty",
+        "empty_json_array",
+        "real_issue_payload",
+    ],
+)
+def test_has_no_python_files_error(*, output: str, expected: bool) -> None:
+    """Detect mypy's no-Python-files diagnostic in combined output.
+
+    Args:
+        output: Combined stdout/stderr captured from the mypy subprocess.
+        expected: Whether the diagnostic should be detected.
+    """
+    result = _has_no_python_files_error(output)
+    assert_that(result).is_equal_to(expected)
+
+
+def test_check_empty_directory_skips_cleanly(
+    mypy_plugin: MypyPlugin,
+    tmp_path: Path,
+) -> None:
+    """Empty directory yields a clean pass with zero issues.
+
+    Args:
+        mypy_plugin: The MypyPlugin instance to test.
+        tmp_path: Temporary directory path with no files.
+    """
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        result = mypy_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.issues).is_none()
+
+
+def test_check_only_non_python_files_skips_cleanly(
+    mypy_plugin: MypyPlugin,
+    tmp_path: Path,
+) -> None:
+    """Directory with only non-Python files yields a clean pass.
+
+    Args:
+        mypy_plugin: The MypyPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    (tmp_path / "README.md").write_text("# Readme\n")
+    (tmp_path / "config.yaml").write_text("key: value\n")
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        result = mypy_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.issues).is_none()
+
+
+def test_check_no_python_files_error_output_skips_cleanly(
+    mypy_plugin: MypyPlugin,
+    tmp_path: Path,
+) -> None:
+    """Mypy's no-Python-files diagnostic is treated as a clean skip.
+
+    This exercises the defensive secondary guard for the execution path where
+    mypy performs its own directory discovery (the Docker/reusable-workflow
+    path) and emits the diagnostic itself rather than lintro pre-empting it.
+
+    Args:
+        mypy_plugin: The MypyPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    # A real Python file makes lintro's pre-flight discovery pass so that mypy
+    # is actually invoked; the mocked subprocess then simulates mypy resolving
+    # an empty scope on its own.
+    (tmp_path / "module.py").write_text('"""Module."""\n')
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            mypy_plugin,
+            "_run_subprocess",
+            return_value=(False, "There are no .py[i] files in directory '.'"),
+        ):
+            result = mypy_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.issues).is_none()
+    assert_that(result.output).contains("No .py/.pyi files found")
+
+
+def test_check_python_file_clean_run_unchanged(
+    mypy_plugin: MypyPlugin,
+    tmp_path: Path,
+) -> None:
+    """A directory with a Python file and no issues passes normally.
+
+    Args:
+        mypy_plugin: The MypyPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    (tmp_path / "module.py").write_text('"""Module."""\n')
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            mypy_plugin,
+            "_run_subprocess",
+            return_value=(True, "[]"),
+        ):
+            result = mypy_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+
+
+def test_check_python_file_with_issue_still_fails(
+    mypy_plugin: MypyPlugin,
+    tmp_path: Path,
+) -> None:
+    """A real type error is still reported when Python files are present.
+
+    Args:
+        mypy_plugin: The MypyPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    (tmp_path / "module.py").write_text('"""Module."""\n')
+    payload = (
+        '[{"path": "module.py", "line": 1, "column": 0, '
+        '"severity": "error", "message": "boom", "code": "misc"}]'
+    )
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            mypy_plugin,
+            "_run_subprocess",
+            return_value=(False, payload),
+        ):
+            result = mypy_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(1)

--- a/tests/unit/tools/mypy/test_mypy_no_python_files.py
+++ b/tests/unit/tools/mypy/test_mypy_no_python_files.py
@@ -188,3 +188,37 @@ def test_check_python_file_with_issue_still_fails(
 
     assert_that(result.success).is_false()
     assert_that(result.issues_count).is_equal_to(1)
+
+
+def test_check_marker_text_with_issue_does_not_suppress(
+    mypy_plugin: MypyPlugin,
+    tmp_path: Path,
+) -> None:
+    """The skip guard never suppresses real issues in mixed output.
+
+    Even if the ``no .py[i] files`` marker text appears alongside parsed
+    issues, the run must still report the issues rather than skip.
+
+    Args:
+        mypy_plugin: The MypyPlugin instance to test.
+        tmp_path: Temporary directory path for test files.
+    """
+    (tmp_path / "module.py").write_text('"""Module."""\n')
+    payload = (
+        '[{"path": "module.py", "line": 1, "column": 0, '
+        '"severity": "error", "message": "no .py[i] files", "code": "misc"}]'
+    )
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            mypy_plugin,
+            "_run_subprocess",
+            return_value=(False, payload),
+        ):
+            result = mypy_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(1)


### PR DESCRIPTION
## Summary

When lintro runs the full tool set against a repository with no `.py`/`.pyi`
files in scope, `mypy` errors out (exit code 2) with:

```text
There are no .py[i] files in directory '.'
```

This turned the `quality / Lintro Quality Checks` job red for non-Python
repositories (observed in `lgtm-hq/homebrew-tap` and `lgtm-hq/podex`), even
though every other language-specific tool correctly no-ops on an empty scope.

## Root cause

lintro's pre-flight file discovery already skips mypy cleanly when it finds no
Python files. But in the `use_project_root` execution path (and the
Docker/reusable-workflow path), mypy performs its own directory discovery: when
lintro passes a directory plus exclude patterns and mypy resolves an empty
scope, mypy itself emits the `no .py[i] files` diagnostic and exits non-zero.
lintro surfaced that as a hard `FAIL ERROR`.

## Fix

Detect mypy's `no .py[i] files` diagnostic in the captured output and treat it
as a clean skip (`success=True`, `0` issues), matching how other language tools
behave when their language is absent. Normal behavior is preserved when Python
files are present: real type errors are still reported, and clean runs still
pass.

## Tests

Added `tests/unit/tools/mypy/test_mypy_no_python_files.py`:

- Parametrized detection of the diagnostic (including case-insensitivity and
  non-matching JSON payloads).
- Empty directory and non-Python-only directory skip cleanly.
- The Docker/self-discovery path (mypy emits the diagnostic itself) skips
  cleanly.
- A present Python file with no issues still passes.
- A real type error is still reported as a failure.

## Gates

- `uv run lintro fmt` — clean
- `uv run lintro chk` — all tools pass, 0 issues
- `uv run pytest` — full suite green

Closes #930
Closes #1071

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes mypy no-op cleanly when no Python files are in scope. The main changes are:

- Added marker detection for mypy's no-files diagnostic.
- Returned a successful zero-issue result for that skip case.
- Added tests for empty scopes, non-Python scopes, and normal mypy failures.
</details>

<h3>Confidence Score: 4/5</h3>

This is close, but the mypy skip path can still hide real type errors.

- Real JSON-array issues can be lost when stdout is combined with stderr before parsing.
- The new skip branch can then return success with zero issues.

lintro/tools/definitions/mypy.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/definitions/mypy.py | Adds no-files marker handling and a clean skip result for mypy runs with no Python files. |
| tests/unit/tools/mypy/test_mypy_no_python_files.py | Adds tests for empty and non-Python mypy scopes, plus checks that normal mypy results still pass or fail as expected. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Ftools%2Fdefinitions%2Fmypy.py%3A503%0A**Mixed%20Output%20Still%20Skips**%0A%0AWhen%20mypy%20writes%20a%20JSON%20array%20of%20real%20issues%20to%20stdout%20and%20the%20%60no%20.py%5Bi%5D%20files%60%20diagnostic%20to%20stderr%2C%20%60_run_subprocess%60%20combines%20both%20streams%20before%20parsing.%20The%20combined%20text%20no%20longer%20parses%20as%20one%20JSON%20value%2C%20and%20the%20fallback%20skips%20the%20issue%20array%20because%20it%20starts%20with%20%60%5B%60%2C%20leaving%20%60issues_count%20%3D%3D%200%60.%20This%20branch%20then%20reports%20a%20clean%20skip%20and%20hides%20real%20type%20errors.%0A%0A&pr=1089&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Ftools%2Fdefinitions%2Fmypy.py%3A503%0A**Mixed%20Output%20Still%20Skips**%0A%0AWhen%20mypy%20writes%20a%20JSON%20array%20of%20real%20issues%20to%20stdout%20and%20the%20%60no%20.py%5Bi%5D%20files%60%20diagnostic%20to%20stderr%2C%20%60_run_subprocess%60%20combines%20both%20streams%20before%20parsing.%20The%20combined%20text%20no%20longer%20parses%20as%20one%20JSON%20value%2C%20and%20the%20fallback%20skips%20the%20issue%20array%20because%20it%20starts%20with%20%60%5B%60%2C%20leaving%20%60issues_count%20%3D%3D%200%60.%20This%20branch%20then%20reports%20a%20clean%20skip%20and%20hides%20real%20type%20errors.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1089&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F930-mypy-no-py-skip%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F930-mypy-no-py-skip%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Ftools%2Fdefinitions%2Fmypy.py%3A503%0A**Mixed%20Output%20Still%20Skips**%0A%0AWhen%20mypy%20writes%20a%20JSON%20array%20of%20real%20issues%20to%20stdout%20and%20the%20%60no%20.py%5Bi%5D%20files%60%20diagnostic%20to%20stderr%2C%20%60_run_subprocess%60%20combines%20both%20streams%20before%20parsing.%20The%20combined%20text%20no%20longer%20parses%20as%20one%20JSON%20value%2C%20and%20the%20fallback%20skips%20the%20issue%20array%20because%20it%20starts%20with%20%60%5B%60%2C%20leaving%20%60issues_count%20%3D%3D%200%60.%20This%20branch%20then%20reports%20a%20clean%20skip%20and%20hides%20real%20type%20errors.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1089&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(mypy): only skip on empty scope when..."](https://github.com/lgtm-hq/py-lintro/commit/29b34554b67f53f5e294e6dd7d11232070a7b2b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41996677)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->