### PR TITLE
fix(ai/review): exclude interpreter command-string operands from workflow script matching

### DIFF
--- a/lintro/ai/review/chunker/workflow_scripts.py
+++ b/lintro/ai/review/chunker/workflow_scripts.py
@@ -281,6 +281,35 @@ def _runtime_short_option_needs_operand(*, runtime: str, option_char: str) -> bo
     return bool(runtime.startswith("node") and option_char == "r")
 
 
+def _runtime_command_string_token(*, runtime: str, token: str) -> bool:
+    """Return True when a token starts an interpreter inline command-string mode.
+
+    In these forms the following operand is inline source code rather than a
+    script path: ``-c`` for python/python3 and ``-e``/``--eval`` for node and
+    bun. ``bash``/``sh -c`` payloads are excluded here because their payload may
+    itself execute a script file and is matched separately.
+
+    Args:
+        runtime: Lowercased interpreter name (for example ``python3``).
+        token: A single shell token beginning with ``-``.
+
+    Returns:
+        True when the token is the runtime's inline command-string option.
+    """
+    if token.startswith("--"):
+        option_name = token[2:].split("=", 1)[0]
+        if runtime.startswith("node") or runtime == "bun":
+            return option_name == "eval"
+        return False
+    if len(token) >= 2 and token[0] == "-" and token[1] != "-":
+        option_char = token[1]
+        if runtime.startswith("python"):
+            return option_char == "c"
+        if runtime.startswith("node") or runtime == "bun":
+            return option_char == "e"
+    return False
+
+
 def _runtime_option_is_terminating(*, runtime: str, token: str) -> bool:
     """Return True when a Node/Bun flag ends execution before any script."""
     if not (runtime.startswith("node") or runtime == "bun"):
@@ -339,7 +368,11 @@ def _strip_shell_interpreter_prefix(*, segment: str) -> str:
             continue
         if _runtime_option_is_terminating(runtime=runtime, token=token):
             return ""
-        if re.match(r"(?i)^-c", token) or re.match(r"(?i)^-s", token):
+        if (
+            re.match(r"(?i)^-c", token)
+            or re.match(r"(?i)^-s", token)
+            or _runtime_command_string_token(runtime=runtime, token=token)
+        ):
             break
         if not token.startswith("-"):
             break
@@ -510,6 +543,75 @@ def _bash_stdin_invocation(*, segment: str) -> bool:
         return False
 
 
+def _segment_leading_interpreter_command_string(*, segment: str) -> bool:
+    """Return True when a segment's leading interpreter runs inline code.
+
+    Walks the interpreter options and reports whether an inline command-string
+    option (``python -c``, ``node -e``/``--eval``, ``bun -e``/``--eval``) is
+    reached before any positional operand. ``bash``/``sh`` are excluded because
+    their ``-c`` payload is matched separately.
+
+    Args:
+        segment: A shell segment whose first token may be an interpreter.
+
+    Returns:
+        True when the leading interpreter is invoked in command-string mode.
+    """
+    remaining = segment.strip()
+    runtime_match = re.match(
+        rf"(?i)^(?P<runtime>{_WORKFLOW_SCRIPT_RUNTIMES})\b",
+        remaining,
+    )
+    if runtime_match is None:
+        return False
+    runtime = runtime_match.group("runtime").lower()
+    if runtime in {"bash", "sh"}:
+        return False
+    remaining = remaining[runtime_match.end() :].lstrip()
+    if runtime == "bun":
+        subcommand = _first_shell_token(segment=remaining)
+        if subcommand is not None and subcommand.lower() in _BUN_SUBCOMMANDS:
+            remaining = _rest_after_first_shell_token(segment=remaining)
+    while True:
+        token = _first_shell_token(segment=remaining)
+        if token is None or not token.startswith("-"):
+            return False
+        if _runtime_command_string_token(runtime=runtime, token=token):
+            return True
+        remaining = _rest_after_first_shell_token(segment=remaining)
+
+
+def _interpreter_command_string_invocation(*, segment: str) -> bool:
+    """Return True when a segment runs python/node/bun in inline-code mode.
+
+    The operand of such invocations is inline source text, not a script path, so
+    it must not be treated as a workflow script reference. Non-executing wrappers
+    (assignments, ``env``, ``sudo``/``timeout``, ``uv run``, ``exec``/``command``
+    and compound leaders) are stripped before the interpreter is inspected.
+
+    Args:
+        segment: A single shell command segment.
+
+    Returns:
+        True when the segment invokes an interpreter in command-string mode.
+    """
+    remaining = segment.strip()
+    while remaining:
+        if _segment_leading_interpreter_command_string(segment=remaining):
+            return True
+        previous = remaining
+        remaining = _strip_leading_shell_prefixes(segment=remaining)
+        remaining = _strip_command_dispatch_prefixes(segment=remaining)
+        if re.match(r"(?i)^uv\s+run\b", remaining):
+            uv_body = re.sub(r"(?i)^uv\s+run\b", "", remaining, count=1).lstrip()
+            remaining = _strip_uv_cli_options(segment=uv_body)
+        remaining = _strip_shell_dispatch_wrappers(segment=remaining)
+        remaining = _strip_shell_compound_leaders(segment=remaining)
+        if remaining == previous:
+            break
+    return False
+
+
 def _shell_command_string_payload(*, segment: str) -> str | None:
     """Return ``bash``/``sh`` ``-c`` payloads that may execute a script path."""
     stripped = segment.strip()
@@ -618,6 +720,8 @@ def _segment_executes_reference_path(*, segment: str, path: str, cwd: str) -> bo
         return False
     if _bash_stdin_invocation(segment=stripped):
         return False
+    if _interpreter_command_string_invocation(segment=stripped):
+        return False
     payload = _shell_command_string_payload_after_wrappers(segment=stripped)
     if payload is not None:
         return _line_references_path(line=payload, path=path, cwd=cwd)
@@ -710,6 +814,8 @@ def _run_line_reference_surface(*, line: str) -> str:
     command = _single_run_command_text(match=single_run)
     if command is None:
         return line
+    if _interpreter_command_string_invocation(segment=command):
+        return line[: single_run.start(1)]
     if _shell_command_string_payload_after_wrappers(segment=command) is not None:
         return line[: single_run.start(1)]
     return line

--- a/test_samples/fixtures/review/chunk_does_not_group_bun_e_command_string.diff
+++ b/test_samples/fixtures/review/chunk_does_not_group_bun_e_command_string.diff
@@ -1,0 +1,12 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1 +1,2 @@
+ name: CI
++run: bun -e scripts/review.ts
+diff --git a/scripts/review.ts b/scripts/review.ts
+--- a/scripts/review.ts
++++ b/scripts/review.ts
+@@ -1 +1,2 @@
+ export {}
++export const ready = true

--- a/test_samples/fixtures/review/chunk_does_not_group_node_e_command_string.diff
+++ b/test_samples/fixtures/review/chunk_does_not_group_node_e_command_string.diff
@@ -1,0 +1,12 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1 +1,2 @@
+ name: CI
++run: node -e scripts/build.js
+diff --git a/scripts/build.js b/scripts/build.js
+--- a/scripts/build.js
++++ b/scripts/build.js
+@@ -1 +1,2 @@
+ console.log('build')
++console.log('done')

--- a/test_samples/fixtures/review/chunk_does_not_group_node_eval_command_string.diff
+++ b/test_samples/fixtures/review/chunk_does_not_group_node_eval_command_string.diff
@@ -1,0 +1,12 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1 +1,2 @@
+ name: CI
++run: node --eval scripts/build.js
+diff --git a/scripts/build.js b/scripts/build.js
+--- a/scripts/build.js
++++ b/scripts/build.js
+@@ -1 +1,2 @@
+ console.log('build')
++console.log('done')

--- a/test_samples/fixtures/review/chunk_does_not_group_python_c_command_string.diff
+++ b/test_samples/fixtures/review/chunk_does_not_group_python_c_command_string.diff
@@ -1,0 +1,12 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1 +1,2 @@
+ name: CI
++run: python -c scripts/review.py
+diff --git a/scripts/review.py b/scripts/review.py
+--- a/scripts/review.py
++++ b/scripts/review.py
+@@ -1 +1,2 @@
+ print('review')
++print('done')

--- a/test_samples/fixtures/review/chunk_groups_workflow_with_python_script.diff
+++ b/test_samples/fixtures/review/chunk_groups_workflow_with_python_script.diff
@@ -1,0 +1,12 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1 +1,2 @@
+ name: CI
++run: python scripts/review.py
+diff --git a/scripts/review.py b/scripts/review.py
+--- a/scripts/review.py
++++ b/scripts/review.py
+@@ -1 +1,2 @@
+ print('review')
++print('done')

--- a/tests/unit/ai/review/test_chunker_workflow_scripts.py
+++ b/tests/unit/ai/review/test_chunker_workflow_scripts.py
@@ -131,6 +131,56 @@ CASES: tuple[WorkflowGroupingCase, ...] = (
         check_warnings=False,
     ),
     WorkflowGroupingCase(
+        id="does_not_group_python_c_command_string_operand",
+        fixture="chunk_does_not_group_python_c_command_string.diff",
+        files=(".github/workflows/ci.yml", "scripts/review.py"),
+        not_contains=("scripts/review.py",),
+        grouped_separately="scripts/review.py",
+        warning=(
+            "Script scripts/review.py changed alongside workflows but is not "
+            "referenced in any changed workflow diff; grouped separately."
+        ),
+    ),
+    WorkflowGroupingCase(
+        id="does_not_group_node_e_command_string_operand",
+        fixture="chunk_does_not_group_node_e_command_string.diff",
+        files=(".github/workflows/ci.yml", "scripts/build.js"),
+        not_contains=("scripts/build.js",),
+        grouped_separately="scripts/build.js",
+        warning=(
+            "Script scripts/build.js changed alongside workflows but is not "
+            "referenced in any changed workflow diff; grouped separately."
+        ),
+    ),
+    WorkflowGroupingCase(
+        id="does_not_group_node_eval_command_string_operand",
+        fixture="chunk_does_not_group_node_eval_command_string.diff",
+        files=(".github/workflows/ci.yml", "scripts/build.js"),
+        not_contains=("scripts/build.js",),
+        grouped_separately="scripts/build.js",
+        warning=(
+            "Script scripts/build.js changed alongside workflows but is not "
+            "referenced in any changed workflow diff; grouped separately."
+        ),
+    ),
+    WorkflowGroupingCase(
+        id="does_not_group_bun_e_command_string_operand",
+        fixture="chunk_does_not_group_bun_e_command_string.diff",
+        files=(".github/workflows/ci.yml", "scripts/review.ts"),
+        not_contains=("scripts/review.ts",),
+        grouped_separately="scripts/review.ts",
+        warning=(
+            "Script scripts/review.ts changed alongside workflows but is not "
+            "referenced in any changed workflow diff; grouped separately."
+        ),
+    ),
+    WorkflowGroupingCase(
+        id="groups_workflow_with_python_script",
+        fixture="chunk_groups_workflow_with_python_script.diff",
+        files=(".github/workflows/ci.yml", "scripts/review.py"),
+        contains=("scripts/review.py",),
+    ),
+    WorkflowGroupingCase(
         id="groups_workflow_with_uv_run_with_editable_script",
         fixture="chunk_groups_workflow_with_uv_run_with_editable_script.diff",
         files=(".github/workflows/ci.yml", "scripts/review.py"),


### PR DESCRIPTION
## Summary

The review chunker's workflow-script matcher treated interpreter **command-string / eval operands** as script-file references. Forms like `run: python -c scripts/review.py`, `run: node -e scripts/build.js`, `run: node --eval scripts/build.js`, and `run: bun -e scripts/review.ts` pass the following token as inline source text, not a file path — so an unrelated changed script was grouped with the workflow and its unreferenced-script warning was suppressed.

Review follow-up from #992. Low impact (degrades review chunk grouping only; no correctness/security effect).

## Changes

- Add `_runtime_command_string_token` to recognize inline command-string options: `-c` for `python`/`python3`, and `-e`/`--eval` for `node`/`bun` (bash/sh `-c` payloads remain handled separately since they may execute a script).
- Add `_interpreter_command_string_invocation` (with `_segment_leading_interpreter_command_string`), which strips non-executing wrappers (assignments, `env`, `sudo`/`timeout`, `uv run`, `exec`/`command`, compound leaders) and reports whether the leading interpreter runs in inline-code mode.
- Short-circuit the reference search in `_segment_executes_reference_path` and hide the operand from the regex surface in `_run_line_reference_surface` when a command-string invocation is detected.
- Extend the `_strip_shell_interpreter_prefix` break to also stop at node/bun `-e`/`--eval` (previously only `-c`/`-s`), so token stripping no longer returns the eval operand as an executable.

## Tests

New parametrized `WorkflowGroupingCase` entries (with fixtures) proving `-c "..."` / `-e` / `--eval` operands are grouped separately and preserve the unreferenced-script warning, plus a genuine `python scripts/review.py` reference that still matches. Existing node/bun/bash real-reference cases continue to pass.

## Gates

- `uv run lintro fmt` — applied
- `uv run lintro chk` — clean (0 issues)
- `uv run pytest` — 5861 passed, 10 skipped

Closes #1029

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates workflow script matching for interpreter inline-code operands. The main changes are:

- Added Python, Node, and Bun command-string detection.
- Skipped script-reference matching for inline-code invocations.
- Hid inline-code operands from run-line regex matching.
- Added workflow grouping fixtures for the new cases.
</details>

<h3>Confidence Score: 4/5</h3>

The changed workflow matching path needs a focused fix for Node option operands.

- Standalone `-c`, `-e`, and `--eval` cases are covered by new fixtures.
- The new option walker can mistake a required option operand for an eval flag.
- That can hide a real script reference and produce incorrect workflow grouping.

lintro/ai/review/chunker/workflow_scripts.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/review/chunker/workflow_scripts.py | Adds command-string detection and matching short-circuits, with an option-walk bug around required Node option operands. |
| tests/unit/ai/review/test_chunker_workflow_scripts.py | Adds workflow grouping cases for standalone command-string operands and a positive Python script reference. |
| test_samples/fixtures/review/chunk_does_not_group_python_c_command_string.diff | Adds a fixture where `python -c` does not group the operand as a script. |
| test_samples/fixtures/review/chunk_does_not_group_node_e_command_string.diff | Adds a fixture where `node -e` does not group the operand as a script. |
| test_samples/fixtures/review/chunk_does_not_group_node_eval_command_string.diff | Adds a fixture where `node --eval` does not group the operand as a script. |
| test_samples/fixtures/review/chunk_does_not_group_bun_e_command_string.diff | Adds a fixture where `bun -e` does not group the operand as a script. |
| test_samples/fixtures/review/chunk_groups_workflow_with_python_script.diff | Adds a fixture where `python scripts/review.py` still groups as a real script reference. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Fai%2Freview%2Fchunker%2Fworkflow_scripts.py%3A579%0A**Option%20Operand%20Becomes%20Eval%20Flag**%0A%0AWhen%20a%20Node%20option%20that%20requires%20an%20operand%20appears%20before%20the%20script%2C%20such%20as%20%60run%3A%20node%20-r%20-e%20scripts%2Fbuild.js%60%20or%20%60run%3A%20node%20--require%20-e%20scripts%2Fbuild.js%60%2C%20this%20new%20detector%20consumes%20%60-r%60%2F%60--require%60%20as%20a%20plain%20option%20and%20then%20treats%20its%20operand%20%60-e%60%20as%20inline-code%20mode.%20%60_segment_executes_reference_path%60%20then%20returns%20%60False%60%2C%20so%20the%20real%20script%20argument%20%60scripts%2Fbuild.js%60%20is%20missed%20and%20the%20workflow%20is%20not%20grouped%20with%20the%20changed%20script.%0A%0A&pr=1091&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Fai%2Freview%2Fchunker%2Fworkflow_scripts.py%3A579%0A**Option%20Operand%20Becomes%20Eval%20Flag**%0A%0AWhen%20a%20Node%20option%20that%20requires%20an%20operand%20appears%20before%20the%20script%2C%20such%20as%20%60run%3A%20node%20-r%20-e%20scripts%2Fbuild.js%60%20or%20%60run%3A%20node%20--require%20-e%20scripts%2Fbuild.js%60%2C%20this%20new%20detector%20consumes%20%60-r%60%2F%60--require%60%20as%20a%20plain%20option%20and%20then%20treats%20its%20operand%20%60-e%60%20as%20inline-code%20mode.%20%60_segment_executes_reference_path%60%20then%20returns%20%60False%60%2C%20so%20the%20real%20script%20argument%20%60scripts%2Fbuild.js%60%20is%20missed%20and%20the%20workflow%20is%20not%20grouped%20with%20the%20changed%20script.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1091&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F1029-workflow-cmd-operands%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1029-workflow-cmd-operands%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Fai%2Freview%2Fchunker%2Fworkflow_scripts.py%3A579%0A**Option%20Operand%20Becomes%20Eval%20Flag**%0A%0AWhen%20a%20Node%20option%20that%20requires%20an%20operand%20appears%20before%20the%20script%2C%20such%20as%20%60run%3A%20node%20-r%20-e%20scripts%2Fbuild.js%60%20or%20%60run%3A%20node%20--require%20-e%20scripts%2Fbuild.js%60%2C%20this%20new%20detector%20consumes%20%60-r%60%2F%60--require%60%20as%20a%20plain%20option%20and%20then%20treats%20its%20operand%20%60-e%60%20as%20inline-code%20mode.%20%60_segment_executes_reference_path%60%20then%20returns%20%60False%60%2C%20so%20the%20real%20script%20argument%20%60scripts%2Fbuild.js%60%20is%20missed%20and%20the%20workflow%20is%20not%20grouped%20with%20the%20changed%20script.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1091&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ai/review): exclude interpreter comm..."](https://github.com/lgtm-hq/py-lintro/commit/e9e47c38f7fdc52e9035449caab3c2ff2d79418f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41997221)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->