### PR TITLE
fix(ai/review): exclude interpreter command-string operands from workflow script matching

### DIFF
--- a/lintro/ai/review/chunker/workflow_scripts.py
+++ b/lintro/ai/review/chunker/workflow_scripts.py
@@ -281,6 +281,32 @@ def _runtime_short_option_needs_operand(*, runtime: str, option_char: str) -> bo
     return bool(runtime.startswith("node") and option_char == "r")
 
 
+def _runtime_command_string_option(*, runtime: str, token: str) -> bool:
+    """Return True when a runtime flag introduces an inline-code operand.
+
+    ``python``/``python3`` treat ``-c`` as a command string, and ``node``/``bun``
+    treat ``-e``/``--eval`` as inline source to evaluate. In these forms the token
+    following the option is code, not a script-file path, so it must not be
+    matched as a workflow script reference. ``bash``/``sh`` ``-c`` is deliberately
+    excluded here because its payload can itself execute a real script path and is
+    handled separately.
+
+    Args:
+        runtime: Lowercased interpreter name (for example ``python3``).
+        token: Candidate option token, including leading dashes.
+
+    Returns:
+        True when ``token`` selects command-string / eval mode for ``runtime``.
+    """
+    if runtime.startswith("python"):
+        return bool(re.match(r"^-c", token))
+    if runtime.startswith("node") or runtime == "bun":
+        if token.startswith("--"):
+            return token[2:].split("=", 1)[0] == "eval"
+        return bool(re.match(r"^-e", token))
+    return False
+
+
 def _runtime_option_is_terminating(*, runtime: str, token: str) -> bool:
     """Return True when a Node/Bun flag ends execution before any script."""
     if not (runtime.startswith("node") or runtime == "bun"):
@@ -339,6 +365,8 @@ def _strip_shell_interpreter_prefix(*, segment: str) -> str:
             continue
         if _runtime_option_is_terminating(runtime=runtime, token=token):
             return ""
+        if _runtime_command_string_option(runtime=runtime, token=token):
+            break
         if re.match(r"(?i)^-c", token) or re.match(r"(?i)^-s", token):
             break
         if not token.startswith("-"):
@@ -548,6 +576,67 @@ def _shell_command_string_payload_after_wrappers(*, segment: str) -> str | None:
     return None
 
 
+def _strip_wrappers_before_interpreter(*, segment: str) -> str:
+    """Strip non-executing wrappers while keeping the leading interpreter.
+
+    Removes ``env``/``VAR=value`` assignments, ``sudo``/``timeout`` dispatch
+    prefixes, ``exec``/``command`` wrappers, compound leaders (``then``/``do``),
+    and ``uv run`` plus its CLI options -- but stops at the interpreter token so
+    its command-string mode can be inspected (including ``uv run python -c ...``).
+
+    Args:
+        segment: Shell command segment to normalize.
+
+    Returns:
+        The segment with leading non-interpreter wrappers removed.
+    """
+    remaining = segment.strip()
+    while True:
+        previous = remaining
+        remaining = _strip_leading_shell_prefixes(segment=remaining)
+        remaining = _strip_command_dispatch_prefixes(segment=remaining)
+        remaining = _strip_shell_dispatch_wrappers(segment=remaining)
+        remaining = _strip_shell_compound_leaders(segment=remaining)
+        if re.match(r"(?i)^uv\s+run\b", remaining):
+            remaining = re.sub(r"(?i)^uv\s+run\b", "", remaining, count=1).lstrip()
+            remaining = _strip_uv_cli_options(segment=remaining)
+        if remaining == previous:
+            break
+    return remaining
+
+
+def _interpreter_command_string_segment(*, segment: str) -> bool:
+    """Return True when the leading interpreter runs an inline-code operand.
+
+    Strips non-executing wrappers, then determines whether the leading
+    ``python``/``node``/``bun`` interpreter runs in command-string mode
+    (``python -c``, ``node -e``/``--eval``, ``bun -e``/``--eval``). ``bash``/``sh``
+    are excluded because their ``-c`` payload may execute a real script path and
+    is handled by :func:`_shell_command_string_payload_after_wrappers`.
+
+    Args:
+        segment: Shell command segment to inspect.
+
+    Returns:
+        True when the interpreter's operand is inline code rather than a script.
+    """
+    exposed = _strip_wrappers_before_interpreter(segment=segment)
+    runtime_match = re.match(
+        rf"(?i)^(?P<runtime>{_WORKFLOW_SCRIPT_RUNTIMES})\b",
+        exposed,
+    )
+    if runtime_match is None:
+        return False
+    runtime = runtime_match.group("runtime").lower()
+    if runtime in {"bash", "sh"}:
+        return False
+    stripped = _strip_shell_interpreter_prefix(segment=exposed)
+    token = _first_shell_token(segment=stripped)
+    if token is None:
+        return False
+    return _runtime_command_string_option(runtime=runtime, token=token)
+
+
 def _first_shell_token(*, segment: str) -> str | None:
     """Return the first token from a shell segment."""
     token_match = re.match(r'\s*"((?:\\.|[^"\\])*)"|\'([^\']*)\'|(\S+)', segment)
@@ -617,6 +706,8 @@ def _segment_executes_reference_path(*, segment: str, path: str, cwd: str) -> bo
     if not stripped or _NON_EXECUTION_COMMAND.match(stripped):
         return False
     if _bash_stdin_invocation(segment=stripped):
+        return False
+    if _interpreter_command_string_segment(segment=stripped):
         return False
     payload = _shell_command_string_payload_after_wrappers(segment=stripped)
     if payload is not None:
@@ -710,7 +801,10 @@ def _run_line_reference_surface(*, line: str) -> str:
     command = _single_run_command_text(match=single_run)
     if command is None:
         return line
-    if _shell_command_string_payload_after_wrappers(segment=command) is not None:
+    shell_payload = _shell_command_string_payload_after_wrappers(segment=command)
+    if shell_payload is not None or _interpreter_command_string_segment(
+        segment=command,
+    ):
         return line[: single_run.start(1)]
     return line
 

--- a/test_samples/fixtures/review/chunk_does_not_group_bun_e_command_string.diff
+++ b/test_samples/fixtures/review/chunk_does_not_group_bun_e_command_string.diff
@@ -1,0 +1,12 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1 +1,2 @@
+ name: CI
++run: bun -e scripts/review.ts
+diff --git a/scripts/review.ts b/scripts/review.ts
+--- a/scripts/review.ts
++++ b/scripts/review.ts
+@@ -1 +1,2 @@
+ console.log('review')
++console.log('done')

--- a/test_samples/fixtures/review/chunk_does_not_group_node_e_command_string.diff
+++ b/test_samples/fixtures/review/chunk_does_not_group_node_e_command_string.diff
@@ -1,0 +1,12 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1 +1,2 @@
+ name: CI
++run: node -e scripts/build.js
+diff --git a/scripts/build.js b/scripts/build.js
+--- a/scripts/build.js
++++ b/scripts/build.js
+@@ -1 +1,2 @@
+ console.log('build')
++console.log('done')

--- a/test_samples/fixtures/review/chunk_does_not_group_node_eval_command_string.diff
+++ b/test_samples/fixtures/review/chunk_does_not_group_node_eval_command_string.diff
@@ -1,0 +1,12 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1 +1,2 @@
+ name: CI
++run: node --eval scripts/build.js
+diff --git a/scripts/build.js b/scripts/build.js
+--- a/scripts/build.js
++++ b/scripts/build.js
+@@ -1 +1,2 @@
+ console.log('build')
++console.log('done')

--- a/test_samples/fixtures/review/chunk_does_not_group_python_c_command_string.diff
+++ b/test_samples/fixtures/review/chunk_does_not_group_python_c_command_string.diff
@@ -1,0 +1,12 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1 +1,2 @@
+ name: CI
++run: python -c scripts/review.py
+diff --git a/scripts/review.py b/scripts/review.py
+--- a/scripts/review.py
++++ b/scripts/review.py
+@@ -1 +1,2 @@
+ print('review')
++print('done')

--- a/test_samples/fixtures/review/chunk_groups_workflow_with_python_script_reference.diff
+++ b/test_samples/fixtures/review/chunk_groups_workflow_with_python_script_reference.diff
@@ -1,0 +1,12 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1 +1,2 @@
+ name: CI
++run: python scripts/review.py
+diff --git a/scripts/review.py b/scripts/review.py
+--- a/scripts/review.py
++++ b/scripts/review.py
+@@ -1 +1,2 @@
+ print('review')
++print('done')

--- a/tests/unit/ai/review/test_chunker_workflow_scripts.py
+++ b/tests/unit/ai/review/test_chunker_workflow_scripts.py
@@ -131,6 +131,56 @@ CASES: tuple[WorkflowGroupingCase, ...] = (
         check_warnings=False,
     ),
     WorkflowGroupingCase(
+        id="does_not_group_python_c_command_string_operand",
+        fixture="chunk_does_not_group_python_c_command_string.diff",
+        files=(".github/workflows/ci.yml", "scripts/review.py"),
+        not_contains=("scripts/review.py",),
+        grouped_separately="scripts/review.py",
+        warning=(
+            "Script scripts/review.py changed alongside workflows but is not "
+            "referenced in any changed workflow diff; grouped separately."
+        ),
+    ),
+    WorkflowGroupingCase(
+        id="does_not_group_node_e_command_string_operand",
+        fixture="chunk_does_not_group_node_e_command_string.diff",
+        files=(".github/workflows/ci.yml", "scripts/build.js"),
+        not_contains=("scripts/build.js",),
+        grouped_separately="scripts/build.js",
+        warning=(
+            "Script scripts/build.js changed alongside workflows but is not "
+            "referenced in any changed workflow diff; grouped separately."
+        ),
+    ),
+    WorkflowGroupingCase(
+        id="does_not_group_node_eval_command_string_operand",
+        fixture="chunk_does_not_group_node_eval_command_string.diff",
+        files=(".github/workflows/ci.yml", "scripts/build.js"),
+        not_contains=("scripts/build.js",),
+        grouped_separately="scripts/build.js",
+        warning=(
+            "Script scripts/build.js changed alongside workflows but is not "
+            "referenced in any changed workflow diff; grouped separately."
+        ),
+    ),
+    WorkflowGroupingCase(
+        id="does_not_group_bun_e_command_string_operand",
+        fixture="chunk_does_not_group_bun_e_command_string.diff",
+        files=(".github/workflows/ci.yml", "scripts/review.ts"),
+        not_contains=("scripts/review.ts",),
+        grouped_separately="scripts/review.ts",
+        warning=(
+            "Script scripts/review.ts changed alongside workflows but is not "
+            "referenced in any changed workflow diff; grouped separately."
+        ),
+    ),
+    WorkflowGroupingCase(
+        id="groups_workflow_with_python_script_reference",
+        fixture="chunk_groups_workflow_with_python_script_reference.diff",
+        files=(".github/workflows/ci.yml", "scripts/review.py"),
+        contains=("scripts/review.py",),
+    ),
+    WorkflowGroupingCase(
         id="groups_workflow_with_uv_run_with_editable_script",
         fixture="chunk_groups_workflow_with_uv_run_with_editable_script.diff",
         files=(".github/workflows/ci.yml", "scripts/review.py"),


### PR DESCRIPTION
## Summary

The review chunker's workflow-script matcher wrongly treated interpreter **command-string / eval operands** as script-file references. Forms like `run: python -c scripts/review.py`, `run: node -e scripts/build.js`, `run: node --eval scripts/build.js`, and `run: bun -e scripts/review.ts` caused an unrelated changed script to be grouped with the workflow and its unreferenced-script warning to be suppressed. The operand after these options is inline source text, not a file path.

This recovers the work from the lost/closed PR #1091 (which was never merged into `main`), re-implemented equivalently.

## Changes

In `lintro/ai/review/chunker/workflow_scripts.py`:

- Added `_runtime_command_string_option` recognizing `-c` (python/python3) and `-e`/`--eval` (node/bun) as inline-code options. `bash`/`sh` `-c` is deliberately excluded because its payload can execute a real script and is handled separately.
- Added `_strip_wrappers_before_interpreter` (strips `env`, `sudo`/`timeout`, `uv run` + options, `exec`/`command`, `VAR=val` assignments, and compound leaders while keeping the interpreter) and `_interpreter_command_string_segment` to determine whether the leading interpreter runs in command-string mode — including the wrapped `uv run python -c ...` form.
- Wired the guard into `_segment_executes_reference_path` (short-circuit path) and `_run_line_reference_surface` (regex fast path) so command-string operands are excluded from both.
- Stopped `_strip_shell_interpreter_prefix` at node/bun `-e`/`--eval`.

## Tests

Added parametrized `WorkflowGroupingCase` entries (and fixtures) proving `python -c`, `node -e`, `node --eval`, and `bun -e` operands are grouped separately with the unreferenced-script warning preserved, while a genuine `python scripts/review.py` reference still groups.

## Gates

- `uv run lintro fmt` / `uv run lintro chk` — clean
- `uv run pytest` — 5879 passed, 10 skipped

Closes #1029

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates workflow script matching for interpreter command strings. The main changes are:

- Detects Python, Node, and Bun inline-code flags.
- Skips command-string operands during workflow script reference matching.
- Preserves separate handling for Bash and sh command payloads.
- Adds fixtures and tests for eval operands and real script references.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/review/chunker/workflow_scripts.py | Adds wrapper-aware detection for Python, Node, and Bun command-string mode and applies it to both workflow matching paths. |
| tests/unit/ai/review/test_chunker_workflow_scripts.py | Adds negative command-string grouping cases and a positive Python script-reference control. |
| test_samples/fixtures/review/chunk_does_not_group_python_c_command_string.diff | Adds a fixture for `python -c` inline-code operands. |
| test_samples/fixtures/review/chunk_does_not_group_node_e_command_string.diff | Adds a fixture for `node -e` inline-code operands. |
| test_samples/fixtures/review/chunk_does_not_group_node_eval_command_string.diff | Adds a fixture for `node --eval` inline-code operands. |
| test_samples/fixtures/review/chunk_does_not_group_bun_e_command_string.diff | Adds a fixture for `bun -e` inline-code operands. |
| test_samples/fixtures/review/chunk_groups_workflow_with_python_script_reference.diff | Adds a fixture showing `python scripts/review.py` still groups as a real script reference. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ai/review): exclude interpreter comm..."](https://github.com/lgtm-hq/py-lintro/commit/4ebe1915a9fcf08f974b4e314d4a8b6245c329ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42004834)</sub>

<!-- /greptile_comment -->