### PR TITLE
fix(ai/review): provider-aware error taxonomy — surface real cause (not generic 'aborted')

### DIFF
--- a/lintro/ai/review/errors_taxonomy.py
+++ b/lintro/ai/review/errors_taxonomy.py
@@ -1,0 +1,369 @@
+"""Provider-aware error taxonomy for AI review failures.
+
+Classifies a raw provider or orchestrator exception into a canonical
+:class:`ReviewErrorKind` so the PR error sticky can surface the *real* cause
+(for example depleted API credits) instead of a generic "review aborted"
+message. Each provider signals the same canonical condition differently
+(Anthropic returns HTTP 400 for depleted credits, OpenAI returns HTTP 429 with
+``insufficient_quota``, CLI transports only emit stderr text), so the mapping is
+expressed as a per-provider signature map layered over a shared fallback set.
+
+Adding a new provider is a single entry in :data:`PROVIDER_ERROR_SIGNATURES`;
+the canonical kinds and their user-facing copy in :data:`KIND_COPY` never
+change.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum, auto
+
+from lintro.ai.exceptions import AIAuthenticationError, AIRateLimitError
+
+
+class ReviewErrorKind(StrEnum):
+    """Canonical, provider-agnostic classification of a review failure.
+
+    Members:
+        AUTH_FAILED: The provider rejected the API key (invalid or missing).
+        INSUFFICIENT_CREDITS: The account balance/credits are depleted or a hard
+            billing limit was hit (distinct from a plan quota window).
+        QUOTA_EXCEEDED: A plan or usage quota was exceeded (distinct from
+            pay-as-you-go credit depletion).
+        RATE_LIMITED: The provider throttled the request (HTTP 429).
+        CONTEXT_LENGTH: The prompt exceeded the model's maximum context window.
+        SERVER_ERROR: The provider returned a 5xx / overloaded response.
+        TIMEOUT: The request timed out before a response was returned.
+        UNKNOWN: No signature matched; the surfaced cause text is shown as-is.
+    """
+
+    AUTH_FAILED = auto()
+    INSUFFICIENT_CREDITS = auto()
+    QUOTA_EXCEEDED = auto()
+    RATE_LIMITED = auto()
+    CONTEXT_LENGTH = auto()
+    SERVER_ERROR = auto()
+    TIMEOUT = auto()
+    UNKNOWN = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class ErrorMatcher:
+    """A single (status codes, substrings) signature for one error kind.
+
+    A matcher fires when the error text contains any of its case-insensitive
+    substrings, or when an extracted HTTP status matches one of its status
+    codes. Substrings are the primary discriminator (CLI transports have no
+    status); status codes corroborate or catch bare-status errors.
+
+    Attributes:
+        substrings: Lowercase needles matched against the lowercased error text.
+        statuses: HTTP status codes that also indicate this kind.
+    """
+
+    substrings: tuple[str, ...] = ()
+    statuses: tuple[int, ...] = ()
+
+    def matches(self, *, status: int | None, text: str) -> bool:
+        """Return whether this matcher fires for the given status and text.
+
+        Args:
+            status: Extracted HTTP status code, or ``None`` when unavailable.
+            text: Lowercased error text to search.
+
+        Returns:
+            True when any substring is present or the status is listed.
+        """
+        text_ok = any(needle in text for needle in self.substrings)
+        status_ok = status is not None and status in self.statuses
+        return text_ok or status_ok
+
+
+# Order in which kinds are tested. More specific/discriminating kinds are
+# checked before broader ones so, e.g., an OpenAI ``insufficient_quota`` on a
+# 429 resolves to INSUFFICIENT_CREDITS rather than a bare RATE_LIMITED.
+_KIND_PRIORITY: tuple[ReviewErrorKind, ...] = (
+    ReviewErrorKind.INSUFFICIENT_CREDITS,
+    ReviewErrorKind.QUOTA_EXCEEDED,
+    ReviewErrorKind.AUTH_FAILED,
+    ReviewErrorKind.CONTEXT_LENGTH,
+    ReviewErrorKind.RATE_LIMITED,
+    ReviewErrorKind.TIMEOUT,
+    ReviewErrorKind.SERVER_ERROR,
+)
+
+
+PROVIDER_ERROR_SIGNATURES: dict[str, dict[ReviewErrorKind, ErrorMatcher]] = {
+    "anthropic": {
+        # Depleted credits: HTTP 400 invalid_request_error, NOT 402/429.
+        ReviewErrorKind.INSUFFICIENT_CREDITS: ErrorMatcher(
+            substrings=("credit balance is too low", "credit balance"),
+        ),
+        ReviewErrorKind.RATE_LIMITED: ErrorMatcher(
+            substrings=("rate_limit_error", "rate limit"),
+            statuses=(429,),
+        ),
+        ReviewErrorKind.AUTH_FAILED: ErrorMatcher(
+            substrings=("authentication_error", "invalid x-api-key", "invalid api key"),
+            statuses=(401,),
+        ),
+        ReviewErrorKind.CONTEXT_LENGTH: ErrorMatcher(
+            substrings=("prompt is too long", "maximum context"),
+        ),
+        ReviewErrorKind.SERVER_ERROR: ErrorMatcher(
+            substrings=("overloaded_error", "overloaded", "api_error"),
+            statuses=(500, 502, 503, 504, 529),
+        ),
+    },
+    "openai": {
+        # Depleted credits / hard billing limit: 429 with insufficient_quota.
+        ReviewErrorKind.INSUFFICIENT_CREDITS: ErrorMatcher(
+            substrings=("insufficient_quota", "billing_hard_limit_reached"),
+        ),
+        ReviewErrorKind.RATE_LIMITED: ErrorMatcher(
+            substrings=("rate_limit_exceeded", "rate limit"),
+            statuses=(429,),
+        ),
+        ReviewErrorKind.AUTH_FAILED: ErrorMatcher(
+            substrings=("invalid_api_key", "invalid api key"),
+            statuses=(401,),
+        ),
+        ReviewErrorKind.CONTEXT_LENGTH: ErrorMatcher(
+            substrings=("context_length_exceeded", "maximum context length"),
+        ),
+        ReviewErrorKind.SERVER_ERROR: ErrorMatcher(
+            substrings=("server_error", "service unavailable"),
+            statuses=(500, 502, 503, 504),
+        ),
+    },
+    "cursor": {
+        # CLI transport: no HTTP status, only stderr text.
+        ReviewErrorKind.INSUFFICIENT_CREDITS: ErrorMatcher(
+            substrings=(
+                "credit balance",
+                "insufficient credits",
+                "out of credits",
+                "usage limit reached",
+            ),
+        ),
+        ReviewErrorKind.RATE_LIMITED: ErrorMatcher(
+            substrings=("rate limit", "too many requests"),
+        ),
+        ReviewErrorKind.AUTH_FAILED: ErrorMatcher(
+            substrings=(
+                "not logged in",
+                "authentication",
+                "unauthorized",
+                "invalid api key",
+                "agent login",
+            ),
+        ),
+        ReviewErrorKind.CONTEXT_LENGTH: ErrorMatcher(
+            substrings=("context length", "too long", "maximum context"),
+        ),
+        ReviewErrorKind.TIMEOUT: ErrorMatcher(
+            substrings=("timed out", "timeout"),
+        ),
+    },
+}
+
+
+# Shared heuristics applied when no provider-specific signature matches. Kept
+# deliberately broad so a novel provider still resolves to a sensible kind.
+_SHARED_SIGNATURES: dict[ReviewErrorKind, ErrorMatcher] = {
+    ReviewErrorKind.INSUFFICIENT_CREDITS: ErrorMatcher(
+        substrings=(
+            "credit balance",
+            "insufficient_quota",
+            "insufficient credits",
+            "out of credits",
+            "billing_hard_limit_reached",
+            "billing hard limit",
+            "payment required",
+        ),
+        statuses=(402,),
+    ),
+    ReviewErrorKind.QUOTA_EXCEEDED: ErrorMatcher(
+        substrings=("quota exceeded", "exceeded your current quota", "usage limit"),
+    ),
+    ReviewErrorKind.AUTH_FAILED: ErrorMatcher(
+        substrings=(
+            "authentication",
+            "unauthorized",
+            "invalid api key",
+            "invalid_api_key",
+        ),
+        statuses=(401,),
+    ),
+    ReviewErrorKind.CONTEXT_LENGTH: ErrorMatcher(
+        substrings=(
+            "context length",
+            "maximum context",
+            "prompt is too long",
+            "context_length_exceeded",
+            "too many tokens",
+        ),
+    ),
+    ReviewErrorKind.RATE_LIMITED: ErrorMatcher(
+        substrings=("rate limit", "rate_limit", "too many requests"),
+        statuses=(429,),
+    ),
+    ReviewErrorKind.TIMEOUT: ErrorMatcher(
+        substrings=("timed out", "timeout"),
+    ),
+    ReviewErrorKind.SERVER_ERROR: ErrorMatcher(
+        substrings=(
+            "server error",
+            "internal server error",
+            "service unavailable",
+            "overloaded",
+            "bad gateway",
+        ),
+        statuses=(500, 502, 503, 504),
+    ),
+}
+
+
+# Provider-agnostic (message, guidance) copy for the PR error sticky.
+KIND_COPY: dict[ReviewErrorKind, tuple[str, str]] = {
+    ReviewErrorKind.AUTH_FAILED: (
+        "authentication failed (invalid or missing API key)",
+        "Check the provider API key configured for this workflow (e.g. the "
+        "`ANTHROPIC_API_KEY` or `OPENAI_API_KEY` secret).",
+    ),
+    ReviewErrorKind.INSUFFICIENT_CREDITS: (
+        "the provider reported no available quota or credits — the account "
+        "balance is depleted",
+        "Top up the provider account (or raise the plan quota), or lower "
+        "`ai.max_cost_usd`, then re-run.",
+    ),
+    ReviewErrorKind.QUOTA_EXCEEDED: (
+        "the provider reported the plan quota was exceeded",
+        "Raise the plan quota/limit or wait for the quota window to reset, then "
+        "re-run.",
+    ),
+    ReviewErrorKind.RATE_LIMITED: (
+        "the provider rate-limited the request (429)",
+        "Retry later, lower review depth, or switch provider/model.",
+    ),
+    ReviewErrorKind.CONTEXT_LENGTH: (
+        "the request exceeded the model's maximum context length",
+        "Narrow `--path` to a smaller diff, lower review depth, or use a model "
+        "with a larger context window.",
+    ),
+    ReviewErrorKind.SERVER_ERROR: (
+        "the provider returned a server error (5xx)",
+        "This is usually transient — retry shortly.",
+    ),
+    ReviewErrorKind.TIMEOUT: (
+        "the request timed out",
+        "Retry, raise `ai.api_timeout`, or narrow `--path` to a smaller diff.",
+    ),
+    ReviewErrorKind.UNKNOWN: (
+        "provider error",
+        "Retry, or check provider status and the workflow logs.",
+    ),
+}
+
+
+_STATUS_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"error code[:\s]+(\d{3})"),
+    re.compile(r"status[_ ]?code[:\s=]+(\d{3})"),
+    re.compile(r"http[/ ]?(?:status[: ]*)?(\d{3})"),
+    re.compile(r"^\s*(\d{3})\b"),
+)
+
+
+def _extract_status(*, text: str) -> int | None:
+    """Extract an HTTP status code from error text when clearly present.
+
+    Args:
+        text: Lowercased error text.
+
+    Returns:
+        The parsed status code, or ``None`` when no confident match is found.
+    """
+    for pattern in _STATUS_PATTERNS:
+        match = pattern.search(text)
+        if match is not None:
+            return int(match.group(1))
+    return None
+
+
+def resolve_cause_text(*, error: Exception) -> str:
+    """Resolve the most specific underlying cause message for an error.
+
+    Unwraps a :class:`~lintro.ai.review.exceptions.ReviewExecutionError` to its
+    captured ``cause_message`` (the real provider error), falling back to the
+    chained ``__cause__`` and finally the exception's own string form.
+
+    Args:
+        error: The exception raised during review.
+
+    Returns:
+        The most informative human-readable cause text available.
+    """
+    from lintro.ai.review.exceptions import ReviewExecutionError
+
+    if isinstance(error, ReviewExecutionError) and error.cause_message:
+        return error.cause_message
+    cause = error.__cause__
+    if isinstance(cause, BaseException):
+        return str(cause)
+    return str(error)
+
+
+def _resolve_cause_exception(*, error: Exception) -> BaseException:
+    """Return the deepest chained cause exception (for ``isinstance`` checks)."""
+    current: BaseException = error
+    while isinstance(current.__cause__, BaseException):
+        current = current.__cause__
+    return current
+
+
+def classify_provider_error(*, provider: str, error: Exception) -> ReviewErrorKind:
+    """Classify a review error into a canonical :class:`ReviewErrorKind`.
+
+    Resolves the underlying provider cause (unwrapping any
+    ``ReviewExecutionError`` wrapper), then tests it against the provider's
+    signature map, the lintro AI exception hierarchy, and finally a shared
+    fallback set before defaulting to :attr:`ReviewErrorKind.UNKNOWN`. When the
+    error already carries a resolved kind (attached by the orchestrator), that
+    kind is authoritative.
+
+    Args:
+        provider: Provider identifier (e.g. ``"anthropic"``); case-insensitive.
+        error: The exception raised during review, possibly a wrapper.
+
+    Returns:
+        The resolved canonical error kind.
+    """
+    from lintro.ai.review.exceptions import ReviewExecutionError
+
+    if isinstance(error, ReviewExecutionError) and error.error_kind is not None:
+        return error.error_kind
+
+    text = resolve_cause_text(error=error).lower()
+    status = _extract_status(text=text)
+    cause_exc = _resolve_cause_exception(error=error)
+
+    signatures = PROVIDER_ERROR_SIGNATURES.get((provider or "").lower(), {})
+    for kind in _KIND_PRIORITY:
+        matcher = signatures.get(kind)
+        if matcher is not None and matcher.matches(status=status, text=text):
+            return kind
+
+    # Subsume the existing lintro AI exception hierarchy: a typed auth/rate-limit
+    # error is authoritative even when its text carries no matching substring.
+    if isinstance(cause_exc, AIAuthenticationError):
+        return ReviewErrorKind.AUTH_FAILED
+    if isinstance(cause_exc, AIRateLimitError):
+        return ReviewErrorKind.RATE_LIMITED
+
+    for kind in _KIND_PRIORITY:
+        matcher = _SHARED_SIGNATURES.get(kind)
+        if matcher is not None and matcher.matches(status=status, text=text):
+            return kind
+
+    return ReviewErrorKind.UNKNOWN

--- a/lintro/ai/review/errors_taxonomy.py
+++ b/lintro/ai/review/errors_taxonomy.py
@@ -35,6 +35,9 @@ class ReviewErrorKind(StrEnum):
         CONTEXT_LENGTH: The prompt exceeded the model's maximum context window.
         SERVER_ERROR: The provider returned a 5xx / overloaded response.
         TIMEOUT: The request timed out before a response was returned.
+        INVALID_RESPONSE: The model returned a malformed/unparseable response
+            (a lintro-side parse/validation failure, not a provider transport
+            error).
         UNKNOWN: No signature matched; the surfaced cause text is shown as-is.
     """
 
@@ -45,6 +48,7 @@ class ReviewErrorKind(StrEnum):
     CONTEXT_LENGTH = auto()
     SERVER_ERROR = auto()
     TIMEOUT = auto()
+    INVALID_RESPONSE = auto()
     UNKNOWN = auto()
 
 
@@ -260,9 +264,14 @@ KIND_COPY: dict[ReviewErrorKind, tuple[str, str]] = {
         "the request timed out",
         "Retry, raise `ai.api_timeout`, or narrow `--path` to a smaller diff.",
     ),
+    ReviewErrorKind.INVALID_RESPONSE: (
+        "the model returned a malformed or unparseable response",
+        "Retry the review — model output may have been malformed — or try a "
+        "different model via `ai.model`.",
+    ),
     ReviewErrorKind.UNKNOWN: (
-        "provider error",
-        "Retry, or check provider status and the workflow logs.",
+        "the review could not be completed",
+        "See the cause above and the workflow logs; retry if it looks transient.",
     ),
 }
 
@@ -365,5 +374,11 @@ def classify_provider_error(*, provider: str, error: Exception) -> ReviewErrorKi
         matcher = _SHARED_SIGNATURES.get(kind)
         if matcher is not None and matcher.matches(status=status, text=text):
             return kind
+
+    # A bare ``ValueError`` cause is a lintro-side parse/validation failure of
+    # the model response, not a provider transport error — surface it as such
+    # rather than misdirecting the user to check provider status.
+    if isinstance(cause_exc, ValueError):
+        return ReviewErrorKind.INVALID_RESPONSE
 
     return ReviewErrorKind.UNKNOWN

--- a/lintro/ai/review/exceptions.py
+++ b/lintro/ai/review/exceptions.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from lintro.ai.exceptions import AIError
 from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
+
+if TYPE_CHECKING:
+    from lintro.ai.review.errors_taxonomy import ReviewErrorKind
 
 
 class ReviewContextError(AIError):
@@ -52,6 +56,8 @@ class ReviewExecutionError(AIError):
         step: Sub-step within the chunk (e.g. "reviewing").
         completed_chunks: Number of chunks successfully reviewed before failure.
         cause_message: Original provider or parser error text.
+        error_kind: Canonical classification of the underlying cause, resolved
+            provider-aware at the raise site. ``None`` when not yet classified.
     """
 
     message: str
@@ -60,6 +66,7 @@ class ReviewExecutionError(AIError):
     step: str | None = None
     completed_chunks: int = 0
     cause_message: str = ""
+    error_kind: ReviewErrorKind | None = None
 
     def __post_init__(self) -> None:
         """Initialize the base exception args from the message field."""

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -17,12 +17,6 @@ from typing import Any
 
 from loguru import logger
 
-from lintro.ai.exceptions import (
-    AIAuthenticationError,
-    AIError,
-    AIProviderError,
-    AIRateLimitError,
-)
 from lintro.ai.integrations.github_pr import GitHubPRReporter
 from lintro.ai.review.checklist_display import (
     cleared_answers,
@@ -31,6 +25,12 @@ from lintro.ai.review.checklist_display import (
     questions_for_finding,
 )
 from lintro.ai.review.enums.checklist_display import ChecklistDisplay
+from lintro.ai.review.errors_taxonomy import (
+    KIND_COPY,
+    ReviewErrorKind,
+    classify_provider_error,
+    resolve_cause_text,
+)
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
@@ -539,16 +539,23 @@ def parse_review_state(*, body: str) -> list[dict[str, Any]]:
 def format_error_comment(
     *,
     error: Exception,
+    provider: str | None = None,
     metadata: ReviewMetadata | None = None,
     prior_runs: list[dict[str, Any]] | None = None,
 ) -> str:
     """Format a provider/API error as a clear PR comment.
 
-    Maps lintro's AI exception hierarchy (and common error text) to a specific,
-    human-readable message instead of a bare failure.
+    Classifies the error provider-aware, against the underlying provider cause
+    (unwrapping any orchestrator wrapper), into a canonical
+    :class:`~lintro.ai.review.errors_taxonomy.ReviewErrorKind` and renders the
+    specific sticky for that kind — for example, depleted credits render as a
+    clear "top up or lower ai.max_cost_usd" message rather than a generic
+    "review aborted". The real underlying cause text is always surfaced.
 
     Args:
         error: The exception raised during review.
+        provider: Provider identifier used for provider-aware classification.
+            Falls back to ``metadata.provider`` when omitted.
         metadata: Optional review metadata for a mechanics footer.
         prior_runs: Run records recovered from the previous sticky comment.
             Re-emitted so a transient error does not reset cumulative telemetry.
@@ -556,7 +563,13 @@ def format_error_comment(
     Returns:
         Markdown comment body describing the failure and next steps.
     """
-    detail, guidance = _classify_error(error=error)
+    resolved_provider = provider or (metadata.provider if metadata else "") or ""
+    kind = classify_provider_error(provider=resolved_provider, error=error)
+    detail, guidance = _render_error_copy(
+        kind=kind,
+        error=error,
+        provider=resolved_provider,
+    )
     lines = [
         STICKY_MARKER,
         "## 🔎 Lintro Review",
@@ -574,44 +587,39 @@ def format_error_comment(
     return body
 
 
-def _classify_error(*, error: Exception) -> tuple[str, str]:
-    """Return a (detail, guidance) pair for a review error."""
-    message = sanitize_comment_text(str(error), limit=500)
-    lowered = message.lower()
+def _render_error_copy(
+    *,
+    kind: ReviewErrorKind,
+    error: Exception,
+    provider: str,
+) -> tuple[str, str]:
+    """Build the (detail, guidance) pair for a classified review error.
 
-    if isinstance(error, AIAuthenticationError) or "401" in lowered:
-        return (
-            "authentication failed (invalid or missing API key)",
-            "Check the provider API key configured for this workflow (e.g. the "
-            "`ANTHROPIC_API_KEY` secret).",
-        )
-    if (
-        isinstance(error, AIRateLimitError)
-        or "429" in lowered
-        or "rate limit" in lowered
-    ):
-        return (
-            "the provider rate-limited the request (429)",
-            "Retry later, lower review depth, or switch provider/model.",
-        )
-    if any(term in lowered for term in ("quota", "credit", "insufficient", "billing")):
-        return (
-            "the provider reported no available quota or credits",
-            "Top up the provider account or raise the plan limit, then re-run.",
-        )
-    if any(term in lowered for term in ("timeout", "timed out")):
-        return (
-            "the request timed out",
-            "Retry, raise `ai.api_timeout`, or narrow `--path` to a smaller diff.",
-        )
-    if any(term in lowered for term in ("500", "502", "503", "504", "server error")):
-        return (
-            "the provider returned a server error (5xx)",
-            "This is usually transient — retry shortly.",
-        )
-    if isinstance(error, (AIProviderError, AIError)):
-        return (f"provider error: {message}", "Retry, or check provider status.")
-    return (f"unexpected error: {message}", "See the workflow logs for details.")
+    The detail is prefixed with the provider label when known and always
+    carries the surfaced underlying cause text. For an unknown kind the cause
+    text is the primary signal; for known kinds it is appended so the real
+    provider message is never lost.
+
+    Args:
+        kind: Resolved canonical error kind.
+        error: The original exception (possibly a wrapper).
+        provider: Provider identifier, used only as a display label.
+
+    Returns:
+        Tuple of ``(detail, guidance)`` markdown strings.
+    """
+    message, guidance = KIND_COPY[kind]
+    cause = sanitize_comment_text(resolve_cause_text(error=error), limit=500)
+    label = f"`{sanitize_comment_text(provider, limit=40)}` " if provider else ""
+
+    if kind is ReviewErrorKind.UNKNOWN:
+        detail = f"{label}{message}: {cause}" if cause else f"{label}{message}"
+        return detail, guidance
+
+    detail = f"{label}{message}"
+    if cause:
+        detail += f" (provider reported: {cause})"
+    return detail, guidance
 
 
 def post_review_to_github(
@@ -675,6 +683,7 @@ def post_review_to_github(
 def post_review_error_to_github(
     *,
     error: Exception,
+    provider: str | None = None,
     metadata: ReviewMetadata | None = None,
     pr_number: int | None = None,
     repo: str | None = None,
@@ -684,6 +693,7 @@ def post_review_error_to_github(
 
     Args:
         error: The exception raised during review.
+        provider: Provider identifier used for provider-aware classification.
         metadata: Optional metadata for a mechanics footer.
         pr_number: Optional PR number override.
         repo: Optional repository override (owner/name).
@@ -699,6 +709,7 @@ def post_review_error_to_github(
     comment_id, prior_runs = _load_prior_runs(reporter=gh_reporter)
     body = format_error_comment(
         error=error,
+        provider=provider,
         metadata=metadata,
         prior_runs=prior_runs,
     )

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -40,6 +40,10 @@ from lintro.ai.prompts.review import (
 from lintro.ai.registry import AIProvider
 from lintro.ai.review.chunker import chunk_review_context
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
+from lintro.ai.review.errors_taxonomy import (
+    classify_provider_error,
+    resolve_cause_text,
+)
 from lintro.ai.review.exceptions import ReviewExecutionError
 from lintro.ai.review.group_labels import REL_DIRECTORY_PREFIX, REL_SINGLE_FILE
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
@@ -106,6 +110,54 @@ def _redact_prompt_text(*, text: str, source: str) -> str:
             source=source,
         )
     return redact_secrets(text)
+
+
+def _aborted_before_completion(
+    *,
+    cause: Exception,
+    provider: BaseAIProvider,
+    chunk_index: int,
+    total_chunks: int,
+    step: str,
+    completed_chunks: int,
+) -> ReviewExecutionError:
+    """Wrap a mid-run chunk failure, preserving and surfacing the real cause.
+
+    Classifies the underlying provider exception into a canonical
+    :class:`~lintro.ai.review.errors_taxonomy.ReviewErrorKind` and logs the real
+    cause text so the true failure (e.g. depleted credits) is never lost behind
+    the generic "aborted" wrapper.
+
+    Args:
+        cause: The underlying provider or parser exception.
+        provider: Configured provider, used to resolve provider-aware kinds.
+        chunk_index: Zero-based index of the failing chunk.
+        total_chunks: Total chunks planned for the review.
+        step: Sub-step within the chunk where the failure occurred.
+        completed_chunks: Number of chunks completed before the failure.
+
+    Returns:
+        A ``ReviewExecutionError`` carrying the resolved kind and cause message.
+    """
+    kind = classify_provider_error(provider=str(provider.name), error=cause)
+    cause_message = resolve_cause_text(error=cause)
+    logger.error(
+        "Review aborted before all chunks completed on chunk {chunk} during "
+        "{step} — kind={kind}, cause: {cause}",
+        chunk=chunk_index,
+        step=step,
+        kind=kind.value,
+        cause=cause_message,
+    )
+    return ReviewExecutionError(
+        message="Review aborted before all chunks completed.",
+        chunk_index=chunk_index,
+        total_chunks=total_chunks,
+        step=step,
+        completed_chunks=completed_chunks,
+        cause_message=cause_message,
+        error_kind=kind,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -246,13 +298,13 @@ def _review_all_chunks(
                     completed_chunks=chunk_index,
                     error=exc,
                 )
-                raise ReviewExecutionError(
-                    message="Review aborted before all chunks completed.",
+                raise _aborted_before_completion(
+                    cause=exc,
+                    provider=provider,
                     chunk_index=chunk_index,
                     total_chunks=len(chunks),
                     step="reviewing",
                     completed_chunks=chunk_index,
-                    cause_message=str(exc),
                 ) from exc
             sequential_partials.append(partial)
             if completed_sink is not None:
@@ -305,13 +357,13 @@ def _review_all_chunks(
                 raise
             except Exception as exc:
                 if first_error is None:
-                    first_error = ReviewExecutionError(
-                        message="Review aborted before all chunks completed.",
+                    first_error = _aborted_before_completion(
+                        cause=exc,
+                        provider=provider,
                         chunk_index=chunk_index,
                         total_chunks=len(chunks),
                         step="reviewing",
                         completed_chunks=completed,
-                        cause_message=str(exc),
                     )
                 for pending in futures:
                     pending.cancel()
@@ -377,13 +429,13 @@ def _review_chunk_with_progress(
             completed_chunks=chunk_index,
             error=exc,
         )
-        raise ReviewExecutionError(
-            message="Review aborted before all chunks completed.",
+        raise _aborted_before_completion(
+            cause=exc,
+            provider=provider,
             chunk_index=chunk_index,
             total_chunks=total_chunks,
             step=last_step,
             completed_chunks=chunk_index,
-            cause_message=str(exc),
         ) from exc
     progress.on_chunk_done(chunk_index=chunk_index)
     return partial

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -286,6 +286,7 @@ def review_command(
             with suppress(Exception):
                 post_review_error_to_github(
                     error=exc,
+                    provider=str(provider.name),
                     pr_number=resolved_pr,
                     repo=effective_repo,
                 )

--- a/tests/unit/ai/review/test_errors_taxonomy.py
+++ b/tests/unit/ai/review/test_errors_taxonomy.py
@@ -1,0 +1,215 @@
+"""Tests for the provider-aware review error taxonomy and its sticky copy."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.ai.exceptions import (
+    AIAuthenticationError,
+    AIProviderError,
+    AIRateLimitError,
+)
+from lintro.ai.review.errors_taxonomy import (
+    KIND_COPY,
+    ReviewErrorKind,
+    classify_provider_error,
+    resolve_cause_text,
+)
+from lintro.ai.review.exceptions import ReviewExecutionError
+from lintro.ai.review.github import format_error_comment
+
+# --- per-provider classification --------------------------------------------
+
+
+def test_anthropic_insufficient_credits() -> None:
+    """Anthropic depleted credits (HTTP 400) classify as INSUFFICIENT_CREDITS."""
+    error = AIProviderError(
+        "Anthropic API error: Error code: 400 - {'type': 'error', 'error': "
+        "{'type': 'invalid_request_error', 'message': 'Your credit balance is "
+        "too low to access the Anthropic API.'}}",
+    )
+    kind = classify_provider_error(provider="anthropic", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.INSUFFICIENT_CREDITS)
+
+
+def test_anthropic_rate_limited() -> None:
+    """Anthropic 429 rate_limit_error classifies as RATE_LIMITED."""
+    error = AIRateLimitError(
+        "Anthropic rate limit exceeded: Error code: 429 - rate_limit_error",
+    )
+    kind = classify_provider_error(provider="anthropic", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.RATE_LIMITED)
+
+
+def test_anthropic_auth_failed() -> None:
+    """Anthropic 401 authentication_error classifies as AUTH_FAILED."""
+    error = AIAuthenticationError(
+        "Anthropic authentication failed: Error code: 401 - authentication_error",
+    )
+    kind = classify_provider_error(provider="anthropic", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.AUTH_FAILED)
+
+
+def test_anthropic_context_length() -> None:
+    """Anthropic 'prompt is too long' classifies as CONTEXT_LENGTH."""
+    error = AIProviderError(
+        "Anthropic API error: prompt is too long: 250000 tokens > 200000 maximum",
+    )
+    kind = classify_provider_error(provider="anthropic", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.CONTEXT_LENGTH)
+
+
+def test_openai_insufficient_credits() -> None:
+    """OpenAI 429 insufficient_quota classifies as INSUFFICIENT_CREDITS."""
+    error = AIProviderError(
+        "OpenAI API error: Error code: 429 - insufficient_quota: You exceeded "
+        "your current quota, billing_hard_limit_reached",
+    )
+    kind = classify_provider_error(provider="openai", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.INSUFFICIENT_CREDITS)
+
+
+def test_openai_rate_limited_bare_429() -> None:
+    """OpenAI rate_limit_exceeded classifies as RATE_LIMITED, not credits."""
+    error = AIRateLimitError(
+        "OpenAI rate limit: Error code: 429 - rate_limit_exceeded",
+    )
+    kind = classify_provider_error(provider="openai", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.RATE_LIMITED)
+
+
+def test_openai_auth_failed() -> None:
+    """OpenAI 401 invalid_api_key classifies as AUTH_FAILED."""
+    error = AIAuthenticationError(
+        "OpenAI authentication failed: Error code: 401 - invalid_api_key",
+    )
+    kind = classify_provider_error(provider="openai", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.AUTH_FAILED)
+
+
+def test_cursor_insufficient_credits_stderr() -> None:
+    """Cursor CLI stderr credit text classifies as INSUFFICIENT_CREDITS."""
+    error = AIProviderError(
+        "cursor-agent failed: you are out of credits, top up to continue",
+    )
+    kind = classify_provider_error(provider="cursor", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.INSUFFICIENT_CREDITS)
+
+
+def test_cursor_auth_failed_stderr() -> None:
+    """Cursor CLI 'not logged in' stderr classifies as AUTH_FAILED."""
+    error = AIProviderError("cursor-agent: not logged in, run agent login")
+    kind = classify_provider_error(provider="cursor", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.AUTH_FAILED)
+
+
+def test_cursor_timeout_stderr() -> None:
+    """Cursor CLI timeout stderr classifies as TIMEOUT."""
+    error = AIProviderError("cursor-agent: request timed out after 600s")
+    kind = classify_provider_error(provider="cursor", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.TIMEOUT)
+
+
+# --- unwrapping and fallbacks -----------------------------------------------
+
+
+def test_classify_unwraps_review_execution_error() -> None:
+    """A ReviewExecutionError wrapper resolves to its underlying cause."""
+    cause = AIProviderError(
+        "Anthropic API error: Your credit balance is too low",
+    )
+    wrapper = ReviewExecutionError(
+        message="Review aborted before all chunks completed.",
+        cause_message=str(cause),
+    )
+    kind = classify_provider_error(provider="anthropic", error=wrapper)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.INSUFFICIENT_CREDITS)
+
+
+def test_classify_prefers_attached_kind() -> None:
+    """An error_kind attached by the orchestrator is authoritative."""
+    wrapper = ReviewExecutionError(
+        message="Review aborted before all chunks completed.",
+        cause_message="totally opaque failure",
+        error_kind=ReviewErrorKind.SERVER_ERROR,
+    )
+    kind = classify_provider_error(provider="anthropic", error=wrapper)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.SERVER_ERROR)
+
+
+def test_classify_unknown_falls_back() -> None:
+    """An unrecognized error falls back to UNKNOWN."""
+    error = AIProviderError("something entirely unexpected happened")
+    kind = classify_provider_error(provider="anthropic", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.UNKNOWN)
+
+
+def test_resolve_cause_text_prefers_cause_message() -> None:
+    """resolve_cause_text surfaces the wrapper's cause_message over the wrapper."""
+    wrapper = ReviewExecutionError(
+        message="Review aborted before all chunks completed.",
+        cause_message="the real provider error",
+    )
+
+    assert_that(resolve_cause_text(error=wrapper)).is_equal_to(
+        "the real provider error",
+    )
+
+
+def test_shared_fallback_without_provider() -> None:
+    """With no provider map, shared heuristics still classify credit errors."""
+    error = AIProviderError("insufficient credits remaining on the account")
+    kind = classify_provider_error(provider="", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.INSUFFICIENT_CREDITS)
+
+
+# --- sticky copy ------------------------------------------------------------
+
+
+def test_insufficient_credits_copy_has_guidance() -> None:
+    """INSUFFICIENT_CREDITS copy names credits/quota and how to fix."""
+    message, guidance = KIND_COPY[ReviewErrorKind.INSUFFICIENT_CREDITS]
+
+    assert_that(message).contains("depleted")
+    assert_that(guidance).contains("Top up")
+    assert_that(guidance).contains("ai.max_cost_usd")
+
+
+def test_error_comment_surfaces_real_cause_for_depleted_credits() -> None:
+    """The credits sticky surfaces the real cause, not the generic wrapper."""
+    cause = AIProviderError(
+        "Anthropic API error: Your credit balance is too low",
+    )
+    wrapper = ReviewExecutionError(
+        message="Review aborted before all chunks completed.",
+        cause_message=str(cause),
+    )
+    body = format_error_comment(error=wrapper, provider="anthropic")
+
+    assert_that(body).contains("depleted")
+    assert_that(body).contains("Top up")
+    assert_that(body).contains("credit balance is too low")
+    assert_that(body).does_not_contain("aborted before all chunks")
+    assert_that(body).contains("`anthropic`")
+
+
+def test_error_comment_unknown_includes_surfaced_cause() -> None:
+    """An unknown error still surfaces its cause text in the sticky."""
+    error = AIProviderError("some brand new failure mode")
+    body = format_error_comment(error=error, provider="anthropic")
+
+    assert_that(body).contains("some brand new failure mode")

--- a/tests/unit/ai/review/test_errors_taxonomy.py
+++ b/tests/unit/ai/review/test_errors_taxonomy.py
@@ -157,6 +157,42 @@ def test_classify_unknown_falls_back() -> None:
     assert_that(kind).is_equal_to(ReviewErrorKind.UNKNOWN)
 
 
+def test_value_error_classifies_as_invalid_response() -> None:
+    """A parse ValueError is an invalid-response failure, not a provider error."""
+    error = ValueError("could not parse model response as JSON")
+    kind = classify_provider_error(provider="anthropic", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.INVALID_RESPONSE)
+
+
+def test_invalid_response_via_wrapped_value_error() -> None:
+    """A ValueError chained under the wrapper still resolves to INVALID_RESPONSE."""
+    cause = ValueError("malformed model output")
+    wrapper = ReviewExecutionError(
+        message="Review aborted before all chunks completed.",
+    )
+    wrapper.__cause__ = cause
+    kind = classify_provider_error(provider="anthropic", error=wrapper)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.INVALID_RESPONSE)
+
+
+def test_invalid_response_copy_points_at_model_output() -> None:
+    """INVALID_RESPONSE copy blames model output, not provider status."""
+    message, guidance = KIND_COPY[ReviewErrorKind.INVALID_RESPONSE]
+
+    assert_that(message).contains("malformed")
+    assert_that(guidance.lower()).does_not_contain("provider status")
+
+
+def test_unknown_copy_does_not_assert_provider_error() -> None:
+    """UNKNOWN copy stays neutral — it must not claim a provider fault."""
+    message, guidance = KIND_COPY[ReviewErrorKind.UNKNOWN]
+
+    assert_that(message).does_not_contain("provider error")
+    assert_that(guidance.lower()).does_not_contain("provider status")
+
+
 def test_resolve_cause_text_prefers_cause_message() -> None:
     """resolve_cause_text surfaces the wrapper's cause_message over the wrapper."""
     wrapper = ReviewExecutionError(


### PR DESCRIPTION
## Summary
Closes #1101.

The first live `--post` dogfood review posted a generic sticky (`provider error: Review aborted before all chunks completed`) when the real cause was **depleted Anthropic API credits**. The real provider exception was swallowed by the `ReviewExecutionError` wrapper, and error detection was ad-hoc string matching that was not provider-aware.

This PR adds a canonical error taxonomy with a per-provider signature map, classifies against the **underlying** provider cause, and renders a specific sticky — depleted credits now say exactly that plus how to fix it, labelled with the provider.

## What changed
**New module `lintro/ai/review/errors_taxonomy.py`**
- `ReviewErrorKind` (StrEnum/auto): `AUTH_FAILED`, `INSUFFICIENT_CREDITS`, `QUOTA_EXCEEDED`, `RATE_LIMITED`, `CONTEXT_LENGTH`, `SERVER_ERROR`, `TIMEOUT`, `UNKNOWN`.
- `PROVIDER_ERROR_SIGNATURES: provider -> kind -> ErrorMatcher` (status codes + case-insensitive substrings) for **anthropic** (credits = 400 + "credit balance is too low"; 429 rate_limit_error; 401 authentication_error; "prompt is too long"/"maximum context"), **openai** (429 insufficient_quota / billing_hard_limit_reached; rate_limit_exceeded; invalid_api_key), and **cursor** (stderr-text matchers, no HTTP status), plus a shared fallback set, then `UNKNOWN`.
- `classify_provider_error(*, provider, error)` unwraps `ReviewExecutionError` to its `cause_message`/`__cause__`, subsumes the existing `AIAuthenticationError`/`AIRateLimitError` hierarchy, and honors an orchestrator-attached kind.
- `KIND_COPY: dict[ReviewErrorKind, (message, guidance)]` — provider-agnostic sticky copy. `INSUFFICIENT_CREDITS` says the balance is depleted and how to fix (top up / raise quota / lower `ai.max_cost_usd`, re-run).

**Wiring**
- `orchestrator.py`: the three "aborted before all chunks completed" raise sites now go through a helper that classifies the underlying cause, attaches `error_kind` to `ReviewExecutionError`, and **logs the real cause_message**.
- `exceptions.py`: `ReviewExecutionError` carries an optional `error_kind`.
- `github.py`: `format_error_comment` / `post_review_error_to_github` classify by `(provider, cause)` and render the specific sticky, always surfacing the real underlying cause. `sanitize_comment_text` (@mention neutralization), the exact/approx footnote, and prior-run state preservation are unchanged.
- `cli_utils/commands/review.py`: the `--post` error path passes the provider.

Adding a new provider is a single entry in `PROVIDER_ERROR_SIGNATURES`; canonical kinds/copy are unchanged.

## Scope
Does **not** implement mid-run graceful-partial-on-cost-cap (#1094) — this is purely about classifying and surfacing hard provider errors.

## Tests
New `tests/unit/ai/review/test_errors_taxonomy.py`: per-provider sample errors per kind, `ReviewExecutionError` unwrapping, attached-kind precedence, unknown-fallback that still surfaces the cause, and that the credits sticky carries the guidance and the real cause (`credit balance is too low`) but not the generic "aborted" text. Existing `test_github.py` unchanged and green.

## Gates
- `uv run lintro fmt` — clean
- `uv run --extra ai lintro chk` — **Total Issues: 0**
- `uv run --extra ai pytest` — **5924 passed, 10 skipped**

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds provider-aware review error handling for failed AI reviews. The main changes are:

- New canonical review error kinds and provider signature matching.
- `ReviewExecutionError` now carries the underlying cause and classified kind.
- GitHub error comments now show provider-specific guidance and the real cause.
- The review CLI passes the selected provider into the error-posting path.
- New unit tests cover provider errors, wrapped causes, and invalid responses.
</details>

<h3>Confidence Score: 4/5</h3>

This is close, but one classification path should be fixed before merging.

- Malformed model output can still be matched as a provider rate-limit, timeout, or server error when its parse message contains provider-looking text.
- Moving the `ValueError` check before shared text/status matching keeps parse failures on the intended invalid-response path.

lintro/ai/review/errors_taxonomy.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/review/errors_taxonomy.py | Adds the taxonomy, provider/shared matchers, cause unwrapping, and user-facing copy; the invalid-response check needs to run before shared text/status matching. |
| lintro/ai/review/github.py | Renders classified review errors with provider labels, guidance, and surfaced cause text. |
| lintro/ai/review/orchestrator.py | Wraps aborted chunk failures through a helper that classifies and preserves the underlying cause. |
| lintro/ai/review/exceptions.py | Adds an optional classified error kind to `ReviewExecutionError`. |
| lintro/cli_utils/commands/review.py | Passes the selected provider when posting review errors to GitHub. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Fai%2Freview%2Ferrors_taxonomy.py%3A373-382%0A**Check%20ValueError%20First**%0A%0AMalformed%20model%20output%20can%20still%20be%20classified%20as%20a%20provider%20failure%20before%20this%20%60ValueError%60%20branch%20runs.%20For%20example%2C%20if%20the%20parse%20failure%20message%20includes%20model%20text%20such%20as%20%60Error%20code%3A%20429%60%20or%20%60rate_limit_exceeded%60%2C%20the%20shared%20matcher%20above%20returns%20rate-limited%20guidance%20instead%20of%20the%20malformed-response%20guidance.%20Since%20%60ValueError%60%20means%20the%20review%20failed%20while%20parsing%20or%20validating%20model%20output%2C%20that%20cause%20should%20win%20before%20text%2Fstatus%20heuristics%20inspect%20the%20error%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20A%20bare%20%60%60ValueError%60%60%20cause%20is%20a%20lintro-side%20parse%2Fvalidation%20failure%20of%0A%20%20%20%20%23%20the%20model%20response%2C%20not%20a%20provider%20transport%20error%20%E2%80%94%20surface%20it%20as%20such%0A%20%20%20%20%23%20rather%20than%20misdirecting%20the%20user%20to%20check%20provider%20status.%0A%20%20%20%20if%20isinstance%28cause_exc%2C%20ValueError%29%3A%0A%20%20%20%20%20%20%20%20return%20ReviewErrorKind.INVALID_RESPONSE%0A%0A%20%20%20%20for%20kind%20in%20_KIND_PRIORITY%3A%0A%20%20%20%20%20%20%20%20matcher%20%3D%20_SHARED_SIGNATURES.get%28kind%29%0A%20%20%20%20%20%20%20%20if%20matcher%20is%20not%20None%20and%20matcher.matches%28status%3Dstatus%2C%20text%3Dtext%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20kind%0A%60%60%60%0A%0A&pr=1102&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Fai%2Freview%2Ferrors_taxonomy.py%3A373-382%0A**Check%20ValueError%20First**%0A%0AMalformed%20model%20output%20can%20still%20be%20classified%20as%20a%20provider%20failure%20before%20this%20%60ValueError%60%20branch%20runs.%20For%20example%2C%20if%20the%20parse%20failure%20message%20includes%20model%20text%20such%20as%20%60Error%20code%3A%20429%60%20or%20%60rate_limit_exceeded%60%2C%20the%20shared%20matcher%20above%20returns%20rate-limited%20guidance%20instead%20of%20the%20malformed-response%20guidance.%20Since%20%60ValueError%60%20means%20the%20review%20failed%20while%20parsing%20or%20validating%20model%20output%2C%20that%20cause%20should%20win%20before%20text%2Fstatus%20heuristics%20inspect%20the%20error%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20A%20bare%20%60%60ValueError%60%60%20cause%20is%20a%20lintro-side%20parse%2Fvalidation%20failure%20of%0A%20%20%20%20%23%20the%20model%20response%2C%20not%20a%20provider%20transport%20error%20%E2%80%94%20surface%20it%20as%20such%0A%20%20%20%20%23%20rather%20than%20misdirecting%20the%20user%20to%20check%20provider%20status.%0A%20%20%20%20if%20isinstance%28cause_exc%2C%20ValueError%29%3A%0A%20%20%20%20%20%20%20%20return%20ReviewErrorKind.INVALID_RESPONSE%0A%0A%20%20%20%20for%20kind%20in%20_KIND_PRIORITY%3A%0A%20%20%20%20%20%20%20%20matcher%20%3D%20_SHARED_SIGNATURES.get%28kind%29%0A%20%20%20%20%20%20%20%20if%20matcher%20is%20not%20None%20and%20matcher.matches%28status%3Dstatus%2C%20text%3Dtext%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20kind%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1102&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F1101-provider-error-taxonomy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1101-provider-error-taxonomy%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Fai%2Freview%2Ferrors_taxonomy.py%3A373-382%0A**Check%20ValueError%20First**%0A%0AMalformed%20model%20output%20can%20still%20be%20classified%20as%20a%20provider%20failure%20before%20this%20%60ValueError%60%20branch%20runs.%20For%20example%2C%20if%20the%20parse%20failure%20message%20includes%20model%20text%20such%20as%20%60Error%20code%3A%20429%60%20or%20%60rate_limit_exceeded%60%2C%20the%20shared%20matcher%20above%20returns%20rate-limited%20guidance%20instead%20of%20the%20malformed-response%20guidance.%20Since%20%60ValueError%60%20means%20the%20review%20failed%20while%20parsing%20or%20validating%20model%20output%2C%20that%20cause%20should%20win%20before%20text%2Fstatus%20heuristics%20inspect%20the%20error%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20A%20bare%20%60%60ValueError%60%60%20cause%20is%20a%20lintro-side%20parse%2Fvalidation%20failure%20of%0A%20%20%20%20%23%20the%20model%20response%2C%20not%20a%20provider%20transport%20error%20%E2%80%94%20surface%20it%20as%20such%0A%20%20%20%20%23%20rather%20than%20misdirecting%20the%20user%20to%20check%20provider%20status.%0A%20%20%20%20if%20isinstance%28cause_exc%2C%20ValueError%29%3A%0A%20%20%20%20%20%20%20%20return%20ReviewErrorKind.INVALID_RESPONSE%0A%0A%20%20%20%20for%20kind%20in%20_KIND_PRIORITY%3A%0A%20%20%20%20%20%20%20%20matcher%20%3D%20_SHARED_SIGNATURES.get%28kind%29%0A%20%20%20%20%20%20%20%20if%20matcher%20is%20not%20None%20and%20matcher.matches%28status%3Dstatus%2C%20text%3Dtext%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20kind%0A%60%60%60%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1102&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(ai/review): classify invalid model r..."](https://github.com/lgtm-hq/py-lintro/commit/bd25f989865a2ccedbd4e0871dbcd43fff5a3b0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42080728)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->