### PR TITLE
fix(ai/review): prioritize non-diff-mappable findings before sticky-comment truncation

### DIFF
--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -440,7 +440,6 @@ def _format_findings_section(
     )
     lines = ["", f"### Findings ({len(findings)})"]
     used = 0
-    rendered = 0
     for index, finding in enumerate(ordered):
         mappable = _is_diff_mappable(finding=finding, diff_lines=diff_lines)
         block = _finding_block(
@@ -452,13 +451,14 @@ def _format_findings_section(
         # Only diff-mappable findings may be budget-truncated: they also post as
         # inline comments, so the "see inline comments" marker is accurate for
         # them. Fallback (non-diff-mappable) findings have no other surface and
-        # are always rendered. Since fallback findings sort first, anything
-        # dropped here is guaranteed diff-mappable. Always render at least one
-        # finding so a single oversized first block is not itself dropped.
+        # are always rendered. Since fallback findings sort first (and every
+        # prior finding was rendered — truncation breaks the loop), anything
+        # dropped here is guaranteed diff-mappable. ``index > 0`` always renders
+        # at least one finding so a single oversized first block is not dropped.
         if (
             char_budget is not None
             and mappable
-            and rendered > 0
+            and index > 0
             and used + block_len > char_budget
         ):
             dropped = len(ordered) - index
@@ -473,7 +473,6 @@ def _format_findings_section(
             break
         lines.extend(block)
         used += block_len
-        rendered += 1
     return lines
 
 

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -419,7 +419,9 @@ def _format_findings_section(
         diff_lines: Diff line map used to order fallback findings first. ``None``
             treats every finding as fallback (preserving severity ordering).
         char_budget: Optional soft character budget for the finding blocks. When
-            exceeded, remaining findings are replaced by a truncation marker.
+            exceeded, remaining *diff-mappable* findings are replaced by a
+            truncation marker (they still exist as inline comments). Fallback
+            findings are never budget-truncated — they have no other surface.
 
     Returns:
         Markdown lines for the findings section.
@@ -438,27 +440,40 @@ def _format_findings_section(
     )
     lines = ["", f"### Findings ({len(findings)})"]
     used = 0
+    rendered = 0
     for index, finding in enumerate(ordered):
+        mappable = _is_diff_mappable(finding=finding, diff_lines=diff_lines)
         block = _finding_block(
             finding=finding,
             checklist_display=checklist_display,
             question_map=question_map,
         )
         block_len = len("\n".join(block))
-        # Always render at least one finding; only truncate once the budget is
-        # actually exceeded so a single oversized finding is not itself dropped.
-        if char_budget is not None and index > 0 and used + block_len > char_budget:
+        # Only diff-mappable findings may be budget-truncated: they also post as
+        # inline comments, so the "see inline comments" marker is accurate for
+        # them. Fallback (non-diff-mappable) findings have no other surface and
+        # are always rendered. Since fallback findings sort first, anything
+        # dropped here is guaranteed diff-mappable. Always render at least one
+        # finding so a single oversized first block is not itself dropped.
+        if (
+            char_budget is not None
+            and mappable
+            and rendered > 0
+            and used + block_len > char_budget
+        ):
             dropped = len(ordered) - index
             lines.extend(
                 [
                     "",
                     f"> ✂️ **{dropped} more finding(s) truncated** to fit "
-                    "GitHub's size limit — see inline comments and workflow logs.",
+                    "GitHub's size limit — see the inline comments and workflow "
+                    "logs.",
                 ],
             )
             break
         lines.extend(block)
         used += block_len
+        rendered += 1
     return lines
 
 

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -441,33 +441,38 @@ def _format_findings_section(
     lines = ["", f"### Findings ({len(findings)})"]
     used = 0
     for index, finding in enumerate(ordered):
-        mappable = _is_diff_mappable(finding=finding, diff_lines=diff_lines)
         block = _finding_block(
             finding=finding,
             checklist_display=checklist_display,
             question_map=question_map,
         )
         block_len = len("\n".join(block))
-        # Only diff-mappable findings may be budget-truncated: they also post as
-        # inline comments, so the "see inline comments" marker is accurate for
-        # them. Fallback (non-diff-mappable) findings have no other surface and
-        # are always rendered. Since fallback findings sort first (and every
-        # prior finding was rendered — truncation breaks the loop), anything
-        # dropped here is guaranteed diff-mappable. ``index > 0`` always renders
-        # at least one finding so a single oversized first block is not dropped.
-        if (
-            char_budget is not None
-            and mappable
-            and index > 0
-            and used + block_len > char_budget
-        ):
-            dropped = len(ordered) - index
+        # The budget is enforced on *every* finding so the section always fits
+        # inside the caller's char_budget — otherwise ``_cap_body`` would later
+        # trim the sticky from the tail and could silently drop findings.
+        # Fallback (non-diff-mappable) findings sort first, so they are only ever
+        # dropped when fallback content alone exceeds GitHub's hard comment limit
+        # (unavoidable). The marker text adapts: if any dropped finding is a
+        # fallback (no inline surface), it points to the workflow logs rather
+        # than to inline comments that do not exist for it. ``index > 0`` always
+        # renders at least one finding so a single oversized block is not lost.
+        if char_budget is not None and index > 0 and used + block_len > char_budget:
+            remaining = ordered[index:]
+            dropped = len(remaining)
+            any_fallback = any(
+                not _is_diff_mappable(finding=item, diff_lines=diff_lines)
+                for item in remaining
+            )
+            where = (
+                "the workflow logs"
+                if any_fallback
+                else "the inline comments and workflow logs"
+            )
             lines.extend(
                 [
                     "",
                     f"> ✂️ **{dropped} more finding(s) truncated** to fit "
-                    "GitHub's size limit — see the inline comments and workflow "
-                    "logs.",
+                    f"GitHub's size limit — see {where} for the full list.",
                 ],
             )
             break

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -58,6 +58,9 @@ STATE_VERSION = 1
 MAX_COMMENT_CHARS = 60_000
 # Cap how many run records are retained in the sticky state block.
 MAX_STORED_RUNS = 30
+# Slack reserved when budgeting the findings section against the comment cap,
+# covering the truncation marker, section joins, and the final _cap_body notice.
+_TRUNCATION_MARGIN = 400
 
 _SEVERITY_EMOJI: dict[Severity, str] = {
     Severity.P1: "🔴",
@@ -256,6 +259,8 @@ def format_review_summary(
     result: ReviewResult,
     checklist_display: ChecklistDisplay = ChecklistDisplay.OFF,
     question_map: dict[int, str] | None = None,
+    diff_lines: dict[str, set[int]] | None = None,
+    findings_char_budget: int | None = None,
 ) -> str:
     """Format the per-run review summary section.
 
@@ -267,6 +272,10 @@ def format_review_summary(
         result: Review result to summarize.
         checklist_display: Structured checklist visibility mode.
         question_map: Prompt id to question text for the checklist appendix.
+        diff_lines: Diff line map used to order fallback findings first in the
+            findings section. ``None`` treats all findings as fallback.
+        findings_char_budget: Optional soft character budget for the findings
+            section; overflow is replaced by an explicit truncation marker.
 
     Returns:
         Markdown summary section body.
@@ -316,6 +325,8 @@ def format_review_summary(
             findings=result.findings,
             checklist_display=checklist_display,
             question_map=question_map or {},
+            diff_lines=diff_lines,
+            char_budget=findings_char_budget,
         ),
     )
 
@@ -327,46 +338,127 @@ def format_review_summary(
     return "\n".join(lines)
 
 
+def _is_diff_mappable(
+    *,
+    finding: ReviewFinding,
+    diff_lines: dict[str, set[int]] | None,
+) -> bool:
+    """Report whether a finding maps onto a line inside the PR diff.
+
+    A diff-mappable finding also posts as an inline review comment, so the
+    sticky comment is not its only surface. A non-diff-mappable ("fallback")
+    finding has no inline path and must survive sticky-comment truncation.
+
+    Args:
+        finding: Review finding to classify.
+        diff_lines: Map of repo-relative path to the set of diff-covered line
+            numbers, or ``None`` when the diff is unavailable (all findings are
+            then treated as fallback).
+
+    Returns:
+        True when the finding lands on a diff-covered line, else False.
+    """
+    rel = finding.file.removeprefix("./").replace("\\", "/")
+    if not rel or finding.line <= 0 or diff_lines is None:
+        return False
+    return finding.line in diff_lines.get(rel, set())
+
+
+def _finding_block(
+    *,
+    finding: ReviewFinding,
+    checklist_display: ChecklistDisplay,
+    question_map: dict[int, str],
+) -> list[str]:
+    """Render the markdown lines for a single finding in the findings list."""
+    location = _location_label(finding=finding)
+    title = sanitize_comment_text(finding.title, limit=200)
+    headline = (
+        f"{_severity_badge(severity=finding.severity)} · "
+        f"{_chip(finding.category)} — **{title}**"
+    )
+    if location:
+        headline += f" · {location}"
+    body = format_finding_comment(
+        finding=finding,
+        checklist_display=checklist_display,
+        question_map=question_map,
+    )
+    return [
+        "",
+        headline,
+        "",
+        "<details><summary>Details</summary>",
+        "",
+        body,
+        "",
+        "</details>",
+    ]
+
+
 def _format_findings_section(
     *,
     findings: tuple[ReviewFinding, ...],
     checklist_display: ChecklistDisplay,
     question_map: dict[int, str],
+    diff_lines: dict[str, set[int]] | None = None,
+    char_budget: int | None = None,
 ) -> list[str]:
-    """Render a compact, collapsible list of all findings."""
+    """Render a compact, collapsible list of all findings.
+
+    Non-diff-mappable ("fallback") findings render first: they have no inline
+    surface, so if truncation must drop anything it only drops findings that
+    also exist as inline comments. When ``char_budget`` is set and the rendered
+    blocks would overflow it, rendering stops early and an explicit marker names
+    how many findings were dropped so nothing silently vanishes.
+
+    Args:
+        findings: Findings to render.
+        checklist_display: Structured checklist visibility mode.
+        question_map: Prompt id to question text for linked display.
+        diff_lines: Diff line map used to order fallback findings first. ``None``
+            treats every finding as fallback (preserving severity ordering).
+        char_budget: Optional soft character budget for the finding blocks. When
+            exceeded, remaining findings are replaced by a truncation marker.
+
+    Returns:
+        Markdown lines for the findings section.
+    """
     if not findings:
         return ["", "### Findings", "", "✅ No actionable findings."]
 
     ordered = sorted(
         findings,
-        key=lambda f: (f.severity.value, f.file, f.line),
+        key=lambda f: (
+            _is_diff_mappable(finding=f, diff_lines=diff_lines),
+            f.severity.value,
+            f.file,
+            f.line,
+        ),
     )
     lines = ["", f"### Findings ({len(findings)})"]
-    for finding in ordered:
-        location = _location_label(finding=finding)
-        title = sanitize_comment_text(finding.title, limit=200)
-        headline = (
-            f"{_severity_badge(severity=finding.severity)} · "
-            f"{_chip(finding.category)} — **{title}**"
-        )
-        if location:
-            headline += f" · {location}"
-        lines.extend(["", headline])
-        body = format_finding_comment(
+    used = 0
+    for index, finding in enumerate(ordered):
+        block = _finding_block(
             finding=finding,
             checklist_display=checklist_display,
             question_map=question_map,
         )
-        lines.extend(
-            [
-                "",
-                "<details><summary>Details</summary>",
-                "",
-                body,
-                "",
-                "</details>",
-            ],
-        )
+        block_len = len("\n".join(block))
+        # Always render at least one finding; only truncate once the budget is
+        # actually exceeded so a single oversized finding is not itself dropped.
+        if char_budget is not None and index > 0 and used + block_len > char_budget:
+            dropped = len(ordered) - index
+            lines.extend(
+                [
+                    "",
+                    f"> ✂️ **{dropped} more finding(s) truncated** to fit "
+                    "GitHub's size limit — see inline comments and workflow logs.",
+                ],
+            )
+            break
+        lines.extend(block)
+        used += block_len
     return lines
 
 
@@ -386,8 +478,15 @@ def build_sticky_comment(
     prior_runs: list[dict[str, Any]] | None = None,
     checklist_display: ChecklistDisplay = ChecklistDisplay.OFF,
     question_map: dict[int, str] | None = None,
+    diff_lines: dict[str, set[int]] | None = None,
 ) -> str:
     """Compose the full sticky PR comment body, including cumulative telemetry.
+
+    Non-diff-mappable ("fallback") findings — whose only surface is this sticky
+    comment — render first in the findings section. When the assembled body
+    exceeds ``MAX_COMMENT_CHARS`` the findings section is re-rendered against a
+    character budget so overflow is dropped explicitly (a visible marker names
+    the count) and only ever falls on findings that also post inline.
 
     Args:
         result: Current review result.
@@ -395,6 +494,9 @@ def build_sticky_comment(
             state block. ``None`` for the first run on a PR.
         checklist_display: Structured checklist visibility mode.
         question_map: Prompt id to question text for the checklist appendix.
+        diff_lines: Diff line map used to order fallback findings first and to
+            decide which findings are safe to truncate. ``None`` treats all
+            findings as fallback.
 
     Returns:
         Complete Markdown body carrying the hidden marker and state block.
@@ -403,25 +505,45 @@ def build_sticky_comment(
     current = _run_record(result=result)
     all_runs = [*prior, current][-MAX_STORED_RUNS:]
 
-    sections = [STICKY_MARKER]
-    sections.append(_format_cumulative_header(runs=all_runs))
-    sections.append(
-        format_review_summary(
-            result=result,
-            checklist_display=checklist_display,
-            question_map=question_map,
-        ),
-    )
-    sections.append(
-        "<details><summary>⚙️ Run mechanics (this run)</summary>\n\n"
-        + format_run_mechanics(metadata=result.metadata)
-        + "\n\n</details>",
-    )
-    if prior:
-        sections.append(_format_previous_runs(runs=prior))
-    sections.append(_FOOTER)
+    def assemble(*, findings_char_budget: int | None) -> str:
+        sections = [STICKY_MARKER, _format_cumulative_header(runs=all_runs)]
+        sections.append(
+            format_review_summary(
+                result=result,
+                checklist_display=checklist_display,
+                question_map=question_map,
+                diff_lines=diff_lines,
+                findings_char_budget=findings_char_budget,
+            ),
+        )
+        sections.append(
+            "<details><summary>⚙️ Run mechanics (this run)</summary>\n\n"
+            + format_run_mechanics(metadata=result.metadata)
+            + "\n\n</details>",
+        )
+        if prior:
+            sections.append(_format_previous_runs(runs=prior))
+        sections.append(_FOOTER)
+        return "\n\n".join(sections)
 
-    body = "\n\n".join(sections)
+    body = assemble(findings_char_budget=None)
+    if len(body) > MAX_COMMENT_CHARS:
+        # Isolate the findings section's contribution so the remaining budget
+        # can be handed back to it explicitly, keeping fallback findings intact.
+        findings_len = len(
+            "\n".join(
+                _format_findings_section(
+                    findings=result.findings,
+                    checklist_display=checklist_display,
+                    question_map=question_map or {},
+                    diff_lines=diff_lines,
+                ),
+            ),
+        )
+        overhead = len(body) - findings_len
+        findings_budget = max(MAX_COMMENT_CHARS - overhead - _TRUNCATION_MARGIN, 0)
+        body = assemble(findings_char_budget=findings_budget)
+
     body = _cap_body(body=body)
     return body + _render_state_block(runs=all_runs)
 
@@ -661,18 +783,20 @@ def post_review_to_github(
 
     prompt_questions = question_map or {}
     comment_id, prior_runs = _load_prior_runs(reporter=gh_reporter)
+    diff_lines = gh_reporter.fetch_pr_diff_lines()
     body = build_sticky_comment(
         result=result,
         prior_runs=prior_runs,
         checklist_display=checklist_display,
         question_map=prompt_questions,
+        diff_lines=diff_lines,
     )
 
     success = _upsert_sticky(reporter=gh_reporter, body=body, comment_id=comment_id)
 
     inline_findings, _fallback = _partition_findings(
-        result=result,
-        reporter=gh_reporter,
+        findings=result.findings,
+        diff_lines=diff_lines,
     )
     if inline_findings and not _post_inline_findings(
         reporter=gh_reporter,
@@ -792,25 +916,26 @@ def _format_checklist_appendix_markdown(*, result: ReviewResult) -> list[str]:
 
 def _partition_findings(
     *,
-    result: ReviewResult,
-    reporter: GitHubPRReporter,
+    findings: tuple[ReviewFinding, ...],
+    diff_lines: dict[str, set[int]] | None,
 ) -> tuple[list[ReviewFinding], list[ReviewFinding]]:
-    """Split findings into inline-capable and fallback groups."""
-    diff_lines = reporter.fetch_pr_diff_lines()
+    """Split findings into inline-capable and fallback groups.
+
+    Args:
+        findings: Findings to partition.
+        diff_lines: Diff line map; ``None`` classifies every finding as fallback.
+
+    Returns:
+        Tuple of ``(inline, fallback)`` finding lists.
+    """
     inline: list[ReviewFinding] = []
     fallback: list[ReviewFinding] = []
 
-    for finding in result.findings:
-        rel = finding.file.removeprefix("./").replace("\\", "/")
-        if (
-            not rel
-            or finding.line <= 0
-            or diff_lines is None
-            or finding.line not in diff_lines.get(rel, set())
-        ):
-            fallback.append(finding)
-        else:
+    for finding in findings:
+        if _is_diff_mappable(finding=finding, diff_lines=diff_lines):
             inline.append(finding)
+        else:
+            fallback.append(finding)
 
     return inline, fallback
 

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -14,6 +14,7 @@ from lintro.ai.exceptions import (
 )
 from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.github import (
+    MAX_COMMENT_CHARS,
     STATE_MARKER_PREFIX,
     STICKY_MARKER,
     build_sticky_comment,
@@ -459,3 +460,150 @@ def test_post_error_comment_recovers_prior_state(
 
     posted_body = reporter.update_issue_comment.call_args.kwargs["body"]
     assert_that(parse_review_state(body=posted_body)).is_length(1)
+
+
+# --- truncation safety for non-diff-mappable findings (#1099) ----------------
+
+
+def _bulky_finding(
+    *,
+    severity: Severity,
+    file: str,
+    line: int,
+    title: str,
+) -> ReviewFinding:
+    """Build a large finding whose rendered block eats into the comment cap."""
+    filler = "detail " * 260
+    return ReviewFinding(
+        severity=severity,
+        category="security",
+        file=file,
+        line=line,
+        title=title,
+        description=filler,
+        cause=filler,
+        fix=filler,
+        confidence="high",
+    )
+
+
+def _result_with_findings(
+    *,
+    base: ReviewResult,
+    findings: tuple[ReviewFinding, ...],
+) -> ReviewResult:
+    """Clone a review result with a replacement findings tuple."""
+    return ReviewResult(
+        metadata=base.metadata,
+        summary=base.summary,
+        checklist=base.checklist,
+        findings=findings,
+    )
+
+
+def test_findings_section_orders_fallback_before_diff_mappable(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Non-diff-mappable findings render ahead of diff-mappable ones."""
+    diff_lines = {"src/mapped.py": {10}}
+    mapped = ReviewFinding(
+        severity=Severity.P1,
+        category="security",
+        file="src/mapped.py",
+        line=10,
+        title="MappedInlineFinding",
+        description="d",
+        cause="c",
+        fix="f",
+        confidence="high",
+    )
+    fallback = ReviewFinding(
+        severity=Severity.P3,
+        category="style",
+        file="src/unmapped.py",
+        line=999,
+        title="FallbackOnlyFinding",
+        description="d",
+        cause="c",
+        fix="f",
+        confidence="low",
+    )
+    result = _result_with_findings(
+        base=sample_review_result,
+        findings=(mapped, fallback),
+    )
+
+    summary = format_review_summary(result=result, diff_lines=diff_lines)
+
+    fallback_at = summary.find("FallbackOnlyFinding")
+    mapped_at = summary.find("MappedInlineFinding")
+    assert_that(fallback_at).is_greater_than(-1)
+    # Fallback (P3) precedes the diff-mappable P1 despite lower severity.
+    assert_that(fallback_at).is_less_than(mapped_at)
+
+
+def test_sticky_truncation_keeps_fallback_and_marks_dropped(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Over-cap sticky keeps the fallback finding and names the dropped count."""
+    diff_lines = {"src/mapped.py": set(range(1, 41))}
+    mapped = tuple(
+        _bulky_finding(
+            severity=Severity.P1,
+            file="src/mapped.py",
+            line=index,
+            title=f"MappedFinding{index}",
+        )
+        for index in range(1, 41)
+    )
+    fallback = _bulky_finding(
+        severity=Severity.P3,
+        file="src/unmapped.py",
+        line=999,
+        title="FallbackOnlyFinding",
+    )
+    result = _result_with_findings(
+        base=sample_review_result,
+        findings=(*mapped, fallback),
+    )
+
+    # Without budgeting the assembled body would blow past the cap.
+    unbudgeted = format_review_summary(result=result, diff_lines=diff_lines)
+    assert_that(len(unbudgeted)).is_greater_than(MAX_COMMENT_CHARS)
+
+    body = build_sticky_comment(result=result, diff_lines=diff_lines)
+
+    # The final body stays within the cap (plus the appended state block).
+    assert_that(len(body)).is_less_than_or_equal_to(MAX_COMMENT_CHARS + 1000)
+    # The fallback finding — with no inline surface — must survive truncation.
+    assert_that(body).contains("FallbackOnlyFinding")
+    # Truncation is explicit, not silent.
+    assert_that(body).contains("more finding(s) truncated")
+
+
+def test_sticky_state_round_trips_after_truncation(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The state block and cumulative header survive a truncated body."""
+    diff_lines = {"src/mapped.py": set(range(1, 41))}
+    findings = tuple(
+        _bulky_finding(
+            severity=Severity.P1,
+            file="src/mapped.py",
+            line=index,
+            title=f"MappedFinding{index}",
+        )
+        for index in range(1, 41)
+    )
+    result = _result_with_findings(
+        base=sample_review_result,
+        findings=findings,
+    )
+
+    body = build_sticky_comment(result=result, diff_lines=diff_lines)
+
+    assert_that(body).contains("**Cumulative (this PR):**")
+    assert_that(body).contains(STATE_MARKER_PREFIX)
+    runs = parse_review_state(body=body)
+    assert_that(runs).is_length(1)
+    assert_that(runs[0]["model"]).is_equal_to("claude-sonnet-4-20250514")

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -17,6 +17,7 @@ from lintro.ai.review.github import (
     MAX_COMMENT_CHARS,
     STATE_MARKER_PREFIX,
     STICKY_MARKER,
+    _format_findings_section,
     build_sticky_comment,
     format_error_comment,
     format_finding_comment,
@@ -579,6 +580,37 @@ def test_sticky_truncation_keeps_fallback_and_marks_dropped(
     assert_that(body).contains("FallbackOnlyFinding")
     # Truncation is explicit, not silent.
     assert_that(body).contains("more finding(s) truncated")
+
+
+def test_findings_section_never_budget_truncates_fallback() -> None:
+    """All-fallback overflow keeps every fallback finding, no inline-ref marker.
+
+    When ``diff_lines`` is ``None`` every finding is fallback (no inline
+    surface), so the budget must not drop any of them behind a marker that
+    points to inline comments that do not exist.
+    """
+    findings = tuple(
+        _bulky_finding(
+            severity=Severity.P2,
+            file=f"src/unmapped{index}.py",
+            line=900 + index,
+            title=f"FallbackFinding{index}",
+        )
+        for index in range(5)
+    )
+
+    lines = _format_findings_section(
+        findings=findings,
+        checklist_display=ChecklistDisplay.OFF,
+        question_map={},
+        diff_lines=None,
+        char_budget=200,  # far below the block sizes: would truncate if applied
+    )
+    body = "\n".join(lines)
+
+    for index in range(5):
+        assert_that(body).contains(f"FallbackFinding{index}")
+    assert_that(body).does_not_contain("more finding(s) truncated")
 
 
 def test_sticky_state_round_trips_after_truncation(

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -582,12 +582,13 @@ def test_sticky_truncation_keeps_fallback_and_marks_dropped(
     assert_that(body).contains("more finding(s) truncated")
 
 
-def test_findings_section_never_budget_truncates_fallback() -> None:
-    """All-fallback overflow keeps every fallback finding, no inline-ref marker.
+def test_all_fallback_overflow_truncates_to_logs_not_inline() -> None:
+    """All-fallback overflow drops via an explicit *workflow-logs* marker.
 
     When ``diff_lines`` is ``None`` every finding is fallback (no inline
-    surface), so the budget must not drop any of them behind a marker that
-    points to inline comments that do not exist.
+    surface). If they exceed GitHub's hard comment limit, truncation is
+    unavoidable — but it must be explicit and must NOT point readers to inline
+    comments that do not exist for fallback findings.
     """
     findings = tuple(
         _bulky_finding(
@@ -604,13 +605,17 @@ def test_findings_section_never_budget_truncates_fallback() -> None:
         checklist_display=ChecklistDisplay.OFF,
         question_map={},
         diff_lines=None,
-        char_budget=200,  # far below the block sizes: would truncate if applied
+        char_budget=200,  # forces overflow so the marker path is exercised
     )
     body = "\n".join(lines)
 
-    for index in range(5):
-        assert_that(body).contains(f"FallbackFinding{index}")
-    assert_that(body).does_not_contain("more finding(s) truncated")
+    # At least the first fallback finding is always rendered.
+    assert_that(body).contains("FallbackFinding0")
+    # Overflow is explicit, and points at the logs — never at (nonexistent)
+    # inline comments for fallback findings.
+    assert_that(body).contains("more finding(s) truncated")
+    assert_that(body).contains("workflow logs")
+    assert_that(body).does_not_contain("inline comments")
 
 
 def test_sticky_state_round_trips_after_truncation(


### PR DESCRIPTION
## Summary

Fixes #1099. Non-diff-mappable ("fallback") findings have **no inline-comment path** — GitHub rejects inline comments on lines outside the PR diff — so the sticky comment is their only output surface. Previously, when the rendered sticky body exceeded `MAX_COMMENT_CHARS`, `_cap_body()` truncated from the end and could **silently drop a fallback finding entirely**.

## Approach

Chosen combination: **ordering (fallback-first) + explicit budgeted truncation marker**.

- Added a shared `_is_diff_mappable()` helper; `_partition_findings()` and the findings-section ordering now use the same notion of which findings have an inline surface.
- Threaded the PR diff line map through `build_sticky_comment` -> `format_review_summary` -> `_format_findings_section` (new keyword-only args, default `None` = fully backward compatible).
- `_format_findings_section` now **orders non-diff-mappable findings first**, so if truncation must drop anything, it only drops findings that *also* exist as inline comments.
- `build_sticky_comment` does a two-pass render: if the assembled body exceeds `MAX_COMMENT_CHARS`, it isolates the findings section's contribution, computes the remaining budget, and re-renders the findings section against that budget. Overflow is replaced by an explicit `… N more finding(s) truncated — see inline comments and workflow logs.` marker rather than a silent cut. `_cap_body()` remains as the final safety net.

`post_review_to_github` now fetches `fetch_pr_diff_lines()` once and reuses it for both the sticky render and inline partition.

Preserved unchanged: `sanitize_comment_text` @mention neutralization, severity ordering within groups, cumulative header, run mechanics, prior-run state block, #1102 error taxonomy, #1103 partial-state rendering.

## Files changed
- `lintro/ai/review/github.py`
- `tests/unit/ai/review/test_github.py`

## Tests
- Fallback findings render ahead of diff-mappable ones (fallback P3 precedes mapped P1).
- Over-cap sticky keeps the fallback finding and emits an explicit dropped-count marker — never silently absent.
- State block + cumulative header still parse/round-trip after truncation.

## Gates
- `uv run lintro fmt` — clean
- `uv run --extra ai lintro chk` — **Total Issues: 0** (github.py is a 979-line WARN, non-blocking; Errors 0)
- `uv run --extra ai pytest` — **5953 passed, 10 skipped**

Closes #1099

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates sticky review comments so fallback findings are handled before truncation. The main changes are:

- Shared diff-line mapping logic for sticky and inline review paths.
- Fallback-first ordering in the findings section.
- Budgeted findings rendering with an explicit truncation marker.
- Reuse of the fetched PR diff line map during GitHub posting.
- Tests for fallback ordering, overflow wording, and state round-tripping.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/review/github.py | Adds shared diff-mappability checks, fallback-first rendering, and budgeted sticky-comment truncation. |
| tests/unit/ai/review/test_github.py | Adds tests for fallback ordering, truncation markers, all-fallback overflow messaging, and sticky state preservation. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/1099-sticky..."](https://github.com/lgtm-hq/py-lintro/commit/0ff7923634ef251db2477afb465129a67e47f2fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42112200)</sub>

<!-- /greptile_comment -->