### PR TITLE
ci(sbom): set fail-on-severity=high to stop 'negligible or higher' warnings

### DIFF
--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -36,6 +36,10 @@ jobs:
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
+      # Only fail the build on high/critical vulns. Left unset, the reusable
+      # passes an empty fail-on to grype, which then flags "negligible or
+      # higher" — noisy warnings on advisories we can't action.
+      fail-on-severity: high
       create-attestation: true
       tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
       egress-policy: block

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -23,6 +23,10 @@ jobs:
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
+      # Only fail the build on high/critical vulns. Left unset, the reusable
+      # passes an empty fail-on to grype, which then flags "negligible or
+      # higher" — noisy warnings on advisories we can't action.
+      fail-on-severity: high
       create-attestation: true
       tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
       egress-policy: block


### PR DESCRIPTION
## What
Set `fail-on-severity: high` on both callers of the lgtm-ci `reusable-sbom.yml` (`sbom-on-main.yml` and the SBOM job in `publish-pypi-on-tag.yml`).

## Why
The reusable's `fail-on-severity` input defaults to `""`, which it passes straight to grype's `fail-on` — grype then treats it as **fail on any severity**, producing the recurring warning:
> Failed minimum severity level. Found vulnerabilities with level 'negligible' or higher

on every SBOM run. Pinning `high` makes the scan gate on **high/critical** (still uploads full SARIF to the Security tab for lower severities) and removes the noise.

## Not covered here
The other SBOM annotation — `` `pre` execution is not supported for local action from './.lgtm-ci-tooling/.github/actions/harden-runner' `` — originates **inside the lgtm-ci reusable** (it invokes `./.lgtm-ci-tooling/.github/actions/checkout-and-harden` etc. as local composite actions, whose `pre:` step can't run by relative path). Not fixable from this repo; filed upstream in lgtm-ci.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes the SBOM vulnerability gate in CI. The main changes are:

- Adds `fail-on-severity: high` to the PyPI publish SBOM job.
- Adds `fail-on-severity: high` to the main-branch SBOM workflow.
- Keeps the existing SBOM format, attestation, tooling ref, and egress settings unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed workflow inputs.
- The change is narrow and applies the same SBOM scan threshold in both callers.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-pypi-on-tag.yml | Adds the SBOM scan threshold input to the release publishing workflow. |
| .github/workflows/sbom-on-main.yml | Adds the SBOM scan threshold input to the main-branch SBOM workflow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(sbom): set fail-on-severity to high t..."](https://github.com/lgtm-hq/py-lintro/commit/81cff9a3fc9851d5d82cc7e6d3d2439fed51a02c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42112851)</sub>

<!-- /greptile_comment -->