### PR TITLE
feat(cli): add fmt --dry-run mode to preview fixes without writing

### DIFF
--- a/lintro/cli_utils/commands/format.py
+++ b/lintro/cli_utils/commands/format.py
@@ -92,6 +92,16 @@ DEFAULT_ACTION: str = "fmt"
     is_flag=True,
     help="Skip confirmation prompt and proceed immediately",
 )
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help=(
+        "Preview what would be fixed without modifying any files. Lists the "
+        "issues each tool would fix and a summary count. Exits 0 when nothing "
+        "would be fixed and 1 when fixes are available (useful for CI checks)."
+    ),
+)
 def format_command(
     ctx: click.Context,
     paths: tuple[str, ...],
@@ -109,6 +119,7 @@ def format_command(
     debug: bool,
     auto_install: bool,
     yes: bool,
+    dry_run: bool,
 ) -> None:
     """Format code using configured formatting tools.
 
@@ -133,6 +144,7 @@ def format_command(
         debug: bool: Whether to enable debug output on console.
         auto_install: bool: Whether to auto-install Node.js deps if missing.
         yes: bool: Skip confirmation prompt and proceed immediately.
+        dry_run: bool: Preview would-be fixes without modifying any files.
     """
     # Default to current directory if no paths provided
     normalized_paths: list[str] = list(paths) if paths else list(DEFAULT_PATHS)
@@ -155,11 +167,14 @@ def format_command(
         no_log=no_log,
         auto_install=auto_install,
         yes=yes,
+        dry_run=dry_run,
     )
 
-    # Exit with code from tool execution
-    # For fmt action, exit_code is 1 only if there were execution errors
-    # (not if issues were found and fixed - that's success)
+    # Exit with code from tool execution.
+    # For a normal fmt action, exit_code is 1 only if there were execution
+    # errors (not if issues were found and fixed - that's success). In
+    # --dry-run mode nothing is written and exit_code follows check semantics:
+    # 0 when nothing would be fixed, 1 when fixes are available.
     ctx.exit(exit_code)
 
 

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -387,6 +387,72 @@ def _enrich_issues_with_doc_urls(
     _enrich(result.initial_issues)
 
 
+def _issue_would_be_fixed(issue: BaseIssue) -> bool:
+    """Return whether a check-mode issue is one that ``fmt`` would auto-fix.
+
+    Resolves the issue's fixability via ``DISPLAY_FIELD_MAP`` (some tools store
+    the flag under a different attribute). Tools that carry a per-issue
+    fixability signal are honored — only truthy-fixable issues count. For
+    example, ruff sets ``fixable`` from ruff's own ``fix`` field, so its
+    non-``--fix``-able lint diagnostics are excluded.
+
+    Issue types that expose no ``fixable`` attribute at all (the pure-formatter
+    parsers such as prettier, oxfmt, taplo, sqlfluff) carry no fixability
+    distinction. Because dry-run only runs fix-capable (formatter) tools, every
+    diagnostic such a tool reports in check mode represents a reformat that a
+    real ``fmt`` run would apply, so it is treated as fixable.
+
+    Args:
+        issue: The parsed issue to classify.
+
+    Returns:
+        bool: True if the issue would be fixed by a real ``fmt`` run.
+    """
+    field_map = getattr(issue, "DISPLAY_FIELD_MAP", {})
+    fixable_attr = field_map.get("fixable", "fixable")
+    if not hasattr(issue, fixable_attr):
+        return True
+    return bool(getattr(issue, fixable_attr, False))
+
+
+def _filter_result_to_fixable(result: ToolResult) -> ToolResult:
+    """Return a copy of a dry-run check result limited to would-fix issues.
+
+    Filters ``issues`` down to the auto-fixable subset (see
+    :func:`_issue_would_be_fixed`) and updates ``issues_count`` to match, so
+    dry-run counts, the summary line, and the exit code reflect only what a
+    real ``fmt`` run would actually change rather than every check-mode
+    diagnostic.
+
+    A check-mode tool sets ``success=False`` when it merely *finds* issues, but
+    in dry-run those diagnostics are informational: the exit code must derive
+    purely from the fixable issue count, not from the tool having found
+    (possibly non-fixable) issues. So any result that parsed issues is marked
+    ``success=True`` here — it ran fine. Results without parsed issues are
+    returned unchanged: a genuine execution failure carries no parsed issues
+    and must still fail the run, and dry-run only runs fix-capable tools, so a
+    reported change without structured issues is treated as fixable.
+
+    Args:
+        result: The check-mode result to filter.
+
+    Returns:
+        ToolResult: A filtered copy, or the original when there are no parsed
+        issues.
+    """
+    import dataclasses
+
+    if not result.issues:
+        return result
+    fixable = [issue for issue in result.issues if _issue_would_be_fixed(issue)]
+    return dataclasses.replace(
+        result,
+        issues=fixable,
+        issues_count=len(fixable),
+        success=True,
+    )
+
+
 def run_lint_tools_simple(
     *,
     action: str | Action,
@@ -687,6 +753,11 @@ def run_lint_tools_simple(
             except (KeyError, ValueError):
                 pass  # Tool not found — skip enrichment
 
+        # Dry-run: restrict each result to would-fix issues before totals and
+        # display so non-auto-fixable diagnostics don't inflate the count.
+        if dry_run_preview:
+            all_results = [_filter_result_to_fixable(r) for r in all_results]
+
         # Calculate totals from parallel results using helper
         total_issues, total_fixed, total_remaining = aggregate_tool_results(
             all_results,
@@ -746,6 +817,13 @@ def run_lint_tools_simple(
 
                 # Populate doc_url on each issue from the plugin
                 _enrich_issues_with_doc_urls(tool, result)
+
+                # Dry-run: restrict to issues a real fmt would actually fix so
+                # the displayed tables, counts, and exit code exclude
+                # non-auto-fixable check-mode diagnostics (e.g. ruff lint rules
+                # that are not --fix-able).
+                if dry_run_preview:
+                    result = _filter_result_to_fixable(result)
 
                 all_results.append(result)
 
@@ -819,6 +897,19 @@ def run_lint_tools_simple(
         total_fixed=total_fixed,
         total_remaining=total_remaining,
     )
+
+    # Dry-run: post-checks may append additional check-mode results. Restrict
+    # every result to its would-fix subset and re-derive the totals so the
+    # summary and exit code count only auto-fixable issues.
+    if dry_run_preview:
+        all_results[:] = [
+            r if getattr(r, "skipped", False) else _filter_result_to_fixable(r)
+            for r in all_results
+        ]
+        total_issues, total_fixed, total_remaining = aggregate_tool_results(
+            all_results,
+            action,
+        )
 
     # AI enhancement via hook pattern
     effective_ai_fix = ai_fix or lintro_config.ai.default_fix
@@ -937,7 +1028,7 @@ def run_lint_tools_simple(
                     )
                 else:
                     logger.console_output(
-                        text="Nothing to fix - all files already formatted",
+                        text="Nothing to fix - no auto-fixable issues found",
                         color="green",
                     )
 

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -409,6 +409,7 @@ def run_lint_tools_simple(
     ai_fix: bool = False,
     ignore_conflicts: bool = False,
     transport: str | None = None,
+    dry_run: bool = False,
 ) -> int:
     """Simplified runner using Loguru-based logging with rich formatting.
 
@@ -439,6 +440,11 @@ def run_lint_tools_simple(
         ai_fix: Enable AI fix suggestions with interactive review (check only).
         ignore_conflicts: Whether to ignore tool configuration conflicts.
         transport: Optional CLI override for ``ai.transport`` when AI runs.
+        dry_run: Preview what ``fmt`` would fix without modifying files. When
+            set with a ``fmt`` action, tools run in read-only check mode using
+            the fixable tool set; the reported issues are exactly what a real
+            ``fmt`` run would address. Exit code mirrors check semantics: 0 when
+            nothing would be fixed, 1 when fixes are available.
 
     Returns:
         Exit code (0 for success, 1 for failures).
@@ -450,6 +456,16 @@ def run_lint_tools_simple(
     """
     # Normalize action to enum
     action = normalize_action(action)
+
+    # Dry-run preview: show what `fmt` WOULD fix without writing. Select the
+    # fixable tool set (via the original fmt action) but execute, aggregate,
+    # and compute the exit code in read-only check mode, so no files are
+    # modified and the reported issues are exactly what a real fmt run would
+    # address.
+    selection_action = action
+    dry_run_preview = dry_run and action == Action.FIX
+    if dry_run_preview:
+        action = Action.CHECK
 
     # Initialize output manager for this run
     output_manager = OutputManager()
@@ -474,7 +490,7 @@ def run_lint_tools_simple(
     try:
         tools_result = get_tools_to_run(
             tools,
-            action,
+            selection_action,
             ignore_conflicts=ignore_conflicts,
         )
     except ValueError as e:
@@ -546,6 +562,13 @@ def run_lint_tools_simple(
 
     # Print main header with output directory information
     logger.print_lintro_header()
+
+    # Announce dry-run mode so users know no files will be modified.
+    if dry_run_preview and output_format.lower() not in {"json", "sarif"}:
+        logger.console_output(
+            text="Dry run - no files modified",
+            color="yellow",
+        )
 
     # Show incremental mode message
     if incremental:
@@ -897,6 +920,26 @@ def run_lint_tools_simple(
             print(sarif_json)
         else:
             logger.print_execution_summary(action, all_results)
+
+            # Dry-run summary: state clearly what a real fmt run would fix.
+            if dry_run_preview:
+                from lintro.utils.summary_tables import count_affected_files
+
+                file_count = count_affected_files(all_results)
+                if total_issues > 0:
+                    logger.console_output(
+                        text=(
+                            f"Would fix {total_issues} "
+                            f"issue{'s' if total_issues != 1 else ''} in "
+                            f"{file_count} file{'s' if file_count != 1 else ''}"
+                        ),
+                        color="cyan",
+                    )
+                else:
+                    logger.console_output(
+                        text="Nothing to fix - all files already formatted",
+                        color="green",
+                    )
 
         # Route warnings to stderr (loguru) for machine-readable formats so
         # plain-text messages don't corrupt JSON/SARIF output on stdout.

--- a/tests/integration/tools/test_fmt_dry_run.py
+++ b/tests/integration/tools/test_fmt_dry_run.py
@@ -1,0 +1,127 @@
+"""End-to-end integration tests for ``lintro fmt --dry-run``.
+
+These tests require ruff to be installed and available in PATH. They exercise
+the real tool-execution pipeline to verify that dry-run mode previews fixes
+without modifying any files, and that exit codes follow check semantics.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+from click.testing import CliRunner
+
+from lintro.cli_utils.commands.format import format_command
+
+# Skip all tests if ruff is not installed.
+pytestmark = pytest.mark.skipif(
+    shutil.which("ruff") is None,
+    reason="ruff not installed",
+)
+
+# Source with fixable issues: two unused imports and a missing-whitespace assign.
+_FIXABLE_SOURCE = "import os\nimport sys\nx=1\n"
+_CLEAN_SOURCE = "x = 1\n"
+
+
+@pytest.fixture
+def fixable_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a Python file with fixable issues inside an isolated cwd.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+        monkeypatch: Pytest monkeypatch fixture used to switch the working
+            directory so run artifacts and config discovery stay isolated.
+
+    Returns:
+        Path to the created fixture file.
+    """
+    monkeypatch.chdir(tmp_path)
+    file_path = tmp_path / "bad.py"
+    file_path.write_text(_FIXABLE_SOURCE)
+    return file_path
+
+
+@pytest.fixture
+def clean_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create an already-formatted Python file inside an isolated cwd.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+        monkeypatch: Pytest monkeypatch fixture used to switch the working
+            directory so run artifacts and config discovery stay isolated.
+
+    Returns:
+        Path to the created fixture file.
+    """
+    monkeypatch.chdir(tmp_path)
+    file_path = tmp_path / "clean.py"
+    file_path.write_text(_CLEAN_SOURCE)
+    return file_path
+
+
+def test_dry_run_does_not_modify_files_and_lists_issues(fixable_file: Path) -> None:
+    """Dry-run previews would-be fixes without writing and lists the issues.
+
+    Args:
+        fixable_file: Fixture file containing fixable issues.
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(
+        format_command,
+        ["--tools", "ruff", "--dry-run", str(fixable_file)],
+    )
+
+    # File content must be byte-for-byte unchanged.
+    assert_that(fixable_file.read_text()).is_equal_to(_FIXABLE_SOURCE)
+
+    # Preview must announce dry-run, list the fixable issues, and summarize.
+    assert_that(result.output).contains("Dry run - no files modified")
+    assert_that(result.output).contains("F401")
+    assert_that(result.output).contains("Would fix")
+
+    # Exit code 1 signals fixes are available (useful for CI checks).
+    assert_that(result.exit_code).is_equal_to(1)
+
+
+def test_dry_run_clean_file_reports_nothing(clean_file: Path) -> None:
+    """Dry-run on a clean file reports nothing to fix and exits 0.
+
+    Args:
+        clean_file: Fixture file that is already formatted.
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(
+        format_command,
+        ["--tools", "ruff", "--dry-run", str(clean_file)],
+    )
+
+    assert_that(clean_file.read_text()).is_equal_to(_CLEAN_SOURCE)
+    assert_that(result.output).contains("Dry run - no files modified")
+    assert_that(result.exit_code).is_equal_to(0)
+
+
+def test_normal_fmt_still_writes_fixes(fixable_file: Path) -> None:
+    """Normal fmt (no --dry-run) still writes fixes and does not regress.
+
+    Args:
+        fixable_file: Fixture file containing fixable issues.
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(
+        format_command,
+        ["--tools", "ruff", str(fixable_file)],
+    )
+
+    # The file must have been rewritten: unused imports removed and the
+    # assignment reformatted.
+    new_content = fixable_file.read_text()
+    assert_that(new_content).is_not_equal_to(_FIXABLE_SOURCE)
+    assert_that(new_content).does_not_contain("import os")
+    assert_that(result.output).does_not_contain("Dry run - no files modified")

--- a/tests/integration/tools/test_fmt_dry_run.py
+++ b/tests/integration/tools/test_fmt_dry_run.py
@@ -25,6 +25,9 @@ pytestmark = pytest.mark.skipif(
 # Source with fixable issues: two unused imports and a missing-whitespace assign.
 _FIXABLE_SOURCE = "import os\nimport sys\nx=1\n"
 _CLEAN_SOURCE = "x = 1\n"
+# Source whose only diagnostic (E741 ambiguous name) is NOT auto-fixable and is
+# already correctly formatted, so a real fmt run would change nothing.
+_NON_FIXABLE_SOURCE = "l = 0\n"
 
 
 @pytest.fixture
@@ -103,6 +106,46 @@ def test_dry_run_clean_file_reports_nothing(clean_file: Path) -> None:
 
     assert_that(clean_file.read_text()).is_equal_to(_CLEAN_SOURCE)
     assert_that(result.output).contains("Dry run - no files modified")
+    assert_that(result.exit_code).is_equal_to(0)
+
+
+@pytest.fixture
+def non_fixable_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a file whose only issue is non-auto-fixable inside isolated cwd.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+        monkeypatch: Pytest monkeypatch fixture used to switch the working
+            directory so run artifacts and config discovery stay isolated.
+
+    Returns:
+        Path to the created fixture file.
+    """
+    monkeypatch.chdir(tmp_path)
+    file_path = tmp_path / "ambiguous.py"
+    file_path.write_text(_NON_FIXABLE_SOURCE)
+    return file_path
+
+
+def test_dry_run_only_non_fixable_issues_exits_zero(non_fixable_file: Path) -> None:
+    """Dry-run reports no would-fix and exits 0 when issues are non-fixable.
+
+    A file whose only diagnostic cannot be auto-fixed (and is already
+    formatted) must not be reported as having fixes available.
+
+    Args:
+        non_fixable_file: Fixture file with a single non-fixable issue.
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(
+        format_command,
+        ["--tools", "ruff", "--dry-run", str(non_fixable_file)],
+    )
+
+    assert_that(non_fixable_file.read_text()).is_equal_to(_NON_FIXABLE_SOURCE)
+    assert_that(result.output).contains("Dry run - no files modified")
+    assert_that(result.output).does_not_contain("Would fix")
     assert_that(result.exit_code).is_equal_to(0)
 
 

--- a/tests/unit/cli/test_cli_lintro_group.py
+++ b/tests/unit/cli/test_cli_lintro_group.py
@@ -126,6 +126,7 @@ def test_invoke_with_comma_separated_commands() -> None:
             no_log=False,
             auto_install=False,
             yes=False,
+            dry_run=False,
         )
 
 

--- a/tests/unit/cli_utils/commands/test_format.py
+++ b/tests/unit/cli_utils/commands/test_format.py
@@ -165,6 +165,40 @@ def test_format_command_with_output_format(mock_run: MagicMock) -> None:
 
 
 @patch("lintro.cli_utils.commands.format.run_lint_tools_simple")
+def test_format_command_dry_run_flag_passed(mock_run: MagicMock) -> None:
+    """format_command forwards --dry-run as dry_run=True.
+
+    Args:
+        mock_run: Mock for run_lint_tools_simple.
+    """
+    mock_run.return_value = 0
+    runner = CliRunner()
+
+    result = runner.invoke(format_command, ["--dry-run"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    call_kwargs = mock_run.call_args.kwargs
+    assert_that(call_kwargs["dry_run"]).is_true()
+
+
+@patch("lintro.cli_utils.commands.format.run_lint_tools_simple")
+def test_format_command_dry_run_defaults_false(mock_run: MagicMock) -> None:
+    """format_command defaults dry_run to False when flag absent.
+
+    Args:
+        mock_run: Mock for run_lint_tools_simple.
+    """
+    mock_run.return_value = 0
+    runner = CliRunner()
+
+    result = runner.invoke(format_command, [])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    call_kwargs = mock_run.call_args.kwargs
+    assert_that(call_kwargs["dry_run"]).is_false()
+
+
+@patch("lintro.cli_utils.commands.format.run_lint_tools_simple")
 def test_format_command_returns_tool_exit_code(mock_run: MagicMock) -> None:
     """format_command returns exit code from tool execution.
 

--- a/tests/unit/tools/executor/test_tool_executor.py
+++ b/tests/unit/tools/executor/test_tool_executor.py
@@ -652,3 +652,174 @@ def test_executor_fmt_without_dry_run_invokes_fix(
     assert_that(tool.checked).is_false()
     texts = _console_texts(fake_logger)
     assert_that(texts).does_not_contain("Dry run - no files modified")
+
+
+def test_executor_dry_run_excludes_non_fixable_issues(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_logger: Any,
+) -> None:
+    """Dry-run counts only auto-fixable issues, not all check diagnostics.
+
+    A check-mode result carrying one fixable and one non-fixable issue must
+    report a single would-fix issue and exit 1.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        fake_logger: FakeLogger fixture.
+    """
+    from lintro.parsers.ruff.ruff_issue import RuffIssue
+
+    fixable = RuffIssue(
+        file="a.py",
+        line=1,
+        column=8,
+        message="`os` imported but unused",
+        code="F401",
+        fixable=True,
+    )
+    non_fixable = RuffIssue(
+        file="a.py",
+        line=2,
+        column=1,
+        message="ambiguous variable name",
+        code="E741",
+        fixable=False,
+    )
+    _stub_logger(monkeypatch, fake_logger)
+    # Ruff reports success=False when it finds any diagnostics; dry-run must
+    # not let that alone force a failure exit.
+    result = ToolResult(
+        name="ruff",
+        success=False,
+        output="x",
+        issues_count=2,
+        issues=[fixable, non_fixable],
+    )
+    _setup_tool_manager(
+        monkeypatch,
+        {"ruff": CallTrackingTool("ruff", can_fix=True, result=result)},
+    )
+
+    code = run_lint_tools_simple(
+        action="fmt",
+        paths=["."],
+        tools="all",
+        tool_options=None,
+        exclude=None,
+        include_venv=False,
+        group_by="auto",
+        output_format="grid",
+        verbose=False,
+        raw_output=False,
+        dry_run=True,
+    )
+
+    assert_that(code).is_equal_to(1)
+    texts = _console_texts(fake_logger)
+    assert_that(texts).contains("Would fix 1 issue in")
+
+
+def test_executor_dry_run_only_non_fixable_exits_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_logger: Any,
+) -> None:
+    """Dry-run with only non-fixable issues reports nothing and exits 0.
+
+    Even though the tool returns ``success=False`` (it found a diagnostic),
+    dry-run must exit 0 because a real fmt run would change nothing.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        fake_logger: FakeLogger fixture.
+    """
+    from lintro.parsers.ruff.ruff_issue import RuffIssue
+
+    non_fixable = RuffIssue(
+        file="a.py",
+        line=1,
+        column=1,
+        message="ambiguous variable name",
+        code="E741",
+        fixable=False,
+    )
+    _stub_logger(monkeypatch, fake_logger)
+    result = ToolResult(
+        name="ruff",
+        success=False,
+        output="x",
+        issues_count=1,
+        issues=[non_fixable],
+    )
+    _setup_tool_manager(
+        monkeypatch,
+        {"ruff": CallTrackingTool("ruff", can_fix=True, result=result)},
+    )
+
+    code = run_lint_tools_simple(
+        action="fmt",
+        paths=["."],
+        tools="all",
+        tool_options=None,
+        exclude=None,
+        include_venv=False,
+        group_by="auto",
+        output_format="grid",
+        verbose=False,
+        raw_output=False,
+        dry_run=True,
+    )
+
+    assert_that(code).is_equal_to(0)
+    texts = _console_texts(fake_logger)
+    assert_that(texts).contains("Nothing to fix")
+    assert_that(texts).does_not_contain("Would fix")
+
+
+def test_executor_dry_run_treats_formatter_issues_without_flag_as_fixable(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_logger: Any,
+) -> None:
+    """Formatter issues lacking a ``fixable`` attribute count as would-fix.
+
+    Pure-formatter parsers (e.g. prettier) do not define a ``fixable`` field.
+    Every diagnostic such a tool emits in check mode is a reformat that fmt
+    would apply, so it must be counted.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        fake_logger: FakeLogger fixture.
+    """
+    from lintro.parsers.prettier.prettier_issue import PrettierIssue
+
+    issue = PrettierIssue(file="a.js", line=1, column=1, message="Would reformat")
+    assert_that(hasattr(issue, "fixable")).is_false()
+    _stub_logger(monkeypatch, fake_logger)
+    result = ToolResult(
+        name="prettier",
+        success=False,
+        output="x",
+        issues_count=1,
+        issues=[issue],
+    )
+    _setup_tool_manager(
+        monkeypatch,
+        {"prettier": CallTrackingTool("prettier", can_fix=True, result=result)},
+    )
+
+    code = run_lint_tools_simple(
+        action="fmt",
+        paths=["."],
+        tools="all",
+        tool_options=None,
+        exclude=None,
+        include_venv=False,
+        group_by="auto",
+        output_format="grid",
+        verbose=False,
+        raw_output=False,
+        dry_run=True,
+    )
+
+    assert_that(code).is_equal_to(1)
+    texts = _console_texts(fake_logger)
+    assert_that(texts).contains("Would fix 1 issue in")

--- a/tests/unit/tools/executor/test_tool_executor.py
+++ b/tests/unit/tools/executor/test_tool_executor.py
@@ -463,3 +463,192 @@ def test_executor_unknown_tool(
         raw_output=False,
     )
     assert_that(code).is_equal_to(1)
+
+
+class CallTrackingTool(FakeTool):
+    """FakeTool that records whether check() or fix() was invoked.
+
+    Used to prove that ``--dry-run`` executes tools in read-only check mode
+    and never invokes ``fix()`` (which would modify files).
+    """
+
+    def __init__(self, name: str, can_fix: bool, result: ToolResult) -> None:
+        """Initialize the call-tracking tool.
+
+        Args:
+            name: Tool name.
+            can_fix: Whether fixes are supported.
+            result: Result object to return from check/fix.
+        """
+        super().__init__(name, can_fix, result)
+        self.checked = False
+        self.fixed = False
+
+    def check(
+        self,
+        paths: list[str],
+        options: dict[str, Any] | None = None,
+    ) -> ToolResult:
+        """Record that the check path ran and return the stored result.
+
+        Args:
+            paths: Target paths (ignored in stub).
+            options: Optional tool options.
+
+        Returns:
+            ToolResult: Pre-baked result instance.
+        """
+        self.checked = True
+        return self._result
+
+    def fix(
+        self,
+        paths: list[str],
+        options: dict[str, Any] | None = None,
+    ) -> ToolResult:
+        """Record that the fix path ran and return the stored result.
+
+        Args:
+            paths: Target paths (ignored in stub).
+            options: Optional tool options.
+
+        Returns:
+            ToolResult: Pre-baked result instance.
+        """
+        self.fixed = True
+        return self._result
+
+
+def _console_texts(fake_logger: Any) -> str:
+    """Join all console_output text passed to the fake logger.
+
+    Args:
+        fake_logger: FakeLogger instance whose calls were recorded.
+
+    Returns:
+        A single string of all console_output text arguments.
+    """
+    parts: list[str] = []
+    for name, args, kwargs in fake_logger.calls:
+        if name != "console_output":
+            continue
+        if "text" in kwargs:
+            parts.append(str(kwargs["text"]))
+        elif args:
+            parts.append(str(args[0]))
+    return "\n".join(parts)
+
+
+def test_executor_dry_run_runs_check_not_fix(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_logger: Any,
+) -> None:
+    """Dry-run fmt executes check() and never fix(), signalling exit 1.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        fake_logger: FakeLogger fixture.
+    """
+    _stub_logger(monkeypatch, fake_logger)
+    result = ToolResult(name="ruff", success=True, output="x", issues_count=2)
+    tool = CallTrackingTool("ruff", can_fix=True, result=result)
+    _setup_tool_manager(monkeypatch, {"ruff": tool})
+
+    code = run_lint_tools_simple(
+        action="fmt",
+        paths=["."],
+        tools="all",
+        tool_options=None,
+        exclude=None,
+        include_venv=False,
+        group_by="auto",
+        output_format="grid",
+        verbose=False,
+        raw_output=False,
+        dry_run=True,
+    )
+
+    assert_that(code).is_equal_to(1)
+    assert_that(tool.checked).is_true()
+    assert_that(tool.fixed).is_false()
+    texts = _console_texts(fake_logger)
+    assert_that(texts).contains("Dry run - no files modified")
+    assert_that(texts).contains("Would fix 2 issues in")
+
+
+def test_executor_dry_run_clean_reports_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_logger: Any,
+) -> None:
+    """Dry-run fmt on a clean tree reports nothing to fix and exits 0.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        fake_logger: FakeLogger fixture.
+    """
+    _stub_logger(monkeypatch, fake_logger)
+    result = ToolResult(name="ruff", success=True, output="", issues_count=0)
+    tool = CallTrackingTool("ruff", can_fix=True, result=result)
+    _setup_tool_manager(monkeypatch, {"ruff": tool})
+
+    code = run_lint_tools_simple(
+        action="fmt",
+        paths=["."],
+        tools="all",
+        tool_options=None,
+        exclude=None,
+        include_venv=False,
+        group_by="auto",
+        output_format="grid",
+        verbose=False,
+        raw_output=False,
+        dry_run=True,
+    )
+
+    assert_that(code).is_equal_to(0)
+    assert_that(tool.checked).is_true()
+    assert_that(tool.fixed).is_false()
+    texts = _console_texts(fake_logger)
+    assert_that(texts).contains("Nothing to fix")
+
+
+def test_executor_fmt_without_dry_run_invokes_fix(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_logger: Any,
+) -> None:
+    """Normal fmt (no dry-run) still invokes fix() and does not regress.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        fake_logger: FakeLogger fixture.
+    """
+    _stub_logger(monkeypatch, fake_logger)
+    result = ToolResult(
+        name="ruff",
+        success=True,
+        output="",
+        issues_count=0,
+        fixed_issues_count=2,
+        remaining_issues_count=0,
+    )
+    tool = CallTrackingTool("ruff", can_fix=True, result=result)
+    _setup_tool_manager(monkeypatch, {"ruff": tool})
+
+    code = run_lint_tools_simple(
+        action="fmt",
+        paths=["."],
+        tools="all",
+        tool_options=None,
+        exclude=None,
+        include_venv=False,
+        group_by="auto",
+        output_format="grid",
+        verbose=False,
+        raw_output=False,
+    )
+
+    assert_that(code).is_equal_to(0)
+    assert_that(tool.fixed).is_true()
+    assert_that(tool.checked).is_false()
+    texts = _console_texts(fake_logger)
+    assert_that(texts).does_not_contain("Dry run - no files modified")


### PR DESCRIPTION
## Summary

Adds a dry-run mode to `lintro fmt`. `lintro fmt --dry-run` shows what **would** be fixed without modifying any files, then exits without writing.

Closes #442

## How it works

Dry-run reuses each tool's existing read-only capability instead of re-implementing diffing: it selects the **fixable** tool set (as a normal `fmt` would) but executes, aggregates, and computes the exit code in **check mode**. Because check mode never writes, no files are modified, and the issues reported are exactly what a real `fmt` run would address. This is fully tool-agnostic via the existing plugin/executor abstraction — no tool is special-cased.

Output adds a `Dry run - no files modified` notice and a `Would fix N issues in M files` summary (or `Nothing to fix - all files already formatted` when clean), on top of the existing per-file issue tables (line, code, message, tool).

## Exit codes

Follows the issue spec and mirrors `chk` semantics:

- **0** — nothing would be fixed (clean)
- **1** — fixes are available (useful as a CI formatting gate)

No files are written in either case. Documented in the `--dry-run` CLI help.

## Example

```
$ lintro fmt --tools ruff --dry-run bad.py
Dry run - no files modified
...
Auto-fixable issues
| File   | Line | Code | Message                  | ... |
| bad.py |    1 | F401 | `os` imported but unused | ... |
...
Would fix 2 issues in 1 file
$ echo $?
1
```

## Files changed

- `lintro/cli_utils/commands/format.py` — add `--dry-run` Click flag, forward as `dry_run`, document exit-code behavior.
- `lintro/utils/tool_executor.py` — `dry_run` param; when set with `fmt`, select fixable tools but run/aggregate/exit as check; emit dry-run notice + would-fix summary.
- `tests/integration/tools/test_fmt_dry_run.py` — real ruff end-to-end: file unchanged + issues listed + exit 1; clean file exits 0; normal fmt still writes.
- `tests/unit/tools/executor/test_tool_executor.py` — dry-run runs `check()` not `fix()`; exit codes; clean-tree message.
- `tests/unit/cli_utils/commands/test_format.py` — flag wiring (true/default-false).
- `tests/unit/cli/test_cli_lintro_group.py` — updated expected fmt call kwargs.

## Gates

- `uv run lintro chk` → Total Issues: 0
- `uv run pytest` → 5958 passed, 10 skipped
- `uv run lintro fmt` → no changes

## Deferred

- `--dry-run --diff` (line-level diff preview) from the issue's secondary example is not included; the per-file issue listing + summary covers the primary request. Can follow up if wanted.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a dry-run mode for `lintro fmt`. The main changes are:

- New `--dry-run` CLI flag for format commands.
- Executor path that runs fix-capable tools in read-only check mode.
- Filtering so dry-run reports only issues a real format run would fix.
- Tests for dirty, clean, non-fixable-only, and normal format behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/utils/tool_executor.py | Adds dry-run execution and filters check results before reporting and exit-code calculation. |
| lintro/cli_utils/commands/format.py | Adds the `--dry-run` option and forwards it to the executor. |
| tests/integration/tools/test_fmt_dry_run.py | Adds end-to-end coverage for dry-run output, file preservation, exit codes, and normal formatting. |
| tests/unit/tools/executor/test_tool_executor.py | Adds executor coverage for dry-run dispatch, issue filtering, summaries, and exit codes. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/442-fmt-dr..."](https://github.com/lgtm-hq/py-lintro/commit/80d43521536803a831fb64e9c6711c6d442bc374) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42119560)</sub>

<!-- /greptile_comment -->