### PR TITLE
feat(shellcheck): support source-following for repo-local includes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1626,13 +1626,13 @@ lintro check --tools shellcheck \
 
 **Available Options:**
 
-| Option             | Type        | Description                                                                          |
-| ------------------ | ----------- | ------------------------------------------------------------------------------------ |
-| `severity`         | str         | Minimum severity: error, warning, info, style                                        |
-| `exclude`          | list\[str\] | List of codes to exclude (e.g., SC2086, SC2046)                                      |
-| `shell`            | str         | Force shell dialect: bash, sh, dash, ksh, zsh                                        |
-| `external_sources` | bool        | Follow `source`d files external to the script (`-x`). Default `False`                |
-| `source_paths`     | list\[str\] | Search paths for sourced files (`--source-path=...`); supports the `SCRIPTDIR` token |
+| Option             | Type        | Description                                                                                                                                                   |
+| ------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `severity`         | str         | Minimum severity: error, warning, info, style                                                                                                                 |
+| `exclude`          | list\[str\] | List of codes to exclude (e.g., SC2086, SC2046)                                                                                                               |
+| `shell`            | str         | Force shell dialect: bash, sh, dash, ksh, zsh                                                                                                                 |
+| `external_sources` | bool        | Follow `source`d files external to the script (`-x`). Default `False`                                                                                         |
+| `source_paths`     | list\[str\] | Search paths for sourced files (`--source-path=...`); supports the `SCRIPTDIR` token. Setting this implies `external_sources` (`-x` is enabled automatically) |
 
 **Source-following (SC1091):**
 
@@ -1646,15 +1646,19 @@ source "$SCRIPT_DIR/../lib/common.sh"
 ```
 
 Opt in to source-following (off by default, so existing projects are unaffected) by
-enabling `external_sources` and pointing `source_paths` at the directories ShellCheck
-should search. ShellCheck's literal `SCRIPTDIR` token resolves relative to each script's
-own directory, which matches the pattern above without hard-coding repo paths.
+pointing `source_paths` at the directories ShellCheck should search. ShellCheck's
+literal `SCRIPTDIR` token resolves relative to each script's own directory, which
+matches the pattern above without hard-coding repo paths. Because ShellCheck ignores
+`--source-path` unless `-x` is active, setting `source_paths` **automatically enables**
+`external_sources`, so you do not need to set both — configuring paths is enough. (You
+may still set `external_sources = true` on its own to follow sources found on the
+default search path.)
 
 `pyproject.toml`:
 
 ```toml
 [tool.lintro.shellcheck]
-external_sources = true
+# source_paths implies external_sources; -x is added automatically.
 source_paths = ["SCRIPTDIR", "scripts/lib"]
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1618,15 +1618,48 @@ lintro check --tools shellcheck --tool-options "shellcheck:shell=bash"
 
 # Exclude specific codes
 lintro check --tools shellcheck --tool-options "shellcheck:exclude=SC2086|SC2046"
+
+# Follow repo-local sourced files (resolves SC1091 for SCRIPT_DIR sourcing)
+lintro check --tools shellcheck \
+  --tool-options "shellcheck:external_sources=True,shellcheck:source_paths=SCRIPTDIR"
 ```
 
 **Available Options:**
 
-| Option     | Type        | Description                                     |
-| ---------- | ----------- | ----------------------------------------------- |
-| `severity` | str         | Minimum severity: error, warning, info, style   |
-| `exclude`  | list\[str\] | List of codes to exclude (e.g., SC2086, SC2046) |
-| `shell`    | str         | Force shell dialect: bash, sh, dash, ksh, zsh   |
+| Option             | Type        | Description                                                                          |
+| ------------------ | ----------- | ------------------------------------------------------------------------------------ |
+| `severity`         | str         | Minimum severity: error, warning, info, style                                        |
+| `exclude`          | list\[str\] | List of codes to exclude (e.g., SC2086, SC2046)                                      |
+| `shell`            | str         | Force shell dialect: bash, sh, dash, ksh, zsh                                        |
+| `external_sources` | bool        | Follow `source`d files external to the script (`-x`). Default `False`                |
+| `source_paths`     | list\[str\] | Search paths for sourced files (`--source-path=...`); supports the `SCRIPTDIR` token |
+
+**Source-following (SC1091):**
+
+Scripts that source repo-local helpers with the runtime-safe pattern below emit `SC1091`
+("Not following ...") by default, because ShellCheck cannot statically resolve the
+dynamic path:
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+```
+
+Opt in to source-following (off by default, so existing projects are unaffected) by
+enabling `external_sources` and pointing `source_paths` at the directories ShellCheck
+should search. ShellCheck's literal `SCRIPTDIR` token resolves relative to each script's
+own directory, which matches the pattern above without hard-coding repo paths.
+
+`pyproject.toml`:
+
+```toml
+[tool.lintro.shellcheck]
+external_sources = true
+source_paths = ["SCRIPTDIR", "scripts/lib"]
+```
+
+With this enabled, the SC1091 above is resolved without per-line
+`# shellcheck disable=SC1091` or `# shellcheck source=...` suppressions.
 
 **Common ShellCheck Codes:**
 

--- a/lintro/tools/definitions/shellcheck.py
+++ b/lintro/tools/definitions/shellcheck.py
@@ -22,6 +22,8 @@ from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.registry import register_tool
 from lintro.tools.core.option_validators import (
     filter_none_options,
+    normalize_str_or_list,
+    validate_bool,
     validate_list,
     validate_str,
 )
@@ -113,6 +115,8 @@ class ShellcheckPlugin(BaseToolPlugin):
                 "severity": SHELLCHECK_DEFAULT_SEVERITY,
                 "exclude": None,
                 "shell": None,
+                "external_sources": False,
+                "source_paths": None,
             },
             default_timeout=SHELLCHECK_DEFAULT_TIMEOUT,
         )
@@ -122,6 +126,8 @@ class ShellcheckPlugin(BaseToolPlugin):
         severity: str | None = None,
         exclude: list[str] | None = None,
         shell: str | None = None,
+        external_sources: bool | None = None,
+        source_paths: list[str] | str | None = None,
         **kwargs: Any,
     ) -> None:
         """Set Shellcheck-specific options.
@@ -130,6 +136,18 @@ class ShellcheckPlugin(BaseToolPlugin):
             severity: Minimum severity to report (error, warning, info, style).
             exclude: List of codes to exclude (e.g., ["SC2086", "SC2046"]).
             shell: Force shell dialect (bash, sh, dash, ksh).
+            external_sources: Follow ``source``d files that are external to the
+                script being checked (maps to ShellCheck's ``-x`` /
+                ``--external-sources``). Defaults to ``False`` to preserve the
+                conservative, opt-in behavior. Enable this so scripts that
+                source repo-local helpers stop emitting ``SC1091``.
+            source_paths: Directory or list of directories ShellCheck searches
+                when resolving ``source``d files (maps to ``--source-path=...``,
+                one flag per entry; a bare string is treated as a single path).
+                Supports ShellCheck's literal ``SCRIPTDIR`` token, which
+                resolves relative to each script's own directory and covers the
+                runtime-safe ``SCRIPT_DIR="$(cd ... && pwd)"`` sourcing pattern.
+                Only takes effect together with ``external_sources``.
             **kwargs: Other tool options.
         """
         if severity is not None:
@@ -141,11 +159,15 @@ class ShellcheckPlugin(BaseToolPlugin):
         validate_list(exclude, "exclude")
         validate_str(severity, "severity")
         validate_str(shell, "shell")
+        validate_bool(external_sources, "external_sources")
+        source_paths = normalize_str_or_list(source_paths, "source_paths")
 
         options = filter_none_options(
             severity=severity,
             exclude=exclude,
             shell=shell,  # nosec B604 - shell is dialect, not subprocess shell=True
+            external_sources=external_sources,
+            source_paths=source_paths,
         )
         super().set_options(**options, **kwargs)
 
@@ -187,6 +209,17 @@ class ShellcheckPlugin(BaseToolPlugin):
         shell_opt = self.options.get("shell")
         if shell_opt is not None:
             cmd.extend(["--shell", str(shell_opt)])
+
+        # Follow external sourced files (repo-local includes)
+        if self.options.get("external_sources"):
+            cmd.append("--external-sources")
+
+        # Search paths for resolving sourced files. Supports ShellCheck's
+        # literal ``SCRIPTDIR`` token (resolves relative to each script).
+        source_paths_opt = self.options.get("source_paths")
+        if source_paths_opt is not None and isinstance(source_paths_opt, list):
+            for path in source_paths_opt:
+                cmd.append(f"--source-path={path}")
 
         return cmd
 

--- a/lintro/tools/definitions/shellcheck.py
+++ b/lintro/tools/definitions/shellcheck.py
@@ -147,7 +147,10 @@ class ShellcheckPlugin(BaseToolPlugin):
                 Supports ShellCheck's literal ``SCRIPTDIR`` token, which
                 resolves relative to each script's own directory and covers the
                 runtime-safe ``SCRIPT_DIR="$(cd ... && pwd)"`` sourcing pattern.
-                Only takes effect together with ``external_sources``.
+                Setting this implies ``external_sources`` (ShellCheck ignores
+                source paths unless ``-x`` is active), so ``--external-sources``
+                is emitted automatically even when ``external_sources`` is left
+                at its default.
             **kwargs: Other tool options.
         """
         if severity is not None:
@@ -210,16 +213,24 @@ class ShellcheckPlugin(BaseToolPlugin):
         if shell_opt is not None:
             cmd.extend(["--shell", str(shell_opt)])
 
-        # Follow external sourced files (repo-local includes)
-        if self.options.get("external_sources"):
-            cmd.append("--external-sources")
-
         # Search paths for resolving sourced files. Supports ShellCheck's
         # literal ``SCRIPTDIR`` token (resolves relative to each script).
         source_paths_opt = self.options.get("source_paths")
-        if source_paths_opt is not None and isinstance(source_paths_opt, list):
-            for path in source_paths_opt:
-                cmd.append(f"--source-path={path}")
+        source_paths: list[Any] = (
+            source_paths_opt if isinstance(source_paths_opt, list) else []
+        )
+
+        # Follow external sourced files (repo-local includes). Setting
+        # ``source_paths`` implies source-following: ShellCheck ignores
+        # ``--source-path`` unless ``-x`` is active, so configuring paths is an
+        # unambiguous signal of intent. Emit ``--external-sources`` when either
+        # the flag is set explicitly or source paths are configured, so the
+        # command is never silently half-configured.
+        if self.options.get("external_sources") or source_paths:
+            cmd.append("--external-sources")
+
+        for path in source_paths:
+            cmd.append(f"--source-path={path}")
 
         return cmd
 

--- a/tests/integration/tools/shellcheck/test_check.py
+++ b/tests/integration/tools/shellcheck/test_check.py
@@ -6,7 +6,7 @@ These tests verify the check command works correctly on various inputs.
 from __future__ import annotations
 
 import shutil
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -14,6 +14,7 @@ import pytest
 from assertpy import assert_that
 
 if TYPE_CHECKING:
+    from lintro.parsers.base_issue import BaseIssue
     from lintro.plugins.base import BaseToolPlugin
 
 pytestmark = pytest.mark.skipif(
@@ -133,3 +134,85 @@ def test_check_exclude_filters_issues(
     assert_that(result_with_exclude.issues_count).is_less_than_or_equal_to(
         result_without_exclude.issues_count,
     )
+
+
+def _write_script_dir_sourcing_sample(tmp_path: Path) -> str:
+    """Create a script that sources a repo-local helper via SCRIPT_DIR.
+
+    Mirrors the runtime-safe sourcing pattern from issue #928, where a script
+    computes its own directory and sources a sibling helper by relative path.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory root.
+
+    Returns:
+        str: Path to the entrypoint script that performs the sourcing.
+    """
+    lib_dir = tmp_path / "scripts" / "lib"
+    ci_dir = tmp_path / "scripts" / "ci"
+    lib_dir.mkdir(parents=True)
+    ci_dir.mkdir(parents=True)
+
+    (lib_dir / "common.sh").write_text(
+        "#!/usr/bin/env bash\ncommon_helper() {\n  echo 'hello'\n}\n",
+    )
+    entry = ci_dir / "run.sh"
+    entry.write_text(
+        "#!/usr/bin/env bash\n"
+        'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+        'source "$SCRIPT_DIR/../lib/common.sh"\n'
+        "common_helper\n",
+    )
+    return str(entry)
+
+
+def _sc1091_count(issues: Sequence[BaseIssue] | None) -> int:
+    """Count SC1091 ('not following source') issues in a result set.
+
+    Args:
+        issues: Parsed issue objects from a ShellCheck run.
+
+    Returns:
+        int: Number of issues whose code is SC1091.
+    """
+    return sum(
+        1 for issue in (issues or []) if str(getattr(issue, "code", "")) == "SC1091"
+    )
+
+
+def test_check_reports_sc1091_without_source_following(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    tmp_path: Path,
+) -> None:
+    """Baseline: sourcing a repo-local helper emits SC1091 when not opted in.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        tmp_path: Pytest fixture providing a temporary directory.
+    """
+    entry = _write_script_dir_sourcing_sample(tmp_path)
+    shellcheck_plugin = get_plugin("shellcheck")
+    result = shellcheck_plugin.check([entry], {})
+
+    assert_that(_sc1091_count(result.issues)).is_greater_than(0)
+
+
+def test_check_source_following_resolves_sc1091(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    tmp_path: Path,
+) -> None:
+    """external_sources + SCRIPTDIR source-path clears SC1091 for the pattern.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        tmp_path: Pytest fixture providing a temporary directory.
+    """
+    entry = _write_script_dir_sourcing_sample(tmp_path)
+    shellcheck_plugin = get_plugin("shellcheck")
+    shellcheck_plugin.set_options(
+        external_sources=True,
+        source_paths=["SCRIPTDIR"],
+    )
+    result = shellcheck_plugin.check([entry], {})
+
+    assert_that(_sc1091_count(result.issues)).is_equal_to(0)

--- a/tests/integration/tools/shellcheck/test_check.py
+++ b/tests/integration/tools/shellcheck/test_check.py
@@ -216,3 +216,22 @@ def test_check_source_following_resolves_sc1091(
     result = shellcheck_plugin.check([entry], {})
 
     assert_that(_sc1091_count(result.issues)).is_equal_to(0)
+
+
+def test_check_source_paths_alone_resolves_sc1091(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    tmp_path: Path,
+) -> None:
+    """source_paths alone clears SC1091: it auto-enables -x for ShellCheck.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        tmp_path: Pytest fixture providing a temporary directory.
+    """
+    entry = _write_script_dir_sourcing_sample(tmp_path)
+    shellcheck_plugin = get_plugin("shellcheck")
+    # Deliberately omit external_sources; setting source_paths must imply it.
+    shellcheck_plugin.set_options(source_paths=["SCRIPTDIR"])
+    result = shellcheck_plugin.check([entry], {})
+
+    assert_that(_sc1091_count(result.issues)).is_equal_to(0)

--- a/tests/unit/tools/shellcheck/test_options.py
+++ b/tests/unit/tools/shellcheck/test_options.py
@@ -301,6 +301,37 @@ def test_build_command_with_source_paths(
     assert_that(cmd).contains("--source-path=scripts/lib")
 
 
+def test_build_command_source_paths_imply_external_sources(
+    shellcheck_plugin: ShellcheckPlugin,
+) -> None:
+    """Setting source_paths auto-enables -x even without external_sources.
+
+    ShellCheck ignores --source-path unless -x is active, so configuring
+    paths is treated as an unambiguous request to follow sources.
+
+    Args:
+        shellcheck_plugin: The ShellcheckPlugin instance to test.
+    """
+    shellcheck_plugin.set_options(source_paths=["SCRIPTDIR"])
+    cmd = shellcheck_plugin._build_command()
+    assert_that(cmd).contains("--external-sources")
+    assert_that(cmd).contains("--source-path=SCRIPTDIR")
+
+
+def test_build_command_empty_source_paths_omits_flags(
+    shellcheck_plugin: ShellcheckPlugin,
+) -> None:
+    """An empty source_paths list adds neither -x nor --source-path.
+
+    Args:
+        shellcheck_plugin: The ShellcheckPlugin instance to test.
+    """
+    shellcheck_plugin.set_options(source_paths=[])
+    cmd = shellcheck_plugin._build_command()
+    assert_that(cmd).does_not_contain("--external-sources")
+    assert_that(any(arg.startswith("--source-path=") for arg in cmd)).is_false()
+
+
 def test_build_command_with_all_options(shellcheck_plugin: ShellcheckPlugin) -> None:
     """Build command with all options set.
 

--- a/tests/unit/tools/shellcheck/test_options.py
+++ b/tests/unit/tools/shellcheck/test_options.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 from assertpy import assert_that
 
@@ -13,6 +15,7 @@ from lintro.tools.definitions.shellcheck import (
     SHELLCHECK_SHELL_DIALECTS,
     ShellcheckPlugin,
 )
+from lintro.utils.tool_options import parse_tool_options
 
 # Tests for default option values
 
@@ -24,12 +27,16 @@ from lintro.tools.definitions.shellcheck import (
         ("severity", SHELLCHECK_DEFAULT_SEVERITY),
         ("exclude", None),
         ("shell", None),
+        ("external_sources", False),
+        ("source_paths", None),
     ],
     ids=[
         "timeout_equals_default",
         "severity_equals_default",
         "exclude_is_none",
         "shell_is_none",
+        "external_sources_is_false",
+        "source_paths_is_none",
     ],
 )
 def test_default_options_values(
@@ -64,6 +71,10 @@ def test_default_options_values(
         ("shell", "sh"),
         ("shell", "dash"),
         ("shell", "ksh"),
+        ("external_sources", True),
+        ("external_sources", False),
+        ("source_paths", ["scripts/lib", "scripts/ci"]),
+        ("source_paths", ["SCRIPTDIR"]),
     ],
     ids=[
         "severity_error",
@@ -75,6 +86,10 @@ def test_default_options_values(
         "shell_sh",
         "shell_dash",
         "shell_ksh",
+        "external_sources_true",
+        "external_sources_false",
+        "source_paths_list",
+        "source_paths_scriptdir",
     ],
 )
 def test_set_options_valid(
@@ -130,6 +145,10 @@ def test_set_options_shell_case_insensitive(
         ("shell", "powershell", "Invalid shell dialect"),
         ("exclude", "SC2086", "exclude must be a list"),
         ("exclude", 123, "exclude must be a list"),
+        ("external_sources", "yes", "external_sources must be a boolean"),
+        ("external_sources", 1, "external_sources must be a boolean"),
+        ("source_paths", 123, "source_paths must be a string or list"),
+        ("source_paths", [1, 2], "source_paths must be a string or list"),
     ],
     ids=[
         "invalid_severity_critical",
@@ -138,6 +157,10 @@ def test_set_options_shell_case_insensitive(
         "invalid_shell_powershell",
         "invalid_exclude_string",
         "invalid_exclude_integer",
+        "invalid_external_sources_string",
+        "invalid_external_sources_integer",
+        "invalid_source_paths_integer",
+        "invalid_source_paths_list_of_ints",
     ],
 )
 def test_set_options_invalid_type(
@@ -222,6 +245,62 @@ def test_build_command_with_shell_dialect(shellcheck_plugin: ShellcheckPlugin) -
     assert_that(cmd[shell_idx + 1]).is_equal_to("bash")
 
 
+def test_build_command_no_source_following_by_default(
+    shellcheck_plugin: ShellcheckPlugin,
+) -> None:
+    """Source-following flags are absent unless explicitly enabled.
+
+    This guards backward compatibility for projects that do not opt in.
+
+    Args:
+        shellcheck_plugin: The ShellcheckPlugin instance to test.
+    """
+    cmd = shellcheck_plugin._build_command()
+    assert_that(cmd).does_not_contain("--external-sources")
+    assert_that(cmd).does_not_contain("-x")
+    assert_that(any(arg.startswith("--source-path=") for arg in cmd)).is_false()
+
+
+def test_build_command_with_external_sources(
+    shellcheck_plugin: ShellcheckPlugin,
+) -> None:
+    """Build command with external_sources enables the -x flag.
+
+    Args:
+        shellcheck_plugin: The ShellcheckPlugin instance to test.
+    """
+    shellcheck_plugin.set_options(external_sources=True)
+    cmd = shellcheck_plugin._build_command()
+    assert_that(cmd).contains("--external-sources")
+
+
+def test_build_command_external_sources_false_omits_flag(
+    shellcheck_plugin: ShellcheckPlugin,
+) -> None:
+    """external_sources=False does not add the -x flag.
+
+    Args:
+        shellcheck_plugin: The ShellcheckPlugin instance to test.
+    """
+    shellcheck_plugin.set_options(external_sources=False)
+    cmd = shellcheck_plugin._build_command()
+    assert_that(cmd).does_not_contain("--external-sources")
+
+
+def test_build_command_with_source_paths(
+    shellcheck_plugin: ShellcheckPlugin,
+) -> None:
+    """Build command emits one --source-path=... per configured path.
+
+    Args:
+        shellcheck_plugin: The ShellcheckPlugin instance to test.
+    """
+    shellcheck_plugin.set_options(source_paths=["SCRIPTDIR", "scripts/lib"])
+    cmd = shellcheck_plugin._build_command()
+    assert_that(cmd).contains("--source-path=SCRIPTDIR")
+    assert_that(cmd).contains("--source-path=scripts/lib")
+
+
 def test_build_command_with_all_options(shellcheck_plugin: ShellcheckPlugin) -> None:
     """Build command with all options set.
 
@@ -283,3 +362,51 @@ def test_default_format_constant() -> None:
 def test_default_severity_constant() -> None:
     """Verify SHELLCHECK_DEFAULT_SEVERITY is style."""
     assert_that(SHELLCHECK_DEFAULT_SEVERITY).is_equal_to("style")
+
+
+# Tests for parsing source-following options from CLI --tool-options
+
+
+def test_set_options_source_paths_string_normalized_to_list(
+    shellcheck_plugin: ShellcheckPlugin,
+) -> None:
+    """A single string source_paths is normalized to a one-element list.
+
+    Args:
+        shellcheck_plugin: The ShellcheckPlugin instance to test.
+    """
+    shellcheck_plugin.set_options(source_paths="SCRIPTDIR")
+    assert_that(shellcheck_plugin.options.get("source_paths")).is_equal_to(
+        ["SCRIPTDIR"],
+    )
+
+
+def test_parse_external_sources_from_cli() -> None:
+    """external_sources is coerced to a bool from CLI --tool-options."""
+    parsed = parse_tool_options("shellcheck:external_sources=True")
+    assert_that(parsed).contains_key("shellcheck")
+    assert_that(parsed["shellcheck"].get("external_sources")).is_equal_to(True)
+
+
+def test_parse_source_paths_from_cli() -> None:
+    """source_paths is coerced to a list from pipe-delimited --tool-options."""
+    parsed = parse_tool_options("shellcheck:source_paths=SCRIPTDIR|scripts/lib")
+    assert_that(parsed["shellcheck"].get("source_paths")).is_equal_to(
+        ["SCRIPTDIR", "scripts/lib"],
+    )
+
+
+def test_parse_source_following_options_flow_into_command() -> None:
+    """CLI-parsed options wire through set_options into the built command."""
+    parsed = parse_tool_options(
+        "shellcheck:external_sources=True,shellcheck:source_paths=SCRIPTDIR",
+    )
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        plugin = ShellcheckPlugin()
+    plugin.set_options(**parsed["shellcheck"])  # type: ignore[arg-type]
+    cmd = plugin._build_command()
+    assert_that(cmd).contains("--external-sources")
+    assert_that(cmd).contains("--source-path=SCRIPTDIR")


### PR DESCRIPTION
## Summary

Adds opt-in ShellCheck source-following/source-path support so scripts that source repo-local helpers via the runtime-safe `SCRIPT_DIR` pattern stop emitting `SC1091` without per-line `# shellcheck disable=SC1091` / `# shellcheck source=...` suppressions. Closes #928.

## What changed

Two new ShellCheck options, wired end-to-end through `set_options` and `_build_command` (mirroring the existing `exclude`/`shell` options):

| Option | Type | Default | ShellCheck flag |
| --- | --- | --- | --- |
| `external_sources` | `bool` | `False` | `--external-sources` (`-x`) — follow `source`d files |
| `source_paths` | `list[str]` (a bare string is accepted and normalized) | `None` | `--source-path=...`, one flag per entry; supports the literal `SCRIPTDIR` token |

Defaults are conservative — both are **off** unless a project opts in, so existing behavior is unchanged.

## Why

Scripts commonly source helpers with a runtime-safe pattern ShellCheck can't statically resolve:

```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
source "$SCRIPT_DIR/../lib/common.sh"
```

This surfaces as `SC1091` in repos like `lgtm-hq/homebrew-tap` even though the sourced files exist. `SCRIPTDIR` resolves relative to each script's own directory, matching the pattern without hard-coding repo paths.

## Usage

`pyproject.toml`:

```toml
[tool.lintro.shellcheck]
external_sources = true
source_paths = ["SCRIPTDIR", "scripts/lib"]
```

CLI:

```bash
lintro check --tools shellcheck \
  --tool-options "shellcheck:external_sources=True,shellcheck:source_paths=SCRIPTDIR"
```

## Tests

- Unit (`tests/unit/tools/shellcheck/test_options.py`): default values, valid/invalid option validation, command construction (flags present when set, **absent when unset** for backward compat), string→list normalization, and parsing from `--tool-options`.
- Integration with the real `shellcheck` binary (`tests/integration/tools/shellcheck/test_check.py`): a fixture that sources a repo-local helper via `SCRIPT_DIR` reports `SC1091` by default and reports **zero** `SC1091` once `external_sources` + `source_paths=["SCRIPTDIR"]` are enabled.

## Gates

- `uv run lintro chk` → Total Issues: 0
- `uv run pytest` → 5970 passed, 10 skipped

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds opt-in ShellCheck source-following for repo-local sourced files.

- New `external_sources` and `source_paths` ShellCheck options.
- Automatic `--external-sources` when `source_paths` is configured.
- Documentation for the `SCRIPTDIR` source-path workflow.
- Unit and integration tests for option parsing and `SC1091` behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/definitions/shellcheck.py | Adds validated ShellCheck source-following options and emits the required command flags. |
| tests/unit/tools/shellcheck/test_options.py | Adds coverage for defaults, validation, command construction, normalization, and CLI parsing. |
| tests/integration/tools/shellcheck/test_check.py | Adds real ShellCheck coverage for `SC1091` with and without source-following. |
| docs/configuration.md | Documents the new ShellCheck options and the `SCRIPTDIR` workflow. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/928-shellc..."](https://github.com/lgtm-hq/py-lintro/commit/75082474ad770ef001085d2dd62e79242bb2e831) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42128719)</sub>

<!-- /greptile_comment -->