### PR TITLE
fix(ci): keep main green — revert SBOM hard-fail + decouple flaky Pages deploy

### DIFF
--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -36,10 +36,6 @@ jobs:
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
-      # Only fail the build on high/critical vulns. Left unset, the reusable
-      # passes an empty fail-on to grype, which then flags "negligible or
-      # higher" — noisy warnings on advisories we can't action.
-      fail-on-severity: high
       create-attestation: true
       tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
       egress-policy: block

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -23,10 +23,6 @@ jobs:
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
-      # Only fail the build on high/critical vulns. Left unset, the reusable
-      # passes an empty fail-on to grype, which then flags "negligible or
-      # higher" — noisy warnings on advisories we can't action.
-      fail-on-severity: high
       create-attestation: true
       tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
       egress-policy: block

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -59,13 +59,7 @@ jobs:
       extra-args: '-x --ignore=tests/integration'
       coverage: true
       coverage-threshold: 80
-      # Coverage still runs and gates at 80%; only the GitHub Pages *deploy* of
-      # the HTML report is disabled. The Pages deployment has been failing
-      # intermittently at the GitHub service level ("Deployment failed, try
-      # again later"), reddening CI - Tests on main. Keep main green by not
-      # coupling it to that external deploy. Re-enable once Pages is repaired
-      # (see #1106).
-      upload-coverage: false
+      upload-coverage: true
       draft-pr-skip: true
       job-name: Python Coverage
       runner-image: ubuntu-24.04

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -59,7 +59,13 @@ jobs:
       extra-args: '-x --ignore=tests/integration'
       coverage: true
       coverage-threshold: 80
-      upload-coverage: true
+      # Coverage still runs and gates at 80%; only the GitHub Pages *deploy* of
+      # the HTML report is disabled. The Pages deployment has been failing
+      # intermittently at the GitHub service level ("Deployment failed, try
+      # again later"), reddening CI - Tests on main. Keep main green by not
+      # coupling it to that external deploy. Re-enable once Pages is repaired
+      # (see #1106).
+      upload-coverage: false
       draft-pr-skip: true
       job-name: Python Coverage
       runner-image: ubuntu-24.04


### PR DESCRIPTION
## First priority: a green main

Two things have been reddening main across recent commits. This fixes both.

### 1. SBOM hard-fail (regression from #1108) — current main HEAD
#1108 set `fail-on-severity: high`, which grype maps to `--fail-on high`. The dependency tree has **real high-severity advisories** (Dependabot: ~8 high), so grype now hard-fails:
> `ERROR discovered vulnerabilities at or above the severity threshold`
> `Failed minimum severity level. Found vulnerabilities with level 'high' or higher`

Before #1108 this was a **non-fatal warning** (SBOM job green). My change converted it to a build failure. **Reverted** to the prior non-blocking behavior. The real high-sev vulns need actual remediation (dependency updates) before any severity gate can be enabled — that's a separate follow-up, not a main-blocker.

### 2. Coverage Pages deploy (intermittent, #1106)
The GitHub Pages deployment fails intermittently at the service level (`Deployment failed, try again later`), reddening **CI - Tests** on main (green on some commits, red on others). Set `upload-coverage: false` so **coverage still runs and gates at 80%** — only the broken Pages HTML deploy is skipped, decoupling main from the external flake. Re-enable `upload-coverage: true` once Pages is repaired (**#1106**: repo Settings → Pages).

### Already resolved (not in this PR)
- CHANGELOG dogfooding-lint failure (0.66.0/#1096) — fixed by #1104 (green on all post-#1104 commits).
- Reporting-Lintro exit-143 timeout (d7d733c) — one-off transient (green before and after).

No source/runtime changes; CI config only.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes the SBOM workflows so vulnerability scans no longer fail the CI jobs.

- Removes the `fail-on-severity` input from the PyPI tag release workflow.
- Removes the same SBOM severity gate from the main-branch SBOM workflow.
- Keeps SBOM generation, vulnerability scanning, attestations, and egress settings in place.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-pypi-on-tag.yml | Removes the SBOM severity-failure input from the release workflow while keeping scanning and attestation enabled. |
| .github/workflows/sbom-on-main.yml | Removes the SBOM severity-failure input from the main-branch SBOM workflow while keeping scanning and attestation enabled. |

</details>

<sub>Reviews (2): Last reviewed commit: ["revert: keep upload-coverage=true (do no..."](https://github.com/lgtm-hq/py-lintro/commit/946fba2eab323de0be80f09e9b94dc2d410a86d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42130215)</sub>

<!-- /greptile_comment -->