### PR TITLE
docs(contributing): document merge-discipline and no-paper-over norms

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -216,9 +216,9 @@ are mandatory for every PR merged to `main`.
 
 ### All required checks must be green
 
-- Every status check marked as required by branch protection or repository rulesets
-  must pass before merge. Use the exact check-run names reported by GitHub when
-  configuring or auditing the required-check list.
+- Every status check marked as required by branch protection or repository rulesets must
+  pass before merge. Use the exact check-run names reported by GitHub when configuring
+  or auditing the required-check list.
 - **Never merge red.** A failing or in-progress required check blocks the merge. Do not
   merge past a failure "to fix it in a follow-up" — fix it first, or revert.
 - Admin bypass of a failing check is not a normal workflow. If an override is ever

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -209,6 +209,47 @@ All contributions go through code review:
 
 ---
 
+## Merge Discipline
+
+Passing CI and clean reviews are enforced, not merely encouraged. The following norms
+are mandatory for every PR merged to `main`.
+
+### All required checks must be green
+
+- Every required status check (for example: `dogfooding-lint`, the test gate,
+  `CI-Docker`, SBOM, CodeQL, and the semantic PR-title check) must pass before merge.
+- **Never merge red.** A failing or in-progress required check blocks the merge. Do not
+  merge past a failure "to fix it in a follow-up" — fix it first, or revert.
+- Admin bypass of a failing check is not a normal workflow. If an override is ever
+  unavoidable, it must be explicit and logged, with the reason recorded on the PR.
+
+### All review threads must be resolved
+
+- Every review conversation must be **resolved** before merge, not just replied to.
+  Replying to a comment is not the same as resolving it.
+- Resolve a thread only when the underlying concern is actually addressed (code changed,
+  or the reviewer agrees no change is needed). Leave the resolution to reflect real
+  agreement, not to clear the merge button.
+- If a comment surfaces follow-up work that is genuinely out of scope, open a tracked
+  issue and link it in the thread before resolving.
+
+### No papering over linters
+
+Do not weaken a gate to make a linter pass. Specifically, **without a written
+justification in the diff** (a code comment or the PR description explaining why), do
+not:
+
+- Add `.lintro-ignore` entries (or equivalent per-tool ignore/suppression rules).
+- Raise or add module-size baselines to absorb a new violation.
+- Downgrade a quality gate — lower a severity threshold, disable a check, or loosen a
+  failure condition — to get a green run.
+
+The default is to fix the underlying issue. Suppressions and baseline bumps are a last
+resort that must be visible and explained in the same change that introduces them, so a
+reviewer can weigh the trade-off deliberately.
+
+---
+
 ## Local Development Commands
 
 > See [Quick Start](#quick-start) above for initial setup. This section covers

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -216,8 +216,9 @@ are mandatory for every PR merged to `main`.
 
 ### All required checks must be green
 
-- Every required status check (for example: `dogfooding-lint`, the test gate,
-  `CI-Docker`, SBOM, CodeQL, and the semantic PR-title check) must pass before merge.
+- Every status check marked as required by branch protection or repository rulesets
+  must pass before merge. Use the exact check-run names reported by GitHub when
+  configuring or auditing the required-check list.
 - **Never merge red.** A failing or in-progress required check blocks the merge. Do not
   merge past a failure "to fix it in a follow-up" — fix it first, or revert.
 - Admin bypass of a failing check is not a normal workflow. If an override is ever


### PR DESCRIPTION
## What's Changing

Adds a **Merge Discipline** section to `docs/contributing.md` documenting the norms
that prompted #1119:

- **All required checks green before merge** — never merge red; admin bypass must be
  explicit and logged.
- **All review threads resolved before merge** — replying to a comment is not the same
  as resolving it.
- **No papering over linters** — no `.lintro-ignore` entries, module-size baseline
  bumps, or gate downgrades to satisfy a linter without a written justification in the
  diff.

This is the code-able part of the issue. The branch-protection enforcement is
admin-only and intentionally **not** applied here (see below).

## Type

- [x] docs

## Admin follow-up (branch protection — not applied by this PR)

The following require repo-admin rights and are out of scope for this PR. The owner
can run these to enforce the norms in settings. **Verify the current setup first**
(rulesets vs. legacy protection) before applying:

```bash
# Inspect current legacy branch protection (if any)
gh api repos/lgtm-hq/py-lintro/branches/main/protection

# Inspect rulesets (the modern equivalent; may supersede legacy protection)
gh api repos/lgtm-hq/py-lintro/rulesets
```

Enable required status checks + require conversation resolution via legacy protection:

```bash
gh api -X PUT repos/lgtm-hq/py-lintro/branches/main/protection \
  -H "Accept: application/vnd.github+json" \
  -f 'required_status_checks[strict]=true' \
  -f 'required_status_checks[checks][][context]=dogfooding-lint' \
  -f 'required_status_checks[checks][][context]=CI-Tests' \
  -f 'required_status_checks[checks][][context]=CI-Docker' \
  -f 'required_status_checks[checks][][context]=SBOM' \
  -f 'required_status_checks[checks][][context]=CodeQL' \
  -f 'required_status_checks[checks][][context]=semantic-title' \
  -F 'enforce_admins=true' \
  -F 'required_pull_request_reviews[required_approving_review_count]=1' \
  -F 'required_conversation_resolution=true' \
  -F 'required_linear_history=true' \
  -F 'restrictions=null' \
  -F 'allow_force_pushes=false' \
  -F 'allow_deletions=false'
```

Notes for the admin:
- Replace the check `context` values with the exact check-run names GitHub reports for
  recent runs on `main` (names must match precisely, e.g. `Test Gate / CI-Tests`).
- `required_conversation_resolution=true` implements "Require conversation resolution
  before merging".
- `enforce_admins=true` disallows silent admin bypass so overrides are logged.
- Verify afterward:
  `gh api repos/lgtm-hq/py-lintro/branches/main/protection` should show the required
  checks and `required_conversation_resolution.enabled: true`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (docs-only)
- [x] Docs updated
- [x] Local lint passed (`uv run lintro chk` / `uv run lintro fmt`)

## Related Issues

Refs #1119

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds merge-discipline guidance to the contributing docs.

- Required checks must be green before merge.
- Review conversations must be resolved before merge.
- Linter suppressions and gate changes need visible justification.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/contributing.md | Adds merge-discipline documentation for checks, review threads, and linter-gate changes. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(contributing): reflow required-chec..."](https://github.com/lgtm-hq/py-lintro/commit/5cbd9f4332148bd00a87a3831712da4c86cb7cc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42152945)</sub>

<!-- /greptile_comment -->