### PR TITLE
fix(ai/review): classify ValueError as INVALID_RESPONSE before shared severity signatures

### DIFF
--- a/lintro/ai/review/errors_taxonomy.py
+++ b/lintro/ai/review/errors_taxonomy.py
@@ -370,15 +370,17 @@ def classify_provider_error(*, provider: str, error: Exception) -> ReviewErrorKi
     if isinstance(cause_exc, AIRateLimitError):
         return ReviewErrorKind.RATE_LIMITED
 
+    # A bare ``ValueError`` cause is a lintro-side parse/validation failure of
+    # the model response, not a provider transport error — surface it as such
+    # rather than misdirecting the user to check provider status. This runs
+    # before the shared text-signature heuristics so an incidental provider-ish
+    # word in the parse message (e.g. "timed out", "429") cannot misclassify it.
+    if isinstance(cause_exc, ValueError):
+        return ReviewErrorKind.INVALID_RESPONSE
+
     for kind in _KIND_PRIORITY:
         matcher = _SHARED_SIGNATURES.get(kind)
         if matcher is not None and matcher.matches(status=status, text=text):
             return kind
-
-    # A bare ``ValueError`` cause is a lintro-side parse/validation failure of
-    # the model response, not a provider transport error — surface it as such
-    # rather than misdirecting the user to check provider status.
-    if isinstance(cause_exc, ValueError):
-        return ReviewErrorKind.INVALID_RESPONSE
 
     return ReviewErrorKind.UNKNOWN

--- a/tests/unit/ai/review/test_errors_taxonomy.py
+++ b/tests/unit/ai/review/test_errors_taxonomy.py
@@ -165,6 +165,24 @@ def test_value_error_classifies_as_invalid_response() -> None:
     assert_that(kind).is_equal_to(ReviewErrorKind.INVALID_RESPONSE)
 
 
+def test_value_error_with_timeout_text_stays_invalid_response() -> None:
+    """A ValueError whose message says "timed out" is still INVALID_RESPONSE."""
+    error = ValueError("parsing timed out on malformed model response")
+    kind = classify_provider_error(provider="anthropic", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.INVALID_RESPONSE)
+    assert_that(kind).is_not_equal_to(ReviewErrorKind.TIMEOUT)
+
+
+def test_value_error_with_429_text_stays_invalid_response() -> None:
+    """A ValueError whose message contains "429" is still INVALID_RESPONSE."""
+    error = ValueError("unexpected token near status 429 in model output")
+    kind = classify_provider_error(provider="openai", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.INVALID_RESPONSE)
+    assert_that(kind).is_not_equal_to(ReviewErrorKind.RATE_LIMITED)
+
+
 def test_invalid_response_via_wrapped_value_error() -> None:
     """A ValueError chained under the wrapper still resolves to INVALID_RESPONSE."""
     cause = ValueError("malformed model output")


### PR DESCRIPTION
## What's Changing

`classify_provider_error` in `lintro/ai/review/errors_taxonomy.py` tested the shared/global text-signature heuristics (rate-limit, timeout, server-error text) **before** the `isinstance(cause, ValueError) -> INVALID_RESPONSE` branch. A lintro-side parse/validation `ValueError` whose message incidentally contained provider-ish text (e.g. "timed out", "429") was therefore misclassified as a provider transport failure (TIMEOUT / RATE_LIMITED), producing the wrong sticky and guidance.

This moves the `ValueError -> INVALID_RESPONSE` check to run **after** provider-specific typed exceptions but **before** the shared text-signature loop. A parse/validation `ValueError` now classifies as `INVALID_RESPONSE` regardless of incidental text. Ordering of provider-specific and typed-exception (auth / rate-limit) classification is unchanged.

Resolves the unaddressed Greptile review thread from #1102 ("Check ValueError First").

## Test Evidence

Added (pytest style, no classes, assertpy, existing module fixtures):

- `test_value_error_with_timeout_text_stays_invalid_response` — `ValueError("... timed out ...")` -> `INVALID_RESPONSE` (not `TIMEOUT`).
- `test_value_error_with_429_text_stays_invalid_response` — `ValueError("... status 429 ...")` -> `INVALID_RESPONSE` (not `RATE_LIMITED`).

Existing typed-exception and provider-signature classifications remain unchanged (24/24 in `tests/unit/ai/review/test_errors_taxonomy.py` pass).

- `uv run lintro chk` — pass (0 issues)
- `uv run lintro fmt` — pass (no changes)
- `uv run pytest` — 5962 passed, 10 skipped. The 2 failures (`test_markdownlint_integration.py::test_markdownlint_direct_vs_lintro_parity`, `test_execution.py::test_prepare_execution_version_check_fails_returns_early_result`) are pre-existing on a clean `origin/main` (verified via `git stash`) and unrelated to this change.

## Related Issues

Closes #1114

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates provider error classification for malformed review responses.

- Moves bare `ValueError` handling before shared provider-text heuristics.
- Keeps typed provider exceptions and provider-specific signatures ahead of that branch.
- Adds tests for `ValueError` messages containing timeout and 429 text.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/review/errors_taxonomy.py | Reorders `ValueError` classification so malformed response errors return `INVALID_RESPONSE` before shared text matching. |
| tests/unit/ai/review/test_errors_taxonomy.py | Adds tests for malformed response `ValueError` messages that include timeout-like and 429-like text. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/1114-valuee..."](https://github.com/lgtm-hq/py-lintro/commit/7056b0c18facc77f046f14b8c3b89a477c08ac7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42153738)</sub>

<!-- /greptile_comment -->