### PR TITLE
fix(output): suppress 'run lintro fmt' hint in test mode

### DIFF
--- a/lintro/utils/summary_tables.py
+++ b/lintro/utils/summary_tables.py
@@ -573,8 +573,9 @@ def print_totals_table(
         total_ai_applied: Total number of AI-applied fixes (FIX mode).
         total_ai_verified: Total number of AI-verified fixes (FIX mode).
         total_fixable: Number of issues the tools flagged as auto-fixable
-            (CHECK mode). When greater than zero, an "Auto-fixable" row and a
-            hint to run ``lintro fmt`` are shown.
+            (CHECK/TEST mode). When greater than zero, an "Auto-fixable" row is
+            shown. The hint to run ``lintro fmt`` is emitted only in CHECK
+            mode; TEST mode is read-only and never advertises ``fmt``.
     """
     try:
         import click
@@ -615,11 +616,11 @@ def print_totals_table(
         console_output_func(text=table)
         console_output_func(text="")
 
-        # In check/test mode, nudge the user toward auto-fixing when the
-        # tools report fixable issues. Only shown when at least one issue is
+        # In check mode, nudge the user toward auto-fixing when the tools
+        # report fixable issues. Only shown when at least one issue is
         # actually flagged fixable, so tools that do not report fixability
-        # stay silent.
-        if action != Action.FIX and total_fixable > 0:
+        # stay silent. Test mode is read-only and must not advertise `fmt`.
+        if action == Action.CHECK and total_fixable > 0:
             noun = "issue" if total_fixable == 1 else "issues"
             console_output_func(
                 text=(

--- a/tests/unit/utils/summary/test_totals_table.py
+++ b/tests/unit/utils/summary/test_totals_table.py
@@ -342,6 +342,53 @@ def test_totals_table_test_mode_uses_check_layout(
     assert_that(combined).contains("Affected Files")
 
 
+def test_totals_table_test_mode_omits_fmt_hint_when_fixable(
+    console_capture: tuple[Callable[..., None], list[str]],
+) -> None:
+    """Verify TEST mode omits the fmt hint even when issues are fixable.
+
+    Test mode is read-only and must not advertise ``fmt``. The Auto-fixable
+    row still renders so users know issues could be fixed elsewhere.
+
+    Args:
+        console_capture: Fixture for capturing console output.
+    """
+    capture_func, output = console_capture
+    print_totals_table(
+        console_output_func=capture_func,
+        action=Action.TEST,
+        total_issues=5,
+        affected_files=2,
+        total_fixable=3,
+    )
+    combined = "\n".join(output)
+    assert_that(combined).contains("Auto-fixable")
+    assert_that(combined).does_not_contain("lintro fmt")
+
+
+def test_totals_table_check_mode_shows_fmt_hint_for_same_input(
+    console_capture: tuple[Callable[..., None], list[str]],
+) -> None:
+    """Verify CHECK mode still shows the fmt hint for the same fixable input.
+
+    Companion to the TEST mode omission test: identical inputs on the check
+    path must continue to nudge toward ``lintro fmt``.
+
+    Args:
+        console_capture: Fixture for capturing console output.
+    """
+    capture_func, output = console_capture
+    print_totals_table(
+        console_output_func=capture_func,
+        action=Action.CHECK,
+        total_issues=5,
+        affected_files=2,
+        total_fixable=3,
+    )
+    combined = "\n".join(output)
+    assert_that(combined).contains("lintro fmt")
+
+
 # =============================================================================
 # print_totals_table Tests - FIX Mode
 # =============================================================================


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(output): suppress 'run lintro fmt' hint in test mode`
- Type: fix (patch)
- Breaking change: no

## What’s Changing

`lintro test` printed the ``run `lintro fmt` `` hint whenever any issue was
flagged fixable, even though test mode is read-only and should not advertise
`fmt` (Greptile finding on #1093, left unresolved at merge).

The nudge in `print_totals_table` (`lintro/utils/summary_tables.py`) was gated
on `action != Action.FIX`, which also matched `Action.TEST`. It is now gated on
`action == Action.CHECK`. The mode is already threaded explicitly via the
`action` argument, so no global state was introduced. The `Auto-fixable` totals
row still renders in test mode; only the `fmt` nudge is suppressed.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing (n/a)
- [x] Local CI passed (full `uv run pytest`)

## Related Issues

Closes #1115

## Details

### Tests (pytest, no classes, assertpy, fixtures)

Added to `tests/unit/utils/summary/test_totals_table.py`:

- `test_totals_table_test_mode_omits_fmt_hint_when_fixable` — TEST mode with
  `total_fixable=3` shows the `Auto-fixable` row but omits `lintro fmt`.
- `test_totals_table_check_mode_shows_fmt_hint_for_same_input` — CHECK mode with
  identical input still shows the `lintro fmt` hint.

### Verification

- `uv run lintro chk` — PASS (0 issues)
- `uv run lintro fmt` — PASS (0 fixed)
- `uv run pytest` (full suite) — 5962 passed, 10 skipped, 2 failed.
  The 2 failures pre-exist on `origin/main` and are unrelated to this change
  (local `markdownlint` 0.22.0 below min 0.22.1, and a version-check ordering
  test); confirmed by re-running them on a clean `origin/main` checkout.
- Targeted `test_totals_table.py` — 26 passed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the totals-table output for fixable issues.

- Suppresses the `lintro fmt` hint in test mode.
- Keeps the hint visible in check mode.
- Preserves the Auto-fixable row in test mode.
- Adds unit tests for the check and test mode behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/utils/summary_tables.py | Changes the totals-table hint gate so `lintro fmt` is only suggested in check mode. |
| tests/unit/utils/summary/test_totals_table.py | Adds tests for the updated check and test mode totals-table output. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/1115-no-fmt..."](https://github.com/lgtm-hq/py-lintro/commit/85c30c7159a6c2b7a1e8d772c0ba58fa677c3f45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42153756)</sub>

<!-- /greptile_comment -->