### PR TITLE
fix(vue-tsc): respect tsconfig.app.json preference in shared config discovery

### DIFF
--- a/lintro/tools/definitions/_ts_checker_base.py
+++ b/lintro/tools/definitions/_ts_checker_base.py
@@ -171,6 +171,36 @@ class TypeScriptCheckerPlugin(BaseToolPlugin):
                 return tsconfig
         return None
 
+    def _preferred_candidate_tsconfig(self, discovery_root: Path) -> Path | None:
+        """Find a subclass-preferred tsconfig ahead of generic discovery.
+
+        Iterates ``_tsconfig_candidates`` in declared order and returns the
+        first candidate that exists directly in *discovery_root* and is listed
+        ahead of the generic ``tsconfig.json`` default. This lets a subclass
+        such as :class:`~lintro.tools.definitions.vue_tsc.VueTscPlugin` — which
+        prefers ``tsconfig.app.json`` for Vite Vue projects — win over generic
+        multi-project discovery on the ``check()`` path (issue #1112).
+
+        Candidates from ``tsconfig.json`` onward are intentionally ignored so
+        that generic discovery (``references``, monorepo directory walking)
+        stays in charge of the default config. Tools whose only candidate is
+        ``tsconfig.json`` (e.g. ``tsc``) therefore never short-circuit here,
+        keeping their behavior unchanged.
+
+        Args:
+            discovery_root: Directory scanned for a preferred tsconfig.
+
+        Returns:
+            Path to the preferred tsconfig if one exists, otherwise ``None``.
+        """
+        for candidate in self._tsconfig_candidates:
+            if candidate == "tsconfig.json":
+                break
+            candidate_path = discovery_root / candidate
+            if candidate_path.exists():
+                return candidate_path.resolve()
+        return None
+
     def _create_temp_tsconfig(
         self,
         base_tsconfig: Path,
@@ -389,6 +419,28 @@ class TypeScriptCheckerPlugin(BaseToolPlugin):
         # Compute the discovery root (per-tool: cwd by default, common
         # ancestor of input paths for tsc's multi-package support).
         discovery_root = self._compute_discovery_root(cwd_path, paths)
+
+        # Respect the subclass's preferred tsconfig ordering before generic
+        # discovery. A subclass (e.g. VueTscPlugin) may declare a
+        # framework-specific config such as ``tsconfig.app.json`` ahead of
+        # ``tsconfig.json``; when that preferred config is present in the
+        # discovery root it must win over generic discovery, which would
+        # otherwise select ``tsconfig.json`` and bypass the Vue preference
+        # (issue #1112). ``tsc`` — whose sole candidate is ``tsconfig.json`` —
+        # is unaffected, so plain projects and monorepos are unchanged.
+        preferred_tsconfig = self._preferred_candidate_tsconfig(discovery_root)
+        if preferred_tsconfig is not None:
+            logger.debug(
+                "[{}] Using preferred tsconfig ahead of discovery: {}",
+                self._tool_label,
+                preferred_tsconfig,
+            )
+            return self._check_single_project(
+                ctx,
+                cwd_path,
+                merged_options,
+                discovered_tsconfig=preferred_tsconfig,
+            )
 
         # Discover tsconfigs for multi-project support
         tsconfigs = discover_tsconfigs(discovery_root, self.exclude_patterns)

--- a/lintro/tools/definitions/_ts_checker_base.py
+++ b/lintro/tools/definitions/_ts_checker_base.py
@@ -420,14 +420,24 @@ class TypeScriptCheckerPlugin(BaseToolPlugin):
         # ancestor of input paths for tsc's multi-package support).
         discovery_root = self._compute_discovery_root(cwd_path, paths)
 
-        # Respect the subclass's preferred tsconfig ordering before generic
-        # discovery. A subclass (e.g. VueTscPlugin) may declare a
+        # Discover tsconfigs for multi-project support. When the discovered
+        # configs span several directories the inputs cover multiple packages,
+        # and multi-project partitioning must keep precedence: each file is
+        # checked against its nearest package config, so a root-level
+        # preferred config must not short-circuit and route child-package
+        # files through the root app config.
+        tsconfigs = discover_tsconfigs(discovery_root, self.exclude_patterns)
+        distinct_dirs = {info.path.parent.resolve() for info in tsconfigs}
+        if len(distinct_dirs) > 1:
+            return self._check_multi_project(ctx, cwd_path, tsconfigs, merged_options)
+
+        # Single project directory: respect the subclass's preferred tsconfig
+        # ordering. A subclass (e.g. VueTscPlugin) may declare a
         # framework-specific config such as ``tsconfig.app.json`` ahead of
-        # ``tsconfig.json``; when that preferred config is present in the
-        # discovery root it must win over generic discovery, which would
-        # otherwise select ``tsconfig.json`` and bypass the Vue preference
-        # (issue #1112). ``tsc`` — whose sole candidate is ``tsconfig.json`` —
-        # is unaffected, so plain projects and monorepos are unchanged.
+        # ``tsconfig.json``; when that preferred config is present it must win
+        # over generic discovery, which would otherwise select
+        # ``tsconfig.json`` and bypass the Vue preference (issue #1112).
+        # ``tsc`` — whose sole candidate is ``tsconfig.json`` — is unaffected.
         preferred_tsconfig = self._preferred_candidate_tsconfig(discovery_root)
         if preferred_tsconfig is not None:
             logger.debug(
@@ -441,9 +451,6 @@ class TypeScriptCheckerPlugin(BaseToolPlugin):
                 merged_options,
                 discovered_tsconfig=preferred_tsconfig,
             )
-
-        # Discover tsconfigs for multi-project support
-        tsconfigs = discover_tsconfigs(discovery_root, self.exclude_patterns)
 
         if len(tsconfigs) > 1:
             return self._check_multi_project(ctx, cwd_path, tsconfigs, merged_options)
@@ -703,8 +710,7 @@ class TypeScriptCheckerPlugin(BaseToolPlugin):
                     rel_project = project_dir
                 count = len(issues)
                 section = (
-                    f"── {rel_project} "
-                    f"({count} issue{'s' if count != 1 else ''}) ──"
+                    f"── {rel_project} ({count} issue{'s' if count != 1 else ''}) ──"
                 )
                 output_sections.append(section)
 

--- a/tests/unit/tools/test_ts_checker_base.py
+++ b/tests/unit/tools/test_ts_checker_base.py
@@ -164,6 +164,157 @@ def test_find_tsconfig_tsc_ignores_app_config(tmp_path: Path) -> None:
 
 
 # =============================================================================
+# Config preference on the check() path (issue #1112)
+# =============================================================================
+
+
+def _project_paths_from_check(
+    *,
+    plugin: TypeScriptCheckerPlugin,
+    paths: list[str],
+) -> list[str]:
+    """Run ``check`` and return the ``--project`` path from every checker call.
+
+    The checker subprocess is mocked to always succeed while recording the
+    commands it is asked to run, so the tsconfig each invocation targets can
+    be observed without executing a real compiler.
+
+    Args:
+        plugin: The checker plugin under test.
+        paths: Paths to pass to ``check``.
+
+    Returns:
+        The ``--project`` argument from each recorded subprocess command,
+        in call order.
+    """
+    calls: list[list[str]] = []
+
+    def _record(*, cmd: list[str], timeout: int, cwd: str) -> tuple[bool, str]:
+        calls.append(cmd)
+        return (True, "")
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(plugin, "_run_subprocess", side_effect=_record):
+            plugin.check(paths, {})
+
+    return [
+        cmd[cmd.index("--project") + 1] for cmd in calls if "--project" in cmd
+    ]
+
+
+@pytest.fixture
+def both_configs_project(tmp_path: Path) -> Path:
+    """A project directory containing both tsconfig.json and tsconfig.app.json.
+
+    Mirrors a Vite Vue layout: vue-tsc should prefer ``tsconfig.app.json``
+    while tsc uses ``tsconfig.json``. Both configs carry explicit ``include``
+    scoping so the checker runs ``-p`` against the config directly (no temp
+    tsconfig), making the selected config observable in the command.
+
+    Args:
+        tmp_path: Temporary directory for the fixture project.
+
+    Returns:
+        Path to the project root containing both configs and source files.
+    """
+    (tmp_path / "tsconfig.json").write_text('{"include": ["*.ts"]}')
+    (tmp_path / "tsconfig.app.json").write_text('{"include": ["*.vue", "*.ts"]}')
+    (tmp_path / "main.ts").write_text("export const x: number = 1;\n")
+    (tmp_path / "App.vue").write_text("<template><div/></template>\n")
+    return tmp_path
+
+
+def test_check_vue_tsc_prefers_app_config_over_generic_discovery(
+    both_configs_project: Path,
+) -> None:
+    """vue-tsc's ``check()`` selects tsconfig.app.json when both configs exist.
+
+    Regression test for issue #1112: generic discovery previously bypassed
+    the VueTscPlugin ``tsconfig.app.json`` preference on the check() path.
+
+    Args:
+        both_configs_project: Fixture project with both tsconfigs present.
+    """
+    project_paths = _project_paths_from_check(
+        plugin=VueTscPlugin(),
+        paths=[str(both_configs_project)],
+    )
+
+    expected = (both_configs_project / "tsconfig.app.json").resolve()
+    assert_that(project_paths).is_length(1)
+    assert_that(Path(project_paths[0]).resolve()).is_equal_to(expected)
+
+
+def test_check_tsc_uses_plain_config_when_both_present(
+    both_configs_project: Path,
+) -> None:
+    """tsc's ``check()`` selects tsconfig.json even when tsconfig.app.json exists.
+
+    tsc declares only ``tsconfig.json`` as a candidate, so the #1112 fix must
+    not change its selection.
+
+    Args:
+        both_configs_project: Fixture project with both tsconfigs present.
+    """
+    project_paths = _project_paths_from_check(
+        plugin=TscPlugin(),
+        paths=[str(both_configs_project)],
+    )
+
+    expected = (both_configs_project / "tsconfig.json").resolve()
+    assert_that(project_paths).is_length(1)
+    assert_that(Path(project_paths[0]).resolve()).is_equal_to(expected)
+
+
+def test_preferred_candidate_tsconfig_vue_selects_app_config(
+    tmp_path: Path,
+) -> None:
+    """vue-tsc resolves tsconfig.app.json as its preferred candidate.
+
+    Args:
+        tmp_path: Temporary directory holding both configs.
+    """
+    (tmp_path / "tsconfig.json").write_text("{}")
+    (tmp_path / "tsconfig.app.json").write_text("{}")
+
+    result = VueTscPlugin()._preferred_candidate_tsconfig(tmp_path)
+
+    assert_that(result).is_equal_to((tmp_path / "tsconfig.app.json").resolve())
+
+
+def test_preferred_candidate_tsconfig_vue_none_without_app_config(
+    tmp_path: Path,
+) -> None:
+    """vue-tsc defers to generic discovery when only tsconfig.json exists.
+
+    Args:
+        tmp_path: Temporary directory holding only tsconfig.json.
+    """
+    (tmp_path / "tsconfig.json").write_text("{}")
+
+    result = VueTscPlugin()._preferred_candidate_tsconfig(tmp_path)
+
+    assert_that(result).is_none()
+
+
+def test_preferred_candidate_tsconfig_tsc_always_none(tmp_path: Path) -> None:
+    """tsc never short-circuits discovery, even with tsconfig.app.json present.
+
+    Args:
+        tmp_path: Temporary directory holding both configs.
+    """
+    (tmp_path / "tsconfig.json").write_text("{}")
+    (tmp_path / "tsconfig.app.json").write_text("{}")
+
+    result = TscPlugin()._preferred_candidate_tsconfig(tmp_path)
+
+    assert_that(result).is_none()
+
+
+# =============================================================================
 # Framework detection (tsc-only delta)
 # =============================================================================
 

--- a/tests/unit/tools/test_ts_checker_base.py
+++ b/tests/unit/tools/test_ts_checker_base.py
@@ -200,9 +200,7 @@ def _project_paths_from_check(
         with patch.object(plugin, "_run_subprocess", side_effect=_record):
             plugin.check(paths, {})
 
-    return [
-        cmd[cmd.index("--project") + 1] for cmd in calls if "--project" in cmd
-    ]
+    return [cmd[cmd.index("--project") + 1] for cmd in calls if "--project" in cmd]
 
 
 @pytest.fixture
@@ -251,7 +249,7 @@ def test_check_vue_tsc_prefers_app_config_over_generic_discovery(
 def test_check_tsc_uses_plain_config_when_both_present(
     both_configs_project: Path,
 ) -> None:
-    """tsc's ``check()`` selects tsconfig.json even when tsconfig.app.json exists.
+    """Tsc's ``check()`` selects tsconfig.json even when tsconfig.app.json exists.
 
     tsc declares only ``tsconfig.json`` as a candidate, so the #1112 fix must
     not change its selection.
@@ -301,7 +299,7 @@ def test_preferred_candidate_tsconfig_vue_none_without_app_config(
 
 
 def test_preferred_candidate_tsconfig_tsc_always_none(tmp_path: Path) -> None:
-    """tsc never short-circuits discovery, even with tsconfig.app.json present.
+    """Tsc never short-circuits discovery, even with tsconfig.app.json present.
 
     Args:
         tmp_path: Temporary directory holding both configs.


### PR DESCRIPTION
## What's Changing

`VueTscPlugin` declares `tsconfig.app.json` ahead of `tsconfig.json` in its `_tsconfig_candidates`, but the shared `check()` path in `_ts_checker_base.py` ran generic `discover_tsconfigs` discovery **before** applying that preference. In a Vite Vue project containing both `tsconfig.json` and `tsconfig.app.json`, vue-tsc was therefore invoked against `tsconfig.json` instead of the intended `tsconfig.app.json` (both configs live in the same directory, so generic discovery routed to multi-project partitioning and picked `tsconfig.json` first).

The fix adds `_preferred_candidate_tsconfig()`, which probes the subclass's `_tsconfig_candidates` in declared order and returns the first candidate present in the discovery root that is listed **ahead of** `tsconfig.json`. `check()` now honors that preference before falling back to generic discovery.

- vue-tsc: prefers `tsconfig.app.json` when present.
- tsc: its only candidate is `tsconfig.json`, so it never short-circuits — plain projects and monorepo/reference discovery are completely unchanged.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (lint + full suite)

## Related Issues

Closes #1112

## Details

Regression tests added in `tests/unit/tools/test_ts_checker_base.py`:

- `test_check_vue_tsc_prefers_app_config_over_generic_discovery` — with both configs present, vue-tsc's `check()` selects `tsconfig.app.json` (asserts the `--project` arg on the mocked subprocess call).
- `test_check_tsc_uses_plain_config_when_both_present` — tsc selects `tsconfig.json` under the same fixture.
- Unit tests for `_preferred_candidate_tsconfig` covering vue (app config present / absent) and tsc (always defers).

pytest style, no test classes, assertpy assertions, fixtures.

### Test evidence

- `uv run lintro chk` — all tools PASS, 0 issues.
- `uv run pytest` (full suite) — **5965 passed, 10 skipped, 2 failed**. Both failures are pre-existing and environmental, confirmed to fail identically on the unmodified branch (stash test):
  - `test_markdownlint_direct_vs_lintro_parity` — local markdownlint 0.22.0 is below the required 0.22.1, so lintro skips it.
  - `test_prepare_execution_version_check_fails_returns_early_result` — cwd/isolation-dependent flake unrelated to tsconfig discovery.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates TypeScript config selection for Vue checker runs. The main changes are:

- Added a helper that finds subclass-preferred configs before `tsconfig.json`.
- Kept multi-project discovery ahead of the Vue preferred-config shortcut.
- Added tests for Vue and plain `tsc` config selection.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/definitions/_ts_checker_base.py | Updates shared TypeScript checker discovery so Vue can prefer `tsconfig.app.json` without bypassing multi-project partitioning. |
| tests/unit/tools/test_ts_checker_base.py | Adds tests for Vue preferred config selection, unchanged `tsc` behavior, and the new helper. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/1112-vue-ts..."](https://github.com/lgtm-hq/py-lintro/commit/dcf9002d374194fdaacbcd5b1944948788589f2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42155030)</sub>

<!-- /greptile_comment -->