### PR TITLE
fix(release): surface release automation failures on main via run-name

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,6 +27,12 @@ trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enf
   `reusable-release-auto-tag.yml` (`create-release: false`; GitHub Release is created by
   publish workflow)
 
+Both callers set a dynamic `run-name` (event + branch) so post-merge release failures
+are traceable from the Actions list rather than the default commit subject. Failure
+visibility itself lives upstream: the reusables run a `report-release-failure` job that
+writes trigger context to the step summary and opens/updates a deduplicated GitHub issue
+on `main` failures — hence the `actions: read` + `issues: write` job permissions.
+
 ## Publish
 
 - **publish-pypi-on-tag.yml** — Production tag publish: `reusable-sbom` →

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -3,6 +3,12 @@
 ---
 name: Release - Auto Tag
 
+# Surface trigger context in the Actions history so post-merge release failures
+# are traceable at a glance (event + branch), not just via the default commit
+# subject. Guarded by test_release_workflows_define_traceable_run_names.
+run-name: >-
+  Release - Auto Tag (${{ github.event_name }} on ${{ github.ref_name }})
+
 'on':
   push:
     branches: [main]

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -3,6 +3,12 @@
 ---
 name: Release - Version PR
 
+# Surface trigger context in the Actions history so post-merge release failures
+# are traceable at a glance (event + branch), not just via the default commit
+# subject. Guarded by test_release_workflows_define_traceable_run_names.
+run-name: >-
+  Release - Version PR (${{ github.event_name }} on ${{ github.ref_name }})
+
 'on':
   push:
     branches: [main]

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -186,6 +186,51 @@ def test_release_workflows_use_paired_egress_presets() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("workflow_name", "identity"),
+    [
+        ("release-auto-tag.yml", "Release - Auto Tag"),
+        ("release-version-pr.yml", "Release - Version PR"),
+    ],
+)
+def test_release_workflows_define_traceable_run_names(
+    *,
+    workflow_name: str,
+    identity: str,
+) -> None:
+    """Release callers set a run-name carrying workflow identity, event, and branch.
+
+    A dynamic ``run-name`` surfaces post-merge release failures in the Actions
+    history (event + branch) instead of the default commit subject, which can
+    look healthy even when a release job fails.
+    """
+    workflow = _load_workflow(name=workflow_name)
+    run_name = workflow["run-name"]
+
+    assert_that(run_name).is_instance_of(str)
+    assert_that(run_name).contains(identity)
+    assert_that(run_name).contains("${{ github.event_name }}")
+    assert_that(run_name).contains("${{ github.ref_name }}")
+
+
+def test_release_workflows_grant_failure_reporting_permissions() -> None:
+    """Both release callers grant the upstream report-release-failure job access.
+
+    The lgtm-ci reusables open/update a deduplicated failure issue on ``main``
+    release failures, which requires reading workflow/run metadata and writing
+    issues. Guarding the permissions keeps that visibility path wired.
+    """
+    for workflow_name, job_name in (
+        ("release-auto-tag.yml", "auto-tag"),
+        ("release-version-pr.yml", "version-pr"),
+    ):
+        permissions = _load_workflow(name=workflow_name)["jobs"][job_name][
+            "permissions"
+        ]
+        assert_that(permissions).contains_entry({"actions": "read"})
+        assert_that(permissions).contains_entry({"issues": "write"})
+
+
 def test_semantic_pr_title_can_write_failure_comments() -> None:
     """Semantic PR title workflow can upsert failure comments on PRs."""
     workflow = _load_workflow(name="semantic-pr-title.yml")


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(release): surface release automation failures on main via run-name`
- Type:
  - [x] fix / perf (patch)
- Breaking change:
  - [ ] none

## What's Changing

Post-merge release automation can fail while `main` still looks green from the
originating push checks, leaving the failure visible only deep in the Actions
history (issue #907).

The heavy lifting — a deduplicated failure issue + trigger context in the step
summary on default-branch failures — already ships in the lgtm-ci reusables
(`reusable-release-auto-tag.yml` / `reusable-release-version-pr.yml` @ v0.46.0),
wired here via the `actions: read` + `issues: write` job permissions. The
remaining repo-local gap identified in the issue's checklist was **Actions-list
traceability** for the thin caller workflows.

This PR:

- Adds a dynamic `run-name` (workflow identity + `github.event_name` +
  `github.ref_name`) to `release-auto-tag.yml` and `release-version-pr.yml` so a
  failed release run is identifiable at a glance instead of by the default commit
  subject.
- Documents the end-to-end failure-visibility path (run-name + upstream
  `report-release-failure` job) in `.github/workflows/README.md`.
- Adds workflow-wiring contract tests asserting the run-names carry event/branch
  context and that the failure-reporting permissions remain granted.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` / `uv run pytest` — only the two known
  env-only pre-existing failures remain)

## Related Issues

Closes #907

## Details

Mechanism chosen: **extend the existing lgtm-ci `report-release-failure`
mechanism** rather than invent a parallel notifier. Failure issues + step-summary
context are handled upstream via the pinned reusables; the repo-local contribution
is the caller-side `run-name` traceability plus contract tests that lock the
failure-reporting permissions and run-name context in place.

Testing: `uv run pytest tests/unit/test_workflow_wiring.py` (22 passed) and the
full suite (5967 passed; the two failures —
`test_markdownlint_direct_vs_lintro_parity` and
`test_prepare_execution_version_check_fails_returns_early_result` — are known
env-only pre-existing failures unrelated to this change).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves release workflow visibility in GitHub Actions. The main changes are:

- Dynamic run names for the release auto-tag workflow.
- Dynamic run names for the release version PR workflow.
- Documentation for release failure visibility through upstream reporting.
- Workflow tests for run-name context and reporting permissions.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-auto-tag.yml | Adds a valid top-level run name using supported GitHub Actions contexts. |
| .github/workflows/release-version-pr.yml | Adds a valid top-level run name using supported GitHub Actions contexts. |
| .github/workflows/README.md | Documents how release failures surface through run names and upstream issue reporting. |
| tests/unit/test_workflow_wiring.py | Adds static checks for release workflow run names and failure-reporting permissions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): surface release automation..."](https://github.com/lgtm-hq/py-lintro/commit/fcbc9743529d8788a740b37123b0bcc6108b29da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42164381)</sub>

<!-- /greptile_comment -->