### PR TITLE
feat(install): distribute lintro as npm package via platform binaries

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -88,6 +88,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -190,6 +192,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -240,8 +240,10 @@ jobs:
           retention-days: 7
 
       - name: Save SHA256 to file
+        env:
+          SHA256: ${{ steps.sha256.outputs.sha256 }}
         run: |
-          echo "${{ steps.sha256.outputs.sha256 }}" > sha256-linux-${{ matrix.arch }}.txt
+          echo "$SHA256" > sha256-linux-${{ matrix.arch }}.txt
 
       - name: Upload SHA256 file
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -158,6 +158,108 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build-linux:
+    name: Build Linux Binary
+    needs: get-release-info
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            uploads.github.com:443
+            nuitka.net:443
+
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: 'latest'
+
+      - name: Install dependencies
+        run: |
+          uv sync --group build --group dev
+
+      - name: Build binary
+        run: |
+          HOST_ARCH="${{ matrix.arch == 'x64' && 'x86_64' || 'arm64' }}"
+          uv run python scripts/build/build_linux.py \
+            --arch "$HOST_ARCH" \
+            --skip-verify
+        env:
+          PYTHONUNBUFFERED: '1'
+
+      - name: Verify binary
+        run: |
+          ls -lh dist/nuitka/
+          ./dist/nuitka/lintro --version
+          ./dist/nuitka/lintro --help | head -20 || echo "Help output truncated"
+
+      - name: Rename binary with architecture
+        run: |
+          mv dist/nuitka/lintro dist/nuitka/lintro-linux-${{ matrix.arch }}
+
+      - name: Calculate SHA256
+        id: sha256
+        run: |
+          BINARY="dist/nuitka/lintro-linux-${{ matrix.arch }}"
+          SHA=$(sha256sum "$BINARY" | cut -d' ' -f1)
+          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+          echo "SHA256 for linux-${{ matrix.arch }}: $SHA"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: lintro-linux-${{ matrix.arch }}
+          path: dist/nuitka/lintro-linux-${{ matrix.arch }}
+          retention-days: 7
+
+      - name: Save SHA256 to file
+        run: |
+          echo "${{ steps.sha256.outputs.sha256 }}" > sha256-linux-${{ matrix.arch }}.txt
+
+      - name: Upload SHA256 file
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: sha256-linux-${{ matrix.arch }}
+          path: sha256-linux-${{ matrix.arch }}.txt
+          retention-days: 7
+
+      - name: Upload to release
+        if: inputs.release_tag != ''
+        # yamllint disable-line rule:line-length
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: ${{ needs.get-release-info.outputs.release_tag }}
+          files: dist/nuitka/lintro-linux-${{ matrix.arch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   create-universal-binary:
     name: Create Universal Binary
     needs: [get-release-info, build-macos]

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,6 +22,10 @@ name: Publish - npm (dry-run)
 
 permissions: {}
 
+concurrency:
+  group: publish-npm-${{ github.event.inputs.release_tag || inputs.release_tag }}
+  cancel-in-progress: false
+
 jobs:
   publish-dry-run:
     name: Package and dry-run publish
@@ -48,6 +52,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -57,10 +63,11 @@ jobs:
       - name: Download release binaries
         run: >-
           scripts/ci/npm/download_release_binaries.sh
-          "${{ inputs.release_tag }}"
+          "$RELEASE_TAG"
           "${{ runner.temp }}/npm-binaries"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
 
       - name: Stage binaries into npm packages
         run: >-
@@ -68,14 +75,18 @@ jobs:
           --artifacts-dir "${{ runner.temp }}/npm-binaries"
 
       - name: Inject release version into manifests
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: >-
           python scripts/ci/npm/sync_npm_version.py
-          --version "${{ inputs.release_tag }}"
+          --version "$RELEASE_TAG"
 
       - name: Verify manifests are in sync
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: >-
           python scripts/ci/npm/sync_npm_version.py
-          --check --version "${{ inputs.release_tag }}"
+          --check --version "$RELEASE_TAG"
 
       - name: Smoke test launcher (Linux x64)
         run: scripts/ci/npm/smoke_test.sh

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,86 @@
+---
+name: Publish - npm (dry-run)
+
+# Distributes lintro as an npm package via platform-specific Nuitka binaries
+# (the esbuild/biome model). This workflow is DRY-RUN ONLY: every `npm
+# publish` runs with `--dry-run`. Going live is a deliberate follow-up that
+# requires wiring NODE_AUTH_TOKEN and flipping LIVE=1 in publish_packages.sh.
+
+'on':
+  workflow_call:
+    inputs:
+      release_tag:
+        description: 'Release tag whose binaries to package'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag whose binaries to package'
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  publish-dry-run:
+    name: Package and dry-run publish
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      # id-token is required for `npm publish --provenance`; harmless in
+      # dry-run and pre-wired for a future live publish.
+      id-token: write
+
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            uploads.github.com:443
+            registry.npmjs.org:443
+
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.11'
+
+      - name: Download release binaries
+        run: >-
+          scripts/ci/npm/download_release_binaries.sh
+          "${{ inputs.release_tag }}"
+          "${{ runner.temp }}/npm-binaries"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stage binaries into npm packages
+        run: >-
+          python scripts/ci/npm/stage_binaries.py
+          --artifacts-dir "${{ runner.temp }}/npm-binaries"
+
+      - name: Inject release version into manifests
+        run: >-
+          python scripts/ci/npm/sync_npm_version.py
+          --version "${{ inputs.release_tag }}"
+
+      - name: Verify manifests are in sync
+        run: >-
+          python scripts/ci/npm/sync_npm_version.py
+          --check --version "${{ inputs.release_tag }}"
+
+      - name: Smoke test launcher (Linux x64)
+        run: scripts/ci/npm/smoke_test.sh
+
+      - name: Publish (dry-run)
+        # LIVE is intentionally unset: this always runs `npm publish
+        # --dry-run`. Do not set LIVE=1 here.
+        run: scripts/ci/npm/publish_packages.sh

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+# npm meta-package launcher library is source, not a Python build artifact.
+!npm/lintro/lib/
 lib64/
 parts/
 sdist/

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,11 +6,5 @@
   "printWidth": 100,
   "trailingComma": "es5",
   "sortPackageJson": false,
-  "ignorePatterns": [
-    "build",
-    "dist",
-    "node_modules",
-    ".venv",
-    ".lintro"
-  ]
+  "ignorePatterns": ["build", "dist", "node_modules", ".venv", ".lintro"]
 }

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxfmt/configuration_schema.json",
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "printWidth": 100,
+  "trailingComma": "es5",
+  "sortPackageJson": false,
+  "ignorePatterns": [
+    "build",
+    "dist",
+    "node_modules",
+    ".venv",
+    ".lintro"
+  ]
+}

--- a/docs/npm-distribution.md
+++ b/docs/npm-distribution.md
@@ -1,56 +1,56 @@
 # npm Distribution
 
 Lintro is distributed to JS/TS developers as an npm package built from
-platform-specific, self-contained Nuitka binaries. This mirrors the proven
-model used by esbuild, Biome, Turbo, and SWC: a small meta-package selects and
-launches the correct native binary at runtime, so consumers need no Python.
+platform-specific, self-contained Nuitka binaries. This mirrors the proven model used by
+esbuild, Biome, Turbo, and SWC: a small meta-package selects and launches the correct
+native binary at runtime, so consumers need no Python.
 
 ## Package layout
 
 The `npm/` directory holds five packages:
 
-| Package | npm name | Contents |
-| --- | --- | --- |
-| Meta | `lintro` | `bin/lintro` launcher + `optionalDependencies` |
-| Platform | `@lgtm-hq/lintro-darwin-arm64` | macOS Apple Silicon binary |
-| Platform | `@lgtm-hq/lintro-darwin-x64` | macOS Intel binary |
-| Platform | `@lgtm-hq/lintro-linux-arm64` | Linux ARM64 binary |
-| Platform | `@lgtm-hq/lintro-linux-x64` | Linux x86_64 binary |
+| Package  | npm name                       | Contents                                       |
+| -------- | ------------------------------ | ---------------------------------------------- |
+| Meta     | `lintro`                       | `bin/lintro` launcher + `optionalDependencies` |
+| Platform | `@lgtm-hq/lintro-darwin-arm64` | macOS Apple Silicon binary                     |
+| Platform | `@lgtm-hq/lintro-darwin-x64`   | macOS Intel binary                             |
+| Platform | `@lgtm-hq/lintro-linux-arm64`  | Linux ARM64 binary                             |
+| Platform | `@lgtm-hq/lintro-linux-x64`    | Linux x86_64 binary                            |
 
-Each platform package declares `os` and `cpu` fields, so npm and bun download
-only the binary matching the host. The meta-package lists all four as
-`optionalDependencies`; the unsupported ones are skipped during install.
+Each platform package declares `os` and `cpu` fields, so npm and bun download only the
+binary matching the host. The meta-package lists all four as `optionalDependencies`; the
+unsupported ones are skipped during install.
 
 ## Runtime resolution
 
-`npm/lintro/bin/lintro` calls `resolveBinary()` in `npm/lintro/lib/resolve.js`,
-which maps `${process.platform}-${process.arch}` to the scoped package, requires
-it, and reads the exported binary `path`. The launcher then `execFileSync`s the
-binary, forwarding argv and stdio and propagating its exit code. Resolution is
-pure and unit-tested (`npm/lintro/test/resolve.test.js`, run with `bun test`).
+`npm/lintro/bin/lintro` calls `resolveBinary()` in `npm/lintro/lib/resolve.js`, which
+maps `${process.platform}-${process.arch}` to the scoped package, requires it, and reads
+the exported binary `path`. The launcher then `execFileSync`s the binary, forwarding
+argv and stdio and propagating its exit code. Resolution is pure and unit-tested
+(`npm/lintro/test/resolve.test.js`, run with `bun test`).
 
 ## Build
 
-`scripts/build/build_linux.py` compiles the Linux binary with Nuitka, mirroring
-the existing `build_macos.py`. Linux has no cross-arch flag, so arm64 and x86_64
-are built natively on their respective runners. The `build-linux` job in
-`.github/workflows/build-binary.yml` uploads `lintro-linux-x64` and
-`lintro-linux-arm64` artifacts alongside the macOS ones.
+`scripts/build/build_linux.py` compiles the Linux binary with Nuitka, mirroring the
+existing `build_macos.py`. Linux has no cross-arch flag, so arm64 and x86_64 are built
+natively on their respective runners. The `build-linux` job in
+`.github/workflows/build-binary.yml` uploads `lintro-linux-x64` and `lintro-linux-arm64`
+artifacts alongside the macOS ones.
 
 ## Versioning
 
 In-repo manifests carry a `0.0.0-dev` placeholder. At publish time,
-`scripts/ci/npm/sync_npm_version.py --version <tag>` injects the release version
-into every manifest and into the meta-package's `@lgtm-hq/lintro-*` pins. The same
-script's `--check` mode guards internal consistency in CI.
+`scripts/ci/npm/sync_npm_version.py --version <tag>` injects the release version into
+every manifest and into the meta-package's `@lgtm-hq/lintro-*` pins. The same script's
+`--check` mode guards internal consistency in CI.
 
 ## Publishing
 
-`.github/workflows/publish-npm.yml` is **dry-run only**. It downloads the
-release binaries, stages them into the npm tree, injects the version, runs a
-smoke test, and calls `scripts/ci/npm/publish_packages.sh`, which always passes
-`--dry-run` unless `LIVE=1` is set. Going live is a deliberate follow-up that
-also requires a `NODE_AUTH_TOKEN` secret and the `@lgtm-hq` npm org.
+`.github/workflows/publish-npm.yml` is **dry-run only**. It downloads the release
+binaries, stages them into the npm tree, injects the version, runs a smoke test, and
+calls `scripts/ci/npm/publish_packages.sh`, which always passes `--dry-run` unless
+`LIVE=1` is set. Going live is a deliberate follow-up that also requires a
+`NODE_AUTH_TOKEN` secret and the `@lgtm-hq` npm org.
 
 ## Install context
 

--- a/docs/npm-distribution.md
+++ b/docs/npm-distribution.md
@@ -1,0 +1,59 @@
+# npm Distribution
+
+Lintro is distributed to JS/TS developers as an npm package built from
+platform-specific, self-contained Nuitka binaries. This mirrors the proven
+model used by esbuild, Biome, Turbo, and SWC: a small meta-package selects and
+launches the correct native binary at runtime, so consumers need no Python.
+
+## Package layout
+
+The `npm/` directory holds five packages:
+
+| Package | npm name | Contents |
+| --- | --- | --- |
+| Meta | `lintro` | `bin/lintro` launcher + `optionalDependencies` |
+| Platform | `@lintro/darwin-arm64` | macOS Apple Silicon binary |
+| Platform | `@lintro/darwin-x64` | macOS Intel binary |
+| Platform | `@lintro/linux-arm64` | Linux ARM64 binary |
+| Platform | `@lintro/linux-x64` | Linux x86_64 binary |
+
+Each platform package declares `os` and `cpu` fields, so npm and bun download
+only the binary matching the host. The meta-package lists all four as
+`optionalDependencies`; the unsupported ones are skipped during install.
+
+## Runtime resolution
+
+`npm/lintro/bin/lintro` calls `resolveBinary()` in `npm/lintro/lib/resolve.js`,
+which maps `${process.platform}-${process.arch}` to the scoped package, requires
+it, and reads the exported binary `path`. The launcher then `execFileSync`s the
+binary, forwarding argv and stdio and propagating its exit code. Resolution is
+pure and unit-tested (`npm/lintro/test/resolve.test.js`, run with `bun test`).
+
+## Build
+
+`scripts/build/build_linux.py` compiles the Linux binary with Nuitka, mirroring
+the existing `build_macos.py`. Linux has no cross-arch flag, so arm64 and x86_64
+are built natively on their respective runners. The `build-linux` job in
+`.github/workflows/build-binary.yml` uploads `lintro-linux-x64` and
+`lintro-linux-arm64` artifacts alongside the macOS ones.
+
+## Versioning
+
+In-repo manifests carry a `0.0.0-dev` placeholder. At publish time,
+`scripts/ci/npm/sync_npm_version.py --version <tag>` injects the release version
+into every manifest and into the meta-package's `@lintro/*` pins. The same
+script's `--check` mode guards internal consistency in CI.
+
+## Publishing
+
+`.github/workflows/publish-npm.yml` is **dry-run only**. It downloads the
+release binaries, stages them into the npm tree, injects the version, runs a
+smoke test, and calls `scripts/ci/npm/publish_packages.sh`, which always passes
+`--dry-run` unless `LIVE=1` is set. Going live is a deliberate follow-up that
+also requires a `NODE_AUTH_TOKEN` secret and the `@lintro` npm org.
+
+## Install context
+
+`InstallContext.NPM_BIN` is detected when the running executable resolves under
+`node_modules/@lintro/`, so install-aware commands can recognize npm-installed
+binaries.

--- a/docs/npm-distribution.md
+++ b/docs/npm-distribution.md
@@ -12,10 +12,10 @@ The `npm/` directory holds five packages:
 | Package | npm name | Contents |
 | --- | --- | --- |
 | Meta | `lintro` | `bin/lintro` launcher + `optionalDependencies` |
-| Platform | `@lintro/darwin-arm64` | macOS Apple Silicon binary |
-| Platform | `@lintro/darwin-x64` | macOS Intel binary |
-| Platform | `@lintro/linux-arm64` | Linux ARM64 binary |
-| Platform | `@lintro/linux-x64` | Linux x86_64 binary |
+| Platform | `@lgtm-hq/lintro-darwin-arm64` | macOS Apple Silicon binary |
+| Platform | `@lgtm-hq/lintro-darwin-x64` | macOS Intel binary |
+| Platform | `@lgtm-hq/lintro-linux-arm64` | Linux ARM64 binary |
+| Platform | `@lgtm-hq/lintro-linux-x64` | Linux x86_64 binary |
 
 Each platform package declares `os` and `cpu` fields, so npm and bun download
 only the binary matching the host. The meta-package lists all four as
@@ -41,7 +41,7 @@ are built natively on their respective runners. The `build-linux` job in
 
 In-repo manifests carry a `0.0.0-dev` placeholder. At publish time,
 `scripts/ci/npm/sync_npm_version.py --version <tag>` injects the release version
-into every manifest and into the meta-package's `@lintro/*` pins. The same
+into every manifest and into the meta-package's `@lgtm-hq/lintro-*` pins. The same
 script's `--check` mode guards internal consistency in CI.
 
 ## Publishing
@@ -50,10 +50,10 @@ script's `--check` mode guards internal consistency in CI.
 release binaries, stages them into the npm tree, injects the version, runs a
 smoke test, and calls `scripts/ci/npm/publish_packages.sh`, which always passes
 `--dry-run` unless `LIVE=1` is set. Going live is a deliberate follow-up that
-also requires a `NODE_AUTH_TOKEN` secret and the `@lintro` npm org.
+also requires a `NODE_AUTH_TOKEN` secret and the `@lgtm-hq` npm org.
 
 ## Install context
 
 `InstallContext.NPM_BIN` is detected when the running executable resolves under
-`node_modules/@lintro/`, so install-aware commands can recognize npm-installed
+`node_modules/@lgtm-hq/lintro-`, so install-aware commands can recognize npm-installed
 binaries.

--- a/lintro/enums/install_context.py
+++ b/lintro/enums/install_context.py
@@ -15,6 +15,7 @@ class InstallContext(StrEnum):
 
     HOMEBREW_FULL = auto()
     HOMEBREW_BIN = auto()
+    NPM_BIN = auto()
     PIP = auto()
     DOCKER = auto()
     DEVELOPMENT = auto()

--- a/lintro/tools/core/install_context.py
+++ b/lintro/tools/core/install_context.py
@@ -75,10 +75,10 @@ def _detect_install_context() -> InstallContext:
     install_path = os.path.realpath(__file__)
 
     # npm binary: the launcher resolves the platform package, so the running
-    # executable lives under node_modules/@lintro/<platform>/. Check before
+    # executable lives under node_modules/@lgtm-hq/lintro-<platform>/. Check before
     # Homebrew because npm installs on macOS can otherwise resemble one.
     if any(
-        "/node_modules/@lintro/" in path for path in (exe_path, install_path)
+        "/node_modules/@lgtm-hq/lintro-" in path for path in (exe_path, install_path)
     ):
         return InstallContext.NPM_BIN
 

--- a/lintro/tools/core/install_context.py
+++ b/lintro/tools/core/install_context.py
@@ -74,6 +74,14 @@ def _detect_install_context() -> InstallContext:
     exe_path = os.path.realpath(sys.executable)
     install_path = os.path.realpath(__file__)
 
+    # npm binary: the launcher resolves the platform package, so the running
+    # executable lives under node_modules/@lintro/<platform>/. Check before
+    # Homebrew because npm installs on macOS can otherwise resemble one.
+    if any(
+        "/node_modules/@lintro/" in path for path in (exe_path, install_path)
+    ):
+        return InstallContext.NPM_BIN
+
     # Homebrew: resolved path under Cellar/ or linuxbrew (formula install).
     # Match lintro-full before lintro to avoid prefix collisions.
     cellar_formulas: tuple[tuple[str, InstallContext], ...] = (

--- a/npm/darwin-arm64/bin/.gitkeep
+++ b/npm/darwin-arm64/bin/.gitkeep
@@ -1,0 +1,1 @@
+Binary injected at publish time by .github/workflows/publish-npm.yml

--- a/npm/darwin-arm64/index.js
+++ b/npm/darwin-arm64/index.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/**
+ * Exports the absolute path to the platform-specific lintro binary.
+ *
+ * The `bin/lintro` file is populated by the publish workflow from the
+ * Nuitka-compiled artifact for this platform. Consumers should not depend
+ * on this package directly; install the `lintro` meta-package instead.
+ */
+
+const path = require("path");
+
+module.exports.path = path.join(__dirname, "bin", "lintro");

--- a/npm/darwin-arm64/index.js
+++ b/npm/darwin-arm64/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 /**
  * Exports the absolute path to the platform-specific lintro binary.
@@ -8,6 +8,6 @@
  * on this package directly; install the `lintro` meta-package instead.
  */
 
-const path = require("path");
+const path = require('path');
 
-module.exports.path = path.join(__dirname, "bin", "lintro");
+module.exports.path = path.join(__dirname, 'bin', 'lintro');

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@lintro/darwin-arm64",
+  "version": "0.0.0-dev",
+  "description": "macOS Apple Silicon binary for lintro. Installed automatically by the `lintro` package.",
+  "homepage": "https://github.com/lgtm-hq/py-lintro#readme",
+  "bugs": {
+    "url": "https://github.com/lgtm-hq/py-lintro/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lgtm-hq/py-lintro.git",
+    "directory": "npm/darwin-arm64"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "index.js",
+  "files": [
+    "bin/lintro",
+    "index.js"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lintro/darwin-arm64",
+  "name": "@lgtm-hq/lintro-darwin-arm64",
   "version": "0.0.0-dev",
   "description": "macOS Apple Silicon binary for lintro. Installed automatically by the `lintro` package.",
   "homepage": "https://github.com/lgtm-hq/py-lintro#readme",

--- a/npm/darwin-x64/bin/.gitkeep
+++ b/npm/darwin-x64/bin/.gitkeep
@@ -1,0 +1,1 @@
+Binary injected at publish time by .github/workflows/publish-npm.yml

--- a/npm/darwin-x64/index.js
+++ b/npm/darwin-x64/index.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/**
+ * Exports the absolute path to the platform-specific lintro binary.
+ *
+ * The `bin/lintro` file is populated by the publish workflow from the
+ * Nuitka-compiled artifact for this platform. Consumers should not depend
+ * on this package directly; install the `lintro` meta-package instead.
+ */
+
+const path = require("path");
+
+module.exports.path = path.join(__dirname, "bin", "lintro");

--- a/npm/darwin-x64/index.js
+++ b/npm/darwin-x64/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 /**
  * Exports the absolute path to the platform-specific lintro binary.
@@ -8,6 +8,6 @@
  * on this package directly; install the `lintro` meta-package instead.
  */
 
-const path = require("path");
+const path = require('path');
 
-module.exports.path = path.join(__dirname, "bin", "lintro");
+module.exports.path = path.join(__dirname, 'bin', 'lintro');

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@lintro/darwin-x64",
+  "version": "0.0.0-dev",
+  "description": "macOS Intel binary for lintro. Installed automatically by the `lintro` package.",
+  "homepage": "https://github.com/lgtm-hq/py-lintro#readme",
+  "bugs": {
+    "url": "https://github.com/lgtm-hq/py-lintro/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lgtm-hq/py-lintro.git",
+    "directory": "npm/darwin-x64"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "index.js",
+  "files": [
+    "bin/lintro",
+    "index.js"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lintro/darwin-x64",
+  "name": "@lgtm-hq/lintro-darwin-x64",
   "version": "0.0.0-dev",
   "description": "macOS Intel binary for lintro. Installed automatically by the `lintro` package.",
   "homepage": "https://github.com/lgtm-hq/py-lintro#readme",

--- a/npm/lintro/bin/lintro
+++ b/npm/lintro/bin/lintro
@@ -5,7 +5,7 @@
  * Launcher for the lintro meta-package.
  *
  * Resolves the self-contained binary shipped by the matching
- * `@lintro/<platform>` optional dependency and forwards all arguments and
+ * `@lgtm-hq/lintro-<platform>` optional dependency and forwards all arguments and
  * stdio to it. Exits with the binary's own exit code.
  */
 

--- a/npm/lintro/bin/lintro
+++ b/npm/lintro/bin/lintro
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * Launcher for the lintro meta-package.
+ *
+ * Resolves the self-contained binary shipped by the matching
+ * `@lintro/<platform>` optional dependency and forwards all arguments and
+ * stdio to it. Exits with the binary's own exit code.
+ */
+
+const { execFileSync } = require("child_process");
+const { resolveBinary } = require("../lib/resolve.js");
+
+function main() {
+  let binaryPath;
+  try {
+    binaryPath = resolveBinary();
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  }
+
+  try {
+    execFileSync(binaryPath, process.argv.slice(2), { stdio: "inherit" });
+  } catch (err) {
+    // execFileSync throws for non-zero exit codes; propagate the child's
+    // status so callers observe the real result.
+    if (typeof err.status === "number") {
+      process.exit(err.status);
+    }
+    process.stderr.write(`lintro: failed to launch binary: ${err.message}\n`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/npm/lintro/lib/resolve.js
+++ b/npm/lintro/lib/resolve.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 /**
  * Platform resolution for the lintro meta-package.
@@ -17,10 +17,10 @@
  * @type {Readonly<Record<string, string>>}
  */
 const PLATFORM_PACKAGES = Object.freeze({
-  "darwin-arm64": "@lgtm-hq/lintro-darwin-arm64",
-  "darwin-x64": "@lgtm-hq/lintro-darwin-x64",
-  "linux-arm64": "@lgtm-hq/lintro-linux-arm64",
-  "linux-x64": "@lgtm-hq/lintro-linux-x64",
+  'darwin-arm64': '@lgtm-hq/lintro-darwin-arm64',
+  'darwin-x64': '@lgtm-hq/lintro-darwin-x64',
+  'linux-arm64': '@lgtm-hq/lintro-linux-arm64',
+  'linux-x64': '@lgtm-hq/lintro-linux-x64',
 });
 
 /**
@@ -67,7 +67,7 @@ function resolveBinary(requireFn, platform, arch) {
   if (!pkg) {
     throw new Error(
       `lintro: unsupported platform ${plat}-${cpu}. ` +
-        `Supported platforms: ${supportedPlatforms().join(", ")}.`,
+        `Supported platforms: ${supportedPlatforms().join(', ')}.`
     );
   }
 
@@ -77,19 +77,17 @@ function resolveBinary(requireFn, platform, arch) {
   } catch (err) {
     throw new Error(
       `lintro: the platform package "${pkg}" is not installed. ` +
-        "This usually means optional dependencies were skipped during " +
-        "install, or the lockfile was generated on a different OS and " +
+        'This usually means optional dependencies were skipped during ' +
+        'install, or the lockfile was generated on a different OS and ' +
         "omits this platform's package (see npm/cli#4828). Reinstall with " +
-        "optional dependencies enabled (e.g. `npm install lintro` or " +
-        "`bun add lintro`), or refresh the lockfile on this platform " +
-        `(e.g. \`npm install --force\`). Cause: ${err.message}`,
+        'optional dependencies enabled (e.g. `npm install lintro` or ' +
+        '`bun add lintro`), or refresh the lockfile on this platform ' +
+        `(e.g. \`npm install --force\`). Cause: ${err.message}`
     );
   }
 
-  if (!mod || typeof mod.path !== "string") {
-    throw new Error(
-      `lintro: platform package "${pkg}" did not export a binary path.`,
-    );
+  if (!mod || typeof mod.path !== 'string') {
+    throw new Error(`lintro: platform package "${pkg}" did not export a binary path.`);
   }
   return mod.path;
 }

--- a/npm/lintro/lib/resolve.js
+++ b/npm/lintro/lib/resolve.js
@@ -4,7 +4,7 @@
  * Platform resolution for the lintro meta-package.
  *
  * Maps a Node `process.platform`/`process.arch` pair to the scoped
- * `@lintro/<platform>` package that ships the matching self-contained
+ * `@lgtm-hq/lintro-<platform>` package that ships the matching self-contained
  * binary. The resolution logic is kept pure and side-effect free so it
  * can be unit-tested without a binary present on disk.
  */
@@ -17,10 +17,10 @@
  * @type {Readonly<Record<string, string>>}
  */
 const PLATFORM_PACKAGES = Object.freeze({
-  "darwin-arm64": "@lintro/darwin-arm64",
-  "darwin-x64": "@lintro/darwin-x64",
-  "linux-arm64": "@lintro/linux-arm64",
-  "linux-x64": "@lintro/linux-x64",
+  "darwin-arm64": "@lgtm-hq/lintro-darwin-arm64",
+  "darwin-x64": "@lgtm-hq/lintro-darwin-x64",
+  "linux-arm64": "@lgtm-hq/lintro-linux-arm64",
+  "linux-x64": "@lgtm-hq/lintro-linux-x64",
 });
 
 /**

--- a/npm/lintro/lib/resolve.js
+++ b/npm/lintro/lib/resolve.js
@@ -78,8 +78,11 @@ function resolveBinary(requireFn, platform, arch) {
     throw new Error(
       `lintro: the platform package "${pkg}" is not installed. ` +
         "This usually means optional dependencies were skipped during " +
-        "install. Reinstall with optional dependencies enabled " +
-        `(e.g. \`npm install lintro\` or \`bun add lintro\`). Cause: ${err.message}`,
+        "install, or the lockfile was generated on a different OS and " +
+        "omits this platform's package (see npm/cli#4828). Reinstall with " +
+        "optional dependencies enabled (e.g. `npm install lintro` or " +
+        "`bun add lintro`), or refresh the lockfile on this platform " +
+        `(e.g. \`npm install --force\`). Cause: ${err.message}`,
     );
   }
 

--- a/npm/lintro/lib/resolve.js
+++ b/npm/lintro/lib/resolve.js
@@ -75,6 +75,9 @@ function resolveBinary(requireFn, platform, arch) {
   try {
     mod = req(pkg);
   } catch (err) {
+    if (err && err.code !== 'MODULE_NOT_FOUND') {
+      throw err;
+    }
     throw new Error(
       `lintro: the platform package "${pkg}" is not installed. ` +
         'This usually means optional dependencies were skipped during ' +

--- a/npm/lintro/lib/resolve.js
+++ b/npm/lintro/lib/resolve.js
@@ -1,0 +1,99 @@
+"use strict";
+
+/**
+ * Platform resolution for the lintro meta-package.
+ *
+ * Maps a Node `process.platform`/`process.arch` pair to the scoped
+ * `@lintro/<platform>` package that ships the matching self-contained
+ * binary. The resolution logic is kept pure and side-effect free so it
+ * can be unit-tested without a binary present on disk.
+ */
+
+/**
+ * Mapping from a `${platform}-${arch}` key to the scoped package name that
+ * provides the binary for that platform. Keys use Node's `process.arch`
+ * values (`x64`, `arm64`), which match the npm `cpu` field.
+ *
+ * @type {Readonly<Record<string, string>>}
+ */
+const PLATFORM_PACKAGES = Object.freeze({
+  "darwin-arm64": "@lintro/darwin-arm64",
+  "darwin-x64": "@lintro/darwin-x64",
+  "linux-arm64": "@lintro/linux-arm64",
+  "linux-x64": "@lintro/linux-x64",
+});
+
+/**
+ * Resolve the scoped package name for a platform/arch pair.
+ *
+ * @param {string} platform - Value of `process.platform` (e.g. `"darwin"`).
+ * @param {string} arch - Value of `process.arch` (e.g. `"arm64"`).
+ * @returns {string | null} The scoped package name, or `null` when the
+ *   platform is unsupported.
+ */
+function packageForPlatform(platform, arch) {
+  const key = `${platform}-${arch}`;
+  return Object.prototype.hasOwnProperty.call(PLATFORM_PACKAGES, key)
+    ? PLATFORM_PACKAGES[key]
+    : null;
+}
+
+/**
+ * List of platform keys supported by the current distribution.
+ *
+ * @returns {string[]} Supported `${platform}-${arch}` keys.
+ */
+function supportedPlatforms() {
+  return Object.keys(PLATFORM_PACKAGES);
+}
+
+/**
+ * Resolve the absolute path to the lintro binary for the running platform.
+ *
+ * @param {NodeJS.Require} [requireFn] - Injectable `require` used to resolve
+ *   the platform package (defaults to this module's `require`).
+ * @param {string} [platform] - Override for `process.platform` (testing).
+ * @param {string} [arch] - Override for `process.arch` (testing).
+ * @returns {string} Absolute path to the binary.
+ * @throws {Error} When the platform is unsupported or the platform package
+ *   is not installed.
+ */
+function resolveBinary(requireFn, platform, arch) {
+  const req = requireFn || require;
+  const plat = platform || process.platform;
+  const cpu = arch || process.arch;
+  const pkg = packageForPlatform(plat, cpu);
+
+  if (!pkg) {
+    throw new Error(
+      `lintro: unsupported platform ${plat}-${cpu}. ` +
+        `Supported platforms: ${supportedPlatforms().join(", ")}.`,
+    );
+  }
+
+  let mod;
+  try {
+    mod = req(pkg);
+  } catch (err) {
+    throw new Error(
+      `lintro: the platform package "${pkg}" is not installed. ` +
+        "This usually means optional dependencies were skipped during " +
+        "install. Reinstall with optional dependencies enabled " +
+        `(e.g. \`npm install lintro\` or \`bun add lintro\`). Cause: ${err.message}`,
+    );
+  }
+
+  if (!mod || typeof mod.path !== "string") {
+    throw new Error(
+      `lintro: platform package "${pkg}" did not export a binary path.`,
+    );
+  }
+  return mod.path;
+}
+
+module.exports = {
+  PLATFORM_PACKAGES,
+  packageForPlatform,
+  supportedPlatforms,
+  resolveBinary,
+};

--- a/npm/lintro/package.json
+++ b/npm/lintro/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "lintro",
+  "version": "0.0.0-dev",
+  "description": "A unified CLI for code formatting, linting, and quality assurance. Ships self-contained platform binaries — no Python required.",
+  "keywords": [
+    "lint",
+    "linter",
+    "formatter",
+    "ruff",
+    "black",
+    "mypy",
+    "prettier",
+    "cli"
+  ],
+  "homepage": "https://github.com/lgtm-hq/py-lintro#readme",
+  "bugs": {
+    "url": "https://github.com/lgtm-hq/py-lintro/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lgtm-hq/py-lintro.git",
+    "directory": "npm/lintro"
+  },
+  "bin": {
+    "lintro": "bin/lintro"
+  },
+  "files": [
+    "bin/lintro",
+    "lib/resolve.js"
+  ],
+  "optionalDependencies": {
+    "@lintro/darwin-arm64": "0.0.0-dev",
+    "@lintro/darwin-x64": "0.0.0-dev",
+    "@lintro/linux-arm64": "0.0.0-dev",
+    "@lintro/linux-x64": "0.0.0-dev"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/npm/lintro/package.json
+++ b/npm/lintro/package.json
@@ -30,10 +30,10 @@
     "lib/resolve.js"
   ],
   "optionalDependencies": {
-    "@lintro/darwin-arm64": "0.0.0-dev",
-    "@lintro/darwin-x64": "0.0.0-dev",
-    "@lintro/linux-arm64": "0.0.0-dev",
-    "@lintro/linux-x64": "0.0.0-dev"
+    "@lgtm-hq/lintro-darwin-arm64": "0.0.0-dev",
+    "@lgtm-hq/lintro-darwin-x64": "0.0.0-dev",
+    "@lgtm-hq/lintro-linux-arm64": "0.0.0-dev",
+    "@lgtm-hq/lintro-linux-x64": "0.0.0-dev"
   },
   "engines": {
     "node": ">=18"

--- a/npm/lintro/test/resolve.test.js
+++ b/npm/lintro/test/resolve.test.js
@@ -10,10 +10,10 @@ const {
 
 describe("packageForPlatform", () => {
   it("maps every supported platform to its scoped package", () => {
-    expect(packageForPlatform("darwin", "arm64")).toBe("@lintro/darwin-arm64");
-    expect(packageForPlatform("darwin", "x64")).toBe("@lintro/darwin-x64");
-    expect(packageForPlatform("linux", "arm64")).toBe("@lintro/linux-arm64");
-    expect(packageForPlatform("linux", "x64")).toBe("@lintro/linux-x64");
+    expect(packageForPlatform("darwin", "arm64")).toBe("@lgtm-hq/lintro-darwin-arm64");
+    expect(packageForPlatform("darwin", "x64")).toBe("@lgtm-hq/lintro-darwin-x64");
+    expect(packageForPlatform("linux", "arm64")).toBe("@lgtm-hq/lintro-linux-arm64");
+    expect(packageForPlatform("linux", "x64")).toBe("@lgtm-hq/lintro-linux-x64");
   });
 
   it("returns null for unsupported platforms", () => {
@@ -48,12 +48,12 @@ describe("supportedPlatforms", () => {
 describe("resolveBinary", () => {
   it("returns the path exported by the resolved platform package", () => {
     const fakeRequire = (name) => {
-      expect(name).toBe("@lintro/linux-x64");
-      return { path: "/somewhere/node_modules/@lintro/linux-x64/bin/lintro" };
+      expect(name).toBe("@lgtm-hq/lintro-linux-x64");
+      return { path: "/somewhere/node_modules/@lgtm-hq/lintro-linux-x64/bin/lintro" };
     };
     const result = resolveBinary(fakeRequire, "linux", "x64");
     expect(result).toBe(
-      "/somewhere/node_modules/@lintro/linux-x64/bin/lintro",
+      "/somewhere/node_modules/@lgtm-hq/lintro-linux-x64/bin/lintro",
     );
   });
 
@@ -68,7 +68,7 @@ describe("resolveBinary", () => {
       throw new Error("Cannot find module");
     };
     expect(() => resolveBinary(failingRequire, "darwin", "arm64")).toThrow(
-      /platform package "@lintro\/darwin-arm64" is not installed/,
+      /platform package "@lgtm-hq\/lintro-darwin-arm64" is not installed/,
     );
   });
 

--- a/npm/lintro/test/resolve.test.js
+++ b/npm/lintro/test/resolve.test.js
@@ -72,6 +72,15 @@ describe("resolveBinary", () => {
     );
   });
 
+  it("mentions the cross-platform lockfile pitfall when not installed", () => {
+    const failingRequire = () => {
+      throw new Error("Cannot find module");
+    };
+    expect(() => resolveBinary(failingRequire, "linux", "x64")).toThrow(
+      /lockfile was generated on a different OS/,
+    );
+  });
+
   it("throws when the platform package exports no path", () => {
     const badRequire = () => ({});
     expect(() => resolveBinary(badRequire, "darwin", "x64")).toThrow(

--- a/npm/lintro/test/resolve.test.js
+++ b/npm/lintro/test/resolve.test.js
@@ -1,0 +1,81 @@
+"use strict";
+
+const { describe, it, expect } = require("bun:test");
+const {
+  PLATFORM_PACKAGES,
+  packageForPlatform,
+  supportedPlatforms,
+  resolveBinary,
+} = require("../lib/resolve.js");
+
+describe("packageForPlatform", () => {
+  it("maps every supported platform to its scoped package", () => {
+    expect(packageForPlatform("darwin", "arm64")).toBe("@lintro/darwin-arm64");
+    expect(packageForPlatform("darwin", "x64")).toBe("@lintro/darwin-x64");
+    expect(packageForPlatform("linux", "arm64")).toBe("@lintro/linux-arm64");
+    expect(packageForPlatform("linux", "x64")).toBe("@lintro/linux-x64");
+  });
+
+  it("returns null for unsupported platforms", () => {
+    expect(packageForPlatform("win32", "x64")).toBeNull();
+    expect(packageForPlatform("linux", "ia32")).toBeNull();
+    expect(packageForPlatform("freebsd", "arm64")).toBeNull();
+  });
+
+  it("is not fooled by prototype keys", () => {
+    expect(packageForPlatform("constructor", "x64")).toBeNull();
+    expect(packageForPlatform("__proto__", "x64")).toBeNull();
+  });
+});
+
+describe("supportedPlatforms", () => {
+  it("lists exactly the four documented platforms", () => {
+    expect(supportedPlatforms().sort()).toEqual([
+      "darwin-arm64",
+      "darwin-x64",
+      "linux-arm64",
+      "linux-x64",
+    ]);
+  });
+
+  it("matches the PLATFORM_PACKAGES keys", () => {
+    expect(supportedPlatforms().sort()).toEqual(
+      Object.keys(PLATFORM_PACKAGES).sort(),
+    );
+  });
+});
+
+describe("resolveBinary", () => {
+  it("returns the path exported by the resolved platform package", () => {
+    const fakeRequire = (name) => {
+      expect(name).toBe("@lintro/linux-x64");
+      return { path: "/somewhere/node_modules/@lintro/linux-x64/bin/lintro" };
+    };
+    const result = resolveBinary(fakeRequire, "linux", "x64");
+    expect(result).toBe(
+      "/somewhere/node_modules/@lintro/linux-x64/bin/lintro",
+    );
+  });
+
+  it("throws a helpful error for unsupported platforms", () => {
+    expect(() => resolveBinary(() => ({ path: "x" }), "win32", "x64")).toThrow(
+      /unsupported platform win32-x64/,
+    );
+  });
+
+  it("throws when the platform package is not installed", () => {
+    const failingRequire = () => {
+      throw new Error("Cannot find module");
+    };
+    expect(() => resolveBinary(failingRequire, "darwin", "arm64")).toThrow(
+      /platform package "@lintro\/darwin-arm64" is not installed/,
+    );
+  });
+
+  it("throws when the platform package exports no path", () => {
+    const badRequire = () => ({});
+    expect(() => resolveBinary(badRequire, "darwin", "x64")).toThrow(
+      /did not export a binary path/,
+    );
+  });
+});

--- a/npm/lintro/test/resolve.test.js
+++ b/npm/lintro/test/resolve.test.js
@@ -59,21 +59,30 @@ describe('resolveBinary', () => {
     );
   });
 
+  const moduleNotFoundRequire = () => {
+    const err = new Error('Cannot find module');
+    err.code = 'MODULE_NOT_FOUND';
+    throw err;
+  };
+
   it('throws when the platform package is not installed', () => {
-    const failingRequire = () => {
-      throw new Error('Cannot find module');
-    };
-    expect(() => resolveBinary(failingRequire, 'darwin', 'arm64')).toThrow(
+    expect(() => resolveBinary(moduleNotFoundRequire, 'darwin', 'arm64')).toThrow(
       /platform package "@lgtm-hq\/lintro-darwin-arm64" is not installed/
     );
   });
 
   it('mentions the cross-platform lockfile pitfall when not installed', () => {
-    const failingRequire = () => {
-      throw new Error('Cannot find module');
-    };
-    expect(() => resolveBinary(failingRequire, 'linux', 'x64')).toThrow(
+    expect(() => resolveBinary(moduleNotFoundRequire, 'linux', 'x64')).toThrow(
       /lockfile was generated on a different OS/
+    );
+  });
+
+  it('rethrows non-MODULE_NOT_FOUND errors unchanged', () => {
+    const brokenPackageRequire = () => {
+      throw new Error('boom from inside the platform package');
+    };
+    expect(() => resolveBinary(brokenPackageRequire, 'linux', 'x64')).toThrow(
+      /boom from inside the platform package/
     );
   });
 

--- a/npm/lintro/test/resolve.test.js
+++ b/npm/lintro/test/resolve.test.js
@@ -1,90 +1,86 @@
-"use strict";
+'use strict';
 
-const { describe, it, expect } = require("bun:test");
+const { describe, it, expect } = require('bun:test');
 const {
   PLATFORM_PACKAGES,
   packageForPlatform,
   supportedPlatforms,
   resolveBinary,
-} = require("../lib/resolve.js");
+} = require('../lib/resolve.js');
 
-describe("packageForPlatform", () => {
-  it("maps every supported platform to its scoped package", () => {
-    expect(packageForPlatform("darwin", "arm64")).toBe("@lgtm-hq/lintro-darwin-arm64");
-    expect(packageForPlatform("darwin", "x64")).toBe("@lgtm-hq/lintro-darwin-x64");
-    expect(packageForPlatform("linux", "arm64")).toBe("@lgtm-hq/lintro-linux-arm64");
-    expect(packageForPlatform("linux", "x64")).toBe("@lgtm-hq/lintro-linux-x64");
+describe('packageForPlatform', () => {
+  it('maps every supported platform to its scoped package', () => {
+    expect(packageForPlatform('darwin', 'arm64')).toBe('@lgtm-hq/lintro-darwin-arm64');
+    expect(packageForPlatform('darwin', 'x64')).toBe('@lgtm-hq/lintro-darwin-x64');
+    expect(packageForPlatform('linux', 'arm64')).toBe('@lgtm-hq/lintro-linux-arm64');
+    expect(packageForPlatform('linux', 'x64')).toBe('@lgtm-hq/lintro-linux-x64');
   });
 
-  it("returns null for unsupported platforms", () => {
-    expect(packageForPlatform("win32", "x64")).toBeNull();
-    expect(packageForPlatform("linux", "ia32")).toBeNull();
-    expect(packageForPlatform("freebsd", "arm64")).toBeNull();
+  it('returns null for unsupported platforms', () => {
+    expect(packageForPlatform('win32', 'x64')).toBeNull();
+    expect(packageForPlatform('linux', 'ia32')).toBeNull();
+    expect(packageForPlatform('freebsd', 'arm64')).toBeNull();
   });
 
-  it("is not fooled by prototype keys", () => {
-    expect(packageForPlatform("constructor", "x64")).toBeNull();
-    expect(packageForPlatform("__proto__", "x64")).toBeNull();
+  it('is not fooled by prototype keys', () => {
+    expect(packageForPlatform('constructor', 'x64')).toBeNull();
+    expect(packageForPlatform('__proto__', 'x64')).toBeNull();
   });
 });
 
-describe("supportedPlatforms", () => {
-  it("lists exactly the four documented platforms", () => {
+describe('supportedPlatforms', () => {
+  it('lists exactly the four documented platforms', () => {
     expect(supportedPlatforms().sort()).toEqual([
-      "darwin-arm64",
-      "darwin-x64",
-      "linux-arm64",
-      "linux-x64",
+      'darwin-arm64',
+      'darwin-x64',
+      'linux-arm64',
+      'linux-x64',
     ]);
   });
 
-  it("matches the PLATFORM_PACKAGES keys", () => {
-    expect(supportedPlatforms().sort()).toEqual(
-      Object.keys(PLATFORM_PACKAGES).sort(),
-    );
+  it('matches the PLATFORM_PACKAGES keys', () => {
+    expect(supportedPlatforms().sort()).toEqual(Object.keys(PLATFORM_PACKAGES).sort());
   });
 });
 
-describe("resolveBinary", () => {
-  it("returns the path exported by the resolved platform package", () => {
+describe('resolveBinary', () => {
+  it('returns the path exported by the resolved platform package', () => {
     const fakeRequire = (name) => {
-      expect(name).toBe("@lgtm-hq/lintro-linux-x64");
-      return { path: "/somewhere/node_modules/@lgtm-hq/lintro-linux-x64/bin/lintro" };
+      expect(name).toBe('@lgtm-hq/lintro-linux-x64');
+      return { path: '/somewhere/node_modules/@lgtm-hq/lintro-linux-x64/bin/lintro' };
     };
-    const result = resolveBinary(fakeRequire, "linux", "x64");
-    expect(result).toBe(
-      "/somewhere/node_modules/@lgtm-hq/lintro-linux-x64/bin/lintro",
+    const result = resolveBinary(fakeRequire, 'linux', 'x64');
+    expect(result).toBe('/somewhere/node_modules/@lgtm-hq/lintro-linux-x64/bin/lintro');
+  });
+
+  it('throws a helpful error for unsupported platforms', () => {
+    expect(() => resolveBinary(() => ({ path: 'x' }), 'win32', 'x64')).toThrow(
+      /unsupported platform win32-x64/
     );
   });
 
-  it("throws a helpful error for unsupported platforms", () => {
-    expect(() => resolveBinary(() => ({ path: "x" }), "win32", "x64")).toThrow(
-      /unsupported platform win32-x64/,
-    );
-  });
-
-  it("throws when the platform package is not installed", () => {
+  it('throws when the platform package is not installed', () => {
     const failingRequire = () => {
-      throw new Error("Cannot find module");
+      throw new Error('Cannot find module');
     };
-    expect(() => resolveBinary(failingRequire, "darwin", "arm64")).toThrow(
-      /platform package "@lgtm-hq\/lintro-darwin-arm64" is not installed/,
+    expect(() => resolveBinary(failingRequire, 'darwin', 'arm64')).toThrow(
+      /platform package "@lgtm-hq\/lintro-darwin-arm64" is not installed/
     );
   });
 
-  it("mentions the cross-platform lockfile pitfall when not installed", () => {
+  it('mentions the cross-platform lockfile pitfall when not installed', () => {
     const failingRequire = () => {
-      throw new Error("Cannot find module");
+      throw new Error('Cannot find module');
     };
-    expect(() => resolveBinary(failingRequire, "linux", "x64")).toThrow(
-      /lockfile was generated on a different OS/,
+    expect(() => resolveBinary(failingRequire, 'linux', 'x64')).toThrow(
+      /lockfile was generated on a different OS/
     );
   });
 
-  it("throws when the platform package exports no path", () => {
+  it('throws when the platform package exports no path', () => {
     const badRequire = () => ({});
-    expect(() => resolveBinary(badRequire, "darwin", "x64")).toThrow(
-      /did not export a binary path/,
+    expect(() => resolveBinary(badRequire, 'darwin', 'x64')).toThrow(
+      /did not export a binary path/
     );
   });
 });

--- a/npm/linux-arm64/bin/.gitkeep
+++ b/npm/linux-arm64/bin/.gitkeep
@@ -1,0 +1,1 @@
+Binary injected at publish time by .github/workflows/publish-npm.yml

--- a/npm/linux-arm64/index.js
+++ b/npm/linux-arm64/index.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/**
+ * Exports the absolute path to the platform-specific lintro binary.
+ *
+ * The `bin/lintro` file is populated by the publish workflow from the
+ * Nuitka-compiled artifact for this platform. Consumers should not depend
+ * on this package directly; install the `lintro` meta-package instead.
+ */
+
+const path = require("path");
+
+module.exports.path = path.join(__dirname, "bin", "lintro");

--- a/npm/linux-arm64/index.js
+++ b/npm/linux-arm64/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 /**
  * Exports the absolute path to the platform-specific lintro binary.
@@ -8,6 +8,6 @@
  * on this package directly; install the `lintro` meta-package instead.
  */
 
-const path = require("path");
+const path = require('path');
 
-module.exports.path = path.join(__dirname, "bin", "lintro");
+module.exports.path = path.join(__dirname, 'bin', 'lintro');

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lintro/linux-arm64",
+  "name": "@lgtm-hq/lintro-linux-arm64",
   "version": "0.0.0-dev",
   "description": "Linux ARM64 binary for lintro. Installed automatically by the `lintro` package.",
   "homepage": "https://github.com/lgtm-hq/py-lintro#readme",

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@lintro/linux-arm64",
+  "version": "0.0.0-dev",
+  "description": "Linux ARM64 binary for lintro. Installed automatically by the `lintro` package.",
+  "homepage": "https://github.com/lgtm-hq/py-lintro#readme",
+  "bugs": {
+    "url": "https://github.com/lgtm-hq/py-lintro/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lgtm-hq/py-lintro.git",
+    "directory": "npm/linux-arm64"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "index.js",
+  "files": [
+    "bin/lintro",
+    "index.js"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/npm/linux-x64/bin/.gitkeep
+++ b/npm/linux-x64/bin/.gitkeep
@@ -1,0 +1,1 @@
+Binary injected at publish time by .github/workflows/publish-npm.yml

--- a/npm/linux-x64/index.js
+++ b/npm/linux-x64/index.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/**
+ * Exports the absolute path to the platform-specific lintro binary.
+ *
+ * The `bin/lintro` file is populated by the publish workflow from the
+ * Nuitka-compiled artifact for this platform. Consumers should not depend
+ * on this package directly; install the `lintro` meta-package instead.
+ */
+
+const path = require("path");
+
+module.exports.path = path.join(__dirname, "bin", "lintro");

--- a/npm/linux-x64/index.js
+++ b/npm/linux-x64/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 /**
  * Exports the absolute path to the platform-specific lintro binary.
@@ -8,6 +8,6 @@
  * on this package directly; install the `lintro` meta-package instead.
  */
 
-const path = require("path");
+const path = require('path');
 
-module.exports.path = path.join(__dirname, "bin", "lintro");
+module.exports.path = path.join(__dirname, 'bin', 'lintro');

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lintro/linux-x64",
+  "name": "@lgtm-hq/lintro-linux-x64",
   "version": "0.0.0-dev",
   "description": "Linux x86_64 binary for lintro. Installed automatically by the `lintro` package.",
   "homepage": "https://github.com/lgtm-hq/py-lintro#readme",

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@lintro/linux-x64",
+  "version": "0.0.0-dev",
+  "description": "Linux x86_64 binary for lintro. Installed automatically by the `lintro` package.",
+  "homepage": "https://github.com/lgtm-hq/py-lintro#readme",
+  "bugs": {
+    "url": "https://github.com/lgtm-hq/py-lintro/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lgtm-hq/py-lintro.git",
+    "directory": "npm/linux-x64"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "index.js",
+  "files": [
+    "bin/lintro",
+    "index.js"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -58,6 +58,20 @@ Scripts for building standalone binaries and distribution packages.
 | Script           | Purpose                                  | Usage                                        |
 | ---------------- | ---------------------------------------- | -------------------------------------------- |
 | `build_macos.py` | Build macOS binary using Nuitka compiler | `uv run python scripts/build/build_macos.py` |
+| `build_linux.py` | Build Linux binary using Nuitka compiler | `uv run python scripts/build/build_linux.py` |
+
+### 📦 npm Distribution Scripts (`ci/npm/`)
+
+Scripts that package the platform binaries into the npm meta-package + per-platform
+packages and (dry-run) publish them. See the [npm distribution design](../docs/npm-distribution.md).
+
+| Script                        | Purpose                                                 | Usage                                                                 |
+| ----------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------- |
+| `sync_npm_version.py`         | Sync/check versions across all `npm/*/package.json`     | `python scripts/ci/npm/sync_npm_version.py --version 1.2.3`           |
+| `stage_binaries.py`           | Copy downloaded platform binaries into the npm tree     | `python scripts/ci/npm/stage_binaries.py --artifacts-dir <dir>`      |
+| `download_release_binaries.sh`| Download release binaries for staging                   | `./scripts/ci/npm/download_release_binaries.sh v1.2.3 <dir>`          |
+| `smoke_test.sh`               | Pack + install the meta-package and run `lintro --version` | `./scripts/ci/npm/smoke_test.sh`                                   |
+| `publish_packages.sh`         | Publish npm packages (dry-run unless `LIVE=1`)          | `./scripts/ci/npm/publish_packages.sh`                               |
 
 ### 🍺 Homebrew Formulas (`ci/homebrew/`)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -63,15 +63,16 @@ Scripts for building standalone binaries and distribution packages.
 ### 📦 npm Distribution Scripts (`ci/npm/`)
 
 Scripts that package the platform binaries into the npm meta-package + per-platform
-packages and (dry-run) publish them. See the [npm distribution design](../docs/npm-distribution.md).
+packages and (dry-run) publish them. See the
+[npm distribution design](../docs/npm-distribution.md).
 
-| Script                        | Purpose                                                 | Usage                                                                 |
-| ----------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------- |
-| `sync_npm_version.py`         | Sync/check versions across all `npm/*/package.json`     | `python scripts/ci/npm/sync_npm_version.py --version 1.2.3`           |
-| `stage_binaries.py`           | Copy downloaded platform binaries into the npm tree     | `python scripts/ci/npm/stage_binaries.py --artifacts-dir <dir>`      |
-| `download_release_binaries.sh`| Download release binaries for staging                   | `./scripts/ci/npm/download_release_binaries.sh v1.2.3 <dir>`          |
-| `smoke_test.sh`               | Pack + install the meta-package and run `lintro --version` | `./scripts/ci/npm/smoke_test.sh`                                   |
-| `publish_packages.sh`         | Publish npm packages (dry-run unless `LIVE=1`)          | `./scripts/ci/npm/publish_packages.sh`                               |
+| Script                         | Purpose                                                    | Usage                                                           |
+| ------------------------------ | ---------------------------------------------------------- | --------------------------------------------------------------- |
+| `sync_npm_version.py`          | Sync/check versions across all `npm/*/package.json`        | `python scripts/ci/npm/sync_npm_version.py --version 1.2.3`     |
+| `stage_binaries.py`            | Copy downloaded platform binaries into the npm tree        | `python scripts/ci/npm/stage_binaries.py --artifacts-dir <dir>` |
+| `download_release_binaries.sh` | Download release binaries for staging                      | `./scripts/ci/npm/download_release_binaries.sh v1.2.3 <dir>`    |
+| `smoke_test.sh`                | Pack + install the meta-package and run `lintro --version` | `./scripts/ci/npm/smoke_test.sh`                                |
+| `publish_packages.sh`          | Publish npm packages (dry-run unless `LIVE=1`)             | `./scripts/ci/npm/publish_packages.sh`                          |
 
 ### 🍺 Homebrew Formulas (`ci/homebrew/`)
 

--- a/scripts/build/build_linux.py
+++ b/scripts/build/build_linux.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Build a standalone Linux binary using Nuitka.
+
+This mirrors ``scripts/build/build_macos.py`` for Linux. Nuitka compiles a
+self-contained onefile executable that embeds the Python runtime and every
+``[full]`` tool, so npm consumers need no Python installed.
+
+Unlike macOS, Linux has no cross-arch flag: the binary targets the host
+architecture, so arm64 and x86_64 are produced on their respective runners.
+
+Usage:
+    python scripts/build/build_linux.py [--arch arm64|x86_64]
+
+Requirements:
+    - Python 3.11+
+    - Nuitka (install with: uv sync --group build)
+    - A C toolchain (gcc/patchelf) for onefile compression
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Project root directory.
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+
+# Output directory for built binaries.
+OUTPUT_DIR = PROJECT_ROOT / "dist" / "nuitka"
+
+# Packages to include in the build (kept in sync with build_macos.py).
+INCLUDE_PACKAGES = [
+    "lintro",
+    "click",
+    "loguru",
+    "tabulate",
+    "defusedxml",
+    "httpx",
+]
+
+# Directory data files to include (relative to package).
+INCLUDE_DATA_DIRS = [
+    "lintro/assets=lintro/assets",
+]
+
+# Non-Python data files required at runtime.
+INCLUDE_DATA_FILES = [
+    "lintro/tools/manifest.json=lintro/tools/manifest.json",
+]
+
+# Architectures Nuitka can target natively on Linux.
+SUPPORTED_ARCHES = ("arm64", "x86_64")
+
+
+def get_default_arch() -> str:
+    """Get the default architecture based on the current system.
+
+    Returns:
+        Architecture string (``arm64`` or ``x86_64``).
+    """
+    machine = platform.machine().lower()
+    if machine in ("arm64", "aarch64"):
+        return "arm64"
+    return "x86_64"
+
+
+def build_nuitka_command(*, verbose: bool = False) -> list[str]:
+    """Build the Nuitka command for a Linux onefile binary.
+
+    The host architecture is used implicitly; Linux offers no cross-arch
+    equivalent to macOS's ``--macos-target-arch``.
+
+    Args:
+        verbose: Enable verbose output during compilation.
+
+    Returns:
+        Nuitka command argv list.
+
+    Raises:
+        FileNotFoundError: If a required runtime data file is missing.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "nuitka",
+        "--standalone",
+        "--onefile",
+        f"--output-dir={OUTPUT_DIR}",
+        "--output-filename=lintro",
+        "--follow-imports",
+        "--assume-yes-for-downloads",
+    ]
+
+    for pkg in INCLUDE_PACKAGES:
+        cmd.append(f"--include-package={pkg}")
+
+    cmd.append("--include-package-data=lintro")
+
+    for data_dir in INCLUDE_DATA_DIRS:
+        data_path = PROJECT_ROOT / data_dir.split("=")[0]
+        if data_path.exists():
+            cmd.append(f"--include-data-dir={data_dir}")
+
+    for data_file in INCLUDE_DATA_FILES:
+        data_path = PROJECT_ROOT / data_file.split("=")[0]
+        if not data_path.exists():
+            msg = f"Required runtime data file missing for Nuitka build: {data_path}"
+            raise FileNotFoundError(msg)
+        cmd.append(f"--include-data-files={data_file}")
+
+    if verbose:
+        cmd.append("--verbose")
+
+    cmd.append(str(PROJECT_ROOT / "lintro" / "__main__.py"))
+    return cmd
+
+
+def build_linux_binary(*, verbose: bool = False) -> int:
+    """Build a standalone Linux binary using Nuitka.
+
+    Args:
+        verbose: Enable verbose output during compilation.
+
+    Returns:
+        Exit code (0 for success, non-zero for failure).
+    """
+    print(f"Building lintro for Linux ({get_default_arch()})...")
+    print(f"Output directory: {OUTPUT_DIR}")
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    try:
+        cmd = build_nuitka_command(verbose=verbose)
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"Running: {' '.join(cmd)}")
+
+    try:
+        result = subprocess.run(cmd, cwd=PROJECT_ROOT, check=True)
+        return result.returncode
+    except subprocess.CalledProcessError as e:
+        print(f"Build failed with exit code {e.returncode}", file=sys.stderr)
+        return e.returncode
+    except FileNotFoundError:
+        print(
+            "Nuitka not found. Install with: uv sync --group build",
+            file=sys.stderr,
+        )
+        return 1
+
+
+def verify_binary() -> bool:
+    """Verify the built binary responds to ``--version`` and ``--help``.
+
+    Returns:
+        True if verification passed, False otherwise.
+    """
+    binary_path = OUTPUT_DIR / "lintro"
+
+    if not binary_path.exists():
+        print(f"Binary not found at {binary_path}", file=sys.stderr)
+        return False
+
+    print(f"\nVerifying binary at {binary_path}...")
+
+    for check_args, label in (
+        (["--version"], "Version"),
+        (["--help"], "Help command"),
+    ):
+        try:
+            result = subprocess.run(
+                [str(binary_path), *check_args],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            print(f"{label} check timed out", file=sys.stderr)
+            return False
+        if result.returncode != 0:
+            print(f"{label} check failed: {result.stderr}", file=sys.stderr)
+            return False
+        print(f"{label}: OK")
+
+    size_mb = binary_path.stat().st_size / (1024 * 1024)
+    print(f"Binary size: {size_mb:.1f} MB")
+    if size_mb > 100:
+        print("Warning: Binary is larger than expected (>100MB)", file=sys.stderr)
+
+    return True
+
+
+def main() -> int:
+    """Main entry point for the Linux build script.
+
+    Returns:
+        Exit code (0 for success, non-zero for failure).
+    """
+    parser = argparse.ArgumentParser(
+        description="Build lintro Linux binary using Nuitka",
+    )
+    parser.add_argument(
+        "--arch",
+        choices=list(SUPPORTED_ARCHES),
+        default=get_default_arch(),
+        help="Target architecture (informational; must match the host).",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose output",
+    )
+    parser.add_argument(
+        "--skip-verify",
+        action="store_true",
+        help="Skip binary verification after build",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Clean output directory before build",
+    )
+
+    args = parser.parse_args()
+
+    host_arch = get_default_arch()
+    if args.arch != host_arch:
+        print(
+            f"Refusing to build {args.arch} on a {host_arch} host: Linux "
+            "builds are native-only (no cross-compilation).",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.clean and OUTPUT_DIR.exists():
+        print(f"Cleaning {OUTPUT_DIR}...")
+        shutil.rmtree(OUTPUT_DIR)
+
+    exit_code = build_linux_binary(verbose=args.verbose)
+    if exit_code != 0:
+        return exit_code
+
+    if not args.skip_verify and not verify_binary():
+        return 1
+
+    print("\nBuild complete!")
+    print(f"Binary location: {OUTPUT_DIR / 'lintro'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/npm/download_release_binaries.sh
+++ b/scripts/ci/npm/download_release_binaries.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# download_release_binaries.sh
+# Download the four platform binaries that build-binary.yml attaches to a
+# GitHub release, laying them out for stage_binaries.py.
+
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" || $# -lt 2 ]]; then
+	cat <<'EOF'
+Download lintro platform binaries from a GitHub release.
+
+Usage: download_release_binaries.sh <release-tag> <dest-dir>
+
+Requires the GH_TOKEN environment variable (gh CLI auth). Places each
+binary at <dest-dir>/<artifact-name>/<artifact-name> so that
+stage_binaries.py can map them into the npm package tree.
+EOF
+	[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && exit 0
+	exit 2
+fi
+
+tag="$1"
+dest="$2"
+
+binaries=(
+	"lintro-macos-arm64"
+	"lintro-macos-x86_64"
+	"lintro-linux-arm64"
+	"lintro-linux-x64"
+)
+
+mkdir -p "$dest"
+for name in "${binaries[@]}"; do
+	target_dir="$dest/$name"
+	mkdir -p "$target_dir"
+	echo "==> Downloading $name from release $tag"
+	gh release download "$tag" --pattern "$name" --dir "$target_dir" --clobber
+done
+
+echo "Downloaded ${#binaries[@]} platform binaries into $dest"

--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# publish_packages.sh
+# Publish the lintro npm packages (platform packages first, then the
+# meta-package). Publishing is DRY-RUN ONLY unless LIVE=1 is set explicitly,
+# which is intentionally never wired into any workflow in this repo — going
+# live is a deliberate, separate follow-up that also requires NODE_AUTH_TOKEN.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+NPM_DIR="$REPO_ROOT/npm"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Publish lintro npm packages.
+
+Usage: publish_packages.sh
+
+Environment:
+  LIVE=1              Perform a real publish. Default (unset) is --dry-run.
+  NPM_PROVENANCE=0    Disable --provenance (default: enabled).
+
+Publishes @lintro/<platform> packages first, then the root meta-package,
+so consumers never resolve a meta-package whose optional deps are missing.
+EOF
+	exit 0
+fi
+
+# Platform packages before the meta-package: the meta-package's
+# optionalDependencies must exist on the registry first.
+PACKAGES=(
+	"darwin-arm64"
+	"darwin-x64"
+	"linux-arm64"
+	"linux-x64"
+	"lintro"
+)
+
+publish_flags=("--access" "public")
+if [[ "${NPM_PROVENANCE:-1}" != "0" ]]; then
+	publish_flags+=("--provenance")
+fi
+if [[ "${LIVE:-0}" != "1" ]]; then
+	publish_flags+=("--dry-run")
+	echo "DRY-RUN mode: no packages will be published. Set LIVE=1 to publish."
+else
+	echo "LIVE mode: packages WILL be published to the registry."
+fi
+
+for pkg in "${PACKAGES[@]}"; do
+	pkg_dir="$NPM_DIR/$pkg"
+	echo "==> Publishing $pkg (${publish_flags[*]})"
+	(cd "$pkg_dir" && npm publish "${publish_flags[@]}")
+done
+
+echo "npm publish step complete."

--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -21,7 +21,7 @@ Environment:
   LIVE=1              Perform a real publish. Default (unset) is --dry-run.
   NPM_PROVENANCE=0    Disable --provenance (default: enabled).
 
-Publishes @lintro/<platform> packages first, then the root meta-package,
+Publishes @lgtm-hq/lintro-<platform> packages first, then the root meta-package,
 so consumers never resolve a meta-package whose optional deps are missing.
 EOF
 	exit 0

--- a/scripts/ci/npm/smoke_test.sh
+++ b/scripts/ci/npm/smoke_test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# smoke_test.sh
+# Verify a packed lintro meta-package resolves and launches its platform
+# binary in a Python-free environment. Runs against locally packed tarballs
+# so it works before anything is published to a registry.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+NPM_DIR="$REPO_ROOT/npm"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Smoke-test the lintro npm meta-package launcher.
+
+Usage: smoke_test.sh
+
+Detects the host platform, packs the meta-package and the matching
+@lintro/<platform> package, installs them into a scratch project, and runs
+`lintro --version`, asserting a zero exit code. Requires the platform binary
+to already be staged into npm/<platform>/bin/lintro.
+EOF
+	exit 0
+fi
+
+node_platform="$(node -e 'process.stdout.write(process.platform)')"
+node_arch="$(node -e 'process.stdout.write(process.arch)')"
+platform_key="${node_platform}-${node_arch}"
+
+platform_dir="$NPM_DIR/$platform_key"
+if [[ ! -d "$platform_dir" ]]; then
+	echo "Unsupported host platform for smoke test: $platform_key" >&2
+	exit 1
+fi
+
+binary="$platform_dir/bin/lintro"
+if [[ ! -x "$binary" ]]; then
+	echo "Platform binary not staged/executable: $binary" >&2
+	echo "Run scripts/ci/npm/stage_binaries.py first." >&2
+	exit 1
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+meta_tarball="$(cd "$NPM_DIR/lintro" && npm pack --pack-destination "$workdir" | tail -n1)"
+platform_tarball="$(cd "$platform_dir" && npm pack --pack-destination "$workdir" | tail -n1)"
+
+cd "$workdir"
+npm init -y >/dev/null 2>&1
+npm install --no-save "$workdir/$platform_tarball" "$workdir/$meta_tarball"
+
+echo "==> lintro --version"
+./node_modules/.bin/lintro --version
+echo "Smoke test passed: launcher resolved and executed the platform binary."

--- a/scripts/ci/npm/smoke_test.sh
+++ b/scripts/ci/npm/smoke_test.sh
@@ -17,7 +17,7 @@ Smoke-test the lintro npm meta-package launcher.
 Usage: smoke_test.sh
 
 Detects the host platform, packs the meta-package and the matching
-@lintro/<platform> package, installs them into a scratch project, and runs
+@lgtm-hq/lintro-<platform> package, installs them into a scratch project, and runs
 `lintro --version`, asserting a zero exit code. Requires the platform binary
 to already be staged into npm/<platform>/bin/lintro.
 EOF

--- a/scripts/ci/npm/stage_binaries.py
+++ b/scripts/ci/npm/stage_binaries.py
@@ -39,11 +39,11 @@ BINARY_MAP: dict[str, str] = {
 def _find_binary(artifacts_dir: Path, artifact_name: str) -> Path | None:
     """Locate the binary file for a given artifact.
 
-    Looks first for ``<artifacts_dir>/<artifact_name>/<artifact_name>`` and
-    falls back to a file matching the artifact name beneath the artifacts
-    directory, but only when exactly one such file exists — multiple
-    candidates (e.g. leftovers from an earlier run) are ambiguous and must
-    fail rather than risk staging a stale binary.
+    Only the direct ``<artifacts_dir>/<artifact_name>/<artifact_name>``
+    layout produced by actions/download-artifact is accepted. There is
+    deliberately no glob fallback: a looser search could stage a stale or
+    duplicate binary from a reused artifacts directory into the wrong
+    platform package, and the smoke test only exercises the host platform.
 
     Args:
         artifacts_dir: Root directory holding downloaded artifacts.
@@ -51,23 +51,9 @@ def _find_binary(artifacts_dir: Path, artifact_name: str) -> Path | None:
 
     Returns:
         The resolved binary path, or ``None`` when not found.
-
-    Raises:
-        RuntimeError: When multiple candidate files match the artifact name.
     """
     direct = artifacts_dir / artifact_name / artifact_name
-    if direct.is_file():
-        return direct
-    matches = sorted(p for p in artifacts_dir.rglob(artifact_name) if p.is_file())
-    if len(matches) > 1:
-        listing = ", ".join(str(p) for p in matches)
-        msg = (
-            f"Ambiguous binary artifact '{artifact_name}': multiple candidate "
-            f"files found under {artifacts_dir} ({listing}). Refusing to pick "
-            "one; clean the artifacts directory and retry."
-        )
-        raise RuntimeError(msg)
-    return matches[0] if matches else None
+    return direct if direct.is_file() else None
 
 
 def stage_binaries(artifacts_dir: Path, *, npm_dir: Path = NPM_DIR) -> list[str]:
@@ -113,8 +99,7 @@ def main(argv: list[str] | None = None) -> int:
         argv: Optional argument vector.
 
     Returns:
-        Process exit code (0 on success, 1 on missing or ambiguous
-        artifacts).
+        Process exit code (0 on success, 1 on missing artifacts).
     """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -127,7 +112,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         staged = stage_binaries(args.artifacts_dir.resolve())
-    except (FileNotFoundError, RuntimeError) as exc:
+    except FileNotFoundError as exc:
         print(str(exc), file=sys.stderr)
         return 1
 

--- a/scripts/ci/npm/stage_binaries.py
+++ b/scripts/ci/npm/stage_binaries.py
@@ -40,8 +40,10 @@ def _find_binary(artifacts_dir: Path, artifact_name: str) -> Path | None:
     """Locate the binary file for a given artifact.
 
     Looks first for ``<artifacts_dir>/<artifact_name>/<artifact_name>`` and
-    falls back to any file matching the artifact name anywhere beneath the
-    artifacts directory.
+    falls back to a file matching the artifact name beneath the artifacts
+    directory, but only when exactly one such file exists — multiple
+    candidates (e.g. leftovers from an earlier run) are ambiguous and must
+    fail rather than risk staging a stale binary.
 
     Args:
         artifacts_dir: Root directory holding downloaded artifacts.
@@ -49,11 +51,22 @@ def _find_binary(artifacts_dir: Path, artifact_name: str) -> Path | None:
 
     Returns:
         The resolved binary path, or ``None`` when not found.
+
+    Raises:
+        RuntimeError: When multiple candidate files match the artifact name.
     """
     direct = artifacts_dir / artifact_name / artifact_name
     if direct.is_file():
         return direct
-    matches = [p for p in artifacts_dir.rglob(artifact_name) if p.is_file()]
+    matches = sorted(p for p in artifacts_dir.rglob(artifact_name) if p.is_file())
+    if len(matches) > 1:
+        listing = ", ".join(str(p) for p in matches)
+        msg = (
+            f"Ambiguous binary artifact '{artifact_name}': multiple candidate "
+            f"files found under {artifacts_dir} ({listing}). Refusing to pick "
+            "one; clean the artifacts directory and retry."
+        )
+        raise RuntimeError(msg)
     return matches[0] if matches else None
 
 
@@ -69,6 +82,7 @@ def stage_binaries(artifacts_dir: Path, *, npm_dir: Path = NPM_DIR) -> list[str]
 
     Raises:
         FileNotFoundError: When an expected binary artifact is missing.
+        RuntimeError: When an artifact name matches multiple candidate files.
     """
     staged: list[str] = []
     for artifact_name, platform_key in BINARY_MAP.items():
@@ -84,7 +98,11 @@ def stage_binaries(artifacts_dir: Path, *, npm_dir: Path = NPM_DIR) -> list[str]
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source, dest)
         dest.chmod(dest.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
-        print(f"Staged {source} -> {dest.relative_to(PROJECT_ROOT)}")
+        try:
+            shown = dest.relative_to(PROJECT_ROOT)
+        except ValueError:
+            shown = dest
+        print(f"Staged {source} -> {shown}")
         staged.append(platform_key)
     return staged
 
@@ -96,7 +114,8 @@ def main(argv: list[str] | None = None) -> int:
         argv: Optional argument vector.
 
     Returns:
-        Process exit code (0 on success, 1 on missing artifacts).
+        Process exit code (0 on success, 1 on missing or ambiguous
+        artifacts).
     """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -109,7 +128,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         staged = stage_binaries(args.artifacts_dir.resolve())
-    except FileNotFoundError as exc:
+    except (FileNotFoundError, RuntimeError) as exc:
         print(str(exc), file=sys.stderr)
         return 1
 

--- a/scripts/ci/npm/stage_binaries.py
+++ b/scripts/ci/npm/stage_binaries.py
@@ -82,7 +82,6 @@ def stage_binaries(artifacts_dir: Path, *, npm_dir: Path = NPM_DIR) -> list[str]
 
     Raises:
         FileNotFoundError: When an expected binary artifact is missing.
-        RuntimeError: When an artifact name matches multiple candidate files.
     """
     staged: list[str] = []
     for artifact_name, platform_key in BINARY_MAP.items():

--- a/scripts/ci/npm/stage_binaries.py
+++ b/scripts/ci/npm/stage_binaries.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Stage downloaded platform binaries into the npm package tree.
+
+The build workflow uploads one artifact per platform
+(``lintro-macos-arm64``, ``lintro-linux-x64``, ...). This script copies each
+into the matching ``npm/<platform>/bin/lintro`` slot, marks it executable,
+and fails loudly if any expected binary is missing.
+
+Usage:
+    python scripts/ci/npm/stage_binaries.py --artifacts-dir <download-root>
+
+The artifacts directory is expected to contain one subdirectory per
+downloaded artifact (the default layout of actions/download-artifact when
+no ``merge-multiple`` is used), each holding the renamed binary file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+NPM_DIR = PROJECT_ROOT / "npm"
+
+# Map: (artifact name, binary filename) -> npm platform package directory.
+# Artifact names mirror the upload steps in build-binary.yml; npm platform
+# keys follow Node's platform-arch convention (darwin/x64, linux/arm64, ...).
+BINARY_MAP: dict[str, str] = {
+    "lintro-macos-arm64": "darwin-arm64",
+    "lintro-macos-x86_64": "darwin-x64",
+    "lintro-linux-arm64": "linux-arm64",
+    "lintro-linux-x64": "linux-x64",
+}
+
+
+def _find_binary(artifacts_dir: Path, artifact_name: str) -> Path | None:
+    """Locate the binary file for a given artifact.
+
+    Looks first for ``<artifacts_dir>/<artifact_name>/<artifact_name>`` and
+    falls back to any file matching the artifact name anywhere beneath the
+    artifacts directory.
+
+    Args:
+        artifacts_dir: Root directory holding downloaded artifacts.
+        artifact_name: The artifact/binary filename to find.
+
+    Returns:
+        The resolved binary path, or ``None`` when not found.
+    """
+    direct = artifacts_dir / artifact_name / artifact_name
+    if direct.is_file():
+        return direct
+    matches = [p for p in artifacts_dir.rglob(artifact_name) if p.is_file()]
+    return matches[0] if matches else None
+
+
+def stage_binaries(artifacts_dir: Path, *, npm_dir: Path = NPM_DIR) -> list[str]:
+    """Copy every platform binary into its npm package's ``bin/lintro`` slot.
+
+    Args:
+        artifacts_dir: Root directory holding downloaded artifacts.
+        npm_dir: Root ``npm/`` directory.
+
+    Returns:
+        The list of platform keys that were staged.
+
+    Raises:
+        FileNotFoundError: When an expected binary artifact is missing.
+    """
+    staged: list[str] = []
+    for artifact_name, platform_key in BINARY_MAP.items():
+        source = _find_binary(artifacts_dir, artifact_name)
+        if source is None:
+            msg = (
+                f"Missing binary artifact '{artifact_name}' under "
+                f"{artifacts_dir}. Cannot stage npm package '{platform_key}'."
+            )
+            raise FileNotFoundError(msg)
+
+        dest = npm_dir / platform_key / "bin" / "lintro"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, dest)
+        dest.chmod(dest.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        print(f"Staged {source} -> {dest.relative_to(PROJECT_ROOT)}")
+        staged.append(platform_key)
+    return staged
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Args:
+        argv: Optional argument vector.
+
+    Returns:
+        Process exit code (0 on success, 1 on missing artifacts).
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifacts-dir",
+        required=True,
+        type=Path,
+        help="Directory containing downloaded platform binary artifacts.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        staged = stage_binaries(args.artifacts_dir.resolve())
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"Staged {len(staged)} platform binaries: {', '.join(staged)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/npm/sync_npm_version.py
+++ b/scripts/ci/npm/sync_npm_version.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Sync npm package versions with the project version.
+
+The npm distribution ships a meta-package (``npm/lintro``) plus four
+platform packages (``npm/<platform>``). Every ``package.json`` carries a
+``"version"`` field, and the meta-package additionally pins each
+``@lintro/<platform>`` optional dependency to the same version. This script
+keeps all of them in lock-step with the canonical project version declared
+in ``lintro/__init__.py``.
+
+Two modes are supported:
+
+* Write mode (default): rewrite every manifest so its version matches the
+  requested version. Used at publish time to inject the release tag.
+* Check mode (``--check``): verify every manifest already matches, exiting
+  non-zero on drift. Used by CI to catch un-synced manifests.
+
+Usage:
+    python scripts/ci/npm/sync_npm_version.py --version 1.2.3
+    python scripts/ci/npm/sync_npm_version.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Repo root: this file lives at scripts/ci/npm/sync_npm_version.py.
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+NPM_DIR = PROJECT_ROOT / "npm"
+META_PACKAGE = "lintro"
+PLATFORM_PACKAGES = (
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64",
+    "linux-x64",
+)
+
+_VERSION_RE = re.compile(r'^__version__\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class VersionMismatch:
+    """A single manifest field whose version differs from the expected one.
+
+    Attributes:
+        manifest: Path to the offending ``package.json`` (repo-relative).
+        field: Human-readable field name (e.g. ``"version"``).
+        found: The value currently in the manifest.
+        expected: The value it should hold.
+    """
+
+    manifest: str
+    field: str
+    found: str
+    expected: str
+
+
+def read_project_version() -> str:
+    """Read the canonical project version from ``lintro/__init__.py``.
+
+    Returns:
+        The version string (without a leading ``v``).
+
+    Raises:
+        ValueError: If the ``__version__`` assignment cannot be found.
+    """
+    init_path = PROJECT_ROOT / "lintro" / "__init__.py"
+    text = init_path.read_text(encoding="utf-8")
+    match = _VERSION_RE.search(text)
+    if match is None:
+        msg = f"Could not find __version__ in {init_path}"
+        raise ValueError(msg)
+    return match.group(1)
+
+
+def read_meta_version(npm_dir: Path = NPM_DIR) -> str:
+    """Read the version declared by the meta-package manifest.
+
+    Used as the source of truth for internal-consistency checks where the
+    in-repo manifests carry a placeholder (``0.0.0-dev``) rather than the
+    real release version.
+
+    Args:
+        npm_dir: Root ``npm/`` directory.
+
+    Returns:
+        The meta-package's ``version`` string.
+    """
+    data = json.loads(meta_manifest_path(npm_dir).read_text(encoding="utf-8"))
+    return str(data.get("version", ""))
+
+
+def meta_manifest_path(npm_dir: Path = NPM_DIR) -> Path:
+    """Return the path to the meta-package manifest.
+
+    Args:
+        npm_dir: Root ``npm/`` directory.
+
+    Returns:
+        Path to ``npm/lintro/package.json``.
+    """
+    return npm_dir / META_PACKAGE / "package.json"
+
+
+def platform_manifest_paths(npm_dir: Path = NPM_DIR) -> list[Path]:
+    """Return the paths to every platform-package manifest.
+
+    Args:
+        npm_dir: Root ``npm/`` directory.
+
+    Returns:
+        A list of ``npm/<platform>/package.json`` paths.
+    """
+    return [npm_dir / name / "package.json" for name in PLATFORM_PACKAGES]
+
+
+def all_manifest_paths(npm_dir: Path = NPM_DIR) -> list[Path]:
+    """Return every npm manifest path (meta + platforms).
+
+    Args:
+        npm_dir: Root ``npm/`` directory.
+
+    Returns:
+        A list of all ``package.json`` paths.
+    """
+    return [meta_manifest_path(npm_dir), *platform_manifest_paths(npm_dir)]
+
+
+def check_versions(version: str, *, npm_dir: Path = NPM_DIR) -> list[VersionMismatch]:
+    """Collect every manifest field that does not match ``version``.
+
+    Args:
+        version: The expected version string.
+        npm_dir: Root ``npm/`` directory.
+
+    Returns:
+        A list of mismatches; empty when every manifest is in sync.
+    """
+    mismatches: list[VersionMismatch] = []
+    for path in all_manifest_paths(npm_dir):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        rel = str(path.relative_to(npm_dir.parent))
+        found = data.get("version", "")
+        if found != version:
+            mismatches.append(
+                VersionMismatch(
+                    manifest=rel,
+                    field="version",
+                    found=found,
+                    expected=version,
+                ),
+            )
+        opt_deps = data.get("optionalDependencies", {})
+        for dep_name, dep_version in opt_deps.items():
+            if dep_name.startswith("@lintro/") and dep_version != version:
+                mismatches.append(
+                    VersionMismatch(
+                        manifest=rel,
+                        field=f"optionalDependencies.{dep_name}",
+                        found=dep_version,
+                        expected=version,
+                    ),
+                )
+    return mismatches
+
+
+def sync_versions(version: str, *, npm_dir: Path = NPM_DIR) -> list[Path]:
+    """Rewrite every manifest so its version fields equal ``version``.
+
+    Both top-level ``version`` fields and the meta-package's
+    ``@lintro/*`` optional-dependency pins are updated. Files are written
+    only when their content actually changes.
+
+    Args:
+        version: The version string to write.
+        npm_dir: Root ``npm/`` directory.
+
+    Returns:
+        The list of manifest paths that were modified.
+    """
+    changed: list[Path] = []
+    for path in all_manifest_paths(npm_dir):
+        original = path.read_text(encoding="utf-8")
+        data = json.loads(original)
+        data["version"] = version
+        opt_deps = data.get("optionalDependencies")
+        if isinstance(opt_deps, dict):
+            for dep_name in opt_deps:
+                if dep_name.startswith("@lintro/"):
+                    opt_deps[dep_name] = version
+        updated = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+        if updated != original:
+            path.write_text(updated, encoding="utf-8")
+            changed.append(path)
+    return changed
+
+
+def _normalise_version(raw: str) -> str:
+    """Strip a leading ``v`` from a tag-style version string.
+
+    Args:
+        raw: A version or tag (e.g. ``"v1.2.3"``).
+
+    Returns:
+        The version without a leading ``v``.
+    """
+    return raw[1:] if raw.startswith("v") else raw
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Args:
+        argv: Optional argument vector (defaults to ``sys.argv``).
+
+    Returns:
+        Process exit code (0 on success, 1 on drift/failure).
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--version",
+        default=None,
+        help=(
+            "Version to sync to (with or without a leading 'v'). "
+            "Defaults to lintro/__init__.py."
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Verify manifests are in sync instead of writing them. Without "
+            "--version this checks internal consistency (all manifests agree "
+            "with the meta-package); with --version it checks against that "
+            "value (publish-time guard)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.check:
+        # In-repo manifests carry a placeholder version, so default checks use
+        # the meta-package as the source of truth rather than pyproject.
+        version = (
+            _normalise_version(args.version)
+            if args.version
+            else read_meta_version()
+        )
+        mismatches = check_versions(version)
+        if mismatches:
+            print(f"npm manifests out of sync (expected {version}):")
+            for mm in mismatches:
+                print(f"  {mm.manifest}: {mm.field} = {mm.found!r}")
+            print("Run: python scripts/ci/npm/sync_npm_version.py")
+            return 1
+        print(f"All npm manifests are in sync at version {version}.")
+        return 0
+
+    version = _normalise_version(args.version or read_project_version())
+    changed = sync_versions(version)
+    if changed:
+        print(f"Synced {len(changed)} npm manifest(s) to version {version}:")
+        for path in changed:
+            print(f"  {path.relative_to(PROJECT_ROOT)}")
+    else:
+        print(f"npm manifests already at version {version}; nothing to do.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/npm/sync_npm_version.py
+++ b/scripts/ci/npm/sync_npm_version.py
@@ -4,7 +4,7 @@
 The npm distribution ships a meta-package (``npm/lintro``) plus four
 platform packages (``npm/<platform>``). Every ``package.json`` carries a
 ``"version"`` field, and the meta-package additionally pins each
-``@lintro/<platform>`` optional dependency to the same version. This script
+``@lgtm-hq/lintro-<platform>`` optional dependency to the same version. This script
 keeps all of them in lock-step with the canonical project version declared
 in ``lintro/__init__.py``.
 
@@ -157,7 +157,7 @@ def check_versions(version: str, *, npm_dir: Path = NPM_DIR) -> list[VersionMism
             )
         opt_deps = data.get("optionalDependencies", {})
         for dep_name, dep_version in opt_deps.items():
-            if dep_name.startswith("@lintro/") and dep_version != version:
+            if dep_name.startswith("@lgtm-hq/lintro-") and dep_version != version:
                 mismatches.append(
                     VersionMismatch(
                         manifest=rel,
@@ -173,7 +173,7 @@ def sync_versions(version: str, *, npm_dir: Path = NPM_DIR) -> list[Path]:
     """Rewrite every manifest so its version fields equal ``version``.
 
     Both top-level ``version`` fields and the meta-package's
-    ``@lintro/*`` optional-dependency pins are updated. Files are written
+    ``@lgtm-hq/lintro-*`` optional-dependency pins are updated. Files are written
     only when their content actually changes.
 
     Args:
@@ -191,7 +191,7 @@ def sync_versions(version: str, *, npm_dir: Path = NPM_DIR) -> list[Path]:
         opt_deps = data.get("optionalDependencies")
         if isinstance(opt_deps, dict):
             for dep_name in opt_deps:
-                if dep_name.startswith("@lintro/"):
+                if dep_name.startswith("@lgtm-hq/lintro-"):
                     opt_deps[dep_name] = version
         updated = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
         if updated != original:

--- a/scripts/ci/npm/sync_npm_version.py
+++ b/scripts/ci/npm/sync_npm_version.py
@@ -246,9 +246,7 @@ def main(argv: list[str] | None = None) -> int:
         # In-repo manifests carry a placeholder version, so default checks use
         # the meta-package as the source of truth rather than pyproject.
         version = (
-            _normalise_version(args.version)
-            if args.version
-            else read_meta_version()
+            _normalise_version(args.version) if args.version else read_meta_version()
         )
         mismatches = check_versions(version)
         if mismatches:

--- a/tests/scripts/test_stage_binaries.py
+++ b/tests/scripts/test_stage_binaries.py
@@ -1,0 +1,132 @@
+"""Tests for the npm binary staging script.
+
+Covers direct-layout resolution, the single-match fallback, ambiguity
+rejection, and the full staging pass against a temporary artifacts tree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from assertpy import assert_that
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "ci" / "npm" / "stage_binaries.py"
+
+
+def _load_module() -> ModuleType:
+    """Import stage_binaries without executing its CLI.
+
+    Returns:
+        The loaded module.
+    """
+    spec = importlib.util.spec_from_file_location("stage_binaries", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["stage_binaries"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_binary(path: Path, content: bytes = b"#!/bin/sh\n") -> None:
+    """Create a fake binary file.
+
+    Args:
+        path: Destination file path.
+        content: File content to write.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def test_find_binary_prefers_direct_layout(tmp_path: Path) -> None:
+    """Direct <artifact>/<artifact> layout wins over fallback matches."""
+    mod = _load_module()
+    direct = tmp_path / "lintro-linux-x64" / "lintro-linux-x64"
+    _write_binary(direct)
+    _write_binary(tmp_path / "stale" / "lintro-linux-x64")
+
+    found = mod._find_binary(tmp_path, "lintro-linux-x64")
+
+    assert_that(str(found)).is_equal_to(str(direct))
+
+
+def test_find_binary_fallback_single_match(tmp_path: Path) -> None:
+    """A single fallback match anywhere in the tree is accepted."""
+    mod = _load_module()
+    nested = tmp_path / "merged" / "lintro-macos-arm64"
+    _write_binary(nested)
+
+    found = mod._find_binary(tmp_path, "lintro-macos-arm64")
+
+    assert_that(str(found)).is_equal_to(str(nested))
+
+
+def test_find_binary_fallback_rejects_ambiguous_matches(tmp_path: Path) -> None:
+    """Multiple fallback candidates raise instead of picking one."""
+    mod = _load_module()
+    _write_binary(tmp_path / "run-1" / "lintro-linux-arm64")
+    _write_binary(tmp_path / "run-2" / "lintro-linux-arm64")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        mod._find_binary(tmp_path, "lintro-linux-arm64")
+
+    assert_that(str(exc_info.value)).contains("Ambiguous binary artifact")
+
+
+def test_find_binary_returns_none_when_missing(tmp_path: Path) -> None:
+    """No candidate files yields None."""
+    mod = _load_module()
+
+    found = mod._find_binary(tmp_path, "lintro-macos-x86_64")
+
+    assert_that(found).is_none()
+
+
+def test_stage_binaries_stages_all_platforms(tmp_path: Path) -> None:
+    """All mapped artifacts are copied into npm/<platform>/bin/lintro."""
+    mod = _load_module()
+    artifacts = tmp_path / "artifacts"
+    for artifact_name in mod.BINARY_MAP:
+        _write_binary(artifacts / artifact_name / artifact_name)
+    npm_dir = tmp_path / "npm"
+
+    staged = mod.stage_binaries(artifacts, npm_dir=npm_dir)
+
+    assert_that(staged).is_equal_to(list(mod.BINARY_MAP.values()))
+    for platform_key in mod.BINARY_MAP.values():
+        dest = npm_dir / platform_key / "bin" / "lintro"
+        assert_that(dest.is_file()).is_true()
+
+
+def test_stage_binaries_missing_artifact_raises(tmp_path: Path) -> None:
+    """A missing artifact fails loudly with FileNotFoundError."""
+    mod = _load_module()
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        mod.stage_binaries(artifacts, npm_dir=tmp_path / "npm")
+
+    assert_that(str(exc_info.value)).contains("Missing binary artifact")
+
+
+def test_main_reports_ambiguity_as_failure(tmp_path: Path) -> None:
+    """The CLI exits non-zero when an artifact name is ambiguous."""
+    mod = _load_module()
+    artifacts = tmp_path / "artifacts"
+    for artifact_name in mod.BINARY_MAP:
+        _write_binary(artifacts / artifact_name / artifact_name)
+    _write_binary(artifacts / "duplicate" / "lintro-macos-arm64")
+    # Remove the direct layout so the ambiguous fallback path is exercised.
+    (artifacts / "lintro-macos-arm64" / "lintro-macos-arm64").unlink()
+    _write_binary(artifacts / "another" / "lintro-macos-arm64")
+
+    exit_code = mod.main(["--artifacts-dir", str(artifacts)])
+
+    assert_that(exit_code).is_equal_to(1)

--- a/tests/scripts/test_stage_binaries.py
+++ b/tests/scripts/test_stage_binaries.py
@@ -1,7 +1,7 @@
 """Tests for the npm binary staging script.
 
-Covers direct-layout resolution, the single-match fallback, ambiguity
-rejection, and the full staging pass against a temporary artifacts tree.
+Covers direct-layout resolution, rejection of files outside that layout,
+and the full staging pass against a temporary artifacts tree.
 """
 
 from __future__ import annotations
@@ -44,39 +44,25 @@ def _write_binary(path: Path, content: bytes = b"#!/bin/sh\n") -> None:
     path.write_bytes(content)
 
 
-def test_find_binary_prefers_direct_layout(tmp_path: Path) -> None:
-    """Direct <artifact>/<artifact> layout wins over fallback matches."""
+def test_find_binary_accepts_direct_layout(tmp_path: Path) -> None:
+    """The <artifact>/<artifact> layout resolves to the binary."""
     mod = _load_module()
     direct = tmp_path / "lintro-linux-x64" / "lintro-linux-x64"
     _write_binary(direct)
-    _write_binary(tmp_path / "stale" / "lintro-linux-x64")
 
     found = mod._find_binary(tmp_path, "lintro-linux-x64")
 
     assert_that(str(found)).is_equal_to(str(direct))
 
 
-def test_find_binary_fallback_single_match(tmp_path: Path) -> None:
-    """A single fallback match anywhere in the tree is accepted."""
+def test_find_binary_ignores_files_outside_direct_layout(tmp_path: Path) -> None:
+    """A matching filename elsewhere in the tree is not accepted."""
     mod = _load_module()
-    nested = tmp_path / "merged" / "lintro-macos-arm64"
-    _write_binary(nested)
+    _write_binary(tmp_path / "stray" / "lintro-macos-arm64")
 
     found = mod._find_binary(tmp_path, "lintro-macos-arm64")
 
-    assert_that(str(found)).is_equal_to(str(nested))
-
-
-def test_find_binary_fallback_rejects_ambiguous_matches(tmp_path: Path) -> None:
-    """Multiple fallback candidates raise instead of picking one."""
-    mod = _load_module()
-    _write_binary(tmp_path / "run-1" / "lintro-linux-arm64")
-    _write_binary(tmp_path / "run-2" / "lintro-linux-arm64")
-
-    with pytest.raises(RuntimeError) as exc_info:
-        mod._find_binary(tmp_path, "lintro-linux-arm64")
-
-    assert_that(str(exc_info.value)).contains("Ambiguous binary artifact")
+    assert_that(found).is_none()
 
 
 def test_find_binary_returns_none_when_missing(tmp_path: Path) -> None:
@@ -116,16 +102,15 @@ def test_stage_binaries_missing_artifact_raises(tmp_path: Path) -> None:
     assert_that(str(exc_info.value)).contains("Missing binary artifact")
 
 
-def test_main_reports_ambiguity_as_failure(tmp_path: Path) -> None:
-    """The CLI exits non-zero when an artifact name is ambiguous."""
+def test_main_reports_missing_artifact_as_failure(tmp_path: Path) -> None:
+    """The CLI exits non-zero when an artifact only exists off-layout."""
     mod = _load_module()
     artifacts = tmp_path / "artifacts"
     for artifact_name in mod.BINARY_MAP:
         _write_binary(artifacts / artifact_name / artifact_name)
-    _write_binary(artifacts / "duplicate" / "lintro-macos-arm64")
-    # Remove the direct layout so the ambiguous fallback path is exercised.
+    # Move one binary out of the direct layout; it must not be picked up.
     (artifacts / "lintro-macos-arm64" / "lintro-macos-arm64").unlink()
-    _write_binary(artifacts / "another" / "lintro-macos-arm64")
+    _write_binary(artifacts / "elsewhere" / "lintro-macos-arm64")
 
     exit_code = mod.main(["--artifacts-dir", str(artifacts)])
 

--- a/tests/scripts/test_sync_npm_version.py
+++ b/tests/scripts/test_sync_npm_version.py
@@ -62,14 +62,14 @@ def _make_npm_tree(root: Path, version: str) -> Path:
             "name": "lintro",
             "version": version,
             "optionalDependencies": {
-                f"@lintro/{plat}": version for plat in mod.PLATFORM_PACKAGES
+                f"@lgtm-hq/lintro-{plat}": version for plat in mod.PLATFORM_PACKAGES
             },
         },
     )
     for plat in mod.PLATFORM_PACKAGES:
         _write_manifest(
             npm_dir / plat / "package.json",
-            {"name": f"@lintro/{plat}", "version": version},
+            {"name": f"@lgtm-hq/lintro-{plat}", "version": version},
         )
     return npm_dir
 

--- a/tests/scripts/test_sync_npm_version.py
+++ b/tests/scripts/test_sync_npm_version.py
@@ -1,0 +1,163 @@
+"""Tests for the npm version-sync script.
+
+Covers version discovery, in-repo internal consistency, and the write/check
+round-trip against a temporary ``npm/`` tree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from assertpy import assert_that
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "ci" / "npm" / "sync_npm_version.py"
+
+
+def _load_module() -> ModuleType:
+    """Import sync_npm_version without executing its CLI.
+
+    Returns:
+        The loaded module.
+    """
+    spec = importlib.util.spec_from_file_location("sync_npm_version", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["sync_npm_version"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_manifest(path: Path, data: dict[str, object]) -> None:
+    """Write a package.json fixture.
+
+    Args:
+        path: Destination manifest path.
+        data: JSON-serialisable manifest content.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _make_npm_tree(root: Path, version: str) -> Path:
+    """Create a minimal npm/ tree with meta + platform manifests.
+
+    Args:
+        root: Temporary base directory.
+        version: Version string to seed every manifest with.
+
+    Returns:
+        The created ``npm/`` directory.
+    """
+    npm_dir = root / "npm"
+    mod = _load_module()
+    _write_manifest(
+        npm_dir / mod.META_PACKAGE / "package.json",
+        {
+            "name": "lintro",
+            "version": version,
+            "optionalDependencies": {
+                f"@lintro/{plat}": version for plat in mod.PLATFORM_PACKAGES
+            },
+        },
+    )
+    for plat in mod.PLATFORM_PACKAGES:
+        _write_manifest(
+            npm_dir / plat / "package.json",
+            {"name": f"@lintro/{plat}", "version": version},
+        )
+    return npm_dir
+
+
+# ---------------------------------------------------------------------------
+# Version discovery
+# ---------------------------------------------------------------------------
+
+
+def test_read_project_version_matches_init() -> None:
+    """read_project_version returns the __version__ from lintro/__init__.py."""
+    mod = _load_module()
+    init_text = (_REPO_ROOT / "lintro" / "__init__.py").read_text(encoding="utf-8")
+    assert_that(init_text).contains(f'__version__ = "{mod.read_project_version()}"')
+
+
+def test_normalise_version_strips_leading_v() -> None:
+    """A leading 'v' is stripped from tag-style versions."""
+    mod = _load_module()
+    assert_that(mod._normalise_version("v1.2.3")).is_equal_to("1.2.3")
+    assert_that(mod._normalise_version("1.2.3")).is_equal_to("1.2.3")
+
+
+# ---------------------------------------------------------------------------
+# In-repo manifests
+# ---------------------------------------------------------------------------
+
+
+def test_repo_manifests_are_internally_consistent() -> None:
+    """Every shipped npm manifest agrees with the meta-package version."""
+    mod = _load_module()
+    meta_version = mod.read_meta_version()
+    mismatches = mod.check_versions(meta_version)
+    assert_that(mismatches).is_empty()
+
+
+def test_all_manifest_paths_covers_five_packages() -> None:
+    """The tree exposes exactly the meta package plus four platforms."""
+    mod = _load_module()
+    paths = mod.all_manifest_paths()
+    assert_that(paths).is_length(5)
+
+
+# ---------------------------------------------------------------------------
+# check / sync round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_check_versions_detects_drift(tmp_path: Path) -> None:
+    """A platform manifest that lags the meta version is reported."""
+    mod = _load_module()
+    npm_dir = _make_npm_tree(tmp_path, "1.0.0")
+    drifting = npm_dir / "linux-x64" / "package.json"
+    data = json.loads(drifting.read_text(encoding="utf-8"))
+    data["version"] = "0.9.0"
+    drifting.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    mismatches = mod.check_versions("1.0.0", npm_dir=npm_dir)
+
+    assert_that(mismatches).is_length(1)
+    assert_that(mismatches[0].manifest).contains("linux-x64")
+    assert_that(mismatches[0].found).is_equal_to("0.9.0")
+
+
+def test_sync_versions_updates_all_fields(tmp_path: Path) -> None:
+    """sync_versions rewrites top-level and optionalDependency versions."""
+    mod = _load_module()
+    npm_dir = _make_npm_tree(tmp_path, "0.0.0-dev")
+
+    changed = mod.sync_versions("2.3.4", npm_dir=npm_dir)
+
+    assert_that(changed).is_length(5)
+    assert_that(mod.check_versions("2.3.4", npm_dir=npm_dir)).is_empty()
+
+    meta = json.loads(
+        (npm_dir / "lintro" / "package.json").read_text(encoding="utf-8"),
+    )
+    assert_that(meta["version"]).is_equal_to("2.3.4")
+    for pin in meta["optionalDependencies"].values():
+        assert_that(pin).is_equal_to("2.3.4")
+
+
+def test_sync_versions_is_idempotent(tmp_path: Path) -> None:
+    """Re-running sync at the same version reports no further changes."""
+    mod = _load_module()
+    npm_dir = _make_npm_tree(tmp_path, "0.0.0-dev")
+
+    mod.sync_versions("2.3.4", npm_dir=npm_dir)
+    second = mod.sync_versions("2.3.4", npm_dir=npm_dir)
+
+    assert_that(second).is_empty()

--- a/tests/unit/tools/core/test_install_context.py
+++ b/tests/unit/tools/core/test_install_context.py
@@ -229,12 +229,12 @@ def test_detect_homebrew_install_context(
     ("install_file", "executable"),
     [
         (
-            "/proj/node_modules/@lintro/darwin-arm64/bin/lintro",
+            "/proj/node_modules/@lgtm-hq/lintro-darwin-arm64/bin/lintro",
             "/usr/bin/node",
         ),
         (
             "/proj/lintro/tools/core/install_context.py",
-            "/proj/node_modules/@lintro/linux-x64/bin/lintro",
+            "/proj/node_modules/@lgtm-hq/lintro-linux-x64/bin/lintro",
         ),
     ],
 )
@@ -243,7 +243,7 @@ def test_detect_npm_bin_install_context(
     executable: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Detect NPM_BIN when the resolved path is under node_modules/@lintro/.
+    """Detect NPM_BIN when the resolved path is under node_modules/@lgtm-hq/lintro-.
 
     Args:
         install_file: Simulated module ``__file__``.

--- a/tests/unit/tools/core/test_install_context.py
+++ b/tests/unit/tools/core/test_install_context.py
@@ -225,6 +225,58 @@ def test_detect_homebrew_install_context(
     assert_that(result).is_equal_to(expected)
 
 
+@pytest.mark.parametrize(
+    ("install_file", "executable"),
+    [
+        (
+            "/proj/node_modules/@lintro/darwin-arm64/bin/lintro",
+            "/usr/bin/node",
+        ),
+        (
+            "/proj/lintro/tools/core/install_context.py",
+            "/proj/node_modules/@lintro/linux-x64/bin/lintro",
+        ),
+    ],
+)
+def test_detect_npm_bin_install_context(
+    install_file: str,
+    executable: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detect NPM_BIN when the resolved path is under node_modules/@lintro/.
+
+    Args:
+        install_file: Simulated module ``__file__``.
+        executable: Simulated ``sys.executable``.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.delenv("LINTRO_DOCKER", raising=False)
+    monkeypatch.delenv("CONTAINER", raising=False)
+
+    with (
+        patch(
+            "lintro.tools.core.install_context.os.path.exists",
+            return_value=False,
+        ),
+        patch(
+            "lintro.tools.core.install_context.__file__",
+            install_file,
+            create=True,
+        ),
+        patch(
+            "lintro.tools.core.install_context.sys.executable",
+            executable,
+        ),
+        patch(
+            "lintro.tools.core.install_context.os.path.realpath",
+            side_effect=lambda path: path,
+        ),
+    ):
+        result = _detect_install_context()
+
+    assert_that(result).is_equal_to(InstallContext.NPM_BIN)
+
+
 # ---------------------------------------------------------------------------
 # CI detection
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1044,7 +1044,7 @@ wheels = [
 
 [[package]]
 name = "lintro"
-version = "0.66.0"
+version = "0.68.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `feat(install): distribute lintro as npm package via platform binaries`

- Type:
  - [x] feat (minor)

- Breaking change:
  - [ ] none

## What’s Changing

Adds the foundational slice of npm distribution for lintro (issue #932),
following the esbuild/Biome model: a `lintro` meta-package that selects and
launches a self-contained Nuitka binary shipped by a platform-specific
`@lintro/<platform>` optional dependency. Zero Python required for consumers.

This PR delivers the package structure, wrapper/launcher, Linux build support,
install-context awareness, and a **dry-run-only** publish skeleton. Live
publishing is intentionally deferred (see below).

### Included

- **npm package tree** (`npm/`):
  - `lintro` meta-package: `bin/lintro` launcher + pure, unit-tested
    resolver (`lib/resolve.js`) mapping `platform-arch` → scoped package,
    with `optionalDependencies` on all four platforms.
  - `@lintro/{darwin-arm64,darwin-x64,linux-arm64,linux-x64}` packages with
    `os`/`cpu` fields and an `index.js` exporting the binary path. Binaries
    are injected at publish time; repo carries `0.0.0-dev` placeholders.
- **Linux builds**: `scripts/build/build_linux.py` (mirrors `build_macos.py`,
  native-only per arch) and a `build-linux` matrix job in `build-binary.yml`
  (`ubuntu-24.04` x64 + `ubuntu-24.04-arm` arm64) uploading
  `lintro-linux-x64` / `lintro-linux-arm64`.
- **Install context**: `InstallContext.NPM_BIN` enum + detection when the
  executable resolves under `node_modules/@lintro/` (checked before Homebrew).
- **Publish skeleton** (`.github/workflows/publish-npm.yml`): downloads release
  binaries, stages them, injects the version, smoke-tests the launcher, and
  runs `npm publish --dry-run`. SHA-pinned actions, `harden-runner` with
  `registry.npmjs.org` allowed. Helper scripts under `scripts/ci/npm/`.
- **Version sync**: `scripts/ci/npm/sync_npm_version.py` keeps every manifest
  and the meta-package's `@lintro/*` pins in lock-step; `--check` guards
  consistency, `--version` injects a release tag.
- **Docs**: `docs/npm-distribution.md` design summary.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated
- [x] `uv run lintro chk` / `fmt` clean; full `uv run pytest` green except the
      two known env-only pre-existing failures
      (`test_markdownlint_direct_vs_lintro_parity`,
      `test_prepare_execution_version_check_fails_returns_early_result`)

## Related Issues

Refs #932

## Details

### Design

Meta-package + `optionalDependencies` is npm/bun's native mechanism for
platform selection: the registry filters candidates by `os`/`cpu`, so a user
only ever downloads their platform's binary. The launcher is a ~30-line
CommonJS shim; all branching logic lives in a pure `resolveBinary()` that is
covered by `bun test` (platform mapping, prototype-pollution safety,
missing-package and missing-path error paths).

### Publishing is dry-run only (deferred)

Per scope, this PR does **not** publish anything. `publish_packages.sh` always
passes `--dry-run` unless `LIVE=1`, which is never set by any workflow here.
Going live is a deliberate follow-up requiring:

- the `@lintro` npm org (or a fallback scope) to exist,
- a `NODE_AUTH_TOKEN` secret, and
- wiring `publish-npm.yml` into the release pipeline via `workflow_call`.

### Deferred to follow-ups (from the issue's phases)

- Phase 3 `lintro doctor` npm-aware upgrade hints (kept out of the 879-line
  `doctor.py` to avoid churn/conflicts; detection + enum landed).
- Phase 5 wiring npm version bump into `semantic_release_compute_next.py`
  (publish-time injection is implemented and preferred; repo-side bump can be
  added later).
- `BinaryStrategy`/`install-tools.sh` Linux enhancements for npm context.
- Windows (`win32-x64`) support.

### Testing

- `bun test` in `npm/lintro` (9 tests): resolution + error paths.
- `tests/scripts/test_sync_npm_version.py`: version discovery, drift
  detection, write/check round-trip, idempotence.
- `tests/unit/tools/core/test_install_context.py`: `NPM_BIN` detection.
- Local end-to-end dry-run of stage → sync → launcher resolution with stub
  binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added npm distribution support with platform-specific packages and a meta-package launcher.
  * Added Linux and macOS binary build/publish workflows, including release artifact uploads and checksums.
  * Added npm version syncing, staging, download, publish, and smoke-test scripts.

* **Bug Fixes**
  * Improved install-source detection for npm-installed runs to avoid misclassification.

* **Documentation**
  * Added docs for npm packaging, publishing, and distribution flow.

* **Tests**
  * Added coverage for binary staging, npm version syncing, platform resolution, and install-context detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds npm package distribution for the lintro CLI. The main changes are:

- A `lintro` npm meta-package with platform package resolution.
- Platform-specific `@lgtm-hq/lintro-*` packages for macOS and Linux binaries.
- Linux binary build support in the release workflow.
- Dry-run npm publish workflow and helper scripts.
- Install-context detection for npm-installed binaries.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/npm/stage_binaries.py | Stages only binaries from the expected release-download layout and fails when artifacts are missing. |
| scripts/ci/npm/download_release_binaries.sh | Downloads each release binary into the layout consumed by the staging script. |
| npm/lintro/lib/resolve.js | Resolves the current platform package and reports missing optional dependency cases with recovery guidance. |
| .github/workflows/publish-npm.yml | Runs the dry-run npm packaging flow from release download through staging, version sync, smoke test, and publish dry-run. |

</details>

<sub>Reviews (7): Last reviewed commit: ["fix(npm): rethrow non-MODULE\_NOT\_FOUND l..."](https://github.com/lgtm-hq/py-lintro/commit/c28c3f547620e2403e5eef5477c8a20d46206743) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42171660)</sub>

<!-- /greptile_comment -->