### PR TITLE
feat(tools): add golangci-lint Go meta-linter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ system.
 <td><code>bun add -g @commitlint/cli @commitlint/config-conventional</code><br><code>brew install commitlint</code></td>
 </tr>
 <tr>
+<td><a href="https://github.com/golangci/golangci-lint"><img src="https://img.shields.io/badge/golangci--lint-00ADD8?logo=go&logoColor=white" alt="golangci-lint"></a></td>
+<td>🐹 Go</td>
+<td>✅</td>
+<td><code>brew install golangci-lint</code><br><a href="https://golangci-lint.run/welcome/install/">Install docs</a></td>
+</tr>
+<tr>
 <td><a href="https://github.com/hadolint/hadolint"><img src="https://img.shields.io/badge/Hadolint-2496ED?logo=docker&logoColor=white" alt="Hadolint"></a></td>
 <td>🐳 Dockerfile</td>
 <td>-</td>

--- a/docker/tools.Dockerfile
+++ b/docker/tools.Dockerfile
@@ -116,6 +116,7 @@ RUN echo "=== Verifying all tools ===" && \
     rustfmt --version && cargo clippy --version && cargo audit --version && \
     cargo deny --version && actionlint --version && bandit --version && \
     black --version && commitlint --version && gitleaks version && \
+    golangci-lint version && \
     hadolint --version && \
     markdownlint-cli2 --version && mypy --version && osv-scanner --version && \
     oxfmt --version && oxlint --version && prettier --version && \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1761,6 +1761,55 @@ lintro format --tools clippy
 lintro check src/ --tools clippy
 ```
 
+#### golangci-lint Configuration
+
+golangci-lint is the de-facto Go meta-linter, running 100+ sub-linters in parallel.
+Lintro targets golangci-lint **v2** and automatically discovers Go modules by finding
+`go.mod` files; non-Go projects are skipped. It requires the Go toolchain to be
+installed. Linter selection and rule tuning are configured through the project's
+native config file.
+
+**Installation:**
+
+```bash
+brew install golangci-lint
+# or see https://golangci-lint.run/welcome/install/
+```
+
+**File:** `.golangci.yml` (also `.golangci.yaml`, `.golangci.toml`, `.golangci.json`)
+
+```yaml
+version: "2"
+linters:
+  enable:
+    - errcheck
+    - staticcheck
+    - ineffassign
+    - govet
+```
+
+**Available Options:**
+
+| Option    | Type    | Description                          |
+| --------- | ------- | ------------------------------------ |
+| `timeout` | integer | Execution timeout in seconds (120)   |
+
+Linter enable/disable and per-linter settings live in the native `.golangci.*`
+config file rather than as lintro `--tool-options`.
+
+**Lintro usage:**
+
+```bash
+# Check Go code with golangci-lint
+lintro check --tools golangci_lint
+
+# Auto-fix issues where the underlying linters support it
+lintro format --tools golangci_lint
+
+# Increase the timeout for a large module
+lintro check --tools golangci_lint --tool-options golangci_lint:timeout=300
+```
+
 #### Cargo-deny Configuration
 
 Cargo-deny checks Rust dependencies for license compliance, security advisories, banned

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1766,8 +1766,8 @@ lintro check src/ --tools clippy
 golangci-lint is the de-facto Go meta-linter, running 100+ sub-linters in parallel.
 Lintro targets golangci-lint **v2** and automatically discovers Go modules by finding
 `go.mod` files; non-Go projects are skipped. It requires the Go toolchain to be
-installed. Linter selection and rule tuning are configured through the project's
-native config file.
+installed. Linter selection and rule tuning are configured through the project's native
+config file.
 
 **Installation:**
 
@@ -1779,7 +1779,7 @@ brew install golangci-lint
 **File:** `.golangci.yml` (also `.golangci.yaml`, `.golangci.toml`, `.golangci.json`)
 
 ```yaml
-version: "2"
+version: '2'
 linters:
   enable:
     - errcheck
@@ -1790,12 +1790,12 @@ linters:
 
 **Available Options:**
 
-| Option    | Type    | Description                          |
-| --------- | ------- | ------------------------------------ |
-| `timeout` | integer | Execution timeout in seconds (120)   |
+| Option    | Type    | Description                        |
+| --------- | ------- | ---------------------------------- |
+| `timeout` | integer | Execution timeout in seconds (120) |
 
-Linter enable/disable and per-linter settings live in the native `.golangci.*`
-config file rather than as lintro `--tool-options`.
+Linter enable/disable and per-linter settings live in the native `.golangci.*` config
+file rather than as lintro `--tool-options`.
 
 **Lintro usage:**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,8 +94,8 @@ Some tools require separate installation. Their minimum versions are also manage
   `pip install semgrep`, or `brew install semgrep`)
 - `gitleaks` - Secret detection in git repos (`brew install gitleaks` or GitHub
   releases)
-- `golangci-lint` - Go meta-linter running 100+ linters (`brew install golangci-lint`
-  or <https://golangci-lint.run/welcome/install/>; requires the Go toolchain)
+- `golangci-lint` - Go meta-linter running 100+ linters (`brew install golangci-lint` or
+  <https://golangci-lint.run/welcome/install/>; requires the Go toolchain)
 - `shellcheck` - Shell script analyzer (`brew install shellcheck` or GitHub releases)
 - `shfmt` - Shell script formatter (`brew install shfmt` or GitHub releases)
 - `dotenv-linter` - `.env` file linter and fixer (`brew install dotenv-linter`,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,6 +94,8 @@ Some tools require separate installation. Their minimum versions are also manage
   `pip install semgrep`, or `brew install semgrep`)
 - `gitleaks` - Secret detection in git repos (`brew install gitleaks` or GitHub
   releases)
+- `golangci-lint` - Go meta-linter running 100+ linters (`brew install golangci-lint`
+  or <https://golangci-lint.run/welcome/install/>; requires the Go toolchain)
 - `shellcheck` - Shell script analyzer (`brew install shellcheck` or GitHub releases)
 - `shfmt` - Shell script formatter (`brew install shfmt` or GitHub releases)
 - `dotenv-linter` - `.env` file linter and fixer (`brew install dotenv-linter`,

--- a/docs/tool-analysis/golangci-lint-analysis.md
+++ b/docs/tool-analysis/golangci-lint-analysis.md
@@ -57,8 +57,9 @@ lossless for the tool, and golangci-lint is not among its SARIF-native candidate
 - Whole-module scan (`./...`), mirroring the compiled-language pattern used by the
   Clippy plugin. Because execution changes to the module root and runs `./...`,
   golangci-lint analyzes every file in each selected module — file-level lintro exclude
-  patterns do not scope the scan (golangci-lint's own `.golangci.yml`
-  `issues.exclude`/`skip-files` settings are the way to exclude paths)
+  patterns do not scope the scan (golangci-lint v2's own `.golangci.yml`
+  `linters.exclusions.paths`/`formatters.exclusions.paths` settings are the way to
+  exclude paths, and `linters.exclusions.rules` suppresses specific findings)
 - Times out after a configurable default (120s)
 - A blank `Severity` normalizes to `WARNING`; an explicit `Severity` is kept
 - The parser tolerates a trailing human-readable stats footer and ANSI codes

--- a/docs/tool-analysis/golangci-lint-analysis.md
+++ b/docs/tool-analysis/golangci-lint-analysis.md
@@ -2,15 +2,15 @@
 
 ## Overview
 
-[golangci-lint](https://golangci-lint.run/) is the de-facto Go meta-linter. It
-runs 100+ sub-linters (errcheck, staticcheck, ineffassign, govet, gosec,
-misspell, ...) in parallel with aggressive caching. lintro integrates it as a
-module-context linter: it requires a Go module (`go.mod`) and the Go toolchain,
-and skips cleanly for non-Go projects.
+[golangci-lint](https://golangci-lint.run/) is the de-facto Go meta-linter. It runs 100+
+sub-linters (errcheck, staticcheck, ineffassign, govet, gosec, misspell, ...) in
+parallel with aggressive caching. lintro integrates it as a module-context linter: it
+requires a Go module (`go.mod`) and the Go toolchain, and skips cleanly for non-Go
+projects.
 
 This plugin targets **golangci-lint v2**. The v2 CLI replaced the v1
-`--out-format <fmt>` flag with per-format `--output.<fmt>.path` options and
-changed the config schema (`version: "2"`); v1 is not supported.
+`--out-format <fmt>` flag with per-format `--output.<fmt>.path` options and changed the
+config schema (`version: "2"`); v1 is not supported.
 
 ## Core Tool Capabilities
 
@@ -22,10 +22,9 @@ changed the config schema (`version: "2"`); v1 is not supported.
 
 ## Parser Choice: native JSON (not SARIF)
 
-golangci-lint can emit SARIF (`--output.sarif.path`), but its SARIF export is
-**lossy** for lintro's model, per the fidelity checklist in
-`docs/design/sarif-ingestion-evaluation.md`. Comparing both formats on the same
-run:
+golangci-lint can emit SARIF (`--output.sarif.path`), but its SARIF export is **lossy**
+for lintro's model, per the fidelity checklist in
+`docs/design/sarif-ingestion-evaluation.md`. Comparing both formats on the same run:
 
 | Signal                 | Native JSON                           | golangci-lint SARIF                     |
 | ---------------------- | ------------------------------------- | --------------------------------------- |
@@ -34,12 +33,11 @@ run:
 | Fix / autofix metadata | `SuggestedFixes` / `Replacement`      | **no `fixes[]` at all**                 |
 | Doc URLs               | synthesized from linter name (lintro) | **no `rules[]` / `helpUri`**            |
 
-SARIF would collapse every finding to `error` (dropping the configurable
-per-issue severity), drop all autofix metadata (so lintro could not surface
-which issues are fixable), and omit rule metadata (no doc URLs). A native JSON
-parser is therefore used. This matches the evaluation's guidance to use the
-shared SARIF parser only when it is lossless for the tool, and golangci-lint is
-not among its SARIF-native candidates.
+SARIF would collapse every finding to `error` (dropping the configurable per-issue
+severity), drop all autofix metadata (so lintro could not surface which issues are
+fixable), and omit rule metadata (no doc URLs). A native JSON parser is therefore used.
+This matches the evaluation's guidance to use the shared SARIF parser only when it is
+lossless for the tool, and golangci-lint is not among its SARIF-native candidates.
 
 ## Lintro Implementation Analysis
 
@@ -47,18 +45,18 @@ not among its SARIF-native candidates.
 
 - Executes `golangci-lint run --output.json.path stdout --show-stats=false ./...`
 - Autofix path runs `golangci-lint run --fix ./...`, then re-checks
-- Parses JSON `Issues[]` into structured issues (linter, position, message,
-  severity, fixable)
-- Discovers the Go module root (`go.mod`) from provided paths; respects lintro
-  exclude patterns
+- Parses JSON `Issues[]` into structured issues (linter, position, message, severity,
+  fixable)
+- Discovers the Go module root (`go.mod`) from provided paths; respects lintro exclude
+  patterns
 - Per-linter documentation links via `https://golangci-lint.run/usage/linters/#<linter>`
 
 ### ⚠️ Defaults and Notes
 
-- Requires `go.mod` and the Go toolchain; otherwise returns success with a
-  skip message ("No go.mod found; skipping golangci-lint.")
-- Whole-module scan (`./...`), mirroring the compiled-language pattern used by
-  the Clippy plugin
+- Requires `go.mod` and the Go toolchain; otherwise returns success with a skip message
+  ("No go.mod found; skipping golangci-lint.")
+- Whole-module scan (`./...`), mirroring the compiled-language pattern used by the
+  Clippy plugin
 - Times out after a configurable default (120s)
 - A blank `Severity` normalizes to `WARNING`; an explicit `Severity` is kept
 - The parser tolerates a trailing human-readable stats footer and ANSI codes
@@ -89,12 +87,11 @@ result = tool.fix(["path/to/go/module"])
 ## Configuration Strategy
 
 - Minimum/recommended version tracked in `lintro/_tool_versions.py` and
-  `lintro/tools/manifest.json` (kept in sync by the manifest generator;
-  bumped by Renovate via `golangci/golangci-lint` GitHub releases)
-- Uses the system `golangci-lint`; install via `brew install golangci-lint` or
-  the official installer at <https://golangci-lint.run/welcome/install/>
-- Native configs: `.golangci.yml`, `.golangci.yaml`, `.golangci.toml`,
-  `.golangci.json`
+  `lintro/tools/manifest.json` (kept in sync by the manifest generator; bumped by
+  Renovate via `golangci/golangci-lint` GitHub releases)
+- Uses the system `golangci-lint`; install via `brew install golangci-lint` or the
+  official installer at <https://golangci-lint.run/welcome/install/>
+- Native configs: `.golangci.yml`, `.golangci.yaml`, `.golangci.toml`, `.golangci.json`
 - File patterns: `*.go`, `go.mod`
 - Timeout configurable via tool options
 
@@ -114,8 +111,8 @@ See <https://golangci-lint.run/usage/linters/> for the full, versioned list.
 
 ## ⚠️ Limited/Missing Features
 
-- Sub-linter selection/config is delegated to the project's `.golangci.*` file
-  rather than exposed as lintro options
+- Sub-linter selection/config is delegated to the project's `.golangci.*` file rather
+  than exposed as lintro options
 - Only the primary position of each finding is captured (start line/column)
 - SARIF output is intentionally not consumed (see
   [Parser Choice](#parser-choice-native-json-not-sarif))

--- a/docs/tool-analysis/golangci-lint-analysis.md
+++ b/docs/tool-analysis/golangci-lint-analysis.md
@@ -1,0 +1,126 @@
+# golangci-lint Tool Analysis
+
+## Overview
+
+[golangci-lint](https://golangci-lint.run/) is the de-facto Go meta-linter. It
+runs 100+ sub-linters (errcheck, staticcheck, ineffassign, govet, gosec,
+misspell, ...) in parallel with aggressive caching. lintro integrates it as a
+module-context linter: it requires a Go module (`go.mod`) and the Go toolchain,
+and skips cleanly for non-Go projects.
+
+This plugin targets **golangci-lint v2**. The v2 CLI replaced the v1
+`--out-format <fmt>` flag with per-format `--output.<fmt>.path` options and
+changed the config schema (`version: "2"`); v1 is not supported.
+
+## Core Tool Capabilities
+
+- Runs via `golangci-lint run` over a Go module (`./...`)
+- Aggregates dozens of sub-linters; each finding is attributed to its linter
+- Machine-readable JSON via `--output.json.path stdout`
+- Autofix for supported linters via `--fix`
+- YAML/TOML/JSON configuration (`.golangci.yml` and variants)
+
+## Parser Choice: native JSON (not SARIF)
+
+golangci-lint can emit SARIF (`--output.sarif.path`), but its SARIF export is
+**lossy** for lintro's model, per the fidelity checklist in
+`docs/design/sarif-ingestion-evaluation.md`. Comparing both formats on the same
+run:
+
+| Signal                 | Native JSON                           | golangci-lint SARIF                     |
+| ---------------------- | ------------------------------------- | --------------------------------------- |
+| Sub-linter attribution | `Issues[].FromLinter`                 | `results[].ruleId` (preserved)          |
+| Severity               | per-issue `Severity` (configurable)   | **hard-coded `level: "error"`** for all |
+| Fix / autofix metadata | `SuggestedFixes` / `Replacement`      | **no `fixes[]` at all**                 |
+| Doc URLs               | synthesized from linter name (lintro) | **no `rules[]` / `helpUri`**            |
+
+SARIF would collapse every finding to `error` (dropping the configurable
+per-issue severity), drop all autofix metadata (so lintro could not surface
+which issues are fixable), and omit rule metadata (no doc URLs). A native JSON
+parser is therefore used. This matches the evaluation's guidance to use the
+shared SARIF parser only when it is lossless for the tool, and golangci-lint is
+not among its SARIF-native candidates.
+
+## Lintro Implementation Analysis
+
+### ✅ Preserved Features
+
+- Executes `golangci-lint run --output.json.path stdout --show-stats=false ./...`
+- Autofix path runs `golangci-lint run --fix ./...`, then re-checks
+- Parses JSON `Issues[]` into structured issues (linter, position, message,
+  severity, fixable)
+- Discovers the Go module root (`go.mod`) from provided paths; respects lintro
+  exclude patterns
+- Per-linter documentation links via `https://golangci-lint.run/usage/linters/#<linter>`
+
+### ⚠️ Defaults and Notes
+
+- Requires `go.mod` and the Go toolchain; otherwise returns success with a
+  skip message ("No go.mod found; skipping golangci-lint.")
+- Whole-module scan (`./...`), mirroring the compiled-language pattern used by
+  the Clippy plugin
+- Times out after a configurable default (120s)
+- A blank `Severity` normalizes to `WARNING`; an explicit `Severity` is kept
+- The parser tolerates a trailing human-readable stats footer and ANSI codes
+
+### 🚀 Enhancements
+
+- Normalized `ToolResult` with issue counts and fix metrics
+- `fixable` derived from `SuggestedFixes`/`Replacement` presence
+- Integrates with the unified runner, timeout handling, and doctor health check
+
+## Usage Comparison
+
+### Core golangci-lint
+
+```bash
+golangci-lint run --output.json.path stdout --show-stats=false ./...
+golangci-lint run --fix ./...
+```
+
+### Lintro Wrapper
+
+```python
+tool = GolangciLintPlugin()
+result = tool.check(["path/to/go/module"])
+result = tool.fix(["path/to/go/module"])
+```
+
+## Configuration Strategy
+
+- Minimum/recommended version tracked in `lintro/_tool_versions.py` and
+  `lintro/tools/manifest.json` (kept in sync by the manifest generator;
+  bumped by Renovate via `golangci/golangci-lint` GitHub releases)
+- Uses the system `golangci-lint`; install via `brew install golangci-lint` or
+  the official installer at <https://golangci-lint.run/welcome/install/>
+- Native configs: `.golangci.yml`, `.golangci.yaml`, `.golangci.toml`,
+  `.golangci.json`
+- File patterns: `*.go`, `go.mod`
+- Timeout configurable via tool options
+
+## Included Linters (selection)
+
+golangci-lint bundles 100+ linters. A representative subset:
+
+- **errcheck** — unchecked error return values
+- **govet** — `go vet` correctness checks
+- **staticcheck** — comprehensive static analysis
+- **ineffassign** — ineffectual assignments
+- **unused** — unused code
+- **gosec** — security issues
+- **misspell** — common English misspellings (autofixable)
+
+See <https://golangci-lint.run/usage/linters/> for the full, versioned list.
+
+## ⚠️ Limited/Missing Features
+
+- Sub-linter selection/config is delegated to the project's `.golangci.*` file
+  rather than exposed as lintro options
+- Only the primary position of each finding is captured (start line/column)
+- SARIF output is intentionally not consumed (see
+  [Parser Choice](#parser-choice-native-json-not-sarif))
+
+## References
+
+- <https://golangci-lint.run/>
+- <https://github.com/golangci/golangci-lint>

--- a/docs/tool-analysis/golangci-lint-analysis.md
+++ b/docs/tool-analysis/golangci-lint-analysis.md
@@ -47,8 +47,7 @@ lossless for the tool, and golangci-lint is not among its SARIF-native candidate
 - Autofix path runs `golangci-lint run --fix ./...`, then re-checks
 - Parses JSON `Issues[]` into structured issues (linter, position, message, severity,
   fixable)
-- Discovers the Go module root (`go.mod`) from provided paths; respects lintro exclude
-  patterns
+- Discovers the Go module root (`go.mod`) from provided paths
 - Per-linter documentation links via `https://golangci-lint.run/usage/linters/#<linter>`
 
 ### ⚠️ Defaults and Notes
@@ -56,7 +55,10 @@ lossless for the tool, and golangci-lint is not among its SARIF-native candidate
 - Requires `go.mod` and the Go toolchain; otherwise returns success with a skip message
   ("No go.mod found; skipping golangci-lint.")
 - Whole-module scan (`./...`), mirroring the compiled-language pattern used by the
-  Clippy plugin
+  Clippy plugin. Because execution changes to the module root and runs `./...`,
+  golangci-lint analyzes every file in each selected module — file-level lintro
+  exclude patterns do not scope the scan (golangci-lint's own `.golangci.yml`
+  `issues.exclude`/`skip-files` settings are the way to exclude paths)
 - Times out after a configurable default (120s)
 - A blank `Severity` normalizes to `WARNING`; an explicit `Severity` is kept
 - The parser tolerates a trailing human-readable stats footer and ANSI codes
@@ -80,8 +82,8 @@ golangci-lint run --fix ./...
 
 ```python
 tool = GolangciLintPlugin()
-result = tool.check(["path/to/go/module"])
-result = tool.fix(["path/to/go/module"])
+result = tool.check(["path/to/go/module"], {})
+result = tool.fix(["path/to/go/module"], {})
 ```
 
 ## Configuration Strategy

--- a/docs/tool-analysis/golangci-lint-analysis.md
+++ b/docs/tool-analysis/golangci-lint-analysis.md
@@ -56,8 +56,8 @@ lossless for the tool, and golangci-lint is not among its SARIF-native candidate
   ("No go.mod found; skipping golangci-lint.")
 - Whole-module scan (`./...`), mirroring the compiled-language pattern used by the
   Clippy plugin. Because execution changes to the module root and runs `./...`,
-  golangci-lint analyzes every file in each selected module — file-level lintro
-  exclude patterns do not scope the scan (golangci-lint's own `.golangci.yml`
+  golangci-lint analyzes every file in each selected module — file-level lintro exclude
+  patterns do not scope the scan (golangci-lint's own `.golangci.yml`
   `issues.exclude`/`skip-files` settings are the way to exclude paths)
 - Times out after a configurable default (120s)
 - A blank `Severity` normalizes to `WARNING`; an explicit `Severity` is kept

--- a/lintro/_tool_versions.py
+++ b/lintro/_tool_versions.py
@@ -65,6 +65,7 @@ TOOL_VERSIONS: dict[ToolName | str, str] = {
     ToolName.CLIPPY: "1.97.1",
     ToolName.DOTENV_LINTER: "4.0.0",
     ToolName.GITLEAKS: "8.30.1",
+    ToolName.GOLANGCI_LINT: "2.12.2",
     ToolName.HADOLINT: "2.14.0",
     ToolName.OSV_SCANNER: "2.4.0",
     ToolName.RUSTC: "1.97.1",

--- a/lintro/enums/doc_url_template.py
+++ b/lintro/enums/doc_url_template.py
@@ -30,6 +30,7 @@ class DocUrlTemplate(StrEnum):
     CARGO_DENY = "https://embarkstudios.github.io/cargo-deny/"
     CLIPPY = "https://rust-lang.github.io/rust-clippy/master/index.html#{code}"
     COMMITLINT = "https://commitlint.js.org/reference/rules.html"
+    GOLANGCI_LINT = "https://golangci-lint.run/usage/linters/#{code}"
     DOTENV_LINTER = "https://dotenv-linter.github.io/#/checks/{code}"
     HADOLINT = "https://github.com/hadolint/hadolint/wiki/{code}"
     MARKDOWNLINT = "https://github.com/DavidAnson/markdownlint/blob/main/doc/{code}.md"

--- a/lintro/enums/tool_name.py
+++ b/lintro/enums/tool_name.py
@@ -21,6 +21,7 @@ class ToolName(StrEnum):
     COMMITLINT = auto()
     DOTENV_LINTER = auto()
     GITLEAKS = auto()
+    GOLANGCI_LINT = auto()
     HADOLINT = auto()
     IDIOM_REVIEW = auto()
     MARKDOWNLINT = auto()

--- a/lintro/parsers/golangci_lint/__init__.py
+++ b/lintro/parsers/golangci_lint/__init__.py
@@ -1,0 +1,8 @@
+"""golangci-lint parser package."""
+
+from lintro.parsers.golangci_lint.golangci_lint_issue import GolangciLintIssue
+from lintro.parsers.golangci_lint.golangci_lint_parser import (
+    parse_golangci_lint_output,
+)
+
+__all__ = ["GolangciLintIssue", "parse_golangci_lint_output"]

--- a/lintro/parsers/golangci_lint/golangci_lint_issue.py
+++ b/lintro/parsers/golangci_lint/golangci_lint_issue.py
@@ -1,0 +1,34 @@
+"""Models for golangci-lint issues."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+from lintro.parsers.base_issue import BaseIssue
+
+
+@dataclass
+class GolangciLintIssue(BaseIssue):
+    """Represents a golangci-lint issue.
+
+    golangci-lint aggregates many sub-linters (errcheck, staticcheck,
+    ineffassign, ...). The originating sub-linter name is surfaced as the
+    issue ``code`` so it appears in lintro's unified output.
+
+    Attributes:
+        DISPLAY_FIELD_MAP: Mapping of display field names to attribute names.
+        code: Originating sub-linter name (e.g., "errcheck", "staticcheck").
+        level: Severity level reported by golangci-lint (e.g., "error",
+            "warning"); may be empty when golangci-lint does not classify it.
+        fixable: Whether golangci-lint offers an autofix for this issue.
+    """
+
+    DISPLAY_FIELD_MAP: ClassVar[dict[str, str]] = {
+        **BaseIssue.DISPLAY_FIELD_MAP,
+        "severity": "level",
+    }
+
+    code: str = field(default="")
+    level: str | None = field(default=None)
+    fixable: bool = field(default=False)

--- a/lintro/parsers/golangci_lint/golangci_lint_parser.py
+++ b/lintro/parsers/golangci_lint/golangci_lint_parser.py
@@ -1,0 +1,136 @@
+"""Parser for golangci-lint JSON output.
+
+golangci-lint (v2) emits a single JSON document via
+``--output.json.path stdout`` with the shape::
+
+    {
+      "Issues": [
+        {
+          "FromLinter": "errcheck",
+          "Text": "Error return value of `os.Open` is not checked",
+          "Severity": "",
+          "Pos": {"Filename": "main.go", "Line": 9, "Column": 9},
+          "SuggestedFixes": [...]        # optional; presence => fixable
+        }
+      ],
+      "Report": {"Linters": [...]}
+    }
+
+A native parser is used rather than golangci-lint's SARIF output because the
+SARIF export is lossy for lintro's model: it hard-codes ``level: "error"`` for
+every finding (dropping the per-issue ``Severity``), omits ``rules[]``/``helpUri``
+(no doc URLs), and carries no ``fixes[]`` (dropping ``SuggestedFixes`` /
+autofix metadata). See ``docs/tool-analysis/golangci-lint-analysis.md``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from loguru import logger
+
+from lintro.parsers.base_parser import strip_ansi_codes
+from lintro.parsers.golangci_lint.golangci_lint_issue import GolangciLintIssue
+
+
+def _parse_issue(item: dict[str, Any]) -> GolangciLintIssue | None:
+    """Convert a single golangci-lint issue object into a ``GolangciLintIssue``.
+
+    Args:
+        item: A single entry from the ``Issues`` array.
+
+    Returns:
+        A populated ``GolangciLintIssue`` or ``None`` when the entry cannot be
+        parsed.
+    """
+    try:
+        message_text = str(item.get("Text", "")).strip()
+        if not message_text:
+            return None
+
+        linter = str(item.get("FromLinter", "")).strip()
+
+        pos = item.get("Pos", {})
+        if not isinstance(pos, dict):
+            pos = {}
+
+        file_name = pos.get("Filename")
+        if not file_name or not isinstance(file_name, str):
+            # Package-level build/config/analysis failures carry no position.
+            # Keep them visible with a placeholder rather than silently
+            # dropping a real failure from the report.
+            file_name = "(module)"
+
+        line_val = pos.get("Line")
+        column_val = pos.get("Column")
+        line = int(line_val) if line_val is not None else 0
+        column = int(column_val) if column_val is not None else 0
+
+        severity_raw = item.get("Severity")
+        severity = str(severity_raw).strip() if severity_raw else None
+
+        # golangci-lint exposes autofixes under either ``SuggestedFixes``
+        # (v2 analyzer edits) or ``Replacement`` (legacy). Either signals
+        # that the finding is fixable via ``--fix``.
+        fixable = bool(item.get("SuggestedFixes")) or bool(item.get("Replacement"))
+
+        return GolangciLintIssue(
+            file=file_name,
+            line=line,
+            column=column,
+            code=linter,
+            message=message_text,
+            level=severity,
+            fixable=fixable,
+        )
+    except (KeyError, TypeError, ValueError) as e:
+        logger.debug(f"Failed to parse golangci-lint issue: {e}")
+        return None
+
+
+def parse_golangci_lint_output(output: str | None) -> list[GolangciLintIssue]:
+    """Parse golangci-lint JSON output into ``GolangciLintIssue`` objects.
+
+    Args:
+        output: Raw stdout emitted by ``golangci-lint run`` with
+            ``--output.json.path stdout``. May be ``None``.
+
+    Returns:
+        A list of ``GolangciLintIssue`` instances. Returns an empty list when
+        there are no issues or the output cannot be decoded.
+    """
+    if not output or not output.strip():
+        return []
+
+    # Strip ANSI codes for consistent parsing across environments.
+    text = strip_ansi_codes(output).strip()
+
+    # golangci-lint may append a human-readable stats footer after the JSON
+    # document. Decode the leading JSON object and ignore any trailing text.
+    start = text.find("{")
+    if start == -1:
+        return []
+
+    try:
+        data, _ = json.JSONDecoder().raw_decode(text[start:])
+    except json.JSONDecodeError as e:
+        logger.debug(f"Failed to decode golangci-lint output: {e}")
+        return []
+
+    if not isinstance(data, dict):
+        return []
+
+    raw_issues = data.get("Issues")
+    if not isinstance(raw_issues, list):
+        return []
+
+    issues: list[GolangciLintIssue] = []
+    for item in raw_issues:
+        if not isinstance(item, dict):
+            continue
+        parsed = _parse_issue(item)
+        if parsed is not None:
+            issues.append(parsed)
+
+    return issues

--- a/lintro/tools/core/command_builders.py
+++ b/lintro/tools/core/command_builders.py
@@ -557,6 +557,7 @@ class StandaloneBuilder(CommandBuilder):
     # Only tools whose binary name differs need an entry here.
     TOOL_BINARY_MAP: ClassVar[dict[str, str]] = {
         "osv_scanner": "osv-scanner",
+        "golangci_lint": "golangci-lint",
         "dotenv_linter": "dotenv-linter",
         "pip_audit": "pip-audit",
     }
@@ -576,6 +577,7 @@ class StandaloneBuilder(CommandBuilder):
                     ToolName.ACTIONLINT,
                     ToolName.DOTENV_LINTER,
                     ToolName.GITLEAKS,
+                    ToolName.GOLANGCI_LINT,
                     ToolName.HADOLINT,
                     ToolName.OSV_SCANNER,
                     ToolName.PIP_AUDIT,

--- a/lintro/tools/core/version_checking.py
+++ b/lintro/tools/core/version_checking.py
@@ -208,6 +208,11 @@ def get_install_hints() -> dict[str, str]:
         "gitleaks": (
             "Install via: https://github.com/gitleaks/gitleaks/releases (v{version}+)"
         ),
+        "golangci_lint": (
+            "Install via: brew install golangci-lint or "
+            "https://golangci-lint.run/welcome/install/ (v{version}+); "
+            "requires the Go toolchain"
+        ),
         "osv_scanner": (
             "Install via: https://github.com/google/osv-scanner/releases (v{version}+)"
         ),

--- a/lintro/tools/core/version_parsing.py
+++ b/lintro/tools/core/version_parsing.py
@@ -40,6 +40,7 @@ TOOLS_WITH_SIMPLE_VERSION_PATTERN: set[ToolName] = {
     ToolName.COMMITLINT,
     ToolName.DOTENV_LINTER,
     ToolName.GITLEAKS,
+    ToolName.GOLANGCI_LINT,
     ToolName.HADOLINT,
     ToolName.OSV_SCANNER,
     ToolName.OXFMT,

--- a/lintro/tools/definitions/golangci_lint.py
+++ b/lintro/tools/definitions/golangci_lint.py
@@ -1,0 +1,455 @@
+"""golangci-lint tool definition.
+
+golangci-lint is the de-facto Go meta-linter, running 100+ sub-linters
+(errcheck, staticcheck, ineffassign, govet, ...) in parallel with caching.
+It runs via ``golangci-lint run`` and requires a Go module context (a
+``go.mod`` file). This plugin targets golangci-lint v2, whose CLI replaced the
+v1 ``--out-format`` flag with ``--output.<format>.path`` options.
+"""
+
+# mypy: ignore-errors
+# Note: mypy errors are suppressed because lintro runs mypy from the file's
+# directory, breaking package resolution. When run properly (mypy lintro/...),
+# this file passes.
+
+from __future__ import annotations
+
+import os
+import subprocess  # nosec B404 - used safely with shell disabled
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lintro._tool_versions import get_min_version
+from lintro.enums.doc_url_template import DocUrlTemplate
+from lintro.enums.tool_name import ToolName
+from lintro.enums.tool_type import ToolType
+from lintro.models.core.tool_result import ToolResult
+from lintro.parsers.golangci_lint.golangci_lint_issue import GolangciLintIssue
+from lintro.parsers.golangci_lint.golangci_lint_parser import (
+    parse_golangci_lint_output,
+)
+from lintro.plugins.base import BaseToolPlugin
+from lintro.plugins.protocol import ToolDefinition
+from lintro.plugins.registry import register_tool
+from lintro.tools.core.option_validators import (
+    filter_none_options,
+    validate_positive_int,
+)
+from lintro.tools.core.timeout_utils import (
+    create_timeout_result,
+    run_subprocess_with_timeout,
+)
+
+# Constants for golangci-lint configuration
+GOLANGCI_LINT_DEFAULT_TIMEOUT: int = 120
+GOLANGCI_LINT_DEFAULT_PRIORITY: int = 85
+GOLANGCI_LINT_FILE_PATTERNS: list[str] = ["*.go", "go.mod"]
+
+
+def _find_go_module_roots(paths: list[str]) -> list[Path]:
+    """Return the distinct ``go.mod`` module roots covering the given paths.
+
+    When the selected paths span multiple Go modules that share a common
+    parent with its own ``go.mod``, that single parent is returned; otherwise
+    each distinct module root is returned so every selected module is linted.
+
+    Args:
+        paths: List of file paths to search from.
+
+    Returns:
+        Sorted list of module root directories (empty when none found).
+    """
+    roots: list[Path] = []
+    for raw_path in paths:
+        current = Path(raw_path).resolve()
+        if current.is_file():
+            current = current.parent
+        for candidate in [current] + list(current.parents):
+            if (candidate / "go.mod").exists():
+                roots.append(candidate)
+                break
+
+    if not roots:
+        return []
+
+    unique_roots = sorted(set(roots))
+    if len(unique_roots) == 1:
+        return unique_roots
+
+    try:
+        common = Path(os.path.commonpath([str(r) for r in unique_roots]))
+    except ValueError:
+        return unique_roots
+
+    # Even when a parent module exists, nested modules are distinct
+    # go.mod roots and must each be linted independently.
+    return unique_roots
+
+
+def _merge_fix_results(*, name: str, results: list[ToolResult]) -> ToolResult:
+    """Merge per-module fix results into a single aggregate result.
+
+    Args:
+        name: Tool name for the aggregate result.
+        results: One fix ToolResult per Go module root.
+
+    Returns:
+        Aggregate ToolResult (success only when every module succeeded).
+    """
+    issues: list[Any] = []
+    initial_issues: list[Any] = []
+    outputs: list[str] = []
+    for result in results:
+        issues.extend(result.issues or [])
+        initial_issues.extend(result.initial_issues or [])
+        if result.output:
+            outputs.append(result.output)
+    return ToolResult(
+        name=name,
+        success=all(r.success for r in results),
+        output="\n".join(outputs) if outputs else None,
+        issues_count=sum(r.issues_count or 0 for r in results),
+        issues=issues,
+        initial_issues_count=sum(r.initial_issues_count or 0 for r in results),
+        fixed_issues_count=sum(r.fixed_issues_count or 0 for r in results),
+        remaining_issues_count=sum(r.remaining_issues_count or 0 for r in results),
+        initial_issues=initial_issues if initial_issues else None,
+    )
+
+
+def _build_golangci_lint_command(fix: bool = False) -> list[str]:
+    """Build the ``golangci-lint run`` command.
+
+    Args:
+        fix: Whether to include the ``--fix`` flag.
+
+    Returns:
+        List of command arguments.
+    """
+    cmd = [
+        "golangci-lint",
+        "run",
+        "--output.json.path",
+        "stdout",
+        "--show-stats=false",
+    ]
+    if fix:
+        cmd.append("--fix")
+    cmd.append("./...")
+    return cmd
+
+
+@register_tool
+@dataclass
+class GolangciLintPlugin(BaseToolPlugin):
+    """golangci-lint Go meta-linter plugin.
+
+    Integrates golangci-lint with lintro for checking Go code across dozens of
+    sub-linters. Requires a Go module (``go.mod``); non-Go projects are skipped
+    cleanly.
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition.
+
+        Returns:
+            ToolDefinition containing tool metadata.
+        """
+        return ToolDefinition(
+            name="golangci_lint",
+            description=(
+                "Go meta-linter running 100+ linters (errcheck, staticcheck, "
+                "ineffassign, govet, ...) in parallel"
+            ),
+            can_fix=True,
+            tool_type=ToolType.LINTER,
+            file_patterns=GOLANGCI_LINT_FILE_PATTERNS,
+            priority=GOLANGCI_LINT_DEFAULT_PRIORITY,
+            conflicts_with=[],
+            native_configs=[
+                ".golangci.yml",
+                ".golangci.yaml",
+                ".golangci.toml",
+                ".golangci.json",
+            ],
+            version_command=["golangci-lint", "version"],
+            min_version=get_min_version(ToolName.GOLANGCI_LINT),
+            default_options={
+                "timeout": GOLANGCI_LINT_DEFAULT_TIMEOUT,
+            },
+            default_timeout=GOLANGCI_LINT_DEFAULT_TIMEOUT,
+        )
+
+    def set_options(
+        self,
+        timeout: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Set golangci-lint-specific options.
+
+        Args:
+            timeout: Timeout in seconds (default: 120).
+            **kwargs: Additional options.
+        """
+        validate_positive_int(timeout, "timeout")
+
+        options = filter_none_options(timeout=timeout)
+        super().set_options(**options, **kwargs)
+
+    def doc_url(self, code: str) -> str | None:
+        """Return the golangci-lint documentation URL for a sub-linter.
+
+        Args:
+            code: Sub-linter name (e.g., "errcheck").
+
+        Returns:
+            URL to the golangci-lint linter documentation, or None when no
+            code is available.
+        """
+        if code:
+            return DocUrlTemplate.GOLANGCI_LINT.format(code=code)
+        return None
+
+    def check(self, paths: list[str], options: dict[str, object]) -> ToolResult:
+        """Run ``golangci-lint run`` and parse linting issues.
+
+        Args:
+            paths: List of file or directory paths to check.
+            options: Runtime options that override defaults.
+
+        Returns:
+            ToolResult with check results.
+        """
+        ctx = self._prepare_execution(
+            paths,
+            options,
+            no_files_message="No Go files found to check.",
+        )
+        if ctx.should_skip:
+            return ctx.early_result  # type: ignore[return-value]
+
+        module_roots = _find_go_module_roots(ctx.files)
+        if not module_roots:
+            return ToolResult(
+                name=self.definition.name,
+                success=True,
+                output="No go.mod found; skipping golangci-lint.",
+                issues_count=0,
+            )
+
+        cmd = _build_golangci_lint_command(fix=False)
+
+        all_issues: list[GolangciLintIssue] = []
+        failure_outputs: list[str] = []
+        overall_success = True
+        for module_root in module_roots:
+            try:
+                success_cmd, output = run_subprocess_with_timeout(
+                    tool=self,
+                    cmd=cmd,
+                    timeout=ctx.timeout,
+                    cwd=str(module_root),
+                    tool_name="golangci_lint",
+                )
+            except subprocess.TimeoutExpired:
+                timeout_result = create_timeout_result(
+                    tool=self,
+                    timeout=ctx.timeout,
+                    cmd=cmd,
+                    tool_name="golangci_lint",
+                )
+                return ToolResult(
+                    name=self.definition.name,
+                    success=timeout_result.success,
+                    output=timeout_result.output,
+                    issues_count=timeout_result.issues_count,
+                    issues=timeout_result.issues,
+                )
+
+            issues = parse_golangci_lint_output(output=output)
+            all_issues.extend(issues)
+            overall_success = overall_success and bool(success_cmd)
+
+            # Preserve output when the command fails with no parsed issues so
+            # config errors or build failures are visible for debugging.
+            if not success_cmd and not issues:
+                failure_outputs.append(output)
+
+        return ToolResult(
+            name=self.definition.name,
+            success=overall_success,
+            output="\n".join(failure_outputs) if failure_outputs else None,
+            issues_count=len(all_issues),
+            issues=all_issues,
+        )
+
+    def fix(self, paths: list[str], options: dict[str, object]) -> ToolResult:
+        """Run ``golangci-lint run --fix`` then re-check for remaining issues.
+
+        Args:
+            paths: List of file or directory paths to fix.
+            options: Runtime options that override defaults.
+
+        Returns:
+            ToolResult with fix results.
+        """
+        ctx = self._prepare_execution(
+            paths,
+            options,
+            no_files_message="No Go files found to fix.",
+        )
+        if ctx.should_skip:
+            return ctx.early_result  # type: ignore[return-value]
+
+        module_roots = _find_go_module_roots(ctx.files)
+        if not module_roots:
+            return ToolResult(
+                name=self.definition.name,
+                success=True,
+                output="No go.mod found; skipping golangci-lint.",
+                issues_count=0,
+                initial_issues_count=0,
+                fixed_issues_count=0,
+                remaining_issues_count=0,
+            )
+
+        results = [
+            self._fix_module_root(module_root=root, timeout=ctx.timeout)
+            for root in module_roots
+        ]
+        if len(results) == 1:
+            return results[0]
+        return _merge_fix_results(name=self.definition.name, results=results)
+
+    def _fix_module_root(self, *, module_root: Path, timeout: int) -> ToolResult:
+        """Run the check/fix/re-check cycle for a single Go module root.
+
+        Args:
+            module_root: Directory containing the module's ``go.mod``.
+            timeout: Timeout in seconds for each golangci-lint invocation.
+
+        Returns:
+            ToolResult for this module root.
+        """
+        check_cmd = _build_golangci_lint_command(fix=False)
+
+        # Count issues before fixing.
+        try:
+            _success_check, output_check = run_subprocess_with_timeout(
+                tool=self,
+                cmd=check_cmd,
+                timeout=timeout,
+                cwd=str(module_root),
+                tool_name="golangci_lint",
+            )
+        except subprocess.TimeoutExpired:
+            timeout_result = create_timeout_result(
+                tool=self,
+                timeout=timeout,
+                cmd=check_cmd,
+                tool_name="golangci_lint",
+            )
+            return ToolResult(
+                name=self.definition.name,
+                success=timeout_result.success,
+                output=timeout_result.output,
+                issues_count=timeout_result.issues_count,
+                issues=timeout_result.issues,
+                initial_issues_count=0,
+                fixed_issues_count=0,
+                remaining_issues_count=1,
+            )
+
+        initial_issues = parse_golangci_lint_output(output=output_check)
+        initial_count = len(initial_issues)
+
+        # Run fix.
+        fix_cmd = _build_golangci_lint_command(fix=True)
+        try:
+            success_fix, output_fix = run_subprocess_with_timeout(
+                tool=self,
+                cmd=fix_cmd,
+                timeout=timeout,
+                cwd=str(module_root),
+                tool_name="golangci_lint",
+            )
+        except subprocess.TimeoutExpired:
+            timeout_result = create_timeout_result(
+                tool=self,
+                timeout=timeout,
+                cmd=fix_cmd,
+                tool_name="golangci_lint",
+            )
+            return ToolResult(
+                name=self.definition.name,
+                success=timeout_result.success,
+                output=timeout_result.output,
+                issues_count=initial_count,
+                issues=initial_issues,
+                initial_issues_count=initial_count,
+                fixed_issues_count=0,
+                remaining_issues_count=initial_count,
+                initial_issues=initial_issues if initial_issues else None,
+            )
+
+        # Re-check after fix to count remaining issues.
+        try:
+            success_after, output_after = run_subprocess_with_timeout(
+                tool=self,
+                cmd=check_cmd,
+                timeout=timeout,
+                cwd=str(module_root),
+                tool_name="golangci_lint",
+            )
+        except subprocess.TimeoutExpired:
+            timeout_result = create_timeout_result(
+                tool=self,
+                timeout=timeout,
+                cmd=check_cmd,
+                tool_name="golangci_lint",
+            )
+            return ToolResult(
+                name=self.definition.name,
+                success=timeout_result.success,
+                output=timeout_result.output,
+                issues_count=initial_count,
+                issues=initial_issues,
+                initial_issues_count=initial_count,
+                fixed_issues_count=0,
+                remaining_issues_count=initial_count,
+                initial_issues=initial_issues if initial_issues else None,
+            )
+
+        remaining_issues = parse_golangci_lint_output(output=output_after)
+        remaining_count = len(remaining_issues)
+        fixed_count = max(0, initial_count - remaining_count)
+
+        # golangci-lint exits non-zero both when lint issues remain and when the
+        # run itself errors (config/build/fixer failure). A failed --fix run must
+        # not be reported as a successful format, and its diagnostic output must
+        # never be dropped: gate success on the fix command succeeding and always
+        # surface the fix command's output whenever it failed — regardless of how
+        # many issues the re-check parsed — so a fixer/config/build error can't be
+        # hidden behind a re-check that happens to report remaining issues.
+        success = remaining_count == 0 and success_after and success_fix
+
+        if not success_fix:
+            output = output_fix or output_after
+        elif not success and remaining_count == 0:
+            output = output_after
+        else:
+            output = None
+
+        return ToolResult(
+            name=self.definition.name,
+            success=success,
+            output=output,
+            issues_count=remaining_count,
+            issues=remaining_issues,
+            initial_issues_count=initial_count,
+            fixed_issues_count=fixed_count,
+            remaining_issues_count=remaining_count,
+            initial_issues=initial_issues if initial_issues else None,
+        )

--- a/lintro/tools/definitions/golangci_lint.py
+++ b/lintro/tools/definitions/golangci_lint.py
@@ -14,7 +14,6 @@ v1 ``--out-format`` flag with ``--output.<format>.path`` options.
 
 from __future__ import annotations
 
-import os
 import subprocess  # nosec B404 - used safely with shell disabled
 from dataclasses import dataclass
 from pathlib import Path
@@ -73,18 +72,9 @@ def _find_go_module_roots(paths: list[str]) -> list[Path]:
     if not roots:
         return []
 
-    unique_roots = sorted(set(roots))
-    if len(unique_roots) == 1:
-        return unique_roots
-
-    try:
-        common = Path(os.path.commonpath([str(r) for r in unique_roots]))
-    except ValueError:
-        return unique_roots
-
     # Even when a parent module exists, nested modules are distinct
     # go.mod roots and must each be linted independently.
-    return unique_roots
+    return sorted(set(roots))
 
 
 def _merge_fix_results(*, name: str, results: list[ToolResult]) -> ToolResult:

--- a/lintro/tools/definitions/golangci_lint.py
+++ b/lintro/tools/definitions/golangci_lint.py
@@ -257,6 +257,7 @@ class GolangciLintPlugin(BaseToolPlugin):
 
         all_issues: list[GolangciLintIssue] = []
         failure_outputs: list[str] = []
+        timeout_failures = 0
         overall_success = True
         for module_root in module_roots:
             try:
@@ -278,6 +279,11 @@ class GolangciLintPlugin(BaseToolPlugin):
                     tool_name="golangci_lint",
                 )
                 overall_success = False
+                # create_timeout_result() counts a timeout as one execution
+                # failure (issues_count=1) with an intentionally empty issues
+                # list. Preserve that count so a lone module timeout is not
+                # silently reported as issues_count=0.
+                timeout_failures += timeout_result.issues_count or 0
                 all_issues.extend(timeout_result.issues or [])
                 if timeout_result.output:
                     failure_outputs.append(timeout_result.output)
@@ -297,7 +303,7 @@ class GolangciLintPlugin(BaseToolPlugin):
             name=self.definition.name,
             success=overall_success,
             output="\n".join(failure_outputs) if failure_outputs else None,
-            issues_count=len(all_issues),
+            issues_count=len(all_issues) + timeout_failures,
             issues=all_issues,
         )
 
@@ -353,7 +359,7 @@ class GolangciLintPlugin(BaseToolPlugin):
 
         # Count issues before fixing.
         try:
-            _success_check, output_check = run_subprocess_with_timeout(
+            success_check, output_check = run_subprocess_with_timeout(
                 tool=self,
                 cmd=check_cmd,
                 timeout=timeout,
@@ -382,6 +388,20 @@ class GolangciLintPlugin(BaseToolPlugin):
             )
 
         initial_issues = parse_golangci_lint_output(output=output_check)
+        # A failed initial check with no parseable JSON means golangci-lint
+        # errored (config/build failure) rather than reporting a clean baseline.
+        # Abort before the mutating --fix phase and surface the diagnostic.
+        if not success_check and not initial_issues:
+            return ToolResult(
+                name=self.definition.name,
+                success=False,
+                output=output_check,
+                issues_count=0,
+                issues=[],
+                initial_issues_count=0,
+                fixed_issues_count=0,
+                remaining_issues_count=0,
+            )
         _rebase_issue_paths(issues=initial_issues, module_root=module_root)
         initial_count = len(initial_issues)
 

--- a/lintro/tools/definitions/golangci_lint.py
+++ b/lintro/tools/definitions/golangci_lint.py
@@ -77,6 +77,34 @@ def _find_go_module_roots(paths: list[str]) -> list[Path]:
     return sorted(set(roots))
 
 
+def _rebase_issue_paths(
+    *,
+    issues: list[GolangciLintIssue],
+    module_root: Path,
+) -> None:
+    """Anchor each issue's relative file path to its module root, in place.
+
+    golangci-lint reports ``Pos.Filename`` relative to the module root it ran
+    in. When findings from several module roots are merged, identical relative
+    names (e.g. ``main.go`` in two sibling modules) become ambiguous, so each
+    path is rewritten to an absolute path under its module root. The synthetic
+    ``(module)`` placeholder used for position-less findings and paths that are
+    already absolute are left untouched.
+
+    Args:
+        issues: Parsed issues to rewrite in place.
+        module_root: Directory golangci-lint ran in for these issues.
+    """
+    for issue in issues:
+        file_path = issue.file
+        if (
+            file_path
+            and file_path != "(module)"
+            and not Path(file_path).is_absolute()
+        ):
+            issue.file = str(module_root / file_path)
+
+
 def _merge_fix_results(*, name: str, results: list[ToolResult]) -> ToolResult:
     """Merge per-module fix results into a single aggregate result.
 
@@ -244,21 +272,23 @@ class GolangciLintPlugin(BaseToolPlugin):
                     tool_name="golangci_lint",
                 )
             except subprocess.TimeoutExpired:
+                # A single module timing out must not discard findings already
+                # collected from earlier roots or skip the remaining roots.
+                # Aggregate the timeout as a failure and continue.
                 timeout_result = create_timeout_result(
                     tool=self,
                     timeout=ctx.timeout,
                     cmd=cmd,
                     tool_name="golangci_lint",
                 )
-                return ToolResult(
-                    name=self.definition.name,
-                    success=timeout_result.success,
-                    output=timeout_result.output,
-                    issues_count=timeout_result.issues_count,
-                    issues=timeout_result.issues,
-                )
+                overall_success = False
+                all_issues.extend(timeout_result.issues or [])
+                if timeout_result.output:
+                    failure_outputs.append(timeout_result.output)
+                continue
 
             issues = parse_golangci_lint_output(output=output)
+            _rebase_issue_paths(issues=issues, module_root=module_root)
             all_issues.extend(issues)
             overall_success = overall_success and bool(success_cmd)
 
@@ -341,6 +371,9 @@ class GolangciLintPlugin(BaseToolPlugin):
                 cmd=check_cmd,
                 tool_name="golangci_lint",
             )
+            # The initial check never completed, so no issues were parsed.
+            # Report zero remaining issues rather than inventing a phantom
+            # finding that would corrupt multi-module fix totals.
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
@@ -349,10 +382,11 @@ class GolangciLintPlugin(BaseToolPlugin):
                 issues=timeout_result.issues,
                 initial_issues_count=0,
                 fixed_issues_count=0,
-                remaining_issues_count=1,
+                remaining_issues_count=0,
             )
 
         initial_issues = parse_golangci_lint_output(output=output_check)
+        _rebase_issue_paths(issues=initial_issues, module_root=module_root)
         initial_count = len(initial_issues)
 
         # Run fix.
@@ -413,6 +447,7 @@ class GolangciLintPlugin(BaseToolPlugin):
             )
 
         remaining_issues = parse_golangci_lint_output(output=output_after)
+        _rebase_issue_paths(issues=remaining_issues, module_root=module_root)
         remaining_count = len(remaining_issues)
         fixed_count = max(0, initial_count - remaining_count)
 

--- a/lintro/tools/definitions/golangci_lint.py
+++ b/lintro/tools/definitions/golangci_lint.py
@@ -97,11 +97,7 @@ def _rebase_issue_paths(
     """
     for issue in issues:
         file_path = issue.file
-        if (
-            file_path
-            and file_path != "(module)"
-            and not Path(file_path).is_absolute()
-        ):
+        if file_path and file_path != "(module)" and not Path(file_path).is_absolute():
             issue.file = str(module_root / file_path)
 
 

--- a/lintro/tools/manifest.json
+++ b/lintro/tools/manifest.json
@@ -36,7 +36,7 @@
     "javascript": ["oxlint", "oxfmt", "prettier"],
     "typescript": ["oxlint", "oxfmt", "prettier", "tsc"],
     "rust": ["clippy", "rustfmt", "rustc", "cargo_audit", "cargo_deny"],
-    "go": ["semgrep"],
+    "go": ["golangci_lint", "semgrep"],
     "ruby": ["semgrep"],
     "sql": ["sqlfluff"],
     "shell": ["shellcheck", "shfmt"],
@@ -186,6 +186,18 @@
       "version_command": ["gitleaks", "version"],
       "languages": ["security"],
       "tags": ["security"]
+    },
+    {
+      "name": "golangci_lint",
+      "version": "2.12.2",
+      "install": {
+        "type": "binary"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["golangci-lint", "version"],
+      "languages": ["go"],
+      "tags": ["linter"]
     },
     {
       "name": "hadolint",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ packages = [
   "lintro.parsers.commitlint",
   "lintro.parsers.dotenv_linter",
   "lintro.parsers.gitleaks",
+  "lintro.parsers.golangci_lint",
   "lintro.parsers.hadolint",
   "lintro.parsers.idiom_review",
   "lintro.parsers.markdownlint",

--- a/renovate.json
+++ b/renovate.json
@@ -244,6 +244,19 @@
       "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
+      "description": "Update golangci-lint in _tool_versions.py (manifest follows via generator)",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "lintro/_tool_versions\\.py"
+      ],
+      "matchStrings": [
+        "ToolName\\.GOLANGCI_LINT:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "golangci/golangci-lint",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
       "description": "Update osv-scanner version in _tool_versions.py",
       "customType": "regex",
       "managerFilePatterns": [

--- a/scripts/utils/install-tools.sh
+++ b/scripts/utils/install-tools.sh
@@ -168,7 +168,7 @@ should_install() {
 # Kept in sync with the should_install blocks and tools_to_verify array.
 SUPPORTED_TOOLS=(
 	"actionlint" "astro" "bandit" "black" "cargo-audit" "cargo-deny"
-	"clippy" "commitlint" "dotenv-linter" "gitleaks" "hadolint" "markdownlint" "markdownlint-cli2" "mypy" "osv-scanner"
+	"clippy" "commitlint" "dotenv-linter" "gitleaks" "golangci-lint" "hadolint" "markdownlint" "markdownlint-cli2" "mypy" "osv-scanner"
 	"oxfmt" "oxlint" "pip-audit" "prettier" "pydoclint" "ruff" "rustfmt" "semgrep"
 	"shellcheck" "shfmt" "sqlfluff" "stylelint" "svelte-check" "taplo" "tsc"
 	"vale" "vue-tsc" "yamllint"
@@ -589,6 +589,72 @@ main() {
 			rm -rf "$tmpdir"
 		fi
 	fi # gitleaks
+
+	# Install golangci-lint (Go meta-linter).
+	# Note: golangci-lint requires the Go toolchain to be present to analyze a
+	# module; this block installs only the golangci-lint binary.
+	if should_install "golangci-lint"; then
+		echo -e "${BLUE}Installing golangci-lint...${NC}"
+		GOLANGCI_LINT_VERSION=$(get_tool_version "golangci_lint") || exit 1
+		if [ $DRY_RUN -eq 1 ]; then
+			log_info "[DRY-RUN] Would install golangci-lint v${GOLANGCI_LINT_VERSION}"
+		elif command -v golangci-lint &>/dev/null; then
+			echo -e "${GREEN}✓ golangci-lint already installed${NC}"
+		else
+			tmpdir=$(mktemp -d)
+			os=$(uname -s | tr '[:upper:]' '[:lower:]')
+			arch=$(uname -m)
+			case "$arch" in
+			x86_64 | amd64) arch_name="amd64" ;;
+			aarch64 | arm64) arch_name="arm64" ;;
+			*) echo -e "${RED}✗ Unsupported architecture: $arch${NC}" && exit 1 ;;
+			esac
+			asset="golangci-lint-${GOLANGCI_LINT_VERSION}-${os}-${arch_name}"
+			base_url="https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}"
+			tgz_url="${base_url}/${asset}.tar.gz"
+			checksum_url="${base_url}/golangci-lint-${GOLANGCI_LINT_VERSION}-checksums.txt"
+			if download_with_retries "$tgz_url" "$tmpdir/golangci-lint.tar.gz" 3; then
+				# Require checksum verification before installing
+				if ! download_with_retries "$checksum_url" "$tmpdir/checksums.txt" 3; then
+					echo -e "${RED}✗ Failed to download checksum file for golangci-lint${NC}"
+					rm -rf "$tmpdir"
+					exit 1
+				fi
+				echo -e "${BLUE}Verifying checksum for golangci-lint...${NC}"
+				# Exact filename match — avoid also matching *.tar.gz.sbom.json.
+				expected=$(awk -v f="${asset}.tar.gz" '$2 == f { print $1; exit }' "$tmpdir/checksums.txt")
+				if [ -z "$expected" ]; then
+					echo -e "${RED}✗ Checksum entry not found for ${asset}.tar.gz${NC}"
+					rm -rf "$tmpdir"
+					exit 1
+				fi
+				if command -v sha256sum >/dev/null 2>&1; then
+					actual=$(sha256sum "$tmpdir/golangci-lint.tar.gz" | awk '{print $1}')
+				elif command -v shasum >/dev/null 2>&1; then
+					actual=$(shasum -a 256 "$tmpdir/golangci-lint.tar.gz" | awk '{print $1}')
+				else
+					echo -e "${RED}✗ Unable to compute checksum: no hash tool found (sha256sum or shasum required)${NC}"
+					rm -rf "$tmpdir"
+					exit 1
+				fi
+				if [ "$expected" != "$actual" ]; then
+					echo -e "${RED}✗ Checksum mismatch for golangci-lint (expected: $expected, got: $actual)${NC}"
+					rm -rf "$tmpdir"
+					exit 1
+				fi
+				echo -e "${GREEN}✓ Checksum verified${NC}"
+				tar -xzf "$tmpdir/golangci-lint.tar.gz" -C "$tmpdir"
+				cp "$tmpdir/${asset}/golangci-lint" "$BIN_DIR/golangci-lint"
+				chmod +x "$BIN_DIR/golangci-lint"
+				echo -e "${GREEN}✓ golangci-lint installed successfully${NC}"
+			else
+				echo -e "${RED}✗ Failed to download golangci-lint${NC}"
+				rm -rf "$tmpdir"
+				exit 1
+			fi
+			rm -rf "$tmpdir"
+		fi
+	fi # golangci-lint
 
 	# Install osv-scanner (multi-ecosystem vulnerability scanner)
 	if should_install "osv-scanner"; then
@@ -1658,7 +1724,7 @@ main() {
 	# Verify installations
 	echo -e "${YELLOW}Verifying installations...${NC}"
 
-	tools_to_verify=("actionlint" "astro" "bandit" "black" "cargo-audit" "cargo-deny" "clippy" "commitlint" "dotenv-linter" "gitleaks" "hadolint" "markdownlint-cli2" "mypy" "osv-scanner" "oxfmt" "oxlint" "pip-audit" "prettier" "pydoclint" "ruff" "rustfmt" "semgrep" "shellcheck" "shfmt" "sqlfluff" "stylelint" "svelte-check" "taplo" "tsc" "vale" "vue-tsc" "yamllint")
+	tools_to_verify=("actionlint" "astro" "bandit" "black" "cargo-audit" "cargo-deny" "clippy" "commitlint" "dotenv-linter" "gitleaks" "golangci-lint" "hadolint" "markdownlint-cli2" "mypy" "osv-scanner" "oxfmt" "oxlint" "pip-audit" "prettier" "pydoclint" "ruff" "rustfmt" "semgrep" "shellcheck" "shfmt" "sqlfluff" "stylelint" "svelte-check" "taplo" "tsc" "vale" "vue-tsc" "yamllint")
 
 	# Filter verification list when --tools is set.
 	# Map aliases so e.g. --tools markdownlint verifies markdownlint-cli2.
@@ -1672,7 +1738,7 @@ main() {
 				filtered+=("$tool")
 			fi
 		done
-		tools_to_verify=("${filtered[@]}")
+		tools_to_verify=("${filtered[@]}" "dotenv-linter" "golangci-lint" "stylelint")
 	fi
 
 	for tool in "${tools_to_verify[@]}"; do

--- a/scripts/utils/install-tools.sh
+++ b/scripts/utils/install-tools.sh
@@ -596,11 +596,11 @@ main() {
 	if should_install "golangci-lint"; then
 		echo -e "${BLUE}Installing golangci-lint...${NC}"
 		GOLANGCI_LINT_VERSION=$(get_tool_version "golangci_lint") || exit 1
-		if [ $DRY_RUN -eq 1 ]; then
-			log_info "[DRY-RUN] Would install golangci-lint v${GOLANGCI_LINT_VERSION}"
-		elif command -v golangci-lint &>/dev/null; then
-			echo -e "${GREEN}✓ golangci-lint already installed${NC}"
-		else
+
+		# Download, verify, and install the pinned golangci-lint binary.
+		install_golangci_lint_binary() {
+			local tmpdir os arch arch_name asset base_url tgz_url checksum_url
+			local expected actual
 			tmpdir=$(mktemp -d)
 			os=$(uname -s | tr '[:upper:]' '[:lower:]')
 			arch=$(uname -m)
@@ -613,46 +613,75 @@ main() {
 			base_url="https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}"
 			tgz_url="${base_url}/${asset}.tar.gz"
 			checksum_url="${base_url}/golangci-lint-${GOLANGCI_LINT_VERSION}-checksums.txt"
-			if download_with_retries "$tgz_url" "$tmpdir/golangci-lint.tar.gz" 3; then
-				# Require checksum verification before installing
-				if ! download_with_retries "$checksum_url" "$tmpdir/checksums.txt" 3; then
-					echo -e "${RED}✗ Failed to download checksum file for golangci-lint${NC}"
-					rm -rf "$tmpdir"
-					exit 1
-				fi
-				echo -e "${BLUE}Verifying checksum for golangci-lint...${NC}"
-				# Exact filename match — avoid also matching *.tar.gz.sbom.json.
-				expected=$(awk -v f="${asset}.tar.gz" '$2 == f { print $1; exit }' "$tmpdir/checksums.txt")
-				if [ -z "$expected" ]; then
-					echo -e "${RED}✗ Checksum entry not found for ${asset}.tar.gz${NC}"
-					rm -rf "$tmpdir"
-					exit 1
-				fi
-				if command -v sha256sum >/dev/null 2>&1; then
-					actual=$(sha256sum "$tmpdir/golangci-lint.tar.gz" | awk '{print $1}')
-				elif command -v shasum >/dev/null 2>&1; then
-					actual=$(shasum -a 256 "$tmpdir/golangci-lint.tar.gz" | awk '{print $1}')
-				else
-					echo -e "${RED}✗ Unable to compute checksum: no hash tool found (sha256sum or shasum required)${NC}"
-					rm -rf "$tmpdir"
-					exit 1
-				fi
-				if [ "$expected" != "$actual" ]; then
-					echo -e "${RED}✗ Checksum mismatch for golangci-lint (expected: $expected, got: $actual)${NC}"
-					rm -rf "$tmpdir"
-					exit 1
-				fi
-				echo -e "${GREEN}✓ Checksum verified${NC}"
-				tar -xzf "$tmpdir/golangci-lint.tar.gz" -C "$tmpdir"
-				cp "$tmpdir/${asset}/golangci-lint" "$BIN_DIR/golangci-lint"
-				chmod +x "$BIN_DIR/golangci-lint"
-				echo -e "${GREEN}✓ golangci-lint installed successfully${NC}"
-			else
+			if ! download_with_retries "$tgz_url" "$tmpdir/golangci-lint.tar.gz" 3; then
 				echo -e "${RED}✗ Failed to download golangci-lint${NC}"
+				rm -rf "$tmpdir"
+				return 1
+			fi
+			# Require checksum verification before installing
+			if ! download_with_retries "$checksum_url" "$tmpdir/checksums.txt" 3; then
+				echo -e "${RED}✗ Failed to download checksum file for golangci-lint${NC}"
 				rm -rf "$tmpdir"
 				exit 1
 			fi
+			echo -e "${BLUE}Verifying checksum for golangci-lint...${NC}"
+			# Exact filename match — avoid also matching *.tar.gz.sbom.json.
+			expected=$(awk -v f="${asset}.tar.gz" '$2 == f { print $1; exit }' "$tmpdir/checksums.txt")
+			if [ -z "$expected" ]; then
+				echo -e "${RED}✗ Checksum entry not found for ${asset}.tar.gz${NC}"
+				rm -rf "$tmpdir"
+				exit 1
+			fi
+			if command -v sha256sum >/dev/null 2>&1; then
+				actual=$(sha256sum "$tmpdir/golangci-lint.tar.gz" | awk '{print $1}')
+			elif command -v shasum >/dev/null 2>&1; then
+				actual=$(shasum -a 256 "$tmpdir/golangci-lint.tar.gz" | awk '{print $1}')
+			else
+				echo -e "${RED}✗ Unable to compute checksum: no hash tool found (sha256sum or shasum required)${NC}"
+				rm -rf "$tmpdir"
+				exit 1
+			fi
+			if [ "$expected" != "$actual" ]; then
+				echo -e "${RED}✗ Checksum mismatch for golangci-lint (expected: $expected, got: $actual)${NC}"
+				rm -rf "$tmpdir"
+				exit 1
+			fi
+			echo -e "${GREEN}✓ Checksum verified${NC}"
+			tar -xzf "$tmpdir/golangci-lint.tar.gz" -C "$tmpdir"
+			cp "$tmpdir/${asset}/golangci-lint" "$BIN_DIR/golangci-lint"
+			chmod +x "$BIN_DIR/golangci-lint"
 			rm -rf "$tmpdir"
+			return 0
+		}
+
+		if [ $DRY_RUN -eq 1 ]; then
+			log_info "[DRY-RUN] Would install golangci-lint v${GOLANGCI_LINT_VERSION}"
+		elif command -v golangci-lint &>/dev/null; then
+			# Honor the pinned version: a stale binary (notably a v1 binary that
+			# cannot parse the v2 config this plugin targets) must be upgraded
+			# rather than silently accepted.
+			installed_version=$(golangci-lint version 2>/dev/null |
+				grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+			if [ -n "$installed_version" ] && version_ge "$installed_version" "$GOLANGCI_LINT_VERSION"; then
+				echo -e "${GREEN}✓ golangci-lint v${installed_version} already installed (>= v${GOLANGCI_LINT_VERSION})${NC}"
+			else
+				if [ -n "$installed_version" ]; then
+					echo -e "${YELLOW}⚠ golangci-lint v${installed_version} is older than required v${GOLANGCI_LINT_VERSION}, upgrading...${NC}"
+				else
+					echo -e "${YELLOW}⚠ Could not determine golangci-lint version, installing v${GOLANGCI_LINT_VERSION}...${NC}"
+				fi
+				if install_golangci_lint_binary; then
+					echo -e "${GREEN}✓ golangci-lint installed successfully${NC}"
+				else
+					exit 1
+				fi
+			fi
+		else
+			if install_golangci_lint_binary; then
+				echo -e "${GREEN}✓ golangci-lint installed successfully${NC}"
+			else
+				exit 1
+			fi
 		fi
 	fi # golangci-lint
 
@@ -1691,6 +1720,7 @@ main() {
 		["clippy"]="Rust linting"
 		["dotenv-linter"]=".env file linting and fixing"
 		["gitleaks"]="Secret detection"
+		["golangci-lint"]="Go meta-linter (requires the Go toolchain)"
 		["hadolint"]="Docker linting"
 		["markdownlint"]="Markdown linting"
 		["mypy"]="Python type checking"
@@ -1738,7 +1768,7 @@ main() {
 				filtered+=("$tool")
 			fi
 		done
-		tools_to_verify=("${filtered[@]}" "dotenv-linter" "golangci-lint" "stylelint")
+		tools_to_verify=("${filtered[@]}" "dotenv-linter" "stylelint")
 	fi
 
 	for tool in "${tools_to_verify[@]}"; do

--- a/scripts/utils/install-tools.sh
+++ b/scripts/utils/install-tools.sh
@@ -1768,7 +1768,7 @@ main() {
 				filtered+=("$tool")
 			fi
 		done
-		tools_to_verify=("${filtered[@]}" "dotenv-linter" "stylelint")
+		tools_to_verify=("${filtered[@]}")
 	fi
 
 	for tool in "${tools_to_verify[@]}"; do

--- a/test_samples/tools/go/golangci_lint/.golangci.yml
+++ b/test_samples/tools/go/golangci_lint/.golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+linters:
+  enable:
+    - errcheck
+    - ineffassign

--- a/test_samples/tools/go/golangci_lint/go.mod
+++ b/test_samples/tools/go/golangci_lint/go.mod
@@ -1,0 +1,3 @@
+module example.com/golangcilintviolations
+
+go 1.24.9

--- a/test_samples/tools/go/golangci_lint/main.go
+++ b/test_samples/tools/go/golangci_lint/main.go
@@ -1,0 +1,17 @@
+// Package main contains intentional golangci-lint violations used as a
+// binary-gated integration fixture. It is a valid Go module so golangci-lint
+// can build it, but triggers errcheck (unchecked error) and ineffassign
+// (ineffectual assignment).
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	os.Open("foo.txt") // errcheck: unchecked error return value
+	x := 1             // ineffassign: this assignment is never used
+	x = 2
+	fmt.Println(x)
+}

--- a/tests/unit/parsers/test_golangci_lint_parser.py
+++ b/tests/unit/parsers/test_golangci_lint_parser.py
@@ -1,0 +1,182 @@
+"""Unit tests for the golangci-lint parser.
+
+Fixtures mirror real golangci-lint v2 ``--output.json.path stdout`` payloads
+captured from a Go module fixture.
+"""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.enums.severity_level import SeverityLevel
+from lintro.parsers.golangci_lint.golangci_lint_issue import GolangciLintIssue
+from lintro.parsers.golangci_lint.golangci_lint_parser import (
+    parse_golangci_lint_output,
+)
+
+# Real captured output: two findings (errcheck + ineffassign), empty Severity.
+_TWO_ISSUES = (
+    '{"Issues":[{"FromLinter":"errcheck",'
+    '"Text":"Error return value of `os.Open` is not checked","Severity":"",'
+    '"SourceLines":["\\tos.Open(\\"foo.txt\\")"],'
+    '"Pos":{"Filename":"main.go","Offset":61,"Line":9,"Column":9},'
+    '"ExpectNoLint":false,"ExpectedNoLintLinter":""},'
+    '{"FromLinter":"ineffassign","Text":"ineffectual assignment to x",'
+    '"Severity":"","SourceLines":["\\tx := 1"],'
+    '"Pos":{"Filename":"main.go","Offset":74,"Line":10,"Column":2},'
+    '"ExpectNoLint":false,"ExpectedNoLintLinter":""}],'
+    '"Report":{"Linters":[{"Name":"errcheck","Enabled":true}]}}'
+)
+
+
+def test_parse_single_issue_fields() -> None:
+    """Parser extracts linter, position, and message for a single issue."""
+    output = (
+        '{"Issues":[{"FromLinter":"ineffassign",'
+        '"Text":"ineffectual assignment to x","Severity":"",'
+        '"Pos":{"Filename":"main.go","Offset":82,"Line":10,"Column":2}}],'
+        '"Report":{"Linters":[]}}'
+    )
+    issues = parse_golangci_lint_output(output)
+    assert_that(issues).is_length(1)
+    issue = issues[0]
+    assert_that(issue.file).is_equal_to("main.go")
+    assert_that(issue.line).is_equal_to(10)
+    assert_that(issue.column).is_equal_to(2)
+    assert_that(issue.code).is_equal_to("ineffassign")
+    assert_that(issue.message).contains("ineffectual assignment")
+    assert_that(issue.fixable).is_false()
+
+
+def test_parse_multiple_issues() -> None:
+    """Parser returns every issue with correct linter attribution."""
+    issues = parse_golangci_lint_output(_TWO_ISSUES)
+    assert_that(issues).is_length(2)
+    assert_that([i.code for i in issues]).is_equal_to(["errcheck", "ineffassign"])
+    assert_that(issues[0].line).is_equal_to(9)
+    assert_that(issues[1].line).is_equal_to(10)
+
+
+def test_parse_returns_issue_instances() -> None:
+    """Parsed items are GolangciLintIssue dataclass instances."""
+    issues = parse_golangci_lint_output(_TWO_ISSUES)
+    assert_that(issues[0]).is_instance_of(GolangciLintIssue)
+
+
+def test_empty_severity_defaults_to_warning() -> None:
+    """A blank Severity normalizes to the WARNING default."""
+    issues = parse_golangci_lint_output(_TWO_ISSUES)
+    assert_that(issues[0].level).is_none()
+    assert_that(issues[0].get_severity()).is_equal_to(SeverityLevel.WARNING)
+
+
+def test_explicit_severity_is_preserved() -> None:
+    """A configured Severity value is retained and normalized."""
+    output = (
+        '{"Issues":[{"FromLinter":"gosec",'
+        '"Text":"potential security issue","Severity":"error",'
+        '"Pos":{"Filename":"main.go","Line":3,"Column":1}}],'
+        '"Report":{"Linters":[]}}'
+    )
+    issues = parse_golangci_lint_output(output)
+    assert_that(issues[0].level).is_equal_to("error")
+    assert_that(issues[0].get_severity()).is_equal_to(SeverityLevel.ERROR)
+
+
+def test_suggested_fixes_marks_fixable() -> None:
+    """Presence of SuggestedFixes marks the issue as fixable."""
+    output = (
+        '{"Issues":[{"FromLinter":"misspell",'
+        '"Text":"`langauge` is a misspelling of `language`","Severity":"",'
+        '"Pos":{"Filename":"main.go","Line":5,"Column":14},'
+        '"SuggestedFixes":[{"Message":"",'
+        '"TextEdits":[{"Pos":41,"End":49,"NewText":"bGFuZ3VhZ2U="}]}]}],'
+        '"Report":{"Linters":[]}}'
+    )
+    issues = parse_golangci_lint_output(output)
+    assert_that(issues[0].fixable).is_true()
+
+
+def test_legacy_replacement_marks_fixable() -> None:
+    """The legacy Replacement field also marks the issue as fixable."""
+    output = (
+        '{"Issues":[{"FromLinter":"gofmt","Text":"File is not gofmted",'
+        '"Severity":"","Pos":{"Filename":"main.go","Line":1,"Column":1},'
+        '"Replacement":{"NewLines":["package main"]}}],'
+        '"Report":{"Linters":[]}}'
+    )
+    issues = parse_golangci_lint_output(output)
+    assert_that(issues[0].fixable).is_true()
+
+
+def test_no_issues_returns_empty() -> None:
+    """A clean run with an empty Issues array yields no issues."""
+    output = '{"Issues":[],"Report":{"Linters":[]}}'
+    assert_that(parse_golangci_lint_output(output)).is_empty()
+
+
+def test_null_issues_returns_empty() -> None:
+    """golangci-lint emits ``"Issues":null`` for a clean run in some versions."""
+    output = '{"Issues":null,"Report":{"Linters":[]}}'
+    assert_that(parse_golangci_lint_output(output)).is_empty()
+
+
+def test_trailing_stats_footer_is_ignored() -> None:
+    """A human-readable stats footer after the JSON is tolerated."""
+    output = _TWO_ISSUES + "\n2 issues:\n* errcheck: 1\n* ineffassign: 1\n"
+    issues = parse_golangci_lint_output(output)
+    assert_that(issues).is_length(2)
+
+
+def test_ansi_codes_are_stripped() -> None:
+    """ANSI escape codes around the JSON are stripped before parsing."""
+    output = "\x1b[33m" + _TWO_ISSUES + "\x1b[0m"
+    issues = parse_golangci_lint_output(output)
+    assert_that(issues).is_length(2)
+
+
+def test_empty_and_none_input() -> None:
+    """Empty, whitespace, and None inputs return an empty list."""
+    assert_that(parse_golangci_lint_output(None)).is_empty()
+    assert_that(parse_golangci_lint_output("")).is_empty()
+    assert_that(parse_golangci_lint_output("   \n  ")).is_empty()
+
+
+def test_malformed_json_returns_empty() -> None:
+    """Malformed JSON is handled gracefully without raising."""
+    assert_that(parse_golangci_lint_output("not json at all")).is_empty()
+    assert_that(parse_golangci_lint_output("{broken")).is_empty()
+
+
+def test_non_object_root_returns_empty() -> None:
+    """A JSON array root (not the expected object) returns an empty list."""
+    assert_that(parse_golangci_lint_output("[1, 2, 3]")).is_empty()
+
+
+def test_issue_missing_position_gets_module_placeholder() -> None:
+    """An issue without a filename is kept with a module-level placeholder.
+
+    Package-level build/config/analysis failures carry no position; dropping
+    them would hide a real failure from the report.
+    """
+    output = (
+        '{"Issues":[{"FromLinter":"errcheck","Text":"no position"},'
+        '{"FromLinter":"ineffassign","Text":"has position",'
+        '"Pos":{"Filename":"main.go","Line":1,"Column":1}}],'
+        '"Report":{"Linters":[]}}'
+    )
+    issues = parse_golangci_lint_output(output)
+    assert_that(issues).is_length(2)
+    assert_that(issues[0].file).is_equal_to("(module)")
+    assert_that(issues[0].line).is_equal_to(0)
+    assert_that(issues[1].code).is_equal_to("ineffassign")
+
+
+def test_issue_missing_text_is_skipped() -> None:
+    """An issue with an empty message is skipped."""
+    output = (
+        '{"Issues":[{"FromLinter":"errcheck","Text":"",'
+        '"Pos":{"Filename":"main.go","Line":1,"Column":1}}],'
+        '"Report":{"Linters":[]}}'
+    )
+    assert_that(parse_golangci_lint_output(output)).is_empty()

--- a/tests/unit/tools/golangci_lint/__init__.py
+++ b/tests/unit/tools/golangci_lint/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the golangci-lint plugin."""

--- a/tests/unit/tools/golangci_lint/conftest.py
+++ b/tests/unit/tools/golangci_lint/conftest.py
@@ -1,0 +1,56 @@
+"""Pytest configuration for golangci-lint plugin tests."""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+from lintro.tools.definitions.golangci_lint import GolangciLintPlugin
+
+# Real golangci-lint JSON output with two findings, used to drive mocked runs.
+GOLANGCI_JSON_TWO_ISSUES = (
+    '{"Issues":[{"FromLinter":"errcheck",'
+    '"Text":"Error return value of `os.Open` is not checked","Severity":"",'
+    '"Pos":{"Filename":"main.go","Line":9,"Column":9}},'
+    '{"FromLinter":"ineffassign","Text":"ineffectual assignment to x",'
+    '"Severity":"","Pos":{"Filename":"main.go","Line":10,"Column":2}}],'
+    '"Report":{"Linters":[]}}'
+)
+
+GOLANGCI_JSON_ONE_ISSUE = (
+    '{"Issues":[{"FromLinter":"errcheck",'
+    '"Text":"Error return value of `os.Open` is not checked","Severity":"",'
+    '"Pos":{"Filename":"main.go","Line":9,"Column":9}}],'
+    '"Report":{"Linters":[]}}'
+)
+
+GOLANGCI_JSON_NO_ISSUES = '{"Issues":[],"Report":{"Linters":[]}}'
+
+
+@pytest.fixture
+def golangci_lint_plugin() -> Generator[GolangciLintPlugin, None, None]:
+    """Provide a GolangciLintPlugin with the version check mocked out.
+
+    Yields:
+        GolangciLintPlugin: Instance whose version verification is bypassed.
+    """
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        yield GolangciLintPlugin()
+
+
+def golangci_lint_available() -> bool:
+    """Return whether golangci-lint and the Go toolchain are on PATH.
+
+    golangci-lint requires the Go toolchain to build and analyze a module, so
+    integration tests are gated on both being present.
+
+    Returns:
+        bool: True when both golangci-lint and go can be invoked.
+    """
+    return shutil.which("golangci-lint") is not None and shutil.which("go") is not None

--- a/tests/unit/tools/golangci_lint/test_definition.py
+++ b/tests/unit/tools/golangci_lint/test_definition.py
@@ -1,0 +1,44 @@
+"""Tests for the golangci-lint plugin definition."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.enums.tool_type import ToolType
+from lintro.tools.definitions.golangci_lint import GolangciLintPlugin
+
+
+def test_definition_basics() -> None:
+    """The definition exposes the expected identity and capabilities."""
+    definition = GolangciLintPlugin().definition
+    assert_that(definition.name).is_equal_to("golangci_lint")
+    assert_that(definition.can_fix).is_true()
+    assert_that(definition.tool_type).is_equal_to(ToolType.LINTER)
+    assert_that(definition.file_patterns).contains("*.go")
+    assert_that(definition.version_command).is_equal_to(
+        ["golangci-lint", "version"],
+    )
+
+
+def test_definition_native_configs() -> None:
+    """All golangci-lint config filenames are declared."""
+    definition = GolangciLintPlugin().definition
+    assert_that(definition.native_configs).contains(
+        ".golangci.yml",
+        ".golangci.yaml",
+        ".golangci.toml",
+        ".golangci.json",
+    )
+
+
+def test_doc_url_for_linter() -> None:
+    """doc_url() builds a per-linter documentation anchor."""
+    plugin = GolangciLintPlugin()
+    assert_that(plugin.doc_url("errcheck")).is_equal_to(
+        "https://golangci-lint.run/usage/linters/#errcheck",
+    )
+
+
+def test_doc_url_empty_code_returns_none() -> None:
+    """doc_url() returns None when no code is supplied."""
+    assert_that(GolangciLintPlugin().doc_url("")).is_none()

--- a/tests/unit/tools/golangci_lint/test_execution.py
+++ b/tests/unit/tools/golangci_lint/test_execution.py
@@ -1,0 +1,301 @@
+"""Unit tests for the golangci-lint plugin execution paths (mocked subprocess)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast,  Any
+from unittest.mock import patch
+
+from assertpy import assert_that
+
+from lintro.parsers.golangci_lint.golangci_lint_issue import GolangciLintIssue
+from lintro.tools.definitions.golangci_lint import GolangciLintPlugin
+from tests.unit.tools.golangci_lint.conftest import (
+    GOLANGCI_JSON_NO_ISSUES,
+    GOLANGCI_JSON_ONE_ISSUE,
+    GOLANGCI_JSON_TWO_ISSUES,
+)
+
+
+def _make_go_module(root: Path) -> None:
+    """Create a minimal Go module with a source file under ``root``.
+
+    Args:
+        root: Directory to populate with go.mod and main.go.
+    """
+    (root / "go.mod").write_text("module example.com/fixture\n\ngo 1.21\n")
+    (root / "main.go").write_text("package main\n\nfunc main() {}\n")
+
+
+def test_check_reports_issues(
+    golangci_lint_plugin: GolangciLintPlugin,
+    tmp_path: Path,
+) -> None:
+    """Check parses issues from golangci-lint JSON output.
+
+    Args:
+        golangci_lint_plugin: Plugin under test.
+        tmp_path: Temporary directory for the Go module.
+    """
+    _make_go_module(tmp_path)
+
+    # golangci-lint exits non-zero when issues are found.
+    with patch.object(
+        golangci_lint_plugin,
+        "_run_subprocess",
+        return_value=(False, GOLANGCI_JSON_TWO_ISSUES),
+    ):
+        result = golangci_lint_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.issues_count).is_equal_to(2)
+    assert_that(result.success).is_false()
+    assert_that(result.issues).is_not_none()
+    issues = cast(list[GolangciLintIssue], result.issues)
+    assert_that([i.code for i in issues]).contains(
+        "errcheck",
+        "ineffassign",
+    )
+
+
+def test_check_clean_module(
+    golangci_lint_plugin: GolangciLintPlugin,
+    tmp_path: Path,
+) -> None:
+    """Check succeeds with zero issues on a clean module.
+
+    Args:
+        golangci_lint_plugin: Plugin under test.
+        tmp_path: Temporary directory for the Go module.
+    """
+    _make_go_module(tmp_path)
+
+    with patch.object(
+        golangci_lint_plugin,
+        "_run_subprocess",
+        return_value=(True, GOLANGCI_JSON_NO_ISSUES),
+    ):
+        result = golangci_lint_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+
+
+def test_check_skips_without_go_mod(
+    golangci_lint_plugin: GolangciLintPlugin,
+    tmp_path: Path,
+) -> None:
+    """Check skips cleanly when a Go file has no enclosing module.
+
+    Args:
+        golangci_lint_plugin: Plugin under test.
+        tmp_path: Temporary directory with a .go file but no go.mod.
+    """
+    (tmp_path / "main.go").write_text("package main\n\nfunc main() {}\n")
+
+    called = False
+
+    def _fail(*_args: Any, **_kwargs: Any) -> tuple[bool, str]:
+        nonlocal called
+        called = True
+        return (True, "")
+
+    with patch.object(golangci_lint_plugin, "_run_subprocess", side_effect=_fail):
+        result = golangci_lint_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.output).contains("go.mod")
+    assert_that(called).is_false()
+
+
+def test_check_no_go_files(
+    golangci_lint_plugin: GolangciLintPlugin,
+    tmp_path: Path,
+) -> None:
+    """Check returns an early no-files result when no Go files are present.
+
+    Args:
+        golangci_lint_plugin: Plugin under test.
+        tmp_path: Temporary directory with a non-Go file.
+    """
+    (tmp_path / "readme.txt").write_text("not go\n")
+    result = golangci_lint_plugin.check([str(tmp_path)], {})
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+
+
+def test_fix_counts_fixed_issues(
+    golangci_lint_plugin: GolangciLintPlugin,
+    tmp_path: Path,
+) -> None:
+    """Fix computes initial/fixed/remaining counts across the run sequence.
+
+    Args:
+        golangci_lint_plugin: Plugin under test.
+        tmp_path: Temporary directory for the Go module.
+    """
+    _make_go_module(tmp_path)
+
+    # Sequence: initial check (2 issues), fix run, re-check (0 issues).
+    outputs = [
+        (False, GOLANGCI_JSON_TWO_ISSUES),
+        (True, ""),
+        (True, GOLANGCI_JSON_NO_ISSUES),
+    ]
+
+    with patch.object(
+        golangci_lint_plugin,
+        "_run_subprocess",
+        side_effect=outputs,
+    ):
+        result = golangci_lint_plugin.fix([str(tmp_path)], {})
+
+    assert_that(result.initial_issues_count).is_equal_to(2)
+    assert_that(result.fixed_issues_count).is_equal_to(2)
+    assert_that(result.remaining_issues_count).is_equal_to(0)
+    assert_that(result.success).is_true()
+
+
+def test_fix_failure_is_not_masked_as_success(
+    golangci_lint_plugin: GolangciLintPlugin,
+    tmp_path: Path,
+) -> None:
+    """A failed --fix run with no parseable re-check issues reports failure.
+
+    Args:
+        golangci_lint_plugin: Plugin under test.
+        tmp_path: Temporary directory for the Go module.
+    """
+    _make_go_module(tmp_path)
+
+    # Sequence: initial check (2 issues), fix run FAILS (config/build error with
+    # non-JSON output), re-check yields no parseable issues.
+    fix_error = "level=error msg=\"can't run linter: build error\""
+    outputs = [
+        (False, GOLANGCI_JSON_TWO_ISSUES),
+        (False, fix_error),
+        (False, ""),
+    ]
+
+    with patch.object(
+        golangci_lint_plugin,
+        "_run_subprocess",
+        side_effect=outputs,
+    ):
+        result = golangci_lint_plugin.fix([str(tmp_path)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.remaining_issues_count).is_equal_to(0)
+    assert_that(result.output).contains("build error")
+
+
+def test_fix_failure_output_preserved_with_remaining_issues(
+    golangci_lint_plugin: GolangciLintPlugin,
+    tmp_path: Path,
+) -> None:
+    """A failed --fix run surfaces its output even when issues still remain.
+
+    Regression guard: when ``golangci-lint run --fix`` exits non-zero (config/
+    build/fixer error) and the follow-up check still parses remaining issues,
+    the fix command's diagnostic output must not be dropped.
+
+    Args:
+        golangci_lint_plugin: Plugin under test.
+        tmp_path: Temporary directory for the Go module.
+    """
+    _make_go_module(tmp_path)
+
+    # Sequence: initial check (2 issues), fix run FAILS (build error), re-check
+    # still parses one remaining issue.
+    fix_error = "level=error msg=\"can't run linter: build error\""
+    outputs = [
+        (False, GOLANGCI_JSON_TWO_ISSUES),
+        (False, fix_error),
+        (False, GOLANGCI_JSON_ONE_ISSUE),
+    ]
+
+    with patch.object(
+        golangci_lint_plugin,
+        "_run_subprocess",
+        side_effect=outputs,
+    ):
+        result = golangci_lint_plugin.fix([str(tmp_path)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.remaining_issues_count).is_equal_to(1)
+    assert_that(result.output).contains("build error")
+
+
+def test_fix_skips_without_go_mod(
+    golangci_lint_plugin: GolangciLintPlugin,
+    tmp_path: Path,
+) -> None:
+    """Fix skips cleanly when there is no enclosing Go module.
+
+    Args:
+        golangci_lint_plugin: Plugin under test.
+        tmp_path: Temporary directory with a .go file but no go.mod.
+    """
+    (tmp_path / "main.go").write_text("package main\n\nfunc main() {}\n")
+
+    with patch.object(
+        golangci_lint_plugin,
+        "_run_subprocess",
+        return_value=(True, ""),
+    ):
+        result = golangci_lint_plugin.fix([str(tmp_path)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.initial_issues_count).is_equal_to(0)
+    assert_that(result.remaining_issues_count).is_equal_to(0)
+
+
+def test_find_module_roots_returns_each_module(tmp_path: Path) -> None:
+    """Two sibling modules without a parent go.mod both become roots."""
+    from lintro.tools.definitions.golangci_lint import _find_go_module_roots
+
+    mod_a = tmp_path / "svc-a"
+    mod_b = tmp_path / "svc-b"
+    mod_a.mkdir()
+    mod_b.mkdir()
+    _make_go_module(mod_a)
+    _make_go_module(mod_b)
+
+    roots = _find_go_module_roots(
+        [str(mod_a / "main.go"), str(mod_b / "main.go")],
+    )
+
+    assert_that(roots).is_length(2)
+    assert_that([r.name for r in roots]).contains("svc-a", "svc-b")
+
+
+def test_check_covers_all_selected_modules(
+    golangci_lint_plugin: GolangciLintPlugin,
+    tmp_path: Path,
+) -> None:
+    """Check runs once per module and aggregates issues across modules."""
+    mod_a = tmp_path / "svc-a"
+    mod_b = tmp_path / "svc-b"
+    mod_a.mkdir()
+    mod_b.mkdir()
+    _make_go_module(mod_a)
+    _make_go_module(mod_b)
+
+    calls: list[str] = []
+
+    def _fake_run(**kwargs: Any) -> tuple[bool, str]:
+        calls.append(kwargs["cwd"])
+        return (False, GOLANGCI_JSON_TWO_ISSUES)
+
+    with patch(
+        "lintro.tools.definitions.golangci_lint.run_subprocess_with_timeout",
+        side_effect=lambda **kwargs: _fake_run(**kwargs),
+    ):
+        result = golangci_lint_plugin.check(
+            [str(mod_a / "main.go"), str(mod_b / "main.go")],
+            {},
+        )
+
+    assert_that(calls).is_length(2)
+    assert_that(result.issues_count).is_equal_to(4)
+    assert_that(result.success).is_false()

--- a/tests/unit/tools/golangci_lint/test_execution.py
+++ b/tests/unit/tools/golangci_lint/test_execution.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast,  Any
+from typing import Any, cast
 from unittest.mock import patch
 
 from assertpy import assert_that
@@ -170,7 +170,7 @@ def test_fix_failure_is_not_masked_as_success(
 
     # Sequence: initial check (2 issues), fix run FAILS (config/build error with
     # non-JSON output), re-check yields no parseable issues.
-    fix_error = "level=error msg=\"can't run linter: build error\""
+    fix_error = 'level=error msg="can\'t run linter: build error"'
     outputs = [
         (False, GOLANGCI_JSON_TWO_ISSUES),
         (False, fix_error),
@@ -207,7 +207,7 @@ def test_fix_failure_output_preserved_with_remaining_issues(
 
     # Sequence: initial check (2 issues), fix run FAILS (build error), re-check
     # still parses one remaining issue.
-    fix_error = "level=error msg=\"can't run linter: build error\""
+    fix_error = 'level=error msg="can\'t run linter: build error"'
     outputs = [
         (False, GOLANGCI_JSON_TWO_ISSUES),
         (False, fix_error),

--- a/tests/unit/tools/golangci_lint/test_execution.py
+++ b/tests/unit/tools/golangci_lint/test_execution.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import subprocess
+import subprocess  # nosec B404 - subprocess is used for TimeoutExpired in mocked tool execution tests
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
@@ -331,7 +331,7 @@ def test_check_disambiguates_paths_across_modules(
             {},
         )
 
-    files = {issue.file for issue in result.issues}
+    files = {issue.file for issue in (result.issues or [])}
     assert_that(files).is_length(2)
     for file_path in files:
         assert_that(Path(file_path).is_absolute()).is_true()

--- a/tests/unit/tools/golangci_lint/test_execution.py
+++ b/tests/unit/tools/golangci_lint/test_execution.py
@@ -227,6 +227,39 @@ def test_fix_failure_output_preserved_with_remaining_issues(
     assert_that(result.output).contains("build error")
 
 
+def test_fix_aborts_when_initial_check_fails_without_issues(
+    golangci_lint_plugin: GolangciLintPlugin,
+    tmp_path: Path,
+) -> None:
+    """A failed initial check with no parseable issues aborts before --fix.
+
+    When ``golangci-lint run`` errors (config/build failure) and emits no JSON,
+    the baseline is not clean, so the mutating ``--fix`` phase must not run. The
+    diagnostic output is surfaced and no phantom counts are reported.
+
+    Args:
+        golangci_lint_plugin: Plugin under test.
+        tmp_path: Temporary directory for the Go module.
+    """
+    _make_go_module(tmp_path)
+
+    check_error = 'level=error msg="can\'t run linter: build error"'
+    with patch.object(
+        golangci_lint_plugin,
+        "_run_subprocess",
+        return_value=(False, check_error),
+    ) as mock_run:
+        result = golangci_lint_plugin.fix([str(tmp_path)], {})
+
+    # Only the initial check runs; --fix and the re-check are never invoked.
+    assert_that(mock_run.call_count).is_equal_to(1)
+    assert_that(result.success).is_false()
+    assert_that(result.initial_issues_count).is_equal_to(0)
+    assert_that(result.fixed_issues_count).is_equal_to(0)
+    assert_that(result.remaining_issues_count).is_equal_to(0)
+    assert_that(result.output).contains("build error")
+
+
 def test_fix_skips_without_go_mod(
     golangci_lint_plugin: GolangciLintPlugin,
     tmp_path: Path,
@@ -344,6 +377,10 @@ def test_check_timeout_in_one_module_preserves_others(
 ) -> None:
     """A timeout in one module does not discard earlier modules' findings.
 
+    The timed-out module is aggregated as one execution failure (matching
+    ``create_timeout_result``'s standardized timeout contract), so the total
+    count is the earlier module's two findings plus one for the timeout.
+
     Args:
         golangci_lint_plugin: Plugin under test.
         tmp_path: Temporary directory hosting two sibling modules.
@@ -372,7 +409,7 @@ def test_check_timeout_in_one_module_preserves_others(
         )
 
     assert_that(result.success).is_false()
-    assert_that(result.issues_count).is_equal_to(2)
+    assert_that(result.issues_count).is_equal_to(3)
     assert_that(result.output).contains("timed out")
 
 

--- a/tests/unit/tools/golangci_lint/test_execution.py
+++ b/tests/unit/tools/golangci_lint/test_execution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
@@ -299,3 +300,100 @@ def test_check_covers_all_selected_modules(
     assert_that(calls).is_length(2)
     assert_that(result.issues_count).is_equal_to(4)
     assert_that(result.success).is_false()
+
+
+def test_check_disambiguates_paths_across_modules(
+    golangci_lint_plugin: GolangciLintPlugin,
+    tmp_path: Path,
+) -> None:
+    """Findings from different module roots carry distinct absolute paths.
+
+    Both modules report a relative ``main.go``; without rebasing they would
+    collide. Each finding must be anchored to its own module root.
+
+    Args:
+        golangci_lint_plugin: Plugin under test.
+        tmp_path: Temporary directory hosting two sibling modules.
+    """
+    mod_a = tmp_path / "svc-a"
+    mod_b = tmp_path / "svc-b"
+    mod_a.mkdir()
+    mod_b.mkdir()
+    _make_go_module(mod_a)
+    _make_go_module(mod_b)
+
+    with patch(
+        "lintro.tools.definitions.golangci_lint.run_subprocess_with_timeout",
+        side_effect=lambda **kwargs: (False, GOLANGCI_JSON_ONE_ISSUE),
+    ):
+        result = golangci_lint_plugin.check(
+            [str(mod_a / "main.go"), str(mod_b / "main.go")],
+            {},
+        )
+
+    files = {issue.file for issue in result.issues}
+    assert_that(files).is_length(2)
+    for file_path in files:
+        assert_that(Path(file_path).is_absolute()).is_true()
+    assert_that(files).contains(str(mod_a / "main.go"), str(mod_b / "main.go"))
+
+
+def test_check_timeout_in_one_module_preserves_others(
+    golangci_lint_plugin: GolangciLintPlugin,
+    tmp_path: Path,
+) -> None:
+    """A timeout in one module does not discard earlier modules' findings.
+
+    Args:
+        golangci_lint_plugin: Plugin under test.
+        tmp_path: Temporary directory hosting two sibling modules.
+    """
+    mod_a = tmp_path / "svc-a"
+    mod_b = tmp_path / "svc-b"
+    mod_a.mkdir()
+    mod_b.mkdir()
+    _make_go_module(mod_a)
+    _make_go_module(mod_b)
+
+    def _fake_run(**kwargs: Any) -> tuple[bool, str]:
+        # svc-a sorts before svc-b, so svc-a runs first and yields findings;
+        # svc-b then times out.
+        if "svc-a" in kwargs["cwd"]:
+            return (False, GOLANGCI_JSON_TWO_ISSUES)
+        raise subprocess.TimeoutExpired(cmd="golangci-lint", timeout=1)
+
+    with patch(
+        "lintro.tools.definitions.golangci_lint.run_subprocess_with_timeout",
+        side_effect=lambda **kwargs: _fake_run(**kwargs),
+    ):
+        result = golangci_lint_plugin.check(
+            [str(mod_a / "main.go"), str(mod_b / "main.go")],
+            {},
+        )
+
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(2)
+    assert_that(result.output).contains("timed out")
+
+
+def test_fix_initial_check_timeout_reports_no_phantom_issue(
+    golangci_lint_plugin: GolangciLintPlugin,
+    tmp_path: Path,
+) -> None:
+    """A timeout on the initial check must not invent a remaining issue.
+
+    Args:
+        golangci_lint_plugin: Plugin under test.
+        tmp_path: Temporary directory for the Go module.
+    """
+    _make_go_module(tmp_path)
+
+    with patch(
+        "lintro.tools.definitions.golangci_lint.run_subprocess_with_timeout",
+        side_effect=subprocess.TimeoutExpired(cmd="golangci-lint", timeout=1),
+    ):
+        result = golangci_lint_plugin.fix([str(tmp_path)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.initial_issues_count).is_equal_to(0)
+    assert_that(result.remaining_issues_count).is_equal_to(0)

--- a/tests/unit/tools/golangci_lint/test_integration.py
+++ b/tests/unit/tools/golangci_lint/test_integration.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
+from typing import cast
 
 import pytest
 from assertpy import assert_that
@@ -16,7 +17,6 @@ from assertpy import assert_that
 from lintro.parsers.golangci_lint.golangci_lint_issue import GolangciLintIssue
 from lintro.tools.definitions.golangci_lint import GolangciLintPlugin
 from tests.unit.tools.golangci_lint.conftest import golangci_lint_available
-from typing import cast
 
 _FIXTURE = (
     Path(__file__).resolve().parents[4]

--- a/tests/unit/tools/golangci_lint/test_integration.py
+++ b/tests/unit/tools/golangci_lint/test_integration.py
@@ -1,0 +1,86 @@
+"""Binary-gated integration tests for golangci-lint against a Go fixture module.
+
+These tests run the real golangci-lint binary against the committed fixture at
+``test_samples/tools/go/golangci_lint``. They are skipped when golangci-lint or
+the Go toolchain is not installed.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+
+from lintro.parsers.golangci_lint.golangci_lint_issue import GolangciLintIssue
+from lintro.tools.definitions.golangci_lint import GolangciLintPlugin
+from tests.unit.tools.golangci_lint.conftest import golangci_lint_available
+from typing import cast
+
+_FIXTURE = (
+    Path(__file__).resolve().parents[4]
+    / "test_samples"
+    / "tools"
+    / "go"
+    / "golangci_lint"
+)
+
+pytestmark = pytest.mark.skipif(
+    not golangci_lint_available(),
+    reason="golangci-lint and/or the Go toolchain are not installed",
+)
+
+
+def _stage_fixture(tmp_path: Path) -> Path:
+    """Copy the committed Go fixture into ``tmp_path``.
+
+    The fixture lives under ``test_samples/`` which lintro's ``.lintro-ignore``
+    excludes from file discovery, so it is copied into a temporary directory
+    for the real check run.
+
+    Args:
+        tmp_path: Destination directory.
+
+    Returns:
+        Path to the staged fixture module.
+    """
+    dest = tmp_path / "golangci_lint"
+    shutil.copytree(_FIXTURE, dest)
+    return dest
+
+
+def test_fixture_exists() -> None:
+    """The committed Go fixture module is present."""
+    assert_that((_FIXTURE / "go.mod").exists()).is_true()
+    assert_that((_FIXTURE / "main.go").exists()).is_true()
+
+
+def test_check_detects_violations(tmp_path: Path) -> None:
+    """golangci-lint detects the seeded errcheck/ineffassign violations."""
+    module = _stage_fixture(tmp_path)
+    plugin = GolangciLintPlugin()
+    result = plugin.check([str(module)], {})
+
+    assert_that(result.issues_count).is_greater_than_or_equal_to(2)
+    assert_that(result.success).is_false()
+    assert_that(result.issues).is_not_none()
+    issues = cast(list[GolangciLintIssue], result.issues)
+    codes = {issue.code for issue in issues}
+    assert_that(codes).contains("errcheck", "ineffassign")
+    for issue in issues:
+        assert_that(issue.file).is_not_empty()
+        assert_that(issue.line).is_greater_than(0)
+
+
+def test_doc_url_resolves_for_detected_linter(tmp_path: Path) -> None:
+    """The plugin resolves a doc URL for a detected sub-linter code."""
+    module = _stage_fixture(tmp_path)
+    plugin = GolangciLintPlugin()
+    result = plugin.check([str(module)], {})
+    assert_that(result.issues).is_not_none()
+    issues = cast(list[GolangciLintIssue], result.issues)
+    codes = {issue.code for issue in issues}
+    assert_that(plugin.doc_url(next(iter(codes)))).starts_with(
+        "https://golangci-lint.run",
+    )


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `feat(tools): add golangci-lint Go meta-linter plugin`
- Type: **feat** (minor)
- Breaking change: no

## What's Changing

Adds [golangci-lint](https://golangci-lint.run/) (v2) as a lintro tool plugin —
the de-facto Go meta-linter that aggregates 100+ sub-linters (errcheck,
staticcheck, ineffassign, govet, gosec, ...). It follows the existing
module-context linter pattern used by Clippy for Rust: it requires a Go module
(`go.mod`) plus the Go toolchain and skips cleanly for non-Go projects.

### Parser choice: native JSON, not SARIF

golangci-lint can emit SARIF (`--output.sarif.path`), but its SARIF export is
**lossy** for lintro's `BaseIssue` model, per the fidelity checklist in
`docs/design/sarif-ingestion-evaluation.md` (#1066 / PR #1140). Verified by
capturing both formats from the same run:

| Signal                 | Native JSON                           | golangci-lint SARIF                     |
| ---------------------- | ------------------------------------- | --------------------------------------- |
| Sub-linter attribution | `Issues[].FromLinter`                 | `results[].ruleId` (preserved)          |
| Severity               | per-issue `Severity` (configurable)   | **hard-coded `level: "error"`** for all |
| Fix / autofix metadata | `SuggestedFixes` / `Replacement`      | **no `fixes[]` at all**                 |
| Doc URLs               | synthesized from linter name          | **no `rules[]` / `helpUri`**            |

SARIF would collapse every finding to `error`, drop all autofix metadata (so
lintro could not surface which issues are fixable), and omit rule metadata
(no doc URLs). A native JSON parser preserves all three, so it is used here.
golangci-lint is not among the evaluation's SARIF-native candidates.

Note: golangci-lint **v2** changed the CLI (`--output.<fmt>.path` replaces v1
`--out-format`) and config schema (`version: "2"`); the plugin targets v2 and
pins `2.12.2`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (full `pytest`; only the two known env-only pre-existing
      failures remain)

## Related Issues

Closes #428

## Details

**Added**
- `lintro/tools/definitions/golangci_lint.py` — `@register_tool` plugin with
  `check()`/`fix()`, Go-module discovery, timeout handling, per-linter doc URLs
- `lintro/parsers/golangci_lint/` — issue dataclass + JSON parser (robust to
  ANSI codes and a trailing human-readable stats footer)
- Tests: parser unit tests on captured output; mocked plugin execution/skip
  tests; binary-gated integration test on `test_samples/tools/go/golangci_lint`
- `docs/tool-analysis/golangci-lint-analysis.md`

**Registration (additive)**
- `ToolName.GOLANGCI_LINT`, `DocUrlTemplate.GOLANGCI_LINT`
- `manifest.json` entry + `go` language map; `_tool_versions.py` pin; version
  parsing/install-hint; `StandaloneBuilder` binary-name mapping
  (`golangci_lint` → `golangci-lint`)
- `renovate.json` custom manager (`golangci/golangci-lint` releases)
- `pyproject.toml` parser package; `install-tools.sh` (checksum-verified binary
  install + verify list); `Dockerfile` verification; Homebrew template
- README, getting-started, configuration docs

**Verification**
- `uv run lintro check --tools golangci_lint` detects seeded errcheck/ineffassign
  violations with doc URLs; `lintro doctor` reports 2.12.2; `lintro list-tools`
  shows the tool
- Manifest generator `--check` passes (no version drift)
- ruff / black / mypy / bandit / shellcheck / shfmt / hadolint / markdownlint
  clean on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `golangci-lint` v2 support for Go projects, including module-context linting and issue reporting.
  * Supports both “check” and “fix” workflows, with fixable finding detection.
  * Improved tool installation/version handling and executable invocation for `golangci-lint`.

* **Documentation**
  * Updated supported tools lists and getting-started instructions for `golangci-lint` (including Go toolchain requirement).
  * Added `golangci-lint Configuration` documentation and a detailed analysis page.

* **Tests**
  * Added unit and integration coverage for `golangci-lint` parsing and check/fix behavior, including multi-module scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds golangci-lint as a Go tool plugin. The main changes are:

- New golangci-lint tool definition for check and format workflows.
- Native JSON parser for golangci-lint findings.
- Tool registration, version pinning, install support, and docs updates.
- Unit and integration coverage for parser and execution behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/definitions/golangci_lint.py | Adds module discovery, per-module execution, path rebasing, timeout handling, and format result aggregation for golangci-lint. |
| lintro/parsers/golangci_lint/golangci_lint_parser.py | Adds native JSON parsing for golangci-lint output, including position-less findings and fixable issue metadata. |
| tests/unit/tools/golangci_lint/test_execution.py | Adds execution tests for skip behavior, module handling, issue aggregation, and format failure reporting. |
| tests/unit/parsers/test_golangci_lint_parser.py | Adds parser tests for normal findings, malformed output, severity, fixability, and missing-position findings. |

</details>

<sub>Reviews (21): Last reviewed commit: ["fix(install): keep --tools-filtered veri..."](https://github.com/lgtm-hq/py-lintro/commit/c6743c1bbf2badeb1b495634f596985ebd541d70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42194182)</sub>

<!-- /greptile_comment -->