### PR TITLE
feat(tools): add vale for prose/documentation linting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,7 @@ RUN echo "=== Verifying all tools ===" && \
     shellcheck --version && shfmt --version && sqlfluff --version && \
     taplo --version && tsc --version && astro --version && \
     svelte-check --version && vue-tsc --version && yamllint --version && \
+    vale --version && \
     echo "=== All tools verified! ==="
 
 # -----------------------------------------------------------------------------
@@ -165,6 +166,7 @@ RUN echo "Verifying tools..." && \
     vue-tsc --version && oxlint --version && oxfmt --version && \
     bandit --version && mypy --version && pydoclint --version && \
     yamllint --version && sqlfluff --version && \
+    vale --version && \
     echo "All tools verified!"
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ system.
 <td><code>bun add -g markdownlint-cli2</code><br><code>npm install -g markdownlint-cli2</code></td>
 </tr>
 <tr>
+<td><a href="https://vale.sh/"><img src="https://img.shields.io/badge/Vale-2ea44f?logo=markdown&logoColor=white" alt="Vale"></a></td>
+<td>📝 Prose / Docs</td>
+<td>-</td>
+<td><code>brew install vale</code><br><a href="https://github.com/errata-ai/vale/releases">GitHub Releases</a></td>
+</tr>
+<tr>
 <td><a href="https://oxc.rs/"><img src="https://img.shields.io/badge/Oxlint-e05d44?logo=javascript&logoColor=white" alt="Oxlint"></a></td>
 <td>🟨 JS/TS</td>
 <td>✅</td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -454,6 +454,7 @@ tool_priorities = { ruff = 5, black = 10, prettier = 1 }
 | ruff         | 20       | Linter/Formatter |
 | markdownlint | 30       | Linter           |
 | yamllint     | 35       | Linter           |
+| vale         | 50       | Linter (docs)    |
 | pydoclint    | 40       | Linter           |
 | bandit       | 45       | Security         |
 | hadolint     | 50       | Infrastructure   |
@@ -1455,6 +1456,51 @@ MD041: false
 - Lintro respects markdownlint-cli2's native configuration discovery
 - Future versions may expose additional options via `[tool.lintro.markdownlint-cli2]` in
   `pyproject.toml`
+
+### Prose / Documentation Tools
+
+#### Vale Configuration {#vale-configuration}
+
+[Vale](https://vale.sh/) is a syntax-aware prose linter. Lintro defers to Vale's native
+configuration discovery, which walks upward from each linted file to find a `.vale.ini`.
+
+> Vale requires a configuration to run. When none is resolvable, Lintro skips vale as a
+> non-error (rather than surfacing vale's `E100` runtime error), keeping mixed-language
+> runs clean.
+
+**Native config detection:** `.vale.ini`, `_vale.ini`, `vale.ini`.
+
+**File:** `.vale.ini`
+
+```ini
+MinAlertLevel = suggestion
+
+[*.md]
+BasedOnStyles = Vale
+```
+
+**Installation:**
+
+```bash
+brew install vale
+# or download from https://github.com/errata-ai/vale/releases
+```
+
+**Available `--tool-options`:**
+
+| Option            | Type   | Description                                              |
+| ----------------- | ------ | -------------------------------------------------------- |
+| `config`          | string | Path to a Vale config file (maps to `--config`)          |
+| `min_alert_level` | string | Minimum alert level: `suggestion`, `warning`, or `error` |
+| `timeout`         | int    | Per-run timeout in seconds (default 30)                  |
+
+**Usage:**
+
+```bash
+lintro check docs/ --tools vale
+lintro check docs/ --tools vale --tool-options vale:min_alert_level=warning
+lintro check docs/ --tools vale --tool-options vale:config=.vale.ini
+```
 
 ### Rust Tools
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -95,6 +95,8 @@ Some tools require separate installation. Their minimum versions are also manage
 - `shfmt` - Shell script formatter (`brew install shfmt` or GitHub releases)
 - `sqlfluff` - SQL linter and formatter (`pip install sqlfluff`)
 - `taplo` - TOML linter and formatter (`brew install taplo` or GitHub releases)
+- `vale` - Prose/documentation linter (`brew install vale` or GitHub releases); requires
+  a `.vale.ini`, otherwise lintro skips it as a non-error
 - `cargo-audit` - Rust dependency vulnerability scanner (`cargo install cargo-audit`)
 - `cargo-deny` - Rust dependency license/advisory checker (`cargo install cargo-deny`)
 - `osv-scanner` - Multi-ecosystem vulnerability scanner using the OSV database

--- a/docs/tool-analysis/vale-analysis.md
+++ b/docs/tool-analysis/vale-analysis.md
@@ -1,0 +1,127 @@
+# Vale Tool Analysis
+
+## Overview
+
+[Vale](https://vale.sh/) is a syntax-aware linter for prose and documentation. It checks
+Markdown, reStructuredText, AsciiDoc, HTML, and plain text against configurable style
+guides (Microsoft, Google, write-good, proselint, alex, and custom rules). This analysis
+compares Lintro's wrapper with the upstream `vale` behavior.
+
+> Vale requires a `.vale.ini` configuration to run. When no config is resolvable, Lintro
+> skips vale as a non-error (rather than surfacing vale's hard `E100` runtime error),
+> keeping `lintro check` clean on projects that do not use Vale.
+
+## Core Tool Capabilities
+
+- Prose linting for Markdown, reStructuredText, AsciiDoc, HTML, and plain text
+- Configurable style guides via `BasedOnStyles` in `.vale.ini`
+- Custom rule support authored in YAML
+- Fast (written in Go) with editor integrations
+- Machine-readable output via `--output=JSON`
+
+## Built-in and Community Styles
+
+- Microsoft Writing Style Guide
+- Google Developer Documentation Style Guide
+- write-good
+- proselint
+- alex (inclusive language)
+- The bundled `Vale` style (ships with the binary; no `vale sync` required)
+
+External styles are installed with `vale sync` after listing `Packages` in `.vale.ini`.
+
+## Lintro Implementation Analysis
+
+### ✅ Preserved Features
+
+- Standard prose linting via `vale --output=JSON`
+- Native config discovery respected (`.vale.ini`, `_vale.ini`, `vale.ini`); vale
+  resolves configuration by walking up from each linted file
+- File targeting for documentation patterns (`*.md`, `*.rst`, `*.adoc`, `*.txt`)
+- Minimum alert level control via `vale:min_alert_level`
+- Explicit config path via `vale:config`
+- Timeout control (default 30s) via `vale:timeout`
+
+### ⚠️ Limited / Missing
+
+- **Config is required.** Vale cannot run without a resolvable configuration. When none
+  is found, Lintro skips the tool as a non-error (with a helpful message) rather than
+  surfacing vale's `E100` runtime error (exit 2).
+- **No auto-fix.** Vale reports prose and style violations only; `fix()` raises
+  `NotImplementedError`.
+- No pass-through of advanced CLI flags (e.g. `--glob`, `--filter`, `--ignore-syntax`)
+  beyond `--config` and `--minAlertLevel`.
+- No custom formatter selection; the JSON output is used internally for parsing.
+
+### 🚀 Enhancements
+
+- Graceful skip when no config is present, keeping mixed-language runs clean
+- Unified `ToolResult` with normalized issues from `vale_parser`
+- Per-issue documentation links are taken from vale's `Link` field when a style provides
+  them
+- Vale's `suggestion` alert level is normalized to Lintro's `INFO` severity
+- Safe version check with a skip result when vale is missing or below the required
+  version
+
+## Usage Comparison
+
+```bash
+# Core vale
+vale --output=JSON docs/
+
+# Lintro wrapper
+lintro check docs/ --tools vale
+lintro check docs/ --tools vale --tool-options vale:min_alert_level=warning
+lintro check docs/ --tools vale --tool-options vale:config=.vale.ini
+lintro check docs/ --tools vale --tool-options vale:timeout=60
+```
+
+## Output Format
+
+Vale emits a JSON object keyed by file path; each value is a list of alerts:
+
+```json
+{
+  "docs/example.md": [
+    {
+      "Action": { "Name": "edit", "Params": ["truncate", " "] },
+      "Span": [1, 7],
+      "Check": "Vale.Repetition",
+      "Description": "",
+      "Link": "",
+      "Message": "'the' is repeated!",
+      "Severity": "error",
+      "Match": "The the",
+      "Line": 3
+    }
+  ]
+}
+```
+
+Lintro's parser maps `Check` to the display code (with the leading `<Style>` recorded
+separately), `Span[0]` to the column, `Severity` to the normalized severity, and `Link`
+to the documentation URL when present.
+
+## Configuration Strategy
+
+- Prefers native configs: `.vale.ini`, `_vale.ini`, or `vale.ini`.
+- A minimal self-contained config uses only the bundled `Vale` style:
+
+  ```ini
+  MinAlertLevel = suggestion
+
+  [*.md]
+  BasedOnStyles = Vale
+  ```
+
+- Richer setups add `BasedOnStyles = Microsoft, Google` and run `vale sync` to download
+  the referenced style packages.
+
+## Comparison with markdownlint
+
+- **markdownlint** checks Markdown _syntax_ and formatting (headings, list spacing, line
+  length).
+- **vale** checks _prose_ quality and style (repetition, passive voice, jargon,
+  inclusive language).
+
+The two are complementary and can run together on the same documentation set.

--- a/lintro/_tool_versions.py
+++ b/lintro/_tool_versions.py
@@ -71,6 +71,7 @@ TOOL_VERSIONS: dict[ToolName | str, str] = {
     ToolName.SHELLCHECK: "0.11.0",
     ToolName.SHFMT: "3.13.0",
     ToolName.TAPLO: "0.10.0",
+    ToolName.VALE: "3.15.1",
 }
 
 _NPM_PACKAGE_TO_TOOL: dict[str, ToolName] = {

--- a/lintro/enums/severity_level.py
+++ b/lintro/enums/severity_level.py
@@ -34,6 +34,8 @@ _SEVERITY_ALIASES: dict[str, SeverityLevel] = {
     "HINT": SeverityLevel.INFO,
     "STYLE": SeverityLevel.INFO,
     "HELP": SeverityLevel.INFO,
+    # Vale alert level
+    "SUGGESTION": SeverityLevel.INFO,
     # Bandit / cargo-audit severity levels
     "HIGH": SeverityLevel.ERROR,
     "CRITICAL": SeverityLevel.ERROR,

--- a/lintro/enums/tool_name.py
+++ b/lintro/enums/tool_name.py
@@ -38,6 +38,7 @@ class ToolName(StrEnum):
     SVELTE_CHECK = auto()
     TAPLO = auto()
     TSC = auto()
+    VALE = auto()
     VUE_TSC = auto()
     YAMLLINT = auto()
 

--- a/lintro/parsers/vale/__init__.py
+++ b/lintro/parsers/vale/__init__.py
@@ -1,0 +1,10 @@
+"""Vale prose linter parser package.
+
+Exposes the Vale issue model and output parser for use by the Vale tool
+plugin and tests.
+"""
+
+from lintro.parsers.vale.vale_issue import ValeIssue
+from lintro.parsers.vale.vale_parser import parse_vale_output
+
+__all__ = ["ValeIssue", "parse_vale_output"]

--- a/lintro/parsers/vale/vale_issue.py
+++ b/lintro/parsers/vale/vale_issue.py
@@ -1,0 +1,44 @@
+"""Vale issue model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+from lintro.enums.severity_level import SeverityLevel
+from lintro.parsers.base_issue import BaseIssue
+
+
+@dataclass
+class ValeIssue(BaseIssue):
+    """Represents a single issue reported by Vale.
+
+    Vale reports prose/style violations keyed by file, each carrying a check
+    name (``<Style>.<Rule>``), a severity, a human-readable message, and an
+    optional documentation link.
+
+    Attributes:
+        DISPLAY_FIELD_MAP: Routes the ``code`` display column to ``check`` and
+            the ``severity`` column to the native ``severity`` string.
+        DEFAULT_SEVERITY: Defaults to WARNING when Vale omits a severity.
+        check: Full Vale check name (e.g., ``Vale.Repetition``,
+            ``Microsoft.Adverbs``).
+        style: Style bundle the check belongs to (e.g., ``Vale``, ``Microsoft``,
+            ``Google``), derived from the portion of ``check`` before the dot.
+        severity: Native Vale severity (``error``, ``warning``, ``suggestion``).
+        match: The source text that triggered the alert (may be empty).
+    """
+
+    DISPLAY_FIELD_MAP: ClassVar[dict[str, str]] = {
+        "code": "check",
+        "severity": "severity",
+        "fixable": "fixable",
+        "message": "message",
+    }
+
+    DEFAULT_SEVERITY: ClassVar[SeverityLevel] = SeverityLevel.WARNING
+
+    check: str = field(default="")
+    style: str = field(default="")
+    severity: str = field(default="")
+    match: str = field(default="")

--- a/lintro/parsers/vale/vale_parser.py
+++ b/lintro/parsers/vale/vale_parser.py
@@ -1,0 +1,110 @@
+"""Parser for Vale JSON output.
+
+Vale (``vale --output=JSON``) emits a JSON object keyed by file path. Each
+value is a list of alert objects with this shape::
+
+    {
+      "docs/example.md": [
+        {
+          "Action": {"Name": "edit", "Params": ["truncate", " "]},
+          "Span": [1, 7],
+          "Check": "Vale.Repetition",
+          "Description": "",
+          "Link": "https://...",
+          "Message": "'the' is repeated!",
+          "Severity": "error",
+          "Match": "The the",
+          "Line": 3
+        }
+      ]
+    }
+
+When Vale cannot find a configuration file it emits a single top-level error
+object (with ``Code`` ``E100``) instead of the per-file mapping; that case is
+handled by the plugin (graceful skip), so this parser simply returns ``[]`` for
+any payload that is not the per-file mapping shape.
+"""
+
+from __future__ import annotations
+
+import json
+
+from lintro.parsers.vale.vale_issue import ValeIssue
+
+
+def _coerce_int(value: object) -> int:
+    """Coerce a JSON value to a non-negative int, defaulting to 0.
+
+    Args:
+        value: Raw value from the parsed JSON payload.
+
+    Returns:
+        The value as an int when convertible and non-negative, else 0.
+    """
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value if value > 0 else 0
+    return 0
+
+
+def parse_vale_output(output: str | None) -> list[ValeIssue]:
+    """Parse Vale JSON output into a list of ``ValeIssue`` objects.
+
+    Args:
+        output: Raw stdout from ``vale --output=JSON``. May be ``None`` or
+            empty when Vale reports no issues.
+
+    Returns:
+        A list of ``ValeIssue`` objects. Returns an empty list for empty,
+        null, malformed, or non-mapping payloads (e.g., Vale's ``E100``
+        no-config error object).
+    """
+    if not output or not output.strip():
+        return []
+
+    try:
+        data = json.loads(output)
+    except (json.JSONDecodeError, ValueError):
+        return []
+
+    # Expected shape is an object mapping file paths to alert lists. Vale's
+    # runtime-error payload is a single object (not a mapping of lists), which
+    # we intentionally ignore here.
+    if not isinstance(data, dict):
+        return []
+
+    issues: list[ValeIssue] = []
+    for file_path, alerts in data.items():
+        if not isinstance(alerts, list):
+            continue
+        for alert in alerts:
+            if not isinstance(alert, dict):
+                continue
+
+            check = str(alert.get("Check", "") or "")
+            style = check.split(".", 1)[0] if "." in check else check
+
+            span = alert.get("Span")
+            column = 0
+            if isinstance(span, list) and span:
+                column = _coerce_int(span[0])
+
+            link = alert.get("Link")
+            doc_url = str(link) if link else ""
+
+            issues.append(
+                ValeIssue(
+                    file=str(file_path),
+                    line=_coerce_int(alert.get("Line")),
+                    column=column,
+                    message=str(alert.get("Message", "") or ""),
+                    check=check,
+                    style=style,
+                    severity=str(alert.get("Severity", "") or ""),
+                    match=str(alert.get("Match", "") or ""),
+                    doc_url=doc_url,
+                ),
+            )
+
+    return issues

--- a/lintro/tools/core/version_checking.py
+++ b/lintro/tools/core/version_checking.py
@@ -203,6 +203,10 @@ def get_install_hints() -> dict[str, str]:
             "Install via: cargo install taplo-cli "
             "or download from https://github.com/tamasfe/taplo/releases (v{version}+)"
         ),
+        "vale": (
+            "Install via: brew install vale "
+            "or download from https://github.com/errata-ai/vale/releases (v{version}+)"
+        ),
         "astro_check": (
             "Install via: bun add astro@>={version} or npm install astro@>={version}"
         ),

--- a/lintro/tools/core/version_parsing.py
+++ b/lintro/tools/core/version_parsing.py
@@ -52,6 +52,7 @@ TOOLS_WITH_SIMPLE_VERSION_PATTERN: set[ToolName] = {
     ToolName.SQLFLUFF,
     ToolName.SVELTE_CHECK,
     ToolName.TAPLO,
+    ToolName.VALE,
     ToolName.VUE_TSC,
 }
 

--- a/lintro/tools/definitions/vale.py
+++ b/lintro/tools/definitions/vale.py
@@ -207,6 +207,19 @@ class ValePlugin(BaseToolPlugin):
         if not issues and self._is_no_config_error(output):
             return self._create_no_config_result()
 
+        # Vale exits 0 on a clean run and 1 when alerts are found; any other
+        # non-zero exit with no parseable alerts is a runtime problem (invalid
+        # config, missing styles package, bad flag). Surface that as a failure
+        # instead of reporting a clean pass from a run that produced nothing.
+        if not issues and not _success:
+            return ToolResult(
+                name=self.definition.name,
+                success=False,
+                output=(output or "Vale exited with an error and produced no results."),
+                issues_count=0,
+                parse_failures_count=1,
+            )
+
         issues_count = len(issues)
         success = issues_count == 0
 

--- a/lintro/tools/definitions/vale.py
+++ b/lintro/tools/definitions/vale.py
@@ -1,0 +1,236 @@
+"""Vale tool definition.
+
+Vale is a syntax-aware linter for prose and documentation. It checks Markdown,
+AsciiDoc, reStructuredText, HTML, and plain text against configurable style
+guides (Microsoft, Google, write-good, proselint, and custom rules).
+
+Vale requires a ``.vale.ini`` configuration to run. When no configuration is
+resolvable, this plugin skips as a non-error (rather than surfacing Vale's hard
+``E100`` runtime error) so ``lintro check`` stays clean on projects that do not
+use Vale.
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 - used safely with shell disabled
+from dataclasses import dataclass
+from typing import Any
+
+from loguru import logger
+
+from lintro._tool_versions import get_min_version
+from lintro.enums.tool_name import ToolName
+from lintro.enums.tool_type import ToolType
+from lintro.models.core.tool_result import ToolResult
+from lintro.parsers.vale.vale_parser import parse_vale_output
+from lintro.plugins.base import BaseToolPlugin
+from lintro.plugins.protocol import ToolDefinition
+from lintro.plugins.registry import register_tool
+from lintro.tools.core.option_validators import (
+    filter_none_options,
+    validate_positive_int,
+    validate_str,
+)
+from lintro.tools.core.timeout_utils import create_timeout_result
+
+# Constants for Vale configuration
+VALE_DEFAULT_TIMEOUT: int = 30
+VALE_DEFAULT_PRIORITY: int = 50
+VALE_FILE_PATTERNS: list[str] = ["*.md", "*.rst", "*.adoc", "*.txt"]
+VALE_CONFIG_FILENAMES: list[str] = [".vale.ini", "_vale.ini", "vale.ini"]
+
+
+@register_tool
+@dataclass
+class ValePlugin(BaseToolPlugin):
+    """Vale prose/documentation linter plugin.
+
+    Integrates Vale with Lintro for linting prose in Markdown, reStructuredText,
+    AsciiDoc, and plain-text files against configurable style guides.
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition.
+
+        Returns:
+            ToolDefinition containing tool metadata.
+        """
+        return ToolDefinition(
+            name="vale",
+            description=(
+                "Syntax-aware prose linter for docs with configurable style guides"
+            ),
+            can_fix=False,
+            tool_type=ToolType.LINTER | ToolType.DOCUMENTATION,
+            file_patterns=VALE_FILE_PATTERNS,
+            priority=VALE_DEFAULT_PRIORITY,
+            conflicts_with=[],
+            native_configs=list(VALE_CONFIG_FILENAMES),
+            version_command=["vale", "--version"],
+            min_version=get_min_version(ToolName.VALE),
+            default_options={
+                "timeout": VALE_DEFAULT_TIMEOUT,
+                "config": None,
+                "min_alert_level": None,
+            },
+            default_timeout=VALE_DEFAULT_TIMEOUT,
+        )
+
+    def set_options(
+        self,
+        config: str | None = None,
+        min_alert_level: str | None = None,
+        timeout: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Set Vale-specific options.
+
+        Args:
+            config: Path to a Vale config file (maps to ``--config``).
+            min_alert_level: Minimum alert level to report
+                (``suggestion``, ``warning``, or ``error``).
+            timeout: Timeout in seconds (default: 30).
+            **kwargs: Other tool options.
+        """
+        validate_str(config, "config")
+        validate_str(min_alert_level, "min_alert_level")
+        validate_positive_int(timeout, "timeout")
+
+        options = filter_none_options(
+            config=config,
+            min_alert_level=min_alert_level,
+            timeout=timeout,
+        )
+        super().set_options(**options, **kwargs)
+
+    @staticmethod
+    def _is_no_config_error(output: str | None) -> bool:
+        """Report whether output indicates a missing Vale configuration.
+
+        Vale requires a ``.vale.ini`` to run and exits with an ``E100``
+        runtime error when none is resolvable. Detect that so lintro can skip
+        gracefully rather than surfacing a hard failure.
+
+        Args:
+            output: Combined stdout/stderr from Vale.
+
+        Returns:
+            True if the output signals a missing/unresolvable configuration.
+        """
+        if not output:
+            return False
+        return (
+            "E100" in output
+            or ".vale.ini not found" in output
+            or "no config file found" in output
+        )
+
+    def _create_no_config_result(self) -> ToolResult:
+        """Create a skip ToolResult for when no Vale config is found.
+
+        Vale cannot lint without a configuration, so lintro skips it (as a
+        non-error) rather than surfacing a hard failure. This keeps runs clean
+        for projects that do not use Vale.
+
+        Returns:
+            ToolResult: Skip result (success=True) with a helpful message.
+        """
+        return ToolResult(
+            name=self.definition.name,
+            success=True,
+            output=(
+                "Skipping vale: no Vale configuration found "
+                "(e.g. .vale.ini). Add one to enable prose linting."
+            ),
+            issues_count=0,
+        )
+
+    def _build_command(self) -> list[str]:
+        """Build the base Vale command, honoring explicit options.
+
+        Config discovery is otherwise delegated to Vale itself, which resolves
+        a ``.vale.ini`` by walking up from each linted file.
+
+        Returns:
+            The base command list.
+        """
+        cmd: list[str] = ["vale", "--output=JSON"]
+
+        config_opt = self.options.get("config")
+        if config_opt:
+            cmd.extend(["--config", str(config_opt)])
+
+        level_opt = self.options.get("min_alert_level")
+        if level_opt:
+            cmd.extend(["--minAlertLevel", str(level_opt)])
+
+        return cmd
+
+    def check(self, paths: list[str], options: dict[str, object]) -> ToolResult:
+        """Check files with Vale.
+
+        Args:
+            paths: List of file or directory paths to check.
+            options: Runtime options that override defaults.
+
+        Returns:
+            ToolResult with check results.
+        """
+        ctx = self._prepare_execution(paths, options)
+        if ctx.should_skip:
+            return ctx.early_result  # type: ignore[return-value]
+
+        cmd = self._build_command() + list(ctx.rel_files)
+        logger.debug(f"[ValePlugin] Running: {' '.join(cmd)} (cwd={ctx.cwd})")
+
+        try:
+            _success, output = self._run_subprocess(
+                cmd=cmd,
+                timeout=ctx.timeout,
+                cwd=ctx.cwd,
+            )
+        except subprocess.TimeoutExpired:
+            timeout_result = create_timeout_result(
+                tool=self,
+                timeout=ctx.timeout,
+                cmd=cmd,
+            )
+            return ToolResult(
+                name=self.definition.name,
+                success=timeout_result.success,
+                output=timeout_result.output,
+                issues_count=timeout_result.issues_count,
+            )
+
+        issues = parse_vale_output(output=output)
+        if not issues and self._is_no_config_error(output):
+            return self._create_no_config_result()
+
+        issues_count = len(issues)
+        success = issues_count == 0
+
+        return ToolResult(
+            name=self.definition.name,
+            success=success,
+            output=output if not success else None,
+            issues_count=issues_count,
+            issues=issues,
+        )
+
+    def fix(self, paths: list[str], options: dict[str, object]) -> ToolResult:
+        """Vale cannot fix issues, only report them.
+
+        Args:
+            paths: List of file or directory paths to fix.
+            options: Runtime options that override defaults.
+
+        Returns:
+            ToolResult: Never returns, always raises NotImplementedError.
+
+        Raises:
+            NotImplementedError: Vale is a linter only and cannot fix issues.
+        """
+        raise NotImplementedError(
+            "Vale cannot fix issues; it reports prose and style violations only.",
+        )

--- a/lintro/tools/manifest.json
+++ b/lintro/tools/manifest.json
@@ -48,7 +48,10 @@
     "security": ["gitleaks", "osv_scanner", "semgrep"],
     "astro": ["astro_check", "prettier"],
     "svelte": ["svelte_check", "prettier"],
-    "vue": ["vue_tsc", "prettier"]
+    "vue": ["vue_tsc", "prettier"],
+    "restructuredtext": ["vale"],
+    "asciidoc": ["vale"],
+    "plaintext": ["vale"]
   },
   "tools": [
     {
@@ -407,7 +410,7 @@
       "tier": "tools",
       "category": "external",
       "version_command": ["vale", "--version"],
-      "languages": ["markdown"],
+      "languages": ["markdown", "restructuredtext", "asciidoc", "plaintext"],
       "tags": ["linter", "documentation"]
     },
     {

--- a/lintro/tools/manifest.json
+++ b/lintro/tools/manifest.json
@@ -42,7 +42,7 @@
     "shell": ["shellcheck", "shfmt"],
     "docker": ["hadolint"],
     "yaml": ["yamllint"],
-    "markdown": ["markdownlint"],
+    "markdown": ["markdownlint", "vale"],
     "toml": ["taplo"],
     "github_actions": ["actionlint"],
     "security": ["gitleaks", "osv_scanner", "semgrep"],
@@ -397,6 +397,18 @@
       "version_command": ["tsc", "--version"],
       "languages": ["typescript"],
       "tags": ["linter", "type_checker"]
+    },
+    {
+      "name": "vale",
+      "version": "3.15.1",
+      "install": {
+        "type": "binary"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["vale", "--version"],
+      "languages": ["markdown"],
+      "tags": ["linter", "documentation"]
     },
     {
       "name": "vue_tsc",

--- a/lintro/utils/console/constants.py
+++ b/lintro/utils/console/constants.py
@@ -26,6 +26,7 @@ TOOL_EMOJIS: dict[str, str] = {
     "oxlint": "⚡",
     "oxfmt": "✨",
     "prettier": "💅",
+    "vale": "✍️",
 }
 DEFAULT_EMOJI: str = "🔧"
 BORDER_LENGTH: int = 70

--- a/lintro/utils/project_detection.py
+++ b/lintro/utils/project_detection.py
@@ -163,7 +163,10 @@ def detect_project_languages() -> list[str]:
     )
     if has_rst:
         langs.add("restructuredtext")
-    if any(cwd.glob("*.adoc")):
+    has_adoc = any(cwd.glob("*.adoc")) or (
+        docs_dir.is_dir() and any(docs_dir.glob("**/*.adoc"))
+    )
+    if has_adoc:
         langs.add("asciidoc")
 
     return sorted(langs)

--- a/lintro/utils/project_detection.py
+++ b/lintro/utils/project_detection.py
@@ -156,6 +156,16 @@ def detect_project_languages() -> list[str]:
     if toml_files:
         langs.add("toml")
 
+    # Prose/documentation formats beyond Markdown (vale targets).
+    docs_dir = cwd / "docs"
+    has_rst = any(cwd.glob("*.rst")) or (
+        docs_dir.is_dir() and any(docs_dir.glob("**/*.rst"))
+    )
+    if has_rst:
+        langs.add("restructuredtext")
+    if any(cwd.glob("*.adoc")):
+        langs.add("asciidoc")
+
     return sorted(langs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ packages = [
   "lintro.parsers.taplo",
   "lintro.parsers.pydoclint",
   "lintro.parsers.tsc",
+  "lintro.parsers.vale",
   "lintro.parsers.vue_tsc",
   "lintro.plugins",
   "lintro.tools",

--- a/renovate.json
+++ b/renovate.json
@@ -66,6 +66,8 @@
         "mvdan/sh",
         "taplo",
         "tamasfe/taplo",
+        "vale",
+        "errata-ai/vale",
         "astro",
         "@astrojs/check",
         "svelte-check",
@@ -248,6 +250,19 @@
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "tamasfe/taplo",
       "extractVersionTemplate": "^(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)$"
+    },
+    {
+      "description": "Update vale version in _tool_versions.py",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "lintro/_tool_versions\\.py"
+      ],
+      "matchStrings": [
+        "ToolName\\.VALE:\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "errata-ai/vale",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "description": "Update cargo-audit version in _tool_versions.py",

--- a/scripts/ci/homebrew/templates/lintro.rb.template
+++ b/scripts/ci/homebrew/templates/lintro.rb.template
@@ -38,6 +38,7 @@ class Lintro < Formula
   depends_on "shfmt"
   depends_on "sqlfluff"
   depends_on "taplo"
+  depends_on "vale"
   depends_on "yamllint"
 
   # Pure Python library dependencies
@@ -73,6 +74,7 @@ class Lintro < Formula
       YAML / TOML:      yamllint, taplo
       Shell:            shellcheck, shfmt
       Markdown:         markdownlint-cli2
+      Prose / docs:     vale
       JS / TS:          oxlint, oxfmt, prettier
       Dockerfiles:      hadolint
       GitHub Actions:   actionlint

--- a/scripts/utils/install-tools.sh
+++ b/scripts/utils/install-tools.sh
@@ -83,6 +83,7 @@ This script installs:
   - shfmt (Shell script formatter)
   - SQLFluff (SQL linter and formatter)
   - Taplo (TOML linter and formatter)
+  - Vale (Prose/documentation linter)
   - TypeScript (TypeScript compiler and type checker)
   - Astro Check (Astro component type checker)
   - Gitleaks (Secret detection scanner)
@@ -169,7 +170,7 @@ SUPPORTED_TOOLS=(
 	"clippy" "gitleaks" "hadolint" "markdownlint" "markdownlint-cli2" "mypy" "osv-scanner"
 	"oxfmt" "oxlint" "prettier" "pydoclint" "ruff" "rustfmt" "semgrep"
 	"shellcheck" "shfmt" "sqlfluff" "svelte-check" "taplo" "tsc"
-	"vue-tsc" "yamllint"
+	"vale" "vue-tsc" "yamllint"
 )
 
 # Validate --tools filter against known tool names (fail-fast on typos).
@@ -749,6 +750,84 @@ main() {
 			fi
 		fi
 	fi # shfmt
+
+	if should_install "vale"; then
+		# Install vale (prose/documentation linter)
+		# Prebuilt binaries: https://github.com/errata-ai/vale/releases
+		echo -e "${BLUE}Installing vale...${NC}"
+		VALE_VERSION=$(get_tool_version "vale") || exit 1
+		if [ $DRY_RUN -eq 1 ]; then
+			log_info "[DRY-RUN] Would install vale v${VALE_VERSION}"
+		elif command -v vale &>/dev/null; then
+			echo -e "${GREEN}✓ vale already installed${NC}"
+		else
+			tmpdir=$(mktemp -d)
+			os=$(uname -s)
+			arch=$(uname -m)
+			case "$os" in
+			Darwin) os_name="macOS" ;;
+			Linux) os_name="Linux" ;;
+			*) os_name="Linux" ;;
+			esac
+			case "$arch" in
+			x86_64 | amd64) arch_name="64-bit" ;;
+			aarch64 | arm64) arch_name="arm64" ;;
+			*) echo -e "${RED}✗ Unsupported architecture: $arch${NC}" && rm -rf "$tmpdir" && exit 1 ;;
+			esac
+			tgz_name="vale_${VALE_VERSION}_${os_name}_${arch_name}.tar.gz"
+			tgz_url="https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/${tgz_name}"
+			if download_with_retries "$tgz_url" "$tmpdir/vale.tgz" 3; then
+				# Require checksum verification before installing
+				checksum_url="https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_checksums.txt"
+				if ! download_with_retries "$checksum_url" "$tmpdir/checksums.txt" 3; then
+					echo -e "${RED}✗ Failed to download checksum file for vale${NC}"
+					rm -rf "$tmpdir"
+					exit 1
+				fi
+				echo -e "${BLUE}Verifying checksum for vale...${NC}"
+				expected=$(grep "$tgz_name" "$tmpdir/checksums.txt" | awk '{print $1}')
+				if [ -z "$expected" ]; then
+					echo -e "${RED}✗ Checksum entry not found for ${tgz_name}${NC}"
+					rm -rf "$tmpdir"
+					exit 1
+				fi
+				if command -v sha256sum >/dev/null 2>&1; then
+					actual=$(sha256sum "$tmpdir/vale.tgz" | awk '{print $1}')
+				elif command -v shasum >/dev/null 2>&1; then
+					actual=$(shasum -a 256 "$tmpdir/vale.tgz" | awk '{print $1}')
+				else
+					echo -e "${RED}✗ No hash tool found (sha256sum or shasum required)${NC}"
+					rm -rf "$tmpdir"
+					exit 1
+				fi
+				if [ "$expected" != "$actual" ]; then
+					echo -e "${RED}✗ Checksum mismatch for vale (expected: $expected, got: $actual)${NC}"
+					rm -rf "$tmpdir"
+					exit 1
+				fi
+				echo -e "${GREEN}✓ Checksum verified${NC}"
+				if ! tar -xzf "$tmpdir/vale.tgz" -C "$tmpdir" >/dev/null 2>&1; then
+					echo -e "${RED}✗ Failed to extract vale archive${NC}"
+					rm -rf "$tmpdir"
+					exit 1
+				fi
+				if [ -f "$tmpdir/vale" ]; then
+					cp "$tmpdir/vale" "$BIN_DIR/vale"
+					chmod +x "$BIN_DIR/vale"
+					echo -e "${GREEN}✓ vale installed successfully${NC}"
+				else
+					echo -e "${RED}✗ Could not find extracted vale binary${NC}"
+					rm -rf "$tmpdir"
+					exit 1
+				fi
+			else
+				echo -e "${RED}✗ Failed to download vale prebuilt binary${NC}"
+				rm -rf "$tmpdir"
+				exit 1
+			fi
+			rm -rf "$tmpdir" || true
+		fi
+	fi # vale
 
 	# Shared helper: ensure Rust toolchain is installed with the required component.
 	# Called by both the rustfmt and clippy blocks to avoid duplicating toolchain setup.
@@ -1450,7 +1529,7 @@ main() {
 	# Verify installations
 	echo -e "${YELLOW}Verifying installations...${NC}"
 
-	tools_to_verify=("actionlint" "astro" "bandit" "black" "cargo-audit" "cargo-deny" "clippy" "rustfmt" "gitleaks" "hadolint" "markdownlint-cli2" "mypy" "osv-scanner" "oxfmt" "oxlint" "prettier" "pydoclint" "ruff" "semgrep" "shellcheck" "shfmt" "sqlfluff" "svelte-check" "taplo" "tsc" "vue-tsc" "yamllint")
+	tools_to_verify=("actionlint" "astro" "bandit" "black" "cargo-audit" "cargo-deny" "clippy" "rustfmt" "gitleaks" "hadolint" "markdownlint-cli2" "mypy" "osv-scanner" "oxfmt" "oxlint" "prettier" "pydoclint" "ruff" "semgrep" "shellcheck" "shfmt" "sqlfluff" "svelte-check" "taplo" "tsc" "vale" "vue-tsc" "yamllint")
 
 	# Filter verification list when --tools is set.
 	# Map aliases so e.g. --tools markdownlint verifies markdownlint-cli2.

--- a/test_samples/tools/config/vale/.vale.ini
+++ b/test_samples/tools/config/vale/.vale.ini
@@ -1,0 +1,7 @@
+# Self-contained Vale config for lintro fixtures.
+# Uses only Vale's built-in "Vale" style (ships with the binary), so no
+# `vale sync` is required to run these fixtures.
+MinAlertLevel = suggestion
+
+[*.md]
+BasedOnStyles = Vale

--- a/test_samples/tools/config/vale/vale_clean.md
+++ b/test_samples/tools/config/vale/vale_clean.md
@@ -1,0 +1,3 @@
+# Prose Sample
+
+A short and clear sentence describes the process well.

--- a/test_samples/tools/config/vale/vale_violations.md
+++ b/test_samples/tools/config/vale/vale_violations.md
@@ -1,0 +1,5 @@
+# Prose Sample
+
+The the quick brown fox is a highly performant animal.
+
+This sentence has a occurrence of repeated words words here.

--- a/tests/integration/tools/test_vale_integration.py
+++ b/tests/integration/tools/test_vale_integration.py
@@ -1,0 +1,131 @@
+"""Integration tests for the Vale tool definition.
+
+These tests require Vale to be installed and available in PATH. They exercise
+the ValePlugin end-to-end against a self-contained ``.vale.ini`` fixture that
+uses only Vale's built-in ``Vale`` style (no ``vale sync`` required).
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from assertpy import assert_that
+
+if TYPE_CHECKING:
+    from lintro.plugins.base import BaseToolPlugin
+
+# Skip all tests if vale is not installed.
+pytestmark = pytest.mark.skipif(
+    shutil.which("vale") is None,
+    reason="vale not installed",
+)
+
+_VALE_INI = """\
+MinAlertLevel = suggestion
+
+[*.md]
+BasedOnStyles = Vale
+"""
+
+
+def _write_configured_project(tmp_path: Path, markdown: str) -> str:
+    """Write a self-contained Vale project and return the Markdown path.
+
+    Args:
+        tmp_path: Temporary directory path.
+        markdown: Markdown content for the sample document.
+
+    Returns:
+        Path to the created Markdown file as a string.
+    """
+    (tmp_path / ".vale.ini").write_text(_VALE_INI)
+    md = tmp_path / "doc.md"
+    md.write_text(markdown)
+    return str(md)
+
+
+def test_definition_attributes(
+    get_plugin: Callable[[str], BaseToolPlugin],
+) -> None:
+    """Verify ValePlugin definition exposes expected values.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+    """
+    plugin = get_plugin("vale")
+
+    assert_that(plugin.definition.name).is_equal_to("vale")
+    assert_that(plugin.definition.can_fix).is_false()
+
+
+def test_check_detects_issues(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    tmp_path: Path,
+) -> None:
+    """Vale should detect prose issues in a configured project.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        tmp_path: Temporary directory path.
+    """
+    md = _write_configured_project(
+        tmp_path,
+        "# Title\n\nThe the quick brown fox jumped.\n",
+    )
+
+    plugin = get_plugin("vale")
+    result = plugin.check([md], {})
+
+    assert_that(result).is_not_none()
+    assert_that(result.name).is_equal_to("vale")
+    assert_that(result.issues_count).is_greater_than(0)
+    assert_that(result.success).is_false()
+
+
+def test_check_clean_document(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    tmp_path: Path,
+) -> None:
+    """Vale should pass on a clean document in a configured project.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        tmp_path: Temporary directory path.
+    """
+    md = _write_configured_project(
+        tmp_path,
+        "# Title\n\nA short and clear sentence.\n",
+    )
+
+    plugin = get_plugin("vale")
+    result = plugin.check([md], {})
+
+    assert_that(result).is_not_none()
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+
+
+def test_check_skips_without_config(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    tmp_path: Path,
+) -> None:
+    """Vale should skip (non-error) when no configuration is present.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        tmp_path: Temporary directory path.
+    """
+    md = tmp_path / "doc.md"
+    md.write_text("# Title\n\nThe the repeated words here.\n")
+
+    plugin = get_plugin("vale")
+    result = plugin.check([str(md)], {})
+
+    assert_that(result).is_not_none()
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.output).contains("Skipping vale")

--- a/tests/unit/parsers/vale_parser/__init__.py
+++ b/tests/unit/parsers/vale_parser/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the Vale output parser."""

--- a/tests/unit/parsers/vale_parser/conftest.py
+++ b/tests/unit/parsers/vale_parser/conftest.py
@@ -1,0 +1,108 @@
+"""Shared fixtures and helpers for Vale parser tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+# Real ``vale --output=JSON`` output captured from Vale 3.15.1 running the
+# built-in ``Vale`` style over a Markdown fixture with repeated words and a
+# spelling issue. Used to validate the parser against genuine tool output.
+REAL_VALE_OUTPUT: str = json.dumps(
+    {
+        "vale_violations.md": [
+            {
+                "Action": {"Name": "edit", "Params": ["truncate", " "]},
+                "Span": [1, 7],
+                "Check": "Vale.Repetition",
+                "Description": "",
+                "Link": "",
+                "Message": "'the' is repeated!",
+                "Severity": "error",
+                "Match": "The the",
+                "Line": 3,
+            },
+            {
+                "Action": {"Name": "suggest", "Params": ["spellings"]},
+                "Span": [37, 46],
+                "Check": "Vale.Spelling",
+                "Description": "",
+                "Link": "",
+                "Message": "Did you really mean 'performant'?",
+                "Severity": "error",
+                "Match": "performant",
+                "Line": 3,
+            },
+            {
+                "Action": {"Name": "edit", "Params": ["truncate", " "]},
+                "Span": [44, 54],
+                "Check": "Vale.Repetition",
+                "Description": "",
+                "Link": "",
+                "Message": "'words' is repeated!",
+                "Severity": "error",
+                "Match": "words words",
+                "Line": 5,
+            },
+        ],
+    },
+)
+
+
+def make_alert(
+    *,
+    check: str = "Vale.Repetition",
+    message: str = "issue",
+    severity: str = "error",
+    line: int = 1,
+    span: list[int] | None = None,
+    link: str = "",
+    match: str = "",
+) -> dict[str, object]:
+    """Build a single Vale alert dict for synthetic parser fixtures.
+
+    Args:
+        check: The Vale check name (``<Style>.<Rule>``).
+        message: Human-readable alert message.
+        severity: Native Vale severity (``error``/``warning``/``suggestion``).
+        line: 1-based line number of the alert.
+        span: Optional ``[start, end]`` column span; column is ``span[0]``.
+        link: Optional documentation URL for the check.
+        match: Optional matched source text.
+
+    Returns:
+        A dict shaped like a single entry in Vale's per-file alert list.
+    """
+    return {
+        "Span": span if span is not None else [1, 5],
+        "Check": check,
+        "Description": "",
+        "Link": link,
+        "Message": message,
+        "Severity": severity,
+        "Match": match,
+        "Line": line,
+    }
+
+
+def make_output(alerts_by_file: dict[str, list[dict[str, object]]]) -> str:
+    """Serialize a mapping of file path to alert list as Vale JSON.
+
+    Args:
+        alerts_by_file: Mapping of file path to a list of alert dicts.
+
+    Returns:
+        A JSON string in Vale's ``--output=JSON`` shape.
+    """
+    return json.dumps(alerts_by_file)
+
+
+@pytest.fixture
+def real_vale_output() -> str:
+    """Return real captured Vale JSON output.
+
+    Returns:
+        The captured ``vale --output=JSON`` payload as a string.
+    """
+    return REAL_VALE_OUTPUT

--- a/tests/unit/parsers/vale_parser/test_edge_cases.py
+++ b/tests/unit/parsers/vale_parser/test_edge_cases.py
@@ -1,0 +1,92 @@
+"""Unit tests for Vale parser edge cases."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.enums.severity_level import SeverityLevel
+from lintro.parsers.vale.vale_parser import parse_vale_output
+
+from .conftest import make_alert, make_output
+
+
+def test_multiple_files() -> None:
+    """Parser should flatten alerts across multiple files."""
+    output = make_output(
+        {
+            "a.md": [make_alert(message="a1"), make_alert(message="a2")],
+            "b.md": [make_alert(message="b1")],
+        },
+    )
+
+    issues = parse_vale_output(output=output)
+
+    assert_that(len(issues)).is_equal_to(3)
+    files = {issue.file for issue in issues}
+    assert_that(files).contains("a.md", "b.md")
+
+
+def test_mixed_severities() -> None:
+    """Parser should preserve each alert's native severity."""
+    output = make_output(
+        {
+            "a.md": [
+                make_alert(severity="error"),
+                make_alert(severity="warning"),
+                make_alert(severity="suggestion"),
+            ],
+        },
+    )
+
+    issues = parse_vale_output(output=output)
+
+    severities = [issue.get_severity() for issue in issues]
+    assert_that(severities).contains(
+        SeverityLevel.ERROR,
+        SeverityLevel.WARNING,
+        SeverityLevel.INFO,
+    )
+
+
+def test_empty_alert_list_yields_no_issues() -> None:
+    """A file with an empty alert list should contribute no issues."""
+    output = make_output({"clean.md": []})
+
+    assert_that(parse_vale_output(output=output)).is_empty()
+
+
+def test_empty_object_yields_no_issues() -> None:
+    """An empty JSON object (no files) should yield no issues."""
+    assert_that(parse_vale_output(output="{}")).is_empty()
+
+
+def test_missing_span_defaults_column_to_zero() -> None:
+    """An alert without a Span should default the column to zero."""
+    output = make_output({"a.md": [make_alert(span=[])]})
+
+    issues = parse_vale_output(output=output)
+
+    assert_that(issues[0].column).is_equal_to(0)
+
+
+def test_missing_optional_fields_use_defaults() -> None:
+    """Missing optional fields should coerce to empty/zero defaults."""
+    output = make_output({"a.md": [{"Check": "Vale.Terms"}]})
+
+    issues = parse_vale_output(output=output)
+
+    issue = issues[0]
+    assert_that(issue.check).is_equal_to("Vale.Terms")
+    assert_that(issue.line).is_equal_to(0)
+    assert_that(issue.column).is_equal_to(0)
+    assert_that(issue.message).is_equal_to("")
+    assert_that(issue.severity).is_equal_to("")
+
+
+def test_negative_line_coerced_to_zero() -> None:
+    """A non-positive line number should be coerced to zero."""
+    output = make_output({"a.md": [make_alert(line=0)]})
+
+    issues = parse_vale_output(output=output)
+
+    assert_that(issues[0].line).is_equal_to(0)

--- a/tests/unit/parsers/vale_parser/test_field_extraction.py
+++ b/tests/unit/parsers/vale_parser/test_field_extraction.py
@@ -1,0 +1,88 @@
+"""Unit tests for Vale parser field extraction."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.parsers.vale.vale_parser import parse_vale_output
+
+from .conftest import make_alert, make_output
+
+
+def test_parse_real_output(real_vale_output: str) -> None:
+    """Parser should extract all issues from real Vale output."""
+    issues = parse_vale_output(output=real_vale_output)
+
+    assert_that(len(issues)).is_equal_to(3)
+    first = issues[0]
+    assert_that(first.file).is_equal_to("vale_violations.md")
+    assert_that(first.line).is_equal_to(3)
+    assert_that(first.column).is_equal_to(1)
+    assert_that(first.check).is_equal_to("Vale.Repetition")
+    assert_that(first.style).is_equal_to("Vale")
+    assert_that(first.severity).is_equal_to("error")
+    assert_that(first.message).is_equal_to("'the' is repeated!")
+    assert_that(first.match).is_equal_to("The the")
+
+
+def test_column_derived_from_span() -> None:
+    """The column should come from the first element of the Span array."""
+    output = make_output(
+        {"a.md": [make_alert(span=[37, 46])]},
+    )
+
+    issues = parse_vale_output(output=output)
+
+    assert_that(issues[0].column).is_equal_to(37)
+
+
+def test_style_extracted_from_check() -> None:
+    """The style bundle should be the portion of Check before the dot."""
+    output = make_output(
+        {
+            "a.md": [
+                make_alert(check="Microsoft.Adverbs"),
+                make_alert(check="Google.Passive"),
+            ],
+        },
+    )
+
+    issues = parse_vale_output(output=output)
+
+    assert_that(issues[0].style).is_equal_to("Microsoft")
+    assert_that(issues[0].check).is_equal_to("Microsoft.Adverbs")
+    assert_that(issues[1].style).is_equal_to("Google")
+
+
+def test_link_populates_doc_url() -> None:
+    """A populated Link should map onto the issue doc_url."""
+    output = make_output(
+        {
+            "a.md": [
+                make_alert(link="https://docs.example.com/rule"),
+            ],
+        },
+    )
+
+    issues = parse_vale_output(output=output)
+
+    assert_that(issues[0].doc_url).is_equal_to("https://docs.example.com/rule")
+
+
+def test_missing_link_yields_empty_doc_url() -> None:
+    """An empty Link should leave doc_url empty for later enrichment."""
+    output = make_output({"a.md": [make_alert(link="")]})
+
+    issues = parse_vale_output(output=output)
+
+    assert_that(issues[0].doc_url).is_equal_to("")
+
+
+def test_check_without_dot_uses_whole_string_as_style() -> None:
+    """A check name without a dot should use the whole value as its style."""
+    output = make_output({"a.md": [make_alert(check="Terms")]})
+
+    issues = parse_vale_output(output=output)
+
+    assert_that(issues[0].style).is_equal_to("Terms")
+    assert_that(issues[0].check).is_equal_to("Terms")

--- a/tests/unit/parsers/vale_parser/test_invalid_input.py
+++ b/tests/unit/parsers/vale_parser/test_invalid_input.py
@@ -1,0 +1,56 @@
+"""Unit tests for Vale parser handling of invalid or empty input."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.parsers.vale.vale_parser import parse_vale_output
+
+
+def test_none_input_returns_empty() -> None:
+    """None input should yield an empty list."""
+    assert_that(parse_vale_output(output=None)).is_empty()
+
+
+def test_empty_string_returns_empty() -> None:
+    """Empty string input should yield an empty list."""
+    assert_that(parse_vale_output(output="")).is_empty()
+
+
+def test_whitespace_only_returns_empty() -> None:
+    """Whitespace-only input should yield an empty list."""
+    assert_that(parse_vale_output(output="   \n\t  ")).is_empty()
+
+
+def test_malformed_json_returns_empty() -> None:
+    """Malformed JSON should yield an empty list rather than raising."""
+    assert_that(parse_vale_output(output="{not valid json")).is_empty()
+
+
+def test_non_object_root_returns_empty() -> None:
+    """A JSON array root (not a mapping) should yield an empty list."""
+    assert_that(parse_vale_output(output="[1, 2, 3]")).is_empty()
+
+
+def test_no_config_error_object_returns_empty() -> None:
+    """Vale's E100 runtime-error object should yield an empty list."""
+    e100 = (
+        '{"Line": 0, "Path": "", "Text": "E100 [.vale.ini not found] '
+        'Runtime error", "Code": "E100", "Span": 0}'
+    )
+
+    assert_that(parse_vale_output(output=e100)).is_empty()
+
+
+def test_non_list_alert_values_are_skipped() -> None:
+    """Files whose value is not a list should be skipped safely."""
+    output = '{"a.md": "not a list", "b.md": null}'
+
+    assert_that(parse_vale_output(output=output)).is_empty()
+
+
+def test_non_dict_alerts_are_skipped() -> None:
+    """Non-dict entries within a file's alert list should be skipped."""
+    output = '{"a.md": ["string", 42, null]}'
+
+    assert_that(parse_vale_output(output=output)).is_empty()

--- a/tests/unit/parsers/vale_parser/test_issue_model.py
+++ b/tests/unit/parsers/vale_parser/test_issue_model.py
@@ -1,0 +1,61 @@
+"""Unit tests for the ValeIssue model."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.enums.severity_level import SeverityLevel
+from lintro.parsers.vale.vale_issue import ValeIssue
+
+
+def test_vale_issue_display_row() -> None:
+    """ValeIssue should produce a correct display row."""
+    issue = ValeIssue(
+        file="docs/guide.md",
+        line=3,
+        column=7,
+        message="'the' is repeated!",
+        check="Vale.Repetition",
+        style="Vale",
+        severity="error",
+        match="The the",
+    )
+
+    row = issue.to_display_row()
+
+    assert_that(row["file"]).is_equal_to("docs/guide.md")
+    assert_that(row["line"]).is_equal_to("3")
+    assert_that(row["column"]).is_equal_to("7")
+    assert_that(row["code"]).is_equal_to("Vale.Repetition")
+    assert_that(row["message"]).is_equal_to("'the' is repeated!")
+    assert_that(row["severity"]).is_equal_to("ERROR")
+
+
+def test_vale_issue_severity_normalization() -> None:
+    """Native Vale severities should normalize to SeverityLevel values."""
+    error = ValeIssue(severity="error")
+    warning = ValeIssue(severity="warning")
+    suggestion = ValeIssue(severity="suggestion")
+
+    assert_that(error.get_severity()).is_equal_to(SeverityLevel.ERROR)
+    assert_that(warning.get_severity()).is_equal_to(SeverityLevel.WARNING)
+    assert_that(suggestion.get_severity()).is_equal_to(SeverityLevel.INFO)
+
+
+def test_vale_issue_default_severity_when_missing() -> None:
+    """A missing severity should fall back to the WARNING default."""
+    issue = ValeIssue(severity="")
+
+    assert_that(issue.get_severity()).is_equal_to(SeverityLevel.WARNING)
+
+
+def test_vale_issue_display_row_defaults() -> None:
+    """Default field values should render sensible display placeholders."""
+    issue = ValeIssue()
+
+    row = issue.to_display_row()
+
+    assert_that(row["line"]).is_equal_to("-")
+    assert_that(row["column"]).is_equal_to("-")
+    assert_that(row["code"]).is_equal_to("")
+    assert_that(row["fixable"]).is_equal_to("")

--- a/tests/unit/tools/vale/__init__.py
+++ b/tests/unit/tools/vale/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the Vale tool plugin."""

--- a/tests/unit/tools/vale/conftest.py
+++ b/tests/unit/tools/vale/conftest.py
@@ -1,0 +1,52 @@
+"""Pytest configuration for Vale plugin tests."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from lintro.tools.definitions.vale import ValePlugin
+
+
+@pytest.fixture
+def vale_plugin() -> ValePlugin:
+    """Provide a ValePlugin instance for testing.
+
+    Returns:
+        A ValePlugin instance.
+    """
+    return ValePlugin()
+
+
+def make_ctx(tmp_path: str, files: list[str]) -> MagicMock:
+    """Build a mock execution context for check() tests.
+
+    Args:
+        tmp_path: Working directory for the context.
+        files: List of discovered file paths.
+
+    Returns:
+        A MagicMock shaped like an ExecutionContext (not skipping).
+    """
+    ctx = MagicMock()
+    ctx.should_skip = False
+    ctx.early_result = None
+    ctx.timeout = 30
+    ctx.cwd = tmp_path
+    ctx.files = files
+    ctx.rel_files = files
+    return ctx
+
+
+def vale_output(alerts_by_file: dict[str, list[dict[str, object]]]) -> str:
+    """Serialize a mapping of file to alerts as Vale JSON output.
+
+    Args:
+        alerts_by_file: Mapping of file path to a list of alert dicts.
+
+    Returns:
+        A JSON string in Vale's ``--output=JSON`` shape.
+    """
+    return json.dumps(alerts_by_file)

--- a/tests/unit/tools/vale/test_execution.py
+++ b/tests/unit/tools/vale/test_execution.py
@@ -1,0 +1,152 @@
+"""Unit tests for ValePlugin execution (check/fix) with mocked subprocess."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.enums.tool_name import ToolName
+from lintro.parsers.vale.vale_issue import ValeIssue
+from lintro.tools.definitions.vale import ValePlugin
+
+from .conftest import make_ctx, vale_output
+
+
+def _write_md(tmp_path: Path) -> str:
+    """Create a Markdown file and return its path.
+
+    Args:
+        tmp_path: Temporary directory path.
+
+    Returns:
+        Path to the created Markdown file as a string.
+    """
+    md = tmp_path / "doc.md"
+    md.write_text("The the repeated words.\n")
+    return str(md)
+
+
+def test_check_with_issues(vale_plugin: ValePlugin, tmp_path: Path) -> None:
+    """Check returns issues when Vale reports alerts.
+
+    Args:
+        vale_plugin: The ValePlugin instance under test.
+        tmp_path: Temporary directory path.
+    """
+    md = _write_md(tmp_path)
+    output = vale_output(
+        {
+            "doc.md": [
+                {
+                    "Span": [1, 7],
+                    "Check": "Vale.Repetition",
+                    "Link": "",
+                    "Message": "'the' is repeated!",
+                    "Severity": "error",
+                    "Match": "The the",
+                    "Line": 1,
+                },
+            ],
+        },
+    )
+
+    with (
+        patch.object(vale_plugin, "_prepare_execution") as mock_prepare,
+        patch.object(vale_plugin, "_run_subprocess", return_value=(False, output)),
+    ):
+        mock_prepare.return_value = make_ctx(str(tmp_path), [md])
+
+        result = vale_plugin.check([md], {})
+
+    assert_that(result.name).is_equal_to(ToolName.VALE)
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(1)
+    assert_that(result.issues).is_not_none()
+    issue = cast(ValeIssue, result.issues[0])  # type: ignore[index]
+    assert_that(issue.check).is_equal_to("Vale.Repetition")
+    assert_that(issue.style).is_equal_to("Vale")
+
+
+def test_check_clean(vale_plugin: ValePlugin, tmp_path: Path) -> None:
+    """Check succeeds with no issues when Vale reports an empty mapping.
+
+    Args:
+        vale_plugin: The ValePlugin instance under test.
+        tmp_path: Temporary directory path.
+    """
+    md = _write_md(tmp_path)
+
+    with (
+        patch.object(vale_plugin, "_prepare_execution") as mock_prepare,
+        patch.object(vale_plugin, "_run_subprocess", return_value=(True, "{}")),
+    ):
+        mock_prepare.return_value = make_ctx(str(tmp_path), [md])
+
+        result = vale_plugin.check([md], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.output).is_none()
+
+
+def test_check_skips_when_no_config(vale_plugin: ValePlugin, tmp_path: Path) -> None:
+    """Check skips as a non-error when Vale reports a missing config.
+
+    Args:
+        vale_plugin: The ValePlugin instance under test.
+        tmp_path: Temporary directory path.
+    """
+    md = _write_md(tmp_path)
+    e100 = (
+        '{"Line": 0, "Path": "", "Text": "E100 [.vale.ini not found] '
+        'Runtime error\\n\\nno config file found", "Code": "E100", "Span": 0}'
+    )
+
+    with (
+        patch.object(vale_plugin, "_prepare_execution") as mock_prepare,
+        patch.object(vale_plugin, "_run_subprocess", return_value=(False, e100)),
+    ):
+        mock_prepare.return_value = make_ctx(str(tmp_path), [md])
+
+        result = vale_plugin.check([md], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.output).contains("Skipping vale")
+
+
+def test_check_returns_early_when_skipping(
+    vale_plugin: ValePlugin,
+    tmp_path: Path,
+) -> None:
+    """Check returns the early result when preparation says to skip.
+
+    Args:
+        vale_plugin: The ValePlugin instance under test.
+        tmp_path: Temporary directory path.
+    """
+    from unittest.mock import MagicMock
+
+    early = MagicMock()
+    ctx = MagicMock()
+    ctx.should_skip = True
+    ctx.early_result = early
+
+    with patch.object(vale_plugin, "_prepare_execution", return_value=ctx):
+        result = vale_plugin.check(["nonexistent"], {})
+
+    assert_that(result).is_same_as(early)
+
+
+def test_fix_raises_not_implemented(vale_plugin: ValePlugin) -> None:
+    """Fix raises NotImplementedError since Vale cannot auto-fix.
+
+    Args:
+        vale_plugin: The ValePlugin instance under test.
+    """
+    with pytest.raises(NotImplementedError):
+        vale_plugin.fix(["doc.md"], {})

--- a/tests/unit/tools/vale/test_execution.py
+++ b/tests/unit/tools/vale/test_execution.py
@@ -150,3 +150,33 @@ def test_fix_raises_not_implemented(vale_plugin: ValePlugin) -> None:
     """
     with pytest.raises(NotImplementedError):
         vale_plugin.fix(["doc.md"], {})
+
+
+def test_check_runtime_error_is_not_clean(
+    vale_plugin: ValePlugin,
+    tmp_path: Path,
+) -> None:
+    """A non-zero exit with no parseable alerts fails instead of passing.
+
+    Args:
+        vale_plugin: The ValePlugin instance under test.
+        tmp_path: Temporary directory path.
+    """
+    md = _write_md(tmp_path)
+    runtime_error = "E201 [styles path does not exist] Runtime error"
+
+    with (
+        patch.object(vale_plugin, "_prepare_execution") as mock_prepare,
+        patch.object(
+            vale_plugin,
+            "_run_subprocess",
+            return_value=(False, runtime_error),
+        ),
+    ):
+        mock_prepare.return_value = make_ctx(str(tmp_path), [md])
+
+        result = vale_plugin.check([md], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.output).contains("E201")

--- a/tests/unit/tools/vale/test_options.py
+++ b/tests/unit/tools/vale/test_options.py
@@ -1,0 +1,72 @@
+"""Unit tests for ValePlugin definition and options."""
+
+from __future__ import annotations
+
+import pytest
+from assertpy import assert_that
+
+from lintro.enums.tool_type import ToolType
+from lintro.tools.definitions.vale import ValePlugin
+
+
+def test_definition_metadata(vale_plugin: ValePlugin) -> None:
+    """The definition should expose the expected metadata.
+
+    Args:
+        vale_plugin: The ValePlugin instance under test.
+    """
+    d = vale_plugin.definition
+
+    assert_that(d.name).is_equal_to("vale")
+    assert_that(d.can_fix).is_false()
+    assert_that(d.file_patterns).contains("*.md", "*.rst", "*.adoc", "*.txt")
+    assert_that(d.native_configs).contains(".vale.ini", "_vale.ini", "vale.ini")
+    assert_that(bool(d.tool_type & ToolType.LINTER)).is_true()
+    assert_that(bool(d.tool_type & ToolType.DOCUMENTATION)).is_true()
+
+
+def test_build_command_default(vale_plugin: ValePlugin) -> None:
+    """The base command should request JSON output.
+
+    Args:
+        vale_plugin: The ValePlugin instance under test.
+    """
+    cmd = vale_plugin._build_command()
+
+    assert_that(cmd).contains("vale", "--output=JSON")
+
+
+def test_build_command_with_config_and_level(vale_plugin: ValePlugin) -> None:
+    """Explicit config and alert level should be added to the command.
+
+    Args:
+        vale_plugin: The ValePlugin instance under test.
+    """
+    vale_plugin.set_options(config="custom.ini", min_alert_level="warning")
+
+    cmd = vale_plugin._build_command()
+
+    assert_that(cmd).contains("--config", "custom.ini")
+    assert_that(cmd).contains("--minAlertLevel", "warning")
+
+
+def test_set_options_rejects_invalid_timeout(vale_plugin: ValePlugin) -> None:
+    """A non-positive timeout should be rejected.
+
+    Args:
+        vale_plugin: The ValePlugin instance under test.
+    """
+    with pytest.raises((ValueError, TypeError)):
+        vale_plugin.set_options(timeout=0)
+
+
+def test_is_no_config_error_detection(vale_plugin: ValePlugin) -> None:
+    """The no-config detector should recognize Vale's E100 error.
+
+    Args:
+        vale_plugin: The ValePlugin instance under test.
+    """
+    assert_that(vale_plugin._is_no_config_error("E100 [.vale.ini not found]")).is_true()
+    assert_that(vale_plugin._is_no_config_error("no config file found")).is_true()
+    assert_that(vale_plugin._is_no_config_error("{}")).is_false()
+    assert_that(vale_plugin._is_no_config_error(None)).is_false()


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `feat(tools): add vale for prose/documentation linting`

- Type:
  - [x] feat (minor)

- Breaking change:
  - [ ] none

## What’s Changing

Adds [Vale](https://vale.sh/) as a lintro tool plugin (check-only) for linting prose and
documentation in Markdown, reStructuredText, AsciiDoc, and plain-text files against
configurable style guides (Microsoft, Google, write-good, proselint, alex, custom rules).

### Parser choice — native (not shared SARIF)

Vale does **not** emit SARIF. Its only output styles are `line`, `JSON`, or a Go-template
file (verified against Vale 3.15.1: `vale --output=sarif` is not supported). Applying the
fidelity checklist from `docs/design/sarif-ingestion-evaluation.md`, the shared SARIF
parser is inapplicable here, so a native `parse_vale_output` was written. It preserves
everything Vale reports: the `Check` name and its `<Style>` prefix, the `Span[0]`-derived
column, the native severity, the matched source text, and the per-issue `Link`
(documentation URL). If a SARIF path existed it would drop Vale's style bundle grouping
and the matched-text context, and depend on style authors populating `helpUri`.

### Skip-on-no-config

Vale requires a `.vale.ini` and fails with an `E100` runtime error when none is
resolvable. Mirroring the stylelint plugin (#1143), the plugin detects this and **skips
as a non-error** so `lintro check` stays clean on projects that do not use Vale. No
`.vale.ini` is added to the repo root; fixtures live under `test_samples/tools/config/vale/`.

### Shared-surface registration (minimal, additive)

`ToolName` enum, `manifest.json` (binary install, version synced via the generator),
`_tool_versions.py`, version parsing + install hints, console emoji, `pyproject.toml`
package, a Renovate custom manager (`errata-ai/vale`), `install-tools.sh` (checksum-
verified GitHub-release install + verify list), both Dockerfile verify blocks, and the
Homebrew template. Vale's `suggestion` alert level is added to the severity alias table
(→ INFO).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated (tool-analysis, README, getting-started, configuration)
- [x] Local checks: native linters on changed files (ruff/black/mypy/pydoclint/bandit,
      shellcheck/shfmt, prettier/markdownlint) + full `uv run pytest`

## Related Issues

Closes #425

## Details

- **Tests:** parser unit tests on real captured Vale output plus edge/invalid cases;
  plugin check/skip/fix tests; binary-gated integration tests using a self-contained
  `.vale.ini` fixture (built-in `Vale` style, no `vale sync` needed).
- **Full suite:** `uv run pytest` → 6028 passed, 2 pre-existing env-only failures
  (`test_markdownlint_direct_vs_lintro_parity`,
  `test_prepare_execution_version_check_fails_returns_early_result`), 10 skipped.
- **lintro-verify:** ran the skill; addressed docs coverage (README/getting-started/
  configuration + tool-analysis), test samples (violations + clean), doctor/list-tools
  visibility, install-tools verify list, and version consistency. No `TOOL_COMMANDS`
  edit needed — `doctor` reads tools from the registry/manifest.
- Note: `lintro chk` cannot scan this worktree under `.claude/`, so changed files were
  linted with the underlying native tools directly (as the stylelint/typos work did).
- Trivial conflicts with sibling tool PRs (#1143–#1146) on shared enums/manifest are
  expected and intentionally not merged here.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds Vale as a prose and documentation linter. The main changes are:

- New Vale tool definition, parser, issue model, and tests.
- Tool registry, manifest, version, install, Docker, Homebrew, and Renovate wiring.
- Documentation updates for Vale setup, options, and usage.
- Project detection for reStructuredText and AsciiDoc documentation.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/definitions/vale.py | Adds the Vale plugin with check-only execution, config-missing skip behavior, parsed issue handling, and runtime-error reporting. |
| lintro/utils/project_detection.py | Adds documentation language detection for root and docs/ reStructuredText and AsciiDoc files. |
| lintro/tools/manifest.json | Registers Vale in the language map and tool metadata for supported documentation formats. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(detection): scan docs/ for AsciiDoc ..."](https://github.com/lgtm-hq/py-lintro/commit/fe7629dddffbfee377e6eaa49ca8c00d39f18a95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42194879)</sub>

<!-- /greptile_comment -->