### PR TITLE
ci(build): allow setup-uv endpoints in binary build egress policy

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -85,6 +85,8 @@ jobs:
             files.pythonhosted.org:443
             raw.githubusercontent.com:443
             release-assets.githubusercontent.com:443
+            astral.sh:443
+            releases.astral.sh:443
             uploads.github.com:443
             nuitka.net:443
 
@@ -191,6 +193,8 @@ jobs:
             files.pythonhosted.org:443
             raw.githubusercontent.com:443
             release-assets.githubusercontent.com:443
+            astral.sh:443
+            releases.astral.sh:443
             uploads.github.com:443
             nuitka.net:443
 

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -83,6 +83,8 @@ jobs:
             objects.githubusercontent.com:443
             pypi.org:443
             files.pythonhosted.org:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             uploads.github.com:443
             nuitka.net:443
 
@@ -187,6 +189,8 @@ jobs:
             objects.githubusercontent.com:443
             pypi.org:443
             files.pythonhosted.org:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             uploads.github.com:443
             nuitka.net:443
 


### PR DESCRIPTION
## Summary
- Add `raw.githubusercontent.com:443` and `release-assets.githubusercontent.com:443` to the harden-runner allowlists of `build-macos` and `build-linux` in `build-binary.yml`.

## Why
First dispatched `build-binary` run after #1141 failed: `astral-sh/setup-uv` fetches version data from `raw.githubusercontent.com` and downloads the uv binary from `release-assets.githubusercontent.com`, both blocked by the egress policy. Harden-runner only enforces `egress-policy: block` on Linux, which is why the macOS jobs always passed — the new Linux matrix jobs are the first to actually enforce the list. Run: https://github.com/lgtm-hq/py-lintro/actions/runs/28827753738

Refs #932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated binary build workflow network permissions to support required external downloads during macOS and Linux builds.
  * Helps keep build jobs running smoothly and reduces the chance of interrupted release artifact generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the binary build workflow egress allowlists. The main changes are:

- Allows GitHub raw content for `setup-uv` version lookups.
- Allows GitHub release asset downloads for `setup-uv` fallback downloads.
- Allows Astral hosts for primary `uv` metadata and binary downloads.
- Applies the same endpoint set to macOS and Linux binary build jobs.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-binary.yml | Adds the required GitHub and Astral endpoints to the macOS and Linux binary build egress allowlists. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/932-linux-b..."](https://github.com/lgtm-hq/py-lintro/commit/1d3c813410352ab964de28fdd43176833dece7a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42221153)</sub>

<!-- /greptile_comment -->