### PR TITLE
feat(cli): add per-tool performance profiling (--profile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- **cli**: `--profile` reports per-tool timing. Timing is always captured; the
-  flag only controls rendering. JSON uses `files_with_issues` (distinct issue
-  paths) and the same issue merge as `results[]`. Crashed tools keep their
-  duration in the table.
+- **cli**: `--profile` reports per-tool timing. Timing is always captured; the flag only
+  controls rendering. JSON uses `files_with_issues` (distinct issue paths) and the same
+  issue merge as `results[]`. Crashed tools keep their duration in the table.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **cli**: `--profile` reports per-tool timing. Timing is always captured; the
+  flag only controls rendering. JSON uses `files_with_issues` (distinct issue
+  paths) and the same issue merge as `results[]`. Crashed tools keep their
+  duration in the table.
+
 ### Changed
 
 ### Deprecated

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -534,8 +534,9 @@ Suggestions:
 ```
 
 The `Files` column counts the distinct files each tool reported issues on. In JSON mode
-the profile is added additively under a top-level `profile` key (`cumulative_tool_duration`,
-`tools[]`, `suggestions[]`) and the existing `results`/`summary` schema is unchanged.
+the profile is added additively under a top-level `profile` key
+(`cumulative_tool_duration`, `tools[]`, `suggestions[]`) and the existing
+`results`/`summary` schema is unchanged.
 
 ## Tips and Tricks
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -500,10 +500,11 @@ lintro check --output-format grid --group-by code
 
 ### Performance Profiling
 
-Add `--profile` to `check` or `format` to see how long each tool took. Timing is
-always captured with a monotonic wall clock around every tool's execution (including
-under parallel execution); the flag only controls whether that data is rendered. The
-`CUMULATIVE` row is the sum of per-tool seconds, not parallel wall-clock.
+Add `--profile` to `check` or `format` to see how long each main-phase tool took.
+Executors always record those timings (including under parallel execution); the
+flag only controls whether they are rendered. Post-checks are omitted. The table
+is human and JSON only — `--score` and csv/sarif/markdown stdout stay unchanged.
+The `CUMULATIVE` row is the sum of per-tool seconds, not parallel wall-clock.
 
 ```bash
 # Show a per-tool timing table with optimization suggestions
@@ -519,14 +520,14 @@ Example output:
 Performance Profile
 
 Tool Timing (sorted by duration):
-┌───────┬──────────┬─────────────┬────────┐
-│ Tool  │ Duration │ Issue files │ Issues │
-├───────┼──────────┼─────────────┼────────┤
-│ mypy  │ 12.34s   │ 2           │ 3      │
-│ ruff  │ 0.42s    │ 5           │ 5      │
-├───────┼──────────┼─────────────┼────────┤
+┌────────────┬──────────┬─────────────┬────────┐
+│ Tool       │ Duration │ Issue files │ Issues │
+├────────────┼──────────┼─────────────┼────────┤
+│ mypy       │ 12.34s   │ 2           │ 3      │
+│ ruff       │ 0.42s    │ 5           │ 5      │
+├────────────┼──────────┼─────────────┼────────┤
 │ CUMULATIVE │ 12.76s   │             │ 8      │
-└───────┴──────────┴─────────────┴────────┘
+└────────────┴──────────┴─────────────┴────────┘
 
 Suggestions:
   - mypy is slowest (97% of total time)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -501,10 +501,10 @@ lintro check --output-format grid --group-by code
 ### Performance Profiling
 
 Add `--profile` to `check` or `format` to see how long each main-phase tool took.
-Executors always record those timings (including under parallel execution); the
-flag only controls whether they are rendered. Post-checks are omitted. The table
-is human and JSON only — `--score` and csv/sarif/markdown stdout stay unchanged.
-The `CUMULATIVE` row is the sum of per-tool seconds, not parallel wall-clock.
+Executors always record those timings (including under parallel execution); the flag
+only controls whether they are rendered. Post-checks are omitted. The table is human and
+JSON only — `--score` and csv/sarif/markdown stdout stay unchanged. The `CUMULATIVE` row
+is the sum of per-tool seconds, not parallel wall-clock.
 
 ```bash
 # Show a per-tool timing table with optimization suggestions
@@ -536,8 +536,8 @@ Suggestions:
 
 The `Issue files` column (JSON `files_with_issues`) counts the distinct files each tool
 reported issues on — not files scanned — so a clean run reports 0. `issues_found` uses
-the same detected/remaining merge as JSON `results[]`. In JSON mode the profile is
-added additively under a top-level `profile` key (`cumulative_tool_duration`, `tools[]`,
+the same detected/remaining merge as JSON `results[]`. In JSON mode the profile is added
+additively under a top-level `profile` key (`cumulative_tool_duration`, `tools[]`,
 `suggestions[]`) and the existing `results`/`summary` schema is unchanged.
 
 ## Tips and Tricks

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -501,9 +501,9 @@ lintro check --output-format grid --group-by code
 ### Performance Profiling
 
 Add `--profile` to `check` or `format` to see how long each tool took. Timing is
-captured with a monotonic wall clock around every tool's execution, so it reflects real
-per-tool cost (including under parallel execution). The flag is opt-in and adds no
-overhead when omitted.
+always captured with a monotonic wall clock around every tool's execution (including
+under parallel execution); the flag only controls whether that data is rendered. The
+`CUMULATIVE` row is the sum of per-tool seconds, not parallel wall-clock.
 
 ```bash
 # Show a per-tool timing table with optimization suggestions
@@ -519,24 +519,25 @@ Example output:
 Performance Profile
 
 Tool Timing (sorted by duration):
-┌───────┬──────────┬───────┬────────┐
-│ Tool  │ Duration │ Files │ Issues │
-├───────┼──────────┼───────┼────────┤
-│ mypy  │ 12.34s   │ 2     │ 3      │
-│ ruff  │ 0.42s    │ 5     │ 5      │
-├───────┼──────────┼───────┼────────┤
-│ CUMULATIVE │ 12.76s   │       │ 8      │
-└───────┴──────────┴───────┴────────┘
+┌───────┬──────────┬─────────────┬────────┐
+│ Tool  │ Duration │ Issue files │ Issues │
+├───────┼──────────┼─────────────┼────────┤
+│ mypy  │ 12.34s   │ 2           │ 3      │
+│ ruff  │ 0.42s    │ 5           │ 5      │
+├───────┼──────────┼─────────────┼────────┤
+│ CUMULATIVE │ 12.76s   │             │ 8      │
+└───────┴──────────┴─────────────┴────────┘
 
 Suggestions:
   - mypy is slowest (97% of total time)
   - mypy: consider incremental mode or the mypy daemon (dmypy)
 ```
 
-The `Files` column counts the distinct files each tool reported issues on. In JSON mode
-the profile is added additively under a top-level `profile` key
-(`cumulative_tool_duration`, `tools[]`, `suggestions[]`) and the existing
-`results`/`summary` schema is unchanged.
+The `Issue files` column (JSON `files_with_issues`) counts the distinct files each tool
+reported issues on — not files scanned — so a clean run reports 0. `issues_found` uses
+the same detected/remaining merge as JSON `results[]`. In JSON mode the profile is
+added additively under a top-level `profile` key (`cumulative_tool_duration`, `tools[]`,
+`suggestions[]`) and the existing `results`/`summary` schema is unchanged.
 
 ## Tips and Tricks
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -498,6 +498,45 @@ lintro check --include-venv
 lintro check --output-format grid --group-by code
 ```
 
+### Performance Profiling
+
+Add `--profile` to `check` or `format` to see how long each tool took. Timing is
+captured with a monotonic wall clock around every tool's execution, so it reflects real
+per-tool cost (including under parallel execution). The flag is opt-in and adds no
+overhead when omitted.
+
+```bash
+# Show a per-tool timing table with optimization suggestions
+lintro check --profile
+
+# Machine-readable timings under a "profile" key in the JSON payload
+lintro check --profile --output-format json
+```
+
+Example output:
+
+```text
+Performance Profile
+
+Tool Timing (sorted by duration):
+┌───────┬──────────┬───────┬────────┐
+│ Tool  │ Duration │ Files │ Issues │
+├───────┼──────────┼───────┼────────┤
+│ mypy  │ 12.34s   │ 2     │ 3      │
+│ ruff  │ 0.42s    │ 5     │ 5      │
+├───────┼──────────┼───────┼────────┤
+│ CUMULATIVE │ 12.76s   │       │ 8      │
+└───────┴──────────┴───────┴────────┘
+
+Suggestions:
+  - mypy is slowest (97% of total time)
+  - mypy: consider incremental mode or the mypy daemon (dmypy)
+```
+
+The `Files` column counts the distinct files each tool reported issues on. In JSON mode
+the profile is added additively under a top-level `profile` key (`cumulative_tool_duration`,
+`tools[]`, `suggestions[]`) and the existing `results`/`summary` schema is unchanged.
+
 ## Tips and Tricks
 
 ### 1. Use Grid Formatting

--- a/lintro/api/pipeline.py
+++ b/lintro/api/pipeline.py
@@ -211,8 +211,10 @@ def run_lint_artifact(
             strictly below this threshold (CI gate).
         diff_base: Git base ref for ``--diff`` scanning, or ``None``.
         no_art: When True, suppress decorative ASCII art.
-        profile: When True, collect per-tool wall-clock timings and render a
-            profiling summary after the run.
+        profile: When True, render the per-tool timing table (human output) or
+            attach a ``profile`` key (JSON). Executors always record main-tool
+            timings; post-checks are omitted. ``--score`` and csv/sarif/markdown
+            stdout stay unchanged.
         ai_enabled: Whether the post-execution AI enhancement may run.
             ``lintro test`` sets this to False because AI never applies to the
             test action. It gates :func:`~lintro.ai.interface.enhance_artifact`
@@ -365,8 +367,10 @@ def run_lint_with_ai(
             strictly below this threshold (CI gate).
         diff_base: Git base ref for ``--diff`` scanning, or ``None``.
         no_art: When True, suppress decorative ASCII art.
-        profile: When True, collect per-tool wall-clock timings and render a
-            profiling summary after the run.
+        profile: When True, render the per-tool timing table (human output) or
+            attach a ``profile`` key (JSON). Executors always record main-tool
+            timings; post-checks are omitted. ``--score`` and csv/sarif/markdown
+            stdout stay unchanged.
         ai_enabled: Whether the post-execution AI enhancement may run.
 
     Returns:

--- a/lintro/api/pipeline.py
+++ b/lintro/api/pipeline.py
@@ -177,6 +177,7 @@ def run_lint_artifact(
     fail_under: float | None = None,
     diff_base: str | None = None,
     no_art: bool = False,
+    profile: bool = False,
     ai_enabled: bool = True,
 ) -> RunArtifact:
     """Execute a run, apply AI enhancement, render it, and return the artifact.
@@ -210,6 +211,8 @@ def run_lint_artifact(
             strictly below this threshold (CI gate).
         diff_base: Git base ref for ``--diff`` scanning, or ``None``.
         no_art: When True, suppress decorative ASCII art.
+        profile: When True, collect per-tool wall-clock timings and render a
+            profiling summary after the run.
         ai_enabled: Whether the post-execution AI enhancement may run.
             ``lintro test`` sets this to False because AI never applies to the
             test action. It gates :func:`~lintro.ai.interface.enhance_artifact`
@@ -234,6 +237,7 @@ def run_lint_artifact(
         no_art=no_art,
         dry_run=dry_run,
         group_by=group_by,
+        profile=profile,
     )
     _capture_fmt_checkpoint(ctx=ctx, paths=paths)
     artifact = execute_run(
@@ -324,6 +328,7 @@ def run_lint_with_ai(
     fail_under: float | None = None,
     diff_base: str | None = None,
     no_art: bool = False,
+    profile: bool = False,
     ai_enabled: bool = True,
 ) -> int:
     """Run the full AI-aware pipeline and return only the process exit code.
@@ -360,6 +365,8 @@ def run_lint_with_ai(
             strictly below this threshold (CI gate).
         diff_base: Git base ref for ``--diff`` scanning, or ``None``.
         no_art: When True, suppress decorative ASCII art.
+        profile: When True, collect per-tool wall-clock timings and render a
+            profiling summary after the run.
         ai_enabled: Whether the post-execution AI enhancement may run.
 
     Returns:
@@ -391,5 +398,6 @@ def run_lint_with_ai(
         fail_under=fail_under,
         diff_base=diff_base,
         no_art=no_art,
+        profile=profile,
         ai_enabled=ai_enabled,
     ).exit_code

--- a/lintro/cli_utils/commands/check.py
+++ b/lintro/cli_utils/commands/check.py
@@ -164,6 +164,11 @@ DEFAULT_ACTION: str = "check"
     is_flag=True,
     help="Suppress the decorative ASCII art printed after the run.",
 )
+@click.option(
+    "--profile",
+    is_flag=True,
+    help="Show a per-tool performance profile (timing table + suggestions)",
+)
 def check_command(
     paths: tuple[str, ...],
     tools: str | None,
@@ -189,6 +194,7 @@ def check_command(
     score: bool,
     fail_under: float | None,
     no_art: bool,
+    profile: bool,
 ) -> None:
     """Check files for issues using the specified tools.
 
@@ -221,6 +227,7 @@ def check_command(
         score: bool: Print only the health score, suppressing the summary.
         fail_under: float | None: Exit 1 if the health score is below this value.
         no_art: bool: Suppress the decorative ASCII art printed after the run.
+        profile: bool: Whether to emit a per-tool performance profile.
 
     Raises:
         SystemExit: Process exit with the aggregated exit code from tools,
@@ -273,6 +280,7 @@ def check_command(
             score=score,
             fail_under=fail_under,
             no_art=no_art,
+            profile=profile,
         )
     except ConfigurationError as exc:
         click.echo(str(exc), err=True)

--- a/lintro/cli_utils/commands/format.py
+++ b/lintro/cli_utils/commands/format.py
@@ -128,6 +128,11 @@ DEFAULT_ACTION: str = "fmt"
     is_flag=True,
     help="Suppress the decorative ASCII art printed after the run.",
 )
+@click.option(
+    "--profile",
+    is_flag=True,
+    help="Show a per-tool performance profile (timing table + suggestions)",
+)
 def format_command(
     ctx: click.Context,
     paths: tuple[str, ...],
@@ -148,6 +153,7 @@ def format_command(
     yes: bool,
     dry_run: bool,
     no_art: bool,
+    profile: bool,
 ) -> None:
     """Format code using configured formatting tools.
 
@@ -179,6 +185,7 @@ def format_command(
         yes: bool: Skip confirmation prompt and proceed immediately.
         dry_run: bool: Preview would-be fixes without modifying any files.
         no_art: bool: Suppress the decorative ASCII art printed after the run.
+        profile: bool: Whether to emit a per-tool performance profile.
 
     Raises:
         SystemExit: Process exit with the aggregated exit code from tools,
@@ -211,6 +218,7 @@ def format_command(
             yes=yes,
             dry_run=dry_run,
             no_art=no_art,
+            profile=profile,
         )
     except ConfigurationError as exc:
         click.echo(str(exc), err=True)

--- a/lintro/models/core/tool_result.py
+++ b/lintro/models/core/tool_result.py
@@ -89,9 +89,10 @@ class ToolResult:
     parse_failures_count: int | None = field(default=None)
 
     # Wall-clock seconds the tool took, recorded by the executor around the
-    # check/fix call. ``None`` when the result was not produced by a run (a
-    # synthetic failure result, or a result built directly in a test).
-    # Surfaced in the optional ``--profile`` report.
+    # check/fix call (and around synthetic crash/timeout failure results so
+    # they still appear in ``--profile``). ``None`` when the result was not
+    # produced by a run (skipped tools, post-checks, or a result built
+    # directly in a test).
     duration_seconds: float | None = field(default=None)
 
     def __post_init__(self) -> None:

--- a/lintro/models/core/tool_result.py
+++ b/lintro/models/core/tool_result.py
@@ -91,6 +91,7 @@ class ToolResult:
     # Wall-clock seconds the tool took, recorded by the executor around the
     # check/fix call. ``None`` when the result was not produced by a run (a
     # synthetic failure result, or a result built directly in a test).
+    # Surfaced in the optional ``--profile`` report.
     duration_seconds: float | None = field(default=None)
 
     def __post_init__(self) -> None:

--- a/lintro/profiling/__init__.py
+++ b/lintro/profiling/__init__.py
@@ -6,7 +6,7 @@ Renders the per-tool wall-clock timings the executors record on each
 optimize their setup.
 """
 
-from lintro.profiling.models import ToolTiming
+from lintro.profiling.models import ProfileData, ProfileToolEntry, ToolTiming
 from lintro.profiling.report import (
     build_profile_data,
     build_timings,
@@ -15,6 +15,8 @@ from lintro.profiling.report import (
 from lintro.profiling.suggestions import get_suggestions
 
 __all__ = [
+    "ProfileData",
+    "ProfileToolEntry",
     "ToolTiming",
     "build_profile_data",
     "build_timings",

--- a/lintro/profiling/__init__.py
+++ b/lintro/profiling/__init__.py
@@ -1,0 +1,23 @@
+"""Performance profiling for lintro tool execution.
+
+Renders the per-tool wall-clock timings the executors record on each
+:class:`~lintro.models.core.tool_result.ToolResult` as an opt-in
+(``--profile``) report and JSON payload, helping users find slow tools and
+optimize their setup.
+"""
+
+from lintro.profiling.models import ToolTiming
+from lintro.profiling.report import (
+    build_profile_data,
+    build_timings,
+    render_profile_report,
+)
+from lintro.profiling.suggestions import get_suggestions
+
+__all__ = [
+    "ToolTiming",
+    "build_profile_data",
+    "build_timings",
+    "get_suggestions",
+    "render_profile_report",
+]

--- a/lintro/profiling/models.py
+++ b/lintro/profiling/models.py
@@ -1,0 +1,27 @@
+"""Data model for lintro performance profiling.
+
+The per-tool wall-clock durations themselves are captured by the executors on
+each :class:`~lintro.models.core.tool_result.ToolResult`; this module holds the
+record the ``--profile`` report and its JSON payload are built from.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ToolTiming:
+    """Per-tool timing attribution for a single profiled run.
+
+    Attributes:
+        tool: Display name of the tool.
+        duration: Wall-clock execution time in seconds.
+        files_checked: Number of distinct files the tool reported issues on.
+        issues_found: Number of issues the tool reported.
+    """
+
+    tool: str
+    duration: float
+    files_checked: int = field(default=0)
+    issues_found: int = field(default=0)

--- a/lintro/profiling/models.py
+++ b/lintro/profiling/models.py
@@ -8,6 +8,39 @@ record the ``--profile`` report and its JSON payload are built from.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TypedDict
+
+
+class ProfileToolEntry(TypedDict):
+    """One tool's object in the ``--profile`` JSON payload.
+
+    Attributes:
+        name: Display name of the tool.
+        duration: Rounded execution time in seconds.
+        files_with_issues: Distinct ``issue.file`` values after the same
+            detected/remaining merge used by JSON ``results[]``.
+        issues_found: Length of that merged issue list.
+    """
+
+    name: str
+    duration: float
+    files_with_issues: int
+    issues_found: int
+
+
+class ProfileData(TypedDict):
+    """JSON-serializable ``--profile`` payload attached at stdout and files.
+
+    Attributes:
+        cumulative_tool_duration: Sum of per-tool seconds (not parallel
+            wall-clock).
+        tools: Per-tool entries sorted slowest first.
+        suggestions: Optimization hints derived from the timings.
+    """
+
+    cumulative_tool_duration: float
+    tools: list[ProfileToolEntry]
+    suggestions: list[str]
 
 
 @dataclass
@@ -17,11 +50,13 @@ class ToolTiming:
     Attributes:
         tool: Display name of the tool.
         duration: Wall-clock execution time in seconds.
-        files_checked: Number of distinct files the tool reported issues on.
-        issues_found: Number of issues the tool reported.
+        files_with_issues: Number of distinct files the tool reported issues
+            on (not the number of files scanned).
+        issues_found: Number of issues after the same detected/remaining
+            merge used by JSON ``results[]``.
     """
 
     tool: str
     duration: float
-    files_checked: int = field(default=0)
+    files_with_issues: int = field(default=0)
     issues_found: int = field(default=0)

--- a/lintro/profiling/report.py
+++ b/lintro/profiling/report.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from lintro.profiling.suggestions import get_suggestions
 from lintro.profiling.models import ToolTiming
+from lintro.profiling.suggestions import get_suggestions
 
 if TYPE_CHECKING:
     from lintro.models.core.tool_result import ToolResult

--- a/lintro/profiling/report.py
+++ b/lintro/profiling/report.py
@@ -7,30 +7,44 @@ table, a JSON-serializable payload, and optimization suggestions.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from lintro.profiling.models import ToolTiming
+from lintro.formatters.formatter import merge_detected_and_remaining
+from lintro.profiling.models import ProfileData, ProfileToolEntry, ToolTiming
 from lintro.profiling.suggestions import get_suggestions
 
 if TYPE_CHECKING:
     from lintro.models.core.tool_result import ToolResult
+    from lintro.parsers.base_issue import BaseIssue
 
 # Rounding precision (decimal places) for reported durations.
 _DURATION_PRECISION: int = 2
 
 
-def _distinct_issue_files(result: ToolResult) -> int:
-    """Count distinct files a tool reported issues on.
+def _merged_issues(result: ToolResult) -> list[BaseIssue]:
+    """Return issues using the same merge as JSON ``results[]``.
 
     Args:
         result: The tool result to inspect.
 
     Returns:
-        Number of unique, non-empty file paths across the result's issues.
+        Deduplicated detected-plus-remaining issues.
     """
-    issues = getattr(result, "issues", None)
-    if not issues:
-        return 0
+    return merge_detected_and_remaining(
+        getattr(result, "initial_issues", None),
+        getattr(result, "issues", None),
+    )
+
+
+def _distinct_issue_files(issues: list[BaseIssue]) -> int:
+    """Count distinct files a tool reported issues on.
+
+    Args:
+        issues: Merged issues for one tool result.
+
+    Returns:
+        Number of unique, non-empty file paths across the issues.
+    """
     files: set[str] = set()
     for issue in issues:
         file_path = getattr(issue, "file", "")
@@ -44,8 +58,9 @@ def build_timings(results: list[ToolResult]) -> list[ToolTiming]:
 
     Only tools that were actually measured are included: skipped tools and
     any result without a captured ``duration`` (e.g. post-checks) are omitted
-    so the profile never fabricates timing data. Ties are broken by tool name
-    for deterministic ordering.
+    so the profile never fabricates timing data. Crashed and timed-out tools
+    are included when the executor recorded ``duration_seconds``. Ties are
+    broken by tool name for deterministic ordering.
 
     Args:
         results: Completed tool results from a run.
@@ -60,46 +75,49 @@ def build_timings(results: list[ToolResult]) -> list[ToolTiming]:
         duration = getattr(result, "duration_seconds", None)
         if duration is None:
             continue
+        merged = _merged_issues(result)
         timings.append(
             ToolTiming(
                 tool=result.name,
                 duration=float(duration),
-                files_checked=_distinct_issue_files(result),
-                issues_found=int(getattr(result, "issues_count", 0) or 0),
+                files_with_issues=_distinct_issue_files(merged),
+                issues_found=len(merged),
             ),
         )
     timings.sort(key=lambda t: (-t.duration, t.tool))
     return timings
 
 
-def build_profile_data(results: list[ToolResult]) -> dict[str, Any]:
+def build_profile_data(results: list[ToolResult]) -> ProfileData:
     """Build the JSON-serializable profile payload from tool results.
 
     Args:
         results: Completed tool results from a run.
 
     Returns:
-        A dict with ``cumulative_tool_duration`` (sum of per-tool seconds; not
-        wall-clock under parallel execution), a ``tools`` list of per-tool
-        objects (``name``, ``duration``, ``files_checked``, ``issues_found``),
-        and a ``suggestions`` list.
+        A payload with ``cumulative_tool_duration`` (sum of per-tool seconds;
+        not wall-clock under parallel execution), a ``tools`` list of
+        per-tool objects (``name``, ``duration``, ``files_with_issues``,
+        ``issues_found``), and a ``suggestions`` list. ``files_with_issues``
+        is distinct ``issue.file`` values, not files scanned.
     """
     timings = build_timings(results)
     total_duration = round(
         sum(t.duration for t in timings),
         _DURATION_PRECISION,
     )
+    tools: list[ProfileToolEntry] = [
+        {
+            "name": t.tool,
+            "duration": round(t.duration, _DURATION_PRECISION),
+            "files_with_issues": t.files_with_issues,
+            "issues_found": t.issues_found,
+        }
+        for t in timings
+    ]
     return {
         "cumulative_tool_duration": total_duration,
-        "tools": [
-            {
-                "name": t.tool,
-                "duration": round(t.duration, _DURATION_PRECISION),
-                "files_checked": t.files_checked,
-                "issues_found": t.issues_found,
-            }
-            for t in timings
-        ],
+        "tools": tools,
         "suggestions": get_suggestions(timings),
     }
 
@@ -114,12 +132,12 @@ def _render_table(timings: list[ToolTiming], total_duration: float) -> list[str]
     Returns:
         The table rendered as individual text lines.
     """
-    headers = ("Tool", "Duration", "Files", "Issues")
+    headers = ("Tool", "Duration", "Issue files", "Issues")
     rows: list[tuple[str, str, str, str]] = [
         (
             t.tool,
             f"{t.duration:.2f}s",
-            str(t.files_checked),
+            str(t.files_with_issues),
             str(t.issues_found),
         )
         for t in timings

--- a/lintro/profiling/report.py
+++ b/lintro/profiling/report.py
@@ -1,0 +1,188 @@
+"""Build and render the lintro performance profile.
+
+The profile turns the per-tool ``duration_seconds`` captured on each
+:class:`~lintro.models.core.tool_result.ToolResult` into a sorted timing
+table, a JSON-serializable payload, and optimization suggestions.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from lintro.profiling.suggestions import get_suggestions
+from lintro.profiling.models import ToolTiming
+
+if TYPE_CHECKING:
+    from lintro.models.core.tool_result import ToolResult
+
+# Rounding precision (decimal places) for reported durations.
+_DURATION_PRECISION: int = 2
+
+
+def _distinct_issue_files(result: ToolResult) -> int:
+    """Count distinct files a tool reported issues on.
+
+    Args:
+        result: The tool result to inspect.
+
+    Returns:
+        Number of unique, non-empty file paths across the result's issues.
+    """
+    issues = getattr(result, "issues", None)
+    if not issues:
+        return 0
+    files: set[str] = set()
+    for issue in issues:
+        file_path = getattr(issue, "file", "")
+        if file_path:
+            files.add(str(file_path))
+    return len(files)
+
+
+def build_timings(results: list[ToolResult]) -> list[ToolTiming]:
+    """Build per-tool timing records, sorted slowest first.
+
+    Only tools that were actually measured are included: skipped tools and
+    any result without a captured ``duration`` (e.g. post-checks) are omitted
+    so the profile never fabricates timing data. Ties are broken by tool name
+    for deterministic ordering.
+
+    Args:
+        results: Completed tool results from a run.
+
+    Returns:
+        Timing records ordered by descending duration.
+    """
+    timings: list[ToolTiming] = []
+    for result in results:
+        if getattr(result, "skipped", False):
+            continue
+        duration = getattr(result, "duration_seconds", None)
+        if duration is None:
+            continue
+        timings.append(
+            ToolTiming(
+                tool=result.name,
+                duration=float(duration),
+                files_checked=_distinct_issue_files(result),
+                issues_found=int(getattr(result, "issues_count", 0) or 0),
+            ),
+        )
+    timings.sort(key=lambda t: (-t.duration, t.tool))
+    return timings
+
+
+def build_profile_data(results: list[ToolResult]) -> dict[str, Any]:
+    """Build the JSON-serializable profile payload from tool results.
+
+    Args:
+        results: Completed tool results from a run.
+
+    Returns:
+        A dict with ``cumulative_tool_duration`` (sum of per-tool seconds; not
+        wall-clock under parallel execution), a ``tools`` list of per-tool
+        objects (``name``, ``duration``, ``files_checked``, ``issues_found``),
+        and a ``suggestions`` list.
+    """
+    timings = build_timings(results)
+    total_duration = round(
+        sum(t.duration for t in timings),
+        _DURATION_PRECISION,
+    )
+    return {
+        "cumulative_tool_duration": total_duration,
+        "tools": [
+            {
+                "name": t.tool,
+                "duration": round(t.duration, _DURATION_PRECISION),
+                "files_checked": t.files_checked,
+                "issues_found": t.issues_found,
+            }
+            for t in timings
+        ],
+        "suggestions": get_suggestions(timings),
+    }
+
+
+def _render_table(timings: list[ToolTiming], total_duration: float) -> list[str]:
+    """Render the timing table as a list of box-drawn lines.
+
+    Args:
+        timings: Per-tool timing records (already sorted).
+        total_duration: Sum of all tool durations in seconds.
+
+    Returns:
+        The table rendered as individual text lines.
+    """
+    headers = ("Tool", "Duration", "Files", "Issues")
+    rows: list[tuple[str, str, str, str]] = [
+        (
+            t.tool,
+            f"{t.duration:.2f}s",
+            str(t.files_checked),
+            str(t.issues_found),
+        )
+        for t in timings
+    ]
+    total_issues = sum(t.issues_found for t in timings)
+    total_row = (
+        "CUMULATIVE",
+        f"{total_duration:.2f}s",
+        "",
+        str(total_issues),
+    )
+
+    # Compute column widths across header, data rows, and the total row.
+    all_rows = [headers, *rows, total_row]
+    widths = [max(len(row[col]) for row in all_rows) for col in range(len(headers))]
+
+    def _sep(left: str, mid: str, right: str) -> str:
+        return left + mid.join("─" * (w + 2) for w in widths) + right
+
+    def _row(cells: tuple[str, ...]) -> str:
+        padded = [f" {cell.ljust(widths[i])} " for i, cell in enumerate(cells)]
+        return "│" + "│".join(padded) + "│"
+
+    lines = [
+        _sep("┌", "┬", "┐"),
+        _row(headers),
+        _sep("├", "┼", "┤"),
+    ]
+    lines.extend(_row(row) for row in rows)
+    lines.append(_sep("├", "┼", "┤"))
+    lines.append(_row(total_row))
+    lines.append(_sep("└", "┴", "┘"))
+    return lines
+
+
+def render_profile_report(results: list[ToolResult]) -> str:
+    """Render the human-readable performance profile report.
+
+    Args:
+        results: Completed tool results from a run.
+
+    Returns:
+        The full report text, or an empty string when no tools were timed.
+    """
+    timings = build_timings(results)
+    if not timings:
+        return ""
+
+    total_duration = round(
+        sum(t.duration for t in timings),
+        _DURATION_PRECISION,
+    )
+    lines: list[str] = [
+        "Performance Profile",
+        "",
+        "Tool Timing (sorted by duration):",
+        *_render_table(timings, total_duration),
+    ]
+
+    suggestions = get_suggestions(timings)
+    if suggestions:
+        lines.append("")
+        lines.append("Suggestions:")
+        lines.extend(f"  - {suggestion}" for suggestion in suggestions)
+
+    return "\n".join(lines)

--- a/lintro/profiling/suggestions.py
+++ b/lintro/profiling/suggestions.py
@@ -63,7 +63,7 @@ def get_suggestions(
     for timing in timings:
         if timing is slowest:
             continue
-        if timing.duration >= slow_threshold:
+        if timing.duration > slow_threshold:
             suggestions.append(
                 f"{timing.tool} took {timing.duration:.2f}s "
                 f"(over the {slow_threshold:.0f}s threshold)",

--- a/lintro/profiling/suggestions.py
+++ b/lintro/profiling/suggestions.py
@@ -1,0 +1,72 @@
+"""Performance optimization suggestions derived from tool timings.
+
+Suggestions are intentionally conservative: they only reference tools that
+actually ran in the current invocation, so users never see advice that does
+not apply to their setup.
+"""
+
+from __future__ import annotations
+
+from lintro.profiling.models import ToolTiming
+
+# Default threshold (seconds) above which a tool is flagged as slow.
+DEFAULT_SLOW_THRESHOLD: float = 5.0
+
+# Tool-specific optimization hints, keyed by tool name (lowercase).
+_TOOL_HINTS: dict[str, str] = {
+    "mypy": "mypy: consider incremental mode or the mypy daemon (dmypy)",
+    "darglint": (
+        "darglint is deprecated and slow; consider replacing it with pydoclint"
+    ),
+    "pylint": "pylint: consider running with --jobs to parallelize analysis",
+}
+
+
+def get_suggestions(
+    timings: list[ToolTiming],
+    *,
+    slow_threshold: float = DEFAULT_SLOW_THRESHOLD,
+) -> list[str]:
+    """Build human-readable optimization suggestions from tool timings.
+
+    The suggestions are ordered as: the slowest-tool summary first, then any
+    tool-specific hints for tools that ran, then per-tool slow-threshold
+    warnings for the remaining tools.
+
+    Args:
+        timings: Per-tool timing records for the run.
+        slow_threshold: Seconds above which a non-slowest tool is flagged.
+
+    Returns:
+        A list of suggestion strings (empty when there is nothing to suggest).
+    """
+    suggestions: list[str] = []
+    if not timings:
+        return suggestions
+
+    total = sum(t.duration for t in timings)
+    slowest = max(timings, key=lambda t: t.duration)
+
+    if total > 0 and slowest.duration > 0:
+        pct = round(slowest.duration / total * 100)
+        suggestions.append(
+            f"{slowest.tool} is slowest ({pct}% of total time)",
+        )
+
+    # Tool-specific hints, in timing order, for tools that actually ran.
+    for timing in timings:
+        hint = _TOOL_HINTS.get(timing.tool.lower())
+        if hint is not None:
+            suggestions.append(hint)
+
+    # Slow-threshold warnings for tools other than the slowest.
+    for timing in timings:
+        if timing is slowest:
+            continue
+        if timing.duration >= slow_threshold:
+            suggestions.append(
+                f"{timing.tool} took {timing.duration:.2f}s "
+                f"(over the {slow_threshold:.0f}s threshold)",
+            )
+
+    return suggestions

--- a/lintro/utils/async_tool_executor.py
+++ b/lintro/utils/async_tool_executor.py
@@ -206,6 +206,12 @@ class AsyncToolExecutor:
 
             Returns:
                 Tuple of (tool_name, ToolResult).
+
+            Raises:
+                KeyboardInterrupt: Re-raised so the process can abort.
+                SystemExit: Re-raised so process exit is not swallowed.
+                asyncio.CancelledError: Re-raised so task cancellation is not
+                    treated as a tool failure.
             """
             started_at[name] = time.monotonic()
             tool_opts = options.get(name, {})

--- a/lintro/utils/async_tool_executor.py
+++ b/lintro/utils/async_tool_executor.py
@@ -162,6 +162,38 @@ class AsyncToolExecutor:
         """
         options = options_per_tool or {}
 
+        from lintro.models.core.tool_result import ToolResult
+
+        def _make_failed_result(
+            name: str,
+            message: str,
+            *,
+            duration_seconds: float,
+        ) -> tuple[str, ToolResult]:
+            """Build a failed ``ToolResult`` entry for the given tool.
+
+            Args:
+                name: Name of the tool the result belongs to.
+                message: Human-readable failure description.
+                duration_seconds: Elapsed time before the failure, so crashed
+                    tools still appear in the ``--profile`` table/JSON.
+
+            Returns:
+                A ``(tool_name, ToolResult)`` tuple with ``success=False``.
+            """
+            return (
+                name,
+                ToolResult(
+                    name=name,
+                    success=False,
+                    output=message,
+                    issues_count=0,
+                    duration_seconds=duration_seconds,
+                ),
+            )
+
+        started_at: dict[str, float] = {}
+
         async def run_with_name(
             name: str,
             tool: BaseToolPlugin,
@@ -175,14 +207,25 @@ class AsyncToolExecutor:
             Returns:
                 Tuple of (tool_name, ToolResult).
             """
+            started_at[name] = time.monotonic()
             tool_opts = options.get(name, {})
-            result = await self.run_tool_async(
-                tool,
-                paths,
-                action,
-                tool_opts,
-                max_fix_retries=max_fix_retries,
-            )
+            try:
+                result = await self.run_tool_async(
+                    tool,
+                    paths,
+                    action,
+                    tool_opts,
+                    max_fix_retries=max_fix_retries,
+                )
+            except (asyncio.CancelledError, KeyboardInterrupt, SystemExit):
+                raise
+            except BaseException as exc:
+                logger.error(f"Tool {name} failed with exception: {exc}")
+                return _make_failed_result(
+                    name=name,
+                    message=f"Parallel execution failed: {exc}",
+                    duration_seconds=time.monotonic() - started_at[name],
+                )
             if on_result:
                 on_result(name, result)
             return (name, result)
@@ -190,30 +233,11 @@ class AsyncToolExecutor:
         tasks = [run_with_name(name, tool) for name, tool in tools]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        from lintro.models.core.tool_result import ToolResult
-
-        def _make_failed_result(
-            name: str,
-            message: str,
-        ) -> tuple[str, ToolResult]:
-            """Build a failed ``ToolResult`` entry for the given tool.
-
-            Args:
-                name: Name of the tool the result belongs to.
-                message: Human-readable failure description.
-
-            Returns:
-                A ``(tool_name, ToolResult)`` tuple with ``success=False``.
-            """
-            return (
-                name,
-                ToolResult(
-                    name=name,
-                    success=False,
-                    output=message,
-                    issues_count=0,
-                ),
-            )
+        def _elapsed(name: str) -> float:
+            started = started_at.get(name)
+            if started is None:
+                return 0.0
+            return time.monotonic() - started
 
         # ``asyncio.gather(return_exceptions=True)`` aggregates *any* raised
         # value, including ``BaseException`` subclasses that are not
@@ -247,6 +271,7 @@ class AsyncToolExecutor:
                     _make_failed_result(
                         name=tool_name,
                         message=f"Parallel execution failed: {result}",
+                        duration_seconds=_elapsed(tool_name),
                     ),
                 )
                 continue
@@ -270,6 +295,7 @@ class AsyncToolExecutor:
                             "Parallel execution produced a malformed result: "
                             f"{result!r}"
                         ),
+                        duration_seconds=_elapsed(tool_name),
                     ),
                 )
 

--- a/lintro/utils/execution/run_context.py
+++ b/lintro/utils/execution/run_context.py
@@ -41,7 +41,9 @@ class RunContext:
             decorative console UI to stderr.
         score_only: Whether stdout must carry only the numeric health score.
         group_by: How to group issues in formatted and JSON output.
-        profile: Whether to emit a per-tool performance profile.
+        profile: Whether to emit the human/JSON performance profile. Timings
+            are recorded for main-phase tools regardless; this flag only
+            gates rendering.
     """
 
     action: Action

--- a/lintro/utils/execution/run_context.py
+++ b/lintro/utils/execution/run_context.py
@@ -41,6 +41,7 @@ class RunContext:
             decorative console UI to stderr.
         score_only: Whether stdout must carry only the numeric health score.
         group_by: How to group issues in formatted and JSON output.
+        profile: Whether to emit a per-tool performance profile.
     """
 
     action: Action
@@ -52,3 +53,4 @@ class RunContext:
     clean_stdout_output: bool
     score_only: bool
     group_by: str = "auto"
+    profile: bool = False

--- a/lintro/utils/execution/run_renderer.py
+++ b/lintro/utils/execution/run_renderer.py
@@ -228,6 +228,7 @@ def _write_artifacts(
     *,
     warn_func: Any = None,
     ai_enrichment: AISarifEnrichment | None = None,
+    profile_data: dict[str, Any] | None = None,
 ) -> None:
     """Write side-channel artifact files alongside primary output.
 
@@ -300,6 +301,9 @@ def _write_artifacts(
                 total_issues=total_issues,
                 total_fixed=total_fixed,
                 ai_enrichment=enrichment,
+                profile_data=(
+                    profile_data if fmt == OutputFormat.JSON else None
+                ),
             )
         except (OSError, ValueError, TypeError) as e:
             _emit(f"Warning: Failed to write {artifact} artifact: {e}")
@@ -369,6 +373,10 @@ def _render_stdout_document(
             exit_code=artifact.exit_code,
             health_score=artifact.health.to_dict() if artifact.health else None,
         )
+        if ctx.profile:
+            from lintro.profiling.report import build_profile_data
+
+            json_data["profile"] = build_profile_data(all_results)
         print(json.dumps(json_data, indent=2))
         return
 
@@ -419,6 +427,14 @@ def _render_console_summary(artifact: RunArtifact, *, ctx: RunContext) -> None:
     """
     logger = ctx.logger
     logger.print_execution_summary(artifact.action, artifact.tool_results)
+
+    if ctx.profile:
+        from lintro.profiling.report import render_profile_report
+
+        profile_report = render_profile_report(artifact.tool_results)
+        if profile_report:
+            logger.console_output(text="")
+            logger.console_output(text=profile_report)
 
     # Dry-run summary: state clearly what a real fmt run would fix.
     if artifact.dry_run_preview:
@@ -531,6 +547,11 @@ def _write_run_files(
                     ai_summary=enrichment.summary,
                 )
             else:
+                file_profile = None
+                if ctx.profile and fmt == OutputFormat.JSON:
+                    from lintro.profiling.report import build_profile_data
+
+                    file_profile = build_profile_data(all_results)
                 write_output_file(
                     output_path=output_file,
                     output_format=fmt,
@@ -538,12 +559,19 @@ def _write_run_files(
                     action=artifact.action,
                     total_issues=artifact.total_issues,
                     total_fixed=artifact.total_fixed,
+                    profile_data=file_profile,
                 )
         except (OSError, ValueError, TypeError) as e:
             warn_func(f"Warning: Failed to write output file: {e}")
 
     # Write side-channel artifact files when configured or when running inside
     # GitHub Actions (SARIF auto-emit for Code Scanning).
+    artifact_profile = None
+    if ctx.profile:
+        from lintro.profiling.report import build_profile_data
+
+        artifact_profile = build_profile_data(all_results)
+
     _write_artifacts(
         all_results,
         ctx.lintro_config,
@@ -553,6 +581,7 @@ def _write_run_files(
         total_fixed=artifact.total_fixed,
         warn_func=warn_func,
         ai_enrichment=ai_enrichment,
+        profile_data=artifact_profile,
     )
 
     # Clean up old run directories to prevent unbounded growth

--- a/lintro/utils/execution/run_renderer.py
+++ b/lintro/utils/execution/run_renderer.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
     from lintro.models.core.run_artifact import RunArtifact
     from lintro.models.core.tool_result import ToolResult
+    from lintro.profiling.models import ProfileData
     from lintro.utils.execution.run_context import RunContext
 
 __all__ = [
@@ -228,7 +229,7 @@ def _write_artifacts(
     *,
     warn_func: Any = None,
     ai_enrichment: AISarifEnrichment | None = None,
-    profile_data: dict[str, Any] | None = None,
+    profile_data: ProfileData | None = None,
 ) -> None:
     """Write side-channel artifact files alongside primary output.
 

--- a/lintro/utils/execution/run_renderer.py
+++ b/lintro/utils/execution/run_renderer.py
@@ -254,11 +254,13 @@ def _write_artifacts(
         ai_enrichment: Optional AI enrichment for a SARIF artifact, supplied by
             the caller. Applied only when SARIF is actually among the
             artifacts, so a non-SARIF run never carries AI data.
+        profile_data: Optional ``--profile`` payload. Attached to the JSON
+            artifact only, so the artifact matches the stdout JSON document.
     """
     import os
     from pathlib import Path
 
-    from lintro.enums.output_format import normalize_output_format
+    from lintro.enums.output_format import OutputFormat, normalize_output_format
     from lintro.utils.output.file_writer import write_output_file
 
     artifacts: list[str] = [a.lower() for a in lintro_config.execution.artifacts]
@@ -301,9 +303,7 @@ def _write_artifacts(
                 total_issues=total_issues,
                 total_fixed=total_fixed,
                 ai_enrichment=enrichment,
-                profile_data=(
-                    profile_data if fmt == OutputFormat.JSON else None
-                ),
+                profile_data=(profile_data if fmt == OutputFormat.JSON else None),
             )
         except (OSError, ValueError, TypeError) as e:
             _emit(f"Warning: Failed to write {artifact} artifact: {e}")

--- a/lintro/utils/output/file_writer.py
+++ b/lintro/utils/output/file_writer.py
@@ -48,6 +48,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     from lintro.models.core.tool_result import ToolResult
+    from lintro.profiling.models import ProfileData
 
 
 def build_doc_url_map(all_results: Sequence[Any]) -> dict[str, str]:
@@ -303,7 +304,7 @@ def write_output_file(
     total_issues: int,
     total_fixed: int,
     ai_enrichment: AISarifEnrichment | None = None,
-    profile_data: dict[str, Any] | None = None,
+    profile_data: ProfileData | None = None,
 ) -> None:
     """Write results to user-specified output file.
 

--- a/lintro/utils/output/file_writer.py
+++ b/lintro/utils/output/file_writer.py
@@ -303,6 +303,7 @@ def write_output_file(
     total_issues: int,
     total_fixed: int,
     ai_enrichment: AISarifEnrichment | None = None,
+    profile_data: dict[str, Any] | None = None,
 ) -> None:
     """Write results to user-specified output file.
 
@@ -316,6 +317,9 @@ def write_output_file(
         ai_enrichment: Optional AI objects for SARIF output, supplied by the
             caller via the AI seam. Ignored for non-SARIF formats. When None,
             SARIF is rendered without AI enrichment.
+        profile_data: Optional performance profile payload; attached to the
+            JSON artifact under ``profile`` so the file output matches the
+            stdout payload when ``--profile`` is on.
     """
     output_file = Path(output_path)
     output_file.parent.mkdir(parents=True, exist_ok=True)
@@ -341,6 +345,8 @@ def write_output_file(
             json_data["results"].append(
                 serialize_tool_result(result, action=action),
             )
+        if profile_data is not None:
+            json_data["profile"] = profile_data
         output_file.write_text(
             json.dumps(json_data, indent=2, ensure_ascii=False),
             encoding="utf-8",

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -84,6 +84,7 @@ def build_run_context(
     no_art: bool = False,
     dry_run: bool = False,
     group_by: str = "auto",
+    profile: bool = False,
 ) -> RunContext:
     """Create the run-scoped state shared by the execute and render phases.
 
@@ -99,6 +100,7 @@ def build_run_context(
         no_art: Whether to suppress the decorative ASCII art.
         dry_run: Whether this is a ``fmt --dry-run`` preview.
         group_by: How to group issues in formatted and JSON output.
+        profile: Whether to collect and emit per-tool performance timings.
 
     Returns:
         RunContext: The shared context for this run.
@@ -157,6 +159,7 @@ def build_run_context(
         clean_stdout_output=clean_stdout_output,
         score_only=score_only,
         group_by=group_by,
+        profile=profile,
     )
 
 
@@ -704,6 +707,7 @@ def run_lint_tools_simple(
     no_art: bool = False,
     on_tool_result: Callable[[ToolResult], None] | None = None,
     render_summary: bool = True,
+    profile: bool = False,
 ) -> int:
     """Run tools and render their output, returning the process exit code.
 
@@ -729,13 +733,29 @@ def run_lint_tools_simple(
         ai_fix: Accepted for signature compatibility; this wrapper runs no AI.
         ignore_conflicts: Whether to ignore tool configuration conflicts.
         transport: Accepted for signature compatibility; this wrapper runs no AI.
-        dry_run: Preview what ``fmt`` would fix without modifying files.
-        score: Print only the numeric health score for human output.
-        fail_under: Fail when the computed health score is below this value.
-        diff_base: Git base ref used to limit scanned files.
-        no_art: Suppress decorative ASCII art.
+        dry_run: Preview what ``fmt`` would fix without modifying files. When
+            set with a ``fmt`` action, tools run in read-only check mode using
+            the fixable tool set; the reported issues are exactly what a real
+            ``fmt`` run would address. Exit code mirrors check semantics: 0 when
+            nothing would be fixed, 1 when fixes are available.
+        score: When True with human-readable output, print only the 0-100
+            health score line and suppress the normal execution summary.
+        fail_under: When set, exit with code 1 if the computed health score is
+            strictly below this threshold (CI gate).
+        diff_base: Git base ref for ``--diff`` scanning. ``None`` scans all
+            files; :data:`~lintro.utils.git_diff.DIFF_DEFAULT_SENTINEL` resolves
+            the repository default base; any other value is used as the base
+            ref. Non-git directories fall back to a full scan with a warning.
+        no_art: When True, suppress decorative ASCII art regardless of the
+            ``output.art`` config value. Art is also suppressed automatically
+            when ``output.art`` is ``False`` or stdout is not a TTY.
         on_tool_result: Optional custom live renderer for each completed tool.
         render_summary: Whether to render the normal final report and summary.
+        profile: When True, render a per-tool performance profile after the run
+            and include the profile payload in JSON output.
+
+    Programming errors raised while a tool executes (``TypeError``,
+    ``AttributeError``) propagate to the caller.
 
     Returns:
         Exit code (0 for success, 1 for failures).
@@ -748,6 +768,7 @@ def run_lint_tools_simple(
         no_art=no_art,
         dry_run=dry_run,
         group_by=group_by,
+        profile=profile,
     )
     try:
         from lintro.utils.execution.run_renderer import make_result_display

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -286,6 +286,7 @@ def _execute_tools_sequential(
     all_results: list[ToolResult] = []
 
     for tool_name in tools_to_run:
+        attempt_started = time.monotonic()
         try:
             tool = tool_manager.get_tool(tool_name)
 
@@ -354,13 +355,15 @@ def _execute_tools_sequential(
             # Show user-friendly error message on console
             logger.console_output(f"Error running {tool_name}: {e}")
 
-            # Create a failed result for this tool
+            # Create a failed result for this tool. Duration is recorded so
+            # crashed tools still appear in the ``--profile`` table/JSON.
             all_results.append(
                 ToolResult(
                     name=tool_name,
                     success=False,
                     output=f"Failed to initialize tool: {e}",
                     issues_count=0,
+                    duration_seconds=time.monotonic() - attempt_started,
                 ),
             )
 

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -100,7 +100,8 @@ def build_run_context(
         no_art: Whether to suppress the decorative ASCII art.
         dry_run: Whether this is a ``fmt --dry-run`` preview.
         group_by: How to group issues in formatted and JSON output.
-        profile: Whether to collect and emit per-tool performance timings.
+        profile: Whether to emit the human/JSON performance profile. Main-tool
+            timings are recorded regardless; this flag only gates rendering.
 
     Returns:
         RunContext: The shared context for this run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ packages = [
   "lintro.parsers.vale",
   "lintro.parsers.vue_tsc",
   "lintro.plugins",
+  "lintro.profiling",
   "lintro.tools",
   "lintro.tools.core",
   "lintro.tools.core.install_strategies",

--- a/tests/unit/cli/test_check_command.py
+++ b/tests/unit/cli/test_check_command.py
@@ -299,6 +299,42 @@ def test_check_command_raw_output_flag(
     assert_that(call_kwargs["raw_output"]).is_true()
 
 
+def test_check_command_profile_flag(
+    cli_runner: CliRunner,
+    mock_run_lint_tools_check: MagicMock,
+) -> None:
+    """Verify --profile flag forwards profile=True.
+
+    Args:
+        cli_runner: The Click CLI test runner.
+        mock_run_lint_tools_check: Mock for the run_lint_tools_check function.
+    """
+    with cli_runner.isolated_filesystem():
+        cli_runner.invoke(check_command, ["--profile"])
+
+    mock_run_lint_tools_check.assert_called_once()
+    call_kwargs = mock_run_lint_tools_check.call_args.kwargs
+    assert_that(call_kwargs["profile"]).is_true()
+
+
+def test_check_command_profile_defaults_false(
+    cli_runner: CliRunner,
+    mock_run_lint_tools_check: MagicMock,
+) -> None:
+    """Verify profile defaults to False when --profile is absent.
+
+    Args:
+        cli_runner: The Click CLI test runner.
+        mock_run_lint_tools_check: Mock for the run_lint_tools_check function.
+    """
+    with cli_runner.isolated_filesystem():
+        cli_runner.invoke(check_command, [])
+
+    mock_run_lint_tools_check.assert_called_once()
+    call_kwargs = mock_run_lint_tools_check.call_args.kwargs
+    assert_that(call_kwargs["profile"]).is_false()
+
+
 def test_check_command_tool_options(
     cli_runner: CliRunner,
     mock_run_lint_tools_check: MagicMock,

--- a/tests/unit/cli/test_cli_lintro_group.py
+++ b/tests/unit/cli/test_cli_lintro_group.py
@@ -112,6 +112,7 @@ def test_invoke_with_comma_separated_commands() -> None:
             score=False,
             fail_under=None,
             no_art=False,
+            profile=False,
         )
         mock_fmt.assert_any_call(
             action="fmt",
@@ -133,6 +134,7 @@ def test_invoke_with_comma_separated_commands() -> None:
             yes=False,
             dry_run=False,
             no_art=False,
+            profile=False,
         )
 
 

--- a/tests/unit/cli_utils/commands/test_format.py
+++ b/tests/unit/cli_utils/commands/test_format.py
@@ -199,6 +199,40 @@ def test_format_command_dry_run_defaults_false(mock_run: MagicMock) -> None:
 
 
 @patch("lintro.cli_utils.commands.format.run_lint_with_ai")
+def test_format_command_profile_defaults_false(mock_run: MagicMock) -> None:
+    """format_command defaults profile to False when flag absent.
+
+    Args:
+        mock_run: Mock for run_lint_with_ai.
+    """
+    mock_run.return_value = 0
+    runner = CliRunner()
+
+    result = runner.invoke(format_command, [])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    call_kwargs = mock_run.call_args.kwargs
+    assert_that(call_kwargs["profile"]).is_false()
+
+
+@patch("lintro.cli_utils.commands.format.run_lint_with_ai")
+def test_format_command_profile_flag_sets_true(mock_run: MagicMock) -> None:
+    """format_command forwards profile=True when --profile is passed.
+
+    Args:
+        mock_run: Mock for run_lint_with_ai.
+    """
+    mock_run.return_value = 0
+    runner = CliRunner()
+
+    result = runner.invoke(format_command, ["--profile"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    call_kwargs = mock_run.call_args.kwargs
+    assert_that(call_kwargs["profile"]).is_true()
+
+
+@patch("lintro.cli_utils.commands.format.run_lint_with_ai")
 def test_format_command_returns_tool_exit_code(mock_run: MagicMock) -> None:
     """format_command returns exit code from tool execution.
 

--- a/tests/unit/profiling/test_models.py
+++ b/tests/unit/profiling/test_models.py
@@ -1,0 +1,15 @@
+"""Tests for the profiling ToolTiming record."""
+
+from assertpy import assert_that
+
+from lintro.profiling.models import ToolTiming
+
+
+def test_tool_timing_defaults() -> None:
+    """ToolTiming defaults files_checked and issues_found to zero."""
+    timing = ToolTiming(tool="ruff", duration=1.5)
+
+    assert_that(timing.tool).is_equal_to("ruff")
+    assert_that(timing.duration).is_equal_to(1.5)
+    assert_that(timing.files_checked).is_equal_to(0)
+    assert_that(timing.issues_found).is_equal_to(0)

--- a/tests/unit/profiling/test_models.py
+++ b/tests/unit/profiling/test_models.py
@@ -6,10 +6,10 @@ from lintro.profiling.models import ToolTiming
 
 
 def test_tool_timing_defaults() -> None:
-    """ToolTiming defaults files_checked and issues_found to zero."""
+    """ToolTiming defaults files_with_issues and issues_found to zero."""
     timing = ToolTiming(tool="ruff", duration=1.5)
 
     assert_that(timing.tool).is_equal_to("ruff")
     assert_that(timing.duration).is_equal_to(1.5)
-    assert_that(timing.files_checked).is_equal_to(0)
+    assert_that(timing.files_with_issues).is_equal_to(0)
     assert_that(timing.issues_found).is_equal_to(0)

--- a/tests/unit/profiling/test_report.py
+++ b/tests/unit/profiling/test_report.py
@@ -55,7 +55,12 @@ def sample_results() -> list[ToolResult]:
             duration_seconds=None,
         ),
         # An untimed result (e.g. a post-check) must be excluded.
-        ToolResult(name="darglint", success=True, issues_count=1, duration_seconds=None),
+        ToolResult(
+            name="darglint",
+            success=True,
+            issues_count=1,
+            duration_seconds=None,
+        ),
     ]
 
 

--- a/tests/unit/profiling/test_report.py
+++ b/tests/unit/profiling/test_report.py
@@ -1,0 +1,145 @@
+"""Tests for the profiling report builder and renderer."""
+
+from __future__ import annotations
+
+import pytest
+from assertpy import assert_that
+
+from lintro.models.core.tool_result import ToolResult
+from lintro.parsers.base_issue import BaseIssue
+from lintro.profiling.report import (
+    build_profile_data,
+    build_timings,
+    render_profile_report,
+)
+
+
+def _issue(file: str) -> BaseIssue:
+    """Build a minimal issue with a ``file`` attribute.
+
+    Args:
+        file: The file path to attach to the issue.
+
+    Returns:
+        A ``BaseIssue`` exposing ``file``.
+    """
+    return BaseIssue(file=file, line=1, column=1, message="test")
+
+
+@pytest.fixture
+def sample_results() -> list[ToolResult]:
+    """Provide a representative set of timed tool results.
+
+    Returns:
+        A list mixing timed, skipped, and untimed (post-check-like) results.
+    """
+    return [
+        ToolResult(
+            name="ruff",
+            success=True,
+            issues_count=2,
+            issues=[_issue("a.py"), _issue("b.py")],
+            duration_seconds=0.4,
+        ),
+        ToolResult(
+            name="mypy",
+            success=False,
+            issues_count=3,
+            issues=[_issue("a.py"), _issue("a.py"), _issue("c.py")],
+            duration_seconds=12.0,
+        ),
+        ToolResult(
+            name="bandit",
+            skipped=True,
+            skip_reason="not installed",
+            duration_seconds=None,
+        ),
+        # An untimed result (e.g. a post-check) must be excluded.
+        ToolResult(name="darglint", success=True, issues_count=1, duration_seconds=None),
+    ]
+
+
+def test_build_timings_sorted_slowest_first(
+    sample_results: list[ToolResult],
+) -> None:
+    """Timings are ordered by descending duration."""
+    timings = build_timings(sample_results)
+
+    assert_that([t.tool for t in timings]).is_equal_to(["mypy", "ruff"])
+
+
+def test_build_timings_excludes_skipped_and_untimed(
+    sample_results: list[ToolResult],
+) -> None:
+    """Skipped tools and untimed results are omitted from the profile."""
+    tools = [t.tool for t in build_timings(sample_results)]
+
+    assert_that(tools).does_not_contain("bandit")
+    assert_that(tools).does_not_contain("darglint")
+
+
+def test_build_timings_attributes_files_and_issues(
+    sample_results: list[ToolResult],
+) -> None:
+    """Per-tool file counts dedupe by path; issue counts mirror the result."""
+    timings = {t.tool: t for t in build_timings(sample_results)}
+
+    assert_that(timings["mypy"].files_checked).is_equal_to(2)
+    assert_that(timings["mypy"].issues_found).is_equal_to(3)
+    assert_that(timings["ruff"].files_checked).is_equal_to(2)
+
+
+def test_build_profile_data_shape(sample_results: list[ToolResult]) -> None:
+    """The JSON payload exposes cumulative_tool_duration, tools, and suggestions."""
+    data = build_profile_data(sample_results)
+
+    assert_that(data).contains_key("cumulative_tool_duration", "tools", "suggestions")
+    assert_that(data["cumulative_tool_duration"]).is_equal_to(12.4)
+    assert_that(data["tools"]).is_length(2)
+    first = data["tools"][0]
+    assert_that(first).contains_key(
+        "name",
+        "duration",
+        "files_checked",
+        "issues_found",
+    )
+    assert_that(first["name"]).is_equal_to("mypy")
+
+
+def test_build_profile_data_empty_when_nothing_timed() -> None:
+    """No timed results yields a zero total and empty tool list."""
+    results = [
+        ToolResult(
+            name="bandit",
+            skipped=True,
+            skip_reason="not installed",
+        ),
+    ]
+
+    data = build_profile_data(results)
+
+    assert_that(data["cumulative_tool_duration"]).is_equal_to(0)
+    assert_that(data["tools"]).is_empty()
+    assert_that(data["suggestions"]).is_empty()
+
+
+def test_render_profile_report_contains_table_and_total(
+    sample_results: list[ToolResult],
+) -> None:
+    """The rendered report includes the header, tools, and CUMULATIVE row."""
+    report = render_profile_report(sample_results)
+
+    assert_that(report).contains("Performance Profile")
+    assert_that(report).contains("mypy")
+    assert_that(report).contains("ruff")
+    assert_that(report).contains("CUMULATIVE")
+    assert_that(report).contains("12.00s")
+
+
+def test_render_profile_report_empty_without_timings() -> None:
+    """Rendering with no timed tools returns an empty string."""
+    report = render_profile_report(
+        [ToolResult(name="x", skipped=True, skip_reason="skip")],
+    )
+
+    assert_that(report).is_equal_to("")

--- a/tests/unit/profiling/test_report.py
+++ b/tests/unit/profiling/test_report.py
@@ -14,16 +14,17 @@ from lintro.profiling.report import (
 )
 
 
-def _issue(file: str) -> BaseIssue:
+def _issue(file: str, *, line: int = 1) -> BaseIssue:
     """Build a minimal issue with a ``file`` attribute.
 
     Args:
         file: The file path to attach to the issue.
+        line: 1-indexed line number (unique lines avoid merge collapse).
 
     Returns:
         A ``BaseIssue`` exposing ``file``.
     """
-    return BaseIssue(file=file, line=1, column=1, message="test")
+    return BaseIssue(file=file, line=line, column=1, message="test")
 
 
 @pytest.fixture
@@ -45,7 +46,7 @@ def sample_results() -> list[ToolResult]:
             name="mypy",
             success=False,
             issues_count=3,
-            issues=[_issue("a.py"), _issue("a.py"), _issue("c.py")],
+            issues=[_issue("a.py", line=1), _issue("a.py", line=2), _issue("c.py")],
             duration_seconds=12.0,
         ),
         ToolResult(
@@ -83,15 +84,57 @@ def test_build_timings_excludes_skipped_and_untimed(
     assert_that(tools).does_not_contain("darglint")
 
 
+def test_build_timings_includes_timed_failures() -> None:
+    """Crashed tools with a recorded duration appear in the profile."""
+    results = [
+        ToolResult(
+            name="ruff",
+            success=False,
+            output="Failed to initialize tool: boom",
+            issues_count=0,
+            duration_seconds=0.12,
+        ),
+    ]
+
+    timings = build_timings(results)
+
+    assert_that(timings).is_length(1)
+    assert_that(timings[0].tool).is_equal_to("ruff")
+    assert_that(timings[0].duration).is_equal_to(0.12)
+    assert_that(timings[0].files_with_issues).is_equal_to(0)
+    assert_that(timings[0].issues_found).is_equal_to(0)
+
+
 def test_build_timings_attributes_files_and_issues(
     sample_results: list[ToolResult],
 ) -> None:
-    """Per-tool file counts dedupe by path; issue counts mirror the result."""
+    """Per-tool file counts dedupe by path; issue counts use the merge."""
     timings = {t.tool: t for t in build_timings(sample_results)}
 
-    assert_that(timings["mypy"].files_checked).is_equal_to(2)
+    assert_that(timings["mypy"].files_with_issues).is_equal_to(2)
     assert_that(timings["mypy"].issues_found).is_equal_to(3)
-    assert_that(timings["ruff"].files_checked).is_equal_to(2)
+    assert_that(timings["ruff"].files_with_issues).is_equal_to(2)
+
+
+def test_build_timings_uses_merged_issue_count_in_fmt_mode() -> None:
+    """``issues_found`` matches JSON ``results[]`` after detected/remaining merge."""
+    detected = [_issue("a.py", line=1), _issue("b.py", line=1)]
+    remaining = [_issue("b.py", line=1)]
+    result = ToolResult(
+        name="ruff",
+        success=True,
+        issues_count=1,
+        initial_issues=detected,
+        issues=remaining,
+        duration_seconds=1.0,
+    )
+
+    timings = build_timings([result])
+
+    assert_that(timings).is_length(1)
+    # Raw issues_count is remaining-only (1); the JSON merge keeps both files.
+    assert_that(timings[0].issues_found).is_equal_to(2)
+    assert_that(timings[0].files_with_issues).is_equal_to(2)
 
 
 def test_build_profile_data_shape(sample_results: list[ToolResult]) -> None:
@@ -105,10 +148,13 @@ def test_build_profile_data_shape(sample_results: list[ToolResult]) -> None:
     assert_that(first).contains_key(
         "name",
         "duration",
-        "files_checked",
+        "files_with_issues",
         "issues_found",
     )
+    assert_that(first).does_not_contain_key("files_checked")
     assert_that(first["name"]).is_equal_to("mypy")
+    assert_that(first["files_with_issues"]).is_equal_to(2)
+    assert_that(first["issues_found"]).is_equal_to(3)
 
 
 def test_build_profile_data_empty_when_nothing_timed() -> None:
@@ -137,6 +183,7 @@ def test_render_profile_report_contains_table_and_total(
     assert_that(report).contains("Performance Profile")
     assert_that(report).contains("mypy")
     assert_that(report).contains("ruff")
+    assert_that(report).contains("Issue files")
     assert_that(report).contains("CUMULATIVE")
     assert_that(report).contains("12.00s")
 

--- a/tests/unit/profiling/test_suggestions.py
+++ b/tests/unit/profiling/test_suggestions.py
@@ -1,0 +1,56 @@
+"""Tests for the profiling suggestions engine."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.profiling.suggestions import get_suggestions
+from lintro.profiling.models import ToolTiming
+
+
+def test_no_timings_yields_no_suggestions() -> None:
+    """An empty timing list produces no suggestions."""
+    assert_that(get_suggestions([])).is_empty()
+
+
+def test_slowest_tool_percentage_reported() -> None:
+    """The slowest tool is surfaced with its share of total time."""
+    timings = [
+        ToolTiming(tool="mypy", duration=8.0),
+        ToolTiming(tool="ruff", duration=2.0),
+    ]
+
+    suggestions = get_suggestions(timings)
+
+    assert_that(suggestions[0]).is_equal_to("mypy is slowest (80% of total time)")
+
+
+def test_mypy_hint_only_when_mypy_ran() -> None:
+    """The mypy-specific hint appears only when mypy is present."""
+    with_mypy = get_suggestions([ToolTiming(tool="mypy", duration=1.0)])
+    without_mypy = get_suggestions([ToolTiming(tool="ruff", duration=1.0)])
+
+    assert_that(any("dmypy" in s for s in with_mypy)).is_true()
+    assert_that(any("dmypy" in s for s in without_mypy)).is_false()
+
+
+def test_slow_threshold_flags_secondary_tools() -> None:
+    """A non-slowest tool over the threshold gets its own warning."""
+    timings = [
+        ToolTiming(tool="mypy", duration=12.0),
+        ToolTiming(tool="bandit", duration=6.0),
+        ToolTiming(tool="ruff", duration=0.4),
+    ]
+
+    suggestions = get_suggestions(timings, slow_threshold=5.0)
+
+    assert_that(any("bandit took 6.00s" in s for s in suggestions)).is_true()
+    # The slowest tool is not double-reported via the threshold path.
+    assert_that(any("mypy took" in s for s in suggestions)).is_false()
+
+
+def test_darglint_deprecation_hint() -> None:
+    """Darglint gets a deprecation/replacement hint when it ran."""
+    suggestions = get_suggestions([ToolTiming(tool="darglint", duration=3.0)])
+
+    assert_that(any("pydoclint" in s for s in suggestions)).is_true()

--- a/tests/unit/profiling/test_suggestions.py
+++ b/tests/unit/profiling/test_suggestions.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from assertpy import assert_that
 
-from lintro.profiling.suggestions import get_suggestions
 from lintro.profiling.models import ToolTiming
+from lintro.profiling.suggestions import get_suggestions
 
 
 def test_no_timings_yields_no_suggestions() -> None:

--- a/tests/unit/profiling/test_suggestions.py
+++ b/tests/unit/profiling/test_suggestions.py
@@ -49,6 +49,27 @@ def test_slow_threshold_flags_secondary_tools() -> None:
     assert_that(any("mypy took" in s for s in suggestions)).is_false()
 
 
+def test_slow_threshold_is_strictly_greater_than() -> None:
+    """A tool exactly at the threshold is not reported as over it."""
+    timings = [
+        ToolTiming(tool="mypy", duration=12.0),
+        ToolTiming(tool="bandit", duration=5.0),
+    ]
+
+    suggestions = get_suggestions(timings, slow_threshold=5.0)
+
+    assert_that(any("bandit took" in s for s in suggestions)).is_false()
+
+
+def test_pylint_hint_only_when_pylint_ran() -> None:
+    """The pylint jobs hint appears only when pylint is present."""
+    with_pylint = get_suggestions([ToolTiming(tool="pylint", duration=1.0)])
+    without_pylint = get_suggestions([ToolTiming(tool="ruff", duration=1.0)])
+
+    assert_that(any("--jobs" in s for s in with_pylint)).is_true()
+    assert_that(any("--jobs" in s for s in without_pylint)).is_false()
+
+
 def test_darglint_deprecation_hint() -> None:
     """Darglint gets a deprecation/replacement hint when it ran."""
     suggestions = get_suggestions([ToolTiming(tool="darglint", duration=3.0)])

--- a/tests/unit/tools/executor/test_execute_render_split.py
+++ b/tests/unit/tools/executor/test_execute_render_split.py
@@ -11,7 +11,7 @@ import csv
 import io
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Never
 from unittest.mock import MagicMock
 
 import pytest
@@ -116,6 +116,7 @@ def _context(
     output_format: str = "grid",
     score_only: bool = False,
     group_by: str = "auto",
+    profile: bool = False,
 ) -> RunContext:
     """Build a run context wired to test doubles.
 
@@ -125,6 +126,7 @@ def _context(
         output_format: Output format the run was asked for.
         score_only: Whether stdout carries only the numeric score.
         group_by: How issues should be grouped in formatted output.
+        profile: Whether to emit the per-tool performance profile.
 
     Returns:
         RunContext: A context safe to hand to either phase.
@@ -141,6 +143,7 @@ def _context(
         clean_stdout_output=output_format in ("json", "sarif", "csv", "markdown"),
         score_only=score_only,
         group_by=group_by,
+        profile=profile,
     )
 
 
@@ -658,3 +661,219 @@ def test_simple_runner_finalizes_output_after_execution_error(
     output_manager.mark_run_complete.assert_called_once_with()
     output_manager.cleanup_old_runs.assert_called_once_with()
     ctx.logger.warning.assert_called_once()
+
+
+def _profiled_artifact() -> RunArtifact:
+    """Build a completed artifact with recorded per-tool duration.
+
+    Returns:
+        RunArtifact: A one-tool artifact whose result can appear in ``--profile``.
+    """
+    issue = RuffIssue(file="a.py", line=1, code="F401", message="unused")
+    results = [
+        ToolResult(
+            name="ruff",
+            success=False,
+            issues_count=1,
+            issues=[issue],
+            duration_seconds=1.25,
+        ),
+    ]
+    return RunArtifact(
+        tool_results=results,
+        action=Action.CHECK,
+        workspace_root=Path.cwd(),
+        health=health_score_for_results(results),
+        total_issues=1,
+        total_fixed=0,
+        total_remaining=1,
+        exit_code=1,
+    )
+
+
+def _console_text(fake_logger: Any) -> str:
+    """Join recorded ``console_output`` calls into one string.
+
+    Args:
+        fake_logger: Logger double capturing method calls.
+
+    Returns:
+        Concatenated console text.
+    """
+    parts: list[str] = []
+    for name, args, kwargs in fake_logger.calls:
+        if name != "console_output":
+            continue
+        if "text" in kwargs:
+            parts.append(str(kwargs["text"]))
+        elif args:
+            parts.append(str(args[0]))
+    return "\n".join(parts)
+
+
+def test_execute_run_records_duration_on_tool_crash(
+    monkeypatch: pytest.MonkeyPatch,
+    executor_doubles: None,
+    tmp_path: Path,
+    fake_logger: Any,
+) -> None:
+    """A sequential crash still records elapsed time on the synthetic result."""
+    monkeypatch.setattr(
+        te,
+        "get_tools_to_run",
+        lambda tools, action, **_kw: ToolsToRunResult(to_run=["ruff"]),
+    )
+
+    def _boom(_name: str) -> Never:
+        raise RuntimeError("ruff exploded")
+
+    monkeypatch.setattr(tool_manager, "get_tool", _boom)
+    ctx = _context(tmp_path=tmp_path, fake_logger=fake_logger)
+
+    artifact = _run_execute(ctx=ctx)
+
+    assert_that(artifact.tool_results).is_length(1)
+    result = artifact.tool_results[0]
+    assert_that(result.name).is_equal_to("ruff")
+    assert_that(result.success).is_false()
+    assert_that(result.duration_seconds).is_not_none()
+    assert_that(result.duration_seconds).is_greater_than_or_equal_to(0.0)
+
+
+def test_render_run_grid_profile_prints_cumulative(
+    tmp_path: Path,
+    fake_logger: Any,
+) -> None:
+    """Grid ``--profile`` prints the timing table including the CUMULATIVE row."""
+    ctx = _context(tmp_path=tmp_path, fake_logger=fake_logger, profile=True)
+
+    render_run(_profiled_artifact(), ctx=ctx, output_format="grid")
+
+    assert_that(_console_text(fake_logger)).contains("CUMULATIVE")
+
+
+def test_render_run_json_stdout_includes_profile(
+    tmp_path: Path,
+    fake_logger: Any,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON stdout attaches the profile payload when ``ctx.profile`` is on."""
+    ctx = _context(
+        tmp_path=tmp_path,
+        fake_logger=fake_logger,
+        output_format="json",
+        profile=True,
+    )
+
+    render_run(_profiled_artifact(), ctx=ctx, output_format="json")
+
+    payload = json.loads(capsys.readouterr().out)
+    assert_that(payload).contains_key("profile")
+    assert_that(payload["profile"]).contains_key(
+        "cumulative_tool_duration",
+        "tools",
+        "suggestions",
+    )
+    assert_that(payload["profile"]["tools"][0]["name"]).is_equal_to("ruff")
+    assert_that(payload["profile"]["tools"][0]).contains_key("files_with_issues")
+    assert_that(payload["profile"]["tools"][0]).does_not_contain_key("files_checked")
+
+
+def test_render_run_json_output_file_includes_profile(
+    tmp_path: Path,
+    fake_logger: Any,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON ``--output`` files carry the same profile payload as stdout."""
+    output_path = tmp_path / "out.json"
+    ctx = _context(
+        tmp_path=tmp_path,
+        fake_logger=fake_logger,
+        output_format="json",
+        profile=True,
+    )
+
+    render_run(
+        _profiled_artifact(),
+        ctx=ctx,
+        output_format="json",
+        output_file=str(output_path),
+    )
+
+    stdout_payload = json.loads(capsys.readouterr().out)
+    file_payload = json.loads(output_path.read_text())
+    assert_that(stdout_payload).contains_key("profile")
+    assert_that(file_payload).contains_key("profile")
+    assert_that(file_payload["profile"]["tools"][0]["files_with_issues"]).is_equal_to(
+        1,
+    )
+
+
+def test_render_run_json_artifact_includes_profile(
+    tmp_path: Path,
+    fake_logger: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Configured JSON artifacts receive the profile payload on a profiled run."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    ctx = _context(
+        tmp_path=tmp_path,
+        fake_logger=fake_logger,
+        output_format="grid",
+        profile=True,
+    )
+    original_artifacts = list(ctx.lintro_config.execution.artifacts)
+    ctx.lintro_config.execution.artifacts = ["json"]
+    try:
+        render_run(_profiled_artifact(), ctx=ctx, output_format="grid")
+    finally:
+        ctx.lintro_config.execution.artifacts = original_artifacts
+
+    artifact_path = tmp_path / ".lintro" / "artifacts" / "json" / "results.json"
+    payload = json.loads(artifact_path.read_text())
+    assert_that(payload).contains_key("profile")
+    assert_that(payload["profile"]["tools"][0]["name"]).is_equal_to("ruff")
+
+
+def test_render_run_csv_stdout_stays_profile_free(
+    tmp_path: Path,
+    fake_logger: Any,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """CSV stdout stays a CSV document even when ``--profile`` is on."""
+    ctx = _context(
+        tmp_path=tmp_path,
+        fake_logger=fake_logger,
+        output_format="csv",
+        profile=True,
+    )
+
+    render_run(_profiled_artifact(), ctx=ctx, output_format="csv")
+
+    out = capsys.readouterr().out
+    assert_that(out).does_not_contain("CUMULATIVE")
+    assert_that(out).does_not_contain('"profile"')
+    rows = list(csv.reader(io.StringIO(out)))
+    assert_that(rows).is_not_empty()
+
+
+def test_render_run_sarif_stdout_stays_profile_free(
+    tmp_path: Path,
+    fake_logger: Any,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """SARIF stdout does not grow a ``profile`` key when ``--profile`` is on."""
+    ctx = _context(
+        tmp_path=tmp_path,
+        fake_logger=fake_logger,
+        output_format="sarif",
+        profile=True,
+    )
+
+    render_run(_profiled_artifact(), ctx=ctx, output_format="sarif")
+
+    payload = json.loads(capsys.readouterr().out)
+    assert_that(payload).does_not_contain_key("profile")
+    assert_that(payload["version"]).is_equal_to("2.1.0")

--- a/tests/unit/utils/async_tool_executor/test_base_exceptions.py
+++ b/tests/unit/utils/async_tool_executor/test_base_exceptions.py
@@ -128,6 +128,8 @@ def test_tool_exception_maps_to_failed_result(
     assert_that(name).is_equal_to("value_tool")
     assert_that(result.success).is_false()
     assert_that(result.output).contains("Parallel execution failed", "boom")
+    assert_that(result.duration_seconds).is_not_none()
+    assert_that(result.duration_seconds).is_greater_than_or_equal_to(0.0)
 
 
 def test_malformed_result_does_not_corrupt_results(
@@ -166,3 +168,5 @@ def test_malformed_result_does_not_corrupt_results(
     assert_that(name).is_equal_to("mock_tool")
     assert_that(result.success).is_false()
     assert_that(result.output).contains("malformed result")
+    assert_that(result.duration_seconds).is_not_none()
+    assert_that(result.duration_seconds).is_greater_than_or_equal_to(0.0)

--- a/tests/unit/utils/async_tool_executor/test_exceptions.py
+++ b/tests/unit/utils/async_tool_executor/test_exceptions.py
@@ -49,3 +49,5 @@ def test_exception_in_tool_creates_failed_result(
     assert_that(name).is_equal_to("raise_tool")
     assert_that(result.success).is_false()
     assert_that(result.output).contains("Parallel execution failed")
+    assert_that(result.duration_seconds).is_not_none()
+    assert_that(result.duration_seconds).is_greater_than_or_equal_to(0.0)

--- a/tests/unit/utils/test_output_writers.py
+++ b/tests/unit/utils/test_output_writers.py
@@ -594,7 +594,7 @@ def test_write_json_output_includes_profile_when_provided(
         action=Action.CHECK,
         total_issues=1,
         total_fixed=0,
-        profile_data={"cumulative_tool_duration": 1.23, "tools": []},
+        profile_data={"cumulative_tool_duration": 1.23, "tools": [], "suggestions": []},
     )
 
     content = json.loads(output_path.read_text())

--- a/tests/unit/utils/test_output_writers.py
+++ b/tests/unit/utils/test_output_writers.py
@@ -573,3 +573,55 @@ def test_empty_doc_url_is_empty_string_in_csv(tmp_path: Path) -> None:
     content = csv_path.read_text()
     assert_that(content).contains("doc_url")
     assert_that(content).does_not_contain("None")
+
+
+def test_write_json_output_includes_profile_when_provided(
+    tmp_path: Path,
+    sample_results: list[ToolResult],
+) -> None:
+    """The JSON file artifact carries the profile payload when provided.
+
+    Args:
+        tmp_path: Temporary directory path for testing.
+        sample_results: Sample tool results for testing.
+    """
+    output_path = tmp_path / "report.json"
+
+    write_output_file(
+        output_path=str(output_path),
+        output_format=OutputFormat.JSON,
+        all_results=sample_results,
+        action=Action.CHECK,
+        total_issues=1,
+        total_fixed=0,
+        profile_data={"cumulative_tool_duration": 1.23, "tools": []},
+    )
+
+    content = json.loads(output_path.read_text())
+    assert_that(content).contains_key("profile")
+    assert_that(content["profile"]["cumulative_tool_duration"]).is_equal_to(1.23)
+
+
+def test_write_json_output_omits_profile_by_default(
+    tmp_path: Path,
+    sample_results: list[ToolResult],
+) -> None:
+    """Without profile data the JSON file schema is unchanged.
+
+    Args:
+        tmp_path: Temporary directory path for testing.
+        sample_results: Sample tool results for testing.
+    """
+    output_path = tmp_path / "report.json"
+
+    write_output_file(
+        output_path=str(output_path),
+        output_format=OutputFormat.JSON,
+        all_results=sample_results,
+        action=Action.CHECK,
+        total_issues=1,
+        total_fixed=0,
+    )
+
+    content = json.loads(output_path.read_text())
+    assert_that(content).does_not_contain_key("profile")


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `feat(cli): add per-tool performance profiling (--profile)`
- Type: feat (minor)
- Breaking change: no

## What's Changing

Implements #446: an opt-in `--profile` flag for `check` and `format` that
captures **internal per-tool wall-clock timing** and surfaces it as a timing
table with optimization suggestions, plus a machine-readable JSON payload.

This is distinct from the external `benchmarks/` harness (PR #1139), which
measures whole-CLI performance from the outside. This PR measures the time
each tool spends inside a single run.

### Design

- **New `lintro/profiling/` module**
  - `timer.py` — `Timer` context manager (monotonic `time.perf_counter`) and the
    `ToolTiming` record.
  - `report.py` — builds sorted per-tool timings, the JSON payload, and renders
    the box-drawn report.
  - `suggestions.py` — conservative optimization hints that only reference tools
    that actually ran (slowest-share summary, tool-specific hints for
    mypy/darglint/pylint, and slow-threshold warnings).
- **Timing capture** — `ToolResult` gains an optional `duration` field (`None`
  when unmeasured). A `Timer` wraps each tool's check/fix call in both the
  sequential executor (`tool_executor.py`) and the parallel executor
  (`async_tool_executor.py`), so attribution is accurate under concurrency.
- **Off by default, zero overhead when omitted.** Skipped tools and untimed
  results (e.g. post-checks) are excluded rather than reported as `0.00s`.
- **JSON output is additive** — the profile is attached under a top-level
  `profile` key; the existing `results`/`summary` schema is unchanged.
- Threaded a `profile: bool` param through `run_lint_tools_simple`.

### Sample output

```text
Performance Profile

Tool Timing (sorted by duration):
┌───────┬──────────┬───────┬────────┐
│ Tool  │ Duration │ Files │ Issues │
├───────┼──────────┼───────┼────────┤
│ ruff  │ 0.46s    │ 0     │ 0      │
├───────┼──────────┼───────┼────────┤
│ TOTAL │ 0.46s    │       │ 0      │
└───────┴──────────┴───────┴────────┘

Suggestions:
  - ruff is slowest (100% of total time)
```

JSON (`--profile --output-format json`):

```json
"profile": {
  "total_duration": 0.04,
  "tools": [
    {"name": "ruff", "duration": 0.04, "files_checked": 0, "issues_found": 0}
  ],
  "suggestions": ["ruff is slowest (100% of total time)"]
}
```

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed

## Related Issues

Closes #446

## Details

- **Tests** (pytest style, assertpy, no test classes): timer monotonicity and
  exception-safety; per-tool attribution / files & issues; skipped and untimed
  results excluded; JSON profile shape; and CLI flag off-by-default + forwarding
  for both `check` and `format`.
- Registered `lintro.profiling` in `pyproject.toml` `[tool.setuptools].packages`.
- Updated `tests/unit/cli/test_cli_lintro_group.py` exact-kwargs assertions to
  include the new `profile=False`.
- Full suite: 6024 passed, 10 skipped. The two known env-only pre-existing
  failures (`test_markdownlint_direct_vs_lintro_parity`,
  `test_prepare_execution_version_check_fails_returns_early_result`) were
  deselected. `benchmarks/**` and all fenced modules were untouched;
  `summary_tables.py` was not modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `--profile` performance profiling to the `check` and `format` commands.
  * Displays per-tool durations, issue counts, cumulative runtime, and performance suggestions.
  * Includes profiling details in JSON output and generated JSON files.
  * Captures timing information for tools that fail or time out.

* **Documentation**
  * Added profiling guidance, examples, output details, and changelog information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds opt-in per-tool profiling for CLI runs. The main changes are:

- New `--profile` flags for `check` and `format`.
- Per-tool timing data stored on tool results.
- Human-readable profiling reports with suggestions.
- Additive JSON profile payloads for stdout, output files, and JSON artifacts.
- Tests for profile rendering, forwarding, and output-file behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.
- No blocking issues found in the changed code.
- JSON profile data now flows through stdout, explicit output files, and configured JSON artifacts when profiling is enabled.
- Non-JSON outputs keep their existing shape.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/utils/execution/run_renderer.py | Adds profile payload generation for stdout JSON, explicit JSON files, and configured JSON artifacts. |
| lintro/utils/output/file_writer.py | Adds optional JSON profile payload writing while keeping the default JSON schema unchanged. |
| lintro/profiling/report.py | Builds sorted timing records, JSON profile data, and the console profiling report. |

</details>

<sub>Reviews (12): Last reviewed commit: ["fix(profile): import OutputFormat in art..."](https://github.com/lgtm-hq/py-lintro/commit/65e60e19e45f4c5d603dd5143639a66c6cf98977) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42249757)</sub>

<!-- /greptile_comment -->