### PR TITLE
feat(cli): add config validate and config init/show subcommands

### DIFF
--- a/.lintro-config.yaml
+++ b/.lintro-config.yaml
@@ -91,6 +91,8 @@ tools:
   # Bandit - Security linter (config in pyproject.toml [tool.bandit])
   bandit:
     enabled: true
+    options:
+      timeout: 120
 
   # Hadolint - Dockerfile linter (defaults above or .hadolint.yaml)
   hadolint:

--- a/.lintro-config.yaml
+++ b/.lintro-config.yaml
@@ -91,8 +91,6 @@ tools:
   # Bandit - Security linter (config in pyproject.toml [tool.bandit])
   bandit:
     enabled: true
-    options:
-      timeout: 120
 
   # Hadolint - Dockerfile linter (defaults above or .hadolint.yaml)
   hadolint:

--- a/.typos.toml
+++ b/.typos.toml
@@ -26,6 +26,8 @@ extend-ignore-re = [
   "\"provdier\"",                              # unknown AI config key fixture
   "ignored: provdier",                         # ...and the message that key produces
   "html-valdate",                              # unknown-tool fixture
+  "enabled_tools: \\[blak\\]",                 # unknown-tool fixture (suggests black)
+  "unknown tool 'blak'",                       # ...and the message that name produces
   "`langauge` is a misspelling of `language`", # golangci-lint parser fixture
 ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **config**: auto-detect `config validate` ignores non-mapping YAML the same way
+  `load_config` does and continues to `[tool.lintro]`; a null `enforce` / `execution` /
+  `defaults` / `tools` section raises `ConfigurationError` instead of crashing (#1165)
+
 ### Security
 
 ## [0.128.0] - 2026-08-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **cli**: add `config validate` plus `config init` / `config show` subcommands (#1165)
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **config**: auto-detect `config validate` ignores non-mapping YAML the same way
   `load_config` does and continues to `[tool.lintro]`; a null `enforce` / `execution` /
-  `defaults` / `tools` section raises `ConfigurationError` instead of crashing (#1165)
+  `defaults` / `tools` section or a non-string `tools:` key raises `ConfigurationError`
+  instead of crashing (#1165)
 
 ### Security
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,6 +145,11 @@ tools:
     auto_install: true # Override global auto_install for this tool only
 ```
 
+Each `tools.<name>` value must be a mapping (`ruff: {}` or `ruff: {enabled: true}`)
+or a boolean (`ruff: true` / `ruff: false`). A bare `tools.ruff:` is YAML null and is
+rejected by `check`, `format`, and `config show` with exit 1. Use
+`lintro config validate` for a structured report.
+
 ### Configuration Report Command
 
 Use `lintro config` to view the current configuration status for all tools:
@@ -597,6 +602,10 @@ enabled = false
 [tool.lintro.tool.trufflehog]
 enabled = false
 ```
+
+`[tool.lintro.execution]` and `[tool.lintro.enforce]` nested tables are equivalent to
+the YAML `execution:` / `enforce:` sections. Flat keys such as `fail_fast` under
+`[tool.lintro]` also work.
 
 `pyproject.toml` is a _fallback_: when a `.lintro-config.yaml` exists, it is the only
 configuration source and these tables are not consulted.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,8 +145,8 @@ tools:
     auto_install: true # Override global auto_install for this tool only
 ```
 
-Each `tools.<name>` value must be a mapping (`ruff: {}` or `ruff: {enabled: true}`)
-or a boolean (`ruff: true` / `ruff: false`). A bare `tools.ruff:` is YAML null and is
+Each `tools.<name>` value must be a mapping (`ruff: {}` or `ruff: {enabled: true}`) or a
+boolean (`ruff: true` / `ruff: false`). A bare `tools.ruff:` is YAML null and is
 rejected by `check`, `format`, and `config show` with exit 1. Use
 `lintro config validate` for a structured report.
 

--- a/lintro/cli_utils/commands/check.py
+++ b/lintro/cli_utils/commands/check.py
@@ -223,7 +223,8 @@ def check_command(
         no_art: bool: Suppress the decorative ASCII art printed after the run.
 
     Raises:
-        SystemExit: Process exit with the aggregated exit code from tools.
+        SystemExit: Process exit with the aggregated exit code from tools,
+            or 1 when the config cannot be parsed.
     """
     # Handle cache clearing
     if no_cache:

--- a/lintro/cli_utils/commands/check.py
+++ b/lintro/cli_utils/commands/check.py
@@ -14,6 +14,7 @@ import click
 from lintro.api import core as api
 from lintro.api.pipeline import run_lint_with_ai
 from lintro.cli_utils.diff_option import validate_diff_base_ref
+from lintro.exceptions.errors import ConfigurationError
 from lintro.utils.git_diff import DIFF_DEFAULT_SENTINEL
 
 # Constants
@@ -272,7 +273,7 @@ def check_command(
             fail_under=fail_under,
             no_art=no_art,
         )
-    except ValueError as exc:
+    except ConfigurationError as exc:
         click.echo(str(exc), err=True)
         raise SystemExit(1) from exc
 

--- a/lintro/cli_utils/commands/check.py
+++ b/lintro/cli_utils/commands/check.py
@@ -245,32 +245,36 @@ def check_command(
     )
 
     # Run the AI-aware pipeline: execute, AI-enhance, render.
-    exit_code: int = run_lint_with_ai(
-        action=DEFAULT_ACTION,
-        paths=path_list,
-        tools=tools,
-        tool_options=combined_tool_options,
-        exclude=exclude,
-        include_venv=include_venv,
-        group_by=group_by,
-        output_format=output_format,
-        verbose=verbose,
-        raw_output=raw_output,
-        output_file=output,
-        incremental=incremental,
-        diff_base=diff_base,
-        debug=debug,
-        stream=stream,
-        no_log=no_log,
-        auto_install=auto_install,
-        yes=yes,
-        ai_fix=ai_fix,
-        ignore_conflicts=ignore_conflicts,
-        transport=transport,
-        score=score,
-        fail_under=fail_under,
-        no_art=no_art,
-    )
+    try:
+        exit_code: int = run_lint_with_ai(
+            action=DEFAULT_ACTION,
+            paths=path_list,
+            tools=tools,
+            tool_options=combined_tool_options,
+            exclude=exclude,
+            include_venv=include_venv,
+            group_by=group_by,
+            output_format=output_format,
+            verbose=verbose,
+            raw_output=raw_output,
+            output_file=output,
+            incremental=incremental,
+            diff_base=diff_base,
+            debug=debug,
+            stream=stream,
+            no_log=no_log,
+            auto_install=auto_install,
+            yes=yes,
+            ai_fix=ai_fix,
+            ignore_conflicts=ignore_conflicts,
+            transport=transport,
+            score=score,
+            fail_under=fail_under,
+            no_art=no_art,
+        )
+    except ValueError as exc:
+        click.echo(str(exc), err=True)
+        raise SystemExit(1) from exc
 
     # Exit with code only; CLI uses this as process exit code and avoids any
     # additional trailing output after the logger's ASCII art.

--- a/lintro/cli_utils/commands/config.py
+++ b/lintro/cli_utils/commands/config.py
@@ -174,9 +174,17 @@ def _run_config_report(
         verbose: Show detailed configuration including native tool configs.
         json_output: Output configuration as JSON.
         export_path: Path to export effective configuration as YAML file.
+
+    Raises:
+        SystemExit: When the config cannot be parsed (for example a null
+            ``tools.<name>:`` entry). Exits 1 with the parse error.
     """
     console = Console()
-    config = get_config(reload=True)
+    try:
+        config = get_config(reload=True)
+    except ValueError as exc:
+        click.echo(str(exc), err=True)
+        raise SystemExit(1) from exc
 
     if export_path:
         _export_yaml(config=config, export_path=export_path, console=console)

--- a/lintro/cli_utils/commands/config.py
+++ b/lintro/cli_utils/commands/config.py
@@ -1,4 +1,11 @@
-"""Config command for displaying Lintro configuration status."""
+"""Config command group for inspecting and validating Lintro configuration.
+
+Provides:
+
+- ``lintro config`` / ``lintro config show``: display effective configuration.
+- ``lintro config validate``: validate a config file against the schema.
+- ``lintro config init``: scaffold a starter config (delegates to ``init``).
+"""
 
 from dataclasses import asdict
 from pathlib import Path
@@ -9,7 +16,9 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from lintro.cli_utils.commands.init import init_command
 from lintro.config import LintroConfig, get_config
+from lintro.config.config_validator import ValidationResult, validate_config_file
 from lintro.utils.unified_config import (
     _load_native_tool_config,
     get_ordered_tools,
@@ -33,7 +42,11 @@ def _get_all_tool_names() -> list[str]:
     return ToolRegistry.get_names()
 
 
-@click.command()
+@click.group(
+    invoke_without_command=True,
+    no_args_is_help=False,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 @click.option(
     "--verbose",
     "-v",
@@ -52,7 +65,40 @@ def _get_all_tool_names() -> list[str]:
     type=click.Path(),
     help="Export effective configuration as a .lintro-config.yaml file.",
 )
+@click.pass_context
 def config_command(
+    ctx: click.Context,
+    verbose: bool,
+    json_output: bool,
+    export_path: str | None,
+) -> None:
+    r"""Inspect and validate Lintro configuration.
+
+    Without a subcommand, displays the effective configuration (same as
+    ``config show``). Subcommands provide validation and scaffolding:
+
+    \b
+    - config show      Display the effective configuration.
+    - config validate  Validate a config file against the schema.
+    - config init      Scaffold a starter .lintro-config.yaml.
+
+    Args:
+        ctx: Click context used to detect subcommand dispatch.
+        verbose: Show detailed configuration including native tool configs.
+        json_output: Output configuration as JSON.
+        export_path: Path to export effective configuration as YAML file.
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+
+    _run_config_report(
+        verbose=verbose,
+        json_output=json_output,
+        export_path=export_path,
+    )
+
+
+def _run_config_report(
     verbose: bool,
     json_output: bool,
     export_path: str | None,
@@ -89,6 +135,157 @@ def config_command(
         config=config,
         verbose=verbose,
     )
+
+
+@config_command.command("show")
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Show detailed configuration including native tool configs.",
+)
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    help="Output configuration as JSON.",
+)
+@click.option(
+    "--export",
+    "export_path",
+    type=click.Path(),
+    help="Export effective configuration as a .lintro-config.yaml file.",
+)
+def config_show_command(
+    verbose: bool,
+    json_output: bool,
+    export_path: str | None,
+) -> None:
+    """Display the effective Lintro configuration.
+
+    Args:
+        verbose: Show detailed configuration including native tool configs.
+        json_output: Output configuration as JSON.
+        export_path: Path to export effective configuration as YAML file.
+    """
+    _run_config_report(
+        verbose=verbose,
+        json_output=json_output,
+        export_path=export_path,
+    )
+
+
+@config_command.command("validate")
+@click.option(
+    "--path",
+    "config_path",
+    type=click.Path(),
+    default=None,
+    help="Path to the config file to validate (default: auto-detect).",
+)
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    help="Output validation results as JSON.",
+)
+def config_validate_command(
+    config_path: str | None,
+    json_output: bool,
+) -> None:
+    """Validate a Lintro configuration file against the schema.
+
+    Reports unknown tools (with typo suggestions), deprecated or unknown
+    options, and hard errors such as invalid value types. Exits non-zero when
+    the configuration is invalid.
+
+    Args:
+        config_path: Explicit config file to validate; auto-detected if None.
+        json_output: Emit machine-readable JSON instead of Rich output.
+
+    Raises:
+        SystemExit: With code 1 when the configuration is invalid.
+    """
+    result = validate_config_file(config_path)
+
+    if json_output:
+        _output_validation_json(result)
+    else:
+        _output_validation_rich(result, console=Console())
+
+    if not result.is_valid:
+        raise SystemExit(1)
+
+
+def _output_validation_json(result: ValidationResult) -> None:
+    """Print validation results as JSON.
+
+    Args:
+        result: The validation result to serialize.
+    """
+    import json
+
+    payload = {
+        "config_path": str(result.config_path) if result.config_path else None,
+        "valid": result.is_valid,
+        "errors": [
+            {
+                "message": msg.message,
+                "location": msg.location,
+                "suggestion": msg.suggestion,
+            }
+            for msg in result.errors
+        ],
+        "warnings": [
+            {
+                "message": msg.message,
+                "location": msg.location,
+                "suggestion": msg.suggestion,
+            }
+            for msg in result.warnings
+        ],
+    }
+    print(json.dumps(payload, indent=2))
+
+
+def _output_validation_rich(result: ValidationResult, console: Console) -> None:
+    """Render validation results using Rich formatting.
+
+    Args:
+        result: The validation result to render.
+        console: Rich console for output.
+    """
+    source = result.config_path or "[dim]none found[/dim]"
+    console.print(f"[bold]Validating[/bold] {source}")
+    console.print()
+
+    if result.warnings:
+        console.print("[bold yellow]Warnings:[/bold yellow]")
+        for msg in result.warnings:
+            console.print(f"  [yellow]⚠️[/yellow]  {msg.render()}")
+        console.print()
+
+    if result.errors:
+        console.print("[bold red]Errors:[/bold red]")
+        for msg in result.errors:
+            console.print(f"  [red]✗[/red] {msg.render()}")
+        console.print()
+
+    n_err = len(result.errors)
+    n_warn = len(result.warnings)
+    if result.is_valid:
+        suffix = f" ({n_warn} warning{'s' if n_warn != 1 else ''})" if n_warn else ""
+        console.print(f"[green]✅ Configuration is VALID{suffix}[/green]")
+    else:
+        console.print(
+            f"[red]❌ Configuration is INVALID "
+            f"({n_err} error{'s' if n_err != 1 else ''}, "
+            f"{n_warn} warning{'s' if n_warn != 1 else ''})[/red]",
+        )
+
+
+# Reuse the top-level init scaffolding as `config init`.
+config_command.add_command(init_command, name="init")
 
 
 def _config_to_export_dict(config: LintroConfig) -> dict[str, Any]:

--- a/lintro/cli_utils/commands/config.py
+++ b/lintro/cli_utils/commands/config.py
@@ -82,6 +82,8 @@ def config_command(
     - config validate  Validate a config file against the schema.
     - config init      Scaffold a starter .lintro-config.yaml.
 
+
+
     Args:
         ctx: Click context used to detect subcommand dispatch.
         verbose: Show detailed configuration including native tool configs.

--- a/lintro/cli_utils/commands/config.py
+++ b/lintro/cli_utils/commands/config.py
@@ -72,17 +72,20 @@ def config_command(
     json_output: bool,
     export_path: str | None,
 ) -> None:
-    r"""Inspect and validate Lintro configuration.
+    """Inspect and validate Lintro configuration.
 
     Without a subcommand, displays the effective configuration (same as
     ``config show``). Subcommands provide validation and scaffolding:
 
-    \b
+    \u0008
     - config show      Display the effective configuration.
     - config validate  Validate a config file against the schema.
     - config init      Scaffold a starter .lintro-config.yaml.
 
+    Group-level flags given before a subcommand (e.g.
+    ``lintro config --json validate``) are forwarded to that subcommand.
 
+    \u000c
 
     Args:
         ctx: Click context used to detect subcommand dispatch.
@@ -91,6 +94,12 @@ def config_command(
         export_path: Path to export effective configuration as YAML file.
     """
     if ctx.invoked_subcommand is not None:
+        _forward_group_options(
+            ctx=ctx,
+            verbose=verbose,
+            json_output=json_output,
+            export_path=export_path,
+        )
         return
 
     _run_config_report(
@@ -98,6 +107,51 @@ def config_command(
         json_output=json_output,
         export_path=export_path,
     )
+
+
+def _forward_group_options(
+    ctx: click.Context,
+    verbose: bool,
+    json_output: bool,
+    export_path: str | None,
+) -> None:
+    """Forward group-level flags to the invoked subcommand.
+
+    Click binds ``lintro config --json validate`` to the *group*'s ``--json``,
+    so without this the subcommand would run with its own defaults and quietly
+    ignore the flag. Values are injected via ``ctx.default_map``, which the
+    subcommand's context consults for any parameter not given explicitly, so
+    an explicit flag on the subcommand still wins.
+
+    Args:
+        ctx: The group's Click context.
+        verbose: Whether ``--verbose`` was given on the group.
+        json_output: Whether ``--json`` was given on the group.
+        export_path: Value of ``--export`` given on the group, if any.
+    """
+    provided: dict[str, Any] = {}
+    if verbose:
+        provided["verbose"] = True
+    if json_output:
+        provided["json_output"] = True
+    if export_path is not None:
+        provided["export_path"] = export_path
+    if not provided:
+        return
+
+    group = cast(click.Group, ctx.command)
+    default_map: dict[str, Any] = dict(ctx.default_map or {})
+    for name, command in group.commands.items():
+        param_names = {param.name for param in command.params}
+        overrides = {
+            key: value for key, value in provided.items() if key in param_names
+        }
+        if not overrides:
+            continue
+        merged: dict[str, Any] = dict(default_map.get(name) or {})
+        merged.update(overrides)
+        default_map[name] = merged
+    ctx.default_map = default_map
 
 
 def _run_config_report(
@@ -165,6 +219,8 @@ def config_show_command(
 ) -> None:
     """Display the effective Lintro configuration.
 
+    \u000c
+
     Args:
         verbose: Show detailed configuration including native tool configs.
         json_output: Output configuration as JSON.
@@ -201,6 +257,8 @@ def config_validate_command(
     options, and hard errors such as invalid value types. Exits non-zero when
     the configuration is invalid.
 
+    \u000c
+
     Args:
         config_path: Explicit config file to validate; auto-detected if None.
         json_output: Emit machine-readable JSON instead of Rich output.
@@ -232,6 +290,7 @@ def _output_validation_json(result: ValidationResult) -> None:
         "valid": result.is_valid,
         "errors": [
             {
+                "code": str(msg.code),
                 "message": msg.message,
                 "location": msg.location,
                 "suggestion": msg.suggestion,
@@ -240,6 +299,7 @@ def _output_validation_json(result: ValidationResult) -> None:
         ],
         "warnings": [
             {
+                "code": str(msg.code),
                 "message": msg.message,
                 "location": msg.location,
                 "suggestion": msg.suggestion,

--- a/lintro/cli_utils/commands/config.py
+++ b/lintro/cli_utils/commands/config.py
@@ -129,6 +129,10 @@ def _forward_group_options(
         verbose: Whether ``--verbose`` was given on the group.
         json_output: Whether ``--json`` was given on the group.
         export_path: Value of ``--export`` given on the group, if any.
+
+    Raises:
+        click.UsageError: When a group flag is not accepted by the
+            invoked subcommand (for example ``--export`` with validate).
     """
     provided: dict[str, Any] = {}
     if verbose:
@@ -140,18 +144,32 @@ def _forward_group_options(
     if not provided:
         return
 
+    invoked = ctx.invoked_subcommand
+    if invoked is None:
+        return
+
     group = cast(click.Group, ctx.command)
-    default_map: dict[str, Any] = dict(ctx.default_map or {})
-    for name, command in group.commands.items():
-        param_names = {param.name for param in command.params}
-        overrides = {
-            key: value for key, value in provided.items() if key in param_names
+    command = group.get_command(ctx, invoked)
+    if command is None:
+        return
+
+    param_names = {param.name for param in command.params}
+    leftover = [key for key in provided if key not in param_names]
+    if leftover:
+        flag_names = {
+            "verbose": "--verbose",
+            "json_output": "--json",
+            "export_path": "--export",
         }
-        if not overrides:
-            continue
-        merged: dict[str, Any] = dict(default_map.get(name) or {})
-        merged.update(overrides)
-        default_map[name] = merged
+        shown = ", ".join(flag_names[key] for key in leftover)
+        raise click.UsageError(
+            f"{shown} cannot be used with 'config {invoked}'.",
+        )
+
+    default_map: dict[str, Any] = dict(ctx.default_map or {})
+    merged: dict[str, Any] = dict(default_map.get(invoked) or {})
+    merged.update(provided)
+    default_map[invoked] = merged
     ctx.default_map = default_map
 
 

--- a/lintro/cli_utils/commands/config.py
+++ b/lintro/cli_utils/commands/config.py
@@ -19,6 +19,7 @@ from rich.table import Table
 from lintro.cli_utils.commands.init import init_command
 from lintro.config import LintroConfig, get_config
 from lintro.config.config_validator import ValidationResult, validate_config_file
+from lintro.exceptions.errors import ConfigurationError
 from lintro.utils.unified_config import (
     _load_native_tool_config,
     get_ordered_tools,
@@ -182,7 +183,7 @@ def _run_config_report(
     console = Console()
     try:
         config = get_config(reload=True)
-    except ValueError as exc:
+    except ConfigurationError as exc:
         click.echo(str(exc), err=True)
         raise SystemExit(1) from exc
 

--- a/lintro/cli_utils/commands/format.py
+++ b/lintro/cli_utils/commands/format.py
@@ -5,6 +5,7 @@ import click
 from lintro.api import core as api
 from lintro.api.pipeline import run_lint_with_ai
 from lintro.cli_utils.diff_option import validate_diff_base_ref
+from lintro.exceptions.errors import ConfigurationError
 from lintro.utils.git_diff import DIFF_DEFAULT_SENTINEL
 
 # Constants
@@ -211,7 +212,7 @@ def format_command(
             dry_run=dry_run,
             no_art=no_art,
         )
-    except ValueError as exc:
+    except ConfigurationError as exc:
         click.echo(str(exc), err=True)
         raise SystemExit(1) from exc
 

--- a/lintro/cli_utils/commands/format.py
+++ b/lintro/cli_utils/commands/format.py
@@ -178,6 +178,10 @@ def format_command(
         yes: bool: Skip confirmation prompt and proceed immediately.
         dry_run: bool: Preview would-be fixes without modifying any files.
         no_art: bool: Suppress the decorative ASCII art printed after the run.
+
+    Raises:
+        SystemExit: Process exit with the aggregated exit code from tools,
+            or 1 when the config cannot be parsed.
     """
     validate_diff_base_ref(diff_base=diff_base)
 
@@ -185,27 +189,31 @@ def format_command(
     normalized_paths: list[str] = list(paths) if paths else list(DEFAULT_PATHS)
 
     # Run the AI-aware pipeline: execute, AI-enhance, render.
-    exit_code: int = run_lint_with_ai(
-        action=DEFAULT_ACTION,
-        paths=normalized_paths,
-        tools=tools,
-        tool_options=tool_options,
-        exclude=exclude,
-        include_venv=include_venv,
-        group_by=group_by,
-        output_format=output_format,
-        verbose=verbose,
-        raw_output=raw_output,
-        output_file=output,
-        diff_base=diff_base,
-        debug=debug,
-        stream=stream,
-        no_log=no_log,
-        auto_install=auto_install,
-        yes=yes,
-        dry_run=dry_run,
-        no_art=no_art,
-    )
+    try:
+        exit_code: int = run_lint_with_ai(
+            action=DEFAULT_ACTION,
+            paths=normalized_paths,
+            tools=tools,
+            tool_options=tool_options,
+            exclude=exclude,
+            include_venv=include_venv,
+            group_by=group_by,
+            output_format=output_format,
+            verbose=verbose,
+            raw_output=raw_output,
+            output_file=output,
+            diff_base=diff_base,
+            debug=debug,
+            stream=stream,
+            no_log=no_log,
+            auto_install=auto_install,
+            yes=yes,
+            dry_run=dry_run,
+            no_art=no_art,
+        )
+    except ValueError as exc:
+        click.echo(str(exc), err=True)
+        raise SystemExit(1) from exc
 
     # Exit with code from tool execution.
     # For a normal fmt action, exit_code is 1 only if there were execution

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -792,6 +792,36 @@ def load_config(
         raise ConfigurationError(str(exc)) from exc
 
 
+def _require_mapping_section(
+    data: dict[str, Any],
+    section: str,
+) -> dict[str, Any]:
+    """Return ``section`` as a mapping, or ``{}`` when the key is absent.
+
+    YAML spells an empty section as ``enforce:`` which deserializes to
+    ``None``. ``dict.get(section, {})`` then returns that ``None``, and
+    the typed parsers call ``.get`` / ``.items`` on it.
+
+    Args:
+        data: Normalized configuration mapping.
+        section: Top-level key that must be a mapping when present.
+
+    Returns:
+        dict[str, Any]: The section mapping, or an empty mapping when
+            the key is omitted.
+
+    Raises:
+        ValueError: When the key is present but is not a mapping.
+    """
+    if section not in data:
+        return {}
+    value = data[section]
+    if isinstance(value, dict):
+        return value
+    actual = "null" if value is None else type(value).__name__
+    raise ValueError(f"{section} must be a mapping, got {actual}")
+
+
 def build_config_from_dict(
     data: dict[str, Any],
     resolved_path: str | None = None,
@@ -810,10 +840,18 @@ def build_config_from_dict(
     Returns:
         LintroConfig: The fully parsed configuration.
     """
-    enforce_config = _parse_enforce_config(data.get("enforce", {}))
-    execution_config = _parse_execution_config(data.get("execution", {}))
-    defaults = _parse_defaults(data.get("defaults", {}))
-    tools_config = _parse_tools_config(data.get("tools", {}))
+    enforce_config = _parse_enforce_config(
+        _require_mapping_section(data=data, section="enforce"),
+    )
+    execution_config = _parse_execution_config(
+        _require_mapping_section(data=data, section="execution"),
+    )
+    defaults = _parse_defaults(
+        _require_mapping_section(data=data, section="defaults"),
+    )
+    tools_config = _parse_tools_config(
+        _require_mapping_section(data=data, section="tools"),
+    )
     # Stored verbatim: parsing belongs to the AI layer (issue #724).
     ai_config = data.get("ai") or {}
     review_config = _parse_review_config(data.get("review", {}))

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from loguru import logger
 
@@ -282,6 +282,10 @@ def _parse_tool_config(tool_name: str, data: dict[str, Any]) -> LintroToolConfig
 def _parse_tools_config(data: dict[str, Any]) -> dict[str, LintroToolConfig]:
     """Parse all tool configurations.
 
+    Each ``tools.<name>`` value must be a mapping (including ``{}``) or a
+    boolean. A bare YAML entry such as ``tools.ruff:`` is null and is
+    rejected.
+
     Args:
         data: Raw 'tools' section from config.
 
@@ -488,18 +492,38 @@ def _parse_score_config(data: Any) -> ScoreConfig:
     return ScoreConfig(**filtered)
 
 
-def _pyproject_lintro_catalog() -> tuple[set[str], dict[str, str], set[str]]:
+class _PyprojectLintroCatalog(NamedTuple):
+    """Name catalog shared by the pyproject converter and validator.
+
+    Attributes:
+        known_tools: Tool names including hyphen/underscore aliases.
+        tool_aliases: Alias-to-canonical tool name map.
+        reserved_keys: Non-tool keys reserved under ``[tool.lintro]``.
+        execution_keys: ``ExecutionConfig`` field names.
+        enforce_keys: ``EnforceConfig`` field names.
+    """
+
+    known_tools: set[str]
+    tool_aliases: dict[str, str]
+    reserved_keys: set[str]
+    execution_keys: frozenset[str]
+    enforce_keys: frozenset[str]
+
+
+def _pyproject_lintro_catalog() -> _PyprojectLintroCatalog:
     """Return known tools, aliases, and reserved keys for ``[tool.lintro]``.
 
     Shared by the pyproject converter and the config validator so YAML
     ``tools:`` entries and TOML tool tables accept the same name set
     (``ToolName``, legacy aliases, and installed plugins). Plugin names come
     from :func:`~lintro.plugins.discovery.get_known_plugin_tool_names`, which
-    does not trigger a discovery pass.
+    does not trigger a discovery pass. Execution and enforce key sets come
+    from the Pydantic models so the converter and validator cannot drift.
 
     Returns:
-        tuple[set[str], dict[str, str], set[str]]: Known tool names (including
-            aliases), alias-to-canonical map, and reserved non-tool keys.
+        _PyprojectLintroCatalog: Known tool names (including aliases),
+            alias-to-canonical map, reserved non-tool keys, and the
+            execution/enforce field sets.
     """
     # Inline imports: ToolName is a static StrEnum that does not trigger
     # the plugin registry. Discovery is imported here to avoid a circular
@@ -513,23 +537,14 @@ def _pyproject_lintro_catalog() -> tuple[set[str], dict[str, str], set[str]]:
     }
     tool_aliases = dict(LEGACY_TOOL_SECTION_ALIASES)
 
-    execution_keys = {
-        "enabled_tools",
-        "tool_order",
-        "fail_fast",
-        "parallel",
-        "max_workers",
-        "auto_install_deps",
-        "max_fix_retries",
-        "artifacts",
-    }
-    enforce_keys = {"line_length", "target_python"}
+    execution_keys = frozenset(ExecutionConfig.model_fields)
+    enforce_keys = frozenset(EnforceConfig.model_fields)
     externally_handled_sections = set(EXTERNALLY_HANDLED_SECTIONS) | set(
         PYPROJECT_ORDERING_KEYS,
     )
     reserved_keys = (
-        execution_keys
-        | enforce_keys
+        set(execution_keys)
+        | set(enforce_keys)
         | externally_handled_sections
         | {
             "ai",
@@ -558,7 +573,13 @@ def _pyproject_lintro_catalog() -> tuple[set[str], dict[str, str], set[str]]:
                 tool_aliases.setdefault(variant, plugin_name)
 
     known_tools.update(tool_aliases.keys())
-    return known_tools, tool_aliases, reserved_keys
+    return _PyprojectLintroCatalog(
+        known_tools=known_tools,
+        tool_aliases=tool_aliases,
+        reserved_keys=reserved_keys,
+        execution_keys=execution_keys,
+        enforce_keys=enforce_keys,
+    )
 
 
 def known_config_tool_names() -> frozenset[str]:
@@ -571,8 +592,8 @@ def known_config_tool_names() -> frozenset[str]:
     Returns:
         frozenset[str]: Recognized tool identifiers.
     """
-    known_tools, _aliases, _reserved = _pyproject_lintro_catalog()
-    return frozenset(known_tools)
+    catalog = _pyproject_lintro_catalog()
+    return frozenset(catalog.known_tools)
 
 
 def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
@@ -598,22 +619,11 @@ def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
         "output": {},
     }
 
-    known_tools, tool_aliases, _reserved_keys = _pyproject_lintro_catalog()
-
-    # Known execution settings
-    execution_keys = {
-        "enabled_tools",
-        "tool_order",
-        "fail_fast",
-        "parallel",
-        "max_workers",
-        "auto_install_deps",
-        "max_fix_retries",
-        "artifacts",
-    }
-
-    # Known enforce settings (formerly global)
-    enforce_keys = {"line_length", "target_python"}
+    catalog = _pyproject_lintro_catalog()
+    known_tools = catalog.known_tools
+    tool_aliases = catalog.tool_aliases
+    execution_keys = catalog.execution_keys
+    enforce_keys = catalog.enforce_keys
 
     # Keys and sections that are valid under [tool.lintro] but are parsed by
     # other loaders, not by this converter. Listing them keeps the unknown-key
@@ -644,6 +654,24 @@ def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
                     continue
                 nested_canonical = tool_aliases.get(nested_lower, nested_lower)
                 result["tools"].setdefault(nested_canonical, nested_value)
+        elif key_lower == "execution":
+            # Nested ``[tool.lintro.execution]`` is the structured form of
+            # the same keys accepted flat under ``[tool.lintro]``.
+            if isinstance(value, dict):
+                result["execution"].update(
+                    {
+                        nested_key.replace("-", "_"): nested_value
+                        for nested_key, nested_value in value.items()
+                    },
+                )
+        elif key_lower == "enforce":
+            if isinstance(value, dict):
+                result["enforce"].update(
+                    {
+                        nested_key.replace("-", "_"): nested_value
+                        for nested_key, nested_value in value.items()
+                    },
+                )
         elif key in execution_keys or key.replace("-", "_") in execution_keys:
             # Execution config
             result["execution"][key.replace("-", "_")] = value

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -129,7 +129,21 @@ def _load_pyproject_fallback() -> tuple[dict[str, Any], Path | None]:
             try:
                 with pyproject_path.open("rb") as f:
                     data = tomllib.load(f)
-                return data.get("tool", {}).get("lintro", {}), pyproject_path
+                tool = data.get("tool", {})
+                if not isinstance(tool, dict):
+                    logger.warning(
+                        f"'tool' in {pyproject_path} is not a table; "
+                        "ignoring pyproject fallback.",
+                    )
+                    return {}, None
+                lintro = tool.get("lintro", {})
+                if not isinstance(lintro, dict):
+                    logger.warning(
+                        f"'tool.lintro' in {pyproject_path} is not a table; "
+                        "ignoring pyproject fallback.",
+                    )
+                    return {}, None
+                return lintro, pyproject_path
             except tomllib.TOMLDecodeError as e:
                 logger.warning(
                     f"Failed to parse pyproject.toml at {pyproject_path}: {e}",
@@ -273,18 +287,27 @@ def _parse_tools_config(data: dict[str, Any]) -> dict[str, LintroToolConfig]:
 
     Returns:
         dict[str, LintroToolConfig]: Tool configurations keyed by tool name.
+
+    Raises:
+        ValueError: If a tool entry is neither a mapping nor a boolean.
     """
     tools: dict[str, LintroToolConfig] = {}
 
     for tool_name, tool_data in data.items():
+        name = tool_name.lower()
         if isinstance(tool_data, dict):
-            tools[tool_name.lower()] = _parse_tool_config(
-                tool_name.lower(),
+            tools[name] = _parse_tool_config(
+                name,
                 tool_data,
             )
         elif isinstance(tool_data, bool):
             # Simple enabled/disabled flag
-            tools[tool_name.lower()] = LintroToolConfig(enabled=tool_data)
+            tools[name] = LintroToolConfig(enabled=tool_data)
+        else:
+            actual = "null" if tool_data is None else type(tool_data).__name__
+            raise ValueError(
+                f"tools.{name} must be a mapping or boolean, got {actual}.",
+            )
 
     return tools
 
@@ -465,6 +488,93 @@ def _parse_score_config(data: Any) -> ScoreConfig:
     return ScoreConfig(**filtered)
 
 
+def _pyproject_lintro_catalog() -> tuple[set[str], dict[str, str], set[str]]:
+    """Return known tools, aliases, and reserved keys for ``[tool.lintro]``.
+
+    Shared by the pyproject converter and the config validator so YAML
+    ``tools:`` entries and TOML tool tables accept the same name set
+    (``ToolName``, legacy aliases, and installed plugins). Plugin names come
+    from :func:`~lintro.plugins.discovery.get_known_plugin_tool_names`, which
+    does not trigger a discovery pass.
+
+    Returns:
+        tuple[set[str], dict[str, str], set[str]]: Known tool names (including
+            aliases), alias-to-canonical map, and reserved non-tool keys.
+    """
+    # Inline imports: ToolName is a static StrEnum that does not trigger
+    # the plugin registry. Discovery is imported here to avoid a circular
+    # dependency between config_loader and the tool subsystem.
+    from lintro.enums.tool_name import ToolName
+    from lintro.plugins.discovery import get_known_plugin_tool_names
+    from lintro.utils.config import LEGACY_TOOL_SECTION_ALIASES
+
+    known_tools = {t.value for t in ToolName} | {
+        t.value.replace("_", "-") for t in ToolName
+    }
+    tool_aliases = dict(LEGACY_TOOL_SECTION_ALIASES)
+
+    execution_keys = {
+        "enabled_tools",
+        "tool_order",
+        "fail_fast",
+        "parallel",
+        "max_workers",
+        "auto_install_deps",
+        "max_fix_retries",
+        "artifacts",
+    }
+    enforce_keys = {"line_length", "target_python"}
+    externally_handled_sections = set(EXTERNALLY_HANDLED_SECTIONS) | set(
+        PYPROJECT_ORDERING_KEYS,
+    )
+    reserved_keys = (
+        execution_keys
+        | enforce_keys
+        | externally_handled_sections
+        | {
+            "ai",
+            "defaults",
+            "output",
+            "review",
+            "score",
+            "tool",
+            "tools",
+            ConfigKey.POST_CHECKS.value.lower(),
+            ConfigKey.VERSIONS.value.lower(),
+        }
+    )
+    reserved_keys |= {name.replace("_", "-") for name in reserved_keys}
+
+    # ToolName never sees entry-point-discovered tools, so config for an
+    # externally installed plugin used to be dropped on the floor (#1757).
+    for plugin_name in get_known_plugin_tool_names():
+        variants = {
+            plugin_name,
+            plugin_name.replace("_", "-"),
+            plugin_name.replace("-", "_"),
+        }
+        for variant in variants:
+            if variant not in known_tools and variant not in reserved_keys:
+                tool_aliases.setdefault(variant, plugin_name)
+
+    known_tools.update(tool_aliases.keys())
+    return known_tools, tool_aliases, reserved_keys
+
+
+def known_config_tool_names() -> frozenset[str]:
+    """Return tool names the loader accepts in configuration.
+
+    Includes ``ToolName`` values (underscore and hyphen forms), legacy
+    section aliases such as ``markdownlint-cli2``, and installed plugin
+    names. Does not trigger plugin discovery.
+
+    Returns:
+        frozenset[str]: Recognized tool identifiers.
+    """
+    known_tools, _aliases, _reserved = _pyproject_lintro_catalog()
+    return frozenset(known_tools)
+
+
 def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
     """Convert pyproject.toml [tool.lintro] format to .lintro-config.yaml format.
 
@@ -488,17 +598,7 @@ def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
         "output": {},
     }
 
-    # Inline imports: ToolName is a static StrEnum that does not trigger
-    # the plugin registry. Both are imported here to avoid a circular
-    # dependency between config_loader and the tool subsystem.
-    from lintro.enums.tool_name import ToolName
-    from lintro.plugins.discovery import get_known_plugin_tool_names
-
-    known_tools = {t.value for t in ToolName} | {
-        t.value.replace("_", "-") for t in ToolName
-    }
-    # Add common aliases for tools
-    tool_aliases = {"markdownlint-cli2": "markdownlint"}
+    known_tools, tool_aliases, _reserved_keys = _pyproject_lintro_catalog()
 
     # Known execution settings
     execution_keys = {
@@ -521,43 +621,6 @@ def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
     externally_handled_sections = set(EXTERNALLY_HANDLED_SECTIONS) | set(
         PYPROJECT_ORDERING_KEYS,
     )
-
-    # Names this converter interprets as config rather than as a tool section.
-    # A plugin must not be able to shadow them by advertising a colliding
-    # entry-point name.
-    reserved_keys = (
-        execution_keys
-        | enforce_keys
-        | externally_handled_sections
-        | {
-            "ai",
-            "defaults",
-            "output",
-            "review",
-            "score",
-            "tool",
-            "tools",
-            ConfigKey.POST_CHECKS.value.lower(),
-            ConfigKey.VERSIONS.value.lower(),
-        }
-    )
-    reserved_keys |= {name.replace("_", "-") for name in reserved_keys}
-
-    # ToolName never sees entry-point-discovered tools, so config for an
-    # externally installed plugin used to be dropped on the floor (#1757).
-    # ``get_known_plugin_tool_names`` reads cached entry-point metadata and
-    # the already-populated registry; it never triggers a discovery pass.
-    for plugin_name in get_known_plugin_tool_names():
-        variants = {
-            plugin_name,
-            plugin_name.replace("_", "-"),
-            plugin_name.replace("-", "_"),
-        }
-        for variant in variants:
-            if variant not in known_tools and variant not in reserved_keys:
-                tool_aliases.setdefault(variant, plugin_name)
-
-    known_tools.update(tool_aliases.keys())
 
     unknown_keys: list[str] = []
 

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -48,6 +48,30 @@ LINTRO_CONFIG_FILENAMES = [
     "lintro-config.yml",
 ]
 
+# Config sections that are valid in both ``.lintro-config.yaml`` and
+# ``[tool.lintro]`` but are parsed by other loaders: ``module_size`` and
+# ``post_checks`` by ``lintro.utils.config``, ``licenses`` by
+# ``lintro.config.licenses_config``, and ``plugins`` by
+# ``lintro.plugins.discovery``. They are part of the schema even though
+# ``LintroConfig`` does not model them, so consumers that build an allowlist
+# of known top-level keys must include them.
+EXTERNALLY_HANDLED_SECTIONS: frozenset[str] = frozenset(
+    {
+        "licenses",
+        "module_size",
+        "plugins",
+    },
+)
+
+# Flat pyproject-only ordering keys read by ``get_tool_order_config``. Unlike
+# the sections above these have no ``.lintro-config.yaml`` equivalent.
+PYPROJECT_ORDERING_KEYS: frozenset[str] = frozenset(
+    {
+        "tool_order_custom",
+        "tool_priorities",
+    },
+)
+
 
 def _find_config_file(start_dir: Path | None = None) -> Path | None:
     """Find .lintro-config.yaml by searching upward from start_dir.
@@ -492,18 +516,11 @@ def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
     enforce_keys = {"line_length", "target_python"}
 
     # Keys and sections that are valid under [tool.lintro] but are parsed by
-    # other loaders, not by this converter: ``module_size`` and ``post_checks``
-    # by lintro.utils.config, ``licenses`` by lintro.config.licenses_config,
-    # ``plugins`` by lintro.plugins.discovery, and the ordering keys by
-    # ``get_tool_order_config``. Listing them keeps the unknown-key warning
-    # below from crying wolf about legitimate config.
-    externally_handled_sections = {
-        "licenses",
-        "module_size",
-        "plugins",
-        "tool_order_custom",
-        "tool_priorities",
-    }
+    # other loaders, not by this converter. Listing them keeps the unknown-key
+    # warning below from crying wolf about legitimate config.
+    externally_handled_sections = set(EXTERNALLY_HANDLED_SECTIONS) | set(
+        PYPROJECT_ORDERING_KEYS,
+    )
 
     # Names this converter interprets as config rather than as a tool section.
     # A plugin must not be able to shadow them by advertising a colliding

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -294,11 +294,16 @@ def _parse_tools_config(data: dict[str, Any]) -> dict[str, LintroToolConfig]:
         dict[str, LintroToolConfig]: Tool configurations keyed by tool name.
 
     Raises:
-        ValueError: If a tool entry is neither a mapping nor a boolean.
+        ValueError: If a tool name is not a string, or a tool entry is
+            neither a mapping nor a boolean.
     """
     tools: dict[str, LintroToolConfig] = {}
 
     for tool_name, tool_data in data.items():
+        if not isinstance(tool_name, str):
+            raise ValueError(
+                f"tool name must be a string, got {type(tool_name).__name__}.",
+            )
         name = tool_name.lower()
         if isinstance(tool_data, dict):
             tools[name] = _parse_tool_config(

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -207,12 +207,13 @@ def _parse_execution_config(data: dict[str, Any]) -> ExecutionConfig:
     )
 
 
-def _parse_tool_config(data: dict[str, Any]) -> LintroToolConfig:
+def _parse_tool_config(tool_name: str, data: dict[str, Any]) -> LintroToolConfig:
     """Parse a single tool configuration.
 
     In the tiered model, tools only have enabled and optional config_source.
 
     Args:
+        tool_name: Name of the tool being parsed (used in error messages).
         data: Raw tool configuration dict.
 
     Returns:
@@ -230,7 +231,7 @@ def _parse_tool_config(data: dict[str, Any]) -> LintroToolConfig:
     elif auto_install_raw is not None:
         type_name = type(auto_install_raw).__name__
         raise ValueError(
-            f"tools.<name>.auto_install must be a boolean, got {type_name}",
+            f"tools.{tool_name}.auto_install must be a boolean, got {type_name}",
         )
 
     return LintroToolConfig(
@@ -253,7 +254,10 @@ def _parse_tools_config(data: dict[str, Any]) -> dict[str, LintroToolConfig]:
 
     for tool_name, tool_data in data.items():
         if isinstance(tool_data, dict):
-            tools[tool_name.lower()] = _parse_tool_config(tool_data)
+            tools[tool_name.lower()] = _parse_tool_config(
+                tool_name.lower(),
+                tool_data,
+            )
         elif isinstance(tool_data, bool):
             # Simple enabled/disabled flag
             tools[tool_name.lower()] = LintroToolConfig(enabled=tool_data)

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -32,6 +32,7 @@ from lintro.config.review_config import (
 )
 from lintro.config.score_config import ScoreConfig
 from lintro.enums.config_key import ConfigKey
+from lintro.exceptions.errors import ConfigurationError
 from lintro.utils.path_utils import find_file_upward
 
 try:
@@ -607,6 +608,10 @@ def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
 
     Returns:
         dict[str, Any]: Converted configuration in .lintro-config.yaml format.
+
+    Raises:
+        ValueError: If a nested ``execution`` or ``enforce`` value is not a
+            mapping.
     """
     result: dict[str, Any] = {
         "enforce": {},
@@ -657,21 +662,29 @@ def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
         elif key_lower == "execution":
             # Nested ``[tool.lintro.execution]`` is the structured form of
             # the same keys accepted flat under ``[tool.lintro]``.
-            if isinstance(value, dict):
-                result["execution"].update(
-                    {
-                        nested_key.replace("-", "_"): nested_value
-                        for nested_key, nested_value in value.items()
-                    },
+            if not isinstance(value, dict):
+                actual = "null" if value is None else type(value).__name__
+                raise ValueError(
+                    f"execution must be a mapping, got {actual}.",
                 )
+            result["execution"].update(
+                {
+                    nested_key.replace("-", "_"): nested_value
+                    for nested_key, nested_value in value.items()
+                },
+            )
         elif key_lower == "enforce":
-            if isinstance(value, dict):
-                result["enforce"].update(
-                    {
-                        nested_key.replace("-", "_"): nested_value
-                        for nested_key, nested_value in value.items()
-                    },
+            if not isinstance(value, dict):
+                actual = "null" if value is None else type(value).__name__
+                raise ValueError(
+                    f"enforce must be a mapping, got {actual}.",
                 )
+            result["enforce"].update(
+                {
+                    nested_key.replace("-", "_"): nested_value
+                    for nested_key, nested_value in value.items()
+                },
+            )
         elif key in execution_keys or key.replace("-", "_") in execution_keys:
             # Execution config
             result["execution"][key.replace("-", "_")] = value
@@ -733,40 +746,50 @@ def load_config(
 
     Returns:
         LintroConfig: Loaded configuration.
+
+    Raises:
+        ConfigurationError: When a parsed config value is invalid (for
+            example a null ``tools.<name>`` entry or a non-mapping
+            ``execution`` / ``enforce`` table).
     """
     data: dict[str, Any] = {}
     resolved_path: str | None = None
 
-    # Try explicit path first
-    if config_path:
-        path = Path(config_path)
-        if path.exists():
-            data = _load_yaml_file(path)
-            resolved_path = str(path.resolve())
-            logger.debug(f"Loaded config from explicit path: {resolved_path}")
-        else:
-            logger.warning(f"Config file not found: {config_path}")
+    try:
+        # Try explicit path first
+        if config_path:
+            path = Path(config_path)
+            if path.exists():
+                data = _load_yaml_file(path)
+                resolved_path = str(path.resolve())
+                logger.debug(f"Loaded config from explicit path: {resolved_path}")
+            else:
+                logger.warning(f"Config file not found: {config_path}")
 
-    # Try searching for .lintro-config.yaml
-    if not data:
-        found_path = _find_config_file()
-        if found_path:
-            data = _load_yaml_file(found_path)
-            resolved_path = str(found_path.resolve())
-            logger.debug(f"Loaded config from: {resolved_path}")
+        # Try searching for .lintro-config.yaml
+        if not data:
+            found_path = _find_config_file()
+            if found_path:
+                data = _load_yaml_file(found_path)
+                resolved_path = str(found_path.resolve())
+                logger.debug(f"Loaded config from: {resolved_path}")
 
-    # Fall back to pyproject.toml
-    if not data and allow_pyproject_fallback:
-        pyproject_data, pyproject_path = _load_pyproject_fallback()
-        if pyproject_data:
-            data = _convert_pyproject_to_config(pyproject_data)
-            resolved_path = str(pyproject_path.resolve()) if pyproject_path else None
-            logger.debug(
-                "Using [tool.lintro] from pyproject.toml. "
-                "Consider migrating to .lintro-config.yaml",
-            )
+        # Fall back to pyproject.toml
+        if not data and allow_pyproject_fallback:
+            pyproject_data, pyproject_path = _load_pyproject_fallback()
+            if pyproject_data:
+                data = _convert_pyproject_to_config(pyproject_data)
+                resolved_path = (
+                    str(pyproject_path.resolve()) if pyproject_path else None
+                )
+                logger.debug(
+                    "Using [tool.lintro] from pyproject.toml. "
+                    "Consider migrating to .lintro-config.yaml",
+                )
 
-    return build_config_from_dict(data, resolved_path=resolved_path)
+        return build_config_from_dict(data, resolved_path=resolved_path)
+    except ValueError as exc:
+        raise ConfigurationError(str(exc)) from exc
 
 
 def build_config_from_dict(

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -658,10 +658,28 @@ def load_config(
                 "Consider migrating to .lintro-config.yaml",
             )
 
-    # Parse enforce config
-    enforce_data = data.get("enforce", {})
+    return build_config_from_dict(data, resolved_path=resolved_path)
 
-    enforce_config = _parse_enforce_config(enforce_data)
+
+def build_config_from_dict(
+    data: dict[str, Any],
+    resolved_path: str | None = None,
+) -> LintroConfig:
+    """Build a ``LintroConfig`` from an already-parsed configuration mapping.
+
+    This runs the typed section parsers (which raise ``ValueError`` on invalid
+    values) against a normalized config dict. It is shared by ``load_config``
+    and by the config validator so that pyproject-derived data can be checked
+    with the same typed logic without round-tripping through the YAML loader.
+
+    Args:
+        data: Normalized configuration mapping (post pyproject conversion).
+        resolved_path: Resolved path recorded on the returned config, if any.
+
+    Returns:
+        LintroConfig: The fully parsed configuration.
+    """
+    enforce_config = _parse_enforce_config(data.get("enforce", {}))
     execution_config = _parse_execution_config(data.get("execution", {}))
     defaults = _parse_defaults(data.get("defaults", {}))
     tools_config = _parse_tools_config(data.get("tools", {}))

--- a/lintro/config/config_validator.py
+++ b/lintro/config/config_validator.py
@@ -13,9 +13,9 @@ directly.
 
 from __future__ import annotations
 
+import tomllib
 from dataclasses import dataclass, field
 from difflib import get_close_matches
-import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -297,10 +297,7 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
     is_pyproject = config_path.name == "pyproject.toml"
     try:
         raw = config_path.read_text(encoding="utf-8")
-        if is_pyproject:
-            parsed = tomllib.loads(raw)
-        else:
-            parsed = yaml.safe_load(raw)
+        parsed = tomllib.loads(raw) if is_pyproject else yaml.safe_load(raw)
     except (OSError, yaml.YAMLError, tomllib.TOMLDecodeError) as exc:
         result.errors.append(
             ValidationMessage(message=f"Could not parse config: {exc}"),
@@ -351,10 +348,9 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
         _check_tool_names(tools, result.warnings)
 
     # Run the real loader to catch typed/value errors (max_fix_retries,
-    # auto_install, review schema, etc.). pyproject configs are validated via
-    # the standard search path rather than an explicit file path.
+    # auto_install, review schema, etc.) against the requested file.
     try:
-        load_config(config_path=None if is_pyproject else config_path)
+        load_config(config_path=config_path)
     except ValueError as exc:
         result.errors.append(ValidationMessage(message=str(exc)))
 

--- a/lintro/config/config_validator.py
+++ b/lintro/config/config_validator.py
@@ -22,6 +22,7 @@ from typing import Any
 from lintro.config.config_loader import (
     _convert_pyproject_to_config,
     _find_config_file,
+    build_config_from_dict,
     load_config,
 )
 from lintro.enums.tool_name import ToolName
@@ -348,9 +349,15 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
         _check_tool_names(tools, result.warnings)
 
     # Run the real loader to catch typed/value errors (max_fix_retries,
-    # auto_install, review schema, etc.) against the requested file.
+    # auto_install, review schema, etc.) against the requested file. The
+    # explicit-path loader reads files as YAML, so for pyproject.toml we feed
+    # the already-normalized TOML data through the shared typed parser instead
+    # of round-tripping the TOML path back through the YAML loader.
     try:
-        load_config(config_path=config_path)
+        if is_pyproject:
+            build_config_from_dict(parsed)
+        else:
+            load_config(config_path=config_path)
     except ValueError as exc:
         result.errors.append(ValidationMessage(message=str(exc)))
 

--- a/lintro/config/config_validator.py
+++ b/lintro/config/config_validator.py
@@ -1,0 +1,355 @@
+"""Validation for Lintro configuration files.
+
+Provides a schema-aware validator used by ``lintro config validate``. It
+surfaces two classes of problems:
+
+- ``errors``: the config cannot be loaded as-is (bad types, invalid values).
+- ``warnings``: the config loads, but contains suspicious content such as
+  unknown tools (often typos), unknown keys, or deprecated options.
+
+The validator is intentionally decoupled from Click so it can be unit tested
+directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from difflib import get_close_matches
+from pathlib import Path
+from typing import Any
+
+from lintro.config.config_loader import (
+    _convert_pyproject_to_config,
+    _find_config_file,
+    load_config,
+)
+from lintro.enums.tool_name import ToolName
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - enforced by packaging
+    yaml = None  # type: ignore[assignment]
+
+# Recognized top-level sections in .lintro-config.yaml.
+KNOWN_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
+    {"enforce", "execution", "defaults", "tools", "ai", "review"},
+)
+
+# Recognized keys within the ``execution`` section.
+KNOWN_EXECUTION_KEYS: frozenset[str] = frozenset(
+    {
+        "enabled_tools",
+        "tool_order",
+        "fail_fast",
+        "parallel",
+        "auto_install_deps",
+        "max_fix_retries",
+    },
+)
+
+# Recognized keys within the ``enforce`` section.
+KNOWN_ENFORCE_KEYS: frozenset[str] = frozenset({"line_length", "target_python"})
+
+# Recognized keys within a per-tool ``tools.<name>`` mapping.
+KNOWN_TOOL_KEYS: frozenset[str] = frozenset(
+    {"enabled", "config_source", "auto_install"},
+)
+
+# Deprecated option names mapped to their modern replacement.
+DEPRECATED_KEYS: dict[str, str] = {
+    "line-length": "line_length",
+    "target-python": "target_python",
+    "global": "enforce",
+}
+
+
+def known_tool_names() -> frozenset[str]:
+    """Return the set of recognized tool names.
+
+    Includes both the canonical underscore form and the hyphenated form for
+    each tool, plus common aliases, so validation matches the loader's
+    tolerance.
+
+    Returns:
+        frozenset[str]: Recognized tool identifiers.
+    """
+    names: set[str] = set()
+    for tool in ToolName:
+        names.add(tool.value)
+        names.add(tool.value.replace("_", "-"))
+    names.add("markdownlint-cli2")
+    return frozenset(names)
+
+
+@dataclass
+class ValidationMessage:
+    """A single validation finding.
+
+    Attributes:
+        message: Human-readable description of the finding.
+        location: Optional dotted path to the offending config key.
+        suggestion: Optional corrected value (e.g. a ``did you mean`` hint).
+    """
+
+    message: str
+    location: str | None = None
+    suggestion: str | None = None
+
+    def render(self) -> str:
+        """Render the message as a single display string.
+
+        Returns:
+            str: Formatted message including location and suggestion.
+        """
+        parts: list[str] = []
+        if self.location:
+            parts.append(f"{self.location}: ")
+        parts.append(self.message)
+        if self.suggestion:
+            parts.append(f" (did you mean '{self.suggestion}'?)")
+        return "".join(parts)
+
+
+@dataclass
+class ValidationResult:
+    """Outcome of validating a configuration file.
+
+    Attributes:
+        config_path: Path to the validated file, or None if none was found.
+        errors: Findings that make the configuration invalid.
+        warnings: Non-fatal findings worth surfacing.
+    """
+
+    config_path: Path | None
+    errors: list[ValidationMessage] = field(default_factory=list)
+    warnings: list[ValidationMessage] = field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        """Whether the configuration is free of errors.
+
+        Returns:
+            bool: True when there are no errors.
+        """
+        return not self.errors
+
+
+def _suggest(name: str, candidates: frozenset[str]) -> str | None:
+    """Return the closest known candidate for a possibly-misspelled name.
+
+    Args:
+        name: The provided (possibly invalid) name.
+        candidates: Recognized names to match against.
+
+    Returns:
+        str | None: Closest match, or None if nothing is close enough.
+    """
+    matches = get_close_matches(name, sorted(candidates), n=1, cutoff=0.6)
+    return matches[0] if matches else None
+
+
+def _check_unknown_keys(
+    data: dict[str, Any],
+    known: frozenset[str],
+    prefix: str,
+    warnings: list[ValidationMessage],
+) -> None:
+    """Append warnings for unknown or deprecated keys in a mapping.
+
+    Args:
+        data: Mapping to inspect.
+        known: Recognized keys for this mapping.
+        prefix: Dotted path prefix for messages (e.g. ``execution``).
+        warnings: List to append findings to.
+    """
+    for key in data:
+        if key in known:
+            continue
+        location = f"{prefix}.{key}" if prefix else key
+        if key in DEPRECATED_KEYS:
+            warnings.append(
+                ValidationMessage(
+                    message="deprecated option",
+                    location=location,
+                    suggestion=DEPRECATED_KEYS[key],
+                ),
+            )
+            continue
+        warnings.append(
+            ValidationMessage(
+                message="unknown option",
+                location=location,
+                suggestion=_suggest(key, known),
+            ),
+        )
+
+
+def _check_tool_names(
+    data: dict[str, Any],
+    warnings: list[ValidationMessage],
+) -> None:
+    """Warn about unknown tool names in the ``tools`` section.
+
+    Args:
+        data: The ``tools`` mapping.
+        warnings: List to append findings to.
+    """
+    known = known_tool_names()
+    for name, tool_data in data.items():
+        if name.lower() in known:
+            if isinstance(tool_data, dict):
+                _check_unknown_keys(
+                    tool_data,
+                    KNOWN_TOOL_KEYS,
+                    f"tools.{name}",
+                    warnings,
+                )
+            continue
+        warnings.append(
+            ValidationMessage(
+                message=f"unknown tool '{name}'",
+                location="tools",
+                suggestion=_suggest(name.lower(), known),
+            ),
+        )
+
+
+def _check_enabled_tools(
+    execution: dict[str, Any],
+    warnings: list[ValidationMessage],
+) -> None:
+    """Warn about unknown tool names in ``execution.enabled_tools``.
+
+    Args:
+        execution: The ``execution`` mapping.
+        warnings: List to append findings to.
+    """
+    enabled = execution.get("enabled_tools")
+    if isinstance(enabled, str):
+        enabled = [enabled]
+    if not isinstance(enabled, list):
+        return
+    known = known_tool_names()
+    for name in enabled:
+        if not isinstance(name, str) or name.lower() in known:
+            continue
+        warnings.append(
+            ValidationMessage(
+                message=f"unknown tool '{name}'",
+                location="execution.enabled_tools",
+                suggestion=_suggest(name.lower(), known),
+            ),
+        )
+
+
+def validate_config_file(path: Path | str | None = None) -> ValidationResult:
+    """Validate a Lintro configuration file.
+
+    Loads the config (or locates one by searching upward), checks it against
+    the known schema, and reports both hard errors and softer warnings.
+
+    Args:
+        path: Explicit path to a config file. When None, the nearest
+            ``.lintro-config.yaml`` is located by searching upward.
+
+    Returns:
+        ValidationResult: Structured validation outcome.
+    """
+    config_path: Path
+    if path is not None:
+        config_path = Path(path)
+        if not config_path.exists():
+            return ValidationResult(
+                config_path=config_path,
+                errors=[
+                    ValidationMessage(message=f"Config file not found: {config_path}"),
+                ],
+            )
+    else:
+        found = _find_config_file()
+        if found is None:
+            return ValidationResult(
+                config_path=None,
+                errors=[
+                    ValidationMessage(
+                        message=(
+                            "No .lintro-config.yaml found. "
+                            "Run 'lintro init' to create one."
+                        ),
+                    ),
+                ],
+            )
+        config_path = found
+
+    result = ValidationResult(config_path=config_path)
+
+    if yaml is None:  # pragma: no cover - enforced by packaging
+        result.errors.append(
+            ValidationMessage(
+                message="PyYAML is required to validate configuration.",
+            ),
+        )
+        return result
+
+    try:
+        raw = config_path.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(raw)
+    except (OSError, yaml.YAMLError) as exc:
+        result.errors.append(
+            ValidationMessage(message=f"Could not parse config: {exc}"),
+        )
+        return result
+
+    if parsed is None:
+        result.warnings.append(
+            ValidationMessage(message="Config file is empty."),
+        )
+        return result
+
+    if not isinstance(parsed, dict):
+        result.errors.append(
+            ValidationMessage(
+                message=(
+                    f"Config root must be a mapping, got {type(parsed).__name__}."
+                ),
+            ),
+        )
+        return result
+
+    # pyproject.toml uses a flat [tool.lintro] layout; normalize before
+    # structural checks so nested keys line up with the schema.
+    is_pyproject = config_path.name == "pyproject.toml"
+    if is_pyproject:
+        parsed = _convert_pyproject_to_config(
+            parsed.get("tool", {}).get("lintro", {}),
+        )
+    else:
+        _check_unknown_keys(parsed, KNOWN_TOP_LEVEL_KEYS, "", result.warnings)
+
+    execution = parsed.get("execution")
+    if isinstance(execution, dict):
+        _check_unknown_keys(
+            execution,
+            KNOWN_EXECUTION_KEYS,
+            "execution",
+            result.warnings,
+        )
+        _check_enabled_tools(execution, result.warnings)
+
+    enforce = parsed.get("enforce")
+    if isinstance(enforce, dict):
+        _check_unknown_keys(enforce, KNOWN_ENFORCE_KEYS, "enforce", result.warnings)
+
+    tools = parsed.get("tools")
+    if isinstance(tools, dict):
+        _check_tool_names(tools, result.warnings)
+
+    # Run the real loader to catch typed/value errors (max_fix_retries,
+    # auto_install, review schema, etc.). pyproject configs are validated via
+    # the standard search path rather than an explicit file path.
+    try:
+        load_config(config_path=None if is_pyproject else config_path)
+    except ValueError as exc:
+        result.errors.append(ValidationMessage(message=str(exc)))
+
+    return result

--- a/lintro/config/config_validator.py
+++ b/lintro/config/config_validator.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from difflib import get_close_matches
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +45,8 @@ KNOWN_EXECUTION_KEYS: frozenset[str] = frozenset(
         "parallel",
         "auto_install_deps",
         "max_fix_retries",
+        "max_workers",
+        "artifacts",
     },
 )
 
@@ -291,10 +294,14 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
         )
         return result
 
+    is_pyproject = config_path.name == "pyproject.toml"
     try:
         raw = config_path.read_text(encoding="utf-8")
-        parsed = yaml.safe_load(raw)
-    except (OSError, yaml.YAMLError) as exc:
+        if is_pyproject:
+            parsed = tomllib.loads(raw)
+        else:
+            parsed = yaml.safe_load(raw)
+    except (OSError, yaml.YAMLError, tomllib.TOMLDecodeError) as exc:
         result.errors.append(
             ValidationMessage(message=f"Could not parse config: {exc}"),
         )
@@ -318,7 +325,6 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
 
     # pyproject.toml uses a flat [tool.lintro] layout; normalize before
     # structural checks so nested keys line up with the schema.
-    is_pyproject = config_path.name == "pyproject.toml"
     if is_pyproject:
         parsed = _convert_pyproject_to_config(
             parsed.get("tool", {}).get("lintro", {}),

--- a/lintro/config/config_validator.py
+++ b/lintro/config/config_validator.py
@@ -376,11 +376,7 @@ def _not_found_result(
 
 
 def _is_empty_document(parsed: Any) -> bool:
-    """Return whether a parsed YAML document is empty for loader purposes.
-
-    ``load_config`` maps ``None`` and non-dicts to ``{}`` then treats a
-    falsy mapping as "nothing found" and continues searching. Validate must
-    not report success for those documents.
+    """Return whether a parsed YAML document is an empty mapping or null.
 
     Args:
         parsed: Value returned by ``yaml.safe_load``.
@@ -389,6 +385,23 @@ def _is_empty_document(parsed: Any) -> bool:
         bool: True when the document is ``None`` or ``{}``.
     """
     return parsed is None or parsed == {}
+
+
+def _is_loader_ignored_yaml(parsed: Any) -> bool:
+    """Return whether ``load_config`` treats this YAML document as not found.
+
+    ``_load_yaml_file`` maps ``None`` and any non-dict to ``{}``, and
+    ``load_config`` then continues searching. Auto-detect validate must
+    follow that fallthrough instead of hard-failing ``INVALID_TYPE`` on a
+    scalar or list and skipping ``[tool.lintro]``.
+
+    Args:
+        parsed: Value returned by ``yaml.safe_load``.
+
+    Returns:
+        bool: True when the document is ``None``, a non-mapping, or ``{}``.
+    """
+    return parsed is None or not isinstance(parsed, dict) or parsed == {}
 
 
 def _empty_yaml_error(config_path: Path) -> ValidationMessage:
@@ -655,11 +668,13 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
     Loads the config (or locates one by searching upward), checks it against
     the known schema, and reports both hard errors and softer warnings.
 
-    Empty YAML (``None`` or ``{}``) is not a successful config: ``load_config``
-    ignores it and continues to ``[tool.lintro]``. Auto-detect therefore
+    Empty or non-mapping YAML (``None``, ``{}``, a list, or a scalar) is
+    not a successful config: ``load_config`` maps those documents to
+    ``{}`` and continues to ``[tool.lintro]``. Auto-detect therefore
     falls through to pyproject the same way; an explicit empty path is
-    reported as ``EMPTY_CONFIG`` so validate never exits 0 while runtime
-    would load a different file.
+    ``EMPTY_CONFIG`` and an explicit non-mapping root is
+    ``INVALID_TYPE``, so validate never exits 0 while runtime would load
+    a different file.
 
     Args:
         path: Explicit path to a config file. When None, the nearest
@@ -711,18 +726,31 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
         return result
     parsed, is_pyproject = parsed_pair
 
-    if not is_pyproject and _is_empty_document(parsed):
+    if not is_pyproject and _is_loader_ignored_yaml(parsed):
         if explicit:
-            result.errors.append(_empty_yaml_error(config_path))
+            if _is_empty_document(parsed):
+                result.errors.append(_empty_yaml_error(config_path))
+            else:
+                result.errors.append(
+                    ValidationMessage(
+                        code=ValidationCode.INVALID_TYPE,
+                        message=(
+                            "Config root must be a mapping, got "
+                            f"{type(parsed).__name__}."
+                        ),
+                    ),
+                )
             return result
-        # Auto-detect: treat empty YAML like the loader — continue to
-        # pyproject rather than reporting VALID for a file runtime ignores.
+        # Auto-detect: treat loader-ignored YAML like empty — continue
+        # to pyproject rather than reporting INVALID_TYPE for a file
+        # runtime ignores.
         result.warnings.append(
             ValidationMessage(
                 code=ValidationCode.EMPTY_CONFIG,
                 message=(
-                    f"{config_path} is empty and will be ignored at runtime; "
-                    "continuing to [tool.lintro] in pyproject.toml."
+                    f"{config_path} is empty or not a mapping and will be "
+                    "ignored at runtime; continuing to [tool.lintro] in "
+                    "pyproject.toml."
                 ),
                 location=str(config_path),
             ),

--- a/lintro/config/config_validator.py
+++ b/lintro/config/config_validator.py
@@ -246,6 +246,9 @@ def _check_tool_names(
 ) -> None:
     """Warn about unknown tool names and reject non-mapping/non-bool entries.
 
+    Non-string keys (YAML ``3.14:`` or ``true:``) are reported as
+    INVALID_TYPE instead of raising ``AttributeError`` on ``.lower()``.
+
     Args:
         data: The ``tools`` mapping.
         warnings: List to append unknown-tool findings to.
@@ -253,6 +256,15 @@ def _check_tool_names(
     """
     known = known_tool_names()
     for name, tool_data in data.items():
+        if not isinstance(name, str):
+            errors.append(
+                ValidationMessage(
+                    code=ValidationCode.INVALID_TYPE,
+                    message=(f"tool name must be a string, got {type(name).__name__}."),
+                    location="tools",
+                ),
+            )
+            continue
         if name.lower() not in known:
             warnings.append(
                 ValidationMessage(
@@ -523,7 +535,17 @@ def _check_raw_pyproject_lintro(
                 continue
             _check_tool_names(value, warnings, errors)
             continue
-        if key_lower in typed_sections and isinstance(value, dict):
+        if key_lower in typed_sections:
+            if not isinstance(value, dict):
+                actual = "null" if value is None else type(value).__name__
+                errors.append(
+                    ValidationMessage(
+                        code=ValidationCode.INVALID_TYPE,
+                        message=(f"'{key_lower}' must be a mapping, got {actual}."),
+                        location=f"tool.lintro.{key_lower}",
+                    ),
+                )
+                continue
             _check_unknown_keys(
                 value,
                 typed_sections[key_lower],

--- a/lintro/config/config_validator.py
+++ b/lintro/config/config_validator.py
@@ -23,8 +23,9 @@ from lintro.config.config_loader import (
     EXTERNALLY_HANDLED_SECTIONS,
     _convert_pyproject_to_config,
     _find_config_file,
-    _load_pyproject_fallback,
+    _pyproject_lintro_catalog,
     build_config_from_dict,
+    known_config_tool_names,
 )
 from lintro.config.lintro_config import (
     EnforceConfig,
@@ -35,9 +36,8 @@ from lintro.config.lintro_config import (
     ReviewConfig,
     ScoreConfig,
 )
-from lintro.enums.tool_name import ToolName
 from lintro.enums.validation_code import ValidationCode
-from lintro.utils.config import STRUCTURAL_SECTIONS
+from lintro.utils.config import STRUCTURAL_SECTIONS, _find_pyproject
 
 try:
     import yaml
@@ -93,19 +93,16 @@ DEPRECATED_KEYS: dict[str, str] = {
 def known_tool_names() -> frozenset[str]:
     """Return the set of recognized tool names.
 
-    Includes both the canonical underscore form and the hyphenated form for
-    each tool, plus common aliases, so validation matches the loader's
-    tolerance.
+    Reuses the loader's known-tool set so YAML ``tools:`` entries and
+    pyproject tool tables accept the same names: ``ToolName`` (underscore
+    and hyphen forms), legacy aliases such as ``markdownlint-cli2``, and
+    installed plugin names from
+    :func:`~lintro.plugins.discovery.get_known_plugin_tool_names`.
 
     Returns:
         frozenset[str]: Recognized tool identifiers.
     """
-    names: set[str] = set()
-    for tool in ToolName:
-        names.add(tool.value)
-        names.add(tool.value.replace("_", "-"))
-    names.add("markdownlint-cli2")
-    return frozenset(names)
+    return known_config_tool_names()
 
 
 @dataclass
@@ -221,35 +218,62 @@ def _check_unknown_keys(
         )
 
 
+def _tool_value_type_error(
+    name: str,
+    tool_data: Any,
+) -> ValidationMessage:
+    """Build an INVALID_TYPE finding for a non-mapping, non-bool tool entry.
+
+    Args:
+        name: Tool name as written in the config.
+        tool_data: The invalid value.
+
+    Returns:
+        ValidationMessage: Type error for ``tools.<name>``.
+    """
+    actual = "null" if tool_data is None else type(tool_data).__name__
+    return ValidationMessage(
+        code=ValidationCode.INVALID_TYPE,
+        message=f"tool entry must be a mapping or boolean, got {actual}.",
+        location=f"tools.{name}",
+    )
+
+
 def _check_tool_names(
     data: dict[str, Any],
     warnings: list[ValidationMessage],
+    errors: list[ValidationMessage],
 ) -> None:
-    """Warn about unknown tool names in the ``tools`` section.
+    """Warn about unknown tool names and reject non-mapping/non-bool entries.
 
     Args:
         data: The ``tools`` mapping.
-        warnings: List to append findings to.
+        warnings: List to append unknown-tool findings to.
+        errors: List to append type findings to.
     """
     known = known_tool_names()
     for name, tool_data in data.items():
-        if name.lower() in known:
-            if isinstance(tool_data, dict):
-                _check_unknown_keys(
-                    tool_data,
-                    KNOWN_TOOL_KEYS,
-                    f"tools.{name}",
-                    warnings,
-                )
+        if name.lower() not in known:
+            warnings.append(
+                ValidationMessage(
+                    code=ValidationCode.UNKNOWN_TOOL,
+                    message=f"unknown tool '{name}'",
+                    location="tools",
+                    suggestion=_suggest(name.lower(), known),
+                ),
+            )
             continue
-        warnings.append(
-            ValidationMessage(
-                code=ValidationCode.UNKNOWN_TOOL,
-                message=f"unknown tool '{name}'",
-                location="tools",
-                suggestion=_suggest(name.lower(), known),
-            ),
-        )
+        if isinstance(tool_data, dict):
+            _check_unknown_keys(
+                tool_data,
+                KNOWN_TOOL_KEYS,
+                f"tools.{name}",
+                warnings,
+            )
+            continue
+        if isinstance(tool_data, bool):
+            continue
+        errors.append(_tool_value_type_error(name, tool_data))
 
 
 def _check_enabled_tools(
@@ -312,70 +336,83 @@ def _check_section_types(
         )
 
 
-def validate_config_file(path: Path | str | None = None) -> ValidationResult:
-    """Validate a Lintro configuration file.
-
-    Loads the config (or locates one by searching upward), checks it against
-    the known schema, and reports both hard errors and softer warnings.
+def _not_found_result(
+    config_path: Path | None,
+    warnings: list[ValidationMessage] | None = None,
+) -> ValidationResult:
+    """Return the standard 'no config file' error result.
 
     Args:
-        path: Explicit path to a config file. When None, the nearest
-            ``.lintro-config.yaml`` is located by searching upward, then
-            ``[tool.lintro]`` in ``pyproject.toml``, mirroring
-            :func:`lintro.config.config_loader.load_config`.
+        config_path: Path to record on the result, if any.
+        warnings: Optional warnings to include (e.g. an ignored empty YAML).
 
     Returns:
-        ValidationResult: Structured validation outcome.
+        ValidationResult: Result with a ``NOT_FOUND`` error.
     """
-    config_path: Path
-    if path is not None:
-        config_path = Path(path)
-        if not config_path.exists():
-            return ValidationResult(
-                config_path=config_path,
-                errors=[
-                    ValidationMessage(
-                        code=ValidationCode.NOT_FOUND,
-                        message=f"Config file not found: {config_path}",
-                    ),
-                ],
-            )
-    else:
-        found = _find_config_file()
-        if found is None:
-            # The loader falls back to [tool.lintro] in pyproject.toml when no
-            # YAML config exists, so auto-detect must consider it too;
-            # otherwise validate reports "no config" for projects that lintro
-            # happily configures itself from.
-            pyproject_data, pyproject_path = _load_pyproject_fallback()
-            if pyproject_data and pyproject_path is not None:
-                found = pyproject_path
-        if found is None:
-            return ValidationResult(
-                config_path=None,
-                errors=[
-                    ValidationMessage(
-                        code=ValidationCode.NOT_FOUND,
-                        message=(
-                            "No .lintro-config.yaml found. "
-                            "Run 'lintro init' to create one."
-                        ),
-                    ),
-                ],
-            )
-        config_path = found
-
-    result = ValidationResult(config_path=config_path)
-
-    if yaml is None:  # pragma: no cover - enforced by packaging
-        result.errors.append(
+    return ValidationResult(
+        config_path=config_path,
+        errors=[
             ValidationMessage(
-                code=ValidationCode.MISSING_DEPENDENCY,
-                message="PyYAML is required to validate configuration.",
+                code=ValidationCode.NOT_FOUND,
+                message=(
+                    "No .lintro-config.yaml found. Run 'lintro init' to create one."
+                ),
             ),
-        )
-        return result
+        ],
+        warnings=list(warnings or []),
+    )
 
+
+def _is_empty_document(parsed: Any) -> bool:
+    """Return whether a parsed YAML document is empty for loader purposes.
+
+    ``load_config`` maps ``None`` and non-dicts to ``{}`` then treats a
+    falsy mapping as "nothing found" and continues searching. Validate must
+    not report success for those documents.
+
+    Args:
+        parsed: Value returned by ``yaml.safe_load``.
+
+    Returns:
+        bool: True when the document is ``None`` or ``{}``.
+    """
+    return parsed is None or parsed == {}
+
+
+def _empty_yaml_error(config_path: Path) -> ValidationMessage:
+    """Build the error for an empty YAML file given as an explicit path.
+
+    Args:
+        config_path: The empty file the caller asked to validate.
+
+    Returns:
+        ValidationMessage: ``EMPTY_CONFIG`` error describing runtime fallback.
+    """
+    return ValidationMessage(
+        code=ValidationCode.EMPTY_CONFIG,
+        message=(
+            f"Config file {config_path} is empty and is not a successful "
+            "config. load_config ignores empty YAML and still searches "
+            "upward for another file or [tool.lintro]."
+        ),
+        location=str(config_path),
+    )
+
+
+def _parse_config_file(
+    config_path: Path,
+    result: ValidationResult,
+) -> tuple[Any, bool] | None:
+    """Read and parse a config file, recording parse errors on ``result``.
+
+    Args:
+        config_path: File to parse.
+        result: Result to append parse errors to.
+
+    Returns:
+        tuple[Any, bool] | None: ``(parsed, is_pyproject)`` on success, or
+            None when a parse error was recorded.
+    """
     is_pyproject = config_path.name == "pyproject.toml"
     try:
         raw = config_path.read_text(encoding="utf-8")
@@ -387,69 +424,192 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
                 message=f"Could not parse config: {exc}",
             ),
         )
-        return result
+        return None
+    return parsed, is_pyproject
 
-    if parsed is None:
-        result.warnings.append(
-            ValidationMessage(
-                code=ValidationCode.EMPTY_CONFIG,
-                message="Config file is empty.",
-            ),
-        )
-        return result
 
-    if not isinstance(parsed, dict):
-        result.errors.append(
+def _pyproject_lintro_table(
+    parsed: dict[str, Any],
+    errors: list[ValidationMessage],
+) -> dict[str, Any] | None:
+    """Extract ``[tool.lintro]``, recording INVALID_TYPE for non-mappings.
+
+    Args:
+        parsed: Parsed pyproject.toml root table.
+        errors: List to append type findings to.
+
+    Returns:
+        dict[str, Any] | None: The lintro table (possibly empty), or None
+            when a type error was recorded and validation should stop.
+    """
+    if "tool" not in parsed:
+        return {}
+    tool = parsed["tool"]
+    if not isinstance(tool, dict):
+        actual = "null" if tool is None else type(tool).__name__
+        errors.append(
             ValidationMessage(
                 code=ValidationCode.INVALID_TYPE,
-                message=(
-                    f"Config root must be a mapping, got {type(parsed).__name__}."
-                ),
+                message=f"'tool' must be a mapping, got {actual}.",
+                location="tool",
             ),
         )
-        return result
-
-    # pyproject.toml uses a flat [tool.lintro] layout; normalize before
-    # structural checks so nested keys line up with the schema.
-    if is_pyproject:
-        parsed = _convert_pyproject_to_config(
-            parsed.get("tool", {}).get("lintro", {}),
+        return None
+    if "lintro" not in tool:
+        return {}
+    lintro = tool["lintro"]
+    if not isinstance(lintro, dict):
+        actual = "null" if lintro is None else type(lintro).__name__
+        errors.append(
+            ValidationMessage(
+                code=ValidationCode.INVALID_TYPE,
+                message=f"'tool.lintro' must be a mapping, got {actual}.",
+                location="tool.lintro",
+            ),
         )
-    else:
+        return None
+    return lintro
+
+
+def _check_raw_pyproject_lintro(
+    data: dict[str, Any],
+    warnings: list[ValidationMessage],
+    errors: list[ValidationMessage],
+) -> None:
+    """Run unknown-key and unknown-tool checks on the raw ``[tool.lintro]``.
+
+    Must run before :func:`_convert_pyproject_to_config`, which drops
+    unrecognized keys (logging only) so they would never reach validate
+    output.
+
+    Args:
+        data: Raw ``[tool.lintro]`` table.
+        warnings: List to append unknown-key/tool findings to.
+        errors: List to append type findings to.
+    """
+    known_tools, _aliases, reserved_keys = _pyproject_lintro_catalog()
+    known = frozenset(known_tools)
+
+    nested_tool_tables = ("tool", "tools")
+    typed_sections: dict[str, frozenset[str]] = {
+        "execution": KNOWN_EXECUTION_KEYS,
+        "enforce": KNOWN_ENFORCE_KEYS,
+        "review": KNOWN_REVIEW_KEYS,
+        "score": KNOWN_SCORE_KEYS,
+        "output": KNOWN_OUTPUT_KEYS,
+    }
+
+    for key, value in data.items():
+        key_lower = key.lower()
+        if key_lower in known_tools:
+            # Top-level [tool.lintro.<tool>] holds native tool config, so
+            # inner keys are not LintroToolConfig fields. Only the value
+            # type is checked here.
+            if not isinstance(value, dict) and not isinstance(value, bool):
+                errors.append(_tool_value_type_error(key, value))
+            continue
+        if key_lower in nested_tool_tables:
+            if not isinstance(value, dict):
+                actual = "null" if value is None else type(value).__name__
+                errors.append(
+                    ValidationMessage(
+                        code=ValidationCode.INVALID_TYPE,
+                        message=(
+                            f"'{key_lower}' must be a mapping, got {actual}."
+                        ),
+                        location=f"tool.lintro.{key_lower}",
+                    ),
+                )
+                continue
+            _check_tool_names(value, warnings, errors)
+            continue
+        if key_lower in typed_sections and isinstance(value, dict):
+            _check_unknown_keys(
+                value,
+                typed_sections[key_lower],
+                key_lower,
+                warnings,
+            )
+            continue
+        if key_lower in reserved_keys or key.replace("-", "_") in reserved_keys:
+            continue
+        location = f"tool.lintro.{key}"
+        if isinstance(value, dict):
+            warnings.append(
+                ValidationMessage(
+                    code=ValidationCode.UNKNOWN_TOOL,
+                    message=f"unknown tool '{key}'",
+                    location="tool.lintro",
+                    suggestion=_suggest(key_lower, known),
+                ),
+            )
+            continue
+        warnings.append(
+            ValidationMessage(
+                code=ValidationCode.UNKNOWN_OPTION,
+                message="unknown option",
+                location=location,
+                suggestion=_suggest(key_lower, frozenset(reserved_keys) | known),
+            ),
+        )
+
+
+def _schema_check_normalized(
+    parsed: dict[str, Any],
+    result: ValidationResult,
+    *,
+    skip_unknown_keys: bool,
+) -> None:
+    """Apply schema warnings and typed-parser checks to a normalized mapping.
+
+    Args:
+        parsed: YAML-shaped configuration mapping.
+        result: Result to append findings to.
+        skip_unknown_keys: When True, skip unknown-key/tool walks that were
+            already performed on the raw pyproject table.
+    """
+    if not skip_unknown_keys:
         _check_unknown_keys(parsed, KNOWN_TOP_LEVEL_KEYS, "", result.warnings)
 
     execution = parsed.get("execution")
     if isinstance(execution, dict):
-        _check_unknown_keys(
-            execution,
-            KNOWN_EXECUTION_KEYS,
-            "execution",
-            result.warnings,
-        )
+        if not skip_unknown_keys:
+            _check_unknown_keys(
+                execution,
+                KNOWN_EXECUTION_KEYS,
+                "execution",
+                result.warnings,
+            )
         _check_enabled_tools(execution, result.warnings)
 
-    enforce = parsed.get("enforce")
-    if isinstance(enforce, dict):
-        _check_unknown_keys(enforce, KNOWN_ENFORCE_KEYS, "enforce", result.warnings)
+    if not skip_unknown_keys:
+        enforce = parsed.get("enforce")
+        if isinstance(enforce, dict):
+            _check_unknown_keys(
+                enforce,
+                KNOWN_ENFORCE_KEYS,
+                "enforce",
+                result.warnings,
+            )
 
-    for section, known in (
-        ("review", KNOWN_REVIEW_KEYS),
-        ("score", KNOWN_SCORE_KEYS),
-        ("output", KNOWN_OUTPUT_KEYS),
-    ):
-        data = parsed.get(section)
-        if isinstance(data, dict):
-            _check_unknown_keys(data, known, section, result.warnings)
+        for section, known in (
+            ("review", KNOWN_REVIEW_KEYS),
+            ("score", KNOWN_SCORE_KEYS),
+            ("output", KNOWN_OUTPUT_KEYS),
+        ):
+            data = parsed.get(section)
+            if isinstance(data, dict):
+                _check_unknown_keys(data, known, section, result.warnings)
 
-    tools = parsed.get("tools")
-    if isinstance(tools, dict):
-        _check_tool_names(tools, result.warnings)
+        tools = parsed.get("tools")
+        if isinstance(tools, dict):
+            _check_tool_names(tools, result.warnings, result.errors)
 
     _check_section_types(parsed, result.errors)
     if result.errors:
         # The typed parsers below assume mappings; running them on a null or
         # scalar section raises instead of reporting the problem.
-        return result
+        return
 
     # Run the real typed parsers to catch value errors (max_fix_retries,
     # auto_install, review schema, etc.) against the requested file. The
@@ -466,4 +626,135 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
             ValidationMessage(code=ValidationCode.INVALID_TYPE, message=str(exc)),
         )
 
+
+def validate_config_file(path: Path | str | None = None) -> ValidationResult:
+    """Validate a Lintro configuration file.
+
+    Loads the config (or locates one by searching upward), checks it against
+    the known schema, and reports both hard errors and softer warnings.
+
+    Empty YAML (``None`` or ``{}``) is not a successful config: ``load_config``
+    ignores it and continues to ``[tool.lintro]``. Auto-detect therefore
+    falls through to pyproject the same way; an explicit empty path is
+    reported as ``EMPTY_CONFIG`` so validate never exits 0 while runtime
+    would load a different file.
+
+    Args:
+        path: Explicit path to a config file. When None, the nearest
+            ``.lintro-config.yaml`` is located by searching upward, then
+            ``[tool.lintro]`` in ``pyproject.toml``, mirroring
+            :func:`lintro.config.config_loader.load_config`.
+
+    Returns:
+        ValidationResult: Structured validation outcome.
+    """
+    explicit = path is not None
+    if explicit:
+        config_path = Path(path)
+        if not config_path.exists():
+            return ValidationResult(
+                config_path=config_path,
+                errors=[
+                    ValidationMessage(
+                        code=ValidationCode.NOT_FOUND,
+                        message=f"Config file not found: {config_path}",
+                    ),
+                ],
+            )
+    else:
+        found = _find_config_file()
+        if found is None:
+            # Locate pyproject.toml by path, then parse it ourselves. The
+            # loader's ``_load_pyproject_fallback`` returns ``{}, None`` on
+            # TOML errors, which would look like NOT_FOUND; validate must
+            # fail closed with PARSE_ERROR instead.
+            found = _find_pyproject()
+        if found is None:
+            return _not_found_result(config_path=None)
+        config_path = found
+
+    result = ValidationResult(config_path=config_path)
+
+    if yaml is None:  # pragma: no cover - enforced by packaging
+        result.errors.append(
+            ValidationMessage(
+                code=ValidationCode.MISSING_DEPENDENCY,
+                message="PyYAML is required to validate configuration.",
+            ),
+        )
+        return result
+
+    parsed_pair = _parse_config_file(config_path, result)
+    if parsed_pair is None:
+        return result
+    parsed, is_pyproject = parsed_pair
+
+    if not is_pyproject and _is_empty_document(parsed):
+        if explicit:
+            result.errors.append(_empty_yaml_error(config_path))
+            return result
+        # Auto-detect: treat empty YAML like the loader — continue to
+        # pyproject rather than reporting VALID for a file runtime ignores.
+        result.warnings.append(
+            ValidationMessage(
+                code=ValidationCode.EMPTY_CONFIG,
+                message=(
+                    f"{config_path} is empty and will be ignored at runtime; "
+                    "continuing to [tool.lintro] in pyproject.toml."
+                ),
+                location=str(config_path),
+            ),
+        )
+        pyproject_path = _find_pyproject()
+        if pyproject_path is None:
+            return _not_found_result(
+                config_path=config_path,
+                warnings=result.warnings,
+            )
+        config_path = pyproject_path
+        result.config_path = config_path
+        parsed_pair = _parse_config_file(config_path, result)
+        if parsed_pair is None:
+            return result
+        parsed, is_pyproject = parsed_pair
+
+    if not isinstance(parsed, dict):
+        result.errors.append(
+            ValidationMessage(
+                code=ValidationCode.INVALID_TYPE,
+                message=(
+                    f"Config root must be a mapping, got {type(parsed).__name__}."
+                ),
+            ),
+        )
+        return result
+
+    if is_pyproject:
+        lintro = _pyproject_lintro_table(parsed, result.errors)
+        if result.errors:
+            return result
+        if not lintro:
+            if explicit:
+                result.errors.append(
+                    ValidationMessage(
+                        code=ValidationCode.EMPTY_CONFIG,
+                        message=(
+                            "pyproject.toml has no [tool.lintro] table; "
+                            "this is not a successful Lintro config."
+                        ),
+                    ),
+                )
+                return result
+            return _not_found_result(
+                config_path=config_path,
+                warnings=result.warnings,
+            )
+        _check_raw_pyproject_lintro(lintro, result.warnings, result.errors)
+        if result.errors:
+            return result
+        parsed = _convert_pyproject_to_config(lintro)
+        _schema_check_normalized(parsed, result, skip_unknown_keys=True)
+        return result
+
+    _schema_check_normalized(parsed, result, skip_unknown_keys=False)
     return result

--- a/lintro/config/config_validator.py
+++ b/lintro/config/config_validator.py
@@ -514,9 +514,7 @@ def _check_raw_pyproject_lintro(
                 errors.append(
                     ValidationMessage(
                         code=ValidationCode.INVALID_TYPE,
-                        message=(
-                            f"'{key_lower}' must be a mapping, got {actual}."
-                        ),
+                        message=(f"'{key_lower}' must be a mapping, got {actual}."),
                         location=f"tool.lintro.{key_lower}",
                     ),
                 )

--- a/lintro/config/config_validator.py
+++ b/lintro/config/config_validator.py
@@ -20,43 +20,66 @@ from pathlib import Path
 from typing import Any
 
 from lintro.config.config_loader import (
+    EXTERNALLY_HANDLED_SECTIONS,
     _convert_pyproject_to_config,
     _find_config_file,
+    _load_pyproject_fallback,
     build_config_from_dict,
-    load_config,
+)
+from lintro.config.lintro_config import (
+    EnforceConfig,
+    ExecutionConfig,
+    LintroConfig,
+    LintroToolConfig,
+    OutputConfig,
+    ReviewConfig,
+    ScoreConfig,
 )
 from lintro.enums.tool_name import ToolName
+from lintro.enums.validation_code import ValidationCode
+from lintro.utils.config import STRUCTURAL_SECTIONS
 
 try:
     import yaml
 except ImportError:  # pragma: no cover - enforced by packaging
     yaml = None  # type: ignore[assignment]
 
-# Recognized top-level sections in .lintro-config.yaml.
+# Recognized top-level sections in .lintro-config.yaml. Derived from the real
+# schema rather than hand-copied: every ``LintroConfig`` field (minus the
+# loader-populated ``config_path``) plus the sections that live in the config
+# file but are parsed by other loaders. Hand-maintained lists drifted from the
+# loader and warned about valid ``score:``/``output:``/``plugins:`` sections.
 KNOWN_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
-    {"enforce", "execution", "defaults", "tools", "ai", "review"},
+    (set(LintroConfig.model_fields) - {"config_path"})
+    | set(EXTERNALLY_HANDLED_SECTIONS)
+    | set(STRUCTURAL_SECTIONS),
 )
 
 # Recognized keys within the ``execution`` section.
-KNOWN_EXECUTION_KEYS: frozenset[str] = frozenset(
-    {
-        "enabled_tools",
-        "tool_order",
-        "fail_fast",
-        "parallel",
-        "auto_install_deps",
-        "max_fix_retries",
-        "max_workers",
-        "artifacts",
-    },
-)
+KNOWN_EXECUTION_KEYS: frozenset[str] = frozenset(ExecutionConfig.model_fields)
 
 # Recognized keys within the ``enforce`` section.
-KNOWN_ENFORCE_KEYS: frozenset[str] = frozenset({"line_length", "target_python"})
+KNOWN_ENFORCE_KEYS: frozenset[str] = frozenset(EnforceConfig.model_fields)
 
 # Recognized keys within a per-tool ``tools.<name>`` mapping.
-KNOWN_TOOL_KEYS: frozenset[str] = frozenset(
-    {"enabled", "config_source", "auto_install"},
+KNOWN_TOOL_KEYS: frozenset[str] = frozenset(LintroToolConfig.model_fields)
+
+# Recognized keys within the remaining typed sections.
+KNOWN_REVIEW_KEYS: frozenset[str] = frozenset(ReviewConfig.model_fields)
+KNOWN_SCORE_KEYS: frozenset[str] = frozenset(ScoreConfig.model_fields)
+KNOWN_OUTPUT_KEYS: frozenset[str] = frozenset(OutputConfig.model_fields)
+
+# Sections whose typed parser calls ``.get``/``.items`` on its input without a
+# type guard. YAML spells an empty section as ``enforce:`` which deserializes
+# to ``None``, so these must be checked up front or the parser raises
+# ``AttributeError`` out of the validator instead of reporting the problem.
+# ``ai``/``review``/``score``/``output`` are excluded on purpose: their parsers
+# accept ``None`` as "absent" and raise a descriptive ``ValueError`` otherwise.
+MAPPING_SECTIONS: tuple[str, ...] = (
+    "enforce",
+    "execution",
+    "defaults",
+    "tools",
 )
 
 # Deprecated option names mapped to their modern replacement.
@@ -90,11 +113,15 @@ class ValidationMessage:
     """A single validation finding.
 
     Attributes:
+        code: Stable machine-readable identifier for the kind of finding.
+            ``--json`` consumers should branch on this rather than on
+            ``message``, whose wording is not part of the contract.
         message: Human-readable description of the finding.
         location: Optional dotted path to the offending config key.
         suggestion: Optional corrected value (e.g. a ``did you mean`` hint).
     """
 
+    code: ValidationCode
     message: str
     location: str | None = None
     suggestion: str | None = None
@@ -173,6 +200,7 @@ def _check_unknown_keys(
         if key in DEPRECATED_KEYS:
             warnings.append(
                 ValidationMessage(
+                    code=ValidationCode.DEPRECATED_OPTION,
                     message="deprecated option",
                     location=location,
                     suggestion=DEPRECATED_KEYS[key],
@@ -181,6 +209,7 @@ def _check_unknown_keys(
             continue
         warnings.append(
             ValidationMessage(
+                code=ValidationCode.UNKNOWN_OPTION,
                 message="unknown option",
                 location=location,
                 suggestion=_suggest(key, known),
@@ -211,6 +240,7 @@ def _check_tool_names(
             continue
         warnings.append(
             ValidationMessage(
+                code=ValidationCode.UNKNOWN_TOOL,
                 message=f"unknown tool '{name}'",
                 location="tools",
                 suggestion=_suggest(name.lower(), known),
@@ -239,9 +269,41 @@ def _check_enabled_tools(
             continue
         warnings.append(
             ValidationMessage(
+                code=ValidationCode.UNKNOWN_TOOL,
                 message=f"unknown tool '{name}'",
                 location="execution.enabled_tools",
                 suggestion=_suggest(name.lower(), known),
+            ),
+        )
+
+
+def _check_section_types(
+    parsed: dict[str, Any],
+    errors: list[ValidationMessage],
+) -> None:
+    """Report sections that are present but are not mappings.
+
+    YAML spells an empty section as ``enforce:`` with nothing under it, which
+    deserializes to ``None``. The typed section parsers call ``.get`` on their
+    input, so without this check the validator would raise ``AttributeError``
+    instead of reporting the configuration as invalid.
+
+    Args:
+        parsed: The parsed configuration mapping.
+        errors: List to append findings to.
+    """
+    for section in MAPPING_SECTIONS:
+        if section not in parsed:
+            continue
+        value = parsed[section]
+        if isinstance(value, dict):
+            continue
+        actual = "null" if value is None else type(value).__name__
+        errors.append(
+            ValidationMessage(
+                code=ValidationCode.INVALID_TYPE,
+                message=f"section must be a mapping, got {actual}.",
+                location=section,
             ),
         )
 
@@ -254,7 +316,9 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
 
     Args:
         path: Explicit path to a config file. When None, the nearest
-            ``.lintro-config.yaml`` is located by searching upward.
+            ``.lintro-config.yaml`` is located by searching upward, then
+            ``[tool.lintro]`` in ``pyproject.toml``, mirroring
+            :func:`lintro.config.config_loader.load_config`.
 
     Returns:
         ValidationResult: Structured validation outcome.
@@ -266,16 +330,28 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
             return ValidationResult(
                 config_path=config_path,
                 errors=[
-                    ValidationMessage(message=f"Config file not found: {config_path}"),
+                    ValidationMessage(
+                        code=ValidationCode.NOT_FOUND,
+                        message=f"Config file not found: {config_path}",
+                    ),
                 ],
             )
     else:
         found = _find_config_file()
         if found is None:
+            # The loader falls back to [tool.lintro] in pyproject.toml when no
+            # YAML config exists, so auto-detect must consider it too;
+            # otherwise validate reports "no config" for projects that lintro
+            # happily configures itself from.
+            pyproject_data, pyproject_path = _load_pyproject_fallback()
+            if pyproject_data and pyproject_path is not None:
+                found = pyproject_path
+        if found is None:
             return ValidationResult(
                 config_path=None,
                 errors=[
                     ValidationMessage(
+                        code=ValidationCode.NOT_FOUND,
                         message=(
                             "No .lintro-config.yaml found. "
                             "Run 'lintro init' to create one."
@@ -290,6 +366,7 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
     if yaml is None:  # pragma: no cover - enforced by packaging
         result.errors.append(
             ValidationMessage(
+                code=ValidationCode.MISSING_DEPENDENCY,
                 message="PyYAML is required to validate configuration.",
             ),
         )
@@ -301,19 +378,26 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
         parsed = tomllib.loads(raw) if is_pyproject else yaml.safe_load(raw)
     except (OSError, yaml.YAMLError, tomllib.TOMLDecodeError) as exc:
         result.errors.append(
-            ValidationMessage(message=f"Could not parse config: {exc}"),
+            ValidationMessage(
+                code=ValidationCode.PARSE_ERROR,
+                message=f"Could not parse config: {exc}",
+            ),
         )
         return result
 
     if parsed is None:
         result.warnings.append(
-            ValidationMessage(message="Config file is empty."),
+            ValidationMessage(
+                code=ValidationCode.EMPTY_CONFIG,
+                message="Config file is empty.",
+            ),
         )
         return result
 
     if not isinstance(parsed, dict):
         result.errors.append(
             ValidationMessage(
+                code=ValidationCode.INVALID_TYPE,
                 message=(
                     f"Config root must be a mapping, got {type(parsed).__name__}."
                 ),
@@ -344,21 +428,38 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
     if isinstance(enforce, dict):
         _check_unknown_keys(enforce, KNOWN_ENFORCE_KEYS, "enforce", result.warnings)
 
+    for section, known in (
+        ("review", KNOWN_REVIEW_KEYS),
+        ("score", KNOWN_SCORE_KEYS),
+        ("output", KNOWN_OUTPUT_KEYS),
+    ):
+        data = parsed.get(section)
+        if isinstance(data, dict):
+            _check_unknown_keys(data, known, section, result.warnings)
+
     tools = parsed.get("tools")
     if isinstance(tools, dict):
         _check_tool_names(tools, result.warnings)
 
-    # Run the real loader to catch typed/value errors (max_fix_retries,
+    _check_section_types(parsed, result.errors)
+    if result.errors:
+        # The typed parsers below assume mappings; running them on a null or
+        # scalar section raises instead of reporting the problem.
+        return result
+
+    # Run the real typed parsers to catch value errors (max_fix_retries,
     # auto_install, review schema, etc.) against the requested file. The
-    # explicit-path loader reads files as YAML, so for pyproject.toml we feed
-    # the already-normalized TOML data through the shared typed parser instead
-    # of round-tripping the TOML path back through the YAML loader.
+    # already-parsed mapping is fed straight through ``build_config_from_dict``
+    # rather than via ``load_config``: the latter treats a falsy config (an
+    # empty ``{}`` document) as "nothing found" and silently falls back to
+    # auto-discovery, which would validate a different file than the one asked
+    # for. ``load_config`` also cannot read pyproject.toml from an explicit
+    # path, since it reads explicit paths as YAML.
     try:
-        if is_pyproject:
-            build_config_from_dict(parsed)
-        else:
-            load_config(config_path=config_path)
-    except ValueError as exc:
-        result.errors.append(ValidationMessage(message=str(exc)))
+        build_config_from_dict(parsed)
+    except (ValueError, TypeError, AttributeError) as exc:
+        result.errors.append(
+            ValidationMessage(code=ValidationCode.INVALID_TYPE, message=str(exc)),
+        )
 
     return result

--- a/lintro/config/config_validator.py
+++ b/lintro/config/config_validator.py
@@ -487,7 +487,9 @@ def _check_raw_pyproject_lintro(
         warnings: List to append unknown-key/tool findings to.
         errors: List to append type findings to.
     """
-    known_tools, _aliases, reserved_keys = _pyproject_lintro_catalog()
+    catalog = _pyproject_lintro_catalog()
+    known_tools = catalog.known_tools
+    reserved_keys = catalog.reserved_keys
     known = frozenset(known_tools)
 
     nested_tool_tables = ("tool", "tools")
@@ -647,7 +649,7 @@ def validate_config_file(path: Path | str | None = None) -> ValidationResult:
         ValidationResult: Structured validation outcome.
     """
     explicit = path is not None
-    if explicit:
+    if path is not None:
         config_path = Path(path)
         if not config_path.exists():
             return ValidationResult(

--- a/lintro/config/config_validator.py
+++ b/lintro/config/config_validator.py
@@ -201,7 +201,11 @@ def _check_unknown_keys(
             warnings.append(
                 ValidationMessage(
                     code=ValidationCode.DEPRECATED_OPTION,
-                    message="deprecated option",
+                    # The YAML loader reads only the modern snake_case names,
+                    # so a deprecated spelling is not merely dated: its value
+                    # never reaches the config. Say so rather than implying it
+                    # still works.
+                    message="deprecated option, no longer applied",
                     location=location,
                     suggestion=DEPRECATED_KEYS[key],
                 ),

--- a/lintro/enums/validation_code.py
+++ b/lintro/enums/validation_code.py
@@ -5,17 +5,32 @@ consumers should branch on ``code`` rather than on the human-readable
 ``message`` text, which may be reworded at any time.
 """
 
-from enum import StrEnum, auto
+from enum import StrEnum
 
 
 class ValidationCode(StrEnum):
-    """Stable identifiers for configuration validation findings."""
+    """Stable identifiers for configuration validation findings.
 
-    NOT_FOUND = auto()
-    PARSE_ERROR = auto()
-    EMPTY_CONFIG = auto()
-    INVALID_TYPE = auto()
-    UNKNOWN_OPTION = auto()
-    DEPRECATED_OPTION = auto()
-    UNKNOWN_TOOL = auto()
-    MISSING_DEPENDENCY = auto()
+    Values are lowercase snake_case and form the JSON ``code`` vocabulary
+    for ``lintro config validate --json``. Adding a member is a
+    backwards-compatible change; renaming one is not.
+
+    Attributes:
+        NOT_FOUND: No config file was found at the requested or detected path.
+        PARSE_ERROR: The config file could not be parsed as YAML or TOML.
+        EMPTY_CONFIG: The file exists but has no usable Lintro configuration.
+        INVALID_TYPE: A value has the wrong type or is otherwise unusable.
+        UNKNOWN_OPTION: A key is not a recognized configuration option.
+        DEPRECATED_OPTION: A key is recognized but no longer applied.
+        UNKNOWN_TOOL: A tool name is not in the known tool set.
+        MISSING_DEPENDENCY: A required helper or section is missing.
+    """
+
+    NOT_FOUND = "not_found"
+    PARSE_ERROR = "parse_error"
+    EMPTY_CONFIG = "empty_config"
+    INVALID_TYPE = "invalid_type"
+    UNKNOWN_OPTION = "unknown_option"
+    DEPRECATED_OPTION = "deprecated_option"
+    UNKNOWN_TOOL = "unknown_tool"
+    MISSING_DEPENDENCY = "missing_dependency"

--- a/lintro/enums/validation_code.py
+++ b/lintro/enums/validation_code.py
@@ -1,0 +1,21 @@
+"""Stable machine-readable codes for configuration validation findings.
+
+These codes are part of the ``lintro config validate --json`` contract:
+consumers should branch on ``code`` rather than on the human-readable
+``message`` text, which may be reworded at any time.
+"""
+
+from enum import StrEnum, auto
+
+
+class ValidationCode(StrEnum):
+    """Stable identifiers for configuration validation findings."""
+
+    NOT_FOUND = auto()
+    PARSE_ERROR = auto()
+    EMPTY_CONFIG = auto()
+    INVALID_TYPE = auto()
+    UNKNOWN_OPTION = auto()
+    DEPRECATED_OPTION = auto()
+    UNKNOWN_TOOL = auto()
+    MISSING_DEPENDENCY = auto()

--- a/lintro/exceptions/errors.py
+++ b/lintro/exceptions/errors.py
@@ -27,8 +27,13 @@ class ParserError(LintroError):
     """Raised when parsing tool output fails."""
 
 
-class ConfigurationError(LintroError):
-    """Raised when configuration loading or validation fails."""
+class ConfigurationError(LintroError, ValueError):
+    """Raised when configuration loading or validation fails.
+
+    Also a ``ValueError`` so existing ``except ValueError`` handlers and
+    tests keep working, while CLI commands can catch this type without
+    swallowing unrelated runtime ``ValueError``s.
+    """
 
 
 class FileAccessError(LintroError):

--- a/lintro/utils/config.py
+++ b/lintro/utils/config.py
@@ -158,14 +158,12 @@ STRUCTURAL_SECTIONS: frozenset[str] = frozenset(
     },
 )
 
-# Legacy/alternate section names that do not match a ``ToolName`` value
-# directly but have historically been treated as tool sections (e.g. the
-# underlying binary name rather than the canonical tool name).
-_LEGACY_TOOL_SECTION_ALIASES: frozenset[str] = frozenset(
-    {
-        "markdownlint-cli2",
-    },
-)
+# Legacy/alternate section names mapped to the canonical ``ToolName`` value.
+# These do not match a ``ToolName`` spelling directly (e.g. the underlying
+# binary name rather than the canonical tool name) but are accepted in config.
+LEGACY_TOOL_SECTION_ALIASES: dict[str, str] = {
+    "markdownlint-cli2": "markdownlint",
+}
 
 
 def _get_tool_sections() -> frozenset[str]:
@@ -189,7 +187,7 @@ def _get_tool_sections() -> frozenset[str]:
 
     tool_sections = {tool.value for tool in ToolName}
     tool_sections |= {tool.value.replace("_", "-") for tool in ToolName}
-    tool_sections |= _LEGACY_TOOL_SECTION_ALIASES
+    tool_sections |= set(LEGACY_TOOL_SECTION_ALIASES)
     return frozenset(tool_sections)
 
 

--- a/tests/cli/test_config_validate_command.py
+++ b/tests/cli/test_config_validate_command.py
@@ -1,0 +1,134 @@
+"""Tests for the `lintro config validate` and `config init` subcommands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+from click.testing import CliRunner
+
+from lintro.cli import cli
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Create a CLI runner for testing.
+
+    Returns:
+        CliRunner: A Click test runner instance.
+    """
+    return CliRunner()
+
+
+def test_validate_valid_config_exits_zero(cli_runner: CliRunner) -> None:
+    """A valid config should validate and exit 0.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    with cli_runner.isolated_filesystem():
+        Path(".lintro-config.yaml").write_text(
+            "tools:\n  ruff:\n    enabled: true\n",
+            encoding="utf-8",
+        )
+
+        result = cli_runner.invoke(cli, ["config", "validate"])
+
+        assert_that(result.exit_code).is_equal_to(0)
+        assert_that(result.output).contains("VALID")
+
+
+def test_validate_invalid_config_exits_nonzero(cli_runner: CliRunner) -> None:
+    """An invalid config should exit non-zero with an error report.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    with cli_runner.isolated_filesystem():
+        Path(".lintro-config.yaml").write_text(
+            'execution:\n  max_fix_retries: "bad"\n',
+            encoding="utf-8",
+        )
+
+        result = cli_runner.invoke(cli, ["config", "validate"])
+
+        assert_that(result.exit_code).is_equal_to(1)
+        assert_that(result.output).contains("INVALID")
+
+
+def test_validate_json_output(cli_runner: CliRunner) -> None:
+    """JSON output should be machine-readable with expected fields.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    with cli_runner.isolated_filesystem():
+        Path(".lintro-config.yaml").write_text(
+            "tools:\n  ruft:\n    enabled: true\n",
+            encoding="utf-8",
+        )
+
+        result = cli_runner.invoke(cli, ["config", "validate", "--json"])
+
+        assert_that(result.exit_code).is_equal_to(0)
+        data = json.loads(result.output)
+        assert_that(data).contains("valid")
+        assert_that(data).contains("warnings")
+        assert_that(data["warnings"][0]["suggestion"]).is_equal_to("ruff")
+
+
+def test_validate_explicit_path(cli_runner: CliRunner, tmp_path: Path) -> None:
+    """The --path option should validate the specified file.
+
+    Args:
+        cli_runner: Click test runner instance.
+        tmp_path: Temporary directory path.
+    """
+    config = tmp_path / "custom.yaml"
+    config.write_text("tools:\n  ruff:\n    enabled: true\n", encoding="utf-8")
+
+    result = cli_runner.invoke(cli, ["config", "validate", "--path", str(config)])
+
+    assert_that(result.exit_code).is_equal_to(0)
+
+
+def test_validate_missing_config_errors(cli_runner: CliRunner) -> None:
+    """Validation with no config present should error and exit non-zero.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    with cli_runner.isolated_filesystem():
+        result = cli_runner.invoke(cli, ["config", "validate"])
+
+        assert_that(result.exit_code).is_equal_to(1)
+        assert_that(result.output).contains("lintro init")
+
+
+def test_config_init_subcommand_scaffolds(cli_runner: CliRunner) -> None:
+    """`config init` should scaffold a config like the top-level init.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    with cli_runner.isolated_filesystem():
+        result = cli_runner.invoke(cli, ["config", "init", "--minimal", "--static"])
+
+        assert_that(result.exit_code).is_equal_to(0)
+        assert_that(Path(".lintro-config.yaml").exists()).is_true()
+
+
+def test_config_show_subcommand(cli_runner: CliRunner) -> None:
+    """`config show --json` should emit the effective config report.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    with cli_runner.isolated_filesystem():
+        result = cli_runner.invoke(cli, ["config", "show", "--json"])
+
+        assert_that(result.exit_code).is_equal_to(0)
+        data = json.loads(result.output)
+        assert_that(data).contains("global_settings")

--- a/tests/cli/test_config_validate_command.py
+++ b/tests/cli/test_config_validate_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,7 @@ from assertpy import assert_that
 from click.testing import CliRunner
 
 from lintro.cli import cli
+from lintro.config.config_loader import clear_config_cache
 from lintro.enums.validation_code import ValidationCode
 
 
@@ -21,6 +23,18 @@ def cli_runner() -> CliRunner:
         CliRunner: A Click test runner instance.
     """
     return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_cache() -> Iterator[None]:
+    """Clear the config cache around every test in this module.
+
+    Yields:
+        None: Control returns to the test body.
+    """
+    clear_config_cache()
+    yield
+    clear_config_cache()
 
 
 def test_validate_valid_config_exits_zero(cli_runner: CliRunner) -> None:
@@ -269,14 +283,11 @@ def test_config_show_null_tool_entry_exits_one(cli_runner: CliRunner) -> None:
     Args:
         cli_runner: Click test runner instance.
     """
-    from lintro.config.config_loader import clear_config_cache
-
     with cli_runner.isolated_filesystem():
         Path(".lintro-config.yaml").write_text(
             "tools:\n  ruff:\n",
             encoding="utf-8",
         )
-        clear_config_cache()
 
         result = cli_runner.invoke(cli, ["config", "show"])
 
@@ -293,15 +304,12 @@ def test_check_null_tool_entry_exits_one(cli_runner: CliRunner) -> None:
     Args:
         cli_runner: Click test runner instance.
     """
-    from lintro.config.config_loader import clear_config_cache
-
     with cli_runner.isolated_filesystem():
         Path(".lintro-config.yaml").write_text(
             "tools:\n  ruff:\n",
             encoding="utf-8",
         )
         Path("sample.py").write_text("x = 1\n", encoding="utf-8")
-        clear_config_cache()
 
         result = cli_runner.invoke(cli, ["check", "sample.py"])
 

--- a/tests/cli/test_config_validate_command.py
+++ b/tests/cli/test_config_validate_command.py
@@ -10,6 +10,7 @@ from assertpy import assert_that
 from click.testing import CliRunner
 
 from lintro.cli import cli
+from lintro.enums.validation_code import ValidationCode
 
 
 @pytest.fixture
@@ -74,9 +75,55 @@ def test_validate_json_output(cli_runner: CliRunner) -> None:
 
         assert_that(result.exit_code).is_equal_to(0)
         data = json.loads(result.output)
-        assert_that(data).contains("valid")
-        assert_that(data).contains("warnings")
-        assert_that(data["warnings"][0]["suggestion"]).is_equal_to("ruff")
+        assert_that(data["valid"]).is_true()
+        assert_that(data["config_path"]).ends_with(".lintro-config.yaml")
+        assert_that(data["errors"]).is_empty()
+        assert_that(data["warnings"]).is_length(1)
+        warning = data["warnings"][0]
+        assert_that(warning["code"]).is_equal_to(ValidationCode.UNKNOWN_TOOL.value)
+        assert_that(warning["location"]).is_equal_to("tools")
+        assert_that(warning["suggestion"]).is_equal_to("ruff")
+
+
+def test_validate_group_json_flag_is_forwarded(cli_runner: CliRunner) -> None:
+    """``config --json validate`` should emit JSON, not Rich output.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    with cli_runner.isolated_filesystem():
+        Path(".lintro-config.yaml").write_text(
+            "tools:\n  ruff:\n    enabled: true\n",
+            encoding="utf-8",
+        )
+
+        result = cli_runner.invoke(cli, ["config", "--json", "validate"])
+
+        assert_that(result.exit_code).is_equal_to(0)
+        data = json.loads(result.output)
+        assert_that(data["valid"]).is_true()
+
+
+def test_validate_subcommand_flag_wins_over_group(cli_runner: CliRunner) -> None:
+    """An explicit subcommand flag should still take effect.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    with cli_runner.isolated_filesystem():
+        Path("custom.yaml").write_text(
+            "tools:\n  ruff:\n    enabled: true\n",
+            encoding="utf-8",
+        )
+
+        result = cli_runner.invoke(
+            cli,
+            ["config", "--json", "validate", "--path", "custom.yaml"],
+        )
+
+        assert_that(result.exit_code).is_equal_to(0)
+        data = json.loads(result.output)
+        assert_that(data["config_path"]).is_equal_to("custom.yaml")
 
 
 def test_validate_explicit_path(cli_runner: CliRunner, tmp_path: Path) -> None:
@@ -89,9 +136,44 @@ def test_validate_explicit_path(cli_runner: CliRunner, tmp_path: Path) -> None:
     config = tmp_path / "custom.yaml"
     config.write_text("tools:\n  ruff:\n    enabled: true\n", encoding="utf-8")
 
-    result = cli_runner.invoke(cli, ["config", "validate", "--path", str(config)])
+    result = cli_runner.invoke(
+        cli,
+        ["config", "validate", "--path", str(config), "--json"],
+    )
 
     assert_that(result.exit_code).is_equal_to(0)
+    data = json.loads(result.output)
+    assert_that(data["config_path"]).is_equal_to(str(config))
+    assert_that(data["valid"]).is_true()
+    assert_that(data["errors"]).is_empty()
+
+    rich_result = cli_runner.invoke(cli, ["config", "validate", "--path", str(config)])
+
+    assert_that(rich_result.exit_code).is_equal_to(0)
+    assert_that(rich_result.output).contains("custom.yaml")
+    assert_that(rich_result.output).contains("VALID")
+
+
+def test_validate_invalid_json_reports_error_code(cli_runner: CliRunner) -> None:
+    """Errors in JSON output should carry a stable machine-readable code.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    with cli_runner.isolated_filesystem():
+        Path(".lintro-config.yaml").write_text(
+            'execution:\n  max_fix_retries: "bad"\n',
+            encoding="utf-8",
+        )
+
+        result = cli_runner.invoke(cli, ["config", "validate", "--json"])
+
+        assert_that(result.exit_code).is_equal_to(1)
+        data = json.loads(result.output)
+        assert_that(data["valid"]).is_false()
+        assert_that(data["errors"][0]["code"]).is_equal_to(
+            ValidationCode.INVALID_TYPE.value,
+        )
 
 
 def test_validate_missing_config_errors(cli_runner: CliRunner) -> None:
@@ -127,7 +209,45 @@ def test_config_show_subcommand(cli_runner: CliRunner) -> None:
         cli_runner: Click test runner instance.
     """
     with cli_runner.isolated_filesystem():
+        Path(".lintro-config.yaml").write_text(
+            "enforce:\n  line_length: 100\nexecution:\n  tool_order: alphabetical\n",
+            encoding="utf-8",
+        )
+
         result = cli_runner.invoke(cli, ["config", "show", "--json"])
+
+        assert_that(result.exit_code).is_equal_to(0)
+        data = json.loads(result.output)
+        assert_that(data).contains(
+            "config_source",
+            "global_settings",
+            "execution",
+            "tool_execution_order",
+            "tool_configs",
+            "warnings",
+        )
+        assert_that(data["config_source"]).ends_with(".lintro-config.yaml")
+        settings = data["global_settings"]
+        assert_that(settings).contains(
+            "line_length",
+            "target_python",
+            "tool_order",
+            "custom_order",
+        )
+        assert_that(settings["line_length"]).is_equal_to(100)
+        assert_that(settings["tool_order"]).is_equal_to("alphabetical")
+        assert_that(data["tool_execution_order"]).is_not_empty()
+        assert_that(data["tool_execution_order"][0]).contains("tool", "priority")
+
+
+def test_config_group_json_flag_forwards_to_show(cli_runner: CliRunner) -> None:
+    """``config --json show`` should emit the same JSON report as ``show --json``.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    with cli_runner.isolated_filesystem():
+        result = cli_runner.invoke(cli, ["config", "--json", "show"])
 
         assert_that(result.exit_code).is_equal_to(0)
         data = json.loads(result.output)

--- a/tests/cli/test_config_validate_command.py
+++ b/tests/cli/test_config_validate_command.py
@@ -263,6 +263,55 @@ def test_config_show_subcommand(cli_runner: CliRunner) -> None:
         assert_that(data["tool_execution_order"][0]).contains("tool", "priority")
 
 
+def test_config_show_null_tool_entry_exits_one(cli_runner: CliRunner) -> None:
+    """``config show`` must exit 1 on a null ``tools.<name>:`` entry.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    from lintro.config.config_loader import clear_config_cache
+
+    with cli_runner.isolated_filesystem():
+        Path(".lintro-config.yaml").write_text(
+            "tools:\n  ruff:\n",
+            encoding="utf-8",
+        )
+        clear_config_cache()
+
+        result = cli_runner.invoke(cli, ["config", "show"])
+
+        assert_that(result.exit_code).is_equal_to(1)
+        assert_that(result.output).contains(
+            "tools.ruff must be a mapping or boolean",
+        )
+        assert_that(result.output).does_not_contain("Traceback")
+
+
+def test_check_null_tool_entry_exits_one(cli_runner: CliRunner) -> None:
+    """``check`` must exit 1 on a null ``tools.<name>:`` entry.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    from lintro.config.config_loader import clear_config_cache
+
+    with cli_runner.isolated_filesystem():
+        Path(".lintro-config.yaml").write_text(
+            "tools:\n  ruff:\n",
+            encoding="utf-8",
+        )
+        Path("sample.py").write_text("x = 1\n", encoding="utf-8")
+        clear_config_cache()
+
+        result = cli_runner.invoke(cli, ["check", "sample.py"])
+
+        assert_that(result.exit_code).is_equal_to(1)
+        assert_that(result.output).contains(
+            "tools.ruff must be a mapping or boolean",
+        )
+        assert_that(result.output).does_not_contain("Traceback")
+
+
 def test_config_group_json_flag_forwards_to_show(cli_runner: CliRunner) -> None:
     """``config --json show`` should emit the same JSON report as ``show --json``.
 

--- a/tests/cli/test_config_validate_command.py
+++ b/tests/cli/test_config_validate_command.py
@@ -136,22 +136,29 @@ def test_validate_explicit_path(cli_runner: CliRunner, tmp_path: Path) -> None:
     config = tmp_path / "custom.yaml"
     config.write_text("tools:\n  ruff:\n    enabled: true\n", encoding="utf-8")
 
-    result = cli_runner.invoke(
-        cli,
-        ["config", "validate", "--path", str(config), "--json"],
-    )
+    # Run from an isolated cwd with no config of its own: if --path were
+    # ignored, auto-detect would have nothing to fall back on and the
+    # assertions below could not pass by accident.
+    with cli_runner.isolated_filesystem():
+        result = cli_runner.invoke(
+            cli,
+            ["config", "validate", "--path", str(config), "--json"],
+        )
 
-    assert_that(result.exit_code).is_equal_to(0)
-    data = json.loads(result.output)
-    assert_that(data["config_path"]).is_equal_to(str(config))
-    assert_that(data["valid"]).is_true()
-    assert_that(data["errors"]).is_empty()
+        assert_that(result.exit_code).is_equal_to(0)
+        data = json.loads(result.output)
+        assert_that(data["config_path"]).is_equal_to(str(config))
+        assert_that(data["valid"]).is_true()
+        assert_that(data["errors"]).is_empty()
 
-    rich_result = cli_runner.invoke(cli, ["config", "validate", "--path", str(config)])
+        rich_result = cli_runner.invoke(
+            cli,
+            ["config", "validate", "--path", str(config)],
+        )
 
-    assert_that(rich_result.exit_code).is_equal_to(0)
-    assert_that(rich_result.output).contains("custom.yaml")
-    assert_that(rich_result.output).contains("VALID")
+        assert_that(rich_result.exit_code).is_equal_to(0)
+        assert_that(rich_result.output).contains("custom.yaml")
+        assert_that(rich_result.output).contains("VALID")
 
 
 def test_validate_invalid_json_reports_error_code(cli_runner: CliRunner) -> None:

--- a/tests/cli/test_config_validate_command.py
+++ b/tests/cli/test_config_validate_command.py
@@ -38,7 +38,8 @@ def test_validate_valid_config_exits_zero(cli_runner: CliRunner) -> None:
         result = cli_runner.invoke(cli, ["config", "validate"])
 
         assert_that(result.exit_code).is_equal_to(0)
-        assert_that(result.output).contains("VALID")
+        assert_that(result.output).contains("Configuration is VALID")
+        assert_that(result.output).does_not_contain("INVALID")
 
 
 def test_validate_invalid_config_exits_nonzero(cli_runner: CliRunner) -> None:
@@ -56,7 +57,8 @@ def test_validate_invalid_config_exits_nonzero(cli_runner: CliRunner) -> None:
         result = cli_runner.invoke(cli, ["config", "validate"])
 
         assert_that(result.exit_code).is_equal_to(1)
-        assert_that(result.output).contains("INVALID")
+        assert_that(result.output).contains("Configuration is INVALID")
+        assert_that(result.output).does_not_contain("Configuration is VALID")
 
 
 def test_validate_json_output(cli_runner: CliRunner) -> None:
@@ -158,7 +160,8 @@ def test_validate_explicit_path(cli_runner: CliRunner, tmp_path: Path) -> None:
 
         assert_that(rich_result.exit_code).is_equal_to(0)
         assert_that(rich_result.output).contains("custom.yaml")
-        assert_that(rich_result.output).contains("VALID")
+        assert_that(rich_result.output).contains("Configuration is VALID")
+        assert_that(rich_result.output).does_not_contain("INVALID")
 
 
 def test_validate_invalid_json_reports_error_code(cli_runner: CliRunner) -> None:
@@ -197,7 +200,7 @@ def test_validate_missing_config_errors(cli_runner: CliRunner) -> None:
 
 
 def test_config_init_subcommand_scaffolds(cli_runner: CliRunner) -> None:
-    """`config init` should scaffold a config like the top-level init.
+    """`config init` should scaffold the same minimal YAML as top-level init.
 
     Args:
         cli_runner: Click test runner instance.
@@ -206,7 +209,20 @@ def test_config_init_subcommand_scaffolds(cli_runner: CliRunner) -> None:
         result = cli_runner.invoke(cli, ["config", "init", "--minimal", "--static"])
 
         assert_that(result.exit_code).is_equal_to(0)
-        assert_that(Path(".lintro-config.yaml").exists()).is_true()
+        config_path = Path(".lintro-config.yaml")
+        assert_that(config_path.exists()).is_true()
+        content = config_path.read_text(encoding="utf-8")
+        assert_that(content).contains("# Lintro Configuration (Minimal)")
+        assert_that(content).contains("enforce:")
+        assert_that(content).contains("line_length: 88")
+        assert_that(content).contains("tools:")
+        assert_that(content).contains("ruff:")
+        assert_that(content).contains("black:")
+        assert_that(content).contains("mypy:")
+
+        top_level = cli_runner.invoke(cli, ["init", "--minimal", "--static", "--force"])
+        assert_that(top_level.exit_code).is_equal_to(0)
+        assert_that(config_path.read_text(encoding="utf-8")).is_equal_to(content)
 
 
 def test_config_show_subcommand(cli_runner: CliRunner) -> None:

--- a/tests/cli/test_config_validate_command.py
+++ b/tests/cli/test_config_validate_command.py
@@ -200,6 +200,79 @@ def test_validate_invalid_json_reports_error_code(cli_runner: CliRunner) -> None
         )
 
 
+def test_validate_missing_explicit_path_is_not_found(
+    cli_runner: CliRunner,
+) -> None:
+    """``validate --path`` on a missing file is NOT_FOUND, not auto-detect.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    with cli_runner.isolated_filesystem():
+        Path(".lintro-config.yaml").write_text(
+            "tools:\n  ruff:\n    enabled: true\n",
+            encoding="utf-8",
+        )
+
+        result = cli_runner.invoke(
+            cli,
+            ["config", "validate", "--path", "nope.yaml", "--json"],
+        )
+
+        assert_that(result.exit_code).is_equal_to(1)
+        data = json.loads(result.output)
+        assert_that(data["valid"]).is_false()
+        assert_that(data["errors"][0]["code"]).is_equal_to(
+            ValidationCode.NOT_FOUND.value,
+        )
+
+
+def test_unmatched_group_export_on_validate_errors(
+    cli_runner: CliRunner,
+) -> None:
+    """``config --export`` must not be silently dropped on validate.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    with cli_runner.isolated_filesystem():
+        Path(".lintro-config.yaml").write_text(
+            "tools:\n  ruff:\n    enabled: true\n",
+            encoding="utf-8",
+        )
+
+        result = cli_runner.invoke(
+            cli,
+            ["config", "--export", "out.yaml", "validate"],
+        )
+
+        assert_that(result.exit_code).is_not_equal_to(0)
+        assert_that(result.output).contains("--export")
+        assert_that(Path("out.yaml").exists()).is_false()
+
+
+def test_format_null_tool_entry_exits_one(cli_runner: CliRunner) -> None:
+    """``format`` must exit 1 on a null ``tools.<name>:`` entry.
+
+    Args:
+        cli_runner: Click test runner instance.
+    """
+    with cli_runner.isolated_filesystem():
+        Path(".lintro-config.yaml").write_text(
+            "tools:\n  ruff:\n",
+            encoding="utf-8",
+        )
+        Path("sample.py").write_text("x = 1\n", encoding="utf-8")
+
+        result = cli_runner.invoke(cli, ["format", "sample.py"])
+
+        assert_that(result.exit_code).is_equal_to(1)
+        assert_that(result.output).contains(
+            "tools.ruff must be a mapping or boolean",
+        )
+        assert_that(result.output).does_not_contain("Traceback")
+
+
 def test_validate_missing_config_errors(cli_runner: CliRunner) -> None:
     """Validation with no config present should error and exit non-zero.
 

--- a/tests/config/test_config_loader.py
+++ b/tests/config/test_config_loader.py
@@ -21,6 +21,7 @@ from lintro.config.config_loader import (
 )
 from lintro.config.enforce_config import EnforceConfig
 from lintro.config.execution_config import ExecutionConfig
+from lintro.exceptions.errors import ConfigurationError
 from lintro.plugins import discovery
 
 
@@ -205,6 +206,31 @@ def test_parse_tools_config_rejects_null_entry() -> None:
     """A null ``tools.<name>`` value must raise ValueError."""
     with pytest.raises(ValueError, match="tools.ruff must be a mapping or boolean"):
         _parse_tools_config({"ruff": None})
+
+
+def test_convert_scalar_execution_raises() -> None:
+    """A scalar ``[tool.lintro] execution`` value must raise ValueError."""
+    with pytest.raises(ValueError, match="execution must be a mapping"):
+        _convert_pyproject_to_config({"execution": False})
+
+
+def test_convert_scalar_enforce_raises() -> None:
+    """A scalar ``[tool.lintro] enforce`` value must raise ValueError."""
+    with pytest.raises(ValueError, match="enforce must be a mapping"):
+        _convert_pyproject_to_config({"enforce": 1})
+
+
+def test_load_config_null_tool_raises_configuration_error(tmp_path: Path) -> None:
+    """Runtime load must wrap a null tool entry as ConfigurationError.
+
+    Args:
+        tmp_path: Temporary directory path for test files.
+    """
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text("tools:\n  ruff:\n", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="tools.ruff must be a mapping"):
+        load_config(config_path=str(config_file))
 
 
 def test_load_yaml_config_with_defaults(tmp_path: Path) -> None:

--- a/tests/config/test_config_loader.py
+++ b/tests/config/test_config_loader.py
@@ -90,6 +90,27 @@ def test_with_bool_values() -> None:
     assert_that(config["prettier"].enabled).is_false()
 
 
+def test_tools_config_rejects_non_string_key() -> None:
+    """A numeric ``tools:`` key must raise ValueError, not AttributeError."""
+    with pytest.raises(ValueError, match="tool name must be a string"):
+        _parse_tools_config({3.14: {"enabled": True}})
+
+
+def test_load_config_non_string_tool_key_raises_configuration_error(
+    tmp_path: Path,
+) -> None:
+    """YAML ``tools.3.14`` must exit as ConfigurationError, not a traceback.
+
+    Args:
+        tmp_path: Temporary directory path for test files.
+    """
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text("tools:\n  3.14:\n    enabled: true\n", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="tool name must be a string"):
+        load_config(config_path=str(config_file))
+
+
 def test_tools_config_rejects_scalar_entry() -> None:
     """A known tool whose value is not a mapping or bool must raise.
 

--- a/tests/config/test_config_loader.py
+++ b/tests/config/test_config_loader.py
@@ -50,7 +50,7 @@ def test_string_enabled_tools() -> None:
 
 def test_tool_config_empty_data() -> None:
     """Should return default ToolConfig."""
-    config = _parse_tool_config({})
+    config = _parse_tool_config("ruff", {})
 
     assert_that(config.enabled).is_true()
     assert_that(config.config_source).is_none()
@@ -60,7 +60,7 @@ def test_disabled_tool() -> None:
     """Should parse enabled=False."""
     data = {"enabled": False}
 
-    config = _parse_tool_config(data)
+    config = _parse_tool_config("ruff", data)
 
     assert_that(config.enabled).is_false()
 

--- a/tests/config/test_config_loader.py
+++ b/tests/config/test_config_loader.py
@@ -15,6 +15,7 @@ from lintro.config.config_loader import (
     _parse_tool_config,
     _parse_tools_config,
     _pyproject_lintro_catalog,
+    build_config_from_dict,
     clear_config_cache,
     get_default_config,
     load_config,
@@ -218,6 +219,43 @@ def test_convert_scalar_enforce_raises() -> None:
     """A scalar ``[tool.lintro] enforce`` value must raise ValueError."""
     with pytest.raises(ValueError, match="enforce must be a mapping"):
         _convert_pyproject_to_config({"enforce": 1})
+
+
+@pytest.mark.parametrize(
+    "section",
+    ["enforce", "execution", "defaults", "tools"],
+)
+def test_build_config_from_dict_rejects_null_mapping_section(
+    section: str,
+) -> None:
+    """A YAML-null mapping section must raise ValueError, not AttributeError.
+
+    Args:
+        section: Top-level key that typed parsers assume is a mapping.
+    """
+    with pytest.raises(ValueError, match=f"{section} must be a mapping"):
+        build_config_from_dict({section: None})
+
+
+@pytest.mark.parametrize(
+    "section",
+    ["enforce", "execution", "defaults", "tools"],
+)
+def test_load_config_null_mapping_section_raises_configuration_error(
+    tmp_path: Path,
+    section: str,
+) -> None:
+    """A bare ``section:`` in YAML must raise ConfigurationError.
+
+    Args:
+        tmp_path: Temporary directory path for test files.
+        section: Top-level mapping section spelled as a YAML null.
+    """
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text(f"{section}:\n", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match=f"{section} must be a mapping"):
+        load_config(config_path=str(config_file))
 
 
 def test_load_config_null_tool_raises_configuration_error(tmp_path: Path) -> None:
@@ -509,8 +547,6 @@ def test_plugin_cannot_shadow_reserved_config_keys(
 def test_nested_pyproject_execution_fail_fast_is_applied() -> None:
     """Valid nested ``[tool.lintro.execution] fail_fast`` must reach LintroConfig."""
     import tomllib
-
-    from lintro.config.config_loader import build_config_from_dict
 
     parsed = tomllib.loads("[tool.lintro.execution]\nfail_fast = true\n")
     converted = _convert_pyproject_to_config(parsed["tool"]["lintro"])

--- a/tests/config/test_config_loader.py
+++ b/tests/config/test_config_loader.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 from assertpy import assert_that
@@ -93,7 +94,9 @@ def test_with_bool_values() -> None:
 def test_tools_config_rejects_non_string_key() -> None:
     """A numeric ``tools:`` key must raise ValueError, not AttributeError."""
     with pytest.raises(ValueError, match="tool name must be a string"):
-        _parse_tools_config({3.14: {"enabled": True}})
+        _parse_tools_config(
+            cast(dict[str, Any], {3.14: {"enabled": True}}),
+        )
 
 
 def test_load_config_non_string_tool_key_raises_configuration_error(

--- a/tests/config/test_config_loader.py
+++ b/tests/config/test_config_loader.py
@@ -85,6 +85,27 @@ def test_with_bool_values() -> None:
     assert_that(config["prettier"].enabled).is_false()
 
 
+def test_tools_config_rejects_scalar_entry() -> None:
+    """A known tool whose value is not a mapping or bool must raise.
+
+    ``tools.ruff: 0`` used to be dropped, so ruff stayed at the default
+    (enabled). The parser must fail closed instead.
+    """
+    with pytest.raises(ValueError) as exc_info:
+        _parse_tools_config({"ruff": 0})
+
+    assert_that(str(exc_info.value)).contains("tools.ruff")
+    assert_that(str(exc_info.value)).contains("mapping or boolean")
+
+
+def test_tools_config_rejects_string_entry() -> None:
+    """A string tool value such as ``"yes"`` must raise."""
+    with pytest.raises(ValueError) as exc_info:
+        _parse_tools_config({"ruff": "yes"})
+
+    assert_that(str(exc_info.value)).contains("tools.ruff")
+
+
 def test_defaults_empty_data() -> None:
     """Should return empty dict for defaults."""
     defaults = _parse_defaults({})

--- a/tests/config/test_config_loader.py
+++ b/tests/config/test_config_loader.py
@@ -14,10 +14,13 @@ from lintro.config.config_loader import (
     _parse_execution_config,
     _parse_tool_config,
     _parse_tools_config,
+    _pyproject_lintro_catalog,
     clear_config_cache,
     get_default_config,
     load_config,
 )
+from lintro.config.enforce_config import EnforceConfig
+from lintro.config.execution_config import ExecutionConfig
 from lintro.plugins import discovery
 
 
@@ -170,6 +173,38 @@ def test_execution_settings() -> None:
 
     assert_that(result["execution"]["tool_order"]).is_equal_to("alphabetical")
     assert_that(result["execution"]["fail_fast"]).is_true()
+
+
+def test_convert_nested_execution_and_enforce_tables() -> None:
+    """Nested ``[tool.lintro.execution]`` / ``enforce`` tables must be merged."""
+    result = _convert_pyproject_to_config(
+        {
+            "execution": {"fail_fast": True, "max_fix_retries": 5},
+            "enforce": {"line_length": 100},
+        },
+    )
+
+    assert_that(result["execution"]["fail_fast"]).is_true()
+    assert_that(result["execution"]["max_fix_retries"]).is_equal_to(5)
+    assert_that(result["enforce"]["line_length"]).is_equal_to(100)
+
+
+def test_pyproject_catalog_keys_match_model_fields() -> None:
+    """Catalog execution/enforce keys must come from the Pydantic models."""
+    catalog = _pyproject_lintro_catalog()
+
+    assert_that(catalog.execution_keys).is_equal_to(
+        frozenset(ExecutionConfig.model_fields),
+    )
+    assert_that(catalog.enforce_keys).is_equal_to(
+        frozenset(EnforceConfig.model_fields),
+    )
+
+
+def test_parse_tools_config_rejects_null_entry() -> None:
+    """A null ``tools.<name>`` value must raise ValueError."""
+    with pytest.raises(ValueError, match="tools.ruff must be a mapping or boolean"):
+        _parse_tools_config({"ruff": None})
 
 
 def test_load_yaml_config_with_defaults(tmp_path: Path) -> None:
@@ -443,3 +478,16 @@ def test_plugin_cannot_shadow_reserved_config_keys(
     assert_that(result["execution"]["fail_fast"]).is_true()
     assert_that(result["enforce"]["line_length"]).is_equal_to(100)
     assert_that(result["tools"]).is_empty()
+
+
+def test_nested_pyproject_execution_fail_fast_is_applied() -> None:
+    """Valid nested ``[tool.lintro.execution] fail_fast`` must reach LintroConfig."""
+    import tomllib
+
+    from lintro.config.config_loader import build_config_from_dict
+
+    parsed = tomllib.loads("[tool.lintro.execution]\nfail_fast = true\n")
+    converted = _convert_pyproject_to_config(parsed["tool"]["lintro"])
+    config = build_config_from_dict(converted)
+
+    assert_that(config.execution.fail_fast).is_true()

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -32,7 +32,6 @@ SUBCOMMAND_SUMMARY_PHRASES: dict[str, str] = {
     "badge": "Generate a shields.io markdown badge for the project health score.",
     "check": "Check files for issues using the specified tools.",
     "completions": "Print a shell completion script for bash, zsh, or fish.",
-    "config": "Inspect and validate Lintro configuration.",
     "doctor": "Check tool installation status and version compatibility.",
     "format": "Format code using configured formatting tools.",
     "init": "Initialize Lintro configuration for your project.",
@@ -98,3 +97,20 @@ def test_subcommand_help_shows_summary_and_options(
     assert_that(result.output).contains("Usage:")
     assert_that(result.output).contains("--help")
     assert_that(result.output).contains(summary)
+
+
+def test_config_help_lists_subcommands() -> None:
+    """``lintro config --help`` must list the real subcommands, not a copied blurb.
+
+    The group docstring is truncated at form-feed for Click; this checks the
+    behavior users see (show / validate / init) rather than echoing the
+    source docstring.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "--help"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains("Usage:")
+    assert_that(result.output).contains("show")
+    assert_that(result.output).contains("validate")
+    assert_that(result.output).contains("init")

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -32,7 +32,7 @@ SUBCOMMAND_SUMMARY_PHRASES: dict[str, str] = {
     "badge": "Generate a shields.io markdown badge for the project health score.",
     "check": "Check files for issues using the specified tools.",
     "completions": "Print a shell completion script for bash, zsh, or fish.",
-    "config": "Display Lintro configuration status.",
+    "config": "Inspect and validate Lintro configuration.",
     "doctor": "Check tool installation status and version compatibility.",
     "format": "Format code using configured formatting tools.",
     "init": "Initialize Lintro configuration for your project.",

--- a/tests/unit/config/test_config_loader.py
+++ b/tests/unit/config/test_config_loader.py
@@ -136,6 +136,28 @@ def test_load_pyproject_os_error_logs_debug(
         assert_that(debug_msg).contains("Could not read pyproject.toml")
 
 
+def test_load_pyproject_non_mapping_tool_does_not_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-table ``tool`` value must not raise AttributeError.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+        monkeypatch: Pytest monkeypatch fixture for chdir.
+    """
+    clear_pyproject_cache()
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('tool = "not-a-table"\n')
+    monkeypatch.chdir(tmp_path)
+
+    result, path = _load_pyproject_fallback()
+
+    assert_that(result).is_equal_to({})
+    assert_that(path).is_none()
+
+
 def test_pyproject_nested_tool_table_disables_a_tool(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -15,7 +16,7 @@ from lintro.config.config_validator import (
 
 
 @pytest.fixture
-def write_config(tmp_path: Path):
+def write_config(tmp_path: Path) -> Callable[[str], Path]:
     """Provide a helper that writes a config file and returns its path.
 
     Args:
@@ -58,7 +59,7 @@ def test_validation_message_render_with_suggestion() -> None:
     assert_that(rendered).contains("did you mean 'ruff'")
 
 
-def test_valid_config_passes(write_config) -> None:
+def test_valid_config_passes(write_config: Callable[[str], Path]) -> None:
     """A well-formed config should validate cleanly.
 
     Args:
@@ -110,7 +111,7 @@ def test_no_config_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     assert_that(result.errors[0].message).contains("lintro init")
 
 
-def test_unknown_tool_warns_with_suggestion(write_config) -> None:
+def test_unknown_tool_warns_with_suggestion(write_config: Callable[[str], Path]) -> None:
     """An unknown tool name should warn and suggest the closest match.
 
     Args:
@@ -133,7 +134,7 @@ tools:
     assert_that(messages[0]).contains("ruff")
 
 
-def test_unknown_enabled_tool_warns(write_config) -> None:
+def test_unknown_enabled_tool_warns(write_config: Callable[[str], Path]) -> None:
     """Unknown names in execution.enabled_tools should warn.
 
     Args:
@@ -153,7 +154,7 @@ execution:
     assert_that(any("black" in m for m in messages)).is_true()
 
 
-def test_unknown_top_level_key_warns(write_config) -> None:
+def test_unknown_top_level_key_warns(write_config: Callable[[str], Path]) -> None:
     """Unknown top-level keys should warn.
 
     Args:
@@ -167,7 +168,7 @@ def test_unknown_top_level_key_warns(write_config) -> None:
     assert_that(locations).contains("bogus_section")
 
 
-def test_deprecated_key_warns(write_config) -> None:
+def test_deprecated_key_warns(write_config: Callable[[str], Path]) -> None:
     """A deprecated key should warn with its replacement.
 
     Args:
@@ -188,7 +189,7 @@ enforce:
     assert_that(dep[0].suggestion).is_equal_to("line_length")
 
 
-def test_invalid_value_type_is_error(write_config) -> None:
+def test_invalid_value_type_is_error(write_config: Callable[[str], Path]) -> None:
     """A bad execution value type should be a hard error.
 
     Args:
@@ -207,7 +208,7 @@ execution:
     assert_that(result.errors[0].message).contains("max_fix_retries")
 
 
-def test_invalid_auto_install_reports_tool_name(write_config) -> None:
+def test_invalid_auto_install_reports_tool_name(write_config: Callable[[str], Path]) -> None:
     """auto_install type errors should name the offending tool.
 
     Args:
@@ -227,7 +228,7 @@ tools:
     assert_that(result.errors[0].message).contains("tools.ruff.auto_install")
 
 
-def test_non_mapping_root_is_error(write_config) -> None:
+def test_non_mapping_root_is_error(write_config: Callable[[str], Path]) -> None:
     """A non-mapping root document should be a hard error.
 
     Args:
@@ -241,7 +242,7 @@ def test_non_mapping_root_is_error(write_config) -> None:
     assert_that(result.errors[0].message).contains("mapping")
 
 
-def test_empty_config_warns(write_config) -> None:
+def test_empty_config_warns(write_config: Callable[[str], Path]) -> None:
     """An empty config file should warn rather than error.
 
     Args:
@@ -255,7 +256,7 @@ def test_empty_config_warns(write_config) -> None:
     assert_that(result.warnings[0].message).contains("empty")
 
 
-def test_malformed_yaml_is_error(write_config) -> None:
+def test_malformed_yaml_is_error(write_config: Callable[[str], Path]) -> None:
     """Unparseable YAML should be reported as an error.
 
     Args:

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -1,0 +1,269 @@
+"""Tests for the Lintro configuration validator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+
+from lintro.config.config_validator import (
+    ValidationMessage,
+    known_tool_names,
+    validate_config_file,
+)
+
+
+@pytest.fixture
+def write_config(tmp_path: Path):
+    """Provide a helper that writes a config file and returns its path.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+
+    Returns:
+        Callable[[str], Path]: Writer that returns the created file path.
+    """
+
+    def _write(content: str, name: str = ".lintro-config.yaml") -> Path:
+        path = tmp_path / name
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    return _write
+
+
+def test_known_tool_names_includes_canonical_and_hyphen() -> None:
+    """Known tools should include underscore and hyphen forms."""
+    names = known_tool_names()
+
+    assert_that(names).contains("ruff")
+    assert_that(names).contains("cargo_audit")
+    assert_that(names).contains("cargo-audit")
+    assert_that(names).contains("markdownlint-cli2")
+
+
+def test_validation_message_render_with_suggestion() -> None:
+    """Render should include location and did-you-mean suggestion."""
+    msg = ValidationMessage(
+        message="unknown tool 'ruft'",
+        location="tools",
+        suggestion="ruff",
+    )
+
+    rendered = msg.render()
+
+    assert_that(rendered).contains("tools")
+    assert_that(rendered).contains("unknown tool 'ruft'")
+    assert_that(rendered).contains("did you mean 'ruff'")
+
+
+def test_valid_config_passes(write_config) -> None:
+    """A well-formed config should validate cleanly.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+enforce:
+  line_length: 88
+execution:
+  tool_order: priority
+tools:
+  ruff:
+    enabled: true
+""",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_true()
+    assert_that(result.errors).is_empty()
+    assert_that(result.warnings).is_empty()
+
+
+def test_missing_file_is_error(tmp_path: Path) -> None:
+    """A nonexistent explicit path should produce an error.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+    """
+    result = validate_config_file(tmp_path / "nope.yaml")
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].message).contains("not found")
+
+
+def test_no_config_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Auto-detect with no config present should error with a hint.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    result = validate_config_file(None)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].message).contains("lintro init")
+
+
+def test_unknown_tool_warns_with_suggestion(write_config) -> None:
+    """An unknown tool name should warn and suggest the closest match.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+tools:
+  ruft:
+    enabled: true
+""",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_true()
+    messages = [w.render() for w in result.warnings]
+    assert_that(messages).is_length(1)
+    assert_that(messages[0]).contains("unknown tool 'ruft'")
+    assert_that(messages[0]).contains("ruff")
+
+
+def test_unknown_enabled_tool_warns(write_config) -> None:
+    """Unknown names in execution.enabled_tools should warn.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+execution:
+  enabled_tools: [blak]
+""",
+    )
+
+    result = validate_config_file(path)
+
+    messages = [w.render() for w in result.warnings]
+    assert_that(any("unknown tool 'blak'" in m for m in messages)).is_true()
+    assert_that(any("black" in m for m in messages)).is_true()
+
+
+def test_unknown_top_level_key_warns(write_config) -> None:
+    """Unknown top-level keys should warn.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config("bogus_section: 1\n")
+
+    result = validate_config_file(path)
+
+    locations = [w.location for w in result.warnings]
+    assert_that(locations).contains("bogus_section")
+
+
+def test_deprecated_key_warns(write_config) -> None:
+    """A deprecated key should warn with its replacement.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+enforce:
+  line-length: 88
+""",
+    )
+
+    result = validate_config_file(path)
+
+    dep = [w for w in result.warnings if w.location == "enforce.line-length"]
+    assert_that(dep).is_length(1)
+    assert_that(dep[0].message).contains("deprecated")
+    assert_that(dep[0].suggestion).is_equal_to("line_length")
+
+
+def test_invalid_value_type_is_error(write_config) -> None:
+    """A bad execution value type should be a hard error.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+execution:
+  max_fix_retries: "not-an-int"
+""",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].message).contains("max_fix_retries")
+
+
+def test_invalid_auto_install_reports_tool_name(write_config) -> None:
+    """auto_install type errors should name the offending tool.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+tools:
+  ruff:
+    auto_install: "yes"
+""",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].message).contains("tools.ruff.auto_install")
+
+
+def test_non_mapping_root_is_error(write_config) -> None:
+    """A non-mapping root document should be a hard error.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config("- just\n- a\n- list\n")
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].message).contains("mapping")
+
+
+def test_empty_config_warns(write_config) -> None:
+    """An empty config file should warn rather than error.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config("")
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_true()
+    assert_that(result.warnings[0].message).contains("empty")
+
+
+def test_malformed_yaml_is_error(write_config) -> None:
+    """Unparseable YAML should be reported as an error.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config("tools:\n  ruff: [unclosed\n")
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].message).contains("parse")

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -272,3 +272,50 @@ def test_malformed_yaml_is_error(write_config: Callable[[str], Path]) -> None:
 
     assert_that(result.is_valid).is_false()
     assert_that(result.errors[0].message).contains("parse")
+
+
+def test_pyproject_typed_error_is_reported(
+    write_config: Callable[[str], Path],
+) -> None:
+    """Typed errors in a pyproject.toml [tool.lintro] table are reported.
+
+    The explicit-path loader reads files as YAML, so validating a
+    pyproject.toml must feed the parsed TOML through the shared typed parser
+    rather than re-reading the TOML path as YAML.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+[tool.lintro]
+max_fix_retries = "not-an-int"
+""",
+        name="pyproject.toml",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].message).contains("max_fix_retries")
+
+
+def test_pyproject_valid_config_passes(
+    write_config: Callable[[str], Path],
+) -> None:
+    """A valid pyproject.toml [tool.lintro] table validates cleanly.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+[tool.lintro]
+max_fix_retries = 3
+""",
+        name="pyproject.toml",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_true()

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -111,7 +111,9 @@ def test_no_config_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     assert_that(result.errors[0].message).contains("lintro init")
 
 
-def test_unknown_tool_warns_with_suggestion(write_config: Callable[[str], Path]) -> None:
+def test_unknown_tool_warns_with_suggestion(
+    write_config: Callable[[str], Path],
+) -> None:
     """An unknown tool name should warn and suggest the closest match.
 
     Args:
@@ -208,7 +210,9 @@ execution:
     assert_that(result.errors[0].message).contains("max_fix_retries")
 
 
-def test_invalid_auto_install_reports_tool_name(write_config: Callable[[str], Path]) -> None:
+def test_invalid_auto_install_reports_tool_name(
+    write_config: Callable[[str], Path],
+) -> None:
     """auto_install type errors should name the offending tool.
 
     Args:

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -9,12 +9,10 @@ import pytest
 from assertpy import assert_that
 
 from lintro.config.config_validator import (
-    KNOWN_TOP_LEVEL_KEYS,
     ValidationMessage,
     known_tool_names,
     validate_config_file,
 )
-from lintro.config.lintro_config import LintroConfig
 from lintro.enums.validation_code import ValidationCode
 
 
@@ -250,8 +248,11 @@ def test_non_mapping_root_is_error(write_config: Callable[..., Path]) -> None:
     assert_that(result.errors[0].message).contains("mapping")
 
 
-def test_empty_config_warns(write_config: Callable[..., Path]) -> None:
-    """An empty config file should warn rather than error.
+def test_empty_config_is_not_valid(write_config: Callable[..., Path]) -> None:
+    """An empty config file is not a successful config.
+
+    ``load_config`` ignores empty YAML and continues searching, so validate
+    must not report VALID for an explicit empty path.
 
     Args:
         write_config: Fixture writing config content to a temp file.
@@ -260,8 +261,9 @@ def test_empty_config_warns(write_config: Callable[..., Path]) -> None:
 
     result = validate_config_file(path)
 
-    assert_that(result.is_valid).is_true()
-    assert_that(result.warnings[0].message).contains("empty")
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.EMPTY_CONFIG)
+    assert_that(result.errors[0].message).contains("empty")
 
 
 def test_malformed_yaml_is_error(write_config: Callable[..., Path]) -> None:
@@ -325,11 +327,153 @@ max_fix_retries = 3
     assert_that(result.is_valid).is_true()
 
 
-def test_known_top_level_keys_cover_schema_fields() -> None:
-    """Every LintroConfig field must be an accepted top-level section."""
-    schema_fields = set(LintroConfig.model_fields) - {"config_path"}
+def test_pyproject_unknown_key_warns(write_config: Callable[..., Path]) -> None:
+    """Unknown keys on the raw [tool.lintro] table must reach validate output.
 
-    assert_that(set(KNOWN_TOP_LEVEL_KEYS)).contains(*sorted(schema_fields))
+    The converter drops unrecognized keys (log only); validate has to inspect
+    the raw table or YAML typos in pyproject would look VALID.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+[tool.lintro]
+bogus_option = 1
+""",
+        name="pyproject.toml",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_true()
+    matches = [w for w in result.warnings if w.location == "tool.lintro.bogus_option"]
+    assert_that(matches).is_length(1)
+    assert_that(matches[0].code).is_equal_to(ValidationCode.UNKNOWN_OPTION)
+
+
+def test_pyproject_unknown_tool_table_warns(
+    write_config: Callable[..., Path],
+) -> None:
+    """An unknown tool table under [tool.lintro] should warn UNKNOWN_TOOL.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+[tool.lintro]
+[tool.lintro.ruft]
+enabled = true
+""",
+        name="pyproject.toml",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_true()
+    matches = [w for w in result.warnings if w.code == ValidationCode.UNKNOWN_TOOL]
+    assert_that(matches).is_not_empty()
+    assert_that(matches[0].message).contains("ruft")
+
+
+def test_pyproject_non_mapping_tool_table_is_error(
+    write_config: Callable[..., Path],
+) -> None:
+    """A non-mapping ``tool`` value must be INVALID_TYPE, not a crash.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+tool = "not-a-table"
+""",
+        name="pyproject.toml",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.INVALID_TYPE)
+    assert_that(result.errors[0].location).is_equal_to("tool")
+
+
+def test_pyproject_non_mapping_lintro_table_is_error(
+    write_config: Callable[..., Path],
+) -> None:
+    """A non-mapping ``tool.lintro`` value must be INVALID_TYPE, not a crash.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+[tool]
+lintro = "not-a-table"
+""",
+        name="pyproject.toml",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.INVALID_TYPE)
+    assert_that(result.errors[0].location).is_equal_to("tool.lintro")
+
+
+def test_scalar_tool_entry_is_error(write_config: Callable[..., Path]) -> None:
+    """A known tool whose value is not a mapping or bool is INVALID_TYPE.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config("tools:\n  ruff: 0\n")
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.INVALID_TYPE)
+    assert_that(result.errors[0].location).is_equal_to("tools.ruff")
+    assert_that(result.errors[0].message).contains("mapping or boolean")
+
+
+def test_string_tool_entry_is_error(write_config: Callable[..., Path]) -> None:
+    """A string tool value such as ``tools.ruff: yes`` is INVALID_TYPE.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config('tools:\n  ruff: "yes"\n')
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.INVALID_TYPE)
+    assert_that(result.errors[0].location).is_equal_to("tools.ruff")
+
+
+def test_pyproject_scalar_tool_entry_is_error(
+    write_config: Callable[..., Path],
+) -> None:
+    """A scalar ``[tool.lintro] ruff = 0`` entry is INVALID_TYPE.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+[tool.lintro]
+ruff = 0
+""",
+        name="pyproject.toml",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.INVALID_TYPE)
+    assert_that(result.errors[0].location).is_equal_to("tools.ruff")
 
 
 @pytest.mark.parametrize(
@@ -451,7 +595,8 @@ def test_empty_mapping_does_not_validate_discovered_config(
     """An explicit empty-mapping file must not fall through to auto-discovery.
 
     ``load_config`` treats a falsy config as "nothing found" and searches
-    upward, which would silently validate a different file than requested.
+    upward. Validate must still report the requested file as empty (not
+    VALID, and not the parent file's typed errors).
 
     Args:
         tmp_path: Pytest temporary directory.
@@ -470,8 +615,10 @@ def test_empty_mapping_does_not_validate_discovered_config(
     result = validate_config_file(target)
 
     assert_that(result.config_path).is_equal_to(target)
-    assert_that(result.errors).is_empty()
-    assert_that(result.is_valid).is_true()
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.EMPTY_CONFIG)
+    messages = [e.message for e in result.errors]
+    assert_that(any("max_fix_retries" in m for m in messages)).is_false()
 
 
 def test_autodetect_falls_back_to_pyproject(
@@ -524,3 +671,101 @@ def test_missing_file_uses_not_found_code(tmp_path: Path) -> None:
     result = validate_config_file(tmp_path / "nope.yaml")
 
     assert_that(result.errors[0].code).is_equal_to(ValidationCode.NOT_FOUND)
+
+
+def test_autodetect_empty_yaml_reports_invalid_pyproject(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty auto-detected YAML must not report VALID when pyproject is invalid.
+
+    Runtime ``load_config`` ignores empty YAML and applies [tool.lintro].
+
+    Args:
+        tmp_path: Pytest temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    (tmp_path / ".lintro-config.yaml").write_text("", encoding="utf-8")
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[tool.lintro]\nmax_fix_retries = "not-an-int"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = validate_config_file(None)
+
+    assert_that(result.config_path).is_equal_to(pyproject)
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].message).contains("max_fix_retries")
+    assert_that(result.warnings[0].code).is_equal_to(ValidationCode.EMPTY_CONFIG)
+
+
+def test_autodetect_malformed_pyproject_is_parse_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken pyproject.toml on auto-detect is PARSE_ERROR, not NOT_FOUND.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("not: [valid toml\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    result = validate_config_file(None)
+
+    assert_that(result.config_path).is_equal_to(pyproject)
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.PARSE_ERROR)
+
+
+def test_plugin_tool_name_is_not_unknown(
+    write_config: Callable[..., Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Installed plugin names must not produce UNKNOWN_TOOL warnings.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        "lintro.plugins.discovery.get_known_plugin_tool_names",
+        lambda: frozenset({"acme_lint"}),
+    )
+    path = write_config(
+        """
+tools:
+  acme_lint:
+    enabled: true
+""",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_true()
+    codes = [w.code for w in result.warnings]
+    assert_that(codes).does_not_contain(ValidationCode.UNKNOWN_TOOL)
+
+
+def test_known_tool_names_includes_plugin_and_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The validator tool set includes plugin names and the markdownlint alias.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        "lintro.plugins.discovery.get_known_plugin_tool_names",
+        lambda: frozenset({"acme_lint"}),
+    )
+
+    names = known_tool_names()
+
+    assert_that(names).contains("acme_lint")
+    assert_that(names).contains("acme-lint")
+    assert_that(names).contains("markdownlint-cli2")

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -9,6 +9,7 @@ import pytest
 from assertpy import assert_that
 
 from lintro.config.config_validator import (
+    KNOWN_TOP_LEVEL_KEYS,
     ValidationMessage,
     known_tool_names,
     validate_config_file,
@@ -560,24 +561,28 @@ ruff = 0
 
 @pytest.mark.parametrize(
     "section",
-    ["score", "output", "plugins", "licenses", "module_size", "post_checks"],
+    sorted(KNOWN_TOP_LEVEL_KEYS),
 )
 def test_documented_sections_do_not_warn(
     write_config: Callable[..., Path],
     section: str,
 ) -> None:
-    """Sections the loader honors must not be reported as unknown options.
+    """Every known top-level section must validate without UNKNOWN_OPTION.
+
+    Uses an empty mapping so the case does not depend on section-specific
+    nested fields (``score.enabled`` is not a ScoreConfig key).
 
     Args:
         write_config: Fixture writing config content to a temp file.
         section: Top-level section name to place in the config.
     """
-    path = write_config(f"{section}:\n  enabled: true\n")
+    path = write_config(f"{section}: {{}}\n")
 
     result = validate_config_file(path)
 
-    locations = [w.location for w in result.warnings]
-    assert_that(locations).does_not_contain(section)
+    unknown = [w for w in result.warnings if w.code == ValidationCode.UNKNOWN_OPTION]
+    assert_that(result.is_valid).is_true()
+    assert_that(unknown).is_empty()
 
 
 def test_score_section_unknown_key_warns(write_config: Callable[..., Path]) -> None:
@@ -753,6 +758,34 @@ def test_missing_file_uses_not_found_code(tmp_path: Path) -> None:
     result = validate_config_file(tmp_path / "nope.yaml")
 
     assert_that(result.errors[0].code).is_equal_to(ValidationCode.NOT_FOUND)
+
+
+def test_autodetect_list_yaml_falls_through_to_pyproject(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A list YAML on auto-detect must follow the loader into pyproject.
+
+    ``load_config`` maps non-dict YAML to ``{}`` and continues searching.
+    Validate must not stop on ``INVALID_TYPE`` and skip ``[tool.lintro]``.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    (tmp_path / ".lintro-config.yaml").write_text(
+        "- just\n- a\n- list\n",
+        encoding="utf-8",
+    )
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.lintro]\nfail_fast = true\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    result = validate_config_file(None)
+
+    assert_that(result.config_path).is_equal_to(pyproject)
+    assert_that(result.is_valid).is_true()
+    assert_that(result.warnings[0].code).is_equal_to(ValidationCode.EMPTY_CONFIG)
 
 
 def test_autodetect_empty_yaml_reports_invalid_pyproject(

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -481,6 +481,45 @@ def test_scalar_tool_entry_is_error(write_config: Callable[..., Path]) -> None:
     assert_that(result.errors[0].message).contains("mapping or boolean")
 
 
+def test_non_string_tool_key_is_error(write_config: Callable[..., Path]) -> None:
+    """A numeric ``tools:`` key must be INVALID_TYPE, not a traceback.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config("tools:\n  3.14:\n    enabled: true\n")
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.INVALID_TYPE)
+    assert_that(result.errors[0].message).contains("tool name must be a string")
+
+
+def test_pyproject_scalar_execution_is_error(
+    write_config: Callable[..., Path],
+) -> None:
+    """A scalar ``[tool.lintro] execution = false`` entry is INVALID_TYPE.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+[tool.lintro]
+execution = false
+""",
+        name="pyproject.toml",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.INVALID_TYPE)
+    assert_that(result.errors[0].message).contains("execution")
+    assert_that(result.errors[0].location).is_equal_to("tool.lintro.execution")
+
+
 def test_string_tool_entry_is_error(write_config: Callable[..., Path]) -> None:
     """A string tool value such as ``tools.ruff: yes`` is INVALID_TYPE.
 

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -280,6 +280,49 @@ def test_malformed_yaml_is_error(write_config: Callable[..., Path]) -> None:
     assert_that(result.errors[0].message).contains("parse")
 
 
+def test_pyproject_nested_execution_invalid_max_fix_retries(
+    write_config: Callable[..., Path],
+) -> None:
+    """Invalid nested ``[tool.lintro.execution]`` values must be INVALID.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+[tool.lintro.execution]
+max_fix_retries = "not-an-int"
+""",
+        name="pyproject.toml",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].message).contains("max_fix_retries")
+
+
+def test_pyproject_nested_execution_fail_fast_valid(
+    write_config: Callable[..., Path],
+) -> None:
+    """A valid nested ``[tool.lintro.execution] fail_fast`` must validate.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        """
+[tool.lintro.execution]
+fail_fast = true
+""",
+        name="pyproject.toml",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_true()
+
+
 def test_pyproject_typed_error_is_reported(
     write_config: Callable[..., Path],
 ) -> None:

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -16,14 +16,14 @@ from lintro.config.config_validator import (
 
 
 @pytest.fixture
-def write_config(tmp_path: Path) -> Callable[[str], Path]:
+def write_config(tmp_path: Path) -> Callable[..., Path]:
     """Provide a helper that writes a config file and returns its path.
 
     Args:
         tmp_path: Pytest temporary directory.
 
     Returns:
-        Callable[[str], Path]: Writer that returns the created file path.
+        Callable[..., Path]: Writer that returns the created file path.
     """
 
     def _write(content: str, name: str = ".lintro-config.yaml") -> Path:
@@ -59,7 +59,7 @@ def test_validation_message_render_with_suggestion() -> None:
     assert_that(rendered).contains("did you mean 'ruff'")
 
 
-def test_valid_config_passes(write_config: Callable[[str], Path]) -> None:
+def test_valid_config_passes(write_config: Callable[..., Path]) -> None:
     """A well-formed config should validate cleanly.
 
     Args:
@@ -112,7 +112,7 @@ def test_no_config_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_unknown_tool_warns_with_suggestion(
-    write_config: Callable[[str], Path],
+    write_config: Callable[..., Path],
 ) -> None:
     """An unknown tool name should warn and suggest the closest match.
 
@@ -136,7 +136,7 @@ tools:
     assert_that(messages[0]).contains("ruff")
 
 
-def test_unknown_enabled_tool_warns(write_config: Callable[[str], Path]) -> None:
+def test_unknown_enabled_tool_warns(write_config: Callable[..., Path]) -> None:
     """Unknown names in execution.enabled_tools should warn.
 
     Args:
@@ -156,7 +156,7 @@ execution:
     assert_that(any("black" in m for m in messages)).is_true()
 
 
-def test_unknown_top_level_key_warns(write_config: Callable[[str], Path]) -> None:
+def test_unknown_top_level_key_warns(write_config: Callable[..., Path]) -> None:
     """Unknown top-level keys should warn.
 
     Args:
@@ -170,7 +170,7 @@ def test_unknown_top_level_key_warns(write_config: Callable[[str], Path]) -> Non
     assert_that(locations).contains("bogus_section")
 
 
-def test_deprecated_key_warns(write_config: Callable[[str], Path]) -> None:
+def test_deprecated_key_warns(write_config: Callable[..., Path]) -> None:
     """A deprecated key should warn with its replacement.
 
     Args:
@@ -191,7 +191,7 @@ enforce:
     assert_that(dep[0].suggestion).is_equal_to("line_length")
 
 
-def test_invalid_value_type_is_error(write_config: Callable[[str], Path]) -> None:
+def test_invalid_value_type_is_error(write_config: Callable[..., Path]) -> None:
     """A bad execution value type should be a hard error.
 
     Args:
@@ -211,7 +211,7 @@ execution:
 
 
 def test_invalid_auto_install_reports_tool_name(
-    write_config: Callable[[str], Path],
+    write_config: Callable[..., Path],
 ) -> None:
     """auto_install type errors should name the offending tool.
 
@@ -232,7 +232,7 @@ tools:
     assert_that(result.errors[0].message).contains("tools.ruff.auto_install")
 
 
-def test_non_mapping_root_is_error(write_config: Callable[[str], Path]) -> None:
+def test_non_mapping_root_is_error(write_config: Callable[..., Path]) -> None:
     """A non-mapping root document should be a hard error.
 
     Args:
@@ -246,7 +246,7 @@ def test_non_mapping_root_is_error(write_config: Callable[[str], Path]) -> None:
     assert_that(result.errors[0].message).contains("mapping")
 
 
-def test_empty_config_warns(write_config: Callable[[str], Path]) -> None:
+def test_empty_config_warns(write_config: Callable[..., Path]) -> None:
     """An empty config file should warn rather than error.
 
     Args:
@@ -260,7 +260,7 @@ def test_empty_config_warns(write_config: Callable[[str], Path]) -> None:
     assert_that(result.warnings[0].message).contains("empty")
 
 
-def test_malformed_yaml_is_error(write_config: Callable[[str], Path]) -> None:
+def test_malformed_yaml_is_error(write_config: Callable[..., Path]) -> None:
     """Unparseable YAML should be reported as an error.
 
     Args:
@@ -275,7 +275,7 @@ def test_malformed_yaml_is_error(write_config: Callable[[str], Path]) -> None:
 
 
 def test_pyproject_typed_error_is_reported(
-    write_config: Callable[[str], Path],
+    write_config: Callable[..., Path],
 ) -> None:
     """Typed errors in a pyproject.toml [tool.lintro] table are reported.
 
@@ -301,7 +301,7 @@ max_fix_retries = "not-an-int"
 
 
 def test_pyproject_valid_config_passes(
-    write_config: Callable[[str], Path],
+    write_config: Callable[..., Path],
 ) -> None:
     """A valid pyproject.toml [tool.lintro] table validates cleanly.
 

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -9,10 +9,13 @@ import pytest
 from assertpy import assert_that
 
 from lintro.config.config_validator import (
+    KNOWN_TOP_LEVEL_KEYS,
     ValidationMessage,
     known_tool_names,
     validate_config_file,
 )
+from lintro.config.lintro_config import LintroConfig
+from lintro.enums.validation_code import ValidationCode
 
 
 @pytest.fixture
@@ -47,6 +50,7 @@ def test_known_tool_names_includes_canonical_and_hyphen() -> None:
 def test_validation_message_render_with_suggestion() -> None:
     """Render should include location and did-you-mean suggestion."""
     msg = ValidationMessage(
+        code=ValidationCode.UNKNOWN_TOOL,
         message="unknown tool 'ruft'",
         location="tools",
         suggestion="ruff",
@@ -319,3 +323,201 @@ max_fix_retries = 3
     result = validate_config_file(path)
 
     assert_that(result.is_valid).is_true()
+
+
+def test_known_top_level_keys_cover_schema_fields() -> None:
+    """Every LintroConfig field must be an accepted top-level section."""
+    schema_fields = set(LintroConfig.model_fields) - {"config_path"}
+
+    assert_that(set(KNOWN_TOP_LEVEL_KEYS)).contains(*sorted(schema_fields))
+
+
+@pytest.mark.parametrize(
+    "section",
+    ["score", "output", "plugins", "licenses", "module_size", "post_checks"],
+)
+def test_documented_sections_do_not_warn(
+    write_config: Callable[..., Path],
+    section: str,
+) -> None:
+    """Sections the loader honors must not be reported as unknown options.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+        section: Top-level section name to place in the config.
+    """
+    path = write_config(f"{section}:\n  enabled: true\n")
+
+    result = validate_config_file(path)
+
+    locations = [w.location for w in result.warnings]
+    assert_that(locations).does_not_contain(section)
+
+
+def test_score_section_unknown_key_warns(write_config: Callable[..., Path]) -> None:
+    """Unknown keys nested under ``score`` should warn like other sections.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config("score:\n  error_weight: 5\n  bogus_weight: 1\n")
+
+    result = validate_config_file(path)
+
+    warnings = [w for w in result.warnings if w.location == "score.bogus_weight"]
+    assert_that(warnings).is_length(1)
+    assert_that(warnings[0].code).is_equal_to(ValidationCode.UNKNOWN_OPTION)
+
+
+@pytest.mark.parametrize(
+    ("content", "location", "suggestion"),
+    [
+        ("enforce:\n  line-length: 88\n", "enforce.line-length", "line_length"),
+        (
+            "enforce:\n  target-python: py311\n",
+            "enforce.target-python",
+            "target_python",
+        ),
+        ("global:\n  line_length: 88\n", "global", "enforce"),
+    ],
+)
+def test_deprecated_keys_warn_with_replacement(
+    write_config: Callable[..., Path],
+    content: str,
+    location: str,
+    suggestion: str,
+) -> None:
+    """Each deprecated key should warn and name its modern replacement.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+        content: Config file body containing the deprecated key.
+        location: Expected dotted location of the warning.
+        suggestion: Expected replacement key name.
+    """
+    path = write_config(content)
+
+    result = validate_config_file(path)
+
+    matches = [w for w in result.warnings if w.location == location]
+    assert_that(matches).is_length(1)
+    assert_that(matches[0].code).is_equal_to(ValidationCode.DEPRECATED_OPTION)
+    assert_that(matches[0].suggestion).is_equal_to(suggestion)
+
+
+@pytest.mark.parametrize("section", ["enforce", "execution", "tools", "defaults"])
+def test_null_section_is_error_not_crash(
+    write_config: Callable[..., Path],
+    section: str,
+) -> None:
+    """An empty (null) YAML section should report INVALID, not traceback.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+        section: Top-level section spelled with no value.
+    """
+    path = write_config(f"{section}:\n")
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.INVALID_TYPE)
+    assert_that(result.errors[0].location).is_equal_to(section)
+    assert_that(result.errors[0].message).contains("mapping")
+    assert_that(result.errors[0].message).contains("null")
+
+
+def test_scalar_section_is_error(write_config: Callable[..., Path]) -> None:
+    """A scalar where a mapping is expected should be a hard error.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config("tools: 5\n")
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].location).is_equal_to("tools")
+
+
+def test_empty_mapping_does_not_validate_discovered_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit empty-mapping file must not fall through to auto-discovery.
+
+    ``load_config`` treats a falsy config as "nothing found" and searches
+    upward, which would silently validate a different file than requested.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    (tmp_path / ".lintro-config.yaml").write_text(
+        'execution:\n  max_fix_retries: "bad"\n',
+        encoding="utf-8",
+    )
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    target = nested / "custom.yaml"
+    target.write_text("{}\n", encoding="utf-8")
+    monkeypatch.chdir(nested)
+
+    result = validate_config_file(target)
+
+    assert_that(result.config_path).is_equal_to(target)
+    assert_that(result.errors).is_empty()
+    assert_that(result.is_valid).is_true()
+
+
+def test_autodetect_falls_back_to_pyproject(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-detect should validate [tool.lintro] when no YAML config exists.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[tool.lintro]\nmax_fix_retries = "not-an-int"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = validate_config_file(None)
+
+    assert_that(result.config_path).is_equal_to(pyproject)
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].message).contains("max_fix_retries")
+
+
+def test_findings_carry_stable_codes(write_config: Callable[..., Path]) -> None:
+    """Findings should expose machine-readable codes for --json consumers.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config("tools:\n  ruft:\n    enabled: true\nbogus: 1\n")
+
+    result = validate_config_file(path)
+
+    codes = {w.code for w in result.warnings}
+    assert_that(codes).contains(
+        ValidationCode.UNKNOWN_TOOL,
+        ValidationCode.UNKNOWN_OPTION,
+    )
+
+
+def test_missing_file_uses_not_found_code(tmp_path: Path) -> None:
+    """A nonexistent explicit path should carry the not_found code.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+    """
+    result = validate_config_file(tmp_path / "nope.yaml")
+
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.NOT_FOUND)

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -722,6 +722,46 @@ def test_autodetect_malformed_pyproject_is_parse_error(
     assert_that(result.errors[0].code).is_equal_to(ValidationCode.PARSE_ERROR)
 
 
+def test_autodetect_empty_yaml_without_pyproject_is_not_found(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty YAML with no pyproject fallback is not a successful config.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    yaml_path = tmp_path / ".lintro-config.yaml"
+    yaml_path.write_text("", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    result = validate_config_file(None)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.NOT_FOUND)
+    assert_that(result.warnings[0].code).is_equal_to(ValidationCode.EMPTY_CONFIG)
+
+
+def test_explicit_pyproject_without_lintro_table_is_empty(
+    write_config: Callable[..., Path],
+) -> None:
+    """An explicit pyproject.toml without [tool.lintro] is EMPTY_CONFIG.
+
+    Args:
+        write_config: Fixture writing config content to a temp file.
+    """
+    path = write_config(
+        '[project]\nname = "example"\n',
+        name="pyproject.toml",
+    )
+
+    result = validate_config_file(path)
+
+    assert_that(result.is_valid).is_false()
+    assert_that(result.errors[0].code).is_equal_to(ValidationCode.EMPTY_CONFIG)
+
+
 def test_plugin_tool_name_is_not_unknown(
     write_config: Callable[..., Path],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/config/test_config_validator.py
+++ b/tests/unit/config/test_config_validator.py
@@ -403,6 +403,9 @@ def test_deprecated_keys_warn_with_replacement(
     assert_that(matches).is_length(1)
     assert_that(matches[0].code).is_equal_to(ValidationCode.DEPRECATED_OPTION)
     assert_that(matches[0].suggestion).is_equal_to(suggestion)
+    # The loader reads only the modern names, so the message must not imply
+    # the deprecated spelling still takes effect.
+    assert_that(matches[0].message).contains("no longer applied")
 
 
 @pytest.mark.parametrize("section", ["enforce", "execution", "tools", "defaults"])

--- a/tests/unit/enums/test_validation_code.py
+++ b/tests/unit/enums/test_validation_code.py
@@ -1,0 +1,39 @@
+"""Tests for the config-validate JSON code contract."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.enums.validation_code import ValidationCode
+
+
+def test_validation_code_json_values_are_snake_case() -> None:
+    """Each ValidationCode.value is the lowercase snake_case JSON string."""
+    assert_that(ValidationCode.NOT_FOUND.value).is_equal_to("not_found")
+    assert_that(ValidationCode.PARSE_ERROR.value).is_equal_to("parse_error")
+    assert_that(ValidationCode.EMPTY_CONFIG.value).is_equal_to("empty_config")
+    assert_that(ValidationCode.INVALID_TYPE.value).is_equal_to("invalid_type")
+    assert_that(ValidationCode.UNKNOWN_OPTION.value).is_equal_to("unknown_option")
+    assert_that(ValidationCode.DEPRECATED_OPTION.value).is_equal_to(
+        "deprecated_option",
+    )
+    assert_that(ValidationCode.UNKNOWN_TOOL.value).is_equal_to("unknown_tool")
+    assert_that(ValidationCode.MISSING_DEPENDENCY.value).is_equal_to(
+        "missing_dependency",
+    )
+
+
+def test_validation_code_members_match_explicit_vocabulary() -> None:
+    """The public JSON vocabulary must stay exactly these eight codes."""
+    assert_that({member.value for member in ValidationCode}).is_equal_to(
+        {
+            "not_found",
+            "parse_error",
+            "empty_config",
+            "invalid_type",
+            "unknown_option",
+            "deprecated_option",
+            "unknown_tool",
+            "missing_dependency",
+        },
+    )

--- a/tests/unit/exceptions/test_exceptions.py
+++ b/tests/unit/exceptions/test_exceptions.py
@@ -105,6 +105,14 @@ def test_subclass_caught_by_base_exception(exception_class: type) -> None:
         raise exception_class("caught by base")
 
 
+def test_configuration_error_is_value_error() -> None:
+    """ConfigurationError must remain catchable as ValueError."""
+    exc = ConfigurationError("bad config")
+
+    assert_that(exc).is_instance_of(ValueError)
+    assert_that(exc).is_instance_of(LintroError)
+
+
 def test_exception_args_preserved() -> None:
     """Test exception args are preserved for introspection."""
     exc = ToolExecutionError("tool failed", "extra", "info")


### PR DESCRIPTION
## What's Changing

Implements `lintro config validate` and related config subcommands from #445.

`lintro config` becomes a Click command group. Bare invocation and the `cfg`
alias keep their existing behavior (the effective-config report), so this is
backward compatible with `config --json` / `--verbose` / `--export`.

New subcommands:

- **`config validate`** — schema-aware validation of `.lintro-config.yaml`
  (also handles `pyproject.toml` `[tool.lintro]`). Reports:
  - **errors** (exit 1): invalid value types (e.g. `execution.max_fix_retries`),
    bad `auto_install` types, unparseable YAML, non-mapping roots.
  - **warnings**: unknown tools with did-you-mean suggestions (`ruft` → `ruff`),
    unknown/deprecated options, unknown tool sub-keys.
  - Supports `--path` and `--json`.
- **`config show`** — explicit alias for the effective-config report.
- **`config init`** — reuses the existing top-level `init` scaffolding.

Also threads the tool name into `tools.<name>.auto_install` validation errors
for clearer debugging (CR nitpick from #569, tracked in this issue).

## Why

Catches configuration mistakes early with actionable messages, and rounds out
the config command surface requested in the issue.

## Design Notes

- New pure module `lintro/config/config_validator.py` (`validate_config_file` →
  `ValidationResult`) is decoupled from Click for direct unit testing.
- Known tool names derive from the static `ToolName` enum (underscore +
  hyphen forms + `markdownlint-cli2`), avoiding heavy plugin discovery.
- Hard errors are surfaced by running the real config loader and catching
  `ValueError`, so validation stays in lockstep with the loader.

## Testing

- `tests/unit/config/test_config_validator.py` — validator happy/invalid paths,
  typo suggestions, deprecated keys, malformed YAML, empty/non-mapping roots.
- `tests/cli/test_config_validate_command.py` — CLI wiring for validate/show/init,
  exit codes, `--json`, `--path`.
- Full suite: 6023 passed; only the two known env-only pre-existing failures
  (`test_markdownlint_direct_vs_lintro_parity`,
  `test_prepare_execution_version_check_fails_returns_early_result`).
- `ruff check`, `ruff format`, and `mypy` clean on changed files.

Closes #445

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds config validation and expands the `lintro config` command surface.

- Adds `config validate` for schema-aware YAML and pyproject checks.
- Adds `config show` as an explicit effective-config report command.
- Adds `config init` as a nested entry point for config scaffolding.
- Shares typed config parsing through `build_config_from_dict()`.
- Updates validation codes and tests for the new command paths.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.
- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/config/config_validator.py | Adds the config validator and validates normalized YAML or pyproject data through the shared typed parser. |
| lintro/config/config_loader.py | Adds shared parsed-dict config construction and routes supported execution fields through the loader. |
| lintro/cli_utils/commands/config.py | Changes `config` into a command group while keeping the existing bare report behavior. |

</details>

<sub>Reviews (13): Last reviewed commit: ["fix(config): say deprecated config keys ..."](https://github.com/lgtm-hq/py-lintro/commit/e1586353c165e7f751aebfd0cad39c38b6f0ec9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42273933)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `config show`, `config validate`, and `config init` subcommands.
  * Added structured configuration validation with Rich or JSON output and stable error codes.
  * Added support for nested `execution` and `enforce` settings in `pyproject.toml`.

* **Bug Fixes**
  * Check and format commands now report configuration errors cleanly and exit with status 1.
  * Invalid, null, malformed, or non-mapping configurations are handled safely.

* **Documentation**
  * Expanded configuration documentation for supported formats, settings, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->