### PR TITLE
ci(release): automate lintro-pre-commit mirror version bumps

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -55,6 +55,7 @@ documentation of their purposes and security considerations.
 | Secret Name                   | Purpose                                             | Scope                                      | Rotation                  |
 | ----------------------------- | --------------------------------------------------- | ------------------------------------------ | ------------------------- |
 | `GITHUB_TOKEN`                | Built-in token for GitHub API access                | Automatic                                  | Per-workflow              |
+| `MIRROR_REPO_TOKEN`           | Bump/tag the lintro-pre-commit mirror on release    | Contents + pull-requests write on mirror   | On compromise or key roll |
 | `HOMEBREW_TAP_DISPATCH_TOKEN` | Trigger tap formula updates via repository_dispatch | Dispatch-only on `homebrew-tap` (no write) | On compromise or key roll |
 | `CODECOV_TOKEN`               | Upload coverage reports                             | Codecov org                                | As needed                 |
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -75,8 +75,9 @@ comments so Renovate can track digest updates. Policy is enforced by
   `scripts/ci/mirror/`; see `docs/pre-commit.md`)
 
 Both callers set a dynamic `run-name` (event + branch) so post-merge release failures
-are traceable from the Actions list rather than the default commit subject. Failure
-visibility itself lives upstream: the reusables run a `report-release-failure` job that
+are traceable from the Actions list rather than the default commit subject. The mirror
+workflow (`mirror-release.yml`) uses a fixed run name because it is triggered by release
+events rather than branch pushes. Failure visibility itself lives upstream: the reusables run a `report-release-failure` job that
 writes trigger context to the step summary and opens/updates a deduplicated GitHub issue
 on `main` failures — hence the `actions: read` + `issues: write` job permissions.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -77,9 +77,10 @@ comments so Renovate can track digest updates. Policy is enforced by
 Both callers set a dynamic `run-name` (event + branch) so post-merge release failures
 are traceable from the Actions list rather than the default commit subject. The mirror
 workflow (`mirror-release.yml`) uses a fixed run name because it is triggered by release
-events rather than branch pushes. Failure visibility itself lives upstream: the reusables run a `report-release-failure` job that
-writes trigger context to the step summary and opens/updates a deduplicated GitHub issue
-on `main` failures — hence the `actions: read` + `issues: write` job permissions.
+events rather than branch pushes. Failure visibility itself lives upstream: the
+reusables run a `report-release-failure` job that writes trigger context to the step
+summary and opens/updates a deduplicated GitHub issue on `main` failures — hence the
+`actions: read` + `issues: write` job permissions.
 
 ## Publish
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -69,6 +69,10 @@ comments so Renovate can track digest updates. Policy is enforced by
 - **release-auto-tag.yml** — Creates tags on release commits via
   `reusable-release-auto-tag.yml` (`create-release: false`; GitHub Release is created by
   publish workflow)
+- **mirror-release.yml** — On `release: published`, bumps the `lintro` pin in the
+  `lgtm-hq/lintro-pre-commit` mirror, merges the version-bump PR, and tags the
+  mirror `vX.Y.Z` so pre-commit consumers install the matching wheel (scripts under
+  `scripts/ci/mirror/`; see `docs/pre-commit.md`)
 
 Both callers set a dynamic `run-name` (event + branch) so post-merge release failures
 are traceable from the Actions list rather than the default commit subject. Failure
@@ -123,6 +127,9 @@ on `main` failures — hence the `actions: read` + `issues: write` job permissio
 - **`secrets.GITHUB_TOKEN`** — CI, PR comments, artifacts
 - **`secrets.RELEASE_APP_*`** — Release PR and auto-tag (GitHub App installation token
   via lgtm-ci release workflows)
+- **`secrets.MIRROR_REPO_TOKEN`** — Cross-repo write to `lgtm-hq/lintro-pre-commit`
+  (fine-grained PAT or GitHub App token with contents + pull-requests write on that
+  repo) used by `mirror-release.yml`
 
 ## Concurrency
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -70,8 +70,8 @@ comments so Renovate can track digest updates. Policy is enforced by
   `reusable-release-auto-tag.yml` (`create-release: false`; GitHub Release is created by
   publish workflow)
 - **mirror-release.yml** — On `release: published`, bumps the `lintro` pin in the
-  `lgtm-hq/lintro-pre-commit` mirror, merges the version-bump PR, and tags the
-  mirror `vX.Y.Z` so pre-commit consumers install the matching wheel (scripts under
+  `lgtm-hq/lintro-pre-commit` mirror, merges the version-bump PR, and tags the mirror
+  `vX.Y.Z` so pre-commit consumers install the matching wheel (scripts under
   `scripts/ci/mirror/`; see `docs/pre-commit.md`)
 
 Both callers set a dynamic `run-name` (event + branch) so post-merge release failures

--- a/.github/workflows/mirror-release.yml
+++ b/.github/workflows/mirror-release.yml
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Release - Mirror Version Bump
+
+# On each published py-lintro release, bump the lintro pin in the
+# lgtm-hq/lintro-pre-commit mirror, merge the version-bump PR, and tag the
+# mirror with the matching version so pre-commit consumers install the new
+# wheel. See docs/pre-commit.md and issue #1171.
+
+'on':
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to mirror (e.g. v0.69.0)'
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: mirror-release-${{ github.event.release.tag_name || inputs.release_tag }}
+  cancel-in-progress: false
+
+jobs:
+  mirror-bump:
+    name: Bump lintro-pre-commit mirror
+    runs-on: ubuntu-24.04
+    permissions:
+      # read: checkout py-lintro CI scripts (mirror writes use MIRROR_REPO_TOKEN)
+      contents: read
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            uploads.github.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+
+      - name: Checkout lintro scripts
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          sparse-checkout: scripts
+          persist-credentials: false
+          path: lintro
+
+      - name: Resolve release version
+        id: resolve
+        run: lintro/scripts/ci/mirror/resolve-version.sh
+
+      - name: Wait for PyPI availability
+        if: ${{ steps.resolve.outputs.is_prerelease == 'false' }}
+        # yamllint disable-line rule:line-length
+        run: lintro/scripts/ci/homebrew/wait-for-pypi.sh lintro "${{ steps.resolve.outputs.version }}"
+
+      - name: Set up Python
+        if: ${{ steps.resolve.outputs.is_prerelease == 'false' }}
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.14'
+
+      - name: Checkout lintro-pre-commit mirror
+        if: ${{ steps.resolve.outputs.is_prerelease == 'false' }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          repository: lgtm-hq/lintro-pre-commit
+          token: ${{ secrets.MIRROR_REPO_TOKEN }}
+          path: mirror
+
+      - name: Publish mirror release
+        if: ${{ steps.resolve.outputs.is_prerelease == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.MIRROR_REPO_TOKEN }}
+          MIRROR_DIR: mirror
+          BUMP_SCRIPT: >-
+            ${{ github.workspace }}/lintro/scripts/ci/mirror/bump_pin.py
+        # yamllint disable-line rule:line-length
+        run: lintro/scripts/ci/mirror/publish-mirror-release.sh "${{ steps.resolve.outputs.version }}"

--- a/.github/workflows/mirror-release.yml
+++ b/.github/workflows/mirror-release.yml
@@ -21,13 +21,14 @@ name: Release - Mirror Version Bump
 permissions: {}
 
 concurrency:
-  group: mirror-release-${{ github.event.release.tag_name || inputs.release_tag }}
+  group: mirror-release
   cancel-in-progress: false
 
 jobs:
   mirror-bump:
     name: Bump lintro-pre-commit mirror
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     permissions:
       # read: checkout py-lintro CI scripts (mirror writes use MIRROR_REPO_TOKEN)
       contents: read
@@ -60,19 +61,19 @@ jobs:
         id: resolve
         run: lintro/scripts/ci/mirror/resolve-version.sh
 
-      - name: Wait for PyPI availability
-        if: ${{ steps.resolve.outputs.is_prerelease == 'false' }}
+      - name: Wait for PyPI wheel
+        if: >-
+          ${{ steps.resolve.outputs.is_prerelease == 'false' &&
+          (github.event_name != 'release' || !github.event.release.prerelease) }}
+        env:
+          LINTRO_VERSION: ${{ steps.resolve.outputs.version }}
         # yamllint disable-line rule:line-length
-        run: lintro/scripts/ci/homebrew/wait-for-pypi.sh lintro "${{ steps.resolve.outputs.version }}"
-
-      - name: Set up Python
-        if: ${{ steps.resolve.outputs.is_prerelease == 'false' }}
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
-        with:
-          python-version: '3.14'
+        run: lintro/scripts/ci/mirror/wait-for-pypi-wheel.sh lintro "$LINTRO_VERSION"
 
       - name: Checkout lintro-pre-commit mirror
-        if: ${{ steps.resolve.outputs.is_prerelease == 'false' }}
+        if: >-
+          ${{ steps.resolve.outputs.is_prerelease == 'false' &&
+          (github.event_name != 'release' || !github.event.release.prerelease) }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: lgtm-hq/lintro-pre-commit
@@ -80,11 +81,14 @@ jobs:
           path: mirror
 
       - name: Publish mirror release
-        if: ${{ steps.resolve.outputs.is_prerelease == 'false' }}
+        if: >-
+          ${{ steps.resolve.outputs.is_prerelease == 'false' &&
+          (github.event_name != 'release' || !github.event.release.prerelease) }}
         env:
           GH_TOKEN: ${{ secrets.MIRROR_REPO_TOKEN }}
           MIRROR_DIR: mirror
           BUMP_SCRIPT: >-
             ${{ github.workspace }}/lintro/scripts/ci/mirror/bump_pin.py
+          LINTRO_VERSION: ${{ steps.resolve.outputs.version }}
         # yamllint disable-line rule:line-length
-        run: lintro/scripts/ci/mirror/publish-mirror-release.sh "${{ steps.resolve.outputs.version }}"
+        run: lintro/scripts/ci/mirror/publish-mirror-release.sh "$LINTRO_VERSION"

--- a/.github/workflows/mirror-release.yml
+++ b/.github/workflows/mirror-release.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: 'block'
           allowed-endpoints: >
@@ -50,7 +50,7 @@ jobs:
             files.pythonhosted.org:443
 
       - name: Checkout lintro scripts
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: scripts
           persist-credentials: false
@@ -67,13 +67,13 @@ jobs:
 
       - name: Set up Python
         if: ${{ steps.resolve.outputs.is_prerelease == 'false' }}
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.14'
 
       - name: Checkout lintro-pre-commit mirror
         if: ${{ steps.resolve.outputs.is_prerelease == 'false' }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: lgtm-hq/lintro-pre-commit
           token: ${{ secrets.MIRROR_REPO_TOKEN }}

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -1,16 +1,16 @@
 # Pre-commit Integration
 
-Lintro ships hook definitions for the [pre-commit](https://pre-commit.com) framework so
-you can run quality checks and formatting automatically before every commit in **your
-own** repository.
+Lintro ships hook definitions for the [pre-commit](https://pre-commit.com)
+framework so you can run quality checks and formatting automatically before
+every commit in **your own** repository.
 
-> This is opt-in. Adding lintro to your `.pre-commit-config.yaml` is entirely up to you
-> — py-lintro itself does not enforce pre-commit.
+> This is opt-in. Adding lintro to your `.pre-commit-config.yaml` is entirely up
+> to you — py-lintro itself does not enforce pre-commit.
 
-The default hooks use your **system-installed lintro** (`language: system`). Lintro is
-written in Python but it's not a Python-only tool: it drives native binaries such as
-`hadolint` and `shellcheck` that a pip-isolated hook environment cannot provide, so a
-system install gives you the full tool set.
+The default hooks use your **system-installed lintro** (`language: system`).
+Lintro is written in Python but it's not a Python-only tool: it drives native
+binaries such as `hadolint` and `shellcheck` that a pip-isolated hook
+environment cannot provide, so a system install gives you the full tool set.
 
 ## Quick Start
 
@@ -46,8 +46,8 @@ system install gives you the full tool set.
    pre-commit run --all-files
    ```
 
-From now on, `git commit` runs `lintro check` against your staged files and blocks the
-commit if any issues are found.
+From now on, `git commit` runs `lintro check` against your staged files and
+blocks the commit if any issues are found.
 
 ## Available Hooks
 
@@ -58,9 +58,9 @@ commit if any issues are found.
 | `lintro-check-python`  | `lintro check`  | Isolated Python env (Python-based tools only) |
 | `lintro-format-python` | `lintro format` | Isolated Python env (Python-based tools only) |
 
-All hooks pass the staged filenames to lintro, so only the files you are committing are
-inspected. lintro applies each underlying tool only to the file types it supports, so a
-mixed set of staged files is fine.
+All hooks pass the staged filenames to lintro, so only the files you are
+committing are inspected. lintro applies each underlying tool only to the file
+types it supports, so a mixed set of staged files is fine.
 
 ### Check only (recommended default)
 
@@ -74,8 +74,8 @@ repos:
 
 ### Auto-format then check
 
-`lintro-format` rewrites files in place. When it changes a file, pre-commit marks the
-run as failed so you can review and re-stage the result:
+`lintro-format` rewrites files in place. When it changes a file, pre-commit
+marks the run as failed so you can review and re-stage the result:
 
 ```yaml
 repos:
@@ -99,10 +99,38 @@ repos:
         files: ^src/
 ```
 
-## Alternative: isolated Python environment
+## Hermetic hooks: the `lintro-pre-commit` mirror (recommended)
 
-If you prefer that pre-commit manage the lintro installation itself — no system install
-required — use the `-python` hook variants:
+If you want pre-commit to manage lintro itself — no system install required —
+use the dedicated mirror repository
+[`lgtm-hq/lintro-pre-commit`](https://github.com/lgtm-hq/lintro-pre-commit):
+
+```yaml
+repos:
+  - repo: https://github.com/lgtm-hq/lintro-pre-commit
+    rev: v0.69.0 # matches the pinned lintro version
+    hooks:
+      - id: lintro-check
+      # - id: lintro-format  # opt in for auto-formatting
+```
+
+The mirror is a tiny repo whose only job is to pin the published `lintro` wheel.
+pre-commit installs that wheel from [PyPI](https://pypi.org/project/lintro/) into
+its isolated environment, so the hook provisions in **seconds** and never builds
+py-lintro from source. This is the endorsed hermetic path — the same model
+[astral-sh/ruff-pre-commit](https://github.com/astral-sh/ruff-pre-commit) uses.
+
+The mirror's `rev:` tracks the lintro version it pins; each py-lintro release
+publishes a matching mirror tag automatically.
+
+## Alternative: isolated Python environment from this repo
+
+The `-python` hook variants also run in a pre-commit-managed Python env, but
+they install lintro by building **py-lintro from source** at the pinned `rev`
+(pre-commit clones this repository and runs a source build). That is slower and
+heavier than the mirror above; prefer the mirror for hermetic hooks and reach
+for these variants only if you specifically need to run against unreleased
+py-lintro code at a given `rev`:
 
 ```yaml
 repos:
@@ -112,26 +140,26 @@ repos:
       - id: lintro-check-python
 ```
 
-These use `language: python`, so pre-commit builds an isolated virtual environment and
-installs lintro from the pinned `rev`. This is hermetic and reproducible, but comes with
-an important limitation:
+Both the mirror and the `-python` variants use `language: python`, so they share
+one important limitation:
 
-> **Native tools do not run in the isolated env.** Only lintro's Python-based tools
-> (ruff, yamllint, ...) are available there. Native binaries such as `hadolint`,
-> `shellcheck`, or `prettier` are not installed into the hook environment, and lintro
-> will skip them. If you rely on those checks, use the default system hooks instead.
+> **Native tools do not run in the isolated env.** Only lintro's Python-based
+> tools (ruff, yamllint, ...) are available there. Native binaries such as
+> `hadolint`, `shellcheck`, or `prettier` are not installed into the hook
+> environment, and lintro will skip them. If you rely on those checks, use the
+> default system hooks instead.
 
-The first run of a `-python` hook is also slower because pre-commit provisions the
-environment (installing lintro and its dependencies from the repo); subsequent runs are
-cached.
+The first run of an isolated hook is also slower because pre-commit provisions
+the environment; subsequent runs are cached.
 
 ## Notes
 
-- The default (`system`) hooks require lintro on `PATH`; pre-commit fails with an
-  "Executable `lintro` not found" error otherwise — install it first (see Quick Start
-  step 1).
-- Always pin `rev:` to a released tag (not a branch) so hook runs are reproducible;
-  `pre-commit autoupdate` can bump it for you.
-- With `language: system`, the `rev:` selects which hook _definitions_ are used; the
-  lintro _version_ that runs is whatever is installed on the machine. With the `-python`
-  variants, `rev:` also pins the lintro version itself.
+- The default (`system`) hooks require lintro on `PATH`; pre-commit fails with
+  an "Executable `lintro` not found" error otherwise — install it first (see
+  Quick Start step 1).
+- Always pin `rev:` to a released tag (not a branch) so hook runs are
+  reproducible; `pre-commit autoupdate` can bump it for you.
+- With `language: system`, the `rev:` selects which hook _definitions_ are
+  used; the lintro _version_ that runs is whatever is installed on the machine.
+  With the mirror and the `-python` variants, `rev:` also pins the lintro
+  version itself.

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -1,16 +1,16 @@
 # Pre-commit Integration
 
-Lintro ships hook definitions for the [pre-commit](https://pre-commit.com)
-framework so you can run quality checks and formatting automatically before
-every commit in **your own** repository.
+Lintro ships hook definitions for the [pre-commit](https://pre-commit.com) framework so
+you can run quality checks and formatting automatically before every commit in **your
+own** repository.
 
-> This is opt-in. Adding lintro to your `.pre-commit-config.yaml` is entirely up
-> to you — py-lintro itself does not enforce pre-commit.
+> This is opt-in. Adding lintro to your `.pre-commit-config.yaml` is entirely up to you
+> — py-lintro itself does not enforce pre-commit.
 
-The default hooks use your **system-installed lintro** (`language: system`).
-Lintro is written in Python but it's not a Python-only tool: it drives native
-binaries such as `hadolint` and `shellcheck` that a pip-isolated hook
-environment cannot provide, so a system install gives you the full tool set.
+The default hooks use your **system-installed lintro** (`language: system`). Lintro is
+written in Python but it's not a Python-only tool: it drives native binaries such as
+`hadolint` and `shellcheck` that a pip-isolated hook environment cannot provide, so a
+system install gives you the full tool set.
 
 ## Quick Start
 
@@ -46,8 +46,8 @@ environment cannot provide, so a system install gives you the full tool set.
    pre-commit run --all-files
    ```
 
-From now on, `git commit` runs `lintro check` against your staged files and
-blocks the commit if any issues are found.
+From now on, `git commit` runs `lintro check` against your staged files and blocks the
+commit if any issues are found.
 
 ## Available Hooks
 
@@ -58,9 +58,9 @@ blocks the commit if any issues are found.
 | `lintro-check-python`  | `lintro check`  | Isolated Python env (Python-based tools only) |
 | `lintro-format-python` | `lintro format` | Isolated Python env (Python-based tools only) |
 
-All hooks pass the staged filenames to lintro, so only the files you are
-committing are inspected. lintro applies each underlying tool only to the file
-types it supports, so a mixed set of staged files is fine.
+All hooks pass the staged filenames to lintro, so only the files you are committing are
+inspected. lintro applies each underlying tool only to the file types it supports, so a
+mixed set of staged files is fine.
 
 ### Check only (recommended default)
 
@@ -74,8 +74,8 @@ repos:
 
 ### Auto-format then check
 
-`lintro-format` rewrites files in place. When it changes a file, pre-commit
-marks the run as failed so you can review and re-stage the result:
+`lintro-format` rewrites files in place. When it changes a file, pre-commit marks the
+run as failed so you can review and re-stage the result:
 
 ```yaml
 repos:
@@ -101,8 +101,8 @@ repos:
 
 ## Hermetic hooks: the `lintro-pre-commit` mirror (recommended)
 
-If you want pre-commit to manage lintro itself — no system install required —
-use the dedicated mirror repository
+If you want pre-commit to manage lintro itself — no system install required — use the
+dedicated mirror repository
 [`lgtm-hq/lintro-pre-commit`](https://github.com/lgtm-hq/lintro-pre-commit):
 
 ```yaml
@@ -115,22 +115,21 @@ repos:
 ```
 
 The mirror is a tiny repo whose only job is to pin the published `lintro` wheel.
-pre-commit installs that wheel from [PyPI](https://pypi.org/project/lintro/) into
-its isolated environment, so the hook provisions in **seconds** and never builds
-py-lintro from source. This is the endorsed hermetic path — the same model
+pre-commit installs that wheel from [PyPI](https://pypi.org/project/lintro/) into its
+isolated environment, so the hook provisions in **seconds** and never builds py-lintro
+from source. This is the endorsed hermetic path — the same model
 [astral-sh/ruff-pre-commit](https://github.com/astral-sh/ruff-pre-commit) uses.
 
-The mirror's `rev:` tracks the lintro version it pins; each py-lintro release
-publishes a matching mirror tag automatically.
+The mirror's `rev:` tracks the lintro version it pins; each py-lintro release publishes
+a matching mirror tag automatically.
 
 ## Alternative: isolated Python environment from this repo
 
-The `-python` hook variants also run in a pre-commit-managed Python env, but
-they install lintro by building **py-lintro from source** at the pinned `rev`
-(pre-commit clones this repository and runs a source build). That is slower and
-heavier than the mirror above; prefer the mirror for hermetic hooks and reach
-for these variants only if you specifically need to run against unreleased
-py-lintro code at a given `rev`:
+The `-python` hook variants also run in a pre-commit-managed Python env, but they
+install lintro by building **py-lintro from source** at the pinned `rev` (pre-commit
+clones this repository and runs a source build). That is slower and heavier than the
+mirror above; prefer the mirror for hermetic hooks and reach for these variants only if
+you specifically need to run against unreleased py-lintro code at a given `rev`:
 
 ```yaml
 repos:
@@ -140,26 +139,24 @@ repos:
       - id: lintro-check-python
 ```
 
-Both the mirror and the `-python` variants use `language: python`, so they share
-one important limitation:
+Both the mirror and the `-python` variants use `language: python`, so they share one
+important limitation:
 
-> **Native tools do not run in the isolated env.** Only lintro's Python-based
-> tools (ruff, yamllint, ...) are available there. Native binaries such as
-> `hadolint`, `shellcheck`, or `prettier` are not installed into the hook
-> environment, and lintro will skip them. If you rely on those checks, use the
-> default system hooks instead.
+> **Native tools do not run in the isolated env.** Only lintro's Python-based tools
+> (ruff, yamllint, ...) are available there. Native binaries such as `hadolint`,
+> `shellcheck`, or `prettier` are not installed into the hook environment, and lintro
+> will skip them. If you rely on those checks, use the default system hooks instead.
 
-The first run of an isolated hook is also slower because pre-commit provisions
-the environment; subsequent runs are cached.
+The first run of an isolated hook is also slower because pre-commit provisions the
+environment; subsequent runs are cached.
 
 ## Notes
 
-- The default (`system`) hooks require lintro on `PATH`; pre-commit fails with
-  an "Executable `lintro` not found" error otherwise — install it first (see
-  Quick Start step 1).
-- Always pin `rev:` to a released tag (not a branch) so hook runs are
-  reproducible; `pre-commit autoupdate` can bump it for you.
-- With `language: system`, the `rev:` selects which hook _definitions_ are
-  used; the lintro _version_ that runs is whatever is installed on the machine.
-  With the mirror and the `-python` variants, `rev:` also pins the lintro
-  version itself.
+- The default (`system`) hooks require lintro on `PATH`; pre-commit fails with an
+  "Executable `lintro` not found" error otherwise — install it first (see Quick Start
+  step 1).
+- Always pin `rev:` to a released tag (not a branch) so hook runs are reproducible;
+  `pre-commit autoupdate` can bump it for you.
+- With `language: system`, the `rev:` selects which hook _definitions_ are used; the
+  lintro _version_ that runs is whatever is installed on the machine. With the mirror
+  and the `-python` variants, `rev:` also pins the lintro version itself.

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -122,7 +122,8 @@ from source. This is the endorsed hermetic path — the same model
 
 The mirror's `rev:` tracks the lintro version it pins. For each **stable** py-lintro
 release, CI waits for the published wheel on PyPI, bumps the mirror pin, and tags the
-mirror automatically once `MIRROR_REPO_TOKEN` is configured. Prerelease tags are skipped.
+mirror automatically once `MIRROR_REPO_TOKEN` is configured. Prerelease tags are
+skipped.
 
 ## Alternative: isolated Python environment from this repo
 

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -120,8 +120,9 @@ isolated environment, so the hook provisions in **seconds** and never builds py-
 from source. This is the endorsed hermetic path — the same model
 [astral-sh/ruff-pre-commit](https://github.com/astral-sh/ruff-pre-commit) uses.
 
-The mirror's `rev:` tracks the lintro version it pins; each py-lintro release publishes
-a matching mirror tag automatically.
+The mirror's `rev:` tracks the lintro version it pins. For each **stable** py-lintro
+release, CI waits for the published wheel on PyPI, bumps the mirror pin, and tags the
+mirror automatically once `MIRROR_REPO_TOKEN` is configured. Prerelease tags are skipped.
 
 ## Alternative: isolated Python environment from this repo
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -87,6 +87,18 @@ renders, validates, and auto-merges `Formula/lintro.rb` (binary) and
 `Formula/lintro-full.rb` (PyPI full install). Only release-support helpers remain here
 (see Homebrew Scripts below).
 
+### 🪞 Mirror Release Scripts (`ci/mirror/`)
+
+Scripts that sync the `lgtm-hq/lintro-pre-commit` pre-commit mirror on each
+py-lintro release (see [pre-commit integration](../docs/pre-commit.md)). Driven
+by `.github/workflows/mirror-release.yml`.
+
+| Script                      | Purpose                                                    | Usage                                                                              |
+| --------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `resolve-version.sh`        | Resolve the release tag/version and prerelease flag        | `RELEASE_TAG=v1.2.3 ./scripts/ci/mirror/resolve-version.sh`                        |
+| `bump_pin.py`               | Rewrite/verify the `lintro==X.Y.Z` pin in mirror pyproject | `python3 scripts/ci/mirror/bump_pin.py --pyproject pyproject.toml --version 1.2.3` |
+| `publish-mirror-release.sh` | Bump pin, merge the version-bump PR, and tag the mirror    | `GH_TOKEN=… ./scripts/ci/mirror/publish-mirror-release.sh 1.2.3`                   |
+
 ### 🔧 CI/CD Scripts (`ci/`)
 
 Scripts for GitHub Actions workflows and continuous integration.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -89,9 +89,9 @@ renders, validates, and auto-merges `Formula/lintro.rb` (binary) and
 
 ### 🪞 Mirror Release Scripts (`ci/mirror/`)
 
-Scripts that sync the `lgtm-hq/lintro-pre-commit` pre-commit mirror on each
-py-lintro release (see [pre-commit integration](../docs/pre-commit.md)). Driven
-by `.github/workflows/mirror-release.yml`.
+Scripts that sync the `lgtm-hq/lintro-pre-commit` pre-commit mirror on each py-lintro
+release (see [pre-commit integration](../docs/pre-commit.md)). Driven by
+`.github/workflows/mirror-release.yml`.
 
 | Script                      | Purpose                                                    | Usage                                                                              |
 | --------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------- |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -96,6 +96,7 @@ release (see [pre-commit integration](../docs/pre-commit.md)). Driven by
 | Script                      | Purpose                                                    | Usage                                                                              |
 | --------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | `resolve-version.sh`        | Resolve the release tag/version and prerelease flag        | `RELEASE_TAG=v1.2.3 ./scripts/ci/mirror/resolve-version.sh`                        |
+| `wait-for-pypi-wheel.sh`    | Poll PyPI until a `bdist_wheel` exists for the version     | `./scripts/ci/mirror/wait-for-pypi-wheel.sh lintro 1.2.3`                          |
 | `bump_pin.py`               | Rewrite/verify the `lintro==X.Y.Z` pin in mirror pyproject | `python3 scripts/ci/mirror/bump_pin.py --pyproject pyproject.toml --version 1.2.3` |
 | `publish-mirror-release.sh` | Bump pin, merge the version-bump PR, and tag the mirror    | `GH_TOKEN=… ./scripts/ci/mirror/publish-mirror-release.sh 1.2.3`                   |
 

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -9,6 +9,7 @@ scripts/ci/
 ├── deployment/          # SBOM helpers and PyPI release validation
 ├── github/              # PR comment posting and cleanup
 ├── homebrew/            # Homebrew formula generation and tap PRs
+├── mirror/              # lintro-pre-commit pin bump + tag automation
 ├── maintenance/         # GHCR prune, security audit, egress checks
 ├── testing/             # Test summaries, image pull helpers
 ├── coverage-badge-update.sh  # Wrapper → testing/coverage-badge-update.sh
@@ -31,6 +32,7 @@ scripts/ci/
 | `publish-pypi-on-tag.yml`     | lgtm-ci quality/SBOM; `build-artifacts` + PyPI publish + GitHub release                                                          |
 | `docker-build-publish.yml`    | `validate-docker-backfill-inputs.sh`, `resolve-allowed-endpoints.sh` (shared harden-runner allowlist, #1821)                     |
 | `pr-comment-cleanup.yml`      | `post-pr-delete-previous.sh`                                                                                                     |
+| `mirror-release.yml`          | `mirror/resolve-version.sh`, `mirror/wait-for-pypi-wheel.sh`, `mirror/publish-mirror-release.sh`                                 |
 | `lintro-report-scheduled.yml` | `resolve-lintro-image.sh`, `pull-lintro-image.sh`, `lintro-report-generate.sh`                                                   |
 | GHCR cleanup (scheduled)      | lgtm-ci `reusable-ghcr-cleanup.yml` + `maintenance/sweep-ci-ghcr-tags.sh` (`ghcr-cleanup.yml`, #1138)                            |
 | Vuln suppression check        | lgtm-ci `reusable-vuln-suppression-check.yml`; local `security/install-osv-scanner.sh` and `security/check-vuln-suppressions.sh` |

--- a/scripts/ci/mirror/bump_pin.py
+++ b/scripts/ci/mirror/bump_pin.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Bump the ``lintro`` dependency pin in the lintro-pre-commit mirror.
+
+The mirror repository (``lgtm-hq/lintro-pre-commit``) carries a single
+``pyproject.toml`` whose only job is to pin the published ``lintro`` wheel, for
+example ``lintro==0.69.0``. On each py-lintro release, CI rewrites that pin to
+the freshly released version so pre-commit installs the matching wheel.
+
+Two modes are supported:
+
+* Write mode (default): rewrite the pin to the requested version.
+* Check mode (``--check``): verify the pin already matches, exiting non-zero on
+  drift.
+
+Usage:
+    python scripts/ci/mirror/bump_pin.py --pyproject PATH --version 1.2.3
+    python scripts/ci/mirror/bump_pin.py --pyproject PATH --version 1.2.3 --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Match the pinned lintro dependency, e.g. ``"lintro==0.69.0"``. The quote style
+# and surrounding whitespace are preserved by only replacing the version token.
+_PIN_RE = re.compile(
+    r'(?P<prefix>["\']lintro==)(?P<version>[^"\']+)(?P<suffix>["\'])',
+)
+
+
+def _read(*, path: Path) -> str:
+    """Return the text content of ``path``.
+
+    Args:
+        path: File to read.
+
+    Returns:
+        The file's UTF-8 text.
+    """
+    return path.read_text(encoding="utf-8")
+
+
+def _current_pin(*, content: str) -> str:
+    """Return the currently pinned lintro version.
+
+    Args:
+        content: The ``pyproject.toml`` text.
+
+    Returns:
+        The pinned version string.
+
+    Raises:
+        ValueError: If no ``lintro==`` pin is present.
+    """
+    match = _PIN_RE.search(content)
+    if match is None:
+        msg = "No 'lintro==<version>' pin found in pyproject.toml"
+        raise ValueError(msg)
+    return match.group("version")
+
+
+def bump(*, path: Path, version: str) -> bool:
+    """Rewrite the lintro pin in ``path`` to ``version``.
+
+    Args:
+        path: Path to the mirror ``pyproject.toml``.
+        version: Target lintro version (no leading ``v``).
+
+    Returns:
+        True if the file was modified, False if it already matched.
+    """
+    content = _read(path=path)
+    current = _current_pin(content=content)
+    if current == version:
+        return False
+    updated = _PIN_RE.sub(
+        lambda m: f"{m.group('prefix')}{version}{m.group('suffix')}",
+        content,
+        count=1,
+    )
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Argument vector excluding the program name.
+
+    Returns:
+        The parsed namespace.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pyproject",
+        required=True,
+        type=Path,
+        help="Path to the mirror's pyproject.toml.",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Target lintro version (without a leading 'v').",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify the pin already matches; exit non-zero on drift.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point.
+
+    Args:
+        argv: Optional argument vector for testing.
+
+    Returns:
+        Process exit code.
+    """
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    version = args.version.lstrip("v")
+    content = _read(path=args.pyproject)
+    current = _current_pin(content=content)
+
+    if args.check:
+        if current == version:
+            print(f"OK: lintro pin already at {version}")
+            return 0
+        print(
+            f"Drift: lintro pin is {current}, expected {version}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if bump(path=args.pyproject, version=version):
+        print(f"Bumped lintro pin: {current} -> {version}")
+    else:
+        print(f"No change: lintro pin already at {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/mirror/bump_pin.py
+++ b/scripts/ci/mirror/bump_pin.py
@@ -20,15 +20,9 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import re
 import sys
+import tomllib
 from pathlib import Path
-
-# Match the pinned lintro dependency, e.g. ``"lintro==0.69.0"``. The quote style
-# and surrounding whitespace are preserved by only replacing the version token.
-_PIN_RE = re.compile(
-    r'(?P<prefix>["\']lintro==)(?P<version>[^"\']+)(?P<suffix>["\'])',
-)
 
 
 def _read(*, path: Path) -> str:
@@ -43,6 +37,55 @@ def _read(*, path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _find_lintro_requirement(*, data: dict[str, object]) -> str:
+    """Return the ``lintro==`` requirement from parsed ``pyproject.toml`` data.
+
+    Args:
+        data: Parsed TOML document.
+
+    Returns:
+        The exact requirement string (for example ``lintro==0.69.0``).
+
+    Raises:
+        ValueError: If no ``lintro==`` dependency is present.
+    """
+    project = data.get("project")
+    if not isinstance(project, dict):
+        msg = "No [project] table found in pyproject.toml"
+        raise ValueError(msg)
+
+    matches: list[str] = []
+    dependencies = project.get("dependencies", [])
+    if isinstance(dependencies, list):
+        matches.extend(
+            dep
+            for dep in dependencies
+            if isinstance(dep, str) and dep.startswith("lintro==")
+        )
+
+    optional = project.get("optional-dependencies", {})
+    if isinstance(optional, dict):
+        for group_deps in optional.values():
+            if not isinstance(group_deps, list):
+                continue
+            matches.extend(
+                dep
+                for dep in group_deps
+                if isinstance(dep, str) and dep.startswith("lintro==")
+            )
+
+    if not matches:
+        msg = "No 'lintro==<version>' pin found in pyproject.toml dependencies"
+        raise ValueError(msg)
+    if len(matches) != 1:
+        msg = (
+            "Expected exactly one 'lintro==<version>' pin, "
+            f"found {len(matches)} in dependencies"
+        )
+        raise ValueError(msg)
+    return matches[0]
+
+
 def _current_pin(*, content: str) -> str:
     """Return the currently pinned lintro version.
 
@@ -55,11 +98,9 @@ def _current_pin(*, content: str) -> str:
     Raises:
         ValueError: If no ``lintro==`` pin is present.
     """
-    match = _PIN_RE.search(content)
-    if match is None:
-        msg = "No 'lintro==<version>' pin found in pyproject.toml"
-        raise ValueError(msg)
-    return match.group("version")
+    data = tomllib.loads(content)
+    requirement = _find_lintro_requirement(data=data)
+    return requirement.split("==", 1)[1]
 
 
 def bump(*, path: Path, version: str) -> bool:
@@ -73,14 +114,21 @@ def bump(*, path: Path, version: str) -> bool:
         True if the file was modified, False if it already matched.
     """
     content = _read(path=path)
-    current = _current_pin(content=content)
+    data = tomllib.loads(content)
+    requirement = _find_lintro_requirement(data=data)
+    current = requirement.split("==", 1)[1]
     if current == version:
         return False
-    updated = _PIN_RE.sub(
-        lambda m: f"{m.group('prefix')}{version}{m.group('suffix')}",
-        content,
-        count=1,
-    )
+
+    new_requirement = f"lintro=={version}"
+    if content.count(requirement) != 1:
+        msg = (
+            "Expected exactly one occurrence of the pinned requirement "
+            f"{requirement!r} in pyproject.toml"
+        )
+        raise ValueError(msg)
+
+    updated = content.replace(requirement, new_requirement, 1)
     path.write_text(updated, encoding="utf-8")
     return True
 

--- a/scripts/ci/mirror/bump_pin.py
+++ b/scripts/ci/mirror/bump_pin.py
@@ -94,9 +94,6 @@ def _current_pin(*, content: str) -> str:
 
     Returns:
         The pinned version string.
-
-    Raises:
-        ValueError: If no ``lintro==`` pin is present.
     """
     data = tomllib.loads(content)
     requirement = _find_lintro_requirement(data=data)
@@ -112,6 +109,9 @@ def bump(*, path: Path, version: str) -> bool:
 
     Returns:
         True if the file was modified, False if it already matched.
+
+    Raises:
+        ValueError: If the pinned requirement string is not unique in the file.
     """
     content = _read(path=path)
     data = tomllib.loads(content)

--- a/scripts/ci/mirror/publish-mirror-release.sh
+++ b/scripts/ci/mirror/publish-mirror-release.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Bump the lintro pin in the lintro-pre-commit mirror, open+merge a
+#          version-bump PR, and tag the mirror with the matching release version.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../utils/utils.sh disable=SC1091
+source "$SCRIPT_DIR/../../utils/utils.sh"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Publish a lintro-pre-commit mirror release for a py-lintro version.
+
+Usage: publish-mirror-release.sh <version>
+
+Arguments:
+  version        Released lintro version without a leading v (e.g. 0.69.0).
+
+Environment:
+  MIRROR_DIR    Checkout of the lintro-pre-commit mirror (default: current dir).
+  BUMP_SCRIPT   Path to bump_pin.py (default: alongside this script).
+  GH_TOKEN      Token with contents + pull-requests write on the mirror repo.
+  GIT_USER_NAME   Commit author name (default: lgtm-release-bot).
+  GIT_USER_EMAIL  Commit author email.
+
+Behavior:
+  * Rewrites pyproject.toml's lintro pin to <version>.
+  * If already pinned (idempotent re-run), ensures the vX.Y.Z tag exists and
+    exits 0 without opening a PR.
+  * Otherwise opens a version-bump PR, merges it, then tags vX.Y.Z on main.
+EOF
+	exit 0
+fi
+
+VERSION="${1:?Version is required}"
+VERSION="${VERSION#v}"
+TAG="v${VERSION}"
+MIRROR_DIR="${MIRROR_DIR:-.}"
+BUMP_SCRIPT="${BUMP_SCRIPT:-$SCRIPT_DIR/bump_pin.py}"
+GIT_USER_NAME="${GIT_USER_NAME:-lgtm-release-bot}"
+GIT_USER_EMAIL="${GIT_USER_EMAIL:-lgtm-release-bot@users.noreply.github.com}"
+BRANCH="mirror/bump-lintro-${VERSION}"
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+cd "$MIRROR_DIR"
+
+git config user.name "$GIT_USER_NAME"
+git config user.email "$GIT_USER_EMAIL"
+
+log_info "Bumping lintro pin to ${VERSION}"
+python3 "$BUMP_SCRIPT" --pyproject pyproject.toml --version "$VERSION"
+
+tag_exists_remote() {
+	git ls-remote --tags origin "refs/tags/$1" | grep -q .
+}
+
+push_tag() {
+	if tag_exists_remote "$TAG"; then
+		log_info "Tag ${TAG} already exists on the mirror; nothing to tag"
+		return 0
+	fi
+	log_info "Tagging mirror ${TAG}"
+	git tag -a "$TAG" -m "$TAG"
+	git push origin "$TAG"
+	log_success "Pushed mirror tag ${TAG}"
+}
+
+if git diff --quiet -- pyproject.toml; then
+	log_info "Mirror already pins lintro==${VERSION}; ensuring tag exists"
+	git fetch origin main --quiet
+	git checkout -q main
+	git reset -q --hard origin/main
+	push_tag
+	exit 0
+fi
+
+log_info "Creating version-bump branch ${BRANCH}"
+git checkout -B "$BRANCH"
+git add pyproject.toml
+git commit -m "chore: bump lintro to ${VERSION}
+
+Sync the pinned lintro wheel to the ${TAG} py-lintro release.
+
+Refs lgtm-hq/py-lintro (mirror-release automation)"
+
+log_info "Pushing branch ${BRANCH}"
+git push --force-with-lease origin "HEAD:$BRANCH"
+
+PR_TITLE="chore: bump lintro to ${VERSION}"
+PR_BODY="Automated version bump: pins the published \`lintro==${VERSION}\` wheel to match py-lintro ${TAG}. Merged and tagged \`${TAG}\` by mirror-release automation."
+
+existing_pr="$(
+	gh pr list --head "$BRANCH" --base main --state open \
+		--json number --jq '.[0].number // ""'
+)"
+
+if [[ -n "$existing_pr" ]]; then
+	log_info "Reusing open mirror PR #${existing_pr}"
+	pr_number="$existing_pr"
+else
+	log_info "Opening mirror version-bump PR"
+	pr_url="$(
+		gh pr create --base main --head "$BRANCH" \
+			--title "$PR_TITLE" --body "$PR_BODY"
+	)"
+	pr_number="${pr_url##*/}"
+fi
+
+log_info "Merging mirror PR #${pr_number}"
+gh pr merge "$pr_number" --squash --admin --delete-branch
+
+git fetch origin main --quiet
+git checkout -q main
+git reset -q --hard origin/main
+push_tag
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	{
+		echo "pr-number=$pr_number"
+		echo "tag=$TAG"
+	} >>"$GITHUB_OUTPUT"
+fi
+
+log_success "Mirror release ${TAG} published (PR #${pr_number})"

--- a/scripts/ci/mirror/publish-mirror-release.sh
+++ b/scripts/ci/mirror/publish-mirror-release.sh
@@ -109,8 +109,13 @@ else
 	pr_number="${pr_url##*/}"
 fi
 
+log_info "Rebasing bump branch onto latest origin/main before merge"
+git fetch origin main --quiet
+git rebase origin/main
+git push --force-with-lease origin "HEAD:$BRANCH"
+
 log_info "Merging mirror PR #${pr_number}"
-gh pr merge "$pr_number" --squash --admin --delete-branch
+gh pr merge "$pr_number" --squash --delete-branch
 
 git fetch origin main --quiet
 git checkout -q main

--- a/scripts/ci/mirror/publish-mirror-release.sh
+++ b/scripts/ci/mirror/publish-mirror-release.sh
@@ -68,6 +68,14 @@ push_tag() {
 	log_success "Pushed mirror tag ${TAG}"
 }
 
+# Fresh Actions checkouts have no remote-tracking ref for the bump branch, so
+# --force-with-lease would treat the remote as empty and refuse to update an
+# existing retry branch. Fetch first so the lease compares the real SHA.
+push_bump_branch() {
+	git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
+	git push --force-with-lease origin "HEAD:${BRANCH}"
+}
+
 if git diff --quiet -- pyproject.toml; then
 	log_info "Mirror already pins lintro==${VERSION}; ensuring tag exists"
 	git fetch origin main --quiet
@@ -87,7 +95,7 @@ Sync the pinned lintro wheel to the ${TAG} py-lintro release.
 Refs lgtm-hq/py-lintro (mirror-release automation)"
 
 log_info "Pushing branch ${BRANCH}"
-git push --force-with-lease origin "HEAD:$BRANCH"
+push_bump_branch()
 
 PR_TITLE="chore: bump lintro to ${VERSION}"
 PR_BODY="Automated version bump: pins the published \`lintro==${VERSION}\` wheel to match py-lintro ${TAG}. Merged and tagged \`${TAG}\` by mirror-release automation."
@@ -112,7 +120,7 @@ fi
 log_info "Rebasing bump branch onto latest origin/main before merge"
 git fetch origin main --quiet
 git rebase origin/main
-git push --force-with-lease origin "HEAD:$BRANCH"
+push_bump_branch()
 
 log_info "Merging mirror PR #${pr_number}"
 gh pr merge "$pr_number" --squash --delete-branch

--- a/scripts/ci/mirror/publish-mirror-release.sh
+++ b/scripts/ci/mirror/publish-mirror-release.sh
@@ -95,7 +95,7 @@ Sync the pinned lintro wheel to the ${TAG} py-lintro release.
 Refs lgtm-hq/py-lintro (mirror-release automation)"
 
 log_info "Pushing branch ${BRANCH}"
-push_bump_branch()
+push_bump_branch
 
 PR_TITLE="chore: bump lintro to ${VERSION}"
 PR_BODY="Automated version bump: pins the published \`lintro==${VERSION}\` wheel to match py-lintro ${TAG}. Merged and tagged \`${TAG}\` by mirror-release automation."
@@ -120,7 +120,7 @@ fi
 log_info "Rebasing bump branch onto latest origin/main before merge"
 git fetch origin main --quiet
 git rebase origin/main
-push_bump_branch()
+push_bump_branch
 
 log_info "Merging mirror PR #${pr_number}"
 gh pr merge "$pr_number" --squash --delete-branch

--- a/scripts/ci/mirror/resolve-version.sh
+++ b/scripts/ci/mirror/resolve-version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Resolve the release tag/version for the lintro-pre-commit mirror bump.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../utils/utils.sh disable=SC1091
+source "$SCRIPT_DIR/../../utils/utils.sh"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Resolve the release tag/version used by the lintro-pre-commit mirror bump.
+
+Usage: resolve-version.sh
+
+Environment:
+  RELEASE_TAG    Release tag from the release event or workflow_dispatch input.
+  GITHUB_OUTPUT  GitHub Actions output file.
+
+Outputs:
+  tag             Release tag, including any leading v prefix (e.g. v0.69.0).
+  version         Version without the leading v (e.g. 0.69.0).
+  is_prerelease   true when the version looks like a prerelease.
+EOF
+	exit 0
+fi
+
+TAG="${RELEASE_TAG:?RELEASE_TAG is required}"
+
+# Trim surrounding whitespace, then fail fast if the tag is still empty.
+TAG="${TAG#"${TAG%%[![:space:]]*}"}"
+TAG="${TAG%"${TAG##*[![:space:]]}"}"
+: "${TAG:?Release tag is required but was empty or whitespace-only}"
+
+VERSION="${TAG#v}"
+IS_PRERELEASE=false
+if [[ "$VERSION" =~ (a|b|rc)[0-9]+ ]]; then
+	IS_PRERELEASE=true
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	{
+		echo "tag=$TAG"
+		echo "version=$VERSION"
+		echo "is_prerelease=$IS_PRERELEASE"
+	} >>"$GITHUB_OUTPUT"
+fi
+
+log_info "Mirror release tag: $TAG (version: $VERSION, prerelease: $IS_PRERELEASE)"

--- a/scripts/ci/mirror/resolve-version.sh
+++ b/scripts/ci/mirror/resolve-version.sh
@@ -34,9 +34,14 @@ TAG="${TAG%"${TAG##*[![:space:]]}"}"
 : "${TAG:?Release tag is required but was empty or whitespace-only}"
 
 VERSION="${TAG#v}"
-IS_PRERELEASE=false
-if [[ "$VERSION" =~ (a|b|rc)[0-9]+ ]]; then
-	IS_PRERELEASE=true
+
+# Fail closed: reuse the same anchored classifier as publish-pypi-on-tag.yml.
+CLASSIFY_SCRIPT="$SCRIPT_DIR/../classify-release-tag.py"
+classification="$(python3 "$CLASSIFY_SCRIPT" "$TAG")"
+IS_PRERELEASE="${classification#is_prerelease=}"
+if [[ "$IS_PRERELEASE" != "true" && "$IS_PRERELEASE" != "false" ]]; then
+	log_error "Unexpected classifier output: ${classification}"
+	exit 1
 fi
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then

--- a/scripts/ci/mirror/wait-for-pypi-wheel.sh
+++ b/scripts/ci/mirror/wait-for-pypi-wheel.sh
@@ -43,7 +43,9 @@ log_info "Waiting for ${PACKAGE_NAME} ${VERSION} wheel on PyPI..."
 log_info "URL: ${PYPI_URL}"
 
 for i in $(seq 1 "$MAX_ATTEMPTS"); do
-	RESPONSE=$(curl -sf "$PYPI_URL" 2>/dev/null || echo "")
+	RESPONSE=$(
+		curl -sf --connect-timeout 10 --max-time 30 "$PYPI_URL" 2>/dev/null || echo ""
+	)
 
 	if [[ -z "$RESPONSE" ]]; then
 		log_info "Attempt ${i}/${MAX_ATTEMPTS}: Package metadata not yet available, waiting ${DELAY_SECONDS}s..."

--- a/scripts/ci/mirror/wait-for-pypi-wheel.sh
+++ b/scripts/ci/mirror/wait-for-pypi-wheel.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Wait for a published wheel on PyPI before bumping the pre-commit mirror.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../utils/utils.sh disable=SC1091
+source "$SCRIPT_DIR/../../utils/utils.sh"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Wait for a package wheel to be available on PyPI.
+
+Usage: wait-for-pypi-wheel.sh <package-name> <version> [max-attempts] [delay-seconds]
+
+Arguments:
+  package-name   The package name on PyPI (e.g., lintro)
+  version        The version to wait for (e.g., 1.0.0)
+  max-attempts   Maximum number of attempts (default: 30)
+  delay-seconds  Delay between attempts in seconds (default: 10)
+EOF
+	exit 0
+fi
+
+PACKAGE_NAME="${1:?Package name is required}"
+VERSION="${2:?Version is required}"
+MAX_ATTEMPTS="${3:-30}"
+DELAY_SECONDS="${4:-10}"
+
+PYPI_URL="https://pypi.org/pypi/${PACKAGE_NAME}/${VERSION}/json"
+
+has_wheel() {
+	local response="$1"
+	if command -v jq &>/dev/null; then
+		echo "$response" | jq -e '.urls[] | select(.packagetype == "bdist_wheel")' &>/dev/null
+	else
+		echo "$response" | grep -E -q '"packagetype"[[:space:]]*:[[:space:]]*"bdist_wheel"'
+	fi
+}
+
+log_info "Waiting for ${PACKAGE_NAME} ${VERSION} wheel on PyPI..."
+log_info "URL: ${PYPI_URL}"
+
+for i in $(seq 1 "$MAX_ATTEMPTS"); do
+	RESPONSE=$(curl -sf "$PYPI_URL" 2>/dev/null || echo "")
+
+	if [[ -z "$RESPONSE" ]]; then
+		log_info "Attempt ${i}/${MAX_ATTEMPTS}: Package metadata not yet available, waiting ${DELAY_SECONDS}s..."
+		sleep "$DELAY_SECONDS"
+		continue
+	fi
+
+	if has_wheel "$RESPONSE"; then
+		log_success "Package ${PACKAGE_NAME} ${VERSION} wheel is available on PyPI"
+		exit 0
+	fi
+
+	log_info "Attempt ${i}/${MAX_ATTEMPTS}: Metadata exists but wheel not yet indexed, waiting ${DELAY_SECONDS}s..."
+	sleep "$DELAY_SECONDS"
+done
+
+log_error "Timeout waiting for ${PACKAGE_NAME} ${VERSION} wheel on PyPI after ${MAX_ATTEMPTS} attempts"
+exit 1

--- a/tests/scripts/ci/test_mirror_release.py
+++ b/tests/scripts/ci/test_mirror_release.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+"""Tests for lintro-pre-commit mirror release automation scripts."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess  # nosec B404 - drives repo shell scripts with shell=False
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+from assertpy import assert_that
+
+ROOT = Path(__file__).resolve().parents[3]
+MIRROR_DIR = ROOT / "scripts" / "ci" / "mirror"
+RESOLVE_SCRIPT = MIRROR_DIR / "resolve-version.sh"
+BUMP_SCRIPT = MIRROR_DIR / "bump_pin.py"
+CLASSIFY_SCRIPT = ROOT / "scripts" / "ci" / "classify-release-tag.py"
+
+
+def _load_bump_pin_module() -> Any:
+    """Load bump_pin.py as an importable module."""
+    spec = importlib.util.spec_from_file_location("bump_pin", BUMP_SCRIPT)
+    assert_that(spec).is_not_none()
+    assert spec is not None
+    assert_that(spec.loader).is_not_none()
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_resolve(
+    *,
+    release_tag: str,
+    github_output: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run resolve-version.sh with the given release tag."""
+    env = os.environ.copy()
+    env["RELEASE_TAG"] = release_tag
+    if github_output is not None:
+        env["GITHUB_OUTPUT"] = str(github_output)
+    else:
+        env.pop("GITHUB_OUTPUT", None)
+    return subprocess.run(  # nosec B603 - fixed argv against repo script; shell=False
+        [str(RESOLVE_SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        cwd=ROOT,
+    )
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected_prerelease"),
+    [
+        ("v1.2.3", "false"),
+        ("1.2.3", "false"),
+        ("v1.2.3+build.1", "false"),
+        ("v1.2.3rc1", "true"),
+        ("v1.2.3-rc.1", "true"),
+        ("v1.2.3-alpha.1", "true"),
+        ("v1.2.3.dev1", "true"),
+        ("v1.2.3RC1", "true"),
+        ("garbage", "true"),
+    ],
+)
+def test_resolve_version_matches_classifier(
+    tag: str,
+    expected_prerelease: str,
+    tmp_path: Path,
+) -> None:
+    """resolve-version.sh classifies tags like classify-release-tag.py."""
+    output_file = tmp_path / "gh_output"
+    result = _run_resolve(release_tag=tag, github_output=output_file)
+
+    assert_that(result.returncode).is_equal_to(0)
+    body = output_file.read_text(encoding="utf-8")
+    assert_that(body).contains(f"is_prerelease={expected_prerelease}")
+    assert_that(body).contains(f"version={tag.lstrip('v')}")
+
+
+def test_resolve_version_writes_tag_and_version(
+    tmp_path: Path,
+) -> None:
+    """resolve-version.sh emits tag and version outputs."""
+    output_file = tmp_path / "gh_output"
+    result = _run_resolve(release_tag="v0.69.0", github_output=output_file)
+
+    assert_that(result.returncode).is_equal_to(0)
+    body = output_file.read_text(encoding="utf-8")
+    assert_that(body).contains("tag=v0.69.0")
+    assert_that(body).contains("version=0.69.0")
+    assert_that(body).contains("is_prerelease=false")
+
+
+def test_bump_updates_real_dependency_not_decoy_comment(tmp_path: Path) -> None:
+    """bump_pin.py rewrites the parsed dependency, not an earlier decoy string."""
+    module = _load_bump_pin_module()
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        textwrap.dedent(
+            """\
+            # Example only: "lintro==0.1.0"
+            [project]
+            name = "lintro-pre-commit"
+            dependencies = [
+              "lintro==0.69.0",
+            ]
+            """,
+        ),
+        encoding="utf-8",
+    )
+
+    changed = module.bump(path=pyproject, version="0.70.0")
+
+    assert_that(changed).is_true()
+    updated = pyproject.read_text(encoding="utf-8")
+    assert_that(updated).contains('"lintro==0.70.0"')
+    assert_that(updated).contains('# Example only: "lintro==0.1.0"')
+
+
+def test_bump_check_reports_drift(tmp_path: Path) -> None:
+    """--check exits non-zero when the parsed pin does not match."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            dependencies = ["lintro==0.69.0"]
+            """,
+        ),
+        encoding="utf-8",
+    )
+
+    ok = subprocess.run(  # nosec B603 - fixed argv; shell=False
+        [
+            "python3",
+            str(BUMP_SCRIPT),
+            "--pyproject",
+            str(pyproject),
+            "--version",
+            "0.69.0",
+            "--check",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    drift = subprocess.run(  # nosec B603 - fixed argv; shell=False
+        [
+            "python3",
+            str(BUMP_SCRIPT),
+            "--pyproject",
+            str(pyproject),
+            "--version",
+            "0.70.0",
+            "--check",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert_that(ok.returncode).is_equal_to(0)
+    assert_that(drift.returncode).is_equal_to(1)
+    assert_that(drift.stderr).contains("Drift")
+
+
+def test_bump_missing_pin_raises(tmp_path: Path) -> None:
+    """Missing lintro dependency raises a clear error."""
+    module = _load_bump_pin_module()
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            dependencies = ["other==1.0.0"]
+            """,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="No 'lintro==<version>' pin"):
+        module.bump(path=pyproject, version="1.0.0")
+
+
+def test_bump_multiple_pins_raises(tmp_path: Path) -> None:
+    """Multiple lintro pins in dependency tables fail closed."""
+    module = _load_bump_pin_module()
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            dependencies = ["lintro==0.69.0"]
+            optional-dependencies.dev = ["lintro==0.68.0"]
+            """,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Expected exactly one"):
+        module.bump(path=pyproject, version="1.0.0")

--- a/tests/scripts/ci/test_mirror_release.py
+++ b/tests/scripts/ci/test_mirror_release.py
@@ -18,6 +18,8 @@ ROOT = Path(__file__).resolve().parents[3]
 MIRROR_DIR = ROOT / "scripts" / "ci" / "mirror"
 RESOLVE_SCRIPT = MIRROR_DIR / "resolve-version.sh"
 BUMP_SCRIPT = MIRROR_DIR / "bump_pin.py"
+WAIT_WHEEL_SCRIPT = MIRROR_DIR / "wait-for-pypi-wheel.sh"
+PUBLISH_SCRIPT = MIRROR_DIR / "publish-mirror-release.sh"
 CLASSIFY_SCRIPT = ROOT / "scripts" / "ci" / "classify-release-tag.py"
 
 
@@ -206,3 +208,84 @@ def test_bump_multiple_pins_raises(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="Expected exactly one"):
         module.bump(path=pyproject, version="1.0.0")
+
+
+def test_resolve_version_rejects_empty_tag() -> None:
+    """Whitespace-only RELEASE_TAG fails closed instead of publishing."""
+    result = _run_resolve(release_tag="   ")
+
+    assert_that(result.returncode).is_not_equal_to(0)
+
+
+def test_publish_script_fetches_bump_branch_before_lease() -> None:
+    """Retry pushes fetch the existing bump branch so --force-with-lease works."""
+    body = PUBLISH_SCRIPT.read_text(encoding="utf-8")
+
+    assert_that(body).contains("push_bump_branch()")
+    assert_that(body).contains(
+        'git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"',
+    )
+    assert_that(body).contains('git push --force-with-lease origin "HEAD:${BRANCH}"')
+    assert_that(body.count("push_bump_branch")).is_greater_than_or_equal_to(3)
+
+
+def _write_fake_curl(bin_dir: Path, payload: str) -> None:
+    """Install a curl stub that prints *payload* and ignores URL/flags."""
+    curl = bin_dir / "curl"
+    curl.write_text(
+        "#!/usr/bin/env bash\n"
+        "cat <<'EOF'\n"
+        f"{payload}\n"
+        "EOF\n",
+        encoding="utf-8",
+    )
+    curl.chmod(0o755)
+
+
+def _run_wait_wheel(
+    *,
+    bin_dir: Path,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run wait-for-pypi-wheel.sh with a stub curl ahead of PATH."""
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(  # nosec B603 - fixed argv against repo script; shell=False
+        [str(WAIT_WHEEL_SCRIPT), "lintro", "1.2.3", "1", "0"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        cwd=ROOT,
+    )
+
+
+def test_wait_for_pypi_wheel_requires_bdist_wheel(tmp_path: Path) -> None:
+    """sdist-only PyPI metadata is not enough to pass the wheel gate."""
+    _write_fake_curl(tmp_path, '{"urls":[{"packagetype":"sdist"}]}')
+    result = _run_wait_wheel(bin_dir=tmp_path)
+
+    assert_that(result.returncode).is_equal_to(1)
+    assert_that(result.stderr + result.stdout).contains("Timeout")
+
+
+def test_wait_for_pypi_wheel_accepts_bdist_wheel(tmp_path: Path) -> None:
+    """A bdist_wheel URL in the PyPI JSON is sufficient."""
+    _write_fake_curl(tmp_path, '{"urls":[{"packagetype":"bdist_wheel"}]}')
+    result = _run_wait_wheel(bin_dir=tmp_path)
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stderr + result.stdout).contains("wheel is available")
+
+
+def test_wait_for_pypi_wheel_times_out_without_metadata(tmp_path: Path) -> None:
+    """Empty curl output (metadata not published yet) exits 1 after attempts."""
+    curl = tmp_path / "curl"
+    curl.write_text("#!/usr/bin/env bash\nexit 22\n", encoding="utf-8")
+    curl.chmod(0o755)
+    result = _run_wait_wheel(bin_dir=tmp_path)
+
+    assert_that(result.returncode).is_equal_to(1)
+    assert_that(result.stderr + result.stdout).contains("Timeout")

--- a/tests/scripts/ci/test_mirror_release.py
+++ b/tests/scripts/ci/test_mirror_release.py
@@ -221,22 +221,19 @@ def test_publish_script_fetches_bump_branch_before_lease() -> None:
     """Retry pushes fetch the existing bump branch so --force-with-lease works."""
     body = PUBLISH_SCRIPT.read_text(encoding="utf-8")
 
-    assert_that(body).contains("push_bump_branch()")
+    assert_that(body).contains("push_bump_branch()")  # definition
     assert_that(body).contains(
         'git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"',
     )
     assert_that(body).contains('git push --force-with-lease origin "HEAD:${BRANCH}"')
-    assert_that(body.count("push_bump_branch")).is_greater_than_or_equal_to(3)
+    assert_that(body.count("\npush_bump_branch\n")).is_equal_to(2)
 
 
 def _write_fake_curl(bin_dir: Path, payload: str) -> None:
     """Install a curl stub that prints *payload* and ignores URL/flags."""
     curl = bin_dir / "curl"
     curl.write_text(
-        "#!/usr/bin/env bash\n"
-        "cat <<'EOF'\n"
-        f"{payload}\n"
-        "EOF\n",
+        "#!/usr/bin/env bash\n" "cat <<'EOF'\n" f"{payload}\n" "EOF\n",
         encoding="utf-8",
     )
     curl.chmod(0o755)

--- a/tests/scripts/ci/test_mirror_release.py
+++ b/tests/scripts/ci/test_mirror_release.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import importlib.util
 import os
 import subprocess  # nosec B404 - drives repo shell scripts with shell=False
+import sys
 import textwrap
 from pathlib import Path
 from typing import Any
@@ -141,7 +142,7 @@ def test_bump_check_reports_drift(tmp_path: Path) -> None:
 
     ok = subprocess.run(  # nosec B603 - fixed argv; shell=False
         [
-            "python3",
+            sys.executable,
             str(BUMP_SCRIPT),
             "--pyproject",
             str(pyproject),
@@ -155,7 +156,7 @@ def test_bump_check_reports_drift(tmp_path: Path) -> None:
     )
     drift = subprocess.run(  # nosec B603 - fixed argv; shell=False
         [
-            "python3",
+            sys.executable,
             str(BUMP_SCRIPT),
             "--pyproject",
             str(pyproject),

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -1929,7 +1929,6 @@ def test_sbom_callers_grant_contents_read_only(workflow_name: str) -> None:
     assert_that(permissions).contains_entry({"attestations": "write"})
 
 
-
 # --- Mirror release automation (#1171) ---------------------------------------
 
 _SHA_PIN_RE = re.compile(r"@[0-9a-f]{40}$")
@@ -2043,6 +2042,7 @@ def test_mirror_release_scripts_are_executable() -> None:
         assert_that(script.stat().st_mode & 0o111).described_as(
             f"{script} is not executable",
         ).is_not_zero()
+
 
 # --- Binary build job timeouts (#1702) ---------------------------------------
 #

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -2050,7 +2050,9 @@ def test_mirror_release_skips_prereleases() -> None:
     assert_that(mirror_checkout["if"]).contains(guard)
     assert_that(mirror_checkout["if"]).contains(github_guard)
 
-    setup_python = [s for s in steps if s.get("uses", "").startswith("actions/setup-python@")]
+    setup_python = [
+        s for s in steps if s.get("uses", "").startswith("actions/setup-python@")
+    ]
     assert_that(setup_python).is_empty()
 
 

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -1959,7 +1959,9 @@ def test_mirror_release_job_has_timeout() -> None:
     """Mirror bump inherits a bounded job timeout instead of the 6-hour default."""
     workflow = _load_workflow(name="mirror-release.yml")
 
-    assert_that(workflow["jobs"]["mirror-bump"]).contains_key("timeout-minutes")
+    timeout = workflow["jobs"]["mirror-bump"]["timeout-minutes"]
+    assert_that(timeout).is_instance_of(int)
+    assert_that(timeout).is_equal_to(20)
 
 
 def test_mirror_release_triggers_on_published_release() -> None:

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -1929,6 +1929,121 @@ def test_sbom_callers_grant_contents_read_only(workflow_name: str) -> None:
     assert_that(permissions).contains_entry({"attestations": "write"})
 
 
+
+# --- Mirror release automation (#1171) ---------------------------------------
+
+_SHA_PIN_RE = re.compile(r"@[0-9a-f]{40}$")
+
+
+def _job_steps(workflow: dict[str, Any], *, job: str) -> list[dict[str, Any]]:
+    """Return the ordered steps of a workflow job.
+
+    Args:
+        workflow: Parsed workflow document.
+        job: Job key.
+
+    Returns:
+        The job's ``steps`` list.
+    """
+    return cast(list[dict[str, Any]], workflow["jobs"][job]["steps"])
+
+
+def test_mirror_release_triggers_on_published_release() -> None:
+    """Mirror bump runs on release publish plus a manual dispatch fallback."""
+    workflow = _load_workflow(name="mirror-release.yml")
+    triggers = workflow["on"]
+
+    assert_that(triggers).contains_key("release", "workflow_dispatch")
+    assert_that(triggers["release"]["types"]).contains("published")
+    assert_that(triggers["workflow_dispatch"]["inputs"]).contains_key("release_tag")
+
+
+def test_mirror_release_job_is_read_only_in_source_repo() -> None:
+    """Cross-repo writes use MIRROR_REPO_TOKEN; source-repo perms stay read-only."""
+    workflow = _load_workflow(name="mirror-release.yml")
+
+    assert_that(workflow["permissions"]).is_equal_to({})
+    assert_that(workflow["jobs"]["mirror-bump"]["permissions"]).is_equal_to(
+        {"contents": "read"},
+    )
+
+
+def test_mirror_release_hardens_runner_with_blocked_egress() -> None:
+    """First step hardens the runner and blocks egress to an allowlist."""
+    workflow = _load_workflow(name="mirror-release.yml")
+    first = _job_steps(workflow, job="mirror-bump")[0]
+
+    assert_that(first["uses"]).starts_with("step-security/harden-runner@")
+    assert_that(first["with"]["egress-policy"]).is_equal_to("block")
+    endpoints = first["with"]["allowed-endpoints"]
+    assert_that(endpoints).contains("pypi.org:443")
+    assert_that(endpoints).contains("files.pythonhosted.org:443")
+    assert_that(endpoints).contains("api.github.com:443")
+
+
+def test_mirror_release_actions_are_sha_pinned() -> None:
+    """Every third-party action in the mirror workflow is pinned to a commit SHA."""
+    workflow = _load_workflow(name="mirror-release.yml")
+    uses = [
+        step["uses"]
+        for step in _job_steps(workflow, job="mirror-bump")
+        if "uses" in step
+    ]
+
+    assert_that(uses).is_not_empty()
+    for ref in uses:
+        assert_that(_SHA_PIN_RE.search(ref)).described_as(ref).is_not_none()
+
+
+def test_mirror_release_uses_cross_repo_token() -> None:
+    """The mirror checkout and publish step authenticate with MIRROR_REPO_TOKEN."""
+    workflow = _load_workflow(name="mirror-release.yml")
+    steps = _job_steps(workflow, job="mirror-bump")
+
+    checkout = next(
+        step
+        for step in steps
+        if step.get("with", {}).get("repository") == "lgtm-hq/lintro-pre-commit"
+    )
+    assert_that(checkout["with"]["token"]).contains("secrets.MIRROR_REPO_TOKEN")
+
+    publish = next(
+        step for step in steps if "publish-mirror-release.sh" in step.get("run", "")
+    )
+    assert_that(publish["env"]["GH_TOKEN"]).contains("secrets.MIRROR_REPO_TOKEN")
+
+
+def test_mirror_release_skips_prereleases() -> None:
+    """Wheel-dependent steps are guarded on a non-prerelease resolution."""
+    workflow = _load_workflow(name="mirror-release.yml")
+    steps = _job_steps(workflow, job="mirror-bump")
+    guard = "steps.resolve.outputs.is_prerelease == 'false'"
+
+    for needle in ("wait-for-pypi.sh", "publish-mirror-release.sh"):
+        step = next(s for s in steps if needle in s.get("run", ""))
+        assert_that(step["if"]).contains(guard)
+
+    mirror_checkout = next(
+        s
+        for s in steps
+        if s.get("with", {}).get("repository") == "lgtm-hq/lintro-pre-commit"
+    )
+    assert_that(mirror_checkout["if"]).contains(guard)
+
+
+def test_mirror_release_scripts_are_executable() -> None:
+    """The CI scripts referenced by the mirror workflow exist and are executable."""
+    scripts = (
+        _REPO_ROOT / "scripts" / "ci" / "mirror" / "resolve-version.sh",
+        _REPO_ROOT / "scripts" / "ci" / "mirror" / "publish-mirror-release.sh",
+        _REPO_ROOT / "scripts" / "ci" / "mirror" / "bump_pin.py",
+    )
+    for script in scripts:
+        assert_that(script.exists()).described_as(str(script)).is_true()
+        assert_that(script.stat().st_mode & 0o111).described_as(
+            f"{script} is not executable",
+        ).is_not_zero()
+
 # --- Binary build job timeouts (#1702) ---------------------------------------
 #
 # No job in build-binary.yml set timeout-minutes, so every binary build

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -1947,6 +1947,21 @@ def _job_steps(workflow: dict[str, Any], *, job: str) -> list[dict[str, Any]]:
     return cast(list[dict[str, Any]], workflow["jobs"][job]["steps"])
 
 
+def test_mirror_release_serializes_with_global_concurrency() -> None:
+    """Only one mirror bump runs at a time to avoid clobbering newer pins."""
+    workflow = _load_workflow(name="mirror-release.yml")
+
+    assert_that(workflow["concurrency"]["group"]).is_equal_to("mirror-release")
+    assert_that(workflow["concurrency"]["cancel-in-progress"]).is_false()
+
+
+def test_mirror_release_job_has_timeout() -> None:
+    """Mirror bump inherits a bounded job timeout instead of the 6-hour default."""
+    workflow = _load_workflow(name="mirror-release.yml")
+
+    assert_that(workflow["jobs"]["mirror-bump"]).contains_key("timeout-minutes")
+
+
 def test_mirror_release_triggers_on_published_release() -> None:
     """Mirror bump runs on release publish plus a manual dispatch fallback."""
     workflow = _load_workflow(name="mirror-release.yml")
@@ -2013,14 +2028,17 @@ def test_mirror_release_uses_cross_repo_token() -> None:
 
 
 def test_mirror_release_skips_prereleases() -> None:
-    """Wheel-dependent steps are guarded on a non-prerelease resolution."""
+    """Wheel-dependent steps are guarded on stable, non-prerelease releases."""
     workflow = _load_workflow(name="mirror-release.yml")
     steps = _job_steps(workflow, job="mirror-bump")
     guard = "steps.resolve.outputs.is_prerelease == 'false'"
+    github_guard = "!github.event.release.prerelease"
 
-    for needle in ("wait-for-pypi.sh", "publish-mirror-release.sh"):
+    for needle in ("wait-for-pypi-wheel.sh", "publish-mirror-release.sh"):
         step = next(s for s in steps if needle in s.get("run", ""))
         assert_that(step["if"]).contains(guard)
+        assert_that(step["if"]).contains(github_guard)
+        assert_that(step.get("env", {})).contains_key("LINTRO_VERSION")
 
     mirror_checkout = next(
         s
@@ -2028,12 +2046,17 @@ def test_mirror_release_skips_prereleases() -> None:
         if s.get("with", {}).get("repository") == "lgtm-hq/lintro-pre-commit"
     )
     assert_that(mirror_checkout["if"]).contains(guard)
+    assert_that(mirror_checkout["if"]).contains(github_guard)
+
+    setup_python = [s for s in steps if s.get("uses", "").startswith("actions/setup-python@")]
+    assert_that(setup_python).is_empty()
 
 
 def test_mirror_release_scripts_are_executable() -> None:
     """The CI scripts referenced by the mirror workflow exist and are executable."""
     scripts = (
         _REPO_ROOT / "scripts" / "ci" / "mirror" / "resolve-version.sh",
+        _REPO_ROOT / "scripts" / "ci" / "mirror" / "wait-for-pypi-wheel.sh",
         _REPO_ROOT / "scripts" / "ci" / "mirror" / "publish-mirror-release.sh",
         _REPO_ROOT / "scripts" / "ci" / "mirror" / "bump_pin.py",
     )


### PR DESCRIPTION
## Summary

Refs #1171. Wires **release automation** for the new
[`lgtm-hq/lintro-pre-commit`](https://github.com/lgtm-hq/lintro-pre-commit)
wheel mirror (ruff-pre-commit model) and documents the mirror as the recommended
hermetic pre-commit path.

The mirror repo itself has already been populated and tagged `v0.69.0` (initial
content: `.pre-commit-hooks.yaml` with `lintro-check`/`lintro-format` at
`language: python`, a `pyproject.toml` pinning `lintro==0.69.0`, README, MIT
LICENSE). This PR adds the py-lintro side so future releases keep it in sync
automatically.

## What's in this PR

- **`.github/workflows/mirror-release.yml`** — on `release: published` (with a
  `workflow_dispatch` fallback), waits for the wheel on PyPI, bumps the mirror's
  `lintro` pin, opens + admin-merges the version-bump PR, and tags the mirror
  `vX.Y.Z`. Actions are SHA-pinned; harden-runner egress is `block`ed with an
  allowlist copied from sibling release workflows; the source-repo job is
  `contents: read` only.
- **`scripts/ci/mirror/`** — dedicated logic (no inline `run:` blocks):
  `resolve-version.sh`, `bump_pin.py` (write/`--check` modes), and
  `publish-mirror-release.sh` (idempotent: re-runs just ensure the tag exists).
  Reuses the existing `wait-for-pypi.sh`.
- **`docs/pre-commit.md`** — mirror is the recommended hermetic path;
  `language: system` remains the full-toolchain default. See dependency note
  below.
- **Contract tests** in `tests/unit/test_workflow_wiring.py` (7 new): trigger,
  read-only source perms, harden-runner egress, SHA-pinning, cross-repo token
  wiring, prerelease skip, and script existence/executability.
- Docs coverage: new scripts documented in `scripts/README.md`;
  `.github/workflows/README.md` updated with the workflow and the new secret.

## Owner follow-ups (required before automation runs)

1. **Create secret `MIRROR_REPO_TOKEN`** — a fine-grained PAT (or GitHub App
   installation token) with **contents: write** and **pull-requests: write** on
   `lgtm-hq/lintro-pre-commit`. Documented in `.github/workflows/README.md`.
2. Automation proves out on the **next release cycle** (first `release:
   published` after merge).

## Dependency on #1167

`docs/pre-commit.md` does not exist on `main` yet — it is introduced by #1167.
This PR's copy is **based on #1167's current branch content** plus the mirror
section, so **this should merge after #1167**. If #1167 merges first, expect a
trivial "both added" conflict on that one file, resolved by keeping this
superset version.

## Verification

- Mirror e2e (scratch consumer repo pointed at the pushed mirror): pre-commit
  installs the **lintro wheel from PyPI in seconds** (no source build);
  `lintro-check` blocks a dirty file, `lintro-format` fixes it, a clean file
  passes.
- Native linters clean on changed files (ruff, black, mypy, shellcheck, shfmt,
  yamllint, markdownlint-cli2).
- `uv run pytest`: 6009 passed (the two documented env-only failures excluded:
  `test_markdownlint_direct_vs_lintro_parity`,
  `test_prepare_execution_version_check_fails_returns_early_result`).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds release automation for the `lintro-pre-commit` mirror. The main changes are:

- A new mirror release workflow triggered by published releases and manual dispatch.
- Helper scripts to resolve versions, bump the mirror pin, merge the mirror PR, and tag the mirror.
- Documentation for the recommended hermetic pre-commit mirror path.
- Workflow wiring tests for permissions, egress, pinned actions, token use, prerelease guards, and script executability.
</details>

<h3>Confidence Score: 4/5</h3>

These release automation issues should be fixed before merging.
- The mirror merge can fail with the documented token permissions.
- Several prerelease tag forms can still reach the mirror publish path.
- The pin bump can still update a decoy string while leaving the installed dependency unchanged.

**Files Needing Attention:** scripts/ci/mirror/publish-mirror-release.sh, scripts/ci/mirror/resolve-version.sh, scripts/ci/mirror/bump_pin.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/mirror-release.yml | Adds the mirror release workflow and calls the new helper scripts with guarded publish steps. |
| scripts/ci/mirror/publish-mirror-release.sh | Adds the mirror publish flow, but the merge command still needs broader token authority than documented. |
| scripts/ci/mirror/resolve-version.sh | Adds release tag resolution, but prerelease detection still misses common prerelease and dev tag forms. |
| scripts/ci/mirror/bump_pin.py | Adds pin rewriting, but the selected pin can still be the first textual match instead of the project dependency. |
| docs/pre-commit.md | Documents the mirror as the recommended hermetic pre-commit path. |
| tests/unit/test_workflow_wiring.py | Adds workflow wiring coverage for the new mirror release workflow. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20lgtm-hq%2Fpy-lintro%20PR%20%231176%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=1176&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Ascripts%2Fci%2Fmirror%2Fpublish-mirror-release.sh%3A113%0A**Admin%20merge%20still%20required**%0A%0AThe%20merge%20still%20uses%20%60--admin%60%2C%20but%20the%20workflow%20docs%20only%20require%20%60MIRROR_REPO_TOKEN%60%20to%20have%20contents%20and%20pull-request%20write%20access%20on%20the%20mirror%20repo.%20With%20that%20documented%20token%2C%20the%20job%20can%20create%20the%20bump%20branch%20and%20PR%2C%20then%20fail%20at%20this%20merge%20because%20admin%20merge%20needs%20repository%20admin%20or%20bypass%20authority.%20The%20script%20exits%20before%20%60push_tag%60%2C%20so%20a%20py-lintro%20release%20can%20finish%20without%20the%20matching%20pre-commit%20mirror%20tag.%0A%0A%23%23%23%20Issue%202%0Ascripts%2Fci%2Fmirror%2Fresolve-version.sh%3A38-40%0A**Prereleases%20still%20pass**%0A%0AThis%20check%20only%20recognizes%20compact%20lowercase%20%60a%60%2C%20%60b%60%2C%20and%20%60rc%60%20forms%20followed%20immediately%20by%20digits.%20Tags%20such%20as%20%60v1.2.3.dev1%60%2C%20%60v1.2.3-rc.1%60%2C%20%60v1.2.3-alpha.1%60%2C%20or%20%60v1.2.3RC1%60%20leave%20%60IS_PRERELEASE%3Dfalse%60%2C%20so%20the%20guarded%20PyPI%20wait%20and%20mirror%20publish%20steps%20run%20for%20releases%20that%20should%20be%20skipped.%20That%20can%20create%20a%20mirror%20tag%20for%20a%20prerelease%20or%20send%20the%20workflow%20into%20a%20PyPI%20wait%20for%20an%20artifact%20that%20is%20not%20meant%20for%20the%20stable%20mirror%20path.%0A%0A%23%23%23%20Issue%203%0Ascripts%2Fci%2Fmirror%2Fbump_pin.py%3A29-31%0A**Pin%20selection%20still%20textual**%0A%0AThe%20script%20still%20selects%20the%20first%20quoted%20%60lintro%3D%3D...%60%20string%20in%20the%20raw%20file%20instead%20of%20the%20%60lintro%60%20dependency%20from%20%60%5Bproject%5D.dependencies%60.%20If%20the%20mirror%20%60pyproject.toml%60%20contains%20an%20earlier%20quoted%20example%2C%20comment%2C%20optional%20dependency%2C%20or%20tool%20setting%2C%20this%20rewrites%20that%20decoy.%20%60publish-mirror-release.sh%60%20then%20sees%20a%20diff%2C%20commits%2C%20merges%2C%20and%20tags%20the%20release%20while%20the%20actual%20pre-commit%20dependency%20remains%20pinned%20to%20the%20old%20wheel.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=1176&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ascripts%2Fci%2Fmirror%2Fpublish-mirror-release.sh%3A113%0A**Admin%20merge%20still%20required**%0A%0AThe%20merge%20still%20uses%20%60--admin%60%2C%20but%20the%20workflow%20docs%20only%20require%20%60MIRROR_REPO_TOKEN%60%20to%20have%20contents%20and%20pull-request%20write%20access%20on%20the%20mirror%20repo.%20With%20that%20documented%20token%2C%20the%20job%20can%20create%20the%20bump%20branch%20and%20PR%2C%20then%20fail%20at%20this%20merge%20because%20admin%20merge%20needs%20repository%20admin%20or%20bypass%20authority.%20The%20script%20exits%20before%20%60push_tag%60%2C%20so%20a%20py-lintro%20release%20can%20finish%20without%20the%20matching%20pre-commit%20mirror%20tag.%0A%0A%23%23%23%20Issue%202%0Ascripts%2Fci%2Fmirror%2Fresolve-version.sh%3A38-40%0A**Prereleases%20still%20pass**%0A%0AThis%20check%20only%20recognizes%20compact%20lowercase%20%60a%60%2C%20%60b%60%2C%20and%20%60rc%60%20forms%20followed%20immediately%20by%20digits.%20Tags%20such%20as%20%60v1.2.3.dev1%60%2C%20%60v1.2.3-rc.1%60%2C%20%60v1.2.3-alpha.1%60%2C%20or%20%60v1.2.3RC1%60%20leave%20%60IS_PRERELEASE%3Dfalse%60%2C%20so%20the%20guarded%20PyPI%20wait%20and%20mirror%20publish%20steps%20run%20for%20releases%20that%20should%20be%20skipped.%20That%20can%20create%20a%20mirror%20tag%20for%20a%20prerelease%20or%20send%20the%20workflow%20into%20a%20PyPI%20wait%20for%20an%20artifact%20that%20is%20not%20meant%20for%20the%20stable%20mirror%20path.%0A%0A%23%23%23%20Issue%203%0Ascripts%2Fci%2Fmirror%2Fbump_pin.py%3A29-31%0A**Pin%20selection%20still%20textual**%0A%0AThe%20script%20still%20selects%20the%20first%20quoted%20%60lintro%3D%3D...%60%20string%20in%20the%20raw%20file%20instead%20of%20the%20%60lintro%60%20dependency%20from%20%60%5Bproject%5D.dependencies%60.%20If%20the%20mirror%20%60pyproject.toml%60%20contains%20an%20earlier%20quoted%20example%2C%20comment%2C%20optional%20dependency%2C%20or%20tool%20setting%2C%20this%20rewrites%20that%20decoy.%20%60publish-mirror-release.sh%60%20then%20sees%20a%20diff%2C%20commits%2C%20merges%2C%20and%20tags%20the%20release%20while%20the%20actual%20pre-commit%20dependency%20remains%20pinned%20to%20the%20old%20wheel.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=lgtm-hq%2Fpy-lintro&pr=1176&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22feat%2F1171-mirror-release-automation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F1171-mirror-release-automation%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Fci%2Fmirror%2Fpublish-mirror-release.sh%3A113%0A**Admin%20merge%20still%20required**%0A%0AThe%20merge%20still%20uses%20%60--admin%60%2C%20but%20the%20workflow%20docs%20only%20require%20%60MIRROR_REPO_TOKEN%60%20to%20have%20contents%20and%20pull-request%20write%20access%20on%20the%20mirror%20repo.%20With%20that%20documented%20token%2C%20the%20job%20can%20create%20the%20bump%20branch%20and%20PR%2C%20then%20fail%20at%20this%20merge%20because%20admin%20merge%20needs%20repository%20admin%20or%20bypass%20authority.%20The%20script%20exits%20before%20%60push_tag%60%2C%20so%20a%20py-lintro%20release%20can%20finish%20without%20the%20matching%20pre-commit%20mirror%20tag.%0A%0A%23%23%23%20Issue%202%0Ascripts%2Fci%2Fmirror%2Fresolve-version.sh%3A38-40%0A**Prereleases%20still%20pass**%0A%0AThis%20check%20only%20recognizes%20compact%20lowercase%20%60a%60%2C%20%60b%60%2C%20and%20%60rc%60%20forms%20followed%20immediately%20by%20digits.%20Tags%20such%20as%20%60v1.2.3.dev1%60%2C%20%60v1.2.3-rc.1%60%2C%20%60v1.2.3-alpha.1%60%2C%20or%20%60v1.2.3RC1%60%20leave%20%60IS_PRERELEASE%3Dfalse%60%2C%20so%20the%20guarded%20PyPI%20wait%20and%20mirror%20publish%20steps%20run%20for%20releases%20that%20should%20be%20skipped.%20That%20can%20create%20a%20mirror%20tag%20for%20a%20prerelease%20or%20send%20the%20workflow%20into%20a%20PyPI%20wait%20for%20an%20artifact%20that%20is%20not%20meant%20for%20the%20stable%20mirror%20path.%0A%0A%23%23%23%20Issue%203%0Ascripts%2Fci%2Fmirror%2Fbump_pin.py%3A29-31%0A**Pin%20selection%20still%20textual**%0A%0AThe%20script%20still%20selects%20the%20first%20quoted%20%60lintro%3D%3D...%60%20string%20in%20the%20raw%20file%20instead%20of%20the%20%60lintro%60%20dependency%20from%20%60%5Bproject%5D.dependencies%60.%20If%20the%20mirror%20%60pyproject.toml%60%20contains%20an%20earlier%20quoted%20example%2C%20comment%2C%20optional%20dependency%2C%20or%20tool%20setting%2C%20this%20rewrites%20that%20decoy.%20%60publish-mirror-release.sh%60%20then%20sees%20a%20diff%2C%20commits%2C%20merges%2C%20and%20tags%20the%20release%20while%20the%20actual%20pre-commit%20dependency%20remains%20pinned%20to%20the%20old%20wheel.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=lgtm-hq%2Fpy-lintro&pr=1176&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["ci(mirror): align action pins with repo ..."](https://github.com/lgtm-hq/py-lintro/commit/82dacd8b0ccde305208a8eb818599f24a32ca90b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42280171)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Published releases can now be automatically mirrored to the pre-commit distribution.
  - Stable and prerelease versions are handled appropriately, with stable releases verified before mirroring.
  - Mirror updates are automatically versioned, merged, and tagged.

- **Documentation**
  - Added setup guidance for the recommended hermetic pre-commit workflow.
  - Documented unreleased-source alternatives, version pinning, and release-mirroring configuration.

- **Tests**
  - Added coverage for release classification, mirror updates, workflow safeguards, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->