### PR TITLE
feat(deps): add dependency version policy validation

### DIFF
--- a/lintro/cli.py
+++ b/lintro/cli.py
@@ -74,6 +74,7 @@ from lintro.cli_utils.commands.badge import badge_command  # noqa: E402
 from lintro.cli_utils.commands.check import check_command  # noqa: E402
 from lintro.cli_utils.commands.completions import completions_command  # noqa: E402
 from lintro.cli_utils.commands.config import config_command  # noqa: E402
+from lintro.cli_utils.commands.deps import deps_command  # noqa: E402
 from lintro.cli_utils.commands.doctor import doctor_command  # noqa: E402
 from lintro.cli_utils.commands.format import format_command  # noqa: E402
 from lintro.cli_utils.commands.init import init_command  # noqa: E402
@@ -249,6 +250,7 @@ cast(Any, badge_command)._canonical_name = "badge"
 cast(Any, check_command)._canonical_name = "check"
 cast(Any, completions_command)._canonical_name = "completions"
 cast(Any, config_command)._canonical_name = "config"
+cast(Any, deps_command)._canonical_name = "deps"
 cast(Any, doctor_command)._canonical_name = "doctor"
 cast(Any, format_command)._canonical_name = "format"
 cast(Any, init_command)._canonical_name = "init"
@@ -266,6 +268,7 @@ cli.add_command(badge_command, name="badge")
 cli.add_command(check_command, name="check")
 cli.add_command(completions_command, name="completions")
 cli.add_command(config_command, name="config")
+cli.add_command(deps_command, name="deps")
 cli.add_command(doctor_command, name="doctor")
 cli.add_command(format_command, name="format")
 cli.add_command(init_command, name="init")

--- a/lintro/cli_utils/commands/deps.py
+++ b/lintro/cli_utils/commands/deps.py
@@ -1,0 +1,266 @@
+"""CLI command for dependency version policy validation."""
+
+from __future__ import annotations
+
+import json as json_lib
+from pathlib import Path
+
+import click
+from loguru import logger
+from rich.console import Console
+from rich.table import Table
+
+from lintro.config.config_loader import get_config
+from lintro.config.deps_config import DepsConfig, DepsPolicy
+from lintro.deps.models import Dependency, DepsCheckResult, VersionViolation
+from lintro.deps.parsers import SUPPORTED_FILENAMES, parse_file
+from lintro.deps.policy_engine import PolicyEngine
+
+__all__ = ["deps_command"]
+
+# Directories skipped during automatic manifest discovery.
+_SKIP_DIRS: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".venv",
+        "venv",
+        "node_modules",
+        "target",
+        "dist",
+        "build",
+        "__pycache__",
+        ".tox",
+        ".mypy_cache",
+    },
+)
+
+
+@click.command("deps")
+@click.option(
+    "--file",
+    "-f",
+    "files",
+    multiple=True,
+    help="Specific dependency file(s) to check. Repeatable.",
+)
+@click.option(
+    "--policy",
+    type=click.Choice([p.value for p in DepsPolicy if p is not DepsPolicy.CUSTOM]),
+    default=None,
+    help="Override the configured policy preset.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["grid", "json"]),
+    default="grid",
+    help="Output format.",
+)
+def deps_command(
+    files: tuple[str, ...],
+    policy: str | None,
+    output_format: str,
+) -> None:
+    """Validate dependency version specifications against a policy.
+
+    Parses dependency manifests (``pyproject.toml``, ``requirements*.txt``,
+    ``package.json``, ``Cargo.toml``), classifies each version specification,
+    and reports specs that violate the active policy. Exits non-zero when any
+    violation is found.
+
+    Args:
+        files: Explicit manifest paths. When empty, manifests are discovered.
+        policy: Optional policy preset overriding configuration.
+        output_format: Output format (``grid`` or ``json``).
+
+    Raises:
+        SystemExit: Process exit; non-zero when any violation is found.
+    """
+    config = _resolve_config(policy)
+    engine = PolicyEngine(config)
+
+    targets = _resolve_targets(files)
+    if not targets:
+        message = "No dependency manifests found."
+        if output_format == "json":
+            click.echo(json_lib.dumps({"error": message}, indent=2))
+        else:
+            Console().print(f"[yellow]{message}[/yellow]")
+        raise SystemExit(0)
+
+    result = _run_checks(targets, engine)
+
+    if output_format == "json":
+        _render_json(result)
+    else:
+        _render_grid(result)
+
+    raise SystemExit(1 if result.violations else 0)
+
+
+def _resolve_config(policy: str | None) -> DepsConfig:
+    """Resolve the deps config, applying an optional CLI policy override.
+
+    Args:
+        policy: Policy preset name from the CLI, or ``None``.
+
+    Returns:
+        DepsConfig: The effective configuration.
+    """
+    try:
+        config = get_config().deps
+    except Exception as exc:  # pragma: no cover - defensive config fallback
+        logger.debug(f"Falling back to default deps config: {exc}")
+        config = DepsConfig()
+
+    if policy is not None:
+        config = config.model_copy(update={"policy": DepsPolicy(policy)})
+    return config
+
+
+def _resolve_targets(files: tuple[str, ...]) -> list[Path]:
+    """Resolve manifest paths from CLI args or auto-discovery.
+
+    Args:
+        files: Explicit manifest paths (may be empty).
+
+    Returns:
+        list[Path]: Existing manifest paths to check.
+    """
+    if files:
+        return [Path(f) for f in files if Path(f).exists()]
+    return _discover_manifests(Path.cwd())
+
+
+def _discover_manifests(root: Path) -> list[Path]:
+    """Discover supported manifests under ``root``.
+
+    Args:
+        root: Directory to search recursively.
+
+    Returns:
+        list[Path]: Discovered manifest paths, sorted for stable output.
+    """
+    found: list[Path] = []
+    for path in root.rglob("*"):
+        if any(part in _SKIP_DIRS for part in path.parts):
+            continue
+        if not path.is_file():
+            continue
+        name = path.name.lower()
+        if name in {n.lower() for n in SUPPORTED_FILENAMES} or (
+            name.startswith("requirements") and name.endswith(".txt")
+        ):
+            found.append(path)
+    return sorted(found)
+
+
+def _run_checks(targets: list[Path], engine: PolicyEngine) -> DepsCheckResult:
+    """Parse and validate all target manifests.
+
+    Args:
+        targets: Manifest paths to check.
+        engine: Configured policy engine.
+
+    Returns:
+        DepsCheckResult: Aggregated dependencies and violations.
+    """
+    dependencies: list[Dependency] = []
+    for target in targets:
+        try:
+            dependencies.extend(parse_file(target))
+        except (ValueError, OSError) as exc:
+            logger.warning(f"Skipping {target}: {exc}")
+    violations = engine.validate(dependencies)
+    return DepsCheckResult(dependencies=dependencies, violations=violations)
+
+
+def _render_grid(result: DepsCheckResult) -> None:
+    """Render results as a grouped Rich table.
+
+    Args:
+        result: The check result to render.
+    """
+    console = Console()
+    violations_by_dep: dict[int, VersionViolation] = {
+        id(v.dependency): v for v in result.violations
+    }
+
+    by_file: dict[str, list[Dependency]] = {}
+    for dep in result.dependencies:
+        by_file.setdefault(dep.file, []).append(dep)
+
+    for file, deps in by_file.items():
+        table = Table(title=f"Dependency Version Check — {file}")
+        table.add_column("Package", style="cyan", no_wrap=True)
+        table.add_column("Version Spec", style="yellow")
+        table.add_column("Type", style="magenta")
+        table.add_column("Status", justify="center")
+        table.add_column("Issue", style="red")
+
+        for dep in deps:
+            violation = violations_by_dep.get(id(dep))
+            if violation is None:
+                status = "[green]✓[/green]"
+                issue = ""
+            else:
+                status = "[red]✗[/red]"
+                issue = violation.message
+            table.add_row(
+                dep.name,
+                dep.version_spec or "*",
+                str(dep.spec_type),
+                status,
+                issue,
+            )
+        console.print(table)
+
+    _render_summary(console, result)
+
+
+def _render_summary(console: Console, result: DepsCheckResult) -> None:
+    """Print a summary line for the check.
+
+    Args:
+        console: Rich console to write to.
+        result: The check result to summarize.
+    """
+    count = len(result.violations)
+    if count == 0:
+        console.print(
+            f"\n[green]✅ All {len(result.dependencies)} dependencies "
+            f"satisfy the policy.[/green]",
+        )
+        return
+
+    console.print(f"\n[red]Summary: {count} issue(s) found[/red]")
+    by_rule: dict[str, int] = {}
+    for violation in result.violations:
+        by_rule[violation.message] = by_rule.get(violation.message, 0) + 1
+    for message, n in sorted(by_rule.items()):
+        console.print(f"  [dim]- {n} dependency(ies): {message}[/dim]")
+
+
+def _render_json(result: DepsCheckResult) -> None:
+    """Render results as JSON.
+
+    Args:
+        result: The check result to render.
+    """
+    payload = {
+        "passed": result.passed,
+        "total": len(result.dependencies),
+        "violation_count": len(result.violations),
+        "violations": [
+            {
+                "package": v.dependency.name,
+                "file": v.dependency.file,
+                "version_spec": v.dependency.version_spec,
+                "spec_type": str(v.dependency.spec_type),
+                "rule": v.rule,
+                "message": v.message,
+            }
+            for v in result.violations
+        ],
+    }
+    click.echo(json_lib.dumps(payload, indent=2))

--- a/lintro/cli_utils/commands/deps.py
+++ b/lintro/cli_utils/commands/deps.py
@@ -76,10 +76,28 @@ def deps_command(
     Raises:
         SystemExit: Process exit; non-zero when any violation is found.
     """
-    config = _resolve_config(policy)
+    try:
+        config = _resolve_config(policy)
+    except ValueError as exc:
+        message = str(exc)
+        if output_format == "json":
+            click.echo(json_lib.dumps({"error": message}, indent=2))
+        else:
+            Console().print(f"[red]{message}[/red]")
+        raise SystemExit(1) from exc
+
     engine = PolicyEngine(config)
 
-    targets = _resolve_targets(files)
+    try:
+        targets = _resolve_targets(files)
+    except FileNotFoundError as exc:
+        message = str(exc)
+        if output_format == "json":
+            click.echo(json_lib.dumps({"error": message}, indent=2))
+        else:
+            Console().print(f"[red]{message}[/red]")
+        raise SystemExit(1) from exc
+
     if not targets:
         message = "No dependency manifests found."
         if output_format == "json":
@@ -88,14 +106,16 @@ def deps_command(
             Console().print(f"[yellow]{message}[/yellow]")
         raise SystemExit(0)
 
-    result = _run_checks(targets, engine)
+    result, parse_errors = _run_checks(targets, engine)
 
     if output_format == "json":
-        _render_json(result)
+        _render_json(result, parse_errors=parse_errors)
     else:
         _render_grid(result)
+        for err in parse_errors:
+            Console().print(f"[red]Failed to parse {err}[/red]")
 
-    raise SystemExit(1 if result.violations else 0)
+    raise SystemExit(1 if result.violations or parse_errors else 0)
 
 
 def _resolve_config(policy: str | None) -> DepsConfig:
@@ -106,12 +126,16 @@ def _resolve_config(policy: str | None) -> DepsConfig:
 
     Returns:
         DepsConfig: The effective configuration.
+
+    Raises:
+        ValueError: When repository deps configuration cannot be loaded.
     """
     try:
         config = get_config().deps
-    except Exception as exc:  # pragma: no cover - defensive config fallback
-        logger.debug(f"Falling back to default deps config: {exc}")
-        config = DepsConfig()
+    except Exception as exc:
+        raise ValueError(
+            f"Invalid deps configuration: {exc}",
+        ) from exc
 
     if policy is not None:
         config = config.model_copy(update={"policy": DepsPolicy(policy)})
@@ -126,9 +150,25 @@ def _resolve_targets(files: tuple[str, ...]) -> list[Path]:
 
     Returns:
         list[Path]: Existing manifest paths to check.
+
+    Raises:
+        FileNotFoundError: When an explicit ``--file`` path does not exist.
     """
     if files:
-        return [Path(f) for f in files if Path(f).exists()]
+        targets: list[Path] = []
+        missing: list[str] = []
+        for raw in files:
+            path = Path(raw)
+            if path.exists():
+                targets.append(path)
+            else:
+                missing.append(raw)
+        if missing:
+            joined = ", ".join(missing)
+            raise FileNotFoundError(
+                f"Explicit dependency manifest(s) not found: {joined}",
+            )
+        return targets
     return _discover_manifests(Path.cwd())
 
 
@@ -155,7 +195,10 @@ def _discover_manifests(root: Path) -> list[Path]:
     return sorted(found)
 
 
-def _run_checks(targets: list[Path], engine: PolicyEngine) -> DepsCheckResult:
+def _run_checks(
+    targets: list[Path],
+    engine: PolicyEngine,
+) -> tuple[DepsCheckResult, list[str]]:
     """Parse and validate all target manifests.
 
     Args:
@@ -163,16 +206,21 @@ def _run_checks(targets: list[Path], engine: PolicyEngine) -> DepsCheckResult:
         engine: Configured policy engine.
 
     Returns:
-        DepsCheckResult: Aggregated dependencies and violations.
+        tuple[DepsCheckResult, list[str]]: Aggregated results and parse errors.
     """
     dependencies: list[Dependency] = []
+    parse_errors: list[str] = []
     for target in targets:
         try:
             dependencies.extend(parse_file(target))
-        except (ValueError, OSError) as exc:
-            logger.warning(f"Skipping {target}: {exc}")
+        except (ValueError, OSError, json_lib.JSONDecodeError) as exc:
+            logger.warning(f"Failed to parse {target}: {exc}")
+            parse_errors.append(f"{target}: {exc}")
     violations = engine.validate(dependencies)
-    return DepsCheckResult(dependencies=dependencies, violations=violations)
+    return (
+        DepsCheckResult(dependencies=dependencies, violations=violations),
+        parse_errors,
+    )
 
 
 def _render_grid(result: DepsCheckResult) -> None:
@@ -241,16 +289,23 @@ def _render_summary(console: Console, result: DepsCheckResult) -> None:
         console.print(f"  [dim]- {n} dependency(ies): {message}[/dim]")
 
 
-def _render_json(result: DepsCheckResult) -> None:
+def _render_json(
+    result: DepsCheckResult,
+    *,
+    parse_errors: list[str] | None = None,
+) -> None:
     """Render results as JSON.
 
     Args:
         result: The check result to render.
+        parse_errors: Manifest parse failures that should fail the run.
     """
+    errors = parse_errors or []
     payload = {
-        "passed": result.passed,
+        "passed": result.passed and not errors,
         "total": len(result.dependencies),
         "violation_count": len(result.violations),
+        "parse_errors": errors,
         "violations": [
             {
                 "package": v.dependency.name,

--- a/lintro/cli_utils/commands/deps.py
+++ b/lintro/cli_utils/commands/deps.py
@@ -13,7 +13,7 @@ from rich.table import Table
 from lintro.config.config_loader import get_config
 from lintro.config.deps_config import DepsConfig, DepsPolicy
 from lintro.deps.models import Dependency, DepsCheckResult, VersionViolation
-from lintro.deps.parsers import SUPPORTED_FILENAMES, parse_file
+from lintro.deps.parsers import is_supported_manifest, parse_file
 from lintro.deps.policy_engine import PolicyEngine
 
 __all__ = ["deps_command"]
@@ -117,8 +117,12 @@ def deps_command(
         message = "No dependency manifests found."
         if strict_discovery:
             message = f"{message} (--strict-discovery)"
+        empty = DepsCheckResult()
         if output_format == "json":
-            click.echo(json_lib.dumps({"error": message}, indent=2))
+            _render_json(
+                empty,
+                parse_errors=[message] if strict_discovery else [],
+            )
         else:
             color = "red" if strict_discovery else "yellow"
             Console().print(f"[{color}]{message}[/{color}]")
@@ -200,17 +204,34 @@ def _discover_manifests(root: Path) -> list[Path]:
         list[Path]: Discovered manifest paths, sorted for stable output.
     """
     found: list[Path] = []
-    for path in root.rglob("*"):
-        if any(part in _SKIP_DIRS for part in path.parts):
+    resolved_root = root.resolve()
+    for path in resolved_root.rglob("*"):
+        if _is_skipped(path, resolved_root):
             continue
-        if not path.is_file():
-            continue
-        name = path.name.lower()
-        if name in {n.lower() for n in SUPPORTED_FILENAMES} or (
-            name.startswith("requirements") and name.endswith(".txt")
-        ):
+        if path.is_file() and is_supported_manifest(path):
             found.append(path)
     return sorted(found)
+
+
+def _is_skipped(path: Path, root: Path) -> bool:
+    """Return whether ``path`` sits under a skip-dir relative to ``root``.
+
+    Absolute ancestors of the scan root are ignored so a checkout whose
+    resolved path contains ``build`` or ``dist`` (for example a Docker
+    ``WORKDIR /build``) still discovers manifests at the root.
+
+    Args:
+        path: Candidate file or directory path.
+        root: Scan root that discovery started from.
+
+    Returns:
+        bool: ``True`` when a relative path component is in ``_SKIP_DIRS``.
+    """
+    try:
+        relative = path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return any(part in _SKIP_DIRS for part in relative.parts)
 
 
 def _run_checks(

--- a/lintro/cli_utils/commands/deps.py
+++ b/lintro/cli_utils/commands/deps.py
@@ -50,6 +50,15 @@ _SKIP_DIRS: frozenset[str] = frozenset(
     help="Override the configured policy preset.",
 )
 @click.option(
+    "--strict-discovery",
+    is_flag=True,
+    default=False,
+    help=(
+        "Exit 1 when auto-discovery finds no manifests. Without this flag an "
+        "empty discovery is reported as a warning and exits 0."
+    ),
+)
+@click.option(
     "--format",
     "output_format",
     type=click.Choice(["grid", "json"]),
@@ -59,6 +68,7 @@ _SKIP_DIRS: frozenset[str] = frozenset(
 def deps_command(
     files: tuple[str, ...],
     policy: str | None,
+    strict_discovery: bool,
     output_format: str,
 ) -> None:
     """Validate dependency version specifications against a policy.
@@ -66,11 +76,17 @@ def deps_command(
     Parses dependency manifests (``pyproject.toml``, ``requirements*.txt``,
     ``package.json``, ``Cargo.toml``), classifies each version specification,
     and reports specs that violate the active policy. Exits non-zero when any
-    violation is found.
+    violation is found, and when any manifest fails to parse.
+
+    Auto-discovery that finds no manifests is a warning and exits 0, so that
+    running ``lintro deps`` in a repository without manifests is not an error.
+    Pass ``--strict-discovery`` (or explicit ``--file`` paths) when using the
+    command as a CI gate, so a wrong working directory fails the job.
 
     Args:
         files: Explicit manifest paths. When empty, manifests are discovered.
         policy: Optional policy preset overriding configuration.
+        strict_discovery: Fail when auto-discovery finds no manifests.
         output_format: Output format (``grid`` or ``json``).
 
     Raises:
@@ -78,6 +94,7 @@ def deps_command(
     """
     try:
         config = _resolve_config(policy)
+        engine = PolicyEngine(config)
     except ValueError as exc:
         message = str(exc)
         if output_format == "json":
@@ -85,8 +102,6 @@ def deps_command(
         else:
             Console().print(f"[red]{message}[/red]")
         raise SystemExit(1) from exc
-
-    engine = PolicyEngine(config)
 
     try:
         targets = _resolve_targets(files)
@@ -100,18 +115,21 @@ def deps_command(
 
     if not targets:
         message = "No dependency manifests found."
+        if strict_discovery:
+            message = f"{message} (--strict-discovery)"
         if output_format == "json":
             click.echo(json_lib.dumps({"error": message}, indent=2))
         else:
-            Console().print(f"[yellow]{message}[/yellow]")
-        raise SystemExit(0)
+            color = "red" if strict_discovery else "yellow"
+            Console().print(f"[{color}]{message}[/{color}]")
+        raise SystemExit(1 if strict_discovery else 0)
 
     result, parse_errors = _run_checks(targets, engine)
 
     if output_format == "json":
         _render_json(result, parse_errors=parse_errors)
     else:
-        _render_grid(result)
+        _render_grid(result, parse_errors=parse_errors)
         for err in parse_errors:
             Console().print(f"[red]Failed to parse {err}[/red]")
 
@@ -223,11 +241,17 @@ def _run_checks(
     )
 
 
-def _render_grid(result: DepsCheckResult) -> None:
+def _render_grid(
+    result: DepsCheckResult,
+    *,
+    parse_errors: list[str] | None = None,
+) -> None:
     """Render results as a grouped Rich table.
 
     Args:
         result: The check result to render.
+        parse_errors: Manifest parse failures that must suppress the green
+            success summary.
     """
     console = Console()
     violations_by_dep: dict[int, VersionViolation] = {
@@ -263,17 +287,32 @@ def _render_grid(result: DepsCheckResult) -> None:
             )
         console.print(table)
 
-    _render_summary(console, result)
+    _render_summary(console, result, parse_errors=parse_errors or [])
 
 
-def _render_summary(console: Console, result: DepsCheckResult) -> None:
+def _render_summary(
+    console: Console,
+    result: DepsCheckResult,
+    *,
+    parse_errors: list[str],
+) -> None:
     """Print a summary line for the check.
 
     Args:
         console: Rich console to write to.
         result: The check result to summarize.
+        parse_errors: Manifest parse failures. When non-empty, the green
+            success line is replaced by a failure line so the summary never
+            contradicts the exit code.
     """
     count = len(result.violations)
+    if count == 0 and parse_errors:
+        console.print(
+            f"\n[red]Summary: {len(parse_errors)} manifest(s) failed to "
+            f"parse; no policy verdict for them.[/red]",
+        )
+        return
+
     if count == 0:
         console.print(
             f"\n[green]✅ All {len(result.dependencies)} dependencies "

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -509,7 +509,11 @@ def _parse_deps_config(data: Any) -> DepsConfig:
         DepsConfig: Parsed dependency policy configuration.
 
     Raises:
-        ValueError: When the deps section is not a mapping.
+        ValueError: When the deps section is not a mapping, or contains an
+            unknown key. Because ``deps`` gates dependency-spec enforcement, a
+            misspelled key (for example ``pollicy`` for ``policy``) must fail
+            loudly rather than silently fall back to the default policy and let
+            specs that should fail pass in CI.
     """
     if data is None:
         return DepsConfig()
@@ -522,12 +526,13 @@ def _parse_deps_config(data: Any) -> DepsConfig:
     known_fields = set(DepsConfig.model_fields)
     unknown = set(data) - known_fields
     if unknown:
-        logger.warning(
-            "Unknown deps config keys ignored: {}",
-            ", ".join(sorted(unknown)),
+        known = ", ".join(sorted(known_fields))
+        msg = (
+            f"Unknown deps config key(s): {', '.join(sorted(unknown))}. "
+            f"Valid keys are: {known}"
         )
-    filtered = {key: value for key, value in data.items() if key in known_fields}
-    return DepsConfig(**filtered)
+        raise ValueError(msg)
+    return DepsConfig(**data)
 
 
 def _parse_watch_config(data: Any) -> WatchConfig:

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -18,6 +18,7 @@ from typing import Any, NamedTuple
 
 from loguru import logger
 
+from lintro.config.deps_config import DepsConfig
 from lintro.config.lintro_config import (
     EnforceConfig,
     ExecutionConfig,
@@ -498,6 +499,36 @@ def _parse_score_config(data: Any) -> ScoreConfig:
     filtered = {key: value for key, value in data.items() if key in known_fields}
     return ScoreConfig(**filtered)
 
+def _parse_deps_config(data: Any) -> DepsConfig:
+    """Parse the ``deps`` configuration section.
+
+    Args:
+        data: Raw ``deps`` section from config.
+
+    Returns:
+        DepsConfig: Parsed dependency policy configuration.
+
+    Raises:
+        ValueError: When the deps section is not a mapping.
+    """
+    if data is None:
+        return DepsConfig()
+    if not isinstance(data, dict):
+        msg = f"deps config must be a mapping, got {type(data).__name__}"
+        raise ValueError(msg)
+    if not data:
+        return DepsConfig()
+
+    known_fields = set(DepsConfig.model_fields)
+    unknown = set(data) - known_fields
+    if unknown:
+        logger.warning(
+            "Unknown deps config keys ignored: {}",
+            ", ".join(sorted(unknown)),
+        )
+    filtered = {key: value for key, value in data.items() if key in known_fields}
+    return DepsConfig(**filtered)
+
 
 def _parse_watch_config(data: Any) -> WatchConfig:
     """Parse the ``watch`` configuration section.
@@ -589,6 +620,7 @@ def _pyproject_lintro_catalog() -> _PyprojectLintroCatalog:
         | {
             "ai",
             "defaults",
+            "deps",
             "output",
             "review",
             "score",
@@ -663,6 +695,7 @@ def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
         "score": {},
         "output": {},
         "watch": {},
+        "deps": {},
     }
 
     catalog = _pyproject_lintro_catalog()
@@ -752,6 +785,8 @@ def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
             result["output"] = value
         elif key_lower == "watch":
             result["watch"] = value
+        elif key_lower == "deps" and isinstance(value, dict):
+            result["deps"] = value
         elif key_lower in externally_handled_sections:
             # Parsed elsewhere; nothing to convert here.
             pass
@@ -901,6 +936,7 @@ def build_config_from_dict(
     score_config = _parse_score_config(data.get("score", {}))
     output_config = _parse_output_config(data.get("output", {}))
     watch_config = _parse_watch_config(data.get("watch", {}))
+    deps_config = _parse_deps_config(data.get("deps", {}))
 
     return LintroConfig(
         execution=execution_config,
@@ -912,6 +948,7 @@ def build_config_from_dict(
         score=score_config,
         output=output_config,
         watch=watch_config,
+        deps=deps_config,
         config_path=resolved_path,
     )
 

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -689,7 +689,8 @@ def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
 
     Raises:
         ValueError: If a nested ``execution`` or ``enforce`` value is not a
-            mapping.
+            mapping. A non-mapping ``deps`` value is passed through so
+            :func:`_parse_deps_config` can fail closed.
     """
     result: dict[str, Any] = {
         "enforce": {},
@@ -791,7 +792,9 @@ def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
             result["output"] = value
         elif key_lower == "watch":
             result["watch"] = value
-        elif key_lower == "deps" and isinstance(value, dict):
+        elif key_lower == "deps":
+            # Pass through non-mappings so ``_parse_deps_config`` fail-closes
+            # instead of treating ``deps = true`` as an unrecognized key.
             result["deps"] = value
         elif key_lower in externally_handled_sections:
             # Parsed elsewhere; nothing to convert here.

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -499,6 +499,7 @@ def _parse_score_config(data: Any) -> ScoreConfig:
     filtered = {key: value for key, value in data.items() if key in known_fields}
     return ScoreConfig(**filtered)
 
+
 def _parse_deps_config(data: Any) -> DepsConfig:
     """Parse the ``deps`` configuration section.
 

--- a/lintro/config/deps_config.py
+++ b/lintro/config/deps_config.py
@@ -1,0 +1,89 @@
+"""Configuration models for the ``lintro deps`` command.
+
+The dependency policy validator enforces version-specification rules across
+dependency manifests (``pyproject.toml``, ``requirements.txt``,
+``package.json``, ``Cargo.toml``). Policies are expressed either through one of
+the built-in presets (``strict``, ``flexible``, ``loose``) or via a ``custom``
+policy that reads the explicit rule fields on :class:`DepsConfig`.
+
+Example ``.lintro-config.yaml``::
+
+    deps:
+      policy: flexible
+      exceptions:
+        - package: "boto3"
+          allowed_types: [exact]
+          reason: "AWS SDK versions are tightly coupled"
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "DepsConfig",
+    "DepsPolicy",
+    "PackageException",
+]
+
+
+class DepsPolicy(StrEnum):
+    """Named policy presets for dependency version validation.
+
+    Attributes:
+        STRICT: Require exact pins for maximum reproducibility.
+        FLEXIBLE: Allow bounded ranges; require an upper bound.
+        LOOSE: Accept any constraint; only flag fully unconstrained specs.
+        CUSTOM: Use the explicit rule fields on :class:`DepsConfig`.
+    """
+
+    STRICT = auto()
+    FLEXIBLE = auto()
+    LOOSE = auto()
+    CUSTOM = auto()
+
+
+class PackageException(BaseModel):
+    """Per-package override of the active policy.
+
+    Attributes:
+        model_config: Pydantic model configuration.
+        package: Package name or ``fnmatch`` glob (e.g. ``aws-*``).
+        allowed_types: Version-spec types permitted for the matched package.
+        require_upper_bound: Optional override of the upper-bound requirement.
+        reason: Human-readable justification for the exception.
+    """
+
+    model_config = ConfigDict(frozen=False, extra="forbid")
+
+    package: str
+    allowed_types: list[str] = Field(default_factory=list)
+    require_upper_bound: bool | None = None
+    reason: str | None = None
+
+
+class DepsConfig(BaseModel):
+    """Configuration for dependency version policy validation.
+
+    Attributes:
+        model_config: Pydantic model configuration.
+        policy: Active policy preset (or ``custom``).
+        require_upper_bound: Whether specs must cap the upper version bound.
+        allowed_types: Version-spec types allowed under a ``custom`` policy.
+        disallowed_types: Version-spec types forbidden under a ``custom`` policy.
+        exceptions: Per-package overrides applied before the base policy.
+    """
+
+    model_config = ConfigDict(frozen=False, extra="forbid")
+
+    policy: DepsPolicy = DepsPolicy.FLEXIBLE
+    require_upper_bound: bool = True
+    allowed_types: list[str] = Field(
+        default_factory=lambda: ["exact", "tilde", "caret", "range", "wildcard"],
+    )
+    disallowed_types: list[str] = Field(
+        default_factory=lambda: ["any", "unbounded"],
+    )
+    exceptions: list[PackageException] = Field(default_factory=list)

--- a/lintro/config/deps_config.py
+++ b/lintro/config/deps_config.py
@@ -6,6 +6,14 @@ dependency manifests (``pyproject.toml``, ``requirements.txt``,
 the built-in presets (``strict``, ``flexible``, ``loose``) or via a ``custom``
 policy that reads the explicit rule fields on :class:`DepsConfig`.
 
+The explicit rule fields (``require_upper_bound``, ``allowed_types``,
+``disallowed_types``) apply **only** when ``policy: custom``. Under a preset
+they are ignored, because the preset defines the whole rule set — setting
+``policy: flexible`` together with ``require_upper_bound: false`` still
+requires an upper bound. Set ``policy: custom`` to make those fields take
+effect. Per-package :class:`PackageException` entries are the supported way to
+relax a preset for individual packages.
+
 Example ``.lintro-config.yaml``::
 
     deps:
@@ -71,9 +79,14 @@ class DepsConfig(BaseModel):
         model_config: Pydantic model configuration.
         policy: Active policy preset (or ``custom``).
         require_upper_bound: Whether specs must cap the upper version bound.
-        allowed_types: Version-spec types allowed under a ``custom`` policy.
-        disallowed_types: Version-spec types forbidden under a ``custom`` policy.
-        exceptions: Per-package overrides applied before the base policy.
+            Applies only when ``policy`` is ``custom``; presets define their
+            own value.
+        allowed_types: Version-spec types allowed. Applies only when ``policy``
+            is ``custom``. Unknown type names are rejected.
+        disallowed_types: Version-spec types forbidden. Applies only when
+            ``policy`` is ``custom``. Unknown type names are rejected.
+        exceptions: Per-package overrides applied before the base policy. These
+            work under every policy, including the presets.
     """
 
     model_config = ConfigDict(frozen=False, extra="forbid")

--- a/lintro/config/lintro_config.py
+++ b/lintro/config/lintro_config.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from lintro.config.deps_config import DepsConfig
 from lintro.config.enforce_config import EnforceConfig
 from lintro.config.execution_config import ExecutionConfig
 from lintro.config.output_config import OutputConfig
@@ -13,6 +14,7 @@ from lintro.config.tool_config import LintroToolConfig
 from lintro.config.watch_config import WatchConfig
 
 __all__ = [
+    "DepsConfig",
     "EnforceConfig",
     "ExecutionConfig",
     "LintroConfig",
@@ -67,6 +69,7 @@ class LintroConfig(BaseModel):
         score: Health score weights and scale (0-100 metric).
         output: Console output presentation settings (e.g. ASCII art toggle).
         watch: Watch-mode (``lintro watch``) defaults.
+        deps: Dependency version policy configuration.
         config_path: Path to the config file (set by loader).
     """
 
@@ -81,6 +84,7 @@ class LintroConfig(BaseModel):
     score: ScoreConfig = Field(default_factory=ScoreConfig)
     output: OutputConfig = Field(default_factory=OutputConfig)
     watch: WatchConfig = Field(default_factory=WatchConfig)
+    deps: DepsConfig = Field(default_factory=DepsConfig)
     config_path: str | None = None
 
     def get_tool_config(self, tool_name: str) -> LintroToolConfig:

--- a/lintro/deps/__init__.py
+++ b/lintro/deps/__init__.py
@@ -1,0 +1,25 @@
+"""Dependency version policy validation for the ``lintro deps`` command.
+
+This package parses dependency manifests, classifies each version
+specification, and validates the specs against a configurable policy.
+"""
+
+from lintro.deps.models import (
+    Dependency,
+    DepsCheckResult,
+    Ecosystem,
+    VersionSpecType,
+    VersionViolation,
+)
+from lintro.deps.policy_engine import PolicyEngine
+from lintro.deps.version_analyzer import VersionAnalyzer
+
+__all__ = [
+    "Dependency",
+    "DepsCheckResult",
+    "Ecosystem",
+    "PolicyEngine",
+    "VersionAnalyzer",
+    "VersionSpecType",
+    "VersionViolation",
+]

--- a/lintro/deps/models.py
+++ b/lintro/deps/models.py
@@ -1,0 +1,117 @@
+"""Data models for dependency version policy validation."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "Dependency",
+    "DepsCheckResult",
+    "Ecosystem",
+    "VersionSpecType",
+    "VersionViolation",
+]
+
+
+class Ecosystem(StrEnum):
+    """Dependency ecosystem, which governs version-spec semantics.
+
+    Attributes:
+        PYTHON: PEP 440 / Poetry constraints (``pyproject.toml``, requirements).
+        NPM: npm/semver constraints (``package.json``).
+        CARGO: Cargo semver constraints (``Cargo.toml``).
+    """
+
+    PYTHON = auto()
+    NPM = auto()
+    CARGO = auto()
+
+
+class VersionSpecType(StrEnum):
+    """Classification of a version specification.
+
+    Attributes:
+        EXACT: Pinned to a single version (``==1.2.3``, npm ``1.2.3``).
+        TILDE: Patch-level updates only (``~=1.2.3``, ``~1.2.3``).
+        CARET: Minor-level updates only (``^1.2.3``).
+        RANGE: Bounded range with an upper limit (``>=1.2.0,<2.0.0``).
+        UNBOUNDED: Lower bound only, no upper limit (``>=1.0.0``).
+        WILDCARD: Wildcard pattern (``1.2.*``, ``1.x``).
+        ANY: No effective constraint (``*``, empty string).
+    """
+
+    EXACT = auto()
+    TILDE = auto()
+    CARET = auto()
+    RANGE = auto()
+    UNBOUNDED = auto()
+    WILDCARD = auto()
+    ANY = auto()
+
+
+class Dependency(BaseModel):
+    """A single parsed dependency and its classified version spec.
+
+    Attributes:
+        model_config: Pydantic model configuration.
+        name: Package name.
+        version_spec: Raw version specification as written in the manifest.
+        spec_type: Classified version-spec type.
+        ecosystem: Ecosystem the dependency belongs to.
+        has_upper_bound: Whether the spec caps the maximum version.
+        file: Manifest file the dependency was parsed from.
+        line: 1-based line number within the manifest, when known.
+    """
+
+    model_config = ConfigDict(frozen=False, extra="forbid")
+
+    name: str
+    version_spec: str
+    spec_type: VersionSpecType
+    ecosystem: Ecosystem
+    has_upper_bound: bool
+    file: str
+    line: int | None = None
+
+
+class VersionViolation(BaseModel):
+    """A policy violation raised against a single dependency.
+
+    Attributes:
+        model_config: Pydantic model configuration.
+        dependency: Dependency that violated the policy.
+        rule: Identifier of the rule that was violated.
+        message: Human-readable description of the violation.
+    """
+
+    model_config = ConfigDict(frozen=False, extra="forbid")
+
+    dependency: Dependency
+    rule: str
+    message: str
+
+
+class DepsCheckResult(BaseModel):
+    """Aggregate result of a dependency policy check.
+
+    Attributes:
+        model_config: Pydantic model configuration.
+        dependencies: All dependencies that were analyzed.
+        violations: Policy violations found across all dependencies.
+    """
+
+    model_config = ConfigDict(frozen=False, extra="forbid")
+
+    dependencies: list[Dependency] = Field(default_factory=list)
+    violations: list[VersionViolation] = Field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        """Return whether the check produced no violations.
+
+        Returns:
+            bool: ``True`` when there are no violations.
+        """
+        return not self.violations

--- a/lintro/deps/parsers/__init__.py
+++ b/lintro/deps/parsers/__init__.py
@@ -1,0 +1,57 @@
+"""Dependency manifest parsers.
+
+Each parser turns a manifest file into a list of
+:class:`~lintro.deps.models.Dependency` objects with classified version specs.
+:func:`parse_file` dispatches to the correct parser by file name.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lintro.deps.models import Dependency
+from lintro.deps.parsers.cargo_parser import CargoParser
+from lintro.deps.parsers.package_json_parser import PackageJsonParser
+from lintro.deps.parsers.pyproject_parser import PyprojectParser
+from lintro.deps.parsers.requirements_parser import RequirementsParser
+
+__all__ = [
+    "CargoParser",
+    "PackageJsonParser",
+    "PyprojectParser",
+    "RequirementsParser",
+    "SUPPORTED_FILENAMES",
+    "parse_file",
+]
+
+# Files the validator knows how to parse, in discovery order.
+SUPPORTED_FILENAMES: tuple[str, ...] = (
+    "pyproject.toml",
+    "package.json",
+    "Cargo.toml",
+)
+
+
+def parse_file(path: Path) -> list[Dependency]:
+    """Parse a dependency manifest into dependencies.
+
+    Args:
+        path: Path to a supported manifest file.
+
+    Returns:
+        list[Dependency]: Parsed dependencies (empty when unsupported).
+
+    Raises:
+        ValueError: When the file name is not a supported manifest.
+    """
+    name = path.name.lower()
+    if name == "pyproject.toml":
+        return PyprojectParser().parse(path)
+    if name == "package.json":
+        return PackageJsonParser().parse(path)
+    if name == "cargo.toml":
+        return CargoParser().parse(path)
+    if name.startswith("requirements") and name.endswith(".txt"):
+        return RequirementsParser().parse(path)
+    msg = f"Unsupported dependency manifest: {path.name}"
+    raise ValueError(msg)

--- a/lintro/deps/parsers/__init__.py
+++ b/lintro/deps/parsers/__init__.py
@@ -21,15 +21,55 @@ __all__ = [
     "PyprojectParser",
     "RequirementsParser",
     "SUPPORTED_FILENAMES",
+    "is_supported_manifest",
     "parse_file",
 ]
 
 # Files the validator knows how to parse, in discovery order.
 SUPPORTED_FILENAMES: tuple[str, ...] = (
     "pyproject.toml",
+    "requirements.txt",
     "package.json",
     "Cargo.toml",
 )
+
+_SUPPORTED_NAME_SET: frozenset[str] = frozenset(
+    name.lower() for name in SUPPORTED_FILENAMES
+)
+
+
+def is_requirements_manifest(path: Path) -> bool:
+    """Return whether ``path`` is a pip requirements file.
+
+    Matches ``requirements*.txt``, ``*requirements.txt``, and ``*.txt``
+    files directly under a ``requirements/`` directory.
+
+    Args:
+        path: Candidate manifest path.
+
+    Returns:
+        bool: ``True`` when the requirements parser should handle the file.
+    """
+    name = path.name.lower()
+    if name.endswith(".txt") and (
+        name.startswith("requirements") or name.endswith("requirements.txt")
+    ):
+        return True
+    return path.parent.name.lower() == "requirements" and name.endswith(".txt")
+
+
+def is_supported_manifest(path: Path) -> bool:
+    """Return whether ``path`` is a known dependency manifest.
+
+    Args:
+        path: Candidate manifest path.
+
+    Returns:
+        bool: ``True`` when :func:`parse_file` can parse the file.
+    """
+    return path.name.lower() in _SUPPORTED_NAME_SET or is_requirements_manifest(
+        path,
+    )
 
 
 def parse_file(path: Path) -> list[Dependency]:
@@ -39,7 +79,7 @@ def parse_file(path: Path) -> list[Dependency]:
         path: Path to a supported manifest file.
 
     Returns:
-        list[Dependency]: Parsed dependencies (empty when unsupported).
+        list[Dependency]: Parsed dependencies.
 
     Raises:
         ValueError: When the file name is not a supported manifest.
@@ -51,7 +91,7 @@ def parse_file(path: Path) -> list[Dependency]:
         return PackageJsonParser().parse(path)
     if name == "cargo.toml":
         return CargoParser().parse(path)
-    if name.startswith("requirements") and name.endswith(".txt"):
+    if is_requirements_manifest(path):
         return RequirementsParser().parse(path)
     msg = f"Unsupported dependency manifest: {path.name}"
     raise ValueError(msg)

--- a/lintro/deps/parsers/_base.py
+++ b/lintro/deps/parsers/_base.py
@@ -1,0 +1,44 @@
+"""Shared helpers for dependency manifest parsers."""
+
+from __future__ import annotations
+
+from lintro.deps.models import Dependency, Ecosystem
+from lintro.deps.version_analyzer import VersionAnalyzer
+
+__all__ = ["build_dependency"]
+
+_ANALYZER = VersionAnalyzer()
+
+
+def build_dependency(
+    *,
+    name: str,
+    version_spec: str,
+    ecosystem: Ecosystem,
+    file: str,
+    line: int | None = None,
+) -> Dependency:
+    """Classify a raw version spec and build a :class:`Dependency`.
+
+    Args:
+        name: Package name.
+        version_spec: Raw version constraint from the manifest.
+        ecosystem: Ecosystem governing the constraint semantics.
+        file: Manifest file the dependency was parsed from.
+        line: 1-based line number within the manifest, when known.
+
+    Returns:
+        Dependency: The classified dependency.
+    """
+    spec = version_spec.strip()
+    spec_type = _ANALYZER.classify(spec, ecosystem)
+    has_upper = _ANALYZER.has_upper_bound(spec, ecosystem)
+    return Dependency(
+        name=name,
+        version_spec=spec,
+        spec_type=spec_type,
+        ecosystem=ecosystem,
+        has_upper_bound=has_upper,
+        file=file,
+        line=line,
+    )

--- a/lintro/deps/parsers/cargo_parser.py
+++ b/lintro/deps/parsers/cargo_parser.py
@@ -1,0 +1,78 @@
+"""Parser for Rust ``Cargo.toml`` dependency tables."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from lintro.deps.models import Dependency, Ecosystem
+from lintro.deps.parsers._base import build_dependency
+
+__all__ = ["CargoParser"]
+
+_DEP_SECTIONS: tuple[str, ...] = (
+    "dependencies",
+    "dev-dependencies",
+    "build-dependencies",
+)
+
+
+class CargoParser:
+    """Parse dependency tables from ``Cargo.toml``."""
+
+    def parse(self, path: Path) -> list[Dependency]:
+        """Parse dependencies from a ``Cargo.toml`` file.
+
+        Reads ``dependencies``, ``dev-dependencies``, and
+        ``build-dependencies`` at the top level.
+
+        Args:
+            path: Path to the ``Cargo.toml`` file.
+
+        Returns:
+            list[Dependency]: Parsed dependencies.
+        """
+        with path.open("rb") as handle:
+            data = tomllib.load(handle)
+
+        file = str(path)
+        deps: list[Dependency] = []
+
+        for section in _DEP_SECTIONS:
+            table = data.get(section)
+            if not isinstance(table, dict):
+                continue
+            for name, constraint in table.items():
+                version_spec = self._constraint(constraint)
+                if version_spec is None:
+                    continue
+                deps.append(
+                    build_dependency(
+                        name=name,
+                        version_spec=version_spec,
+                        ecosystem=Ecosystem.CARGO,
+                        file=file,
+                    ),
+                )
+
+        return deps
+
+    @staticmethod
+    def _constraint(constraint: Any) -> str | None:
+        """Extract a version string from a Cargo dependency value.
+
+        Args:
+            constraint: Raw Cargo value (string or table).
+
+        Returns:
+            str | None: The version constraint, or ``None`` to skip
+            git/path dependencies that lack a version.
+        """
+        if isinstance(constraint, str):
+            return constraint
+        if isinstance(constraint, dict):
+            version = constraint.get("version")
+            if isinstance(version, str):
+                return version
+        return None

--- a/lintro/deps/parsers/cargo_parser.py
+++ b/lintro/deps/parsers/cargo_parser.py
@@ -41,21 +41,49 @@ class CargoParser:
 
         for section in _DEP_SECTIONS:
             table = data.get(section)
-            if not isinstance(table, dict):
-                continue
-            for name, constraint in table.items():
-                version_spec = self._constraint(constraint)
-                if version_spec is None:
-                    continue
-                deps.append(
-                    build_dependency(
-                        name=name,
-                        version_spec=version_spec,
-                        ecosystem=Ecosystem.CARGO,
-                        file=file,
-                    ),
-                )
+            if isinstance(table, dict):
+                deps.extend(self._from_table(table, file))
 
+        # Platform-specific deps: [target.'cfg(...)'.dependencies]
+        target = data.get("target")
+        if isinstance(target, dict):
+            for target_table in target.values():
+                if not isinstance(target_table, dict):
+                    continue
+                for section in _DEP_SECTIONS:
+                    nested = target_table.get(section)
+                    if isinstance(nested, dict):
+                        deps.extend(self._from_table(nested, file))
+
+        return deps
+
+    def _from_table(
+        self,
+        table: dict[str, Any],
+        file: str,
+    ) -> list[Dependency]:
+        """Build dependencies from one Cargo dependency table.
+
+        Args:
+            table: Mapping of package name to constraint.
+            file: Manifest path string.
+
+        Returns:
+            list[Dependency]: Parsed dependencies from the table.
+        """
+        deps: list[Dependency] = []
+        for name, constraint in table.items():
+            version_spec = self._constraint(constraint)
+            if version_spec is None:
+                continue
+            deps.append(
+                build_dependency(
+                    name=name,
+                    version_spec=version_spec,
+                    ecosystem=Ecosystem.CARGO,
+                    file=file,
+                ),
+            )
         return deps
 
     @staticmethod

--- a/lintro/deps/parsers/cargo_parser.py
+++ b/lintro/deps/parsers/cargo_parser.py
@@ -24,8 +24,11 @@ class CargoParser:
     def parse(self, path: Path) -> list[Dependency]:
         """Parse dependencies from a ``Cargo.toml`` file.
 
-        Reads ``dependencies``, ``dev-dependencies``, and
-        ``build-dependencies`` at the top level.
+        Reads ``dependencies``, ``dev-dependencies``,
+        ``build-dependencies``, platform-specific ``[target.*]`` tables, and
+        ``[workspace.dependencies]``. Member entries declared as
+        ``{ workspace = true }`` are resolved against the workspace table when
+        it is present in the same manifest.
 
         Args:
             path: Path to the ``Cargo.toml`` file.
@@ -39,10 +42,19 @@ class CargoParser:
         file = str(path)
         deps: list[Dependency] = []
 
+        workspace = data.get("workspace")
+        workspace_deps: dict[str, Any] = {}
+        if isinstance(workspace, dict) and isinstance(
+            workspace.get("dependencies"),
+            dict,
+        ):
+            workspace_deps = workspace["dependencies"]
+            deps.extend(self._from_table(workspace_deps, file, {}))
+
         for section in _DEP_SECTIONS:
             table = data.get(section)
             if isinstance(table, dict):
-                deps.extend(self._from_table(table, file))
+                deps.extend(self._from_table(table, file, workspace_deps))
 
         # Platform-specific deps: [target.'cfg(...)'.dependencies]
         target = data.get("target")
@@ -53,20 +65,47 @@ class CargoParser:
                 for section in _DEP_SECTIONS:
                     nested = target_table.get(section)
                     if isinstance(nested, dict):
-                        deps.extend(self._from_table(nested, file))
+                        deps.extend(self._from_table(nested, file, workspace_deps))
 
-        return deps
+        return self._dedupe(deps)
+
+    @staticmethod
+    def _dedupe(deps: list[Dependency]) -> list[Dependency]:
+        """Drop repeats of the same name/spec pair.
+
+        A workspace root that both declares ``[workspace.dependencies]`` and
+        consumes them via ``{ workspace = true }`` would otherwise report the
+        same crate twice.
+
+        Args:
+            deps: Parsed dependencies, in discovery order.
+
+        Returns:
+            list[Dependency]: Dependencies with duplicates removed.
+        """
+        seen: set[tuple[str, str]] = set()
+        unique: list[Dependency] = []
+        for dep in deps:
+            key = (dep.name, dep.version_spec)
+            if key in seen:
+                continue
+            seen.add(key)
+            unique.append(dep)
+        return unique
 
     def _from_table(
         self,
         table: dict[str, Any],
         file: str,
+        workspace_deps: dict[str, Any],
     ) -> list[Dependency]:
         """Build dependencies from one Cargo dependency table.
 
         Args:
             table: Mapping of package name to constraint.
             file: Manifest path string.
+            workspace_deps: ``[workspace.dependencies]`` used to resolve
+                ``{ workspace = true }`` entries.
 
         Returns:
             list[Dependency]: Parsed dependencies from the table.
@@ -74,6 +113,8 @@ class CargoParser:
         deps: list[Dependency] = []
         for name, constraint in table.items():
             version_spec = self._constraint(constraint)
+            if version_spec is None and self._inherits_workspace(constraint):
+                version_spec = self._constraint(workspace_deps.get(name))
             if version_spec is None:
                 continue
             deps.append(
@@ -85,6 +126,18 @@ class CargoParser:
                 ),
             )
         return deps
+
+    @staticmethod
+    def _inherits_workspace(constraint: Any) -> bool:
+        """Return whether an entry inherits its version from the workspace.
+
+        Args:
+            constraint: Raw Cargo value (string or table).
+
+        Returns:
+            bool: ``True`` for ``{ workspace = true }`` entries.
+        """
+        return isinstance(constraint, dict) and constraint.get("workspace") is True
 
     @staticmethod
     def _constraint(constraint: Any) -> str | None:

--- a/lintro/deps/parsers/cargo_parser.py
+++ b/lintro/deps/parsers/cargo_parser.py
@@ -28,7 +28,7 @@ class CargoParser:
         ``build-dependencies``, platform-specific ``[target.*]`` tables, and
         ``[workspace.dependencies]``. Member entries declared as
         ``{ workspace = true }`` are resolved against the workspace table when
-        it is present in the same manifest.
+        it is present in the same manifest, or in a parent ``Cargo.toml``.
 
         Args:
             path: Path to the ``Cargo.toml`` file.
@@ -43,18 +43,22 @@ class CargoParser:
         deps: list[Dependency] = []
 
         workspace = data.get("workspace")
-        workspace_deps: dict[str, Any] = {}
+        local_workspace_deps: dict[str, Any] = {}
         if isinstance(workspace, dict) and isinstance(
             workspace.get("dependencies"),
             dict,
         ):
-            workspace_deps = workspace["dependencies"]
-            deps.extend(self._from_table(workspace_deps, file, {}))
+            local_workspace_deps = workspace["dependencies"]
+            deps.extend(self._from_table(local_workspace_deps, file, {}))
+
+        resolve_from = local_workspace_deps or self._find_parent_workspace_deps(
+            path,
+        )
 
         for section in _DEP_SECTIONS:
             table = data.get(section)
             if isinstance(table, dict):
-                deps.extend(self._from_table(table, file, workspace_deps))
+                deps.extend(self._from_table(table, file, resolve_from))
 
         # Platform-specific deps: [target.'cfg(...)'.dependencies]
         target = data.get("target")
@@ -65,7 +69,7 @@ class CargoParser:
                 for section in _DEP_SECTIONS:
                     nested = target_table.get(section)
                     if isinstance(nested, dict):
-                        deps.extend(self._from_table(nested, file, workspace_deps))
+                        deps.extend(self._from_table(nested, file, resolve_from))
 
         return self._dedupe(deps)
 
@@ -126,6 +130,34 @@ class CargoParser:
                 ),
             )
         return deps
+
+    @staticmethod
+    def _find_parent_workspace_deps(path: Path) -> dict[str, Any]:
+        """Walk parents for a ``[workspace.dependencies]`` table.
+
+        Args:
+            path: Member ``Cargo.toml`` being parsed.
+
+        Returns:
+            dict[str, Any]: Workspace dependency table, or empty when none
+            is found.
+        """
+        for parent in path.resolve().parents:
+            candidate = parent / "Cargo.toml"
+            if not candidate.is_file():
+                continue
+            try:
+                with candidate.open("rb") as handle:
+                    data = tomllib.load(handle)
+            except (OSError, tomllib.TOMLDecodeError):
+                continue
+            workspace = data.get("workspace")
+            if not isinstance(workspace, dict):
+                continue
+            deps_table = workspace.get("dependencies")
+            if isinstance(deps_table, dict):
+                return deps_table
+        return {}
 
     @staticmethod
     def _inherits_workspace(constraint: Any) -> bool:

--- a/lintro/deps/parsers/package_json_parser.py
+++ b/lintro/deps/parsers/package_json_parser.py
@@ -45,10 +45,18 @@ class PackageJsonParser:
             for name, version_spec in table.items():
                 if not isinstance(version_spec, str):
                     continue
-                # Skip non-registry references (workspaces, git, file paths).
-                if any(
-                    token in version_spec
-                    for token in ("workspace:", "file:", "git", "://", "npm:")
+                # Skip non-registry references (workspaces, git URLs, file paths).
+                # Match protocol prefixes only — avoid false positives like
+                # ``1.0.0-git.1`` prerelease tags.
+                lowered = version_spec.lower()
+                if (
+                    lowered.startswith("workspace:")
+                    or lowered.startswith("file:")
+                    or lowered.startswith("npm:")
+                    or lowered.startswith("git+")
+                    or lowered.startswith("git:")
+                    or "://" in lowered
+                    or lowered.endswith(".git")
                 ):
                     continue
                 deps.append(

--- a/lintro/deps/parsers/package_json_parser.py
+++ b/lintro/deps/parsers/package_json_parser.py
@@ -1,0 +1,63 @@
+"""Parser for npm ``package.json`` dependency maps."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from lintro.deps.models import Dependency, Ecosystem
+from lintro.deps.parsers._base import build_dependency
+
+__all__ = ["PackageJsonParser"]
+
+_DEP_SECTIONS: tuple[str, ...] = (
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+)
+
+
+class PackageJsonParser:
+    """Parse dependency maps from ``package.json``."""
+
+    def parse(self, path: Path) -> list[Dependency]:
+        """Parse dependencies from a ``package.json`` file.
+
+        Reads ``dependencies``, ``devDependencies``,
+        ``peerDependencies``, and ``optionalDependencies``.
+
+        Args:
+            path: Path to the ``package.json`` file.
+
+        Returns:
+            list[Dependency]: Parsed dependencies.
+        """
+        data: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+        file = str(path)
+        deps: list[Dependency] = []
+
+        for section in _DEP_SECTIONS:
+            table = data.get(section)
+            if not isinstance(table, dict):
+                continue
+            for name, version_spec in table.items():
+                if not isinstance(version_spec, str):
+                    continue
+                # Skip non-registry references (workspaces, git, file paths).
+                if any(
+                    token in version_spec
+                    for token in ("workspace:", "file:", "git", "://", "npm:")
+                ):
+                    continue
+                deps.append(
+                    build_dependency(
+                        name=name,
+                        version_spec=version_spec,
+                        ecosystem=Ecosystem.NPM,
+                        file=file,
+                    ),
+                )
+
+        return deps

--- a/lintro/deps/parsers/package_json_parser.py
+++ b/lintro/deps/parsers/package_json_parser.py
@@ -18,6 +18,22 @@ _DEP_SECTIONS: tuple[str, ...] = (
     "optionalDependencies",
 )
 
+# Protocol prefixes that mean "not a registry semver range". Matched as
+# prefixes only, to avoid false positives like the ``1.0.0-git.1`` prerelease.
+_NON_REGISTRY_PREFIXES: tuple[str, ...] = (
+    "workspace:",
+    "file:",
+    "link:",
+    "portal:",
+    "npm:",
+    "git+",
+    "git:",
+    "github:",
+    "gitlab:",
+    "bitbucket:",
+    "bitbucket.org:",
+)
+
 
 class PackageJsonParser:
     """Parse dependency maps from ``package.json``."""
@@ -45,19 +61,7 @@ class PackageJsonParser:
             for name, version_spec in table.items():
                 if not isinstance(version_spec, str):
                     continue
-                # Skip non-registry references (workspaces, git URLs, file paths).
-                # Match protocol prefixes only — avoid false positives like
-                # ``1.0.0-git.1`` prerelease tags.
-                lowered = version_spec.lower()
-                if (
-                    lowered.startswith("workspace:")
-                    or lowered.startswith("file:")
-                    or lowered.startswith("npm:")
-                    or lowered.startswith("git+")
-                    or lowered.startswith("git:")
-                    or "://" in lowered
-                    or lowered.endswith(".git")
-                ):
+                if self._is_non_registry(version_spec):
                     continue
                 deps.append(
                     build_dependency(
@@ -69,3 +73,26 @@ class PackageJsonParser:
                 )
 
         return deps
+
+    @staticmethod
+    def _is_non_registry(version_spec: str) -> bool:
+        """Return whether a spec points somewhere other than the registry.
+
+        npm accepts protocol shorthands (``github:owner/repo``) and bare
+        ``owner/repo`` GitHub shorthands. These carry no semver comparator, so
+        classifying them would report a floating git reference as an exact pin.
+
+        Args:
+            version_spec: Raw value from a ``package.json`` dependency map.
+
+        Returns:
+            bool: ``True`` when the spec is not a registry semver range.
+        """
+        lowered = version_spec.strip().lower()
+        if lowered.startswith(_NON_REGISTRY_PREFIXES):
+            return True
+        if "://" in lowered or lowered.endswith(".git"):
+            return True
+        # Bare ``owner/repo`` (optionally ``owner/repo#ref``) GitHub shorthand.
+        # No registry semver range contains a slash.
+        return "/" in lowered

--- a/lintro/deps/parsers/pyproject_parser.py
+++ b/lintro/deps/parsers/pyproject_parser.py
@@ -1,0 +1,159 @@
+"""Parser for ``pyproject.toml`` dependency tables."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from packaging.requirements import InvalidRequirement, Requirement
+
+from lintro.deps.models import Dependency, Ecosystem
+from lintro.deps.parsers._base import build_dependency
+
+__all__ = ["PyprojectParser"]
+
+
+class PyprojectParser:
+    """Parse PEP 621 and Poetry dependency tables from ``pyproject.toml``."""
+
+    def parse(self, path: Path) -> list[Dependency]:
+        """Parse dependencies from a ``pyproject.toml`` file.
+
+        Reads ``[project.dependencies]``,
+        ``[project.optional-dependencies]``, and
+        ``[tool.poetry.dependencies]``.
+
+        Args:
+            path: Path to the ``pyproject.toml`` file.
+
+        Returns:
+            list[Dependency]: Parsed dependencies.
+        """
+        with path.open("rb") as handle:
+            data = tomllib.load(handle)
+
+        file = str(path)
+        deps: list[Dependency] = []
+
+        project = data.get("project", {})
+        if isinstance(project, dict):
+            deps.extend(self._parse_pep621(project, file))
+
+        poetry = data.get("tool", {}).get("poetry", {})
+        if isinstance(poetry, dict):
+            deps.extend(self._parse_poetry(poetry, file))
+
+        return deps
+
+    def _parse_pep621(self, project: dict[str, Any], file: str) -> list[Dependency]:
+        """Parse PEP 621 ``dependencies`` and ``optional-dependencies``.
+
+        Args:
+            project: The ``[project]`` table.
+            file: Manifest path string.
+
+        Returns:
+            list[Dependency]: Parsed dependencies.
+        """
+        deps: list[Dependency] = []
+        raw: list[str] = []
+
+        if isinstance(project.get("dependencies"), list):
+            raw.extend(project["dependencies"])
+
+        optional = project.get("optional-dependencies", {})
+        if isinstance(optional, dict):
+            for group in optional.values():
+                if isinstance(group, list):
+                    raw.extend(group)
+
+        for entry in raw:
+            dep = self._from_requirement_string(entry, file)
+            if dep is not None:
+                deps.append(dep)
+        return deps
+
+    def _parse_poetry(self, poetry: dict[str, Any], file: str) -> list[Dependency]:
+        """Parse ``[tool.poetry.dependencies]`` and group dependencies.
+
+        Args:
+            poetry: The ``[tool.poetry]`` table.
+            file: Manifest path string.
+
+        Returns:
+            list[Dependency]: Parsed dependencies.
+        """
+        deps: list[Dependency] = []
+        tables: list[dict[str, Any]] = []
+
+        main = poetry.get("dependencies", {})
+        if isinstance(main, dict):
+            tables.append(main)
+
+        group = poetry.get("group", {})
+        if isinstance(group, dict):
+            for spec in group.values():
+                if isinstance(spec, dict) and isinstance(
+                    spec.get("dependencies"),
+                    dict,
+                ):
+                    tables.append(spec["dependencies"])
+
+        for table in tables:
+            for name, constraint in table.items():
+                if name.lower() == "python":
+                    continue
+                version_spec = self._poetry_constraint(constraint)
+                if version_spec is None:
+                    continue
+                deps.append(
+                    build_dependency(
+                        name=name,
+                        version_spec=version_spec,
+                        ecosystem=Ecosystem.PYTHON,
+                        file=file,
+                    ),
+                )
+        return deps
+
+    @staticmethod
+    def _poetry_constraint(constraint: Any) -> str | None:
+        """Extract a version string from a Poetry dependency value.
+
+        Args:
+            constraint: Raw Poetry value (string or table).
+
+        Returns:
+            str | None: The version constraint, or ``None`` to skip
+            non-version entries (e.g. git/path dependencies).
+        """
+        if isinstance(constraint, str):
+            return constraint
+        if isinstance(constraint, dict):
+            version = constraint.get("version")
+            if isinstance(version, str):
+                return version
+        return None
+
+    @staticmethod
+    def _from_requirement_string(entry: str, file: str) -> Dependency | None:
+        """Build a dependency from a PEP 508 requirement string.
+
+        Args:
+            entry: Requirement string (e.g. ``requests>=2.28.0``).
+            file: Manifest path string.
+
+        Returns:
+            Dependency | None: Parsed dependency, or ``None`` when invalid.
+        """
+        try:
+            requirement = Requirement(entry)
+        except InvalidRequirement:
+            return None
+        return build_dependency(
+            name=requirement.name,
+            version_spec=str(requirement.specifier),
+            ecosystem=Ecosystem.PYTHON,
+            file=file,
+        )

--- a/lintro/deps/parsers/pyproject_parser.py
+++ b/lintro/deps/parsers/pyproject_parser.py
@@ -91,6 +91,11 @@ class PyprojectParser:
         if isinstance(main, dict):
             tables.append(main)
 
+        # Legacy Poetry table still common in existing projects.
+        legacy_dev = poetry.get("dev-dependencies", {})
+        if isinstance(legacy_dev, dict):
+            tables.append(legacy_dev)
+
         group = poetry.get("group", {})
         if isinstance(group, dict):
             for spec in group.values():

--- a/lintro/deps/parsers/pyproject_parser.py
+++ b/lintro/deps/parsers/pyproject_parser.py
@@ -15,48 +15,66 @@ __all__ = ["PyprojectParser"]
 
 
 class PyprojectParser:
-    """Parse PEP 621 and Poetry dependency tables from ``pyproject.toml``."""
+    """Parse PEP 621, PEP 735 and Poetry dependency tables."""
 
     def parse(self, path: Path) -> list[Dependency]:
         """Parse dependencies from a ``pyproject.toml`` file.
 
         Reads ``[project.dependencies]``,
-        ``[project.optional-dependencies]``, and
-        ``[tool.poetry.dependencies]``.
+        ``[project.optional-dependencies]``, PEP 735
+        ``[dependency-groups]``, and ``[tool.poetry.dependencies]``.
 
         Args:
             path: Path to the ``pyproject.toml`` file.
 
         Returns:
             list[Dependency]: Parsed dependencies.
+
+        Raises:
+            ValueError: When any requirement string is not valid PEP 508. The
+                check fails closed rather than silently dropping the entry.
         """
         with path.open("rb") as handle:
             data = tomllib.load(handle)
 
         file = str(path)
         deps: list[Dependency] = []
+        invalid: list[str] = []
 
         project = data.get("project", {})
         if isinstance(project, dict):
-            deps.extend(self._parse_pep621(project, file))
+            deps.extend(self._parse_pep621(project, file, invalid))
+
+        groups = data.get("dependency-groups", {})
+        if isinstance(groups, dict):
+            deps.extend(self._parse_dependency_groups(groups, file, invalid))
 
         poetry = data.get("tool", {}).get("poetry", {})
         if isinstance(poetry, dict):
             deps.extend(self._parse_poetry(poetry, file))
 
+        if invalid:
+            joined = ", ".join(repr(entry) for entry in invalid)
+            msg = f"invalid requirement specification(s): {joined}"
+            raise ValueError(msg)
         return deps
 
-    def _parse_pep621(self, project: dict[str, Any], file: str) -> list[Dependency]:
+    def _parse_pep621(
+        self,
+        project: dict[str, Any],
+        file: str,
+        invalid: list[str],
+    ) -> list[Dependency]:
         """Parse PEP 621 ``dependencies`` and ``optional-dependencies``.
 
         Args:
             project: The ``[project]`` table.
             file: Manifest path string.
+            invalid: Accumulator for requirement strings that fail to parse.
 
         Returns:
             list[Dependency]: Parsed dependencies.
         """
-        deps: list[Dependency] = []
         raw: list[str] = []
 
         if isinstance(project.get("dependencies"), list):
@@ -68,11 +86,32 @@ class PyprojectParser:
                 if isinstance(group, list):
                     raw.extend(group)
 
-        for entry in raw:
-            dep = self._from_requirement_string(entry, file)
-            if dep is not None:
-                deps.append(dep)
-        return deps
+        return self._from_requirement_strings(raw, file, invalid)
+
+    def _parse_dependency_groups(
+        self,
+        groups: dict[str, Any],
+        file: str,
+        invalid: list[str],
+    ) -> list[Dependency]:
+        """Parse PEP 735 ``[dependency-groups]`` tables.
+
+        Args:
+            groups: The ``[dependency-groups]`` table.
+            file: Manifest path string.
+            invalid: Accumulator for requirement strings that fail to parse.
+
+        Returns:
+            list[Dependency]: Parsed dependencies.
+        """
+        raw: list[str] = []
+        for entries in groups.values():
+            if not isinstance(entries, list):
+                continue
+            # ``{include-group = "..."}`` entries are references, not
+            # requirements; the referenced group is parsed on its own.
+            raw.extend(entry for entry in entries if isinstance(entry, str))
+        return self._from_requirement_strings(raw, file, invalid)
 
     def _parse_poetry(self, poetry: dict[str, Any], file: str) -> list[Dependency]:
         """Parse ``[tool.poetry.dependencies]`` and group dependencies.
@@ -142,23 +181,34 @@ class PyprojectParser:
         return None
 
     @staticmethod
-    def _from_requirement_string(entry: str, file: str) -> Dependency | None:
-        """Build a dependency from a PEP 508 requirement string.
+    def _from_requirement_strings(
+        entries: list[str],
+        file: str,
+        invalid: list[str],
+    ) -> list[Dependency]:
+        """Build dependencies from PEP 508 requirement strings.
 
         Args:
-            entry: Requirement string (e.g. ``requests>=2.28.0``).
+            entries: Requirement strings (e.g. ``requests>=2.28.0``).
             file: Manifest path string.
+            invalid: Accumulator for entries that fail to parse.
 
         Returns:
-            Dependency | None: Parsed dependency, or ``None`` when invalid.
+            list[Dependency]: Parsed dependencies.
         """
-        try:
-            requirement = Requirement(entry)
-        except InvalidRequirement:
-            return None
-        return build_dependency(
-            name=requirement.name,
-            version_spec=str(requirement.specifier),
-            ecosystem=Ecosystem.PYTHON,
-            file=file,
-        )
+        deps: list[Dependency] = []
+        for entry in entries:
+            try:
+                requirement = Requirement(entry)
+            except InvalidRequirement:
+                invalid.append(entry)
+                continue
+            deps.append(
+                build_dependency(
+                    name=requirement.name,
+                    version_spec=str(requirement.specifier),
+                    ecosystem=Ecosystem.PYTHON,
+                    file=file,
+                ),
+            )
+        return deps

--- a/lintro/deps/parsers/pyproject_parser.py
+++ b/lintro/deps/parsers/pyproject_parser.py
@@ -203,6 +203,8 @@ class PyprojectParser:
             except InvalidRequirement:
                 invalid.append(entry)
                 continue
+            if requirement.url:
+                continue
             deps.append(
                 build_dependency(
                     name=requirement.name,

--- a/lintro/deps/parsers/requirements_parser.py
+++ b/lintro/deps/parsers/requirements_parser.py
@@ -1,0 +1,73 @@
+"""Parser for pip ``requirements.txt`` files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from packaging.requirements import InvalidRequirement, Requirement
+
+from lintro.deps.models import Dependency, Ecosystem
+from lintro.deps.parsers._base import build_dependency
+
+__all__ = ["RequirementsParser"]
+
+
+class RequirementsParser:
+    """Parse ``requirements.txt``-style dependency lists."""
+
+    def parse(self, path: Path) -> list[Dependency]:
+        """Parse dependencies from a requirements file.
+
+        Skips comments, blank lines, options (``-r``, ``--hash``), and
+        non-versioned references (URLs, editable installs).
+
+        Args:
+            path: Path to the requirements file.
+
+        Returns:
+            list[Dependency]: Parsed dependencies.
+        """
+        file = str(path)
+        deps: list[Dependency] = []
+
+        for lineno, raw_line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(),
+            start=1,
+        ):
+            line = raw_line.strip()
+            if not line or line.startswith(("#", "-")):
+                continue
+            # Strip inline comments and environment markers.
+            line = line.split(" #", 1)[0].split(";", 1)[0].strip()
+            if not line or "://" in line:
+                continue
+
+            dep = self._parse_line(line, file, lineno)
+            if dep is not None:
+                deps.append(dep)
+
+        return deps
+
+    @staticmethod
+    def _parse_line(line: str, file: str, lineno: int) -> Dependency | None:
+        """Parse a single requirement line.
+
+        Args:
+            line: Cleaned requirement text.
+            file: Manifest path string.
+            lineno: 1-based line number.
+
+        Returns:
+            Dependency | None: Parsed dependency, or ``None`` when invalid.
+        """
+        try:
+            requirement = Requirement(line)
+        except InvalidRequirement:
+            return None
+        return build_dependency(
+            name=requirement.name,
+            version_spec=str(requirement.specifier),
+            ecosystem=Ecosystem.PYTHON,
+            file=file,
+            line=lineno,
+        )

--- a/lintro/deps/parsers/requirements_parser.py
+++ b/lintro/deps/parsers/requirements_parser.py
@@ -26,9 +26,14 @@ class RequirementsParser:
 
         Returns:
             list[Dependency]: Parsed dependencies.
+
+        Raises:
+            ValueError: When any line is not a valid PEP 508 requirement. The
+                check fails closed rather than silently dropping the line.
         """
         file = str(path)
         deps: list[Dependency] = []
+        invalid: list[str] = []
 
         for lineno, raw_line in enumerate(
             path.read_text(encoding="utf-8").splitlines(),
@@ -42,32 +47,23 @@ class RequirementsParser:
             if not line or "://" in line:
                 continue
 
-            dep = self._parse_line(line, file, lineno)
-            if dep is not None:
-                deps.append(dep)
+            try:
+                requirement = Requirement(line)
+            except InvalidRequirement:
+                invalid.append(f"line {lineno}: {line!r}")
+                continue
+            deps.append(
+                build_dependency(
+                    name=requirement.name,
+                    version_spec=str(requirement.specifier),
+                    ecosystem=Ecosystem.PYTHON,
+                    file=file,
+                    line=lineno,
+                ),
+            )
 
+        if invalid:
+            joined = "; ".join(invalid)
+            msg = f"invalid requirement specification(s): {joined}"
+            raise ValueError(msg)
         return deps
-
-    @staticmethod
-    def _parse_line(line: str, file: str, lineno: int) -> Dependency | None:
-        """Parse a single requirement line.
-
-        Args:
-            line: Cleaned requirement text.
-            file: Manifest path string.
-            lineno: 1-based line number.
-
-        Returns:
-            Dependency | None: Parsed dependency, or ``None`` when invalid.
-        """
-        try:
-            requirement = Requirement(line)
-        except InvalidRequirement:
-            return None
-        return build_dependency(
-            name=requirement.name,
-            version_spec=str(requirement.specifier),
-            ecosystem=Ecosystem.PYTHON,
-            file=file,
-            line=lineno,
-        )

--- a/lintro/deps/parsers/requirements_parser.py
+++ b/lintro/deps/parsers/requirements_parser.py
@@ -18,8 +18,9 @@ class RequirementsParser:
     def parse(self, path: Path) -> list[Dependency]:
         """Parse dependencies from a requirements file.
 
-        Skips comments, blank lines, options (``-r``, ``--hash``), and
-        non-versioned references (URLs, editable installs).
+        Skips comments, blank lines, and pip options. Follows ``-r`` /
+        ``--requirement`` includes. Strips trailing ``--hash`` options.
+        Skips non-versioned references (URLs, editable installs).
 
         Args:
             path: Path to the requirements file.
@@ -28,9 +29,31 @@ class RequirementsParser:
             list[Dependency]: Parsed dependencies.
 
         Raises:
-            ValueError: When any line is not a valid PEP 508 requirement. The
-                check fails closed rather than silently dropping the line.
+            ValueError: When any line is not a valid PEP 508 requirement, or
+                an included file is missing. The check fails closed rather
+                than silently dropping the line.
         """
+        return self._parse_path(path, seen=set())
+
+    def _parse_path(self, path: Path, seen: set[Path]) -> list[Dependency]:
+        """Parse one requirements file, following ``-r`` includes.
+
+        Args:
+            path: Path to the requirements file.
+            seen: Already-visited resolved paths, used to break cycles.
+
+        Returns:
+            list[Dependency]: Parsed dependencies from this file and includes.
+
+        Raises:
+            ValueError: When a line is not a valid PEP 508 requirement, or an
+                included file is missing.
+        """
+        resolved = path.resolve()
+        if resolved in seen:
+            return []
+        seen.add(resolved)
+
         file = str(path)
         deps: list[Dependency] = []
         invalid: list[str] = []
@@ -40,10 +63,23 @@ class RequirementsParser:
             start=1,
         ):
             line = raw_line.strip()
-            if not line or line.startswith(("#", "-")):
+            if not line or line.startswith("#"):
                 continue
-            # Strip inline comments and environment markers.
-            line = line.split(" #", 1)[0].split(";", 1)[0].strip()
+            line = line.split(" #", 1)[0].strip()
+            include = self._include_target(line)
+            if include is not None:
+                deps.extend(
+                    self._parse_include(
+                        path=path,
+                        include=include,
+                        seen=seen,
+                    ),
+                )
+                continue
+            if line.startswith("-"):
+                continue
+            # Strip trailing pip options (``--hash``, ``--only-binary``, …).
+            line = line.split(" --", 1)[0].split(";", 1)[0].strip()
             if not line or "://" in line:
                 continue
 
@@ -51,6 +87,8 @@ class RequirementsParser:
                 requirement = Requirement(line)
             except InvalidRequirement:
                 invalid.append(f"line {lineno}: {line!r}")
+                continue
+            if requirement.url:
                 continue
             deps.append(
                 build_dependency(
@@ -67,3 +105,48 @@ class RequirementsParser:
             msg = f"invalid requirement specification(s): {joined}"
             raise ValueError(msg)
         return deps
+
+    def _parse_include(
+        self,
+        *,
+        path: Path,
+        include: str,
+        seen: set[Path],
+    ) -> list[Dependency]:
+        """Parse a ``-r`` / ``--requirement`` include.
+
+        Args:
+            path: The file that referenced the include.
+            include: Relative or absolute include path.
+            seen: Already-visited resolved paths.
+
+        Returns:
+            list[Dependency]: Dependencies from the included file.
+
+        Raises:
+            ValueError: When the included file does not exist.
+        """
+        include_path = Path(include)
+        if not include_path.is_absolute():
+            include_path = path.parent / include_path
+        if not include_path.is_file():
+            msg = f"included requirements file not found: {include}"
+            raise ValueError(msg)
+        return self._parse_path(include_path, seen)
+
+    @staticmethod
+    def _include_target(line: str) -> str | None:
+        """Return an include path from a ``-r`` / ``--requirement`` line.
+
+        Args:
+            line: A stripped requirements line.
+
+        Returns:
+            str | None: The include path, or ``None`` when the line is not
+            an include directive.
+        """
+        if line.startswith("-r ") or line.startswith("--requirement "):
+            return line.split(None, 1)[1].strip()
+        if line.startswith("--requirement="):
+            return line.split("=", 1)[1].strip()
+        return None

--- a/lintro/deps/parsers/requirements_parser.py
+++ b/lintro/deps/parsers/requirements_parser.py
@@ -33,7 +33,10 @@ class RequirementsParser:
                 an included file is missing. The check fails closed rather
                 than silently dropping the line.
         """
-        return self._parse_path(path, seen=set())
+        try:
+            return self._parse_path(path, seen=set())
+        except ValueError:
+            raise
 
     def _parse_path(self, path: Path, seen: set[Path]) -> list[Dependency]:
         """Parse one requirements file, following ``-r`` includes.

--- a/lintro/deps/policy_engine.py
+++ b/lintro/deps/policy_engine.py
@@ -1,0 +1,243 @@
+"""Policy engine that validates dependencies against version-spec rules."""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+
+from lintro.config.deps_config import DepsConfig, DepsPolicy, PackageException
+from lintro.deps.models import Dependency, VersionSpecType, VersionViolation
+
+__all__ = ["PolicyEngine", "PolicyRules"]
+
+
+@dataclass(frozen=True)
+class PolicyRules:
+    """Resolved rule set applied to a dependency.
+
+    Attributes:
+        allowed_types: Version-spec types that satisfy the policy.
+        disallowed_types: Version-spec types that always violate the policy.
+        require_upper_bound: Whether an upper bound is mandatory.
+    """
+
+    allowed_types: frozenset[VersionSpecType]
+    disallowed_types: frozenset[VersionSpecType]
+    require_upper_bound: bool
+
+
+_ALL_TYPES: frozenset[VersionSpecType] = frozenset(VersionSpecType)
+
+_PRESETS: dict[DepsPolicy, PolicyRules] = {
+    DepsPolicy.STRICT: PolicyRules(
+        allowed_types=frozenset({VersionSpecType.EXACT}),
+        disallowed_types=_ALL_TYPES - {VersionSpecType.EXACT},
+        require_upper_bound=True,
+    ),
+    DepsPolicy.FLEXIBLE: PolicyRules(
+        allowed_types=frozenset(
+            {
+                VersionSpecType.EXACT,
+                VersionSpecType.TILDE,
+                VersionSpecType.CARET,
+                VersionSpecType.RANGE,
+                VersionSpecType.WILDCARD,
+            },
+        ),
+        disallowed_types=frozenset(
+            {VersionSpecType.ANY, VersionSpecType.UNBOUNDED},
+        ),
+        require_upper_bound=True,
+    ),
+    DepsPolicy.LOOSE: PolicyRules(
+        allowed_types=_ALL_TYPES,
+        disallowed_types=frozenset({VersionSpecType.ANY}),
+        require_upper_bound=False,
+    ),
+}
+
+
+class PolicyEngine:
+    """Apply version-spec policy rules and generate violations."""
+
+    def __init__(self, config: DepsConfig) -> None:
+        """Initialize the engine.
+
+        Args:
+            config: Resolved dependency policy configuration.
+        """
+        self.config = config
+        self._base_rules = self._resolve_base_rules(config)
+
+    def get_preset_rules(self, preset: DepsPolicy) -> PolicyRules:
+        """Return the rule set for a named policy preset.
+
+        Args:
+            preset: The policy preset to look up.
+
+        Returns:
+            PolicyRules: The preset's rules (flexible when ``custom``).
+        """
+        return _PRESETS.get(preset, _PRESETS[DepsPolicy.FLEXIBLE])
+
+    def validate(self, dependencies: list[Dependency]) -> list[VersionViolation]:
+        """Validate dependencies against the active policy.
+
+        Args:
+            dependencies: Parsed dependencies to check.
+
+        Returns:
+            list[VersionViolation]: One violation per failing rule.
+        """
+        violations: list[VersionViolation] = []
+        for dep in dependencies:
+            violations.extend(self._validate_one(dep))
+        return violations
+
+    def _validate_one(self, dep: Dependency) -> list[VersionViolation]:
+        """Validate a single dependency.
+
+        Args:
+            dep: The dependency to check.
+
+        Returns:
+            list[VersionViolation]: Violations raised for this dependency.
+        """
+        rules = self._rules_for(dep)
+        violations: list[VersionViolation] = []
+
+        if dep.spec_type in rules.disallowed_types:
+            violations.append(
+                VersionViolation(
+                    dependency=dep,
+                    rule="disallowed_type",
+                    message=self._disallowed_message(dep.spec_type),
+                ),
+            )
+        elif dep.spec_type not in rules.allowed_types:
+            violations.append(
+                VersionViolation(
+                    dependency=dep,
+                    rule="allowed_types",
+                    message=(f"Spec type '{dep.spec_type}' is not allowed by policy"),
+                ),
+            )
+
+        if rules.require_upper_bound and not dep.has_upper_bound:
+            already_flagged = any(
+                v.rule in {"disallowed_type", "allowed_types"} for v in violations
+            )
+            if not already_flagged:
+                violations.append(
+                    VersionViolation(
+                        dependency=dep,
+                        rule="require_upper_bound",
+                        message="No upper bound",
+                    ),
+                )
+
+        return violations
+
+    def _rules_for(self, dep: Dependency) -> PolicyRules:
+        """Resolve rules for a dependency, honoring package exceptions.
+
+        Args:
+            dep: The dependency being validated.
+
+        Returns:
+            PolicyRules: The effective rule set for this dependency.
+        """
+        exception = self._matching_exception(dep.name)
+        if exception is None:
+            return self._base_rules
+
+        allowed = self._base_rules.allowed_types
+        disallowed = self._base_rules.disallowed_types
+        if exception.allowed_types:
+            allowed = frozenset(
+                self._parse_types(exception.allowed_types),
+            )
+            disallowed = _ALL_TYPES - allowed
+
+        require_upper = self._base_rules.require_upper_bound
+        if exception.require_upper_bound is not None:
+            require_upper = exception.require_upper_bound
+
+        return PolicyRules(
+            allowed_types=allowed,
+            disallowed_types=disallowed,
+            require_upper_bound=require_upper,
+        )
+
+    def _matching_exception(self, name: str) -> PackageException | None:
+        """Find the first package exception matching ``name``.
+
+        Args:
+            name: Package name to match against exception globs.
+
+        Returns:
+            PackageException | None: The matching exception, if any.
+        """
+        for exception in self.config.exceptions:
+            if fnmatch.fnmatch(name.lower(), exception.package.lower()):
+                return exception
+        return None
+
+    def _resolve_base_rules(self, config: DepsConfig) -> PolicyRules:
+        """Resolve the base rule set from the config's policy.
+
+        Args:
+            config: Dependency policy configuration.
+
+        Returns:
+            PolicyRules: Rules from the preset, or custom fields when the
+            policy is ``custom``.
+        """
+        if config.policy is DepsPolicy.CUSTOM:
+            allowed = frozenset(self._parse_types(config.allowed_types))
+            disallowed = frozenset(self._parse_types(config.disallowed_types))
+            return PolicyRules(
+                allowed_types=allowed,
+                disallowed_types=disallowed,
+                require_upper_bound=config.require_upper_bound,
+            )
+        return self.get_preset_rules(config.policy)
+
+    @staticmethod
+    def _parse_types(names: list[str]) -> set[VersionSpecType]:
+        """Convert type name strings into :class:`VersionSpecType` values.
+
+        Args:
+            names: Version-spec type names (unknown names are ignored).
+
+        Returns:
+            set[VersionSpecType]: The parsed types.
+        """
+        parsed: set[VersionSpecType] = set()
+        for name in names:
+            try:
+                parsed.add(VersionSpecType(name.strip().lower()))
+            except ValueError:
+                continue
+        return parsed
+
+    @staticmethod
+    def _disallowed_message(spec_type: VersionSpecType) -> str:
+        """Return a friendly message for a disallowed spec type.
+
+        Args:
+            spec_type: The disallowed spec type.
+
+        Returns:
+            str: Human-readable violation message.
+        """
+        messages = {
+            VersionSpecType.ANY: "No constraint",
+            VersionSpecType.UNBOUNDED: "No upper bound",
+            VersionSpecType.WILDCARD: "Wildcard spec not allowed",
+            VersionSpecType.RANGE: "Range spec not allowed",
+            VersionSpecType.CARET: "Caret spec not allowed",
+            VersionSpecType.TILDE: "Tilde spec not allowed",
+            VersionSpecType.EXACT: "Exact spec not allowed",
+        }
+        return messages.get(spec_type, f"Spec type '{spec_type}' not allowed")

--- a/lintro/deps/policy_engine.py
+++ b/lintro/deps/policy_engine.py
@@ -63,11 +63,18 @@ class PolicyEngine:
     def __init__(self, config: DepsConfig) -> None:
         """Initialize the engine.
 
+        Every configured spec-type name is parsed eagerly, so a typo in
+        ``allowed_types``/``disallowed_types`` (on the config or on a package
+        exception) surfaces here as a ``ValueError`` instead of silently
+        dropping the rule at validation time.
+
         Args:
             config: Resolved dependency policy configuration.
         """
         self.config = config
         self._base_rules = self._resolve_base_rules(config)
+        for exception in config.exceptions:
+            self._parse_types(exception.allowed_types)
 
     def get_preset_rules(self, preset: DepsPolicy) -> PolicyRules:
         """Return the rule set for a named policy preset.
@@ -191,7 +198,8 @@ class PolicyEngine:
 
         Returns:
             PolicyRules: Rules from the preset, or custom fields when the
-            policy is ``custom``.
+            policy is ``custom``. Propagates ``ValueError`` from
+            :meth:`_parse_types` when a spec-type name is unknown.
         """
         if config.policy is DepsPolicy.CUSTOM:
             allowed = frozenset(self._parse_types(config.allowed_types))
@@ -208,17 +216,23 @@ class PolicyEngine:
         """Convert type name strings into :class:`VersionSpecType` values.
 
         Args:
-            names: Version-spec type names (unknown names are ignored).
+            names: Version-spec type names.
 
         Returns:
             set[VersionSpecType]: The parsed types.
+
+        Raises:
+            ValueError: When a name is not a known spec type. Failing closed
+                keeps a typo in ``disallowed_types`` from dropping the rule.
         """
         parsed: set[VersionSpecType] = set()
+        known = ", ".join(sorted(t.value for t in VersionSpecType))
         for name in names:
             try:
                 parsed.add(VersionSpecType(name.strip().lower()))
-            except ValueError:
-                continue
+            except ValueError as exc:
+                msg = f"Unknown version spec type '{name}'. Known types: {known}"
+                raise ValueError(msg) from exc
         return parsed
 
     @staticmethod

--- a/lintro/deps/policy_engine.py
+++ b/lintro/deps/policy_engine.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import fnmatch
 from dataclasses import dataclass
 
+from packaging.utils import canonicalize_name
+
 from lintro.config.deps_config import DepsConfig, DepsPolicy, PackageException
 from lintro.deps.models import Dependency, VersionSpecType, VersionViolation
 
@@ -185,8 +187,10 @@ class PolicyEngine:
         Returns:
             PackageException | None: The matching exception, if any.
         """
+        canonical = canonicalize_name(name)
         for exception in self.config.exceptions:
-            if fnmatch.fnmatch(name.lower(), exception.package.lower()):
+            pattern = canonicalize_name(exception.package)
+            if fnmatch.fnmatch(canonical, pattern):
                 return exception
         return None
 

--- a/lintro/deps/version_analyzer.py
+++ b/lintro/deps/version_analyzer.py
@@ -1,0 +1,155 @@
+"""Classification of version specifications across ecosystems.
+
+The analyzer maps a raw version constraint (as written in a manifest) to a
+:class:`~lintro.deps.models.VersionSpecType` and reports whether the constraint
+caps the maximum installable version. Semantics differ per ecosystem — most
+notably, a bare ``1.2.3`` is an exact pin in npm but a caret range in Cargo.
+"""
+
+from __future__ import annotations
+
+import re
+
+from lintro.deps.models import Ecosystem, VersionSpecType
+
+__all__ = ["VersionAnalyzer"]
+
+# Tokens that mean "no constraint at all".
+_ANY_TOKENS = frozenset({"", "*", "x", "latest", "any"})
+
+# A wildcard component such as ``1.2.*``, ``1.x`` or ``1.2.x``.
+_WILDCARD_RE = re.compile(r"\.\*|(?:^|\.)x(?:\.|$)")
+
+
+class VersionAnalyzer:
+    """Classify version specifications and detect upper bounds."""
+
+    def classify(
+        self,
+        version_spec: str,
+        ecosystem: Ecosystem,
+    ) -> VersionSpecType:
+        """Classify a version specification by type.
+
+        Args:
+            version_spec: Raw version constraint from the manifest.
+            ecosystem: Ecosystem governing the constraint semantics.
+
+        Returns:
+            VersionSpecType: The classified spec type.
+        """
+        spec = version_spec.strip()
+        normalized = spec.lower()
+
+        if normalized in _ANY_TOKENS:
+            return VersionSpecType.ANY
+
+        # Wildcards are checked before operators so ``1.2.*`` wins over range.
+        if self._is_wildcard(spec):
+            return VersionSpecType.WILDCARD
+
+        if spec.startswith("^"):
+            return VersionSpecType.CARET
+
+        if spec.startswith("~"):
+            # ``~=`` (PEP 440) and ``~`` (npm/cargo) are both tilde ranges.
+            return VersionSpecType.TILDE
+
+        if spec.startswith("=="):
+            return VersionSpecType.EXACT
+
+        if spec.startswith("="):
+            # Cargo exact pin (``=1.2.3``); npm treats ``=`` as exact too.
+            return VersionSpecType.EXACT
+
+        # Multi-clause or comparator constraints (``>=1,<2``, ``>=1``).
+        if any(op in spec for op in (">", "<", ",")):
+            if self.has_upper_bound(spec, ecosystem):
+                return VersionSpecType.RANGE
+            return VersionSpecType.UNBOUNDED
+
+        # A bare version number. Cargo treats it as caret; npm/python as exact.
+        if ecosystem is Ecosystem.CARGO:
+            return VersionSpecType.CARET
+        return VersionSpecType.EXACT
+
+    def has_upper_bound(
+        self,
+        version_spec: str,
+        ecosystem: Ecosystem,
+    ) -> bool:
+        """Report whether a version spec caps the maximum version.
+
+        Args:
+            version_spec: Raw version constraint from the manifest.
+            ecosystem: Ecosystem governing the constraint semantics.
+
+        Returns:
+            bool: ``True`` when the maximum installable version is bounded.
+        """
+        spec = version_spec.strip()
+        spec_type = self._quick_type(spec, ecosystem)
+
+        # These forms inherently cap the upper bound.
+        if spec_type in {
+            VersionSpecType.EXACT,
+            VersionSpecType.TILDE,
+            VersionSpecType.CARET,
+            VersionSpecType.WILDCARD,
+        }:
+            return True
+        if spec_type is VersionSpecType.ANY:
+            return False
+
+        # Comparator constraints: an upper bound needs ``<`` or ``<=``, or a
+        # ``==``/``=`` exact clause somewhere in the expression.
+        if "<" in spec:
+            return True
+        clauses = re.split(r"[,\s]+", spec)
+        for clause in clauses:
+            token = clause.strip()
+            if token.startswith("==") or (
+                token.startswith("=") and not token.startswith("==")
+            ):
+                return True
+        return False
+
+    def _quick_type(self, spec: str, ecosystem: Ecosystem) -> VersionSpecType:
+        """Classify without recursing into :meth:`has_upper_bound`.
+
+        Args:
+            spec: Stripped version constraint.
+            ecosystem: Ecosystem governing the constraint semantics.
+
+        Returns:
+            VersionSpecType: A best-effort classification.
+        """
+        normalized = spec.lower()
+        if normalized in _ANY_TOKENS:
+            return VersionSpecType.ANY
+        if self._is_wildcard(spec):
+            return VersionSpecType.WILDCARD
+        if spec.startswith("^"):
+            return VersionSpecType.CARET
+        if spec.startswith("~"):
+            return VersionSpecType.TILDE
+        if spec.startswith("=="):
+            return VersionSpecType.EXACT
+        if spec.startswith("="):
+            return VersionSpecType.EXACT
+        if any(op in spec for op in (">", "<", ",")):
+            return VersionSpecType.RANGE
+        if ecosystem is Ecosystem.CARGO:
+            return VersionSpecType.CARET
+        return VersionSpecType.EXACT
+
+    def _is_wildcard(self, spec: str) -> bool:
+        """Return whether the spec uses a wildcard component.
+
+        Args:
+            spec: Stripped version constraint.
+
+        Returns:
+            bool: ``True`` for patterns like ``1.2.*`` or ``1.x``.
+        """
+        return bool(_WILDCARD_RE.search(spec))

--- a/lintro/deps/version_analyzer.py
+++ b/lintro/deps/version_analyzer.py
@@ -48,12 +48,23 @@ class VersionAnalyzer:
         if self._is_wildcard(spec):
             return VersionSpecType.WILDCARD
 
+        # Alternative clauses (npm ``||``, Cargo commas already handled below)
+        # are never a single exact pin.
+        if "||" in spec:
+            if self.has_upper_bound(spec, ecosystem):
+                return VersionSpecType.RANGE
+            return VersionSpecType.UNBOUNDED
+
         if spec.startswith("^"):
             return VersionSpecType.CARET
 
         if spec.startswith("~"):
             # ``~=`` (PEP 440) and ``~`` (npm/cargo) are both tilde ranges.
             return VersionSpecType.TILDE
+
+        # Exclusion-only specs (``!=1.2.3``) are unbounded, not exact pins.
+        if spec.startswith("!=") or spec.startswith("≠"):
+            return VersionSpecType.UNBOUNDED
 
         if spec.startswith("=="):
             return VersionSpecType.EXACT
@@ -63,7 +74,7 @@ class VersionAnalyzer:
             return VersionSpecType.EXACT
 
         # Multi-clause or comparator constraints (``>=1,<2``, ``>=1``).
-        if any(op in spec for op in (">", "<", ",")):
+        if any(op in spec for op in (">", "<", ",", "!=")):
             if self.has_upper_bound(spec, ecosystem):
                 return VersionSpecType.RANGE
             return VersionSpecType.UNBOUNDED
@@ -129,15 +140,19 @@ class VersionAnalyzer:
             return VersionSpecType.ANY
         if self._is_wildcard(spec):
             return VersionSpecType.WILDCARD
+        if "||" in spec:
+            return VersionSpecType.RANGE
         if spec.startswith("^"):
             return VersionSpecType.CARET
         if spec.startswith("~"):
             return VersionSpecType.TILDE
+        if spec.startswith("!="):
+            return VersionSpecType.UNBOUNDED
         if spec.startswith("=="):
             return VersionSpecType.EXACT
         if spec.startswith("="):
             return VersionSpecType.EXACT
-        if any(op in spec for op in (">", "<", ",")):
+        if any(op in spec for op in (">", "<", ",", "!=")):
             return VersionSpecType.RANGE
         if ecosystem is Ecosystem.CARGO:
             return VersionSpecType.CARET

--- a/lintro/deps/version_analyzer.py
+++ b/lintro/deps/version_analyzer.py
@@ -184,4 +184,4 @@ class VersionAnalyzer:
         Returns:
             bool: ``True`` for patterns like ``1.2.*`` or ``1.x``.
         """
-        return bool(_WILDCARD_RE.search(spec))
+        return bool(_WILDCARD_RE.search(spec.lower()))

--- a/lintro/deps/version_analyzer.py
+++ b/lintro/deps/version_analyzer.py
@@ -4,6 +4,10 @@ The analyzer maps a raw version constraint (as written in a manifest) to a
 :class:`~lintro.deps.models.VersionSpecType` and reports whether the constraint
 caps the maximum installable version. Semantics differ per ecosystem — most
 notably, a bare ``1.2.3`` is an exact pin in npm but a caret range in Cargo.
+
+Alternative clauses (npm ``a || b``) are always evaluated clause by clause: the
+expression is bounded only when *every* alternative is bounded, since npm is
+free to resolve any one of them.
 """
 
 from __future__ import annotations
@@ -19,6 +23,20 @@ _ANY_TOKENS = frozenset({"", "*", "x", "latest", "any"})
 
 # A wildcard component such as ``1.2.*``, ``1.x`` or ``1.2.x``.
 _WILDCARD_RE = re.compile(r"\.\*|(?:^|\.)x(?:\.|$)")
+
+# An npm hyphen range (``1.2.3 - 2.3.4``), which requires surrounding spaces
+# and is therefore distinguishable from a prerelease tag like ``1.2.3-alpha``.
+_HYPHEN_RANGE_RE = re.compile(r"^\S+\s+-\s+\S+$")
+
+# Types that inherently cap the maximum installable version.
+_INHERENTLY_BOUNDED = frozenset(
+    {
+        VersionSpecType.EXACT,
+        VersionSpecType.TILDE,
+        VersionSpecType.CARET,
+        VersionSpecType.WILDCARD,
+    },
+)
 
 
 class VersionAnalyzer:
@@ -39,50 +57,24 @@ class VersionAnalyzer:
             VersionSpecType: The classified spec type.
         """
         spec = version_spec.strip()
-        normalized = spec.lower()
 
-        if normalized in _ANY_TOKENS:
+        if spec.lower() in _ANY_TOKENS:
             return VersionSpecType.ANY
 
-        # Wildcards are checked before operators so ``1.2.*`` wins over range.
-        if self._is_wildcard(spec):
-            return VersionSpecType.WILDCARD
-
-        # Alternative clauses (npm ``||``, Cargo commas already handled below)
-        # are never a single exact pin.
+        # Alternatives are handled before any single-clause heuristic so that a
+        # wildcard or comparator on one side cannot classify the whole spec.
         if "||" in spec:
             if self.has_upper_bound(spec, ecosystem):
                 return VersionSpecType.RANGE
             return VersionSpecType.UNBOUNDED
 
-        if spec.startswith("^"):
-            return VersionSpecType.CARET
-
-        if spec.startswith("~"):
-            # ``~=`` (PEP 440) and ``~`` (npm/cargo) are both tilde ranges.
-            return VersionSpecType.TILDE
-
-        # Exclusion-only specs (``!=1.2.3``) are unbounded, not exact pins.
-        if spec.startswith("!=") or spec.startswith("≠"):
+        spec_type = self._quick_type(spec, ecosystem)
+        if spec_type is VersionSpecType.RANGE and not self.has_upper_bound(
+            spec,
+            ecosystem,
+        ):
             return VersionSpecType.UNBOUNDED
-
-        if spec.startswith("=="):
-            return VersionSpecType.EXACT
-
-        if spec.startswith("="):
-            # Cargo exact pin (``=1.2.3``); npm treats ``=`` as exact too.
-            return VersionSpecType.EXACT
-
-        # Multi-clause or comparator constraints (``>=1,<2``, ``>=1``).
-        if any(op in spec for op in (">", "<", ",", "!=")):
-            if self.has_upper_bound(spec, ecosystem):
-                return VersionSpecType.RANGE
-            return VersionSpecType.UNBOUNDED
-
-        # A bare version number. Cargo treats it as caret; npm/python as exact.
-        if ecosystem is Ecosystem.CARGO:
-            return VersionSpecType.CARET
-        return VersionSpecType.EXACT
+        return spec_type
 
     def has_upper_bound(
         self,
@@ -99,37 +91,41 @@ class VersionAnalyzer:
             bool: ``True`` when the maximum installable version is bounded.
         """
         spec = version_spec.strip()
+
+        # Every alternative must be bounded; one unbounded clause is enough for
+        # the resolver to float to a future major.
+        if "||" in spec:
+            clauses = [part.strip() for part in spec.split("||") if part.strip()]
+            return bool(clauses) and all(
+                self.has_upper_bound(clause, ecosystem) for clause in clauses
+            )
+
         spec_type = self._quick_type(spec, ecosystem)
 
-        # These forms inherently cap the upper bound.
-        if spec_type in {
-            VersionSpecType.EXACT,
-            VersionSpecType.TILDE,
-            VersionSpecType.CARET,
-            VersionSpecType.WILDCARD,
-        }:
+        if spec_type in _INHERENTLY_BOUNDED:
             return True
-        if spec_type is VersionSpecType.ANY:
+        if spec_type in {VersionSpecType.ANY, VersionSpecType.UNBOUNDED}:
             return False
+        if self._is_hyphen_range(spec, ecosystem):
+            return True
 
         # Comparator constraints: an upper bound needs ``<`` or ``<=``, or a
         # ``==``/``=`` exact clause somewhere in the expression.
         if "<" in spec:
             return True
-        clauses = re.split(r"[,\s]+", spec)
-        for clause in clauses:
-            token = clause.strip()
-            if token.startswith("==") or (
-                token.startswith("=") and not token.startswith("==")
-            ):
+        for clause in re.split(r"[,\s]+", spec):
+            if clause.strip().startswith("="):
                 return True
         return False
 
     def _quick_type(self, spec: str, ecosystem: Ecosystem) -> VersionSpecType:
-        """Classify without recursing into :meth:`has_upper_bound`.
+        """Classify a single (alternative-free) clause.
+
+        ``RANGE`` here means "comparator or hyphen expression"; the caller
+        decides whether it is actually bounded via :meth:`has_upper_bound`.
 
         Args:
-            spec: Stripped version constraint.
+            spec: Stripped version constraint without ``||`` alternatives.
             ecosystem: Ecosystem governing the constraint semantics.
 
         Returns:
@@ -138,25 +134,46 @@ class VersionAnalyzer:
         normalized = spec.lower()
         if normalized in _ANY_TOKENS:
             return VersionSpecType.ANY
+        # ``1.2.3 - 2.3.4`` is a bounded range, not a bare exact version.
+        if self._is_hyphen_range(spec, ecosystem):
+            return VersionSpecType.RANGE
         if self._is_wildcard(spec):
             return VersionSpecType.WILDCARD
-        if "||" in spec:
-            return VersionSpecType.RANGE
         if spec.startswith("^"):
             return VersionSpecType.CARET
         if spec.startswith("~"):
+            # ``~=`` (PEP 440) and ``~`` (npm/cargo) are both tilde ranges.
             return VersionSpecType.TILDE
-        if spec.startswith("!="):
+        # Exclusion-only specs (``!=1.2.3``) are unbounded, not exact pins.
+        if spec.startswith("!=") or spec.startswith("≠"):
             return VersionSpecType.UNBOUNDED
         if spec.startswith("=="):
             return VersionSpecType.EXACT
         if spec.startswith("="):
+            # Cargo exact pin (``=1.2.3``); npm treats ``=`` as exact too.
             return VersionSpecType.EXACT
+        # Multi-clause or comparator constraints (``>=1,<2``, ``>=1``).
         if any(op in spec for op in (">", "<", ",", "!=")):
             return VersionSpecType.RANGE
+        # A bare version number. Cargo treats it as caret; npm/python as exact.
         if ecosystem is Ecosystem.CARGO:
             return VersionSpecType.CARET
         return VersionSpecType.EXACT
+
+    @staticmethod
+    def _is_hyphen_range(spec: str, ecosystem: Ecosystem) -> bool:
+        """Return whether the spec is an npm hyphen range.
+
+        Args:
+            spec: Stripped version constraint.
+            ecosystem: Ecosystem governing the constraint semantics.
+
+        Returns:
+            bool: ``True`` for npm specs like ``1.2.3 - 2.3.4``.
+        """
+        if ecosystem is not Ecosystem.NPM:
+            return False
+        return bool(_HYPHEN_RANGE_RE.match(spec))
 
     def _is_wildcard(self, spec: str) -> bool:
         """Return whether the spec uses a wildcard component.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,8 @@ packages = [
   "lintro.mcp.enums",
   "lintro.mcp.toolkits",
   "lintro.config",
+  "lintro.deps",
+  "lintro.deps.parsers",
   "lintro.enums",
   "lintro.exceptions",
   "lintro.formatters",

--- a/tests/deps/__init__.py
+++ b/tests/deps/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for dependency version policy validation."""

--- a/tests/deps/test_config.py
+++ b/tests/deps/test_config.py
@@ -1,0 +1,47 @@
+"""Tests for deps configuration loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from assertpy import assert_that
+
+from lintro.config.config_loader import load_config
+from lintro.config.deps_config import DepsPolicy
+
+
+def test_load_config_parses_deps_section(tmp_path: Path) -> None:
+    """A deps section in config is parsed into DepsConfig.
+
+    Args:
+        tmp_path: Temporary directory.
+    """
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text(
+        "\n".join(
+            [
+                "deps:",
+                "  policy: strict",
+                "  exceptions:",
+                '    - package: "pytest"',
+                "      allowed_types: [tilde, caret]",
+                '      reason: "test tooling"',
+            ],
+        ),
+    )
+    config = load_config(config_path=config_file, allow_pyproject_fallback=False)
+    assert_that(config.deps.policy).is_equal_to(DepsPolicy.STRICT)
+    assert_that(config.deps.exceptions).is_length(1)
+    assert_that(config.deps.exceptions[0].package).is_equal_to("pytest")
+
+
+def test_load_config_defaults_deps_when_absent(tmp_path: Path) -> None:
+    """Config without a deps section yields default DepsConfig.
+
+    Args:
+        tmp_path: Temporary directory.
+    """
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text("execution:\n  parallel: true\n")
+    config = load_config(config_path=config_file, allow_pyproject_fallback=False)
+    assert_that(config.deps.policy).is_equal_to(DepsPolicy.FLEXIBLE)

--- a/tests/deps/test_config.py
+++ b/tests/deps/test_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from assertpy import assert_that
 
 from lintro.config.config_loader import load_config
@@ -45,3 +46,20 @@ def test_load_config_defaults_deps_when_absent(tmp_path: Path) -> None:
     config_file.write_text("execution:\n  parallel: true\n")
     config = load_config(config_path=config_file, allow_pyproject_fallback=False)
     assert_that(config.deps.policy).is_equal_to(DepsPolicy.FLEXIBLE)
+
+
+def test_load_config_rejects_unknown_deps_key(tmp_path: Path) -> None:
+    """A misspelled deps key fails loading instead of silently defaulting.
+
+    Because ``deps`` gates dependency-spec enforcement, a typo such as
+    ``pollicy`` must raise rather than fall back to the default policy and let
+    non-conforming specs pass in CI.
+
+    Args:
+        tmp_path: Temporary directory.
+    """
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text("deps:\n  pollicy: strict\n")
+
+    with pytest.raises(ValueError, match="Unknown deps config key"):
+        load_config(config_path=config_file, allow_pyproject_fallback=False)

--- a/tests/deps/test_config.py
+++ b/tests/deps/test_config.py
@@ -9,6 +9,7 @@ from assertpy import assert_that
 
 from lintro.config.config_loader import load_config
 from lintro.config.deps_config import DepsPolicy
+from lintro.exceptions.errors import ConfigurationError
 
 
 def test_load_config_parses_deps_section(tmp_path: Path) -> None:
@@ -34,6 +35,10 @@ def test_load_config_parses_deps_section(tmp_path: Path) -> None:
     assert_that(config.deps.policy).is_equal_to(DepsPolicy.STRICT)
     assert_that(config.deps.exceptions).is_length(1)
     assert_that(config.deps.exceptions[0].package).is_equal_to("pytest")
+    assert_that(config.deps.exceptions[0].allowed_types).is_equal_to(
+        ["tilde", "caret"],
+    )
+    assert_that(config.deps.exceptions[0].reason).is_equal_to("test tooling")
 
 
 def test_load_config_defaults_deps_when_absent(tmp_path: Path) -> None:
@@ -63,3 +68,34 @@ def test_load_config_rejects_unknown_deps_key(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="Unknown deps config key"):
         load_config(config_path=config_file, allow_pyproject_fallback=False)
+
+
+def test_load_config_rejects_non_mapping_deps_in_yaml(tmp_path: Path) -> None:
+    """A scalar YAML ``deps`` section fails closed.
+
+    Args:
+        tmp_path: Temporary directory.
+    """
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text("deps: true\n")
+
+    with pytest.raises(ConfigurationError, match="deps config must be a mapping"):
+        load_config(config_path=config_file, allow_pyproject_fallback=False)
+
+
+def test_load_config_rejects_non_mapping_deps_in_pyproject(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A scalar ``[tool.lintro] deps`` table fails closed.
+
+    Args:
+        tmp_path: Temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.lintro]\ndeps = true\n")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ConfigurationError, match="deps config must be a mapping"):
+        load_config(allow_pyproject_fallback=True)

--- a/tests/deps/test_deps_command.py
+++ b/tests/deps/test_deps_command.py
@@ -117,8 +117,11 @@ def test_deps_strict_policy_flags_range(
     assert_that(result.exit_code).is_equal_to(1)
 
 
-def test_deps_no_manifest_found(cli_runner: CliRunner, tmp_path: Path) -> None:
-    """Missing manifests report cleanly and exit 0.
+def test_deps_explicit_missing_file_fails(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """Explicit ``--file`` paths that do not exist exit non-zero.
 
     Args:
         cli_runner: The Click runner.
@@ -126,5 +129,23 @@ def test_deps_no_manifest_found(cli_runner: CliRunner, tmp_path: Path) -> None:
     """
     missing = tmp_path / "nope.txt"
     result = cli_runner.invoke(cli, ["deps", "--file", str(missing)])
+    assert_that(result.exit_code).is_equal_to(1)
+    assert_that(result.output).contains("not found")
+
+
+def test_deps_no_manifest_found_on_discovery(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-discovery with no manifests exits 0.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.chdir(tmp_path)
+    result = cli_runner.invoke(cli, ["deps"])
     assert_that(result.exit_code).is_equal_to(0)
     assert_that(result.output).contains("No dependency manifests found")

--- a/tests/deps/test_deps_command.py
+++ b/tests/deps/test_deps_command.py
@@ -1,0 +1,130 @@
+"""Tests for the lintro deps CLI command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+from click.testing import CliRunner
+
+from lintro.cli import cli
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Provide a Click CLI runner.
+
+    Returns:
+        CliRunner: A test runner.
+    """
+    return CliRunner()
+
+
+def _write_pyproject(tmp_path: Path) -> Path:
+    """Write a pyproject.toml with mixed specs.
+
+    Args:
+        tmp_path: Temporary directory.
+
+    Returns:
+        Path: Path to the manifest.
+    """
+    manifest = tmp_path / "pyproject.toml"
+    manifest.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo"',
+                "dependencies = [",
+                '  "pydantic==2.0",',
+                '  "requests>=2.28.0",',
+                "]",
+            ],
+        ),
+    )
+    return manifest
+
+
+def test_deps_grid_reports_violations(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """Grid output flags an unbounded dependency and exits non-zero.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+    """
+    manifest = _write_pyproject(tmp_path)
+    result = cli_runner.invoke(cli, ["deps", "--file", str(manifest)])
+    assert_that(result.exit_code).is_equal_to(1)
+    assert_that(result.output).contains("No upper bound")
+
+
+def test_deps_json_output(cli_runner: CliRunner, tmp_path: Path) -> None:
+    """JSON output contains structured violation data.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+    """
+    manifest = _write_pyproject(tmp_path)
+    result = cli_runner.invoke(
+        cli,
+        ["deps", "--file", str(manifest), "--format", "json"],
+    )
+    payload = json.loads(result.output)
+    assert_that(payload["passed"]).is_false()
+    assert_that(payload["violation_count"]).is_equal_to(1)
+    assert_that(payload["violations"][0]["package"]).is_equal_to("requests")
+
+
+def test_deps_loose_policy_passes(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """Loose policy passes an unbounded spec (exit 0).
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+    """
+    manifest = _write_pyproject(tmp_path)
+    result = cli_runner.invoke(
+        cli,
+        ["deps", "--file", str(manifest), "--policy", "loose"],
+    )
+    assert_that(result.exit_code).is_equal_to(0)
+
+
+def test_deps_strict_policy_flags_range(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """Strict policy flags a non-exact spec.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+    """
+    manifest = _write_pyproject(tmp_path)
+    result = cli_runner.invoke(
+        cli,
+        ["deps", "--file", str(manifest), "--policy", "strict"],
+    )
+    assert_that(result.exit_code).is_equal_to(1)
+
+
+def test_deps_no_manifest_found(cli_runner: CliRunner, tmp_path: Path) -> None:
+    """Missing manifests report cleanly and exit 0.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+    """
+    missing = tmp_path / "nope.txt"
+    result = cli_runner.invoke(cli, ["deps", "--file", str(missing)])
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains("No dependency manifests found")

--- a/tests/deps/test_deps_command.py
+++ b/tests/deps/test_deps_command.py
@@ -10,6 +10,7 @@ from assertpy import assert_that
 from click.testing import CliRunner
 
 from lintro.cli import cli
+from lintro.config.config_loader import clear_config_cache
 
 
 @pytest.fixture
@@ -256,3 +257,155 @@ def test_deps_npm_alternatives_flagged_end_to_end(
     assert_that(result.exit_code).is_equal_to(1)
     payload = json.loads(result.output)
     assert_that(payload["violations"][0]["package"]).is_equal_to("mixed")
+
+
+def test_deps_json_empty_discovery_uses_standard_schema(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty discovery JSON uses the result schema, not ``{"error": ...}``.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.chdir(tmp_path)
+    result = cli_runner.invoke(cli, ["deps", "--format", "json"])
+    assert_that(result.exit_code).is_equal_to(0)
+    payload = json.loads(result.output)
+    assert_that(payload["passed"]).is_true()
+    assert_that(payload["total"]).is_equal_to(0)
+    assert_that(payload["violation_count"]).is_equal_to(0)
+    assert_that(payload["parse_errors"]).is_equal_to([])
+    assert_that(payload["violations"]).is_equal_to([])
+    assert_that("error" in payload).is_false()
+
+
+def test_deps_json_strict_discovery_uses_standard_schema(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Strict empty discovery stays on the standard JSON schema.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.chdir(tmp_path)
+    result = cli_runner.invoke(
+        cli,
+        ["deps", "--format", "json", "--strict-discovery"],
+    )
+    assert_that(result.exit_code).is_equal_to(1)
+    payload = json.loads(result.output)
+    assert_that(payload["passed"]).is_false()
+    assert_that(payload["parse_errors"]).is_length(1)
+    assert_that("error" in payload).is_false()
+
+
+def test_deps_discovery_keeps_manifest_when_root_is_skip_name(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A scan root named ``build`` still discovers its own manifests.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    root = tmp_path / "build"
+    root.mkdir()
+    (root / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo"',
+                'dependencies = ["pydantic==2.0"]',
+            ],
+        ),
+    )
+    monkeypatch.chdir(root)
+    result = cli_runner.invoke(cli, ["deps", "--format", "json"])
+    payload = json.loads(result.output)
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(payload["total"]).is_equal_to(1)
+
+
+def test_deps_discovery_skips_nested_build_dir(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manifests under a relative ``build/`` directory are not discovered.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo"',
+                'dependencies = ["pydantic==2.0"]',
+            ],
+        ),
+    )
+    nested = tmp_path / "build"
+    nested.mkdir()
+    (nested / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "nested"',
+                'dependencies = ["requests>=2.0"]',
+            ],
+        ),
+    )
+    monkeypatch.chdir(tmp_path)
+    result = cli_runner.invoke(cli, ["deps", "--format", "json"])
+    payload = json.loads(result.output)
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(payload["total"]).is_equal_to(1)
+    assert_that(payload["violations"]).is_equal_to([])
+
+
+def test_deps_auto_discovery_applies_repo_config(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``lintro deps`` discovers manifests and honors repo config.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    (tmp_path / ".lintro-config.yaml").write_text("deps:\n  policy: strict\n")
+    (tmp_path / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo"',
+                'dependencies = ["pydantic==2.0", "requests>=2.28.0"]',
+            ],
+        ),
+    )
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+    try:
+        result = cli_runner.invoke(cli, ["deps", "--format", "json"])
+    finally:
+        clear_config_cache()
+    assert_that(result.exit_code).is_equal_to(1)
+    payload = json.loads(result.output)
+    flagged = {item["package"] for item in payload["violations"]}
+    assert_that(flagged).contains("requests")

--- a/tests/deps/test_deps_command.py
+++ b/tests/deps/test_deps_command.py
@@ -149,3 +149,110 @@ def test_deps_no_manifest_found_on_discovery(
     result = cli_runner.invoke(cli, ["deps"])
     assert_that(result.exit_code).is_equal_to(0)
     assert_that(result.output).contains("No dependency manifests found")
+
+
+def test_deps_strict_discovery_fails_on_empty_discovery(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--strict-discovery`` turns an empty discovery into a gate failure.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.chdir(tmp_path)
+    result = cli_runner.invoke(cli, ["deps", "--strict-discovery"])
+    assert_that(result.exit_code).is_equal_to(1)
+    assert_that(result.output).contains("No dependency manifests found")
+
+
+def test_deps_strict_discovery_help_documents_default(
+    cli_runner: CliRunner,
+) -> None:
+    """The command help states the empty-discovery exit behavior.
+
+    Args:
+        cli_runner: The Click runner.
+    """
+    result = cli_runner.invoke(cli, ["deps", "--help"])
+    assert_that(result.output).contains("--strict-discovery")
+    assert_that(result.output).contains("exits 0")
+
+
+def test_deps_invalid_requirement_exits_non_zero(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """A malformed requirement is a parse error, not a silently dropped line.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+    """
+    manifest = tmp_path / "requirements.txt"
+    manifest.write_text("requests==2.31.0\nbroken>=\n")
+    result = cli_runner.invoke(
+        cli,
+        ["deps", "--file", str(manifest), "--format", "json"],
+    )
+    assert_that(result.exit_code).is_equal_to(1)
+    payload = json.loads(result.output)
+    assert_that(payload["passed"]).is_false()
+    assert_that(payload["parse_errors"]).is_length(1)
+
+
+def test_deps_grid_does_not_claim_success_with_parse_errors(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """Grid output never prints the green summary alongside parse errors.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+    """
+    good = tmp_path / "pyproject.toml"
+    good.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo"',
+                'dependencies = ["pydantic==2.0"]',
+            ],
+        ),
+    )
+    bad = tmp_path / "package.json"
+    bad.write_text("{not json")
+    result = cli_runner.invoke(
+        cli,
+        ["deps", "--file", str(good), "--file", str(bad)],
+    )
+    assert_that(result.exit_code).is_equal_to(1)
+    assert_that(result.output).does_not_contain("satisfy the policy")
+    assert_that(result.output).contains("failed to")
+
+
+def test_deps_npm_alternatives_flagged_end_to_end(
+    cli_runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """A mixed ``||`` spec fails the default flexible policy via the CLI.
+
+    Args:
+        cli_runner: The Click runner.
+        tmp_path: Temporary directory.
+    """
+    manifest = tmp_path / "package.json"
+    manifest.write_text(
+        json.dumps({"dependencies": {"mixed": ">=1.0.0 || >=2.0.0 <3.0.0"}}),
+    )
+    result = cli_runner.invoke(
+        cli,
+        ["deps", "--file", str(manifest), "--format", "json"],
+    )
+    assert_that(result.exit_code).is_equal_to(1)
+    payload = json.loads(result.output)
+    assert_that(payload["violations"][0]["package"]).is_equal_to("mixed")

--- a/tests/deps/test_parsers.py
+++ b/tests/deps/test_parsers.py
@@ -1,0 +1,180 @@
+"""Tests for dependency manifest parsers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from assertpy import assert_that
+
+from lintro.deps.models import Ecosystem, VersionSpecType
+from lintro.deps.parsers import parse_file
+from lintro.deps.parsers.cargo_parser import CargoParser
+from lintro.deps.parsers.package_json_parser import PackageJsonParser
+from lintro.deps.parsers.pyproject_parser import PyprojectParser
+from lintro.deps.parsers.requirements_parser import RequirementsParser
+
+
+def _by_name(deps: list, name: str):
+    """Return the first dependency matching ``name``.
+
+    Args:
+        deps: Parsed dependencies.
+        name: Package name to find.
+
+    Returns:
+        The matching dependency.
+    """
+    return next(d for d in deps if d.name == name)
+
+
+def test_pyproject_parser_pep621(tmp_path: Path) -> None:
+    """PEP 621 dependencies parse with classified specs.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "pyproject.toml"
+    manifest.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo"',
+                "dependencies = [",
+                '  "requests>=2.28.0",',
+                '  "pydantic==2.0",',
+                '  "click",',
+                "]",
+                "[project.optional-dependencies]",
+                'dev = ["pytest~=8.1.0"]',
+            ],
+        ),
+    )
+    deps = PyprojectParser().parse(manifest)
+    names = {d.name for d in deps}
+    assert_that(names).contains("requests", "pydantic", "click", "pytest")
+    assert_that(_by_name(deps, "requests").spec_type).is_equal_to(
+        VersionSpecType.UNBOUNDED,
+    )
+    assert_that(_by_name(deps, "pydantic").spec_type).is_equal_to(
+        VersionSpecType.EXACT,
+    )
+    assert_that(_by_name(deps, "click").spec_type).is_equal_to(VersionSpecType.ANY)
+    assert_that(_by_name(deps, "pytest").ecosystem).is_equal_to(Ecosystem.PYTHON)
+
+
+def test_pyproject_parser_poetry(tmp_path: Path) -> None:
+    """Poetry dependency tables parse and skip the python entry.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "pyproject.toml"
+    manifest.write_text(
+        "\n".join(
+            [
+                "[tool.poetry.dependencies]",
+                'python = "^3.11"',
+                'requests = "^2.28.0"',
+                'httpx = { version = ">=0.24,<1.0" }',
+            ],
+        ),
+    )
+    deps = PyprojectParser().parse(manifest)
+    names = {d.name for d in deps}
+    assert_that(names).does_not_contain("python")
+    assert_that(_by_name(deps, "requests").spec_type).is_equal_to(
+        VersionSpecType.CARET,
+    )
+    assert_that(_by_name(deps, "httpx").spec_type).is_equal_to(VersionSpecType.RANGE)
+
+
+def test_requirements_parser(tmp_path: Path) -> None:
+    """requirements.txt lines parse, skipping comments and options.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "requirements.txt"
+    manifest.write_text(
+        "\n".join(
+            [
+                "# a comment",
+                "-r other.txt",
+                "requests>=2.28.0",
+                "flask==2.3.0  # inline",
+                "numpy>=1.20,<2.0",
+                "https://example.com/pkg.whl",
+                "",
+            ],
+        ),
+    )
+    deps = RequirementsParser().parse(manifest)
+    names = {d.name for d in deps}
+    assert_that(names).is_equal_to({"requests", "flask", "numpy"})
+    assert_that(_by_name(deps, "flask").spec_type).is_equal_to(VersionSpecType.EXACT)
+    assert_that(_by_name(deps, "numpy").line).is_not_none()
+
+
+def test_package_json_parser(tmp_path: Path) -> None:
+    """package.json dependency maps parse across sections.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "package.json"
+    manifest.write_text(
+        '{"dependencies": {"react": "18.2.0", "lodash": "*", '
+        '"local": "file:../x"}, "devDependencies": {"jest": "~29.0.0"}}',
+    )
+    deps = PackageJsonParser().parse(manifest)
+    names = {d.name for d in deps}
+    assert_that(names).is_equal_to({"react", "lodash", "jest"})
+    assert_that(_by_name(deps, "react").spec_type).is_equal_to(VersionSpecType.EXACT)
+    assert_that(_by_name(deps, "lodash").spec_type).is_equal_to(VersionSpecType.ANY)
+
+
+def test_cargo_parser(tmp_path: Path) -> None:
+    """Cargo.toml dependencies parse with Cargo caret semantics.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "Cargo.toml"
+    manifest.write_text(
+        "\n".join(
+            [
+                "[dependencies]",
+                'serde = "1.0.100"',
+                'rand = "=0.8.5"',
+                'tokio = { version = "^1.20", features = ["full"] }',
+            ],
+        ),
+    )
+    deps = CargoParser().parse(manifest)
+    assert_that(_by_name(deps, "serde").spec_type).is_equal_to(VersionSpecType.CARET)
+    assert_that(_by_name(deps, "rand").spec_type).is_equal_to(VersionSpecType.EXACT)
+    assert_that(_by_name(deps, "tokio").spec_type).is_equal_to(VersionSpecType.CARET)
+
+
+def test_parse_file_dispatch_unsupported(tmp_path: Path) -> None:
+    """parse_file raises on unsupported manifest names.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "go.sum"
+    manifest.write_text("")
+    assert_that(parse_file).raises(ValueError).when_called_with(manifest)
+
+
+def test_parse_file_dispatch_requirements(tmp_path: Path) -> None:
+    """parse_file routes requirements-dev.txt to the requirements parser.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "requirements-dev.txt"
+    manifest.write_text("pytest==8.0.0\n")
+    deps = parse_file(manifest)
+    assert_that(deps).is_length(1)
+    assert_that(deps[0].name).is_equal_to("pytest")

--- a/tests/deps/test_parsers.py
+++ b/tests/deps/test_parsers.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from assertpy import assert_that
 
-from lintro.deps.models import Ecosystem, VersionSpecType
+from lintro.deps.models import Dependency, Ecosystem, VersionSpecType
 from lintro.deps.parsers import parse_file
 from lintro.deps.parsers.cargo_parser import CargoParser
 from lintro.deps.parsers.package_json_parser import PackageJsonParser
@@ -14,7 +14,7 @@ from lintro.deps.parsers.pyproject_parser import PyprojectParser
 from lintro.deps.parsers.requirements_parser import RequirementsParser
 
 
-def _by_name(deps: list, name: str):
+def _by_name(deps: list[Dependency], name: str) -> Dependency:
     """Return the first dependency matching ``name``.
 
     Args:

--- a/tests/deps/test_parsers.py
+++ b/tests/deps/test_parsers.py
@@ -178,3 +178,64 @@ def test_parse_file_dispatch_requirements(tmp_path: Path) -> None:
     deps = parse_file(manifest)
     assert_that(deps).is_length(1)
     assert_that(deps[0].name).is_equal_to("pytest")
+
+
+def test_pyproject_parser_poetry_legacy_dev_dependencies(tmp_path: Path) -> None:
+    """Legacy ``[tool.poetry.dev-dependencies]`` tables are parsed.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "pyproject.toml"
+    manifest.write_text(
+        "\n".join(
+            [
+                "[tool.poetry.dependencies]",
+                'python = "^3.11"',
+                'requests = "^2.28.0"',
+                "[tool.poetry.dev-dependencies]",
+                'pytest = "*"',
+            ],
+        ),
+    )
+    deps = PyprojectParser().parse(manifest)
+    names = {d.name for d in deps}
+    assert_that(names).contains("requests", "pytest")
+
+
+def test_cargo_parser_target_dependencies(tmp_path: Path) -> None:
+    """Platform-specific ``[target.*.dependencies]`` tables are parsed.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "Cargo.toml"
+    manifest.write_text(
+        "\n".join(
+            [
+                "[dependencies]",
+                'serde = "1.0"',
+                "[target.'cfg(windows)'.dependencies]",
+                'winapi = "0.3"',
+            ],
+        ),
+    )
+    deps = CargoParser().parse(manifest)
+    names = {d.name for d in deps}
+    assert_that(names).contains("serde", "winapi")
+
+
+def test_package_json_parser_keeps_git_prerelease(tmp_path: Path) -> None:
+    """Semver prereleases containing ``git`` are not skipped as git URLs.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "package.json"
+    manifest.write_text(
+        '{"dependencies": {"demo": "1.0.0-git.1", "other": "git+https://example.com/x.git"}}',
+    )
+    deps = PackageJsonParser().parse(manifest)
+    names = {d.name for d in deps}
+    assert_that(names).contains("demo")
+    assert_that(names).does_not_contain("other")

--- a/tests/deps/test_parsers.py
+++ b/tests/deps/test_parsers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from assertpy import assert_that
@@ -239,3 +240,138 @@ def test_package_json_parser_keeps_git_prerelease(tmp_path: Path) -> None:
     names = {d.name for d in deps}
     assert_that(names).contains("demo")
     assert_that(names).does_not_contain("other")
+
+
+def test_package_json_parser_skips_host_shorthands(tmp_path: Path) -> None:
+    """Non-registry locators are skipped instead of read as exact pins.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "package.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "dependencies": {
+                    "gh": "github:owner/repo",
+                    "gl": "gitlab:owner/repo",
+                    "bb": "bitbucket:owner/repo",
+                    "short": "owner/repo#semver:^1.0.0",
+                    "linked": "link:../x",
+                    "real": "^1.0.0",
+                },
+            },
+        ),
+    )
+    deps = PackageJsonParser().parse(manifest)
+    assert_that({d.name for d in deps}).is_equal_to({"real"})
+
+
+def test_pyproject_parser_dependency_groups(tmp_path: Path) -> None:
+    """PEP 735 ``[dependency-groups]`` entries are parsed.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "pyproject.toml"
+    manifest.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo"',
+                'dependencies = ["requests==2.31.0"]',
+                "[dependency-groups]",
+                'dev = ["pytest>=8.0", {include-group = "test"}]',
+                'test = ["coverage~=7.4"]',
+            ],
+        ),
+    )
+    deps = PyprojectParser().parse(manifest)
+    names = {d.name for d in deps}
+    assert_that(names).is_equal_to({"requests", "pytest", "coverage"})
+    assert_that(_by_name(deps, "pytest").spec_type).is_equal_to(
+        VersionSpecType.UNBOUNDED,
+    )
+
+
+def test_pyproject_parser_invalid_requirement_raises(tmp_path: Path) -> None:
+    """A malformed PEP 508 entry fails the parse instead of being dropped.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "pyproject.toml"
+    manifest.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo"',
+                'dependencies = ["requests>=", "click==1.0"]',
+            ],
+        ),
+    )
+    parser = PyprojectParser()
+    assert_that(parser.parse).raises(ValueError).when_called_with(
+        manifest,
+    ).contains("invalid requirement")
+
+
+def test_requirements_parser_invalid_line_raises(tmp_path: Path) -> None:
+    """A malformed requirements line fails the parse instead of being dropped.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "requirements.txt"
+    manifest.write_text("requests>=2.28.0\nbroken>=\n")
+    parser = RequirementsParser()
+    assert_that(parser.parse).raises(ValueError).when_called_with(
+        manifest,
+    ).contains("line 2")
+
+
+def test_cargo_parser_workspace_dependencies(tmp_path: Path) -> None:
+    """``[workspace.dependencies]`` and ``workspace = true`` members parse.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "Cargo.toml"
+    manifest.write_text(
+        "\n".join(
+            [
+                "[workspace.dependencies]",
+                'serde = "1.0.100"',
+                'anyhow = { version = ">=1.0", features = ["std"] }',
+                "[dependencies]",
+                "serde = { workspace = true }",
+                "anyhow = { workspace = true }",
+            ],
+        ),
+    )
+    deps = CargoParser().parse(manifest)
+    assert_that({d.name for d in deps}).is_equal_to({"serde", "anyhow"})
+    assert_that(_by_name(deps, "serde").spec_type).is_equal_to(VersionSpecType.CARET)
+    assert_that(_by_name(deps, "anyhow").spec_type).is_equal_to(
+        VersionSpecType.UNBOUNDED,
+    )
+
+
+def test_cargo_parser_skips_unresolvable_workspace_member(tmp_path: Path) -> None:
+    """A ``workspace = true`` entry with no workspace table is skipped.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "Cargo.toml"
+    manifest.write_text(
+        "\n".join(
+            [
+                "[dependencies]",
+                "serde = { workspace = true }",
+                'rand = "0.8"',
+            ],
+        ),
+    )
+    deps = CargoParser().parse(manifest)
+    assert_that({d.name for d in deps}).is_equal_to({"rand"})

--- a/tests/deps/test_parsers.py
+++ b/tests/deps/test_parsers.py
@@ -100,7 +100,7 @@ def test_requirements_parser(tmp_path: Path) -> None:
         "\n".join(
             [
                 "# a comment",
-                "-r other.txt",
+                "--index-url https://example.com/simple",
                 "requests>=2.28.0",
                 "flask==2.3.0  # inline",
                 "numpy>=1.20,<2.0",
@@ -354,6 +354,169 @@ def test_cargo_parser_workspace_dependencies(tmp_path: Path) -> None:
     assert_that(_by_name(deps, "serde").spec_type).is_equal_to(VersionSpecType.CARET)
     assert_that(_by_name(deps, "anyhow").spec_type).is_equal_to(
         VersionSpecType.UNBOUNDED,
+    )
+
+
+def test_requirements_parser_strips_inline_hash_options(tmp_path: Path) -> None:
+    """A hashed pin is parsed instead of rejected as an invalid spec.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "requirements.txt"
+    manifest.write_text(
+        "requests==2.31.0 --hash=sha256:abcd1234\n",
+    )
+    deps = RequirementsParser().parse(manifest)
+    assert_that(deps).is_length(1)
+    assert_that(deps[0].name).is_equal_to("requests")
+    assert_that(deps[0].spec_type).is_equal_to(VersionSpecType.EXACT)
+
+
+def test_requirements_parser_follows_equals_include(tmp_path: Path) -> None:
+    """``--requirement=`` includes are parsed.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    included = tmp_path / "pins.txt"
+    included.write_text("click==8.1.0\n")
+    manifest = tmp_path / "requirements.txt"
+    manifest.write_text(f"--requirement={included}\n")
+    deps = RequirementsParser().parse(manifest)
+    assert_that({d.name for d in deps}).is_equal_to({"click"})
+
+
+def test_requirements_parser_skips_url_lines(tmp_path: Path) -> None:
+    """PEP 508 URL locators in requirements files are skipped.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "requirements.txt"
+    manifest.write_text(
+        "requests==2.31.0\ndemo @ git+https://example.com/demo.git\n",
+    )
+    deps = RequirementsParser().parse(manifest)
+    assert_that({d.name for d in deps}).is_equal_to({"requests"})
+
+
+def test_requirements_parser_breaks_include_cycles(tmp_path: Path) -> None:
+    """Cyclic ``-r`` includes do not recurse forever.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    first = tmp_path / "a.txt"
+    second = tmp_path / "b.txt"
+    first.write_text("-r b.txt\nflask==2.3.0\n")
+    second.write_text("-r a.txt\n")
+    deps = RequirementsParser().parse(first)
+    assert_that({d.name for d in deps}).is_equal_to({"flask"})
+
+
+def test_requirements_parser_follows_includes(tmp_path: Path) -> None:
+    """``-r`` includes are parsed relative to the referencing file.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    included = tmp_path / "base.txt"
+    included.write_text("flask==2.3.0\n")
+    manifest = tmp_path / "requirements.txt"
+    manifest.write_text("-r base.txt\nrequests==2.31.0\n")
+    deps = RequirementsParser().parse(manifest)
+    assert_that({d.name for d in deps}).is_equal_to({"flask", "requests"})
+
+
+def test_requirements_parser_missing_include_raises(tmp_path: Path) -> None:
+    """A missing ``-r`` include fails closed.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "requirements.txt"
+    manifest.write_text("-r missing.txt\n")
+    parser = RequirementsParser()
+    assert_that(parser.parse).raises(ValueError).when_called_with(
+        manifest,
+    ).contains("not found")
+
+
+def test_parse_file_dev_requirements_and_requirements_dir(
+    tmp_path: Path,
+) -> None:
+    """parse_file accepts ``*requirements.txt`` and ``requirements/*.txt``.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    dev = tmp_path / "dev-requirements.txt"
+    dev.write_text("pytest==8.0.0\n")
+    req_dir = tmp_path / "requirements"
+    req_dir.mkdir()
+    nested = req_dir / "base.txt"
+    nested.write_text("click==8.1.0\n")
+    assert_that(parse_file(dev)[0].name).is_equal_to("pytest")
+    assert_that(parse_file(nested)[0].name).is_equal_to("click")
+
+
+def test_pyproject_parser_skips_url_requirements(tmp_path: Path) -> None:
+    """PEP 508 URL/VCS locators are skipped instead of flagged as unbounded.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    manifest = tmp_path / "pyproject.toml"
+    manifest.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo"',
+                "dependencies = [",
+                '  "requests==2.31.0",',
+                '  "demo @ git+https://example.com/demo.git",',
+                "]",
+            ],
+        ),
+    )
+    deps = PyprojectParser().parse(manifest)
+    assert_that({d.name for d in deps}).is_equal_to({"requests"})
+
+
+def test_cargo_parser_resolves_parent_workspace_member(tmp_path: Path) -> None:
+    """A member ``{ workspace = true }`` reads the parent workspace table.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    root = tmp_path / "Cargo.toml"
+    root.write_text(
+        "\n".join(
+            [
+                "[workspace]",
+                'members = ["member"]',
+                "[workspace.dependencies]",
+                'serde = "1.0.100"',
+            ],
+        ),
+    )
+    member_dir = tmp_path / "member"
+    member_dir.mkdir()
+    member = member_dir / "Cargo.toml"
+    member.write_text(
+        "\n".join(
+            [
+                "[dependencies]",
+                "serde = { workspace = true }",
+                'rand = "0.8"',
+            ],
+        ),
+    )
+    deps = CargoParser().parse(member)
+    assert_that({d.name for d in deps}).is_equal_to({"serde", "rand"})
+    assert_that(_by_name(deps, "serde").spec_type).is_equal_to(
+        VersionSpecType.CARET,
     )
 
 

--- a/tests/deps/test_policy_engine.py
+++ b/tests/deps/test_policy_engine.py
@@ -1,0 +1,130 @@
+"""Tests for the dependency policy engine."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.config.deps_config import DepsConfig, DepsPolicy, PackageException
+from lintro.deps.models import Dependency, Ecosystem, VersionSpecType
+from lintro.deps.policy_engine import PolicyEngine
+
+
+def _dep(
+    name: str,
+    spec: str,
+    spec_type: VersionSpecType,
+    has_upper: bool,
+) -> Dependency:
+    """Build a Dependency for testing.
+
+    Args:
+        name: Package name.
+        spec: Raw version spec.
+        spec_type: Classified type.
+        has_upper: Whether it caps the upper bound.
+
+    Returns:
+        Dependency: The constructed dependency.
+    """
+    return Dependency(
+        name=name,
+        version_spec=spec,
+        spec_type=spec_type,
+        ecosystem=Ecosystem.PYTHON,
+        has_upper_bound=has_upper,
+        file="pyproject.toml",
+    )
+
+
+def test_flexible_flags_unbounded_and_any() -> None:
+    """Flexible policy flags unbounded and any specs only."""
+    engine = PolicyEngine(DepsConfig(policy=DepsPolicy.FLEXIBLE))
+    deps = [
+        _dep("caretpkg", "^1.0", VersionSpecType.CARET, True),
+        _dep("unb", ">=1.0", VersionSpecType.UNBOUNDED, False),
+        _dep("anypkg", "*", VersionSpecType.ANY, False),
+    ]
+    violations = engine.validate(deps)
+    flagged = {v.dependency.name for v in violations}
+    assert_that(flagged).is_equal_to({"unb", "anypkg"})
+
+
+def test_strict_requires_exact() -> None:
+    """Strict policy flags anything that is not an exact pin."""
+    engine = PolicyEngine(DepsConfig(policy=DepsPolicy.STRICT))
+    deps = [
+        _dep("exactpkg", "==1.0", VersionSpecType.EXACT, True),
+        _dep("caretpkg", "^1.0", VersionSpecType.CARET, True),
+    ]
+    violations = engine.validate(deps)
+    flagged = {v.dependency.name for v in violations}
+    assert_that(flagged).is_equal_to({"caretpkg"})
+
+
+def test_loose_only_flags_any() -> None:
+    """Loose policy flags only fully unconstrained specs."""
+    engine = PolicyEngine(DepsConfig(policy=DepsPolicy.LOOSE))
+    deps = [
+        _dep("unb", ">=1.0", VersionSpecType.UNBOUNDED, False),
+        _dep("anypkg", "*", VersionSpecType.ANY, False),
+    ]
+    violations = engine.validate(deps)
+    flagged = {v.dependency.name for v in violations}
+    assert_that(flagged).is_equal_to({"anypkg"})
+
+
+def test_no_double_flag_for_disallowed_unbounded() -> None:
+    """An unbounded spec yields a single violation, not two."""
+    engine = PolicyEngine(DepsConfig(policy=DepsPolicy.FLEXIBLE))
+    deps = [_dep("unb", ">=1.0", VersionSpecType.UNBOUNDED, False)]
+    violations = engine.validate(deps)
+    assert_that(violations).is_length(1)
+
+
+def test_package_exception_relaxes_policy() -> None:
+    """A matching exception overrides the base policy for a package."""
+    config = DepsConfig(
+        policy=DepsPolicy.STRICT,
+        exceptions=[
+            PackageException(package="pytest", allowed_types=["tilde", "caret"]),
+        ],
+    )
+    engine = PolicyEngine(config)
+    deps = [_dep("pytest", "~=8.1", VersionSpecType.TILDE, True)]
+    violations = engine.validate(deps)
+    assert_that(violations).is_empty()
+
+
+def test_package_exception_glob_match() -> None:
+    """Glob-based exceptions match by pattern."""
+    config = DepsConfig(
+        policy=DepsPolicy.STRICT,
+        exceptions=[PackageException(package="aws-*", allowed_types=["caret"])],
+    )
+    engine = PolicyEngine(config)
+    deps = [_dep("aws-sdk", "^1.0", VersionSpecType.CARET, True)]
+    assert_that(engine.validate(deps)).is_empty()
+
+
+def test_custom_policy_uses_explicit_fields() -> None:
+    """Custom policy honors explicit allowed/disallowed fields."""
+    config = DepsConfig(
+        policy=DepsPolicy.CUSTOM,
+        allowed_types=["exact"],
+        disallowed_types=["caret", "any", "unbounded"],
+        require_upper_bound=True,
+    )
+    engine = PolicyEngine(config)
+    deps = [
+        _dep("exactpkg", "==1.0", VersionSpecType.EXACT, True),
+        _dep("caretpkg", "^1.0", VersionSpecType.CARET, True),
+    ]
+    flagged = {v.dependency.name for v in engine.validate(deps)}
+    assert_that(flagged).is_equal_to({"caretpkg"})
+
+
+def test_get_preset_rules_custom_falls_back_to_flexible() -> None:
+    """Requesting preset rules for custom returns the flexible ruleset."""
+    engine = PolicyEngine(DepsConfig(policy=DepsPolicy.FLEXIBLE))
+    rules = engine.get_preset_rules(DepsPolicy.CUSTOM)
+    assert_that(rules.require_upper_bound).is_true()

--- a/tests/deps/test_policy_engine.py
+++ b/tests/deps/test_policy_engine.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from assertpy import assert_that
 
 from lintro.config.deps_config import DepsConfig, DepsPolicy, PackageException
 from lintro.deps.models import Dependency, Ecosystem, VersionSpecType
+from lintro.deps.parsers import parse_file
 from lintro.deps.policy_engine import PolicyEngine
 
 
@@ -128,3 +132,107 @@ def test_get_preset_rules_custom_falls_back_to_flexible() -> None:
     engine = PolicyEngine(DepsConfig(policy=DepsPolicy.FLEXIBLE))
     rules = engine.get_preset_rules(DepsPolicy.CUSTOM)
     assert_that(rules.require_upper_bound).is_true()
+
+
+def test_unknown_custom_type_name_is_rejected() -> None:
+    """A typo in a custom type list fails closed instead of dropping a rule."""
+    config = DepsConfig(
+        policy=DepsPolicy.CUSTOM,
+        allowed_types=["exact"],
+        disallowed_types=["unbounded", "unbouded"],
+    )
+    assert_that(PolicyEngine).raises(ValueError).when_called_with(config).contains(
+        "unbouded",
+    )
+
+
+def test_unknown_exception_type_name_is_rejected() -> None:
+    """A typo in a package exception's allowed_types fails closed."""
+    config = DepsConfig(
+        policy=DepsPolicy.STRICT,
+        exceptions=[PackageException(package="boto3", allowed_types=["exac"])],
+    )
+    assert_that(PolicyEngine).raises(ValueError).when_called_with(config).contains(
+        "exac",
+    )
+
+
+def _deps_from_manifest(tmp_path: Path, body: str, name: str) -> list[Dependency]:
+    """Parse a manifest snippet through the real parser pipeline.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        body: Manifest contents.
+        name: Manifest file name.
+
+    Returns:
+        list[Dependency]: Dependencies classified by ``VersionAnalyzer``.
+    """
+    manifest = tmp_path / name
+    manifest.write_text(body)
+    return parse_file(manifest)
+
+
+def test_pipeline_flexible_flags_unbounded_npm_alternatives(tmp_path: Path) -> None:
+    """A real package.json flows through parser, analyzer and engine.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    deps = _deps_from_manifest(
+        tmp_path,
+        json.dumps(
+            {
+                "dependencies": {
+                    "mixed": ">=1.0.0 || >=2.0.0 <3.0.0",
+                    "wildcard-alt": "1.2.* || >=3.0.0",
+                    "hyphen": "1.2.3 - 2.3.4",
+                    "dual-major": "^1.0.0 || ^2.0.0",
+                },
+            },
+        ),
+        "package.json",
+    )
+    engine = PolicyEngine(DepsConfig(policy=DepsPolicy.FLEXIBLE))
+    flagged = {v.dependency.name for v in engine.validate(deps)}
+    assert_that(flagged).is_equal_to({"mixed", "wildcard-alt"})
+
+
+def test_pipeline_strict_flags_npm_hyphen_range(tmp_path: Path) -> None:
+    """A hyphen range is a range, so strict policy flags it as non-exact.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    deps = _deps_from_manifest(
+        tmp_path,
+        json.dumps({"dependencies": {"hyphen": "1.2.3 - 2.3.4"}}),
+        "package.json",
+    )
+    assert_that(deps[0].spec_type).is_equal_to(VersionSpecType.RANGE)
+    engine = PolicyEngine(DepsConfig(policy=DepsPolicy.STRICT))
+    assert_that(engine.validate(deps)).is_length(1)
+
+
+def test_pipeline_pyproject_groups_are_policed(tmp_path: Path) -> None:
+    """PEP 735 group members reach the policy engine.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    deps = _deps_from_manifest(
+        tmp_path,
+        "\n".join(
+            [
+                "[project]",
+                'name = "demo"',
+                'dependencies = ["requests==2.31.0"]',
+                "[dependency-groups]",
+                'dev = ["pytest>=8.0"]',
+            ],
+        ),
+        "pyproject.toml",
+    )
+    engine = PolicyEngine(DepsConfig(policy=DepsPolicy.FLEXIBLE))
+    flagged = {v.dependency.name for v in engine.validate(deps)}
+    assert_that(flagged).is_equal_to({"pytest"})

--- a/tests/deps/test_policy_engine.py
+++ b/tests/deps/test_policy_engine.py
@@ -110,6 +110,24 @@ def test_package_exception_glob_match() -> None:
     assert_that(engine.validate(deps)).is_empty()
 
 
+def test_package_exception_glob_matches_pep503_normalized_name() -> None:
+    """Exception globs match PEP 503 names (``_`` vs ``-``)."""
+    config = DepsConfig(
+        policy=DepsPolicy.STRICT,
+        exceptions=[
+            PackageException(
+                package="google-cloud-*",
+                allowed_types=["caret"],
+            ),
+        ],
+    )
+    engine = PolicyEngine(config)
+    deps = [
+        _dep("google_cloud_storage", "^1.0", VersionSpecType.CARET, True),
+    ]
+    assert_that(engine.validate(deps)).is_empty()
+
+
 def test_custom_policy_uses_explicit_fields() -> None:
     """Custom policy honors explicit allowed/disallowed fields."""
     config = DepsConfig(

--- a/tests/deps/test_version_analyzer.py
+++ b/tests/deps/test_version_analyzer.py
@@ -1,0 +1,91 @@
+"""Tests for the version specification analyzer."""
+
+from __future__ import annotations
+
+import pytest
+from assertpy import assert_that
+
+from lintro.deps.models import Ecosystem, VersionSpecType
+from lintro.deps.version_analyzer import VersionAnalyzer
+
+
+@pytest.fixture
+def analyzer() -> VersionAnalyzer:
+    """Provide a VersionAnalyzer instance.
+
+    Returns:
+        VersionAnalyzer: A fresh analyzer.
+    """
+    return VersionAnalyzer()
+
+
+@pytest.mark.parametrize(
+    ("spec", "ecosystem", "expected"),
+    [
+        ("==1.2.3", Ecosystem.PYTHON, VersionSpecType.EXACT),
+        ("~=1.2.3", Ecosystem.PYTHON, VersionSpecType.TILDE),
+        ("^1.2.3", Ecosystem.PYTHON, VersionSpecType.CARET),
+        (">=1.2.0,<2.0.0", Ecosystem.PYTHON, VersionSpecType.RANGE),
+        (">=1.0.0", Ecosystem.PYTHON, VersionSpecType.UNBOUNDED),
+        ("1.2.*", Ecosystem.PYTHON, VersionSpecType.WILDCARD),
+        ("*", Ecosystem.PYTHON, VersionSpecType.ANY),
+        ("", Ecosystem.PYTHON, VersionSpecType.ANY),
+        ("1.2.3", Ecosystem.NPM, VersionSpecType.EXACT),
+        ("~1.2.3", Ecosystem.NPM, VersionSpecType.TILDE),
+        ("^5.0.0", Ecosystem.NPM, VersionSpecType.CARET),
+        ("1.x", Ecosystem.NPM, VersionSpecType.WILDCARD),
+        (">=1.0.0 <2.0.0", Ecosystem.NPM, VersionSpecType.RANGE),
+        ("latest", Ecosystem.NPM, VersionSpecType.ANY),
+        ("1.0.100", Ecosystem.CARGO, VersionSpecType.CARET),
+        ("=0.8.5", Ecosystem.CARGO, VersionSpecType.EXACT),
+        ("~1.2", Ecosystem.CARGO, VersionSpecType.TILDE),
+        ("*", Ecosystem.CARGO, VersionSpecType.ANY),
+    ],
+)
+def test_classify(
+    analyzer: VersionAnalyzer,
+    spec: str,
+    ecosystem: Ecosystem,
+    expected: VersionSpecType,
+) -> None:
+    """Classification returns the expected spec type per ecosystem.
+
+    Args:
+        analyzer: The analyzer under test.
+        spec: Raw version spec.
+        ecosystem: Ecosystem for the spec.
+        expected: Expected classification.
+    """
+    assert_that(analyzer.classify(spec, ecosystem)).is_equal_to(expected)
+
+
+@pytest.mark.parametrize(
+    ("spec", "ecosystem", "expected"),
+    [
+        ("==1.2.3", Ecosystem.PYTHON, True),
+        ("~=1.2.3", Ecosystem.PYTHON, True),
+        ("^1.2.3", Ecosystem.PYTHON, True),
+        (">=1.0,<2.0", Ecosystem.PYTHON, True),
+        ("<2.0", Ecosystem.PYTHON, True),
+        (">=1.0.0", Ecosystem.PYTHON, False),
+        (">1.0", Ecosystem.PYTHON, False),
+        ("*", Ecosystem.PYTHON, False),
+        ("1.2.*", Ecosystem.PYTHON, True),
+        ("1.0.100", Ecosystem.CARGO, True),
+    ],
+)
+def test_has_upper_bound(
+    analyzer: VersionAnalyzer,
+    spec: str,
+    ecosystem: Ecosystem,
+    expected: bool,
+) -> None:
+    """Upper-bound detection matches expectations.
+
+    Args:
+        analyzer: The analyzer under test.
+        spec: Raw version spec.
+        ecosystem: Ecosystem for the spec.
+        expected: Whether an upper bound is expected.
+    """
+    assert_that(analyzer.has_upper_bound(spec, ecosystem)).is_equal_to(expected)

--- a/tests/deps/test_version_analyzer.py
+++ b/tests/deps/test_version_analyzer.py
@@ -40,6 +40,8 @@ def analyzer() -> VersionAnalyzer:
         ("=0.8.5", Ecosystem.CARGO, VersionSpecType.EXACT),
         ("~1.2", Ecosystem.CARGO, VersionSpecType.TILDE),
         ("*", Ecosystem.CARGO, VersionSpecType.ANY),
+        ("!=1.2.3", Ecosystem.PYTHON, VersionSpecType.UNBOUNDED),
+        ("==1.2.3 || ==2.0.0", Ecosystem.NPM, VersionSpecType.RANGE),
     ],
 )
 def test_classify(

--- a/tests/deps/test_version_analyzer.py
+++ b/tests/deps/test_version_analyzer.py
@@ -42,6 +42,16 @@ def analyzer() -> VersionAnalyzer:
         ("*", Ecosystem.CARGO, VersionSpecType.ANY),
         ("!=1.2.3", Ecosystem.PYTHON, VersionSpecType.UNBOUNDED),
         ("==1.2.3 || ==2.0.0", Ecosystem.NPM, VersionSpecType.RANGE),
+        # Alternatives: bounded only when every clause is bounded.
+        (">=1.0.0 || >=2.0.0", Ecosystem.NPM, VersionSpecType.UNBOUNDED),
+        (">=1.0.0 || >=2.0.0 <3.0.0", Ecosystem.NPM, VersionSpecType.UNBOUNDED),
+        ("1.2.* || >=3.0.0", Ecosystem.NPM, VersionSpecType.UNBOUNDED),
+        ("^1.0.0 || ^2.0.0", Ecosystem.NPM, VersionSpecType.RANGE),
+        (">=1.0.0 <2.0.0 || >=3.0.0 <4.0.0", Ecosystem.NPM, VersionSpecType.RANGE),
+        # npm hyphen ranges are bounded ranges, not exact pins.
+        ("1.2.3 - 2.3.4", Ecosystem.NPM, VersionSpecType.RANGE),
+        ("1.2.3-alpha", Ecosystem.NPM, VersionSpecType.EXACT),
+        ("1.2.3 - 2.3.4 || 4.0.0", Ecosystem.NPM, VersionSpecType.RANGE),
     ],
 )
 def test_classify(
@@ -74,6 +84,19 @@ def test_classify(
         ("*", Ecosystem.PYTHON, False),
         ("1.2.*", Ecosystem.PYTHON, True),
         ("1.0.100", Ecosystem.CARGO, True),
+        # Every ``||`` clause must be bounded.
+        (">=1.0.0 || >=2.0.0", Ecosystem.NPM, False),
+        (">=1.0.0 || >=2.0.0 <3.0.0", Ecosystem.NPM, False),
+        (">=1.0.0 <2.0.0 || >=3.0.0", Ecosystem.NPM, False),
+        ("1.2.* || >=3.0.0", Ecosystem.NPM, False),
+        ("^1.0.0 || ^2.0.0", Ecosystem.NPM, True),
+        (">=1.0.0 <2.0.0 || >=3.0.0 <4.0.0", Ecosystem.NPM, True),
+        ("||", Ecosystem.NPM, False),
+        # Hyphen ranges cap the maximum; prerelease tags are exact pins.
+        ("1.2.3 - 2.3.4", Ecosystem.NPM, True),
+        ("1.2.3-alpha", Ecosystem.NPM, True),
+        # Hyphen-range syntax is npm-only; Cargo reads it as a caret spec.
+        ("1.2.3 - 2.3.4", Ecosystem.CARGO, True),
     ],
 )
 def test_has_upper_bound(

--- a/tests/deps/test_version_analyzer.py
+++ b/tests/deps/test_version_analyzer.py
@@ -28,6 +28,8 @@ def analyzer() -> VersionAnalyzer:
         (">=1.2.0,<2.0.0", Ecosystem.PYTHON, VersionSpecType.RANGE),
         (">=1.0.0", Ecosystem.PYTHON, VersionSpecType.UNBOUNDED),
         ("1.2.*", Ecosystem.PYTHON, VersionSpecType.WILDCARD),
+        ("1.2.X", Ecosystem.PYTHON, VersionSpecType.WILDCARD),
+        ("1.X", Ecosystem.NPM, VersionSpecType.WILDCARD),
         ("*", Ecosystem.PYTHON, VersionSpecType.ANY),
         ("", Ecosystem.PYTHON, VersionSpecType.ANY),
         ("1.2.3", Ecosystem.NPM, VersionSpecType.EXACT),


### PR DESCRIPTION
## What’s Changing

Adds a new `lintro deps` command that validates dependency version
specifications against a configurable policy, implementing #481.

- **Command** `lintro deps [--file ...] [--policy strict|flexible|loose] [--format grid|json]`.
  Auto-discovers manifests when no `--file` is given; exits non-zero on violations.
- **Parsers** for `pyproject.toml` (PEP 621 + Poetry), `requirements*.txt`,
  `package.json`, and `Cargo.toml`.
- **VersionAnalyzer** classifies each spec (exact / tilde / caret / range /
  unbounded / wildcard / any) and detects upper bounds with ecosystem-aware
  semantics (e.g. bare `1.2.3` is exact in npm but caret in Cargo).
- **PolicyEngine** applies preset or custom rules with per-package exceptions
  (glob-matched, e.g. `aws-*`).
- **Config**: `DepsConfig` wired into `LintroConfig` and the config loader,
  readable from a `deps:` section in `.lintro-config.yaml` / `[tool.lintro]`.

Uses stdlib `tomllib` and the already-present `packaging`; no new runtime deps.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (full `uv run pytest` green apart from the two known
      env-only failures)

## Related Issues

Closes #481

## Details

- 50 new tests under `tests/deps/` cover spec classification, all four
  parsers, policy presets, custom policy, package exceptions, config loading,
  and the CLI (grid/json, exit codes, discovery).
- New packages `lintro.deps` / `lintro.deps.parsers` registered in
  `[tool.setuptools].packages`.
- Testing: `uv run pytest` — 6054 passed, 10 skipped, 2 known env-only
  failures (`test_markdownlint_direct_vs_lintro_parity`,
  `test_prepare_execution_version_check_fails_returns_early_result`). ruff,
  ruff format, mypy, and pydoclint clean on changed files.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds dependency version policy checks to `lintro`. The main changes are:

- New `lintro deps` command with grid and JSON output.
- Parsers for Python, npm, and Cargo dependency manifests.
- Version spec classification across ecosystems.
- Policy presets, custom rules, and package exceptions.
- Config loading for the new `deps` section.
- Tests covering CLI behavior, parser coverage, policy rules, and config loading.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.
- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/cli_utils/commands/deps.py | Adds the dependency check command and handles missing files, parse errors, config errors, output, and exit codes. |
| lintro/config/config_loader.py | Loads the new `deps` config section and rejects unknown keys. |
| lintro/deps/parsers/pyproject_parser.py | Parses PEP 621, dependency groups, Poetry dependencies, and legacy Poetry dev dependencies. |
| lintro/deps/parsers/cargo_parser.py | Parses top-level, target-specific, build, dev, and workspace Cargo dependencies. |
| lintro/deps/parsers/package_json_parser.py | Parses npm dependency sections and skips non-registry references without dropping valid prerelease versions. |
| lintro/deps/version_analyzer.py | Classifies version specs and checks upper bounds with ecosystem-specific behavior. |
| lintro/deps/policy_engine.py | Applies dependency policy rules, custom settings, and package exceptions. |

</details>

<sub>Reviews (8): Last reviewed commit: ["fix(deps): close analyzer, parser and ga..."](https://github.com/lgtm-hq/py-lintro/commit/e5b8fb56976763a4ee573ae19955a78edbe504ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42280196)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `lintro deps` command to validate dependency version specifications.
  * Supports Python, npm, and Cargo manifests, including recursive discovery and requirements includes.
  * Added strict, flexible, loose, and custom validation policies with package-specific exceptions.
  * Added grid and JSON output formats with actionable violation reporting and status codes.
  * Added dependency-policy configuration through project settings.
* **Tests**
  * Added comprehensive coverage for parsing, policy validation, discovery, output formats, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->