### PR TITLE
fix(npm): scope meta-package as @lgtm-hq/lintro

### DIFF
--- a/docs/npm-distribution.md
+++ b/docs/npm-distribution.md
@@ -11,7 +11,7 @@ The `npm/` directory holds five packages:
 
 | Package  | npm name                       | Contents                                       |
 | -------- | ------------------------------ | ---------------------------------------------- |
-| Meta     | `lintro`                       | `bin/lintro` launcher + `optionalDependencies` |
+| Meta     | `@lgtm-hq/lintro`              | `bin/lintro` launcher + `optionalDependencies` |
 | Platform | `@lgtm-hq/lintro-darwin-arm64` | macOS Apple Silicon binary                     |
 | Platform | `@lgtm-hq/lintro-darwin-x64`   | macOS Intel binary                             |
 | Platform | `@lgtm-hq/lintro-linux-arm64`  | Linux ARM64 binary                             |

--- a/npm/lintro/lib/resolve.js
+++ b/npm/lintro/lib/resolve.js
@@ -83,8 +83,9 @@ function resolveBinary(requireFn, platform, arch) {
         'This usually means optional dependencies were skipped during ' +
         'install, or the lockfile was generated on a different OS and ' +
         "omits this platform's package (see npm/cli#4828). Reinstall with " +
-        'optional dependencies enabled (e.g. `npm install lintro` or ' +
-        '`bun add lintro`), or refresh the lockfile on this platform ' +
+        'optional dependencies enabled (e.g. `npm install @lgtm-hq/lintro` ' +
+        'or `bun add @lgtm-hq/lintro`), or refresh the lockfile on this ' +
+        'platform ' +
         `(e.g. \`npm install --force\`). Cause: ${err.message}`
     );
   }

--- a/npm/lintro/package.json
+++ b/npm/lintro/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lintro",
+  "name": "@lgtm-hq/lintro",
   "version": "0.0.0-dev",
   "description": "A unified CLI for code formatting, linting, and quality assurance. Ships self-contained platform binaries — no Python required.",
   "keywords": [


### PR DESCRIPTION
## Summary
- Rename the npm meta-package `lintro` → `@lgtm-hq/lintro` (manifest, launcher error message, docs).
- Sync `uv.lock` to 0.69.0.

## Why
npm rejected publishing unscoped `lintro`: *Package name too similar to existing packages listr, listr2* (permanent typosquat rule). The scoped name matches the platform packages and the @biomejs/biome model. All five packages are published at 0.69.0; install verified end-to-end (`bun add @lgtm-hq/lintro` → `lintro --version` OK).

Refs #932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated package layout/distribution docs to use the scoped launcher name `@lgtm-hq/lintro`.
* **Bug Fixes**
  * Refreshed the missing platform optional dependency error message to show correct npm and bun install examples using `@lgtm-hq/lintro`.
* **Chores**
  * Renamed the published npm package from `lintro` to `@lgtm-hq/lintro`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR scopes the npm launcher package under `@lgtm-hq/lintro`. The main changes are:

- Renamed the meta-package in `npm/lintro/package.json`.
- Updated the missing platform package install message.
- Updated the npm distribution docs to show the scoped package name.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| npm/lintro/package.json | Renames the npm meta-package while keeping the CLI binary name and platform dependencies aligned. |
| npm/lintro/lib/resolve.js | Updates the reinstall guidance to use the scoped package name. |
| docs/npm-distribution.md | Documents the scoped launcher package in the npm package layout. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/932-meta-pa..."](https://github.com/lgtm-hq/py-lintro/commit/5c0d8fa5de7ca947a4efab5c17e40e20b84364a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42300768)</sub>

<!-- /greptile_comment -->