### PR TITLE
chore(ci): bump lgtm-ci reusables to v0.47.1

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`4aaefe64763b7841b6d92d94dc47185083d34c9a` (**v0.46.0**). All workflow SHA pins include
+`3d3e577c8e50e11ead6bd36cb559361d33796a9d` (**v0.47.1**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
       build-mode: none
       config-file: .github/codeql/codeql-config.yml
       category: '/language:all'
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       languages: python
       build-mode: none

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,7 +21,7 @@ jobs:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       fail-on-severity: high
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       fail-on-severity: high
       tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -53,7 +53,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: docker
       allowed-endpoints-mode: append
@@ -95,7 +95,7 @@ jobs:
       no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
       provenance: false
       sbom: false
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: docker
       allowed-endpoints-mode: append

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     permissions:
       contents: read
       packages: write
@@ -65,7 +65,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -222,7 +222,7 @@ jobs:
         needs.manifest-sync.result == 'skipped'
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
@@ -258,7 +258,7 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
@@ -279,7 +279,7 @@ jobs:
         github.event.pull_request.draft == false
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     permissions:
       contents: read
     with:
@@ -357,7 +357,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -227,7 +227,7 @@ jobs:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
@@ -264,7 +264,7 @@ jobs:
       pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
 
@@ -283,7 +283,7 @@ jobs:
     permissions:
       contents: read
     with:
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       job-name: '🛠️ Lintro Code Quality'
       runner-image: ubuntu-24.04
       upstream-result: >-

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -44,7 +44,7 @@ jobs:
       min-age-days: >-
         ${{ github.event_name != 'workflow_dispatch' && 7 || inputs.min_age_days }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append
@@ -66,7 +66,7 @@ jobs:
       min-age-days: >-
         ${{ github.event_name != 'workflow_dispatch' && 7 || inputs.min_age_days }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -35,7 +35,7 @@ permissions: {}
 jobs:
   prune-untagged:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     permissions:
       contents: read # checkout repo and lgtm-ci tooling sparse checkout
       packages: write # delete untagged GHCR package versions via Packages API
@@ -57,7 +57,7 @@ jobs:
 
   prune-untagged-base:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     permissions:
       contents: read # checkout repo and lgtm-ci tooling sparse checkout
       packages: write # delete untagged GHCR package versions via Packages API

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -15,7 +15,7 @@ jobs:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       codeowners-path: .github/CODEOWNERS
       tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -16,7 +16,7 @@ jobs:
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -30,7 +30,7 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       target: .
       target-type: dir
@@ -57,7 +57,7 @@ jobs:
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
@@ -116,7 +116,7 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
         with:
           artifact-name: python-dist
           python-version: '3.14'
@@ -139,7 +139,7 @@ jobs:
     needs: [pypi-upload]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     permissions:
       # write: create GitHub Release and upload dist assets
       contents: write

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -37,7 +37,7 @@ jobs:
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: sbom
     permissions:
@@ -64,7 +64,7 @@ jobs:
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -120,7 +120,7 @@ jobs:
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+          tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       - name: Upload to PyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
@@ -146,7 +146,7 @@ jobs:
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -18,7 +18,7 @@ jobs:
   pypi-build:
     name: Build Python distribution
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
@@ -80,7 +80,7 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
         with:
           artifact-name: python-dist
           python-version: '3.14'

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -27,7 +27,7 @@ jobs:
       verify-tag-version: false
       ensure-tag-on-default-branch: false
       artifact-name: python-dist
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -84,7 +84,7 @@ jobs:
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+          tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       - name: Upload to TestPyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -20,7 +20,7 @@ jobs:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       create-release: false
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       # Paired with release-version-pr.yml (egress-preset: pypi).
       # Guarded by test_release_workflows_use_paired_egress_presets.

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       create-release: false
       tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       ecosystems: python
       auto-merge: true

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -22,7 +22,7 @@ jobs:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       # Paired with release-auto-tag.yml (egress-preset: github-tooling).
       # Guarded by test_release_workflows_use_paired_egress_presets.

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -44,7 +44,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -24,7 +24,7 @@ jobs:
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: sbom
     permissions:

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       target: .
       target-type: dir

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -19,7 +19,7 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
       egress-policy: block

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -20,7 +20,7 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
       egress-policy: block

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -34,7 +34,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -63,7 +63,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Coverage
       runner-image: ubuntu-24.04
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -116,7 +116,7 @@ jobs:
     permissions:
       contents: read
     with:
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       job-name: '🧪 Test Suite & Coverage'
       runner-image: ubuntu-24.04
       upstream-result: ${{ needs.test-gate.outputs.result }}
@@ -138,7 +138,7 @@ jobs:
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: github-pages
     permissions:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -23,7 +23,7 @@ jobs:
   # Compat mode: multi-runtime matrix, no coverage or PR comments
   test-compat:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       publish-test-summary: false
       python-versions: '3.11,3.14'
@@ -50,7 +50,7 @@ jobs:
   # Coverage mode: single runtime with coverage reporting
   test-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       publish-test-summary: true
       python-version: '3.14'
@@ -112,7 +112,7 @@ jobs:
     needs: test-gate
     if: always()
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     permissions:
       contents: read
     with:
@@ -132,7 +132,7 @@ jobs:
       github.event_name == 'push' &&
       needs.test-coverage.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       coverage-percent: ${{ needs.test-coverage.outputs.coverage-percent }}
       upload-coverage: true

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
       tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
       egress-policy: block

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -24,7 +24,7 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     with:
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write # open PRs for stale/expired suppressions
     with:
       job-name: '🔍 Check Vulnerability Suppressions'
-      tooling-ref: '4aaefe64763b7841b6d92d94dc47185083d34c9a' # v0.46.0
+      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
       workflow-file: vuln-suppression-check.yml
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   check-suppressions:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
     permissions:
       contents: write # commit auto-remediation suppressions on default branch
       pull-requests: write # open PRs for stale/expired suppressions


### PR DESCRIPTION
## Summary

Bumps all `lgtm-hq/lgtm-ci` reusable-workflow/action refs from **v0.46.0** (`4aaefe6`) to **v0.47.1** (`3d3e577`) across 18 workflows.

This adopts the `reusable-docker` fix from **lgtm-hq/lgtm-ci#434**:

- multi-arch release publish no longer orphans index children (destructive cleanup removed);
- a **non-skippable verify-published gate** pulls the published image back from GHCR and **fails the release on any dangling child**;
- hardened for variant platforms and GHCR read-after-write lag.

This is step 2 of the remediation for **lgtm-hq/lgtm-ci#433** — every `ghcr.io/lgtm-hq/py-lintro` multi-arch image since **0.64.3** has been a dangling index (children 404) while the release reported green. On the next release cut after this merges, the fixed publisher produces a complete image, or the new gate fails loudly.

## Interface impact

None required. The `reusable-docker` fix is internal. The only interface delta anywhere in the bump is a new **optional** `timeout-minutes` input (defaulted) added to several reusables — fully backward compatible; no caller changes needed.

## Verification

- All 30 lgtm-ci refs updated; no stale `v0.46.0`/`4aaefe6` refs remain.
- `uv run lintro chk .github/workflows/` → 0 issues.
- Full suite: 6012 passed, 7 skipped, 1 failed (`test_markdownlint_direct_vs_lintro_parity` — known env-only local failure, markdownlint 0.22.0 < min 0.22.1).

Refs: lgtm-hq/lgtm-ci#433, lgtm-hq/lgtm-ci#434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated many automation workflows to newer shared workflow/action versions.
  * This includes CI, security checks, release/publishing, labeling, assignment, cleanup, and SBOM-related workflows.
  * No user-facing behavior or app features changed; the update keeps workflow tooling aligned on a newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the shared lgtm-ci workflow pins used by repository automation.

- Bumps reusable workflow and action refs from v0.46.0 to v0.47.1.
- Aligns matching `tooling-ref` inputs with the new shared pin.
- Updates the workflow README to document the new pinned version.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/docker-build-publish.yml | Docker publish jobs now use the same v0.47.1 pin for the reusable workflow and tooling input. |
| .github/workflows/docker-ci.yml | Docker CI reusable workflow, action, and tooling refs were moved to the new shared pin. |
| .github/workflows/test-ci.yml | Test, coverage, publish, and required-check reusable refs were moved to the new shared pin. |
| .github/workflows/README.md | Workflow documentation now lists the new lgtm-ci pin and version. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): bump tooling-ref inputs to v0.4..."](https://github.com/lgtm-hq/py-lintro/commit/cd18f2c802c6bafeaa097b060b924e92cf08e9f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42460342)</sub>

<!-- /greptile_comment -->