### PR TITLE
ci(docker): bump lgtm-ci to v0.48.0 and add historical backfill dispatch

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`3d3e577c8e50e11ead6bd36cb559361d33796a9d` (**v0.47.1**). All workflow SHA pins include
+`1014e3d7d5441a63215d2096545a46cff6de101c` (**v0.48.0**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,13 +25,13 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
       languages: python
       build-mode: none
       config-file: .github/codeql/codeql-config.yml
       category: '/language:all'
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,10 +18,10 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
       fail-on-severity: high
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -15,6 +15,17 @@ name: Build - Docker Image & Registry
         description: 'Run publish on this branch (manual testing)'
         required: false
         default: 'false'
+      backfill_version:
+        description: >-
+          Backfill: version to (re)publish, e.g. 0.65.0.
+          Leave empty for normal builds. When set, builds from backfill_ref,
+          tags that version, and does NOT move the latest tag.
+        required: false
+        default: ''
+      backfill_ref:
+        description: 'Backfill: git ref to build that version from, e.g. v0.65.0.'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -23,7 +34,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     permissions:
       contents: read
       packages: write
@@ -35,25 +46,36 @@ jobs:
       target: full
       image-name: lgtm-hq/py-lintro
       version: >-
-        ${{ startsWith(github.ref, 'refs/tags/')
+        ${{ (github.event_name == 'workflow_dispatch'
+        && inputs.backfill_version != '') && inputs.backfill_version
+        || (startsWith(github.ref, 'refs/tags/')
         && github.ref_name
-        || (github.event_name == 'release' && github.event.release.tag_name || '') }}
+        || (github.event_name == 'release' && github.event.release.tag_name || '')) }}
       push: >-
         ${{ github.event_name != 'pull_request'
         && (github.ref == 'refs/heads/main'
         || startsWith(github.ref, 'refs/tags/')
         || github.event_name == 'release'
         || (github.event_name == 'workflow_dispatch'
-        && inputs.force_publish == 'true')) }}
+        && (inputs.force_publish == 'true' || inputs.backfill_version != ''))) }}
+      source-ref: >-
+        ${{ github.event_name == 'workflow_dispatch'
+        && inputs.backfill_ref || '' }}
+      tag-latest: >-
+        ${{ !(github.event_name == 'workflow_dispatch'
+        && inputs.backfill_version != '') }}
       platforms: linux/amd64,linux/arm64
       runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
       smoke-test: lintro --version
       validate-on-pr: false
       cache-registry-ref: ghcr.io/lgtm-hq/py-lintro:cache
-      no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
+      no-cache: >-
+        ${{ startsWith(github.ref, 'refs/tags/')
+        || (github.event_name == 'workflow_dispatch'
+        && inputs.backfill_version != '') }}
       provenance: false
       sbom: false
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: docker
       allowed-endpoints-mode: append
@@ -65,7 +87,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     permissions:
       contents: read
       packages: write
@@ -77,25 +99,36 @@ jobs:
       target: base
       image-name: lgtm-hq/py-lintro-base
       version: >-
-        ${{ startsWith(github.ref, 'refs/tags/')
+        ${{ (github.event_name == 'workflow_dispatch'
+        && inputs.backfill_version != '') && inputs.backfill_version
+        || (startsWith(github.ref, 'refs/tags/')
         && github.ref_name
-        || (github.event_name == 'release' && github.event.release.tag_name || '') }}
+        || (github.event_name == 'release' && github.event.release.tag_name || '')) }}
       push: >-
         ${{ github.event_name != 'pull_request'
         && (github.ref == 'refs/heads/main'
         || startsWith(github.ref, 'refs/tags/')
         || github.event_name == 'release'
         || (github.event_name == 'workflow_dispatch'
-        && inputs.force_publish == 'true')) }}
+        && (inputs.force_publish == 'true' || inputs.backfill_version != ''))) }}
+      source-ref: >-
+        ${{ github.event_name == 'workflow_dispatch'
+        && inputs.backfill_ref || '' }}
+      tag-latest: >-
+        ${{ !(github.event_name == 'workflow_dispatch'
+        && inputs.backfill_version != '') }}
       platforms: linux/amd64,linux/arm64
       runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
       smoke-test: lintro --version
       validate-on-pr: false
       cache-registry-ref: ghcr.io/lgtm-hq/py-lintro-base:cache
-      no-cache: ${{ startsWith(github.ref, 'refs/tags/') }}
+      no-cache: >-
+        ${{ startsWith(github.ref, 'refs/tags/')
+        || (github.event_name == 'workflow_dispatch'
+        && inputs.backfill_version != '') }}
       provenance: false
       sbom: false
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: docker
       allowed-endpoints-mode: append

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -222,12 +222,12 @@ jobs:
         needs.manifest-sync.result == 'skipped'
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,osv_scanner:check_suppressions=false
@@ -258,13 +258,13 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
 
@@ -279,11 +279,11 @@ jobs:
         github.event.pull_request.draft == false
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     permissions:
       contents: read
     with:
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       job-name: '🛠️ Lintro Code Quality'
       runner-image: ubuntu-24.04
       upstream-result: >-
@@ -357,7 +357,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -35,7 +35,7 @@ permissions: {}
 jobs:
   prune-untagged:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     permissions:
       contents: read # checkout repo and lgtm-ci tooling sparse checkout
       packages: write # delete untagged GHCR package versions via Packages API
@@ -44,7 +44,7 @@ jobs:
       min-age-days: >-
         ${{ github.event_name != 'workflow_dispatch' && 7 || inputs.min_age_days }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append
@@ -57,7 +57,7 @@ jobs:
 
   prune-untagged-base:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     permissions:
       contents: read # checkout repo and lgtm-ci tooling sparse checkout
       packages: write # delete untagged GHCR package versions via Packages API
@@ -66,7 +66,7 @@ jobs:
       min-age-days: >-
         ${{ github.event_name != 'workflow_dispatch' && 7 || inputs.min_age_days }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,10 +12,10 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,11 +12,11 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -30,14 +30,14 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
       target: .
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: sbom
     permissions:
@@ -57,14 +57,14 @@ jobs:
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -116,11 +116,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+          tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       - name: Upload to PyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
@@ -139,14 +139,14 @@ jobs:
     needs: [pypi-upload]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     permissions:
       # write: create GitHub Release and upload dist assets
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -18,7 +18,7 @@ jobs:
   pypi-build:
     name: Build Python distribution
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
@@ -27,7 +27,7 @@ jobs:
       verify-tag-version: false
       ensure-tag-on-default-branch: false
       artifact-name: python-dist
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -80,11 +80,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+          tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       - name: Upload to TestPyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -23,10 +23,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
       create-release: false
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       # Paired with release-version-pr.yml (egress-preset: pypi).
       # Guarded by test_release_workflows_use_paired_egress_presets.

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -23,12 +23,12 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
       ecosystems: python
       auto-merge: true
       max-bump: minor
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       # Paired with release-auto-tag.yml (egress-preset: github-tooling).
       # Guarded by test_release_workflows_use_paired_egress_presets.

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -44,7 +44,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,14 +17,14 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
       target: .
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: sbom
     permissions:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -18,9 +18,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -23,7 +23,7 @@ jobs:
   # Compat mode: multi-runtime matrix, no coverage or PR comments
   test-compat:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
       publish-test-summary: false
       python-versions: '3.11,3.14'
@@ -34,7 +34,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -50,7 +50,7 @@ jobs:
   # Coverage mode: single runtime with coverage reporting
   test-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
       publish-test-summary: true
       python-version: '3.14'
@@ -63,7 +63,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Coverage
       runner-image: ubuntu-24.04
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -112,11 +112,11 @@ jobs:
     needs: test-gate
     if: always()
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     permissions:
       contents: read
     with:
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       job-name: '🧪 Test Suite & Coverage'
       runner-image: ubuntu-24.04
       upstream-result: ${{ needs.test-gate.outputs.result }}
@@ -132,13 +132,13 @@ jobs:
       github.event_name == 'push' &&
       needs.test-coverage.outputs.passed == 'true'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python-publish.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
       coverage-percent: ${{ needs.test-coverage.outputs.coverage-percent }}
       upload-coverage: true
       job-name: Deploy Coverage to Pages
       runner-image: ubuntu-24.04
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: github-pages
     permissions:

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -22,9 +22,9 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -18,13 +18,13 @@ concurrency:
 jobs:
   check-suppressions:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@3d3e577c8e50e11ead6bd36cb559361d33796a9d # v0.47.1
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     permissions:
       contents: write # commit auto-remediation suppressions on default branch
       pull-requests: write # open PRs for stale/expired suppressions
     with:
       job-name: '🔍 Check Vulnerability Suppressions'
-      tooling-ref: '3d3e577c8e50e11ead6bd36cb559361d33796a9d' # v0.47.1
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       workflow-file: vuln-suppression-check.yml
       runner-image: ubuntu-24.04
       egress-policy: block


### PR DESCRIPTION
## Summary

Two changes enabling **historical GHCR backfill** of the images broken by the dangling-index bug (lgtm-ci#433) since **0.64.3**:

1. **Bump lgtm-ci refs v0.47.1 → v0.48.0** across 18 workflows (`uses:` + `tooling-ref:`), adopting reusable-docker's new `source-ref` + `tag-latest` inputs (lgtm-ci#437).
2. **Add backfill dispatch** to `docker-build-publish.yml`:
   - `backfill_version` — version tag to (re)publish, e.g. `0.65.0`
   - `backfill_ref` — git ref to build it from, e.g. `v0.65.0`

## How backfill works

The Dockerfile builds lintro from local source (not a PyPI pin), so a correct `0.65.0` image must be built from the `v0.65.0` tree. On dispatch with those inputs, the job:
- checks out `source-ref = backfill_ref` (old source) via v0.48.0's new input,
- tags `version = backfill_version`,
- sets `tag-latest = false` (does **not** move `latest` backward),
- sets `no-cache = true` (no cache poisoning across versions),
- and the v0.48.0 verify-published gate fails loudly if any platform child is missing.

Both `docker-full` and `docker-base` jobs updated.

## Safety

Every new `inputs.*` reference is **event-guarded** (`github.event_name == 'workflow_dispatch' && …`), so the release / `workflow_call` path is unchanged. In particular `tag-latest` stays `true` on real releases (a naive `inputs.backfill_version == ''` would evaluate false on release due to null-vs-empty-string and silently stop tagging `latest`).

## Verification

- `uv run lintro chk .github/` → 0 issues.
- `tests/unit/test_workflow_wiring.py` → 22 passed.
- Full suite: 6015 passed, 7 skipped, 1 failed (`test_markdownlint_direct_vs_lintro_parity` — known env-only local failure).
- YAML parses; release/`workflow_call` path expressions preserved.

## Follow-up (after merge)

Dispatch per tag `0.64.3 … 0.69.4` to backfill; verify children resolve; repoint lgtm-ci#203 to a good digest + matching `lintro==` pin.

Refs: lgtm-hq/lgtm-ci#433, lgtm-hq/lgtm-ci#437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual Docker publish options to backfill and republish a specific version from a chosen source, without moving the latest tag.
* **Chores**
  * Refreshed multiple CI, release, security, and publishing workflows to use the latest shared workflow version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the GitHub Actions workflow stack for Docker backfills. The main changes are:

- Bumps lgtm-ci workflow and action pins to v0.48.0.
- Adds `backfill_version` and `backfill_ref` dispatch inputs for Docker publishing.
- Passes Docker backfill settings through both full and base image jobs.
- Updates workflow documentation with the new lgtm-ci pin.
</details>

<h3>Confidence Score: 4/5</h3>

The Docker backfill path needs input and publishing safeguards before merging.

- `backfill_version` can trigger publishing without a matching `backfill_ref`.
- Manual force publishing can still move `latest` from a branch build.
- The base image repair path remains coupled to the full image job.

.github/workflows/docker-build-publish.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/docker-build-publish.yml | Adds Docker backfill inputs and reusable-docker parameters; the new manual paths need tighter guards around source refs, latest tagging, and base-image independence. |
| .github/workflows/README.md | Updates the documented lgtm-ci pin to v0.48.0. |
| .github/workflows/docker-ci.yml | Updates lgtm-ci workflow and action pins used by Docker CI quality checks. |
| .github/workflows/test-ci.yml | Updates lgtm-ci pins used by Python test and coverage workflows. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Fdocker-build-publish.yml%3A25-28%0A**Backfill%20Ref%20Can%20Be%20Empty**%0A%0AWhen%20%60backfill_version%60%20is%20set%20but%20%60backfill_ref%60%20is%20left%20empty%2C%20%60push%60%20still%20becomes%20true%20while%20%60source-ref%60%20is%20passed%20as%20an%20empty%20string.%20That%20can%20publish%20a%20historical%20tag%20such%20as%20%600.65.0%60%20from%20the%20current%20dispatch%20ref%20instead%20of%20%60v0.65.0%60%2C%20leaving%20GHCR%20with%20a%20version%20tag%20built%20from%20the%20wrong%20source%20tree.%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Fdocker-build-publish.yml%3A64-66%0A**Force%20Publish%20Moves%20Latest**%0A%0AA%20manual%20dispatch%20with%20%60force_publish%20%3D%3D%20'true'%60%20and%20no%20%60backfill_version%60%20now%20passes%20%60tag-latest%3A%20true%60%20while%20%60version%60%20falls%20back%20to%20an%20empty%20string%20on%20non-tag%20branches.%20That%20can%20move%20the%20%60latest%60%20image%20tag%20to%20a%20branch%20build%20during%20the%20documented%20manual%20testing%20path%2C%20which%20makes%20consumers%20pulling%20%60latest%60%20receive%20unreleaseable%20code.%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Fdocker-build-publish.yml%3A88%0A**Base%20Backfill%20Depends%20On%20Full**%0A%0AThe%20base%20image%20backfill%20still%20depends%20on%20%60docker-full%60%2C%20so%20a%20transient%20or%20full-image-only%20failure%20skips%20%60docker-base%60%20even%20when%20the%20base%20package%20is%20the%20tag%20that%20needs%20repair.%20A%20dispatch%20for%20%60backfill_version%3A%200.65.0%60%20can%20leave%20%60py-lintro-base%3A0.65.0%60%20broken%20solely%20because%20the%20separate%20full%20image%20job%20failed%20first.%0A%0A&pr=1193&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Fdocker-build-publish.yml%3A25-28%0A**Backfill%20Ref%20Can%20Be%20Empty**%0A%0AWhen%20%60backfill_version%60%20is%20set%20but%20%60backfill_ref%60%20is%20left%20empty%2C%20%60push%60%20still%20becomes%20true%20while%20%60source-ref%60%20is%20passed%20as%20an%20empty%20string.%20That%20can%20publish%20a%20historical%20tag%20such%20as%20%600.65.0%60%20from%20the%20current%20dispatch%20ref%20instead%20of%20%60v0.65.0%60%2C%20leaving%20GHCR%20with%20a%20version%20tag%20built%20from%20the%20wrong%20source%20tree.%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Fdocker-build-publish.yml%3A64-66%0A**Force%20Publish%20Moves%20Latest**%0A%0AA%20manual%20dispatch%20with%20%60force_publish%20%3D%3D%20'true'%60%20and%20no%20%60backfill_version%60%20now%20passes%20%60tag-latest%3A%20true%60%20while%20%60version%60%20falls%20back%20to%20an%20empty%20string%20on%20non-tag%20branches.%20That%20can%20move%20the%20%60latest%60%20image%20tag%20to%20a%20branch%20build%20during%20the%20documented%20manual%20testing%20path%2C%20which%20makes%20consumers%20pulling%20%60latest%60%20receive%20unreleaseable%20code.%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Fdocker-build-publish.yml%3A88%0A**Base%20Backfill%20Depends%20On%20Full**%0A%0AThe%20base%20image%20backfill%20still%20depends%20on%20%60docker-full%60%2C%20so%20a%20transient%20or%20full-image-only%20failure%20skips%20%60docker-base%60%20even%20when%20the%20base%20package%20is%20the%20tag%20that%20needs%20repair.%20A%20dispatch%20for%20%60backfill_version%3A%200.65.0%60%20can%20leave%20%60py-lintro-base%3A0.65.0%60%20broken%20solely%20because%20the%20separate%20full%20image%20job%20failed%20first.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1193&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2Fbackfill-lgtm-ci-v0.48.0%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fbackfill-lgtm-ci-v0.48.0%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.github%2Fworkflows%2Fdocker-build-publish.yml%3A25-28%0A**Backfill%20Ref%20Can%20Be%20Empty**%0A%0AWhen%20%60backfill_version%60%20is%20set%20but%20%60backfill_ref%60%20is%20left%20empty%2C%20%60push%60%20still%20becomes%20true%20while%20%60source-ref%60%20is%20passed%20as%20an%20empty%20string.%20That%20can%20publish%20a%20historical%20tag%20such%20as%20%600.65.0%60%20from%20the%20current%20dispatch%20ref%20instead%20of%20%60v0.65.0%60%2C%20leaving%20GHCR%20with%20a%20version%20tag%20built%20from%20the%20wrong%20source%20tree.%0A%0A%23%23%23%20Issue%202%20of%203%0A.github%2Fworkflows%2Fdocker-build-publish.yml%3A64-66%0A**Force%20Publish%20Moves%20Latest**%0A%0AA%20manual%20dispatch%20with%20%60force_publish%20%3D%3D%20'true'%60%20and%20no%20%60backfill_version%60%20now%20passes%20%60tag-latest%3A%20true%60%20while%20%60version%60%20falls%20back%20to%20an%20empty%20string%20on%20non-tag%20branches.%20That%20can%20move%20the%20%60latest%60%20image%20tag%20to%20a%20branch%20build%20during%20the%20documented%20manual%20testing%20path%2C%20which%20makes%20consumers%20pulling%20%60latest%60%20receive%20unreleaseable%20code.%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Fdocker-build-publish.yml%3A88%0A**Base%20Backfill%20Depends%20On%20Full**%0A%0AThe%20base%20image%20backfill%20still%20depends%20on%20%60docker-full%60%2C%20so%20a%20transient%20or%20full-image-only%20failure%20skips%20%60docker-base%60%20even%20when%20the%20base%20package%20is%20the%20tag%20that%20needs%20repair.%20A%20dispatch%20for%20%60backfill_version%3A%200.65.0%60%20can%20leave%20%60py-lintro-base%3A0.65.0%60%20broken%20solely%20because%20the%20separate%20full%20image%20job%20failed%20first.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1193&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci(docker): bump lgtm-ci to v0.48.0 and ..."](https://github.com/lgtm-hq/py-lintro/commit/281b811cef244ba0ef98233e4d49936dafd67397) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42519299)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->