### PR TITLE
feat(npm): publish via OIDC trusted publishing on release tags

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -65,6 +65,7 @@ jobs:
             objects.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             uploads.github.com:443
+            token.actions.githubusercontent.com:443
             nodejs.org:443
             registry.npmjs.org:443
             fulcio.sigstore.dev:443

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,10 +1,15 @@
 ---
-name: Publish - npm (dry-run)
+name: Publish - npm
 
 # Distributes lintro as an npm package via platform-specific Nuitka binaries
-# (the esbuild/biome model). This workflow is DRY-RUN ONLY: every `npm
-# publish` runs with `--dry-run`. Going live is a deliberate follow-up that
-# requires wiring NODE_AUTH_TOKEN and flipping LIVE=1 in publish_packages.sh.
+# (the esbuild/biome model). Publishing uses npm trusted publishing (OIDC):
+# no NODE_AUTH_TOKEN secret is required. The `npm` environment gates every
+# live publish behind maintainer approval, mirroring the `pypi` environment.
+#
+# Set the `dry_run` input to skip the real publish (still requires the
+# environment approval). The platform binaries are downloaded from the
+# GitHub release created earlier in the tag pipeline, so this workflow must
+# run after build-binary.yml has uploaded them.
 
 'on':
   workflow_call:
@@ -13,12 +18,22 @@ name: Publish - npm (dry-run)
         description: 'Release tag whose binaries to package'
         required: true
         type: string
+      dry_run:
+        description: 'Run npm publish with --dry-run instead of publishing'
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       release_tag:
         description: 'Release tag whose binaries to package'
         required: true
         type: string
+      dry_run:
+        description: 'Run npm publish with --dry-run instead of publishing'
+        required: false
+        default: true
+        type: boolean
 
 permissions: {}
 
@@ -27,13 +42,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish-dry-run:
-    name: Package and dry-run publish
+  publish:
+    name: Package and publish
     runs-on: ubuntu-24.04
+    environment: npm
     permissions:
+      # read: checkout and download release assets
       contents: read
-      # id-token is required for `npm publish --provenance`; harmless in
-      # dry-run and pre-wired for a future live publish.
+      # write: OIDC for npm trusted publishing + provenance attestation
       id-token: write
 
     steps:
@@ -47,13 +63,28 @@ jobs:
             api.github.com:443
             codeload.github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             uploads.github.com:443
+            nodejs.org:443
             registry.npmjs.org:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde3c81b512cef77b # v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Ensure npm supports trusted publishing
+        # OIDC trusted publishing and --provenance require npm >= 11.5.1.
+        run: npm install --global npm@latest
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -91,7 +122,11 @@ jobs:
       - name: Smoke test launcher (Linux x64)
         run: scripts/ci/npm/smoke_test.sh
 
-      - name: Publish (dry-run)
-        # LIVE is intentionally unset: this always runs `npm publish
-        # --dry-run`. Do not set LIVE=1 here.
+      - name: Publish to npm
+        # LIVE drives publish_packages.sh: 1 for a real publish, 0 for
+        # --dry-run. Trusted publishing generates provenance automatically;
+        # disable the explicit flag on dry-runs where nothing is published.
+        env:
+          LIVE: ${{ inputs.dry_run && '0' || '1' }}
+          NPM_PROVENANCE: ${{ inputs.dry_run && '0' || '1' }}
         run: scripts/ci/npm/publish_packages.sh

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -189,7 +189,9 @@ jobs:
       id-token: write
     with:
       release_tag: ${{ github.ref_name }}
-    secrets: inherit
+    # No secrets: inherit — publishing is OIDC-only (id-token), and the
+    # reusable workflow's GITHUB_TOKEN for release-asset download is provided
+    # automatically. Avoids exposing all org/repo secrets to the call.
 
   docker-publish:
     name: Publish Docker Images to GHCR

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -169,6 +169,28 @@ jobs:
       arch: universal
     secrets: inherit
 
+  npm-publish:
+    name: Publish to npm
+    # Needs homebrew-tap: that job (build-binary.yml) uploads the four
+    # platform binaries to the GitHub release, which publish-npm.yml
+    # downloads. Gated to stable releases only, since build-binary does not
+    # run for prereleases.
+    needs: [homebrew-tap]
+    if: >-
+      !startsWith(github.ref_name, 'actions-v') &&
+      !contains(github.ref_name, 'a') &&
+      !contains(github.ref_name, 'b') &&
+      !contains(github.ref_name, 'rc')
+    uses: ./.github/workflows/publish-npm.yml
+    permissions:
+      # read: checkout and download release assets
+      contents: read
+      # write: OIDC for npm trusted publishing + provenance
+      id-token: write
+    with:
+      release_tag: ${{ github.ref_name }}
+    secrets: inherit
+
   docker-publish:
     name: Publish Docker Images to GHCR
     needs: [pypi-upload]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ assurance tools under a single command-line interface.
 ## 🚀 Quick Start
 
 ```bash
-uv pip install lintro              # Install (or: pip install lintro)
+# Install (choose one)
+uv pip install lintro              # Python / PyPI (or: pip install lintro)
+bun add -g @lgtm-hq/lintro         # Node / npm — self-contained, no Python
+
 lintro check .                     # Find issues (alias: chk)
 lintro format .                    # Fix issues (alias: fmt)
 lintro check --output-format grid  # Beautiful output

--- a/docs/npm-distribution.md
+++ b/docs/npm-distribution.md
@@ -46,11 +46,18 @@ every manifest and into the meta-package's `@lgtm-hq/lintro-*` pins. The same sc
 
 ## Publishing
 
-`.github/workflows/publish-npm.yml` is **dry-run only**. It downloads the release
-binaries, stages them into the npm tree, injects the version, runs a smoke test, and
-calls `scripts/ci/npm/publish_packages.sh`, which always passes `--dry-run` unless
-`LIVE=1` is set. Going live is a deliberate follow-up that also requires a
-`NODE_AUTH_TOKEN` secret and the `@lgtm-hq` npm org.
+`.github/workflows/publish-npm.yml` downloads the release binaries, stages them into the
+npm tree, injects the version, runs a smoke test, and calls
+`scripts/ci/npm/publish_packages.sh` with `LIVE=1`. It is invoked from the tag pipeline
+(`publish-pypi-on-tag.yml`) after `build-binary.yml` uploads the platform binaries to
+the GitHub release.
+
+Publishing uses npm **trusted publishing (OIDC)**: no `NODE_AUTH_TOKEN` secret is
+required. Each package on npmjs is configured with a trusted publisher pointing at this
+repo, the `publish-npm.yml` workflow, and the `npm` environment. That `npm` environment
+gates every publish behind maintainer approval, mirroring the `pypi` environment; npm
+generates provenance attestations automatically. A manual `workflow_dispatch` defaults
+to `dry_run: true` for safe testing.
 
 ## Install context
 

--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -50,6 +50,19 @@ fi
 
 for pkg in "${PACKAGES[@]}"; do
 	pkg_dir="$NPM_DIR/$pkg"
+	# Idempotency: if this exact name@version is already on the registry
+	# (e.g. a rerun after a mid-loop failure published some packages), skip
+	# it. Without this a retry would fail on the already-published versions
+	# and leave the release partially published. Only meaningful for a real
+	# publish; dry-runs always run to exercise the tarball.
+	if [[ "${LIVE:-0}" == "1" ]]; then
+		pkg_name="$(node -p "require('$pkg_dir/package.json').name")"
+		pkg_version="$(node -p "require('$pkg_dir/package.json').version")"
+		if npm view "$pkg_name@$pkg_version" version >/dev/null 2>&1; then
+			echo "==> Skipping $pkg_name@$pkg_version (already published)"
+			continue
+		fi
+	fi
 	echo "==> Publishing $pkg (${publish_flags[*]})"
 	(cd "$pkg_dir" && npm publish "${publish_flags[@]}")
 done

--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -58,9 +58,19 @@ for pkg in "${PACKAGES[@]}"; do
 	if [[ "${LIVE:-0}" == "1" ]]; then
 		pkg_name="$(node -p "require('$pkg_dir/package.json').name")"
 		pkg_version="$(node -p "require('$pkg_dir/package.json').version")"
-		if npm view "$pkg_name@$pkg_version" version >/dev/null 2>&1; then
+		# Distinguish "version not published" (npm E404) from a lookup that
+		# failed for another reason (network, rate-limit, auth). Only a real
+		# 404 means "safe to publish". Any other failure must abort rather
+		# than fall through to a publish that would error on a duplicate and
+		# leave the release partially published.
+		view_err="$(npm view "$pkg_name@$pkg_version" version 2>&1 >/dev/null)" && view_ok=1 || view_ok=0
+		if [[ "$view_ok" == "1" ]]; then
 			echo "==> Skipping $pkg_name@$pkg_version (already published)"
 			continue
+		elif ! grep -qi 'E404\|404 Not Found\|is not in this registry' <<<"$view_err"; then
+			echo "ERROR: could not verify $pkg_name@$pkg_version on the registry" >&2
+			echo "$view_err" >&2
+			exit 1
 		fi
 	fi
 	echo "==> Publishing $pkg (${publish_flags[*]})"

--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # publish_packages.sh
 # Publish the lintro npm packages (platform packages first, then the
-# meta-package). Publishing is DRY-RUN ONLY unless LIVE=1 is set explicitly,
-# which is intentionally never wired into any workflow in this repo — going
-# live is a deliberate, separate follow-up that also requires NODE_AUTH_TOKEN.
+# meta-package). Publishing is DRY-RUN unless LIVE=1 is set. The tag pipeline
+# (publish-npm.yml, gated by the `npm` environment) sets LIVE=1; authentication
+# is via npm trusted publishing (OIDC), so no NODE_AUTH_TOKEN is required.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Turns the npm distribution live and automated, mirroring the PyPI release flow.

- `publish-npm.yml`: dry-run → live publish, gated by the **`npm` environment** (maintainer approval, same as `pypi`).
- Auth is **npm trusted publishing (OIDC)** — no `NODE_AUTH_TOKEN` secret. `setup-node` + `id-token: write`; npm auto-detects OIDC and generates provenance automatically.
- Wired into `publish-pypi-on-tag.yml` as `npm-publish`, `needs: [homebrew-tap]` so it runs after `build-binary.yml` uploads the four platform binaries to the GitHub release. Gated to stable releases (no a/b/rc), matching the Homebrew/Docker jobs.
- Manual `workflow_dispatch` defaults to `dry_run: true` for safe testing.
- Docs: README Quick Start now shows `bun add -g @lgtm-hq/lintro`; npm distribution guide describes the OIDC flow.

## Prerequisites (done)

- All 5 packages published at 0.69.0 (bootstrap) and configured with trusted publishers → repo `py-lintro`, workflow `publish-npm.yml`, environment `npm`.
- `npm` environment created with maintainer as required reviewer.

## Release flow going forward

release-please version PR merged → tag → PyPI + build-binary + GitHub release → **npm-publish waits in the `npm` environment** → maintainer approves → packages publish with provenance. Zero-touch except the approval click, identical to PyPI.

## Testing

- yamllint + actionlint clean on both workflows.
- `lintro chk` on all changed files: 0 issues.
- Full suite: 6013 passed.
- OIDC setup verified against npm trusted-publishing docs (setup-node + registry-url, no token, npm ≥ 11.5.1, provenance automatic).

Refs #932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced npm publishing with a single workflow supporting safe dry-runs and live publishes.
  * Enabled npm trusted publishing/provenance via OIDC (no token needed).
  * Added conditional npm publication on stable tags after the Homebrew tap workflow.
  * Updated installation docs with a Node.js/global option.
* **Bug Fixes**
  * During live releases, avoids republishing packages already present in the npm registry (name/version check).
* **Documentation**
  * Updated README install options and npm distribution/publishing guidance to match the new workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR turns npm distribution into an automated trusted-publishing release path. The main changes are:

- Live npm publishing through the `npm` environment.
- OIDC-based npm auth without a token secret.
- Tag pipeline wiring after the binary release job.
- Idempotent package publishing for live reruns.
- README and npm distribution docs updates.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The live rerun path now skips package versions that are already published.
- Registry lookup failures now stop the publish instead of falling through to a duplicate publish.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-npm.yml | Adds the live npm publish job with OIDC auth, environment approval, Node setup, and dry-run controls. |
| .github/workflows/publish-pypi-on-tag.yml | Adds the npm publish job to the stable tag release flow after the binary upload path. |
| scripts/ci/npm/publish_packages.sh | Adds live-mode registry checks so reruns skip package versions that already exist. |
| README.md | Adds the npm global install option to the quick start. |
| docs/npm-distribution.md | Documents the OIDC-based npm publishing flow and manual dry-run behavior. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): allow OIDC token endpoint and d..."](https://github.com/lgtm-hq/py-lintro/commit/75a27f464b8b4ad8755d1a90b8ebde61dfc096e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42612475)</sub>

<!-- /greptile_comment -->