### PR TITLE
fix(ci): always run CodeQL on PRs so its required check reports

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,11 @@ name: Security - CodeQL Code Scanning
     paths: ['**.py', 'pyproject.toml', '.github/**']
   pull_request:
     branches: [main]
-    paths: ['**.py', 'pyproject.toml', '.github/**']
+    # No paths filter: `codeql / CodeQL` is a required status check, and a
+    # path-filtered workflow that does not run leaves that context absent
+    # (not skipped), which permanently blocks the merge queue for PRs that
+    # touch only non-matching files (docs, npm/, etc.). Always run on PRs so
+    # the required check always reports.
   merge_group:
     types: [checks_requested]
   schedule:


### PR DESCRIPTION
## Summary

Removes the `paths` filter from `codeql.yml`'s `pull_request` trigger so the required `codeql / CodeQL` status check always reports on PRs.

## Problem

`codeql / CodeQL` is a **required** check in the `checks-py-lintro` ruleset, but the CodeQL workflow only triggered on `**.py` / `pyproject.toml` / `.github/**`. A PR touching only other files (docs, `npm/`, `uv.lock`) never ran CodeQL, so that required context was **absent** — not skipped — and GitHub's merge queue waits indefinitely for it. Such PRs sit `BLOCKED` forever; auto-merge can never enqueue them.

This blocked **#1182** (npm meta-package rename — docs/npm only). #1194 was unaffected only because it changed `.github/**`.

## Why this approach

`codeql / CodeQL` is a nested context from lgtm-ci's `reusable-codeql.yml`; gating the caller job with `if:` makes the whole reusable workflow (and its context) vanish, reproducing the block. `reusable-codeql.yml` has no early-exit input. Always-running on PRs is the robust fix and matches repo convention — `test-ci.yml` and `docker-ci.yml` already run on every PR with no `paths` filter.

- `push` paths filter kept (post-merge runs stay scoped).
- `merge_group` unchanged — still validates in the queue.

## Testing

- yamllint + actionlint clean.
- This PR changes `.github/**`, so CodeQL runs on it (proving the check reports).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated security checks to run on all pull requests, even when changes are limited to specific files.
  * Improved workflow reliability so required status checks are consistently available during merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the CodeQL required check report on every pull request. The main changes are:

- Removes the `pull_request` path filter from `.github/workflows/codeql.yml`.
- Keeps the scoped `push` path filter unchanged.
- Adds a comment explaining why PR-triggered CodeQL must always run.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The workflow now emits the required CodeQL check for PRs that only touch non-Python paths.
- The existing reusable CodeQL job, permissions, push trigger, and merge queue trigger stay unchanged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/codeql.yml | Removes the PR path filter so the CodeQL workflow always reports its required check on pull requests. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): always run CodeQL on PRs so its..."](https://github.com/lgtm-hq/py-lintro/commit/0b0f0da7c238ebece0586851f22414ab6a1881e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42658904)</sub>

<!-- /greptile_comment -->