### PR TITLE
fix(homebrew): sync binary formula generator with tap's authoritative output

### DIFF
--- a/scripts/ci/homebrew/generate-binary-formula.sh
+++ b/scripts/ci/homebrew/generate-binary-formula.sh
@@ -36,7 +36,7 @@ log_info "ARM64 SHA256: ${ARM64_SHA}"
 log_info "x86_64 SHA256: ${X86_SHA}"
 
 cat >"$OUTPUT_FILE" <<EOF
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 # Homebrew formula for lintro binary distribution
@@ -47,15 +47,23 @@ class Lintro < Formula
   version "${VERSION}"
   license "MIT"
 
-  RELEASE_BASE = "https://github.com/lgtm-hq/py-lintro/releases"
+  # Track the latest GitHub release via the releases API rather than scanning all
+  # tags, so the stray single-component "v1" tag is ignored. url :stable is
+  # required by FormulaAudit/LivecheckUrlSymbol; github_latest derives the repo
+  # from it, and the semver regex is a defensive filter on the release tag.
+  livecheck do
+    url :stable
+    strategy :github_latest
+    regex(/^v?(\d+\.\d+\.\d+)$/i)
+  end
 
   on_macos do
     on_arm do
-      url "#{RELEASE_BASE}/download/v#{version}/lintro-macos-arm64"
+      url "https://github.com/lgtm-hq/py-lintro/releases/download/v#{version}/lintro-macos-arm64"
       sha256 "${ARM64_SHA}"
     end
     on_intel do
-      url "#{RELEASE_BASE}/download/v#{version}/lintro-macos-x86_64"
+      url "https://github.com/lgtm-hq/py-lintro/releases/download/v#{version}/lintro-macos-x86_64"
       sha256 "${X86_SHA}"
     end
   end


### PR DESCRIPTION
## Summary

py-lintro's `scripts/ci/homebrew/generate-binary-formula.sh` (used by the `update-homebrew` release job to render the formula pushed to lgtm-hq/homebrew-tap) still emitted the pre-livecheck formula shape (`typed: false`, `RELEASE_BASE` constant, no livecheck). The tap's generator was modernized in homebrew-tap #52/#72/#77, and its `shell-tests` parity test regenerates the formula with the tap's own script and diffs against the committed file — so **every lintro release PR since 0.65.0 (tap PRs #90–#102) failed CI and never auto-merged**.

This syncs py-lintro's generator to emit byte-identical output (verified: generated 0.65.0 formula diffs clean against the tap generator's output).

## Note on the duplication

Two copies of this generator existing at all is the underlying smell — the tap already has a `repository_dispatch`-driven `update-formula.yml` that renders with the authoritative script. Migrating the `update-homebrew` job to dispatch (deleting py-lintro's render path) is the durable fix; that belongs with the CI consolidation tracked in #1183/#1184 rather than this unblock.

## Testing

- Generated formula is byte-identical to the tap generator's output for 0.65.0.
- shellcheck/shfmt clean via lintro; full suite 6013 passed.
- The stuck tap PRs #90–#102 are being repaired separately (regenerated in ascending version order so tap history matches PyPI order).

Refs #932

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR syncs the Homebrew binary formula generator with the tap output. The main changes are:

- Switch the generated formula sigil to `# typed: strict`.
- Add a GitHub-release-based `livecheck` block.
- Inline the GitHub release asset URLs for each macOS architecture.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after checking the tap’s livecheck behavior.

- No blocking issues found in the changed code.
- The only noted risk is a compatibility edge in the generated Homebrew formula metadata.

scripts/ci/homebrew/generate-binary-formula.sh

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/homebrew/generate-binary-formula.sh | Updates the generated Homebrew binary formula shape, with a possible livecheck/audit compatibility concern around `url :stable` and conditional URLs. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fhomebrew%2Fgenerate-binary-formula.sh%3A55%0A**Stable%20URL%20May%20Be%20Unresolvable**%0A%0AWhen%20the%20tap%20runs%20livecheck%20or%20audit%2C%20%60url%20%3Astable%60%20depends%20on%20Homebrew%20finding%20a%20stable%20URL%20for%20the%20formula.%20This%20generated%20formula%20only%20declares%20%60url%60%20inside%20the%20nested%20%60on_macos%60%20architecture%20blocks%2C%20so%20a%20Homebrew%20version%20that%20does%20not%20resolve%20conditional%20URLs%20as%20the%20stable%20URL%20can%20fail%20livecheck%2Faudit%20before%20the%20release%20PR%20can%20merge.%0A%0A&pr=1199&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fhomebrew%2Fgenerate-binary-formula.sh%3A55%0A**Stable%20URL%20May%20Be%20Unresolvable**%0A%0AWhen%20the%20tap%20runs%20livecheck%20or%20audit%2C%20%60url%20%3Astable%60%20depends%20on%20Homebrew%20finding%20a%20stable%20URL%20for%20the%20formula.%20This%20generated%20formula%20only%20declares%20%60url%60%20inside%20the%20nested%20%60on_macos%60%20architecture%20blocks%2C%20so%20a%20Homebrew%20version%20that%20does%20not%20resolve%20conditional%20URLs%20as%20the%20stable%20URL%20can%20fail%20livecheck%2Faudit%20before%20the%20release%20PR%20can%20merge.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1199&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2Fhomebrew-formula-generator-parity%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhomebrew-formula-generator-parity%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fhomebrew%2Fgenerate-binary-formula.sh%3A55%0A**Stable%20URL%20May%20Be%20Unresolvable**%0A%0AWhen%20the%20tap%20runs%20livecheck%20or%20audit%2C%20%60url%20%3Astable%60%20depends%20on%20Homebrew%20finding%20a%20stable%20URL%20for%20the%20formula.%20This%20generated%20formula%20only%20declares%20%60url%60%20inside%20the%20nested%20%60on_macos%60%20architecture%20blocks%2C%20so%20a%20Homebrew%20version%20that%20does%20not%20resolve%20conditional%20URLs%20as%20the%20stable%20URL%20can%20fail%20livecheck%2Faudit%20before%20the%20release%20PR%20can%20merge.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1199&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(homebrew): sync binary formula gener..."](https://github.com/lgtm-hq/py-lintro/commit/46d083049bb3323c5b6f2c11fd902630031e0d2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42691089)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic release tracking for the Homebrew formula so updates can be discovered more reliably.
* **Bug Fixes**
  * Improved macOS download link generation in the formula to use direct release URLs, helping ensure the correct installer is fetched for both Apple Silicon and Intel Macs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->