### PR TITLE
fix(ci): correct setup-node pin to real v6.4.0 SHA

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -78,7 +78,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde3c81b512cef77b # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): correct setup-node pin to real v6.4.0 SHA
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

`publish-npm.yml` pinned `actions/setup-node` to a nonexistent SHA
(`1d0ff469b7ec7b3cb9d8673fde3c81b512cef77b`), introduced in #1194. Every npm
publish fails at job setup before any step runs (see run 28943312225).

Replace the pin with the real `actions/setup-node` v6.4.0 SHA
(`48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`).

The systemic validator fix (checking SHA existence, not just pin format) belongs
in `lgtm-hq/lgtm-ci` (`reusable-validate-action-pinning.yml`) and is intentionally
out of scope here — #1200 should stay open for that follow-up.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Relates to #1200

## Details

- Only change: `.github/workflows/publish-npm.yml` setup-node pin (sole occurrence
  in this repo).
- Verified SHA exists via GitHub API (`repos/actions/setup-node/commits/...`).
- `uv run lintro chk`: 0 issues.
- Local `uv run lintro tst` reported 1 failure in
  `tests/integration/test_markdownlint_integration.py::test_markdownlint_direct_vs_lintro_parity`
  due to an environment markdownlint-cli2 version skip (`0.22.0` below minimum
  `0.22.1`). Confirmed pre-existing / unrelated: the same test **passed** on a
  clean `origin/main` worktree; this PR is workflow-YAML-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing workflow to use a newer, pinned runtime setup step for improved stability and consistency during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a broken `actions/setup-node` pin in `publish-npm.yml` by replacing a nonexistent SHA (`1d0ff469b7ec7b3cb9d8673fde3c81b512cef77b`) with the verified commit SHA for v6.4.0 (`48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`), which was introduced in #1194 and was causing every npm publish job to fail at setup.

- Replaces the phantom SHA on `actions/setup-node` with the real v6.4.0 commit hash, confirmed against the upstream `actions/setup-node` repository.
- The fix is surgical — one line changed in one file; no logic, scripts, or other workflow steps are affected.
</details>

<h3>Confidence Score: 5/5</h3>

A one-line SHA correction in a CI workflow; the new SHA is the real v6.4.0 release commit in actions/setup-node, confirmed via the upstream repository.

The change replaces one SHA with another. The replacement SHA (48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e) maps directly to the 'Update Node.js versions in versions.yml and bump package to v6.4.0' merge commit in actions/setup-node, published on 2026-04-20. No logic, permissions, secrets, or other workflow steps are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-npm.yml | Single-line fix replacing a nonexistent setup-node SHA with the verified v6.4.0 commit hash; SHA confirmed against upstream actions/setup-node repository. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([workflow_call / workflow_dispatch]) --> B[Harden Runner\nstep-security/harden-runner\negress-policy: block]
    B --> C[Checkout code\nactions/checkout]
    C --> D["Set up Node.js\nactions/setup-node@48b55a0 ✅ v6.4.0\n(was: nonexistent SHA ❌)"]
    D --> E[Ensure npm supports trusted publishing\nnpm install --global npm@latest]
    E --> F[Set up Python\nactions/setup-python]
    F --> G[Download release binaries\nscripts/ci/npm/download_release_binaries.sh]
    G --> H[Stage binaries into npm packages\nstage_binaries.py]
    H --> I[Inject release version into manifests\nsync_npm_version.py]
    I --> J[Verify manifests are in sync\nsync_npm_version.py --check]
    J --> K[Smoke test launcher\nsmoke_test.sh]
    K --> L{dry_run?}
    L -- No --> M[Publish to npm\npublish_packages.sh LIVE=1]
    L -- Yes --> N[Dry-run publish\npublish_packages.sh LIVE=0]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([workflow_call / workflow_dispatch]) --> B[Harden Runner\nstep-security/harden-runner\negress-policy: block]
    B --> C[Checkout code\nactions/checkout]
    C --> D["Set up Node.js\nactions/setup-node@48b55a0 ✅ v6.4.0\n(was: nonexistent SHA ❌)"]
    D --> E[Ensure npm supports trusted publishing\nnpm install --global npm@latest]
    E --> F[Set up Python\nactions/setup-python]
    F --> G[Download release binaries\nscripts/ci/npm/download_release_binaries.sh]
    G --> H[Stage binaries into npm packages\nstage_binaries.py]
    H --> I[Inject release version into manifests\nsync_npm_version.py]
    I --> J[Verify manifests are in sync\nsync_npm_version.py --check]
    J --> K[Smoke test launcher\nsmoke_test.sh]
    K --> L{dry_run?}
    L -- No --> M[Publish to npm\npublish_packages.sh LIVE=1]
    L -- Yes --> N[Dry-run publish\npublish_packages.sh LIVE=0]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): correct setup-node pin to real ..."](https://github.com/lgtm-hq/py-lintro/commit/1dc52496ae7035c03e085cc3cc67fadd63502435) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42965182)</sub>

<!-- /greptile_comment -->