### PR TITLE
docs: add AGENTS.md with Cursor Cloud setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Lintro is a single-product **Python CLI** (package `lintro`, managed with `uv`). It
+wraps many third-party linters/formatters and runs as a command that exits — there is
+**no long-running service, server, or database** to start. "Running the app" means
+invoking the `lintro` CLI.
+
+### Environment already provided by the update script
+
+The update script runs `uv sync --dev --extra full`, which creates `.venv` with all
+Python dependencies and the Python-based wrapped tools (ruff, black, mypy, bandit,
+pydoclint, yamllint). `uv` lives in `~/.local/bin`, which (together with `~/.bun/bin`)
+is on `PATH` via `~/.bashrc`.
+
+### Running / linting / testing / building
+
+All commands run through `uv` (do not call bare `python`/`pytest`). Standard targets are
+already defined in the `Makefile` and `docs/contributing.md`; prefer those:
+
+- Run the CLI: `uv run lintro check .`, `uv run lintro format .`,
+  `uv run lintro list-tools`.
+- Lint: `make lint` (runs `mypy` then `lintro check .`); type-check only: `make mypy`.
+- Test (with coverage): `make test`, or `./scripts/local/run-tests.sh`, or
+  `uv run pytest`. `pytest.ini` always enables coverage (term/html/xml).
+- Build a wheel/sdist: `uv build`.
+
+### Non-obvious gotchas
+
+- **External (non-Python) tools are optional.** `uv sync` does NOT install prettier,
+  hadolint, shellcheck, actionlint, oxlint, taplo, gitleaks, etc. `lintro check .`
+  silently **skips** any tool missing from `PATH`, so it still passes without them. To
+  exercise every integration, install them with
+  `./scripts/utils/install-tools.sh --local` (network-heavy; installs into
+  `~/.local/bin`, `~/.bun/bin`, and `~/.cargo/bin`, and pulls a Rust toolchain). This is
+  intentionally kept out of the update script.
+- **`tests/integration/test_built_package.py` needs the system `python3.12-venv`
+  package.** Those two wheel tests call stdlib `python -m venv`; without `ensurepip`
+  they fail with "ensurepip is not available" (not a code bug). Install once with
+  `sudo apt-get install -y python3.12-venv` if it is ever missing on a fresh VM.
+- The interpreter is the system Python (3.12); `requires-python` is `>=3.11`.
+- Set `UV_LINK_MODE=copy` to avoid uv hardlink warnings when running tests.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (present tense):

  ```text
  docs: add AGENTS.md with Cursor Cloud setup instructions
  ```

- Type:
  - [x] docs

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Sets up the Cloud Agent development environment for `lintro` and documents it. The only
code change is adding `AGENTS.md` with a `## Cursor Cloud specific instructions` section
capturing durable, non-obvious setup/run guidance for future agents. No product code is
modified.

Environment work performed (no repo changes beyond `AGENTS.md`):
- Installed `uv`, then `uv sync --dev --extra full --extra tools` to build `.venv`.
- Installed the external (non-Python) wrapped tools via `scripts/utils/install-tools.sh --local`.
- Installed system `python3.12-venv` (needed by the wheel-build integration tests).
- Registered the startup update script: `uv sync --dev --extra full --extra tools`.

## Verification / Walkthrough

`lintro` is a CLI (no long-running service). Verified end-to-end by using it to detect
and auto-fix real code issues, plus lint/test/build of the repo itself.

- Hello-world (detect → auto-fix → clean): see `lintro_hello_world.log`.
- Aggregate lint/test/build results: see `verification_summary.log`.

[lintro_hello_world.log](https://cursor.com/agents/bc-55a88c38-89d2-4702-8d6f-cd672a9f41a4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flintro_hello_world.log)
[verification_summary.log](https://cursor.com/agents/bc-55a88c38-89d2-4702-8d6f-cd672a9f41a4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverification_summary.log)

Commands run:
- ✅ `uv run lintro check .` — 0 issues
- ✅ `uv run lintro check . --tools mypy` — no issues
- ✅ `uv run pytest tests` (coverage) — 6013 passed, 10 skipped, 84% coverage
- ✅ `uv build` — built wheel + sdist
- ✅ `uv run lintro format` — auto-fixed a sample file (hello-world)

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (docs-only change)
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run pytest tests`)

## Related Issues

Related #

## Details

Testing strategy: since `lintro` is a terminal CLI, evidence is captured as terminal
logs. The hello-world demonstrates the core functionality (detecting and auto-fixing
lint/format violations). Note the two `tests/integration/test_built_package.py` wheel
tests require the system `python3.12-venv` package (`ensurepip`); this is documented in
`AGENTS.md` and installed in the environment.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55a88c38-89d2-4702-8d6f-cd672a9f41a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55a88c38-89d2-4702-8d6f-cd672a9f41a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

