### PR TITLE
fix(ci): use Node 24 bundled npm for trusted publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -71,6 +71,7 @@ jobs:
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
+            oauth2.sigstore.dev:443
 
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -78,14 +79,14 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
+        # Node 24 ships npm ≥ 11.5.1 (required for OIDC trusted publishing).
+        # Do not run `npm install -g npm` here: in-place self-upgrade corrupts
+        # the toolcache tree and breaks `npm publish --provenance` (missing
+        # sigstore). See #1203.
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Ensure npm supports trusted publishing
-        # OIDC trusted publishing and --provenance require npm >= 11.5.1.
-        run: npm install --global npm@latest
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6

--- a/docs/npm-distribution.md
+++ b/docs/npm-distribution.md
@@ -59,6 +59,11 @@ gates every publish behind maintainer approval, mirroring the `pypi` environment
 generates provenance attestations automatically. A manual `workflow_dispatch` defaults
 to `dry_run: true` for safe testing.
 
+Trusted publishing requires **npm ≥ 11.5.1**. The workflow uses **Node 24**, which ships
+a compatible bundled npm — do **not** run `npm install -g npm` (or any in-place
+self-upgrade) in CI. That mutates the Actions toolcache npm tree and breaks
+`npm publish --provenance` with `Cannot find module 'sigstore'`.
+
 ## Install context
 
 `InstallContext.NPM_BIN` is detected when the running executable resolves under

--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -4,6 +4,8 @@
 # meta-package). Publishing is DRY-RUN unless LIVE=1 is set. The tag pipeline
 # (publish-npm.yml, gated by the `npm` environment) sets LIVE=1; authentication
 # is via npm trusted publishing (OIDC), so no NODE_AUTH_TOKEN is required.
+# Caller must provide npm ≥ 11.5.1 (Node 24 bundled npm in CI). Do not
+# self-upgrade npm in-place before invoking this script.
 
 set -euo pipefail
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): use Node 24 bundled npm for trusted publish
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`publish-npm.yml` ran `npm install --global npm@latest` after setup-node (Node 24).
That in-place self-upgrade corrupts the toolcache npm tree, so live
`npm publish --provenance` fails with `Cannot find module 'sigstore'`
(run 29010067197). Node 24 already ships npm ≥ 11.5.1 for trusted publishing.

This PR:

- Removes the global npm self-upgrade step
- Adds `oauth2.sigstore.dev:443` to the harden-runner allowlist (parity with PyPI)
- Documents the Node 24 / no-self-upgrade policy in `docs/npm-distribution.md`
- Clarifies the caller npm requirement in `publish_packages.sh`

Platform follow-up for shared reusable npm publish remains in lgtm-ci#456.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1203
- Relates to https://github.com/lgtm-hq/lgtm-ci/issues/456

## Details

- After merge: re-dispatch `Publish - npm` with `release_tag=v0.70.0`,
  `dry_run=false` (needs `npm` environment approval).
- Local `uv run lintro chk`: 0 issues.
- Local `uv run lintro tst`: 1 pre-existing environmental failure in
  `test_markdownlint_direct_vs_lintro_parity` (markdownlint-cli2 0.22.0 below
  min 0.22.1); unrelated to this workflow/docs change.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a CI breakage where `npm install --global npm@latest` was corrupting the Actions toolcache npm tree, causing `npm publish --provenance` to fail with `Cannot find module 'sigstore'`. It removes the self-upgrade step, relying instead on the npm bundled with Node 24 (≥ 11.5.1), and adds `oauth2.sigstore.dev:443` to the harden-runner egress allowlist.

- Removes the "Ensure npm supports trusted publishing" step that ran `npm install -g npm@latest` and corrupted the toolcache — Node 24's bundled npm already meets the `≥ 11.5.1` requirement for OIDC trusted publishing.
- Adds `oauth2.sigstore.dev:443` to the harden-runner allowlist, completing the set of Sigstore endpoints needed for provenance attestation (the other three were already present).
- Updates `docs/npm-distribution.md` and the `publish_packages.sh` header comment to document the no-self-upgrade policy for future maintainers.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted CI fix removing a step that was actively breaking trusted publishes, with no logic changes to application code.

All three changed files are CI/docs only. The removed step was the confirmed root cause of the failure. The added oauth2.sigstore.dev:443 allowlist entry completes the Sigstore endpoint set. The script and docs changes are comment-only. There are no logic regressions, no missing guards, and the fix is well-scoped.

No files require special attention. All changes are confined to the publish workflow, its docs, and a script header comment.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-npm.yml | Removes the npm install --global npm@latest step and adds oauth2.sigstore.dev:443 to the harden-runner allowlist; changes are minimal, correct, and directly address the reported failure. |
| docs/npm-distribution.md | Adds a prose paragraph documenting the npm >= 11.5.1 requirement, the Node 24 reliance, and the prohibition on in-place self-upgrades; accurate and helpful. |
| scripts/ci/npm/publish_packages.sh | Adds two header comment lines clarifying the npm version requirement; no logic changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GHA as GitHub Actions
    participant HR as Harden Runner
    participant SN as setup-node (Node 24)
    participant Script as publish_packages.sh
    participant Sigstore as Sigstore (fulcio / rekor / oauth2)
    participant npm as registry.npmjs.org

    GHA->>HR: enforce egress allowlist (now includes oauth2.sigstore.dev:443)
    GHA->>SN: "node-version: '24' (bundled npm >= 11.5.1 — no self-upgrade)"
    SN-->>GHA: Node 24 + npm ready
    GHA->>Script: "LIVE=1 NPM_PROVENANCE=1"
    loop each platform pkg then meta-pkg
        Script->>npm: "npm view pkg@version (idempotency check)"
        npm-->>Script: 404 - safe to publish
        Script->>Sigstore: npm publish --provenance (OIDC token via oauth2.sigstore.dev, cert via fulcio, tlog via rekor)
        Sigstore-->>Script: provenance attestation
        Script->>npm: publish package + attestation
    end
    npm-->>GHA: publish complete
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GHA as GitHub Actions
    participant HR as Harden Runner
    participant SN as setup-node (Node 24)
    participant Script as publish_packages.sh
    participant Sigstore as Sigstore (fulcio / rekor / oauth2)
    participant npm as registry.npmjs.org

    GHA->>HR: enforce egress allowlist (now includes oauth2.sigstore.dev:443)
    GHA->>SN: "node-version: '24' (bundled npm >= 11.5.1 — no self-upgrade)"
    SN-->>GHA: Node 24 + npm ready
    GHA->>Script: "LIVE=1 NPM_PROVENANCE=1"
    loop each platform pkg then meta-pkg
        Script->>npm: "npm view pkg@version (idempotency check)"
        npm-->>Script: 404 - safe to publish
        Script->>Sigstore: npm publish --provenance (OIDC token via oauth2.sigstore.dev, cert via fulcio, tlog via rekor)
        Sigstore-->>Script: provenance attestation
        Script->>npm: publish package + attestation
    end
    npm-->>GHA: publish complete
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): use Node 24 bundled npm for tru..."](https://github.com/lgtm-hq/py-lintro/commit/facc27fadc85f7ae5b24a45f8921c42dffdd009c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42976718)</sub>

<!-- /greptile_comment -->