### PR TITLE
fix(ci): restore main Pages deploy after docs site merge

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -30,8 +30,11 @@ jobs:
       pages: write
       id-token: write
       actions: read
+    # v0.32.4+ passes github.token as GH_TOKEN into bundle-workflow-artifacts
+    # (lgtm-ci#300). v0.32.3 left gh unauthenticated and blocked Pages deploy
+    # after #974 (see #1227). Pin with the repo-standard v0.48.0 tooling.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
     with:
       site-root: apps/site/dist
       build-command: bash scripts/ci/site/build.sh
@@ -41,7 +44,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -139,15 +139,19 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
         with:
           egress-policy: block
+          # raw.githubusercontent.com is required by astral-sh/setup-uv (versions
+          # manifest). Omitting it fails this job and turns CI - Tests red on
+          # main even when tests passed (see #1227).
           allowed-endpoints: >
             github.com:443
             api.github.com:443
             codeload.github.com:443
             objects.githubusercontent.com:443
             release-assets.githubusercontent.com:443
+            raw.githubusercontent.com:443
             pypi.org:443
             files.pythonhosted.org:443
             astral.sh:443
@@ -155,11 +159,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
         with:
           python-version: '3.14'
           install-dependencies: 'true'

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -469,7 +469,7 @@ def test_stage_coverage_html_allows_setup_uv_manifest_host() -> None:
     workflow = _load_workflow(name="test-ci.yml")
     steps = workflow["jobs"]["stage-coverage-html"]["steps"]
     harden = next(step for step in steps if step.get("name") == "Harden Runner")
-    allowed = harden["with"]["allowed-endpoints"]
+    allowed = set(harden["with"]["allowed-endpoints"].split())
 
     assert_that(allowed).contains("raw.githubusercontent.com:443")
     assert_that(allowed).contains("astral.sh:443")

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -452,3 +452,45 @@ def test_docker_ci_lintro_code_quality_wires_upstream_jobs() -> None:
             "|| needs.dogfooding-lint.result }}",
         ),
     )
+
+
+# Canonical lgtm-ci pin used by most py-lintro workflows (v0.48.0).
+# Pages deploy must not regress to v0.32.3 (missing GH_TOKEN in bundler).
+_LGTM_CI_V0480 = "1014e3d7d5441a63215d2096545a46cff6de101c"
+
+
+def test_stage_coverage_html_allows_setup_uv_manifest_host() -> None:
+    """Coverage staging must allow raw.githubusercontent.com for setup-uv.
+
+    Without this host, astral-sh/setup-uv cannot fetch its versions manifest
+    under harden-runner block mode, the staging job fails, and CI - Tests goes
+    red on main even when the test gate passed (#1227).
+    """
+    workflow = _load_workflow(name="test-ci.yml")
+    steps = workflow["jobs"]["stage-coverage-html"]["steps"]
+    harden = next(step for step in steps if step.get("name") == "Harden Runner")
+    allowed = harden["with"]["allowed-endpoints"]
+
+    assert_that(allowed).contains("raw.githubusercontent.com:443")
+    assert_that(allowed).contains("astral.sh:443")
+    assert_that(allowed).contains("releases.astral.sh:443")
+
+
+def test_deploy_pages_pins_bundler_with_github_token() -> None:
+    """Pages deploy must use lgtm-ci tooling that exports GH_TOKEN to gh.
+
+    reusable-deploy-site-with-reports checks out tooling-ref for
+    bundle-workflow-artifacts. v0.32.3 omitted GH_TOKEN; v0.32.4+ (lgtm-ci#300)
+    sets ``GH_TOKEN: ${{ github.token }}``. Stay on the repo-standard v0.48.0 pin.
+    """
+    workflow = _load_workflow(name="deploy-pages.yml")
+    deploy = workflow["jobs"]["deploy"]
+    uses = deploy["uses"]
+    tooling_ref = deploy["with"]["tooling-ref"]
+
+    assert_that(uses).contains(_LGTM_CI_V0480)
+    assert_that(uses).contains("reusable-deploy-site-with-reports.yml")
+    assert_that(tooling_ref).contains(_LGTM_CI_V0480)
+    assert_that(deploy["permissions"]).contains_entry({"actions": "read"})
+    assert_that(deploy["permissions"]).contains_entry({"pages": "write"})
+    assert_that(deploy["permissions"]).contains_entry({"id-token": "write"})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): restore main Pages deploy after docs site merge
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Unblocks **main** after [#974](https://github.com/lgtm-hq/py-lintro/pull/974):

1. **`stage-coverage-html`** — add `raw.githubusercontent.com:443` to harden-runner allowlist so `setup-uv` can fetch its versions manifest (was failing CI - Tests on every main push even when tests passed). Align staging action pins to lgtm-ci v0.48.0.
2. **`deploy-pages.yml`** — bump `reusable-deploy-site-with-reports` + `tooling-ref` from v0.32.3 → v0.48.0 so `bundle-workflow-artifacts` receives `GH_TOKEN` (lgtm-ci#300; v0.32.3 left `gh` unauthenticated and blocked Pages publish).
3. Contract tests in `tests/unit/test_workflow_wiring.py` guard both invariants.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt` / `chk`, wiring tests)

## Closes

- Closes #1227

## Details

- Failing main runs: [CI - Tests](https://github.com/lgtm-hq/py-lintro/actions/runs/29084736145), prior [Pages deploy](https://github.com/lgtm-hq/py-lintro/actions/runs/29078492591)
- Not a duplicate of #1106 (different failure mode / path)
- Priority: restore green main + docs site deploy

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores the CI and Pages workflow wiring after the docs site merge. The main changes are:

- Adds `raw.githubusercontent.com:443` to the coverage staging allowlist.
- Moves the affected lgtm-ci workflow and action pins to v0.48.0.
- Adds workflow wiring tests for the coverage allowlist and Pages deploy pins.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/test-ci.yml | Updates the coverage staging harden-runner allowlist and lgtm-ci action pins. |
| .github/workflows/deploy-pages.yml | Updates the Pages deploy reusable workflow and tooling ref to the v0.48.0 lgtm-ci pin. |
| tests/unit/test_workflow_wiring.py | Adds workflow contract tests for the coverage allowlist and Pages deploy configuration. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ci): assert harden endpoints by exa..."](https://github.com/lgtm-hq/py-lintro/commit/d468951577033d9ef2ac333e5ef399d300415f25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43265356)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub Pages deployment reliability by updating deployment tooling and authentication support.
  * Prevented coverage workflow failures by allowing required package manifest downloads.
  * Updated CI security and setup actions to newer versions.

* **Tests**
  * Added automated checks for deployment configuration, required permissions, tooling versions, and permitted network endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->