### PR TITLE
refactor(tools): rename manifest ToolRegistry to ManifestRegistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **tools/core**: rename `lintro.tools.core.tool_registry.ToolRegistry` to
+  `ManifestRegistry` to disambiguate it from `lintro.plugins.registry.ToolRegistry`
+  (#1220)
+
 ### Deprecated
+
+- **tools/core**: `lintro.tools.core.tool_registry.ToolRegistry` is deprecated in favor
+  of `ManifestRegistry`; importing or using the old name now emits a
+  `DeprecationWarning` and will be removed in a future release (#1220)
 
 ### Removed
 

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -20,7 +20,11 @@ from lintro.ai.doctor_checks import AICheckResult, check_ai_configuration
 from lintro.enums.tool_status import ToolStatus
 from lintro.tools.core.install_context import RuntimeContext
 from lintro.tools.core.install_strategies import get_strategy
-from lintro.tools.core.tool_registry import CATEGORY_LABELS, ManifestTool, ToolRegistry
+from lintro.tools.core.tool_registry import (
+    CATEGORY_LABELS,
+    ManifestRegistry,
+    ManifestTool,
+)
 from lintro.tools.core.version_parsing import (
     compare_versions,
     extract_version_from_output,
@@ -468,7 +472,7 @@ def doctor_command(
     """
     display_console = Console()
 
-    registry = ToolRegistry.load()
+    registry = ManifestRegistry.load()
     context = RuntimeContext.detect()
 
     env_report = None
@@ -837,7 +841,7 @@ def _run_fix(
     console: Console,
     results: list[ToolCheckResult],
     context: RuntimeContext,
-    registry: ToolRegistry,
+    registry: ManifestRegistry,
 ) -> None:
     """Attempt to install missing/outdated tools via the central installer."""
     from lintro.tools.core.tool_installer import ToolInstaller

--- a/lintro/cli_utils/commands/init.py
+++ b/lintro/cli_utils/commands/init.py
@@ -19,7 +19,7 @@ from rich.console import Console
 from rich.panel import Panel
 
 from lintro.cli_utils.onboarding import print_install_next_steps
-from lintro.tools.core.tool_registry import ToolRegistry
+from lintro.tools.core.tool_registry import ManifestRegistry
 from lintro.utils.project_detection import detect_project_languages
 
 # Static templates retained for tests and --static mode
@@ -356,7 +356,7 @@ def init_command(
         tool_names: list[str] = _extract_tool_names(config_content)
         detected_langs: list[str] = []
     else:
-        registry = ToolRegistry.load()
+        registry = ManifestRegistry.load()
         detected_langs = detect_project_languages()
         effective_profile = profile or ("minimal" if minimal else "recommended")
 

--- a/lintro/cli_utils/commands/install.py
+++ b/lintro/cli_utils/commands/install.py
@@ -29,7 +29,7 @@ from lintro.tools.core.install_lock import (
     write_install_lock,
 )
 from lintro.tools.core.tool_installer import ToolInstaller
-from lintro.tools.core.tool_registry import ToolRegistry
+from lintro.tools.core.tool_registry import ManifestRegistry
 
 
 @click.command()
@@ -107,7 +107,7 @@ def install_command(
     """
     console = Console()
 
-    registry = ToolRegistry.load()
+    registry = ManifestRegistry.load()
     context = RuntimeContext.detect()
     installer = ToolInstaller(registry, context)
 
@@ -295,7 +295,7 @@ def _display_plan(console: Console, plan: object) -> None:
 
 def _interactive_select(
     console: Console,
-    registry: ToolRegistry,
+    registry: ManifestRegistry,
     profile: str | None,
     detected_langs: list[str] | None,
 ) -> tuple[list[str] | None, str | None]:

--- a/lintro/cli_utils/commands/setup.py
+++ b/lintro/cli_utils/commands/setup.py
@@ -20,7 +20,7 @@ from rich.console import Console
 
 from lintro.tools.core.install_context import RuntimeContext
 from lintro.tools.core.tool_installer import ToolInstaller
-from lintro.tools.core.tool_registry import ToolRegistry
+from lintro.tools.core.tool_registry import ManifestRegistry
 from lintro.utils.project_detection import (
     detect_package_managers,
     detect_project_languages,
@@ -167,7 +167,7 @@ def setup_command(
     console.print()
 
     # ── Load registry ──
-    registry = ToolRegistry.load()
+    registry = ManifestRegistry.load()
     context = RuntimeContext.detect()
 
     # ── Resolve profile ──

--- a/lintro/plugins/registry.py
+++ b/lintro/plugins/registry.py
@@ -1,7 +1,14 @@
 """Tool registry for discovering and managing Lintro plugins.
 
 This module provides a central registry for all Lintro tools, supporting
-both built-in tools and external plugins discovered via entry points.
+both built-in tools and external plugins discovered via entry points. It
+owns *live plugin instances* (registered ``BaseToolPlugin`` subclasses) and
+handles registration, lazy instantiation, and lookup by name.
+
+This is distinct from :class:`lintro.tools.core.tool_registry.ManifestRegistry`
+(formerly also named ``ToolRegistry``), which owns static tool *metadata*
+(versions, install commands, language mappings, profiles) parsed from
+``manifest.json`` rather than live plugin instances.
 
 Example:
     >>> from lintro.plugins.registry import ToolRegistry, register_tool
@@ -36,6 +43,10 @@ class ToolRegistry:
     and listing tools.
 
     The registry is thread-safe and uses lazy instantiation for tool instances.
+
+    Not to be confused with
+    :class:`lintro.tools.core.tool_registry.ManifestRegistry`, which manages
+    manifest-derived tool metadata rather than live plugin instances.
     """
 
     _tools: dict[str, type[BaseToolPlugin]] = {}

--- a/lintro/tools/core/runtime_discovery.py
+++ b/lintro/tools/core/runtime_discovery.py
@@ -54,9 +54,9 @@ def _get_tool_probe_info() -> dict[str, _ToolProbeInfo] | None:
         or None if the registry is unavailable (early startup).
     """
     try:
-        from lintro.tools.core.tool_registry import ToolRegistry
+        from lintro.tools.core.tool_registry import ManifestRegistry
 
-        registry = ToolRegistry.load()
+        registry = ManifestRegistry.load()
         return {
             tool.name: _ToolProbeInfo(
                 version_command=tool.version_command,

--- a/lintro/tools/core/tool_installer.py
+++ b/lintro/tools/core/tool_installer.py
@@ -6,10 +6,10 @@ install-tools.sh for binary downloads) based on the tool's install type.
 
 Usage:
     from lintro.tools.core.tool_installer import ToolInstaller
-    from lintro.tools.core.tool_registry import ToolRegistry
+    from lintro.tools.core.tool_registry import ManifestRegistry
     from lintro.tools.core.install_context import RuntimeContext
 
-    registry = ToolRegistry.load()
+    registry = ManifestRegistry.load()
     context = RuntimeContext.detect()
     installer = ToolInstaller(registry, context)
 
@@ -30,7 +30,7 @@ from loguru import logger
 from lintro.tools.core.install_context import RuntimeContext
 from lintro.tools.core.install_plan import InstallPlan, InstallResult
 from lintro.tools.core.install_strategies import get_strategy
-from lintro.tools.core.tool_registry import ManifestTool, ToolRegistry
+from lintro.tools.core.tool_registry import ManifestRegistry, ManifestTool
 from lintro.tools.core.version_parsing import (
     compare_versions,
     extract_version_from_output,
@@ -54,7 +54,7 @@ class ToolInstaller:
 
     def __init__(
         self,
-        registry: ToolRegistry,
+        registry: ManifestRegistry,
         context: RuntimeContext,
     ) -> None:
         """Initialize the installer with registry and context."""

--- a/lintro/tools/core/tool_registry.py
+++ b/lintro/tools/core/tool_registry.py
@@ -1,15 +1,21 @@
-"""Unified tool registry loaded from manifest.json.
+"""Unified manifest registry loaded from manifest.json.
 
-This module is the single source of truth for all tool metadata. It replaces
-three parallel tool-to-version-command dicts that previously existed in:
+This module owns static tool *metadata* (versions, install commands,
+language mappings, profiles) parsed from ``manifest.json``. It is the single
+source of truth for that metadata and replaces three parallel
+tool-to-version-command dicts that previously existed in:
 - doctor.py (TOOL_COMMANDS)
 - version_requirements.py (tool_commands)
 - runtime_discovery.py (TOOL_VERSION_COMMANDS)
 
-Usage:
-    from lintro.tools.core.tool_registry import ToolRegistry
+This is distinct from :class:`lintro.plugins.registry.ToolRegistry`, which
+tracks *live plugin instances* (registered ``BaseToolPlugin`` subclasses)
+rather than manifest metadata.
 
-    registry = ToolRegistry.load()
+Usage:
+    from lintro.tools.core.tool_registry import ManifestRegistry
+
+    registry = ManifestRegistry.load()
     tool = registry.get("ruff")
     print(tool.version_command)  # ["ruff", "--version"]
 """
@@ -18,6 +24,7 @@ from __future__ import annotations
 
 import json
 import logging
+import warnings
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -28,9 +35,10 @@ from lintro.tools.core.manifest_models import ManifestTool, ProfileDefinition
 # continues to work.
 __all__ = [
     "CATEGORY_LABELS",
+    "ManifestRegistry",
     "ManifestTool",
     "ProfileDefinition",
-    "ToolRegistry",
+    "ToolRegistry",  # noqa: F822 - deprecated alias resolved via module __getattr__
 ]
 
 # Use stdlib logging to avoid external dependencies during early imports
@@ -46,11 +54,14 @@ CATEGORY_LABELS: dict[str, str] = {
 }
 
 
-class ToolRegistry:
+class ManifestRegistry:
     """Single source of truth for all tool metadata.
 
     Loaded from manifest.json v2. Provides typed access to tool metadata,
     version commands, language mappings, and profiles.
+
+    Not to be confused with :class:`lintro.plugins.registry.ToolRegistry`,
+    which manages live plugin instances rather than manifest metadata.
     """
 
     def __init__(
@@ -66,13 +77,13 @@ class ToolRegistry:
 
     @classmethod
     @lru_cache(maxsize=1)
-    def load(cls) -> ToolRegistry:
+    def load(cls) -> ManifestRegistry:
         """Load the registry from manifest.json.
 
         Cached via lru_cache — call clear_cache() to force a reload.
 
         Returns:
-            ToolRegistry: Loaded and cached registry instance.
+            ManifestRegistry: Loaded and cached registry instance.
         """
         return cls._load_from_path(_MANIFEST_PATH)
 
@@ -86,14 +97,14 @@ class ToolRegistry:
         cls.load.cache_clear()
 
     @classmethod
-    def _load_from_path(cls, path: Path) -> ToolRegistry:
+    def _load_from_path(cls, path: Path) -> ManifestRegistry:
         """Load registry from a specific manifest path.
 
         Args:
             path: Path to manifest.json.
 
         Returns:
-            ToolRegistry: Loaded registry.
+            ManifestRegistry: Loaded registry.
 
         Raises:
             ValueError: If the manifest is malformed or has an invalid version.
@@ -431,3 +442,32 @@ class ToolRegistry:
     def __contains__(self, name: str) -> bool:
         """Check if a tool is in the registry."""
         return name in self._tools
+
+
+def __getattr__(name: str) -> Any:
+    """Provide a deprecated ``ToolRegistry`` alias for :class:`ManifestRegistry`.
+
+    Implements `PEP 562 <https://peps.python.org/pep-0562/>`_ module-level
+    attribute access so that ``from lintro.tools.core.tool_registry import
+    ToolRegistry`` keeps working, while emitting a ``DeprecationWarning`` the
+    first time the old name is used.
+
+    Args:
+        name: Attribute name being looked up on this module.
+
+    Returns:
+        ``ManifestRegistry`` when ``name`` is ``"ToolRegistry"``.
+
+    Raises:
+        AttributeError: If ``name`` is not a recognized module attribute.
+    """
+    if name == "ToolRegistry":
+        warnings.warn(
+            "lintro.tools.core.tool_registry.ToolRegistry is deprecated and "
+            "will be removed in a future release; use ManifestRegistry "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return ManifestRegistry
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/lintro/tools/core/version_requirements.py
+++ b/lintro/tools/core/version_requirements.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from loguru import logger
 
-from lintro.tools.core.tool_registry import ToolRegistry
+from lintro.tools.core.tool_registry import ManifestRegistry
 from lintro.tools.core.version_checking import (
     get_install_hints,
     get_minimum_versions,
@@ -32,13 +32,13 @@ __all__ = [
 def get_all_tool_versions() -> dict[str, ToolVersionInfo]:
     """Get version information for all supported tools.
 
-    Uses the unified ToolRegistry (manifest.json) as the single source of truth
+    Uses the unified ManifestRegistry (manifest.json) as the single source of truth
     for tool commands and version requirements.
 
     Returns:
         dict[str, ToolVersionInfo]: Dictionary mapping tool names to version info.
     """
-    registry = ToolRegistry.load()
+    registry = ManifestRegistry.load()
     results = {}
     minimum_versions = get_minimum_versions()
     install_hints = get_install_hints()

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -362,7 +362,7 @@ def test_markdown_report_contains_headers() -> None:
 
 
 def _patch_doctor_deps() -> tuple[Any, Any]:
-    """Patch ToolRegistry.load and RuntimeContext.detect for CLI tests.
+    """Patch ManifestRegistry.load and RuntimeContext.detect for CLI tests.
 
     Returns:
         Tuple of two context-manager patches.
@@ -376,7 +376,7 @@ def _patch_doctor_deps() -> tuple[Any, Any]:
 
     return (
         patch(
-            "lintro.cli_utils.commands.doctor.ToolRegistry.load",
+            "lintro.cli_utils.commands.doctor.ManifestRegistry.load",
             return_value=registry,
         ),
         patch(

--- a/tests/unit/cli_utils/commands/test_install_command.py
+++ b/tests/unit/cli_utils/commands/test_install_command.py
@@ -29,7 +29,7 @@ def _make_tool(name: str = "ruff", version: str = "0.14.0") -> ManifestTool:
 
 
 def _mock_registry() -> MagicMock:
-    """Build a mock ToolRegistry."""
+    """Build a mock ManifestRegistry."""
     registry = MagicMock()
     registry.profile_names = [
         "minimal",
@@ -52,7 +52,7 @@ def _patches() -> tuple[Any, Any]:
     registry = _mock_registry()
     return (
         patch(
-            "lintro.cli_utils.commands.install.ToolRegistry.load",
+            "lintro.cli_utils.commands.install.ManifestRegistry.load",
             return_value=registry,
         ),
         patch(

--- a/tests/unit/cli_utils/commands/test_setup_command.py
+++ b/tests/unit/cli_utils/commands/test_setup_command.py
@@ -206,7 +206,7 @@ def _patch_setup_deps() -> tuple[Any, Any, Any, Any]:
 
     return (
         patch(
-            "lintro.cli_utils.commands.setup.ToolRegistry.load",
+            "lintro.cli_utils.commands.setup.ManifestRegistry.load",
             return_value=registry,
         ),
         patch(

--- a/tests/unit/core/test_version_requirements.py
+++ b/tests/unit/core/test_version_requirements.py
@@ -427,9 +427,9 @@ def test_get_all_tool_versions(mock_run: MagicMock) -> None:
     results = get_all_tool_versions()
 
     # Dynamically build expected set from registry (same source of truth)
-    from lintro.tools.core.tool_registry import ToolRegistry
+    from lintro.tools.core.tool_registry import ManifestRegistry
 
-    registry = ToolRegistry.load()
+    registry = ManifestRegistry.load()
     expected_tools = {
         tool.name
         for tool in registry.all_tools(include_dev=True)

--- a/tests/unit/tools/core/test_tool_installer.py
+++ b/tests/unit/tools/core/test_tool_installer.py
@@ -80,10 +80,10 @@ def context() -> RuntimeContext:
 
 @pytest.fixture()
 def registry() -> MagicMock:
-    """Return a mock ToolRegistry.
+    """Return a mock ManifestRegistry.
 
     Returns:
-        A MagicMock standing in for ToolRegistry.
+        A MagicMock standing in for ManifestRegistry.
     """
     return MagicMock()
 
@@ -93,7 +93,7 @@ def installer(registry: MagicMock, context: RuntimeContext) -> ToolInstaller:
     """Return a ToolInstaller wired to mock registry and real context.
 
     Args:
-        registry: Mock ToolRegistry.
+        registry: Mock ManifestRegistry.
         context: RuntimeContext fixture.
 
     Returns:
@@ -408,7 +408,7 @@ def test_plan_tool_manual_no_cargo(
     """Place cargo tool in manual when cargo is not available.
 
     Args:
-        registry: Mock ToolRegistry.
+        registry: Mock ManifestRegistry.
         make_tool: ManifestTool factory.
     """
     from lintro.tools.core.install_strategies.environment import InstallEnvironment
@@ -447,7 +447,7 @@ def test_plan_tool_manual_no_npm(
     """Place npm tool in manual when bun and npm are both unavailable.
 
     Args:
-        registry: Mock ToolRegistry.
+        registry: Mock ManifestRegistry.
         make_tool: ManifestTool factory.
     """
     from lintro.tools.core.install_strategies.environment import InstallEnvironment
@@ -493,7 +493,7 @@ def test_plan_with_tools_list(
 
     Args:
         installer: ToolInstaller fixture.
-        registry: Mock ToolRegistry.
+        registry: Mock ManifestRegistry.
         make_tool: ManifestTool factory.
     """
     tool_a = make_tool(name="tool_a")
@@ -518,7 +518,7 @@ def test_plan_deduplicates_tools(
 
     Args:
         installer: ToolInstaller fixture.
-        registry: Mock ToolRegistry.
+        registry: Mock ManifestRegistry.
         make_tool: ManifestTool factory.
     """
     tool_a = make_tool(name="tool_a")
@@ -540,7 +540,7 @@ def test_plan_with_profile(
 
     Args:
         installer: ToolInstaller fixture.
-        registry: Mock ToolRegistry.
+        registry: Mock ManifestRegistry.
         make_tool: ManifestTool factory.
     """
     tool_a = make_tool(name="profiled_tool")
@@ -562,7 +562,7 @@ def test_plan_with_upgrade_flag(
 
     Args:
         installer: ToolInstaller fixture.
-        registry: Mock ToolRegistry.
+        registry: Mock ManifestRegistry.
         make_tool: ManifestTool factory.
     """
     tool_a = make_tool(name="upgradable")
@@ -588,7 +588,7 @@ def test_check_prerequisites_cargo_missing(
     """Return skip reason when cargo is not available for a cargo tool.
 
     Args:
-        registry: Mock ToolRegistry.
+        registry: Mock ManifestRegistry.
         make_tool: ManifestTool factory.
     """
     from lintro.tools.core.install_strategies.environment import InstallEnvironment
@@ -625,7 +625,7 @@ def test_check_prerequisites_npm_missing(
     """Return skip reason when npm and bun are both unavailable for npm tool.
 
     Args:
-        registry: Mock ToolRegistry.
+        registry: Mock ManifestRegistry.
         make_tool: ManifestTool factory.
     """
     from lintro.tools.core.install_strategies.environment import InstallEnvironment
@@ -662,7 +662,7 @@ def test_check_prerequisites_pip_missing(
     """Return skip reason when uv and pip are both unavailable for pip tool.
 
     Args:
-        registry: Mock ToolRegistry.
+        registry: Mock ManifestRegistry.
         make_tool: ManifestTool factory.
     """
     from lintro.tools.core.install_strategies.environment import InstallEnvironment

--- a/tests/unit/tools/core/test_tool_registry.py
+++ b/tests/unit/tools/core/test_tool_registry.py
@@ -1,4 +1,4 @@
-"""Unit tests for ToolRegistry manifest loading and query methods."""
+"""Unit tests for ManifestRegistry manifest loading and query methods."""
 
 from __future__ import annotations
 
@@ -10,8 +10,8 @@ import pytest
 from assertpy import assert_that
 
 from lintro.tools.core.tool_registry import (
+    ManifestRegistry,
     ManifestTool,
-    ToolRegistry,
 )
 
 # ---------------------------------------------------------------------------
@@ -38,16 +38,16 @@ def v2_manifest_path(tmp_path: Path) -> Path:
 
 
 @pytest.fixture()
-def registry(v2_manifest_path: Path) -> ToolRegistry:
-    """Load a ToolRegistry from the v2 test manifest.
+def registry(v2_manifest_path: Path) -> ManifestRegistry:
+    """Load a ManifestRegistry from the v2 test manifest.
 
     Args:
         v2_manifest_path: Path to the test manifest.
 
     Returns:
-        ToolRegistry loaded from the test manifest.
+        ManifestRegistry loaded from the test manifest.
     """
-    return ToolRegistry._load_from_path(v2_manifest_path)
+    return ManifestRegistry._load_from_path(v2_manifest_path)
 
 
 # ===========================================================================
@@ -55,7 +55,7 @@ def registry(v2_manifest_path: Path) -> ToolRegistry:
 # ===========================================================================
 
 
-def test_load_v2_manifest(registry: ToolRegistry) -> None:
+def test_load_v2_manifest(registry: ManifestRegistry) -> None:
     """Loading a v2 manifest populates tools, profiles, and language_map."""
     assert_that(len(registry)).is_equal_to(6)
     assert_that(registry.profile_names).is_length(4)
@@ -80,7 +80,7 @@ def test_load_v1_compat(tmp_path: Path) -> None:
     path = tmp_path / "manifest.json"
     path.write_text(json.dumps(manifest), encoding="utf-8")
 
-    reg = ToolRegistry._load_from_path(path)
+    reg = ManifestRegistry._load_from_path(path)
     tool = reg.get("old-tool")
     assert_that(tool.version_command).is_equal_to(("old-tool", "-V"))
     assert_that(tool.category).is_equal_to("bundled")
@@ -102,7 +102,7 @@ def test_load_missing_name_skips_tool(tmp_path: Path) -> None:
     path = tmp_path / "manifest.json"
     path.write_text(json.dumps(manifest), encoding="utf-8")
 
-    reg = ToolRegistry._load_from_path(path)
+    reg = ManifestRegistry._load_from_path(path)
     assert_that(len(reg)).is_equal_to(1)
     assert_that("good" in reg).is_true()
 
@@ -123,7 +123,7 @@ def test_load_missing_version_skips_tool(tmp_path: Path) -> None:
     path = tmp_path / "manifest.json"
     path.write_text(json.dumps(manifest), encoding="utf-8")
 
-    reg = ToolRegistry._load_from_path(path)
+    reg = ManifestRegistry._load_from_path(path)
     assert_that(len(reg)).is_equal_to(1)
     assert_that("no-ver" in reg).is_false()
 
@@ -134,7 +134,7 @@ def test_load_invalid_manifest_version(tmp_path: Path) -> None:
     path = tmp_path / "manifest.json"
     path.write_text(json.dumps(manifest), encoding="utf-8")
 
-    assert_that(ToolRegistry._load_from_path).raises(ValueError).when_called_with(
+    assert_that(ManifestRegistry._load_from_path).raises(ValueError).when_called_with(
         path,
     ).is_equal_to("manifest 'version' must be an integer, got 'not_int'")
 
@@ -155,7 +155,7 @@ def test_parse_tool_entry_invalid_version_command(tmp_path: Path) -> None:
     path = tmp_path / "manifest.json"
     path.write_text(json.dumps(manifest), encoding="utf-8")
 
-    reg = ToolRegistry._load_from_path(path)
+    reg = ManifestRegistry._load_from_path(path)
     tool = reg.get("bad-cmd")
     assert_that(tool.version_command).is_equal_to(())
 
@@ -165,21 +165,21 @@ def test_parse_tool_entry_invalid_version_command(tmp_path: Path) -> None:
 # ===========================================================================
 
 
-def test_all_tools_excludes_dev_by_default(registry: ToolRegistry) -> None:
+def test_all_tools_excludes_dev_by_default(registry: ManifestRegistry) -> None:
     """Dev-tier tools are excluded when include_dev is False (default)."""
     tools = registry.all_tools()
     names = [t.name for t in tools]
     assert_that(names).does_not_contain("dev-tool")
 
 
-def test_all_tools_includes_dev(registry: ToolRegistry) -> None:
+def test_all_tools_includes_dev(registry: ManifestRegistry) -> None:
     """Dev-tier tools are included when include_dev is True."""
     tools = registry.all_tools(include_dev=True)
     names = [t.name for t in tools]
     assert_that(names).contains("dev-tool")
 
 
-def test_all_tools_sorted_by_name(registry: ToolRegistry) -> None:
+def test_all_tools_sorted_by_name(registry: ManifestRegistry) -> None:
     """Returned tools are sorted alphabetically by name."""
     tools = registry.all_tools(include_dev=True)
     names = [t.name for t in tools]
@@ -191,14 +191,14 @@ def test_all_tools_sorted_by_name(registry: ToolRegistry) -> None:
 # ===========================================================================
 
 
-def test_tools_for_languages_single(registry: ToolRegistry) -> None:
+def test_tools_for_languages_single(registry: ManifestRegistry) -> None:
     """Passing ['python'] returns python-mapped tools plus security."""
     tools = registry.tools_for_languages(["python"])
     names = [t.name for t in tools]
     assert_that(names).contains("ruff", "mypy", "gitleaks")
 
 
-def test_tools_for_languages_multiple(registry: ToolRegistry) -> None:
+def test_tools_for_languages_multiple(registry: ManifestRegistry) -> None:
     """Passing multiple languages returns the union of their tool sets."""
     tools = registry.tools_for_languages(["python", "docker"])
     names = [t.name for t in tools]
@@ -206,7 +206,7 @@ def test_tools_for_languages_multiple(registry: ToolRegistry) -> None:
 
 
 def test_tools_for_languages_always_includes_security(
-    registry: ToolRegistry,
+    registry: ManifestRegistry,
 ) -> None:
     """Security tools are always included regardless of language list."""
     tools = registry.tools_for_languages(["docker"])
@@ -214,7 +214,7 @@ def test_tools_for_languages_always_includes_security(
     assert_that(names).contains("gitleaks")
 
 
-def test_tools_for_languages_unknown_lang(registry: ToolRegistry) -> None:
+def test_tools_for_languages_unknown_lang(registry: ManifestRegistry) -> None:
     """An unknown language returns only security tools."""
     tools = registry.tools_for_languages(["cobol"])
     names = [t.name for t in tools]
@@ -226,7 +226,7 @@ def test_tools_for_languages_unknown_lang(registry: ToolRegistry) -> None:
 # ===========================================================================
 
 
-def test_tools_for_profile_explicit(registry: ToolRegistry) -> None:
+def test_tools_for_profile_explicit(registry: ManifestRegistry) -> None:
     """The 'minimal' explicit profile returns exactly the listed tools."""
     tools = registry.tools_for_profile("minimal")
     names = [t.name for t in tools]
@@ -234,7 +234,7 @@ def test_tools_for_profile_explicit(registry: ToolRegistry) -> None:
 
 
 def test_tools_for_profile_auto_detect_with_langs(
-    registry: ToolRegistry,
+    registry: ManifestRegistry,
 ) -> None:
     """The 'recommended' profile with detected_langs delegates to tools_for_languages."""
     tools = registry.tools_for_profile("recommended", detected_langs=["python"])
@@ -243,7 +243,7 @@ def test_tools_for_profile_auto_detect_with_langs(
 
 
 def test_tools_for_profile_auto_detect_no_langs_falls_back_to_minimal(
-    registry: ToolRegistry,
+    registry: ManifestRegistry,
 ) -> None:
     """The 'recommended' profile without detected languages falls back to 'minimal'."""
     tools = registry.tools_for_profile("recommended")
@@ -251,7 +251,7 @@ def test_tools_for_profile_auto_detect_no_langs_falls_back_to_minimal(
     assert_that(names).is_equal_to(["mypy", "ruff"])
 
 
-def test_tools_for_profile_all(registry: ToolRegistry) -> None:
+def test_tools_for_profile_all(registry: ManifestRegistry) -> None:
     """The 'complete' profile returns every tool, including dev."""
     tools = registry.tools_for_profile("complete")
     names = [t.name for t in tools]
@@ -260,7 +260,7 @@ def test_tools_for_profile_all(registry: ToolRegistry) -> None:
 
 
 def test_tools_for_profile_filter_excludes_formatters(
-    registry: ToolRegistry,
+    registry: ManifestRegistry,
 ) -> None:
     """The 'ci' profile excludes tools whose tags are a subset of ['formatter'].
 
@@ -276,7 +276,7 @@ def test_tools_for_profile_filter_excludes_formatters(
     assert_that(names).does_not_contain("black")
 
 
-def test_tools_for_profile_unknown_raises(registry: ToolRegistry) -> None:
+def test_tools_for_profile_unknown_raises(registry: ManifestRegistry) -> None:
     """An unknown profile name raises KeyError."""
     assert_that(registry.tools_for_profile).raises(KeyError).when_called_with(
         "nonexistent",
@@ -288,7 +288,7 @@ def test_tools_for_profile_unknown_raises(registry: ToolRegistry) -> None:
 # ===========================================================================
 
 
-def test_get_existing_tool(registry: ToolRegistry) -> None:
+def test_get_existing_tool(registry: ManifestRegistry) -> None:
     """get() returns the ManifestTool for a known tool name."""
     tool = registry.get("ruff")
     assert_that(tool).is_instance_of(ManifestTool)
@@ -296,12 +296,12 @@ def test_get_existing_tool(registry: ToolRegistry) -> None:
     assert_that(tool.version).is_equal_to("0.14.0")
 
 
-def test_get_missing_tool_raises_key_error(registry: ToolRegistry) -> None:
+def test_get_missing_tool_raises_key_error(registry: ManifestRegistry) -> None:
     """get() raises KeyError for an unknown tool name."""
     assert_that(registry.get).raises(KeyError).when_called_with("nope")
 
 
-def test_get_or_none_existing(registry: ToolRegistry) -> None:
+def test_get_or_none_existing(registry: ManifestRegistry) -> None:
     """get_or_none() returns the ManifestTool when the tool exists."""
     tool = registry.get_or_none("mypy")
     assert_that(tool).is_not_none()
@@ -310,22 +310,45 @@ def test_get_or_none_existing(registry: ToolRegistry) -> None:
     assert_that(tool.name).is_equal_to("mypy")
 
 
-def test_get_or_none_missing(registry: ToolRegistry) -> None:
+def test_get_or_none_missing(registry: ManifestRegistry) -> None:
     """get_or_none() returns None when the tool does not exist."""
     tool = registry.get_or_none("nope")
     assert_that(tool).is_none()
 
 
-def test_contains_true(registry: ToolRegistry) -> None:
+def test_contains_true(registry: ManifestRegistry) -> None:
     """__contains__ returns True for a registered tool."""
     assert_that("ruff" in registry).is_true()
 
 
-def test_contains_false(registry: ToolRegistry) -> None:
+def test_contains_false(registry: ManifestRegistry) -> None:
     """__contains__ returns False for an unregistered tool."""
     assert_that("nope" in registry).is_false()
 
 
-def test_len(registry: ToolRegistry) -> None:
+def test_len(registry: ManifestRegistry) -> None:
     """__len__ returns the total number of tools in the registry."""
     assert_that(len(registry)).is_equal_to(6)
+
+
+# ===========================================================================
+# ToolRegistry rename (#1220)
+# ===========================================================================
+
+
+def test_manifest_registry_importable() -> None:
+    """ManifestRegistry is importable from lintro.tools.core.tool_registry."""
+    from lintro.tools.core.tool_registry import ManifestRegistry
+
+    assert_that(isinstance(ManifestRegistry, type)).is_true()
+
+
+def test_plugin_tool_registry_distinct() -> None:
+    """The plugin and manifest registries are different, unrelated classes."""
+    from lintro.plugins.registry import ToolRegistry as PluginToolRegistry
+    from lintro.tools.core.tool_registry import ManifestRegistry
+
+    assert_that(PluginToolRegistry).is_not_equal_to(ManifestRegistry)
+    assert_that(PluginToolRegistry.__name__).is_not_equal_to(
+        ManifestRegistry.__name__,
+    )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(tools): rename manifest ToolRegistry to ManifestRegistry
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Two unrelated classes were both named `ToolRegistry`:

- `lintro/plugins/registry.py` — owns live plugin instances (registered
  `BaseToolPlugin` subclasses)
- `lintro/tools/core/tool_registry.py` — owns static tool metadata parsed
  from `manifest.json`

This PR renames the manifest-backed class to `ManifestRegistry`, eliminating
the collision while keeping the plugin registry name unchanged:

- Rename `ToolRegistry` → `ManifestRegistry` in
  `lintro/tools/core/tool_registry.py` and update all importers
  (`tool_installer`, `version_requirements`, `runtime_discovery`, and the
  `doctor`/`init`/`install`/`setup` CLI commands) plus their tests.
- Add a PEP 562 module `__getattr__` deprecation alias: importing or
  accessing the old `ToolRegistry` name still works but emits a
  `DeprecationWarning` pointing at `ManifestRegistry`.
- Extend module docstrings in both registry modules to state exactly what
  each registry owns (manifest metadata vs live plugin instances).
- Add `test_manifest_registry_importable` and
  `test_plugin_tool_registry_distinct` (pytest + assertpy).
- Document the rename and deprecation in `CHANGELOG.md`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` + full `uv run pytest`)

## Related Issues

Closes #1220

## Details

The deprecation alias is implemented via module-level `__getattr__` (PEP
562) rather than a subclass, so `ToolRegistry is ManifestRegistry` holds for
any code that still imports the old name — `lru_cache` on `load()` and
`isinstance` checks behave identically. The warning fires once per import
site with `stacklevel=2` so callers see their own location.

`lintro/plugins/discovery.py` was intentionally left untouched (parallel
work in #1219 modifies it).

Testing: full `uv run pytest` — 6311 passed, 10 skipped, 0 failed.
`uv run lintro chk` clean (bandit/gitleaks show transient timeout errors
only under full parallel runs; both pass when run individually — a known
contention flake unrelated to this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ManifestRegistry` as the primary source for tool metadata and manifest-based configuration.
  * Existing `ToolRegistry` imports remain supported temporarily but now emit a deprecation warning.

* **Documentation**
  * Updated changelog and registry documentation to explain the rename and compatibility timeline.

* **Tests**
  * Updated coverage for manifest loading, tool lookups, profiles, compatibility behavior, and deprecation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR renames the manifest-backed tool registry to avoid confusion with the plugin registry. The main changes are:

- `ManifestRegistry` replaces the manifest metadata class name.
- Internal CLI and core callers now import `ManifestRegistry` directly.
- The old manifest `ToolRegistry` name remains as a deprecated module alias.
- Registry docs, tests, and changelog entries were updated for the rename.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/core/tool_registry.py | Renames the manifest metadata registry class and keeps the old name available through a deprecation alias. |
| lintro/tools/core/tool_installer.py | Updates the installer to type and import the manifest metadata registry under its new name. |
| lintro/cli_utils/commands/doctor.py | Updates doctor command registry loading and fix flow annotations to use `ManifestRegistry`. |
| lintro/cli_utils/commands/install.py | Updates install command registry loading and selection helper annotations to use `ManifestRegistry`. |
| lintro/cli_utils/commands/init.py | Updates init command registry loading to use `ManifestRegistry`. |
| lintro/cli_utils/commands/setup.py | Updates setup command registry loading to use `ManifestRegistry`. |
| lintro/tools/core/runtime_discovery.py | Updates runtime discovery to load manifest metadata through `ManifestRegistry`. |
| lintro/tools/core/version_requirements.py | Updates version requirement collection to load manifest metadata through `ManifestRegistry`. |
| lintro/plugins/registry.py | Clarifies that the plugin registry owns live plugin instances, not manifest metadata. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into refactor/1220-r..."](https://github.com/lgtm-hq/py-lintro/commit/8273cfc70b45b83cc4e5e0babdb3b094b676a324) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43505387)</sub>

<!-- /greptile_comment -->