### PR TITLE
chore(renovate): drop package rules redundant with org preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,20 +8,9 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["docker"],
-      "matchUpdateTypes": ["digest", "patch"],
-      "automerge": true,
-      "automergeType": "branch"
-    },
-    {
       "matchDatasources": ["pypi"],
       "matchUpdateTypes": ["minor"],
       "automerge": false
-    },
-    {
-      "groupName": "pytest packages",
-      "groupSlug": "pytest",
-      "matchPackageNames": ["/^pytest/"]
     },
     {
       "matchManagers": [


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Org-wide Renovate review found repo-level rules duplicating or conflicting with the shared preset `lgtm-hq/.github:renovate-config`:

- Remove the docker `digest`/`patch` branch-automerge rule — the preset already automerges `patch`+`digest` for all managers
- Remove the `pytest packages` group — the preset's `test-tools` group already matches `pytest` and `pytest-**`, so pytest updates now land in the same group name as sibling repos

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1261

## Details

Config-only change. Validated with `bunx --package renovate renovate-config-validator --strict renovate.json` → "Config validated successfully"; `uv run lintro chk renovate.json` → 100/100.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes repo-local Renovate rules that are expected to come from the shared org preset.

- Drops the Docker digest and patch branch-automerge package rule.
- Drops the local pytest package grouping rule.
- Keeps the remaining repo-specific Renovate rules in place.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Removes two Renovate package rules that now rely on the shared org preset. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/1261-reno..."](https://github.com/lgtm-hq/py-lintro/commit/81bdac879a48fd567a780c0557cae60e9e94132a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43506058)</sub>

<!-- /greptile_comment -->