### PR TITLE
fix(execution): handle BaseException in gather results and nested event loops

### DIFF
--- a/lintro/utils/async_tool_executor.py
+++ b/lintro/utils/async_tool_executor.py
@@ -148,6 +148,14 @@ class AsyncToolExecutor:
 
         Returns:
             List of (tool_name, ToolResult) tuples in completion order.
+
+        Raises:
+            asyncio.CancelledError: If a tool task was cancelled; re-raised
+                after executor cleanup so cancellation propagates.
+            KeyboardInterrupt: If a tool task raised it; re-raised after
+                executor cleanup.
+            SystemExit: If a tool task raised it; re-raised after executor
+                cleanup.
         """
         options = options_per_tool or {}
 
@@ -179,25 +187,88 @@ class AsyncToolExecutor:
         tasks = [run_with_name(name, tool) for name, tool in tools]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        # Handle any exceptions that occurred
+        from lintro.models.core.tool_result import ToolResult
+
+        def _make_failed_result(
+            name: str,
+            message: str,
+        ) -> tuple[str, ToolResult]:
+            """Build a failed ``ToolResult`` entry for the given tool.
+
+            Args:
+                name: Name of the tool the result belongs to.
+                message: Human-readable failure description.
+
+            Returns:
+                A ``(tool_name, ToolResult)`` tuple with ``success=False``.
+            """
+            return (
+                name,
+                ToolResult(
+                    name=name,
+                    success=False,
+                    output=message,
+                    issues_count=0,
+                ),
+            )
+
+        # ``asyncio.gather(return_exceptions=True)`` aggregates *any* raised
+        # value, including ``BaseException`` subclasses that are not
+        # ``Exception`` (``CancelledError``, ``KeyboardInterrupt``,
+        # ``SystemExit``). Those must never be treated as tool results: fatal
+        # control-flow exceptions are re-raised after cleanup, non-fatal
+        # per-tool exceptions map to failed results, and only structurally
+        # valid ``(str, ToolResult)`` tuples enter the success branch.
         processed_results: list[tuple[str, ToolResult]] = []
         for i, result in enumerate(results):
             tool_name = tools[i][0]
-            if isinstance(result, Exception):
-                logger.error(f"Tool {tool_name} failed with exception: {result}")
-                # Create a failed result
-                from lintro.models.core.tool_result import ToolResult
 
-                failed_result = ToolResult(
-                    name=tool_name,
-                    success=False,
-                    output=f"Parallel execution failed: {result}",
-                    issues_count=0,
+            if isinstance(
+                result,
+                (asyncio.CancelledError, KeyboardInterrupt, SystemExit),
+            ):
+                logger.warning(
+                    f"Tool {tool_name} raised fatal "
+                    f"{type(result).__name__}; propagating after cleanup",
                 )
-                processed_results.append((tool_name, failed_result))
+                self.shutdown()
+                if isinstance(result, asyncio.CancelledError):
+                    raise asyncio.CancelledError(*result.args) from result
+                if isinstance(result, KeyboardInterrupt):
+                    raise KeyboardInterrupt(*result.args) from result
+                raise SystemExit(result.code) from result
+
+            if isinstance(result, BaseException):
+                logger.error(f"Tool {tool_name} failed with exception: {result}")
+                processed_results.append(
+                    _make_failed_result(
+                        name=tool_name,
+                        message=f"Parallel execution failed: {result}",
+                    ),
+                )
+                continue
+
+            if (
+                isinstance(result, tuple)
+                and len(result) == 2
+                and isinstance(result[0], str)
+                and isinstance(result[1], ToolResult)
+            ):
+                processed_results.append(result)
             else:
-                # Result is tuple[str, ToolResult] (type narrowed by isinstance check)
-                processed_results.append(result)  # type: ignore[arg-type]
+                logger.error(
+                    f"Tool {tool_name} returned a malformed result "
+                    f"({type(result).__name__}); recording as failure",
+                )
+                processed_results.append(
+                    _make_failed_result(
+                        name=tool_name,
+                        message=(
+                            "Parallel execution produced a malformed result: "
+                            f"{result!r}"
+                        ),
+                    ),
+                )
 
         return processed_results
 

--- a/lintro/utils/execution/parallel_executor.py
+++ b/lintro/utils/execution/parallel_executor.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from typing import TYPE_CHECKING
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, TypeVar
 
 from rich.progress import (
     BarColumn,
@@ -24,7 +25,48 @@ from lintro.utils.execution.tool_configuration import configure_tool_for_executi
 from lintro.utils.unified_config import UnifiedConfigManager
 
 if TYPE_CHECKING:
+    from collections.abc import Coroutine
+
     from lintro.plugins.base import BaseToolPlugin
+
+_T = TypeVar("_T")
+
+
+def _run_coroutine_blocking(coro: Coroutine[object, object, _T]) -> _T:
+    """Run a coroutine to completion from a synchronous context.
+
+    This helper guarantees the parallel executor can be embedded inside an
+    environment that already owns a running event loop (Jupyter, async web
+    frameworks, or a programmatic library caller invoking lintro from async
+    code). Loop ownership is only safe to assume at the CLI boundary, so the
+    executor must never assume it can create its own loop unconditionally.
+
+    Behavior:
+        - No running loop in the current thread: the coroutine runs via
+          ``asyncio.run`` on this thread. This keeps the CLI path
+          byte-for-byte identical to the previous ``asyncio.run(...)`` call.
+        - A loop is already running in the current thread: the coroutine is
+          dispatched to a dedicated worker thread with its own fresh event
+          loop, avoiding the ``RuntimeError`` that ``asyncio.run`` raises when
+          a loop is already running.
+
+    Args:
+        coro: The coroutine to execute to completion.
+
+    Returns:
+        The value returned by the coroutine.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop in this thread: it is safe to own one here.
+        return asyncio.run(coro)
+
+    # A loop is already running in this thread. Run the coroutine on a fresh
+    # loop inside a dedicated worker thread and block for its result.
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(asyncio.run, coro)
+        return future.result()
 
 
 def run_tools_parallel(
@@ -149,8 +191,11 @@ def run_tools_parallel(
                         description=desc,
                     )
 
-                # Run batch in parallel with progress callback
-                batch_results = asyncio.run(
+                # Run batch in parallel with progress callback. Use the
+                # loop-aware runner so the executor works both from the CLI
+                # (no running loop) and when embedded in an already-running
+                # event loop.
+                batch_results = _run_coroutine_blocking(
                     executor.run_tools_parallel(
                         tools=tools_with_instances,
                         paths=paths,

--- a/tests/unit/utils/async_tool_executor/test_base_exceptions.py
+++ b/tests/unit/utils/async_tool_executor/test_base_exceptions.py
@@ -1,0 +1,168 @@
+"""Tests for BaseException handling in ``run_tools_parallel``.
+
+These cover the fatal control-flow exceptions that ``asyncio.gather`` returns
+as values under ``return_exceptions=True`` (``CancelledError``,
+``KeyboardInterrupt``, ``SystemExit``), plus malformed results that must never
+enter the success branch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+from assertpy import assert_that
+
+from lintro.enums.action import Action
+from lintro.models.core.tool_result import ToolResult
+from lintro.plugins.base import BaseToolPlugin
+from lintro.utils.async_tool_executor import AsyncToolExecutor
+
+from .conftest import MockToolDefinition, MockToolPlugin
+
+
+def _tool_raising(
+    name: str,
+    exc: BaseException,
+) -> tuple[str, BaseToolPlugin]:
+    """Build a mock tool whose ``check`` raises the given exception.
+
+    Args:
+        name: Name to assign to the mock tool.
+        exc: Exception instance to raise from ``check``.
+
+    Returns:
+        A ``(tool_name, tool)`` tuple ready for ``run_tools_parallel``.
+    """
+    tool = MockToolPlugin(definition=MockToolDefinition(name=name))
+
+    def raising_check(
+        paths: list[str],
+        options: dict[str, Any] | None = None,
+    ) -> ToolResult:
+        raise exc
+
+    object.__setattr__(tool, "check", raising_check)
+    return (name, cast(BaseToolPlugin, tool))
+
+
+def test_cancelled_error_reraised(executor: AsyncToolExecutor) -> None:
+    """A task raising ``CancelledError`` propagates cancellation.
+
+    Args:
+        executor: AsyncToolExecutor fixture.
+    """
+    tools = [_tool_raising(name="cancel_tool", exc=asyncio.CancelledError())]
+
+    async def run_test() -> Any:
+        return await executor.run_tools_parallel(
+            tools=tools,
+            paths=["."],
+            action=Action.CHECK,
+        )
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(run_test())
+
+
+def test_keyboard_interrupt_propagates(executor: AsyncToolExecutor) -> None:
+    """A task raising ``KeyboardInterrupt`` propagates to the caller.
+
+    Args:
+        executor: AsyncToolExecutor fixture.
+    """
+    tools = [_tool_raising(name="kbi_tool", exc=KeyboardInterrupt())]
+
+    async def run_test() -> Any:
+        return await executor.run_tools_parallel(
+            tools=tools,
+            paths=["."],
+            action=Action.CHECK,
+        )
+
+    with pytest.raises(KeyboardInterrupt):
+        asyncio.run(run_test())
+
+
+def test_system_exit_propagates(executor: AsyncToolExecutor) -> None:
+    """A task raising ``SystemExit`` propagates to the caller.
+
+    Args:
+        executor: AsyncToolExecutor fixture.
+    """
+    tools = [_tool_raising(name="exit_tool", exc=SystemExit(2))]
+
+    async def run_test() -> Any:
+        return await executor.run_tools_parallel(
+            tools=tools,
+            paths=["."],
+            action=Action.CHECK,
+        )
+
+    with pytest.raises(SystemExit):
+        asyncio.run(run_test())
+
+
+def test_tool_exception_maps_to_failed_result(
+    executor: AsyncToolExecutor,
+) -> None:
+    """A per-tool ``ValueError`` becomes a failed ``ToolResult``.
+
+    Args:
+        executor: AsyncToolExecutor fixture.
+    """
+    tools = [_tool_raising(name="value_tool", exc=ValueError("boom"))]
+
+    async def run_test() -> Any:
+        return await executor.run_tools_parallel(
+            tools=tools,
+            paths=["."],
+            action=Action.CHECK,
+        )
+
+    results = asyncio.run(run_test())
+
+    assert_that(results).is_length(1)
+    name, result = results[0]
+    assert_that(name).is_equal_to("value_tool")
+    assert_that(result.success).is_false()
+    assert_that(result.output).contains("Parallel execution failed", "boom")
+
+
+def test_malformed_result_does_not_corrupt_results(
+    executor: AsyncToolExecutor,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-tuple gather result never lands in the success branch.
+
+    Args:
+        executor: AsyncToolExecutor fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    sentinel = object()
+
+    async def fake_gather(*args: Any, **kwargs: Any) -> list[Any]:
+        return [sentinel]
+
+    monkeypatch.setattr(asyncio, "gather", fake_gather)
+
+    tools = cast(
+        list[tuple[str, BaseToolPlugin]],
+        [("mock_tool", MockToolPlugin(definition=MockToolDefinition()))],
+    )
+
+    async def run_test() -> Any:
+        return await executor.run_tools_parallel(
+            tools=tools,
+            paths=["."],
+            action=Action.CHECK,
+        )
+
+    results = asyncio.run(run_test())
+
+    assert_that(results).is_length(1)
+    name, result = results[0]
+    assert_that(name).is_equal_to("mock_tool")
+    assert_that(result.success).is_false()
+    assert_that(result.output).contains("malformed result")

--- a/tests/unit/utils/execution/__init__.py
+++ b/tests/unit/utils/execution/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for lintro execution utilities."""

--- a/tests/unit/utils/execution/test_parallel_executor_loop.py
+++ b/tests/unit/utils/execution/test_parallel_executor_loop.py
@@ -1,0 +1,171 @@
+"""Tests for loop-aware execution in the parallel executor.
+
+Verify that ``run_tools_parallel`` works both from a normal synchronous
+context (CLI path) and from within an already-running event loop (embedded /
+library usage), never raising the nested-loop ``RuntimeError``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+from assertpy import assert_that
+
+import lintro.utils.async_tool_executor as async_module
+import lintro.utils.execution.parallel_executor as parallel_module
+from lintro.enums.action import Action
+from lintro.models.core.tool_result import ToolResult
+from lintro.tools import tool_manager
+from lintro.utils.execution.parallel_executor import (
+    _run_coroutine_blocking,
+    run_tools_parallel,
+)
+from lintro.utils.unified_config import UnifiedConfigManager
+
+
+class _FakeExecutor:
+    """Minimal stand-in for ``AsyncToolExecutor`` avoiding real tool runs."""
+
+    def __init__(self, max_workers: int) -> None:
+        """Store the requested worker count.
+
+        Args:
+            max_workers: Maximum parallel workers (unused by the fake).
+        """
+        self.max_workers = max_workers
+        self.shutdown_called = False
+
+    async def run_tools_parallel(
+        self,
+        tools: list[tuple[str, Any]],
+        paths: list[str],
+        action: Action,
+        on_result: Any = None,
+        max_fix_retries: int = 3,
+    ) -> list[tuple[str, ToolResult]]:
+        """Return a successful result for each tool without subprocess work.
+
+        Args:
+            tools: List of ``(tool_name, tool)`` tuples.
+            paths: Paths to process (unused).
+            action: Action to perform (unused).
+            on_result: Optional per-tool completion callback.
+            max_fix_retries: Fix retry budget (unused).
+
+        Returns:
+            A ``(tool_name, ToolResult)`` tuple for each input tool.
+        """
+        out: list[tuple[str, ToolResult]] = []
+        for name, _tool in tools:
+            result = ToolResult(
+                name=name,
+                success=True,
+                output="ok",
+                issues_count=0,
+            )
+            if on_result is not None:
+                on_result(name, result)
+            out.append((name, result))
+        return out
+
+    def shutdown(self) -> None:
+        """Record that shutdown was requested."""
+        self.shutdown_called = True
+
+
+@pytest.fixture
+def patched_parallel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch heavy collaborators so ``run_tools_parallel`` stays deterministic.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(async_module, "AsyncToolExecutor", _FakeExecutor)
+    monkeypatch.setattr(
+        async_module,
+        "get_parallel_batches",
+        lambda tools, tool_manager: [list(tools)],
+    )
+    monkeypatch.setattr(
+        tool_manager,
+        "get_tool",
+        lambda name: object(),
+    )
+    monkeypatch.setattr(
+        parallel_module,
+        "configure_tool_for_execution",
+        lambda **kwargs: kwargs["tool"],
+    )
+
+
+def _invoke() -> list[ToolResult]:
+    """Call ``run_tools_parallel`` with a single mock tool.
+
+    Returns:
+        The list of ``ToolResult`` objects produced by the executor.
+    """
+    return run_tools_parallel(
+        tools_to_run=["mock_tool"],
+        paths=["."],
+        action=Action.CHECK,
+        config_manager=cast(UnifiedConfigManager, object()),
+        tool_option_dict={},
+        exclude=None,
+        include_venv=False,
+        post_tools=set(),
+        max_workers=2,
+    )
+
+
+def test_parallel_executor_from_sync_context(patched_parallel: None) -> None:
+    """The executor runs normally from a synchronous context.
+
+    Args:
+        patched_parallel: Fixture patching heavy collaborators.
+    """
+    results = _invoke()
+
+    assert_that(results).is_length(1)
+    assert_that(results[0].name).is_equal_to("mock_tool")
+    assert_that(results[0].success).is_true()
+
+
+def test_parallel_executor_inside_running_loop(patched_parallel: None) -> None:
+    """The executor returns results when a loop is already running.
+
+    Args:
+        patched_parallel: Fixture patching heavy collaborators.
+    """
+
+    async def caller() -> list[ToolResult]:
+        # A loop is running in this thread; the executor must not crash.
+        return _invoke()
+
+    results = asyncio.run(caller())
+
+    assert_that(results).is_length(1)
+    assert_that(results[0].name).is_equal_to("mock_tool")
+    assert_that(results[0].success).is_true()
+
+
+def test_run_coroutine_blocking_from_sync_context() -> None:
+    """The helper runs a coroutine directly when no loop is running."""
+
+    async def coro() -> int:
+        return 21 * 2
+
+    assert_that(_run_coroutine_blocking(coro())).is_equal_to(42)
+
+
+def test_run_coroutine_blocking_inside_running_loop() -> None:
+    """The helper offloads to a worker thread when a loop is running."""
+
+    async def coro() -> str:
+        return "done"
+
+    async def caller() -> str:
+        return _run_coroutine_blocking(coro())
+
+    assert_that(asyncio.run(caller())).is_equal_to("done")


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(execution): handle BaseException in gather results and nested event loops
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Fixes two asyncio bugs in the parallel execution path:

**#1218 — `asyncio.gather` result handling misclassifies `BaseException`/`CancelledError`** (`lintro/utils/async_tool_executor.py`)

`run_tools_parallel` gathered with `return_exceptions=True` but classified failures with `isinstance(result, Exception)`. `CancelledError`, `KeyboardInterrupt`, and `SystemExit` derive from `BaseException`, not `Exception`, so they fell through into the success branch and were unpacked as `(tool_name, ToolResult)` tuples — corrupting results and swallowing cancellation (reproduced on main: `TypeError: cannot unpack non-iterable CancelledError object`).

Now:

- Fatal control-flow exceptions (`CancelledError`, `KeyboardInterrupt`, `SystemExit`) are re-raised after executor cleanup so cancellation/interrupt propagates predictably.
- Non-fatal per-tool exceptions still map to failed `ToolResult` entries (unchanged behavior).
- Only results that structurally match `(str, ToolResult)` enter the success branch; anything else becomes a failed `ToolResult` with a clear message instead of a silent unpack.

**#1222 — `asyncio.run()` nested-loop fragility** (`lintro/utils/execution/parallel_executor.py`)

`run_tools_parallel` called `asyncio.run()` unconditionally, which raises `RuntimeError: asyncio.run() cannot be called from a running event loop` when invoked from Jupyter, async web frameworks, or a programmatic library caller (reproduced on main). A new loop-aware runner `_run_coroutine_blocking`:

- No running loop in the current thread: uses `asyncio.run()` — CLI path byte-for-byte identical.
- Loop already running: dispatches the coroutine to a fresh loop in a dedicated worker thread and blocks for the result.

The docstring documents the embedding guarantee. Coordinates with the library-API extraction in #1217.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` + full `uv run pytest`)

## Related Issues

Closes #1218
Closes #1222
Related #1217

## Details

New tests (pytest style, no test classes, assertpy):

- `tests/unit/utils/async_tool_executor/test_base_exceptions.py` — cancellation re-raised, `KeyboardInterrupt`/`SystemExit` propagate, per-tool `ValueError` maps to failed `ToolResult`, malformed (non-tuple) gather result never corrupts results.
- `tests/unit/utils/execution/test_parallel_executor_loop.py` — executor works from a sync context (CLI path) and from inside an already-running event loop; direct coverage of `_run_coroutine_blocking` in both modes.

Testing: `uv run lintro chk` fully green (Total Issues 0). Full suite: **6299 passed, 10 skipped** (19 deselected: `tests/integration/tools/test_oxfmt_integration.py` and `test_cargo_deny_integration.py::test_check_no_cargo_toml`, which fail identically on pristine main due to local environment — oxfmt 0.43.0 < required 0.57.0).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes parallel tool execution handle fatal asyncio cases more predictably. The main changes are:

- Fatal gather results now propagate instead of being unpacked as successes.
- Non-fatal and malformed gather results now become failed tool results.
- Nested event-loop callers now run the async executor on a worker-thread loop.
- Unit tests cover BaseException handling and sync versus nested-loop execution.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/utils/async_tool_executor.py | Updates gather result processing to separate fatal exceptions, normal tool failures, and malformed results. |
| lintro/utils/execution/parallel_executor.py | Adds a loop-aware coroutine runner and uses it for batch execution. |
| tests/unit/utils/async_tool_executor/test_base_exceptions.py | Adds coverage for fatal exception propagation, failed tool results, and malformed gather output. |
| tests/unit/utils/execution/test_parallel_executor_loop.py | Adds coverage for sync calls and calls made while an event loop is already running. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/1218-execut..."](https://github.com/lgtm-hq/py-lintro/commit/ca6b9e11eab2e4c40f4dbe2b44291568fc8fc162) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43506180)</sub>

<!-- /greptile_comment -->