### PR TITLE
refactor(ai): remove process-global os.chdir from rerun path

### DIFF
--- a/lintro/ai/rerun.py
+++ b/lintro/ai/rerun.py
@@ -1,90 +1,47 @@
 """Tool re-execution service for post-fix verification.
 
 Re-runs tools on files modified by AI fixes to get fresh remaining
-issue counts, using the original tool execution cwd for consistency.
+issue counts. Files are passed as absolute paths so each tool resolves
+its own working directory from the target files, matching the directory
+used during the original run without mutating the process-global cwd.
 """
 
 from __future__ import annotations
 
-import os
-import threading
-from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loguru import logger
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from lintro.models.core.tool_result import ToolResult
     from lintro.parsers.base_issue import BaseIssue
 
-_rerun_cwd_lock = threading.Lock()
 
-
-@contextmanager
-def _tool_cwd(cwd: str | None) -> Iterator[None]:
-    """Context manager for tool execution in a specific cwd.
-
-    Uses a process-global lock because ``os.chdir`` is process-wide
-    and tools call ``subprocess.run`` internally without a ``cwd`` param.
-
-    Known V1 limitation: ``os.chdir()`` is process-global, so other
-    concurrent code sees the changed cwd even though the lock serializes
-    reruns. Long-term fix: pass ``cwd`` to ``subprocess.run`` in the
-    tool abstraction layer.
-
-    Args:
-        cwd: Directory to chdir into, or None to skip.
-    """
-    if not cwd:
-        yield
-        return
-
-    with _rerun_cwd_lock:
-        original_cwd = Path.cwd()
-        os.chdir(cwd)
-        try:
-            yield
-        finally:
-            os.chdir(original_cwd)
-
-
-def paths_for_context(
+def absolute_paths_for_context(
     *,
     file_paths: list[str],
-    cwd: str | None,
 ) -> list[str]:
-    """Prefer paths relative to tool cwd when possible.
+    """Resolve file paths to absolute form for cwd-explicit rerun.
+
+    Passing absolute paths lets each tool derive its subprocess working
+    directory from the common parent of the targets, which resolves the
+    same directory the original run used without relying on ``os.chdir``.
 
     Args:
-        file_paths: Absolute file paths to relativize.
-        cwd: Tool's original working directory.
+        file_paths: File paths to resolve. May be absolute or relative.
 
     Returns:
-        List of paths, made relative to cwd where possible.
+        List of absolute path strings. Unresolvable paths are returned
+        unchanged so the tool can surface its own error.
     """
-    if not cwd:
-        return file_paths
-
-    try:
-        cwd_path = Path(cwd).resolve()
-    except OSError:
-        return file_paths
-
-    contextual_paths: list[str] = []
+    resolved_paths: list[str] = []
     for file_path in file_paths:
         try:
-            resolved = Path(file_path).resolve()
+            resolved_paths.append(str(Path(file_path).resolve()))
         except OSError:
-            contextual_paths.append(file_path)
-            continue
-        try:
-            contextual_paths.append(str(resolved.relative_to(cwd_path)))
-        except ValueError:
-            contextual_paths.append(str(resolved))
-    return contextual_paths
+            resolved_paths.append(file_path)
+    return resolved_paths
 
 
 def rerun_tools(
@@ -92,7 +49,9 @@ def rerun_tools(
 ) -> list[ToolResult] | None:
     """Re-run tools on analyzed files to get fresh remaining issue counts.
 
-    Reuses the original tool execution cwd for path/config consistency.
+    Each tool is re-run against absolute file paths so it resolves the same
+    working directory (and therefore the same config) as the original run,
+    without mutating the process-global cwd.
 
     Args:
         by_tool: Dict mapping tool name to (result, issues) pairs.
@@ -106,17 +65,16 @@ def rerun_tools(
         return None
 
     rerun_results: list[ToolResult] = []
-    for tool_name, (result, issues) in by_tool.items():
+    for tool_name, (_result, issues) in by_tool.items():
         file_paths = sorted({issue.file for issue in issues if issue.file})
         if not file_paths:
             continue
 
-        rerun_paths = paths_for_context(file_paths=file_paths, cwd=result.cwd)
+        rerun_paths = absolute_paths_for_context(file_paths=file_paths)
 
         try:
             tool = tool_manager.get_tool(tool_name)
-            with _tool_cwd(result.cwd):
-                rerun_results.append(tool.check(rerun_paths, {}))
+            rerun_results.append(tool.check(rerun_paths, {}))
         except (KeyError, ImportError):
             logger.debug(
                 f"AI post-fix rerun skipped for {tool_name}: tool not available",

--- a/tests/unit/ai/test_orchestrator_multi.py
+++ b/tests/unit/ai/test_orchestrator_multi.py
@@ -12,7 +12,7 @@ from lintro.ai.config import AIConfig
 from lintro.ai.enums import AITransport
 from lintro.ai.models import AIFixSuggestion
 from lintro.ai.orchestrator import run_ai_enhancement
-from lintro.ai.rerun import _rerun_cwd_lock, paths_for_context, rerun_tools
+from lintro.ai.rerun import absolute_paths_for_context, rerun_tools
 from lintro.ai.validation import ValidationResult
 from lintro.config.lintro_config import LintroConfig
 from lintro.enums.action import Action
@@ -277,8 +277,8 @@ def test_run_ai_enhancement_fix_action_json_uses_fresh_rerun_results(
 # ---------------------------------------------------------------------------
 
 
-def test_rerun_context_paths_for_context_relativizes_to_tool_cwd(tmp_path):
-    """Paths inside tool cwd become relative; outside stay absolute."""
+def test_rerun_context_absolute_paths_for_context_resolves_targets(tmp_path):
+    """Target paths are resolved to absolute form for cwd-explicit rerun."""
     tool_cwd = tmp_path / "tool"
     tool_cwd.mkdir(parents=True)
     inside = tool_cwd / "src" / "main.py"
@@ -287,18 +287,28 @@ def test_rerun_context_paths_for_context_relativizes_to_tool_cwd(tmp_path):
     outside = tmp_path / "outside.py"
     outside.write_text("x = 1\n", encoding="utf-8")
 
-    rerun_paths = paths_for_context(
+    rerun_paths = absolute_paths_for_context(
         file_paths=[str(inside), str(outside)],
-        cwd=str(tool_cwd),
     )
 
-    assert_that(rerun_paths[0]).is_equal_to("src/main.py")
+    assert_that(rerun_paths[0]).is_equal_to(str(inside.resolve()))
     assert_that(rerun_paths[1]).is_equal_to(str(outside.resolve()))
 
 
 @patch("lintro.tools.tool_manager.get_tool")
-def test_rerun_context_rerun_uses_original_tool_cwd(mock_get_tool, tmp_path):
-    """Verify rerun_tools changes cwd to the original tool working directory."""
+def test_rerun_context_rerun_passes_absolute_paths_without_chdir(
+    mock_get_tool,
+    tmp_path,
+    monkeypatch,
+):
+    """rerun_tools hands absolute paths to the tool without any os.chdir."""
+    import os
+
+    def _fail_chdir(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("rerun_tools must not call os.chdir")
+
+    monkeypatch.setattr(os, "chdir", _fail_chdir)
+
     tool_cwd = tmp_path / "tool"
     tool_cwd.mkdir(parents=True)
     source = tool_cwd / "src" / "main.py"
@@ -327,8 +337,6 @@ def test_rerun_context_rerun_uses_original_tool_cwd(mock_get_tool, tmp_path):
 
     class _FakeTool:
         def check(self, paths: Any, options: Any) -> ToolResult:
-            import os
-
             captured["cwd"] = os.getcwd()
             captured["paths"] = paths
             return ToolResult(
@@ -339,19 +347,13 @@ def test_rerun_context_rerun_uses_original_tool_cwd(mock_get_tool, tmp_path):
             )
 
     mock_get_tool.return_value = _FakeTool()
+
+    before = os.getcwd()
     rerun_results = rerun_tools(by_tool)
 
     assert_that(rerun_results).is_length(1)
-    assert_that(captured.get("cwd")).is_equal_to(str(tool_cwd))
-    assert_that(captured.get("paths")).is_equal_to(["src/main.py"])
-
-
-def test_rerun_context_rerun_cwd_lock_exists():
-    """Verify the module-level threading lock is a Lock instance."""
-    # threading.Lock() returns a _thread.lock instance; verify it has
-    # the acquire/release protocol rather than comparing type identity.
-    assert_that(hasattr(_rerun_cwd_lock, "acquire")).is_true()
-    assert_that(hasattr(_rerun_cwd_lock, "release")).is_true()
+    assert_that(captured.get("cwd")).is_equal_to(before)
+    assert_that(captured.get("paths")).is_equal_to([str(source.resolve())])
 
 
 @patch("lintro.tools.tool_manager.get_tool")

--- a/tests/unit/ai/test_rerun.py
+++ b/tests/unit/ai/test_rerun.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from assertpy import assert_that
 
 from lintro.ai.rerun import (
-    _tool_cwd,
+    absolute_paths_for_context,
     apply_rerun_results,
-    paths_for_context,
     rerun_tools,
 )
 from lintro.models.core.tool_result import ToolResult
@@ -22,54 +23,147 @@ from .conftest import MockIssue
 _ByTool = dict[str, tuple[ToolResult, list[BaseIssue]]]
 
 
-# -- TestToolCwd: Tests for _tool_cwd context manager. -----------------------
+# -- TestAbsolutePathsForContext: Tests for absolute_paths_for_context. ------
 
 
-def test_tool_cwd_restores_original_cwd(tmp_path: Path) -> None:
-    """_tool_cwd changes cwd and restores it after exit."""
-    original = os.getcwd()
-    target = str(tmp_path)
+def test_absolute_paths_for_context_resolves_relative_paths(tmp_path: Path) -> None:
+    """Relative paths are resolved to absolute form for cwd-explicit rerun."""
+    child = tmp_path / "src" / "main.py"
+    child.parent.mkdir(parents=True)
+    child.write_text("x = 1\n", encoding="utf-8")
 
-    with _tool_cwd(target):
-        assert_that(os.getcwd()).is_equal_to(target)
+    monkeyed_cwd = os.getcwd()
+    try:
+        os.chdir(str(tmp_path))
+        result = absolute_paths_for_context(file_paths=["src/main.py"])
+    finally:
+        os.chdir(monkeyed_cwd)
 
-    assert_that(os.getcwd()).is_equal_to(original)
-
-
-def test_tool_cwd_skips_when_none() -> None:
-    """When cwd is None, the context manager yields without changing directory."""
-    original = os.getcwd()
-
-    with _tool_cwd(None):
-        assert_that(os.getcwd()).is_equal_to(original)
-
-    assert_that(os.getcwd()).is_equal_to(original)
+    assert_that(result).is_length(1)
+    assert_that(result[0]).is_equal_to(str(child.resolve()))
+    assert_that(Path(result[0]).is_absolute()).is_true()
 
 
-# -- TestPathsForContext: Tests for paths_for_context. -----------------------
+def test_absolute_paths_for_context_keeps_absolute_paths(tmp_path: Path) -> None:
+    """Already-absolute paths are returned in resolved absolute form."""
+    absolute = str(tmp_path / "a" / "b.py")
+
+    result = absolute_paths_for_context(file_paths=[absolute])
+
+    assert_that(result).is_length(1)
+    assert_that(result[0]).is_equal_to(str(Path(absolute).resolve()))
 
 
-def test_paths_for_context_relativizes_paths(tmp_path: Path) -> None:
-    """Given absolute paths and a cwd, returns relative paths for children."""
-    cwd = str(tmp_path)
-    child = str(tmp_path / "src" / "main.py")
-    outside = "/some/other/path/file.py"
-
-    result = paths_for_context(file_paths=[child, outside], cwd=cwd)
-
-    assert_that(result).is_length(2)
-    assert_that(result[0]).is_equal_to(str(Path("src") / "main.py"))
-    # Outside path stays absolute (resolved)
-    assert_that(result[1]).is_equal_to(str(Path(outside).resolve()))
+# -- TestRerunNoChdir: rerun must never mutate the process-global cwd. -------
 
 
-def test_paths_for_context_returns_originals_when_no_cwd() -> None:
-    """When cwd is None, returns original paths unchanged."""
-    paths = ["/a/b/c.py", "/d/e/f.py"]
+@patch("lintro.tools.tool_manager.get_tool")
+def test_ai_rerun_does_not_chdir(
+    mock_get_tool: MagicMock,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """rerun_tools must not call os.chdir; the process cwd stays unchanged."""
 
-    result = paths_for_context(file_paths=paths, cwd=None)
+    def _fail_chdir(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("rerun_tools must not call os.chdir")
 
-    assert_that(result).is_equal_to(paths)
+    monkeypatch.setattr(os, "chdir", _fail_chdir)
+
+    source = tmp_path / "src" / "main.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("x = 1\n", encoding="utf-8")
+
+    issue = MockIssue(
+        file=str(source),
+        line=1,
+        column=1,
+        message="test",
+        code="E501",
+        severity="warning",
+    )
+    result = ToolResult(
+        name="ruff",
+        success=False,
+        issues_count=1,
+        issues=[issue],
+        cwd=str(tmp_path),
+    )
+    by_tool: _ByTool = {"ruff": (result, [issue])}
+
+    captured: dict[str, Any] = {}
+
+    class _FakeTool:
+        def check(self, paths: Any, options: Any) -> ToolResult:
+            captured["paths"] = paths
+            return ToolResult(name="ruff", success=True, issues_count=0, issues=[])
+
+    mock_get_tool.return_value = _FakeTool()
+
+    before = os.getcwd()
+    results = rerun_tools(by_tool)
+    after = os.getcwd()
+
+    assert_that(after).is_equal_to(before)
+    assert_that(results).is_length(1)
+    # Tool receives absolute paths so it derives its own cwd.
+    assert_that(captured["paths"]).is_equal_to([str(source.resolve())])
+
+
+@patch("lintro.plugins.base.run_subprocess")
+def test_ai_rerun_passes_cwd_to_subprocess(
+    mock_run_subprocess: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """The stubbed subprocess layer receives the intended cwd during rerun.
+
+    A real tool (ruff) is re-run through ``rerun_tools`` with the subprocess
+    layer stubbed. Because rerun passes absolute paths, the tool resolves its
+    working directory from the target file's parent and hands that cwd to
+    ``run_subprocess`` — no process-global ``os.chdir`` involved.
+    """
+    from lintro.plugins.subprocess_executor import SubprocessResult
+
+    source = tmp_path / "main.py"
+    source.write_text("x = 1\n", encoding="utf-8")
+    expected_cwd = str(source.resolve().parent)
+
+    captured_cwds: list[str | None] = []
+
+    def _fake_run_subprocess(
+        cmd: list[str],
+        timeout: float,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        stdin: int | None = None,
+    ) -> SubprocessResult:
+        captured_cwds.append(cwd)
+        return SubprocessResult(returncode=0, stdout="", stderr="", output="")
+
+    mock_run_subprocess.side_effect = _fake_run_subprocess
+
+    issue = MockIssue(
+        file=str(source),
+        line=1,
+        column=1,
+        message="test",
+        code="E501",
+        severity="warning",
+    )
+    result = ToolResult(
+        name="ruff",
+        success=False,
+        issues_count=1,
+        issues=[issue],
+        cwd=expected_cwd,
+    )
+    by_tool: _ByTool = {"ruff": (result, [issue])}
+
+    results = rerun_tools(by_tool)
+
+    assert_that(results).is_length(1)
+    assert_that(captured_cwds).is_not_empty()
+    assert_that(captured_cwds).contains(expected_cwd)
 
 
 # -- TestRerunTools: Tests for rerun_tools. ----------------------------------


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(ai): remove process-global os.chdir from rerun path
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Removes the process-global `os.chdir` from the AI post-fix rerun path
(`lintro/ai/rerun.py`) and replaces it with cwd-explicit execution.

Previously, `rerun_tools` wrapped each tool re-check in a `_tool_cwd`
context manager that called `os.chdir` under a module-level threading
lock. `os.chdir` is process-wide, so any concurrent code observed the
mutated working directory even though the lock serialized reruns —
a known V1 limitation called out in the module itself.

Now `rerun_tools` passes absolute file paths to `tool.check()`. Every
tool already derives its subprocess working directory from the common
parent of its target files (via `get_cwd` / `prepare_execution`) and
hands that `cwd` explicitly to the subprocess executor, so the rerun
resolves the same directory (and the same tool config) as the original
run without touching process state.

- `_tool_cwd` context manager and `_rerun_cwd_lock` removed.
- `paths_for_context` (relativize-to-cwd) replaced by
  `absolute_paths_for_context` (resolve-to-absolute).
- No intermediate helpers needed changes: the subprocess executor and
  plugin base already accept `cwd` explicitly end to end.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` + full `uv run pytest`)

## Related Issues

Closes #1223

## Details

Testing strategy:

- `test_ai_rerun_does_not_chdir`: monkeypatches `os.chdir` to raise,
  runs the rerun path with a stubbed tool, and asserts the process cwd
  is unchanged and the tool receives absolute paths.
- `test_ai_rerun_passes_cwd_to_subprocess`: re-runs a real tool (ruff)
  through `rerun_tools` with the subprocess layer stubbed and asserts
  `run_subprocess` receives the expected explicit `cwd` (the target
  file's parent), proving cwd-explicit execution end to end.
- Existing chdir-asserting tests in `test_orchestrator_multi.py` were
  replaced with no-chdir/absolute-path equivalents; the
  `_rerun_cwd_lock` existence test was removed with the lock.

Verification: `uv run lintro chk` clean (0 issues); full suite
`uv run pytest` — 6308 passed, 10 skipped, 0 failed. All assertions
use assertpy; no test classes.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes AI post-fix reruns to avoid mutating the process cwd. The main changes are:

- Removal of the chdir context manager and rerun cwd lock.
- Absolute-path handoff from rerun code into tool checks.
- Updated tests for no-chdir behavior and subprocess cwd propagation.
</details>

<h3>Confidence Score: 4/5</h3>

This is close, but the rerun path can still produce incorrect results.

- Relative issue paths can resolve against the current process cwd instead of the original tool cwd.
- The tool can then check the wrong file or load config from the wrong directory.
- The updated tests cover absolute inputs but not this relative-path case.

lintro/ai/rerun.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/ai/rerun.py | Replaces chdir-based reruns with absolute-path reruns, but relative issue paths can still resolve from the wrong directory. |
| tests/unit/ai/test_rerun.py | Updates rerun coverage for no-chdir behavior and subprocess cwd propagation. |
| tests/unit/ai/test_orchestrator_multi.py | Updates orchestrator rerun expectations for absolute-path tool inputs. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Fai%2Frerun.py%3A41%0A**Resolve%20Against%20Tool%20Cwd**%0A%0A%60Path%28file_path%29.resolve%28%29%60%20still%20uses%20the%20current%20process%20cwd%20for%20relative%20%60issue.file%60%20values.%20When%20a%20parser%20reports%20a%20path%20like%20%60src%2Ffoo.py%60%20and%20the%20rerun%20runs%20from%20a%20different%20directory%20than%20the%20original%20tool%20execution%2C%20this%20turns%20the%20issue%20path%20into%20%60%2Fcurrent%2Fcwd%2Fsrc%2Ffoo.py%60%20instead%20of%20resolving%20it%20under%20the%20recorded%20tool%20cwd.%20The%20rerun%20tool%20can%20then%20check%20a%20missing%20or%20unrelated%20file%20and%20derive%20its%20subprocess%20cwd%2Fconfig%20from%20the%20wrong%20location%2C%20leaving%20the%20remaining%20issue%20count%20stale%20or%20incorrect.%0A%0A&pr=1265&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Fai%2Frerun.py%3A41%0A**Resolve%20Against%20Tool%20Cwd**%0A%0A%60Path%28file_path%29.resolve%28%29%60%20still%20uses%20the%20current%20process%20cwd%20for%20relative%20%60issue.file%60%20values.%20When%20a%20parser%20reports%20a%20path%20like%20%60src%2Ffoo.py%60%20and%20the%20rerun%20runs%20from%20a%20different%20directory%20than%20the%20original%20tool%20execution%2C%20this%20turns%20the%20issue%20path%20into%20%60%2Fcurrent%2Fcwd%2Fsrc%2Ffoo.py%60%20instead%20of%20resolving%20it%20under%20the%20recorded%20tool%20cwd.%20The%20rerun%20tool%20can%20then%20check%20a%20missing%20or%20unrelated%20file%20and%20derive%20its%20subprocess%20cwd%2Fconfig%20from%20the%20wrong%20location%2C%20leaving%20the%20remaining%20issue%20count%20stale%20or%20incorrect.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1265&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22refactor%2F1223-remove-ai-chdir%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2F1223-remove-ai-chdir%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Fai%2Frerun.py%3A41%0A**Resolve%20Against%20Tool%20Cwd**%0A%0A%60Path%28file_path%29.resolve%28%29%60%20still%20uses%20the%20current%20process%20cwd%20for%20relative%20%60issue.file%60%20values.%20When%20a%20parser%20reports%20a%20path%20like%20%60src%2Ffoo.py%60%20and%20the%20rerun%20runs%20from%20a%20different%20directory%20than%20the%20original%20tool%20execution%2C%20this%20turns%20the%20issue%20path%20into%20%60%2Fcurrent%2Fcwd%2Fsrc%2Ffoo.py%60%20instead%20of%20resolving%20it%20under%20the%20recorded%20tool%20cwd.%20The%20rerun%20tool%20can%20then%20check%20a%20missing%20or%20unrelated%20file%20and%20derive%20its%20subprocess%20cwd%2Fconfig%20from%20the%20wrong%20location%2C%20leaving%20the%20remaining%20issue%20count%20stale%20or%20incorrect.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1265&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into refactor/1223-r..."](https://github.com/lgtm-hq/py-lintro/commit/19b2bf0fe9b8514d6b5e0afc6a6d2e325fa73549) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43506199)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->