### PR TITLE
fix(tools): preserve explicit timeout=0 and route ruff through _prepare_execution

### DIFF
--- a/lintro/plugins/execution_preparation.py
+++ b/lintro/plugins/execution_preparation.py
@@ -187,6 +187,7 @@ def prepare_execution(
         exclude_patterns=exclude_patterns,
         include_venv=include_venv,
         diff_base=diff_base if isinstance(diff_base, str) else None,
+        incremental=bool(merged_options.get("incremental", False)),
     )
 
     if not files:

--- a/lintro/plugins/file_discovery.py
+++ b/lintro/plugins/file_discovery.py
@@ -75,6 +75,7 @@ def discover_files(
     include_venv: bool = False,
     show_progress: bool = True,
     diff_base: str | None = None,
+    incremental: bool = False,
 ) -> list[str]:
     """Discover files matching the tool's patterns.
 
@@ -86,6 +87,9 @@ def discover_files(
         show_progress: Whether to show a progress spinner during discovery.
         diff_base: Resolved git base ref. When set, restricts discovery to files
             changed relative to this ref.
+        incremental: When True, restrict discovery to files changed since the
+            last run using the per-tool fingerprint cache. The tool name is
+            taken from ``definition.name`` for the cache key.
 
     Returns:
         List of matching file paths.
@@ -105,6 +109,8 @@ def discover_files(
             file_patterns=definition.file_patterns,
             exclude_patterns=exclude_patterns,
             include_venv=include_venv,
+            incremental=incremental,
+            tool_name=definition.name,
             diff_base=diff_base,
         )
         progress.update(task, description=f"Found {len(files)} files")

--- a/lintro/tools/core/timeout_utils.py
+++ b/lintro/tools/core/timeout_utils.py
@@ -35,10 +35,20 @@ def run_subprocess_with_timeout(
     This is a wrapper around tool._run_subprocess that provides consistent
     timeout error handling and messaging across different tools.
 
+    Timeout resolution policy:
+        Only ``None`` triggers the fallback to the tool's configured/default
+        timeout. Any explicit numeric value provided by the caller is
+        preserved verbatim, including ``0``. A ``timeout`` of ``0`` is treated
+        as a valid caller-provided value (an effectively immediate deadline)
+        and is reported as-is in error messages rather than being silently
+        replaced by the default. Callers that want no timeout must pass
+        ``None`` explicitly.
+
     Args:
         tool: Tool instance with _run_subprocess method.
         cmd: Command to run.
-        timeout: Timeout in seconds. If None, uses tool's default timeout.
+        timeout: Timeout in seconds. If None, uses tool's configured or default
+            timeout. An explicit ``0`` is preserved (not treated as missing).
         cwd: Working directory for command execution.
         tool_name: Name of the tool for error messages. If None, uses tool.name.
 
@@ -56,8 +66,15 @@ def run_subprocess_with_timeout(
         success, output = tool._run_subprocess(cmd=cmd, timeout=timeout, cwd=cwd)
         return bool(success), str(output)
     except subprocess.TimeoutExpired as e:
-        # Re-raise with more context for the calling tool
-        actual_timeout = timeout or tool.options.get("timeout", tool._default_timeout)
+        # Re-raise with more context for the calling tool. Only ``None`` falls
+        # back to the configured/default timeout; an explicit ``0`` (or any
+        # other numeric value) is preserved so the message reflects the actual
+        # deadline that was enforced.
+        actual_timeout = (
+            timeout
+            if timeout is not None
+            else tool.options.get("timeout", tool._default_timeout)
+        )
         timeout_msg = (
             f"{tool_name} execution timed out ({actual_timeout}s limit exceeded).\n\n"
             "This may indicate:\n"

--- a/lintro/tools/implementations/ruff/check.py
+++ b/lintro/tools/implementations/ruff/check.py
@@ -16,17 +16,19 @@ from lintro.parsers.ruff.ruff_parser import (
 )
 from lintro.tools.core.timeout_utils import (
     create_timeout_result,
-    get_timeout_value,
     run_subprocess_with_timeout,
 )
-from lintro.utils.path_filtering import walk_files_with_excludes
+
+# Re-exported so callers keep a single source of truth for the default Ruff
+# timeout (defined in lintro.tools.definitions.ruff). Importing here preserves
+# the historical ``from ...ruff.check import RUFF_DEFAULT_TIMEOUT`` entry point.
+from lintro.tools.definitions.ruff import RUFF_DEFAULT_TIMEOUT
 
 if TYPE_CHECKING:
     from lintro.models.core.tool_result import ToolResult
     from lintro.tools.definitions.ruff import RuffPlugin
 
-# Default timeout for Ruff operations
-RUFF_DEFAULT_TIMEOUT: int = 30
+__all__ = ["RUFF_DEFAULT_TIMEOUT", "execute_ruff_check"]
 
 
 def execute_ruff_check(
@@ -48,62 +50,23 @@ def execute_ruff_check(
         build_ruff_format_command,
     )
 
-    # Check version requirements
-    version_result = tool._verify_tool_version()
-    if version_result is not None:
-        return version_result
-
-    tool._validate_paths(paths=paths)
-    if not paths:
-        return ToolResult(
-            name=tool.definition.name,
-            success=True,
-            output="No files to check.",
-            issues_count=0,
-        )
-
-    # Use shared utility for file discovery
-    diff_base_opt = tool.options.get("diff_base")
-    diff_base = diff_base_opt if isinstance(diff_base_opt, str) else None
-    python_files: list[str] = walk_files_with_excludes(
+    # Delegate file discovery, version checking, cwd/rel-path computation, and
+    # timeout resolution to the shared preparation pipeline so ruff behaves
+    # consistently with every other tool plugin.
+    ctx = tool._prepare_execution(
         paths=paths,
-        file_patterns=tool.definition.file_patterns,
-        exclude_patterns=tool.exclude_patterns,
-        include_venv=tool.include_venv,
-        incremental=bool(tool.options.get("incremental", False)),
-        tool_name="ruff",
-        diff_base=diff_base,
+        options={},
+        no_files_message="No files to check.",
     )
+    if ctx.should_skip:
+        return ctx.early_result  # type: ignore[return-value]
 
-    if not python_files:
-        return ToolResult(
-            name=tool.definition.name,
-            success=True,
-            output="No Python files found to check.",
-            issues_count=0,
-        )
-
-    # Ensure Ruff discovers the correct configuration by setting the
-    # working directory to the common parent of the target files and by
-    # passing file paths relative to that directory.
-    cwd: str | None = tool._get_cwd(paths=python_files)
-    rel_files: list[str] = []
-    for f in python_files:
-        if cwd:
-            try:
-                # Try to get relative path; may fail on Windows
-                # if paths are on different drives
-                rel_path = os.path.relpath(f, cwd)
-                rel_files.append(rel_path)
-            except ValueError:
-                # Paths are on different drives (Windows) or other error
-                # - use absolute path
-                rel_files.append(os.path.abspath(f))
-        else:
-            # No common directory - use absolute paths
-            rel_files.append(os.path.abspath(f))
-
-    timeout: int = get_timeout_value(tool, RUFF_DEFAULT_TIMEOUT)
+    # Ruff must run from the common parent directory of the target files (so it
+    # discovers the correct configuration) and receive file paths relative to
+    # that directory.
+    cwd: str | None = ctx.cwd
+    rel_files: list[str] = ctx.rel_files
+    timeout: int = int(ctx.timeout)
     # Lint check
     cmd: list[str] = build_ruff_check_command(tool=tool, files=rel_files, fix=False)
     success_lint: bool

--- a/lintro/tools/implementations/ruff/fix.py
+++ b/lintro/tools/implementations/ruff/fix.py
@@ -14,18 +14,19 @@ from lintro.parsers.ruff.ruff_parser import (
     parse_ruff_format_check_output,
     parse_ruff_output,
 )
-from lintro.tools.core.timeout_utils import (
-    create_timeout_result,
-    get_timeout_value,
-)
-from lintro.utils.path_filtering import walk_files_with_excludes
+from lintro.tools.core.timeout_utils import create_timeout_result
+
+# Re-exported so callers keep a single source of truth for the default Ruff
+# timeout (defined in lintro.tools.definitions.ruff). Importing here preserves
+# the historical ``from ...ruff.fix import RUFF_DEFAULT_TIMEOUT`` entry point.
+from lintro.tools.definitions.ruff import RUFF_DEFAULT_TIMEOUT
 
 if TYPE_CHECKING:
     from lintro.models.core.tool_result import ToolResult
     from lintro.tools.definitions.ruff import RuffPlugin
 
-# Constants from tool_ruff.py
-RUFF_DEFAULT_TIMEOUT: int = 30
+__all__ = ["RUFF_DEFAULT_TIMEOUT", "execute_ruff_fix"]
+
 DEFAULT_REMAINING_ISSUES_DISPLAY: int = 5
 
 
@@ -88,42 +89,19 @@ def execute_ruff_fix(
         build_ruff_format_command,
     )
 
-    # Check version requirements
-    version_result = tool._verify_tool_version()
-    if version_result is not None:
-        return version_result
-
-    tool._validate_paths(paths=paths)
-    if not paths:
-        return ToolResult(
-            name=tool.definition.name,
-            success=True,
-            output="No files to fix.",
-            issues_count=0,
-        )
-
-    # Use shared utility for file discovery
-    diff_base_opt = tool.options.get("diff_base")
-    diff_base = diff_base_opt if isinstance(diff_base_opt, str) else None
-    python_files: list[str] = walk_files_with_excludes(
+    # Delegate file discovery, version checking, and timeout resolution to the
+    # shared preparation pipeline so ruff behaves consistently with every other
+    # tool plugin.
+    ctx = tool._prepare_execution(
         paths=paths,
-        file_patterns=tool.definition.file_patterns,
-        exclude_patterns=tool.exclude_patterns,
-        include_venv=tool.include_venv,
-        incremental=bool(tool.options.get("incremental", False)),
-        tool_name="ruff",
-        diff_base=diff_base,
+        options={},
+        no_files_message="No files to fix.",
     )
+    if ctx.should_skip:
+        return ctx.early_result  # type: ignore[return-value]
 
-    if not python_files:
-        return ToolResult(
-            name=tool.definition.name,
-            success=True,
-            output="No Python files found to fix.",
-            issues_count=0,
-        )
-
-    timeout: int = get_timeout_value(tool, RUFF_DEFAULT_TIMEOUT)
+    python_files: list[str] = ctx.files
+    timeout: int = int(ctx.timeout)
     overall_success: bool = True
 
     # Track unsafe fixes for internal decisioning; do not emit as user-facing noise

--- a/tests/unit/tools/ruff/check/test_config_detection.py
+++ b/tests/unit/tools/ruff/check/test_config_detection.py
@@ -12,16 +12,12 @@ from lintro.tools.implementations.ruff.check import execute_ruff_check
 def test_execute_ruff_check_uses_cwd_for_config_discovery(
     mock_ruff_tool: MagicMock,
 ) -> None:
-    """Use cwd for config file discovery.
+    """Use cwd from the prepared execution context for config discovery.
 
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
     """
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["/test/project/test.py"],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(True, "[]"),
@@ -33,10 +29,10 @@ def test_execute_ruff_check_uses_cwd_for_config_discovery(
     ):
         execute_ruff_check(mock_ruff_tool, ["/test/project"])
 
-        # Verify _get_cwd was called to determine working directory
-        mock_ruff_tool._get_cwd.assert_called()
+        # Verify the shared preparation pipeline resolved the working directory
+        mock_ruff_tool._prepare_execution.assert_called()
 
-        # Verify subprocess was called with cwd
+        # Verify subprocess was called with cwd from the execution context
         mock_subprocess.assert_called()
         call_kwargs = mock_subprocess.call_args
         assert_that(call_kwargs.kwargs.get("cwd")).is_equal_to("/test/project")
@@ -56,10 +52,6 @@ def test_execute_ruff_check_with_config_args(
     ]
 
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(True, "[]"),

--- a/tests/unit/tools/ruff/check/test_error_handling.py
+++ b/tests/unit/tools/ruff/check/test_error_handling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess  # nosec B404 - subprocess is used to drive the tool/CLI under test; invocations use shell=False
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 from assertpy import assert_that
@@ -20,15 +21,9 @@ def test_execute_ruff_check_handles_timeout(
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
     """
-    with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
-        patch(
-            "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
-            side_effect=subprocess.TimeoutExpired(cmd=["ruff"], timeout=30),
-        ),
+    with patch(
+        "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
+        side_effect=subprocess.TimeoutExpired(cmd=["ruff"], timeout=30),
     ):
         result = execute_ruff_check(mock_ruff_tool, ["/test/project"])
 
@@ -51,10 +46,6 @@ def test_execute_ruff_check_handles_format_timeout(
     ]
 
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
         ) as mock_subprocess,
@@ -92,10 +83,6 @@ def test_execute_ruff_check_subprocess_failure_respected(
     """
     with (
         patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
-        patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             # Subprocess fails (exit code != 0) but produces empty/no output
             return_value=(False, "[]"),
@@ -115,11 +102,16 @@ def test_execute_ruff_check_subprocess_failure_respected(
 
 def test_execute_ruff_check_version_check_failure(
     mock_ruff_tool: MagicMock,
+    ruff_execution_context: Callable[..., MagicMock],
 ) -> None:
-    """Return early when version check fails.
+    """Return early when the prepared context reports a version failure.
+
+    Version checking now happens inside the shared ``_prepare_execution``
+    pipeline, which surfaces the failure via ``early_result``.
 
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
+        ruff_execution_context: Factory for mock execution contexts.
     """
     version_error_result = ToolResult(
         name="ruff",
@@ -127,7 +119,9 @@ def test_execute_ruff_check_version_check_failure(
         output="Skipping ruff: version too old",
         issues_count=0,
     )
-    mock_ruff_tool._verify_tool_version.return_value = version_error_result
+    mock_ruff_tool._prepare_execution.return_value = ruff_execution_context(
+        early_result=version_error_result,
+    )
 
     result = execute_ruff_check(mock_ruff_tool, ["/test/project"])
 

--- a/tests/unit/tools/ruff/check/test_format_normalization.py
+++ b/tests/unit/tools/ruff/check/test_format_normalization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import cast
 from unittest.mock import MagicMock, patch
 
@@ -13,20 +14,22 @@ from lintro.tools.implementations.ruff.check import execute_ruff_check
 
 def test_execute_ruff_check_normalizes_format_paths_to_absolute(
     mock_ruff_tool: MagicMock,
+    ruff_execution_context: Callable[..., MagicMock],
 ) -> None:
     """Normalize format check file paths to absolute paths.
 
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
+        ruff_execution_context: Factory for mock execution contexts.
     """
     mock_ruff_tool.options["format_check"] = True
-    mock_ruff_tool._get_cwd.return_value = "/test/project"
+    mock_ruff_tool._prepare_execution.return_value = ruff_execution_context(
+        files=["/test/project/test.py"],
+        rel_files=["test.py"],
+        cwd="/test/project",
+    )
 
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["/test/project/test.py"],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
         ) as mock_subprocess,

--- a/tests/unit/tools/ruff/check/test_json_parsing.py
+++ b/tests/unit/tools/ruff/check/test_json_parsing.py
@@ -25,10 +25,6 @@ def test_execute_ruff_check_parses_json_output_correctly(
 
     with (
         patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
-        patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(False, sample_ruff_json_output),
         ),
@@ -69,10 +65,6 @@ def test_execute_ruff_check_empty_json_output(
     """
     with (
         patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
-        patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(True, sample_ruff_json_empty_output),
         ),
@@ -103,14 +95,6 @@ def test_execute_ruff_check_parses_format_check_output(
 
     with (
         patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py", "src/module.py"],
-        ),
-        patch(
-            "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
-            return_value=(True, ""),
-        ),
-        patch(
             "lintro.tools.implementations.ruff.check.parse_ruff_output",
             return_value=[],
         ),
@@ -118,19 +102,18 @@ def test_execute_ruff_check_parses_format_check_output(
             "lintro.tools.implementations.ruff.check.parse_ruff_format_check_output",
             side_effect=parse_ruff_format_check_output,
         ),
-    ):
-        # Need a separate mock for the format check subprocess call
-        with patch(
+        patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
-        ) as mock_subprocess:
-            # First call: lint check, Second call: format check
-            mock_subprocess.side_effect = [
-                (True, "[]"),
-                (False, sample_ruff_format_check_output),
-            ]
+        ) as mock_subprocess,
+    ):
+        # First call: lint check, Second call: format check
+        mock_subprocess.side_effect = [
+            (True, "[]"),
+            (False, sample_ruff_format_check_output),
+        ]
 
-            result = execute_ruff_check(mock_ruff_tool, ["/test/project"])
+        result = execute_ruff_check(mock_ruff_tool, ["/test/project"])
 
-            # Format check subprocess failed, so overall result should be failure
-            assert_that(result.success).is_false()
-            assert_that(result.issues_count).is_equal_to(2)
+        # Format check subprocess failed, so overall result should be failure
+        assert_that(result.success).is_false()
+        assert_that(result.issues_count).is_equal_to(2)

--- a/tests/unit/tools/ruff/check/test_no_issues.py
+++ b/tests/unit/tools/ruff/check/test_no_issues.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 from assertpy import assert_that
 
+from lintro.models.core.tool_result import ToolResult
 from lintro.tools.implementations.ruff.check import execute_ruff_check
 
 
@@ -18,10 +20,6 @@ def test_execute_ruff_check_no_issues_returns_success(
         mock_ruff_tool: Mock RuffTool instance for testing.
     """
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(True, "[]"),
@@ -50,10 +48,6 @@ def test_execute_ruff_check_no_issues_with_format_check(
 
     with (
         patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
-        patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(True, ""),
         ),
@@ -74,13 +68,22 @@ def test_execute_ruff_check_no_issues_with_format_check(
 
 def test_execute_ruff_check_empty_paths_returns_no_files_message(
     mock_ruff_tool: MagicMock,
+    ruff_execution_context: Callable[..., MagicMock],
 ) -> None:
-    """Return no files message when paths list is empty after validation.
+    """Return no files message when the prepared context short-circuits.
 
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
+        ruff_execution_context: Factory for mock execution contexts.
     """
-    mock_ruff_tool._validate_paths.return_value = None
+    mock_ruff_tool._prepare_execution.return_value = ruff_execution_context(
+        early_result=ToolResult(
+            name="ruff",
+            success=True,
+            output="No files to check.",
+            issues_count=0,
+        ),
+    )
 
     result = execute_ruff_check(mock_ruff_tool, [])
 
@@ -91,18 +94,25 @@ def test_execute_ruff_check_empty_paths_returns_no_files_message(
 
 def test_execute_ruff_check_no_python_files_found(
     mock_ruff_tool: MagicMock,
+    ruff_execution_context: Callable[..., MagicMock],
 ) -> None:
-    """Return no Python files message when no matching files are discovered.
+    """Return no files message when no matching files are discovered.
 
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
+        ruff_execution_context: Factory for mock execution contexts.
     """
-    with patch(
-        "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-        return_value=[],
-    ):
-        result = execute_ruff_check(mock_ruff_tool, ["/test/project"])
+    mock_ruff_tool._prepare_execution.return_value = ruff_execution_context(
+        early_result=ToolResult(
+            name="ruff",
+            success=True,
+            output="No py/pyi files found to check.",
+            issues_count=0,
+        ),
+    )
 
-        assert_that(result.success).is_true()
-        assert_that(result.output).is_equal_to("No Python files found to check.")
-        assert_that(result.issues_count).is_equal_to(0)
+    result = execute_ruff_check(mock_ruff_tool, ["/test/project"])
+
+    assert_that(result.success).is_true()
+    assert_that(result.output).is_equal_to("No py/pyi files found to check.")
+    assert_that(result.issues_count).is_equal_to(0)

--- a/tests/unit/tools/ruff/check/test_output_format.py
+++ b/tests/unit/tools/ruff/check/test_output_format.py
@@ -20,10 +20,6 @@ def test_execute_ruff_check_output_is_none_on_success(
     """
     with (
         patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
-        patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(True, "[]"),
         ),
@@ -51,10 +47,6 @@ def test_execute_ruff_check_output_is_none_with_issues(
     ]
 
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(False, "[]"),

--- a/tests/unit/tools/ruff/check/test_output_truncation.py
+++ b/tests/unit/tools/ruff/check/test_output_truncation.py
@@ -26,10 +26,6 @@ def test_check_failure_logs_output_to_debug_only(
 
     with (
         patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
-        patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(False, long_output),
         ),
@@ -76,10 +72,6 @@ def test_format_check_failure_logs_output_to_debug_only(
     long_format_output = "Would reformat: " + "x" * 3000
 
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
         ) as mock_subprocess,
@@ -132,10 +124,6 @@ def test_check_success_does_not_log_output(
         mock_ruff_tool: Mock RuffTool instance for testing.
     """
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(True, "[]"),

--- a/tests/unit/tools/ruff/check/test_path_filtering.py
+++ b/tests/unit/tools/ruff/check/test_path_filtering.py
@@ -1,7 +1,14 @@
-"""Tests for path filtering in execute_ruff_check."""
+"""Tests for path handling in execute_ruff_check.
+
+File discovery, exclude patterns, and venv handling are owned by the shared
+``BaseToolPlugin._prepare_execution`` pipeline. These tests verify that
+``execute_ruff_check`` delegates discovery to that pipeline and consumes the
+resulting execution context (relative files and cwd) when building commands.
+"""
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 from assertpy import assert_that
@@ -9,19 +16,15 @@ from assertpy import assert_that
 from lintro.tools.implementations.ruff.check import execute_ruff_check
 
 
-def test_execute_ruff_check_filters_python_files(
+def test_execute_ruff_check_delegates_discovery_to_prepare_execution(
     mock_ruff_tool: MagicMock,
 ) -> None:
-    """Filter files to only Python files.
+    """Delegate file discovery to the shared preparation pipeline.
 
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
     """
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py", "module.pyi"],
-        ) as mock_walk,
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(True, "[]"),
@@ -33,92 +36,31 @@ def test_execute_ruff_check_filters_python_files(
     ):
         execute_ruff_check(mock_ruff_tool, ["/test/project"])
 
-        mock_walk.assert_called_once()
-        call_kwargs = mock_walk.call_args.kwargs
-        assert_that(call_kwargs["file_patterns"]).contains("*.py", "*.pyi")
-
-
-def test_execute_ruff_check_uses_exclude_patterns(
-    mock_ruff_tool: MagicMock,
-) -> None:
-    """Pass exclude patterns to file walker.
-
-    Args:
-        mock_ruff_tool: Mock RuffTool instance for testing.
-    """
-    mock_ruff_tool.exclude_patterns = ["*_test.py", "__pycache__"]
-
-    with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["main.py"],
-        ) as mock_walk,
-        patch(
-            "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
-            return_value=(True, "[]"),
-        ),
-        patch(
-            "lintro.tools.implementations.ruff.check.parse_ruff_output",
-            return_value=[],
-        ),
-    ):
-        execute_ruff_check(mock_ruff_tool, ["/test/project"])
-
-        call_kwargs = mock_walk.call_args.kwargs
-        assert_that(call_kwargs["exclude_patterns"]).contains(
-            "*_test.py",
-            "__pycache__",
-        )
-
-
-def test_execute_ruff_check_respects_include_venv(
-    mock_ruff_tool: MagicMock,
-) -> None:
-    """Pass include_venv setting to file walker.
-
-    Args:
-        mock_ruff_tool: Mock RuffTool instance for testing.
-    """
-    mock_ruff_tool.include_venv = True
-
-    with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ) as mock_walk,
-        patch(
-            "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
-            return_value=(True, "[]"),
-        ),
-        patch(
-            "lintro.tools.implementations.ruff.check.parse_ruff_output",
-            return_value=[],
-        ),
-    ):
-        execute_ruff_check(mock_ruff_tool, ["/test/project"])
-
-        call_kwargs = mock_walk.call_args.kwargs
-        assert_that(call_kwargs["include_venv"]).is_true()
+        mock_ruff_tool._prepare_execution.assert_called_once()
+        call = mock_ruff_tool._prepare_execution.call_args
+        assert_that(call.kwargs.get("paths")).is_equal_to(["/test/project"])
 
 
 def test_execute_ruff_check_converts_paths_to_relative(
     mock_ruff_tool: MagicMock,
+    ruff_execution_context: Callable[..., MagicMock],
 ) -> None:
-    """Convert absolute file paths to relative paths for ruff command.
+    """Use relative file paths from the execution context for the ruff command.
 
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
+        ruff_execution_context: Factory for mock execution contexts.
     """
-    mock_ruff_tool._get_cwd.return_value = "/test/project"
+    mock_ruff_tool._prepare_execution.return_value = ruff_execution_context(
+        files=[
+            "/test/project/src/main.py",
+            "/test/project/tests/test_main.py",
+        ],
+        rel_files=["src/main.py", "tests/test_main.py"],
+        cwd="/test/project",
+    )
 
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=[
-                "/test/project/src/main.py",
-                "/test/project/tests/test_main.py",
-            ],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(True, "[]"),
@@ -142,26 +84,28 @@ def test_execute_ruff_check_converts_paths_to_relative(
 
         call_args = mock_build_cmd.call_args
         files_arg = call_args.kwargs.get("files") or call_args.args[1]
-        # Files should be relative paths
+        # Files should be the relative paths from the execution context
         assert_that(files_arg).contains("src/main.py")
         assert_that(files_arg).contains("tests/test_main.py")
 
 
 def test_execute_ruff_check_handles_multiple_directories(
     mock_ruff_tool: MagicMock,
+    ruff_execution_context: Callable[..., MagicMock],
 ) -> None:
     """Handle files from multiple directories.
 
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
+        ruff_execution_context: Factory for mock execution contexts.
     """
-    mock_ruff_tool._get_cwd.return_value = "/test"
+    mock_ruff_tool._prepare_execution.return_value = ruff_execution_context(
+        files=["/test/project1/main.py", "/test/project2/main.py"],
+        rel_files=["project1/main.py", "project2/main.py"],
+        cwd="/test",
+    )
 
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["/test/project1/main.py", "/test/project2/main.py"],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(True, "[]"),
@@ -178,19 +122,21 @@ def test_execute_ruff_check_handles_multiple_directories(
 
 def test_execute_ruff_check_uses_absolute_paths_when_no_cwd(
     mock_ruff_tool: MagicMock,
+    ruff_execution_context: Callable[..., MagicMock],
 ) -> None:
-    """Use absolute paths when cwd cannot be determined.
+    """Use absolute paths when the context has no common working directory.
 
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
+        ruff_execution_context: Factory for mock execution contexts.
     """
-    mock_ruff_tool._get_cwd.return_value = None
+    mock_ruff_tool._prepare_execution.return_value = ruff_execution_context(
+        files=["/test/project/test.py"],
+        rel_files=["/test/project/test.py"],
+        cwd=None,
+    )
 
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["/test/project/test.py"],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(True, "[]"),

--- a/tests/unit/tools/ruff/check/test_timeout.py
+++ b/tests/unit/tools/ruff/check/test_timeout.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 from assertpy import assert_that
@@ -17,21 +18,21 @@ def test_execute_ruff_check_uses_default_timeout() -> None:
     assert_that(RUFF_DEFAULT_TIMEOUT).is_equal_to(30)
 
 
-def test_execute_ruff_check_uses_tool_timeout(
+def test_execute_ruff_check_uses_context_timeout(
     mock_ruff_tool: MagicMock,
+    ruff_execution_context: Callable[..., MagicMock],
 ) -> None:
-    """Use timeout from tool options.
+    """Use the timeout resolved by the shared preparation pipeline.
 
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
+        ruff_execution_context: Factory for mock execution contexts.
     """
-    mock_ruff_tool.options["timeout"] = 60
+    mock_ruff_tool._prepare_execution.return_value = ruff_execution_context(
+        timeout=60,
+    )
 
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(True, "[]"),
@@ -39,10 +40,6 @@ def test_execute_ruff_check_uses_tool_timeout(
         patch(
             "lintro.tools.implementations.ruff.check.parse_ruff_output",
             return_value=[],
-        ),
-        patch(
-            "lintro.tools.implementations.ruff.check.get_timeout_value",
-            return_value=60,
         ),
     ):
         execute_ruff_check(mock_ruff_tool, ["/test/project"])

--- a/tests/unit/tools/ruff/check/test_with_issues.py
+++ b/tests/unit/tools/ruff/check/test_with_issues.py
@@ -34,10 +34,6 @@ def test_execute_ruff_check_with_lint_issues_returns_failure(
 
     with (
         patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
-        patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(False, '[{"code": "F401"}]'),
         ),
@@ -72,10 +68,6 @@ def test_execute_ruff_check_with_multiple_lint_issues(
 
     with (
         patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
-        patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(False, "[]"),
         ),
@@ -102,10 +94,6 @@ def test_execute_ruff_check_with_format_issues_returns_failure(
     mock_ruff_tool.options["format_check"] = True
 
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py"],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(True, ""),
@@ -142,10 +130,6 @@ def test_execute_ruff_check_combines_lint_and_format_issues(
     ]
 
     with (
-        patch(
-            "lintro.tools.implementations.ruff.check.walk_files_with_excludes",
-            return_value=["test.py", "other.py"],
-        ),
         patch(
             "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
             return_value=(False, "[]"),

--- a/tests/unit/tools/ruff/conftest.py
+++ b/tests/unit/tools/ruff/conftest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
@@ -12,7 +12,57 @@ import pytest
 from lintro.enums.tool_name import ToolName
 
 if TYPE_CHECKING:
+    from lintro.models.core.tool_result import ToolResult
     from lintro.tools.definitions.ruff import RuffPlugin
+
+
+def make_ruff_execution_context(
+    *,
+    files: list[str] | None = None,
+    rel_files: list[str] | None = None,
+    cwd: str | None = "/test/project",
+    timeout: int = 30,
+    should_skip: bool = False,
+    early_result: ToolResult | None = None,
+) -> MagicMock:
+    """Build a mock ``ExecutionContext`` for ruff execution tests.
+
+    Mirrors the shape returned by ``BaseToolPlugin._prepare_execution`` so
+    ruff's ``execute_ruff_check``/``execute_ruff_fix`` helpers, which now route
+    through that shared pipeline, can be exercised in isolation.
+
+    Args:
+        files: Absolute file paths the tool should process.
+        rel_files: File paths relative to ``cwd``. Defaults to ``files``.
+        cwd: Working directory for command execution.
+        timeout: Timeout value in seconds.
+        should_skip: Whether execution should short-circuit to ``early_result``.
+        early_result: Result returned when ``should_skip`` is True.
+
+    Returns:
+        MagicMock: Object exposing the ``ExecutionContext`` attributes used by
+        the ruff execution helpers.
+    """
+    resolved_files = ["test.py"] if files is None else files
+    ctx = MagicMock()
+    ctx.files = resolved_files
+    ctx.rel_files = resolved_files if rel_files is None else rel_files
+    ctx.cwd = cwd
+    ctx.timeout = timeout
+    ctx.should_skip = should_skip or (early_result is not None)
+    ctx.early_result = early_result
+    return ctx
+
+
+@pytest.fixture
+def ruff_execution_context() -> Callable[..., MagicMock]:
+    """Provide a factory for mock ruff execution contexts.
+
+    Returns:
+        Callable[..., MagicMock]: Factory delegating to
+        :func:`make_ruff_execution_context`.
+    """
+    return make_ruff_execution_context
 
 
 @pytest.fixture
@@ -43,6 +93,11 @@ def mock_ruff_tool() -> MagicMock:
     tool._get_cwd.return_value = "/test/project"
     tool._build_config_args.return_value = []
     tool._get_enforced_settings.return_value = {}
+
+    # Ruff execution helpers now route through the shared
+    # BaseToolPlugin._prepare_execution pipeline. Provide a sensible default
+    # context (one file, no skip) that individual tests can override.
+    tool._prepare_execution.return_value = make_ruff_execution_context()
 
     return tool
 

--- a/tests/unit/tools/ruff/fix/test_combined_issues.py
+++ b/tests/unit/tools/ruff/fix/test_combined_issues.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from assertpy import assert_that
 
@@ -23,19 +23,14 @@ def test_execute_ruff_fix_combined_lint_and_format_issues(
     """
     mock_ruff_tool.options["format"] = True
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (False, sample_ruff_json_output),  # Initial lint: 2 issues
+        (False, sample_ruff_format_check_output),  # Format check: 2 files
+        (True, "[]"),  # Lint fix: all fixed
+        (True, ""),  # Format fix: success
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (False, sample_ruff_json_output),  # Initial lint: 2 issues
-            (False, sample_ruff_format_check_output),  # Format check: 2 files
-            (True, "[]"),  # Lint fix: all fixed
-            (True, ""),  # Format fix: success
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     assert_that(result.success).is_true()
     # 2 lint + 2 format = 4 total initial
@@ -67,20 +62,15 @@ def test_execute_ruff_fix_partial_fix_with_format(
         }
     ]"""
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (False, lint_with_unfixable),  # Initial lint: 1 unfixable
+        (False, sample_ruff_format_check_output),  # Format check: 2 files
+        (False, lint_with_unfixable),  # Lint fix: still 1 remaining
+        (False, lint_with_unfixable),  # Unsafe check
+        (True, ""),  # Format fix
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (False, lint_with_unfixable),  # Initial lint: 1 unfixable
-            (False, sample_ruff_format_check_output),  # Format check: 2 files
-            (False, lint_with_unfixable),  # Lint fix: still 1 remaining
-            (False, lint_with_unfixable),  # Unsafe check
-            (True, ""),  # Format fix
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     assert_that(result.success).is_false()
     # 1 lint + 2 format initial

--- a/tests/unit/tools/ruff/fix/test_config.py
+++ b/tests/unit/tools/ruff/fix/test_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from lintro.tools.implementations.ruff.fix import execute_ruff_fix
 
@@ -19,17 +19,12 @@ def test_execute_ruff_fix_uses_config_args(
     """
     mock_ruff_tool._build_config_args.return_value = ["--line-length", "100"]
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (True, sample_ruff_json_empty_output),
+        (True, sample_ruff_json_empty_output),
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (True, sample_ruff_json_empty_output),
-            (True, sample_ruff_json_empty_output),
-        ]
-
-        execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     # Verify _build_config_args was called (via build_ruff_check_command)
     mock_ruff_tool._build_config_args.assert_called()

--- a/tests/unit/tools/ruff/fix/test_edge_cases.py
+++ b/tests/unit/tools/ruff/fix/test_edge_cases.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from assertpy import assert_that
 
@@ -17,17 +17,12 @@ def test_execute_ruff_fix_handles_malformed_json(
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
     """
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (True, "not valid json"),  # Initial check with bad output
+        (True, "[]"),  # Fix succeeds
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (True, "not valid json"),  # Initial check with bad output
-            (True, "[]"),  # Fix succeeds
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     # Should not crash, parser handles malformed JSON
     assert_that(result).is_not_none()
@@ -42,17 +37,12 @@ def test_execute_ruff_fix_handles_empty_output(
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
     """
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (True, ""),  # Empty output
+        (True, ""),
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (True, ""),  # Empty output
-            (True, ""),
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     assert_that(result.success).is_true()
     assert_that(result.issues_count).is_equal_to(0)
@@ -72,19 +62,14 @@ def test_execute_ruff_fix_format_exit_code_handling(
     """
     mock_ruff_tool.options["format"] = True
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (True, sample_ruff_json_empty_output),  # Lint check
+        (False, sample_ruff_format_check_output),  # Format check (exit 1)
+        (True, sample_ruff_json_empty_output),  # Lint fix
+        (False, ""),  # Format fix (exit 1 means files were formatted)
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (True, sample_ruff_json_empty_output),  # Lint check
-            (False, sample_ruff_format_check_output),  # Format check (exit 1)
-            (True, sample_ruff_json_empty_output),  # Lint fix
-            (False, ""),  # Format fix (exit 1 means files were formatted)
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     # Format with exit code 1 and initial format issues should still be success
     assert_that(result.success).is_true()
@@ -102,16 +87,11 @@ def test_execute_ruff_fix_multiple_files(
         temp_python_files: List of temporary Python files for testing.
         sample_ruff_json_empty_output: Sample empty JSON output from ruff.
     """
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = temp_python_files
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (True, sample_ruff_json_empty_output),
+        (True, sample_ruff_json_empty_output),
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (True, sample_ruff_json_empty_output),
-            (True, sample_ruff_json_empty_output),
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, temp_python_files)
+    result = execute_ruff_fix(mock_ruff_tool, temp_python_files)
 
     assert_that(result.success).is_true()

--- a/tests/unit/tools/ruff/fix/test_format_option.py
+++ b/tests/unit/tools/ruff/fix/test_format_option.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from assertpy import assert_that
 
@@ -23,19 +23,14 @@ def test_execute_ruff_fix_with_format_enabled(
     """
     mock_ruff_tool.options["format"] = True
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (True, sample_ruff_json_empty_output),  # Initial lint check
+        (False, sample_ruff_format_check_output),  # Format check (2 files)
+        (True, sample_ruff_json_empty_output),  # Lint fix
+        (True, ""),  # Format fix
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (True, sample_ruff_json_empty_output),  # Initial lint check
-            (False, sample_ruff_format_check_output),  # Format check (2 files)
-            (True, sample_ruff_json_empty_output),  # Lint fix
-            (True, ""),  # Format fix
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     assert_that(result.success).is_true()
     # 2 format issues were found and fixed
@@ -54,17 +49,12 @@ def test_execute_ruff_fix_format_disabled(
     """
     mock_ruff_tool.options["format"] = False
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (True, sample_ruff_json_empty_output),  # Initial check
+        (True, sample_ruff_json_empty_output),  # Fix
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (True, sample_ruff_json_empty_output),  # Initial check
-            (True, sample_ruff_json_empty_output),  # Fix
-        ]
-
-        execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     # Should only call _run_subprocess twice (check and fix), not format
     assert_that(mock_ruff_tool._run_subprocess.call_count).is_equal_to(2)
@@ -83,16 +73,11 @@ def test_execute_ruff_fix_lint_fix_disabled(
     mock_ruff_tool.options["lint_fix"] = False
     mock_ruff_tool.options["format"] = False
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (True, sample_ruff_json_empty_output),  # Initial check only
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (True, sample_ruff_json_empty_output),  # Initial check only
-        ]
-
-        execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     # Should only call initial check, not fix
     assert_that(mock_ruff_tool._run_subprocess.call_count).is_equal_to(1)

--- a/tests/unit/tools/ruff/fix/test_no_files.py
+++ b/tests/unit/tools/ruff/fix/test_no_files.py
@@ -2,20 +2,35 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from assertpy import assert_that
 
+from lintro.models.core.tool_result import ToolResult
 from lintro.tools.implementations.ruff.fix import execute_ruff_fix
 
 
-def test_execute_ruff_fix_no_paths(mock_ruff_tool: MagicMock) -> None:
+def test_execute_ruff_fix_no_paths(
+    mock_ruff_tool: MagicMock,
+    ruff_execution_context: Callable[..., MagicMock],
+) -> None:
     """Return success with no files message when paths list is empty.
 
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
+        ruff_execution_context: Factory for mock execution contexts.
     """
+    mock_ruff_tool._prepare_execution.return_value = ruff_execution_context(
+        early_result=ToolResult(
+            name="ruff",
+            success=True,
+            output="No files to fix.",
+            issues_count=0,
+        ),
+    )
+
     result = execute_ruff_fix(mock_ruff_tool, [])
 
     assert_that(result.success).is_true()
@@ -25,25 +40,27 @@ def test_execute_ruff_fix_no_paths(mock_ruff_tool: MagicMock) -> None:
 
 def test_execute_ruff_fix_no_python_files_found(
     mock_ruff_tool: MagicMock,
+    ruff_execution_context: Callable[..., MagicMock],
     tmp_path: Any,
 ) -> None:
-    """Return success with no Python files message when no .py files exist.
+    """Return success with no files message when no matching files exist.
 
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
+        ruff_execution_context: Factory for mock execution contexts.
         tmp_path: Temporary directory path for testing.
     """
-    # Create a non-Python file
-    text_file = tmp_path / "readme.txt"
-    text_file.write_text("Hello")
+    mock_ruff_tool._prepare_execution.return_value = ruff_execution_context(
+        early_result=ToolResult(
+            name="ruff",
+            success=True,
+            output="No py/pyi files found to check.",
+            issues_count=0,
+        ),
+    )
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = []
-
-        result = execute_ruff_fix(mock_ruff_tool, [str(tmp_path)])
+    result = execute_ruff_fix(mock_ruff_tool, [str(tmp_path)])
 
     assert_that(result.success).is_true()
-    assert_that(result.output).is_equal_to("No Python files found to fix.")
+    assert_that(result.output).is_equal_to("No py/pyi files found to check.")
     assert_that(result.issues_count).is_equal_to(0)

--- a/tests/unit/tools/ruff/fix/test_successful_fix.py
+++ b/tests/unit/tools/ruff/fix/test_successful_fix.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from assertpy import assert_that
 
@@ -21,19 +21,14 @@ def test_execute_ruff_fix_with_fixable_issues(
         sample_ruff_json_output: Sample JSON output from ruff with issues.
         sample_ruff_json_empty_output: Sample empty JSON output from ruff.
     """
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    # First call: check (finds 2 issues)
+    # Second call: fix (returns empty - all fixed)
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (False, sample_ruff_json_output),  # Initial check finds issues
+        (True, sample_ruff_json_empty_output),  # After fix, no remaining
+    ]
 
-        # First call: check (finds 2 issues)
-        # Second call: fix (returns empty - all fixed)
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (False, sample_ruff_json_output),  # Initial check finds issues
-            (True, sample_ruff_json_empty_output),  # After fix, no remaining
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     assert_that(result.success).is_true()
     assert_that(result.initial_issues_count).is_equal_to(2)
@@ -52,17 +47,12 @@ def test_execute_ruff_fix_with_no_issues(
         mock_ruff_tool: Mock RuffTool instance for testing.
         sample_ruff_json_empty_output: Sample empty JSON output from ruff.
     """
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (True, sample_ruff_json_empty_output),  # Initial check: no issues
+        (True, sample_ruff_json_empty_output),  # Fix: no issues
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (True, sample_ruff_json_empty_output),  # Initial check: no issues
-            (True, sample_ruff_json_empty_output),  # Fix: no issues
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     assert_that(result.success).is_true()
     assert_that(result.output).is_equal_to("No fixes applied.")
@@ -88,18 +78,13 @@ def test_execute_ruff_fix_with_unfixable_issues(
         }
     ]"""
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (False, unfixable_output),  # Initial check
+        (False, unfixable_output),  # After fix attempt (still has issues)
+        (False, unfixable_output),  # Unsafe fix check
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (False, unfixable_output),  # Initial check
-            (False, unfixable_output),  # After fix attempt (still has issues)
-            (False, unfixable_output),  # Unsafe fix check
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     assert_that(result.success).is_false()
     assert_that(result.remaining_issues_count).is_equal_to(1)

--- a/tests/unit/tools/ruff/fix/test_timeout.py
+++ b/tests/unit/tools/ruff/fix/test_timeout.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import subprocess  # nosec B404 - subprocess is used to drive the tool/CLI under test; invocations use shell=False
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from assertpy import assert_that
 
@@ -18,17 +18,12 @@ def test_execute_ruff_fix_timeout_on_initial_check(
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
     """
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = subprocess.TimeoutExpired(
+        cmd=["ruff", "check"],
+        timeout=30,
+    )
 
-        mock_ruff_tool._run_subprocess.side_effect = subprocess.TimeoutExpired(
-            cmd=["ruff", "check"],
-            timeout=30,
-        )
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     assert_that(result.success).is_false()
     assert_that(result.output).contains("timed out")
@@ -54,17 +49,12 @@ def test_execute_ruff_fix_timeout_on_fix_command(
         }
     ]"""
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (False, single_issue_output),  # Initial check: 1 issue
+        subprocess.TimeoutExpired(cmd=["ruff", "check", "--fix"], timeout=30),
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (False, single_issue_output),  # Initial check: 1 issue
-            subprocess.TimeoutExpired(cmd=["ruff", "check", "--fix"], timeout=30),
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     assert_that(result.success).is_false()
     assert_that(result.output).contains("timed out")
@@ -91,17 +81,12 @@ def test_execute_ruff_fix_timeout_on_format_check(
         }
     ]"""
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (False, single_issue_output),  # Initial lint check: 1 issue
+        subprocess.TimeoutExpired(cmd=["ruff", "format", "--check"], timeout=30),
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (False, single_issue_output),  # Initial lint check: 1 issue
-            subprocess.TimeoutExpired(cmd=["ruff", "format", "--check"], timeout=30),
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     assert_that(result.success).is_false()
     assert_that(result.output).contains("timed out")
@@ -122,19 +107,14 @@ def test_execute_ruff_fix_timeout_on_format_command(
     # Only 1 format issue so validation passes (1 = 0 + 1)
     single_format_issue = "Would reformat: test.py\n"
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (True, sample_ruff_json_empty_output),  # Initial lint check: 0 issues
+        (False, single_format_issue),  # Format check: 1 file needs formatting
+        (True, sample_ruff_json_empty_output),  # Lint fix
+        subprocess.TimeoutExpired(cmd=["ruff", "format"], timeout=30),  # Format fix
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (True, sample_ruff_json_empty_output),  # Initial lint check: 0 issues
-            (False, single_format_issue),  # Format check: 1 file needs formatting
-            (True, sample_ruff_json_empty_output),  # Lint fix
-            subprocess.TimeoutExpired(cmd=["ruff", "format"], timeout=30),  # Format fix
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     assert_that(result.success).is_false()
     assert_that(result.output).contains("timed out")
@@ -159,18 +139,13 @@ def test_execute_ruff_fix_timeout_on_unsafe_check_continues(
         }
     ]"""
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (False, remaining_output),  # Initial check
+        (False, remaining_output),  # Fix attempt
+        subprocess.TimeoutExpired(cmd=["ruff"], timeout=30),  # Unsafe check timeout
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (False, remaining_output),  # Initial check
-            (False, remaining_output),  # Fix attempt
-            subprocess.TimeoutExpired(cmd=["ruff"], timeout=30),  # Unsafe check timeout
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     # Should still complete with remaining issues
     assert_that(result.success).is_false()

--- a/tests/unit/tools/ruff/fix/test_unsafe_fixes.py
+++ b/tests/unit/tools/ruff/fix/test_unsafe_fixes.py
@@ -21,17 +21,12 @@ def test_execute_ruff_fix_unsafe_fixes_enabled(
     """
     mock_ruff_tool.options["unsafe_fixes"] = True
 
-    with patch(
-        "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-    ) as mock_walk:
-        mock_walk.return_value = ["test.py"]
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (True, sample_ruff_json_empty_output),  # Initial check
+        (True, sample_ruff_json_empty_output),  # Fix with unsafe
+    ]
 
-        mock_ruff_tool._run_subprocess.side_effect = [
-            (True, sample_ruff_json_empty_output),  # Initial check
-            (True, sample_ruff_json_empty_output),  # Fix with unsafe
-        ]
-
-        result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
+    result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 
     assert_that(result.success).is_true()
 
@@ -55,14 +50,7 @@ def test_execute_ruff_fix_warns_about_unsafe_fixes(
         }
     ]"""
 
-    with (
-        patch(
-            "lintro.tools.implementations.ruff.fix.walk_files_with_excludes",
-        ) as mock_walk,
-        patch("lintro.tools.implementations.ruff.fix.logger") as mock_logger,
-    ):
-        mock_walk.return_value = ["test.py"]
-
+    with patch("lintro.tools.implementations.ruff.fix.logger") as mock_logger:
         mock_ruff_tool._run_subprocess.side_effect = [
             (False, remaining_output),  # Initial check
             (False, remaining_output),  # Fix attempt

--- a/tests/unit/tools/ruff/fix/test_version_check.py
+++ b/tests/unit/tools/ruff/fix/test_version_check.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 from assertpy import assert_that
@@ -10,11 +11,18 @@ from lintro.models.core.tool_result import ToolResult
 from lintro.tools.implementations.ruff.fix import execute_ruff_fix
 
 
-def test_execute_ruff_fix_version_check_fails(mock_ruff_tool: MagicMock) -> None:
-    """Return version error result when version check fails.
+def test_execute_ruff_fix_version_check_fails(
+    mock_ruff_tool: MagicMock,
+    ruff_execution_context: Callable[..., MagicMock],
+) -> None:
+    """Return version error result when the prepared context reports a failure.
+
+    Version checking now happens inside the shared ``_prepare_execution``
+    pipeline, which surfaces the failure via ``early_result``.
 
     Args:
         mock_ruff_tool: Mock RuffTool instance for testing.
+        ruff_execution_context: Factory for mock execution contexts.
     """
     version_error = ToolResult(
         name="ruff",
@@ -22,7 +30,9 @@ def test_execute_ruff_fix_version_check_fails(mock_ruff_tool: MagicMock) -> None
         output="Ruff version too old",
         issues_count=0,
     )
-    mock_ruff_tool._verify_tool_version.return_value = version_error
+    mock_ruff_tool._prepare_execution.return_value = ruff_execution_context(
+        early_result=version_error,
+    )
 
     result = execute_ruff_fix(mock_ruff_tool, ["test.py"])
 

--- a/tests/unit/tools/ruff/test_timeout_single_source.py
+++ b/tests/unit/tools/ruff/test_timeout_single_source.py
@@ -1,0 +1,111 @@
+"""Tests that ruff has a single source of truth for its default timeout.
+
+Regression coverage for #1229: ``RUFF_DEFAULT_TIMEOUT`` was independently
+redefined in three modules. It must now be defined once in the ruff definition
+and re-exported from the execution helpers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
+
+from assertpy import assert_that
+
+from lintro.tools.definitions.ruff import RUFF_DEFAULT_TIMEOUT as DEFINITION_TIMEOUT
+from lintro.tools.implementations.ruff.check import (
+    RUFF_DEFAULT_TIMEOUT as CHECK_TIMEOUT,
+)
+from lintro.tools.implementations.ruff.fix import RUFF_DEFAULT_TIMEOUT as FIX_TIMEOUT
+
+
+def test_ruff_timeout_single_source_check() -> None:
+    """The check module re-exports the definition constant (import identity)."""
+    assert_that(CHECK_TIMEOUT).is_equal_to(DEFINITION_TIMEOUT)
+    assert_that(CHECK_TIMEOUT is DEFINITION_TIMEOUT).is_true()
+
+
+def test_ruff_timeout_single_source_fix() -> None:
+    """The fix module re-exports the definition constant (import identity)."""
+    assert_that(FIX_TIMEOUT).is_equal_to(DEFINITION_TIMEOUT)
+    assert_that(FIX_TIMEOUT is DEFINITION_TIMEOUT).is_true()
+
+
+def test_ruff_check_routes_through_prepare_execution(
+    mock_ruff_tool: MagicMock,
+) -> None:
+    """``execute_ruff_check`` delegates preparation to ``_prepare_execution``.
+
+    Args:
+        mock_ruff_tool: Mock RuffTool instance for testing.
+    """
+    from lintro.tools.implementations.ruff.check import execute_ruff_check
+
+    with (
+        patch(
+            "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
+            return_value=(True, "[]"),
+        ),
+        patch(
+            "lintro.tools.implementations.ruff.check.parse_ruff_output",
+            return_value=[],
+        ),
+    ):
+        execute_ruff_check(mock_ruff_tool, ["/test/project"])
+
+    mock_ruff_tool._prepare_execution.assert_called_once()
+
+
+def test_ruff_fix_routes_through_prepare_execution(
+    mock_ruff_tool: MagicMock,
+    sample_ruff_json_empty_output: str,
+) -> None:
+    """``execute_ruff_fix`` delegates preparation to ``_prepare_execution``.
+
+    Args:
+        mock_ruff_tool: Mock RuffTool instance for testing.
+        sample_ruff_json_empty_output: Sample empty JSON output from ruff.
+    """
+    from lintro.tools.implementations.ruff.fix import execute_ruff_fix
+
+    mock_ruff_tool._run_subprocess.side_effect = [
+        (True, sample_ruff_json_empty_output),
+        (True, sample_ruff_json_empty_output),
+    ]
+
+    execute_ruff_fix(mock_ruff_tool, ["/test/project"])
+
+    mock_ruff_tool._prepare_execution.assert_called_once()
+
+
+def test_ruff_plugin_check_and_fix_invoke_prepare_execution(
+    ruff_execution_context: Callable[..., MagicMock],
+) -> None:
+    """The real plugin's ``check``/``fix`` route ruff through ``_prepare_execution``.
+
+    Args:
+        ruff_execution_context: Factory for mock execution contexts.
+    """
+    import os
+
+    with patch.dict(os.environ, {"LINTRO_TEST_MODE": "1"}):
+        from lintro.tools.definitions.ruff import RuffPlugin
+
+        plugin = RuffPlugin()
+
+    with (
+        patch.object(
+            plugin,
+            "_prepare_execution",
+            return_value=ruff_execution_context(),
+        ) as mock_prepare,
+        patch.object(plugin, "_run_subprocess", return_value=(True, "[]")),
+        patch(
+            "lintro.tools.implementations.ruff.check.run_subprocess_with_timeout",
+            return_value=(True, "[]"),
+        ),
+    ):
+        plugin.check(["/test/project"], {})
+        plugin.fix(["/test/project"], {})
+
+    assert_that(mock_prepare.call_count).is_equal_to(2)

--- a/tests/unit/utils/test_timeout_utils.py
+++ b/tests/unit/utils/test_timeout_utils.py
@@ -137,3 +137,79 @@ def test_run_subprocess_with_timeout_exception() -> None:
     # Verify the exception has enhanced message
     assert_that(str(exc_info.value.output)).contains("test_tool execution timed out")
     assert_that(str(exc_info.value.output)).contains("(10s limit exceeded)")
+
+
+def _timeout_tool(default_timeout: int = 300, option_timeout: int | None = 30) -> Any:
+    """Build a mock tool whose subprocess always times out.
+
+    Args:
+        default_timeout: Value for ``tool._default_timeout``.
+        option_timeout: Value stored under ``tool.options['timeout']``; omitted
+            when None so the option key is absent.
+
+    Returns:
+        Any: Configured MockTool that raises TimeoutExpired on subprocess runs.
+    """
+    tool = MockTool(default_timeout=default_timeout)
+    if option_timeout is not None:
+        tool.options["timeout"] = option_timeout
+
+    def _raise(
+        cmd: list[str],
+        timeout: int | None = None,
+        cwd: str | None = None,
+    ) -> tuple[bool, str]:
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout or 0)
+
+    tool._run_subprocess = _raise  # type: ignore[method-assign]
+    return tool
+
+
+def test_run_subprocess_timeout_zero_preserved() -> None:
+    """An explicit timeout=0 is preserved, not replaced by the option/default.
+
+    Regression test for the falsy-zero bug (#1221): ``timeout or fallback``
+    treated ``0`` as missing and reported the configured timeout instead.
+    """
+    tool = _timeout_tool(default_timeout=300, option_timeout=30)
+
+    with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+        run_subprocess_with_timeout(tool, ["slow"], timeout=0)
+
+    # The reported timeout must be the caller-provided 0, not the 30s option.
+    assert_that(exc_info.value.timeout).is_equal_to(0)
+    assert_that(str(exc_info.value.output)).contains("(0s limit exceeded)")
+    assert_that(str(exc_info.value.output)).does_not_contain("(30s limit exceeded)")
+
+
+def test_run_subprocess_timeout_none_uses_option_fallback() -> None:
+    """A timeout of None falls back to the tool option, then the default."""
+    tool = _timeout_tool(default_timeout=300, option_timeout=45)
+
+    with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+        run_subprocess_with_timeout(tool, ["slow"], timeout=None)
+
+    assert_that(exc_info.value.timeout).is_equal_to(45)
+    assert_that(str(exc_info.value.output)).contains("(45s limit exceeded)")
+
+
+def test_run_subprocess_timeout_none_uses_default_when_no_option() -> None:
+    """A timeout of None falls back to the tool default when no option is set."""
+    tool = _timeout_tool(default_timeout=300, option_timeout=None)
+
+    with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+        run_subprocess_with_timeout(tool, ["slow"], timeout=None)
+
+    assert_that(exc_info.value.timeout).is_equal_to(300)
+    assert_that(str(exc_info.value.output)).contains("(300s limit exceeded)")
+
+
+def test_run_subprocess_timeout_positive_passthrough() -> None:
+    """An explicit positive timeout is passed through unchanged."""
+    tool = _timeout_tool(default_timeout=300, option_timeout=30)
+
+    with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+        run_subprocess_with_timeout(tool, ["slow"], timeout=45)
+
+    assert_that(exc_info.value.timeout).is_equal_to(45)
+    assert_that(str(exc_info.value.output)).contains("(45s limit exceeded)")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title: `fix(tools): preserve explicit timeout=0 and route ruff through _prepare_execution`

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Two related tool-timeout plumbing fixes, implemented together:

### #1221 — timeout=0 treated as missing (falsy check)

`run_subprocess_with_timeout()` resolved the reported timeout with
`timeout or tool.options.get("timeout", tool._default_timeout)`, so an explicit
`timeout=0` was silently replaced by the configured/default value in the
enhanced `TimeoutExpired` message. Now only `None` triggers the fallback:

- `timeout=0` is preserved as the caller-provided value (valid immediate
  deadline) and reported as `0s` in error messages.
- Policy documented in the function docstring: explicit numeric values
  (including `0`) are preserved verbatim; callers wanting no timeout pass
  `None`. Audited the rest of `timeout_utils.py` — no other `or`-based numeric
  fallbacks exist.

### #1229 — dedupe RUFF_DEFAULT_TIMEOUT and route ruff through _prepare_execution

- `RUFF_DEFAULT_TIMEOUT` was independently defined in three modules
  (`definitions/ruff.py`, `implementations/ruff/check.py`,
  `implementations/ruff/fix.py`). It is now defined once in
  `lintro/tools/definitions/ruff.py` and re-exported from the execution
  helpers (no circular import — verified by import-identity tests).
- `execute_ruff_check()` and `execute_ruff_fix()` now call the shared
  `BaseToolPlugin._prepare_execution()` pipeline and consume the returned
  `ExecutionContext` (files, rel_files, cwd, timeout, early results) instead
  of hand-rolling `walk_files_with_excludes()`, cwd/rel-path computation, and
  timeout resolution.
- To keep behavior identical, the `incremental` option is now threaded through
  `prepare_execution()` → `discover_files()` → `walk_files_with_excludes()`
  (ruff previously passed `incremental`/`tool_name` directly; the shared
  pipeline did not support it).

Behavior parity verified end-to-end: same files checked, same command
construction, same timeout defaults (`lintro chk`/`lintro fmt` on sample files
produce identical results).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing (not user-facing)
- [x] Local CI passed (`uv run lintro chk` clean; `uv run pytest` 6357 passed, 10 skipped)

## Related Issues

Closes #1221
Closes #1229

## Details

- Ruff unit tests rewritten from the `walk_files_with_excludes` patch pattern
  to the `_prepare_execution` mock-context pattern used by other plugins; a
  shared `ruff_execution_context` factory fixture was added to
  `tests/unit/tools/ruff/conftest.py`.
- New tests:
  - `tests/unit/utils/test_timeout_utils.py`: `timeout=0` preserved,
    `None` → option/default fallback, positive passthrough.
  - `tests/unit/tools/ruff/test_timeout_single_source.py`: import identity of
    the constant across modules; `check`/`fix` route through
    `_prepare_execution` (both helper-level and real-plugin-level).
- Early-exit messages for ruff now come from the shared pipeline: empty input
  keeps "No files to check." / "No files to fix."; the no-matches message is
  the standardized "No py/pyi files found to check." (previously
  "No Python files found to check/fix.").
- `return ctx.early_result  # type: ignore[return-value]` follows the
  established narrowing pattern used by black/bandit/etc.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates Ruff execution plumbing and timeout reporting. The main changes are:

- Preserves explicit `timeout=0` in timeout error messages.
- Routes Ruff check and fix through the shared execution preparation path.
- Threads incremental discovery through shared file discovery.
- Re-exports Ruff’s default timeout from a single definition.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after small timeout and filtering cleanups.

- Ruff now follows the shared preparation path.
- Fractional Ruff timeouts can be rounded down before execution.
- Combining diff filtering with incremental caching can skip files that are still changed against the base.

lintro/tools/implementations/ruff/check.py, lintro/tools/implementations/ruff/fix.py, lintro/plugins/execution_preparation.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/core/timeout_utils.py | Preserves explicit numeric timeout values when formatting timeout errors. |
| lintro/plugins/execution_preparation.py | Adds incremental discovery forwarding to the shared execution preparation path. |
| lintro/plugins/file_discovery.py | Forwards incremental discovery settings and tool name into file walking. |
| lintro/tools/implementations/ruff/check.py | Uses the shared execution context for Ruff check files, cwd, and timeout. |
| lintro/tools/implementations/ruff/fix.py | Uses the shared execution context for Ruff fix files and timeout. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alintro%2Ftools%2Fimplementations%2Fruff%2Fcheck.py%3A69%0A**Subsecond%20Timeout%20Becomes%20Immediate**%0A%0AWhen%20a%20caller%20configures%20a%20fractional%20timeout%20such%20as%20%600.5%60%2C%20the%20shared%20preparation%20path%20preserves%20it%20as%20a%20float%2C%20but%20this%20cast%20turns%20it%20into%20%600%60.%20Ruff%20check%20then%20runs%20with%20an%20immediate%20deadline%20and%20can%20report%20a%20timeout%20even%20though%20the%20configured%20timeout%20has%20not%20elapsed.%0A%0A%60%60%60suggestion%0A%20%20%20%20timeout%3A%20float%20%3D%20ctx.timeout%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Alintro%2Ftools%2Fimplementations%2Fruff%2Ffix.py%3A104%0A**Subsecond%20Timeout%20Becomes%20Immediate**%0A%0AWhen%20a%20caller%20configures%20a%20fractional%20timeout%20such%20as%20%600.5%60%2C%20the%20shared%20preparation%20path%20preserves%20it%20as%20a%20float%2C%20but%20this%20cast%20turns%20it%20into%20%600%60.%20Ruff%20fix%20then%20runs%20with%20an%20immediate%20deadline%20and%20can%20report%20a%20timeout%20before%20the%20configured%20timeout%20has%20elapsed.%0A%0A%60%60%60suggestion%0A%20%20%20%20timeout%3A%20float%20%3D%20ctx.timeout%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Alintro%2Fplugins%2Fexecution_preparation.py%3A190%0A**Diff%20Files%20Can%20Be%20Skipped**%0A%0AWhen%20%60diff_base%60%20and%20%60incremental%60%20are%20both%20set%2C%20discovery%20first%20narrows%20to%20files%20changed%20against%20the%20base%20branch%20and%20then%20applies%20the%20last-run%20cache.%20A%20file%20that%20is%20still%20changed%20relative%20to%20the%20base%20but%20unchanged%20since%20the%20previous%20lint%20run%20can%20be%20filtered%20out%2C%20so%20a%20diff-based%20Ruff%20run%20can%20miss%20issues%20that%20remain%20in%20the%20PR.%0A%0A&pr=1266&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alintro%2Ftools%2Fimplementations%2Fruff%2Fcheck.py%3A69%0A**Subsecond%20Timeout%20Becomes%20Immediate**%0A%0AWhen%20a%20caller%20configures%20a%20fractional%20timeout%20such%20as%20%600.5%60%2C%20the%20shared%20preparation%20path%20preserves%20it%20as%20a%20float%2C%20but%20this%20cast%20turns%20it%20into%20%600%60.%20Ruff%20check%20then%20runs%20with%20an%20immediate%20deadline%20and%20can%20report%20a%20timeout%20even%20though%20the%20configured%20timeout%20has%20not%20elapsed.%0A%0A%60%60%60suggestion%0A%20%20%20%20timeout%3A%20float%20%3D%20ctx.timeout%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Alintro%2Ftools%2Fimplementations%2Fruff%2Ffix.py%3A104%0A**Subsecond%20Timeout%20Becomes%20Immediate**%0A%0AWhen%20a%20caller%20configures%20a%20fractional%20timeout%20such%20as%20%600.5%60%2C%20the%20shared%20preparation%20path%20preserves%20it%20as%20a%20float%2C%20but%20this%20cast%20turns%20it%20into%20%600%60.%20Ruff%20fix%20then%20runs%20with%20an%20immediate%20deadline%20and%20can%20report%20a%20timeout%20before%20the%20configured%20timeout%20has%20elapsed.%0A%0A%60%60%60suggestion%0A%20%20%20%20timeout%3A%20float%20%3D%20ctx.timeout%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Alintro%2Fplugins%2Fexecution_preparation.py%3A190%0A**Diff%20Files%20Can%20Be%20Skipped**%0A%0AWhen%20%60diff_base%60%20and%20%60incremental%60%20are%20both%20set%2C%20discovery%20first%20narrows%20to%20files%20changed%20against%20the%20base%20branch%20and%20then%20applies%20the%20last-run%20cache.%20A%20file%20that%20is%20still%20changed%20relative%20to%20the%20base%20but%20unchanged%20since%20the%20previous%20lint%20run%20can%20be%20filtered%20out%2C%20so%20a%20diff-based%20Ruff%20run%20can%20miss%20issues%20that%20remain%20in%20the%20PR.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1266&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F1221-timeout-handling%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1221-timeout-handling%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alintro%2Ftools%2Fimplementations%2Fruff%2Fcheck.py%3A69%0A**Subsecond%20Timeout%20Becomes%20Immediate**%0A%0AWhen%20a%20caller%20configures%20a%20fractional%20timeout%20such%20as%20%600.5%60%2C%20the%20shared%20preparation%20path%20preserves%20it%20as%20a%20float%2C%20but%20this%20cast%20turns%20it%20into%20%600%60.%20Ruff%20check%20then%20runs%20with%20an%20immediate%20deadline%20and%20can%20report%20a%20timeout%20even%20though%20the%20configured%20timeout%20has%20not%20elapsed.%0A%0A%60%60%60suggestion%0A%20%20%20%20timeout%3A%20float%20%3D%20ctx.timeout%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Alintro%2Ftools%2Fimplementations%2Fruff%2Ffix.py%3A104%0A**Subsecond%20Timeout%20Becomes%20Immediate**%0A%0AWhen%20a%20caller%20configures%20a%20fractional%20timeout%20such%20as%20%600.5%60%2C%20the%20shared%20preparation%20path%20preserves%20it%20as%20a%20float%2C%20but%20this%20cast%20turns%20it%20into%20%600%60.%20Ruff%20fix%20then%20runs%20with%20an%20immediate%20deadline%20and%20can%20report%20a%20timeout%20before%20the%20configured%20timeout%20has%20elapsed.%0A%0A%60%60%60suggestion%0A%20%20%20%20timeout%3A%20float%20%3D%20ctx.timeout%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Alintro%2Fplugins%2Fexecution_preparation.py%3A190%0A**Diff%20Files%20Can%20Be%20Skipped**%0A%0AWhen%20%60diff_base%60%20and%20%60incremental%60%20are%20both%20set%2C%20discovery%20first%20narrows%20to%20files%20changed%20against%20the%20base%20branch%20and%20then%20applies%20the%20last-run%20cache.%20A%20file%20that%20is%20still%20changed%20relative%20to%20the%20base%20but%20unchanged%20since%20the%20previous%20lint%20run%20can%20be%20filtered%20out%2C%20so%20a%20diff-based%20Ruff%20run%20can%20miss%20issues%20that%20remain%20in%20the%20PR.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1266&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tools): preserve explicit timeout=0 ..."](https://github.com/lgtm-hq/py-lintro/commit/481c5ebb932e6a85c954ecffb654776b0d524ae9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43506296)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->