### PR TITLE
fix(core): route programmatic execution through real library API

### DIFF
--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -16,6 +16,7 @@ the CLI.
 
 ## Debug & extend
 
+- [Library API](./library-api.md) — embed `check`/`fmt`/`test` in Python programs
 - [AI features](../ai-features.md) — summaries, explanations, and fix suggestions
 - [Troubleshooting](../troubleshooting.md) — common failures and fixes
 - [Debugging](../debugging.md) — verbose runs and internals

--- a/docs/usage/library-api.md
+++ b/docs/usage/library-api.md
@@ -1,0 +1,56 @@
+# Library API
+
+Lintro exposes a small, stable Python API for embedding checks, formatting, and tests in
+your own programs.
+
+```python
+from lintro.api import check, fmt, test
+
+result = check(paths=["src"], tools="ruff")
+if not result.success:
+    raise SystemExit(result.exit_code)
+```
+
+Each entry point returns a `LintroResult`:
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LintroResult:
+    action: str      # "check", "fmt", or "test"
+    exit_code: int   # 0 on success, non-zero when issues/errors occur
+
+    @property
+    def success(self) -> bool: ...
+```
+
+Available functions (all keyword-only):
+
+- `check(...)` — run linting/quality tools against paths.
+- `format(...)` — auto-fix formatting issues. Also exported as `fmt`.
+- `test(...)` — run pytest through Lintro's output formatting.
+
+Exceptions raised during execution propagate normally to the caller, and tool output is
+written directly to the console (no buffering).
+
+## Migration note
+
+Previous releases exposed thin programmatic wrappers in the command modules
+(`lintro.cli_utils.commands.check.check`,
+`lintro.cli_utils.commands.format.format_code`, and
+`lintro.cli_utils.commands.test.test`). Internally these invoked the Click commands
+through `click.testing.CliRunner`, a test helper that swallowed exceptions into a result
+object and buffered stdout/stderr.
+
+Those wrappers still exist for backward compatibility, but now delegate to the real
+library API in `lintro.api`. External callers should migrate to `lintro.api.check` /
+`lintro.api.format` (`fmt`) / `lintro.api.test`, which:
+
+- return a structured `LintroResult` instead of a Click `Result`;
+- let exceptions propagate instead of capturing them; and
+- do not redirect or buffer console output.
+
+`CliRunner` is no longer used anywhere in the `lintro` package; it remains only in the
+test suite, where it is the appropriate tool for exercising the CLI.

--- a/lintro/api/__init__.py
+++ b/lintro/api/__init__.py
@@ -1,0 +1,30 @@
+"""Public library API for programmatic lintro invocation.
+
+Import these functions to embed lintro in another Python program::
+
+    from lintro.api import check, fmt, test
+
+    result = check(paths=["src"], tools="ruff")
+    if not result.success:
+        ...
+
+Unlike the CLI entry points, these functions return a structured
+:class:`~lintro.api.core.LintroResult` and let exceptions propagate to the
+caller instead of swallowing them.
+"""
+
+from lintro.api.core import (
+    LintroResult,
+    check,
+    fmt,
+    format,
+    test,
+)
+
+__all__ = [
+    "LintroResult",
+    "check",
+    "fmt",
+    "format",
+    "test",
+]

--- a/lintro/api/core.py
+++ b/lintro/api/core.py
@@ -1,0 +1,345 @@
+"""Real library API for programmatic lintro invocation.
+
+This module exposes :func:`check`, :func:`format` (aliased :func:`fmt`), and
+:func:`test` as genuine Python functions that perform the work directly by
+delegating to :func:`lintro.utils.tool_executor.run_lint_tools_simple`.
+
+Unlike the previous approach that routed programmatic calls through
+``click.testing.CliRunner``, these functions:
+
+- Return a structured :class:`LintroResult` instead of a Click ``Result``.
+- Let exceptions propagate to the caller instead of swallowing them.
+- Do not redirect or buffer stdout/stderr, so live output stays visible.
+
+The Click commands and the backward-compatible programmatic wrappers in
+``lintro.cli_utils.commands`` are thin layers over this API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lintro.enums.action import Action
+from lintro.utils.tool_executor import run_lint_tools_simple
+
+# Constants
+DEFAULT_PATHS: list[str] = ["."]
+
+
+@dataclass(frozen=True)
+class LintroResult:
+    """Structured result of a programmatic lintro invocation.
+
+    Attributes:
+        action: The action that was performed ("check", "fmt", or "test").
+        exit_code: Aggregated process exit code (0 on success, non-zero when
+            issues were found or an execution error occurred).
+    """
+
+    action: str
+    exit_code: int
+
+    @property
+    def success(self) -> bool:
+        """Whether the invocation completed without issues.
+
+        Returns:
+            bool: ``True`` when :attr:`exit_code` is zero.
+        """
+        return self.exit_code == 0
+
+
+def _ensure_pytest_prefix(option_fragment: str) -> str:
+    """Normalize tool option fragments to use the pytest prefix.
+
+    Args:
+        option_fragment: Raw option fragment from ``tool_options``.
+
+    Returns:
+        str: Fragment guaranteed to start with ``pytest:``.
+    """
+    fragment = option_fragment.strip()
+    if not fragment:
+        return fragment
+
+    lowered = fragment.lower()
+    if lowered.startswith("pytest:"):
+        _, rest = fragment.split(":", 1)
+        return f"pytest:{rest}"
+    return f"pytest:{fragment}"
+
+
+def check(
+    *,
+    paths: list[str] | tuple[str, ...] | None = None,
+    tools: str | None = None,
+    tool_options: str | None = None,
+    exclude: str | None = None,
+    include_venv: bool = False,
+    output: str | None = None,
+    output_format: str = "grid",
+    group_by: str = "file",
+    ignore_conflicts: bool = False,
+    verbose: bool = False,
+    no_log: bool = False,
+    raw_output: bool = False,
+    incremental: bool = False,
+    diff_base: str | None = None,
+    stream: bool = False,
+    debug: bool = False,
+    auto_install: bool = False,
+    yes: bool = False,
+    ai_fix: bool = False,
+    transport: str | None = None,
+    score: bool = False,
+    fail_under: float | None = None,
+) -> LintroResult:
+    """Check files for issues using the specified tools.
+
+    Args:
+        paths: File/directory paths to check. Defaults to the current directory.
+        tools: Comma-separated list of tool names to run, or ``"all"``.
+        tool_options: Tool-specific configuration options.
+        exclude: Comma-separated patterns of files/dirs to exclude.
+        include_venv: Whether to include virtual environment directories.
+        output: Path to an output file for results.
+        output_format: Format for displaying results (grid, json, etc).
+        group_by: How to group issues in output (file, code, none, auto).
+        ignore_conflicts: Whether to ignore tool configuration conflicts.
+        verbose: Whether to show verbose output during execution.
+        no_log: Whether to disable logging to file.
+        raw_output: Whether to show raw tool output instead of formatted output.
+        incremental: Whether to only check files changed since the last run.
+        diff_base: Git base ref for ``--diff`` scanning, or ``None``.
+        stream: Whether to stream tool output in real-time.
+        debug: Whether to enable debug output on console.
+        auto_install: Whether to auto-install Node.js deps if missing.
+        yes: Skip confirmation prompt and proceed immediately.
+        ai_fix: Generate AI fix suggestions.
+        transport: Override AI transport (``api`` or ``cli``).
+        score: Print only the health score, suppressing the summary.
+        fail_under: Exit non-zero if the health score is below this value.
+
+    Returns:
+        LintroResult: Structured result carrying the aggregated exit code.
+    """
+    path_list: list[str] = list(paths) if paths else list(DEFAULT_PATHS)
+
+    exit_code: int = run_lint_tools_simple(
+        action=Action.CHECK,
+        paths=path_list,
+        tools=tools,
+        tool_options=tool_options,
+        exclude=exclude,
+        include_venv=include_venv,
+        group_by=group_by,
+        output_format=output_format,
+        verbose=verbose,
+        raw_output=raw_output,
+        output_file=output,
+        incremental=incremental,
+        diff_base=diff_base,
+        debug=debug,
+        stream=stream,
+        no_log=no_log,
+        auto_install=auto_install,
+        yes=yes,
+        ai_fix=ai_fix,
+        ignore_conflicts=ignore_conflicts,
+        transport=transport,
+        score=score,
+        fail_under=fail_under,
+    )
+    return LintroResult(action="check", exit_code=exit_code)
+
+
+def format(
+    *,
+    paths: list[str] | tuple[str, ...] | None = None,
+    tools: str | None = None,
+    tool_options: str | None = None,
+    exclude: str | None = None,
+    include_venv: bool = False,
+    group_by: str = "auto",
+    output: str | None = None,
+    output_format: str = "grid",
+    verbose: bool = False,
+    no_log: bool = False,
+    raw_output: bool = False,
+    diff_base: str | None = None,
+    stream: bool = False,
+    debug: bool = False,
+    auto_install: bool = False,
+    yes: bool = False,
+    dry_run: bool = False,
+) -> LintroResult:
+    """Format code using the configured formatting tools.
+
+    Args:
+        paths: File/directory paths to format. Defaults to the current directory.
+        tools: Comma-separated list of tool names to run, or ``"all"``.
+        tool_options: Tool-specific configuration options.
+        exclude: Comma-separated patterns of files/dirs to exclude.
+        include_venv: Whether to include virtual environment directories.
+        group_by: How to group issues in output (file, code, none, auto).
+        output: Path to an output file for results.
+        output_format: Format for displaying results (grid, json, etc).
+        verbose: Whether to show verbose output during execution.
+        no_log: Whether to disable logging to file.
+        raw_output: Whether to show raw tool output instead of formatted output.
+        diff_base: Git base ref for ``--diff`` scanning, or ``None``.
+        stream: Whether to stream tool output in real-time.
+        debug: Whether to enable debug output on console.
+        auto_install: Whether to auto-install Node.js deps if missing.
+        yes: Skip confirmation prompt and proceed immediately.
+        dry_run: Preview would-be fixes without modifying any files.
+
+    Returns:
+        LintroResult: Structured result carrying the aggregated exit code.
+    """
+    path_list: list[str] = list(paths) if paths else list(DEFAULT_PATHS)
+
+    exit_code: int = run_lint_tools_simple(
+        action="fmt",
+        paths=path_list,
+        tools=tools,
+        tool_options=tool_options,
+        exclude=exclude,
+        include_venv=include_venv,
+        group_by=group_by,
+        output_format=output_format,
+        verbose=verbose,
+        raw_output=raw_output,
+        output_file=output,
+        diff_base=diff_base,
+        debug=debug,
+        stream=stream,
+        no_log=no_log,
+        auto_install=auto_install,
+        yes=yes,
+        dry_run=dry_run,
+    )
+    return LintroResult(action="fmt", exit_code=exit_code)
+
+
+# Alias: ``fmt`` is the canonical CLI verb; ``format`` mirrors the CLI command
+# name while avoiding surprises for callers who prefer the shorter spelling.
+fmt = format
+
+
+def test(
+    *,
+    paths: list[str] | tuple[str, ...] | None = None,
+    exclude: str | None = None,
+    include_venv: bool = False,
+    output: str | None = None,
+    output_format: str = "grid",
+    group_by: str = "file",
+    verbose: bool = False,
+    raw_output: bool = False,
+    tool_options: str | None = None,
+    list_plugins: bool = False,
+    check_plugins: bool = False,
+    collect_only: bool = False,
+    fixtures: bool = False,
+    fixture_info: str | None = None,
+    markers: bool = False,
+    parametrize_help: bool = False,
+    coverage: bool = False,
+    debug: bool = False,
+    yes: bool = False,
+) -> LintroResult:
+    """Run tests using pytest through lintro's output formatting.
+
+    Args:
+        paths: Paths to test files or directories. Defaults to the current dir.
+        exclude: Comma-separated patterns of files/dirs to exclude.
+        include_venv: Whether to include virtual environment directories.
+        output: Path to an output file for results.
+        output_format: Format for displaying results (grid, json, etc).
+        group_by: How to group issues in output (file, code, none, auto).
+        verbose: Whether to show verbose output during execution.
+        raw_output: Whether to show raw tool output instead of formatted output.
+        tool_options: Tool-specific options in ``option=value`` form.
+        list_plugins: List all installed pytest plugins.
+        check_plugins: Check whether required plugins are installed.
+        collect_only: List tests without executing them.
+        fixtures: List all available fixtures.
+        fixture_info: Show detailed information about a specific fixture.
+        markers: List all available markers.
+        parametrize_help: Show help for parametrized tests.
+        coverage: Generate a test coverage report with missing lines.
+        debug: Whether to enable debug output on console.
+        yes: Skip confirmation prompt and proceed immediately.
+
+    Returns:
+        LintroResult: Structured result carrying the aggregated exit code.
+    """
+    path_list: list[str] = list(paths) if paths else list(DEFAULT_PATHS)
+
+    tool_option_parts: list[str] = []
+
+    boolean_flags: list[tuple[bool, str]] = [
+        (list_plugins, "pytest:list_plugins=True"),
+        (check_plugins, "pytest:check_plugins=True"),
+        (collect_only, "pytest:collect_only=True"),
+        (fixtures, "pytest:list_fixtures=True"),
+        (markers, "pytest:list_markers=True"),
+        (parametrize_help, "pytest:parametrize_help=True"),
+        (coverage, "pytest:coverage_term_missing=True"),
+    ]
+
+    for flag_value, option_string in boolean_flags:
+        if flag_value:
+            tool_option_parts.append(option_string)
+
+    if fixture_info:
+        tool_option_parts.append(f"pytest:fixture_info={fixture_info}")
+
+    if tool_options:
+        # Parse options carefully to handle values containing commas, mirroring
+        # the CLI's ``--tool-options`` handling. Format: ``key=value,key=value``
+        # where values may themselves contain commas.
+        prefixed_options: list[str] = []
+        parts = tool_options.split(",")
+        i = 0
+
+        while i < len(parts):
+            current_part = parts[i].strip()
+            if not current_part:
+                i += 1
+                continue
+
+            if "=" in current_part or current_part.lower().startswith("pytest:"):
+                normalized_part = _ensure_pytest_prefix(current_part)
+                prefixed_options.append(normalized_part)
+                i += 1
+            else:
+                if prefixed_options and "=" in prefixed_options[-1]:
+                    prefixed_options[-1] = f"{prefixed_options[-1]},{current_part}"
+                else:
+                    prefixed_options.append(_ensure_pytest_prefix(current_part))
+                i += 1
+
+        tool_option_parts.append(",".join(prefixed_options))
+
+    combined_tool_options: str | None = (
+        ",".join(tool_option_parts) if tool_option_parts else None
+    )
+
+    exit_code: int = run_lint_tools_simple(
+        action=Action.TEST,
+        paths=path_list,
+        tools="pytest",
+        tool_options=combined_tool_options,
+        exclude=exclude,
+        include_venv=include_venv,
+        group_by=group_by,
+        output_format=output_format,
+        verbose=verbose,
+        raw_output=raw_output,
+        output_file=output,
+        debug=debug,
+        yes=yes,
+    )
+    return LintroResult(action="test", exit_code=exit_code)

--- a/lintro/cli_utils/commands/check.py
+++ b/lintro/cli_utils/commands/check.py
@@ -10,8 +10,8 @@ Functions:
 import sys
 
 import click
-from click.testing import CliRunner
 
+from lintro.api import core as api
 from lintro.utils.git_diff import DIFF_DEFAULT_SENTINEL
 from lintro.utils.tool_executor import run_lint_tools_simple
 
@@ -297,39 +297,22 @@ def check(
     Returns:
         None: This function does not return a value.
     """
-    # Build arguments for the click command
-    args: list[str] = []
-    if paths:
-        args.extend(list(paths))
-    if tools:
-        args.extend(["--tools", tools])
-    if tool_options:
-        args.extend(["--tool-options", tool_options])
-    if exclude:
-        args.extend(["--exclude", exclude])
-    if include_venv:
-        args.append("--include-venv")
-    if output:
-        args.extend(["--output", output])
-    if output_format:
-        args.extend(["--output-format", output_format])
-    if group_by:
-        args.extend(["--group-by", group_by])
-    if ignore_conflicts:
-        args.append("--ignore-conflicts")
-    if verbose:
-        args.append("--verbose")
-    if no_log:
-        args.append("--no-log")
-    if auto_install:
-        args.append("--auto-install")
-    if yes:
-        args.append("--yes")
-    if ai_fix:
-        args.append("--fix")
-
-    runner = CliRunner()
-    result = runner.invoke(check_command, args)
+    result = api.check(
+        paths=paths,
+        tools=tools,
+        tool_options=tool_options,
+        exclude=exclude,
+        include_venv=include_venv,
+        output=output,
+        output_format=output_format,
+        group_by=group_by,
+        ignore_conflicts=ignore_conflicts,
+        verbose=verbose,
+        no_log=no_log,
+        auto_install=auto_install,
+        yes=yes,
+        ai_fix=ai_fix,
+    )
 
     if result.exit_code != DEFAULT_EXIT_CODE:
         sys.exit(result.exit_code)

--- a/lintro/cli_utils/commands/format.py
+++ b/lintro/cli_utils/commands/format.py
@@ -1,8 +1,8 @@
 """Format command implementation using simplified Loguru-based approach."""
 
 import click
-from click.testing import CliRunner
 
+from lintro.api import core as api
 from lintro.utils.git_diff import DIFF_DEFAULT_SENTINEL
 from lintro.utils.tool_executor import run_lint_tools_simple
 
@@ -230,32 +230,20 @@ def format_code(
     Raises:
         RuntimeError: If format fails for any reason.
     """
-    args: list[str] = []
-    if paths:
-        args.extend(paths)
-    if tools:
-        args.extend(["--tools", tools])
-    if tool_options:
-        args.extend(["--tool-options", tool_options])
-    if exclude:
-        args.extend(["--exclude", exclude])
-    if include_venv:
-        args.append("--include-venv")
-    if group_by:
-        args.extend(["--group-by", group_by])
-    if output_format:
-        args.extend(["--output-format", output_format])
-    if verbose:
-        args.append("--verbose")
-    if auto_install:
-        args.append("--auto-install")
-    if yes:
-        args.append("--yes")
-
-    runner = CliRunner()
-    result = runner.invoke(format_command, args)
+    result = api.format(
+        paths=paths,
+        tools=tools,
+        tool_options=tool_options,
+        exclude=exclude,
+        include_venv=include_venv,
+        group_by=group_by,
+        output_format=output_format,
+        verbose=verbose,
+        auto_install=auto_install,
+        yes=yes,
+    )
     if result.exit_code != DEFAULT_EXIT_CODE:
-        raise RuntimeError(f"Format failed: {result.output}")
+        raise RuntimeError(f"Format failed with exit code {result.exit_code}")
     return None
 
 

--- a/lintro/cli_utils/commands/test.py
+++ b/lintro/cli_utils/commands/test.py
@@ -3,8 +3,8 @@
 from typing import Any, cast
 
 import click
-from click.testing import CliRunner
 
+from lintro.api import core as api
 from lintro.utils.tool_executor import run_lint_tools_simple
 
 # Constants
@@ -305,31 +305,18 @@ def test(
     Returns:
         None: This function does not return a value.
     """
-    # Build arguments for the click command
-    args: list[str] = []
-    if paths:
-        args.extend(list(paths))
-    if exclude:
-        args.extend(["--exclude", exclude])
-    if include_venv:
-        args.append("--include-venv")
-    if output:
-        args.extend(["--output", output])
-    if output_format:
-        args.extend(["--output-format", output_format])
-    if group_by:
-        args.extend(["--group-by", group_by])
-    if verbose:
-        args.append("--verbose")
-    if raw_output:
-        args.append("--raw-output")
-    if tool_options:
-        args.extend(["--tool-options", tool_options])
-    if yes:
-        args.append("--yes")
-
-    runner = CliRunner()
-    result = runner.invoke(test_command, args)
+    result = api.test(
+        paths=paths,
+        exclude=exclude,
+        include_venv=include_venv,
+        output=output,
+        output_format=output_format,
+        group_by=group_by,
+        verbose=verbose,
+        raw_output=raw_output,
+        tool_options=tool_options,
+        yes=yes,
+    )
 
     if result.exit_code != DEFAULT_EXIT_CODE:
         import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ build = ["nuitka>=2.8.9", "ordered-set>=4.1.0", "zstandard>=0.25.0"]
 [tool.setuptools]
 packages = [
   "lintro",
+  "lintro.api",
   "lintro.ai",
   "lintro.ai.display",
   "lintro.ai.enums",

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -1,0 +1,100 @@
+"""Unit tests for the real library API (``lintro.api``)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro import api
+from lintro.api import LintroResult, check, fmt
+
+
+def test_api_check_propagates_exceptions() -> None:
+    """A failure inside the executor surfaces to the caller unchanged."""
+    with patch(
+        "lintro.api.core.run_lint_tools_simple",
+        side_effect=RuntimeError("boom"),
+    ):
+        assert_that(check).raises(RuntimeError).when_called_with(
+            paths=["."],
+            tools="ruff",
+        )
+
+
+def test_api_check_returns_result(tmp_path: Path) -> None:
+    """check() returns a structured LintroResult carrying the exit code."""
+    sample = tmp_path / "sample.py"
+    sample.write_text("x = 1\n", encoding="utf-8")
+
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
+        result = check(paths=[str(tmp_path)], tools="ruff")
+
+    assert_that(result).is_instance_of(LintroResult)
+    assert_that(result.action).is_equal_to("check")
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.success).is_true()
+    mock_run.assert_called_once()
+    assert_that(mock_run.call_args.kwargs["paths"]).is_equal_to([str(tmp_path)])
+
+
+def test_api_check_result_reports_failure() -> None:
+    """A non-zero exit code produces an unsuccessful result (no raise)."""
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=1):
+        result = check(paths=["."], tools="ruff")
+
+    assert_that(result.exit_code).is_equal_to(1)
+    assert_that(result.success).is_false()
+
+
+def test_api_fmt_is_alias_of_format() -> None:
+    """``fmt`` is exported as an alias of ``format``."""
+    assert_that(fmt).is_same_as(api.format)
+
+
+def test_api_format_returns_result() -> None:
+    """format() returns a LintroResult tagged with the ``fmt`` action."""
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
+        result = fmt(paths=["."], tools="ruff")
+
+    assert_that(result.action).is_equal_to("fmt")
+    assert_that(result.success).is_true()
+    assert_that(mock_run.call_args.kwargs["action"]).is_equal_to("fmt")
+
+
+def test_api_exports() -> None:
+    """The public package exposes the documented entry points."""
+    for name in ("check", "format", "fmt", "test", "LintroResult"):
+        assert_that(hasattr(api, name)).described_as(name).is_true()
+
+
+def test_no_clirunner_in_production() -> None:
+    """No production module under ``lintro/`` imports ``click.testing``."""
+    lintro_dir = Path(__file__).resolve().parents[3] / "lintro"
+    assert_that(lintro_dir.is_dir()).described_as(str(lintro_dir)).is_true()
+
+    offenders: list[str] = []
+    for py_file in lintro_dir.rglob("*.py"):
+        for raw_line in py_file.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            imports_test_helper = line.startswith(
+                ("from click.testing", "import click.testing"),
+            )
+            instantiates_runner = "CliRunner(" in line
+            if imports_test_helper or instantiates_runner:
+                offenders.append(f"{py_file}: {line}")
+
+    assert_that(offenders).described_as(
+        "click.testing import / CliRunner use found in production lintro package",
+    ).is_empty()
+
+
+@pytest.mark.parametrize(
+    "action_name",
+    ["check", "format", "test"],
+)
+def test_api_callables_are_functions(action_name: str) -> None:
+    """Each documented API entry point is a real callable."""
+    assert_that(callable(getattr(api, action_name))).is_true()

--- a/tests/unit/cli/test_check_command.py
+++ b/tests/unit/cli/test_check_command.py
@@ -326,19 +326,12 @@ def test_check_command_output_file(
 # =============================================================================
 
 
-def test_check_function_calls_command(mock_run_lint_tools_check: MagicMock) -> None:
-    """Verify check() function invokes the check_command.
-
-    Args:
-        mock_run_lint_tools_check: Mock for the run_lint_tools_check function.
-    """
-    with patch("lintro.cli_utils.commands.check.CliRunner") as mock_runner_cls:
-        mock_runner = MagicMock()
-        mock_result = MagicMock()
-        mock_result.exit_code = 0
-        mock_runner.invoke.return_value = mock_result
-        mock_runner_cls.return_value = mock_runner
-
+def test_check_function_calls_command() -> None:
+    """Verify check() routes through the library API."""
+    with patch(
+        "lintro.api.core.run_lint_tools_simple",
+        return_value=0,
+    ) as mock_run:
         check(
             paths=("src",),
             tools="ruff",
@@ -353,18 +346,12 @@ def test_check_function_calls_command(mock_run_lint_tools_check: MagicMock) -> N
             no_log=False,
         )
 
-        mock_runner.invoke.assert_called_once()
+        mock_run.assert_called_once()
 
 
 def test_check_function_exits_on_failure() -> None:
     """Verify check() function exits with non-zero code on failure."""
-    with patch("lintro.cli_utils.commands.check.CliRunner") as mock_runner_cls:
-        mock_runner = MagicMock()
-        mock_result = MagicMock()
-        mock_result.exit_code = 1
-        mock_runner.invoke.return_value = mock_result
-        mock_runner_cls.return_value = mock_runner
-
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=1):
         with pytest.raises(SystemExit) as exc_info:
             check(
                 paths=("src",),

--- a/tests/unit/cli/test_cli_programmatic.py
+++ b/tests/unit/cli/test_cli_programmatic.py
@@ -18,10 +18,10 @@ def test_check_programmatic_success(monkeypatch: pytest.MonkeyPatch) -> None:
     Args:
         monkeypatch: Pytest monkeypatch fixture to stub executor return.
     """
-    import lintro.cli_utils.commands.check as check_mod
+    import lintro.api.core as api_core
 
     mock_run = MagicMock(return_value=0)
-    monkeypatch.setattr(check_mod, "run_lint_tools_simple", mock_run, raising=True)
+    monkeypatch.setattr(api_core, "run_lint_tools_simple", mock_run, raising=True)
 
     # Function returns None on success (no exception raised)
     check_prog(
@@ -51,10 +51,10 @@ def test_check_programmatic_failure_raises(monkeypatch: pytest.MonkeyPatch) -> N
     Args:
         monkeypatch: Pytest fixture for patching modules and attributes.
     """
-    import lintro.cli_utils.commands.check as check_mod
+    import lintro.api.core as api_core
 
     monkeypatch.setattr(
-        check_mod,
+        api_core,
         "run_lint_tools_simple",
         lambda **k: 1,
         raising=True,
@@ -82,11 +82,11 @@ def test_format_programmatic_success(monkeypatch: pytest.MonkeyPatch) -> None:
     Args:
         monkeypatch: Pytest fixture for patching modules and attributes.
     """
-    import lintro.cli_utils.commands.format as format_mod
+    import lintro.api.core as api_core
 
     mock_run = MagicMock(return_value=0)
     monkeypatch.setattr(
-        format_mod,
+        api_core,
         "run_lint_tools_simple",
         mock_run,
         raising=True,
@@ -117,10 +117,10 @@ def test_format_programmatic_failure_raises(monkeypatch: pytest.MonkeyPatch) -> 
     Args:
         monkeypatch: Pytest fixture for patching modules and attributes.
     """
-    import lintro.cli_utils.commands.format as format_mod
+    import lintro.api.core as api_core
 
     monkeypatch.setattr(
-        format_mod,
+        api_core,
         "run_lint_tools_simple",
         lambda **k: 1,
         raising=True,

--- a/tests/unit/cli/test_format_command.py
+++ b/tests/unit/cli/test_format_command.py
@@ -342,14 +342,8 @@ def test_format_command_uses_fmt_action(
 
 
 def test_format_code_function_calls_command() -> None:
-    """Verify format_code() function invokes the format_command."""
-    with patch("lintro.cli_utils.commands.format.CliRunner") as mock_runner_cls:
-        mock_runner = MagicMock()
-        mock_result = MagicMock()
-        mock_result.exit_code = 0
-        mock_runner.invoke.return_value = mock_result
-        mock_runner_cls.return_value = mock_runner
-
+    """Verify format_code() routes through the library API."""
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         format_code(
             paths=["src"],
             tools="ruff",
@@ -361,19 +355,12 @@ def test_format_code_function_calls_command() -> None:
             verbose=False,
         )
 
-        mock_runner.invoke.assert_called_once()
+        mock_run.assert_called_once()
 
 
 def test_format_code_function_raises_on_failure() -> None:
     """Verify format_code() function raises RuntimeError on failure."""
-    with patch("lintro.cli_utils.commands.format.CliRunner") as mock_runner_cls:
-        mock_runner = MagicMock()
-        mock_result = MagicMock()
-        mock_result.exit_code = 1
-        mock_result.output = "Error occurred"
-        mock_runner.invoke.return_value = mock_result
-        mock_runner_cls.return_value = mock_runner
-
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=1):
         with pytest.raises(RuntimeError) as exc_info:
             format_code(
                 paths=["src"],
@@ -385,33 +372,18 @@ def test_format_code_function_raises_on_failure() -> None:
 
 def test_format_code_function_default_parameters() -> None:
     """Verify format_code() function uses default parameters."""
-    with patch("lintro.cli_utils.commands.format.CliRunner") as mock_runner_cls:
-        mock_runner = MagicMock()
-        mock_result = MagicMock()
-        mock_result.exit_code = 0
-        mock_runner.invoke.return_value = mock_result
-        mock_runner_cls.return_value = mock_runner
-
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         # Call with only required parameters (all have defaults)
         format_code()
 
-        mock_runner.invoke.assert_called_once()
-        # Verify defaults were used (no paths means empty args)
-        call_args = mock_runner.invoke.call_args
-        args = call_args[0][1]  # Second positional arg is the args list
-        # Should not contain --tools if tools=None
-        assert_that("--tools" not in args).is_true()
+        mock_run.assert_called_once()
+        # Verify defaults were used (no tools means tools=None)
+        assert_that(mock_run.call_args.kwargs["tools"]).is_none()
 
 
 def test_format_code_function_with_all_options() -> None:
     """Verify format_code() passes all options correctly."""
-    with patch("lintro.cli_utils.commands.format.CliRunner") as mock_runner_cls:
-        mock_runner = MagicMock()
-        mock_result = MagicMock()
-        mock_result.exit_code = 0
-        mock_runner.invoke.return_value = mock_result
-        mock_runner_cls.return_value = mock_runner
-
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         format_code(
             paths=["src", "tests"],
             tools="ruff,black",
@@ -423,16 +395,14 @@ def test_format_code_function_with_all_options() -> None:
             verbose=True,
         )
 
-        mock_runner.invoke.assert_called_once()
-        call_args = mock_runner.invoke.call_args
-        args = call_args[0][1]
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args.kwargs
 
-        assert_that(args).contains("src")
-        assert_that(args).contains("tests")
-        assert_that(args).contains("--tools")
-        assert_that(args).contains("ruff,black")
-        assert_that(args).contains("--include-venv")
-        assert_that(args).contains("--verbose")
+        assert_that(call_kwargs["paths"]).contains("src")
+        assert_that(call_kwargs["paths"]).contains("tests")
+        assert_that(call_kwargs["tools"]).is_equal_to("ruff,black")
+        assert_that(call_kwargs["include_venv"]).is_true()
+        assert_that(call_kwargs["verbose"]).is_true()
 
 
 # =============================================================================

--- a/tests/unit/cli_utils/commands/test_format.py
+++ b/tests/unit/cli_utils/commands/test_format.py
@@ -218,54 +218,41 @@ def test_format_command_returns_tool_exit_code(mock_run: MagicMock) -> None:
 # =============================================================================
 
 
-@patch("lintro.cli_utils.commands.format.CliRunner")
-def test_format_code_invokes_command(mock_runner_class: MagicMock) -> None:
-    """format_code invokes format_command via CliRunner.
+@patch("lintro.api.core.run_lint_tools_simple")
+def test_format_code_invokes_command(mock_run: MagicMock) -> None:
+    """format_code routes through the library API.
 
     Args:
-        mock_runner_class: Mock for CliRunner class.
+        mock_run: Mock for run_lint_tools_simple used by the API.
     """
-    mock_runner = MagicMock()
-    mock_result = MagicMock()
-    mock_result.exit_code = 0
-    mock_runner.invoke.return_value = mock_result
-    mock_runner_class.return_value = mock_runner
+    mock_run.return_value = 0
 
     format_code(paths=["src/"])
 
-    mock_runner.invoke.assert_called_once()
+    mock_run.assert_called_once()
 
 
-@patch("lintro.cli_utils.commands.format.CliRunner")
-def test_format_code_raises_on_failure(mock_runner_class: MagicMock) -> None:
+@patch("lintro.api.core.run_lint_tools_simple")
+def test_format_code_raises_on_failure(mock_run: MagicMock) -> None:
     """format_code raises RuntimeError on non-zero exit.
 
     Args:
-        mock_runner_class: Mock for CliRunner class.
+        mock_run: Mock for run_lint_tools_simple used by the API.
     """
-    mock_runner = MagicMock()
-    mock_result = MagicMock()
-    mock_result.exit_code = 1
-    mock_result.output = "Format error"
-    mock_runner.invoke.return_value = mock_result
-    mock_runner_class.return_value = mock_runner
+    mock_run.return_value = 1
 
     with pytest.raises(RuntimeError, match="Format failed"):
         format_code(paths=["src/"])
 
 
-@patch("lintro.cli_utils.commands.format.CliRunner")
-def test_format_code_passes_options(mock_runner_class: MagicMock) -> None:
-    """format_code passes all options to command.
+@patch("lintro.api.core.run_lint_tools_simple")
+def test_format_code_passes_options(mock_run: MagicMock) -> None:
+    """format_code passes all options through to the API.
 
     Args:
-        mock_runner_class: Mock for CliRunner class.
+        mock_run: Mock for run_lint_tools_simple used by the API.
     """
-    mock_runner = MagicMock()
-    mock_result = MagicMock()
-    mock_result.exit_code = 0
-    mock_runner.invoke.return_value = mock_result
-    mock_runner_class.return_value = mock_runner
+    mock_run.return_value = 0
 
     format_code(
         paths=["src/"],
@@ -275,11 +262,9 @@ def test_format_code_passes_options(mock_runner_class: MagicMock) -> None:
         verbose=True,
     )
 
-    call_args = mock_runner.invoke.call_args[0][1]
-    assert_that(call_args).contains("src/")
-    assert_that(call_args).contains("--tools")
-    assert_that(call_args).contains("ruff")
-    assert_that(call_args).contains("--exclude")
-    assert_that(call_args).contains("*.bak")
-    assert_that(call_args).contains("--include-venv")
-    assert_that(call_args).contains("--verbose")
+    call_kwargs = mock_run.call_args.kwargs
+    assert_that(call_kwargs["paths"]).is_equal_to(["src/"])
+    assert_that(call_kwargs["tools"]).is_equal_to("ruff")
+    assert_that(call_kwargs["exclude"]).is_equal_to("*.bak")
+    assert_that(call_kwargs["include_venv"]).is_true()
+    assert_that(call_kwargs["verbose"]).is_true()

--- a/tests/unit/pytest/test_pytest_programmatic_api.py
+++ b/tests/unit/pytest/test_pytest_programmatic_api.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
+import pytest
 from assertpy import assert_that
 
 from lintro.cli_utils.commands.test import test
@@ -11,10 +12,7 @@ from lintro.cli_utils.commands.test import test
 
 def test_test_function_with_default_options() -> None:
     """Test programmatic test function with explicit default options."""
-    with patch("lintro.cli_utils.commands.test.CliRunner.invoke") as mock_invoke:
-        mock_result = Mock()
-        mock_result.exit_code = 0
-        mock_invoke.return_value = mock_result
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         test(
             paths=(),
             exclude=None,
@@ -25,15 +23,13 @@ def test_test_function_with_default_options() -> None:
             verbose=False,
             tool_options=None,
         )
-        assert_that(mock_invoke.called).is_true()
+        assert_that(mock_run.called).is_true()
+        assert_that(mock_run.call_args.kwargs["tools"]).is_equal_to("pytest")
 
 
 def test_test_function_with_paths() -> None:
     """Test programmatic test function with paths."""
-    with patch("lintro.cli_utils.commands.test.CliRunner.invoke") as mock_invoke:
-        mock_result = Mock()
-        mock_result.exit_code = 0
-        mock_invoke.return_value = mock_result
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         test(
             paths=("tests/",),
             exclude=None,
@@ -44,16 +40,12 @@ def test_test_function_with_paths() -> None:
             verbose=False,
             tool_options=None,
         )
-        call_args = mock_invoke.call_args
-        assert_that(call_args[0][1]).contains("tests/")
+        assert_that(mock_run.call_args.kwargs["paths"]).contains("tests/")
 
 
 def test_test_function_with_exclude() -> None:
     """Test programmatic test function with exclude patterns."""
-    with patch("lintro.cli_utils.commands.test.CliRunner.invoke") as mock_invoke:
-        mock_result = Mock()
-        mock_result.exit_code = 0
-        mock_invoke.return_value = mock_result
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         test(
             paths=(),
             exclude="*.venv",
@@ -64,17 +56,12 @@ def test_test_function_with_exclude() -> None:
             verbose=False,
             tool_options=None,
         )
-        call_args = mock_invoke.call_args
-        assert_that(call_args[0][1]).contains("--exclude")
-        assert_that(call_args[0][1]).contains("*.venv")
+        assert_that(mock_run.call_args.kwargs["exclude"]).is_equal_to("*.venv")
 
 
 def test_test_function_with_include_venv() -> None:
     """Test programmatic test function with include-venv."""
-    with patch("lintro.cli_utils.commands.test.CliRunner.invoke") as mock_invoke:
-        mock_result = Mock()
-        mock_result.exit_code = 0
-        mock_invoke.return_value = mock_result
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         test(
             paths=(),
             exclude=None,
@@ -85,16 +72,12 @@ def test_test_function_with_include_venv() -> None:
             verbose=False,
             tool_options=None,
         )
-        call_args = mock_invoke.call_args
-        assert_that(call_args[0][1]).contains("--include-venv")
+        assert_that(mock_run.call_args.kwargs["include_venv"]).is_true()
 
 
 def test_test_function_with_output() -> None:
     """Test programmatic test function with output file."""
-    with patch("lintro.cli_utils.commands.test.CliRunner.invoke") as mock_invoke:
-        mock_result = Mock()
-        mock_result.exit_code = 0
-        mock_invoke.return_value = mock_result
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         test(
             paths=(),
             exclude=None,
@@ -105,17 +88,14 @@ def test_test_function_with_output() -> None:
             verbose=False,
             tool_options=None,
         )
-        call_args = mock_invoke.call_args
-        assert_that(call_args[0][1]).contains("--output")
-        assert_that(call_args[0][1]).contains("/tmp/output.txt")
+        assert_that(mock_run.call_args.kwargs["output_file"]).is_equal_to(
+            "/tmp/output.txt",
+        )
 
 
 def test_test_function_with_output_format() -> None:
     """Test programmatic test function with output format."""
-    with patch("lintro.cli_utils.commands.test.CliRunner.invoke") as mock_invoke:
-        mock_result = Mock()
-        mock_result.exit_code = 0
-        mock_invoke.return_value = mock_result
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         test(
             paths=(),
             exclude=None,
@@ -126,17 +106,12 @@ def test_test_function_with_output_format() -> None:
             verbose=False,
             tool_options=None,
         )
-        call_args = mock_invoke.call_args
-        assert_that(call_args[0][1]).contains("--output-format")
-        assert_that(call_args[0][1]).contains("json")
+        assert_that(mock_run.call_args.kwargs["output_format"]).is_equal_to("json")
 
 
 def test_test_function_with_group_by() -> None:
     """Test programmatic test function with group-by."""
-    with patch("lintro.cli_utils.commands.test.CliRunner.invoke") as mock_invoke:
-        mock_result = Mock()
-        mock_result.exit_code = 0
-        mock_invoke.return_value = mock_result
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         test(
             paths=(),
             exclude=None,
@@ -147,17 +122,12 @@ def test_test_function_with_group_by() -> None:
             verbose=False,
             tool_options=None,
         )
-        call_args = mock_invoke.call_args
-        assert_that(call_args[0][1]).contains("--group-by")
-        assert_that(call_args[0][1]).contains("code")
+        assert_that(mock_run.call_args.kwargs["group_by"]).is_equal_to("code")
 
 
 def test_test_function_with_verbose() -> None:
     """Test programmatic test function with verbose flag."""
-    with patch("lintro.cli_utils.commands.test.CliRunner.invoke") as mock_invoke:
-        mock_result = Mock()
-        mock_result.exit_code = 0
-        mock_invoke.return_value = mock_result
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         test(
             paths=(),
             exclude=None,
@@ -168,16 +138,12 @@ def test_test_function_with_verbose() -> None:
             verbose=True,
             tool_options=None,
         )
-        call_args = mock_invoke.call_args
-        assert_that(call_args[0][1]).contains("--verbose")
+        assert_that(mock_run.call_args.kwargs["verbose"]).is_true()
 
 
 def test_test_function_with_raw_output() -> None:
     """Test programmatic test function with raw-output flag."""
-    with patch("lintro.cli_utils.commands.test.CliRunner.invoke") as mock_invoke:
-        mock_result = Mock()
-        mock_result.exit_code = 0
-        mock_invoke.return_value = mock_result
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         test(
             paths=(),
             exclude=None,
@@ -189,16 +155,12 @@ def test_test_function_with_raw_output() -> None:
             raw_output=True,
             tool_options=None,
         )
-        call_args = mock_invoke.call_args
-        assert_that(call_args[0][1]).contains("--raw-output")
+        assert_that(mock_run.call_args.kwargs["raw_output"]).is_true()
 
 
 def test_test_function_with_tool_options() -> None:
     """Test programmatic test function with tool options."""
-    with patch("lintro.cli_utils.commands.test.CliRunner.invoke") as mock_invoke:
-        mock_result = Mock()
-        mock_result.exit_code = 0
-        mock_invoke.return_value = mock_result
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         test(
             paths=(),
             exclude=None,
@@ -209,17 +171,14 @@ def test_test_function_with_tool_options() -> None:
             verbose=False,
             tool_options="maxfail=5",
         )
-        call_args = mock_invoke.call_args
-        assert_that(call_args[0][1]).contains("--tool-options")
-        assert_that(call_args[0][1]).contains("maxfail=5")
+        assert_that(mock_run.call_args.kwargs["tool_options"]).contains(
+            "pytest:maxfail=5",
+        )
 
 
 def test_test_function_exit_code_success() -> None:
-    """Test programmatic function exits with success code."""
-    with patch("lintro.cli_utils.commands.test.CliRunner.invoke") as mock_invoke:
-        mock_result = Mock()
-        mock_result.exit_code = 0
-        mock_invoke.return_value = mock_result
+    """Test programmatic function returns on success code."""
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=0) as mock_run:
         # test() returns None on success, no assignment needed
         test(
             paths=(),
@@ -231,16 +190,13 @@ def test_test_function_exit_code_success() -> None:
             verbose=False,
             tool_options=None,
         )
-        assert_that(mock_invoke.called).is_true()
+        assert_that(mock_run.called).is_true()
 
 
 def test_test_function_exit_code_failure() -> None:
     """Test programmatic function exits with failure code."""
-    with patch("lintro.cli_utils.commands.test.CliRunner.invoke") as mock_invoke:
-        mock_result = Mock()
-        mock_result.exit_code = 1
-        mock_invoke.return_value = mock_result
-        with patch("sys.exit") as mock_exit:
+    with patch("lintro.api.core.run_lint_tools_simple", return_value=1):
+        with pytest.raises(SystemExit) as exc_info:
             test(
                 paths=(),
                 exclude=None,
@@ -251,4 +207,4 @@ def test_test_function_exit_code_failure() -> None:
                 verbose=False,
                 tool_options=None,
             )
-            mock_exit.assert_called_once_with(1)
+        assert_that(exc_info.value.code).is_equal_to(1)


### PR DESCRIPTION
## What’s Changing

Production code invoked Click commands through `click.testing.CliRunner`, a test
helper never intended for embedding. This swallowed exceptions into a `Result`
object and buffered stdout/stderr, breaking programmatic/library consumers.

This PR extracts a real library API and routes programmatic execution through it:

- New `lintro.api` package exposing `check()`, `format()` (aliased `fmt`), and
  `test()` as genuine functions that call `run_lint_tools_simple` directly and
  return a structured `LintroResult` (`action`, `exit_code`, `success`).
- Exceptions now propagate to the caller; console output is no longer buffered.
- The backward-compatible programmatic wrappers in the `check`, `format`, and
  `test` command modules now delegate to the library API, and all
  `from click.testing import CliRunner` imports are removed from production code.
  Their public signatures and exit-code behaviour are unchanged.
- `CliRunner` now lives only under `tests/`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` + full `uv run pytest`)

## Related Issues

Closes #1217

## Details

New tests (`tests/unit/api/test_api.py`):

- `test_api_check_propagates_exceptions` — an internal executor failure surfaces
  to the caller unchanged (previously swallowed into `SystemExit(1)`).
- `test_api_check_returns_result` — structured `LintroResult` against a tmp_path
  sample project.
- `test_no_clirunner_in_production` — scans the `lintro/` package and asserts no
  `click.testing` import or `CliRunner(...)` use remains in production.

Existing tests that patched `CliRunner`/`.invoke` in production were updated to
patch `lintro.api.core.run_lint_tools_simple` and assert on its kwargs. The new
`lintro.api` package is registered in `pyproject.toml` `[tool.setuptools].packages`.

A migration note for external callers is added at `docs/usage/library-api.md`
(linked from the usage index).

### Coordination

- `lintro/utils/execution/parallel_executor.py` was **not** touched, so there is
  no overlap with open PR #1264 (`fix/1218-executor-asyncio-fixes`). The
  asyncio loop-ownership work there and this API extraction are independent.

### Testing

- `uv run lintro chk`: health score 100/100, no errors/warnings.
- `uv run pytest`: 6426 passed, 10 skipped. No oxfmt/cargo-deny env failures
  observed in this run.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces production `CliRunner` embedding with a real library API. The main changes are:

- Added `lintro.api` with structured `check`, `format`/`fmt`, and `test` entry points.
- Routed legacy programmatic wrappers through the new API.
- Registered the new package in setuptools configuration.
- Added API tests and library usage documentation.
</details>

<h3>Confidence Score: 5/5</h3>

The changed flow looks mergeable after a small cleanup to pytest option parsing.

- The new import and package setup is consistent.
- The legacy wrappers keep their exposed parameters and exit behavior.
- Comma-containing pytest option values can still be truncated in the new API path.

lintro/api/core.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/api/core.py | Adds the new library API and pytest option construction; comma-containing pytest option values can be truncated. |
| lintro/api/__init__.py | Exports the public API symbols from `lintro.api.core`. |
| lintro/cli_utils/commands/check.py | Routes the legacy `check()` wrapper through the new API. |
| lintro/cli_utils/commands/format.py | Routes `format_code()` through the new API while preserving failure-by-exception behavior. |
| lintro/cli_utils/commands/test.py | Routes the legacy pytest wrapper through the new API. |
| pyproject.toml | Adds `lintro.api` to the explicit setuptools package list. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Fapi%2Fcore.py%3A301-302%0A**Comma%20Values%20Get%20Truncated**%0A%0AWhen%20%60test%28tool_options%3D%22ignore%3Dtest_a%2Ctest_b%22%29%60%20reaches%20this%20new%20API%20path%2C%20the%20loop%20rebuilds%20%60pytest%3Aignore%3Dtest_a%2Ctest_b%60%20and%20the%20downstream%20parser%20splits%20it%20again%20on%20commas.%20The%20parser%20keeps%20%60ignore%3Dtest_a%60%20and%20drops%20the%20%60test_b%60%20fragment%2C%20so%20programmatic%20callers%20get%20a%20silently%20narrowed%20pytest%20option%20value.%0A%0A&pr=1269&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Fapi%2Fcore.py%3A301-302%0A**Comma%20Values%20Get%20Truncated**%0A%0AWhen%20%60test%28tool_options%3D%22ignore%3Dtest_a%2Ctest_b%22%29%60%20reaches%20this%20new%20API%20path%2C%20the%20loop%20rebuilds%20%60pytest%3Aignore%3Dtest_a%2Ctest_b%60%20and%20the%20downstream%20parser%20splits%20it%20again%20on%20commas.%20The%20parser%20keeps%20%60ignore%3Dtest_a%60%20and%20drops%20the%20%60test_b%60%20fragment%2C%20so%20programmatic%20callers%20get%20a%20silently%20narrowed%20pytest%20option%20value.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1269&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F1217-programmatic-execution%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1217-programmatic-execution%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Fapi%2Fcore.py%3A301-302%0A**Comma%20Values%20Get%20Truncated**%0A%0AWhen%20%60test%28tool_options%3D%22ignore%3Dtest_a%2Ctest_b%22%29%60%20reaches%20this%20new%20API%20path%2C%20the%20loop%20rebuilds%20%60pytest%3Aignore%3Dtest_a%2Ctest_b%60%20and%20the%20downstream%20parser%20splits%20it%20again%20on%20commas.%20The%20parser%20keeps%20%60ignore%3Dtest_a%60%20and%20drops%20the%20%60test_b%60%20fragment%2C%20so%20programmatic%20callers%20get%20a%20silently%20narrowed%20pytest%20option%20value.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1269&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(core): route programmatic execution ..."](https://github.com/lgtm-hq/py-lintro/commit/ac937579fdea49ecee09d03154ea9125040a0976) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43507946)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->