### PR TITLE
fix(mypy): run mypy from project root for individual files

### DIFF
--- a/lintro/tools/definitions/mypy.py
+++ b/lintro/tools/definitions/mypy.py
@@ -8,6 +8,7 @@ your code is type-safe.
 from __future__ import annotations
 
 import fnmatch
+import os
 import subprocess  # nosec B404 - used safely with shell disabled
 from dataclasses import dataclass
 from pathlib import Path
@@ -459,9 +460,21 @@ class MypyPlugin(BaseToolPlugin):
                 ),
             )
         else:
-            # For individual files, use the computed cwd and relative paths
-            effective_cwd = ctx.cwd
-            mypy_targets = ctx.rel_files if ctx.rel_files else target_paths
+            # For individual files, run mypy from the project root (where the
+            # config file lives) rather than from each file's parent directory.
+            # Running from the file's directory (the previous behavior) broke
+            # Python package resolution: imports like ``from lintro.plugins.base
+            # import BaseToolPlugin`` resolved to ``Any`` and every ``type:
+            # ignore`` comment was reported as unused (#492). Paths are made
+            # relative to the project root so mypy resolves the full module
+            # path (e.g. ``lintro.tools.definitions.clippy``).
+            project_root = str(Path.cwd())
+            effective_cwd = project_root
+            mypy_targets = [
+                os.path.relpath(os.path.abspath(f), project_root) for f in ctx.files
+            ]
+            if not mypy_targets:
+                mypy_targets = target_paths
 
         cmd = self._build_command(
             files=mypy_targets,

--- a/tests/unit/tools/mypy/test_mypy_plugin.py
+++ b/tests/unit/tools/mypy/test_mypy_plugin.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -269,3 +271,146 @@ def test_build_command_non_strict_omits_allow_any_flags(
         "--allow-untyped-decorators",
     )
     assert_that(cmd).contains("--ignore-missing-imports")
+
+
+# Tests for MypyPlugin.check working-directory handling.
+#
+# Regression coverage for #492: mypy must run from the project root (where the
+# config file lives), passing file paths relative to that root, so Python
+# package/module resolution works. Running from the file's parent directory
+# resolved imports to ``Any`` and mis-flagged ``type: ignore`` comments.
+
+
+def _make_project(tmp_path: Path) -> Path:
+    """Create a minimal Python package tree with a mypy config.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+
+    Returns:
+        Path: The project root containing ``pyproject.toml`` and a nested
+        ``pkg/sub/mod.py`` source file.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.mypy]\npython_version = "3.11"\n',
+        encoding="utf-8",
+    )
+    nested = tmp_path / "pkg" / "sub"
+    nested.mkdir(parents=True)
+    (tmp_path / "pkg" / "__init__.py").write_text("", encoding="utf-8")
+    (nested / "__init__.py").write_text("", encoding="utf-8")
+    (nested / "mod.py").write_text("x: int = 1\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_check_runs_from_project_root_for_single_file(
+    mypy_plugin: MypyPlugin,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run mypy from the project root with a root-relative path (#492).
+
+    Args:
+        mypy_plugin: The MypyPlugin instance to test.
+        tmp_path: Temporary directory provided by pytest.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    project_root = _make_project(tmp_path)
+    monkeypatch.chdir(project_root)
+
+    captured: dict[str, object] = {}
+
+    def fake_run_subprocess(
+        cmd: list[str],
+        timeout: float,
+        cwd: str | None = None,
+        **_: object,
+    ) -> tuple[bool, str]:
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        return True, ""
+
+    monkeypatch.setattr(mypy_plugin, "_run_subprocess", fake_run_subprocess)
+    mypy_plugin.set_options()
+
+    result = mypy_plugin.check([os.path.join("pkg", "sub", "mod.py")], {})
+
+    assert_that(result.success).is_true()
+    assert_that(captured["cwd"]).is_equal_to(str(project_root))
+    # The target path is relative to the project root, not the file's basename.
+    assert_that(captured["cmd"]).contains(os.path.join("pkg", "sub", "mod.py"))
+    assert_that(captured["cmd"]).does_not_contain("mod.py")
+
+
+def test_check_target_is_relative_to_root_not_basename(
+    mypy_plugin: MypyPlugin,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pass a full root-relative path so module resolution works (#492).
+
+    Args:
+        mypy_plugin: The MypyPlugin instance to test.
+        tmp_path: Temporary directory provided by pytest.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    project_root = _make_project(tmp_path)
+    monkeypatch.chdir(project_root)
+
+    captured: dict[str, object] = {}
+
+    def fake_run_subprocess(
+        cmd: list[str],
+        timeout: float,
+        cwd: str | None = None,
+        **_: object,
+    ) -> tuple[bool, str]:
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        return True, ""
+
+    monkeypatch.setattr(mypy_plugin, "_run_subprocess", fake_run_subprocess)
+    mypy_plugin.set_options()
+
+    mypy_plugin.check([os.path.join("pkg", "sub", "mod.py")], {})
+
+    target = captured["cmd"][-1]  # type: ignore[index]
+    assert_that(target).is_equal_to(os.path.join("pkg", "sub", "mod.py"))
+    # A path relative to the file's own directory would collapse to the basename.
+    assert_that(str(target)).contains(os.sep)
+
+
+def test_check_directory_target_runs_from_project_root(
+    mypy_plugin: MypyPlugin,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run mypy from the project root when a directory is passed (#492).
+
+    Args:
+        mypy_plugin: The MypyPlugin instance to test.
+        tmp_path: Temporary directory provided by pytest.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    project_root = _make_project(tmp_path)
+    monkeypatch.chdir(project_root)
+
+    captured: dict[str, object] = {}
+
+    def fake_run_subprocess(
+        cmd: list[str],
+        timeout: float,
+        cwd: str | None = None,
+        **_: object,
+    ) -> tuple[bool, str]:
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        return True, ""
+
+    monkeypatch.setattr(mypy_plugin, "_run_subprocess", fake_run_subprocess)
+    mypy_plugin.set_options()
+
+    result = mypy_plugin.check(["pkg"], {})
+
+    assert_that(result.success).is_true()
+    assert_that(captured["cwd"]).is_equal_to(str(project_root))


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(mypy): run mypy from project root for individual files`

- Type:
  - [x] fix / perf (patch)

- Breaking change:
  - [ ] No

## What's Changing

Fixes #492. When lintro checked individual Python files, the mypy plugin ran
the mypy subprocess from each file's parent directory (the common-parent `cwd`
computed for the discovered files) and passed only the file's basename as the
target (e.g. `clippy.py`).

That broke Python package/module resolution: imports such as
`from lintro.plugins.base import BaseToolPlugin` resolved to `Any`, and every
`type: ignore` comment was reported as an unused ignore — producing false
positive type errors. The tell-tale symptom was mypy output showing
`./clippy.py` instead of the full `lintro/tools/definitions/clippy.py`.

The fix runs mypy from the project root (where the config file is discovered,
i.e. `Path.cwd()`) and passes file paths relative to that root, so mypy
resolves the full module path (e.g. `lintro.tools.definitions.clippy`). This
mirrors the pre-existing directory-target branch, which already runs from the
project root.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing (no user-facing docs affected)
- [x] Local CI passed (full lint + `uv run pytest`)

## Related Issues

Closes #492

## Details

- `lintro/tools/definitions/mypy.py`: in the individual-files branch of
  `check()`, set `effective_cwd` to the project root and build `mypy_targets`
  as paths relative to that root from `ctx.files` (falling back to the raw
  target paths if empty). Added `import os`.
- `tests/unit/tools/mypy/test_mypy_plugin.py`: added three regression tests
  that build a temp package tree with a `pyproject.toml`, spy on the mypy
  subprocess, and assert the cwd is the project root and the target is the
  full root-relative path (not the basename) for both single-file and
  directory inputs.

Verification: `uv run lintro chk lintro/tools/definitions/clippy.py` reports
0 mypy issues, and debug logging confirms
`cwd=<project root>` with target `lintro/tools/definitions/clippy.py`.

Test results: full suite `6418 passed, 10 skipped`; `uv run lintro chk` on the
changed files and clippy.py reports 0 issues (health score 100/100).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates how the mypy plugin runs checks for individual Python files. The main changes are:

- Run individual-file mypy checks from the current root-like directory.
- Pass mypy file targets as paths relative to that directory.
- Add tests for single-file and directory target subprocess cwd handling.
</details>

<h3>Confidence Score: 4/5</h3>

The changed mypy execution path needs a fix for subdirectory invocation before merging.

- Running from a project subdirectory can still make mypy treat checked files as top-level modules.
- The new tests cover project-root invocation, but not the subdirectory case that keeps the same package-resolution failure mode.

lintro/tools/definitions/mypy.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/definitions/mypy.py | Updates individual-file mypy execution, but still ties the subprocess root to the process cwd instead of the discovered config root. |
| tests/unit/tools/mypy/test_mypy_plugin.py | Adds tests for root-relative target handling when the test process has already changed into the project root. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Ftools%2Fdefinitions%2Fmypy.py%3A470-474%0A**Subdirectory%20Cwd%20Remains%20Root**%0A%0AWhen%20lintro%20is%20launched%20from%20a%20project%20subdirectory%2C%20config%20discovery%20can%20still%20walk%20up%20to%20the%20project%20%60pyproject.toml%60%2C%20but%20this%20branch%20runs%20mypy%20from%20the%20subdirectory%20and%20rewrites%20targets%20relative%20to%20that%20subdirectory.%20A%20check%20like%20%60lintro%20chk%20mod.py%60%20from%20%60pkg%2Fsub%2F%60%20can%20still%20pass%20%60mod.py%60%20with%20%60cwd%3Dpkg%2Fsub%60%2C%20so%20mypy%20sees%20the%20file%20as%20a%20top-level%20module%20and%20the%20package-resolution%20false%20positives%20can%20remain.%0A%0A&pr=1270&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Ftools%2Fdefinitions%2Fmypy.py%3A470-474%0A**Subdirectory%20Cwd%20Remains%20Root**%0A%0AWhen%20lintro%20is%20launched%20from%20a%20project%20subdirectory%2C%20config%20discovery%20can%20still%20walk%20up%20to%20the%20project%20%60pyproject.toml%60%2C%20but%20this%20branch%20runs%20mypy%20from%20the%20subdirectory%20and%20rewrites%20targets%20relative%20to%20that%20subdirectory.%20A%20check%20like%20%60lintro%20chk%20mod.py%60%20from%20%60pkg%2Fsub%2F%60%20can%20still%20pass%20%60mod.py%60%20with%20%60cwd%3Dpkg%2Fsub%60%2C%20so%20mypy%20sees%20the%20file%20as%20a%20top-level%20module%20and%20the%20package-resolution%20false%20positives%20can%20remain.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1270&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F492-mypy-project-root%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F492-mypy-project-root%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alintro%2Ftools%2Fdefinitions%2Fmypy.py%3A470-474%0A**Subdirectory%20Cwd%20Remains%20Root**%0A%0AWhen%20lintro%20is%20launched%20from%20a%20project%20subdirectory%2C%20config%20discovery%20can%20still%20walk%20up%20to%20the%20project%20%60pyproject.toml%60%2C%20but%20this%20branch%20runs%20mypy%20from%20the%20subdirectory%20and%20rewrites%20targets%20relative%20to%20that%20subdirectory.%20A%20check%20like%20%60lintro%20chk%20mod.py%60%20from%20%60pkg%2Fsub%2F%60%20can%20still%20pass%20%60mod.py%60%20with%20%60cwd%3Dpkg%2Fsub%60%2C%20so%20mypy%20sees%20the%20file%20as%20a%20top-level%20module%20and%20the%20package-resolution%20false%20positives%20can%20remain.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1270&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(mypy): run mypy from project root fo..."](https://github.com/lgtm-hq/py-lintro/commit/827e884a6fd64ee1a3f9cdf503a9649519867051) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43509282)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->