### PR TITLE
fix(release): gate publish jobs on anchored prerelease classifier

### DIFF
--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -26,6 +26,41 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  classify-tag:
+    name: Classify release tag
+    if: ${{ !startsWith(github.ref_name, 'actions-v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      # read: sparse checkout of scripts for the classifier
+      contents: read
+    outputs:
+      # true when github.ref_name is a prerelease (alpha/beta/rc or any
+      # non-``X.Y.Z`` suffix); false for stable releases including +build
+      # metadata. Consumed by Homebrew/npm/Docker gating below.
+      is_prerelease: ${{ steps.classify.outputs.is_prerelease }}
+    steps:
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+      - name: Checkout scripts
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          sparse-checkout: scripts/ci/classify-release-tag.py
+          sparse-checkout-cone-mode: false
+      - name: Classify tag
+        id: classify
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: python3 scripts/ci/classify-release-tag.py "$TAG_NAME"
+
   sbom:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
@@ -154,12 +189,10 @@ jobs:
 
   homebrew-tap:
     name: Publish Homebrew Tap
-    needs: [pypi-upload, github-release]
+    needs: [classify-tag, pypi-upload, github-release]
     if: >-
       !startsWith(github.ref_name, 'actions-v') &&
-      !contains(github.ref_name, 'a') &&
-      !contains(github.ref_name, 'b') &&
-      !contains(github.ref_name, 'rc')
+      needs.classify-tag.outputs.is_prerelease == 'false'
     uses: ./.github/workflows/build-binary.yml
     permissions:
       # write: push formula updates to Homebrew tap repository
@@ -175,12 +208,10 @@ jobs:
     # platform binaries to the GitHub release, which publish-npm.yml
     # downloads. Gated to stable releases only, since build-binary does not
     # run for prereleases.
-    needs: [homebrew-tap]
+    needs: [classify-tag, homebrew-tap]
     if: >-
       !startsWith(github.ref_name, 'actions-v') &&
-      !contains(github.ref_name, 'a') &&
-      !contains(github.ref_name, 'b') &&
-      !contains(github.ref_name, 'rc')
+      needs.classify-tag.outputs.is_prerelease == 'false'
     uses: ./.github/workflows/publish-npm.yml
     permissions:
       # read: checkout and download release assets
@@ -195,13 +226,11 @@ jobs:
 
   docker-publish:
     name: Publish Docker Images to GHCR
-    needs: [pypi-upload]
+    needs: [classify-tag, pypi-upload]
     # yamllint disable-line rule:line-length
     if: >-
       !startsWith(github.ref_name, 'actions-v') &&
-      !contains(github.ref_name, 'a') &&
-      !contains(github.ref_name, 'b') &&
-      !contains(github.ref_name, 'rc')
+      needs.classify-tag.outputs.is_prerelease == 'false'
     uses: ./.github/workflows/docker-build-publish.yml
     permissions:
       # read: checkout for Docker build context

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -105,6 +105,7 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `run-ai-review.sh`                   | Dogfood `lintro review` on a PR using trusted base-branch lintro      | `PR_NUMBER=123 ./scripts/ci/run-ai-review.sh`                                      |
 | `enable_review_config.py`            | Enable AI review + cost cap in `.lintro-config.yaml` for a CI run     | `python3 scripts/ci/enable_review_config.py --help`                                |
 | `classify-osv-results.py`            | Classify osv_scanner JSON as ok, vulns, or error for CI status        | `python3 scripts/ci/classify-osv-results.py osv-results.json`                      |
+| `classify-release-tag.py`            | Classify a release tag as stable or prerelease for publish gating     | `python3 scripts/ci/classify-release-tag.py v1.2.3`                                |
 | `format-security-comment.py`         | Format lintro osv_scanner JSON as security PR comment markdown        | `python3 scripts/ci/format-security-comment.py osv-results.json`                   |
 | `format-changelog.py`                | Reflow generated `CHANGELOG.md` to lintro 88-col markdown             | `python3 scripts/ci/format-changelog.py CHANGELOG.md`                              |
 | `test-install-package.sh`            | Install and verify built package in isolated venv                     | `./scripts/ci/test-install-package.sh wheel`                                       |

--- a/scripts/ci/classify-release-tag.py
+++ b/scripts/ci/classify-release-tag.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+"""Classify a release tag as a stable release or a prerelease.
+
+Downstream publish jobs (Homebrew, npm, Docker) must only run for stable
+releases. Substring checks such as ``contains(github.ref_name, 'b')`` are
+unsafe because they match anywhere in the tag: a stable tag like
+``v1.2.3+build.1`` contains a ``b`` (in ``build``) and is wrongly treated as a
+prerelease. This classifier applies an anchored version check instead.
+
+A tag is considered **stable** iff, after stripping an optional leading ``v``,
+it is exactly a three-part version core ``X.Y.Z`` optionally followed by
+SemVer ``+build`` metadata. Any other suffix — SemVer ``-<prerelease>`` (for
+example ``-rc.1``) or a PEP 440 bare prerelease (``a1``/``b2``/``rc1``) — marks
+the tag as a prerelease. Build metadata never marks a tag as a prerelease.
+Unrecognized tags default to prerelease so publishing fails closed.
+
+Usage:
+    python3 scripts/ci/classify-release-tag.py <tag>
+
+Behavior:
+    - Prints ``is_prerelease=true`` or ``is_prerelease=false`` to stdout.
+    - When ``GITHUB_OUTPUT`` is set, appends the same ``is_prerelease`` line so
+      GitHub Actions jobs can gate on ``steps.<id>.outputs.is_prerelease``.
+
+Exit codes:
+    0 — Classification printed.
+    1 — Invalid arguments (wrong number of positional arguments).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# Stable release: optional leading ``v``, a three-part ``X.Y.Z`` core, and an
+# optional SemVer ``+build`` metadata segment. Anything else is a prerelease.
+_STABLE_TAG = re.compile(
+    r"^v?\d+\.\d+\.\d+(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$",
+)
+
+
+def is_prerelease_tag(*, tag: str) -> bool:
+    """Return whether ``tag`` names a prerelease rather than a stable release.
+
+    Args:
+        tag: The git tag name, with or without a leading ``v`` (for example
+            ``v1.2.3``, ``v1.2.3-rc.1``, ``v1.2.3rc1``, ``v1.2.3+build.1``).
+
+    Returns:
+        ``False`` when the tag is a stable ``X.Y.Z`` release (optionally with
+        ``+build`` metadata); ``True`` for any prerelease or unrecognized tag.
+    """
+    return not bool(_STABLE_TAG.match(tag.strip()))
+
+
+def _write_output(*, is_prerelease: bool) -> None:
+    """Emit the classification to stdout and to ``GITHUB_OUTPUT`` when set."""
+    line = f"is_prerelease={'true' if is_prerelease else 'false'}"
+    print(line)
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with Path(github_output).open("a", encoding="utf-8") as handle:
+            handle.write(f"{line}\n")
+
+
+def main() -> int:
+    """Classify the tag passed as the sole positional argument."""
+    if len(sys.argv) != 2:
+        print(
+            f"Usage: {Path(sys.argv[0]).name} <tag>",
+            file=sys.stderr,
+        )
+        return 1
+
+    _write_output(is_prerelease=is_prerelease_tag(tag=sys.argv[1]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/ci/test_classify_release_tag.py
+++ b/tests/scripts/ci/test_classify_release_tag.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+"""Tests for the release-tag prerelease classifier script."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+from assertpy import assert_that
+
+ROOT = Path(__file__).resolve().parents[3]
+CLASSIFY_SCRIPT = ROOT / "scripts" / "ci" / "classify-release-tag.py"
+
+
+def _load_module() -> Any:
+    """Load the hyphenated classifier script as an importable module."""
+    spec = importlib.util.spec_from_file_location(
+        "classify_release_tag",
+        CLASSIFY_SCRIPT,
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        # Stable releases (with and without a leading v).
+        ("v1.2.3", False),
+        ("1.2.3", False),
+        ("v0.70.6", False),
+        ("v10.20.30", False),
+        # Build metadata must never mark a tag prerelease (the core defect:
+        # the b in "build" tripped the old contains() gate).
+        ("v1.2.3+build.1", False),
+        ("v1.2.3+20240101", False),
+        ("1.2.3+build.abc", False),
+        # PEP 440 bare prerelease forms (the repo's actual prerelease tags).
+        ("v1.2.3a1", True),
+        ("v1.2.3b2", True),
+        ("v1.2.3rc1", True),
+        ("1.2.3a1", True),
+        # SemVer prerelease components.
+        ("v1.2.3-alpha", True),
+        ("v1.2.3-beta.2", True),
+        ("v1.2.3-rc.1", True),
+        # Combined prerelease + build metadata stays prerelease.
+        ("v1.2.3-rc.1+build.2", True),
+        # actions-v tags are not stable version cores (also excluded upstream
+        # by startsWith in the workflow); fail closed to prerelease.
+        ("actions-v1.0.0", True),
+        # Unrecognized / malformed tags fail closed to prerelease.
+        ("garbage", True),
+        ("v1.2", True),
+        ("v1.2.3.4", True),
+        ("", True),
+    ],
+)
+def test_is_prerelease_tag(tag: str, expected: bool) -> None:
+    """Classify representative stable and prerelease tag forms."""
+    module = _load_module()
+    assert_that(module.is_prerelease_tag(tag=tag)).is_equal_to(expected)
+
+
+def test_surrounding_whitespace_is_ignored() -> None:
+    """A tag padded with whitespace classifies like its trimmed form."""
+    module = _load_module()
+    assert_that(module.is_prerelease_tag(tag="  v1.2.3  ")).is_false()
+    assert_that(module.is_prerelease_tag(tag="  v1.2.3-rc.1  ")).is_true()
+
+
+def test_main_writes_github_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """main() prints and appends is_prerelease to GITHUB_OUTPUT."""
+    module = _load_module()
+    output_file = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    monkeypatch.setattr("sys.argv", ["classify-release-tag.py", "v1.2.3+build.1"])
+
+    exit_code = module.main()
+
+    assert_that(exit_code).is_equal_to(0)
+    assert_that(capsys.readouterr().out.strip()).is_equal_to("is_prerelease=false")
+    assert_that(output_file.read_text(encoding="utf-8")).is_equal_to(
+        "is_prerelease=false\n",
+    )
+
+
+def test_main_prerelease_output(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """main() reports prerelease tags without requiring GITHUB_OUTPUT."""
+    module = _load_module()
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setattr("sys.argv", ["classify-release-tag.py", "v1.2.3-rc.1"])
+
+    exit_code = module.main()
+
+    assert_that(exit_code).is_equal_to(0)
+    assert_that(capsys.readouterr().out.strip()).is_equal_to("is_prerelease=true")
+
+
+def test_main_rejects_wrong_arg_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() returns exit code 1 when not given exactly one tag argument."""
+    module = _load_module()
+    monkeypatch.setattr("sys.argv", ["classify-release-tag.py"])
+    assert_that(module.main()).is_equal_to(1)


### PR DESCRIPTION
## What's Changing

Replaces the substring-based prerelease gating in `.github/workflows/publish-pypi-on-tag.yml` with a single computed `is_prerelease` output that all downstream publish jobs consume.

**Defect:** Homebrew, npm, and Docker jobs gated on `!contains(github.ref_name, 'a') && !contains(github.ref_name, 'b') && !contains(github.ref_name, 'rc')`. `contains` matches anywhere in the string, so a stable tag like `v1.2.3+build.1` (the `b` in `build`) was misclassified as a prerelease — those jobs were skipped while PyPI still published, producing an incomplete release.

**Fix:**
- New `scripts/ci/classify-release-tag.py` — an anchored classifier. A tag is stable iff, after an optional leading `v`, it is exactly `X.Y.Z` with optional SemVer `+build` metadata. Any `-<prerelease>` component or bare PEP 440 `aN`/`bN`/`rcN` suffix marks it prerelease; `+build` metadata never does; unrecognized tags fail closed to prerelease.
- New early `classify-tag` job runs the classifier once (SHA-pinned harden-runner + sparse checkout, stdlib-only Python — no network) and exposes `is_prerelease`.
- Homebrew, npm, and Docker jobs now gate on `needs.classify-tag.outputs.is_prerelease == 'false'`. The `actions-v*` `startsWith` exclusion and all job-dependency ordering (including npm `needs: homebrew-tap`) are preserved.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing (scripts/README.md)
- [x] Local CI passed (full `lintro chk` clean, full pytest 6439 passed)

## Related Issues

Closes #1195

## Details

Repo tags are `vX.Y.Z` (stable) and PEP 440 `vX.Y.ZaN`/`bN`/`rcN` (prereleases), matching the workflow's `on.push.tags` globs; the classifier also handles SemVer `-rc.1` and `+build` forms per the issue's acceptance criteria.

Classifier verified against the acceptance matrix and the repo's real tag history. New pytest coverage in `tests/scripts/ci/test_classify_release_tag.py` (parametrized: stable, `+build`, `aN`/`bN`/`rcN`, SemVer `-alpha`/`-beta`/`-rc`, combined `-rc.1+build.2`, `actions-v`, malformed; plus GITHUB_OUTPUT emission and arg validation).

`actionlint` passes on the modified workflow. No `contains(github.ref_name, 'a'|'b'|'rc')` prerelease checks remain; actions stay SHA-pinned; no new non-trivial inline shell (workflow calls the dedicated script).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR centralizes release-tag classification for publish jobs. The main changes are:

- New `classify-release-tag.py` script for stable versus prerelease tags.
- New `classify-tag` workflow job that exposes `is_prerelease`.
- Homebrew, npm, and Docker publish gates now use the shared classifier output.
- Tests and script documentation were added.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-pypi-on-tag.yml | Adds a classifier job and routes stable-only publish gates through its output while keeping the existing `actions-v*` exclusion. |
| scripts/ci/classify-release-tag.py | Adds a stdlib-only tag classifier that treats exact three-part versions with optional build metadata as stable and fails closed otherwise. |
| tests/scripts/ci/test_classify_release_tag.py | Adds coverage for stable tags, prerelease suffixes, build metadata, malformed tags, output writing, and argument validation. |
| scripts/README.md | Documents the new release-tag classifier script in the scripts table. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): gate publish jobs on ancho..."](https://github.com/lgtm-hq/py-lintro/commit/8f1064e687df0b050065f0dced77edc08d3e4996) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43510033)</sub>

<!-- /greptile_comment -->