### PR TITLE
chore(ci): unify lgtm-ci pins at v0.52.3

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`1014e3d7d5441a63215d2096545a46cff6de101c` (**v0.48.0**). All workflow SHA pins include
+`66cad82ead0e5d119928c895c7d7da9c837989e5` (**v0.52.3**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,8 +38,19 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
-      allowed-endpoints-mode: append
-      allowed-endpoints: release-assets.githubusercontent.com:443
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the github-tooling baseline.
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        uploads.github.com:443
+        pipelines.actions.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,13 +29,13 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       languages: python
       build-mode: none
       config-file: .github/codeql/codeql-config.yml
       category: '/language:all'
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,8 +24,22 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: scorecard
-      allowed-endpoints-mode: append
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the scorecard preset baseline.
+      allowed-endpoints-mode: replace
       allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        uploads.github.com:443
+        pipelines.actions.githubusercontent.com:443
+        gcr.io:443
+        api.osv.dev:443
+        api.scorecard.dev:443
+        api.securityscorecards.dev:443
         api.deps.dev:443
         release-assets.githubusercontent.com:443
     permissions:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,10 +18,10 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       fail-on-severity: high
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -32,9 +32,9 @@ jobs:
       actions: read
     # v0.32.4+ passes github.token as GH_TOKEN into bundle-workflow-artifacts
     # (lgtm-ci#300). v0.32.3 left gh unauthenticated and blocked Pages deploy
-    # after #974 (see #1227). Pin with the repo-standard v0.48.0 tooling.
+    # after #974 (see #1227). Pin with the repo-standard v0.52.3 tooling.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       site-root: apps/site/dist
       build-command: bash scripts/ci/site/build.sh
@@ -44,7 +44,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -78,8 +78,26 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: docker
-      allowed-endpoints-mode: append
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the docker preset baseline.
+      allowed-endpoints-mode: replace
       allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        ghcr.io:443
+        pkg-containers.githubusercontent.com:443
+        docker.io:443
+        registry-1.docker.io:443
+        auth.docker.io:443
+        production.cloudflare.docker.com:443
+        production.cloudfront.docker.com:443
         semgrep.dev:443
         metrics.semgrep.dev:443
 
@@ -131,7 +149,25 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: docker
-      allowed-endpoints-mode: append
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the docker preset baseline.
+      allowed-endpoints-mode: replace
       allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        ghcr.io:443
+        pkg-containers.githubusercontent.com:443
+        docker.io:443
+        registry-1.docker.io:443
+        auth.docker.io:443
+        production.cloudflare.docker.com:443
+        production.cloudfront.docker.com:443
         semgrep.dev:443
         metrics.semgrep.dev:443

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -34,7 +34,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read
       packages: write
@@ -75,7 +75,7 @@ jobs:
         && inputs.backfill_version != '') }}
       provenance: false
       sbom: false
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: docker
       allowed-endpoints-mode: append
@@ -87,7 +87,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read
       packages: write
@@ -128,7 +128,7 @@ jobs:
         && inputs.backfill_version != '') }}
       provenance: false
       sbom: false
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: docker
       allowed-endpoints-mode: append

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -222,12 +222,12 @@ jobs:
         needs.manifest-sync.result == 'skipped'
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,bandit:timeout=120,osv_scanner:check_suppressions=false
@@ -258,13 +258,13 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
     with:
       exit-code: ${{ needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
 
@@ -279,11 +279,11 @@ jobs:
         github.event.pull_request.draft == false
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read
     with:
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: '🛠️ Lintro Code Quality'
       runner-image: ubuntu-24.04
       upstream-result: >-
@@ -357,7 +357,7 @@ jobs:
         if: github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -47,8 +47,18 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
-      allowed-endpoints-mode: append
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the github-tooling baseline.
+      allowed-endpoints-mode: replace
       allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        uploads.github.com:443
+        pipelines.actions.githubusercontent.com:443
         ghcr.io:443
         pkg-containers.githubusercontent.com:443
       runner-image: ubuntu-24.04
@@ -69,8 +79,18 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
-      allowed-endpoints-mode: append
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the github-tooling baseline.
+      allowed-endpoints-mode: replace
       allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        uploads.github.com:443
+        pipelines.actions.githubusercontent.com:443
         ghcr.io:443
         pkg-containers.githubusercontent.com:443
       runner-image: ubuntu-24.04

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -35,7 +35,7 @@ permissions: {}
 jobs:
   prune-untagged:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read # checkout repo and lgtm-ci tooling sparse checkout
       packages: write # delete untagged GHCR package versions via Packages API
@@ -44,7 +44,7 @@ jobs:
       min-age-days: >-
         ${{ github.event_name != 'workflow_dispatch' && 7 || inputs.min_age_days }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append
@@ -57,7 +57,7 @@ jobs:
 
   prune-untagged-base:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read # checkout repo and lgtm-ci tooling sparse checkout
       packages: write # delete untagged GHCR package versions via Packages API
@@ -66,7 +66,7 @@ jobs:
       min-age-days: >-
         ${{ github.event_name != 'workflow_dispatch' && 7 || inputs.min_age_days }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,10 +12,10 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,11 +12,11 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -65,14 +65,14 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       target: .
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: sbom
     permissions:
@@ -92,14 +92,14 @@ jobs:
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -151,11 +151,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+          tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       - name: Upload to PyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
@@ -174,14 +174,14 @@ jobs:
     needs: [pypi-upload]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       # write: create GitHub Release and upload dist assets
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
       allowed-endpoints-mode: append

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -102,8 +102,22 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: pypi
-      allowed-endpoints-mode: append
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the pypi preset baseline.
+      allowed-endpoints-mode: replace
       allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        pypi.org:443
+        files.pythonhosted.org:443
+        test.pypi.org:443
+        upload.pypi.org:443
+        upload.test.pypi.org:443
         astral.sh:443
         releases.astral.sh:443
         github-releases.githubusercontent.com:443
@@ -184,8 +198,18 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
-      allowed-endpoints-mode: append
-      allowed-endpoints: uploads.github.com:443
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the github-tooling baseline.
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        uploads.github.com:443
+        pipelines.actions.githubusercontent.com:443
 
   homebrew-tap:
     name: Publish Homebrew Tap

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -30,8 +30,22 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: pypi
-      allowed-endpoints-mode: append
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the pypi preset baseline.
+      allowed-endpoints-mode: replace
       allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        pypi.org:443
+        files.pythonhosted.org:443
+        test.pypi.org:443
+        upload.pypi.org:443
+        upload.test.pypi.org:443
         astral.sh:443
         releases.astral.sh:443
         github-releases.githubusercontent.com:443

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -18,7 +18,7 @@ jobs:
   pypi-build:
     name: Build Python distribution
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
@@ -27,7 +27,7 @@ jobs:
       verify-tag-version: false
       ensure-tag-on-default-branch: false
       artifact-name: python-dist
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -80,11 +80,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+          tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       - name: Upload to TestPyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -23,10 +23,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       create-release: false
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       # Paired with release-version-pr.yml (egress-preset: pypi).
       # Guarded by test_release_workflows_use_paired_egress_presets.

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       ecosystems: python
       auto-merge: true
@@ -33,7 +33,7 @@ jobs:
       # PRs pass dogfooding-lint without CHANGELOG.md being ignored (#1117).
       # Shell/format logic lives in the dedicated script, not an inline run.
       version-update-script: scripts/ci/format-changelog.py
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       # Paired with release-auto-tag.yml (egress-preset: github-tooling).
       # Guarded by test_release_workflows_use_paired_egress_presets.

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -44,7 +44,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,14 +17,14 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       target: .
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: sbom
     permissions:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,9 +17,9 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: scorecard
       allowed-endpoints-mode: append

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -22,8 +22,21 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: scorecard
-      allowed-endpoints-mode: append
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the scorecard preset baseline.
+      allowed-endpoints-mode: replace
       allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        gcr.io:443
+        api.osv.dev:443
+        api.scorecard.dev:443
+        api.securityscorecards.dev:443
         agent.api.stepsecurity.io:443
         fulcio.sigstore.dev:443
         rekor.sigstore.dev:443

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -18,9 +18,9 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -54,18 +54,18 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           python-version: '3.12'
           install-dependencies: false
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           node-version: '22'
           working-directory: apps/site
@@ -84,7 +84,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+          ref: 66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -131,7 +131,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -148,18 +148,18 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           python-version: '3.12'
           install-dependencies: false
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@f469f4d5c187f0700ccec4c023152fb68ee3dc89 # v0.32.3
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           node-version: '22'
           working-directory: apps/site

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -23,7 +23,7 @@ jobs:
   # Compat mode: multi-runtime matrix, no coverage or PR comments
   test-compat:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       publish-test-summary: false
       python-versions: '3.11,3.14'
@@ -34,7 +34,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -50,7 +50,7 @@ jobs:
   # Coverage mode: single runtime with coverage reporting
   test-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
       publish-test-summary: true
       python-version: '3.14'
@@ -63,7 +63,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Coverage
       runner-image: ubuntu-24.04
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: pypi
       allowed-endpoints-mode: append
@@ -112,11 +112,11 @@ jobs:
     needs: test-gate
     if: always()
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: read
     with:
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       job-name: '🧪 Test Suite & Coverage'
       runner-image: ubuntu-24.04
       upstream-result: ${{ needs.test-gate.outputs.result }}
@@ -139,7 +139,7 @@ jobs:
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/harden-runner@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: block
           # raw.githubusercontent.com is required by astral-sh/setup-uv (versions
@@ -159,11 +159,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
         with:
           python-version: '3.14'
           install-dependencies: 'true'

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -37,8 +37,22 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: pypi
-      allowed-endpoints-mode: append
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the pypi preset baseline.
+      allowed-endpoints-mode: replace
       allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        pypi.org:443
+        files.pythonhosted.org:443
+        test.pypi.org:443
+        upload.pypi.org:443
+        upload.test.pypi.org:443
         astral.sh:443
         releases.astral.sh:443
     permissions:
@@ -66,8 +80,22 @@ jobs:
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: pypi
-      allowed-endpoints-mode: append
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the pypi preset baseline.
+      allowed-endpoints-mode: replace
       allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        pypi.org:443
+        files.pythonhosted.org:443
+        test.pypi.org:443
+        upload.pypi.org:443
+        upload.test.pypi.org:443
         astral.sh:443
         releases.astral.sh:443
     permissions:

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -22,9 +22,9 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -18,13 +18,13 @@ concurrency:
 jobs:
   check-suppressions:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@1014e3d7d5441a63215d2096545a46cff6de101c # v0.48.0
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     permissions:
       contents: write # commit auto-remediation suppressions on default branch
       pull-requests: write # open PRs for stale/expired suppressions
     with:
       job-name: '🔍 Check Vulnerability Suppressions'
-      tooling-ref: '1014e3d7d5441a63215d2096545a46cff6de101c' # v0.48.0
+      tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       workflow-file: vuln-suppression-check.yml
       runner-image: ubuntu-24.04
       egress-policy: block

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -505,6 +505,31 @@ def test_publish_npm_exposes_dist_tag_for_backfills() -> None:
 _LGTM_CI_PIN = "66cad82ead0e5d119928c895c7d7da9c837989e5"
 
 
+def test_all_lgtm_ci_refs_use_the_canonical_pin() -> None:
+    """Every lgtm-ci ref in workflows must match the single canonical pin.
+
+    Guards the repo-wide invariant from #1280: `uses:` refs and
+    `tooling-ref:` inputs all point at the same lgtm-ci commit, so pins
+    cannot silently drift apart again.
+    """
+    ref_pattern = re.compile(
+        r"lgtm-hq/lgtm-ci/[^@\s]+@([0-9a-f]{40})" r"|tooling-ref: '([0-9a-f]{40})'",
+    )
+    workflows_dir = _REPO_ROOT / ".github" / "workflows"
+    offenders: list[str] = []
+    for path in sorted(workflows_dir.glob("*.yml")):
+        for lineno, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(),
+            start=1,
+        ):
+            for match in ref_pattern.finditer(line):
+                sha = match.group(1) or match.group(2)
+                if sha != _LGTM_CI_PIN:
+                    offenders.append(f"{path.name}:{lineno}: {sha}")
+
+    assert_that(offenders).is_empty()
+
+
 def test_stage_coverage_html_allows_setup_uv_manifest_host() -> None:
     """Coverage staging must allow raw.githubusercontent.com for setup-uv.
 

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -508,24 +508,44 @@ _LGTM_CI_PIN = "66cad82ead0e5d119928c895c7d7da9c837989e5"
 def test_all_lgtm_ci_refs_use_the_canonical_pin() -> None:
     """Every lgtm-ci ref in workflows must match the single canonical pin.
 
-    Guards the repo-wide invariant from #1280: `uses:` refs and
-    `tooling-ref:` inputs all point at the same lgtm-ci commit, so pins
-    cannot silently drift apart again.
+    Guards the repo-wide invariant from #1280: `uses:` refs,
+    `tooling-ref:` inputs, and manual `actions/checkout` steps targeting
+    lgtm-hq/lgtm-ci all point at the same lgtm-ci commit, so pins cannot
+    silently drift apart again. Any ref shape (tag, branch, short SHA,
+    any quoting) that is not the canonical pin is an offender.
     """
     ref_pattern = re.compile(
-        r"lgtm-hq/lgtm-ci/[^@\s]+@([0-9a-f]{40})" r"|tooling-ref: '([0-9a-f]{40})'",
+        r"lgtm-hq/lgtm-ci/[^@\s]+@([^\s#]+)|tooling-ref:\s*[\"']?([^\"'\s#]+)",
     )
     workflows_dir = _REPO_ROOT / ".github" / "workflows"
     offenders: list[str] = []
-    for path in sorted(workflows_dir.glob("*.yml")):
+    workflow_paths = sorted(
+        (*workflows_dir.glob("*.yml"), *workflows_dir.glob("*.yaml")),
+    )
+    for path in workflow_paths:
         for lineno, line in enumerate(
             path.read_text(encoding="utf-8").splitlines(),
             start=1,
         ):
             for match in ref_pattern.finditer(line):
-                sha = match.group(1) or match.group(2)
-                if sha != _LGTM_CI_PIN:
-                    offenders.append(f"{path.name}:{lineno}: {sha}")
+                ref = match.group(1) or match.group(2)
+                if ref != _LGTM_CI_PIN:
+                    offenders.append(f"{path.name}:{lineno}: {ref}")
+
+        # Manual lgtm-ci tooling checkouts pin via a separate `ref:` field
+        # (e.g. site-quality.yml); a bare `ref:` regex would false-positive
+        # on checkouts of other repositories, so walk the parsed YAML.
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_id, job in (workflow.get("jobs") or {}).items():
+            for step in job.get("steps") or []:
+                with_block = step.get("with") or {}
+                if with_block.get("repository") != "lgtm-hq/lgtm-ci":
+                    continue
+                if with_block.get("ref") != _LGTM_CI_PIN:
+                    offenders.append(
+                        f"{path.name}:{job_id}: checkout ref "
+                        f"{with_block.get('ref')!r}",
+                    )
 
     assert_that(offenders).is_empty()
 

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -500,9 +500,9 @@ def test_publish_npm_exposes_dist_tag_for_backfills() -> None:
     assert_that(publish_step["env"]["NPM_DIST_TAG"]).contains("inputs.dist_tag")
 
 
-# Canonical lgtm-ci pin used by most py-lintro workflows (v0.48.0).
+# Canonical lgtm-ci pin used by all py-lintro workflows (v0.52.3).
 # Pages deploy must not regress to v0.32.3 (missing GH_TOKEN in bundler).
-_LGTM_CI_V0480 = "1014e3d7d5441a63215d2096545a46cff6de101c"
+_LGTM_CI_PIN = "66cad82ead0e5d119928c895c7d7da9c837989e5"
 
 
 def test_stage_coverage_html_allows_setup_uv_manifest_host() -> None:
@@ -527,16 +527,16 @@ def test_deploy_pages_pins_bundler_with_github_token() -> None:
 
     reusable-deploy-site-with-reports checks out tooling-ref for
     bundle-workflow-artifacts. v0.32.3 omitted GH_TOKEN; v0.32.4+ (lgtm-ci#300)
-    sets ``GH_TOKEN: ${{ github.token }}``. Stay on the repo-standard v0.48.0 pin.
+    sets ``GH_TOKEN: ${{ github.token }}``. Stay on the repo-standard v0.52.3 pin.
     """
     workflow = _load_workflow(name="deploy-pages.yml")
     deploy = workflow["jobs"]["deploy"]
     uses = deploy["uses"]
     tooling_ref = deploy["with"]["tooling-ref"]
 
-    assert_that(uses).contains(_LGTM_CI_V0480)
+    assert_that(uses).contains(_LGTM_CI_PIN)
     assert_that(uses).contains("reusable-deploy-site-with-reports.yml")
-    assert_that(tooling_ref).contains(_LGTM_CI_V0480)
+    assert_that(tooling_ref).contains(_LGTM_CI_PIN)
     assert_that(deploy["permissions"]).contains_entry({"actions": "read"})
     assert_that(deploy["permissions"]).contains_entry({"pages": "write"})
     assert_that(deploy["permissions"]).contains_entry({"id-token": "write"})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title:

  ```text
  chore(ci): unify lgtm-ci pins at v0.52.3
  ```

- Type:
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Unifies the split lgtm-ci pins — v0.48.0 (`1014e3d7`, 34 pins) and v0.32.3
(`f469f4d5`, 9 refs, all in `site-quality.yml`) — at a single ref:
`66cad82ead0e5d119928c895c7d7da9c837989e5` # v0.52.3, with `# v0.52.3`
comments on every pin (Renovate-trackable). Every `uses:` line, `tooling-ref:`
input, and the sparse tooling checkout `ref:` in `site-quality.yml` now point
at the same release; `.github/workflows/README.md` documents the new pin.

### v0.32.3 straggler verdict

The 9 v0.32.3 refs were all introduced wholesale when `site-quality.yml` was
added in #974 and never touched since. No comments or history indicate an
intentional compatibility pin — they are stale, not deliberate, so they are
bumped like the rest. (The `deploy-pages.yml` comment about v0.32.3 breaking
Pages deploys documents why that file was already ahead; comment updated to
reference v0.52.3.)

### Migration: harden-runner composite removed in lgtm-ci v0.50.0

`lgtm-hq/lgtm-ci/.github/actions/harden-runner` no longer exists at v0.52.3
(only allowlist-resolution helpers remain). Per
`lgtm-ci/docs/workflow-contract.md` ("Harden-runner distribution"), egress
enforcement must be a direct remote step. The 4 composite usages
(`test-ci.yml` stage-coverage-html, `renovate.yml`, `site-quality.yml` ×2) are
replaced inline with
`step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0`
— the exact pin the old composite wrapped — with identical
`egress-policy` / `allowed-endpoints` inputs (all literal allowlists, so no
`resolve-egress-allowlist` step is needed).

### Version-gap verification (v0.32.3/v0.48.0 → v0.52.3)

- All 24 reusable-workflow callers verified: every `with:` input and secret
  passed by py-lintro exists in the target workflow at `66cad82` (scripted
  check against a checkout of the target ref). No `#281` publish-test-summary
  or `#340` compat/coverage renames apply — py-lintro already uses the
  post-rename input names.
- All composite-action usages (`secure-checkout`, `setup-python`,
  `setup-node`, `prepare-pypi-upload`, `post-pr-comment`) exist at `66cad82`
  with compatible inputs.
- Egress presets used by py-lintro (`github-tooling`, `pypi`, `osv-scanner`,
  `sbom`, `scorecard`, `docker`, `quality`) are unchanged between v0.48.0 and
  v0.52.3 (only `npm-publish` gained endpoints); caller-side literal
  allowlists untouched.
- `scripts/ci/actions/build-lychee-args.sh` (consumed by `site-quality.yml`
  from the sparse tooling checkout) is byte-identical across the gap.

### Contract conformance

- `merge_group:` present on all required-check callers (`test-ci.yml`,
  `docker-ci.yml`, `codeql.yml`, `semantic-pr-title.yml`) — already conformant.
- No `on.pull_request.paths` / `on.merge_group.paths` on required-check
  workflows. `codeql.yml` keeps its `on.push.paths` (main-branch analysis
  only; PR/merge_group triggers are unfiltered and documented as such
  in-file), so required contexts always report.
- Caller job ids and reusable inner job names are identical at v0.48.0 and
  v0.52.3 — reported check names do not change.

### Deferred: local detect-changes script migration (lgtm-ci#484)

Not migrated. `scripts/ci/detect-changes.sh` detects a dirty working tree
(`git diff` vs HEAD → `has_changes` output) and is not referenced by any
workflow — only by `scripts/README.md` and its shell test. The lgtm-ci
`detect-changes` composite is a changed-paths filter (dorny/paths-filter
wrapper replacing `on.*.paths`), i.e. different semantics, so this is not a
drop-in migration and is out of scope for a pin-unification PR.

## Ruleset lockstep

None. All 13 required contexts in the `checks-py-lintro` org ruleset are
unchanged: caller job ids are untouched and the inner `name:` / `job-name`
handling of `reusable-test-python`, `reusable-required-check`,
`reusable-codeql`, `reusable-quality-lint`, and `reusable-semantic-pr-title`
is identical between v0.48.0 and v0.52.3.

### Migration: egress allowlist replace semantics (v0.50.0+)

Since v0.50.0 the reusables pass the caller's `allowed-endpoints` verbatim to
`step-security/harden-runner` at job start, so a non-empty value **replaces**
the preset/default baseline instead of being appended by
`allowed-endpoints-mode: append` (the merge now only affects the resolved
audit output). The first push of this PR broke codeql, dependency-review,
test-compat/test-coverage and the required-check gates with
`Failed to connect to github.com port 443` because the 12 caller jobs that
passed extras-only lists lost the github baseline. All 12 now pass complete
allowlists (preset baseline + extras) with `allowed-endpoints-mode: replace`,
mirroring lgtm-ci's own first-party callers.

### Tests

`tests/unit/test_workflow_wiring.py` pins the canonical lgtm-ci SHA
(`test_deploy_pages_pins_bundler_with_github_token`); the `_LGTM_CI_V0480`
constant is renamed to `_LGTM_CI_PIN` and updated to `66cad82` so the
regression guard now enforces the unified v0.52.3 pin. A new
`test_all_lgtm_ci_refs_use_the_canonical_pin` asserts every lgtm-ci `uses:`
ref and `tooling-ref:` across all workflows matches the canonical pin
(addresses review feedback that the guard covered only deploy-pages).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (workflow-wiring pin guard updated to v0.52.3)
- [x] Docs updated if user-facing (`.github/workflows/README.md` pin note)
- [x] Local CI passed (`uv run lintro chk` clean, `uv run pytest -x -q` green)

## Related Issues

## Closes

- Closes #1280
- Relates to lgtm-hq/lgtm-ci#510

## Details

Mechanical SHA swap plus the mandated harden-runner inlining; no workflow
logic, job ids, display names, permissions, or egress allowlists changed.
Verification was scripted: caller `with:`/`secrets:` keys diffed against
`workflow_call` inputs at `66cad82`, composite action inputs checked the same
way, and egress presets + tooling scripts diffed across the version gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Updated automated workflows to newer, consistently pinned tooling.
  * Strengthened network access controls with explicit endpoint allowlists.
  * Improved runner hardening and secure checkout coverage.

* **Bug Fixes**
  * Added validation to ensure workflow references remain aligned with the approved tooling version.

* **Tests**
  * Expanded workflow wiring checks to detect inconsistent action pins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves the repository workflows to one lgtm-ci pin. The main changes are:

- Updated lgtm-ci reusable workflow and action refs to v0.52.3.
- Replaced removed lgtm-ci harden-runner composites with direct step-security/harden-runner steps.
- Expanded egress allowlists for the newer replace behavior.
- Added a workflow test for canonical lgtm-ci refs, tooling refs, and manual lgtm-ci checkouts.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/unit/test_workflow_wiring.py | Adds a repo-wide lgtm-ci pin check for workflow refs, tooling refs, and manual lgtm-ci checkout refs. |
| .github/workflows/site-quality.yml | Updates stale lgtm-ci refs and switches harden-runner usage to the direct pinned action. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(ci): harden lgtm-ci pin guard again..."](https://github.com/lgtm-hq/py-lintro/commit/ed021624600f3da01e676dac83b77bd6186ce933) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43523076)</sub>

<!-- /greptile_comment -->