### PR TITLE
chore(ci): adopt canonical emoji check names

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,8 @@ name: Security - CodeQL Code Scanning
     paths: ['**.py', 'pyproject.toml', '.github/**']
   pull_request:
     branches: [main]
-    # No paths filter: `codeql / CodeQL` is a required status check, and a
+    # No paths filter: `codeql / 🔬 CodeQL Analysis` is a required status
+    # check, and a
     # path-filtered workflow that does not run leaves that context absent
     # (not skipped), which permanently blocks the merge queue for PRs that
     # touch only non-matching files (docs, npm/, etc.). Always run on PRs so
@@ -31,6 +32,8 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
+      # Org ruleset (checks-py-lintro): codeql / 🔬 CodeQL Analysis
+      job-name: '🔬 CodeQL Analysis'
       languages: python
       build-mode: none
       config-file: .github/codeql/codeql-config.yml

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -20,6 +20,8 @@ jobs:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@66cad82ead0e5d119928c895c7d7da9c837989e5 # v0.52.3
     with:
+      # Org ruleset (checks-py-lintro): semantic-title / 📝 Validate PR Title
+      job-name: '📝 Validate PR Title'
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       egress-policy: block
       egress-preset: github-tooling

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -105,7 +105,7 @@ jobs:
 
   # Evaluate both upstream jobs into a single result for the required-check gate
   test-gate:
-    name: Test Gate
+    name: 🚦 Test Gate
     needs: [test-compat, test-coverage]
     if: always()
     runs-on: ubuntu-24.04


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(ci): adopt canonical emoji check names
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Adopts the canonical emoji check names defined in lgtm-hq/lgtm-ci#514 for the
three required contexts in the `checks-py-lintro` ruleset that were still on
their legacy names:

- `codeql.yml`: pass `job-name: '🔬 CodeQL Analysis'` to `reusable-codeql`
  (previously the default `CodeQL`); updated the paths-filter comment that
  referenced the old context name.
- `semantic-pr-title.yml`: pass `job-name: '📝 Validate PR Title'` to
  `reusable-semantic-pr-title` (previously the default `Semantic PR Title`).
- `test-ci.yml`: rename the inline gate job `name: Test Gate` →
  `name: 🚦 Test Gate`.

All other required contexts were already canonical and are unchanged
(`lintro-code-quality / 🛠️ Lintro Code Quality`,
`test-suite-coverage / 🧪 Test Suite & Coverage`,
`test-compat / Python Compatibility`, `test-coverage / Python Coverage`,
`🐳 Build Docker Images`, `🔐 Security Audit`, `🧪 Docker Integration Tests`).

## Ruleset lockstep

The `checks-py-lintro` org ruleset must be updated to the new contexts when
this PR merges:

| Old required context | New required context |
| --- | --- |
| `codeql / CodeQL` | `codeql / 🔬 CodeQL Analysis` |
| `semantic-title / Semantic PR Title` | `semantic-title / 📝 Validate PR Title` |
| `Test Gate` | `🚦 Test Gate` |

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (n/a — `tests/unit/test_workflow_wiring.py` does not
      assert job display names; full unit suite passes: 5636 passed, 7 skipped)
- [ ] Docs updated if user-facing (not user-facing)
- [x] Local CI passed (`uv run lintro chk` clean, unit suite green)

## Related Issues

Closes #1282 | Related lgtm-hq/lgtm-ci#514

## Details

Both `reusable-codeql` and `reusable-semantic-pr-title` at the pinned v0.52.3
(`66cad82`) expose a `job-name` input that sets the job's display name, so the
rename is a pure caller-side input; the `🚦 Test Gate` job is defined inline in
`test-ci.yml`. The downstream `test-gate` consumers reference the job by its
`test-gate` id/outputs, not its display name, so no wiring changes are needed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the remaining CI check names to their canonical emoji contexts.

- `codeql.yml` passes the new CodeQL display name.
- `semantic-pr-title.yml` passes the new PR title check display name.
- `test-ci.yml` renames the inline test gate display name.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge once the external ruleset update is coordinated.

- The workflow wiring still uses stable job ids and outputs.
- The only identified risk is a temporary required-check mismatch if the org ruleset is not updated with the renamed contexts.

.github/workflows/test-ci.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/codeql.yml | Adds the canonical CodeQL job display name and updates the required-check comment. |
| .github/workflows/semantic-pr-title.yml | Adds the canonical semantic PR title job display name. |
| .github/workflows/test-ci.yml | Renames the inline test gate display name, which needs the matching ruleset context update. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Ftest-ci.yml%3A108%0A**Required%20Context%20Name%20Drift**%0A%0AWhen%20this%20rename%20lands%20before%20the%20org%20ruleset%20is%20updated%2C%20the%20workflow%20reports%20%60%F0%9F%9A%A6%20Test%20Gate%60%20while%20branch%20protection%20still%20waits%20for%20%60Test%20Gate%60.%20In%20that%20state%2C%20every%20PR%20can%20have%20passing%20tests%20but%20remain%20blocked%20because%20the%20required%20context%20never%20appears.%0A%0A&pr=1283&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Ftest-ci.yml%3A108%0A**Required%20Context%20Name%20Drift**%0A%0AWhen%20this%20rename%20lands%20before%20the%20org%20ruleset%20is%20updated%2C%20the%20workflow%20reports%20%60%F0%9F%9A%A6%20Test%20Gate%60%20while%20branch%20protection%20still%20waits%20for%20%60Test%20Gate%60.%20In%20that%20state%2C%20every%20PR%20can%20have%20passing%20tests%20but%20remain%20blocked%20because%20the%20required%20context%20never%20appears.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1283&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22chore%2F1282-emoji-check-names%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F1282-emoji-check-names%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Ftest-ci.yml%3A108%0A**Required%20Context%20Name%20Drift**%0A%0AWhen%20this%20rename%20lands%20before%20the%20org%20ruleset%20is%20updated%2C%20the%20workflow%20reports%20%60%F0%9F%9A%A6%20Test%20Gate%60%20while%20branch%20protection%20still%20waits%20for%20%60Test%20Gate%60.%20In%20that%20state%2C%20every%20PR%20can%20have%20passing%20tests%20but%20remain%20blocked%20because%20the%20required%20context%20never%20appears.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1283&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): adopt canonical emoji check n..."](https://github.com/lgtm-hq/py-lintro/commit/ac6fe5681d5eba008b0b57c696e40fd77748e162) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43535663)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->