### PR TITLE
fix(ci): grant permissions required by lgtm-ci v0.52.3 reusables

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,7 +29,10 @@ jobs:
       contents: read
       pages: write
       id-token: write
-      actions: read
+      # write: reusable-deploy-site-with-reports v0.52.3 requests actions:
+      # write (self-heal rerun artifact pruning, lgtm-ci#415); a lower caller
+      # grant is a parse-time startup_failure
+      actions: write
     # v0.32.4+ passes github.token as GH_TOKEN into bundle-workflow-artifacts
     # (lgtm-ci#300). v0.32.3 left gh unauthenticated and blocked Pages deploy
     # after #974 (see #1227). Pin with the repo-standard v0.52.3 tooling.

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -76,8 +76,9 @@ jobs:
       egress-policy: block
       egress-preset: sbom
     permissions:
-      # read: checkout repo for SBOM generation
-      contents: read
+      # write: reusable-sbom v0.52.3 requests contents: write (attach SBOM to
+      # release assets, lgtm-ci#505); a lower grant is a startup_failure
+      contents: write
       # write: upload vulnerability findings to GitHub Security tab
       security-events: write
       # write: OIDC for SBOM attestation signing

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -28,7 +28,9 @@ jobs:
       egress-policy: block
       egress-preset: sbom
     permissions:
-      contents: read
+      # write: reusable-sbom v0.52.3 requests contents: write (release SBOM
+      # asset upload); a lower caller grant is a parse-time startup_failure
+      contents: write
       security-events: write
       id-token: write
       attestations: write

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -582,6 +582,8 @@ def test_deploy_pages_pins_bundler_with_github_token() -> None:
     assert_that(uses).contains(_LGTM_CI_PIN)
     assert_that(uses).contains("reusable-deploy-site-with-reports.yml")
     assert_that(tooling_ref).contains(_LGTM_CI_PIN)
-    assert_that(deploy["permissions"]).contains_entry({"actions": "read"})
+    # v0.52.3 build job requests actions: write (lgtm-ci#415 rerun
+    # self-heal); a lower caller grant is a parse-time startup_failure.
+    assert_that(deploy["permissions"]).contains_entry({"actions": "write"})
     assert_that(deploy["permissions"]).contains_entry({"pages": "write"})
     assert_that(deploy["permissions"]).contains_entry({"id-token": "write"})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): grant permissions required by lgtm-ci v0.52.3 reusables
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Two workflows on `main` fail with `startup_failure` (no jobs, no logs) since #1281 unified lgtm-ci pins at v0.52.3 (`66cad82`):

- Security - SBOM Generation (run 29163398479)
- Deploy - GitHub Pages (run 29163507039)

Between v0.48.0 and v0.52.3 the reusable workflows escalated their job-level permissions:

- `reusable-sbom.yml`: `contents: read` → `contents: write` (attach SBOM to release assets)
- `reusable-deploy-site-with-reports.yml` build job: `actions: read` → `actions: write` (self-heal rerun artifact pruning, lgtm-ci#415)

GitHub Actions rejects a reusable-workflow call at parse time when the caller grants fewer permissions than the called workflow requests, which surfaces as `startup_failure`. This PR raises the caller grants to match:

- `.github/workflows/sbom-on-main.yml`: job `contents: read` → `contents: write`
- `.github/workflows/deploy-pages.yml`: job `actions: read` → `actions: write`
- `tests/unit/test_workflow_wiring.py`: assert the new `actions: write` grant

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` + `tests/unit/test_workflow_wiring.py`)

## Related Issues

Closes #1284

## Details

All `uses:` refs and inputs were verified to exist at `66cad82`; only the permission grants were stale. After merge, both workflows will be re-run via `workflow_dispatch` to confirm they start and succeed on `main`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates workflow permissions so the pinned reusable CI workflows can run.

- Grants `contents: write` to SBOM jobs that call the newer reusable SBOM workflow.
- Grants `actions: write` to the Pages deploy job for the newer reusable deploy workflow.
- Updates the workflow wiring test to expect the new Pages deploy permission.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/sbom-on-main.yml | Grants the SBOM reusable workflow `contents: write` on main and manual runs. |
| .github/workflows/publish-pypi-on-tag.yml | Grants the PyPI tag SBOM job `contents: write` for the reusable SBOM workflow. |
| .github/workflows/deploy-pages.yml | Grants the Pages deploy reusable workflow `actions: write`. |
| tests/unit/test_workflow_wiring.py | Updates the Pages deploy workflow permission assertion. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): grant contents write to sbom jo..."](https://github.com/lgtm-hq/py-lintro/commit/362b493ea15466795006aecba2d6174d2f3208ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43549634)</sub>

<!-- /greptile_comment -->