### PR TITLE
fix(ci): pass complete egress allowlist to release version-pr job

### DIFF
--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -38,6 +38,21 @@ jobs:
       # Paired with release-auto-tag.yml (egress-preset: github-tooling).
       # Guarded by test_release_workflows_use_paired_egress_presets.
       egress-preset: pypi
+      # Since lgtm-ci v0.50.0 the enforcing harden-runner step runs before
+      # preset resolution, so the preset's extra hosts never reach it and
+      # pip is blocked from PyPI (#1287, lgtm-hq/lgtm-ci#512). Pass the
+      # complete list explicitly; harden-runner splits on spaces, so keep
+      # the folded scalar.
+      allowed-endpoints: >-
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        uploads.github.com:443
+        pipelines.actions.githubusercontent.com:443
+        pypi.org:443
+        files.pythonhosted.org:443
     secrets:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [x] fix / perf (patch)

## What’s Changing

`Release - Version PR (push on main)` fails since v0.52.3: pip cannot reach PyPI (run 29168361917) because the enforcing harden-runner step runs before `egress-preset: pypi` resolution (lgtm-ci v0.50.0 semantics). Adds the complete explicit `allowed-endpoints` list (github baseline + PyPI hosts) alongside the preset, mirroring the verified podex#161 fix. The preset-pairing guard test still passes (preset input unchanged).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (wiring test suite passes unchanged)
- [x] Local CI passed

## Closes

- Closes #1287

## Details

NOTE for the session managing this repo's PR queue: auto-merge deliberately NOT armed — merge at your discretion. Until merged, every push to main fails the release version-pr workflow (releases are effectively frozen).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the release version-PR workflow egress configuration.

- Adds an explicit GitHub endpoint allowlist.
- Adds read-only PyPI endpoints for package installation.
- Keeps the existing `egress-preset: pypi` pairing.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed workflow.
- The explicit allowlist covers the GitHub baseline and the PyPI read endpoints used by package installation.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-version-pr.yml | Adds explicit `allowed-endpoints` for the release version-PR reusable workflow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): pass complete egress allowlist ..."](https://github.com/lgtm-hq/py-lintro/commit/6bd3d71f85dfd1aaf5ddd1af6fee8a5430902d8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43556907)</sub>

<!-- /greptile_comment -->