### PR TITLE
fix(ci): unblock main deploy-pages egress and dogfooding black finding

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -59,6 +59,7 @@ jobs:
       allowed-endpoints-build: >-
         github.com:443
         api.github.com:443
+        actions.githubusercontent.com:443
         codeload.github.com:443
         objects.githubusercontent.com:443
         raw.githubusercontent.com:443

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -48,6 +48,36 @@ jobs:
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
+      # Since lgtm-ci v0.50.0 the enforcing harden-runner step runs before
+      # preset resolution, and harden-runner splits allowed-endpoints on
+      # spaces, so the reusable's newline-separated per-job defaults collapse
+      # into one unmatchable token — even github.com is dropped at checkout
+      # (#1299, class of #1287 / lgtm-hq/lgtm-ci#512). Pass the complete
+      # lists explicitly as space-separated folded scalars; contents mirror
+      # the playwright (build) and github-pages (deploy) presets that
+      # governed these jobs when they last passed (v0.48.0).
+      allowed-endpoints-build: >-
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        registry.npmjs.org:443
+        bun.sh:443
+        cdn.playwright.dev:443
+        playwright.azureedge.net:443
+        playwright-akamai.azureedge.net:443
+        archive.ubuntu.com:80
+        security.ubuntu.com:80
+      allowed-endpoints-deploy: >-
+        github.com:443
+        api.github.com:443
+        actions.githubusercontent.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
       build-job-name: Build site and bundle reports
       deploy-job-name: Deploy to GitHub Pages
       runner-image: ubuntu-24.04

--- a/tests/unit/tools/pytest_tool/test_addopts_coverage.py
+++ b/tests/unit/tools/pytest_tool/test_addopts_coverage.py
@@ -205,6 +205,7 @@ def test_detects_parent_pytest_ini_from_subdirectory(
     monkeypatch.chdir(subdir)
     assert_that(config_addopts_enable_coverage()).is_true()
 
+
 def test_nearer_config_without_coverage_stops_walk(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -283,4 +284,3 @@ def test_pyproject_coverage_wins_over_setup_cfg_without_coverage(
         encoding="utf-8",
     )
     assert_that(config_addopts_enable_coverage(tmp_path)).is_true()
-


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): unblock main deploy-pages egress and dogfooding black finding
  ```

- Type:
  - [x] fix / perf (patch)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Fixes the two deterministic main-branch workflow failures diagnosed in #1299:

1. **Deploy - GitHub Pages** (failing on every main push since the v0.52.3 pin, #1281): the enforcing harden-runner pre-hook in `reusable-deploy-site-with-reports.yml` receives the reusable's *default* `allowed-endpoints-build` / `allowed-endpoints-deploy`, which are newline-separated literal blocks. harden-runner splits `allowed-endpoints` on spaces, so the newline-joined string matches nothing — even `github.com:443` is dropped and checkout dies (`Failed to connect to github.com`, `ip address dropped: 140.82.116.3`, run 29178327657). Same v0.50.0 class as #1287 / lgtm-hq/lgtm-ci#512, fixed the same way as merged #1288: the caller now passes complete space-separated folded-scalar (`>-`) per-job lists that override the broken defaults. Contents exactly mirror the `playwright` (build) and `github-pages` (deploy) presets that governed these jobs when they last passed under v0.48.0 (c54e9c01).
2. **dogfooding-lint / lintro-code-quality** (failing on every main push since a42b9851): #1164 introduced a real black finding — `Would reformat file` on `tests/unit/tools/pytest_tool/test_addopts_coverage.py` (missing second blank line between functions, stray trailing blank line). Reformatted via `uv run lintro fmt`; `black --check` now clean.

Not changed here (per #1299): the two Docker Integration Tests failures (2ef40163 artifact-upload flake; a497a8ce transient GHCR `manifest unknown` on a base manifest pushed successfully 4 minutes earlier) are non-deterministic one-offs — the runs on the six intervening main commits passed. The CI - Docker run on this PR / on main after merge re-exercises them.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (formatting-only test change; `tests/unit/test_workflow_wiring.py` 28 passed)
- [ ] Docs updated if user-facing (not user-facing)
- [x] Local CI passed (`uv run lintro chk` exit 0 on changed files; affected unit tests pass)

## Related Issues

Closes #1299

## Details

- `uv run lintro chk .github/workflows/deploy-pages.yml tests/unit/tools/pytest_tool/test_addopts_coverage.py` → exit 0
- `uv run pytest tests/unit/test_workflow_wiring.py -q` → 28 passed
- `uv run pytest tests/unit/tools/pytest_tool/test_addopts_coverage.py -q` → 15 passed
- Endpoint lists are folded scalars (`>-`, space-separated) as required by harden-runner's space-splitting; caller permissions untouched (no escalation → no startup_failure risk).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes deterministic CI failures in the Pages deploy path and formatting checks.

- Explicit space-separated egress allowlists for the deploy-pages reusable workflow.
- Build and deploy endpoint lists passed from the caller instead of relying on newline defaults.
- Black formatting cleanup in the pytest coverage tests.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-pages.yml | Adds explicit build and deploy endpoint allowlists for the reusable Pages workflow. |
| tests/unit/tools/pytest_tool/test_addopts_coverage.py | Applies formatting-only cleanup to satisfy Black. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): allow actions.githubusercontent..."](https://github.com/lgtm-hq/py-lintro/commit/a64fcc6548cab1442e52431279fb0f6712b428ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43598484)</sub>

<!-- /greptile_comment -->