### PR TITLE
fix(docker): stop main-push overwriting multi-arch latest

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -530,7 +530,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
       - name: Extract metadata (base)
         id: meta-base
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
@@ -542,7 +541,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push Docker image
         # yamllint disable-line rule:line-length
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(docker): stop main-push overwriting multi-arch latest
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

GHCR `:latest` for `py-lintro` / `py-lintro-base` was single-arch most of the time because `docker-ci.yml`'s push-to-main publish job tagged `latest` without multi-arch platforms, overwriting the release workflow’s multi-arch index after every merge to main.

This PR removes `type=raw,value=latest,enable={{is_default_branch}}` from both metadata blocks so main-push only publishes `main` / `sha-*` / semver tags. Release `docker-build-publish.yml` remains the sole writer of `latest`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1322
- Relates to #880

## Details

After merge, repair the current single-arch `latest` once via:

```bash
gh workflow run docker-build-publish.yml -f force_publish=true
```

or wait for the next tag release. Verify `latest` is a multi-arch index (manifest list children return 200).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes how Docker tags are published from the main-branch workflow.

- Removes the `latest` tag from the `py-lintro` metadata block.
- Removes the `latest` tag from the `py-lintro-base` metadata block.
- Leaves branch, SHA, and semver tag generation in the main-push workflow.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after confirming the intended meaning of `latest`.

- The workflow change matches the goal of stopping main-push builds from overwriting the multi-arch release tag.
- The only noted risk is a docs-and-consumer expectation mismatch if `latest` should still track default-branch builds.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/docker-ci.yml | Removes raw `latest` tag generation for both Docker images in the main-branch publish job. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fdocker-ci.yml%3A530%0A**Latest%20No%20Longer%20Tracks%20Main**%0A%0AWhen%20the%20default%20branch%20publish%20job%20runs%2C%20this%20metadata%20block%20now%20emits%20%60main%60%20and%20%60sha-*%60%20but%20not%20%60latest%60.%20If%20%60latest%60%20is%20still%20meant%20to%20be%20the%20default-branch%20image%20as%20documented%2C%20users%20pulling%20%60ghcr.io%2Flgtm-hq%2Fpy-lintro%3Alatest%60%20will%20stay%20on%20the%20last%20release%20image%20until%20the%20next%20release%20workflow%20updates%20it.%0A%0A&pr=1323&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fdocker-ci.yml%3A530%0A**Latest%20No%20Longer%20Tracks%20Main**%0A%0AWhen%20the%20default%20branch%20publish%20job%20runs%2C%20this%20metadata%20block%20now%20emits%20%60main%60%20and%20%60sha-*%60%20but%20not%20%60latest%60.%20If%20%60latest%60%20is%20still%20meant%20to%20be%20the%20default-branch%20image%20as%20documented%2C%20users%20pulling%20%60ghcr.io%2Flgtm-hq%2Fpy-lintro%3Alatest%60%20will%20stay%20on%20the%20last%20release%20image%20until%20the%20next%20release%20workflow%20updates%20it.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1323&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F1322-stop-docker-ci-overwriting-latest%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1322-stop-docker-ci-overwriting-latest%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fdocker-ci.yml%3A530%0A**Latest%20No%20Longer%20Tracks%20Main**%0A%0AWhen%20the%20default%20branch%20publish%20job%20runs%2C%20this%20metadata%20block%20now%20emits%20%60main%60%20and%20%60sha-*%60%20but%20not%20%60latest%60.%20If%20%60latest%60%20is%20still%20meant%20to%20be%20the%20default-branch%20image%20as%20documented%2C%20users%20pulling%20%60ghcr.io%2Flgtm-hq%2Fpy-lintro%3Alatest%60%20will%20stay%20on%20the%20last%20release%20image%20until%20the%20next%20release%20workflow%20updates%20it.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1323&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(docker): stop main-push overwriting ..."](https://github.com/lgtm-hq/py-lintro/commit/3c16a7e68ffe9c28e55d39ff97bf9905b1ea9565) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43639673)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->