### PR TITLE
chore(security): verify ANTHROPIC_API_KEY exposure ordering for dogfood AI review

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -18,6 +18,17 @@ name: AI Review - Dogfood
 # When the ANTHROPIC_API_KEY secret is absent (not configured yet, or a fork PR
 # that cannot read secrets) the script skips gracefully. This is intentionally
 # NOT a required check.
+#
+# ACTIVATION PRECONDITION (audited #1317, follow-up to #1072/#1074):
+# Safe to add the ANTHROPIC_API_KEY repository secret only when all of the
+# following hold (structurally asserted in tests/scripts/test_run_ai_review.py):
+#   1. Job if-guard: non-draft, same-repository PRs only (fork PRs never run).
+#   2. Trusted install: checkout ref is pull_request.base.sha, never PR head.
+#   3. Secret ordering: ANTHROPIC_API_KEY is injected only into the final
+#      review step env, after the trusted base-ref checkout and uv sync.
+# No GitHub Environment gate is required once (1–3) hold; the trusted-install
+# mechanism from #1074 is the primary control. Re-audit if the checkout ref,
+# job guard, or secret injection site changes.
 
 'on':
   pull_request:

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -80,6 +80,22 @@ Secrets and variables → Actions**). Because reviews run using trusted base-bra
 lintro, the key is safe to enable. Until that secret exists the workflow runs but skips
 gracefully, so merging it never breaks CI.
 
+#### Activation precondition (security audit #1317)
+
+Before enabling `ANTHROPIC_API_KEY`, confirm the dogfood workflow still satisfies all
+three controls (also asserted in `tests/scripts/test_run_ai_review.py`):
+
+1. **Same-repo only** — the job `if` guard requires
+   `pull_request.head.repo.full_name == github.repository` (fork PRs never run).
+2. **Trusted install** — the checkout step uses `pull_request.base.sha`, never the PR
+   head, so code that runs with the key is always from the trusted base ref.
+3. **Secret ordering** — `ANTHROPIC_API_KEY` is injected only into the final review
+   step's `env`, after checkout and dependency install.
+
+These controls landed with #1074; #1317 verified them against current `main`. A
+dedicated GitHub Environment with required reviewers is optional once (1–3) hold. Re-run
+the audit if the checkout ref, job guard, or secret injection site changes.
+
 #### JSON error contract
 
 Under `--output json`, a **provider failure** (invalid key, rate limit, depleted

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -289,7 +289,7 @@ def test_workflow_secret_scoped_to_review_step_only() -> None:
 
     assert_that(steps_with_key).is_length(1)
     assert_that(steps_with_key[0]).is_equal_to(
-        "Run AI review (posts comment, non-blocking)"
+        "Run AI review (posts comment, non-blocking)",
     )
 
 

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -271,6 +271,28 @@ def test_workflow_installs_from_base_ref_not_pr_head() -> None:
     )
 
 
+def test_workflow_secret_scoped_to_review_step_only() -> None:
+    """ANTHROPIC_API_KEY is injected only into the final review step env.
+
+    The secret must not appear in earlier steps (checkout, uv sync, etc.) so
+    PR-controlled code paths never receive the key before the trusted base-ref
+    install completes. This is the ordering control audited in #1317.
+    """
+    loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+    steps = loaded["jobs"]["ai-review"]["steps"]
+    steps_with_key = [
+        step["name"]
+        for step in steps
+        if "ANTHROPIC_API_KEY" in yaml.dump(step, default_flow_style=False)
+    ]
+
+    assert_that(steps_with_key).is_length(1)
+    assert_that(steps_with_key[0]).is_equal_to(
+        "Run AI review (posts comment, non-blocking)"
+    )
+
+
 def test_workflow_reviews_pr_via_gh_not_working_tree() -> None:
     """The executable review command targets the PR and emits JSON.
 


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(security): verify ANTHROPIC_API_KEY exposure ordering for dogfood AI review
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Security audit follow-up to #1072/#1074 (#1317). Verified that the dogfood
`ai-review.yml` workflow already satisfies the trusted-install controls needed
before enabling `ANTHROPIC_API_KEY`; no behavioral change required.

**Audit findings (current `main`):**

1. **Secret state** — `ANTHROPIC_API_KEY` is not configured at repo level (API
   lists no Actions secrets; only `github-pages`, `npm`, `pypi` environments
   exist). The workflow skips gracefully when the secret is absent.
2. **Same-repo gate** — job `if` requires non-draft PRs with
   `head.repo.full_name == github.repository` (fork PRs never run).
3. **Trusted install (#1074)** — checkout uses `pull_request.base.sha`, never
   PR head; PR diff is fetched via `gh` API, not executed from the working tree.
4. **Secret ordering** — `ANTHROPIC_API_KEY` is injected only into the final
   review step env, after trusted checkout and `uv sync`.

This PR records the audit outcome in workflow/docs comments and adds a
structural test for secret ordering. No GitHub Environment gate is required
once controls (1–4) hold.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`tests/scripts/test_run_ai_review.py` — 21 passed)

## Closes

- Closes #1317
- Relates to #1072
- Relates to #1074

## Details

- Added `ACTIVATION PRECONDITION` block to `.github/workflows/ai-review.yml`
- Documented audit checklist in `docs/github-integration.md`
- Added `test_workflow_secret_scoped_to_review_step_only` asserting the key
  appears only in the final review step env

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR records the security audit for enabling the dogfood AI review secret. The main changes are:

- Added activation-precondition comments to the AI review workflow.
- Documented the same-repo, trusted-install, and secret-ordering controls.
- Added a structural test for the review-step secret placement.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No new separate blocking issue was found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ai-review.yml | Adds comments documenting the workflow activation controls for the AI review secret. |
| docs/github-integration.md | Adds the audit checklist for enabling the dogfood AI review key. |
| tests/scripts/test_run_ai_review.py | Adds a structural test for the AI review workflow secret placement. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: add trailing comma in AI review wor..."](https://github.com/lgtm-hq/py-lintro/commit/4f1dff0f92e587488fe37526b9015758b8fc9e32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43669386)</sub>

<!-- /greptile_comment -->