### PR TITLE
fix(ci): harden vuln suppression install against curl exit 23

### DIFF
--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -26,6 +26,8 @@ jobs:
       job-name: '🔍 Check Vulnerability Suppressions'
       tooling-ref: '66cad82ead0e5d119928c895c7d7da9c837989e5' # v0.52.3
       workflow-file: vuln-suppression-check.yml
+      install-script: scripts/ci/security/install-osv-scanner.sh
+      check-script: scripts/ci/security/check-vuln-suppressions.sh
       runner-image: ubuntu-24.04
       egress-policy: block
       egress-preset: osv-scanner

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -102,6 +102,8 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `fail-on-security-audit.sh`          | Fail CI when security audit finds vulnerabilities                     | `./scripts/ci/fail-on-security-audit.sh`                                           |
 | `free-disk-space.sh`                 | Free disk space on CI runner for Docker builds                        | `./scripts/ci/free-disk-space.sh`                                                  |
 | `security-comment.sh`                | Run osv-scanner via lintro in Docker and generate security PR comment | `./scripts/ci/security-comment.sh --help`                                          |
+| `install-osv-scanner.sh`             | Download and verify osv-scanner with curl exit-23 retries             | `./scripts/ci/security/install-osv-scanner.sh`                                     |
+| `check-vuln-suppressions.sh`         | Verbose wrapper for lgtm-ci vulnerability suppression check           | `./scripts/ci/security/check-vuln-suppressions.sh`                                 |
 | `run-ai-review.sh`                   | Dogfood `lintro review` on a PR using trusted base-branch lintro      | `PR_NUMBER=123 ./scripts/ci/run-ai-review.sh`                                      |
 | `enable_review_config.py`            | Enable AI review + cost cap in `.lintro-config.yaml` for a CI run     | `python3 scripts/ci/enable_review_config.py --help`                                |
 | `classify-osv-results.py`            | Classify osv_scanner JSON as ok, vulns, or error for CI status        | `python3 scripts/ci/classify-osv-results.py osv-results.json`                      |

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -29,7 +29,7 @@ scripts/ci/
 | `lintro-report-scheduled.yml` | `lintro-report-generate.sh`                                                 |
 | GHCR cleanup (docker-ci)      | `maintenance/delete-ci-ghcr-tags.sh`                                        |
 | GHCR cleanup (scheduled)      | lgtm-ci `reusable-ghcr-cleanup.yml` (`ghcr-cleanup.yml`)                    |
-| Vuln suppression check        | lgtm-ci `reusable-vuln-suppression-check.yml`                               |
+| Vuln suppression check        | lgtm-ci `reusable-vuln-suppression-check.yml`; local `security/install-osv-scanner.sh` and `security/check-vuln-suppressions.sh` |
 
 Release versioning and auto-tagging use lgtm-ci reusable workflows
 (`release-version-pr.yml`, `release-auto-tag.yml`).

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -20,15 +20,15 @@ scripts/ci/
 
 ## Workflow Mapping
 
-| Workflow                      | Scripts                                                                     |
-| ----------------------------- | --------------------------------------------------------------------------- |
-| `test-ci.yml`                 | lgtm-ci reusable (coverage + PR comments)                                   |
-| `docker-ci.yml`               | Fork detect, image pull/load, lgtm-ci quality, test summary, security audit |
-| `publish-pypi-on-tag.yml`     | lgtm-ci quality/SBOM; `build-artifacts` + PyPI publish + GitHub release     |
-| `pr-comment-cleanup.yml`      | `post-pr-delete-previous.sh`                                                |
-| `lintro-report-scheduled.yml` | `lintro-report-generate.sh`                                                 |
-| GHCR cleanup (docker-ci)      | `maintenance/delete-ci-ghcr-tags.sh`                                        |
-| GHCR cleanup (scheduled)      | lgtm-ci `reusable-ghcr-cleanup.yml` (`ghcr-cleanup.yml`)                    |
+| Workflow                      | Scripts                                                                                                                          |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `test-ci.yml`                 | lgtm-ci reusable (coverage + PR comments)                                                                                        |
+| `docker-ci.yml`               | Fork detect, image pull/load, lgtm-ci quality, test summary, security audit                                                      |
+| `publish-pypi-on-tag.yml`     | lgtm-ci quality/SBOM; `build-artifacts` + PyPI publish + GitHub release                                                          |
+| `pr-comment-cleanup.yml`      | `post-pr-delete-previous.sh`                                                                                                     |
+| `lintro-report-scheduled.yml` | `lintro-report-generate.sh`                                                                                                      |
+| GHCR cleanup (docker-ci)      | `maintenance/delete-ci-ghcr-tags.sh`                                                                                             |
+| GHCR cleanup (scheduled)      | lgtm-ci `reusable-ghcr-cleanup.yml` (`ghcr-cleanup.yml`)                                                                         |
 | Vuln suppression check        | lgtm-ci `reusable-vuln-suppression-check.yml`; local `security/install-osv-scanner.sh` and `security/check-vuln-suppressions.sh` |
 
 Release versioning and auto-tagging use lgtm-ci reusable workflows

--- a/scripts/ci/security/check-vuln-suppressions.sh
+++ b/scripts/ci/security/check-vuln-suppressions.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+#
+# check-vuln-suppressions.sh — Verbose wrapper for lgtm-ci suppression check.
+#
+# Local override for py-lintro vuln-suppression-check (#1314). Adds trace
+# logging and explicit failure context around the tooling script.
+#
+# Usage:
+#   check-vuln-suppressions.sh
+#
+# Environment:
+#   GH_TOKEN      GitHub token for PR creation (required by tooling script)
+#   CONFIG_PATH   Suppression TOML path (default: .osv-scanner.toml)
+#   VERBOSE       Set to 1 to enable bash trace (set -x); auto-enabled in Actions
+
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Usage: check-vuln-suppressions.sh
+
+Detect stale or expired vulnerability suppressions in .osv-scanner.toml.
+
+Delegates to lgtm-ci check-vuln-suppressions.sh with verbose diagnostics.
+EOF
+	exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${GITHUB_WORKSPACE:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+TOOLING_SCRIPT="${REPO_ROOT}/.lgtm-ci-tooling/scripts/ci/security/check-vuln-suppressions.sh"
+TOOLING_LIB="${REPO_ROOT}/.lgtm-ci-tooling/scripts/ci/lib"
+
+_log_info() {
+	echo "[INFO] $*" >&2
+}
+
+_log_error() {
+	echo "[ERROR] $*" >&2
+}
+
+if [[ -f "${TOOLING_LIB}/log.sh" ]]; then
+	# shellcheck source=/dev/null
+	source "${TOOLING_LIB}/log.sh"
+else
+	log_info() { _log_info "$@"; }
+	log_error() { _log_error "$@"; }
+fi
+
+if [[ "${GITHUB_ACTIONS:-}" == "true" || "${VERBOSE:-}" == "1" ]]; then
+	set -x
+fi
+
+log_info "Vulnerability suppression check starting"
+log_info "Repository root: ${REPO_ROOT}"
+log_info "CONFIG_PATH=${CONFIG_PATH:-.osv-scanner.toml}"
+log_info "WORKFLOW_FILE=${WORKFLOW_FILE:-<unset>}"
+log_info "Tooling script: ${TOOLING_SCRIPT}"
+
+if [[ ! -f "$TOOLING_SCRIPT" ]]; then
+	log_error "Missing lgtm-ci tooling script: ${TOOLING_SCRIPT}"
+	log_error "Ensure checkout-and-harden runs before this step."
+	exit 1
+fi
+
+set +e
+bash "$TOOLING_SCRIPT"
+exit_code=$?
+set -e
+
+if [[ "$exit_code" -ne 0 ]]; then
+	log_error "check-vuln-suppressions failed with exit code ${exit_code}"
+	log_error "Review osv-scanner probe output and suppression config above."
+	exit "$exit_code"
+fi

--- a/scripts/ci/security/install-osv-scanner.sh
+++ b/scripts/ci/security/install-osv-scanner.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+#
+# install-osv-scanner.sh — Download and verify osv-scanner with retries.
+#
+# Local override for py-lintro vuln-suppression-check (#1314). Uses lgtm-ci
+# hardened curl helpers and retries transient curl failures (e.g. exit 23).
+#
+# Usage:
+#   install-osv-scanner.sh [version]
+#
+# Environment:
+#   OSV_VERSION            Release version (default: 2.3.5)
+#   INSTALL_DIR            Install directory (default: /usr/local/bin or ~/.local/bin)
+#   DOWNLOAD_MAX_ATTEMPTS  Retry count for downloads (default: 3)
+
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Usage: install-osv-scanner.sh [version]
+
+Download and verify the osv-scanner release binary with retries.
+
+Version: $1 > $OSV_VERSION > 2.3.5
+Install dir: $INSTALL_DIR > /usr/local/bin > ~/.local/bin
+EOF
+	exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${GITHUB_WORKSPACE:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+TOOLING_LIB="${REPO_ROOT}/.lgtm-ci-tooling/scripts/ci/lib"
+
+if [[ ! -d "$TOOLING_LIB" ]]; then
+	echo "[ERROR] lgtm-ci tooling not found at ${TOOLING_LIB}" >&2
+	echo "[ERROR] Ensure checkout-and-harden runs before this script." >&2
+	exit 1
+fi
+
+# shellcheck source=/dev/null
+source "${TOOLING_LIB}/log.sh"
+# shellcheck source=/dev/null
+source "${TOOLING_LIB}/fs.sh"
+# shellcheck source=/dev/null
+source "${TOOLING_LIB}/network/download.sh"
+
+OSV_VERSION="${1:-${OSV_VERSION:-2.3.5}}"
+DOWNLOAD_MAX_ATTEMPTS="${DOWNLOAD_MAX_ATTEMPTS:-3}"
+
+_explain_download_failure() {
+	local url="$1"
+	local dest="$2"
+	local parent
+	parent="$(dirname "$dest")"
+
+	log_error "Failed to download after ${DOWNLOAD_MAX_ATTEMPTS} attempt(s): ${url}"
+	log_error "curl exit 23 means 'Failure writing output to destination'"
+	log_error "Common causes: disk full, unwritable directory, or transient I/O"
+	log_error "Destination: ${dest}"
+	if [[ -d "$parent" ]]; then
+		if [[ -w "$parent" ]]; then
+			log_error "Parent directory writable: yes"
+		else
+			log_error "Parent directory writable: no"
+		fi
+		log_error "Disk space for ${parent}:"
+		df -h "$parent" 2>/dev/null || true
+	fi
+}
+
+_download_or_fail() {
+	local url="$1"
+	local dest="$2"
+	local label="$3"
+
+	log_info "Downloading ${label} from ${url}..."
+	if download_with_retries "$url" "$dest" "$DOWNLOAD_MAX_ATTEMPTS"; then
+		return 0
+	fi
+	_explain_download_failure "$url" "$dest"
+	return 1
+}
+
+OS=$(uname -s)
+if [[ "$OS" != "Linux" ]]; then
+	log_error "osv-scanner install supports Linux runners only (detected: $OS)"
+	exit 1
+fi
+
+ARCH=$(uname -m)
+case "$ARCH" in
+x86_64) PLATFORM="linux_amd64" ;;
+aarch64 | arm64) PLATFORM="linux_arm64" ;;
+*)
+	log_error "Unsupported architecture: $ARCH"
+	exit 1
+	;;
+esac
+
+BASE_URL="https://github.com/google/osv-scanner/releases/download/v${OSV_VERSION}"
+BINARY_URL="${BASE_URL}/osv-scanner_${PLATFORM}"
+CHECKSUMS_URL="${BASE_URL}/osv-scanner_SHA256SUMS"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+if [[ ! -w "$INSTALL_DIR" ]]; then
+	INSTALL_DIR="${HOME}/.local/bin"
+	mkdir -p "$INSTALL_DIR"
+fi
+
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/py-lintro-osv.XXXXXXXXXX")
+trap 'rm -rf "$WORKDIR"' EXIT
+
+log_info "Installing osv-scanner v${OSV_VERSION} (${PLATFORM}) to ${INSTALL_DIR}..."
+log_info "Temporary workdir: ${WORKDIR}"
+
+_download_or_fail "$BINARY_URL" "${WORKDIR}/osv-scanner" "osv-scanner binary"
+_download_or_fail "$CHECKSUMS_URL" "${WORKDIR}/SHA256SUMS" "SHA256SUMS"
+
+CHECKSUMS_SIG_URL="${BASE_URL}/osv-scanner_SHA256SUMS.sig"
+CHECKSUMS_CERT_URL="${BASE_URL}/osv-scanner_SHA256SUMS.pem"
+if download_with_retries "$CHECKSUMS_SIG_URL" "${WORKDIR}/SHA256SUMS.sig" 1 2>/dev/null &&
+	download_with_retries "$CHECKSUMS_CERT_URL" "${WORKDIR}/SHA256SUMS.pem" 1 2>/dev/null; then
+	if command -v cosign >/dev/null 2>&1; then
+		log_info "Verifying SHA256SUMS sigstore signature..."
+		cosign verify-blob \
+			--signature "${WORKDIR}/SHA256SUMS.sig" \
+			--certificate "${WORKDIR}/SHA256SUMS.pem" \
+			--certificate-identity-regexp='https://github\.com/google/osv-scanner/.*' \
+			--certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+			"${WORKDIR}/SHA256SUMS"
+		log_success "SHA256SUMS signature verified"
+	else
+		log_warn "cosign not found; skipping SHA256SUMS signature verification"
+	fi
+else
+	log_info "Release does not publish SHA256SUMS sigstore assets; verifying binary checksum only"
+fi
+
+EXPECTED=$(
+	awk -v fn="osv-scanner_${PLATFORM}" '$2 == fn { print $1; exit }' "${WORKDIR}/SHA256SUMS"
+)
+if [[ -z "$EXPECTED" ]]; then
+	log_error "No checksum entry for osv-scanner_${PLATFORM} in SHA256SUMS"
+	exit 1
+fi
+
+printf '%s  osv-scanner\n' "$EXPECTED" | (
+	cd "${WORKDIR}" && sha256sum -c -
+)
+log_success "SHA256 verified: ${EXPECTED}"
+
+chmod +x "${WORKDIR}/osv-scanner"
+mv "${WORKDIR}/osv-scanner" "${INSTALL_DIR}/osv-scanner"
+
+"${INSTALL_DIR}/osv-scanner" --version
+log_success "osv-scanner v${OSV_VERSION} installed to ${INSTALL_DIR}"
+
+if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
+	export PATH="${INSTALL_DIR}:${PATH}"
+	if [[ -n "${GITHUB_PATH:-}" ]]; then
+		echo "$INSTALL_DIR" >>"$GITHUB_PATH"
+	fi
+fi

--- a/tests/scripts/test_vuln_suppression_scripts.py
+++ b/tests/scripts/test_vuln_suppression_scripts.py
@@ -96,7 +96,7 @@ def test_check_script_reports_missing_tooling(tmp_path: Path) -> None:
         env={
             **os.environ.copy(),
             "GITHUB_WORKSPACE": str(workspace),
-            "GH_TOKEN": "fake-token",
+            "GH_TOKEN": "fake-token",  # nosec B105 - test-only placeholder, not a real credential
         },
     )
 
@@ -203,7 +203,7 @@ def test_install_script_retries_transient_curl_exit_23(tmp_path: Path) -> None:
     env["PATH"] = f"{mock_bin}:{env['PATH']}"
     env["DOWNLOAD_MAX_ATTEMPTS"] = "3"
 
-    result = subprocess.run(  # nosec B603 - fixed argv run against a real binary in a controlled test; shell=False, no user shell input
+    result = subprocess.run(  # nosec B603 B607 - fixed argv run against a real binary in a controlled test; bash resolved from PATH in controlled env; shell=False, no user shell input
         ["bash", str(script_copy), "9.9.9"],
         capture_output=True,
         text=True,
@@ -222,9 +222,9 @@ def test_vuln_suppression_workflow_uses_local_scripts() -> None:
     content = workflow_path.read_text(encoding="utf-8")
 
     assert_that(content).contains(
-        "install-script: scripts/ci/security/install-osv-scanner.sh"
+        "install-script: scripts/ci/security/install-osv-scanner.sh",
     )
     assert_that(content).contains(
-        "check-script: scripts/ci/security/check-vuln-suppressions.sh"
+        "check-script: scripts/ci/security/check-vuln-suppressions.sh",
     )
     assert_that(content).contains(_LGTM_CI_PIN)

--- a/tests/scripts/test_vuln_suppression_scripts.py
+++ b/tests/scripts/test_vuln_suppression_scripts.py
@@ -1,0 +1,230 @@
+"""Tests for vuln-suppression-check security helper scripts."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess  # nosec B404 - subprocess is used to drive the tool/CLI under test; invocations use shell=False
+import textwrap
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_INSTALL_SCRIPT = _REPO_ROOT / "scripts/ci/security/install-osv-scanner.sh"
+_CHECK_SCRIPT = _REPO_ROOT / "scripts/ci/security/check-vuln-suppressions.sh"
+_LGTM_CI_PIN = "66cad82ead0e5d119928c895c7d7da9c837989e5"
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        "scripts/ci/security/install-osv-scanner.sh",
+        "scripts/ci/security/check-vuln-suppressions.sh",
+    ],
+)
+def test_vuln_suppression_scripts_expose_help(script: str) -> None:
+    """Each vuln-suppression helper should support --help."""
+    script_path = (_REPO_ROOT / script).resolve()
+    result = subprocess.run(  # nosec B603 - fixed argv run against a real binary in a controlled test; shell=False, no user shell input
+        [str(script_path), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("Usage:")
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        "scripts/ci/security/install-osv-scanner.sh",
+        "scripts/ci/security/check-vuln-suppressions.sh",
+    ],
+)
+def test_vuln_suppression_scripts_pass_syntax_check(script: str) -> None:
+    """Each vuln-suppression helper should pass bash -n."""
+    script_path = (_REPO_ROOT / script).resolve()
+    result = subprocess.run(  # nosec B603 B607 - fixed argv run against a real binary in a controlled test; binary name resolved from PATH, not attacker-controlled; shell=False, no user shell input
+        ["bash", "-n", str(script_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stderr).is_empty()
+
+
+def test_install_script_reports_missing_tooling(tmp_path: Path) -> None:
+    """install-osv-scanner.sh should fail clearly without lgtm-ci libs."""
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    script_copy = workspace / "install-osv-scanner.sh"
+    script_copy.write_text(_INSTALL_SCRIPT.read_text())
+    script_copy.chmod(script_copy.stat().st_mode | stat.S_IXUSR)
+
+    result = subprocess.run(  # nosec B603 - fixed argv run against a real binary in a controlled test; shell=False, no user shell input
+        [str(script_copy)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            **os.environ.copy(),
+            "GITHUB_WORKSPACE": str(workspace),
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(1)
+    assert_that(result.stderr).contains("lgtm-ci tooling not found")
+
+
+def test_check_script_reports_missing_tooling(tmp_path: Path) -> None:
+    """check-vuln-suppressions.sh should fail clearly without tooling script."""
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    script_copy = workspace / "check-vuln-suppressions.sh"
+    script_copy.write_text(_CHECK_SCRIPT.read_text())
+    script_copy.chmod(script_copy.stat().st_mode | stat.S_IXUSR)
+
+    result = subprocess.run(  # nosec B603 - fixed argv run against a real binary in a controlled test; shell=False, no user shell input
+        [str(script_copy)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            **os.environ.copy(),
+            "GITHUB_WORKSPACE": str(workspace),
+            "GH_TOKEN": "fake-token",
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(1)
+    assert_that(result.stderr).contains("Missing lgtm-ci tooling script")
+
+
+def test_install_script_retries_transient_curl_exit_23(tmp_path: Path) -> None:
+    """Transient curl exit 23 should be retried before surfacing diagnostics."""
+    workspace = tmp_path / "repo"
+    tooling_lib = workspace / ".lgtm-ci-tooling/scripts/ci/lib"
+    network_lib = tooling_lib / "network"
+    network_lib.mkdir(parents=True)
+
+    (tooling_lib / "log.sh").write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            log_info() { echo "[INFO] $*" >&2; }
+            log_success() { echo "[SUCCESS] $*" >&2; }
+            log_warn() { echo "[WARN] $*" >&2; }
+            log_error() { echo "[ERROR] $*" >&2; }
+            log_verbose() { :; }
+            """,
+        ),
+    )
+    (tooling_lib / "fs.sh").write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            # shellcheck source=log.sh
+            source "$(dirname "${BASH_SOURCE[0]}")/log.sh"
+            """,
+        ),
+    )
+    (network_lib / "download.sh").write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            # shellcheck source=../log.sh
+            source "$(dirname "${BASH_SOURCE[0]}")/../log.sh"
+            _lgtm_ci_build_curl_args() { _LGTM_CI_CURL_ARGS=(-fsSL); return 0; }
+            download_with_retries() {
+              local url="$1"
+              local out="$2"
+              local attempts="${3:-3}"
+              local i
+              for ((i = 1; i <= attempts; i++)); do
+                if curl "${_LGTM_CI_CURL_ARGS[@]}" "$url" -o "$out"; then
+                  return 0
+                fi
+              done
+              return 1
+            }
+            """,
+        ),
+    )
+
+    mock_bin = tmp_path / "bin"
+    mock_bin.mkdir()
+    attempts_file = tmp_path / "curl-attempts"
+    uname_mock = mock_bin / "uname"
+    uname_mock.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            if [[ "${1:-}" == "-s" ]]; then
+              echo Linux
+              exit 0
+            fi
+            if [[ "${1:-}" == "-m" ]]; then
+              echo x86_64
+              exit 0
+            fi
+            exit 1
+            """,
+        ),
+    )
+    uname_mock.chmod(uname_mock.stat().st_mode | stat.S_IXUSR)
+    curl_mock = mock_bin / "curl"
+    curl_mock.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            attempts=0
+            if [[ -f "{attempts_file}" ]]; then
+              attempts=$(cat "{attempts_file}")
+            fi
+            echo $((attempts + 1)) > "{attempts_file}"
+            echo "curl: (23) Failure writing output to destination" >&2
+            exit 23
+            """,
+        ),
+    )
+    curl_mock.chmod(curl_mock.stat().st_mode | stat.S_IXUSR)
+
+    script_copy = workspace / "install-osv-scanner.sh"
+    script_copy.write_text(_INSTALL_SCRIPT.read_text())
+    script_copy.chmod(script_copy.stat().st_mode | stat.S_IXUSR)
+
+    env = os.environ.copy()
+    env["GITHUB_WORKSPACE"] = str(workspace)
+    env["PATH"] = f"{mock_bin}:{env['PATH']}"
+    env["DOWNLOAD_MAX_ATTEMPTS"] = "3"
+
+    result = subprocess.run(  # nosec B603 - fixed argv run against a real binary in a controlled test; shell=False, no user shell input
+        ["bash", str(script_copy), "9.9.9"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert_that(result.returncode).is_equal_to(1)
+    assert_that(int(attempts_file.read_text().strip())).is_greater_than_or_equal_to(3)
+    assert_that(result.stderr).contains("curl exit 23")
+
+
+def test_vuln_suppression_workflow_uses_local_scripts() -> None:
+    """vuln-suppression-check.yml should wire local install/check scripts."""
+    workflow_path = _REPO_ROOT / ".github/workflows/vuln-suppression-check.yml"
+    content = workflow_path.read_text(encoding="utf-8")
+
+    assert_that(content).contains(
+        "install-script: scripts/ci/security/install-osv-scanner.sh"
+    )
+    assert_that(content).contains(
+        "check-script: scripts/ci/security/check-vuln-suppressions.sh"
+    )
+    assert_that(content).contains(_LGTM_CI_PIN)


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): harden vuln suppression install against curl exit 23
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Scheduled **Security - Vulnerability Suppression Check** runs failed with exit code 23 and no actionable logs. Investigation of runs on 2026-06-22, 2026-06-29, and 2026-07-06 shows the failure occurs during **Install osv-scanner**, not the suppression check step:

```
curl: (23) Failure writing output to destination
```

Exit 23 is curl's write-error code (disk/permissions/transient I/O), not a suppression-specific status.

This PR wires local security scripts into the reusable workflow:

- `scripts/ci/security/install-osv-scanner.sh` — uses lgtm-ci `download_with_retries`, logs curl exit 23 context (destination path, writability, disk space), and retries transient failures.
- `scripts/ci/security/check-vuln-suppressions.sh` — verbose wrapper (`set -x` in Actions) delegating to lgtm-ci tooling with explicit failure context.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1314

## Details

**Root cause:** lgtm-ci `install-osv-scanner.sh` (v0.52.3) calls raw `curl` without retries; transient write failures surface only as exit 23.

**Post-egress note:** The next scheduled run after recent egress changes is 2026-07-13 (not yet executed at PR open). Prior failures predate the docker egress fix (#1304); this PR adds retries and diagnostics so any recurrence is triageable from logs.

**Testing:**
- `tests/scripts/test_vuln_suppression_scripts.py` — help/syntax, missing-tooling errors, simulated curl exit 23 retry/diagnostics, workflow wiring.
- Targeted pytest: `tests/scripts/test_vuln_suppression_scripts.py`, `tests/unit/test_workflow_wiring.py` (36 passed).
- `shellcheck` on new scripts; `ruff` on new tests.

**Lint note:** Full `uv run lintro chk` / `uv run lintro tst` timed out locally on this large worktree (prettier/black/gitleaks 30–120s limits). Changed files were verified with targeted tooling.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the scheduled vulnerability suppression workflow. The main changes are:

- Adds local install and check wrappers for the reusable workflow.
- Retries osv-scanner downloads and logs write-failure context.
- Delegates suppression checks with clearer failure output.
- Documents the new CI security scripts.
- Adds targeted tests for script behavior and workflow wiring.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/vuln-suppression-check.yml | Wires the local install and check scripts into the reusable vulnerability suppression workflow. |
| scripts/ci/security/install-osv-scanner.sh | Adds an osv-scanner installer wrapper with retries, diagnostics, checksum verification, and PATH setup. |
| scripts/ci/security/check-vuln-suppressions.sh | Adds a verbose wrapper that delegates to the lgtm-ci suppression check. |
| tests/scripts/test_vuln_suppression_scripts.py | Adds tests for helper script help output, syntax checks, missing tooling failures, retry handling, and workflow wiring. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: document security scripts and satis..."](https://github.com/lgtm-hq/py-lintro/commit/82c4e515e55bd3511c459c65d2693ef300306c3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43671583)</sub>

<!-- /greptile_comment -->