### PR TITLE
fix(pytest): honor zero coverage threshold and guard pyproject parsing

### DIFF
--- a/lintro/tools/implementations/pytest/addopts_coverage.py
+++ b/lintro/tools/implementations/pytest/addopts_coverage.py
@@ -50,6 +50,40 @@ def _addopts_has_coverage(addopts: str | list[str] | None) -> bool:
     return any(_token_enables_coverage(token) for token in tokens)
 
 
+def _load_pyproject_toml(path: Path) -> dict | None:
+    """Load and parse a ``pyproject.toml`` file.
+
+    Args:
+        path: Path to the ``pyproject.toml`` file to read.
+
+    Returns:
+        dict | None: Parsed TOML data, or None when unreadable.
+    """
+    try:
+        with path.open("rb") as handle:
+            return tomllib.load(handle)
+    except (tomllib.TOMLDecodeError, OSError):
+        return None
+
+
+def _pyproject_pytest_tool(data: dict) -> dict | None:
+    """Return the ``[tool.pytest]`` table when it is a valid mapping.
+
+    Args:
+        data: Parsed ``pyproject.toml`` data.
+
+    Returns:
+        dict | None: The pytest tool table, or None when absent or malformed.
+    """
+    tool = data.get("tool")
+    if not isinstance(tool, dict):
+        return None
+    pytest_config = tool.get("pytest")
+    if not isinstance(pytest_config, dict):
+        return None
+    return pytest_config
+
+
 def _ini_addopts_has_coverage(path: Path, section: str) -> bool:
     """Return whether an INI-style config's section enables coverage.
 
@@ -79,12 +113,15 @@ def _pyproject_addopts_has_coverage(path: Path) -> bool:
     Returns:
         bool: True if ``[tool.pytest.ini_options].addopts`` enables coverage.
     """
-    try:
-        with path.open("rb") as handle:
-            data = tomllib.load(handle)
-    except (tomllib.TOMLDecodeError, OSError):
+    data = _load_pyproject_toml(path)
+    if data is None:
         return False
-    ini_options = data.get("tool", {}).get("pytest", {}).get("ini_options", {})
+    pytest_config = _pyproject_pytest_tool(data)
+    if pytest_config is None:
+        return False
+    ini_options = pytest_config.get("ini_options")
+    if not isinstance(ini_options, dict):
+        return False
     return _addopts_has_coverage(ini_options.get("addopts"))
 
 
@@ -115,13 +152,11 @@ def _pyproject_has_pytest_config(path: Path) -> bool:
     Returns:
         bool: True when ``[tool.pytest.ini_options]`` is present.
     """
-    try:
-        with path.open("rb") as handle:
-            data = tomllib.load(handle)
-    except (tomllib.TOMLDecodeError, OSError):
+    data = _load_pyproject_toml(path)
+    if data is None:
         return False
-    pytest_tool = data.get("tool", {}).get("pytest", {})
-    return isinstance(pytest_tool, dict) and "ini_options" in pytest_tool
+    pytest_config = _pyproject_pytest_tool(data)
+    return pytest_config is not None and "ini_options" in pytest_config
 
 
 def _winning_pytest_config(base: Path) -> Path | None:

--- a/lintro/tools/implementations/pytest/addopts_coverage.py
+++ b/lintro/tools/implementations/pytest/addopts_coverage.py
@@ -50,7 +50,7 @@ def _addopts_has_coverage(addopts: str | list[str] | None) -> bool:
     return any(_token_enables_coverage(token) for token in tokens)
 
 
-def _load_pyproject_toml(path: Path) -> dict | None:
+def _load_pyproject_toml(path: Path) -> dict[str, object] | None:
     """Load and parse a ``pyproject.toml`` file.
 
     Args:
@@ -66,7 +66,7 @@ def _load_pyproject_toml(path: Path) -> dict | None:
         return None
 
 
-def _pyproject_pytest_tool(data: dict) -> dict | None:
+def _pyproject_pytest_tool(data: dict[str, object]) -> dict[str, object] | None:
     """Return the ``[tool.pytest]`` table when it is a valid mapping.
 
     Args:

--- a/lintro/tools/implementations/pytest/pytest_command_builder.py
+++ b/lintro/tools/implementations/pytest/pytest_command_builder.py
@@ -159,7 +159,10 @@ def add_coverage_options(cmd: list[str], options: dict[str, Any]) -> None:
 
     # Add coverage collection if any coverage options are specified
     needs_coverage = (
-        coverage_html or coverage_xml or coverage_term_missing or coverage_threshold
+        coverage_html
+        or coverage_xml
+        or coverage_term_missing
+        or coverage_threshold is not None
     )
     if needs_coverage:
         # Add --cov flag to enable coverage collection

--- a/tests/unit/tools/pytest_tool/test_addopts_coverage.py
+++ b/tests/unit/tools/pytest_tool/test_addopts_coverage.py
@@ -16,6 +16,9 @@ from assertpy import assert_that
 from lintro.tools.implementations.pytest.addopts_coverage import (
     config_addopts_enable_coverage,
 )
+from lintro.tools.implementations.pytest.pytest_command_builder import (
+    add_coverage_options,
+)
 from lintro.tools.implementations.pytest.pytest_config import PytestConfiguration
 from lintro.tools.implementations.pytest.pytest_executor import PytestExecutor
 
@@ -102,6 +105,20 @@ def test_detects_coverage_in_pyproject_toml_list_addopts(tmp_path: Path) -> None
     assert_that(config_addopts_enable_coverage(tmp_path)).is_true()
 
 
+def test_malformed_pyproject_tool_value_does_not_crash(tmp_path: Path) -> None:
+    """A non-table pyproject tool value is handled as no pytest configuration.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        'tool = "not-a-table"\n',
+        encoding="utf-8",
+    )
+
+    assert_that(config_addopts_enable_coverage(tmp_path)).is_false()
+
+
 def test_detects_coverage_in_setup_cfg(tmp_path: Path) -> None:
     """Coverage flags in setup.cfg [tool:pytest] are detected.
 
@@ -174,6 +191,32 @@ def test_banner_reports_disabled_without_coverage_config(
 
     banner = capsys.readouterr().out
     assert_that(banner).contains("Coverage: disabled")
+
+
+def test_zero_coverage_threshold_enables_collection() -> None:
+    """An explicit zero threshold enables coverage collection."""
+    command: list[str] = []
+
+    add_coverage_options(command, {"coverage_threshold": 0})
+
+    assert_that(command).contains("--cov-fail-under", "0", "--cov=.")
+
+
+def test_banner_reports_enabled_for_zero_coverage_threshold(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Banner reports coverage enabled when threshold is explicitly zero.
+
+    Args:
+        capsys: Pytest capture fixture for stdout/stderr.
+    """
+    config = PytestConfiguration(coverage_threshold=0)
+    executor = PytestExecutor(config=config, tool=None)
+
+    executor.display_run_config(total_tests=1, target_files=["."])
+
+    banner = capsys.readouterr().out
+    assert_that(banner).contains("Coverage: enabled")
 
 
 def test_report_only_cov_flags_do_not_enable_coverage(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(pytest): honor zero coverage threshold and guard pyproject parsing
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Fixes two coverage-threshold bugs from PR #1164:

1. **Zero-threshold truthiness** — `coverage_threshold = 0` is now treated as an explicit setting in the command builder (`is not None`), so `--cov=.` is added and the banner stays aligned with actual coverage behavior.
2. **Unguarded pyproject parsing** — `addopts_coverage.py` validates that `tool`, `pytest`, and `ini_options` are tables before chaining `.get()`, preventing `AttributeError` on malformed `pyproject.toml` files.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1318

## Details

**Implementation**
- Added `_load_pyproject_toml` and `_pyproject_pytest_tool` helpers in `addopts_coverage.py` for defensive TOML shape validation.
- Updated `add_coverage_options` in `pytest_command_builder.py` to use `coverage_threshold is not None` when deciding whether to enable collection.

**Testing**
- Regression tests for `coverage_threshold = 0` (command builder + banner).
- Regression test for malformed non-table `tool` value in `pyproject.toml` (no crash, reports no coverage).
- `uv run lintro fmt`, `uv run lintro chk`, and `uv run pytest tests/unit` all pass locally.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes coverage detection for pytest configuration and zero thresholds. The main changes are:

- Guarded `pyproject.toml` parsing for malformed pytest table shapes.
- Treated `coverage_threshold = 0` as an explicit coverage setting.
- Added tests for malformed pyproject input and zero-threshold coverage behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/implementations/pytest/addopts_coverage.py | Adds defensive TOML loading and pytest table checks before reading coverage addopts. |
| lintro/tools/implementations/pytest/pytest_command_builder.py | Updates coverage command building so an explicit zero threshold enables coverage collection. |
| tests/unit/tools/pytest_tool/test_addopts_coverage.py | Adds tests for malformed pyproject handling and zero-threshold coverage behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: add dict type parameters for mypy t..."](https://github.com/lgtm-hq/py-lintro/commit/e29605a7e243bc387fc6d1a0ebcbea75d185726d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43674351)</sub>

<!-- /greptile_comment -->