### PR TITLE
fix(ci): sync vuln-suppression workflow pin assertion

### DIFF
--- a/tests/scripts/test_vuln_suppression_scripts.py
+++ b/tests/scripts/test_vuln_suppression_scripts.py
@@ -20,7 +20,7 @@ _USES_PIN_RE = re.compile(
     r"reusable-vuln-suppression-check\.yml@([0-9a-f]{40})",
 )
 _TOOLING_REF_RE = re.compile(
-    r"tooling-ref:\s*'([0-9a-f]{40})'",
+    r"tooling-ref:\s*[\"']?([0-9a-f]{40})[\"']?",
 )
 
 

--- a/tests/scripts/test_vuln_suppression_scripts.py
+++ b/tests/scripts/test_vuln_suppression_scripts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import stat
 import subprocess  # nosec B404 - subprocess is used to drive the tool/CLI under test; invocations use shell=False
 import textwrap
@@ -14,7 +15,13 @@ from assertpy import assert_that
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _INSTALL_SCRIPT = _REPO_ROOT / "scripts/ci/security/install-osv-scanner.sh"
 _CHECK_SCRIPT = _REPO_ROOT / "scripts/ci/security/check-vuln-suppressions.sh"
-_LGTM_CI_PIN = "66cad82ead0e5d119928c895c7d7da9c837989e5"
+_WORKFLOW_PATH = _REPO_ROOT / ".github/workflows/vuln-suppression-check.yml"
+_USES_PIN_RE = re.compile(
+    r"reusable-vuln-suppression-check\.yml@([0-9a-f]{40})",
+)
+_TOOLING_REF_RE = re.compile(
+    r"tooling-ref:\s*'([0-9a-f]{40})'",
+)
 
 
 @pytest.mark.parametrize(
@@ -218,8 +225,7 @@ def test_install_script_retries_transient_curl_exit_23(tmp_path: Path) -> None:
 
 def test_vuln_suppression_workflow_uses_local_scripts() -> None:
     """vuln-suppression-check.yml should wire local install/check scripts."""
-    workflow_path = _REPO_ROOT / ".github/workflows/vuln-suppression-check.yml"
-    content = workflow_path.read_text(encoding="utf-8")
+    content = _WORKFLOW_PATH.read_text(encoding="utf-8")
 
     assert_that(content).contains(
         "install-script: scripts/ci/security/install-osv-scanner.sh",
@@ -227,4 +233,11 @@ def test_vuln_suppression_workflow_uses_local_scripts() -> None:
     assert_that(content).contains(
         "check-script: scripts/ci/security/check-vuln-suppressions.sh",
     )
-    assert_that(content).contains(_LGTM_CI_PIN)
+
+    uses_match = _USES_PIN_RE.search(content)
+    tooling_match = _TOOLING_REF_RE.search(content)
+    assert_that(uses_match).is_not_none()
+    assert_that(tooling_match).is_not_none()
+    assert uses_match is not None
+    assert tooling_match is not None
+    assert_that(uses_match.group(1)).is_equal_to(tooling_match.group(1))


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): sync vuln-suppression workflow pin assertion
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`main` is red after #1328: the vuln-suppression workflow pin moved to v0.52.4 / `768a6b72…` while the unit test still asserted the old SHA. This PR makes the test derive and cross-check the `uses` / `tooling-ref` SHAs from the workflow so pin bumps cannot desync CI again.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt/chk/tst`)

## Closes

- Closes #1339

## Details

Priority hotfix to restore green `main`. Open release #1338 stays parked until this lands and main is green.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR keeps the vuln-suppression workflow pin test in sync with the workflow. The main changes are:

- Adds regex extraction for the reusable workflow SHA.
- Adds regex extraction for the `tooling-ref` SHA.
- Compares both extracted SHAs instead of checking a hardcoded pin.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/scripts/test_vuln_suppression_scripts.py | Updates the workflow pin test to compare the `uses` and `tooling-ref` SHAs, including optional quotes around `tooling-ref`. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(test): accept optional quotes on too..."](https://github.com/lgtm-hq/py-lintro/commit/a3da935a0f5ba6f6dcaec0989a5bd7af77cd8437) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43742149)</sub>

<!-- /greptile_comment -->