### PR TITLE
fix(config): address unresolved #1267 review threads

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2295,6 +2295,7 @@ Set `default_fix` to avoid typing the flag every time:
 ai:
   enabled: true
   lint: true
+  review: true
   default_fix: false # only run --fix when explicitly requested
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2295,7 +2295,6 @@ Set `default_fix` to avoid typing the flag every time:
 ai:
   enabled: true
   lint: true
-  review: false
   default_fix: false # only run --fix when explicitly requested
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2275,6 +2275,8 @@ export ANTHROPIC_API_KEY=sk-ant-...
 # .lintro-config.yaml
 ai:
   enabled: true
+  lint: true # AI summaries / --fix on chk/fmt
+  review: false # lintro review (opt-in separately)
   provider: anthropic
 ```
 
@@ -2292,6 +2294,8 @@ Set `default_fix` to avoid typing the flag every time:
 ```yaml
 ai:
   enabled: true
+  lint: true
+  review: false
   default_fix: false # only run --fix when explicitly requested
 ```
 

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import warnings
 
+from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from lintro.ai.config_views import AIBudgetConfig, AIOutputConfig, AIProviderConfig
@@ -230,13 +231,15 @@ class AIConfig(BaseModel):
         if self.enabled and "lint" not in fields_set and "review" not in fields_set:
             self.lint = True
             self.review = True
-            warnings.warn(
+            message = (
                 "ai.enabled without ai.lint/ai.review is deprecated; both AI "
                 "lint summarization and AI review were enabled for backward "
-                "compatibility. Set ai.lint and/or ai.review explicitly.",
-                DeprecationWarning,
-                stacklevel=2,
+                "compatibility. Set ai.lint and/or ai.review explicitly."
             )
+            # DeprecationWarning from library code is ignored by Python's default
+            # filters; also log so installed-CLI users see the migration hint.
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            logger.warning(message)
         return self
 
     @model_validator(mode="after")

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -154,12 +154,12 @@ def _warn_ai_fix_disabled(
     *,
     action: Action,
     ai_fix: bool,
-    ai_enabled: bool,
+    ai_lint_enabled: bool,
     logger: Any,
     output_format: str = "",
 ) -> None:
-    """Warn when users request AI fixes but AI is disabled in config."""
-    if action != Action.CHECK or not ai_fix or ai_enabled:
+    """Warn when users request AI fixes but AI lint is disabled in config."""
+    if action != Action.CHECK or not ai_fix or ai_lint_enabled:
         return
     # Suppress plain-text warnings for machine-readable output formats
     if output_format.lower() in ("json", "sarif"):
@@ -993,7 +993,7 @@ def run_lint_tools_simple(
     _warn_ai_fix_disabled(
         action=action,
         ai_fix=effective_ai_fix,
-        ai_enabled=lintro_config.ai.lint_enabled,
+        ai_lint_enabled=lintro_config.ai.lint_enabled,
         logger=logger,
         output_format=output_format,
     )

--- a/tests/unit/ai/test_config.py
+++ b/tests/unit/ai/test_config.py
@@ -285,6 +285,23 @@ def test_legacy_enabled_enables_both_with_deprecation_warning() -> None:
     assert_that(config.review_enabled).is_true()
 
 
+def test_legacy_enabled_also_logs_deprecation_via_logger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Library DeprecationWarnings are easy to miss; also emit via loguru."""
+    logged: list[str] = []
+
+    def _capture(message: str, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+        logged.append(str(message))
+
+    monkeypatch.setattr("lintro.ai.config.logger.warning", _capture)
+    with pytest.warns(DeprecationWarning, match="ai.lint/ai.review"):
+        AIConfig(enabled=True)
+    assert_that(logged).is_length(1)
+    assert_that(logged[0]).contains("ai.lint/ai.review")
+
+
 def test_explicit_sub_toggle_suppresses_legacy_default(
     recwarn: pytest.WarningsRecorder,
 ) -> None:

--- a/tests/unit/utils/test_tool_executor_ai.py
+++ b/tests/unit/utils/test_tool_executor_ai.py
@@ -29,7 +29,7 @@ def test_warn_ai_fix_disabled_warns_only_for_check_when_fix_requested_and_ai_dis
     _warn_ai_fix_disabled(
         action=Action.CHECK,
         ai_fix=True,
-        ai_enabled=False,
+        ai_lint_enabled=False,
         logger=logger,
     )
 
@@ -46,19 +46,19 @@ def test_warn_ai_fix_disabled_no_warning_for_other_states():
     _warn_ai_fix_disabled(
         action=Action.FIX,
         ai_fix=True,
-        ai_enabled=False,
+        ai_lint_enabled=False,
         logger=logger,
     )
     _warn_ai_fix_disabled(
         action=Action.CHECK,
         ai_fix=False,
-        ai_enabled=False,
+        ai_lint_enabled=False,
         logger=logger,
     )
     _warn_ai_fix_disabled(
         action=Action.CHECK,
         ai_fix=True,
-        ai_enabled=True,
+        ai_lint_enabled=True,
         logger=logger,
     )
 
@@ -72,7 +72,7 @@ def test_warn_ai_fix_disabled_suppressed_for_json_output():
     _warn_ai_fix_disabled(
         action=Action.CHECK,
         ai_fix=True,
-        ai_enabled=False,
+        ai_lint_enabled=False,
         logger=logger,
         output_format="json",
     )
@@ -87,7 +87,7 @@ def test_warn_ai_fix_disabled_suppressed_for_sarif_output():
     _warn_ai_fix_disabled(
         action=Action.CHECK,
         ai_fix=True,
-        ai_enabled=False,
+        ai_lint_enabled=False,
         logger=logger,
         output_format="sarif",
     )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(config): address unresolved #1267 review threads
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Follow-up for three unresolved CodeRabbit threads on #1267 that were still valid after merge:

1. Docs AI examples now set explicit `lint` / `review` toggles
2. Legacy `ai.enabled`-only path also logs via loguru (DeprecationWarning alone is filtered for library code)
3. `_warn_ai_fix_disabled` parameter renamed to `ai_lint_enabled`

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt/chk/tst`)

## Closes

- Closes #1340
- Relates to #1267

## Details

Process correction after #1267 was merged with unresolved threads. Main is green at 0.79.2; this is the next priority after the #1339 hotfix.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the AI configuration behavior and examples. The main changes are:

- Explicit `lint` and `review` toggles in the documentation examples.
- A visible loguru warning for legacy `ai.enabled`-only configs.
- Clearer naming for the AI lint disabled warning helper.
- Tests for the new warning behavior and renamed helper argument.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/configuration.md | Updates AI config examples to show explicit `lint` and `review` settings. |
| lintro/ai/config.py | Adds a loguru warning for the legacy `ai.enabled` migration path. |
| lintro/utils/tool_executor.py | Renames the AI fix warning helper parameter to match the `lint_enabled` value it receives. |
| tests/unit/ai/test_config.py | Adds coverage for the loguru warning emitted by legacy AI config parsing. |
| tests/unit/utils/test_tool_executor_ai.py | Updates AI fix warning helper tests for the renamed argument. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(config): set review:true in default..."](https://github.com/lgtm-hq/py-lintro/commit/59b7b45506291c54faf8d5ee4f156437649a643f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43759032)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documentation for separate `ai.lint` and `ai.review` configuration switches.
  - `ai.lint` controls AI summaries and fix behavior for checking and formatting.
  - `ai.review` controls the AI review command.

- **Bug Fixes**
  - Improved warnings when AI fixes are requested while AI linting is disabled.
  - Legacy `ai.enabled` deprecation notices are now reported consistently through application logging as well as standard warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->