### PR TITLE
perf(ci): add path filters to docker-ci and test-ci with always-green gates

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -6,6 +6,16 @@ name: CI - Docker
 # Docker build once → dogfooding quality (reusable-quality-lint + CI image) →
 # integration tests → security audit → publish (main).
 # manifest-sync runs in parallel (no Docker).
+#
+# Path filtering: 🐳 Build Docker Images, 🔐 Security Audit, and
+# 🧪 Docker Integration Tests are required checks (org ruleset
+# checks-py-lintro), so this workflow must report on every PR — an
+# on.<event>.paths filter would leave those contexts absent and deadlock
+# merges (see codeql.yml and lgtm-ci docs/workflow-contract.md,
+# "Required-check-safe conditional workflows"). Instead the `changes` job
+# maps changed paths to the `pipeline` filter and the heavy jobs early-exit
+# green when only docs changed. merge_group, push, and workflow_dispatch
+# always run the full pipeline.
 
 'on':
   push:
@@ -27,15 +37,125 @@ env:
   CACHE_OPTS: mode=max,compression=zstd,oci-mediatypes=true,image-manifest=true
 
 jobs:
-  manifest-sync:
-    name: 📋 Manifest Sync
+  # Required-check-safe replacement for on.<event>.paths (see header
+  # comment). Only pull_request events are filtered; every other event
+  # resolves pipeline=true. detect-changes fails open (all filters true)
+  # when the diff base is unresolvable, and resolve-pipeline-relevance.sh
+  # fails open on missing/unparsable JSON, so a filter infrastructure
+  # failure runs the full pipeline rather than silently skipping it.
+  changes:
+    name: 🔎 Detect Relevant Changes
     runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 5
+    outputs:
+      pipeline: ${{ steps.result.outputs.pipeline }}
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect changed paths
+        id: detect
+        if: github.event_name == 'pull_request'
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/detect-changes@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        with:
+          # Everything that can affect the image, the integration tests, or
+          # dogfooding lint behavior. Err broad: a missed path here is a
+          # silent coverage hole. Only pure docs (*.md, docs/, assets/) may
+          # skip; test_samples/ holds lint fixtures (including *.md) that
+          # feed the integration tests, and docs/.markdownlint-cli2.jsonc
+          # is lint config, so both stay in the filter via the directory
+          # and root-glob rules below.
+          filters: |
+            pipeline:
+              - 'lintro/**'
+              - 'tests/**'
+              - 'test_samples/**'
+              - 'scripts/**'
+              - 'benchmarks/**'
+              - 'apps/**'
+              - 'npm/**'
+              - 'tools/**'
+              - '.github/**'
+              - '.allstar/**'
+              - 'Dockerfile'
+              - 'docker/**'
+              - 'docker-compose.yml'
+              - '.dockerignore'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'pytest.ini'
+              - 'tox.ini'
+              - 'Makefile'
+              - 'MANIFEST.in'
+              - 'LICENSE'
+              - 'package.json'
+              - 'bun.lock'
+              - '.node-version'
+              - '.actrc'
+              - '.codecov.yml'
+              - '.gitattributes'
+              - '.gitignore'
+              - '.gitleaks.toml'
+              - '.hadolint.yaml'
+              - '.lintro-config.yaml'
+              - '.lintro-ignore'
+              - '.markdownlint-cli2.jsonc'
+              - '.osv-scanner.toml'
+              - '.oxfmtrc.json'
+              - '.pre-commit-hooks.yaml'
+              - '.prettierignore'
+              - '.prettierrc.json'
+              - '.yamllint'
+              - 'renovate.json'
+              - 'socket.yml'
+              - 'docs/.markdownlint-cli2.jsonc'
+              # Catch-alls: any new root-level config file (dotfile or
+              # tool config) triggers the full pipeline by default.
+              - '.*'
+              - '*.toml'
+              - '*.yaml'
+              - '*.yml'
+              - '*.json'
+              - '*.jsonc'
+              - '*.lock'
+              - '*.ini'
+              - '*.cfg'
+              - '*.py'
+              - '*.sh'
+      - name: Resolve pipeline relevance
+        id: result
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CHANGES_JSON: ${{ steps.detect.outputs.changes }}
+        run: scripts/ci/resolve-pipeline-relevance.sh
+
+  manifest-sync:
+    name: 📋 Manifest Sync
+    needs: [changes]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    # Not a required check: safe to skip the whole job on docs-only PRs.
     if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false
+      needs.changes.outputs.pipeline == 'true' &&
+      (
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.draft == false
+      )
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
@@ -68,6 +188,10 @@ jobs:
 
   docker-build:
     name: 🐳 Build Docker Images
+    # Required check (org ruleset checks-py-lintro): the job itself always
+    # runs so the context reports; heavy steps are gated on the `pipeline`
+    # filter and the job early-exits green on docs-only PRs.
+    needs: [changes]
     runs-on: ubuntu-24.04
     permissions:
       contents: read # checkout and build context
@@ -125,20 +249,28 @@ jobs:
           IS_FORK_PR: ${{ github.event.pull_request.head.repo.fork }}
         run: scripts/ci/detect-fork-pr.sh
       - name: Free disk space (fork fallback)
-        if: steps.fork-check.outputs.is-fork == 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          steps.fork-check.outputs.is-fork == 'true'
         run: scripts/ci/free-disk-space.sh
       - name: Set up Docker Buildx (fork)
-        if: steps.fork-check.outputs.is-fork == 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          steps.fork-check.outputs.is-fork == 'true'
         # yamllint disable-line rule:line-length
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver: docker
       - name: Set up Docker Buildx
-        if: steps.fork-check.outputs.is-fork != 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          steps.fork-check.outputs.is-fork != 'true'
         # yamllint disable-line rule:line-length
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Log in to GitHub Container Registry
-        if: steps.fork-check.outputs.is-fork != 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          steps.fork-check.outputs.is-fork != 'true'
         # yamllint disable-line rule:line-length
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
@@ -146,7 +278,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Docker image (fork)
-        if: steps.fork-check.outputs.is-fork == 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          steps.fork-check.outputs.is-fork == 'true'
         # yamllint disable-line rule:line-length
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
@@ -158,7 +292,9 @@ jobs:
           cache-from: type=gha
           provenance: false
       - name: Build and push Docker image (GHCR CI tag)
-        if: steps.fork-check.outputs.is-fork != 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          steps.fork-check.outputs.is-fork != 'true'
         # yamllint disable-line rule:line-length
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
@@ -173,7 +309,9 @@ jobs:
             type=registry,ref=ghcr.io/lgtm-hq/py-lintro:cache,${{ env.CACHE_OPTS }}
           provenance: false
       - name: Build Base Docker image (fork)
-        if: steps.fork-check.outputs.is-fork == 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          steps.fork-check.outputs.is-fork == 'true'
         # yamllint disable-line rule:line-length
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
@@ -185,7 +323,9 @@ jobs:
           cache-from: type=gha
           provenance: false
       - name: Build and push Base Docker image (GHCR CI tag)
-        if: steps.fork-check.outputs.is-fork != 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          steps.fork-check.outputs.is-fork != 'true'
         # yamllint disable-line rule:line-length
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
@@ -200,22 +340,32 @@ jobs:
             type=registry,ref=ghcr.io/lgtm-hq/py-lintro-base:cache,${{ env.CACHE_OPTS }}
           provenance: false
       - name: Save Docker images to tarball (fork fallback)
-        if: steps.fork-check.outputs.is-fork == 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          steps.fork-check.outputs.is-fork == 'true'
         run: scripts/docker/save-ci-images-tarball.sh
       - name: Upload Docker images artifact (fork fallback)
-        if: steps.fork-check.outputs.is-fork == 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          steps.fork-check.outputs.is-fork == 'true'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: docker-images
           path: /tmp/py-lintro-images.tar
           retention-days: 1
+      - name: Skip heavy build (docs-only change)
+        if: needs.changes.outputs.pipeline != 'true'
+        run: scripts/ci/ci-log.sh "Docs-only change; Docker build skipped"
 
   dogfooding-lint:
-    needs: [docker-build, manifest-sync]
-    # Run when docker-build succeeds even if manifest-sync was skipped (draft PRs).
+    needs: [changes, docker-build, manifest-sync]
+    # Run when docker-build succeeds even if manifest-sync was skipped (draft
+    # PRs). Skipped entirely on docs-only PRs (docker-build early-exits green
+    # without pushing a CI image, so there is nothing to lint with).
     if: >-
       always() &&
       !cancelled() &&
+      needs.changes.outputs.pipeline == 'true' &&
       needs.docker-build.result == 'success' &&
       (
         needs.manifest-sync.result == 'success' ||
@@ -269,8 +419,12 @@ jobs:
       egress-policy: block
 
   # Org ruleset (checks-py-lintro): lintro-code-quality / 🛠️ Lintro Code Quality
+  # Always-green gate: reports success when the heavy jobs were path-skipped
+  # (docs-only PRs), mirrors their result when they ran, and fails when the
+  # `changes` detection job itself failed (so a broken filter can never
+  # green-light a merge).
   lintro-code-quality:
-    needs: [docker-build, manifest-sync, dogfooding-lint]
+    needs: [changes, docker-build, manifest-sync, dogfooding-lint]
     if: >-
       always() &&
       !cancelled() &&
@@ -288,7 +442,9 @@ jobs:
       runner-image: ubuntu-24.04
       upstream-result: >-
         ${{
-          needs.docker-build.result != 'success' && needs.docker-build.result
+          needs.changes.result != 'success' && needs.changes.result
+          || needs.changes.outputs.pipeline != 'true' && 'success'
+          || needs.docker-build.result != 'success' && needs.docker-build.result
           || (
             needs.manifest-sync.result != 'success' &&
             needs.manifest-sync.result != 'skipped'
@@ -302,7 +458,9 @@ jobs:
 
   security-audit:
     name: 🔐 Security Audit
-    needs: [docker-build]
+    # Required check: always runs so the context reports; heavy steps are
+    # gated on the `pipeline` filter (docs-only PRs early-exit green).
+    needs: [changes, docker-build]
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -327,7 +485,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Log in to GHCR
-        if: needs.docker-build.outputs.is-fork != 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          needs.docker-build.outputs.is-fork != 'true'
         # yamllint disable-line rule:line-length
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
@@ -335,26 +495,35 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull CI image from GHCR
-        if: needs.docker-build.outputs.is-fork != 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          needs.docker-build.outputs.is-fork != 'true'
         env:
           CI_TAG: ci-${{ github.run_id }}
         run: scripts/ci/testing/pull-ci-docker-images.sh full
       - name: Download Docker images artifact (fork fallback)
-        if: needs.docker-build.outputs.is-fork == 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          needs.docker-build.outputs.is-fork == 'true'
         # yamllint disable-line rule:line-length
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: docker-images
           path: /tmp
       - name: Load Docker images (fork fallback)
-        if: needs.docker-build.outputs.is-fork == 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          needs.docker-build.outputs.is-fork == 'true'
         run: scripts/ci/testing/load-ci-docker-images.sh
       - name: Run security audit
         id: audit
+        if: needs.changes.outputs.pipeline == 'true'
         continue-on-error: true
         run: scripts/ci/security-comment.sh
       - name: Comment PR with security audit results
-        if: github.event_name == 'pull_request'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
         uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
@@ -368,7 +537,9 @@ jobs:
 
   integration-test:
     name: 🧪 Docker Integration Tests
-    needs: [docker-build]
+    # Required check: always runs so the context reports; heavy steps are
+    # gated on the `pipeline` filter (docs-only PRs early-exit green).
+    needs: [changes, docker-build]
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -418,7 +589,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Log in to GHCR
-        if: needs.docker-build.outputs.is-fork != 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          needs.docker-build.outputs.is-fork != 'true'
         # yamllint disable-line rule:line-length
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
@@ -426,33 +599,42 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull CI images from GHCR
-        if: needs.docker-build.outputs.is-fork != 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          needs.docker-build.outputs.is-fork != 'true'
         env:
           CI_TAG: ci-${{ github.run_id }}
         run: scripts/ci/testing/pull-ci-docker-images.sh both
       - name: Download Docker images artifact (fork fallback)
-        if: needs.docker-build.outputs.is-fork == 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          needs.docker-build.outputs.is-fork == 'true'
         # yamllint disable-line rule:line-length
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: docker-images
           path: /tmp
       - name: Load Docker images (fork fallback)
-        if: needs.docker-build.outputs.is-fork == 'true'
+        if: >-
+          needs.changes.outputs.pipeline == 'true' &&
+          needs.docker-build.outputs.is-fork == 'true'
         run: scripts/ci/testing/load-ci-docker-images.sh
       - name: Smoke Test Docker Image
+        if: needs.changes.outputs.pipeline == 'true'
         run: ./scripts/docker/docker-build-test.sh
       - name: Smoke Test Base Image
+        if: needs.changes.outputs.pipeline == 'true'
         run: scripts/docker/smoke-test-base-image.sh
       - name: Run Docker integration tests
+        if: needs.changes.outputs.pipeline == 'true'
         run: scripts/docker/run-docker-test-suite.sh
       - name: Extract test summary
-        if: always()
+        if: always() && needs.changes.outputs.pipeline == 'true'
         run: >-
           scripts/ci/testing/extract-test-summary.sh
           test-output.log test-summary.json || true
       - name: Upload test summary artifact
-        if: always()
+        if: always() && needs.changes.outputs.pipeline == 'true'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: test-summary
@@ -574,9 +756,17 @@ jobs:
 
   cleanup-ci-images:
     name: 🧹 Cleanup CI Images
-    needs: [docker-build, dogfooding-lint, security-audit, integration-test, publish]
+    needs:
+      - changes
+      - docker-build
+      - dogfooding-lint
+      - security-audit
+      - integration-test
+      - publish
+    # Nothing to clean up when the build was path-skipped (no CI tags pushed).
     if: >-
       always() &&
+      needs.changes.outputs.pipeline == 'true' &&
       needs.docker-build.outputs.is-fork != 'true'
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -122,8 +122,14 @@ jobs:
               - 'renovate.json'
               - 'socket.yml'
               - 'docs/.markdownlint-cli2.jsonc'
-              # Catch-alls: any new root-level config file (dotfile or
-              # tool config) triggers the full pipeline by default.
+              # Catch-alls: ANY new root-level file except pure markdown
+              # triggers the full pipeline by default ('!(*.md)' is a
+              # picomatch extglob matching every root-level filename —
+              # dotfiles included, dorny sets dot:true — that does not end
+              # in .md; it has no slash so it never crosses directories).
+              # The extension globs are defense-in-depth should extglob
+              # handling ever regress upstream.
+              - '!(*.md)'
               - '.*'
               - '*.toml'
               - '*.yaml'
@@ -135,6 +141,10 @@ jobs:
               - '*.cfg'
               - '*.py'
               - '*.sh'
+              - '*.mjs'
+              - '*.cjs'
+              - '*.js'
+              - '*.ts'
       - name: Resolve pipeline relevance
         id: result
         env:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -39,10 +39,13 @@ env:
 jobs:
   # Required-check-safe replacement for on.<event>.paths (see header
   # comment). Only pull_request events are filtered; every other event
-  # resolves pipeline=true. detect-changes fails open (all filters true)
-  # when the diff base is unresolvable, and resolve-pipeline-relevance.sh
-  # fails open on missing/unparsable JSON, so a filter infrastructure
-  # failure runs the full pipeline rather than silently skipping it.
+  # resolves pipeline=true. Every layer fails open so a filter
+  # infrastructure failure runs the full pipeline rather than silently
+  # skipping it: detect-changes reports all filters true when the diff base
+  # is unresolvable, resolve-pipeline-relevance.sh resolves true on
+  # missing/unparsable JSON, and downstream gates compare != 'false' with
+  # !cancelled() so a failed changes job (empty output) still runs
+  # everything. Only an explicit pipeline == 'false' skips work.
   changes:
     name: 🔎 Detect Relevant Changes
     runs-on: ubuntu-24.04
@@ -160,8 +163,11 @@ jobs:
       contents: read
     timeout-minutes: 5
     # Not a required check: safe to skip the whole job on docs-only PRs.
+    # !cancelled() keeps it running (fail-open) if the changes job failed:
+    # the pipeline output is then empty, which is != 'false'.
     if: >-
-      needs.changes.outputs.pipeline == 'true' &&
+      !cancelled() &&
+      needs.changes.outputs.pipeline != 'false' &&
       (
         github.event_name != 'pull_request' ||
         github.event.pull_request.draft == false
@@ -200,8 +206,11 @@ jobs:
     name: 🐳 Build Docker Images
     # Required check (org ruleset checks-py-lintro): the job itself always
     # runs so the context reports; heavy steps are gated on the `pipeline`
-    # filter and the job early-exits green on docs-only PRs.
+    # filter and the job early-exits green on docs-only PRs. !cancelled()
+    # keeps it running (fail-open, full build) if the changes job failed —
+    # the pipeline output is then empty, which is != 'false' at every step.
     needs: [changes]
+    if: '!cancelled()'
     runs-on: ubuntu-24.04
     permissions:
       contents: read # checkout and build context
@@ -260,12 +269,12 @@ jobs:
         run: scripts/ci/detect-fork-pr.sh
       - name: Free disk space (fork fallback)
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           steps.fork-check.outputs.is-fork == 'true'
         run: scripts/ci/free-disk-space.sh
       - name: Set up Docker Buildx (fork)
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           steps.fork-check.outputs.is-fork == 'true'
         # yamllint disable-line rule:line-length
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -273,13 +282,13 @@ jobs:
           driver: docker
       - name: Set up Docker Buildx
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           steps.fork-check.outputs.is-fork != 'true'
         # yamllint disable-line rule:line-length
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Log in to GitHub Container Registry
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           steps.fork-check.outputs.is-fork != 'true'
         # yamllint disable-line rule:line-length
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -289,7 +298,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Docker image (fork)
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           steps.fork-check.outputs.is-fork == 'true'
         # yamllint disable-line rule:line-length
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
@@ -303,7 +312,7 @@ jobs:
           provenance: false
       - name: Build and push Docker image (GHCR CI tag)
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           steps.fork-check.outputs.is-fork != 'true'
         # yamllint disable-line rule:line-length
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
@@ -320,7 +329,7 @@ jobs:
           provenance: false
       - name: Build Base Docker image (fork)
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           steps.fork-check.outputs.is-fork == 'true'
         # yamllint disable-line rule:line-length
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
@@ -334,7 +343,7 @@ jobs:
           provenance: false
       - name: Build and push Base Docker image (GHCR CI tag)
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           steps.fork-check.outputs.is-fork != 'true'
         # yamllint disable-line rule:line-length
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
@@ -351,12 +360,12 @@ jobs:
           provenance: false
       - name: Save Docker images to tarball (fork fallback)
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           steps.fork-check.outputs.is-fork == 'true'
         run: scripts/docker/save-ci-images-tarball.sh
       - name: Upload Docker images artifact (fork fallback)
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           steps.fork-check.outputs.is-fork == 'true'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
@@ -364,7 +373,7 @@ jobs:
           path: /tmp/py-lintro-images.tar
           retention-days: 1
       - name: Skip heavy build (docs-only change)
-        if: needs.changes.outputs.pipeline != 'true'
+        if: needs.changes.outputs.pipeline == 'false'
         run: scripts/ci/ci-log.sh "Docs-only change; Docker build skipped"
 
   dogfooding-lint:
@@ -375,7 +384,7 @@ jobs:
     if: >-
       always() &&
       !cancelled() &&
-      needs.changes.outputs.pipeline == 'true' &&
+      needs.changes.outputs.pipeline != 'false' &&
       needs.docker-build.result == 'success' &&
       (
         needs.manifest-sync.result == 'success' ||
@@ -430,9 +439,10 @@ jobs:
 
   # Org ruleset (checks-py-lintro): lintro-code-quality / 🛠️ Lintro Code Quality
   # Always-green gate: reports success when the heavy jobs were path-skipped
-  # (docs-only PRs), mirrors their result when they ran, and fails when the
-  # `changes` detection job itself failed (so a broken filter can never
-  # green-light a merge).
+  # (docs-only PRs, pipeline == 'false') and mirrors their result when they
+  # ran. A failed changes job fails open — its pipeline output is empty, the
+  # full pipeline runs, and this gate mirrors the real results — so a broken
+  # filter can never skip coverage or green-light an untested merge.
   lintro-code-quality:
     needs: [changes, docker-build, manifest-sync, dogfooding-lint]
     if: >-
@@ -452,8 +462,7 @@ jobs:
       runner-image: ubuntu-24.04
       upstream-result: >-
         ${{
-          needs.changes.result != 'success' && needs.changes.result
-          || needs.changes.outputs.pipeline != 'true' && 'success'
+          needs.changes.outputs.pipeline == 'false' && 'success'
           || needs.docker-build.result != 'success' && needs.docker-build.result
           || (
             needs.manifest-sync.result != 'success' &&
@@ -468,9 +477,14 @@ jobs:
 
   security-audit:
     name: 🔐 Security Audit
-    # Required check: always runs so the context reports; heavy steps are
-    # gated on the `pipeline` filter (docs-only PRs early-exit green).
+    # Required check: runs whenever docker-build reported success (real or
+    # docs-only early-exit) so the context reports; heavy steps are gated on
+    # the `pipeline` filter. !cancelled() keeps it running (fail-open) if
+    # the changes job failed.
     needs: [changes, docker-build]
+    if: >-
+      !cancelled() &&
+      needs.docker-build.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -496,7 +510,7 @@ jobs:
           persist-credentials: false
       - name: Log in to GHCR
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           needs.docker-build.outputs.is-fork != 'true'
         # yamllint disable-line rule:line-length
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -506,14 +520,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull CI image from GHCR
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           needs.docker-build.outputs.is-fork != 'true'
         env:
           CI_TAG: ci-${{ github.run_id }}
         run: scripts/ci/testing/pull-ci-docker-images.sh full
       - name: Download Docker images artifact (fork fallback)
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           needs.docker-build.outputs.is-fork == 'true'
         # yamllint disable-line rule:line-length
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -522,17 +536,17 @@ jobs:
           path: /tmp
       - name: Load Docker images (fork fallback)
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           needs.docker-build.outputs.is-fork == 'true'
         run: scripts/ci/testing/load-ci-docker-images.sh
       - name: Run security audit
         id: audit
-        if: needs.changes.outputs.pipeline == 'true'
+        if: needs.changes.outputs.pipeline != 'false'
         continue-on-error: true
         run: scripts/ci/security-comment.sh
       - name: Comment PR with security audit results
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
@@ -547,9 +561,14 @@ jobs:
 
   integration-test:
     name: 🧪 Docker Integration Tests
-    # Required check: always runs so the context reports; heavy steps are
-    # gated on the `pipeline` filter (docs-only PRs early-exit green).
+    # Required check: runs whenever docker-build reported success (real or
+    # docs-only early-exit) so the context reports; heavy steps are gated on
+    # the `pipeline` filter. !cancelled() keeps it running (fail-open) if
+    # the changes job failed.
     needs: [changes, docker-build]
+    if: >-
+      !cancelled() &&
+      needs.docker-build.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -600,7 +619,7 @@ jobs:
           persist-credentials: false
       - name: Log in to GHCR
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           needs.docker-build.outputs.is-fork != 'true'
         # yamllint disable-line rule:line-length
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -610,14 +629,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull CI images from GHCR
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           needs.docker-build.outputs.is-fork != 'true'
         env:
           CI_TAG: ci-${{ github.run_id }}
         run: scripts/ci/testing/pull-ci-docker-images.sh both
       - name: Download Docker images artifact (fork fallback)
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           needs.docker-build.outputs.is-fork == 'true'
         # yamllint disable-line rule:line-length
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -626,25 +645,25 @@ jobs:
           path: /tmp
       - name: Load Docker images (fork fallback)
         if: >-
-          needs.changes.outputs.pipeline == 'true' &&
+          needs.changes.outputs.pipeline != 'false' &&
           needs.docker-build.outputs.is-fork == 'true'
         run: scripts/ci/testing/load-ci-docker-images.sh
       - name: Smoke Test Docker Image
-        if: needs.changes.outputs.pipeline == 'true'
+        if: needs.changes.outputs.pipeline != 'false'
         run: ./scripts/docker/docker-build-test.sh
       - name: Smoke Test Base Image
-        if: needs.changes.outputs.pipeline == 'true'
+        if: needs.changes.outputs.pipeline != 'false'
         run: scripts/docker/smoke-test-base-image.sh
       - name: Run Docker integration tests
-        if: needs.changes.outputs.pipeline == 'true'
+        if: needs.changes.outputs.pipeline != 'false'
         run: scripts/docker/run-docker-test-suite.sh
       - name: Extract test summary
-        if: always() && needs.changes.outputs.pipeline == 'true'
+        if: always() && needs.changes.outputs.pipeline != 'false'
         run: >-
           scripts/ci/testing/extract-test-summary.sh
           test-output.log test-summary.json || true
       - name: Upload test summary artifact
-        if: always() && needs.changes.outputs.pipeline == 'true'
+        if: always() && needs.changes.outputs.pipeline != 'false'
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: test-summary
@@ -776,7 +795,7 @@ jobs:
     # Nothing to clean up when the build was path-skipped (no CI tags pushed).
     if: >-
       always() &&
-      needs.changes.outputs.pipeline == 'true' &&
+      needs.changes.outputs.pipeline != 'false' &&
       needs.docker-build.outputs.is-fork != 'true'
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -3,6 +3,19 @@
 ---
 name: CI - Tests
 
+# No paths filter, and no job-level path-skip of test-compat/test-coverage
+# either (#1359): the org ruleset (checks-py-lintro) requires the NESTED
+# contexts reported from inside reusable-test-python (test-compat / Python
+# Compatibility, test-compat / Aggregate Python Results, test-coverage /
+# Python Coverage, test-coverage / Aggregate Python Results). A path-filtered
+# workflow never reports them, and a skipped reusable *caller* collapses to a
+# single check run named after the caller job — the nested contexts are never
+# created (verified on commit fdc94ea) — so either approach leaves required
+# checks permanently "Expected" and deadlocks merges (see codeql.yml and
+# lgtm-ci docs/workflow-contract.md, "Required-check-safe conditional
+# workflows"). Path-skipping this matrix needs an internal skip input in
+# lgtm-ci reusable-test-python (jobs skipped INSIDE a running reusable do
+# report their contexts as skipped, like draft-pr-skip does today).
 'on':
   push:
     branches: [main]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -98,6 +98,7 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `egress-audit-lite.sh`               | Audit reachability of allowed endpoints                               | `./scripts/ci/egress-audit-lite.sh --help`                                         |
 | `detect-changes.sh`                  | Detect repo diffs and set has_changes output                          | `./scripts/ci/detect-changes.sh --help`                                            |
 | `detect-fork-pr.sh`                  | Detect fork PRs and set `is-fork` output for conditional steps        | `EVENT_NAME=pull_request ./scripts/ci/detect-fork-pr.sh`                           |
+| `resolve-pipeline-relevance.sh`      | Resolve heavy-pipeline path relevance and set `pipeline` output       | `./scripts/ci/resolve-pipeline-relevance.sh --help`                                |
 | `evaluate-test-gate.sh`              | Evaluate upstream compat/coverage results for required-check gate     | `COMPAT_RESULT=success COVERAGE_RESULT=success ./scripts/ci/evaluate-test-gate.sh` |
 | `fail-on-security-audit.sh`          | Fail CI when security audit finds vulnerabilities                     | `./scripts/ci/fail-on-security-audit.sh`                                           |
 | `free-disk-space.sh`                 | Free disk space on CI runner for Docker builds                        | `./scripts/ci/free-disk-space.sh`                                                  |

--- a/scripts/ci/resolve-pipeline-relevance.sh
+++ b/scripts/ci/resolve-pipeline-relevance.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# resolve-pipeline-relevance.sh
+#
+# Resolve whether the heavy CI pipeline is relevant for this run and write a
+# `pipeline` output (true|false) to GITHUB_OUTPUT for downstream job and step
+# conditions.
+#
+# Non-pull_request events (push, merge_group, workflow_dispatch) always run
+# the full pipeline. pull_request events consult the JSON produced by the
+# lgtm-hq/lgtm-ci detect-changes action (filter name -> boolean). Missing or
+# unparsable JSON fails open (pipeline=true) so required checks run their
+# full jobs instead of silently early-exiting.
+#
+# Usage:
+#   EVENT_NAME=<event> CHANGES_JSON='{"pipeline":true}' \
+#     scripts/ci/resolve-pipeline-relevance.sh
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Resolve heavy-pipeline path relevance for GitHub Actions.
+
+Usage:
+  EVENT_NAME=<event> CHANGES_JSON='{"pipeline":true}' \
+    scripts/ci/resolve-pipeline-relevance.sh
+
+Environment:
+  EVENT_NAME    github.event_name
+  CHANGES_JSON  detect-changes `changes` output (JSON filter -> boolean);
+                only consulted when EVENT_NAME is pull_request
+
+Behavior:
+  - Non-pull_request events always resolve pipeline=true (merge_group and
+    push runs never path-skip).
+  - pull_request events resolve the `pipeline` filter from CHANGES_JSON.
+  - Missing or unparsable CHANGES_JSON fails open (pipeline=true).
+
+Outputs (via GITHUB_OUTPUT):
+  pipeline=true|false
+EOF
+	exit 0
+fi
+
+event_name="${EVENT_NAME:-}"
+changes_json="${CHANGES_JSON:-}"
+pipeline="true"
+
+if [[ "$event_name" == "pull_request" ]]; then
+	# Plain -r (not -e): jq -e exits nonzero for a legitimate false value.
+	if resolved="$(jq -r '.pipeline' <<<"$changes_json" 2>/dev/null)"; then
+		case "$resolved" in
+		true)
+			pipeline="true"
+			;;
+		false)
+			pipeline="false"
+			;;
+		*)
+			echo "::warning::Unexpected pipeline filter value" \
+				"'${resolved}'; failing open (pipeline=true)"
+			pipeline="true"
+			;;
+		esac
+	else
+		echo "::warning::detect-changes JSON missing or unparsable;" \
+			"failing open (pipeline=true)"
+		pipeline="true"
+	fi
+fi
+
+echo "event=${event_name:-<unset>} pipeline=${pipeline}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	echo "pipeline=${pipeline}" >>"$GITHUB_OUTPUT"
+else
+	echo "pipeline=${pipeline}"
+fi

--- a/tests/scripts/test_shell_scripts.py
+++ b/tests/scripts/test_shell_scripts.py
@@ -29,6 +29,7 @@ def test_resolve_pipeline_relevance_help() -> None:
         [str(script_path), "--help"],
         capture_output=True,
         text=True,
+        check=False,
     )
     assert_that(result.returncode).is_equal_to(0)
     assert_that(result.stdout).contains("Usage:")
@@ -60,6 +61,7 @@ def test_resolve_pipeline_relevance_outputs() -> None:
             [str(script_path)],
             capture_output=True,
             text=True,
+            check=False,
             env={"PATH": "/usr/bin:/bin:/usr/local/bin", **env},
         )
         assert_that(result.returncode).is_equal_to(0)

--- a/tests/scripts/test_shell_scripts.py
+++ b/tests/scripts/test_shell_scripts.py
@@ -22,6 +22,50 @@ def test_detect_changes_help() -> None:
     assert_that(result.stdout).contains("Usage:")
 
 
+def test_resolve_pipeline_relevance_help() -> None:
+    """resolve-pipeline-relevance.sh should provide help and exit 0."""
+    script_path = Path("scripts/ci/resolve-pipeline-relevance.sh").resolve()
+    result = subprocess.run(  # nosec B603 - fixed argv run against a real binary in a controlled test; shell=False, no user shell input
+        [str(script_path), "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("Usage:")
+
+
+def test_resolve_pipeline_relevance_outputs() -> None:
+    """resolve-pipeline-relevance.sh should resolve pipeline per event/JSON."""
+    script_path = Path("scripts/ci/resolve-pipeline-relevance.sh").resolve()
+    cases: list[tuple[dict[str, str], str]] = [
+        # merge_group and push never path-skip.
+        ({"EVENT_NAME": "merge_group"}, "pipeline=true"),
+        ({"EVENT_NAME": "push"}, "pipeline=true"),
+        # pull_request honors the detect-changes filter value.
+        (
+            {"EVENT_NAME": "pull_request", "CHANGES_JSON": '{"pipeline":true}'},
+            "pipeline=true",
+        ),
+        (
+            {"EVENT_NAME": "pull_request", "CHANGES_JSON": '{"pipeline":false}'},
+            "pipeline=false",
+        ),
+        # Missing or unparsable JSON fails open.
+        ({"EVENT_NAME": "pull_request", "CHANGES_JSON": ""}, "pipeline=true"),
+        ({"EVENT_NAME": "pull_request", "CHANGES_JSON": "not json"}, "pipeline=true"),
+        ({"EVENT_NAME": "pull_request", "CHANGES_JSON": "{}"}, "pipeline=true"),
+    ]
+    for env, expected in cases:
+        result = subprocess.run(  # nosec B603 - fixed argv run against a real binary in a controlled test; shell=False, no user shell input
+            [str(script_path)],
+            capture_output=True,
+            text=True,
+            env={"PATH": "/usr/bin:/bin:/usr/local/bin", **env},
+        )
+        assert_that(result.returncode).is_equal_to(0)
+        assert_that(result.stdout).contains(expected)
+
+
 def test_renovate_regex_manager_current_value() -> None:
     """Ensure Renovate custom managers use currentValue to satisfy schema."""
     config_path = Path("renovate.json")

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -147,6 +147,16 @@ def _evaluate_github_if(
                     token=f"needs.{job}.outputs.{output_name} != 'true'",
                     replacement=repr(output_value != "true"),
                 )
+                expr = _replace_github_token(
+                    expr,
+                    token=f"needs.{job}.outputs.{output_name} == 'false'",
+                    replacement=repr(output_value == "false"),
+                )
+                expr = _replace_github_token(
+                    expr,
+                    token=f"needs.{job}.outputs.{output_name} != 'false'",
+                    replacement=repr(output_value != "false"),
+                )
     if event_is_pull_request is not None:
         expr = _replace_github_token(
             expr,
@@ -285,7 +295,7 @@ def test_docker_ci_dogfooding_lint_waits_on_manifest_sync() -> None:
     assert_that(lint_needs).contains("changes", "docker-build", "manifest-sync")
     assert_that(lint_condition).contains("always()")
     assert_that(lint_condition).contains("!cancelled()")
-    assert_that(lint_condition).contains("needs.changes.outputs.pipeline == 'true'")
+    assert_that(lint_condition).contains("needs.changes.outputs.pipeline != 'false'")
     assert_that(lint_condition).contains("needs.docker-build.result == 'success'")
     assert_that(lint_condition).contains("manifest-sync.result == 'skipped'")
     assert_that(lint_condition).contains("manifest-sync.result == 'success'")
@@ -319,8 +329,9 @@ def test_docker_ci_dogfooding_lint_waits_on_manifest_sync() -> None:
         # Docs-only PR: docker-build early-exits green and manifest-sync is
         # path-skipped; dogfooding-lint must not run (no CI image pushed).
         ("false", "success", "skipped", False, False),
-        # Broken changes job: pipeline output is empty; never run the lint.
-        ("", "success", "success", False, False),
+        # Broken changes job fails open: pipeline output is empty (not
+        # 'false'), the full build ran, so the lint runs too.
+        ("", "success", "success", False, True),
     ],
 )
 def test_docker_ci_lint_condition_semantics(
@@ -485,8 +496,7 @@ def test_docker_ci_lintro_code_quality_wires_upstream_jobs() -> None:
     upstream = _normalize_github_expr(job["with"]["upstream-result"])
     assert_that(upstream).is_equal_to(
         _normalize_github_expr(
-            "${{ needs.changes.result != 'success' && needs.changes.result "
-            "|| needs.changes.outputs.pipeline != 'true' && 'success' "
+            "${{ needs.changes.outputs.pipeline == 'false' && 'success' "
             "|| needs.docker-build.result != 'success' && needs.docker-build.result "
             "|| ( needs.manifest-sync.result != 'success' && "
             "needs.manifest-sync.result != 'skipped' ) && needs.manifest-sync.result "

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -137,6 +137,16 @@ def _evaluate_github_if(
                     token=f"needs.{job}.outputs.{output_name} != ''",
                     replacement=repr(output_value != ""),
                 )
+                expr = _replace_github_token(
+                    expr,
+                    token=f"needs.{job}.outputs.{output_name} == 'true'",
+                    replacement=repr(output_value == "true"),
+                )
+                expr = _replace_github_token(
+                    expr,
+                    token=f"needs.{job}.outputs.{output_name} != 'true'",
+                    replacement=repr(output_value != "true"),
+                )
     if event_is_pull_request is not None:
         expr = _replace_github_token(
             expr,
@@ -272,9 +282,10 @@ def test_docker_ci_dogfooding_lint_waits_on_manifest_sync() -> None:
     lint_condition = lint_job["if"]
     comment_condition = comment_job["if"]
 
-    assert_that(lint_needs).contains("docker-build", "manifest-sync")
+    assert_that(lint_needs).contains("changes", "docker-build", "manifest-sync")
     assert_that(lint_condition).contains("always()")
     assert_that(lint_condition).contains("!cancelled()")
+    assert_that(lint_condition).contains("needs.changes.outputs.pipeline == 'true'")
     assert_that(lint_condition).contains("needs.docker-build.result == 'success'")
     assert_that(lint_condition).contains("manifest-sync.result == 'skipped'")
     assert_that(lint_condition).contains("manifest-sync.result == 'success'")
@@ -298,17 +309,23 @@ def test_docker_ci_dogfooding_lint_waits_on_manifest_sync() -> None:
 
 
 @pytest.mark.parametrize(
-    ("docker_build", "manifest_sync", "cancelled", "expected"),
+    ("pipeline", "docker_build", "manifest_sync", "cancelled", "expected"),
     [
-        ("success", "success", False, True),
-        ("success", "skipped", False, True),
-        ("success", "failure", False, False),
-        ("failure", "success", False, False),
-        ("success", "success", True, False),
+        ("true", "success", "success", False, True),
+        ("true", "success", "skipped", False, True),
+        ("true", "success", "failure", False, False),
+        ("true", "failure", "success", False, False),
+        ("true", "success", "success", True, False),
+        # Docs-only PR: docker-build early-exits green and manifest-sync is
+        # path-skipped; dogfooding-lint must not run (no CI image pushed).
+        ("false", "success", "skipped", False, False),
+        # Broken changes job: pipeline output is empty; never run the lint.
+        ("", "success", "success", False, False),
     ],
 )
 def test_docker_ci_lint_condition_semantics(
     *,
+    pipeline: str,
     docker_build: str,
     manifest_sync: str,
     cancelled: bool,
@@ -326,6 +343,7 @@ def test_docker_ci_lint_condition_semantics(
                 "docker-build": docker_build,
                 "manifest-sync": manifest_sync,
             },
+            outputs={"changes": {"pipeline": pipeline}},
         ),
     ).is_equal_to(expected)
 
@@ -458,6 +476,7 @@ def test_docker_ci_lintro_code_quality_wires_upstream_jobs() -> None:
     job = docker_ci["jobs"]["lintro-code-quality"]
 
     assert_that(job["needs"]).contains(
+        "changes",
         "docker-build",
         "manifest-sync",
         "dogfooding-lint",
@@ -466,7 +485,9 @@ def test_docker_ci_lintro_code_quality_wires_upstream_jobs() -> None:
     upstream = _normalize_github_expr(job["with"]["upstream-result"])
     assert_that(upstream).is_equal_to(
         _normalize_github_expr(
-            "${{ needs.docker-build.result != 'success' && needs.docker-build.result "
+            "${{ needs.changes.result != 'success' && needs.changes.result "
+            "|| needs.changes.outputs.pipeline != 'true' && 'success' "
+            "|| needs.docker-build.result != 'success' && needs.docker-build.result "
             "|| ( needs.manifest-sync.result != 'success' && "
             "needs.manifest-sync.result != 'skipped' ) && needs.manifest-sync.result "
             "|| needs.dogfooding-lint.result }}",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  perf(ci): add path filters to docker-ci and test-ci with always-green gates
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Implements #1359 (epic #1357): path filtering for the heavy Docker pipeline with always-green required-check gates, using the org's required-check-safe pattern (lgtm-ci workflow contract) instead of `on.<event>.paths`.

Docs-only PRs now skip the ~20m Docker build/dogfood/integration/audit work while **every required check still reports green**. Any change that can affect the image or lint behavior still runs the full pipeline.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1359
- Relates to #1357

## Details

- `uv run pytest tests/scripts/test_shell_scripts.py` — 4 passed (new `--help` + behavior matrix tests for `resolve-pipeline-relevance.sh`)
- `uv run lintro chk` on all changed files — clean
- `actionlint` on both workflows — clean
