### PR TITLE
feat(docker): publish lintro-tools base image with digest-pinned FROM

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -49,8 +49,8 @@ on `main` failures — hence the `actions: read` + `issues: write` job permissio
 - **docker-tools-publish.yml** — Publishes the `lintro-tools` toolchain base image
   (`docker/tools.Dockerfile`) via `reusable-docker.yml` on tool-pin changes plus a
   weekly no-cache rebuild for CVE freshness; cosign-signed with SBOM + provenance
-  attestations. The root `Dockerfile` consumes it via a Renovate-managed digest-pinned
-  `FROM`.
+  attestations. A follow-up root `Dockerfile` change will consume it via a
+  Renovate-managed digest-pinned `FROM`.
 
 ## Security & maintenance
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -46,6 +46,11 @@ on `main` failures — hence the `actions: read` + `issues: write` job permissio
   (same three-step pattern with `repository-url: https://test.pypi.org/legacy/`)
 - **docker-build-publish.yml** — Multi-arch GHCR publish via `reusable-docker.yml`
   (full + base images, registry cache at `:cache`, no-cache on version tags)
+- **docker-tools-publish.yml** — Publishes the `lintro-tools` toolchain base image
+  (`docker/tools.Dockerfile`) via `reusable-docker.yml` on tool-pin changes plus a
+  weekly no-cache rebuild for CVE freshness; cosign-signed with SBOM + provenance
+  attestations. The root `Dockerfile` consumes it via a Renovate-managed digest-pinned
+  `FROM`.
 
 ## Security & maintenance
 

--- a/.github/workflows/docker-tools-publish.yml
+++ b/.github/workflows/docker-tools-publish.yml
@@ -4,8 +4,9 @@
 name: Build - Lintro Tools Image
 # Builds and publishes the pre-built external toolchain base image
 # ghcr.io/lgtm-hq/lintro-tools (Rust toolchain, bun, ~40 linter binaries)
-# via lgtm-ci reusable-docker. The root Dockerfile consumes this image
-# through a digest-pinned FROM; Renovate bumps the digest (see renovate.json).
+# via lgtm-ci reusable-docker. Once the first image is published, the root
+# Dockerfile flips to a digest-pinned FROM on it; Renovate bumps the digest
+# from then on (see renovate.json and issue #1360).
 #
 # Triggers:
 #   - push (main) / pull_request touching the tools Dockerfile, the pinned

--- a/.github/workflows/docker-tools-publish.yml
+++ b/.github/workflows/docker-tools-publish.yml
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Build - Lintro Tools Image
+# Builds and publishes the pre-built external toolchain base image
+# ghcr.io/lgtm-hq/lintro-tools (Rust toolchain, bun, ~40 linter binaries)
+# via lgtm-ci reusable-docker. The root Dockerfile consumes this image
+# through a digest-pinned FROM; Renovate bumps the digest (see renovate.json).
+#
+# Triggers:
+#   - push (main) / pull_request touching the tools Dockerfile, the pinned
+#     tool versions, or the installer script. PR runs validate only (no push).
+#     Not a required check, so on.<event>.paths filtering is safe here (see
+#     docker-ci.yml header for the required-check deadlock caveat).
+#   - weekly schedule with no-cache so tool binaries and the OS layer pick up
+#     fresh CVE patches instead of stale cached layers.
+#   - workflow_dispatch with force_publish for maintainer-driven publishes
+#     from a branch (e.g. seeding the first image before the FROM flip).
+
+'on':
+  push:
+    branches: [main]
+    paths:
+      - 'docker/tools.Dockerfile'
+      - '.github/workflows/docker-tools-publish.yml'
+      - 'lintro/_tool_versions.py'
+      - 'lintro/tools/manifest.json'
+      - 'scripts/utils/install-tools.sh'
+      - 'scripts/utils/utils.sh'
+      - 'package.json'
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'docker/tools.Dockerfile'
+      - '.github/workflows/docker-tools-publish.yml'
+      - 'lintro/_tool_versions.py'
+      - 'lintro/tools/manifest.json'
+      - 'scripts/utils/install-tools.sh'
+      - 'scripts/utils/utils.sh'
+      - 'package.json'
+  schedule:
+    # Weekly rebuild (Monday 03:17 UTC) for CVE freshness in tool binaries.
+    - cron: '17 3 * * 1'
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: 'Publish from this branch (maintainer seeding/testing)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-tools-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  tools-image:
+    name: 🐳 Lintro Tools Image
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      security-events: write
+    with:
+      file: docker/tools.Dockerfile
+      image-name: lgtm-hq/lintro-tools
+      # No app version: the image floats on latest/main/sha-* tags and
+      # consumers pin by digest (Renovate-managed FROM in the root
+      # Dockerfile).
+      tags: latest
+      push: >-
+        ${{ github.event_name != 'pull_request'
+        && (github.ref == 'refs/heads/main'
+        || (github.event_name == 'workflow_dispatch'
+        && inputs.force_publish == 'true')) }}
+      platforms: linux/amd64,linux/arm64
+      runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
+      # Build-time RUN steps already verify every bundled tool; the smoke
+      # test just proves the published manifest runs on each platform.
+      smoke-test: bun --version
+      validate-on-pr: true
+      cache-registry-ref: ghcr.io/lgtm-hq/lintro-tools:cache
+      # Scheduled rebuilds must not reuse cached layers, otherwise the
+      # weekly CVE-freshness rebuild is a no-op cache hit.
+      no-cache: ${{ github.event_name == 'schedule' }}
+      provenance: true
+      sbom: true
+      cosign-sign: true
+      scan: true
+      scan-exit-code: '0'
+      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      egress-policy: block
+      egress-preset: docker
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the docker preset baseline. The
+      # sigstore hosts cover cosign keyless signing in the merge job;
+      # mirror.gcr.io is the Trivy vulnerability DB fallback.
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        ghcr.io:443
+        pkg-containers.githubusercontent.com:443
+        docker.io:443
+        registry-1.docker.io:443
+        auth.docker.io:443
+        production.cloudflare.docker.com:443
+        production.cloudfront.docker.com:443
+        deb.debian.org:80
+        pypi.org:443
+        files.pythonhosted.org:443
+        static.rust-lang.org:443
+        bun.sh:443
+        astral.sh:443
+        releases.astral.sh:443
+        sh.rustup.rs:443
+        registry.npmjs.org:443
+        crates.io:443
+        static.crates.io:443
+        index.crates.io:443
+        semgrep.dev:443
+        metrics.semgrep.dev:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+        oauth2.sigstore.dev:443
+        mirror.gcr.io:443

--- a/.github/workflows/docker-tools-publish.yml
+++ b/.github/workflows/docker-tools-publish.yml
@@ -64,10 +64,10 @@ jobs:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
-      security-events: write
+      packages: write # push image, cache, and staging tags to GHCR
+      id-token: write # OIDC token for cosign keyless signing
+      attestations: write # publish SBOM + build provenance attestations
+      security-events: write # upload Trivy SARIF to code scanning
     with:
       file: docker/tools.Dockerfile
       image-name: lgtm-hq/lintro-tools

--- a/.github/workflows/docker-tools-publish.yml
+++ b/.github/workflows/docker-tools-publish.yml
@@ -102,7 +102,8 @@ jobs:
       # allowed-endpoints verbatim to step-security/harden-runner, so a
       # non-empty value must include the docker preset baseline. The
       # sigstore hosts cover cosign keyless signing in the merge job;
-      # mirror.gcr.io is the Trivy vulnerability DB fallback.
+      # get.trivy.dev serves the Trivy binary download and mirror.gcr.io is
+      # the Trivy vulnerability DB fallback.
       allowed-endpoints-mode: replace
       allowed-endpoints: >
         github.com:443
@@ -138,4 +139,5 @@ jobs:
         rekor.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
         oauth2.sigstore.dev:443
+        get.trivy.dev:443
         mirror.gcr.io:443

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@
 # -----------------------------------------------------------------------------
 # Stage: tools — pre-built linting toolchains
 # -----------------------------------------------------------------------------
+# NOTE: this stage is mirrored at docker/tools.Dockerfile, which publishes
+# ghcr.io/lgtm-hq/lintro-tools (see docker-tools-publish.yml). Once the first
+# lintro-tools image is on GHCR, this inline stage will be replaced by a
+# digest-pinned `FROM ghcr.io/lgtm-hq/lintro-tools@sha256:…` (issue #1360).
+# Until then, keep the two definitions in sync.
 FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1 AS tools
 
 ARG BUN_VERSION=1.3.14

--- a/docker/tools.Dockerfile
+++ b/docker/tools.Dockerfile
@@ -7,9 +7,10 @@
 # .github/workflows/docker-tools-publish.yml (weekly + on changes to this file
 # or the pinned tool versions).
 #
-# The root Dockerfile consumes this image via a digest-pinned FROM so the
-# slow, rarely-changing tools layer stays off the per-PR build path. Renovate
-# manages the digest bump (native Docker digest support — see renovate.json).
+# Once the first image is published, the root Dockerfile will consume it via
+# a digest-pinned FROM so the slow, rarely-changing tools layer stays off the
+# per-PR build path. Renovate manages the digest bump (native Docker digest
+# support — see renovate.json).
 #
 # Build context is the repository root:
 #   docker build -f docker/tools.Dockerfile .

--- a/docker/tools.Dockerfile
+++ b/docker/tools.Dockerfile
@@ -1,0 +1,128 @@
+# syntax=docker/dockerfile:1
+# =============================================================================
+# Lintro Tools Base Image
+# =============================================================================
+# Pre-built external linting toolchains (Rust, Node/bun, ~40 linter binaries).
+# Published as ghcr.io/lgtm-hq/lintro-tools by
+# .github/workflows/docker-tools-publish.yml (weekly + on changes to this file
+# or the pinned tool versions).
+#
+# The root Dockerfile consumes this image via a digest-pinned FROM so the
+# slow, rarely-changing tools layer stays off the per-PR build path. Renovate
+# manages the digest bump (native Docker digest support — see renovate.json).
+#
+# Build context is the repository root:
+#   docker build -f docker/tools.Dockerfile .
+#
+# Tool versions come from lintro/_tool_versions.py via
+# scripts/utils/install-tools.sh — this file mirrors the `tools` stage in the
+# root Dockerfile until the FROM flip lands (see issue #1360).
+# =============================================================================
+
+FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1 AS tools
+
+ARG BUN_VERSION=1.3.14
+ARG UV_VERSION=0.11.28
+
+LABEL maintainer="lgtm-hq"
+LABEL org.opencontainers.image.source="https://github.com/lgtm-hq/py-lintro"
+LABEL org.opencontainers.image.description="Pre-built tools layer for lintro"
+LABEL org.opencontainers.image.licenses="MIT"
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_SYSTEM_PYTHON=1 \
+    BUN_INSTALL="/opt/bun" \
+    CARGO_HOME="/opt/cargo" \
+    RUSTUP_HOME="/opt/rustup" \
+    PATH="/usr/local/bin:/opt/cargo/bin:/opt/bun/bin:${PATH}"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+WORKDIR /app
+
+# hadolint ignore=DL3008
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    build-essential \
+    git \
+    libssl-dev \
+    pkg-config \
+    unzip \
+    jq && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# hadolint ignore=DL3003,SC2086
+RUN --mount=type=cache,target=/root/.cache/bun,sharing=locked \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then BUN_ARCH="x64"; \
+    elif [ "$ARCH" = "aarch64" ]; then BUN_ARCH="aarch64"; \
+    else echo "Unsupported arch: $ARCH" && exit 1; fi && \
+    BUN_ZIP="bun-linux-${BUN_ARCH}.zip" && \
+    BUN_URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${BUN_ZIP}" && \
+    CHECKSUM_URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/SHASUMS256.txt" && \
+    curl -fsSL "$BUN_URL" -o "/tmp/${BUN_ZIP}" && \
+    curl -fsSL "$CHECKSUM_URL" -o /tmp/SHASUMS256.txt && \
+    cd /tmp && grep "${BUN_ZIP}" SHASUMS256.txt | sha256sum -c - && \
+    unzip -q "${BUN_ZIP}" && \
+    mv "bun-linux-${BUN_ARCH}/bun" /usr/local/bin/bun && \
+    chmod +x /usr/local/bin/bun && \
+    ln -sf /usr/local/bin/bun /usr/local/bin/bunx && \
+    ln -sf /usr/local/bin/bun /usr/local/bin/node && \
+    rm -rf /tmp/bun* /tmp/SHASUMS256.txt
+
+# hadolint ignore=DL3003,SC2086
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then UV_ARCH="x86_64"; \
+    elif [ "$ARCH" = "aarch64" ]; then UV_ARCH="aarch64"; \
+    else echo "Unsupported arch: $ARCH" && exit 1; fi && \
+    UV_TAR="uv-${UV_ARCH}-unknown-linux-gnu.tar.gz" && \
+    UV_URL="https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_TAR}" && \
+    CHECKSUM_URL="https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_TAR}.sha256" && \
+    curl -fsSL "$UV_URL" -o "/tmp/${UV_TAR}" && \
+    curl -fsSL "$CHECKSUM_URL" -o "/tmp/${UV_TAR}.sha256" && \
+    cd /tmp && sha256sum -c "${UV_TAR}.sha256" && \
+    tar -xzf "${UV_TAR}" && \
+    mv "uv-${UV_ARCH}-unknown-linux-gnu/uv" /usr/local/bin/uv && \
+    chmod +x /usr/local/bin/uv && \
+    rm -rf /tmp/uv*
+
+COPY lintro/ /app/lintro/
+COPY scripts/ /app/scripts/
+COPY package.json /app/package.json
+
+RUN groupadd -r tools && \
+    mkdir -p /opt/bun /opt/cargo /opt/rustup
+
+RUN --mount=type=cache,target=/opt/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/opt/cargo/git,sharing=locked \
+    --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    find /app/scripts -type f -name "*.sh" -exec chmod +x {} \; && \
+    /app/scripts/utils/install-tools.sh --docker && \
+    rustup default stable && \
+    rustup component add clippy
+
+RUN chgrp -R tools /opt/cargo /opt/rustup /opt/bun && \
+    chmod -R g+rwX /opt/cargo /opt/rustup /opt/bun && \
+    chmod -R a+rX /opt/cargo /opt/rustup /opt/bun
+
+RUN echo "=== Verifying all tools ===" && \
+    bun --version && uv --version && cargo --version && rustc --version && \
+    rustfmt --version && cargo clippy --version && cargo audit --version && \
+    cargo deny --version && actionlint --version && bandit --version && \
+    black --version && commitlint --version && gitleaks version && \
+    hadolint --version && \
+    markdownlint-cli2 --version && mypy --version && osv-scanner --version && \
+    oxfmt --version && oxlint --version && prettier --version && \
+    pydoclint --version && ruff --version && semgrep --version && \
+    shellcheck --version && shfmt --version && sqlfluff --version && \
+    dotenv-linter --version && \
+    stylelint --version && \
+    taplo --version && tsc --version && astro --version && \
+    svelte-check --version && vue-tsc --version && yamllint --version && \
+    vale --version && \
+    echo "=== All tools verified! ==="

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -89,10 +89,12 @@ distinction).
 The **tools base** image is published as **`ghcr.io/lgtm-hq/lintro-tools`**. It contains
 the full external toolchain lintro drives — Rust toolchain (clippy, rustfmt,
 cargo-audit, cargo-deny), bun/Node tools (prettier, oxlint, tsc, stylelint, …), and
-standalone binaries (hadolint, shellcheck, shfmt, gitleaks, vale, …) — but not the
-lintro application layer. After the planned digest-pinned `FROM` flip, the `py-lintro`
-full image will be built on top of it; you can also use it directly as a base for your
-own images when you want the pre-built linter toolchain without lintro:
+standalone binaries (hadolint, shellcheck, shfmt, gitleaks, vale, …) — but not an
+installed lintro application (no virtualenv or entrypoint; lintro source is present
+under `/app` only because the installer reads its tool-version manifest from it). After
+the planned digest-pinned `FROM` flip, the `py-lintro` full image will be built on top
+of it; you can also use it directly as a base for your own images when you want the
+pre-built linter toolchain without lintro:
 
 ```dockerfile
 # Pin by digest for reproducible builds (recommended)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -103,8 +103,8 @@ FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:<digest>
 
 Details:
 
-- Built from [`docker/tools.Dockerfile`](../docker/tools.Dockerfile); tool versions are
-  pinned in `lintro/_tool_versions.py`.
+- Built from `docker/tools.Dockerfile` in the repository root; tool versions are pinned
+  in `lintro/_tool_versions.py`.
 - Rebuilt when the tools Dockerfile or pinned tool versions change, plus a weekly
   no-cache rebuild so tool binaries and the OS layer pick up fresh CVE patches.
 - Signed with Sigstore Cosign (keyless) and published with SBOM and build provenance

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -84,6 +84,33 @@ distinction).
 `py-lintro:vX.Y.Z-base`. Use `ghcr.io/lgtm-hq/py-lintro-base:latest` or
 `py-lintro-base:vX.Y.Z` instead.
 
+### Tools Base Image (`lintro-tools`)
+
+The **tools base** image is published as **`ghcr.io/lgtm-hq/lintro-tools`**. It contains
+the full external toolchain lintro drives — Rust toolchain (clippy, rustfmt,
+cargo-audit, cargo-deny), bun/Node tools (prettier, oxlint, tsc, stylelint, …), and
+standalone binaries (hadolint, shellcheck, shfmt, gitleaks, vale, …) — but not the
+lintro application layer. The `py-lintro` full image is built on top of it, and you can
+use it directly as a base for your own images when you want the pre-built linter
+toolchain without lintro:
+
+```dockerfile
+# Pin by digest for reproducible builds (recommended)
+FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:<digest>
+```
+
+Details:
+
+- Built from [`docker/tools.Dockerfile`](../docker/tools.Dockerfile); tool versions are
+  pinned in `lintro/_tool_versions.py`.
+- Rebuilt when the tools Dockerfile or pinned tool versions change, plus a weekly
+  no-cache rebuild so tool binaries and the OS layer pick up fresh CVE patches.
+- Signed with Sigstore Cosign (keyless) and published with SBOM and build provenance
+  attestations.
+- Tags: `latest`, `main`, and immutable `sha-<commit>` tags. Pin by digest and let
+  Renovate's native Docker digest support manage bumps (this repository does exactly
+  that for the root `Dockerfile`).
+
 ### Using the Published Image
 
 ```bash

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -90,9 +90,9 @@ The **tools base** image is published as **`ghcr.io/lgtm-hq/lintro-tools`**. It 
 the full external toolchain lintro drives — Rust toolchain (clippy, rustfmt,
 cargo-audit, cargo-deny), bun/Node tools (prettier, oxlint, tsc, stylelint, …), and
 standalone binaries (hadolint, shellcheck, shfmt, gitleaks, vale, …) — but not the
-lintro application layer. The `py-lintro` full image is built on top of it, and you can
-use it directly as a base for your own images when you want the pre-built linter
-toolchain without lintro:
+lintro application layer. After the planned digest-pinned `FROM` flip, the `py-lintro`
+full image will be built on top of it; you can also use it directly as a base for your
+own images when you want the pre-built linter toolchain without lintro:
 
 ```dockerfile
 # Pin by digest for reproducible builds (recommended)

--- a/renovate.json
+++ b/renovate.json
@@ -68,10 +68,20 @@
       "automerge": false
     },
     {
+      "description": "lintro-tools base image digest pin (FROM in Dockerfile); native docker digest support, full CI validates the bump",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/lgtm-hq/lintro-tools"
+      ],
+      "matchUpdateTypes": ["digest"],
+      "automerge": false
+    },
+    {
       "description": "Regenerate _tool_versions.py when tool version sources change",
       "matchManagers": ["custom.regex"],
       "matchFileNames": [
         "Dockerfile",
+        "docker/tools.Dockerfile",
         "lintro/_tool_versions.py",
         "lintro/tools/manifest.json"
       ],
@@ -85,7 +95,8 @@
           "lintro/tools/manifest.json",
           "package.json",
           "pyproject.toml",
-          "Dockerfile"
+          "Dockerfile",
+          "docker/tools.Dockerfile"
         ],
         "executionMode": "branch"
       }
@@ -123,7 +134,10 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["Dockerfile"],
+      "managerFilePatterns": [
+        "Dockerfile",
+        "docker/tools.Dockerfile"
+      ],
       "matchStrings": [
         "ARG BUN_VERSION=(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
       ],
@@ -133,7 +147,10 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["Dockerfile"],
+      "managerFilePatterns": [
+        "Dockerfile",
+        "docker/tools.Dockerfile"
+      ],
       "matchStrings": [
         "ARG UV_VERSION=(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
       ],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(docker): publish lintro-tools base image with digest-pinned FROM
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Restores the published tools base image — as `ghcr.io/lgtm-hq/lintro-tools` (the
`py-` prefix is intentionally dropped) — so the slowest, rarest-changing layer (Rust
toolchain, bun, ~40 linter binaries) can leave the per-PR critical path. Modernized
per #1360: Renovate manages the digest pin natively; none of the pre-#939 custom
machinery (auto-pin workflows, drift checks, `resolve-tools-image` action) returns.

- **`docker/tools.Dockerfile`** — the `tools` stage split into a standalone,
  publishable Dockerfile (repo-root build context). Content is byte-identical to the
  root Dockerfile's inline `tools` stage.
- **`.github/workflows/docker-tools-publish.yml`** — builds + publishes
  `ghcr.io/lgtm-hq/lintro-tools` via lgtm-ci `reusable-docker.yml`:
  - push (main) / PR-validate when the tools Dockerfile, pinned tool versions
    (`lintro/_tool_versions.py`, `lintro/tools/manifest.json`, `package.json`), or
    the installer script change (path-filtered; not a required check, so no
    required-check deadlock — see docker-ci.yml header)
  - weekly schedule with `no-cache: true` so the CVE-freshness rebuild is not a
    cache no-op
  - cosign keyless signing + SBOM + build provenance attestations, Trivy scan
    (advisory SARIF), multi-arch (amd64 + arm64 native runners), harden-runner
    egress block with a full replace-mode allowlist (docker baseline +
    rust/bun/npm/crates + sigstore + Trivy DB mirror)
  - `workflow_dispatch` with `force_publish` for maintainer-driven seeding/testing
    from a branch
- **Root `Dockerfile`** — comment marking the inline `tools` stage as mirrored by
  `docker/tools.Dockerfile` until the FROM flip (no functional change; CI builds
  exactly as before).
- **`renovate.json`** — digest packageRule for `ghcr.io/lgtm-hq/lintro-tools`
  (native Docker digest support, no automerge, full CI validates the bump);
  `BUN_VERSION`/`UV_VERSION` custom managers and the `generate-tool-versions.py`
  postUpgradeTask now also cover `docker/tools.Dockerfile`.
- **`docs/docker.md`** — consumer documentation for `lintro-tools` as a base image.
- **`.github/workflows/README.md`** — workflow inventory entry.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (no runtime code changed; existing workflow-wiring tests
      cover the new workflow's canonical-pin invariant)
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` clean repo-wide; full unit suite green)

## Closes

- Closes #1360
- Relates to #1357

## Details

### Follow-up: the FROM flip (kept out of this PR so CI stays green)

The root Dockerfile cannot pin `FROM ghcr.io/lgtm-hq/lintro-tools@sha256:<digest>`
before a first image exists on GHCR, so this PR keeps the inline `tools` stage
untouched. Plan after merge:

1. Merge this PR → the push-to-main run of `docker-tools-publish.yml` publishes the
   first `lintro-tools` image (signed, attested) and reports its digest.
2. Immediate follow-up PR: replace the inline `tools` stage in `Dockerfile` with
   `FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:<digest> AS tools` and delete
   the mirrored stage body (plus the then root-unused `BUN_VERSION`/`UV_VERSION`
   ARGs). Renovate keeps the digest fresh from then on.

Alternative single-PR path (maintainer's call): `docker-tools-publish.yml` supports
`workflow_dispatch` with `force_publish=true` from this branch, so a maintainer
could seed the first image pre-merge and the FROM flip could land here as a
follow-up commit. The two-PR path is the default because it needs no manual action
and every intermediate state is green.

### Note on the lgtm-ci pin

The issue plan suggested lgtm-ci v0.54.0 for the new workflow. The repo invariant
from #1280 (`test_all_lgtm_ci_refs_use_the_canonical_pin`) requires every lgtm-ci
ref to match the single canonical pin, currently v0.52.4
(`768a6b72f0a5346b5ecba3f4e13b90040472341c`) — and v0.52.4's `reusable-docker.yml`
already supports every input used here (`cosign-sign`, `sbom`, `provenance`,
`tags`, `validate-on-pr`, `no-cache`, replace-mode egress). So this workflow uses
the canonical pin; the repo-wide bump to v0.54.0 belongs to the usual
Renovate-driven pin update, not this PR.

### Testing strategy

- `uv run lintro chk` — clean on all changed files and repo-wide (100/100)
- `uv run pytest tests/unit tests/test_documentation.py` — 5749 passed, including
  `test_workflow_wiring.py` canonical-pin and docker-ci gating contracts
- No new shell scripts (the workflow is a thin reusable caller with zero inline
  `run:` steps), so no BATS additions; `script-test-coverage-allowlist.txt`
  untouched
- The new workflow's PR path (`validate-on-pr: true`, no push) exercises the
  tools Dockerfile build on any future PR touching the filtered paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-built `lintro-tools` container image containing the project’s external toolchain.
  * Added automated multi-platform image publishing with signing, SBOM/provenance attestations, scanning, and validation.
  * Added weekly rebuilds to incorporate operating system and security updates.

* **Documentation**
  * Documented the tools image, supported tags, digest pinning, publishing process, and rebuild schedule.
  * Updated workflow documentation with the new image publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a publishable tools base image for the lintro toolchain. The main changes are:

- A new `docker/tools.Dockerfile` for the standalone tools image.
- A new GitHub Actions workflow to build, validate, publish, sign, and scan the image.
- Documentation for using `ghcr.io/lgtm-hq/lintro-tools` as a base image.
- Renovate updates for future digest management and mirrored tool version pins.
- Comments clarifying that the root `Dockerfile` will consume the tools image in a later change.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/README.md | Adds the tools-image workflow entry and describes root Dockerfile consumption as a later change. |
| .github/workflows/docker-tools-publish.yml | Adds the workflow that validates and publishes the `lintro-tools` image. |
| Dockerfile | Adds comments explaining that the inline tools stage remains until the later digest-pinned base image switch. |
| docker/tools.Dockerfile | Adds the standalone tools image Dockerfile that mirrors the current inline tools stage. |
| docs/docker.md | Documents the new tools base image and its planned relationship to the full image. |
| renovate.json | Extends Renovate configuration for mirrored tool version pins and future tools-image digest updates. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ci): allow get.trivy.dev egress and ..."](https://github.com/lgtm-hq/py-lintro/commit/1ba370e413caa35e239852045293fb185010c043) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44014533)</sub>

<!-- /greptile_comment -->