### PR TITLE
fix(ci): allow timestamp.sigstore.dev egress in lintro-tools publish

### DIFF
--- a/.github/workflows/docker-tools-publish.yml
+++ b/.github/workflows/docker-tools-publish.yml
@@ -138,6 +138,7 @@ jobs:
         fulcio.sigstore.dev:443
         rekor.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
+        timestamp.sigstore.dev:443
         oauth2.sigstore.dev:443
         get.trivy.dev:443
         mirror.gcr.io:443


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): allow timestamp.sigstore.dev egress in lintro-tools publish
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

One-line allowlist fix: cosign's RFC 3161 timestamp request (`timestamp.sigstore.dev`) was refused under the replace-mode egress list in `docker-tools-publish.yml`, failing the first main publish at Merge Manifests (run 29303125087) after both platform builds succeeded. Identical failure class to lgtm-hq/Rustume#465 (fixed there in Rustume#464).

Follow-up of #1364 / #1360. Epic #1357.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Relates to #1357

## Details

_See What’s Changing._
