### PR TITLE
feat(docker): build full image FROM published lintro-tools base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,123 +9,13 @@
 # =============================================================================
 
 # -----------------------------------------------------------------------------
-# Stage: tools — pre-built linting toolchains
+# Stage: tools — published lintro-tools base image (digest-pinned)
 # -----------------------------------------------------------------------------
-# NOTE: this stage is mirrored at docker/tools.Dockerfile, which publishes
-# ghcr.io/lgtm-hq/lintro-tools (see docker-tools-publish.yml). Once the first
-# lintro-tools image is on GHCR, this inline stage will be replaced by a
-# digest-pinned `FROM ghcr.io/lgtm-hq/lintro-tools@sha256:…` (issue #1360).
-# Until then, keep the two definitions in sync.
-FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1 AS tools
+# Built from docker/tools.Dockerfile and published by docker-tools-publish.yml
+# (cosign-signed, SBOM + provenance). Renovate manages the digest bump (#1360).
+# yamllint / hadolint: pin is immutable by digest; tag is informational.
+FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:0f615df97d0db6cc8a9e7844edd962250a70c49f25026885ea1e672e3996a8eb AS tools
 
-ARG BUN_VERSION=1.3.14
-ARG UV_VERSION=0.11.28
-
-LABEL maintainer="lgtm-hq"
-LABEL org.opencontainers.image.source="https://github.com/lgtm-hq/py-lintro"
-LABEL org.opencontainers.image.description="Pre-built tools layer for lintro"
-LABEL org.opencontainers.image.licenses="MIT"
-
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    UV_SYSTEM_PYTHON=1 \
-    BUN_INSTALL="/opt/bun" \
-    CARGO_HOME="/opt/cargo" \
-    RUSTUP_HOME="/opt/rustup" \
-    PATH="/usr/local/bin:/opt/cargo/bin:/opt/bun/bin:${PATH}"
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-WORKDIR /app
-
-# hadolint ignore=DL3008
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    ca-certificates \
-    build-essential \
-    git \
-    libssl-dev \
-    pkg-config \
-    unzip \
-    jq && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# hadolint ignore=DL3003,SC2086
-RUN --mount=type=cache,target=/root/.cache/bun,sharing=locked \
-    ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then BUN_ARCH="x64"; \
-    elif [ "$ARCH" = "aarch64" ]; then BUN_ARCH="aarch64"; \
-    else echo "Unsupported arch: $ARCH" && exit 1; fi && \
-    BUN_ZIP="bun-linux-${BUN_ARCH}.zip" && \
-    BUN_URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${BUN_ZIP}" && \
-    CHECKSUM_URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/SHASUMS256.txt" && \
-    curl -fsSL "$BUN_URL" -o "/tmp/${BUN_ZIP}" && \
-    curl -fsSL "$CHECKSUM_URL" -o /tmp/SHASUMS256.txt && \
-    cd /tmp && grep "${BUN_ZIP}" SHASUMS256.txt | sha256sum -c - && \
-    unzip -q "${BUN_ZIP}" && \
-    mv "bun-linux-${BUN_ARCH}/bun" /usr/local/bin/bun && \
-    chmod +x /usr/local/bin/bun && \
-    ln -sf /usr/local/bin/bun /usr/local/bin/bunx && \
-    ln -sf /usr/local/bin/bun /usr/local/bin/node && \
-    rm -rf /tmp/bun* /tmp/SHASUMS256.txt
-
-# hadolint ignore=DL3003,SC2086
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then UV_ARCH="x86_64"; \
-    elif [ "$ARCH" = "aarch64" ]; then UV_ARCH="aarch64"; \
-    else echo "Unsupported arch: $ARCH" && exit 1; fi && \
-    UV_TAR="uv-${UV_ARCH}-unknown-linux-gnu.tar.gz" && \
-    UV_URL="https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_TAR}" && \
-    CHECKSUM_URL="https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_TAR}.sha256" && \
-    curl -fsSL "$UV_URL" -o "/tmp/${UV_TAR}" && \
-    curl -fsSL "$CHECKSUM_URL" -o "/tmp/${UV_TAR}.sha256" && \
-    cd /tmp && sha256sum -c "${UV_TAR}.sha256" && \
-    tar -xzf "${UV_TAR}" && \
-    mv "uv-${UV_ARCH}-unknown-linux-gnu/uv" /usr/local/bin/uv && \
-    chmod +x /usr/local/bin/uv && \
-    rm -rf /tmp/uv*
-
-COPY lintro/ /app/lintro/
-COPY scripts/ /app/scripts/
-COPY package.json /app/package.json
-
-RUN groupadd -r tools && \
-    mkdir -p /opt/bun /opt/cargo /opt/rustup
-
-RUN --mount=type=cache,target=/opt/cargo/registry,sharing=locked \
-    --mount=type=cache,target=/opt/cargo/git,sharing=locked \
-    --mount=type=cache,target=/root/.cache/uv,sharing=locked \
-    find /app/scripts -type f -name "*.sh" -exec chmod +x {} \; && \
-    /app/scripts/utils/install-tools.sh --docker && \
-    rustup default stable && \
-    rustup component add clippy
-
-RUN chgrp -R tools /opt/cargo /opt/rustup /opt/bun && \
-    chmod -R g+rwX /opt/cargo /opt/rustup /opt/bun && \
-    chmod -R a+rX /opt/cargo /opt/rustup /opt/bun
-
-RUN echo "=== Verifying all tools ===" && \
-    bun --version && uv --version && cargo --version && rustc --version && \
-    rustfmt --version && cargo clippy --version && cargo audit --version && \
-    cargo deny --version && actionlint --version && bandit --version && \
-    black --version && commitlint --version && gitleaks version && \
-    hadolint --version && \
-    markdownlint-cli2 --version && mypy --version && osv-scanner --version && \
-    oxfmt --version && oxlint --version && prettier --version && \
-    pydoclint --version && ruff --version && semgrep --version && \
-    shellcheck --version && shfmt --version && sqlfluff --version && \
-    dotenv-linter --version && \
-    stylelint --version && \
-    taplo --version && tsc --version && astro --version && \
-    svelte-check --version && vue-tsc --version && yamllint --version && \
-    vale --version && \
-    echo "=== All tools verified! ==="
-
-# -----------------------------------------------------------------------------
-# Stage: full — lintro application (default target)
 # -----------------------------------------------------------------------------
 FROM tools AS full
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(docker): build full image FROM published lintro-tools base
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Completes #1360 (follow-up to #1364): the root Dockerfile's inline `tools` stage is replaced by `FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:0f615df9…` — the image published, signed, and attested by `docker-tools-publish.yml` from `docker/tools.Dockerfile`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1360
- Relates to #1364
- Relates to #1357

## Details

- `COPY --from=tools /usr/local/bin/uv` and PATH entries verified against the published image contents (same stage definition, byte-identical per #1364).
- PR validate builds both platforms from the pinned base — green checks on this PR are the end-to-end proof.

Closes #1360. Epic #1357.
