### PR TITLE
perf(ci): promote docker images by digest instead of rebuilding in publish

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -118,6 +118,7 @@ jobs:
         index.crates.io:443
         semgrep.dev:443
         metrics.semgrep.dev:443
+        token.actions.githubusercontent.com:443
         fulcio.sigstore.dev:443
         rekor.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
@@ -212,6 +213,7 @@ jobs:
         index.crates.io:443
         semgrep.dev:443
         metrics.semgrep.dev:443
+        token.actions.githubusercontent.com:443
         fulcio.sigstore.dev:443
         rekor.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -69,18 +69,24 @@ jobs:
       smoke-test: lintro --version
       validate-on-pr: false
       cache-registry-ref: ghcr.io/lgtm-hq/py-lintro:cache
+      # Release (tag) builds reuse the registry cache (#1358): BuildKit
+      # cache is content-addressed, so a tag build reassembles exactly the
+      # layers already built and validated on main instead of a cold
+      # multi-arch rebuild. Backfills stay no-cache so historical
+      # republishes remain fully cold.
       no-cache: >-
-        ${{ startsWith(github.ref, 'refs/tags/')
-        || (github.event_name == 'workflow_dispatch'
-        && inputs.backfill_version != '') }}
+        ${{ github.event_name == 'workflow_dispatch'
+        && inputs.backfill_version != '' }}
       provenance: false
       sbom: false
+      cosign-sign: true
       tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
       egress-policy: block
       egress-preset: docker
       # Full list (v0.50.0+ replace semantics): the reusable passes
       # allowed-endpoints verbatim to step-security/harden-runner, so a
-      # non-empty value must include the docker preset baseline.
+      # non-empty value must include the docker preset baseline. The
+      # sigstore hosts cover cosign keyless signing in the merge job.
       allowed-endpoints-mode: replace
       allowed-endpoints: >
         github.com:443
@@ -112,6 +118,11 @@ jobs:
         index.crates.io:443
         semgrep.dev:443
         metrics.semgrep.dev:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+        timestamp.sigstore.dev:443
+        oauth2.sigstore.dev:443
 
   docker-base:
     name: 🐳 Docker Base Image
@@ -152,18 +163,24 @@ jobs:
       smoke-test: lintro --version
       validate-on-pr: false
       cache-registry-ref: ghcr.io/lgtm-hq/py-lintro-base:cache
+      # Release (tag) builds reuse the registry cache (#1358): BuildKit
+      # cache is content-addressed, so a tag build reassembles exactly the
+      # layers already built and validated on main instead of a cold
+      # multi-arch rebuild. Backfills stay no-cache so historical
+      # republishes remain fully cold.
       no-cache: >-
-        ${{ startsWith(github.ref, 'refs/tags/')
-        || (github.event_name == 'workflow_dispatch'
-        && inputs.backfill_version != '') }}
+        ${{ github.event_name == 'workflow_dispatch'
+        && inputs.backfill_version != '' }}
       provenance: false
       sbom: false
+      cosign-sign: true
       tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
       egress-policy: block
       egress-preset: docker
       # Full list (v0.50.0+ replace semantics): the reusable passes
       # allowed-endpoints verbatim to step-security/harden-runner, so a
-      # non-empty value must include the docker preset baseline.
+      # non-empty value must include the docker preset baseline. The
+      # sigstore hosts cover cosign keyless signing in the merge job.
       allowed-endpoints-mode: replace
       allowed-endpoints: >
         github.com:443
@@ -195,3 +212,8 @@ jobs:
         index.crates.io:443
         semgrep.dev:443
         metrics.semgrep.dev:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+        timestamp.sigstore.dev:443
+        oauth2.sigstore.dev:443

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -706,6 +706,8 @@ jobs:
             objects.githubusercontent.com:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
+            token.actions.githubusercontent.com:443
+            pipelines.actions.githubusercontent.com:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -671,6 +671,11 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
 
+  # Publishes by digest promotion (#1358): the ci-${run_id} images that
+  # docker-build pushed and the downstream jobs validated are retagged to
+  # the release tags with `docker buildx imagetools create` — no rebuild,
+  # so the published image is bit-identical to the image CI tested. The
+  # promoted digests are then signed with Cosign (keyless OIDC).
   publish:
     name: 📦 Publish to GHCR
     needs: [dogfooding-lint, security-audit, integration-test]
@@ -678,13 +683,17 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read # checkout and metadata extraction
-      packages: write # push release images to GHCR
-    timeout-minutes: 30
+      packages: write # promote (retag) release images in GHCR
+      id-token: write # OIDC token for cosign keyless signing
+    timeout-minutes: 15
     concurrency:
       group: publish-${{ github.ref }}
       cancel-in-progress: false
     steps:
       - name: Harden Runner
+        # No build happens here anymore (#1358): the allowlist covers
+        # checkout, GHCR retagging, cosign download, and sigstore keyless
+        # signing only.
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -697,25 +706,11 @@ jobs:
             objects.githubusercontent.com:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
-            docker.io:443
-            registry-1.docker.io:443
-            auth.docker.io:443
-            production.cloudflare.docker.com:443
-            production.cloudfront.docker.com:443
-            deb.debian.org:80
-            pypi.org:443
-            files.pythonhosted.org:443
-            static.rust-lang.org:443
-            bun.sh:443
-            astral.sh:443
-            releases.astral.sh:443
-            sh.rustup.rs:443
-            registry.npmjs.org:443
-            crates.io:443
-            static.crates.io:443
-            index.crates.io:443
-            semgrep.dev:443
-            metrics.semgrep.dev:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            timestamp.sigstore.dev:443
+            oauth2.sigstore.dev:443
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -723,13 +718,14 @@ jobs:
           fetch-tags: true
           persist-credentials: false
       - name: Setup Docker (Buildx + login)
+        # Default `docker` driver: imagetools talks to the registry from
+        # the CLI, no BuildKit container (or Docker Hub pull) needed.
         uses: ./.github/actions/setup-docker
         with:
           login: 'true'
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          driver: docker-container
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
@@ -752,36 +748,29 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-      - name: Build and push Docker image
+      - name: Promote CI image to release tags (digest retag)
+        id: promote
+        env:
+          SOURCE_IMAGE: ghcr.io/lgtm-hq/py-lintro
+          CI_TAG: ci-${{ github.run_id }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: scripts/ci/promote-ci-docker-images.sh
+      - name: Promote Base CI image to release tags (digest retag)
+        id: promote-base
+        env:
+          SOURCE_IMAGE: ghcr.io/lgtm-hq/py-lintro-base
+          CI_TAG: ci-${{ github.run_id }}
+          TAGS: ${{ steps.meta-base.outputs.tags }}
+        run: scripts/ci/promote-ci-docker-images.sh
+      - name: Install Cosign
         # yamllint disable-line rule:line-length
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: .
-          target: full
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: |
-            type=registry,ref=ghcr.io/lgtm-hq/py-lintro:cache
-          cache-to: >-
-            type=registry,ref=ghcr.io/lgtm-hq/py-lintro:cache,${{ env.CACHE_OPTS }}
-          provenance: false
-          sbom: false
-      - name: Build and push Base Docker image
-        # yamllint disable-line rule:line-length
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: .
-          target: base
-          push: true
-          tags: ${{ steps.meta-base.outputs.tags }}
-          labels: ${{ steps.meta-base.outputs.labels }}
-          cache-from: |
-            type=registry,ref=ghcr.io/lgtm-hq/py-lintro-base:cache
-          cache-to: >-
-            type=registry,ref=ghcr.io/lgtm-hq/py-lintro-base:cache,${{ env.CACHE_OPTS }}
-          provenance: false
-          sbom: false
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Sign promoted digests (keyless)
+        env:
+          IMAGES: |
+            ghcr.io/lgtm-hq/py-lintro@${{ steps.promote.outputs.digest }}
+            ghcr.io/lgtm-hq/py-lintro-base@${{ steps.promote-base.outputs.digest }}
+        run: scripts/ci/cosign-sign-images.sh
 
   cleanup-ci-images:
     name: 🧹 Cleanup CI Images
@@ -793,10 +782,19 @@ jobs:
       - integration-test
       - publish
     # Nothing to clean up when the build was path-skipped (no CI tags pushed).
+    # Sequencing (#1138, #1358): cleanup only runs when every consumer of the
+    # ci-${run_id} tags — including publish, which promotes them by digest —
+    # finished green or was skipped (publish is skipped on PRs). On any
+    # failure the CI tags survive so a re-run of failed jobs can still pull
+    # and promote them; re-runs share the run_id, so the eventual green
+    # re-run deletes the same tags. Cross-run digest sharing is handled
+    # inside delete-ci-ghcr-tags.sh (sole-tag versions only).
     if: >-
       always() &&
       needs.changes.outputs.pipeline != 'false' &&
-      needs.docker-build.outputs.is-fork != 'true'
+      needs.docker-build.outputs.is-fork != 'true' &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-24.04
     permissions:
       contents: read # checkout delete-ci-ghcr-tags.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -93,6 +93,8 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `lintro-report-generate.sh`          | Generate comprehensive Lintro reports                                 | `./scripts/ci/lintro-report-generate.sh`                                           |
 | `pull-lintro-image.sh`               | Pull lintro Docker image from GHCR and log digest                     | `./scripts/ci/testing/pull-lintro-image.sh`                                        |
 | `maintenance/delete-ci-ghcr-tags.sh` | Delete ephemeral CI GHCR tags after PR merge or close                 | `./scripts/ci/maintenance/delete-ci-ghcr-tags.sh`                                  |
+| `promote-ci-docker-images.sh`        | Promote CI-validated image to release tags by digest retag            | `./scripts/ci/promote-ci-docker-images.sh --help`                                  |
+| `cosign-sign-images.sh`              | Sign promoted image digests with Cosign keyless OIDC                  | `./scripts/ci/cosign-sign-images.sh --help`                                        |
 | `coverage-badge-update.sh`           | Generate and update coverage badge                                    | `./scripts/ci/coverage-badge-update.sh --help`                                     |
 | `sbom-generate.sh`                   | Generate and export SBOMs via bomctl                                  | `./scripts/ci/sbom-generate.sh --help`                                             |
 | `egress-audit-lite.sh`               | Audit reachability of allowed endpoints                               | `./scripts/ci/egress-audit-lite.sh --help`                                         |

--- a/scripts/ci/cosign-sign-images.sh
+++ b/scripts/ci/cosign-sign-images.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# cosign-sign-images.sh
+#
+# Sign promoted image digests with Sigstore Cosign (keyless OIDC).
+# Refs must be pinned by digest (image@sha256:...) so the signature is
+# bound to the exact manifest CI validated and promoted (#1358) — never
+# to a floating tag that could move between promotion and signing.
+
+show_help() {
+	cat <<'EOF'
+Sign image digests with Cosign (keyless).
+
+Usage:
+  IMAGES=<refs> scripts/ci/cosign-sign-images.sh
+
+Environment:
+  IMAGES  Whitespace/newline-separated image refs pinned by digest,
+          e.g. ghcr.io/lgtm-hq/py-lintro@sha256:... (required)
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	show_help
+	exit 0
+fi
+
+images="${IMAGES:-}"
+
+if [[ -z "$images" ]]; then
+	echo "IMAGES is required" >&2
+	exit 2
+fi
+
+refs=()
+while IFS= read -r ref; do
+	[[ -z "$ref" ]] && continue
+	if [[ "$ref" != *@sha256:* ]]; then
+		echo "Refusing to sign non-digest ref: ${ref}" >&2
+		echo "(signatures must bind to a digest, not a floating tag)" >&2
+		exit 2
+	fi
+	refs+=("$ref")
+done <<<"$images"
+
+if [[ ${#refs[@]} -eq 0 ]]; then
+	echo "IMAGES did not contain any refs" >&2
+	exit 2
+fi
+
+for ref in "${refs[@]}"; do
+	echo "Signing ${ref}"
+	cosign sign --yes "$ref"
+done
+
+echo "Signed ${#refs[@]} image(s)"

--- a/scripts/ci/maintenance/delete-ci-ghcr-tags.sh
+++ b/scripts/ci/maintenance/delete-ci-ghcr-tags.sh
@@ -4,6 +4,18 @@ set -euo pipefail
 # delete-ci-ghcr-tags.sh
 #
 # Delete ephemeral CI tags from py-lintro and py-lintro-base GHCR packages.
+#
+# The GHCR Packages API deletes whole *versions* (one version = one digest
+# carrying every tag that points at it), not individual tags. Two safety
+# rules follow (#1138, #1358):
+#   - A version is deleted only when the requested CI tag is its ONLY tag.
+#   - A version carrying any other tag is skipped: release tags promoted by
+#     digest (#1358) share the version with the CI tag, and byte-identical
+#     builds from concurrent runs share it with foreign ci-* tags — deleting
+#     the version would strip those too (incident: run 29305625795).
+# Skipped CI tags are harmless aliases of a kept digest (no extra storage);
+# versions they keep alive are removed by the scheduled GHCR prune once the
+# real tags are gone.
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 	cat <<'EOF'
@@ -15,6 +27,9 @@ Usage:
 Environment:
   CI_TAG    Ephemeral tag to delete (required)
   GH_TOKEN  GitHub token with packages:write (required)
+
+A package version is deleted only when CI_TAG is its sole tag; versions
+shared with release tags or other runs' CI tags are left in place.
 EOF
 	exit 0
 fi
@@ -35,35 +50,53 @@ fi
 delete_ci_tag() {
 	local pkg="$1"
 	local tag="$2"
-	local version_id=""
 	local output=""
 	local delete_output=""
+	local vid=""
+	local version_tags=""
 
+	# One TSV line per matching version: <id>\t<space-joined tags>
 	if ! output=$(gh api \
 		"orgs/lgtm-hq/packages/container/${pkg}/versions" \
 		--paginate \
 		--jq ".[] |
-			select((.metadata.container.tags // [])[] == \"${tag}\") |
-			.id" 2>&1); then
+			select(((.metadata.container.tags // []) |
+				index(\"${tag}\")) != null) |
+			[(.id | tostring),
+				((.metadata.container.tags // []) | join(\" \"))] |
+			@tsv" 2>&1); then
 		echo "::warning::Failed to query versions for ${pkg}:${tag}: ${output}" >&2
 		return
 	fi
-	version_id="$output"
 
-	if [[ -n "$version_id" ]]; then
-		while IFS= read -r vid; do
-			[[ -z "$vid" ]] && continue
-			if delete_output=$(gh api --method DELETE \
-				"orgs/lgtm-hq/packages/container/${pkg}/versions/${vid}" \
-				2>&1); then
-				echo "Deleted version ${vid} (${pkg}:${tag})"
-			else
-				echo "::warning::Failed to delete version ${vid}: ${delete_output}"
-			fi
-		done <<<"$version_id"
-	else
+	if [[ -z "$output" ]]; then
 		echo "No version found for ${pkg}:${tag}"
+		return
 	fi
+
+	while IFS=$'\t' read -r vid version_tags; do
+		[[ -z "$vid" ]] && continue
+		local only_ci_tag="true"
+		local t=""
+		for t in $version_tags; do
+			if [[ "$t" != "$tag" ]]; then
+				only_ci_tag="false"
+				break
+			fi
+		done
+		if [[ "$only_ci_tag" != "true" ]]; then
+			echo "Skipping version ${vid} (${pkg}:${tag}): digest is shared" \
+				"with other tags [${version_tags}] (#1138)"
+			continue
+		fi
+		if delete_output=$(gh api --method DELETE \
+			"orgs/lgtm-hq/packages/container/${pkg}/versions/${vid}" \
+			2>&1); then
+			echo "Deleted version ${vid} (${pkg}:${tag})"
+		else
+			echo "::warning::Failed to delete version ${vid}: ${delete_output}"
+		fi
+	done <<<"$output"
 }
 
 delete_ci_tag py-lintro "$ci_tag"

--- a/scripts/ci/maintenance/delete-ci-ghcr-tags.sh
+++ b/scripts/ci/maintenance/delete-ci-ghcr-tags.sh
@@ -89,6 +89,31 @@ delete_ci_tag() {
 				"with other tags [${version_tags}] (#1138)"
 			continue
 		fi
+		# Re-check immediately before deleting: another run may have
+		# attached a tag (promotion or a byte-identical build) between
+		# the paginated snapshot and now. This narrows the TOCTOU window
+		# to a single API round-trip; a stale-but-kept version is
+		# harmless and swept later, a deleted shared version is not.
+		local current_tags=""
+		if ! current_tags=$(gh api \
+			"orgs/lgtm-hq/packages/container/${pkg}/versions/${vid}" \
+			--jq '(.metadata.container.tags // []) | join(" ")' 2>&1); then
+			echo "::warning::Failed to re-check version ${vid}; skipping" \
+				"deletion: ${current_tags}"
+			continue
+		fi
+		local recheck_ok="true"
+		for t in $current_tags; do
+			if [[ "$t" != "$tag" ]]; then
+				recheck_ok="false"
+				break
+			fi
+		done
+		if [[ "$recheck_ok" != "true" ]]; then
+			echo "Skipping version ${vid} (${pkg}:${tag}): tags changed" \
+				"since snapshot [${current_tags}] (#1138)"
+			continue
+		fi
 		if delete_output=$(gh api --method DELETE \
 			"orgs/lgtm-hq/packages/container/${pkg}/versions/${vid}" \
 			2>&1); then

--- a/scripts/ci/promote-ci-docker-images.sh
+++ b/scripts/ci/promote-ci-docker-images.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# promote-ci-docker-images.sh
+#
+# Promote the CI-validated image to release tags by digest instead of
+# rebuilding (#1358). Resolves the digest behind the ephemeral CI tag,
+# retags it with `docker buildx imagetools create`, then verifies every
+# promoted tag resolves to that same digest — the published image is
+# bit-identical to the image CI built, tested, and scanned.
+#
+# Promotion targets the digest (image@sha256:...), not the CI tag, so a
+# concurrent run deleting the CI tag cannot race the promotion (#1138).
+# Retagging is a registry-side manifest reference: the manifest (or
+# manifest index, children included) is content-addressed and untouched,
+# so attestation/signature children of an index are preserved.
+
+show_help() {
+	cat <<'EOF'
+Promote a CI-tagged image to release tags by digest.
+
+Usage:
+  SOURCE_IMAGE=<image> CI_TAG=<tag> TAGS=<refs> \
+    scripts/ci/promote-ci-docker-images.sh
+
+Environment:
+  SOURCE_IMAGE   Image repository, e.g. ghcr.io/lgtm-hq/py-lintro (required)
+  CI_TAG         Ephemeral CI tag to promote, e.g. ci-123456789 (required)
+  TAGS           Whitespace/newline-separated destination refs, e.g. the
+                 docker/metadata-action tags output (required)
+  GITHUB_OUTPUT  When set, `digest=<sha256:...>` is appended for
+                 downstream steps (e.g. cosign signing)
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	show_help
+	exit 0
+fi
+
+source_image="${SOURCE_IMAGE:-}"
+ci_tag="${CI_TAG:-}"
+tags="${TAGS:-}"
+
+if [[ -z "$source_image" ]]; then
+	echo "SOURCE_IMAGE is required" >&2
+	exit 2
+fi
+
+if [[ -z "$ci_tag" ]]; then
+	echo "CI_TAG is required" >&2
+	exit 2
+fi
+
+if [[ -z "$tags" ]]; then
+	echo "TAGS is required" >&2
+	exit 2
+fi
+
+source_ref="${source_image}:${ci_tag}"
+
+digest="$(docker buildx imagetools inspect \
+	--format '{{.Manifest.Digest}}' "$source_ref")"
+
+if [[ "$digest" != sha256:* ]]; then
+	echo "Could not resolve digest for ${source_ref} (got: ${digest})" >&2
+	exit 1
+fi
+
+echo "Promoting ${source_ref} (${digest})"
+
+tag_args=()
+tag_list=()
+while IFS= read -r tag; do
+	[[ -z "$tag" ]] && continue
+	tag_args+=(--tag "$tag")
+	tag_list+=("$tag")
+done <<<"$tags"
+
+if [[ ${#tag_list[@]} -eq 0 ]]; then
+	echo "TAGS did not contain any destination refs" >&2
+	exit 2
+fi
+
+docker buildx imagetools create "${source_image}@${digest}" "${tag_args[@]}"
+
+# Verify the retag preserved the manifest: every promoted tag must resolve
+# to the exact digest CI validated.
+for tag in "${tag_list[@]}"; do
+	promoted="$(docker buildx imagetools inspect \
+		--format '{{.Manifest.Digest}}' "$tag")"
+	if [[ "$promoted" != "$digest" ]]; then
+		echo "Digest mismatch after promotion: ${tag} resolved to" \
+			"${promoted}, expected ${digest}" >&2
+		exit 1
+	fi
+	echo "Verified ${tag} -> ${promoted}"
+done
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	echo "digest=${digest}" >>"$GITHUB_OUTPUT"
+fi
+
+echo "Promoted ${source_ref} to ${#tag_list[@]} tag(s) at ${digest}"

--- a/scripts/ci/promote-ci-docker-images.sh
+++ b/scripts/ci/promote-ci-docker-images.sh
@@ -82,7 +82,12 @@ if [[ ${#tag_list[@]} -eq 0 ]]; then
 	exit 2
 fi
 
-docker buildx imagetools create "${source_image}@${digest}" "${tag_args[@]}"
+# --prefer-index=false: with a single-manifest source (CI images are
+# built with provenance disabled), the default prefer-index=true would
+# wrap the manifest in a new one-entry index — a different digest. A
+# carbon copy keeps the promoted tags on the exact CI-validated digest.
+docker buildx imagetools create --prefer-index=false \
+	"${source_image}@${digest}" "${tag_args[@]}"
 
 # Verify the retag preserved the manifest: every promoted tag must resolve
 # to the exact digest CI validated.

--- a/tests/scripts/test_docker_ci_scripts.py
+++ b/tests/scripts/test_docker_ci_scripts.py
@@ -193,7 +193,8 @@ def test_promote_ci_docker_images_promotes_by_digest(tmp_path: Path) -> None:
     assert_that(result.returncode).is_equal_to(0)
     log = docker_log.read_text()
     assert_that(log).contains(
-        "buildx imagetools create ghcr.io/example/app@sha256:aaa111 "
+        "buildx imagetools create --prefer-index=false "
+        "ghcr.io/example/app@sha256:aaa111 "
         "--tag ghcr.io/example/app:main --tag ghcr.io/example/app:sha-abc",
     )
     # Source resolve + two per-tag verifications.
@@ -311,6 +312,10 @@ def test_delete_ci_ghcr_tags_deletes_only_sole_tag_versions(
             'if [[ "$*" == *"DELETE"* ]]; then\n'
             "  exit 0\n"
             "fi\n"
+            'if [[ "$*" == *"/versions/"* ]]; then\n'
+            '  echo "$GH_VERSION_TAGS"\n'
+            "  exit 0\n"
+            "fi\n"
             'printf "%s\\n" "$GH_VERSIONS_TSV"'
         ),
     )
@@ -325,6 +330,8 @@ def test_delete_ci_ghcr_tags_deletes_only_sole_tag_versions(
             "GH_TOKEN": "dummy",  # nosec B105 - fake token for stubbed gh
             "GH_LOG": str(gh_log),
             "GH_VERSIONS_TSV": versions_tsv,
+            # Pre-delete re-check still sees only the CI tag on 102.
+            "GH_VERSION_TAGS": "ci-123",
         },
     )
 
@@ -332,5 +339,48 @@ def test_delete_ci_ghcr_tags_deletes_only_sole_tag_versions(
     assert_that(result.stdout).contains("Skipping version 101")
     assert_that(result.stdout).contains("Deleted version 102")
     log = gh_log.read_text()
+    assert_that(log).contains("--method DELETE")
     assert_that(log).contains("versions/102")
     assert_that(log).does_not_contain("versions/101")
+
+
+def test_delete_ci_ghcr_tags_recheck_catches_new_tags(
+    tmp_path: Path,
+) -> None:
+    """A tag attached between snapshot and delete must abort the delete."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh_log = tmp_path / "gh.log"
+    _write_stub(
+        bin_dir,
+        "gh",
+        (
+            'echo "$*" >> "$GH_LOG"\n'
+            'if [[ "$*" == *"DELETE"* ]]; then\n'
+            "  exit 0\n"
+            "fi\n"
+            'if [[ "$*" == *"/versions/"* ]]; then\n'
+            '  echo "$GH_VERSION_TAGS"\n'
+            "  exit 0\n"
+            "fi\n"
+            'printf "%s\\n" "$GH_VERSIONS_TSV"'
+        ),
+    )
+
+    result = _run_with_stubs(
+        "scripts/ci/maintenance/delete-ci-ghcr-tags.sh",
+        bin_dir,
+        {
+            "CI_TAG": "ci-123",
+            "GH_TOKEN": "dummy",  # nosec B105 - fake token for stubbed gh
+            "GH_LOG": str(gh_log),
+            # Snapshot sees a sole-tag version...
+            "GH_VERSIONS_TSV": "102\tci-123",
+            # ...but a concurrent run attached a tag before the delete.
+            "GH_VERSION_TAGS": "ci-123 sha-def",
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("tags changed since snapshot")
+    assert_that(gh_log.read_text()).does_not_contain("--method DELETE")

--- a/tests/scripts/test_docker_ci_scripts.py
+++ b/tests/scripts/test_docker_ci_scripts.py
@@ -19,6 +19,8 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
         "scripts/ci/detect-fork-pr.sh",
         "scripts/ci/free-disk-space.sh",
         "scripts/ci/fail-on-security-audit.sh",
+        "scripts/ci/promote-ci-docker-images.sh",
+        "scripts/ci/cosign-sign-images.sh",
         "scripts/ci/testing/pull-ci-docker-images.sh",
         "scripts/ci/testing/load-ci-docker-images.sh",
         "scripts/ci/maintenance/delete-ci-ghcr-tags.sh",
@@ -90,3 +92,245 @@ def test_pull_ci_docker_images_requires_ci_tag() -> None:
     )
     assert_that(result.returncode).is_equal_to(2)
     assert_that(result.stderr).contains("CI_TAG is required")
+
+
+def _write_stub(bin_dir: Path, name: str, body: str) -> None:
+    """Write an executable stub binary into a PATH shim directory.
+
+    Args:
+        bin_dir: Directory prepended to PATH for the script under test.
+        name: Binary name to shadow (e.g. ``docker``).
+        body: Bash script body executed when the stub is invoked.
+    """
+    stub = bin_dir / name
+    stub.write_text(f"#!/usr/bin/env bash\n{body}\n")
+    stub.chmod(0o755)
+
+
+def _run_with_stubs(
+    script: str,
+    bin_dir: Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Run a repo script with stub binaries shadowing PATH lookups.
+
+    Args:
+        script: Script path relative to the repository root.
+        bin_dir: Directory containing stub binaries, prepended to PATH.
+        env: Extra environment variables for the script.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed process.
+    """
+    script_path = (_REPO_ROOT / script).resolve()
+    return subprocess.run(  # nosec B603 - fixed argv run against a repo script in a controlled test; shell=False, no user shell input
+        [str(script_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            **os.environ.copy(),
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            **env,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["SOURCE_IMAGE", "CI_TAG", "TAGS"],
+)
+def test_promote_ci_docker_images_requires_env(missing: str) -> None:
+    """promote-ci-docker-images.sh should fail fast on missing env vars."""
+    script_path = (_REPO_ROOT / "scripts/ci/promote-ci-docker-images.sh").resolve()
+    env = {
+        "SOURCE_IMAGE": "ghcr.io/example/app",
+        "CI_TAG": "ci-1",
+        "TAGS": "ghcr.io/example/app:main",
+    }
+    env[missing] = ""
+    result = subprocess.run(  # nosec B603 - fixed argv run against a repo script in a controlled test; shell=False, no user shell input
+        [str(script_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ.copy(), **env},
+    )
+    assert_that(result.returncode).is_equal_to(2)
+    assert_that(result.stderr).contains(f"{missing} is required")
+
+
+def test_promote_ci_docker_images_promotes_by_digest(tmp_path: Path) -> None:
+    """The promote script should retag by digest and verify each tag."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker_log = tmp_path / "docker.log"
+    github_output = tmp_path / "github_output"
+    github_output.touch()
+    _write_stub(
+        bin_dir,
+        "docker",
+        (
+            'echo "$*" >> "$DOCKER_LOG"\n'
+            'if [[ "$*" == *" inspect "* ]]; then\n'
+            '  echo "sha256:aaa111"\n'
+            "fi"
+        ),
+    )
+
+    result = _run_with_stubs(
+        "scripts/ci/promote-ci-docker-images.sh",
+        bin_dir,
+        {
+            "SOURCE_IMAGE": "ghcr.io/example/app",
+            "CI_TAG": "ci-1",
+            "TAGS": "ghcr.io/example/app:main\nghcr.io/example/app:sha-abc",
+            "DOCKER_LOG": str(docker_log),
+            "GITHUB_OUTPUT": str(github_output),
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    log = docker_log.read_text()
+    assert_that(log).contains(
+        "buildx imagetools create ghcr.io/example/app@sha256:aaa111 "
+        "--tag ghcr.io/example/app:main --tag ghcr.io/example/app:sha-abc",
+    )
+    # Source resolve + two per-tag verifications.
+    assert_that(log).contains("{{.Manifest.Digest}} ghcr.io/example/app:ci-1")
+    assert_that(log).contains("{{.Manifest.Digest}} ghcr.io/example/app:main")
+    assert_that(log).contains("{{.Manifest.Digest}} ghcr.io/example/app:sha-abc")
+    assert_that(github_output.read_text()).contains("digest=sha256:aaa111")
+
+
+def test_promote_ci_docker_images_fails_on_digest_mismatch(
+    tmp_path: Path,
+) -> None:
+    """A promoted tag resolving to a different digest should fail the run."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_stub(
+        bin_dir,
+        "docker",
+        (
+            'if [[ "$*" == *" inspect "* ]]; then\n'
+            '  if [[ "${@: -1}" == "ghcr.io/example/app:ci-1" ]]; then\n'
+            '    echo "sha256:aaa111"\n'
+            "  else\n"
+            '    echo "sha256:bbb222"\n'
+            "  fi\n"
+            "fi"
+        ),
+    )
+
+    result = _run_with_stubs(
+        "scripts/ci/promote-ci-docker-images.sh",
+        bin_dir,
+        {
+            "SOURCE_IMAGE": "ghcr.io/example/app",
+            "CI_TAG": "ci-1",
+            "TAGS": "ghcr.io/example/app:main",
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(1)
+    assert_that(result.stderr).contains("Digest mismatch after promotion")
+
+
+def test_cosign_sign_images_requires_images() -> None:
+    """cosign-sign-images.sh should fail when IMAGES is missing."""
+    script_path = (_REPO_ROOT / "scripts/ci/cosign-sign-images.sh").resolve()
+    result = subprocess.run(  # nosec B603 - fixed argv run against a repo script in a controlled test; shell=False, no user shell input
+        [str(script_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ.copy(), "IMAGES": ""},
+    )
+    assert_that(result.returncode).is_equal_to(2)
+    assert_that(result.stderr).contains("IMAGES is required")
+
+
+def test_cosign_sign_images_rejects_tag_refs(tmp_path: Path) -> None:
+    """Signing must be refused for refs not pinned by digest."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_stub(bin_dir, "cosign", "exit 0")
+
+    result = _run_with_stubs(
+        "scripts/ci/cosign-sign-images.sh",
+        bin_dir,
+        {"IMAGES": "ghcr.io/example/app:main"},
+    )
+
+    assert_that(result.returncode).is_equal_to(2)
+    assert_that(result.stderr).contains("Refusing to sign non-digest ref")
+
+
+def test_cosign_sign_images_signs_each_digest(tmp_path: Path) -> None:
+    """Every digest-pinned ref should be signed exactly once."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    cosign_log = tmp_path / "cosign.log"
+    _write_stub(bin_dir, "cosign", 'echo "$*" >> "$COSIGN_LOG"')
+
+    result = _run_with_stubs(
+        "scripts/ci/cosign-sign-images.sh",
+        bin_dir,
+        {
+            "IMAGES": (
+                "ghcr.io/example/app@sha256:aaa111\n"
+                "ghcr.io/example/app-base@sha256:bbb222"
+            ),
+            "COSIGN_LOG": str(cosign_log),
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    lines = cosign_log.read_text().strip().splitlines()
+    assert_that(lines).is_equal_to(
+        [
+            "sign --yes ghcr.io/example/app@sha256:aaa111",
+            "sign --yes ghcr.io/example/app-base@sha256:bbb222",
+        ],
+    )
+
+
+def test_delete_ci_ghcr_tags_deletes_only_sole_tag_versions(
+    tmp_path: Path,
+) -> None:
+    """Versions sharing a digest with other tags must be skipped (#1138)."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh_log = tmp_path / "gh.log"
+    _write_stub(
+        bin_dir,
+        "gh",
+        (
+            'echo "$*" >> "$GH_LOG"\n'
+            'if [[ "$*" == *"DELETE"* ]]; then\n'
+            "  exit 0\n"
+            "fi\n"
+            'printf "%s\\n" "$GH_VERSIONS_TSV"'
+        ),
+    )
+    # Version 101 shares the digest with a promoted tag; 102 is CI-only.
+    versions_tsv = "101\tci-123 main\n102\tci-123"
+
+    result = _run_with_stubs(
+        "scripts/ci/maintenance/delete-ci-ghcr-tags.sh",
+        bin_dir,
+        {
+            "CI_TAG": "ci-123",
+            "GH_TOKEN": "dummy",  # nosec B105 - fake token for stubbed gh
+            "GH_LOG": str(gh_log),
+            "GH_VERSIONS_TSV": versions_tsv,
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("Skipping version 101")
+    assert_that(result.stdout).contains("Deleted version 102")
+    log = gh_log.read_text()
+    assert_that(log).contains("versions/102")
+    assert_that(log).does_not_contain("versions/101")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  perf(ci): promote docker images by digest instead of rebuilding in publish
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Closes #1358 (epic #1357). Also hardens the CI-tag cleanup against the cross-run interference documented on #1138 (run 29305625795).

### Publish by digest promotion (`docker-ci.yml`)

The `publish` job no longer reruns `build-push-action` for `full` + `base`. Instead it:

1. Resolves the digest behind `ghcr.io/lgtm-hq/py-lintro:ci-${run_id}` (and `-base`) with `docker buildx imagetools inspect --format '{{.Manifest.Digest}}'`.
2. Retags **the digest** (`image@sha256:...`, not the CI tag) to the metadata-action release tags via `docker buildx imagetools create` — immune to CI-tag deletion races (#1138), and the published image is bit-identical to the image `docker-build` built and `dogfooding-lint` / `security-audit` / `integration-test` validated.
3. Verifies every promoted tag resolves back to the exact source digest (in-CI proof that the GHCR retag preserved the manifest; retagging is a registry-side reference to the same content-addressed manifest, so manifest-index children — attestations/signatures — are preserved by construction).
4. Signs the **promoted digests** with Cosign keyless OIDC (`sigstore/cosign-installer`, same SHA pin lgtm-ci uses). Signing binds to `@sha256:...`, never a floating tag. SBOM/provenance attestations remain explicitly disabled repo-wide (`provenance: false` / `sbom: false` predate this PR and are unchanged — nothing weakened).

Logic lives in dedicated scripts: `scripts/ci/promote-ci-docker-images.sh` and `scripts/ci/cosign-sign-images.sh`. The publish job's egress allowlist shrinks to checkout + GHCR + sigstore hosts (no build → no Docker Hub/PyPI/Rust/etc.), and the Buildx driver drops to the default `docker` driver (imagetools talks to the registry from the CLI; no BuildKit container pull).

### Release path decision (`docker-build-publish.yml`) — cache ref, not promotion

**Decision: keep the native multi-arch build, feed it the `:cache` ref instead of `no-cache`.**

Evidence for why main's digest cannot be promoted:

- `docker-ci.yml`'s publish pushes a **single-arch linux/amd64** image (`build-push-action` on `ubuntu-24.04`, no `platforms` input).
- The tag-triggered release builds a **linux/amd64 + linux/arm64 manifest index** on native runners (`runner-map: {"linux/arm64":"ubuntu-24.04-arm"}`) with per-platform smoke tests via `reusable-docker.yml`'s split path. There is no arm64 digest on main to promote.

So `no-cache` is now limited to backfill dispatches (historical republishes stay fully cold). Tag builds use the registry cache that main's `docker-build` writes on every push; BuildKit cache is content-addressed, so the release reassembles exactly the layers already built and validated on main. `cosign-sign: true` is enabled for both release jobs (the jobs already had `id-token: write`; sigstore hosts added to the egress allowlists).

### Cleanup sequencing + tag-safe deletion (#1138)

- `cleanup-ci-images` now runs only when **every** job in its `needs` graph (including `publish`, the promotion consumer) is green or skipped (`!contains(needs.*.result, 'failure'/'cancelled')`). On any failure the CI tags survive for re-runs; re-runs share the `run_id`, so the eventual green re-run deletes the same tags.
- `delete-ci-ghcr-tags.sh` deletes a GHCR **version** only when the CI tag is its *sole* tag. GHCR deletion is per-version (one digest, all its tags), and after digest promotion the release tags share the version with the CI tag; byte-identical images from concurrent runs share it with foreign `ci-*` tags (the run 29305625795 incident). Shared versions are skipped with a log line; the leftover CI tag is a zero-storage alias and the scheduled prune removes the version once real tags are gone.

### Invariants preserved

- Fork PRs never reach `publish` (`github.ref == 'refs/heads/main' && github.event_name == 'push'` unchanged); fork tarball path untouched.
- All actions SHA-pinned; lgtm-ci pin stays at the canonical v0.52.4 (`768a6b7`).
- No inline workflow shell: all new logic in `scripts/ci/*.sh` with pytest coverage (`tests/scripts/test_docker_ci_scripts.py`, the repo's established harness for CI shell scripts — 24 tests pass, incl. digest-mismatch, non-digest-ref signing refusal, and shared-version skip cases).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1358
- Relates to #1138
- Relates to #1357

## Details

_See What’s Changing._
