### PR TITLE
perf(ci): skip heavy CI on auto version-bump PRs

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -17,6 +17,19 @@ name: CI - Docker
 # green when only docs changed. merge_group, push, and workflow_dispatch
 # always run the full pipeline.
 #
+# Version-bump PRs (#1362): the `changes` job also classifies automated
+# release version-bump PRs (release-version-pr.yml) via
+# scripts/ci/release-bump-only.sh — identity signals (bot author, title,
+# release/v* branch) nominate, a diff allowlist decides (only the version
+# stamp in pyproject.toml / uv.lock / lintro/__init__.py plus CHANGELOG.md
+# may change). Verified bump PRs resolve pipeline=false, so the heavy jobs
+# early-exit green exactly like the docs-only path, with skip-reason
+# "version-bump PR". Only the pull_request run is skipped: the merge push
+# to main still builds and publishes (digest promotion, #1358/#1368), and
+# the release-auto-tag → publish-pypi-on-tag chain is untouched. test-ci.yml
+# keeps running in full on bump PRs (see its header — skipping the reusable
+# callers collapses the nested required contexts, #1359).
+#
 # Dogfooding lint scope (#1361): the `changes` job also maps the diff to a
 # `full-lint` filter (paths with global lint impact — tool configs, the
 # Docker context, workflows, scripts, lintro itself). PRs that miss the
@@ -66,6 +79,9 @@ jobs:
       # PR diff explicitly missed the full-lint filter; every failure mode
       # (missing JSON, failed job → empty output) resolves to full-repo lint.
       lint-scope: ${{ steps.result.outputs.lint-scope }}
+      # Human-readable reason when pipeline=false ("docs-only change" or
+      # "version-bump PR", #1362); empty when the pipeline runs.
+      skip-reason: ${{ steps.result.outputs.skip-reason }}
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length
@@ -236,11 +252,28 @@ jobs:
               - '*.jsonc'
               - '*.ini'
               - '*.cfg'
+      - name: Check for release version-bump PR
+        # Nominate-then-verify (#1362): identity signals (release-bot
+        # author, chore(release) title, release/v* branch) only nominate;
+        # the script's diff allowlist decides. Fails closed to
+        # release-bump=false on anything unexpected, so the full pipeline
+        # runs. continue-on-error keeps a script failure from turning the
+        # fail-open changes job into a hard failure.
+        id: bump
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: scripts/ci/release-bump-only.sh
       - name: Resolve pipeline relevance
         id: result
         env:
           EVENT_NAME: ${{ github.event_name }}
           CHANGES_JSON: ${{ steps.detect.outputs.changes }}
+          RELEASE_BUMP: ${{ steps.bump.outputs.release-bump }}
         run: scripts/ci/resolve-pipeline-relevance.sh
 
   manifest-sync:
@@ -460,9 +493,11 @@ jobs:
           name: docker-images
           path: /tmp/py-lintro-images.tar
           retention-days: 1
-      - name: Skip heavy build (docs-only change)
+      - name: Skip heavy build (pipeline not relevant)
         if: needs.changes.outputs.pipeline == 'false'
-        run: scripts/ci/ci-log.sh "Docs-only change; Docker build skipped"
+        env:
+          SKIP_REASON: ${{ needs.changes.outputs.skip-reason }}
+        run: scripts/ci/ci-log.sh "skipped:" "$SKIP_REASON" "(Docker build)"
 
   dogfooding-lint:
     needs: [changes, docker-build, manifest-sync]
@@ -777,6 +812,11 @@ jobs:
           needs.changes.outputs.pipeline != 'false' &&
           needs.docker-build.outputs.is-fork == 'true'
         run: scripts/ci/testing/load-ci-docker-images.sh
+      - name: Skip security audit (pipeline not relevant)
+        if: needs.changes.outputs.pipeline == 'false'
+        env:
+          SKIP_REASON: ${{ needs.changes.outputs.skip-reason }}
+        run: scripts/ci/ci-log.sh "skipped:" "$SKIP_REASON" "(security audit)"
       - name: Run security audit
         id: audit
         if: needs.changes.outputs.pipeline != 'false'
@@ -886,6 +926,12 @@ jobs:
           needs.changes.outputs.pipeline != 'false' &&
           needs.docker-build.outputs.is-fork == 'true'
         run: scripts/ci/testing/load-ci-docker-images.sh
+      - name: Skip integration tests (pipeline not relevant)
+        if: needs.changes.outputs.pipeline == 'false'
+        env:
+          SKIP_REASON: ${{ needs.changes.outputs.skip-reason }}
+        run: >-
+          scripts/ci/ci-log.sh "skipped:" "$SKIP_REASON" "(integration tests)"
       - name: Smoke Test Docker Image
         if: needs.changes.outputs.pipeline != 'false'
         run: ./scripts/docker/docker-build-test.sh

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -16,6 +16,13 @@ name: CI - Tests
 # workflows"). Path-skipping this matrix needs an internal skip input in
 # lgtm-ci reusable-test-python (jobs skipped INSIDE a running reusable do
 # report their contexts as skipped, like draft-pr-skip does today).
+#
+# Version-bump PRs (#1362) are NOT skipped here for the same reason: the
+# skip signal would have to gate the reusable callers, which collapses the
+# nested required contexts and deadlocks the merge. Only docker-ci.yml
+# skips its heavy jobs on verified bump PRs; this matrix runs in full
+# until reusable-test-python grows an internal skip input (deferred like
+# the #1359 path-skip).
 'on':
   push:
     branches: [main]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -101,6 +101,7 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `detect-changes.sh`                  | Detect repo diffs and set has_changes output                          | `./scripts/ci/detect-changes.sh --help`                                            |
 | `detect-fork-pr.sh`                  | Detect fork PRs and set `is-fork` output for conditional steps        | `EVENT_NAME=pull_request ./scripts/ci/detect-fork-pr.sh`                           |
 | `resolve-pipeline-relevance.sh`      | Resolve heavy-pipeline path relevance and set `pipeline` output       | `./scripts/ci/resolve-pipeline-relevance.sh --help`                                |
+| `release-bump-only.sh`               | Classify automated version-bump PRs via diff allowlist (#1362)        | `./scripts/ci/release-bump-only.sh --help`                                         |
 | `dogfood-changed-files.sh`           | Lint only PR-changed files via lintro Docker (full-repo fallback)     | `./scripts/ci/dogfood-changed-files.sh --help`                                     |
 | `evaluate-test-gate.sh`              | Evaluate upstream compat/coverage results for required-check gate     | `COMPAT_RESULT=success COVERAGE_RESULT=success ./scripts/ci/evaluate-test-gate.sh` |
 | `fail-on-security-audit.sh`          | Fail CI when security audit finds vulnerabilities                     | `./scripts/ci/fail-on-security-audit.sh`                                           |

--- a/scripts/ci/release-bump-only.sh
+++ b/scripts/ci/release-bump-only.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+set -euo pipefail
+
+# release-bump-only.sh
+#
+# Decide whether a pull request is an automated release version-bump PR so
+# the heavy Docker pipeline can be skipped for it (#1362). Two layers:
+#
+#   1. Nomination (identity signals — spoofable, so they only NOMINATE):
+#      PR author is the release bot, title matches
+#      `chore(release): version X.Y.Z`, and the head branch is
+#      `release/vX.Y.Z` (what reusable-release-version-pr produces).
+#   2. Verification (diff allowlist — DECIDES): the diff vs the PR base must
+#      touch only CHANGELOG.md, pyproject.toml, uv.lock, and
+#      <package>/__init__.py, and outside CHANGELOG.md the only permitted
+#      change is the project's own version stamp:
+#        - pyproject.toml: only the [project] `version = "..."` line;
+#        - <package>/__init__.py: only the `__version__ = "..."` line;
+#        - uv.lock: only the `version = "..."` line of the project's own
+#          [[package]] block. A bare version-line diff check would be
+#          spoofable by a dependency bump whose diff also only touches
+#          version lines, so each file is compared with its version stamp
+#          stripped from BOTH revisions — the remainders must be
+#          byte-identical (prior art: lgtm-hq/Rustume
+#          scripts/ci/docker/release_bump_only.sh, #457).
+#
+# CHANGELOG.md content is not inspected (prose never affects the image or
+# the test matrix). Every unexpected condition fails closed to "false" so
+# the full pipeline runs.
+#
+# Usage (from the docker-ci `changes` job, pull_request events only):
+#   EVENT_NAME=pull_request PR_AUTHOR='lgtm-release-bot[bot]' \
+#     PR_TITLE='chore(release): version 1.2.3' HEAD_REF=release/v1.2.3 \
+#     scripts/ci/release-bump-only.sh
+#
+# The diff range defaults to HEAD^1..HEAD, which on the pull_request merge
+# ref is exactly the PR's effect against its base; a non-merge HEAD fails
+# closed. BASE_SHA/HEAD_SHA override the range (tests).
+#
+# Outputs (via GITHUB_OUTPUT, also echoed):
+#   release-bump=true|false
+
+show_help() {
+	cat <<'EOF'
+Classify a pull request as an automated release version-bump PR.
+
+Usage:
+  EVENT_NAME=pull_request PR_AUTHOR=<login> PR_TITLE=<title> \
+    HEAD_REF=<branch> scripts/ci/release-bump-only.sh
+
+Environment:
+  EVENT_NAME    github.event_name; anything but pull_request resolves false
+  PR_AUTHOR     github.event.pull_request.user.login
+  PR_TITLE      github.event.pull_request.title
+  HEAD_REF      github.head_ref (PR head branch name)
+  RELEASE_BOT   Release bot login (default: lgtm-release-bot[bot])
+  PACKAGE_NAME  Python package directory name (default: lintro)
+  BASE_SHA      Diff base override (default: HEAD^1 of the merge ref)
+  HEAD_SHA      Diff head override (default: HEAD)
+
+Behavior:
+  - Identity signals (bot author + chore(release) title + release/v*
+    branch) only nominate; the diff allowlist decides.
+  - Qualifying diffs touch only CHANGELOG.md, pyproject.toml, uv.lock,
+    and <package>/__init__.py, and change nothing beyond the project's
+    own version stamp in the latter three.
+  - Any unexpected condition fails closed to release-bump=false.
+
+Outputs (via GITHUB_OUTPUT):
+  release-bump=true|false
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	show_help
+	exit 0
+fi
+
+event_name="${EVENT_NAME:-}"
+pr_author="${PR_AUTHOR:-}"
+pr_title="${PR_TITLE:-}"
+head_ref="${HEAD_REF:-}"
+release_bot="${RELEASE_BOT:-lgtm-release-bot[bot]}"
+package_name="${PACKAGE_NAME:-lintro}"
+init_file="${package_name}/__init__.py"
+
+emit() {
+	local value="$1"
+	echo "release-bump=${value}"
+	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		echo "release-bump=${value}" >>"$GITHUB_OUTPUT"
+	fi
+	exit 0
+}
+
+# --- Layer 1: nomination (identity signals) --------------------------------
+
+if [[ "$event_name" != "pull_request" ]]; then
+	echo "not a pull_request event (${event_name:-<unset>})"
+	emit "false"
+fi
+
+semver='[0-9]+\.[0-9]+\.[0-9]+'
+if [[ "$pr_author" != "$release_bot" ]]; then
+	echo "not nominated: author '${pr_author}' is not '${release_bot}'"
+	emit "false"
+fi
+if [[ ! "$pr_title" =~ ^chore\(release\):\ version\ ${semver}$ ]]; then
+	echo "not nominated: title '${pr_title}' is not a version-bump title"
+	emit "false"
+fi
+if [[ ! "$head_ref" =~ ^release/v${semver}$ ]]; then
+	echo "not nominated: head ref '${head_ref}' is not release/vX.Y.Z"
+	emit "false"
+fi
+
+# --- Diff range -------------------------------------------------------------
+
+base="${BASE_SHA:-}"
+head="${HEAD_SHA:-}"
+if [[ -z "$base" || -z "$head" ]]; then
+	# pull_request checkouts sit on the synthetic merge commit; its first
+	# parent is the base branch tip, so HEAD^1..HEAD is exactly the change
+	# the merge would land. A non-merge HEAD means we cannot trust the
+	# range — fail closed.
+	if ! git rev-parse --verify --quiet 'HEAD^2' >/dev/null; then
+		echo "HEAD is not a PR merge commit; failing closed" >&2
+		emit "false"
+	fi
+	base="$(git rev-parse 'HEAD^1')"
+	head="$(git rev-parse HEAD)"
+fi
+
+# --- Layer 2: verification (diff allowlist decides) -------------------------
+
+allowed_files=("CHANGELOG.md" "pyproject.toml" "uv.lock" "$init_file")
+
+changed_files="$(git diff --name-only "$base" "$head")"
+
+if [[ -z "$changed_files" ]]; then
+	echo "not bump-only: empty diff"
+	emit "false"
+fi
+
+while IFS= read -r f; do
+	ok=false
+	for a in "${allowed_files[@]}"; do
+		if [[ "$f" == "$a" ]]; then
+			ok=true
+			break
+		fi
+	done
+	if [[ "$ok" == "false" ]]; then
+		echo "not bump-only: ${f} outside allowlist"
+		emit "false"
+	fi
+done <<<"$changed_files"
+
+# pyproject.toml: a bare version-line check is section-blind — a
+# `version = "..."` line under a dependency table looks identical to the
+# project's own stamp. Strip the version line from the [project] section of
+# both revisions and require the remainders to be byte-identical.
+strip_project_version() {
+	git show "$1:pyproject.toml" 2>/dev/null | awk '
+		/^\[/ { in_project = ($0 == "[project]") }
+		!(in_project && /^version = "[0-9]+\.[0-9]+\.[0-9]+[^"]*"$/)
+	'
+}
+
+if ! git diff --quiet "$base" "$head" -- pyproject.toml; then
+	if ! diff -q <(strip_project_version "$base") \
+		<(strip_project_version "$head") >/dev/null; then
+		echo "not bump-only: pyproject.toml changed beyond [project] version"
+		emit "false"
+	fi
+fi
+
+# <package>/__init__.py: only the __version__ stamp may change.
+strip_dunder_version() {
+	git show "$1:${init_file}" 2>/dev/null |
+		grep -v '^__version__ = "[0-9]\+\.[0-9]\+\.[0-9]\+[^"]*"$' || true
+}
+
+if ! git diff --quiet "$base" "$head" -- "$init_file"; then
+	if ! diff -q <(strip_dunder_version "$base") \
+		<(strip_dunder_version "$head") >/dev/null; then
+		echo "not bump-only: ${init_file} changed beyond __version__"
+		emit "false"
+	fi
+fi
+
+# uv.lock: only the project's own [[package]] block may change, and only its
+# version line. Strip that single line from both revisions and require the
+# remainders to be byte-identical — any dependency entry change (version,
+# hashes, additions, removals) survives the strip and fails the diff.
+strip_lock_project_version() {
+	git show "$1:uv.lock" 2>/dev/null | awk -v pkg="$2" '
+		/^\[/ { own = 0 }
+		$0 == "name = \"" pkg "\"" && in_block { own = 1 }
+		/^\[\[package\]\]$/ { in_block = 1 }
+		/^\[/ && !/^\[\[package\]\]$/ { in_block = 0 }
+		!(own && /^version = "[0-9]+\.[0-9]+\.[0-9]+[^"]*"$/)
+	'
+}
+
+if ! git diff --quiet "$base" "$head" -- uv.lock; then
+	if ! diff -q <(strip_lock_project_version "$base" "$package_name") \
+		<(strip_lock_project_version "$head" "$package_name") >/dev/null; then
+		echo "not bump-only: uv.lock changed beyond the ${package_name} version"
+		emit "false"
+	fi
+fi
+
+echo "version-bump PR verified: diff limited to version stamp + CHANGELOG"
+emit "true"

--- a/scripts/ci/resolve-pipeline-relevance.sh
+++ b/scripts/ci/resolve-pipeline-relevance.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 # resolve-pipeline-relevance.sh
 #
 # Resolve whether the heavy CI pipeline is relevant for this run and write a
-# `pipeline` output (true|false) plus a `lint-scope` output (full|changed) to
+# `pipeline` output (true|false), a `lint-scope` output (full|changed), and a
+# `skip-reason` output (human-readable, empty when pipeline=true) to
 # GITHUB_OUTPUT for downstream job and step conditions.
 #
 # Non-pull_request events (push, merge_group, workflow_dispatch) always run
@@ -19,9 +20,17 @@ set -euo pipefail
 # other case — non-PR events, filter hit, missing filter, unparsable JSON —
 # resolves `full` so a filter regression can never narrow lint coverage.
 #
+# RELEASE_BUMP (#1362): when release-bump-only.sh verified the PR as an
+# automated version-bump PR (diff limited to the version stamp + CHANGELOG),
+# the pipeline is skipped even though pyproject.toml hits both the pipeline
+# and full-lint filters — the diff allowlist is a stronger guarantee than
+# the path filters, so this override intentionally outranks the full-lint
+# drift guard below. Only the exact string "true" skips; anything else
+# (empty, "false", garbage, a failed bump step) keeps the resolved value.
+#
 # Usage:
 #   EVENT_NAME=<event> CHANGES_JSON='{"pipeline":true,"full-lint":false}' \
-#     scripts/ci/resolve-pipeline-relevance.sh
+#     RELEASE_BUMP=false scripts/ci/resolve-pipeline-relevance.sh
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 	cat <<'EOF'
@@ -29,12 +38,15 @@ Resolve heavy-pipeline path relevance for GitHub Actions.
 
 Usage:
   EVENT_NAME=<event> CHANGES_JSON='{"pipeline":true,"full-lint":false}' \
-    scripts/ci/resolve-pipeline-relevance.sh
+    RELEASE_BUMP=false scripts/ci/resolve-pipeline-relevance.sh
 
 Environment:
   EVENT_NAME    github.event_name
   CHANGES_JSON  detect-changes `changes` output (JSON filter -> boolean);
                 only consulted when EVENT_NAME is pull_request
+  RELEASE_BUMP  release-bump-only.sh verdict; the exact string "true" on a
+                pull_request skips the pipeline (verified version-bump PR,
+                #1362), anything else keeps the resolved value
 
 Behavior:
   - Non-pull_request events always resolve pipeline=true (merge_group and
@@ -44,18 +56,23 @@ Behavior:
     `full-lint` filter is explicitly false; anything else resolves full.
   - Missing or unparsable CHANGES_JSON fails open (pipeline=true,
     lint-scope=full).
+  - RELEASE_BUMP=true on a pull_request forces pipeline=false with
+    skip-reason "version-bump PR", outranking the full-lint drift guard.
 
 Outputs (via GITHUB_OUTPUT):
   pipeline=true|false
   lint-scope=full|changed
+  skip-reason=<reason>  (empty when pipeline=true)
 EOF
 	exit 0
 fi
 
 event_name="${EVENT_NAME:-}"
 changes_json="${CHANGES_JSON:-}"
+release_bump="${RELEASE_BUMP:-}"
 pipeline="true"
 lint_scope="full"
+skip_reason=""
 
 if [[ "$event_name" == "pull_request" ]]; then
 	# Plain -r (not -e): jq -e exits nonzero for a legitimate false value.
@@ -96,16 +113,39 @@ if [[ "$event_name" == "pull_request" ]]; then
 			pipeline="true"
 		fi
 	fi
+
+	# Verified version-bump PR (#1362): skip the heavy pipeline. This
+	# override intentionally outranks the drift guard above — the bump PR
+	# always hits the pipeline and full-lint filters via pyproject.toml,
+	# but the diff allowlist in release-bump-only.sh has already proven
+	# the change is version-stamp-only. Fail-safe: only the exact string
+	# "true" (a completed, positive verdict) skips.
+	if [[ "$release_bump" == "true" ]]; then
+		pipeline="false"
+		echo "::notice::skipped: version-bump PR (diff limited to" \
+			"version stamp + CHANGELOG, #1362)"
+	fi
 fi
 
-echo "event=${event_name:-<unset>} pipeline=${pipeline} lint-scope=${lint_scope}"
+if [[ "$pipeline" == "false" ]]; then
+	if [[ "$release_bump" == "true" ]]; then
+		skip_reason="version-bump PR"
+	else
+		skip_reason="docs-only change"
+	fi
+fi
+
+echo "event=${event_name:-<unset>} pipeline=${pipeline}" \
+	"lint-scope=${lint_scope} skip-reason=${skip_reason:-<none>}"
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
 	{
 		echo "pipeline=${pipeline}"
 		echo "lint-scope=${lint_scope}"
+		echo "skip-reason=${skip_reason}"
 	} >>"$GITHUB_OUTPUT"
 else
 	echo "pipeline=${pipeline}"
 	echo "lint-scope=${lint_scope}"
+	echo "skip-reason=${skip_reason}"
 fi

--- a/tests/scripts/test_release_bump_only.py
+++ b/tests/scripts/test_release_bump_only.py
@@ -1,0 +1,394 @@
+"""Tests for scripts/ci/release-bump-only.sh (#1362).
+
+The script classifies automated release version-bump PRs with two layers:
+identity signals (bot author, chore(release) title, release/v* branch) only
+nominate; a diff allowlist plus version-stamp-only content checks decide.
+These tests drive both layers against synthetic git repositories.
+"""
+
+import subprocess  # nosec B404 - subprocess drives the script under test; shell=False
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+
+SCRIPT_PATH = Path("scripts/ci/release-bump-only.sh").resolve()
+
+NOMINATED_ENV = {
+    "EVENT_NAME": "pull_request",
+    "PR_AUTHOR": "lgtm-release-bot[bot]",
+    "PR_TITLE": "chore(release): version 0.2.0",
+    "HEAD_REF": "release/v0.2.0",
+}
+
+PYPROJECT_TEMPLATE = """\
+[build-system]
+requires = ["setuptools"]
+
+[project]
+name = "lintro"
+version = "{version}"
+dependencies = [
+  "click=={click_version}",
+]
+
+[tool.ruff]
+line-length = 88
+"""
+
+UV_LOCK_TEMPLATE = """\
+version = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "click"
+version = "{click_version}"
+source = {{ registry = "https://pypi.org/simple" }}
+sdist = {{ url = "https://example.invalid/click.tar.gz", hash = "sha256:{click_hash}" }}
+
+[[package]]
+name = "lintro"
+version = "{version}"
+source = {{ editable = "." }}
+dependencies = [
+    {{ name = "click" }},
+]
+
+[package.metadata]
+requires-dist = [{{ name = "click", specifier = "=={click_version}" }}]
+"""
+
+INIT_TEMPLATE = '"""Lintro."""\n\n__version__ = "{version}"\n'
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run a git command inside the fixture repository.
+
+    Args:
+        repo: Repository working directory.
+        *args: git subcommand and arguments.
+
+    Returns:
+        str: Captured stdout, stripped.
+    """
+    result = (
+        subprocess.run(  # nosec B603 B607 - fixed git argv in a test-owned temp repo
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            check=True,
+            env={
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+                "GIT_AUTHOR_NAME": "t",
+                "GIT_AUTHOR_EMAIL": "t@example.invalid",
+                "GIT_COMMITTER_NAME": "t",
+                "GIT_COMMITTER_EMAIL": "t@example.invalid",
+                "HOME": str(repo),
+            },
+        )
+    )
+    return result.stdout.strip()
+
+
+def _write_release_files(
+    repo: Path,
+    version: str,
+    click_version: str = "8.1.7",
+    click_hash: str = "aa",
+    changelog: str = "# Changelog\n",
+) -> None:
+    """Write the four release-touched files at the given versions.
+
+    Args:
+        repo: Repository working directory.
+        version: Project version stamp to write.
+        click_version: Pinned click version for pyproject/uv.lock.
+        click_hash: Fake sdist hash for the click uv.lock entry.
+        changelog: CHANGELOG.md content.
+    """
+    (repo / "pyproject.toml").write_text(
+        PYPROJECT_TEMPLATE.format(version=version, click_version=click_version),
+    )
+    (repo / "uv.lock").write_text(
+        UV_LOCK_TEMPLATE.format(
+            version=version,
+            click_version=click_version,
+            click_hash=click_hash,
+        ),
+    )
+    (repo / "lintro").mkdir(exist_ok=True)
+    (repo / "lintro" / "__init__.py").write_text(
+        INIT_TEMPLATE.format(version=version),
+    )
+    (repo / "CHANGELOG.md").write_text(changelog)
+
+
+@pytest.fixture
+def bump_repo(tmp_path: Path) -> Path:
+    """Create a git repo with a base commit at version 0.1.0.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+
+    Returns:
+        Path: The repository working directory.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _write_release_files(repo, version="0.1.0")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+    return repo
+
+
+def _run_script(
+    repo: Path,
+    env: dict[str, str],
+    output_file: Path,
+) -> subprocess.CompletedProcess[str]:
+    """Run release-bump-only.sh inside the fixture repository.
+
+    Args:
+        repo: Repository working directory.
+        env: Script environment (identity signals, SHA overrides).
+        output_file: File to expose as GITHUB_OUTPUT.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed script run.
+    """
+    return subprocess.run(  # nosec B603 - fixed argv against the script under test; shell=False
+        [str(SCRIPT_PATH)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=repo,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "GITHUB_OUTPUT": str(output_file),
+            **env,
+        },
+    )
+
+
+def _classify(
+    repo: Path,
+    tmp_path: Path,
+    env_overrides: dict[str, str] | None = None,
+) -> tuple[str, str]:
+    """Commit the working tree as the head and classify base..head.
+
+    Args:
+        repo: Repository with a clean base commit and dirty working tree.
+        tmp_path: Pytest-provided temporary directory.
+        env_overrides: Extra/overriding script environment entries.
+
+    Returns:
+        tuple[str, str]: (release-bump output value, combined stdout+stderr).
+    """
+    base = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "head")
+    head = _git(repo, "rev-parse", "HEAD")
+    output_file = tmp_path / "github-output"
+    env = {**NOMINATED_ENV, "BASE_SHA": base, "HEAD_SHA": head}
+    env.update(env_overrides or {})
+    result = _run_script(repo, env, output_file)
+    assert_that(result.returncode).is_equal_to(0)
+    lines = output_file.read_text().splitlines()
+    values = [line.removeprefix("release-bump=") for line in lines]
+    assert_that(values).is_length(1)
+    return values[0], result.stdout + result.stderr
+
+
+def test_release_bump_only_help() -> None:
+    """release-bump-only.sh should provide help and exit 0."""
+    result = subprocess.run(  # nosec B603 - fixed argv against the script under test; shell=False
+        [str(SCRIPT_PATH), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("Usage:")
+
+
+def test_clean_version_bump_qualifies(bump_repo: Path, tmp_path: Path) -> None:
+    """A version-stamp-only diff plus CHANGELOG entry resolves true.
+
+    Args:
+        bump_repo: Fixture repository at version 0.1.0.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    _write_release_files(
+        bump_repo,
+        version="0.2.0",
+        changelog="# Changelog\n\n## 0.2.0\n",
+    )
+    verdict, _ = _classify(bump_repo, tmp_path)
+    assert_that(verdict).is_equal_to("true")
+
+
+@pytest.mark.parametrize(
+    ("env_overrides", "expected_log"),
+    [
+        ({"PR_AUTHOR": "TurboCoder13"}, "not nominated: author"),
+        ({"PR_TITLE": "feat: version 0.2.0"}, "not nominated: title"),
+        ({"HEAD_REF": "feat/version-bump"}, "not nominated: head ref"),
+        ({"EVENT_NAME": "push"}, "not a pull_request event"),
+    ],
+)
+def test_identity_signal_mismatch_fails_closed(
+    bump_repo: Path,
+    tmp_path: Path,
+    env_overrides: dict[str, str],
+    expected_log: str,
+) -> None:
+    """Any missing identity signal resolves false even for a clean diff.
+
+    Args:
+        bump_repo: Fixture repository at version 0.1.0.
+        tmp_path: Pytest-provided temporary directory.
+        env_overrides: Identity signal to break.
+        expected_log: Log fragment explaining the rejection.
+    """
+    _write_release_files(bump_repo, version="0.2.0")
+    verdict, log = _classify(bump_repo, tmp_path, env_overrides)
+    assert_that(verdict).is_equal_to("false")
+    assert_that(log).contains(expected_log)
+
+
+def test_file_outside_allowlist_fails(bump_repo: Path, tmp_path: Path) -> None:
+    """A nominated PR touching a non-allowlisted file resolves false.
+
+    Args:
+        bump_repo: Fixture repository at version 0.1.0.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    _write_release_files(bump_repo, version="0.2.0")
+    (bump_repo / "lintro" / "cli.py").write_text("print('payload')\n")
+    verdict, log = _classify(bump_repo, tmp_path)
+    assert_that(verdict).is_equal_to("false")
+    assert_that(log).contains("outside allowlist")
+
+
+def test_pyproject_dependency_change_fails(
+    bump_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """A dependency pin change in pyproject.toml resolves false.
+
+    Args:
+        bump_repo: Fixture repository at version 0.1.0.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    _write_release_files(bump_repo, version="0.2.0", click_version="8.2.0")
+    verdict, log = _classify(bump_repo, tmp_path)
+    assert_that(verdict).is_equal_to("false")
+    assert_that(log).contains("pyproject.toml changed beyond")
+
+
+def test_uv_lock_external_package_change_fails(
+    bump_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """An external-package uv.lock change resolves false (spoof guard).
+
+    The diff touches only allowlisted files and only `version = "..."` /
+    hash lines, so a bare line-level check would pass — the block-aware
+    strip must reject it.
+
+    Args:
+        bump_repo: Fixture repository at version 0.1.0.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    _write_release_files(bump_repo, version="0.2.0")
+    lock = bump_repo / "uv.lock"
+    # Only uv.lock carries the dependency change; pyproject keeps its pin.
+    lock.write_text(
+        lock.read_text().replace('version = "8.1.7"', 'version = "8.2.0"'),
+    )
+    verdict, log = _classify(bump_repo, tmp_path)
+    assert_that(verdict).is_equal_to("false")
+    assert_that(log).contains("uv.lock changed beyond")
+
+
+def test_init_change_beyond_version_fails(
+    bump_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """Extra code in lintro/__init__.py resolves false.
+
+    Args:
+        bump_repo: Fixture repository at version 0.1.0.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    _write_release_files(bump_repo, version="0.2.0")
+    init_file = bump_repo / "lintro" / "__init__.py"
+    init_file.write_text(init_file.read_text() + "import os  # payload\n")
+    verdict, log = _classify(bump_repo, tmp_path)
+    assert_that(verdict).is_equal_to("false")
+    assert_that(log).contains("__init__.py changed beyond __version__")
+
+
+def test_empty_diff_fails(bump_repo: Path, tmp_path: Path) -> None:
+    """An empty diff resolves false.
+
+    Args:
+        bump_repo: Fixture repository at version 0.1.0.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    base = _git(bump_repo, "rev-parse", "HEAD")
+    output_file = tmp_path / "github-output"
+    env = {**NOMINATED_ENV, "BASE_SHA": base, "HEAD_SHA": base}
+    result = _run_script(bump_repo, env, output_file)
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(output_file.read_text()).contains("release-bump=false")
+    assert_that(result.stdout).contains("empty diff")
+
+
+def test_non_merge_head_without_shas_fails_closed(
+    bump_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """Without SHA overrides, a non-merge HEAD resolves false.
+
+    Args:
+        bump_repo: Fixture repository at version 0.1.0.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    output_file = tmp_path / "github-output"
+    result = _run_script(bump_repo, dict(NOMINATED_ENV), output_file)
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(output_file.read_text()).contains("release-bump=false")
+    assert_that(result.stderr).contains("not a PR merge commit")
+
+
+def test_merge_commit_diff_range_qualifies(
+    bump_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """A PR-style merge commit derives its own base..head range.
+
+    Args:
+        bump_repo: Fixture repository at version 0.1.0.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    _git(bump_repo, "checkout", "-q", "-b", "release/v0.2.0")
+    _write_release_files(bump_repo, version="0.2.0")
+    _git(bump_repo, "add", "-A")
+    _git(bump_repo, "commit", "-q", "-m", "chore(release): version 0.2.0")
+    _git(bump_repo, "checkout", "-q", "-")
+    _git(
+        bump_repo,
+        "merge",
+        "-q",
+        "--no-ff",
+        "-m",
+        "merge",
+        "release/v0.2.0",
+    )
+    output_file = tmp_path / "github-output"
+    result = _run_script(bump_repo, dict(NOMINATED_ENV), output_file)
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(output_file.read_text()).contains("release-bump=true")

--- a/tests/scripts/test_shell_scripts.py
+++ b/tests/scripts/test_shell_scripts.py
@@ -151,6 +151,70 @@ def test_resolve_pipeline_relevance_lint_scope(tmp_path: Path) -> None:
         assert_that(output_file.read_text().splitlines()).contains(expected)
 
 
+def test_resolve_pipeline_relevance_release_bump(tmp_path: Path) -> None:
+    """RELEASE_BUMP=true skips the pipeline on pull_request events (#1362).
+
+    The override must outrank the full-lint drift guard (bump PRs always
+    hit both filters via pyproject.toml), apply only to pull_request
+    events, and only on the exact string "true".
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    cases: list[tuple[dict[str, str], list[str]]] = [
+        # Verified bump PR: skip even though both filters matched.
+        (
+            {
+                "EVENT_NAME": "pull_request",
+                "CHANGES_JSON": '{"pipeline":true,"full-lint":true}',
+                "RELEASE_BUMP": "true",
+            },
+            ["pipeline=false", "skip-reason=version-bump PR"],
+        ),
+        # Non-PR events never skip, whatever RELEASE_BUMP claims.
+        (
+            {"EVENT_NAME": "push", "RELEASE_BUMP": "true"},
+            ["pipeline=true", "skip-reason="],
+        ),
+        (
+            {"EVENT_NAME": "merge_group", "RELEASE_BUMP": "true"},
+            ["pipeline=true", "skip-reason="],
+        ),
+        # Anything but the exact string "true" keeps the resolved value.
+        (
+            {
+                "EVENT_NAME": "pull_request",
+                "CHANGES_JSON": '{"pipeline":true,"full-lint":true}',
+                "RELEASE_BUMP": "false",
+            },
+            ["pipeline=true", "skip-reason="],
+        ),
+        (
+            {
+                "EVENT_NAME": "pull_request",
+                "CHANGES_JSON": '{"pipeline":true,"full-lint":true}',
+                "RELEASE_BUMP": "garbage",
+            },
+            ["pipeline=true", "skip-reason="],
+        ),
+        # Docs-only path keeps its own reason.
+        (
+            {
+                "EVENT_NAME": "pull_request",
+                "CHANGES_JSON": '{"pipeline":false,"full-lint":false}',
+            },
+            ["pipeline=false", "skip-reason=docs-only change"],
+        ),
+    ]
+    for index, (env, expected_lines) in enumerate(cases):
+        output_file = tmp_path / f"github-output-{index}"
+        result = _run_resolve_pipeline_relevance(env, output_file)
+        assert_that(result.returncode).is_equal_to(0)
+        output_lines = output_file.read_text().splitlines()
+        for expected in expected_lines:
+            assert_that(output_lines).contains(expected)
+
+
 def test_renovate_regex_manager_current_value() -> None:
     """Ensure Renovate custom managers use currentValue to satisfy schema."""
     config_path = Path("renovate.json")

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -299,6 +299,62 @@ def test_semantic_pr_title_can_write_failure_comments() -> None:
     )
 
 
+def test_docker_ci_changes_job_classifies_version_bump_prs() -> None:
+    """The changes job nominates bump PRs and feeds the verdict downstream.
+
+    Nominate-then-verify (#1362): the bump step runs only on pull_request
+    events with the identity signals in env (never interpolated into the
+    run script), and the resolve step consumes its output as RELEASE_BUMP.
+    """
+    docker_ci = _load_workflow(name="docker-ci.yml")
+    changes_job = docker_ci["jobs"]["changes"]
+    steps = {step.get("id"): step for step in changes_job["steps"] if "id" in step}
+
+    bump_step = steps["bump"]
+    assert_that(bump_step["if"]).contains(_github_event_name_is_pull_request_token())
+    assert_that(bump_step["run"]).is_equal_to("scripts/ci/release-bump-only.sh")
+    assert_that(bump_step["continue-on-error"]).is_true()
+    bump_env = bump_step["env"]
+    assert_that(bump_env["PR_AUTHOR"]).contains(
+        f"github.event.{_GITHUB_PULL_REQUEST_EVENT}.user.login",
+    )
+    assert_that(bump_env["PR_TITLE"]).contains(
+        f"github.event.{_GITHUB_PULL_REQUEST_EVENT}.title",
+    )
+    assert_that(bump_env["HEAD_REF"]).contains("github.head_ref")
+
+    resolve_step = steps["result"]
+    assert_that(resolve_step["env"]["RELEASE_BUMP"]).contains(
+        "steps.bump.outputs.release-bump",
+    )
+    assert_that(changes_job["outputs"]["skip-reason"]).contains(
+        "steps.result.outputs.skip-reason",
+    )
+
+
+def test_docker_ci_heavy_jobs_log_skip_reason() -> None:
+    """docker-build, security-audit, and integration-test log skip notices.
+
+    Required-check gates must report green with a logged reason when the
+    pipeline is skipped (docs-only or version-bump PR, #1362).
+    """
+    docker_ci = _load_workflow(name="docker-ci.yml")
+    for job_name in ("docker-build", "security-audit", "integration-test"):
+        job = docker_ci["jobs"][job_name]
+        skip_steps = [
+            step
+            for step in job["steps"]
+            if step.get("if") == "needs.changes.outputs.pipeline == 'false'"
+            and "ci-log.sh" in step.get("run", "")
+        ]
+        assert_that(skip_steps).described_as(job_name).is_length(1)
+        skip_step = skip_steps[0]
+        assert_that(skip_step["run"]).contains('"skipped:"')
+        assert_that(skip_step["env"]["SKIP_REASON"]).contains(
+            "needs.changes.outputs.skip-reason",
+        )
+
+
 def test_docker_ci_dogfooding_lint_waits_on_manifest_sync() -> None:
     """Dogfooding lint depends on manifest-sync and allows draft-PR skips."""
     docker_ci = _load_workflow(name="docker-ci.yml")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  perf(ci): skip heavy CI on auto version-bump PRs
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Automated release version-bump PRs (from `release-version-pr.yml`) change only the version stamp and CHANGELOG, yet run the full Docker build + dogfood + integration pipeline. This PR skips the heavy `docker-ci.yml` jobs for verified bump PRs, cutting their CI from ~20m to ~2m.

### Design: nominate-then-verify

Prior art: `lgtm-hq/Rustume` `scripts/ci/docker/release_bump_only.sh` (lgtm-hq/Rustume#457), adapted to Python packaging.

- **Identity signals only NOMINATE** (they can be spoofed): PR author is `lgtm-release-bot[bot]`, title matches `chore(release): version X.Y.Z`, head branch matches `release/vX.Y.Z` — exactly what `reusable-release-version-pr` produces (verified against merged bump PR #1356).
- **A diff allowlist DECIDES**: the diff (first parent of the PR merge ref → HEAD) may touch only `CHANGELOG.md`, `pyproject.toml`, `uv.lock`, and `lintro/__init__.py`, and outside CHANGELOG.md only the project's own version stamp may change:
  - `pyproject.toml`: only the `[project]` `version = "..."` line (section-aware strip; a `version` line under a dependency table would fail),
  - `lintro/__init__.py`: only the `__version__` line,
  - `uv.lock`: only the `version` line of the project's own `[[package]]` block (block-aware strip; any dependency entry change — version, hashes, additions, removals — survives the strip and fails the comparison, so a dependency bump whose diff also touches only version lines cannot spoof the check).

  Each file is compared with the stamp stripped from **both** revisions; the remainders must be byte-identical.

### Integration with the #1363 changes graph

No parallel mechanism: `scripts/ci/release-bump-only.sh` runs as a step in the existing `changes` job, and `resolve-pipeline-relevance.sh` folds the verdict into the existing `pipeline` output (plus a new human-readable `skip-reason` output). Verified bump PRs resolve `pipeline=false`, so `docker-build`, `dogfooding-lint`, `security-audit`, and `integration-test` early-exit green exactly like the docs-only path, and the `lintro-code-quality` gate reports success. The override intentionally outranks the full-lint drift guard (a bump PR always hits both filters via `pyproject.toml`) because the diff allowlist is a strictly stronger guarantee than path filters. Each skipped heavy job logs `skipped: version-bump PR`.

**Fail-closed everywhere**: wrong author/title/branch, non-merge HEAD, empty diff, any file outside the allowlist, any content beyond the stamp, a failed bump step (`continue-on-error` + empty output ≠ `"true"`) → full pipeline.

### What is NOT skipped, and why

- **`test-ci.yml` matrix**: the org ruleset requires the NESTED contexts reported from inside `reusable-test-python` (`test-compat` / `test-coverage`); gating the reusable callers collapses those contexts and deadlocks merges (#1359 finding, verified on fdc94ea). Deferred until `reusable-test-python` grows an internal skip input — documented in both workflow headers.
- **Cheap checks** (semantic PR title, action pinning) keep running.
- **merge_group / push events**: never bump-skipped (`resolve-pipeline-relevance.sh` only consults the verdict on `pull_request`).

### Release chain verification

- The bump **merge push to main** still runs the full pipeline (push events always resolve `pipeline=true`), so `publish` keeps promoting the same-run `ci-${run_id}` digests (#1358/#1368) — nothing to promote would be missing.
- `release-auto-tag.yml` (push to main) → `publish-pypi-on-tag.yml` (tag) react only to push/tag events and are untouched.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1362
- Relates to #1357

## Details

- `tests/scripts/test_release_bump_only.py` (13 tests, synthetic git repos): clean bump → true; each broken identity signal → false; file outside allowlist → false; pyproject dependency change → false; uv.lock external-package spoof (version-lines-only diff) → false; `__init__.py` payload → false; empty diff → false; non-merge HEAD without SHA overrides fails closed; PR-style merge commit derives its own range.
- `tests/scripts/test_shell_scripts.py`: RELEASE_BUMP semantics for `resolve-pipeline-relevance.sh` (skips only on PRs, only on exact `"true"`, outranks drift guard, docs-only reason preserved).
- `tests/unit/test_workflow_wiring.py`: bump step env wiring (identity via env, never interpolated), RELEASE_BUMP handoff, `skip-reason` output, and skip-log steps on all three heavy jobs.
- Manually ran the classifier against real history: bump commit `a91ea5b4` (#1356) → true; dependency-pin commit `c4265089` with spoofed identity → false.
- `uv run pytest tests/scripts tests/unit/test_workflow_wiring.py` → 312 passed; `uv run lintro chk` clean on all changed files.

Refs #1362 (closes), epic #1357.

Closes #1362
