### PR TITLE
refactor(ci): invert docker-ci path filter to deny-by-default skip-list with drift test

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -13,9 +13,19 @@ name: CI - Docker
 # on.<event>.paths filter would leave those contexts absent and deadlock
 # merges (see codeql.yml and lgtm-ci docs/workflow-contract.md,
 # "Required-check-safe conditional workflows"). Instead the `changes` job
-# maps changed paths to the `pipeline` filter and the heavy jobs early-exit
-# green when only docs changed. merge_group, push, and workflow_dispatch
-# always run the full pipeline.
+# classifies the PR diff and the heavy jobs early-exit green when only
+# docs changed. merge_group, push, and workflow_dispatch always run the
+# full pipeline.
+#
+# Deny-by-default classification (#1369): pipeline relevance is decided by
+# scripts/ci/resolve-pipeline-relevance.sh from the PR's changed-file list
+# against a small skip-list ('**/*.md', 'docs/**', 'assets/**', with
+# 'test_samples/**' and 'docs/.markdownlint-cli2.jsonc' carved out as
+# pipeline-relevant) — pipeline=false only when EVERY changed file is
+# skippable. There is no allow-list of relevant paths to rot: new
+# top-level directories, configs, and file types trigger the pipeline by
+# default, and the skip-list only grows deliberately (drift test in
+# tests/unit/test_workflow_wiring.py).
 #
 # Version-bump PRs (#1362): the `changes` job also classifies automated
 # release version-bump PRs (release-version-pr.yml) via
@@ -60,13 +70,14 @@ env:
 jobs:
   # Required-check-safe replacement for on.<event>.paths (see header
   # comment). Only pull_request events are filtered; every other event
-  # resolves pipeline=true. Every layer fails open so a filter
+  # resolves pipeline=true. Every layer fails open so a classification
   # infrastructure failure runs the full pipeline rather than silently
-  # skipping it: detect-changes reports all filters true when the diff base
-  # is unresolvable, resolve-pipeline-relevance.sh resolves true on
-  # missing/unparsable JSON, and downstream gates compare != 'false' with
-  # !cancelled() so a failed changes job (empty output) still runs
-  # everything. Only an explicit pipeline == 'false' skips work.
+  # skipping it: resolve-pipeline-relevance.sh resolves pipeline=true when
+  # the changed-file list is unavailable (non-merge HEAD, failed diff),
+  # detect-changes reports all filters true when the diff base is
+  # unresolvable (lint-scope then stays full), and downstream gates compare
+  # != 'false' with !cancelled() so a failed changes job (empty output)
+  # still runs everything. Only an explicit pipeline == 'false' skips work.
   changes:
     name: 🔎 Detect Relevant Changes
     runs-on: ubuntu-24.04
@@ -102,105 +113,28 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: lgtm-hq/lgtm-ci/.github/actions/detect-changes@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
         with:
-          # Everything that can affect the image, the integration tests, or
-          # dogfooding lint behavior. Err broad: a missed path here is a
-          # silent coverage hole. Only pure docs (*.md, docs/, assets/) may
-          # skip; test_samples/ holds lint fixtures (including *.md) that
-          # feed the integration tests, and docs/.markdownlint-cli2.jsonc
-          # is lint config, so both stay in the filter via the directory
-          # and root-glob rules below.
+          # Pipeline relevance is NOT decided here (#1369): the resolve
+          # step below computes it deny-by-default from the changed-file
+          # list, so there is no allow-list of relevant paths to rot. This
+          # filter only feeds the lint-scope decision.
+          #
+          # full-lint stays an allow-list deliberately: its rot direction
+          # is soft. A missed global-impact path degrades to changed-files
+          # lint — the PR's own files are still linted with the identical
+          # tool set, and dogfood-nightly.yml runs the full repo as a
+          # backstop — whereas inverting it would require enumerating every
+          # "no global lint impact" leaf path, a larger and less stable
+          # list than this one.
           filters: |
-            pipeline:
-              - 'lintro/**'
-              - 'tests/**'
-              - 'test_samples/**'
-              - 'scripts/**'
-              - 'benchmarks/**'
-              - 'apps/**'
-              - 'npm/**'
-              - 'tools/**'
-              - '.github/**'
-              - '.allstar/**'
-              - 'Dockerfile'
-              - 'docker/**'
-              - 'docker-compose.yml'
-              - '.dockerignore'
-              - 'pyproject.toml'
-              - 'uv.lock'
-              - 'pytest.ini'
-              - 'tox.ini'
-              - 'Makefile'
-              - 'MANIFEST.in'
-              - 'LICENSE'
-              - 'package.json'
-              - 'bun.lock'
-              - '.node-version'
-              - '.actrc'
-              - '.codecov.yml'
-              - '.gitattributes'
-              - '.gitignore'
-              - '.gitleaks.toml'
-              - '.hadolint.yaml'
-              - '.lintro-config.yaml'
-              - '.lintro-ignore'
-              - '.markdownlint-cli2.jsonc'
-              - '.osv-scanner.toml'
-              - '.oxfmtrc.json'
-              - '.pre-commit-hooks.yaml'
-              - '.prettierignore'
-              - '.prettierrc.json'
-              - '.yamllint'
-              - 'renovate.json'
-              - 'socket.yml'
-              - 'docs/.markdownlint-cli2.jsonc'
-              # Catch-alls: ANY new root-level file except pure markdown
-              # triggers the full pipeline by default ('!(*.md)' is a
-              # picomatch extglob matching every root-level filename —
-              # dotfiles included, dorny sets dot:true — that does not end
-              # in .md; it has no slash so it never crosses directories).
-              # The extension globs are defense-in-depth should extglob
-              # handling ever regress upstream.
-              - '!(*.md)'
-              - '.*'
-              - '*.toml'
-              - '*.yaml'
-              - '*.yml'
-              - '*.json'
-              - '*.jsonc'
-              - '*.lock'
-              - '*.ini'
-              - '*.cfg'
-              - '*.py'
-              - '*.sh'
-              - '*.mjs'
-              - '*.cjs'
-              - '*.js'
-              - '*.ts'
-              # Nested manifests/lockfiles/tool configs at any depth: keep
-              # in lockstep with the full-lint globs below so a path can
-              # never be full-lint-relevant while pipeline-skipped
-              # (resolve-pipeline-relevance.sh enforces the same invariant
-              # as a runtime fail-safe).
-              - '**/pyproject.toml'
-              - '**/package.json'
-              - '**/tsconfig.json'
-              - '**/tsconfig.*.json'
-              - '**/*.lock'
-              - '**/package-lock.json'
-              - '**/pnpm-lock.yaml'
-              - '**/yarn.lock'
-              - '**/bun.lockb'
-              - '**/ruff.toml'
-              - '**/setup.cfg'
-              - '**/tox.ini'
-              - '**/pytest.ini'
-              - '**/Dockerfile*'
             # Paths with GLOBAL lint impact (#1361): touching any of these
             # forces full-repo dogfooding lint on the PR; PRs that miss this
             # filter lint only their changed files. Err broad — when in
             # doubt whether a path can change lint results elsewhere, it
             # belongs here. Leaf content (tests/, test_samples/, docs
             # prose, app/npm/tool sources) is covered by changed-files mode.
+            # A full-lint hit can never be pipeline-skipped:
+            # resolve-pipeline-relevance.sh forces pipeline=true when this
+            # filter matches a diff whose files were all skippable.
             full-lint:
               # The linter itself: behavior changes affect every file.
               - 'lintro/**'
@@ -269,6 +203,11 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
         run: scripts/ci/release-bump-only.sh
       - name: Resolve pipeline relevance
+        # Deny-by-default (#1369): the script derives the PR's changed-file
+        # list from the merge-commit checkout (HEAD^1..HEAD; requires the
+        # fetch-depth: 0 checkout above) and resolves pipeline=false only
+        # when every file matches the skip-list. CHANGES_JSON feeds the
+        # lint-scope decision only.
         id: result
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -327,7 +266,7 @@ jobs:
     name: 🐳 Build Docker Images
     # Required check (org ruleset checks-py-lintro): the job itself always
     # runs so the context reports; heavy steps are gated on the `pipeline`
-    # filter and the job early-exits green on docs-only PRs. !cancelled()
+    # output and the job early-exits green on docs-only PRs. !cancelled()
     # keeps it running (fail-open, full build) if the changes job failed —
     # the pipeline output is then empty, which is != 'false' at every step.
     needs: [changes]
@@ -752,7 +691,7 @@ jobs:
     name: 🔐 Security Audit
     # Required check: runs whenever docker-build reported success (real or
     # docs-only early-exit) so the context reports; heavy steps are gated on
-    # the `pipeline` filter. !cancelled() keeps it running (fail-open) if
+    # the `pipeline` output. !cancelled() keeps it running (fail-open) if
     # the changes job failed.
     needs: [changes, docker-build]
     if: >-
@@ -841,7 +780,7 @@ jobs:
     name: 🧪 Docker Integration Tests
     # Required check: runs whenever docker-build reported success (real or
     # docs-only early-exit) so the context reports; heavy steps are gated on
-    # the `pipeline` filter. !cancelled() keeps it running (fail-open) if
+    # the `pipeline` output. !cancelled() keeps it running (fail-open) if
     # the changes job failed.
     needs: [changes, docker-build]
     if: >-

--- a/scripts/ci/resolve-pipeline-relevance.sh
+++ b/scripts/ci/resolve-pipeline-relevance.sh
@@ -9,27 +9,52 @@ set -euo pipefail
 # GITHUB_OUTPUT for downstream job and step conditions.
 #
 # Non-pull_request events (push, merge_group, workflow_dispatch) always run
-# the full pipeline with full-repo lint. pull_request events consult the JSON
-# produced by the lgtm-hq/lgtm-ci detect-changes action (filter name ->
-# boolean). Missing or unparsable JSON fails open (pipeline=true,
-# lint-scope=full) so required checks run their full jobs instead of silently
-# early-exiting.
+# the full pipeline with full-repo lint.
 #
-# lint-scope resolves `changed` only when the PR diff explicitly missed the
-# `full-lint` filter (no path with global lint impact was touched); every
-# other case — non-PR events, filter hit, missing filter, unparsable JSON —
-# resolves `full` so a filter regression can never narrow lint coverage.
+# Pipeline classification is deny-by-default (#1369): instead of enumerating
+# every pipeline-relevant path (an allow-list that rots as the repo grows),
+# the script enumerates the small, stable set of paths that may SKIP the
+# pipeline and resolves pipeline=false only when EVERY changed file matches
+# that skip-list:
+#
+#   - '**/*.md'   pure markdown prose at any depth
+#   - 'docs/**'   documentation tree
+#   - 'assets/**' images and static assets
+#
+# with two carve-outs that stay pipeline-RELEVANT despite matching the
+# globs above (they feed the integration tests / lint config):
+#
+#   - 'test_samples/**'              lint fixtures, including *.md samples
+#   - 'docs/.markdownlint-cli2.jsonc' markdownlint config living under docs/
+#
+# Any changed file outside the skip-list — including files in brand-new
+# top-level directories — runs the full pipeline. New paths trigger by
+# default; the skip-list only grows deliberately (guarded by the drift test
+# in tests/unit/test_workflow_wiring.py).
+#
+# The changed-file list is derived from the PR merge commit (HEAD^1..HEAD,
+# same technique as release-bump-only.sh); BASE_SHA/HEAD_SHA override the
+# range (tests). A non-merge HEAD, a failed diff, or an empty diff fails
+# open (pipeline=true) so required checks run their full jobs instead of
+# silently early-exiting.
+#
+# lint-scope consults the JSON produced by the lgtm-hq/lgtm-ci detect-changes
+# action (filter name -> boolean) and resolves `changed` only when the PR
+# diff explicitly missed the `full-lint` filter (no path with global lint
+# impact was touched); every other case — non-PR events, filter hit, missing
+# filter, unparsable JSON — resolves `full` so a filter regression can never
+# narrow lint coverage.
 #
 # RELEASE_BUMP (#1362): when release-bump-only.sh verified the PR as an
 # automated version-bump PR (diff limited to the version stamp + CHANGELOG),
-# the pipeline is skipped even though pyproject.toml hits both the pipeline
-# and full-lint filters — the diff allowlist is a stronger guarantee than
-# the path filters, so this override intentionally outranks the full-lint
+# the pipeline is skipped even though pyproject.toml/uv.lock miss the
+# skip-list — the diff allowlist is a stronger guarantee than the path
+# classification, so this override intentionally outranks the full-lint
 # drift guard below. Only the exact string "true" skips; anything else
 # (empty, "false", garbage, a failed bump step) keeps the resolved value.
 #
 # Usage:
-#   EVENT_NAME=<event> CHANGES_JSON='{"pipeline":true,"full-lint":false}' \
+#   EVENT_NAME=<event> CHANGES_JSON='{"full-lint":false}' \
 #     RELEASE_BUMP=false scripts/ci/resolve-pipeline-relevance.sh
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
@@ -37,25 +62,33 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Resolve heavy-pipeline path relevance for GitHub Actions.
 
 Usage:
-  EVENT_NAME=<event> CHANGES_JSON='{"pipeline":true,"full-lint":false}' \
+  EVENT_NAME=<event> CHANGES_JSON='{"full-lint":false}' \
     RELEASE_BUMP=false scripts/ci/resolve-pipeline-relevance.sh
 
 Environment:
   EVENT_NAME    github.event_name
   CHANGES_JSON  detect-changes `changes` output (JSON filter -> boolean);
-                only consulted when EVENT_NAME is pull_request
+                only the `full-lint` filter is consulted, and only when
+                EVENT_NAME is pull_request
   RELEASE_BUMP  release-bump-only.sh verdict; the exact string "true" on a
                 pull_request skips the pipeline (verified version-bump PR,
                 #1362), anything else keeps the resolved value
+  BASE_SHA      Diff base override (default: HEAD^1 of the PR merge ref)
+  HEAD_SHA      Diff head override (default: HEAD)
 
 Behavior:
   - Non-pull_request events always resolve pipeline=true (merge_group and
     push runs never path-skip) and lint-scope=full.
-  - pull_request events resolve the `pipeline` filter from CHANGES_JSON.
+  - pull_request events resolve pipeline=false only when EVERY changed
+    file matches the skip-list ('**/*.md', 'docs/**', 'assets/**') and
+    none hits a carve-out ('test_samples/**',
+    'docs/.markdownlint-cli2.jsonc'). Anything else — new directories,
+    new configs, new file types — resolves pipeline=true (deny-by-default,
+    #1369).
   - pull_request events resolve lint-scope=changed only when the
     `full-lint` filter is explicitly false; anything else resolves full.
-  - Missing or unparsable CHANGES_JSON fails open (pipeline=true,
-    lint-scope=full).
+  - An unavailable or empty changed-file list and missing or unparsable
+    CHANGES_JSON fail open (pipeline=true, lint-scope=full).
   - RELEASE_BUMP=true on a pull_request forces pipeline=false with
     skip-reason "version-bump PR", outranking the full-lint drift guard.
 
@@ -74,30 +107,65 @@ pipeline="true"
 lint_scope="full"
 skip_reason=""
 
+# The deny-by-default skip-list (#1369). A changed file may skip the
+# pipeline only when this function returns 0. Keep the carve-outs first:
+# they are pipeline-RELEVANT paths that would otherwise match the skip
+# globs. The drift test in tests/unit/test_workflow_wiring.py asserts these
+# literals stay in sync with the top-level categorization.
+is_skippable_path() {
+	local path="$1"
+	case "$path" in
+	# Carve-outs (pipeline-relevant despite matching the globs below):
+	# test_samples/ holds lint fixtures (including *.md) feeding the
+	# integration tests; docs/.markdownlint-cli2.jsonc is lint config.
+	test_samples/*) return 1 ;;
+	docs/.markdownlint-cli2.jsonc) return 1 ;;
+	# Skip-list: pure prose and static assets.
+	*.md) return 0 ;;
+	docs/*) return 0 ;;
+	assets/*) return 0 ;;
+	esac
+	return 1
+}
+
+# Print the PR's changed files (one per line). BASE_SHA/HEAD_SHA override;
+# otherwise derive from the pull_request merge ref: its first parent is the
+# base branch tip, so HEAD^1..HEAD is exactly the change the merge would
+# land. A non-merge HEAD returns nonzero so the caller fails open.
+resolve_changed_files() {
+	local base="${BASE_SHA:-}"
+	local head="${HEAD_SHA:-}"
+	if [[ -z "$base" || -z "$head" ]]; then
+		if ! git rev-parse --verify --quiet 'HEAD^2' >/dev/null 2>&1; then
+			return 1
+		fi
+		base="$(git rev-parse 'HEAD^1')"
+		head="$(git rev-parse HEAD)"
+	fi
+	git diff --name-only "$base" "$head"
+}
+
 if [[ "$event_name" == "pull_request" ]]; then
-	# Plain -r (not -e): jq -e exits nonzero for a legitimate false value.
-	if resolved="$(jq -r '.pipeline' <<<"$changes_json" 2>/dev/null)"; then
-		case "$resolved" in
-		true)
-			pipeline="true"
-			;;
-		false)
-			pipeline="false"
-			;;
-		*)
-			echo "::warning::Unexpected pipeline filter value" \
-				"'${resolved}'; failing open (pipeline=true)"
-			pipeline="true"
-			;;
-		esac
+	# Deny-by-default (#1369): assume relevant, prove every changed file
+	# skippable. An unavailable or empty diff fails open (pipeline=true).
+	if changed_files="$(resolve_changed_files 2>/dev/null)" &&
+		[[ -n "$changed_files" ]]; then
+		pipeline="false"
+		while IFS= read -r changed_file; do
+			if ! is_skippable_path "$changed_file"; then
+				pipeline="true"
+				break
+			fi
+		done <<<"$changed_files"
 	else
-		echo "::warning::detect-changes JSON missing or unparsable;" \
-			"failing open (pipeline=true)"
+		echo "::warning::changed-file list unavailable (non-merge HEAD," \
+			"failed or empty diff); failing open (pipeline=true)"
 		pipeline="true"
 	fi
 	# lint-scope narrows to `changed` only on an explicit full-lint=false;
 	# true, missing, or unparsable all keep full-repo lint (fail-safe: a
 	# filter regression widens coverage, never narrows it).
+	# Plain -r (not -e): jq -e exits nonzero for a legitimate false value.
 	if resolved_full_lint="$(
 		jq -r '."full-lint"' <<<"$changes_json" 2>/dev/null
 	)"; then
@@ -105,21 +173,22 @@ if [[ "$event_name" == "pull_request" ]]; then
 			lint_scope="changed"
 		elif [[ "$resolved_full_lint" == "true" && "$pipeline" == "false" ]]; then
 			# Invariant guard: a path with global lint impact must never be
-			# pipeline-skipped. The filter lists are kept in lockstep, but if
-			# they ever drift, run the full pipeline rather than skipping the
-			# dogfooding lint of a full-lint-relevant change.
-			echo "::warning::full-lint filter matched while pipeline did" \
-				"not; forcing pipeline=true (filter lists drifted)"
+			# pipeline-skipped. The skip-list is deliberately tiny, but a
+			# full-lint-relevant file can still hide inside it (e.g. a new
+			# dotfile config under docs/) — run the full pipeline rather
+			# than skipping the dogfooding lint of a global-impact change.
+			echo "::warning::full-lint filter matched while every changed" \
+				"file was skippable; forcing pipeline=true"
 			pipeline="true"
 		fi
 	fi
 
 	# Verified version-bump PR (#1362): skip the heavy pipeline. This
 	# override intentionally outranks the drift guard above — the bump PR
-	# always hits the pipeline and full-lint filters via pyproject.toml,
-	# but the diff allowlist in release-bump-only.sh has already proven
-	# the change is version-stamp-only. Fail-safe: only the exact string
-	# "true" (a completed, positive verdict) skips.
+	# always resolves pipeline=true via pyproject.toml/uv.lock, but the
+	# diff allowlist in release-bump-only.sh has already proven the change
+	# is version-stamp-only. Fail-safe: only the exact string "true" (a
+	# completed, positive verdict) skips.
 	if [[ "$release_bump" == "true" ]]; then
 		pipeline="false"
 		echo "::notice::skipped: version-bump PR (diff limited to" \

--- a/scripts/ci/resolve-pipeline-relevance.sh
+++ b/scripts/ci/resolve-pipeline-relevance.sh
@@ -132,6 +132,11 @@ is_skippable_path() {
 # otherwise derive from the pull_request merge ref: its first parent is the
 # base branch tip, so HEAD^1..HEAD is exactly the change the merge would
 # land. A non-merge HEAD returns nonzero so the caller fails open.
+# --no-renames: rename detection would collapse a rename to its destination
+# path only, so moving a pipeline-relevant file into a skippable location
+# (e.g. lintro/core.py -> docs/core.py) could classify as docs-only; with
+# renames disabled both the deleted source and the added destination are
+# listed and the source keeps the pipeline on.
 resolve_changed_files() {
 	local base="${BASE_SHA:-}"
 	local head="${HEAD_SHA:-}"
@@ -142,7 +147,7 @@ resolve_changed_files() {
 		base="$(git rev-parse 'HEAD^1')"
 		head="$(git rev-parse HEAD)"
 	fi
-	git diff --name-only "$base" "$head"
+	git diff --name-only --no-renames "$base" "$head"
 }
 
 if [[ "$event_name" == "pull_request" ]]; then

--- a/tests/scripts/test_shell_scripts.py
+++ b/tests/scripts/test_shell_scripts.py
@@ -7,34 +7,135 @@ have correct syntax, and provide appropriate help/usage information.
 import subprocess  # nosec B404 - subprocess is used to drive the tool/CLI under test; invocations use shell=False
 from pathlib import Path
 
+import pytest
 from assertpy import assert_that
+
+RESOLVE_SCRIPT_PATH = Path("scripts/ci/resolve-pipeline-relevance.sh").resolve()
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run a git command inside a fixture repository.
+
+    Args:
+        repo: Repository working directory.
+        *args: git subcommand and arguments.
+
+    Returns:
+        str: Captured stdout, stripped.
+    """
+    result = (
+        subprocess.run(  # nosec B603 B607 - fixed git argv in a test-owned temp repo
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            check=True,
+            env={
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+                "GIT_AUTHOR_NAME": "t",
+                "GIT_AUTHOR_EMAIL": "t@example.invalid",
+                "GIT_COMMITTER_NAME": "t",
+                "GIT_COMMITTER_EMAIL": "t@example.invalid",
+                "HOME": str(repo),
+            },
+        )
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def diff_repo(tmp_path: Path) -> Path:
+    """Create a git repo with a seed base commit for diff classification.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+
+    Returns:
+        Path: The repository working directory.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "seed.txt").write_text("seed\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+    return repo
+
+
+def _commit_paths(repo: Path, paths: list[str]) -> tuple[str, str]:
+    """Write and commit the given paths, returning the (base, head) SHAs.
+
+    Args:
+        repo: Repository with a clean base commit.
+        paths: Repository-relative file paths to create/modify.
+
+    Returns:
+        tuple[str, str]: (base SHA before the commit, head SHA after).
+    """
+    base = _git(repo, "rev-parse", "HEAD")
+    for path in paths:
+        target = repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"content of {path}\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "head")
+    head = _git(repo, "rev-parse", "HEAD")
+    return base, head
 
 
 def _run_resolve_pipeline_relevance(
     env: dict[str, str],
     output_file: Path,
+    cwd: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run resolve-pipeline-relevance.sh with a GITHUB_OUTPUT file.
 
     Args:
-        env: EVENT_NAME/CHANGES_JSON environment for the script.
+        env: EVENT_NAME/CHANGES_JSON/SHA environment for the script.
         output_file: File to expose as GITHUB_OUTPUT.
+        cwd: Working directory for the run (a fixture git repo when the
+            deny-by-default diff classification is under test).
 
     Returns:
         subprocess.CompletedProcess[str]: The completed script run.
     """
-    script_path = Path("scripts/ci/resolve-pipeline-relevance.sh").resolve()
     return subprocess.run(  # nosec B603 - fixed argv run against a real binary in a controlled test; shell=False, no user shell input
-        [str(script_path)],
+        [str(RESOLVE_SCRIPT_PATH)],
         capture_output=True,
         text=True,
         check=False,
+        cwd=cwd,
         env={
             "PATH": "/usr/bin:/bin:/usr/local/bin",
             "GITHUB_OUTPUT": str(output_file),
             **env,
         },
     )
+
+
+def _classify_paths(
+    diff_repo: Path,
+    tmp_path: Path,
+    paths: list[str],
+    env_overrides: dict[str, str] | None = None,
+) -> tuple[list[str], str]:
+    """Classify a synthetic PR diff touching only the given paths.
+
+    Args:
+        diff_repo: Fixture repository with a seed base commit.
+        tmp_path: Pytest-provided temporary directory.
+        paths: Changed paths making up the PR diff.
+        env_overrides: Extra/overriding script environment entries.
+
+    Returns:
+        tuple[list[str], str]: (GITHUB_OUTPUT lines, stdout+stderr).
+    """
+    base, head = _commit_paths(diff_repo, paths)
+    output_file = tmp_path / "github-output"
+    env = {"EVENT_NAME": "pull_request", "BASE_SHA": base, "HEAD_SHA": head}
+    env.update(env_overrides or {})
+    result = _run_resolve_pipeline_relevance(env, output_file, cwd=diff_repo)
+    assert_that(result.returncode).is_equal_to(0)
+    return output_file.read_text().splitlines(), result.stdout + result.stderr
 
 
 def test_detect_changes_help() -> None:
@@ -51,9 +152,8 @@ def test_detect_changes_help() -> None:
 
 def test_resolve_pipeline_relevance_help() -> None:
     """resolve-pipeline-relevance.sh should provide help and exit 0."""
-    script_path = Path("scripts/ci/resolve-pipeline-relevance.sh").resolve()
     result = subprocess.run(  # nosec B603 - fixed argv run against a real binary in a controlled test; shell=False, no user shell input
-        [str(script_path), "--help"],
+        [str(RESOLVE_SCRIPT_PATH), "--help"],
         capture_output=True,
         text=True,
         check=False,
@@ -62,44 +162,158 @@ def test_resolve_pipeline_relevance_help() -> None:
     assert_that(result.stdout).contains("Usage:")
 
 
-def test_resolve_pipeline_relevance_outputs(tmp_path: Path) -> None:
-    """resolve-pipeline-relevance.sh should resolve pipeline per event/JSON.
+def test_resolve_pipeline_relevance_non_pr_events_never_skip(
+    tmp_path: Path,
+) -> None:
+    """merge_group, push, and dispatch always resolve pipeline=true.
 
     Args:
         tmp_path: Pytest-provided temporary directory.
     """
-    cases: list[tuple[dict[str, str], str]] = [
-        # merge_group and push never path-skip.
-        ({"EVENT_NAME": "merge_group"}, "pipeline=true"),
-        ({"EVENT_NAME": "push"}, "pipeline=true"),
-        # pull_request honors the detect-changes filter value.
-        (
-            {"EVENT_NAME": "pull_request", "CHANGES_JSON": '{"pipeline":true}'},
-            "pipeline=true",
-        ),
-        (
-            {"EVENT_NAME": "pull_request", "CHANGES_JSON": '{"pipeline":false}'},
-            "pipeline=false",
-        ),
-        # Missing or unparsable JSON fails open.
-        ({"EVENT_NAME": "pull_request", "CHANGES_JSON": ""}, "pipeline=true"),
-        ({"EVENT_NAME": "pull_request", "CHANGES_JSON": "not json"}, "pipeline=true"),
-        ({"EVENT_NAME": "pull_request", "CHANGES_JSON": "{}"}, "pipeline=true"),
-        # Invariant guard: full-lint relevance forces the pipeline on even
-        # if the pipeline filter missed (filter lists drifted).
-        (
-            {
-                "EVENT_NAME": "pull_request",
-                "CHANGES_JSON": '{"pipeline":false,"full-lint":true}',
-            },
-            "pipeline=true",
-        ),
-    ]
-    for index, (env, expected) in enumerate(cases):
+    for index, event in enumerate(("merge_group", "push", "workflow_dispatch")):
         output_file = tmp_path / f"github-output-{index}"
-        result = _run_resolve_pipeline_relevance(env, output_file)
+        result = _run_resolve_pipeline_relevance(
+            {"EVENT_NAME": event},
+            output_file,
+            cwd=tmp_path,
+        )
         assert_that(result.returncode).is_equal_to(0)
-        assert_that(output_file.read_text().splitlines()).contains(expected)
+        lines = output_file.read_text().splitlines()
+        assert_that(lines).contains("pipeline=true")
+        assert_that(lines).contains("lint-scope=full")
+
+
+@pytest.mark.parametrize(
+    ("paths", "expected"),
+    [
+        # Skip-list: pure prose and assets resolve pipeline=false.
+        (["README.md"], "pipeline=false"),
+        (["docs/guide.md"], "pipeline=false"),
+        (["docs/tutorial/example.py"], "pipeline=false"),
+        (["assets/logo.svg"], "pipeline=false"),
+        (["README.md", "docs/guide.md", "assets/logo.svg"], "pipeline=false"),
+        # Markdown at any depth is prose, wherever it lives.
+        (["lintro/README.md"], "pipeline=false"),
+        # Any file outside the skip-list runs the pipeline.
+        (["lintro/core.py"], "pipeline=true"),
+        # A single relevant file poisons an otherwise skippable diff.
+        (["README.md", "docs/guide.md", "lintro/core.py"], "pipeline=true"),
+        # Deny-by-default (#1369): brand-new top-level directories and root
+        # files trigger without anyone extending an allow-list.
+        (["new_build_system/build.gradle"], "pipeline=true"),
+        (["justfile"], "pipeline=true"),
+        (["infra/terraform/main.tf"], "pipeline=true"),
+        # Carve-outs: lint fixtures and lint config that match the skip
+        # globs but feed the integration tests / lint behavior.
+        (["test_samples/sample.md"], "pipeline=true"),
+        (["test_samples/violations.py"], "pipeline=true"),
+        (["docs/.markdownlint-cli2.jsonc"], "pipeline=true"),
+    ],
+)
+def test_resolve_pipeline_relevance_deny_by_default(
+    diff_repo: Path,
+    tmp_path: Path,
+    paths: list[str],
+    expected: str,
+) -> None:
+    """pipeline=false only when EVERY changed file matches the skip-list.
+
+    Args:
+        diff_repo: Fixture repository with a seed base commit.
+        tmp_path: Pytest-provided temporary directory.
+        paths: Changed paths making up the PR diff.
+        expected: Expected pipeline output line.
+    """
+    lines, _ = _classify_paths(diff_repo, tmp_path, paths)
+    assert_that(lines).contains(expected)
+    if expected == "pipeline=false":
+        assert_that(lines).contains("skip-reason=docs-only change")
+    else:
+        assert_that(lines).contains("skip-reason=")
+
+
+def test_resolve_pipeline_relevance_fails_open_without_diff(
+    tmp_path: Path,
+) -> None:
+    """An unavailable changed-file list fails open to pipeline=true.
+
+    Covers a non-repo working directory and a repo whose HEAD is not a PR
+    merge commit (no BASE_SHA/HEAD_SHA overrides in either case).
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    non_repo = tmp_path / "non-repo"
+    non_repo.mkdir()
+    plain_repo = tmp_path / "plain-repo"
+    plain_repo.mkdir()
+    _git(plain_repo, "init", "-q")
+    (plain_repo / "file.txt").write_text("x\n")
+    _git(plain_repo, "add", "-A")
+    _git(plain_repo, "commit", "-q", "-m", "single")
+    for index, cwd in enumerate((non_repo, plain_repo)):
+        output_file = tmp_path / f"github-output-{index}"
+        result = _run_resolve_pipeline_relevance(
+            {"EVENT_NAME": "pull_request"},
+            output_file,
+            cwd=cwd,
+        )
+        assert_that(result.returncode).is_equal_to(0)
+        assert_that(result.stdout).contains("failing open")
+        lines = output_file.read_text().splitlines()
+        assert_that(lines).contains("pipeline=true")
+        assert_that(lines).contains("skip-reason=")
+
+
+def test_resolve_pipeline_relevance_fails_open_on_empty_diff(
+    diff_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """An empty diff (BASE_SHA == HEAD_SHA) fails open to pipeline=true.
+
+    Args:
+        diff_repo: Fixture repository with a seed base commit.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    head = _git(diff_repo, "rev-parse", "HEAD")
+    output_file = tmp_path / "github-output"
+    result = _run_resolve_pipeline_relevance(
+        {"EVENT_NAME": "pull_request", "BASE_SHA": head, "HEAD_SHA": head},
+        output_file,
+        cwd=diff_repo,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("failing open")
+    assert_that(output_file.read_text().splitlines()).contains("pipeline=true")
+
+
+def test_resolve_pipeline_relevance_derives_range_from_merge_commit(
+    diff_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """Without SHA overrides, a PR-style merge commit supplies the range.
+
+    Args:
+        diff_repo: Fixture repository with a seed base commit.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    default_branch = _git(diff_repo, "rev-parse", "--abbrev-ref", "HEAD")
+    _git(diff_repo, "checkout", "-q", "-b", "docs-change")
+    (diff_repo / "README.md").write_text("# docs only\n")
+    _git(diff_repo, "add", "-A")
+    _git(diff_repo, "commit", "-q", "-m", "docs")
+    _git(diff_repo, "checkout", "-q", default_branch)
+    _git(diff_repo, "merge", "-q", "--no-ff", "-m", "merge", "docs-change")
+    output_file = tmp_path / "github-output"
+    result = _run_resolve_pipeline_relevance(
+        {"EVENT_NAME": "pull_request"},
+        output_file,
+        cwd=diff_repo,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    lines = output_file.read_text().splitlines()
+    assert_that(lines).contains("pipeline=false")
+    assert_that(lines).contains("skip-reason=docs-only change")
 
 
 def test_resolve_pipeline_relevance_lint_scope(tmp_path: Path) -> None:
@@ -107,7 +321,8 @@ def test_resolve_pipeline_relevance_lint_scope(tmp_path: Path) -> None:
 
     lint-scope narrows to `changed` only when a pull_request diff explicitly
     missed the `full-lint` filter; every other case (non-PR events, filter
-    hit, missing filter, unparsable JSON) stays full-repo.
+    hit, missing filter, unparsable JSON) stays full-repo. The PR cases run
+    outside a git repo so the pipeline half fails open independently.
 
     Args:
         tmp_path: Pytest-provided temporary directory.
@@ -121,22 +336,18 @@ def test_resolve_pipeline_relevance_lint_scope(tmp_path: Path) -> None:
         (
             {
                 "EVENT_NAME": "pull_request",
-                "CHANGES_JSON": '{"pipeline":true,"full-lint":false}',
+                "CHANGES_JSON": '{"full-lint":false}',
             },
             "lint-scope=changed",
         ),
         (
             {
                 "EVENT_NAME": "pull_request",
-                "CHANGES_JSON": '{"pipeline":true,"full-lint":true}',
+                "CHANGES_JSON": '{"full-lint":true}',
             },
             "lint-scope=full",
         ),
         # Missing filter, empty, or unparsable JSON fail safe to full.
-        (
-            {"EVENT_NAME": "pull_request", "CHANGES_JSON": '{"pipeline":true}'},
-            "lint-scope=full",
-        ),
         ({"EVENT_NAME": "pull_request", "CHANGES_JSON": ""}, "lint-scope=full"),
         (
             {"EVENT_NAME": "pull_request", "CHANGES_JSON": "not json"},
@@ -146,73 +357,95 @@ def test_resolve_pipeline_relevance_lint_scope(tmp_path: Path) -> None:
     ]
     for index, (env, expected) in enumerate(cases):
         output_file = tmp_path / f"github-output-{index}"
-        result = _run_resolve_pipeline_relevance(env, output_file)
+        result = _run_resolve_pipeline_relevance(env, output_file, cwd=tmp_path)
         assert_that(result.returncode).is_equal_to(0)
         assert_that(output_file.read_text().splitlines()).contains(expected)
 
 
-def test_resolve_pipeline_relevance_release_bump(tmp_path: Path) -> None:
-    """RELEASE_BUMP=true skips the pipeline on pull_request events (#1362).
+def test_resolve_pipeline_relevance_full_lint_invariant_guard(
+    diff_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """A full-lint hit forces pipeline=true even on an all-skippable diff.
 
-    The override must outrank the full-lint drift guard (bump PRs always
-    hit both filters via pyproject.toml), apply only to pull_request
-    events, and only on the exact string "true".
+    A global-lint-impact file can hide inside the skip-list (e.g. a new
+    dotfile config under docs/); the runtime guard must run the full
+    pipeline rather than skipping the dogfooding lint of such a change.
 
     Args:
+        diff_repo: Fixture repository with a seed base commit.
         tmp_path: Pytest-provided temporary directory.
     """
-    cases: list[tuple[dict[str, str], list[str]]] = [
-        # Verified bump PR: skip even though both filters matched.
-        (
+    lines, log = _classify_paths(
+        diff_repo,
+        tmp_path,
+        ["docs/.prettierrc.json", "docs/guide.md"],
+        env_overrides={"CHANGES_JSON": '{"full-lint":true}'},
+    )
+    assert_that(lines).contains("pipeline=true")
+    assert_that(lines).contains("skip-reason=")
+    assert_that(log).contains("forcing pipeline=true")
+
+
+def test_resolve_pipeline_relevance_release_bump(
+    diff_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """RELEASE_BUMP=true skips the pipeline on pull_request events (#1362).
+
+    The override must outrank the deny-by-default classification and the
+    full-lint drift guard (bump PRs always resolve pipeline=true via
+    pyproject.toml/uv.lock), apply only to pull_request events, and only on
+    the exact string "true".
+
+    Args:
+        diff_repo: Fixture repository with a seed base commit.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    bump_paths = ["CHANGELOG.md", "pyproject.toml", "uv.lock"]
+    # Verified bump PR: skip even though the diff misses the skip-list.
+    lines, _ = _classify_paths(
+        diff_repo,
+        tmp_path,
+        bump_paths,
+        env_overrides={
+            "CHANGES_JSON": '{"full-lint":true}',
+            "RELEASE_BUMP": "true",
+        },
+    )
+    assert_that(lines).contains("pipeline=false")
+    assert_that(lines).contains("skip-reason=version-bump PR")
+    # Anything but the exact string "true" keeps the resolved value.
+    for index, verdict in enumerate(("false", "garbage", "")):
+        base = _git(diff_repo, "rev-parse", "HEAD^1")
+        head = _git(diff_repo, "rev-parse", "HEAD")
+        output_file = tmp_path / f"github-output-bump-{index}"
+        result = _run_resolve_pipeline_relevance(
             {
                 "EVENT_NAME": "pull_request",
-                "CHANGES_JSON": '{"pipeline":true,"full-lint":true}',
-                "RELEASE_BUMP": "true",
+                "BASE_SHA": base,
+                "HEAD_SHA": head,
+                "RELEASE_BUMP": verdict,
             },
-            ["pipeline=false", "skip-reason=version-bump PR"],
-        ),
-        # Non-PR events never skip, whatever RELEASE_BUMP claims.
-        (
-            {"EVENT_NAME": "push", "RELEASE_BUMP": "true"},
-            ["pipeline=true", "skip-reason="],
-        ),
-        (
-            {"EVENT_NAME": "merge_group", "RELEASE_BUMP": "true"},
-            ["pipeline=true", "skip-reason="],
-        ),
-        # Anything but the exact string "true" keeps the resolved value.
-        (
-            {
-                "EVENT_NAME": "pull_request",
-                "CHANGES_JSON": '{"pipeline":true,"full-lint":true}',
-                "RELEASE_BUMP": "false",
-            },
-            ["pipeline=true", "skip-reason="],
-        ),
-        (
-            {
-                "EVENT_NAME": "pull_request",
-                "CHANGES_JSON": '{"pipeline":true,"full-lint":true}',
-                "RELEASE_BUMP": "garbage",
-            },
-            ["pipeline=true", "skip-reason="],
-        ),
-        # Docs-only path keeps its own reason.
-        (
-            {
-                "EVENT_NAME": "pull_request",
-                "CHANGES_JSON": '{"pipeline":false,"full-lint":false}',
-            },
-            ["pipeline=false", "skip-reason=docs-only change"],
-        ),
-    ]
-    for index, (env, expected_lines) in enumerate(cases):
-        output_file = tmp_path / f"github-output-{index}"
-        result = _run_resolve_pipeline_relevance(env, output_file)
+            output_file,
+            cwd=diff_repo,
+        )
         assert_that(result.returncode).is_equal_to(0)
-        output_lines = output_file.read_text().splitlines()
-        for expected in expected_lines:
-            assert_that(output_lines).contains(expected)
+        lines = output_file.read_text().splitlines()
+        assert_that(lines).contains("pipeline=true")
+        assert_that(lines).contains("skip-reason=")
+    # Non-PR events never skip, whatever RELEASE_BUMP claims.
+    for index, event in enumerate(("push", "merge_group")):
+        output_file = tmp_path / f"github-output-event-{index}"
+        result = _run_resolve_pipeline_relevance(
+            {"EVENT_NAME": event, "RELEASE_BUMP": "true"},
+            output_file,
+            cwd=tmp_path,
+        )
+        assert_that(result.returncode).is_equal_to(0)
+        lines = output_file.read_text().splitlines()
+        assert_that(lines).contains("pipeline=true")
+        assert_that(lines).contains("skip-reason=")
 
 
 def test_renovate_regex_manager_current_value() -> None:

--- a/tests/scripts/test_shell_scripts.py
+++ b/tests/scripts/test_shell_scripts.py
@@ -232,6 +232,41 @@ def test_resolve_pipeline_relevance_deny_by_default(
         assert_that(lines).contains("skip-reason=")
 
 
+def test_resolve_pipeline_relevance_rename_into_skippable_path_triggers(
+    diff_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """Renaming a relevant file into the skip-list keeps the pipeline on.
+
+    git rename detection would report only the destination path
+    (docs/core.py), classifying the move as docs-only; the script must diff
+    with --no-renames so the deleted source path (lintro/core.py) is listed
+    and keeps the pipeline running.
+
+    Args:
+        diff_repo: Fixture repository with a seed base commit.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    source = diff_repo / "lintro" / "core.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("".join(f"line {i}\n" for i in range(50)))
+    _git(diff_repo, "add", "-A")
+    _git(diff_repo, "commit", "-q", "-m", "add module")
+    base = _git(diff_repo, "rev-parse", "HEAD")
+    (diff_repo / "docs").mkdir()
+    _git(diff_repo, "mv", "lintro/core.py", "docs/core.py")
+    _git(diff_repo, "commit", "-q", "-m", "move module under docs")
+    head = _git(diff_repo, "rev-parse", "HEAD")
+    output_file = tmp_path / "github-output"
+    result = _run_resolve_pipeline_relevance(
+        {"EVENT_NAME": "pull_request", "BASE_SHA": base, "HEAD_SHA": head},
+        output_file,
+        cwd=diff_repo,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(output_file.read_text().splitlines()).contains("pipeline=true")
+
+
 def test_resolve_pipeline_relevance_fails_open_without_diff(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import re
+import subprocess  # nosec B404 - subprocess runs fixed git argv against this repo
 from pathlib import Path
 from typing import Any, cast
 
@@ -697,6 +698,188 @@ def test_docker_ci_lintro_code_quality_wires_upstream_jobs() -> None:
             "|| needs.dogfooding-lint.outputs.status }}",
         ),
     )
+
+
+# --- Deny-by-default pipeline skip-list drift guard (#1369) ------------------
+#
+# docker-ci pipeline relevance is decided by
+# scripts/ci/resolve-pipeline-relevance.sh against a small skip-list instead
+# of an allow-list of relevant paths, so new top-level directories trigger
+# the pipeline by default. These tests make the categorization explicit:
+# every tracked top-level path must be listed as either skippable or
+# pipeline-relevant, and the skippable set must match the script's
+# skip-list, so a new top-level path fails CI loudly until a human
+# categorizes it (instead of silently under- or over-triggering).
+
+_RESOLVE_PIPELINE_SCRIPT = (
+    _REPO_ROOT / "scripts" / "ci" / "resolve-pipeline-relevance.sh"
+)
+
+# Top-level directories whose entire content may skip the heavy Docker
+# pipeline (pure prose/assets). Must stay in lockstep with the skip-list in
+# scripts/ci/resolve-pipeline-relevance.sh (is_skippable_path); a dedicated
+# test below enforces that. Root-level *.md files are skippable by the
+# script's '*.md' rule and need no listing here.
+_PIPELINE_SKIPPABLE_TOP_LEVEL: frozenset[str] = frozenset(
+    {
+        "assets",
+        "docs",  # except docs/.markdownlint-cli2.jsonc (script carve-out)
+    },
+)
+
+# Every other tracked top-level path: changes there run the full pipeline.
+# This list is documentation-as-test — the script does NOT consult it; any
+# path absent from the skip-list triggers by default. test_samples is
+# deliberately here despite holding *.md files: they are lint fixtures
+# feeding the integration tests (script carve-out).
+_PIPELINE_RELEVANT_TOP_LEVEL: frozenset[str] = frozenset(
+    {
+        ".actrc",
+        ".allstar",
+        ".codecov.yml",
+        ".dockerignore",
+        ".gitattributes",
+        ".github",
+        ".gitignore",
+        ".gitleaks.toml",
+        ".hadolint.yaml",
+        ".lintro-config.yaml",
+        ".lintro-ignore",
+        ".markdownlint-cli2.jsonc",
+        ".node-version",
+        ".osv-scanner.toml",
+        ".oxfmtrc.json",
+        ".pre-commit-hooks.yaml",
+        ".prettierignore",
+        ".prettierrc.json",
+        ".yamllint",
+        "apps",
+        "benchmarks",
+        "bun.lock",
+        "docker",
+        "docker-compose.yml",
+        "Dockerfile",
+        "LICENSE",
+        "lintro",
+        "Makefile",
+        "MANIFEST.in",
+        "npm",
+        "package.json",
+        "pyproject.toml",
+        "pytest.ini",
+        "renovate.json",
+        "scripts",
+        "socket.yml",
+        "test_samples",
+        "tests",
+        "tools",
+        "tox.ini",
+        "uv.lock",
+    },
+)
+
+
+def _tracked_top_level_paths() -> set[str]:
+    """Return the first path segment of every git-tracked file.
+
+    Returns:
+        set[str]: Top-level directory and file names under version control.
+    """
+    output = subprocess.run(  # nosec B603 B607 - fixed git argv against this repo
+        ["git", "-C", str(_REPO_ROOT), "ls-files"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return {line.split("/", 1)[0] for line in output.splitlines() if line}
+
+
+def test_every_top_level_path_is_categorized_for_pipeline_relevance() -> None:
+    """Every tracked top-level path is explicitly skippable or relevant.
+
+    Deny-by-default means an uncategorized path already triggers the
+    pipeline at runtime; this test exists so the categorization is a
+    conscious decision rather than an accident of the default.
+    """
+    top_level = _tracked_top_level_paths()
+    categorized = _PIPELINE_SKIPPABLE_TOP_LEVEL | _PIPELINE_RELEVANT_TOP_LEVEL
+    uncategorized = sorted(
+        path
+        for path in top_level
+        if path not in categorized and not path.endswith(".md")
+    )
+    assert_that(uncategorized).described_as(
+        "New top-level path(s) are not categorized for docker-ci pipeline "
+        "relevance (#1369). Add each one to _PIPELINE_RELEVANT_TOP_LEVEL in "
+        "tests/unit/test_workflow_wiring.py (the safe default: anything "
+        "that can affect the Docker image, the integration tests, or lint "
+        "behavior — it already triggers the pipeline automatically), or — "
+        "ONLY for pure prose/static assets — to _PIPELINE_SKIPPABLE_TOP_LEVEL "
+        "here AND to is_skippable_path in "
+        "scripts/ci/resolve-pipeline-relevance.sh",
+    ).is_empty()
+
+
+def test_pipeline_relevance_categories_are_disjoint() -> None:
+    """No top-level path may be both skippable and pipeline-relevant."""
+    overlap = _PIPELINE_SKIPPABLE_TOP_LEVEL & _PIPELINE_RELEVANT_TOP_LEVEL
+    assert_that(sorted(overlap)).is_empty()
+
+
+def test_skippable_categorization_matches_resolver_skip_list() -> None:
+    """The test's skippable set mirrors the script's actual skip-list.
+
+    Parses the ``is_skippable_path`` case arms out of
+    resolve-pipeline-relevance.sh: directory globs returning 0 must equal
+    _PIPELINE_SKIPPABLE_TOP_LEVEL, the '*.md' prose rule must be present,
+    and the pipeline-relevant carve-outs (test_samples/**,
+    docs/.markdownlint-cli2.jsonc) must return 1 and be categorized as
+    relevant here.
+    """
+    script = _RESOLVE_PIPELINE_SCRIPT.read_text(encoding="utf-8")
+
+    skip_dir_globs = set(re.findall(r"^\s*(\S+)/\*\)\s*return 0", script, re.M))
+    assert_that(skip_dir_globs).is_equal_to(set(_PIPELINE_SKIPPABLE_TOP_LEVEL))
+
+    skip_file_globs = re.findall(r"^\s*(\*\.\w+)\)\s*return 0", script, re.M)
+    assert_that(skip_file_globs).is_equal_to(["*.md"])
+
+    carve_outs = set(re.findall(r"^\s*(\S+)\)\s*return 1", script, re.M))
+    assert_that(carve_outs).is_equal_to(
+        {"test_samples/*", "docs/.markdownlint-cli2.jsonc"},
+    )
+    assert_that(_PIPELINE_RELEVANT_TOP_LEVEL).contains("test_samples")
+
+
+def test_docker_ci_detect_step_has_no_pipeline_allow_list() -> None:
+    """The detect-changes filter feeds lint-scope only, never pipeline.
+
+    Reintroducing a `pipeline:` dorny filter would resurrect the rotting
+    allow-list that #1369 removed; relevance must stay computed by
+    resolve-pipeline-relevance.sh from the changed-file list.
+    """
+    docker_ci = _load_workflow(name="docker-ci.yml")
+    changes_job = docker_ci["jobs"]["changes"]
+    steps = {step.get("id"): step for step in changes_job["steps"] if "id" in step}
+
+    detect_step = steps["detect"]
+    filters = detect_step["with"]["filters"]
+    filter_names = re.findall(r"^([^#\s][^:]*):\s*$", filters, re.M)
+    assert_that(filter_names).is_equal_to(["full-lint"])
+
+    resolve_step = steps["result"]
+    assert_that(resolve_step["run"]).is_equal_to(
+        "scripts/ci/resolve-pipeline-relevance.sh",
+    )
+    # The script diffs the merge commit (HEAD^1..HEAD): the changes job
+    # checkout must keep full history for that range to resolve.
+    checkout_steps = [
+        step
+        for step in changes_job["steps"]
+        if "actions/checkout" in step.get("uses", "")
+    ]
+    assert_that(checkout_steps).is_length(1)
+    assert_that(checkout_steps[0]["with"]["fetch-depth"]).is_equal_to(0)
 
 
 def test_publish_npm_exposes_dist_tag_for_backfills() -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(ci): invert docker-ci path filter to deny-by-default skip-list with drift test
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Hardens the #1363 docker-ci path filtering against long-term rot by inverting the classification (#1369, epic #1357):

- **Deny-by-default pipeline classification**: the long dorny allow-list of pipeline-relevant paths is gone. `scripts/ci/resolve-pipeline-relevance.sh` now derives the PR's changed-file list from the merge-commit checkout (`HEAD^1..HEAD`, same technique as `release-bump-only.sh`, with `BASE_SHA`/`HEAD_SHA` test overrides) and resolves `pipeline=false` only when **every** changed file matches the small skip-list:
  - `**/*.md` (prose at any depth), `docs/**`, `assets/**`
  - carve-outs that stay pipeline-**relevant** despite matching those globs: `test_samples/**` (lint fixtures feeding the integration tests) and `docs/.markdownlint-cli2.jsonc` (lint config)

  Any file outside the skip-list — including files in brand-new top-level directories, new root configs, new file types — runs the full pipeline. Silent under-triggering becomes structurally impossible instead of policed by memory.
- **`full-lint` filter deliberately NOT inverted** (decision documented in the workflow): its rot direction is soft — a missed global-impact path degrades to changed-files lint, where the PR's own files are still linted with the identical tool set, and `dogfood-nightly.yml` runs the full repo as a backstop. Inverting it would require enumerating every "no global lint impact" leaf path, a larger and less stable list than the current one. The detect-changes dorny step now carries only this filter.
- **Drift test** in `tests/unit/test_workflow_wiring.py`: every top-level path in `git ls-files` must be explicitly categorized as skippable or pipeline-relevant; the skippable set is asserted to match the script's `is_skippable_path` literals (parsed from the case arms, including the carve-outs); the dorny filter is asserted to never regrow a `pipeline:` allow-list; and the changes-job checkout must keep `fetch-depth: 0` for the merge-ref diff. An uncategorized new top-level directory fails CI with a message telling the developer exactly where to categorize it.

### Preserved behaviors

- Fail-open on classification errors: unavailable changed-file list (non-merge HEAD, failed/empty diff) resolves `pipeline=true`; missing/unparsable `CHANGES_JSON` keeps `lint-scope=full`; a failed changes job leaves outputs empty, which downstream `!= 'false'` gates treat as run-everything.
- Full runs on `push` / `merge_group` / `workflow_dispatch` (#1363).
- `lint-scope` full/changed semantics and the full-lint invariant guard (#1370) — a full-lint hit on an all-skippable diff still forces `pipeline=true` (e.g. a new dotfile config under `docs/`).
- `RELEASE_BUMP` nominate-then-verify override precedence and `skip-reason` output (#1371/#1362): verified bump PRs skip with `skip-reason=version-bump PR`, outranking the drift guard; only the exact string `true` skips.
- Required-check gate semantics (`docker-build`, `security-audit`, `integration-test`, `lintro-code-quality`) are untouched.

### Behavior delta (intentional)

Markdown files inside code directories (e.g. `lintro/README.md`, `.github/*.md`) previously triggered the pipeline via their directory's allow-list entry; under the skip-list they are prose and may skip (`.github/**` markdown still triggers in practice via the full-lint invariant guard). `test_samples/**` markdown keeps triggering via the carve-out.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1369
- Relates to #1357

## Details

**Drift-test behavior demo** — adding an uncategorized top-level directory (`frobnicator/config.toml`, tracked) fails:

```text
AssertionError: [New top-level path(s) are not categorized for docker-ci pipeline
relevance (#1369). Add each one to _PIPELINE_RELEVANT_TOP_LEVEL in
tests/unit/test_workflow_wiring.py (the safe default: anything that can affect the
Docker image, the integration tests, or lint behavior — it already triggers the
pipeline automatically), or — ONLY for pure prose/static assets — to
_PIPELINE_SKIPPABLE_TOP_LEVEL here AND to is_skippable_path in
scripts/ci/resolve-pipeline-relevance.sh] Expected <['frobnicator']> to be empty, but was not.
```

At runtime the same directory already resolves `pipeline=true` with no list change (deny-by-default), verified by `test_resolve_pipeline_relevance_deny_by_default` cases (`new_build_system/build.gradle`, `justfile`, `infra/terraform/main.tf`).

**Testing**: `tests/scripts/test_shell_scripts.py` rewritten to drive the script against synthetic git repos (skip-list matrix, carve-outs, mixed diffs, fail-open on non-merge HEAD / non-repo / empty diff, merge-commit range derivation, invariant guard, RELEASE_BUMP precedence). Full runs: `tests/unit` 5768 passed / 7 skipped; `tests/scripts` + wiring 334 passed; `uv run lintro chk` clean on all four changed files.
