### PR TITLE
chore(ci): unify lgtm-ci pin at v0.54.0

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
 [lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`768a6b72f0a5346b5ecba3f4e13b90040472341c` (**v0.52.4**). All workflow SHA pins include
+`31c25ef2e8992960e218524780e34f44f51271b5` (**v0.54.0**). All workflow SHA pins include
 trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the

--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Auto Rerun on Infra Failure
+
+# When a listed workflow fails and its failed-job logs match a known
+# GitHub-side outage signature ("Failed to resolve action download info",
+# runner shutdown signals, harden-runner allowed-domain resolution errors),
+# re-run only the failed jobs — once (run-attempt guard upstream). This repo
+# saw a ghcr.io login timeout (run 29325278849) and a runner shutdown during
+# #1370's CI, both manually rerun. See #1374 and Rustume's equivalent (#474).
+#
+# workflow_run triggers only run from the definition on the default branch,
+# so changes here take effect after merging to main.
+
+'on':
+  workflow_run:
+    workflows:
+      - Build - Docker Image & Registry
+      - Build - Lintro Tools Image
+      - CI - Docker
+      - CI - Tests
+      - Deploy - GitHub Pages
+    types: [completed]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  rerun:
+    if: github.event.workflow_run.conclusion == 'failure'
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
+    permissions:
+      actions: write
+      contents: read
+    with:
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
+      # run id/attempt are numbers in the event payload; format() passes them
+      # as the strings the reusable workflow inputs expect.
+      run-id: ${{ format('{0}', github.event.workflow_run.id) }}
+      run-attempt: ${{ format('{0}', github.event.workflow_run.run_attempt) }}
+      egress-policy: block
+      egress-preset: github-minimal

--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -28,7 +28,12 @@ permissions: {}
 
 jobs:
   rerun:
-    if: github.event.workflow_run.conclusion == 'failure'
+    # Same-repo guard: the branches filter matches the triggering run's head
+    # branch name, so a fork branch named "main" would otherwise reach the
+    # actions:write rerun with the upstream token.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       # Org ruleset (checks-py-lintro): codeql / 🔬 CodeQL Analysis
       job-name: '🔬 CodeQL Analysis'
@@ -38,7 +38,7 @@ jobs:
       build-mode: none
       config-file: .github/codeql/codeql-config.yml
       category: '/language:all'
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: github-tooling
       # Full list (v0.50.0+ replace semantics): the reusable passes

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,10 +18,10 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       fail-on-severity: high
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: scorecard
       # Full list (v0.50.0+ replace semantics): the reusable passes

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -37,7 +37,7 @@ jobs:
     # (lgtm-ci#300). v0.32.3 left gh unauthenticated and blocked Pages deploy
     # after #974 (see #1227). Pin with the repo-standard v0.52.3 tooling.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       site-root: apps/site/dist
       build-command: bash scripts/ci/site/build.sh
@@ -47,7 +47,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       # Since lgtm-ci v0.50.0 the enforcing harden-runner step runs before
       # preset resolution, and harden-runner splits allowed-endpoints on
       # spaces, so the reusable's newline-separated per-job defaults collapse

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -34,7 +34,7 @@ jobs:
   docker-full:
     name: 🐳 Docker Full Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
       packages: write
@@ -80,7 +80,7 @@ jobs:
       provenance: false
       sbom: false
       cosign-sign: true
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: docker
       # Full list (v0.50.0+ replace semantics): the reusable passes
@@ -129,7 +129,7 @@ jobs:
     name: 🐳 Docker Base Image
     needs: docker-full
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
       packages: write
@@ -175,7 +175,7 @@ jobs:
       provenance: false
       sbom: false
       cosign-sign: true
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: docker
       # Full list (v0.50.0+ replace semantics): the reusable passes

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -111,7 +111,7 @@ jobs:
         id: detect
         if: github.event_name == 'pull_request'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/detect-changes@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/detect-changes@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           # Pipeline relevance is NOT decided here (#1369): the resolve
           # step below computes it deny-by-default from the changed-file
@@ -459,12 +459,12 @@ jobs:
         needs.manifest-sync.result == 'skipped'
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,osv_scanner:check_suppressions=false
@@ -623,7 +623,7 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
@@ -632,7 +632,7 @@ jobs:
         ${{ needs.changes.outputs.lint-scope == 'changed'
         && needs.dogfooding-lint-changed.outputs.exit-code
         || needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
 
@@ -657,11 +657,11 @@ jobs:
         github.event.pull_request.draft == false
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
     with:
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: '🛠️ Lintro Code Quality'
       runner-image: ubuntu-24.04
       # Mirrors whichever dogfooding job ran (#1361): lint-scope 'changed'
@@ -767,7 +767,7 @@ jobs:
           github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/docker-tools-publish.yml
+++ b/.github/workflows/docker-tools-publish.yml
@@ -61,7 +61,7 @@ jobs:
   tools-image:
     name: 🐳 Lintro Tools Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
       packages: write # push image, cache, and staging tags to GHCR
@@ -95,7 +95,7 @@ jobs:
       cosign-sign: true
       scan: true
       scan-exit-code: '0'
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: docker
       # Full list (v0.50.0+ replace semantics): the reusable passes

--- a/.github/workflows/dogfood-nightly.yml
+++ b/.github/workflows/dogfood-nightly.yml
@@ -29,12 +29,12 @@ jobs:
     # Same reusable workflow and tool options as the docker-ci.yml full run
     # (dogfooding-lint) so nightly coverage matches the pre-merge gate.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: '🌙 Nightly Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,osv_scanner:check_suppressions=false
@@ -54,11 +54,11 @@ jobs:
     # first failure opens `fix(ci): main workflow failed: dogfood-nightly`,
     # repeat failures comment on the open issue instead of piling up.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-main-failure-notifier.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-main-failure-notifier.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       actions: read # read workflow/job metadata for the failure context
       contents: read # repository context for the issue body
       issues: write # open or ping the deduplicated failure issue
     with:
       workflow-key: dogfood-nightly
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -35,7 +35,7 @@ permissions: {}
 jobs:
   prune-untagged:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read # checkout repo and lgtm-ci tooling sparse checkout
       packages: write # delete untagged GHCR package versions via Packages API
@@ -44,7 +44,7 @@ jobs:
       min-age-days: >-
         ${{ github.event_name != 'workflow_dispatch' && 7 || inputs.min_age_days }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: github-tooling
       # Full list (v0.50.0+ replace semantics): the reusable passes
@@ -67,7 +67,7 @@ jobs:
 
   prune-untagged-base:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read # checkout repo and lgtm-ci tooling sparse checkout
       packages: write # delete untagged GHCR package versions via Packages API
@@ -76,7 +76,7 @@ jobs:
       min-age-days: >-
         ${{ github.event_name != 'workflow_dispatch' && 7 || inputs.min_age_days }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: github-tooling
       # Full list (v0.50.0+ replace semantics): the reusable passes

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,10 +12,10 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,11 +12,11 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -65,14 +65,14 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       target: .
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: sbom
     permissions:
@@ -93,14 +93,14 @@ jobs:
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: pypi
       # Full list (v0.50.0+ replace semantics): the reusable passes
@@ -166,11 +166,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+          tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       - name: Upload to PyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
@@ -189,14 +189,14 @@ jobs:
     needs: [pypi-upload]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       # write: create GitHub Release and upload dist assets
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: github-tooling
       # Full list (v0.50.0+ replace semantics): the reusable passes

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -18,7 +18,7 @@ jobs:
   pypi-build:
     name: Build Python distribution
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
@@ -27,7 +27,7 @@ jobs:
       verify-tag-version: false
       ensure-tag-on-default-branch: false
       artifact-name: python-dist
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: pypi
       # Full list (v0.50.0+ replace semantics): the reusable passes
@@ -94,11 +94,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+          tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       - name: Upload to TestPyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -23,10 +23,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       create-release: false
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       # Paired with release-version-pr.yml (egress-preset: pypi).
       # Guarded by test_release_workflows_use_paired_egress_presets.

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       ecosystems: python
       auto-merge: true
@@ -33,7 +33,7 @@ jobs:
       # PRs pass dogfooding-lint without CHANGELOG.md being ignored (#1117).
       # Shell/format logic lives in the dedicated script, not an inline run.
       version-update-script: scripts/ci/format-changelog.py
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       # Paired with release-auto-tag.yml (egress-preset: github-tooling).
       # Guarded by test_release_workflows_use_paired_egress_presets.

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,14 +17,14 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       target: .
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: sbom
     permissions:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       # v0.52.4 drops lgtm-ci composites from this job so scorecard-action
       # publish_results passes workflow verification (#518, lgtm-ci #535).

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -18,11 +18,11 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       # Org ruleset (checks-py-lintro): semantic-title / 📝 Validate PR Title
       job-name: '📝 Validate PR Title'
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -54,18 +54,18 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           python-version: '3.12'
           install-dependencies: false
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           node-version: '24'
           working-directory: apps/site
@@ -84,7 +84,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: 768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+          ref: 31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -148,18 +148,18 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           python-version: '3.12'
           install-dependencies: false
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           node-version: '24'
           working-directory: apps/site

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -43,7 +43,7 @@ jobs:
   # Compat mode: multi-runtime matrix, no coverage or PR comments
   test-compat:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       publish-test-summary: false
       python-versions: '3.11,3.14'
@@ -54,7 +54,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: pypi
       # Full list (v0.50.0+ replace semantics): the reusable passes
@@ -84,7 +84,7 @@ jobs:
   # Coverage mode: single runtime with coverage reporting
   test-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
       publish-test-summary: true
       python-version: '3.14'
@@ -97,7 +97,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Coverage
       runner-image: ubuntu-24.04
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: pypi
       # Full list (v0.50.0+ replace semantics): the reusable passes
@@ -160,11 +160,11 @@ jobs:
     needs: test-gate
     if: always()
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: read
     with:
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       job-name: '🧪 Test Suite & Coverage'
       runner-image: ubuntu-24.04
       upstream-result: ${{ needs.test-gate.outputs.result }}
@@ -207,11 +207,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
         with:
           python-version: '3.14'
           install-dependencies: 'true'

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -22,9 +22,9 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     with:
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -18,13 +18,13 @@ concurrency:
 jobs:
   check-suppressions:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@768a6b72f0a5346b5ecba3f4e13b90040472341c # v0.52.4
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@31c25ef2e8992960e218524780e34f44f51271b5 # v0.54.0
     permissions:
       contents: write # commit auto-remediation suppressions on default branch
       pull-requests: write # open PRs for stale/expired suppressions
     with:
       job-name: '🔍 Check Vulnerability Suppressions'
-      tooling-ref: '768a6b72f0a5346b5ecba3f4e13b90040472341c' # v0.52.4
+      tooling-ref: '31c25ef2e8992960e218524780e34f44f51271b5' # v0.54.0
       workflow-file: vuln-suppression-check.yml
       install-script: scripts/ci/security/install-osv-scanner.sh
       check-script: scripts/ci/security/check-vuln-suppressions.sh

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -910,7 +910,7 @@ def test_publish_npm_exposes_dist_tag_for_backfills() -> None:
 
 # Canonical lgtm-ci pin used by all py-lintro workflows (v0.52.4).
 # Pages deploy must not regress to v0.32.3 (missing GH_TOKEN in bundler).
-_LGTM_CI_PIN = "768a6b72f0a5346b5ecba3f4e13b90040472341c"
+_LGTM_CI_PIN = "31c25ef2e8992960e218524780e34f44f51271b5"
 
 
 def test_all_lgtm_ci_refs_use_the_canonical_pin() -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(ci): unify lgtm-ci pin at v0.54.0
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Bumps the repo-wide canonical lgtm-ci pin from v0.52.4 (`768a6b7`) to v0.54.0 (`31c25ef2e8992960e218524780e34f44f51271b5`, peeled release SHA). The single-pin invariant test (`test_all_lgtm_ci_refs_use_the_canonical_pin`) is updated with the new SHA.

v0.54.0 brings:
- **Blocked-egress diagnostics** (lgtm-ci#568) — failed docker builds annotate the likely-blocked host:port instead of hanging silently (would have explained #1366 instantly).
- **Auto-rerun on infra failures** (lgtm-ci#569) — wired here as `auto-rerun-on-infra-failure.yml`, a `workflow_run` caller watching the heavy main-branch workflows (Docker builds, tools image, CI, pages). Known GitHub-side outage signatures re-run failed jobs once (run-attempt guarded upstream). Tag-triggered publish workflows are excluded: the `branches: [main]` filter never matches tag runs.
- **Release guard-race fix** (lgtm-ci#572) — release reusables pin checkout to the triggering commit.

Checked `reusable-scorecards` inputs against v0.54.0: this repo's caller passes only `egress-policy`/`allowed-endpoints`, both still accepted — no hard-cut input cleanup needed.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1374

## Details

- `tests/unit/test_workflow_wiring.py` (49) green, including the single-pin invariant.
- lintro clean on changed files.

Closes #1374
