### PR TITLE
perf(ci): path-filter test-ci with pipeline-skip and always-green gate

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -37,8 +37,7 @@ name: CI - Docker
 # "version-bump PR". Only the pull_request run is skipped: the merge push
 # to main still builds and publishes (digest promotion, #1358/#1368), and
 # the release-auto-tag → publish-pypi-on-tag chain is untouched. test-ci.yml
-# keeps running in full on bump PRs (see its header — skipping the reusable
-# callers collapses the nested required contexts, #1359).
+# skips its matrix on verified bump PRs the same way (#1359 pipeline-skip).
 #
 # Dogfooding lint scope (#1361): the `changes` job also maps the diff to a
 # `full-lint` filter (paths with global lint impact — tool configs, the

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -3,26 +3,28 @@
 ---
 name: CI - Tests
 
-# No paths filter, and no job-level path-skip of test-compat/test-coverage
-# either (#1359): the org ruleset (checks-py-lintro) requires the NESTED
-# contexts reported from inside reusable-test-python (test-compat / Python
-# Compatibility, test-compat / Aggregate Python Results, test-coverage /
-# Python Coverage, test-coverage / Aggregate Python Results). A path-filtered
-# workflow never reports them, and a skipped reusable *caller* collapses to a
-# single check run named after the caller job — the nested contexts are never
-# created (verified on commit fdc94ea) — so either approach leaves required
-# checks permanently "Expected" and deadlocks merges (see codeql.yml and
-# lgtm-ci docs/workflow-contract.md, "Required-check-safe conditional
-# workflows"). Path-skipping this matrix needs an internal skip input in
-# lgtm-ci reusable-test-python (jobs skipped INSIDE a running reusable do
-# report their contexts as skipped, like draft-pr-skip does today).
+# Path filtering (#1359): the org ruleset (checks-py-lintro) requires NESTED
+# contexts from inside reusable-test-python (test-compat / Python Compatibility,
+# test-compat / Aggregate Python Results, test-coverage / Python Coverage,
+# test-coverage / Aggregate Python Results). A path-filtered workflow or a
+# skipped reusable *caller* collapses to a single check run — nested contexts
+# are never created and merges deadlock (see codeql.yml and lgtm-ci
+# docs/workflow-contract.md, "Required-check-safe conditional workflows").
 #
-# Version-bump PRs (#1362) are NOT skipped here for the same reason: the
-# skip signal would have to gate the reusable callers, which collapses the
-# nested required contexts and deadlocks the merge. Only docker-ci.yml
-# skips its heavy jobs on verified bump PRs; this matrix runs in full
-# until reusable-test-python grows an internal skip input (deferred like
-# the #1359 path-skip).
+# Instead: a `changes` job classifies the PR diff (same deny-by-default
+# skip-list as docker-ci.yml via resolve-pipeline-relevance.sh) and the reusable
+# callers always run (`if: '!cancelled()'` fail-open on classifier failure —
+# empty pipeline != 'false' → full matrix), passing pipeline-skip=true when
+# pipeline=false so jobs skip INSIDE the reusable and still report their nested
+# contexts as skipped (lgtm-ci reusable-test-python pipeline-skip input).
+# merge_group, push, and workflow_dispatch always run the full matrix. The
+# test-suite-coverage gate reports success only when changes succeeded and the
+# matrix was path-skipped; otherwise it mirrors test-gate.
+#
+# Version-bump PRs (#1362): release-bump-only.sh can force pipeline=false on
+# verified bump PRs, so the matrix skips exactly like docs-only PRs once
+# pipeline-skip is wired (previously blocked on the nested-context constraint).
+
 'on':
   push:
     branches: [main]
@@ -40,8 +42,57 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  # Compat mode: multi-runtime matrix, no coverage or PR comments
+  # Required-check-safe replacement for on.<event>.paths (see header). Only
+  # pull_request events are filtered; every other event resolves pipeline=true.
+  # Fails open on classification errors so a broken filter runs the full
+  # matrix rather than silently skipping it.
+  changes:
+    name: 🔎 Detect Relevant Changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    outputs:
+      pipeline: ${{ steps.result.outputs.pipeline }}
+      skip-reason: ${{ steps.result.outputs.skip-reason }}
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check for release version-bump PR
+        id: bump
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: scripts/ci/release-bump-only.sh
+      - name: Resolve pipeline relevance
+        id: result
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_BUMP: ${{ steps.bump.outputs.release-bump }}
+        run: scripts/ci/resolve-pipeline-relevance.sh
+
+  # Compat mode: multi-runtime matrix, no coverage or PR comments.
+  # !cancelled() fail-opens like docker-ci docker-build: a failed changes
+  # job leaves pipeline empty (!= 'false'), so pipeline-skip is false and
+  # the full matrix runs instead of collapsing to skipped → false green.
   test-compat:
+    needs: [changes]
+    if: '!cancelled()'
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@f8ce689b2453b7520a41b617d1a72051bfb1c1c0 # v0.63.7
     with:
@@ -52,6 +103,7 @@ jobs:
       extra-args: '-x --ignore=tests/integration'
       coverage: false
       draft-pr-skip: true
+      pipeline-skip: ${{ needs.changes.outputs.pipeline == 'false' }}
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
       tooling-ref: 'f8ce689b2453b7520a41b617d1a72051bfb1c1c0' # v0.63.7
@@ -82,8 +134,11 @@ jobs:
       contents: read
       pull-requests: write
 
-  # Coverage mode: single runtime with coverage reporting
+  # Coverage mode: single runtime with coverage reporting.
+  # Same !cancelled() fail-open as test-compat (see above).
   test-coverage:
+    needs: [changes]
+    if: '!cancelled()'
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@f8ce689b2453b7520a41b617d1a72051bfb1c1c0 # v0.63.7
     with:
@@ -96,6 +151,7 @@ jobs:
       coverage-threshold: 80
       upload-coverage: true
       draft-pr-skip: true
+      pipeline-skip: ${{ needs.changes.outputs.pipeline == 'false' }}
       job-name: Python Coverage
       runner-image: ubuntu-24.04
       tooling-ref: 'f8ce689b2453b7520a41b617d1a72051bfb1c1c0' # v0.63.7
@@ -128,8 +184,8 @@ jobs:
   # Evaluate both upstream jobs into a single result for the required-check gate
   test-gate:
     name: 🚦 Test Gate
-    needs: [test-compat, test-coverage]
-    if: always()
+    needs: [changes, test-compat, test-coverage]
+    if: always() && !cancelled()
     runs-on: ubuntu-24.04
     permissions: {}
     outputs:
@@ -158,9 +214,14 @@ jobs:
           fi
 
   # Org ruleset (checks-py-lintro): test-suite-coverage / 🧪 Test Suite & Coverage
+  # Always-green gate: reports success only when changes succeeded AND the
+  # matrix was intentionally path-skipped (pipeline == 'false'). A failed
+  # changes job never takes the success shortcut — empty pipeline fails open
+  # into the full matrix via !cancelled() on the reusable callers, and this
+  # gate mirrors test-gate.
   test-suite-coverage:
-    needs: test-gate
-    if: always()
+    needs: [changes, test-gate]
+    if: always() && !cancelled()
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@f8ce689b2453b7520a41b617d1a72051bfb1c1c0 # v0.63.7
     permissions:
@@ -169,15 +230,27 @@ jobs:
       tooling-ref: 'f8ce689b2453b7520a41b617d1a72051bfb1c1c0' # v0.63.7
       job-name: '🧪 Test Suite & Coverage'
       runner-image: ubuntu-24.04
-      upstream-result: ${{ needs.test-gate.outputs.result }}
-      passed-output: ${{ needs.test-gate.outputs.passed }}
+      upstream-result: >-
+        ${{
+          needs.changes.result == 'success' &&
+          needs.changes.outputs.pipeline == 'false' && 'success'
+          || needs.test-gate.outputs.result
+        }}
+      passed-output: >-
+        ${{
+          needs.changes.result == 'success' &&
+          needs.changes.outputs.pipeline == 'false' && 'true'
+          || needs.test-gate.outputs.passed
+        }}
       egress-policy: block
       egress-preset: github-tooling
 
   stage-coverage-html:
     name: Stage coverage HTML for Pages bundle
-    needs: test-coverage
+    needs: [changes, test-coverage]
     if: >-
+      !cancelled() &&
+      needs.changes.outputs.pipeline != 'false' &&
       github.ref == 'refs/heads/main' &&
       github.event_name == 'push' &&
       needs.test-coverage.outputs.passed == 'true'

--- a/scripts/ci/evaluate-test-gate.sh
+++ b/scripts/ci/evaluate-test-gate.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # Evaluate upstream test job results for the required org-ruleset gate.
 # Fails when any upstream job reports "failure" or "cancelled"; treats
-# "skipped" (draft PRs) as acceptable.
+# "skipped" (draft PRs, pipeline-skip) as acceptable.
 #
 # Required environment variables:
 #   COMPAT_RESULT  - needs.test-compat.result
@@ -15,7 +15,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 Evaluate upstream test job results for the required org-ruleset gate.
 
 Fails when any upstream job reports "failure" or "cancelled"; treats
-"skipped" (draft PRs) as acceptable.
+"skipped" (draft PRs, pipeline-skip) as acceptable.
 
 Usage:
   COMPAT_RESULT=success COVERAGE_RESULT=success scripts/ci/evaluate-test-gate.sh

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -828,18 +828,28 @@ def test_test_ci_changes_job_resolves_pipeline_relevance() -> None:
 
 
 def test_test_ci_reusables_wire_pipeline_skip() -> None:
-    """Reusable callers always run and pass pipeline-skip for docs-only PRs."""
+    """Reusable callers fail-open on changes failure and wire pipeline-skip.
+
+    ``if: '!cancelled()'`` mirrors docker-ci's docker-build gate: a failed
+    changes job must still run the matrix (empty pipeline != 'false' →
+    pipeline-skip false) instead of collapsing to skipped → false green.
+    """
     test_ci = _load_workflow(name="test-ci.yml")
     for job_name in ("test-compat", "test-coverage"):
         job = test_ci["jobs"][job_name]
         assert_that(job["needs"]).contains("changes")
+        assert_that(job["if"]).is_equal_to("!cancelled()")
         assert_that(job["with"]["pipeline-skip"]).is_equal_to(
             "${{ needs.changes.outputs.pipeline == 'false' }}",
         )
 
 
 def test_test_ci_suite_coverage_gate_is_always_green_when_path_skipped() -> None:
-    """Required gate reports success when the matrix was path-skipped (#1359)."""
+    """Required gate greens only on intentional path-skip after changes success.
+
+    A failed changes job must never take the success shortcut — even if
+    pipeline were somehow empty/false — and must mirror test-gate instead.
+    """
     test_ci = _load_workflow(name="test-ci.yml")
     gate = test_ci["jobs"]["test-suite-coverage"]
 
@@ -847,14 +857,16 @@ def test_test_ci_suite_coverage_gate_is_always_green_when_path_skipped() -> None
     upstream = _normalize_github_expr(gate["with"]["upstream-result"])
     assert_that(upstream).is_equal_to(
         _normalize_github_expr(
-            "${{ needs.changes.outputs.pipeline == 'false' && 'success' "
+            "${{ needs.changes.result == 'success' && "
+            "needs.changes.outputs.pipeline == 'false' && 'success' "
             "|| needs.test-gate.outputs.result }}",
         ),
     )
     passed_output = _normalize_github_expr(gate["with"]["passed-output"])
     assert_that(passed_output).is_equal_to(
         _normalize_github_expr(
-            "${{ needs.changes.outputs.pipeline == 'false' && 'true' "
+            "${{ needs.changes.result == 'success' && "
+            "needs.changes.outputs.pipeline == 'false' && 'true' "
             "|| needs.test-gate.outputs.passed }}",
         ),
     )

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -801,6 +801,65 @@ def test_dogfood_skip_gate_has_bounded_timeout() -> None:
         assert_that(timeout).is_between(18, 28)
 
 
+def test_test_ci_changes_job_resolves_pipeline_relevance() -> None:
+    """test-ci classifies PR diffs before calling the reusable matrix (#1359)."""
+    test_ci = _load_workflow(name="test-ci.yml")
+    changes_job = test_ci["jobs"]["changes"]
+    steps = {step.get("id"): step for step in changes_job["steps"] if "id" in step}
+
+    assert_that(changes_job["outputs"]["pipeline"]).contains(
+        "steps.result.outputs.pipeline",
+    )
+    assert_that(changes_job["outputs"]["skip-reason"]).contains(
+        "steps.result.outputs.skip-reason",
+    )
+
+    bump_step = steps["bump"]
+    assert_that(bump_step["if"]).contains(_github_event_name_is_pull_request_token())
+    assert_that(bump_step["run"]).is_equal_to("scripts/ci/release-bump-only.sh")
+
+    resolve_step = steps["result"]
+    assert_that(resolve_step["run"]).is_equal_to(
+        "scripts/ci/resolve-pipeline-relevance.sh",
+    )
+    assert_that(resolve_step["env"]["RELEASE_BUMP"]).contains(
+        "steps.bump.outputs.release-bump",
+    )
+
+
+def test_test_ci_reusables_wire_pipeline_skip() -> None:
+    """Reusable callers always run and pass pipeline-skip for docs-only PRs."""
+    test_ci = _load_workflow(name="test-ci.yml")
+    for job_name in ("test-compat", "test-coverage"):
+        job = test_ci["jobs"][job_name]
+        assert_that(job["needs"]).contains("changes")
+        assert_that(job["with"]["pipeline-skip"]).is_equal_to(
+            "${{ needs.changes.outputs.pipeline == 'false' }}",
+        )
+
+
+def test_test_ci_suite_coverage_gate_is_always_green_when_path_skipped() -> None:
+    """Required gate reports success when the matrix was path-skipped (#1359)."""
+    test_ci = _load_workflow(name="test-ci.yml")
+    gate = test_ci["jobs"]["test-suite-coverage"]
+
+    assert_that(gate["needs"]).contains("changes", "test-gate")
+    upstream = _normalize_github_expr(gate["with"]["upstream-result"])
+    assert_that(upstream).is_equal_to(
+        _normalize_github_expr(
+            "${{ needs.changes.outputs.pipeline == 'false' && 'success' "
+            "|| needs.test-gate.outputs.result }}",
+        ),
+    )
+    passed_output = _normalize_github_expr(gate["with"]["passed-output"])
+    assert_that(passed_output).is_equal_to(
+        _normalize_github_expr(
+            "${{ needs.changes.outputs.pipeline == 'false' && 'true' "
+            "|| needs.test-gate.outputs.passed }}",
+        ),
+    )
+
+
 # --- Deny-by-default pipeline skip-list drift guard (#1369) ------------------
 #
 # docker-ci pipeline relevance is decided by


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  perf(ci): path-filter test-ci via pipeline-skip and always-green gate
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Completes the deferred half of #1359: `test-ci.yml` now path-filters docs-only and verified version-bump PRs the same way `docker-ci.yml` already does, without deadlocking required nested contexts.

- **`changes` job** classifies PR diffs via `resolve-pipeline-relevance.sh` (deny-by-default skip-list shared with docker-ci).
- **Reusable callers always run**; `pipeline-skip: true` is passed into `reusable-test-python` when `pipeline=false` so jobs skip *inside* the reusable and nested required contexts (`test-compat / …`, `test-coverage / …`) still report as skipped.
- **`test-suite-coverage` gate** reports success when the matrix was path-skipped and mirrors `test-gate` when it ran.
- **lgtm-ci bump** to `9416eb2` (v0.55.0) for the new `pipeline-skip` input ([lgtm-ci#578](https://github.com/lgtm-hq/lgtm-ci/pull/578)).

`merge_group`, `push`, and `workflow_dispatch` always run the full matrix. `codeql.yml` stays unfiltered.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`, `uv run lintro fmt`, `uv run lintro tst` / serial pytest fallback for one pre-existing flaky parallel test)

## Closes

- Closes #1359

## Details

### Dependency

Requires [lgtm-hq/lgtm-ci#578](https://github.com/lgtm-hq/lgtm-ci/pull/578) (`pipeline-skip` on `reusable-test-python`). This PR pins `9416eb2` from that branch.

### Verification

| Hypothetical diff | `pipeline` | test-ci behavior |
| --- | --- | --- |
| `README.md` only | `false` | matrix jobs skip inside reusables (~seconds); nested + gate contexts report green |
| `lintro/tools/ruff.py` | `true` | full matrix |
| verified version-bump PR | `false` | matrix skipped (now aligned with docker-ci) |
| any diff via `merge_group` / `push` | `true` | full matrix |

### Tests

- `tests/unit/test_workflow_wiring.py`: changes job, `pipeline-skip` wiring, always-green gate expression
- `uv run lintro chk` — clean
- `uv run pytest -n0` — 6644 passed

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds path-aware skipping for the test CI workflow while keeping required checks reporting. The main changes are:

- Adds a `changes` job to classify pull request diffs.
- Passes `pipeline-skip` into the reusable Python test workflows.
- Keeps reusable workflow callers running so nested required checks are still created.
- Adds a coverage gate shortcut for intentional path skips.
- Updates the shared `lgtm-ci` pin to v0.55.0 across workflows.
- Adds workflow wiring tests for the new test CI behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/test-ci.yml | Adds path classification, fail-open reusable test wiring, and a guarded required coverage gate. |
| scripts/ci/evaluate-test-gate.sh | Updates help text to describe skipped test results for draft and path-skipped runs. |
| tests/unit/test_workflow_wiring.py | Adds tests that check the new test CI workflow wiring. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): fail-open test matrix when chan..."](https://github.com/lgtm-hq/py-lintro/commit/06f7c7083df6cec2ceb8f97ab4de21f95b4e2f58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44207189)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Improved test workflow routing to skip irrelevant pull-request pipelines while preserving full validation for other changes.
  * Added support for safely handling release-bump pull requests and canceled or failed classification checks.
  * Compatibility and coverage checks now report intentional pipeline skips clearly.

* **Tests**
  * Added coverage to verify workflow routing, skip propagation, fail-open behavior, and suite-gate results.

* **Documentation**
  * Clarified workflow comments and gate help text for skipped pipeline scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->