### PR TITLE
fix(ci): Renovate tool-pin bumps break generated-versions check

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -77,13 +77,20 @@
       "automerge": false
     },
     {
-      "description": "Regenerate _tool_versions.py when tool version sources change",
-      "matchManagers": ["custom.regex"],
+      "description": "Regenerate version artifacts when tool version sources change",
+      "matchManagers": [
+        "custom.regex",
+        "npm",
+        "pep621",
+        "uv"
+      ],
       "matchFileNames": [
         "Dockerfile",
         "docker/tools.Dockerfile",
         "lintro/_tool_versions.py",
-        "lintro/tools/manifest.json"
+        "lintro/tools/manifest.json",
+        "package.json",
+        "pyproject.toml"
       ],
       "postUpgradeTasks": {
         "commands": [

--- a/renovate.json
+++ b/renovate.json
@@ -81,7 +81,8 @@
       "matchManagers": [
         "custom.regex",
         "npm",
-        "pep621"
+        "pep621",
+        "uv"
       ],
       "matchFileNames": [
         "Dockerfile",

--- a/renovate.json
+++ b/renovate.json
@@ -81,8 +81,7 @@
       "matchManagers": [
         "custom.regex",
         "npm",
-        "pep621",
-        "uv"
+        "pep621"
       ],
       "matchFileNames": [
         "Dockerfile",

--- a/tests/scripts/generate_tool_versions/test_main.py
+++ b/tests/scripts/generate_tool_versions/test_main.py
@@ -38,6 +38,19 @@ def test_main_check_clean_exits_zero(retargeted_gen: ModuleType) -> None:
     assert_that(retargeted_gen.main(["--check"])).is_equal_to(retargeted_gen.EXIT_OK)
 
 
+def _bump_oxfmt_version(fake_repo: Path, version: str) -> None:
+    """Simulate a Renovate-style pin bump in package.json.
+
+    Args:
+        fake_repo: Fake repo fixture root.
+        version: New oxfmt version pin to write.
+    """
+    pkg = fake_repo / "package.json"
+    data = json.loads(pkg.read_text())
+    data["devDependencies"]["oxfmt"] = version
+    pkg.write_text(json.dumps(data, indent=2))
+
+
 def test_main_check_drift_exits_one(
     retargeted_gen: ModuleType,
     fake_repo: Path,
@@ -52,10 +65,7 @@ def test_main_check_drift_exits_one(
     """
     retargeted_gen.main([])
 
-    pkg = fake_repo / "package.json"
-    data = json.loads(pkg.read_text())
-    data["devDependencies"]["oxfmt"] = "0.99.0"
-    pkg.write_text(json.dumps(data, indent=2))
+    _bump_oxfmt_version(fake_repo, "0.99.0")
 
     rc = retargeted_gen.main(["--check"])
     assert_that(rc).is_equal_to(retargeted_gen.EXIT_DRIFT)
@@ -76,10 +86,7 @@ def test_pin_bump_then_regenerate_passes_check(
     """
     retargeted_gen.main([])
 
-    pkg = fake_repo / "package.json"
-    data = json.loads(pkg.read_text())
-    data["devDependencies"]["oxfmt"] = "0.99.0"
-    pkg.write_text(json.dumps(data, indent=2))
+    _bump_oxfmt_version(fake_repo, "0.99.0")
 
     assert_that(retargeted_gen.main(["--check"])).is_equal_to(
         retargeted_gen.EXIT_DRIFT,

--- a/tests/scripts/generate_tool_versions/test_main.py
+++ b/tests/scripts/generate_tool_versions/test_main.py
@@ -64,6 +64,30 @@ def test_main_check_drift_exits_one(
     assert_that(captured.err).contains("Drift detected")
 
 
+def test_pin_bump_then_regenerate_passes_check(
+    retargeted_gen: ModuleType,
+    fake_repo: Path,
+) -> None:
+    """Simulated Renovate pin bump plus regeneration clears the drift gate.
+
+    Args:
+        retargeted_gen: Generator module pointed at the fake repo.
+        fake_repo: Fake repo fixture root.
+    """
+    retargeted_gen.main([])
+
+    pkg = fake_repo / "package.json"
+    data = json.loads(pkg.read_text())
+    data["devDependencies"]["oxfmt"] = "0.99.0"
+    pkg.write_text(json.dumps(data, indent=2))
+
+    assert_that(retargeted_gen.main(["--check"])).is_equal_to(
+        retargeted_gen.EXIT_DRIFT,
+    )
+    assert_that(retargeted_gen.main([])).is_equal_to(retargeted_gen.EXIT_OK)
+    assert_that(retargeted_gen.main(["--check"])).is_equal_to(retargeted_gen.EXIT_OK)
+
+
 def test_main_input_error_exits_two(
     retargeted_gen: ModuleType,
     fake_repo: Path,

--- a/tests/scripts/test_shell_scripts.py
+++ b/tests/scripts/test_shell_scripts.py
@@ -509,7 +509,7 @@ def test_renovate_post_upgrade_tasks_cover_tool_pin_managers() -> None:
         file_names.update(rule.get("matchFileNames", []))
         commands.update(rule["postUpgradeTasks"].get("commands", []))
 
-    assert_that(managers).contains("custom.regex", "npm", "pep621")
+    assert_that(managers).contains("custom.regex", "npm", "pep621", "uv")
     assert_that(file_names).contains(
         "package.json",
         "pyproject.toml",

--- a/tests/scripts/test_shell_scripts.py
+++ b/tests/scripts/test_shell_scripts.py
@@ -509,7 +509,7 @@ def test_renovate_post_upgrade_tasks_cover_tool_pin_managers() -> None:
         file_names.update(rule.get("matchFileNames", []))
         commands.update(rule["postUpgradeTasks"].get("commands", []))
 
-    assert_that(managers).contains("custom.regex", "npm", "pep621", "uv")
+    assert_that(managers).contains("custom.regex", "npm", "pep621")
     assert_that(file_names).contains(
         "package.json",
         "pyproject.toml",

--- a/tests/scripts/test_shell_scripts.py
+++ b/tests/scripts/test_shell_scripts.py
@@ -4,6 +4,7 @@ This module tests the shell scripts to ensure they follow best practices,
 have correct syntax, and provide appropriate help/usage information.
 """
 
+import json
 import subprocess  # nosec B404 - subprocess is used to drive the tool/CLI under test; invocations use shell=False
 from pathlib import Path
 
@@ -489,3 +490,32 @@ def test_renovate_regex_manager_current_value() -> None:
     content = config_path.read_text()
     assert_that(content).contains("customManagers")
     assert_that(content).contains("currentValue")
+
+
+def test_renovate_post_upgrade_tasks_cover_tool_pin_managers() -> None:
+    """Renovate runs the generator after npm, pypi, and regex pin bumps."""
+    config_path = Path("renovate.json")
+    config = json.loads(config_path.read_text())
+    regen_rules = [
+        rule for rule in config.get("packageRules", []) if "postUpgradeTasks" in rule
+    ]
+    assert_that(regen_rules).is_not_empty()
+
+    managers: set[str] = set()
+    file_names: set[str] = set()
+    commands: set[str] = set()
+    for rule in regen_rules:
+        managers.update(rule.get("matchManagers", []))
+        file_names.update(rule.get("matchFileNames", []))
+        commands.update(rule["postUpgradeTasks"].get("commands", []))
+
+    assert_that(managers).contains("custom.regex", "npm", "pep621", "uv")
+    assert_that(file_names).contains(
+        "package.json",
+        "pyproject.toml",
+        "lintro/_tool_versions.py",
+    )
+    assert_that(commands).contains("python3 scripts/ci/generate-tool-versions.py")
+    assert_that(config.get("allowedCommands")).contains(
+        "python3 scripts/ci/generate-tool-versions.py",
+    )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): regenerate versions on Renovate npm/pypi pin bumps
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Renovate `postUpgradeTasks` previously ran the tool-versions generator only for `custom.regex` managers (Dockerfile and `lintro/_tool_versions.py` pins). npm/pypi pin bumps in `package.json` and `pyproject.toml` — such as the linting-tools group — left `lintro/_generated_versions.py` stale and caused `test_generator_check_passes_against_real_repo` to fail deterministically.

This PR extends the existing postUpgradeTasks package rule to also match `npm`, `pep621`, and `uv` managers on the canonical version source files, so Renovate commits the regenerated artifacts after every tool-pin bump.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`, `uv run lintro fmt`, `uv run lintro tst`)

## Closes

- Closes #1346

## Details

- **renovate.json**: broaden the regeneration package rule to `npm`, `pep621`, and `uv` managers and add `package.json` / `pyproject.toml` to `matchFileNames`; keep the existing stdlib-only `scripts/ci/generate-tool-versions.py` hook and `allowedCommands` entry.
- **tests**: add a renovate-config wiring test asserting postUpgradeTasks cover npm/pypi managers, and a generator test simulating a pin bump followed by regeneration clearing the `--check` drift gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic version artifact updates when tool versions change across supported project configuration files.
  * Ensured generated version data stays synchronized after dependency pin updates.

* **Tests**
  * Added coverage verifying version checks detect changes and pass after regeneration.
  * Added validation that automated update rules cover all supported package managers and version sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a CI drift issue where Renovate's `postUpgradeTasks` only ran the version-artifact generator for `custom.regex` managers, leaving `lintro/_generated_versions.py` stale whenever npm or pypi tool-pin bumps occurred in `package.json` or `pyproject.toml`.

- **`renovate.json`**: Extends the postUpgradeTasks package rule to also match `npm`, `pep621`, and `uv` managers, and adds `package.json`/`pyproject.toml` to `matchFileNames`, so the generator runs for every covered package manager.
- **Tests**: Adds a wiring assertion that all four managers (`custom.regex`, `npm`, `pep621`, `uv`) are covered, and a new end-to-end generator test verifying that a simulated pin bump triggers drift, re-running the generator clears the drift gate, and `--check` then exits cleanly.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive and low-risk, only broadening which Renovate managers trigger an already-established postUpgradeTasks hook.

All three managers (npm, pep621, uv) and both new file names are correctly wired in renovate.json. The new wiring test verifies this at parse time, and the end-to-end generator test confirms the full bump→drift→regenerate→pass cycle. No logic outside of Renovate config and test code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Extends postUpgradeTasks matchManagers to include npm, pep621, and uv, and adds package.json and pyproject.toml to matchFileNames — correct and complete. |
| tests/scripts/generate_tool_versions/test_main.py | Refactors inline bump code into _bump_oxfmt_version helper and adds a thorough end-to-end test covering the drift → regenerate → pass cycle. |
| tests/scripts/test_shell_scripts.py | Adds a wiring test that parses renovate.json at runtime and asserts all four managers and key file names are covered, including uv. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Renovate detects version update] --> B{Which manager?}
    B -->|custom.regex\nDockerfile / _tool_versions.py| C[postUpgradeTasks rule matches]
    B -->|npm\npackage.json| C
    B -->|pep621 / uv\npyproject.toml| C
    B -->|other managers| D[No postUpgradeTasks]
    C --> E[Run: python3 scripts/ci/generate-tool-versions.py]
    E --> F[lintro/_generated_versions.py updated]
    F --> G[Renovate commits regenerated artifact]
    G --> H[--check drift gate passes in CI]
    D --> I[_generated_versions.py stays stale]
    I --> J[drift gate FAILS in CI]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Renovate detects version update] --> B{Which manager?}
    B -->|custom.regex\nDockerfile / _tool_versions.py| C[postUpgradeTasks rule matches]
    B -->|npm\npackage.json| C
    B -->|pep621 / uv\npyproject.toml| C
    B -->|other managers| D[No postUpgradeTasks]
    C --> E[Run: python3 scripts/ci/generate-tool-versions.py]
    E --> F[lintro/_generated_versions.py updated]
    F --> G[Renovate commits regenerated artifact]
    G --> H[--check drift gate passes in CI]
    D --> I[_generated_versions.py stays stale]
    I --> J[drift gate FAILS in CI]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ci): restore uv manager in Renovate ..."](https://github.com/lgtm-hq/py-lintro/commit/546bea30b879631dee6495e3e55d6c59699cffd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44228089)</sub>

<!-- /greptile_comment -->