### PR TITLE
refactor(core): migrate os.path usage to pathlib in line_length_checker, install_context, git_diff

### DIFF
--- a/lintro/tools/core/install_context.py
+++ b/lintro/tools/core/install_context.py
@@ -19,6 +19,7 @@ import os
 import platform
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 from lintro.enums.install_context import CISystem, InstallContext
 from lintro.tools.core.install_strategies.environment import InstallEnvironment
@@ -63,7 +64,7 @@ def _detect_install_context() -> InstallContext:
     """Detect how lintro was installed based on the executable path."""
     # Docker: check for Docker indicators
     if (
-        os.path.exists("/.dockerenv")
+        Path("/.dockerenv").exists()
         or os.environ.get("LINTRO_DOCKER") == "1"
         or os.environ.get("CONTAINER") == "docker"
     ):
@@ -71,8 +72,8 @@ def _detect_install_context() -> InstallContext:
 
     # Resolve symlinks so pip installs under /opt/homebrew/lib aren't
     # misclassified as Homebrew formula installs.
-    exe_path = os.path.realpath(sys.executable)
-    install_path = os.path.realpath(__file__)
+    exe_path = str(Path(sys.executable).resolve())
+    install_path = str(Path(__file__).resolve())
 
     # npm binary: the launcher resolves the platform package, so the running
     # executable lives under node_modules/@lgtm-hq/lintro-<platform>/. Check before
@@ -99,18 +100,16 @@ def _detect_install_context() -> InstallContext:
             continue
         if "lintro-full" in lower:
             return InstallContext.HOMEBREW_FULL
-        name = os.path.basename(lower)
-        parent = os.path.basename(os.path.dirname(lower))
+        name = Path(lower).name
+        parent = Path(lower).parent.name
         if name == "lintro" and parent in {"bin", "sbin"}:
             return InstallContext.HOMEBREW_BIN
 
     # Development: running from a git checkout
     # install_path is lintro/tools/core/install_context.py — 4 levels to repo root
-    source_root = os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.dirname(install_path))),
-    )
-    # Use os.path.exists (not isdir) to also detect .git files (worktrees/submodules)
-    if os.path.exists(os.path.join(source_root, ".git")):
+    source_root = Path(install_path).parents[3]
+    # Use exists() (not is_dir()) to also detect .git files (worktrees/submodules)
+    if (source_root / ".git").exists():
         return InstallContext.DEVELOPMENT
 
     # Default: pip/uv install

--- a/lintro/tools/core/install_context.py
+++ b/lintro/tools/core/install_context.py
@@ -25,6 +25,19 @@ from lintro.enums.install_context import CISystem, InstallContext
 from lintro.tools.core.install_strategies.environment import InstallEnvironment
 
 
+def _dockerenv_exists() -> bool:
+    """Return whether the Docker container marker file is present."""
+    return Path("/.dockerenv").exists()
+
+
+def _git_root_marker_exists(install_path: str) -> bool:
+    """Return whether a ``.git`` marker exists at the inferred source root."""
+    source_root = Path(install_path)
+    for _ in range(4):
+        source_root = source_root.parent
+    return (source_root / ".git").exists()
+
+
 @dataclass(frozen=True)
 class RuntimeContext:
     """Detected runtime context for install-aware commands.
@@ -64,7 +77,7 @@ def _detect_install_context() -> InstallContext:
     """Detect how lintro was installed based on the executable path."""
     # Docker: check for Docker indicators
     if (
-        Path("/.dockerenv").exists()
+        _dockerenv_exists()
         or os.environ.get("LINTRO_DOCKER") == "1"
         or os.environ.get("CONTAINER") == "docker"
     ):
@@ -107,9 +120,7 @@ def _detect_install_context() -> InstallContext:
 
     # Development: running from a git checkout
     # install_path is lintro/tools/core/install_context.py — 4 levels to repo root
-    source_root = Path(install_path).parents[3]
-    # Use exists() (not is_dir()) to also detect .git files (worktrees/submodules)
-    if (source_root / ".git").exists():
+    if _git_root_marker_exists(install_path):
         return InstallContext.DEVELOPMENT
 
     # Default: pip/uv install

--- a/lintro/tools/core/line_length_checker.py
+++ b/lintro/tools/core/line_length_checker.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 from loguru import logger
 
+from lintro.utils.path_utils import absolute_path
+
 
 @dataclass
 class LineLengthViolation:
@@ -36,24 +38,6 @@ class LineLengthViolation:
     column: int
     message: str
     code: str = "E501"
-
-
-def _absolute_path(file_path: str, cwd: str | None = None) -> str:
-    """Return ``file_path`` as an absolute path without resolving symlinks.
-
-    Args:
-        file_path: Relative or absolute file path.
-        cwd: Base directory for relative paths when supplied.
-
-    Returns:
-        Absolute path string matching ``os.path.abspath`` semantics.
-    """
-    path = Path(file_path)
-    if path.is_absolute():
-        return file_path
-    if cwd is not None:
-        return str((Path(cwd) / path).absolute())
-    return str(path.absolute())
 
 
 def check_line_length_violations(
@@ -97,7 +81,10 @@ def check_line_length_violations(
         logger.debug("Ruff not found in PATH, skipping line length check")
         return []
 
-    abs_files = [_absolute_path(file_path, cwd=cwd) for file_path in files]
+    abs_files = [
+        absolute_path(file_path, base_dir=Path(cwd) if cwd else None)
+        for file_path in files
+    ]
 
     # Build the Ruff command
     cmd: list[str] = [
@@ -143,7 +130,7 @@ def check_line_length_violations(
             # Ruff JSON format has: filename, row, column, message, code
             file_path = issue.get("filename", "")
             if not Path(file_path).is_absolute() and cwd:
-                file_path = _absolute_path(file_path, cwd=cwd)
+                file_path = absolute_path(file_path, base_dir=Path(cwd))
 
             # Handle both old and new Ruff JSON formats
             line = issue.get("location", {}).get("row") or issue.get("row", 0)

--- a/lintro/tools/core/line_length_checker.py
+++ b/lintro/tools/core/line_length_checker.py
@@ -8,10 +8,10 @@ making the architecture more modular.
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import subprocess  # nosec B404 - used safely with shell disabled
 from dataclasses import dataclass
+from pathlib import Path
 
 from loguru import logger
 
@@ -36,6 +36,24 @@ class LineLengthViolation:
     column: int
     message: str
     code: str = "E501"
+
+
+def _absolute_path(file_path: str, cwd: str | None = None) -> str:
+    """Return ``file_path`` as an absolute path without resolving symlinks.
+
+    Args:
+        file_path: Relative or absolute file path.
+        cwd: Base directory for relative paths when supplied.
+
+    Returns:
+        Absolute path string matching ``os.path.abspath`` semantics.
+    """
+    path = Path(file_path)
+    if path.is_absolute():
+        return file_path
+    if cwd is not None:
+        return str((Path(cwd) / path).absolute())
+    return str(path.absolute())
 
 
 def check_line_length_violations(
@@ -79,19 +97,7 @@ def check_line_length_violations(
         logger.debug("Ruff not found in PATH, skipping line length check")
         return []
 
-    # Convert relative paths to absolute paths
-    abs_files: list[str] = []
-    for file_path in files:
-        if cwd and not os.path.isabs(file_path):
-            abs_files.append(os.path.abspath(os.path.join(cwd, file_path)))
-        else:
-            abs_files.append(
-                (
-                    os.path.abspath(file_path)
-                    if not os.path.isabs(file_path)
-                    else file_path
-                ),
-            )
+    abs_files = [_absolute_path(file_path, cwd=cwd) for file_path in files]
 
     # Build the Ruff command
     cmd: list[str] = [
@@ -136,8 +142,8 @@ def check_line_length_violations(
         for issue in issues_data:
             # Ruff JSON format has: filename, row, column, message, code
             file_path = issue.get("filename", "")
-            if not os.path.isabs(file_path) and cwd:
-                file_path = os.path.abspath(os.path.join(cwd, file_path))
+            if not Path(file_path).is_absolute() and cwd:
+                file_path = _absolute_path(file_path, cwd=cwd)
 
             # Handle both old and new Ruff JSON formats
             line = issue.get("location", {}).get("row") or issue.get("row", 0)

--- a/lintro/utils/git_diff.py
+++ b/lintro/utils/git_diff.py
@@ -24,6 +24,8 @@ import subprocess  # nosec B404 - subprocess is the core mechanism for invoking 
 from functools import lru_cache
 from pathlib import Path
 
+from lintro.utils.path_utils import absolute_path
+
 # Sentinel used by the ``--diff`` CLI option to mean "flag supplied without an
 # explicit base"; resolved to the repository's default base ref at runtime.
 DIFF_DEFAULT_SENTINEL: str = "\x00lintro-diff-default\x00"
@@ -42,21 +44,6 @@ _GIT_TIMEOUT_SECONDS: float = 30.0
 
 class DiffResolutionError(Exception):
     """Raised when an explicit ``--diff`` base ref cannot be resolved."""
-
-
-def _absolute_path(path: str) -> str:
-    """Return ``path`` as absolute without resolving symlinks.
-
-    Args:
-        path: Relative or absolute path string.
-
-    Returns:
-        Absolute path string matching ``os.path.abspath`` semantics.
-    """
-    path_obj = Path(path)
-    if path_obj.is_absolute():
-        return path
-    return str(path_obj.absolute())
 
 
 def _run_git(args: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
@@ -250,7 +237,7 @@ def get_changed_files(base: str, cwd: str = ".") -> frozenset[str]:
     Raises:
         DiffResolutionError: When ``base`` does not resolve to a commit.
     """
-    root = _repo_root(cwd) or _absolute_path(cwd)
+    root = _repo_root(cwd) or absolute_path(cwd)
 
     if not _ref_exists(base, cwd):
         raise DiffResolutionError(
@@ -266,7 +253,7 @@ def get_changed_files(base: str, cwd: str = ".") -> frozenset[str]:
 
     changed: set[str] = set()
     for name in names:
-        abs_path = _absolute_path(str(Path(root) / name))
+        abs_path = absolute_path(str(Path(root) / name))
         # Drop deletions / rename sources that no longer exist on disk.
         if Path(abs_path).is_file():
             changed.add(abs_path)
@@ -324,7 +311,7 @@ def _files_under_scan_path(files: list[str], scan_path: str) -> list[str]:
     return [
         f
         for f in files
-        if Path(f).absolute() == abs_scan or abs_scan in Path(f).absolute().parents
+        if abs_scan in (abs_f := Path(f).absolute()).parents or abs_f == abs_scan
     ]
 
 
@@ -466,7 +453,7 @@ def filter_files_by_diff_for_paths(
         if repo_root is None:
             for scan_path in group_paths:
                 for file_path in _files_under_scan_path(files, scan_path):
-                    included.add(_absolute_path(file_path))
+                    included.add(absolute_path(file_path))
             continue
 
         resolved_base = _resolve_base_for_repo(base, repo_root)
@@ -475,9 +462,9 @@ def filter_files_by_diff_for_paths(
 
         repo_files = [f for f in files if _path_in_repo(f, repo_root)]
         for file_path in filter_files_by_diff(repo_files, resolved_base, repo_root):
-            included.add(_absolute_path(file_path))
+            included.add(absolute_path(file_path))
 
-    return [f for f in files if _absolute_path(f) in included]
+    return [f for f in files if absolute_path(f) in included]
 
 
 def filter_files_by_diff(
@@ -498,4 +485,4 @@ def filter_files_by_diff(
     changed = get_changed_files(base, cwd)
     if not changed:
         return []
-    return [f for f in files if _absolute_path(f) in changed]
+    return [f for f in files if absolute_path(f) in changed]

--- a/lintro/utils/git_diff.py
+++ b/lintro/utils/git_diff.py
@@ -19,10 +19,10 @@ produce phantom paths that would break downstream tools.
 
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess  # nosec B404 - subprocess is the core mechanism for invoking git; all invocations use shell=False
 from functools import lru_cache
+from pathlib import Path
 
 # Sentinel used by the ``--diff`` CLI option to mean "flag supplied without an
 # explicit base"; resolved to the repository's default base ref at runtime.
@@ -42,6 +42,21 @@ _GIT_TIMEOUT_SECONDS: float = 30.0
 
 class DiffResolutionError(Exception):
     """Raised when an explicit ``--diff`` base ref cannot be resolved."""
+
+
+def _absolute_path(path: str) -> str:
+    """Return ``path`` as absolute without resolving symlinks.
+
+    Args:
+        path: Relative or absolute path string.
+
+    Returns:
+        Absolute path string matching ``os.path.abspath`` semantics.
+    """
+    path_obj = Path(path)
+    if path_obj.is_absolute():
+        return path
+    return str(path_obj.absolute())
 
 
 def _run_git(args: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
@@ -235,7 +250,7 @@ def get_changed_files(base: str, cwd: str = ".") -> frozenset[str]:
     Raises:
         DiffResolutionError: When ``base`` does not resolve to a commit.
     """
-    root = _repo_root(cwd) or os.path.abspath(cwd)
+    root = _repo_root(cwd) or _absolute_path(cwd)
 
     if not _ref_exists(base, cwd):
         raise DiffResolutionError(
@@ -251,9 +266,9 @@ def get_changed_files(base: str, cwd: str = ".") -> frozenset[str]:
 
     changed: set[str] = set()
     for name in names:
-        abs_path = os.path.abspath(os.path.join(root, name))
+        abs_path = _absolute_path(str(Path(root) / name))
         # Drop deletions / rename sources that no longer exist on disk.
-        if os.path.isfile(abs_path):
+        if Path(abs_path).is_file():
             changed.add(abs_path)
     return frozenset(changed)
 
@@ -267,13 +282,13 @@ def _probe_path_for_repo(path: str) -> str:
     Returns:
         Directory path suitable for ``git rev-parse``.
     """
-    abs_path = os.path.abspath(path)
-    if os.path.isfile(abs_path):
-        return os.path.dirname(abs_path) or abs_path
-    if os.path.isdir(abs_path):
-        return abs_path
-    parent = os.path.dirname(abs_path)
-    return parent if parent else "."
+    abs_path = Path(path).absolute()
+    if abs_path.is_file():
+        return str(abs_path.parent) or str(abs_path)
+    if abs_path.is_dir():
+        return str(abs_path)
+    parent = abs_path.parent
+    return str(parent) if str(parent) != str(abs_path) else "."
 
 
 def _path_in_repo(path: str, repo_root: str) -> bool:
@@ -286,9 +301,11 @@ def _path_in_repo(path: str, repo_root: str) -> bool:
     Returns:
         True when ``path`` is the root itself or a path beneath it.
     """
-    abs_path = os.path.abspath(path)
-    abs_root = os.path.abspath(repo_root)
-    return abs_path == abs_root or abs_path.startswith(abs_root + os.sep)
+    abs_path = Path(path).absolute()
+    abs_root = Path(repo_root).absolute()
+    if abs_path == abs_root:
+        return True
+    return abs_root in abs_path.parents
 
 
 def _files_under_scan_path(files: list[str], scan_path: str) -> list[str]:
@@ -301,15 +318,13 @@ def _files_under_scan_path(files: list[str], scan_path: str) -> list[str]:
     Returns:
         Files contained in or equal to ``scan_path``.
     """
-    abs_scan = os.path.abspath(scan_path)
-    if os.path.isfile(abs_scan):
-        return [f for f in files if os.path.abspath(f) == abs_scan]
-    prefix = abs_scan if abs_scan.endswith(os.sep) else abs_scan + os.sep
+    abs_scan = Path(scan_path).absolute()
+    if abs_scan.is_file():
+        return [f for f in files if Path(f).absolute() == abs_scan]
     return [
         f
         for f in files
-        if os.path.abspath(f).startswith(prefix)
-        or os.path.abspath(f) == abs_scan.rstrip(os.sep)
+        if Path(f).absolute() == abs_scan or abs_scan in Path(f).absolute().parents
     ]
 
 
@@ -451,7 +466,7 @@ def filter_files_by_diff_for_paths(
         if repo_root is None:
             for scan_path in group_paths:
                 for file_path in _files_under_scan_path(files, scan_path):
-                    included.add(os.path.abspath(file_path))
+                    included.add(_absolute_path(file_path))
             continue
 
         resolved_base = _resolve_base_for_repo(base, repo_root)
@@ -460,9 +475,9 @@ def filter_files_by_diff_for_paths(
 
         repo_files = [f for f in files if _path_in_repo(f, repo_root)]
         for file_path in filter_files_by_diff(repo_files, resolved_base, repo_root):
-            included.add(os.path.abspath(file_path))
+            included.add(_absolute_path(file_path))
 
-    return [f for f in files if os.path.abspath(f) in included]
+    return [f for f in files if _absolute_path(f) in included]
 
 
 def filter_files_by_diff(
@@ -483,4 +498,4 @@ def filter_files_by_diff(
     changed = get_changed_files(base, cwd)
     if not changed:
         return []
-    return [f for f in files if os.path.abspath(f) in changed]
+    return [f for f in files if _absolute_path(f) in changed]

--- a/lintro/utils/path_utils.py
+++ b/lintro/utils/path_utils.py
@@ -15,6 +15,45 @@ from loguru import logger
 _IGNORE_SEARCH_MAX_DEPTH = 20
 
 
+def absolute_path(path: str | Path, *, base_dir: Path | None = None) -> str:
+    """Return an absolute path without resolving symlinks.
+
+    Matches ``os.path.abspath`` normalization of ``.`` and ``..`` components.
+
+    Args:
+        path: Relative or absolute path.
+        base_dir: Base directory for relative paths when supplied.
+
+    Returns:
+        Absolute normalized path string.
+    """
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = (base_dir or Path.cwd()) / candidate
+    return str(_normalize_absolute(candidate))
+
+
+def _normalize_absolute(path: Path) -> Path:
+    """Collapse ``.`` and ``..`` parts without resolving symlinks."""
+    parts: list[str] = []
+    for part in path.parts:
+        if part in (".", ""):
+            continue
+        if part == "..":
+            if path.is_absolute():
+                if len(parts) > 1:
+                    parts.pop()
+            elif parts and parts[-1] != "..":
+                parts.pop()
+            else:
+                parts.append("..")
+            continue
+        parts.append(part)
+    if not parts:
+        return Path(path.anchor)
+    return Path(*parts)
+
+
 def find_file_upward(
     start: Path,
     filenames: Sequence[str],

--- a/tests/unit/tools/core/test_install_context.py
+++ b/tests/unit/tools/core/test_install_context.py
@@ -84,7 +84,10 @@ def test_runtime_context_environment_reflects_managers() -> None:
 
 def test_detect_docker_via_dockerenv() -> None:
     """Detect Docker context when /.dockerenv file exists."""
-    with patch.object(Path, "exists", return_value=True):
+    with patch(
+        "lintro.tools.core.install_context._dockerenv_exists",
+        return_value=True,
+    ):
         result = _detect_install_context()
 
     assert_that(result).is_equal_to(InstallContext.DOCKER)
@@ -95,7 +98,10 @@ def test_detect_docker_via_env_var(
 ) -> None:
     """Detect Docker context via LINTRO_DOCKER=1 env var."""
     monkeypatch.setenv("LINTRO_DOCKER", "1")
-    with patch.object(Path, "exists", return_value=False):
+    with patch(
+        "lintro.tools.core.install_context._dockerenv_exists",
+        return_value=False,
+    ):
         result = _detect_install_context()
 
     assert_that(result).is_equal_to(InstallContext.DOCKER)
@@ -111,7 +117,10 @@ def test_detect_docker_via_container_env_var(
     """
     monkeypatch.delenv("LINTRO_DOCKER", raising=False)
     monkeypatch.setenv("CONTAINER", "docker")
-    with patch.object(Path, "exists", return_value=False):
+    with patch(
+        "lintro.tools.core.install_context._dockerenv_exists",
+        return_value=False,
+    ):
         result = _detect_install_context()
 
     assert_that(result).is_equal_to(InstallContext.DOCKER)
@@ -130,7 +139,14 @@ def test_detect_pip_default(
     monkeypatch.delenv("CONTAINER", raising=False)
 
     with (
-        patch.object(Path, "exists", return_value=False),
+        patch(
+            "lintro.tools.core.install_context._dockerenv_exists",
+            return_value=False,
+        ),
+        patch(
+            "lintro.tools.core.install_context._git_root_marker_exists",
+            return_value=False,
+        ),
         patch(
             "lintro.tools.core.install_context.__file__",
             "/usr/lib/python3.11/site-packages/lintro/tools/core/install_context.py",
@@ -197,7 +213,14 @@ def test_detect_homebrew_install_context(
     monkeypatch.delenv("CONTAINER", raising=False)
 
     with (
-        patch.object(Path, "exists", return_value=False),
+        patch(
+            "lintro.tools.core.install_context._dockerenv_exists",
+            return_value=False,
+        ),
+        patch(
+            "lintro.tools.core.install_context._git_root_marker_exists",
+            return_value=False,
+        ),
         patch(
             "lintro.tools.core.install_context.__file__",
             install_file,
@@ -243,7 +266,14 @@ def test_detect_npm_bin_install_context(
     monkeypatch.delenv("CONTAINER", raising=False)
 
     with (
-        patch.object(Path, "exists", return_value=False),
+        patch(
+            "lintro.tools.core.install_context._dockerenv_exists",
+            return_value=False,
+        ),
+        patch(
+            "lintro.tools.core.install_context._git_root_marker_exists",
+            return_value=False,
+        ),
         patch(
             "lintro.tools.core.install_context.__file__",
             install_file,

--- a/tests/unit/tools/core/test_install_context.py
+++ b/tests/unit/tools/core/test_install_context.py
@@ -7,6 +7,7 @@ and CI detection.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -83,10 +84,7 @@ def test_runtime_context_environment_reflects_managers() -> None:
 
 def test_detect_docker_via_dockerenv() -> None:
     """Detect Docker context when /.dockerenv file exists."""
-    with patch(
-        "lintro.tools.core.install_context.os.path.exists",
-        return_value=True,
-    ):
+    with patch.object(Path, "exists", return_value=True):
         result = _detect_install_context()
 
     assert_that(result).is_equal_to(InstallContext.DOCKER)
@@ -97,10 +95,7 @@ def test_detect_docker_via_env_var(
 ) -> None:
     """Detect Docker context via LINTRO_DOCKER=1 env var."""
     monkeypatch.setenv("LINTRO_DOCKER", "1")
-    with patch(
-        "lintro.tools.core.install_context.os.path.exists",
-        return_value=False,
-    ):
+    with patch.object(Path, "exists", return_value=False):
         result = _detect_install_context()
 
     assert_that(result).is_equal_to(InstallContext.DOCKER)
@@ -116,13 +111,15 @@ def test_detect_docker_via_container_env_var(
     """
     monkeypatch.delenv("LINTRO_DOCKER", raising=False)
     monkeypatch.setenv("CONTAINER", "docker")
-    with patch(
-        "lintro.tools.core.install_context.os.path.exists",
-        return_value=False,
-    ):
+    with patch.object(Path, "exists", return_value=False):
         result = _detect_install_context()
 
     assert_that(result).is_equal_to(InstallContext.DOCKER)
+
+
+def _resolve_passthrough(self: Path) -> Path:
+    """Return the path unchanged, mimicking identity ``realpath`` in tests."""
+    return self
 
 
 def test_detect_pip_default(
@@ -133,10 +130,7 @@ def test_detect_pip_default(
     monkeypatch.delenv("CONTAINER", raising=False)
 
     with (
-        patch(
-            "lintro.tools.core.install_context.os.path.exists",
-            return_value=False,
-        ),
+        patch.object(Path, "exists", return_value=False),
         patch(
             "lintro.tools.core.install_context.__file__",
             "/usr/lib/python3.11/site-packages/lintro/tools/core/install_context.py",
@@ -146,6 +140,7 @@ def test_detect_pip_default(
             "lintro.tools.core.install_context.sys.executable",
             "/usr/bin/python3",
         ),
+        patch.object(Path, "resolve", new=_resolve_passthrough),
     ):
         result = _detect_install_context()
 
@@ -202,10 +197,7 @@ def test_detect_homebrew_install_context(
     monkeypatch.delenv("CONTAINER", raising=False)
 
     with (
-        patch(
-            "lintro.tools.core.install_context.os.path.exists",
-            return_value=False,
-        ),
+        patch.object(Path, "exists", return_value=False),
         patch(
             "lintro.tools.core.install_context.__file__",
             install_file,
@@ -215,10 +207,7 @@ def test_detect_homebrew_install_context(
             "lintro.tools.core.install_context.sys.executable",
             executable,
         ),
-        patch(
-            "lintro.tools.core.install_context.os.path.realpath",
-            side_effect=lambda path: path,
-        ),
+        patch.object(Path, "resolve", new=_resolve_passthrough),
     ):
         result = _detect_install_context()
 
@@ -254,10 +243,7 @@ def test_detect_npm_bin_install_context(
     monkeypatch.delenv("CONTAINER", raising=False)
 
     with (
-        patch(
-            "lintro.tools.core.install_context.os.path.exists",
-            return_value=False,
-        ),
+        patch.object(Path, "exists", return_value=False),
         patch(
             "lintro.tools.core.install_context.__file__",
             install_file,
@@ -267,10 +253,7 @@ def test_detect_npm_bin_install_context(
             "lintro.tools.core.install_context.sys.executable",
             executable,
         ),
-        patch(
-            "lintro.tools.core.install_context.os.path.realpath",
-            side_effect=lambda path: path,
-        ),
+        patch.object(Path, "resolve", new=_resolve_passthrough),
     ):
         result = _detect_install_context()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(core): migrate os.path to pathlib in core modules
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Migrates remaining `os.path` usage in three core modules to `pathlib.Path`, aligning with stand-py and eliminating mixed string/path handling.

- `line_length_checker.py`: `Path.is_absolute()`, `Path.absolute()`, and `/` joins (no symlink resolution).
- `install_context.py`: `Path.exists()`, `Path.resolve()` for realpath semantics, and `Path.parents` for repo-root detection.
- `git_diff.py`: pathlib helpers for abspath, containment checks, and file probes; preserves #1342 multi-repo diff behavior.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1349

## Details

- Uses `Path.absolute()` where the old code used `os.path.abspath` (does not resolve symlinks).
- Uses `Path.resolve()` where the old code used `os.path.realpath` in install-context detection.
- Updated `test_install_context.py` mocks to patch `Path.exists` / `Path.resolve` instead of `os.path`.
- Full `uv run lintro chk`, `uv run lintro fmt`, and `uv run lintro tst` pass locally.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates `os.path` usage to `pathlib` across three core modules (`line_length_checker`, `install_context`, `git_diff`) and introduces a new `absolute_path()` / `_normalize_absolute()` utility in `path_utils.py` that correctly replicates `os.path.abspath` normalization (collapsing `.` and `..`) without resolving symlinks.

- **`path_utils.py`**: New `absolute_path()` centralizes the abspath-without-symlink-resolution idiom; `_normalize_absolute()` manually collapses `..` parts by walking `path.parts`, correctly clamping at the filesystem root for absolute paths.
- **`install_context.py`**: Filesystem side-effects are extracted into mockable helpers (`_dockerenv_exists`, `_git_root_marker_exists`); the 4-level parent traversal now uses a safe `.parent` loop; tests are updated to patch the helpers directly.
- **`git_diff.py`**: Path operations are unified through `absolute_path()` and pathlib comparisons; the `_files_under_scan_path` list comprehension uses the walrus operator to avoid computing `Path(f).absolute()` twice per file.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the refactor preserves all observable behaviors and the new `_normalize_absolute` implementation correctly replicates `os.path.abspath` normalization for the paths that actually flow through these functions.

All three migrated modules produce semantically equivalent output to the original `os.path` code for the path shapes encountered in practice. The new `absolute_path()` utility correctly handles `.` and `..` normalization without symlink resolution. Helper extraction in `install_context.py` improves testability without changing logic.

No files require special attention; `lintro/utils/git_diff.py` has two minor dead-code patterns worth cleaning up but neither affects correctness.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/utils/path_utils.py | Adds `absolute_path()` utility and `_normalize_absolute()` helper to replicate `os.path.abspath` normalization without symlink resolution; logic is correct for the normal absolute-path case. |
| lintro/utils/git_diff.py | Replaces `os.path` calls with `absolute_path()` and pathlib equivalents; contains two minor dead-code patterns: the unreachable `or str(abs_path)` fallback and a redundant `Path(abs_path)` re-wrap. |
| lintro/tools/core/install_context.py | Extracts filesystem side-effects into testable helpers; uses a safe `.parent` loop; semantic equivalence to the old `os.path` code is preserved. |
| lintro/tools/core/line_length_checker.py | Straightforward substitution of the hand-rolled abs-path loop with `absolute_path()`; both the pre-pass and the Ruff-output normalization paths are covered cleanly. |
| tests/unit/tools/core/test_install_context.py | Test patches are updated to target the new helper functions and `Path.resolve` is patched via a passthrough; tests remain behaviorally equivalent. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["path input"] --> B["absolute_path()"]
    B --> C["Path.expanduser()"]
    C --> D{"is_absolute?"}
    D -- No --> E["prepend base_dir or cwd"]
    D -- Yes --> F["_normalize_absolute()"]
    E --> F
    F --> G["iterate path.parts"]
    G --> H{"part == '..'?"}
    H -- "yes, depth gt 1" --> J["parts.pop()"]
    H -- "yes, at root" --> K["skip"]
    H -- "dot or empty" --> L["skip"]
    H -- other --> M["parts.append"]
    J --> G
    K --> G
    L --> G
    M --> G
    G --> N["return normalized str"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["path input"] --> B["absolute_path()"]
    B --> C["Path.expanduser()"]
    C --> D{"is_absolute?"}
    D -- No --> E["prepend base_dir or cwd"]
    D -- Yes --> F["_normalize_absolute()"]
    E --> F
    F --> G["iterate path.parts"]
    G --> H{"part == '..'?"}
    H -- "yes, depth gt 1" --> J["parts.pop()"]
    H -- "yes, at root" --> K["skip"]
    H -- "dot or empty" --> L["skip"]
    H -- other --> M["parts.append"]
    J --> G
    K --> G
    L --> G
    M --> G
    G --> N["return normalized str"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(core): address pathlib review feedba..."](https://github.com/lgtm-hq/py-lintro/commit/304e8d183d8f1fa5eaa1ad5c34036f312f3e3ddb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44229096)</sub>

<!-- /greptile_comment -->