### PR TITLE
chore(deps): ignore Renovate bumps for lintro npm placeholders

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,9 @@
   "packageRules": [
     {
       "description": "npm platform-binary placeholders are stamped at publish time; never bump in-repo",
-      "matchPackageNames": ["/^@lgtm-hq\\/lintro(-|$)/"],
+      "matchPackageNames": [
+        "/^@lgtm-hq\\/lintro(-|$)/"
+      ],
       "enabled": false
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,11 @@
   ],
   "packageRules": [
     {
+      "description": "npm platform-binary placeholders are stamped at publish time; never bump in-repo",
+      "matchPackageNames": ["/^@lgtm-hq\\/lintro(-|$)/"],
+      "enabled": false
+    },
+    {
       "matchDatasources": ["pypi"],
       "matchUpdateTypes": ["minor"],
       "automerge": false


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(deps): ignore Renovate bumps for lintro npm placeholders
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Adds a Renovate `packageRules` entry that disables updates for `@lgtm-hq/lintro` and `@lgtm-hq/lintro-*` packages. Those optionalDependency pins are intentional `0.0.0-dev` placeholders stamped at publish time; Renovate otherwise re-opens four platform-package PRs every release.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1407
- Relates to #1411
- Relates to #1412

## Details

Rule matches `/^@lgtm-hq\/lintro(-|$)/` with `enabled: false`. After merge, close the open placeholder bump PRs (#1411, #1412) as superseded by this config.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a single `packageRules` entry to `renovate.json` that disables Renovate update PRs for the `@lgtm-hq/lintro` family of npm packages. Those packages (`@lgtm-hq/lintro`, `@lgtm-hq/lintro-darwin-arm64`, `@lgtm-hq/lintro-darwin-x64`, `@lgtm-hq/lintro-linux-arm64`, `@lgtm-hq/lintro-linux-x64`) are pinned at `0.0.0-dev` in the repo as publish-time placeholders and should never be bumped by a bot.

- The regex `/^@lgtm-hq\/lintro(-|$)/` correctly covers both the root package (matched by the `$` branch) and all current and future platform-specific sub-packages (matched by the `-` branch), so newly added platform packages like `lintro-win32-x64` would also be silenced automatically.
- `enabled: false` is the canonical Renovate mechanism for suppressing updates; placing the rule first in `packageRules` is harmless since Renovate merges all matching rules additively.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-line config addition with no risk of breaking existing update behaviour for other packages.

The change is a narrowly scoped Renovate config entry that opts out of automated bumps for internal placeholder packages pinned at 0.0.0-dev. The regex is correctly anchored and covers all existing platform sub-packages. No other rules are modified, and the rest of the Renovate workflow is unaffected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Adds a packageRules entry with enabled: false to suppress Renovate bumps for @lgtm-hq/lintro and all @lgtm-hq/lintro-* platform packages pinned at 0.0.0-dev |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Renovate scans npm deps] --> B{Matches packageRule regex}
    B -- yes --> C[enabled: false — no PR created]
    B -- no --> D[Normal update rules apply]
    C --> E1[at-lgtm-hq/lintro]
    C --> E2[at-lgtm-hq/lintro-darwin-arm64]
    C --> E3[at-lgtm-hq/lintro-darwin-x64]
    C --> E4[at-lgtm-hq/lintro-linux-arm64]
    C --> E5[at-lgtm-hq/lintro-linux-x64]
    D --> F[Other deps follow existing packageRules]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Renovate scans npm deps] --> B{Matches packageRule regex}
    B -- yes --> C[enabled: false — no PR created]
    B -- no --> D[Normal update rules apply]
    C --> E1[at-lgtm-hq/lintro]
    C --> E2[at-lgtm-hq/lintro-darwin-arm64]
    C --> E3[at-lgtm-hq/lintro-darwin-x64]
    C --> E4[at-lgtm-hq/lintro-linux-arm64]
    C --> E5[at-lgtm-hq/lintro-linux-x64]
    D --> F[Other deps follow existing packageRules]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["style(deps): format renovate.json with p..."](https://github.com/lgtm-hq/py-lintro/commit/7a592cbe744c1dda0c47b61ba98c9471abd9a649) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44812815)</sub>

<!-- /greptile_comment -->