### PR TITLE
chore(deps): hold prettier >3.9.4 in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,11 @@
   ],
   "packageRules": [
     {
+      "description": "Hold prettier 3.9.5+ until Docker integration prettier fixtures are updated",
+      "matchPackageNames": ["prettier"],
+      "allowedVersions": "<=3.9.4"
+    },
+    {
       "description": "npm platform-binary placeholders are stamped at publish time; never bump in-repo",
       "matchPackageNames": [
         "/^@lgtm-hq\\/lintro(-|$)/"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(deps): hold prettier >3.9.4 in Renovate
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

- Renovate hold: \`prettier <=3.9.4\` until Docker integration tests are updated for 3.9.5.
- Lets us close #1434 without leaving a stuck majors/patch PR open.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1434

## Details

_See What’s Changing._
