### PR TITLE
refactor(ci): extract inline shell from build-binary.yml into dedicated scripts

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -255,24 +255,15 @@ jobs:
           retention-days: 7
 
       - name: Verify binary
-        run: |
-          ls -lh dist/nuitka/
-          # Fail if binary can't execute --version (required for valid build)
-          ./dist/nuitka/lintro --version
-          # Show help output for debugging (non-fatal)
-          ./dist/nuitka/lintro --help | head -20 || echo "Help output truncated"
+        run: scripts/build/verify_built_binary.sh dist/nuitka/lintro
 
-      - name: Rename binary with architecture
-        run: |
-          mv dist/nuitka/lintro dist/nuitka/lintro-macos-${{ matrix.arch }}
-
-      - name: Calculate SHA256
+      - name: Finalize binary
         id: sha256
-        run: |
-          BINARY="dist/nuitka/lintro-macos-${{ matrix.arch }}"
-          SHA=$(shasum -a 256 "$BINARY" | cut -d' ' -f1)
-          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
-          echo "SHA256 for ${{ matrix.arch }}: $SHA"
+        run: >-
+          scripts/build/finalize_binary.sh
+          dist/nuitka/lintro
+          dist/nuitka/lintro-macos-${{ matrix.arch }}
+          ${{ matrix.arch }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -405,22 +396,15 @@ jobs:
           retention-days: 7
 
       - name: Verify binary
-        run: |
-          ls -lh dist/nuitka/
-          ./dist/nuitka/lintro --version
-          ./dist/nuitka/lintro --help | head -20 || echo "Help output truncated"
+        run: scripts/build/verify_built_binary.sh dist/nuitka/lintro
 
-      - name: Rename binary with architecture
-        run: |
-          mv dist/nuitka/lintro dist/nuitka/lintro-linux-${{ matrix.arch }}
-
-      - name: Calculate SHA256
+      - name: Finalize binary
         id: sha256
-        run: |
-          BINARY="dist/nuitka/lintro-linux-${{ matrix.arch }}"
-          SHA=$(sha256sum "$BINARY" | cut -d' ' -f1)
-          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
-          echo "SHA256 for linux-${{ matrix.arch }}: $SHA"
+        run: >-
+          scripts/build/finalize_binary.sh
+          dist/nuitka/lintro
+          dist/nuitka/lintro-linux-${{ matrix.arch }}
+          linux-${{ matrix.arch }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -486,17 +470,11 @@ jobs:
           path: binaries/
 
       - name: Create universal binary
-        run: |
-          lipo -create \
-            binaries/lintro-macos-arm64 \
-            binaries/lintro-macos-x86_64 \
-            -output binaries/lintro-macos-universal
-          chmod +x binaries/lintro-macos-universal
-
-      - name: Verify universal binary
-        run: |
-          file binaries/lintro-macos-universal
-          ls -lh binaries/lintro-macos-universal
+        run: >-
+          scripts/build/create_universal.sh
+          binaries/lintro-macos-arm64
+          binaries/lintro-macos-x86_64
+          binaries/lintro-macos-universal
 
       - name: Upload universal artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -273,8 +273,10 @@ jobs:
           retention-days: 7
 
       - name: Save SHA256 to file
+        env:
+          SHA256: ${{ steps.sha256.outputs.sha256 }}
         run: |
-          echo "${{ steps.sha256.outputs.sha256 }}" > sha256-${{ matrix.arch }}.txt
+          echo "$SHA256" > sha256-${{ matrix.arch }}.txt
 
       - name: Upload SHA256 file
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -458,7 +460,7 @@ jobs:
             uploads.github.com:443
 
       - name: Checkout scripts
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: scripts
           persist-credentials: false

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -457,6 +457,12 @@ jobs:
             api.github.com:443
             uploads.github.com:443
 
+      - name: Checkout scripts
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          sparse-checkout: scripts
+          persist-credentials: false
+
       - name: Download arm64 binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -257,13 +257,18 @@ jobs:
       - name: Verify binary
         run: scripts/build/verify_built_binary.sh dist/nuitka/lintro
 
+      # matrix.arch reaches the shell via env, not template expansion: on
+      # workflow_call inputs.arch is a free-form string that feeds this matrix
+      # (same hardening as the Build binary step above).
       - name: Finalize binary
         id: sha256
+        env:
+          BUILD_ARCH: ${{ matrix.arch }}
         run: >-
           scripts/build/finalize_binary.sh
           dist/nuitka/lintro
-          dist/nuitka/lintro-macos-${{ matrix.arch }}
-          ${{ matrix.arch }}
+          "dist/nuitka/lintro-macos-$BUILD_ARCH"
+          "$BUILD_ARCH"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -275,8 +280,9 @@ jobs:
       - name: Save SHA256 to file
         env:
           SHA256: ${{ steps.sha256.outputs.sha256 }}
+          BUILD_ARCH: ${{ matrix.arch }}
         run: |
-          echo "$SHA256" > sha256-${{ matrix.arch }}.txt
+          echo "$SHA256" > "sha256-$BUILD_ARCH.txt"
 
       - name: Upload SHA256 file
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -400,13 +406,17 @@ jobs:
       - name: Verify binary
         run: scripts/build/verify_built_binary.sh dist/nuitka/lintro
 
+      # Kept symmetric with the macOS job: both call sites pass the arch
+      # through env so the two never drift apart.
       - name: Finalize binary
         id: sha256
+        env:
+          BUILD_ARCH: ${{ matrix.arch }}
         run: >-
           scripts/build/finalize_binary.sh
           dist/nuitka/lintro
-          dist/nuitka/lintro-linux-${{ matrix.arch }}
-          linux-${{ matrix.arch }}
+          "dist/nuitka/lintro-linux-$BUILD_ARCH"
+          "linux-$BUILD_ARCH"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -457,8 +457,13 @@ jobs:
           allowed-endpoints: >
             github.com:443
             api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
             uploads.github.com:443
 
+      # Needed for scripts/build/create_universal.sh. The codeload /
+      # objects.githubusercontent.com endpoints above are what actions/checkout
+      # fetches through, and match the other sparse-checkout jobs here.
       - name: Checkout scripts
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ __pycache__/
 build/
 !scripts/build/
 !scripts/build/**
+!tests/bats/unit/build/
+!tests/bats/unit/build/**
 scripts/build/__pycache__/
 develop-eggs/
 dist/

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,12 +55,15 @@ scripts/
 
 Scripts for building standalone binaries and distribution packages.
 
-| Script                                | Purpose                                                                                                     | Usage                                                       |
-| ------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| `build_macos.py`                      | Build macOS binary using Nuitka compiler                                                                    | `uv run python scripts/build/build_macos.py`                |
-| `build_linux.py`                      | Build Linux binary using Nuitka compiler                                                                    | `uv run python scripts/build/build_linux.py`                |
-| `generate-man-page.py`                | Generate the lintro(1) man page from Click help                                                             | `uv run python scripts/generate-man-page.py`                |
-| `generate-checklist-corpus-schema.py` | Generate the review checklist corpus JSON Schema from the Python enums (`--check` diffs instead of writing) | `uv run python scripts/generate-checklist-corpus-schema.py` |
+| Script                                | Purpose                                                                                                     | Usage                                                           |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `build_macos.py`                      | Build macOS binary using Nuitka compiler                                                                    | `uv run python scripts/build/build_macos.py`                    |
+| `build_linux.py`                      | Build Linux binary using Nuitka compiler                                                                    | `uv run python scripts/build/build_linux.py`                    |
+| `generate-man-page.py`                | Generate the lintro(1) man page from Click help                                                             | `uv run python scripts/generate-man-page.py`                    |
+| `generate-checklist-corpus-schema.py` | Generate the review checklist corpus JSON Schema from the Python enums (`--check` diffs instead of writing) | `uv run python scripts/generate-checklist-corpus-schema.py`     |
+| `verify_built_binary.sh`              | Verify a built binary responds to `--version` and `--help`                                                  | `./scripts/build/verify_built_binary.sh dist/nuitka/lintro`     |
+| `finalize_binary.sh`                  | Rename binary, ensure executable, compute SHA256, write the `sha256` step output                            | `./scripts/build/finalize_binary.sh <source> <target> [label]`  |
+| `create_universal.sh`                 | Combine arm64 and x86_64 macOS binaries into a universal fat binary with `lipo`                             | `./scripts/build/create_universal.sh <arm64> <x86_64> <output>` |
 
 ### 📦 npm Distribution Scripts (`ci/npm/`)
 
@@ -83,18 +86,6 @@ sends a `repository_dispatch` with release facts (version, binary checksums); th
 renders, validates, and auto-merges `Formula/lintro.rb` (binary) and
 `Formula/lintro-full.rb` (PyPI full install). Only release-support helpers remain here
 (see Homebrew Scripts below).
-
-### 📦 Build Scripts (`build/`)
-
-Scripts for building standalone binaries and distribution packages.
-
-| Script                   | Purpose                                                       | Usage                                                                 |
-| ------------------------ | ------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `build_macos.py`         | Build macOS binary using Nuitka compiler                      | `uv run python scripts/build/build_macos.py`                          |
-| `build_linux.py`         | Build Linux binary using Nuitka compiler                        | `uv run python scripts/build/build_linux.py`                          |
-| `verify_built_binary.sh` | Verify a built binary responds to `--version` and `--help`    | `./scripts/build/verify_built_binary.sh dist/nuitka/lintro`           |
-| `finalize_binary.sh`     | Rename binary, compute SHA256, write GitHub Actions output    | `./scripts/build/finalize_binary.sh <source> <target> [label]`        |
-| `create_universal.sh`    | Combine arm64 and x86_64 macOS binaries into a universal fat binary | `./scripts/build/create_universal.sh <arm64> <x86_64> <output>` |
 
 ### 🔧 CI/CD Scripts (`ci/`)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,6 +84,18 @@ renders, validates, and auto-merges `Formula/lintro.rb` (binary) and
 `Formula/lintro-full.rb` (PyPI full install). Only release-support helpers remain here
 (see Homebrew Scripts below).
 
+### 📦 Build Scripts (`build/`)
+
+Scripts for building standalone binaries and distribution packages.
+
+| Script                   | Purpose                                                       | Usage                                                                 |
+| ------------------------ | ------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `build_macos.py`         | Build macOS binary using Nuitka compiler                      | `uv run python scripts/build/build_macos.py`                          |
+| `build_linux.py`         | Build Linux binary using Nuitka compiler                        | `uv run python scripts/build/build_linux.py`                          |
+| `verify_built_binary.sh` | Verify a built binary responds to `--version` and `--help`    | `./scripts/build/verify_built_binary.sh dist/nuitka/lintro`           |
+| `finalize_binary.sh`     | Rename binary, compute SHA256, write GitHub Actions output    | `./scripts/build/finalize_binary.sh <source> <target> [label]`        |
+| `create_universal.sh`    | Combine arm64 and x86_64 macOS binaries into a universal fat binary | `./scripts/build/create_universal.sh <arm64> <x86_64> <output>` |
+
 ### 🔧 CI/CD Scripts (`ci/`)
 
 Scripts for GitHub Actions workflows and continuous integration.

--- a/scripts/build/create_universal.sh
+++ b/scripts/build/create_universal.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Create a macOS universal binary from arm64 and x86_64 builds.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../utils/utils.sh disable=SC1091
+source "$SCRIPT_DIR/../utils/utils.sh"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" || $# -lt 3 ]]; then
+	cat <<'EOF'
+Create a macOS universal lintro binary with lipo.
+
+Usage: create_universal.sh <arm64-binary> <x86_64-binary> <output-path>
+
+Combines the two architecture-specific binaries, marks the result executable,
+and prints file(1) and ls verification output.
+EOF
+	[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && exit 0
+	exit 2
+fi
+
+ARM64_BINARY="$1"
+X86_64_BINARY="$2"
+OUTPUT="$3"
+
+for binary in "$ARM64_BINARY" "$X86_64_BINARY"; do
+	if [[ ! -f "$binary" ]]; then
+		log_error "Input binary not found: $binary"
+		exit 1
+	fi
+done
+
+if ! command -v lipo >/dev/null 2>&1; then
+	log_error "lipo not found (macOS only)"
+	exit 1
+fi
+
+OUTPUT_DIR="$(dirname "$OUTPUT")"
+mkdir -p "$OUTPUT_DIR"
+
+lipo -create "$ARM64_BINARY" "$X86_64_BINARY" -output "$OUTPUT"
+chmod +x "$OUTPUT"
+
+file "$OUTPUT"
+ls -lh "$OUTPUT"

--- a/scripts/build/create_universal.sh
+++ b/scripts/build/create_universal.sh
@@ -43,5 +43,6 @@ mkdir -p "$OUTPUT_DIR"
 lipo -create "$ARM64_BINARY" "$X86_64_BINARY" -output "$OUTPUT"
 chmod +x "$OUTPUT"
 
-file "$OUTPUT"
-ls -lh "$OUTPUT"
+# Display-only: a missing file(1)/ls must not fail a successful lipo.
+file "$OUTPUT" || true
+ls -lh "$OUTPUT" || true

--- a/scripts/build/finalize_binary.sh
+++ b/scripts/build/finalize_binary.sh
@@ -57,6 +57,11 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
 	echo "sha256=$SHA" >>"$GITHUB_OUTPUT"
 fi
 
-SIZE_HUMAN="$(ls -lh "$TARGET" | awk '{print $5}')"
+if command -v stat >/dev/null 2>&1; then
+	SIZE_BYTES="$(stat -f %z "$TARGET" 2>/dev/null || stat -c %s "$TARGET")"
+	SIZE_HUMAN="${SIZE_BYTES} bytes"
+else
+	SIZE_HUMAN="$(ls -lh "$TARGET" | awk '{print $5}')"
+fi
 log_info "SHA256 for ${LABEL}: $SHA"
 log_success "Finalized ${TARGET}: size=${SIZE_HUMAN} sha256=${SHA}"

--- a/scripts/build/finalize_binary.sh
+++ b/scripts/build/finalize_binary.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Rename a built binary, ensure executable, compute SHA256, and write GitHub output.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../utils/utils.sh disable=SC1091
+source "$SCRIPT_DIR/../utils/utils.sh"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" || $# -lt 2 ]]; then
+	cat <<'EOF'
+Finalize a built lintro binary for CI artifact upload.
+
+Usage: finalize_binary.sh <source-binary> <target-path> [label]
+
+Moves the source binary to the target path, ensures it is executable,
+computes SHA256, writes sha256 to GITHUB_OUTPUT when set, and prints a
+verification line with file size and hash.
+
+Arguments:
+  source-binary  Path to the built binary before rename.
+  target-path    Destination path (e.g. dist/nuitka/lintro-macos-arm64).
+  label          Optional display label for log output (defaults to target basename).
+
+Environment:
+  GITHUB_OUTPUT  When set, appends sha256=<hash> for downstream workflow steps.
+EOF
+	[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && exit 0
+	exit 2
+fi
+
+SOURCE="$1"
+TARGET="$2"
+LABEL="${3:-$(basename "$TARGET")}"
+
+if [[ ! -f "$SOURCE" ]]; then
+	log_error "Source binary not found: $SOURCE"
+	exit 1
+fi
+
+TARGET_DIR="$(dirname "$TARGET")"
+mkdir -p "$TARGET_DIR"
+mv "$SOURCE" "$TARGET"
+chmod +x "$TARGET"
+
+if command -v sha256sum >/dev/null 2>&1; then
+	SHA="$(sha256sum "$TARGET" | cut -d' ' -f1)"
+elif command -v shasum >/dev/null 2>&1; then
+	SHA="$(shasum -a 256 "$TARGET" | cut -d' ' -f1)"
+else
+	log_error "No SHA256 tool found (expected sha256sum or shasum)"
+	exit 1
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	echo "sha256=$SHA" >>"$GITHUB_OUTPUT"
+fi
+
+SIZE_HUMAN="$(ls -lh "$TARGET" | awk '{print $5}')"
+log_info "SHA256 for ${LABEL}: $SHA"
+log_success "Finalized ${TARGET}: size=${SIZE_HUMAN} sha256=${SHA}"

--- a/scripts/build/finalize_binary.sh
+++ b/scripts/build/finalize_binary.sh
@@ -57,11 +57,18 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
 	echo "sha256=$SHA" >>"$GITHUB_OUTPUT"
 fi
 
-if command -v stat >/dev/null 2>&1; then
-	SIZE_BYTES="$(stat -f %z "$TARGET" 2>/dev/null || stat -c %s "$TARGET")"
-	SIZE_HUMAN="${SIZE_BYTES} bytes"
+# Everything below is display-only: the rename, chmod, hash and GITHUB_OUTPUT
+# write are already done. Under `set -e` a failure here would fail the step and
+# skip the upload, so every command in this block falls back instead of aborting.
+# BSD stat wants -f %z, GNU stat wants -c %s, and a stat missing both (or
+# missing entirely) yields 0 rather than a non-zero exit.
+SIZE_BYTES="$(stat -f %z "$TARGET" 2>/dev/null || stat -c %s "$TARGET" 2>/dev/null || echo 0)"
+if command -v numfmt >/dev/null 2>&1; then
+	# Restores the readable "11M" form the old `ls -lh` parsing gave us, without
+	# depending on ls output columns. numfmt is GNU-only, hence the fallback.
+	SIZE_DISPLAY="$(numfmt --to=iec "$SIZE_BYTES" 2>/dev/null || printf '%s bytes' "$SIZE_BYTES")"
 else
-	SIZE_HUMAN="$(ls -lh "$TARGET" | awk '{print $5}')"
+	SIZE_DISPLAY="${SIZE_BYTES} bytes"
 fi
 log_info "SHA256 for ${LABEL}: $SHA"
-log_success "Finalized ${TARGET}: size=${SIZE_HUMAN} sha256=${SHA}"
+log_success "Finalized ${TARGET}: size=${SIZE_DISPLAY} sha256=${SHA}"

--- a/scripts/build/verify_built_binary.sh
+++ b/scripts/build/verify_built_binary.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Verify a built lintro binary responds to --version and --help.
+
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" || $# -lt 1 ]]; then
+	cat <<'EOF'
+Verify a built lintro binary before packaging.
+
+Usage: verify_built_binary.sh <binary-path>
+
+Runs --version (required) and --help (non-fatal truncation) checks.
+EOF
+	[[ "${1:-}" == "--help" || "${1:-}" == "-h" ]] && exit 0
+	exit 2
+fi
+
+BINARY="$1"
+
+if [[ ! -f "$BINARY" ]]; then
+	echo "Binary not found: $BINARY" >&2
+	exit 1
+fi
+
+ls -lh "$(dirname "$BINARY")"
+"$BINARY" --version
+"$BINARY" --help | head -20 || echo "Help output truncated"

--- a/scripts/build/verify_built_binary.sh
+++ b/scripts/build/verify_built_binary.sh
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../utils/utils.sh disable=SC1091
+source "$SCRIPT_DIR/../utils/utils.sh"
+
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" || $# -lt 1 ]]; then
 	cat <<'EOF'
 Verify a built lintro binary before packaging.
@@ -19,7 +23,7 @@ fi
 BINARY="$1"
 
 if [[ ! -f "$BINARY" ]]; then
-	echo "Binary not found: $BINARY" >&2
+	log_error "Binary not found: $BINARY"
 	exit 1
 fi
 

--- a/scripts/build/verify_built_binary.sh
+++ b/scripts/build/verify_built_binary.sh
@@ -28,5 +28,20 @@ if [[ ! -f "$BINARY" ]]; then
 fi
 
 ls -lh "$(dirname "$BINARY")"
+
+# --version is the build gate: a binary that cannot report its version is not
+# a valid build.
 "$BINARY" --version
-"$BINARY" --help | head -20 || echo "Help output truncated"
+
+# --help stays non-fatal (it is diagnostic output only), but capture it before
+# truncating: piping straight into `head` under `set -o pipefail` turns head's
+# SIGPIPE into a failure that is indistinguishable from a genuinely broken
+# --help, and the old `|| echo "Help output truncated"` swallowed both.
+HELP_OUTPUT="$(mktemp)"
+trap 'rm -f "$HELP_OUTPUT"' EXIT
+if "$BINARY" --help >"$HELP_OUTPUT" 2>&1; then
+	head -20 "$HELP_OUTPUT"
+else
+	log_warning "--help exited non-zero (non-fatal); first 20 lines follow"
+	head -20 "$HELP_OUTPUT"
+fi

--- a/scripts/build/verify_built_binary.sh
+++ b/scripts/build/verify_built_binary.sh
@@ -27,7 +27,8 @@ if [[ ! -f "$BINARY" ]]; then
 	exit 1
 fi
 
-ls -lh "$(dirname "$BINARY")"
+# Display-only: a missing ls must not skip the --version gate.
+ls -lh "$(dirname "$BINARY")" || true
 
 # --version is the build gate: a binary that cannot report its version is not
 # a valid build.

--- a/tests/bats/helpers/common.bash
+++ b/tests/bats/helpers/common.bash
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Common utilities for py-lintro BATS tests.
+
+HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${HELPERS_DIR}/../../.." && pwd)"
+export PROJECT_ROOT
+export BUILD_SCRIPTS_DIR="${PROJECT_ROOT}/scripts/build"
+
+_load_bats_library() {
+	local name="$1"
+	local paths=(
+		"${BATS_TEST_DIRNAME}/../../node_modules/bats-${name}/load.bash"
+		"/opt/homebrew/lib/bats-${name}/load.bash"
+		"/usr/local/lib/bats-${name}/load.bash"
+		"/usr/lib/bats-${name}/load.bash"
+	)
+
+	for path in "${paths[@]}"; do
+		if [[ -f "${path}" ]]; then
+			# shellcheck disable=SC1090
+			source "${path}"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+if ! _load_bats_library "support"; then
+	fail() {
+		echo "# $*" >&2
+		return 1
+	}
+fi
+
+if ! _load_bats_library "assert"; then
+	# shellcheck disable=SC2154
+	assert_success() {
+		[[ "${status}" -eq 0 ]] || {
+			echo "# Expected success, got exit ${status}" >&2
+			echo "# Output: ${output}" >&2
+			return 1
+		}
+	}
+
+	# shellcheck disable=SC2154
+	assert_failure() {
+		[[ "${status}" -ne 0 ]] || {
+			echo "# Expected failure, got exit 0" >&2
+			echo "# Output: ${output}" >&2
+			return 1
+		}
+	}
+
+	# shellcheck disable=SC2154
+	assert_output() {
+		local expected
+		if [[ "$1" == "--partial" ]]; then
+			expected="$2"
+			[[ "${output}" == *"${expected}"* ]] || {
+				echo "# Expected output to contain: ${expected}" >&2
+				echo "# Actual output: ${output}" >&2
+				return 1
+			}
+		else
+			expected="$1"
+			[[ "${output}" == "${expected}" ]] || {
+				echo "# Expected output: ${expected}" >&2
+				echo "# Actual output: ${output}" >&2
+				return 1
+			}
+		fi
+	}
+
+	assert_equal() {
+		[[ "$1" == "$2" ]] || {
+			echo "# Expected: $1" >&2
+			echo "# Actual:   $2" >&2
+			return 1
+		}
+	}
+fi
+
+setup_temp_dir() {
+	if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
+		local tmpdir
+		if ! tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/bats-test.XXXXXXXXXX")"; then
+			echo "# Failed to create BATS temp directory" >&2
+			return 1
+		fi
+		export BATS_TEST_TMPDIR="${tmpdir}"
+	fi
+}
+
+teardown_temp_dir() {
+	if [[ -n "${BATS_TEST_TMPDIR:-}" ]] && [[ -d "${BATS_TEST_TMPDIR}" ]]; then
+		rm -rf "${BATS_TEST_TMPDIR}"
+	fi
+}
+
+setup_github_env() {
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github_output"
+	touch "$GITHUB_OUTPUT"
+}
+
+get_github_output() {
+	local key="$1"
+	grep -m1 "^${key}=" "${GITHUB_OUTPUT}" | cut -d= -f2-
+}
+
+compute_expected_sha256() {
+	local file="$1"
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$file" | cut -d' ' -f1
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$file" | cut -d' ' -f1
+	else
+		echo "# No SHA256 tool available" >&2
+		return 1
+	fi
+}
+
+create_fake_binary() {
+	local path="$1"
+	local content="${2:-fake-binary}"
+	mkdir -p "$(dirname "$path")"
+	printf '%s\n' "$content" >"$path"
+	chmod +x "$path"
+}

--- a/tests/bats/helpers/common.bash
+++ b/tests/bats/helpers/common.bash
@@ -83,20 +83,11 @@ if ! _load_bats_library "assert"; then
 fi
 
 setup_temp_dir() {
-	if [[ -z "${BATS_TEST_TMPDIR:-}" ]]; then
-		local tmpdir
-		if ! tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/bats-test.XXXXXXXXXX")"; then
-			echo "# Failed to create BATS temp directory" >&2
-			return 1
-		fi
-		export BATS_TEST_TMPDIR="${tmpdir}"
-	fi
+	: "${BATS_TEST_TMPDIR:?BATS_TEST_TMPDIR must be set by BATS}"
 }
 
 teardown_temp_dir() {
-	if [[ -n "${BATS_TEST_TMPDIR:-}" ]] && [[ -d "${BATS_TEST_TMPDIR}" ]]; then
-		rm -rf "${BATS_TEST_TMPDIR}"
-	fi
+	:
 }
 
 setup_github_env() {

--- a/tests/bats/helpers/common.bash
+++ b/tests/bats/helpers/common.bash
@@ -120,11 +120,11 @@ compute_expected_sha256() {
 make_stub_path() {
 	local dir="$1"
 	shift
-	mkdir -p "$dir"
+	mkdir -p "$dir" || return 1
 	local tool src
 	for tool in "$@"; do
 		src="$(command -v "$tool")" || return 1
-		ln -sf "$src" "${dir}/${tool}"
+		ln -sf "$src" "${dir}/${tool}" || return 1
 	done
 	printf '%s' "$dir"
 }

--- a/tests/bats/helpers/common.bash
+++ b/tests/bats/helpers/common.bash
@@ -112,6 +112,23 @@ compute_expected_sha256() {
 	fi
 }
 
+# Build a directory holding symlinks to only the named commands, and echo it.
+# Running a script with PATH set to that directory exercises fail-closed
+# branches (a required tool being absent) without touching the real
+# environment. Include `bash`: the `#!/usr/bin/env bash` shebang resolves the
+# interpreter through PATH, so omitting it fails the script before it starts.
+make_stub_path() {
+	local dir="$1"
+	shift
+	mkdir -p "$dir"
+	local tool src
+	for tool in "$@"; do
+		src="$(command -v "$tool")" || return 1
+		ln -sf "$src" "${dir}/${tool}"
+	done
+	printf '%s' "$dir"
+}
+
 create_fake_binary() {
 	local path="$1"
 	local content="${2:-fake-binary}"

--- a/tests/bats/unit/build/test_create_universal.bats
+++ b/tests/bats/unit/build/test_create_universal.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/build/create_universal.sh
+
+load "../../helpers/common"
+
+SCRIPT="${BUILD_SCRIPTS_DIR}/create_universal.sh"
+
+setup() {
+	setup_temp_dir
+	WORKDIR="${BATS_TEST_TMPDIR}/work"
+	mkdir -p "${WORKDIR}/binaries"
+	ARM64="${WORKDIR}/binaries/lintro-macos-arm64"
+	X86="${WORKDIR}/binaries/lintro-macos-x86_64"
+	OUTPUT="${WORKDIR}/binaries/lintro-macos-universal"
+
+	if command -v cc >/dev/null 2>&1; then
+		cat >"${BATS_TEST_TMPDIR}/stub.c" <<'EOF'
+int main(void) {
+	return 0;
+}
+EOF
+		cc -arch arm64 -o "$ARM64" "${BATS_TEST_TMPDIR}/stub.c" 2>/dev/null || true
+		cc -arch x86_64 -o "$X86" "${BATS_TEST_TMPDIR}/stub.c" 2>/dev/null || true
+	fi
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "create_universal.sh: --help exits 0" {
+	run bash "$SCRIPT" --help
+	assert_success
+	assert_output --partial "Create a macOS universal lintro binary"
+}
+
+@test "create_universal.sh: missing args exits 2" {
+	run bash "$SCRIPT"
+	assert_failure
+	assert_equal "2" "$status"
+}
+
+@test "create_universal.sh: fails when input binary is missing" {
+	create_fake_binary "$X86" "lintro-x86_64"
+	run bash "$SCRIPT" "${WORKDIR}/missing-arm64" "$X86" "$OUTPUT"
+	assert_failure
+	assert_output --partial "Input binary not found"
+}
+
+@test "create_universal.sh: creates universal binary with lipo when available" {
+	if ! command -v lipo >/dev/null 2>&1; then
+		skip "lipo not available on this host"
+	fi
+	if [[ ! -f "$ARM64" || ! -f "$X86" ]]; then
+		skip "could not compile arm64 and x86_64 stub binaries"
+	fi
+
+	run bash "$SCRIPT" "$ARM64" "$X86" "$OUTPUT"
+	assert_success
+	[[ -f "$OUTPUT" ]]
+	[[ -x "$OUTPUT" ]]
+	assert_output --partial "lintro-macos-universal"
+}

--- a/tests/bats/unit/build/test_create_universal.bats
+++ b/tests/bats/unit/build/test_create_universal.bats
@@ -45,6 +45,7 @@ teardown() {
 	create_fake_binary "$X86" "lintro-x86_64"
 	run "$SCRIPT" "${WORKDIR}/missing-arm64" "$X86" "$OUTPUT"
 	assert_failure
+	assert_equal "1" "$status"
 	assert_output --partial "Input binary not found"
 }
 
@@ -76,5 +77,6 @@ teardown() {
 
 	run "$SCRIPT" "$ARM64" "$X86" "$OUTPUT"
 	assert_failure
+	assert_equal "1" "$status"
 	assert_output --partial "lipo not found"
 }

--- a/tests/bats/unit/build/test_create_universal.bats
+++ b/tests/bats/unit/build/test_create_universal.bats
@@ -30,20 +30,20 @@ teardown() {
 }
 
 @test "create_universal.sh: --help exits 0" {
-	run bash "$SCRIPT" --help
+	run "$SCRIPT" --help
 	assert_success
 	assert_output --partial "Create a macOS universal lintro binary"
 }
 
 @test "create_universal.sh: missing args exits 2" {
-	run bash "$SCRIPT"
+	run "$SCRIPT"
 	assert_failure
 	assert_equal "2" "$status"
 }
 
 @test "create_universal.sh: fails when input binary is missing" {
 	create_fake_binary "$X86" "lintro-x86_64"
-	run bash "$SCRIPT" "${WORKDIR}/missing-arm64" "$X86" "$OUTPUT"
+	run "$SCRIPT" "${WORKDIR}/missing-arm64" "$X86" "$OUTPUT"
 	assert_failure
 	assert_output --partial "Input binary not found"
 }
@@ -56,9 +56,21 @@ teardown() {
 		skip "could not compile arm64 and x86_64 stub binaries"
 	fi
 
-	run bash "$SCRIPT" "$ARM64" "$X86" "$OUTPUT"
+	run "$SCRIPT" "$ARM64" "$X86" "$OUTPUT"
 	assert_success
 	[[ -f "$OUTPUT" ]]
 	[[ -x "$OUTPUT" ]]
 	assert_output --partial "lintro-macos-universal"
+}
+
+@test "create_universal.sh: aborts when lipo is unavailable" {
+	if command -v lipo >/dev/null 2>&1; then
+		skip "lipo is available on this host; guard only fires without it"
+	fi
+	create_fake_binary "$ARM64" "lintro-arm64"
+	create_fake_binary "$X86" "lintro-x86_64"
+
+	run "$SCRIPT" "$ARM64" "$X86" "$OUTPUT"
+	assert_failure
+	assert_output --partial "lipo not found"
 }

--- a/tests/bats/unit/build/test_create_universal.bats
+++ b/tests/bats/unit/build/test_create_universal.bats
@@ -60,7 +60,11 @@ teardown() {
 	assert_success
 	[[ -f "$OUTPUT" ]]
 	[[ -x "$OUTPUT" ]]
-	assert_output --partial "lintro-macos-universal"
+	# The filename alone appears in `ls` output for any file at that path, so
+	# assert the file(1) line that only a real fat binary produces.
+	assert_output --partial "Mach-O universal binary"
+	assert_output --partial "arm64"
+	assert_output --partial "x86_64"
 }
 
 @test "create_universal.sh: aborts when lipo is unavailable" {

--- a/tests/bats/unit/build/test_create_universal.bats
+++ b/tests/bats/unit/build/test_create_universal.bats
@@ -69,13 +69,11 @@ teardown() {
 }
 
 @test "create_universal.sh: aborts when lipo is unavailable" {
-	if command -v lipo >/dev/null 2>&1; then
-		skip "lipo is available on this host; guard only fires without it"
-	fi
+	stub_path="$(make_stub_path "${BATS_TEST_TMPDIR}/stubbin" bash dirname mkdir chmod)"
 	create_fake_binary "$ARM64" "lintro-arm64"
 	create_fake_binary "$X86" "lintro-x86_64"
 
-	run "$SCRIPT" "$ARM64" "$X86" "$OUTPUT"
+	PATH="$stub_path" run "$SCRIPT" "$ARM64" "$X86" "$OUTPUT"
 	assert_failure
 	assert_equal "1" "$status"
 	assert_output --partial "lipo not found"

--- a/tests/bats/unit/build/test_finalize_binary.bats
+++ b/tests/bats/unit/build/test_finalize_binary.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/build/finalize_binary.sh
+
+load "../../helpers/common"
+
+SCRIPT="${BUILD_SCRIPTS_DIR}/finalize_binary.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+	WORKDIR="${BATS_TEST_TMPDIR}/work"
+	mkdir -p "${WORKDIR}/dist/nuitka"
+	SOURCE="${WORKDIR}/dist/nuitka/lintro"
+	TARGET="${WORKDIR}/dist/nuitka/lintro-macos-arm64"
+	create_fake_binary "$SOURCE" "lintro-arm64-build"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "finalize_binary.sh: --help exits 0" {
+	run bash "$SCRIPT" --help
+	assert_success
+	assert_output --partial "Finalize a built lintro binary"
+}
+
+@test "finalize_binary.sh: missing args exits 2" {
+	run bash "$SCRIPT"
+	assert_failure
+	assert_equal "2" "$status"
+}
+
+@test "finalize_binary.sh: renames binary and writes sha256 output" {
+	run bash "$SCRIPT" "$SOURCE" "$TARGET" arm64
+	assert_success
+	[[ -f "$TARGET" ]]
+	[[ ! -f "$SOURCE" ]]
+	assert_output --partial "SHA256 for arm64:"
+	assert_output --partial "Finalized ${TARGET}:"
+	expected_sha="$(compute_expected_sha256 "$TARGET")"
+	assert_equal "$expected_sha" "$(get_github_output sha256)"
+}
+
+@test "finalize_binary.sh: fails when source binary is missing" {
+	run bash "$SCRIPT" "${WORKDIR}/missing" "$TARGET"
+	assert_failure
+	assert_output --partial "Source binary not found"
+}

--- a/tests/bats/unit/build/test_finalize_binary.bats
+++ b/tests/bats/unit/build/test_finalize_binary.bats
@@ -21,19 +21,19 @@ teardown() {
 }
 
 @test "finalize_binary.sh: --help exits 0" {
-	run bash "$SCRIPT" --help
+	run "$SCRIPT" --help
 	assert_success
 	assert_output --partial "Finalize a built lintro binary"
 }
 
 @test "finalize_binary.sh: missing args exits 2" {
-	run bash "$SCRIPT"
+	run "$SCRIPT"
 	assert_failure
 	assert_equal "2" "$status"
 }
 
 @test "finalize_binary.sh: renames binary and writes sha256 output" {
-	run bash "$SCRIPT" "$SOURCE" "$TARGET" arm64
+	run "$SCRIPT" "$SOURCE" "$TARGET" arm64
 	assert_success
 	[[ -f "$TARGET" ]]
 	[[ ! -f "$SOURCE" ]]
@@ -44,7 +44,18 @@ teardown() {
 }
 
 @test "finalize_binary.sh: fails when source binary is missing" {
-	run bash "$SCRIPT" "${WORKDIR}/missing" "$TARGET"
+	run "$SCRIPT" "${WORKDIR}/missing" "$TARGET"
 	assert_failure
 	assert_output --partial "Source binary not found"
+}
+
+@test "finalize_binary.sh: succeeds without GITHUB_OUTPUT set" {
+	# Outside Actions there is no GITHUB_OUTPUT; the rename and hashing must
+	# still succeed and nothing may be written to the (absent) output file.
+	local output_file="$GITHUB_OUTPUT"
+	run env -u GITHUB_OUTPUT "$SCRIPT" "$SOURCE" "$TARGET" arm64
+	assert_success
+	[[ -f "$TARGET" ]]
+	assert_output --partial "SHA256 for arm64:"
+	assert_equal "" "$(cat "$output_file")"
 }

--- a/tests/bats/unit/build/test_finalize_binary.bats
+++ b/tests/bats/unit/build/test_finalize_binary.bats
@@ -46,6 +46,7 @@ teardown() {
 @test "finalize_binary.sh: fails when source binary is missing" {
 	run "$SCRIPT" "${WORKDIR}/missing" "$TARGET"
 	assert_failure
+	assert_equal "1" "$status"
 	assert_output --partial "Source binary not found"
 }
 

--- a/tests/bats/unit/build/test_finalize_binary.bats
+++ b/tests/bats/unit/build/test_finalize_binary.bats
@@ -33,9 +33,14 @@ teardown() {
 }
 
 @test "finalize_binary.sh: renames binary and writes sha256 output" {
+	# create_fake_binary leaves the source executable and `mv` preserves that
+	# bit, so without stripping it first this would pass even if the script
+	# stopped running chmod +x. Nuitka output is not reliably executable.
+	chmod a-x "$SOURCE"
 	run "$SCRIPT" "$SOURCE" "$TARGET" arm64
 	assert_success
 	[[ -f "$TARGET" ]]
+	[[ -x "$TARGET" ]]
 	[[ ! -f "$SOURCE" ]]
 	assert_output --partial "SHA256 for arm64:"
 	assert_output --partial "Finalized ${TARGET}:"

--- a/tests/bats/unit/build/test_finalize_binary.bats
+++ b/tests/bats/unit/build/test_finalize_binary.bats
@@ -55,6 +55,52 @@ teardown() {
 	assert_output --partial "Source binary not found"
 }
 
+@test "finalize_binary.sh: fails closed when no SHA256 tool is available" {
+	# The sha256sum/shasum fallback chain ends in an explicit abort. Run with a
+	# PATH holding only what the script needs to reach that branch, so neither
+	# hashing tool resolves and the fail-closed path is actually taken.
+	stub_path="$(make_stub_path "${BATS_TEST_TMPDIR}/stubbin" bash dirname mkdir mv chmod)"
+
+	run env PATH="$stub_path" "$SCRIPT" "$SOURCE" "$TARGET" arm64
+	assert_failure
+	assert_equal "1" "$status"
+	assert_output --partial "No SHA256 tool found"
+	# Nothing may be published when the hash could not be computed.
+	assert_equal "" "$(cat "$GITHUB_OUTPUT")"
+}
+
+@test "finalize_binary.sh: matches the macOS workflow BUILD_ARCH argv contract" {
+	# Same argv/env shape as build-macos' "Finalize binary" step: BUILD_ARCH
+	# arrives via env and the workflow expands it inside the quoted arguments.
+	# Renaming the env var or mis-quoting an argument breaks this test.
+	cd "$WORKDIR"
+	create_fake_binary dist/nuitka/lintro "lintro-macos-build"
+	export BUILD_ARCH=arm64
+
+	run bash -c '"$0" dist/nuitka/lintro "dist/nuitka/lintro-macos-$BUILD_ARCH" "$BUILD_ARCH"' "$SCRIPT"
+	assert_success
+	[[ -f "dist/nuitka/lintro-macos-arm64" ]]
+	[[ -x "dist/nuitka/lintro-macos-arm64" ]]
+	assert_output --partial "SHA256 for arm64:"
+	expected_sha="$(compute_expected_sha256 dist/nuitka/lintro-macos-arm64)"
+	assert_equal "$expected_sha" "$(get_github_output sha256)"
+}
+
+@test "finalize_binary.sh: matches the Linux workflow BUILD_ARCH argv contract" {
+	# build-linux uses the same shape but a linux- prefixed target and a
+	# linux-<arch> label, which is what feeds sha256-linux-<arch>.txt.
+	cd "$WORKDIR"
+	create_fake_binary dist/nuitka/lintro "lintro-linux-build"
+	export BUILD_ARCH=x64
+
+	run bash -c '"$0" dist/nuitka/lintro "dist/nuitka/lintro-linux-$BUILD_ARCH" "linux-$BUILD_ARCH"' "$SCRIPT"
+	assert_success
+	[[ -f "dist/nuitka/lintro-linux-x64" ]]
+	assert_output --partial "SHA256 for linux-x64:"
+	expected_sha="$(compute_expected_sha256 dist/nuitka/lintro-linux-x64)"
+	assert_equal "$expected_sha" "$(get_github_output sha256)"
+}
+
 @test "finalize_binary.sh: succeeds without GITHUB_OUTPUT set" {
 	# Outside Actions there is no GITHUB_OUTPUT; the rename and hashing must
 	# still succeed and nothing may be written to the (absent) output file.

--- a/tests/bats/unit/build/test_verify_built_binary.bats
+++ b/tests/bats/unit/build/test_verify_built_binary.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/build/verify_built_binary.sh
+
+load "../../helpers/common"
+
+SCRIPT="${BUILD_SCRIPTS_DIR}/verify_built_binary.sh"
+
+setup() {
+	setup_temp_dir
+	WORKDIR="${BATS_TEST_TMPDIR}/work"
+	mkdir -p "${WORKDIR}/dist/nuitka"
+	BINARY="${WORKDIR}/dist/nuitka/lintro"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "verify_built_binary.sh: --help exits 0" {
+	run bash "$SCRIPT" --help
+	assert_success
+	assert_output --partial "Verify a built lintro binary"
+}
+
+@test "verify_built_binary.sh: missing args exits 2" {
+	run bash "$SCRIPT"
+	assert_failure
+	assert_equal "2" "$status"
+}
+
+@test "verify_built_binary.sh: fails when binary is missing" {
+	run bash "$SCRIPT" "${WORKDIR}/missing"
+	assert_failure
+	assert_output --partial "Binary not found"
+}
+
+@test "verify_built_binary.sh: runs --version on a shell script binary" {
+	cat >"$BINARY" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+--version) echo "lintro test 0.0.0"; exit 0 ;;
+--help) echo "help"; exit 0 ;;
+*) exit 1 ;;
+esac
+EOF
+	chmod +x "$BINARY"
+
+	run bash "$SCRIPT" "$BINARY"
+	assert_success
+	assert_output --partial "lintro test 0.0.0"
+}

--- a/tests/bats/unit/build/test_verify_built_binary.bats
+++ b/tests/bats/unit/build/test_verify_built_binary.bats
@@ -32,6 +32,7 @@ teardown() {
 @test "verify_built_binary.sh: fails when binary is missing" {
 	run "$SCRIPT" "${WORKDIR}/missing"
 	assert_failure
+	assert_equal "1" "$status"
 	assert_output --partial "Binary not found"
 }
 

--- a/tests/bats/unit/build/test_verify_built_binary.bats
+++ b/tests/bats/unit/build/test_verify_built_binary.bats
@@ -51,6 +51,23 @@ EOF
 	assert_output --partial "lintro test 0.0.0"
 }
 
+@test "verify_built_binary.sh: --help failure stays non-fatal" {
+	cat >"$BINARY" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+--version) echo "lintro test 0.0.0"; exit 0 ;;
+*) echo "help exploded"; exit 4 ;;
+esac
+EOF
+	chmod +x "$BINARY"
+
+	run "$SCRIPT" "$BINARY"
+	assert_success
+	assert_output --partial "lintro test 0.0.0"
+	assert_output --partial "--help exited non-zero"
+	assert_output --partial "help exploded"
+}
+
 @test "verify_built_binary.sh: fails when --version exits non-zero" {
 	cat >"$BINARY" <<'EOF'
 #!/usr/bin/env bash

--- a/tests/bats/unit/build/test_verify_built_binary.bats
+++ b/tests/bats/unit/build/test_verify_built_binary.bats
@@ -18,19 +18,19 @@ teardown() {
 }
 
 @test "verify_built_binary.sh: --help exits 0" {
-	run bash "$SCRIPT" --help
+	run "$SCRIPT" --help
 	assert_success
 	assert_output --partial "Verify a built lintro binary"
 }
 
 @test "verify_built_binary.sh: missing args exits 2" {
-	run bash "$SCRIPT"
+	run "$SCRIPT"
 	assert_failure
 	assert_equal "2" "$status"
 }
 
 @test "verify_built_binary.sh: fails when binary is missing" {
-	run bash "$SCRIPT" "${WORKDIR}/missing"
+	run "$SCRIPT" "${WORKDIR}/missing"
 	assert_failure
 	assert_output --partial "Binary not found"
 }
@@ -46,7 +46,20 @@ esac
 EOF
 	chmod +x "$BINARY"
 
-	run bash "$SCRIPT" "$BINARY"
+	run "$SCRIPT" "$BINARY"
 	assert_success
 	assert_output --partial "lintro test 0.0.0"
+}
+
+@test "verify_built_binary.sh: fails when --version exits non-zero" {
+	cat >"$BINARY" <<'EOF'
+#!/usr/bin/env bash
+echo "boom" >&2
+exit 3
+EOF
+	chmod +x "$BINARY"
+
+	run "$SCRIPT" "$BINARY"
+	assert_failure
+	assert_equal "3" "$status"
 }


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(ci): extract inline shell from build-binary.yml into dedicated scripts
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Extracts non-trivial inline shell from `build-binary.yml` into dedicated scripts under `scripts/build/`, keeping artifact names and `sha256` step outputs unchanged. Adds BATS coverage for the new scripts.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1184

## Details

### New scripts

- `scripts/build/verify_built_binary.sh` — pre-package `--version` / `--help` checks
- `scripts/build/finalize_binary.sh` — rename, `chmod +x`, SHA256 + `GITHUB_OUTPUT`
- `scripts/build/create_universal.sh` — `lipo` universal binary creation + verification

### Workflow

- `build-macos` / `build-linux` jobs now call the scripts instead of inline `run:` blocks
- `create-universal-binary` job delegates to `create_universal.sh`
- Artifact names and `sha256` outputs remain byte-identical for downstream Homebrew/npm pipelines

### Tests

- BATS unit tests in `tests/bats/unit/build/`
- `.gitignore` exception so `tests/bats/unit/build/` is tracked (mirrors `scripts/build/`)
