### PR TITLE
test(execution): exercise multi-tool parallel path in integration tests

### DIFF
--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -26,7 +26,7 @@ from lintro.tools import tool_manager
 from lintro.utils.async_tool_executor import get_parallel_batches
 from lintro.utils.tool_executor import run_lint_tools_simple
 
-pytestmark = pytest.mark.skipif(
+_requires_ruff = pytest.mark.skipif(
     shutil.which("ruff") is None,
     reason="ruff not installed",
 )
@@ -141,8 +141,11 @@ def _run_check(
 
     Returns:
         Process exit code.
+
+    Raises:
+        TypeError: If ``run_lint_tools_simple`` does not return an int.
     """
-    return run_lint_tools_simple(
+    exit_code = run_lint_tools_simple(
         action="check",
         paths=paths,
         tools=tools,
@@ -156,6 +159,11 @@ def _run_check(
         output_file=output_file,
         yes=True,
     )
+    # Narrow for dogfooding mypy, which type-checks this file in isolation and
+    # otherwise treats run_lint_tools_simple as returning Any (no-any-return).
+    if not isinstance(exit_code, int):
+        raise TypeError(f"expected int exit code, got {type(exit_code)!r}")
+    return exit_code
 
 
 # =============================================================================
@@ -163,6 +171,7 @@ def _run_check(
 # =============================================================================
 
 
+@_requires_ruff
 def test_single_tool_check_multiple_files(temp_python_files: list[str]) -> None:
     """Smoke: single-tool check on multiple files completes without crashing.
 
@@ -173,6 +182,7 @@ def test_single_tool_check_multiple_files(temp_python_files: list[str]) -> None:
     assert_that(exit_code).is_instance_of(int)
 
 
+@_requires_ruff
 def test_single_tool_consistent_results_across_runs(
     temp_python_files: list[str],
 ) -> None:
@@ -186,6 +196,7 @@ def test_single_tool_consistent_results_across_runs(
     assert_that(exit_code_1).is_equal_to(exit_code_2)
 
 
+@_requires_ruff
 def test_single_tool_check_with_one_file(temp_python_files: list[str]) -> None:
     """Smoke: single-tool check on one file completes without crashing.
 
@@ -196,6 +207,7 @@ def test_single_tool_check_with_one_file(temp_python_files: list[str]) -> None:
     assert_that(exit_code).is_instance_of(int)
 
 
+@_requires_ruff
 def test_single_tool_format_action(temp_python_files: list[str]) -> None:
     """Smoke: single-tool format action completes without crashing.
 
@@ -217,6 +229,7 @@ def test_single_tool_format_action(temp_python_files: list[str]) -> None:
     assert_that(exit_code).is_instance_of(int)
 
 
+@_requires_ruff
 def test_single_tool_different_output_formats(temp_python_files: list[str]) -> None:
     """Smoke: single-tool check works across output formats.
 
@@ -241,21 +254,12 @@ def test_ruff_tool_definition_exists() -> None:
     assert_that(ruff_tool.definition.name).is_equal_to("ruff")
 
 
-def test_single_tool_execution_order_is_stable(temp_python_files: list[str]) -> None:
-    """Smoke: repeated single-tool runs stay exit-code stable.
-
-    Args:
-        temp_python_files: Pytest fixture providing temp files.
-    """
-    results = [_run_check(paths=temp_python_files, tools="ruff") for _ in range(3)]
-    assert_that(len(set(results))).is_equal_to(1)
-
-
 # =============================================================================
 # Multi-tool parallel execution
 # =============================================================================
 
 
+@_requires_ruff
 def test_parallel_check_runs_multiple_non_conflicting_tools(
     multi_tool_fixture_dir: Path,
     disable_post_checks: None,

--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -264,7 +264,7 @@ def test_parallel_check_runs_multiple_non_conflicting_tools(
     multi_tool_fixture_dir: Path,
     disable_post_checks: None,
     skip_if_tool_unavailable: Callable[[str], None],
-    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Run ruff + yamllint in parallel and assert both report issues.
 
@@ -272,9 +272,32 @@ def test_parallel_check_runs_multiple_non_conflicting_tools(
         multi_tool_fixture_dir: Fixture dir with one violation per tool.
         disable_post_checks: Ensures only selected tools appear in results.
         skip_if_tool_unavailable: Skip helper when a binary is missing.
-        capsys: Capture stdout/stderr for the parallel banner.
+        monkeypatch: Used to spy that the parallel executor path was entered.
     """
     skip_if_tool_unavailable("yamllint")
+
+    import lintro.utils.tool_executor as tool_executor
+
+    parallel_calls: list[list[str]] = []
+    original_parallel = tool_executor.run_tools_parallel
+
+    def _spy_run_tools_parallel(
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        tools_arg = kwargs.get("tools_to_run", args[0] if args else None)
+        if not isinstance(tools_arg, list):
+            raise TypeError(
+                f"expected tools_to_run list, got {type(tools_arg)!r}",
+            )
+        parallel_calls.append([str(name) for name in tools_arg])
+        return original_parallel(*args, **kwargs)
+
+    monkeypatch.setattr(
+        tool_executor,
+        "run_tools_parallel",
+        _spy_run_tools_parallel,
+    )
 
     output_path = multi_tool_fixture_dir / "results.json"
     exit_code = _run_check(
@@ -284,24 +307,41 @@ def test_parallel_check_runs_multiple_non_conflicting_tools(
         output_file=str(output_path),
     )
 
-    captured = capsys.readouterr()
-    combined = f"{captured.out}\n{captured.err}"
-    assert_that(combined).contains("Running 2 tools in parallel")
+    assert_that(parallel_calls).is_length(1)
+    assert_that(parallel_calls[0]).contains("ruff", "yamllint")
+    assert_that(len(parallel_calls[0])).is_greater_than_or_equal_to(2)
 
     assert_that(exit_code).is_not_equal_to(0)
     assert_that(output_path.exists()).is_true()
 
-    payload = json.loads(output_path.read_text())
-    results_by_tool = {item["tool"]: item for item in payload["results"]}
+    raw_output = output_path.read_text()
+    try:
+        payload = json.loads(raw_output)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f"output_file was not valid JSON: {exc}; body={raw_output[:200]!r}",
+        ) from exc
+
+    assert_that(payload).contains_key("results")
+    assert_that(payload["results"]).is_instance_of(list)
+    assert_that(payload["results"]).is_not_empty()
+
+    results_by_tool = {
+        item["tool"]: item
+        for item in payload["results"]
+        if isinstance(item, dict) and "tool" in item
+    }
 
     assert_that(results_by_tool).contains_key("ruff")
     assert_that(results_by_tool).contains_key("yamllint")
+    assert_that(results_by_tool["ruff"]).contains_key("issues_count")
+    assert_that(results_by_tool["yamllint"]).contains_key("issues_count")
     assert_that(results_by_tool["ruff"]["issues_count"]).is_greater_than_or_equal_to(1)
     assert_that(
         results_by_tool["yamllint"]["issues_count"],
     ).is_greater_than_or_equal_to(1)
-    assert_that(results_by_tool["ruff"]["issues"]).is_not_empty()
-    assert_that(results_by_tool["yamllint"]["issues"]).is_not_empty()
+    assert_that(results_by_tool["ruff"].get("issues")).is_not_empty()
+    assert_that(results_by_tool["yamllint"].get("issues")).is_not_empty()
 
 
 def test_non_conflicting_tools_share_one_parallel_batch() -> None:

--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -1,17 +1,35 @@
-"""Integration tests for parallel tool execution."""
+"""Integration tests for parallel tool execution.
+
+Single-tool smoke tests below exercise the sequential path only
+(``use_parallel`` requires ``len(tools_to_run) > 1``). Multi-tool tests
+exercise the asyncio + ThreadPoolExecutor path and conflict-aware batching.
+"""
 
 from __future__ import annotations
 
 import contextlib
+import json
 import os
+import shutil
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from assertpy import assert_that
 
 from lintro.plugins import ToolRegistry
+from lintro.tools import tool_manager
+from lintro.utils.async_tool_executor import get_parallel_batches
 from lintro.utils.tool_executor import run_lint_tools_simple
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ruff") is None,
+    reason="ruff not installed",
+)
 
 
 @pytest.fixture(autouse=True)
@@ -29,7 +47,7 @@ def set_lintro_test_mode_env(lintro_test_mode: object) -> Iterator[None]:
 
 @pytest.fixture
 def temp_python_files() -> Iterator[list[str]]:
-    """Create multiple temporary Python files for parallel testing.
+    """Create multiple temporary Python files for single-tool smoke tests.
 
     Yields:
         list[str]: List of paths to temporary Python files.
@@ -37,7 +55,6 @@ def temp_python_files() -> Iterator[list[str]]:
     files: list[str] = []
     temp_dir = tempfile.mkdtemp()
 
-    # Create multiple files with various issues
     file_contents = [
         (
             "file1.py",
@@ -61,7 +78,6 @@ def temp_python_files() -> Iterator[list[str]]:
 
     yield files
 
-    # Cleanup
     for file_path in files:
         with contextlib.suppress(FileNotFoundError):
             os.unlink(file_path)
@@ -69,87 +85,119 @@ def temp_python_files() -> Iterator[list[str]]:
         os.rmdir(temp_dir)
 
 
-def test_check_multiple_files(temp_python_files: list[str]) -> None:
-    """Test running check on multiple files.
+@pytest.fixture
+def multi_tool_fixture_dir(tmp_path: Path) -> Path:
+    """Create a fixture directory with one ruff and one yamllint violation.
 
     Args:
-        temp_python_files: Pytest fixture providing temp files.
+        tmp_path: Pytest temporary directory.
+
+    Returns:
+        Path to the fixture directory containing ``bad.py`` and ``bad.yaml``.
     """
-    exit_code = run_lint_tools_simple(
+    (tmp_path / "bad.py").write_text("import os\n")
+    # document-start present; trailing spaces is the sole yamllint finding
+    (tmp_path / "bad.yaml").write_text("---\nname: test   \n")
+    return tmp_path
+
+
+@pytest.fixture
+def disable_post_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable post-checks so only explicitly selected tools appear in results.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    import lintro.utils.post_checks as post_checks
+    import lintro.utils.tool_executor as tool_executor
+
+    empty_post: dict[str, object] = {"enabled": False, "tools": []}
+    monkeypatch.setattr(
+        tool_executor,
+        "load_post_checks_config",
+        lambda: empty_post,
+    )
+    monkeypatch.setattr(
+        post_checks,
+        "load_post_checks_config",
+        lambda: empty_post,
+    )
+
+
+def _run_check(
+    *,
+    paths: list[str],
+    tools: str,
+    output_format: str = "grid",
+    output_file: str | None = None,
+) -> int:
+    """Run a check via ``run_lint_tools_simple`` with shared defaults.
+
+    Args:
+        paths: Paths to lint.
+        tools: Comma-separated tool names.
+        output_format: Output format string.
+        output_file: Optional path for structured output.
+
+    Returns:
+        Process exit code.
+    """
+    return run_lint_tools_simple(
         action="check",
-        paths=temp_python_files,
-        tools="ruff",
+        paths=paths,
+        tools=tools,
         tool_options=None,
         exclude=None,
         include_venv=False,
         group_by="file",
-        output_format="grid",
+        output_format=output_format,
         verbose=False,
         raw_output=False,
+        output_file=output_file,
+        yes=True,
     )
 
-    # Should complete without crashing
+
+# =============================================================================
+# Single-tool smoke tests (sequential path only — not true parallelism)
+# =============================================================================
+
+
+def test_single_tool_check_multiple_files(temp_python_files: list[str]) -> None:
+    """Smoke: single-tool check on multiple files completes without crashing.
+
+    Args:
+        temp_python_files: Pytest fixture providing temp files.
+    """
+    exit_code = _run_check(paths=temp_python_files, tools="ruff")
     assert_that(exit_code).is_instance_of(int)
 
 
-def test_consistent_results_across_runs(temp_python_files: list[str]) -> None:
-    """Test that multiple runs produce consistent results.
+def test_single_tool_consistent_results_across_runs(
+    temp_python_files: list[str],
+) -> None:
+    """Smoke: repeated single-tool runs produce the same exit code.
 
     Args:
         temp_python_files: Pytest fixture providing temp files.
     """
-    # Run twice
-    exit_code_1 = run_lint_tools_simple(
-        action="check",
-        paths=temp_python_files,
-        tools="ruff",
-        tool_options=None,
-        exclude=None,
-        include_venv=False,
-        group_by="file",
-        output_format="grid",
-        verbose=False,
-    )
-
-    exit_code_2 = run_lint_tools_simple(
-        action="check",
-        paths=temp_python_files,
-        tools="ruff",
-        tool_options=None,
-        exclude=None,
-        include_venv=False,
-        group_by="file",
-        output_format="grid",
-        verbose=False,
-    )
-
-    # Exit codes should match
+    exit_code_1 = _run_check(paths=temp_python_files, tools="ruff")
+    exit_code_2 = _run_check(paths=temp_python_files, tools="ruff")
     assert_that(exit_code_1).is_equal_to(exit_code_2)
 
 
-def test_check_with_single_file(temp_python_files: list[str]) -> None:
-    """Test check with single file.
+def test_single_tool_check_with_one_file(temp_python_files: list[str]) -> None:
+    """Smoke: single-tool check on one file completes without crashing.
 
     Args:
         temp_python_files: Pytest fixture providing temp files.
     """
-    exit_code = run_lint_tools_simple(
-        action="check",
-        paths=[temp_python_files[0]],
-        tools="ruff",
-        tool_options=None,
-        exclude=None,
-        include_venv=False,
-        group_by="file",
-        output_format="grid",
-        verbose=False,
-    )
-
+    exit_code = _run_check(paths=[temp_python_files[0]], tools="ruff")
     assert_that(exit_code).is_instance_of(int)
 
 
-def test_format_action(temp_python_files: list[str]) -> None:
-    """Test format action.
+def test_single_tool_format_action(temp_python_files: list[str]) -> None:
+    """Smoke: single-tool format action completes without crashing.
 
     Args:
         temp_python_files: Pytest fixture providing temp files.
@@ -164,34 +212,28 @@ def test_format_action(temp_python_files: list[str]) -> None:
         group_by="file",
         output_format="grid",
         verbose=False,
+        yes=True,
     )
-
     assert_that(exit_code).is_instance_of(int)
 
 
-def test_different_output_formats(temp_python_files: list[str]) -> None:
-    """Test different output formats.
+def test_single_tool_different_output_formats(temp_python_files: list[str]) -> None:
+    """Smoke: single-tool check works across output formats.
 
     Args:
         temp_python_files: Pytest fixture providing temp files.
     """
     for fmt in ["grid", "plain", "json"]:
-        exit_code = run_lint_tools_simple(
-            action="check",
+        exit_code = _run_check(
             paths=temp_python_files,
             tools="ruff",
-            tool_options=None,
-            exclude=None,
-            include_venv=False,
-            group_by="file",
             output_format=fmt,
-            verbose=False,
         )
         assert_that(exit_code).is_instance_of(int)
 
 
-def test_tool_definition_exists() -> None:
-    """Test that ruff tool has proper definition."""
+def test_ruff_tool_definition_exists() -> None:
+    """Smoke: ruff tool is registered with a valid definition."""
     ruff_tool = ToolRegistry.get("ruff")
 
     assert_that(ruff_tool).is_not_none()
@@ -199,27 +241,119 @@ def test_tool_definition_exists() -> None:
     assert_that(ruff_tool.definition.name).is_equal_to("ruff")
 
 
-def test_tool_respects_execution_order(temp_python_files: list[str]) -> None:
-    """Test that tool execution order is predictable.
+def test_single_tool_execution_order_is_stable(temp_python_files: list[str]) -> None:
+    """Smoke: repeated single-tool runs stay exit-code stable.
 
     Args:
         temp_python_files: Pytest fixture providing temp files.
     """
-    # Run multiple times to verify consistency
-    results = []
-    for _ in range(3):
-        exit_code = run_lint_tools_simple(
-            action="check",
-            paths=temp_python_files,
-            tools="ruff",
-            tool_options=None,
-            exclude=None,
-            include_venv=False,
-            group_by="file",
-            output_format="grid",
-            verbose=False,
-        )
-        results.append(exit_code)
-
-    # All runs should produce same exit code
+    results = [_run_check(paths=temp_python_files, tools="ruff") for _ in range(3)]
     assert_that(len(set(results))).is_equal_to(1)
+
+
+# =============================================================================
+# Multi-tool parallel execution
+# =============================================================================
+
+
+def test_parallel_check_runs_multiple_non_conflicting_tools(
+    multi_tool_fixture_dir: Path,
+    disable_post_checks: None,
+    skip_if_tool_unavailable: Callable[[str], None],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Run ruff + yamllint in parallel and assert both report issues.
+
+    Args:
+        multi_tool_fixture_dir: Fixture dir with one violation per tool.
+        disable_post_checks: Ensures only selected tools appear in results.
+        skip_if_tool_unavailable: Skip helper when a binary is missing.
+        capsys: Capture stdout/stderr for the parallel banner.
+    """
+    skip_if_tool_unavailable("yamllint")
+
+    output_path = multi_tool_fixture_dir / "results.json"
+    exit_code = _run_check(
+        paths=[str(multi_tool_fixture_dir)],
+        tools="ruff,yamllint",
+        output_format="json",
+        output_file=str(output_path),
+    )
+
+    captured = capsys.readouterr()
+    combined = f"{captured.out}\n{captured.err}"
+    assert_that(combined).contains("Running 2 tools in parallel")
+
+    assert_that(exit_code).is_not_equal_to(0)
+    assert_that(output_path.exists()).is_true()
+
+    payload = json.loads(output_path.read_text())
+    results_by_tool = {item["tool"]: item for item in payload["results"]}
+
+    assert_that(results_by_tool).contains_key("ruff")
+    assert_that(results_by_tool).contains_key("yamllint")
+    assert_that(results_by_tool["ruff"]["issues_count"]).is_greater_than_or_equal_to(1)
+    assert_that(
+        results_by_tool["yamllint"]["issues_count"],
+    ).is_greater_than_or_equal_to(1)
+    assert_that(results_by_tool["ruff"]["issues"]).is_not_empty()
+    assert_that(results_by_tool["yamllint"]["issues"]).is_not_empty()
+
+
+def test_non_conflicting_tools_share_one_parallel_batch() -> None:
+    """Real ruff + yamllint definitions have no conflicts → one batch."""
+    batches = get_parallel_batches(["ruff", "yamllint"], tool_manager)
+
+    assert_that(batches).is_length(1)
+    assert_that(batches[0]).contains("ruff", "yamllint")
+
+
+# =============================================================================
+# Conflict-aware batching
+# =============================================================================
+
+
+def test_conflicting_tools_are_batched_separately() -> None:
+    """Tools whose definitions declare conflicts_with land in separate batches.
+
+    No shipped tools currently declare conflicts, so this builds definitions
+    from the live registry (black/ruff) with synthetic ``conflicts_with`` via
+    ``dataclasses.replace``.
+    """
+    black_def = replace(
+        tool_manager.get_tool("black").definition,
+        conflicts_with=["ruff"],
+    )
+    ruff_def = replace(
+        tool_manager.get_tool("ruff").definition,
+        conflicts_with=["black"],
+    )
+    mypy_def = tool_manager.get_tool("mypy").definition
+
+    definitions = {
+        "black": black_def,
+        "ruff": ruff_def,
+        "mypy": mypy_def,
+    }
+    manager = MagicMock()
+    manager.get_tool.side_effect = lambda name: SimpleNamespace(
+        definition=definitions[name],
+    )
+
+    batches = get_parallel_batches(["black", "ruff", "mypy"], manager)
+
+    assert_that(len(batches)).is_greater_than_or_equal_to(2)
+
+    black_batch_idx: int | None = None
+    ruff_batch_idx: int | None = None
+    for index, batch in enumerate(batches):
+        if "black" in batch:
+            black_batch_idx = index
+            assert_that(batch).does_not_contain("ruff")
+        if "ruff" in batch:
+            ruff_batch_idx = index
+            assert_that(batch).does_not_contain("black")
+
+    assert_that(black_batch_idx).is_not_none()
+    assert_that(ruff_batch_idx).is_not_none()
+    assert_that(black_batch_idx).is_not_equal_to(ruff_batch_idx)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  test(execution): exercise multi-tool parallel path in integration tests
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

`tests/integration/test_parallel_execution.py` previously only ran `tools="ruff"`, so `use_parallel` never became true and the asyncio/ThreadPoolExecutor path plus conflict batching stayed untested at integration level.

- Add multi-tool parallel check for ruff + yamllint with fixture violations; assert the parallel banner, both tools ran, and both issues are reported.
- Add conflict-aware batching coverage via live definitions with synthetic `conflicts_with`.
- Rename existing single-tool cases so they are clearly sequential smoke tests.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1421

## Details

- Full `uv run lintro fmt` / `chk` passed before commit.
- Unit suite green (5757 passed); parallel integration file green (10 passed).
- Full suite under heavy local load saw unrelated env flakes (xdist worker crashes on built-package tests; commitlint skipped locally on 21.2.0 < min 21.2.1).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the parallel execution integration test suite to actually exercise the asyncio/ThreadPoolExecutor code path and conflict-aware batching logic, which were previously untested at integration level because all existing tests ran only a single tool.

- Adds `test_parallel_check_runs_multiple_non_conflicting_tools` that runs ruff + yamllint together, spies on the module-level `run_tools_parallel` call to confirm the parallel path was entered, and validates both tools reported issues via JSON output.
- Adds `test_non_conflicting_tools_share_one_parallel_batch` and `test_conflicting_tools_are_batched_separately` to cover the `get_parallel_batches` greedy batching logic using live registry definitions with synthetic `conflicts_with` values.
- Refactors existing single-tool tests: replaces the module-level `pytestmark` skip guard with per-test `@_requires_ruff` markers, extracts a shared `_run_check` helper, and renames tests to clarify they exercise the sequential path only.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a test-only change with no modifications to production code.

The change touches only the integration test file. The new tests correctly spy on the module-level import binding (making monkeypatch effective), the fixture violations reliably trigger findings under both default and project yamllint/ruff configs, and the parallel default (parallel: bool = True) ensures the async path is reached with two tools. The two comments left are minor robustness nits in the test assertions themselves, not functional defects in the code under test.

tests/integration/test_parallel_execution.py — the conflict-batching test's bare registry lookups for "black" and "mypy" and the unguarded .get("issues") assertion are worth a second look, but neither blocks the PR.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/integration/test_parallel_execution.py | Adds multi-tool parallel integration tests and conflict-aware batching coverage; refactors existing single-tool tests with per-test skip markers and a shared _run_check helper. Two minor robustness issues: unguarded registry lookups for "black"/"mypy" in the conflict batching test, and a .get("issues") call that can return None before an emptiness check. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T as Test
    participant TE as tool_executor.run_lint_tools_simple
    participant Spy as _spy_run_tools_parallel
    participant PE as parallel_executor.run_tools_parallel
    participant AE as AsyncToolExecutor
    participant Ruff as ruff (subprocess)
    participant YL as yamllint (subprocess)

    T->>TE: "_run_check(paths, tools=ruff,yamllint)"
    TE->>TE: "use_parallel = True (parallel=True, len>1)"
    TE->>Spy: "run_tools_parallel(tools_to_run=[ruff,yamllint], ...)"
    Spy->>Spy: parallel_calls.append([ruff,yamllint])
    Spy->>PE: "original_parallel(tools_to_run=[ruff,yamllint], ...)"
    PE->>PE: get_parallel_batches → [[ruff,yamllint]]
    PE->>AE: asyncio.run(executor.run_tools_parallel(batch))
    AE-->>Ruff: ThreadPoolExecutor → ruff.check(paths)
    AE-->>YL: ThreadPoolExecutor → yamllint.check(paths)
    Ruff-->>AE: ToolResult (F401 issue)
    YL-->>AE: ToolResult (trailing-spaces issue)
    AE-->>PE: [(ruff, result), (yamllint, result)]
    PE-->>Spy: [ToolResult, ToolResult]
    Spy-->>TE: [ToolResult, ToolResult]
    TE-->>T: "exit_code != 0"
    T->>T: "assert parallel_calls length == 1"
    T->>T: assert both tools in parallel_calls[0]
    T->>T: "parse JSON output, assert issues_count >= 1 per tool"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T as Test
    participant TE as tool_executor.run_lint_tools_simple
    participant Spy as _spy_run_tools_parallel
    participant PE as parallel_executor.run_tools_parallel
    participant AE as AsyncToolExecutor
    participant Ruff as ruff (subprocess)
    participant YL as yamllint (subprocess)

    T->>TE: "_run_check(paths, tools=ruff,yamllint)"
    TE->>TE: "use_parallel = True (parallel=True, len>1)"
    TE->>Spy: "run_tools_parallel(tools_to_run=[ruff,yamllint], ...)"
    Spy->>Spy: parallel_calls.append([ruff,yamllint])
    Spy->>PE: "original_parallel(tools_to_run=[ruff,yamllint], ...)"
    PE->>PE: get_parallel_batches → [[ruff,yamllint]]
    PE->>AE: asyncio.run(executor.run_tools_parallel(batch))
    AE-->>Ruff: ThreadPoolExecutor → ruff.check(paths)
    AE-->>YL: ThreadPoolExecutor → yamllint.check(paths)
    Ruff-->>AE: ToolResult (F401 issue)
    YL-->>AE: ToolResult (trailing-spaces issue)
    AE-->>PE: [(ruff, result), (yamllint, result)]
    PE-->>Spy: [ToolResult, ToolResult]
    Spy-->>TE: [ToolResult, ToolResult]
    TE-->>T: "exit_code != 0"
    T->>T: "assert parallel_calls length == 1"
    T->>T: assert both tools in parallel_calls[0]
    T->>T: "parse JSON output, assert issues_count >= 1 per tool"
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["test(execution): spy parallel path and h..."](https://github.com/lgtm-hq/py-lintro/commit/83a65705e0aa6cee88fdb379835e466e46583877) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44896490)</sub>

<!-- /greptile_comment -->