### PR TITLE
test(site): add missing rehype devDependencies for doc-links suite

### DIFF
--- a/apps/site/bun.lock
+++ b/apps/site/bun.lock
@@ -18,6 +18,8 @@
         "@types/sanitize-html": "2.16.1",
         "@vitest/coverage-v8": "4.1.10",
         "pagefind": "1.5.2",
+        "rehype": "13.0.2",
+        "rehype-stringify": "10.0.1",
         "typescript": "6.0.3",
         "vitest": "4.1.10",
         "yaml": "2.9.0",
@@ -834,6 +836,8 @@
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "rehype": ["rehype@13.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "rehype-parse": "^9.0.0", "rehype-stringify": "^10.0.0", "unified": "^11.0.0" } }, "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A=="],
 
     "rehype-parse": ["rehype-parse@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-from-html": "^2.0.0", "unified": "^11.0.0" } }, "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag=="],
 

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -30,6 +30,8 @@
     "pagefind": "1.5.2",
     "@types/sanitize-html": "2.16.1",
     "@vitest/coverage-v8": "4.1.10",
+    "rehype": "13.0.2",
+    "rehype-stringify": "10.0.1",
     "typescript": "6.0.3",
     "vitest": "4.1.10",
     "yaml": "2.9.0"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  test(site): add missing rehype devDependencies for doc-links suite
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

- `Quality - Documentation Site` is failing on main since the Astro 7 / Vite 8 migration (#1428): `rehype-doc-links.test.mjs` imports `rehype` and `rehype-stringify`, which were never declared and stopped resolving as phantom transitive dependencies after the unified/rehype graph changed.
- Declares both as pinned devDependencies in `apps/site/package.json` and updates `bun.lock`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

_No linked issues._

## Details

- `bun run test` in `apps/site`: 11 files / 117 tests pass (previously 1 suite failed with `ERR_MODULE_NOT_FOUND`).
