### PR TITLE
chore(deps): unblock prettier 3.9.5 and harden Docker test isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,9 @@ lib/
 lib64/
 parts/
 sdist/
-var/
+# Root-only: do not use bare "var/" — that also matches macOS /var/folders
+# temp paths when Prettier resolves ignore files from the repo cwd.
+/var/
 wheels/
 share/python-wheels/
 *.egg-info/

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "markdownlint-cli2": "0.23.2",
         "oxfmt": "0.63.0",
         "oxlint": "1.78.0",
-        "prettier": "3.9.4",
+        "prettier": "3.9.5",
         "prettier-plugin-astro": "0.14.1",
         "stylelint": "17.14.1",
         "svelte": "5.56.9",
@@ -983,7 +983,7 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
-    "prettier": ["prettier@3.9.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg=="],
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
 
     "prettier-plugin-astro": ["prettier-plugin-astro@0.14.1", "", { "dependencies": { "@astrojs/compiler": "^2.9.1", "prettier": "^3.0.0", "sass-formatter": "^0.7.6" } }, "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw=="],
 
@@ -1241,6 +1241,8 @@
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "prettier-plugin-astro/prettier": ["prettier@3.9.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg=="],
+
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "qified/hookified": ["hookified@2.2.0", "", {}, "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA=="],
@@ -1264,6 +1266,8 @@
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "yaml-language-server/prettier": ["prettier@3.9.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg=="],
 
     "yaml-language-server/request-light": ["request-light@0.5.8", "", {}, "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="],
 

--- a/lintro/_generated_versions.py
+++ b/lintro/_generated_versions.py
@@ -18,7 +18,7 @@ NPM_VERSIONS: dict[str, str] = {
     "markdownlint-cli2": "0.23.2",
     "oxfmt": "0.63.0",
     "oxlint": "1.78.0",
-    "prettier": "3.9.4",
+    "prettier": "3.9.5",
     "stylelint": "17.14.1",
     "svelte-check": "4.7.6",
     "typescript": "6.0.3",

--- a/lintro/config/tool_config_generator.py
+++ b/lintro/config/tool_config_generator.py
@@ -449,7 +449,9 @@ def get_defaults_injection_args(
         "bandit": ["-c", config_str],
         "oxlint": ["--config", config_str],
         "oxfmt": ["--config", config_str],
-        "prettier": ["--no-config", "--config", config_str],
+        # Prettier forbids combining --no-config with --config (prettier#12221).
+        # --config alone selects the generated defaults file.
+        "prettier": ["--config", config_str],
     }
 
     return config_flags.get(tool_lower, [])

--- a/lintro/tools/definitions/prettier.py
+++ b/lintro/tools/definitions/prettier.py
@@ -9,6 +9,7 @@ re-printing code.
 from __future__ import annotations
 
 import json
+import os
 import subprocess  # nosec B404 - used safely with shell disabled
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,6 +18,7 @@ from typing import Any
 from loguru import logger
 
 from lintro._tool_versions import get_min_version
+from lintro.enums.env_bool import EnvBool
 from lintro.enums.tool_name import ToolName
 from lintro.enums.tool_type import ToolType
 from lintro.models.core.tool_result import ToolResult
@@ -35,6 +37,7 @@ from lintro.utils.path_utils import find_file_upward
 # Constants for Prettier configuration
 PRETTIER_DEFAULT_TIMEOUT: int = 120
 PRETTIER_DEFAULT_PRIORITY: int = 80
+PRETTIER_TEST_MODE_ENV: str = "LINTRO_TEST_MODE"
 # Note: JS/TS/Vue files are handled by oxfmt (faster).
 # Prettier handles file types that oxfmt doesn't support.
 PRETTIER_CONFIG_FILENAMES: tuple[str, ...] = (
@@ -127,6 +130,33 @@ class PrettierPlugin(BaseToolPlugin):
             line_length=line_length,
         )
         super().set_options(**options, **kwargs)
+
+    def _test_mode_isolation_args(self, cwd: str | None = None) -> list[str]:
+        """Return CLI args that isolate Prettier from ambient project ignore/config.
+
+        When ``LINTRO_TEST_MODE=1``:
+        - Always neutralize ignore-file discovery so repo ``.gitignore`` patterns
+          (e.g. bare ``var/`` matching macOS ``/var/folders`` temps) cannot hide
+          fixture files.
+        - Force ``--no-config`` only when the execution cwd has no local Prettier
+          config, so fixtures that ship a cwd-local ``.prettierrc`` (Astro plugin
+          tests) still resolve it.
+
+        Args:
+            cwd: Working directory for the Prettier invocation.
+
+        Returns:
+            Extra CLI arguments, or an empty list outside test mode.
+        """
+        if os.environ.get(PRETTIER_TEST_MODE_ENV) != EnvBool.TRUE:
+            return []
+        args: list[str] = [
+            "--ignore-path",
+            os.devnull,
+        ]
+        if cwd is None or self._find_prettier_config(search_dir=cwd) is None:
+            args.insert(0, "--no-config")
+        return args
 
     def _find_prettier_config(self, search_dir: str | None = None) -> str | None:
         """Locate prettier config file by walking up the directory tree.
@@ -330,9 +360,13 @@ class PrettierPlugin(BaseToolPlugin):
             "--check",
         ]
 
-        # Add Lintro config injection args (--no-config, --config)
+        # Add Lintro config injection args (--config) unless test mode isolates
+        isolation_args = self._test_mode_isolation_args(cwd=ctx.cwd)
         config_args = self._build_config_args()
-        if config_args:
+        if isolation_args:
+            cmd.extend(isolation_args)
+            logger.debug("[PrettierPlugin] Using test-mode config isolation")
+        elif config_args:
             cmd.extend(config_args)
             logger.debug("[PrettierPlugin] Using Lintro config injection")
         else:
@@ -427,10 +461,14 @@ class PrettierPlugin(BaseToolPlugin):
         if ctx.should_skip:
             return ctx.early_result  # type: ignore[return-value]
 
-        # Get Lintro config injection args (--no-config, --config)
+        # Prefer test-mode isolation, then Lintro injection, then fallbacks.
+        isolation_args = self._test_mode_isolation_args(cwd=ctx.cwd)
         config_args = self._build_config_args()
         fallback_args: list[str] = []
-        if not config_args:
+        if isolation_args:
+            config_args = isolation_args
+            logger.debug("[PrettierPlugin] Using test-mode config isolation")
+        elif not config_args:
             # Fallback: Find config and ignore files by walking up from cwd
             found_config = self._find_prettier_config(search_dir=ctx.cwd)
             if found_config:

--- a/lintro/tools/manifest.json
+++ b/lintro/tools/manifest.json
@@ -311,7 +311,7 @@
     },
     {
       "name": "prettier",
-      "version": "3.9.4",
+      "version": "3.9.5",
       "install": {
         "type": "npm",
         "package": "prettier"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "markdownlint-cli2": "0.23.2",
     "oxfmt": "0.63.0",
     "oxlint": "1.78.0",
-    "prettier": "3.9.4",
+    "prettier": "3.9.5",
     "prettier-plugin-astro": "0.14.1",
     "stylelint": "17.14.1",
     "svelte": "5.56.9",

--- a/renovate.json
+++ b/renovate.json
@@ -14,11 +14,6 @@
       "enabled": false
     },
     {
-      "description": "Hold prettier 3.9.5+ until Docker integration prettier fixtures are updated",
-      "matchPackageNames": ["prettier"],
-      "allowedVersions": "<=3.9.4"
-    },
-    {
       "description": "npm platform-binary placeholders are stamped at publish time; never bump in-repo",
       "matchPackageNames": [
         "/^@lgtm-hq\\/lintro(-|$)/"

--- a/scripts/local/run-tests.sh
+++ b/scripts/local/run-tests.sh
@@ -304,13 +304,27 @@ main() {
 	ensure_python_cli_tools
 
 	# Install project-level node_modules for integration tests that need
-	# npm plugins (e.g. prettier-plugin-astro for astro formatting tests)
-	if command -v bun &>/dev/null && [ -f "package.json" ] && [ ! -d "node_modules" ]; then
-		echo -e "${BLUE}Installing project node_modules for integration tests...${NC}"
+	# npm plugins (e.g. prettier-plugin-astro for astro formatting tests).
+	# Always install when package.json exists so Docker/CI picks up the
+	# package.json-pinned prettier (global image tools can lag behind).
+	if command -v bun &>/dev/null && [ -f "package.json" ]; then
+		if [ ! -d "node_modules" ]; then
+			echo -e "${BLUE}Installing project node_modules for integration tests...${NC}"
+		else
+			echo -e "${BLUE}Syncing project node_modules for integration tests...${NC}"
+		fi
 		if ! bun install --no-save; then
 			echo -e "${RED}✗ bun install failed — astro/prettier integration tests may be skipped${NC}"
 			exit 1
 		fi
+	fi
+
+	# Prefer project-pinned Node CLIs over stale globals from the tools image
+	# (e.g. /opt/bun/bin/prettier@3.9.4 vs node_modules prettier@3.9.5).
+	if [ -d "node_modules/.bin" ]; then
+		local_node_bin="$(pwd)/node_modules/.bin"
+		export PATH="${local_node_bin}:${PATH}"
+		echo -e "${GREEN}✓ Prepended ${local_node_bin} to PATH${NC}"
 	fi
 
 	# Discover available tools and tests

--- a/tests/config/test_tool_config_generator.py
+++ b/tests/config/test_tool_config_generator.py
@@ -533,7 +533,10 @@ def test_has_native_config_prettier_detects_prettierrc(
 
 
 def test_get_defaults_injection_args_prettier(tmp_path: Path) -> None:
-    """Should return --no-config --config args for prettier.
+    """Should return --config args for prettier (not --no-config).
+
+    Prettier rejects combining --no-config with --config (prettier#12221),
+    so defaults injection uses --config alone.
 
     Args:
         tmp_path: Pytest temporary directory fixture.
@@ -542,4 +545,4 @@ def test_get_defaults_injection_args_prettier(tmp_path: Path) -> None:
     config_path.write_text("{}")
     args = get_defaults_injection_args("prettier", config_path)
 
-    assert_that(args).is_equal_to(["--no-config", "--config", str(config_path)])
+    assert_that(args).is_equal_to(["--config", str(config_path)])

--- a/tests/integration/tools/test_prettier_integration.py
+++ b/tests/integration/tools/test_prettier_integration.py
@@ -39,7 +39,11 @@ def temp_json_file_unformatted(tmp_path: Path) -> str:
         Path to the created file as a string.
     """
     file_path = tmp_path / "unformatted.json"
-    file_path.write_text('{"name":"test","version":"1.0.0","dependencies":{}}')
+    # Spaces around ":" / "," are rejected under both Prettier defaults and
+    # configs that keep compact JSON (e.g. singleQuote via --config).
+    file_path.write_text(
+        '{ "name" : "test" , "version" : "1.0.0" , "dependencies" : {} }',
+    )
     return str(file_path)
 
 
@@ -154,6 +158,7 @@ def test_check_json_file_formatting_state(
 
     assert_that(result).is_not_none()
     assert_that(result.name).is_equal_to("prettier")
+    assert_that(result.skipped).is_false()
     if expect_issues:
         assert_that(result.issues_count).is_greater_than(0)
     else:
@@ -183,6 +188,7 @@ def test_fix_formats_json_file(
 
     assert_that(result).is_not_none()
     assert_that(result.success).is_true()
+    assert_that(result.skipped).is_false()
 
     new_content = Path(temp_json_file_unformatted).read_text()
     assert_that(new_content).is_not_equal_to(original)
@@ -337,6 +343,7 @@ def test_check_astro_file_formatting_state(
 
     assert_that(result).is_not_none()
     assert_that(result.name).is_equal_to("prettier")
+    assert_that(result.skipped).is_false()
     if expect_issues:
         assert_that(result.issues_count).is_greater_than(0)
     else:

--- a/tests/unit/tools/prettier/test_config_discovery.py
+++ b/tests/unit/tools/prettier/test_config_discovery.py
@@ -165,12 +165,10 @@ def test_build_config_args_returns_args_when_builtin_defaults_exist(
             mock_gen.return_value = Path("/tmp/test.json")
             args = prettier_plugin._build_config_args()
 
-    # Should have generated args since builtin defaults exist for prettier
-    assert_that(args).contains("--no-config")
+    # Should have generated args since builtin defaults exist for prettier.
+    # Prettier forbids --no-config with --config (prettier#12221); inject
+    # the generated defaults via --config alone.
     assert_that(args).contains("--config")
-    # Verify correct ordering: --no-config before --config <path>
-    no_config_idx = args.index("--no-config")
+    assert_that(args).does_not_contain("--no-config")
     config_idx = args.index("--config")
-    assert_that(no_config_idx).is_less_than(config_idx)
-    # The path should follow --config
     assert_that(args[config_idx + 1]).is_equal_to("/tmp/test.json")

--- a/tests/unit/tools/prettier/test_test_mode_isolation.py
+++ b/tests/unit/tools/prettier/test_test_mode_isolation.py
@@ -1,0 +1,98 @@
+"""Tests for Prettier's ``LINTRO_TEST_MODE`` config/ignore isolation."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+from assertpy import assert_that
+
+from lintro.tools.definitions.prettier import PRETTIER_TEST_MODE_ENV
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from lintro.tools.definitions.prettier import PrettierPlugin
+
+
+def test_isolation_args_empty_outside_test_mode(
+    prettier_plugin: PrettierPlugin,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Returns no extra args when test mode is off.
+
+    Args:
+        prettier_plugin: The PrettierPlugin instance to test.
+        tmp_path: Temporary directory path used as the execution cwd.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.delenv(PRETTIER_TEST_MODE_ENV, raising=False)
+
+    args = prettier_plugin._test_mode_isolation_args(cwd=str(tmp_path))
+
+    assert_that(args).is_empty()
+
+
+def test_isolation_args_neutralize_ignore_file_discovery(
+    prettier_plugin: PrettierPlugin,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Points ``--ignore-path`` at the null device so fixtures stay visible.
+
+    Args:
+        prettier_plugin: The PrettierPlugin instance to test.
+        tmp_path: Temporary directory path used as the execution cwd.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setenv(PRETTIER_TEST_MODE_ENV, "1")
+
+    args = prettier_plugin._test_mode_isolation_args(cwd=str(tmp_path))
+
+    assert_that(args).contains("--ignore-path")
+    assert_that(args[args.index("--ignore-path") + 1]).is_equal_to(os.devnull)
+
+
+def test_isolation_args_force_no_config_without_local_config(
+    prettier_plugin: PrettierPlugin,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Adds ``--no-config`` when the execution cwd has no Prettier config.
+
+    Args:
+        prettier_plugin: The PrettierPlugin instance to test.
+        tmp_path: Temporary directory path used as the execution cwd.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setenv(PRETTIER_TEST_MODE_ENV, "1")
+
+    args = prettier_plugin._test_mode_isolation_args(cwd=str(tmp_path))
+
+    assert_that(args).contains("--no-config")
+
+
+def test_isolation_args_keep_local_config(
+    prettier_plugin: PrettierPlugin,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omits ``--no-config`` when the cwd ships its own Prettier config.
+
+    Fixtures such as the Astro plugin tests rely on a cwd-local
+    ``.prettierrc`` still being resolved under test mode.
+
+    Args:
+        prettier_plugin: The PrettierPlugin instance to test.
+        tmp_path: Temporary directory path used as the execution cwd.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setenv(PRETTIER_TEST_MODE_ENV, "1")
+    (tmp_path / ".prettierrc").write_text("{}")
+
+    args = prettier_plugin._test_mode_isolation_args(cwd=str(tmp_path))
+
+    assert_that(args).does_not_contain("--no-config")
+    assert_that(args).contains("--ignore-path")


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(prettier): prefer project-local binary over stale Docker global
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Unblocks prettier `3.9.4` → `3.9.5` after Renovate PRs were closed for Docker
integration failures (#1394 / #1434).

**Real Docker failure root cause:** the tools image still ships global
`prettier@3.9.4` on `PATH`, while `package.json` pins `3.9.5`. Lintro’s
minimum-version gate then *skipped* prettier (`issues_count=0`), so only the
“unformatted” fixture assertions failed. Formatted fixtures still “passed”.

Changes:
- Bump prettier to 3.9.5; regenerate tool-version artifacts; refresh bun lockfile
- Drop the Renovate hold for prettier `<=3.9.4`
- Prefer project-local `node_modules/.bin` for Node CLIs (including prettier)
  over stale globals; prepend local bin in `run-tests.sh`
- Harden test-mode ignore/config isolation and JSON fixtures
- Scope `.gitignore` `var/` → `/var/`
- Pin `apps/site` astro to `7.0.9` (clear OSV `MAL-2026-10726` from caret → 7.1.0)

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` / `uv run pytest`; Docker prettier suite green)

## Closes

- Closes #1406

## Details

Reproduced in Docker: global `/opt/bun/bin/prettier` → 3.9.4, local
`node_modules` → 3.9.5, skip reason `Version 3.9.4 is below minimum requirement
3.9.5`. After local-bin preference + PATH prepend, all 11 prettier integration
tests pass in Docker. Full local pytest: 6654 passed. `lintro chk`: 100/100.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR unblocks prettier 3.9.5 by fixing the real Docker failure root-cause: the tools image's global `prettier@3.9.4` on PATH was shadowing the package.json-pinned `3.9.5`, causing Lintro's minimum-version gate to skip prettier silently. The fix prepends `node_modules/.bin` to PATH in `run-tests.sh` and adds a test-mode isolation layer (`_test_mode_isolation_args`) that prevents ambient repo configs and ignore files from interfering with fixture-based tests.

- **Version bump & Renovate hold removal**: `package.json`, `bun.lock`, `manifest.json`, and `_generated_versions.py` all move prettier from 3.9.4 → 3.9.5; the `allowedVersions: <=3.9.4` Renovate hold is removed.
- **`--no-config` drop from config injection**: `get_defaults_injection_args` for prettier no longer emits `--no-config` alongside `--config`, since prettier 3.9.5 rejects that combination (prettier#12221); `--config` alone already overrides config discovery.
- **Test hardening**: integration fixtures gain `result.skipped` assertions to catch the silent-skip regression; the unformatted JSON fixture now uses spaces around `:` / `,` that Prettier rejects regardless of config; `.gitignore` scopes `var/` to `/var/` to stop macOS temp paths from leaking into ignore resolution.
</details>

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the root cause of the Docker failures is addressed and the isolation logic is correctly guarded so it only activates when LINTRO_TEST_MODE=1.
- All changed code paths are well-tested and the PR is narrowly scoped to the Docker prettier-version skip and the --no-config/--config incompatibility. The isolation logic is mutually exclusive with the normal config-injection path, integration fixtures are hardened with skipped assertions, and the lockfile regeneration is mechanically correct.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/definitions/prettier.py | Adds `_test_mode_isolation_args()` that prepends `--no-config` + `--ignore-path /dev/null` in test mode, neutralizing ambient repo configs/ignores. Both `check()` and `fix()` now prefer isolation args over config injection, and the two branches are mutually exclusive. Logic is correct. |
| lintro/config/tool_config_generator.py | Drops `--no-config` from prettier's defaults-injection args since Prettier 3.9.5 forbids combining `--no-config` with `--config` (prettier#12221). `--config` alone correctly overrides config discovery; the fix is sound. |
| scripts/local/run-tests.sh | Always runs `bun install --no-save` when `package.json` exists (not just when `node_modules` is absent), then prepends `$(pwd)/node_modules/.bin` to PATH. Ensures the package.json-pinned prettier binary shadows any stale global binary in Docker. Change is intentional and safe. |
| tests/unit/tools/prettier/test_test_mode_isolation.py | New unit test file covering `_test_mode_isolation_args`: off by default, `--ignore-path /dev/null` always added in test mode, `--no-config` present without local config, and absent when local `.prettierrc` exists. All four branches are now explicitly asserted. |
| tests/integration/tools/test_prettier_integration.py | Hardens the unformatted JSON fixture (spaces around `:` / `,` ensure Prettier rejects it regardless of config). Adds `result.skipped` assertions to catch the version-gate silent-skip that was the root cause of the Docker failures. |
| .gitignore | Scopes `var/` to `/var/` (root-anchored) to prevent macOS `/var/folders` temp paths from matching when Prettier resolves ignore files from the repo root. Correct fix with an explanatory comment. |
| renovate.json | Removes the `allowedVersions: <=3.9.4` hold that was blocking prettier 3.9.5. Now that the root cause is fixed, the hold is no longer needed. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[check / fix called] --> B[_prepare_execution]
    B --> C{ctx.should_skip?}
    C -- yes --> D[return early_result]
    C -- no --> E[_test_mode_isolation_args cwd]

    E --> F{LINTRO_TEST_MODE=1?}
    F -- no --> G[isolation_args = empty]
    F -- yes --> H[args = --ignore-path /dev/null]
    H --> I{_find_prettier_config cwd walks up}
    I -- config found --> J[keep args as-is]
    I -- no config --> K[prepend --no-config to args]
    J --> L[isolation_args = args]
    K --> L

    G --> M[_build_config_args]
    M --> N{builtin defaults exist?}
    N -- yes --> O[config_args = --config generated.json]
    N -- no --> P[config_args = empty → fallback walk-up]

    L --> Q{isolation_args truthy?}
    Q -- yes --> R[cmd.extend isolation_args\nlog: test-mode isolation]
    Q -- no --> S{config_args truthy?}
    S -- yes --> T[cmd.extend config_args\nlog: Lintro injection]
    S -- no --> U[fallback: walk-up for config + ignore]

    R --> V[run prettier subprocess]
    T --> V
    U --> V
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(prettier): cover test-mode config a..."](https://github.com/lgtm-hq/py-lintro/commit/4d9087e03cf4ae408db0f335f243f8a0304fa968) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44908332)</sub>

<!-- /greptile_comment -->