### PR TITLE
fix(cli): let explicit --tools bypass enabled_tools allowlist

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,8 +40,9 @@ configure specific commands rather than tool resolution.
 The configuration system works in a specific order:
 
 1. **Execution Tier** - Determines which tools run and in what order
-   - `enabled_tools`: Empty list means all enabled tools run. Explicit `--tools` on the
-     CLI bypasses this allowlist; it only scopes default runs.
+   - `enabled_tools`: Empty list means all enabled tools run. An explicit named
+     `--tools` list on the CLI bypasses this allowlist; default runs and `--tools all`
+     remain filtered by it.
    - `tool_order`: Controls execution order (priority, alphabetical, or custom)
    - `fail_fast`: Whether to stop on first tool failure
    - `parallel`: Whether to run tools in parallel (default: `true`)
@@ -387,13 +388,13 @@ This summary is shown for all output formats except JSON (`--output-format json`
 When tools are skipped, Lintro reports them in the summary table with a `SKIP` status
 and a note explaining the reason. Common skip reasons:
 
-| Reason                   | Description                                                                                           |
-| ------------------------ | ----------------------------------------------------------------------------------------------------- |
-| `node_modules not found` | Node.js deps missing and auto-install is disabled                                                     |
-| `disabled in config`     | Tool disabled via `tools.<name>.enabled: false`                                                       |
-| `not in enabled_tools`   | Tool not in `execution.enabled_tools` allowlist (default runs only; explicit `--tools` bypasses this) |
-| `deferred to <tool>`     | Framework tool preferred (e.g., tsc to vue-tsc)                                                       |
-| Version check messages   | Tool version below minimum required                                                                   |
+| Reason                   | Description                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `node_modules not found` | Node.js deps missing and auto-install is disabled                                                      |
+| `disabled in config`     | Tool disabled via `tools.<name>.enabled: false`                                                        |
+| `not in enabled_tools`   | Tool not in `execution.enabled_tools` allowlist (default/`--tools all` only; named `--tools` bypasses) |
+| `deferred to <tool>`     | Framework tool preferred (e.g., tsc to vue-tsc)                                                        |
+| Version check messages   | Tool version below minimum required                                                                    |
 
 Skipped tools do not affect exit codes — only tools that run and find issues contribute
 to a non-zero exit.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,8 @@ configure specific commands rather than tool resolution.
 The configuration system works in a specific order:
 
 1. **Execution Tier** - Determines which tools run and in what order
-   - `enabled_tools`: Empty list means all enabled tools run
+   - `enabled_tools`: Empty list means all enabled tools run. Explicit `--tools` on the
+     CLI bypasses this allowlist; it only scopes default runs.
    - `tool_order`: Controls execution order (priority, alphabetical, or custom)
    - `fail_fast`: Whether to stop on first tool failure
    - `parallel`: Whether to run tools in parallel (default: `true`)
@@ -386,13 +387,13 @@ This summary is shown for all output formats except JSON (`--output-format json`
 When tools are skipped, Lintro reports them in the summary table with a `SKIP` status
 and a note explaining the reason. Common skip reasons:
 
-| Reason                   | Description                                       |
-| ------------------------ | ------------------------------------------------- |
-| `node_modules not found` | Node.js deps missing and auto-install is disabled |
-| `disabled in config`     | Tool disabled via `tools.<name>.enabled: false`   |
-| `not in enabled_tools`   | Tool not in `execution.enabled_tools` allowlist   |
-| `deferred to <tool>`     | Framework tool preferred (e.g., tsc to vue-tsc)   |
-| Version check messages   | Tool version below minimum required               |
+| Reason                   | Description                                                                                           |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `node_modules not found` | Node.js deps missing and auto-install is disabled                                                     |
+| `disabled in config`     | Tool disabled via `tools.<name>.enabled: false`                                                       |
+| `not in enabled_tools`   | Tool not in `execution.enabled_tools` allowlist (default runs only; explicit `--tools` bypasses this) |
+| `deferred to <tool>`     | Framework tool preferred (e.g., tsc to vue-tsc)                                                       |
+| Version check messages   | Tool version below minimum required                                                                   |
 
 Skipped tools do not affect exit codes — only tools that run and find issues contribute
 to a non-zero exit.

--- a/lintro/config/execution_config.py
+++ b/lintro/config/execution_config.py
@@ -24,7 +24,9 @@ class ExecutionConfig(BaseModel):
 
     Attributes:
         model_config: Pydantic model configuration.
-        enabled_tools: List of tool names to run. If empty/None, all tools run.
+        enabled_tools: List of tool names to run on default (no ``--tools``)
+            runs. If empty/None, all tools run. Explicit ``--tools`` bypasses
+            this allowlist.
         tool_order: Execution order strategy. One of:
             - "priority": Use default priority (formatters before linters)
             - "alphabetical": Alphabetical order

--- a/lintro/config/execution_config.py
+++ b/lintro/config/execution_config.py
@@ -25,8 +25,8 @@ class ExecutionConfig(BaseModel):
     Attributes:
         model_config: Pydantic model configuration.
         enabled_tools: List of tool names to run on default (no ``--tools``)
-            runs. If empty/None, all tools run. Explicit ``--tools`` bypasses
-            this allowlist.
+            and ``--tools all`` runs. If empty/None, all tools run. An
+            explicit comma-separated ``--tools`` list bypasses this allowlist.
         tool_order: Execution order strategy. One of:
             - "priority": Use default priority (formatters before linters)
             - "alphabetical": Alphabetical order

--- a/lintro/utils/execution/tool_configuration.py
+++ b/lintro/utils/execution/tool_configuration.py
@@ -269,12 +269,24 @@ def get_tools_to_run(
         # Use tool_manager to trigger discovery before checking registration
         if not tool_manager.is_tool_registered("pytest"):
             raise ValueError("pytest tool is not available")
-        # Respect enabled/disabled config for pytest
+        # Explicit --tools pytest bypasses execution.enabled_tools; default
+        # runs (tools is None) still apply the allowlist. Per-tool
+        # tools.pytest.enabled: false always applies.
         config = lintro_config or get_config()
-        if not config.is_tool_enabled("pytest"):
-            reason = _get_disabled_reason(config, "pytest")
+        if tools is None:
+            if not config.is_tool_enabled("pytest"):
+                reason = _get_disabled_reason(config, "pytest")
+                return ToolsToRunResult(
+                    skipped=[SkippedTool(name="pytest", reason=reason)],
+                )
+        elif not config.get_tool_config("pytest").enabled:
             return ToolsToRunResult(
-                skipped=[SkippedTool(name="pytest", reason=reason)],
+                skipped=[
+                    SkippedTool(
+                        name="pytest",
+                        reason="disabled in config",
+                    ),
+                ],
             )
         return ToolsToRunResult(to_run=["pytest"])
 

--- a/lintro/utils/execution/tool_configuration.py
+++ b/lintro/utils/execution/tool_configuration.py
@@ -239,6 +239,10 @@ def get_tools_to_run(
 ) -> ToolsToRunResult:
     """Get the list of tools to run based on the tools string and action.
 
+    ``execution.enabled_tools`` filters default / ``all`` runs only. An
+    explicit ``--tools`` list bypasses that allowlist so named tools still
+    run; per-tool ``tools.<name>.enabled: false`` continues to apply.
+
     Args:
         tools: Comma-separated tool names, "all", or None.
         action: "check", "fmt", or "test".
@@ -327,10 +331,14 @@ def get_tools_to_run(
             raise ValueError(
                 f"Unknown tool '{name}'. Available tools: {available_names}",
             )
-        # Track disabled tools with reason
-        if not config.is_tool_enabled(name):
-            reason = _get_disabled_reason(config, name)
-            skipped.append(SkippedTool(name=name, reason=reason))
+        # Explicit --tools bypasses execution.enabled_tools (that allowlist
+        # scopes default / --tools all runs only). Still honor per-tool
+        # tools.<name>.enabled: false.
+        tool_config = config.get_tool_config(name)
+        if not tool_config.enabled:
+            skipped.append(
+                SkippedTool(name=name, reason="disabled in config"),
+            )
             continue
         # Verify the tool supports the requested action
         if action == Action.FIX:

--- a/tests/unit/tools/executor/test_tool_configuration_enabled.py
+++ b/tests/unit/tools/executor/test_tool_configuration_enabled.py
@@ -385,6 +385,124 @@ def test_default_run_still_filters_by_enabled_tools(
     )
 
 
+def test_tools_all_still_filters_by_enabled_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--tools all`` still applies enabled_tools filtering."""
+    from lintro.tools import tool_manager
+
+    monkeypatch.setattr(
+        tool_manager,
+        "get_check_tools",
+        lambda: ["ruff", "yamllint"],
+    )
+
+    config = LintroConfig(
+        execution=ExecutionConfig(enabled_tools=["yamllint"]),
+    )
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(tools="all", action="check")
+
+    assert_that(result.to_run).is_equal_to(["yamllint"])
+    skipped_by_name = {s.name: s for s in result.skipped}
+    assert_that(skipped_by_name).contains_key("ruff")
+    assert_that(skipped_by_name["ruff"].reason).is_equal_to(
+        "not in enabled_tools",
+    )
+
+
+def test_explicit_tools_still_honors_per_tool_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit --tools still skips tools with tools.<name>.enabled false."""
+    from lintro.tools import tool_manager
+
+    monkeypatch.setattr(
+        tool_manager,
+        "is_tool_registered",
+        lambda name: name in {"ruff", "yamllint"},
+    )
+    monkeypatch.setattr(
+        tool_manager,
+        "get_tool_names",
+        lambda: ["ruff", "yamllint"],
+    )
+
+    config = LintroConfig(
+        execution=ExecutionConfig(enabled_tools=["yamllint"]),
+        tools={"ruff": LintroToolConfig(enabled=False)},
+    )
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(tools="ruff", action="check")
+
+    assert_that(result.to_run).is_empty()
+    assert_that(result.skipped).is_length(1)
+    assert_that(result.skipped[0].name).is_equal_to("ruff")
+    assert_that(result.skipped[0].reason).is_equal_to("disabled in config")
+
+
+def test_explicit_pytest_bypasses_enabled_tools_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit --tools pytest bypasses enabled_tools on the test action."""
+    from lintro.tools import tool_manager
+
+    monkeypatch.setattr(
+        tool_manager,
+        "is_tool_registered",
+        lambda name: name == "pytest",
+    )
+
+    config = LintroConfig(
+        execution=ExecutionConfig(enabled_tools=["ruff"]),
+    )
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(tools="pytest", action="test")
+
+    assert_that(result.to_run).is_equal_to(["pytest"])
+    assert_that(result.skipped).is_empty()
+
+
+def test_default_test_run_still_filters_by_enabled_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default lintro test still applies enabled_tools to pytest."""
+    from lintro.tools import tool_manager
+
+    monkeypatch.setattr(
+        tool_manager,
+        "is_tool_registered",
+        lambda name: name == "pytest",
+    )
+
+    config = LintroConfig(
+        execution=ExecutionConfig(enabled_tools=["ruff"]),
+    )
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(tools=None, action="test")
+
+    assert_that(result.to_run).is_empty()
+    assert_that(result.skipped).is_length(1)
+    assert_that(result.skipped[0].name).is_equal_to("pytest")
+    assert_that(result.skipped[0].reason).is_equal_to("not in enabled_tools")
+
+
 # =============================================================================
 # Fix action
 # =============================================================================

--- a/tests/unit/tools/executor/test_tool_configuration_enabled.py
+++ b/tests/unit/tools/executor/test_tool_configuration_enabled.py
@@ -324,6 +324,67 @@ def test_execution_enabled_tools_combined_with_tool_disabled(
     assert_that(result.to_run).is_equal_to(["ruff"])
 
 
+def test_explicit_tools_bypasses_enabled_tools_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit --tools runs even when absent from enabled_tools."""
+    from lintro.tools import tool_manager
+
+    monkeypatch.setattr(
+        tool_manager,
+        "is_tool_registered",
+        lambda name: name in {"ruff", "yamllint"},
+    )
+    monkeypatch.setattr(
+        tool_manager,
+        "get_tool_names",
+        lambda: ["ruff", "yamllint"],
+    )
+
+    config = LintroConfig(
+        execution=ExecutionConfig(enabled_tools=["yamllint"]),
+    )
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(tools="ruff", action="check")
+
+    assert_that(result.to_run).is_equal_to(["ruff"])
+    assert_that(result.skipped).is_empty()
+
+
+def test_default_run_still_filters_by_enabled_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without --tools, enabled_tools still excludes tools not on the list."""
+    from lintro.tools import tool_manager
+
+    monkeypatch.setattr(
+        tool_manager,
+        "get_check_tools",
+        lambda: ["ruff", "yamllint"],
+    )
+
+    config = LintroConfig(
+        execution=ExecutionConfig(enabled_tools=["yamllint"]),
+    )
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(tools=None, action="check")
+
+    assert_that(result.to_run).is_equal_to(["yamllint"])
+    skipped_by_name = {s.name: s for s in result.skipped}
+    assert_that(skipped_by_name).contains_key("ruff")
+    assert_that(skipped_by_name["ruff"].reason).is_equal_to(
+        "not in enabled_tools",
+    )
+
+
 # =============================================================================
 # Fix action
 # =============================================================================


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(cli): let explicit --tools bypass enabled_tools allowlist
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Explicit `--tools` now bypasses `execution.enabled_tools`. Default runs (and `--tools all`) remain filtered by the allowlist; per-tool `tools.<name>.enabled: false` still applies. Covers check/fmt and the test action (`--tools pytest`). Docs and tests updated for both directions.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1415

## Details

Previously `get_tools_to_run` applied `config.is_tool_enabled()` on explicit `--tools` selections, so tools absent from `execution.enabled_tools` were silently skipped even when named on the CLI.

- Explicit comma-separated `--tools` lists check only `tools.<name>.enabled`
- Default / `--tools all` paths still use the allowlist
- `lintro test --tools pytest` matches the same bypass; bare `lintro test` still filters
- Unit tests cover bypass, default filtering, `--tools all`, per-tool disable, and test-action cases

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes `get_tools_to_run` so that an explicit `--tools <name>` list on the CLI bypasses `execution.enabled_tools`, while default (no `--tools`) and `--tools all` runs continue to be filtered by the allowlist. Per-tool `tools.<name>.enabled: false` still applies in all paths.

- **`tool_configuration.py`**: In the test-action branch a two-arm conditional (`if tools is None` / `elif`) now selects between `is_tool_enabled` (checks allowlist + per-tool flag) and `get_tool_config().enabled` (per-tool flag only). The check/fmt explicit-tools loop similarly switches from `is_tool_enabled` to `get_tool_config().enabled`.
- **Tests**: Six new unit tests cover bypass, default filtering, `--tools all`, per-tool disable (check action), and both bypass and default-filter directions for the test action; the `elif` branch covering explicit `--tools pytest` with `tools.pytest.enabled: false` has no corresponding test.
- **Docs/docstrings**: `enabled_tools` semantics are clearly updated in both `execution_config.py` and `docs/configuration.md`.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge. The four control-flow paths in `get_tools_to_run` all resolve correctly, and the split between allowlist-aware and per-tool-only checks is applied consistently in both the test-action branch and the check/fmt explicit-tools loop.

The implementation correctly separates `is_tool_enabled` (allowlist + per-tool flag) for default/all runs from `get_tool_config().enabled` (per-tool flag only) for explicit CLI lists. The one gap is an untested code branch: the `elif not config.get_tool_config("pytest").enabled` path for `action=test` with explicit `--tools pytest` and `tools.pytest.enabled: false` has no dedicated test case, leaving that arm of the new conditional unverified.

The test file `tests/unit/tools/executor/test_tool_configuration_enabled.py` is worth a second look — the new `elif` branch in the test-action path of `tool_configuration.py` is not exercised by any of the six added tests.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lintro/utils/execution/tool_configuration.py | Core logic change: explicit --tools paths now check only `get_tool_config().enabled` (per-tool flag) rather than `is_tool_enabled()` (which also enforces the allowlist). Both the test-action branch and the check/fmt explicit-tools branch are updated consistently and the four control-flow paths all resolve correctly. |
| tests/unit/tools/executor/test_tool_configuration_enabled.py | Six new tests covering bypass, default filtering, --tools all, per-tool disable (check action), and pytest-specific test-action variants. The `elif` branch for explicit --tools pytest + per-tool disabled is not covered. |
| lintro/config/execution_config.py | Doc-string update only — `enabled_tools` now documents the bypass behaviour for explicit CLI lists. No functional change. |
| docs/configuration.md | Documentation updated in two places: the configuration order description and the skip-reason table. Both accurately describe the new bypass semantics. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[get_tools_to_run] --> B{action == TEST?}

    B -->|Yes| C{tools is None?}
    C -->|Yes - default run| D[is_tool_enabled\nchecks allowlist + per-tool flag]
    D -->|disabled| E[return skipped]
    D -->|enabled| F[return pytest]

    C -->|No - explicit pytest| G[get_tool_config.enabled\nper-tool flag only\nallowlist bypassed]
    G -->|enabled=False| H[return skipped]
    G -->|enabled=True| F

    B -->|No - check/fmt| I{tools is None or all?}

    I -->|Yes - default or all| J[Loop all tools\nis_tool_enabled\nallowlist + per-tool flag]
    J -->|disabled| L[skipped with reason]
    J -->|enabled| M[to_run list]
    M --> N[conflict resolution]

    I -->|No - explicit list| O[Loop named tools\nget_tool_config.enabled\nallowlist bypassed]
    O -->|disabled| Q[skipped: disabled in config]
    O -->|enabled| R[to_run list]
    R --> S[conflict resolution]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[get_tools_to_run] --> B{action == TEST?}

    B -->|Yes| C{tools is None?}
    C -->|Yes - default run| D[is_tool_enabled\nchecks allowlist + per-tool flag]
    D -->|disabled| E[return skipped]
    D -->|enabled| F[return pytest]

    C -->|No - explicit pytest| G[get_tool_config.enabled\nper-tool flag only\nallowlist bypassed]
    G -->|enabled=False| H[return skipped]
    G -->|enabled=True| F

    B -->|No - check/fmt| I{tools is None or all?}

    I -->|Yes - default or all| J[Loop all tools\nis_tool_enabled\nallowlist + per-tool flag]
    J -->|disabled| L[skipped with reason]
    J -->|enabled| M[to_run list]
    M --> N[conflict resolution]

    I -->|No - explicit list| O[Loop named tools\nget_tool_config.enabled\nallowlist bypassed]
    O -->|disabled| Q[skipped: disabled in config]
    O -->|enabled| R[to_run list]
    R --> S[conflict resolution]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/unit/tools/executor/test_tool_configuration_enabled.py`, line 432-509 ([link](https://github.com/lgtm-hq/py-lintro/blob/c169a322682a73fd2ca2f77a840232537e19d2df/tests/unit/tools/executor/test_tool_configuration_enabled.py#L432-L509)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing test: explicit `--tools pytest` with `tools.pytest.enabled: false`**

   The PR adds `test_explicit_tools_still_honors_per_tool_disabled` for check/fmt actions but does not cover the symmetric case for the test action. The new `elif not config.get_tool_config("pytest").enabled:` branch (lines 282–290 in `tool_configuration.py`) is therefore not exercised by any test in this changeset. A config with `tools={"pytest": LintroToolConfig(enabled=False)}` and `get_tools_to_run(tools="pytest", action="test")` would exercise that branch and should assert `result.skipped[0].reason == "disabled in config"`.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Funit%2Ftools%2Fexecutor%2Ftest_tool_configuration_enabled.py%0ALine%3A%20432-509%0A%0AComment%3A%0A**Missing%20test%3A%20explicit%20%60--tools%20pytest%60%20with%20%60tools.pytest.enabled%3A%20false%60**%0A%0AThe%20PR%20adds%20%60test_explicit_tools_still_honors_per_tool_disabled%60%20for%20check%2Ffmt%20actions%20but%20does%20not%20cover%20the%20symmetric%20case%20for%20the%20test%20action.%20The%20new%20%60elif%20not%20config.get_tool_config%28%22pytest%22%29.enabled%3A%60%20branch%20%28lines%20282%E2%80%93290%20in%20%60tool_configuration.py%60%29%20is%20therefore%20not%20exercised%20by%20any%20test%20in%20this%20changeset.%20A%20config%20with%20%60tools%3D%7B%22pytest%22%3A%20LintroToolConfig%28enabled%3DFalse%29%7D%60%20and%20%60get_tools_to_run%28tools%3D%22pytest%22%2C%20action%3D%22test%22%29%60%20would%20exercise%20that%20branch%20and%20should%20assert%20%60result.skipped%5B0%5D.reason%20%3D%3D%20%22disabled%20in%20config%22%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=1451&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Funit%2Ftools%2Fexecutor%2Ftest_tool_configuration_enabled.py%0ALine%3A%20432-509%0A%0AComment%3A%0A**Missing%20test%3A%20explicit%20%60--tools%20pytest%60%20with%20%60tools.pytest.enabled%3A%20false%60**%0A%0AThe%20PR%20adds%20%60test_explicit_tools_still_honors_per_tool_disabled%60%20for%20check%2Ffmt%20actions%20but%20does%20not%20cover%20the%20symmetric%20case%20for%20the%20test%20action.%20The%20new%20%60elif%20not%20config.get_tool_config%28%22pytest%22%29.enabled%3A%60%20branch%20%28lines%20282%E2%80%93290%20in%20%60tool_configuration.py%60%29%20is%20therefore%20not%20exercised%20by%20any%20test%20in%20this%20changeset.%20A%20config%20with%20%60tools%3D%7B%22pytest%22%3A%20LintroToolConfig%28enabled%3DFalse%29%7D%60%20and%20%60get_tools_to_run%28tools%3D%22pytest%22%2C%20action%3D%22test%22%29%60%20would%20exercise%20that%20branch%20and%20should%20assert%20%60result.skipped%5B0%5D.reason%20%3D%3D%20%22disabled%20in%20config%22%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fpy-lintro&pr=1451&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F1415-tools-enabled-precedence%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1415-tools-enabled-precedence%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Funit%2Ftools%2Fexecutor%2Ftest_tool_configuration_enabled.py%0ALine%3A%20432-509%0A%0AComment%3A%0A**Missing%20test%3A%20explicit%20%60--tools%20pytest%60%20with%20%60tools.pytest.enabled%3A%20false%60**%0A%0AThe%20PR%20adds%20%60test_explicit_tools_still_honors_per_tool_disabled%60%20for%20check%2Ffmt%20actions%20but%20does%20not%20cover%20the%20symmetric%20case%20for%20the%20test%20action.%20The%20new%20%60elif%20not%20config.get_tool_config%28%22pytest%22%29.enabled%3A%60%20branch%20%28lines%20282%E2%80%93290%20in%20%60tool_configuration.py%60%29%20is%20therefore%20not%20exercised%20by%20any%20test%20in%20this%20changeset.%20A%20config%20with%20%60tools%3D%7B%22pytest%22%3A%20LintroToolConfig%28enabled%3DFalse%29%7D%60%20and%20%60get_tools_to_run%28tools%3D%22pytest%22%2C%20action%3D%22test%22%29%60%20would%20exercise%20that%20branch%20and%20should%20assert%20%60result.skipped%5B0%5D.reason%20%3D%3D%20%22disabled%20in%20config%22%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fpy-lintro&pr=1451&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Funit%2Ftools%2Fexecutor%2Ftest_tool_configuration_enabled.py%3A432-509%0A**Missing%20test%3A%20explicit%20%60--tools%20pytest%60%20with%20%60tools.pytest.enabled%3A%20false%60**%0A%0AThe%20PR%20adds%20%60test_explicit_tools_still_honors_per_tool_disabled%60%20for%20check%2Ffmt%20actions%20but%20does%20not%20cover%20the%20symmetric%20case%20for%20the%20test%20action.%20The%20new%20%60elif%20not%20config.get_tool_config%28%22pytest%22%29.enabled%3A%60%20branch%20%28lines%20282%E2%80%93290%20in%20%60tool_configuration.py%60%29%20is%20therefore%20not%20exercised%20by%20any%20test%20in%20this%20changeset.%20A%20config%20with%20%60tools%3D%7B%22pytest%22%3A%20LintroToolConfig%28enabled%3DFalse%29%7D%60%20and%20%60get_tools_to_run%28tools%3D%22pytest%22%2C%20action%3D%22test%22%29%60%20would%20exercise%20that%20branch%20and%20should%20assert%20%60result.skipped%5B0%5D.reason%20%3D%3D%20%22disabled%20in%20config%22%60.%0A%0A&pr=1451&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Funit%2Ftools%2Fexecutor%2Ftest_tool_configuration_enabled.py%3A432-509%0A**Missing%20test%3A%20explicit%20%60--tools%20pytest%60%20with%20%60tools.pytest.enabled%3A%20false%60**%0A%0AThe%20PR%20adds%20%60test_explicit_tools_still_honors_per_tool_disabled%60%20for%20check%2Ffmt%20actions%20but%20does%20not%20cover%20the%20symmetric%20case%20for%20the%20test%20action.%20The%20new%20%60elif%20not%20config.get_tool_config%28%22pytest%22%29.enabled%3A%60%20branch%20%28lines%20282%E2%80%93290%20in%20%60tool_configuration.py%60%29%20is%20therefore%20not%20exercised%20by%20any%20test%20in%20this%20changeset.%20A%20config%20with%20%60tools%3D%7B%22pytest%22%3A%20LintroToolConfig%28enabled%3DFalse%29%7D%60%20and%20%60get_tools_to_run%28tools%3D%22pytest%22%2C%20action%3D%22test%22%29%60%20would%20exercise%20that%20branch%20and%20should%20assert%20%60result.skipped%5B0%5D.reason%20%3D%3D%20%22disabled%20in%20config%22%60.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1451&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F1415-tools-enabled-precedence%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1415-tools-enabled-precedence%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Funit%2Ftools%2Fexecutor%2Ftest_tool_configuration_enabled.py%3A432-509%0A**Missing%20test%3A%20explicit%20%60--tools%20pytest%60%20with%20%60tools.pytest.enabled%3A%20false%60**%0A%0AThe%20PR%20adds%20%60test_explicit_tools_still_honors_per_tool_disabled%60%20for%20check%2Ffmt%20actions%20but%20does%20not%20cover%20the%20symmetric%20case%20for%20the%20test%20action.%20The%20new%20%60elif%20not%20config.get_tool_config%28%22pytest%22%29.enabled%3A%60%20branch%20%28lines%20282%E2%80%93290%20in%20%60tool_configuration.py%60%29%20is%20therefore%20not%20exercised%20by%20any%20test%20in%20this%20changeset.%20A%20config%20with%20%60tools%3D%7B%22pytest%22%3A%20LintroToolConfig%28enabled%3DFalse%29%7D%60%20and%20%60get_tools_to_run%28tools%3D%22pytest%22%2C%20action%3D%22test%22%29%60%20would%20exercise%20that%20branch%20and%20should%20assert%20%60result.skipped%5B0%5D.reason%20%3D%3D%20%22disabled%20in%20config%22%60.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1451&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): honor --tools bypass for test ..."](https://github.com/lgtm-hq/py-lintro/commit/c169a322682a73fd2ca2f77a840232537e19d2df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44927307)</sub>

<!-- /greptile_comment -->