### PR TITLE
fix(cli): omit Args/Raises from subcommand --help

### DIFF
--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -5,3 +5,12 @@
 # OSV Scanner still runs in CI via lintro; this file remains as the project hook
 # for future suppressions when no patched version is available yet.
 # Review periodically and add [[IgnoredVulns]] entries only when necessary.
+
+# Amazon Inspector flagged legitimate Astro 7.1.0 (published 2026-07-16 by
+# withastro) as malware because Astro 7 renamed utility deps (piccolore, obug,
+# @astrojs/markdown-satteri). The bun.lock integrity matches registry.npmjs.org
+# /astro/7.1.0; keep until the MAL entry is withdrawn or Astro is cleared.
+[[IgnoredVulns]]
+id = "MAL-2026-10726"
+ignoreUntil = 2026-10-16
+reason = "False positive: official astro@7.1.0 from withastro; renamed deps are not typosquats"

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -6,11 +6,12 @@
 # for future suppressions when no patched version is available yet.
 # Review periodically and add [[IgnoredVulns]] entries only when necessary.
 
-# Amazon Inspector flagged legitimate Astro 7.1.0 (published 2026-07-16 by
-# withastro) as malware because Astro 7 renamed utility deps (piccolore, obug,
-# @astrojs/markdown-satteri). The bun.lock integrity matches registry.npmjs.org
-# /astro/7.1.0; keep until the MAL entry is withdrawn or Astro is cleared.
+# MAL-2026-10726: Amazon Inspector flagged official withastro astro@7.1.0 after
+# Astro 7 renamed utility deps (piccolore, obug, @astrojs/markdown-satteri).
+# bun.lock integrity matches registry.npmjs.org/astro/7.1.0. Renovate also
+# blocks 7.1.0 (allowedVersions !=7.1.0) as belt-and-suspenders until a clean
+# release ships or the MAL entry is withdrawn — keep both aligned.
 [[IgnoredVulns]]
 id = "MAL-2026-10726"
 ignoreUntil = 2026-10-16
-reason = "False positive: official astro@7.1.0 from withastro; renamed deps are not typosquats"
+reason = "Inspector FP on official astro@7.1.0 renamed deps; Renovate also holds !=7.1.0"

--- a/lintro/cli_utils/commands/check.py
+++ b/lintro/cli_utils/commands/check.py
@@ -21,7 +21,7 @@ DEFAULT_EXIT_CODE: int = 0
 DEFAULT_ACTION: str = "check"
 
 
-@click.command("check")
+@click.command("check", help="Check files for issues using the specified tools.")
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))
 @click.option(
     "--tools",

--- a/lintro/cli_utils/commands/config.py
+++ b/lintro/cli_utils/commands/config.py
@@ -33,7 +33,15 @@ def _get_all_tool_names() -> list[str]:
     return ToolRegistry.get_names()
 
 
-@click.command()
+@click.command(help=("""Display Lintro configuration status.
+
+Shows the unified configuration for all tools including:
+- Config source (.lintro-config.yaml or pyproject.toml)
+- Global settings (line_length, tool ordering strategy)
+- Tool execution order based on configured strategy
+- Per-tool effective configuration
+- Configuration warnings and inconsistencies
+"""))
 @click.option(
     "--verbose",
     "-v",

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -404,7 +404,11 @@ def _generate_markdown_report(
     return "\n".join(lines)
 
 
-@click.command()
+@click.command(help=("""Check tool installation status and version compatibility.
+
+Checks all supported tools grouped by category (bundled, npm, external).
+Shows actionable install commands for missing or outdated tools.
+"""))
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
 @click.option(
     "--tools",

--- a/lintro/cli_utils/commands/format.py
+++ b/lintro/cli_utils/commands/format.py
@@ -12,7 +12,11 @@ DEFAULT_EXIT_CODE: int = 0
 DEFAULT_ACTION: str = "fmt"
 
 
-@click.command()
+@click.command(help=("""Format code using configured formatting tools.
+
+Runs code formatting tools on the specified paths to automatically fix style issues.
+Uses simplified Loguru-based logging for clean output and proper file logging.
+"""))
 @click.pass_context
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))
 @click.option(

--- a/lintro/cli_utils/commands/format.py
+++ b/lintro/cli_utils/commands/format.py
@@ -15,7 +15,6 @@ DEFAULT_ACTION: str = "fmt"
 @click.command(help=("""Format code using configured formatting tools.
 
 Runs code formatting tools on the specified paths to automatically fix style issues.
-Uses simplified Loguru-based logging for clean output and proper file logging.
 """))
 @click.pass_context
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))

--- a/lintro/cli_utils/commands/init.py
+++ b/lintro/cli_utils/commands/init.py
@@ -287,7 +287,14 @@ def _generate_native_configs(console: Console, *, force: bool) -> list[str]:
     return created
 
 
-@click.command("init")
+@click.command(
+    "init",
+    help=("""Initialize Lintro configuration for your project.
+
+Detects languages, enables appropriate tools in config, and prints
+next steps for installing tools and running checks.
+"""),
+)
 @click.option(
     "--minimal",
     "-m",

--- a/lintro/cli_utils/commands/install.py
+++ b/lintro/cli_utils/commands/install.py
@@ -32,7 +32,12 @@ from lintro.tools.core.tool_installer import ToolInstaller
 from lintro.tools.core.tool_registry import ToolRegistry
 
 
-@click.command()
+@click.command(help=("""Install or upgrade external tools used by lintro.
+
+Without arguments, installs all missing tools for the current project.
+Specify tool names to install specific tools, or use --profile for
+predefined sets.
+"""))
 @click.argument("tools", nargs=-1)
 @click.option(
     "--profile",

--- a/lintro/cli_utils/commands/licenses.py
+++ b/lintro/cli_utils/commands/licenses.py
@@ -45,8 +45,7 @@ def _collect_packages(langs: tuple[str, ...]) -> list[PackageLicense]:
 
 Scans resolved dependencies, normalizes their licenses to SPDX
 identifiers, and evaluates them against the configured allow/deny policy
-(``[tool.lintro.licenses]`` or the ``licenses:`` section of
-``.lintro-config.yaml``).
+([tool.lintro.licenses] or the licenses: section of .lintro-config.yaml).
 """))
 @click.option(
     "--check",

--- a/lintro/cli_utils/commands/licenses.py
+++ b/lintro/cli_utils/commands/licenses.py
@@ -41,7 +41,13 @@ def _collect_packages(langs: tuple[str, ...]) -> list[PackageLicense]:
     return packages
 
 
-@click.command()
+@click.command(help=("""Check dependency licenses for policy compliance.
+
+Scans resolved dependencies, normalizes their licenses to SPDX
+identifiers, and evaluates them against the configured allow/deny policy
+(``[tool.lintro.licenses]`` or the ``licenses:`` section of
+``.lintro-config.yaml``).
+"""))
 @click.option(
     "--check",
     is_flag=True,

--- a/lintro/cli_utils/commands/list_tools.py
+++ b/lintro/cli_utils/commands/list_tools.py
@@ -41,7 +41,7 @@ def _resolve_conflicts(
     return conflict_names
 
 
-@click.command("list-tools")
+@click.command("list-tools", help="List all available tools and their configurations.")
 @click.option(
     "--output",
     type=click.Path(),

--- a/lintro/cli_utils/commands/setup.py
+++ b/lintro/cli_utils/commands/setup.py
@@ -83,7 +83,11 @@ def _generate_config(
     return "\n".join(lines)
 
 
-@click.command()
+@click.command(help=("""Set up lintro for your project.
+
+Scans your project, detects languages and frameworks, recommends tools,
+installs missing ones, and generates a .lintro-config.yaml.
+"""))
 @click.option(
     "--profile",
     type=str,

--- a/lintro/cli_utils/commands/test.py
+++ b/lintro/cli_utils/commands/test.py
@@ -33,7 +33,13 @@ def _ensure_pytest_prefix(option_fragment: str) -> str:
     return f"pytest:{fragment}"
 
 
-@click.command("test")
+@click.command(
+    "test",
+    help=("""Run tests using pytest.
+
+This CLI command wraps pytest with lintro's output formatting.
+"""),
+)
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))
 @click.option(
     "--exclude",

--- a/lintro/cli_utils/commands/versions.py
+++ b/lintro/cli_utils/commands/versions.py
@@ -9,7 +9,11 @@ from rich.table import Table
 from lintro.tools.core.version_requirements import get_all_tool_versions
 
 
-@click.command()
+@click.command(help=("""Display version information for all supported tools.
+
+Shows each tool's current version, minimum required version, and status.
+Use --verbose to see installation hints for tools that don't meet requirements.
+"""))
 @click.option(
     "--verbose",
     "-v",

--- a/tests/unit/cli/test_subcommand_help_docstrings.py
+++ b/tests/unit/cli/test_subcommand_help_docstrings.py
@@ -8,32 +8,41 @@ from click.testing import CliRunner
 
 from lintro.cli import cli
 
-# Canonical subcommand names registered on the root CLI group.
-_SUBCOMMANDS: tuple[str, ...] = (
-    "check",
-    "config",
-    "doctor",
-    "format",
-    "init",
-    "install",
-    "licenses",
-    "list-tools",
-    "review",
-    "setup",
-    "test",
-    "versions",
+# Canonical subcommand names and a distinctive help snippet for each.
+_SUBCOMMAND_HELP: tuple[tuple[str, str], ...] = (
+    ("check", "Check files for issues using the specified tools."),
+    ("config", "Display Lintro configuration status."),
+    ("doctor", "Check tool installation status and version compatibility."),
+    ("format", "Format code using configured formatting tools."),
+    ("init", "Initialize Lintro configuration for your project."),
+    ("install", "Install or upgrade external tools used by lintro."),
+    ("licenses", "Check dependency licenses for policy compliance."),
+    ("list-tools", "List all available tools and their configurations."),
+    ("review", "Run AI-powered diff-based code review."),
+    ("setup", "Set up lintro for your project."),
+    ("test", "Run tests using pytest."),
+    ("versions", "Display version information for all supported tools."),
 )
 
 
-@pytest.mark.parametrize("subcommand", _SUBCOMMANDS)
-def test_subcommand_help_omits_args_and_raises(subcommand: str) -> None:
-    """Subcommand --help must not dump Args:/Raises: docstring sections.
+@pytest.mark.parametrize(
+    ("subcommand", "help_snippet"),
+    _SUBCOMMAND_HELP,
+    ids=[name for name, _ in _SUBCOMMAND_HELP],
+)
+def test_subcommand_help_omits_args_and_raises(
+    subcommand: str,
+    help_snippet: str,
+) -> None:
+    """Subcommand --help must show human text without Args:/Raises: dumps.
 
     Args:
         subcommand: Canonical CLI subcommand name under test.
+        help_snippet: Expected first-paragraph help text for the subcommand.
     """
     runner = CliRunner()
     result = runner.invoke(cli, [subcommand, "--help"])
     assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains(help_snippet)
     assert_that(result.output).does_not_contain("Args:")
     assert_that(result.output).does_not_contain("Raises:")

--- a/tests/unit/cli/test_subcommand_help_docstrings.py
+++ b/tests/unit/cli/test_subcommand_help_docstrings.py
@@ -1,0 +1,39 @@
+"""Tests that subcommand --help omits Google-style docstring sections."""
+
+from __future__ import annotations
+
+import pytest
+from assertpy import assert_that
+from click.testing import CliRunner
+
+from lintro.cli import cli
+
+# Canonical subcommand names registered on the root CLI group.
+_SUBCOMMANDS: tuple[str, ...] = (
+    "check",
+    "config",
+    "doctor",
+    "format",
+    "init",
+    "install",
+    "licenses",
+    "list-tools",
+    "review",
+    "setup",
+    "test",
+    "versions",
+)
+
+
+@pytest.mark.parametrize("subcommand", _SUBCOMMANDS)
+def test_subcommand_help_omits_args_and_raises(subcommand: str) -> None:
+    """Subcommand --help must not dump Args:/Raises: docstring sections.
+
+    Args:
+        subcommand: Canonical CLI subcommand name under test.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, [subcommand, "--help"])
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).does_not_contain("Args:")
+    assert_that(result.output).does_not_contain("Raises:")

--- a/tests/unit/plugins/test_entry_point_plugins.py
+++ b/tests/unit/plugins/test_entry_point_plugins.py
@@ -288,7 +288,12 @@ def test_list_tools_shows_origin_for_builtin_and_external() -> None:
     buffer = io.StringIO()
     with redirect_stdout(buffer):
         list_tools(output=None, show_conflicts=False, json_output=True)
-    data = json.loads(buffer.getvalue())
+    # Tool discovery may emit loguru lines to stdout under parallel pytest-xdist
+    # workers; locate the JSON object rather than requiring a pristine buffer.
+    raw = buffer.getvalue()
+    json_start = raw.find("{")
+    assert_that(json_start).is_greater_than_or_equal_to(0)
+    data = json.loads(raw[json_start:])
 
     assert_that(data["ruff"]["origin"]).is_equal_to("builtin")
     assert_that(data["ext-good"]["origin"]).is_equal_to("lintro-ext-good")

--- a/tests/unit/plugins/test_entry_point_plugins.py
+++ b/tests/unit/plugins/test_entry_point_plugins.py
@@ -284,19 +284,30 @@ def test_list_tools_shows_origin_for_builtin_and_external() -> None:
     import io
     import json
     from contextlib import redirect_stdout
+    from typing import Any, cast
 
     buffer = io.StringIO()
     with redirect_stdout(buffer):
         list_tools(output=None, show_conflicts=False, json_output=True)
     # Tool discovery may emit loguru lines to stdout under parallel pytest-xdist
-    # workers; locate the JSON object rather than requiring a pristine buffer.
+    # workers; decode the first JSON object that contains the expected tools.
     raw = buffer.getvalue()
-    json_start = raw.find("{")
-    assert_that(json_start).is_greater_than_or_equal_to(0)
-    data = json.loads(raw[json_start:])
-
-    assert_that(data["ruff"]["origin"]).is_equal_to("builtin")
-    assert_that(data["ext-good"]["origin"]).is_equal_to("lintro-ext-good")
+    decoder = json.JSONDecoder()
+    data: dict[str, object] | None = None
+    for index, char in enumerate(raw):
+        if char != "{":
+            continue
+        try:
+            candidate, _ = decoder.raw_decode(raw[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(candidate, dict) and {"ruff", "ext-good"} <= candidate.keys():
+            data = cast(dict[str, Any], candidate)
+            break
+    assert_that(data).is_not_none()
+    parsed = cast(dict[str, Any], data)
+    assert_that(parsed["ruff"]["origin"]).is_equal_to("builtin")
+    assert_that(parsed["ext-good"]["origin"]).is_equal_to("lintro-ext-good")
 
 
 # =============================================================================


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(cli): omit Args/Raises from subcommand --help
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Most Click subcommands rendered full Google-style docstrings (including `Args:` / `Raises:`) in `--help`, producing a long run-on paragraph above the options list. `review --help` was already clean.

This PR sets explicit `help=` on each affected `@click.command()` so user-facing help stays concise while pydoclint-compatible `Args:`/`Raises:` sections remain in the function docstrings. Also suppresses the Amazon Inspector false-positive `MAL-2026-10726` for official `astro@7.1.0` (aligned with Renovate’s `!=7.1.0` hold) so dogfood/CI osv-scanner stays green.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk` / `uv run lintro tst`)

## Closes

- Closes #1417

## Details

- Explicit `help=` on check/config/doctor/format/init/install/licenses/list-tools/setup/test/versions (review unchanged).
- Parametrized CliRunner tests assert each subcommand’s help snippet appears and `Args:`/`Raises:` do not.
- Hardened list-tools JSON origin test against parallel loguru stdout noise.
- Local: lint health 100/100; full pytest green after rebase onto latest main.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes 11 Click subcommands that were leaking Google-style `Args:`/`Raises:` sections into `--help` output by adding explicit `help=` strings to each `@click.command()` decorator, leaving the pydoclint-compatible function docstrings intact. It also adds a parametrized CliRunner test suite covering all 12 subcommands, hardens the list-tools JSON origin test against loguru stdout noise under pytest-xdist, and suppresses an Amazon Inspector false-positive (`MAL-2026-10726`) in `.osv-scanner.toml`.

- **11 command files updated**: each gets a short, user-facing `help=` string; the function docstrings (with `Args:`/`Raises:`) remain unchanged for static-analysis tools.
- **New test** `test_subcommand_help_omits_args_and_raises` parametrizes all subcommands, asserting the expected first-sentence snippet is present and neither `Args:` nor `Raises:` appears in the output.
- **`test_entry_point_plugins.py`** hardened: instead of a direct `json.loads`, the test now scans the captured buffer for the first JSON object containing both expected keys, tolerating loguru lines that may interleave under parallel workers.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive decorators or test improvements with no behavioural risk to CLI execution.

Every changed file is either adding a `help=` string to a Click decorator (no effect on command logic), adding a new test, or adjusting a test fixture for robustness. The OSV Scanner suppression uses the documented TOML local-date format. No runtime paths, option parsing, or data handling are touched.

`lintro/cli_utils/commands/config.py` — the bullet-list paragraph in the `help=` string will be reflowed by Click into a run-on sentence; a `\b` marker before the list would preserve the intended formatting.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .osv-scanner.toml | Adds an IgnoredVulns entry suppressing MAL-2026-10726 (Amazon Inspector false-positive on astro@7.1.0); uses the TOML local-date format `YYYY-MM-DD` that OSV Scanner's official docs show, with a 90-day expiry aligned to the Renovate hold. |
| lintro/cli_utils/commands/config.py | Adds a multi-paragraph `help=` with a bullet list; without a `\b` paragraph marker before the list, Click will reflow the bullets into a single run-on paragraph in terminal output. |
| lintro/cli_utils/commands/doctor.py | Adds two-paragraph `help=` with no bullets; both sentences reflow cleanly as Click prose. |
| lintro/cli_utils/commands/licenses.py | Adds two-paragraph `help=` with plain-text config key references; clean prose that Click will reflow without issue. |
| tests/unit/cli/test_subcommand_help_docstrings.py | New parametrized test asserting all 12 subcommands show their expected help snippet and contain neither `Args:` nor `Raises:`; logic is straightforward and covers the full set of affected commands. |
| tests/unit/plugins/test_entry_point_plugins.py | Hardens the list-tools JSON origin test by scanning for the first valid JSON object containing the expected keys, guarding against loguru lines emitted to stdout under pytest-xdist; approach is correct. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User runs: lintro <subcommand> --help"] --> B{help= set on\n@click.command?}
    B -- "Before this PR\n(no explicit help=)" --> C["Click uses function docstring\nas help text"]
    C --> D["Args:/Raises: sections\nleak into terminal output"]
    B -- "After this PR\n(explicit help= added)" --> E["Click uses the\nexplicit help= string"]
    E --> F["Clean, concise help text\nno Args:/Raises: leak"]
    G["Function docstring\n(Args:/Raises: intact)"] --> H["pydoclint / static analysis\nstill satisfied"]
    E -.-> G
    F --> I["Verified by\ntest_subcommand_help_omits_args_and_raises"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["User runs: lintro <subcommand> --help"] --> B{help= set on\n@click.command?}
    B -- "Before this PR\n(no explicit help=)" --> C["Click uses function docstring\nas help text"]
    C --> D["Args:/Raises: sections\nleak into terminal output"]
    B -- "After this PR\n(explicit help= added)" --> E["Click uses the\nexplicit help= string"]
    E --> F["Clean, concise help text\nno Args:/Raises: leak"]
    G["Function docstring\n(Args:/Raises: intact)"] --> H["pydoclint / static analysis\nstill satisfied"]
    E -.-> G
    F --> I["Verified by\ntest_subcommand_help_omits_args_and_raises"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cli): clean subcommand help wording ..."](https://github.com/lgtm-hq/py-lintro/commit/75bf84efcac70cf827051b0f1325050229f63982) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44933834)</sub>

<!-- /greptile_comment -->