### PR TITLE
fix(ci): use valid npm range syntax for astro allowedVersions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -92,7 +92,7 @@
     {
       "description": "Block malicious astro@7.1.0 (MAL-2026-10726); lift once a clean release ships",
       "matchPackageNames": ["astro"],
-      "allowedVersions": "!=7.1.0",
+      "allowedVersions": "<7.1.0 || >7.1.0",
       "automerge": false
     },
     {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): use valid npm range syntax for astro allowedVersions
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

- Renovate halted PR creation (#1449): `allowedVersions: "!=7.1.0"` (added in #1448) is not valid npm range syntax.
- Replace with the equivalent valid range `"<7.1.0 || >7.1.0"` — still blocks the MAL-2026-10726-flagged `astro@7.1.0` while allowing later clean releases.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1449

## Details

- `renovate-config-validator renovate.json`: config validated successfully.

Closes #1449
