### PR TITLE
fix(cli): explicit --tools overrides enabled_tools filter

### DIFF
--- a/lintro/utils/execution/tool_configuration.py
+++ b/lintro/utils/execution/tool_configuration.py
@@ -327,10 +327,13 @@ def get_tools_to_run(
             raise ValueError(
                 f"Unknown tool '{name}'. Available tools: {available_names}",
             )
-        # Track disabled tools with reason
-        if not config.is_tool_enabled(name):
-            reason = _get_disabled_reason(config, name)
-            skipped.append(SkippedTool(name=name, reason=reason))
+        # An explicit --tools selection is a higher-precedence override than
+        # execution.enabled_tools, which scopes only *default* (no --tools)
+        # runs. So the enabled_tools allowlist is bypassed here; a per-tool
+        # `enabled: false` remains authoritative as a deliberate disable.
+        tool_config = config.get_tool_config(name)
+        if not tool_config.enabled:
+            skipped.append(SkippedTool(name=name, reason="disabled in config"))
             continue
         # Verify the tool supports the requested action
         if action == Action.FIX:

--- a/tests/unit/tools/executor/test_tool_configuration_enabled.py
+++ b/tests/unit/tools/executor/test_tool_configuration_enabled.py
@@ -325,6 +325,118 @@ def test_execution_enabled_tools_combined_with_tool_disabled(
 
 
 # =============================================================================
+# Explicit --tools overrides execution.enabled_tools (issue #1415)
+# =============================================================================
+
+
+def test_explicit_tools_overrides_enabled_tools_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit --tools runs a tool absent from execution.enabled_tools.
+
+    Regression for #1415: an explicit CLI selection is higher-precedence
+    than the enabled_tools allowlist (which scopes only default runs), so
+    the named tool must run instead of being silently skipped.
+    """
+    from lintro.tools import tool_manager
+
+    monkeypatch.setattr(
+        tool_manager,
+        "is_tool_registered",
+        lambda name: name in ["ruff", "yamllint"],
+    )
+    monkeypatch.setattr(
+        tool_manager,
+        "get_tool_names",
+        lambda: ["ruff", "yamllint"],
+    )
+
+    config = LintroConfig(
+        execution=ExecutionConfig(enabled_tools=["yamllint"]),
+    )
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(tools="ruff", action="check")
+
+    assert_that(result.to_run).is_equal_to(["ruff"])
+    assert_that(result.skipped).is_empty()
+
+
+def test_default_run_still_filters_by_enabled_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without --tools, enabled_tools continues to filter default runs.
+
+    Regression for #1415: the override applies only to explicit selections;
+    a default run (tools=None) must still honor the enabled_tools allowlist,
+    so ruff stays skipped when only yamllint is enabled.
+    """
+    from lintro.tools import tool_manager
+
+    monkeypatch.setattr(
+        tool_manager,
+        "get_check_tools",
+        lambda: ["ruff", "yamllint"],
+    )
+
+    config = LintroConfig(
+        execution=ExecutionConfig(enabled_tools=["yamllint"]),
+    )
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(tools=None, action="check")
+
+    assert_that(result.to_run).is_equal_to(["yamllint"])
+    skipped_by_name = {s.name: s for s in result.skipped}
+    assert_that(skipped_by_name).contains_key("ruff")
+    assert_that(skipped_by_name["ruff"].reason).is_equal_to("not in enabled_tools")
+
+
+def test_explicit_disabled_tool_still_skipped_despite_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A per-tool ``enabled: false`` remains authoritative under --tools.
+
+    The #1415 override bypasses the enabled_tools allowlist only; a
+    deliberate per-tool disable still skips the tool with a clear reason.
+    """
+    from lintro.tools import tool_manager
+
+    monkeypatch.setattr(
+        tool_manager,
+        "is_tool_registered",
+        lambda name: name in ["ruff", "mypy"],
+    )
+    monkeypatch.setattr(
+        tool_manager,
+        "get_tool_names",
+        lambda: ["ruff", "mypy"],
+    )
+
+    config = LintroConfig(
+        execution=ExecutionConfig(enabled_tools=["yamllint"]),
+        tools={"mypy": LintroToolConfig(enabled=False)},
+    )
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(tools="ruff,mypy", action="check")
+
+    assert_that(result.to_run).is_equal_to(["ruff"])
+    skipped_by_name = {s.name: s for s in result.skipped}
+    assert_that(skipped_by_name).contains_key("mypy")
+    assert_that(skipped_by_name["mypy"].reason).is_equal_to("disabled in config")
+
+
+# =============================================================================
 # Fix action
 # =============================================================================
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(cli): explicit --tools overrides enabled_tools filter
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Fixes #1415. An explicitly requested tool (`lintro chk file --tools ruff`) was silently skipped with `⏭️ SKIP | not in enabled_tools` and exited 0 when `.lintro-config.yaml` had an `execution.enabled_tools` list that excluded it — even though the file had real issues.

An explicit `--tools` selection is a higher-precedence override than the `enabled_tools` allowlist, which should scope only *default* (no `--tools`) runs. The explicit-tools path in `get_tools_to_run` now bypasses the `enabled_tools` filter so named tools run. A deliberate per-tool `enabled: false` remains authoritative. Default runs are unchanged and still honor `enabled_tools`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1415

## Details

- `uv run lintro chk` — clean (100/100)
- `uv run pytest -n auto` — 6653 passed; only the known worktree-spurious `test_prepare_execution_version_check_fails_returns_early_result` failed
- New assertpy regression tests in `test_tool_configuration_enabled.py`:
  - explicit `--tools ruff` with `enabled_tools=[yamllint]` → ruff runs
  - default run (no `--tools`) → ruff still skipped as `not in enabled_tools`
  - explicit `--tools` with per-tool `enabled: false` → still skipped as `disabled in config`
- Manual repro before/after: before, ruff skipped + exit 0; after, ruff runs, finds the issue, exit 1

Closes #1415
