### PR TITLE
test(execution): exercise real multi-tool parallel execution

### DIFF
--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -441,7 +441,7 @@ def test_parallel_preserves_input_ordering_contract() -> None:
     executor must still return results positionally aligned with the input
     tool list (the ordering contract callers rely on for display).
     """
-    slow = _FakeTool(name="slow", sleep_for=0.20, issues_count=1)
+    slow = _FakeTool(name="slow", sleep_for=0.01, issues_count=1)
     fast = _FakeTool(name="fast", sleep_for=0.0, issues_count=2)
 
     with AsyncToolExecutor(max_workers=4) as executor:
@@ -478,7 +478,7 @@ def test_parallel_isolates_tool_failures() -> None:
             ),
         )
 
-    by_name = {name: result for name, result in results}
+    by_name = dict(results)
     assert_that(sorted(by_name.keys())).is_equal_to(["boom", "healthy"])
 
     # Failing tool is isolated into a failed result, not propagated.

--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -1,17 +1,41 @@
-"""Integration tests for parallel tool execution."""
+"""Integration tests for parallel tool execution.
+
+This module has two parts:
+
+* Single-tool smoke tests exercise ``run_lint_tools_simple`` end to end but
+  intentionally stay on the sequential code path (one tool per invocation).
+  They are named ``*_smoke`` so their limited scope is honest.
+* Multi-tool parallel tests drive the real parallel executor
+  (:func:`lintro.utils.execution.parallel_executor.run_tools_parallel` and
+  :class:`lintro.utils.async_tool_executor.AsyncToolExecutor`) with two or more
+  tools over mixed-language samples and assert result aggregation, the ordering
+  contract, failure isolation, and conflict-aware batching.
+"""
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import os
 import tempfile
+import time
 from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
 
 import pytest
 from assertpy import assert_that
 
+from lintro.enums.action import Action
+from lintro.models.core.tool_result import ToolResult
 from lintro.plugins import ToolRegistry
+from lintro.utils.async_tool_executor import (
+    AsyncToolExecutor,
+    get_parallel_batches,
+)
+from lintro.utils.execution.parallel_executor import run_tools_parallel
 from lintro.utils.tool_executor import run_lint_tools_simple
+from lintro.utils.unified_config import UnifiedConfigManager
 
 
 @pytest.fixture(autouse=True)
@@ -69,8 +93,138 @@ def temp_python_files() -> Iterator[list[str]]:
         os.rmdir(temp_dir)
 
 
-def test_check_multiple_files(temp_python_files: list[str]) -> None:
-    """Test running check on multiple files.
+@pytest.fixture
+def mixed_language_sample() -> Iterator[list[str]]:
+    """Create a mixed-language sample with one violation per tool.
+
+    The Python file has an unused import (ruff ``F401``) and the YAML file has
+    inconsistent spacing plus a missing document start (yamllint), so ruff and
+    yamllint each own exactly one file and each report at least one issue. This
+    lets multi-tool tests assert real cross-tool aggregation.
+
+    Yields:
+        list[str]: Paths ``[python_file, yaml_file]``.
+    """
+    temp_dir = tempfile.mkdtemp()
+    py_path = os.path.join(temp_dir, "bad.py")
+    yaml_path = os.path.join(temp_dir, "bad.yaml")
+
+    with open(py_path, "w") as f:
+        f.write("import os\n\n\ndef add(a, b):\n    return a + b\n")
+    with open(yaml_path, "w") as f:
+        f.write("a: 1\nb: 2\nc:  3\n")
+
+    paths = [py_path, yaml_path]
+    yield paths
+
+    for file_path in paths:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(file_path)
+    with contextlib.suppress(OSError):
+        os.rmdir(temp_dir)
+
+
+# ---------------------------------------------------------------------------
+# Fakes for failure-isolation and batching contracts
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeDefinition:
+    """Minimal stand-in for a tool definition.
+
+    Attributes:
+        name: Tool name.
+        conflicts_with: Names of tools this one conflicts with.
+    """
+
+    name: str
+    conflicts_with: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _FakeTool:
+    """Minimal tool double used to drive the async executor deterministically.
+
+    Attributes:
+        name: Tool name (mirrored into the fake definition).
+        conflicts_with: Conflicting tool names for batching tests.
+        sleep_for: Seconds to block inside ``check`` to control completion order.
+        raises: Whether ``check`` should raise to test failure isolation.
+        issues_count: Issue count reported by the returned result on success.
+    """
+
+    name: str
+    conflicts_with: list[str] = field(default_factory=list)
+    sleep_for: float = 0.0
+    raises: bool = False
+    issues_count: int = 0
+
+    def __post_init__(self) -> None:
+        """Build the fake definition from the tool name."""
+        self.definition = _FakeDefinition(
+            name=self.name,
+            conflicts_with=self.conflicts_with,
+        )
+
+    def check(
+        self,
+        paths: list[str],
+        options: dict[str, Any],
+    ) -> ToolResult:
+        """Simulate a tool check run.
+
+        Args:
+            paths: Paths passed by the executor (unused).
+            options: Options passed by the executor (unused).
+
+        Returns:
+            ToolResult: A success result after an optional delay.
+
+        Raises:
+            RuntimeError: When ``raises`` is set, to test isolation.
+        """
+        if self.sleep_for:
+            time.sleep(self.sleep_for)
+        if self.raises:
+            raise RuntimeError(f"{self.name} boom")
+        return ToolResult(
+            name=self.name,
+            success=True,
+            output=f"{self.name} ok",
+            issues_count=self.issues_count,
+        )
+
+
+@dataclass
+class _FakeToolManager:
+    """Tool manager double returning fake tools for batching tests.
+
+    Attributes:
+        tools: Mapping of tool name to fake tool instance.
+    """
+
+    tools: dict[str, _FakeTool]
+
+    def get_tool(self, name: str) -> _FakeTool:
+        """Return the fake tool registered under ``name``.
+
+        Args:
+            name: Tool name to look up.
+
+        Returns:
+            _FakeTool: The registered fake tool.
+        """
+        return self.tools[name]
+
+
+# ---------------------------------------------------------------------------
+# Single-tool smoke tests (sequential path — one tool per invocation)
+# ---------------------------------------------------------------------------
+
+
+def test_check_multiple_files_smoke(temp_python_files: list[str]) -> None:
+    """Smoke check on multiple files with a single tool.
 
     Args:
         temp_python_files: Pytest fixture providing temp files.
@@ -92,8 +246,8 @@ def test_check_multiple_files(temp_python_files: list[str]) -> None:
     assert_that(exit_code).is_instance_of(int)
 
 
-def test_consistent_results_across_runs(temp_python_files: list[str]) -> None:
-    """Test that multiple runs produce consistent results.
+def test_consistent_results_across_runs_smoke(temp_python_files: list[str]) -> None:
+    """Smoke test that repeated single-tool runs are consistent.
 
     Args:
         temp_python_files: Pytest fixture providing temp files.
@@ -127,8 +281,8 @@ def test_consistent_results_across_runs(temp_python_files: list[str]) -> None:
     assert_that(exit_code_1).is_equal_to(exit_code_2)
 
 
-def test_check_with_single_file(temp_python_files: list[str]) -> None:
-    """Test check with single file.
+def test_check_with_single_file_smoke(temp_python_files: list[str]) -> None:
+    """Smoke check with a single file and single tool.
 
     Args:
         temp_python_files: Pytest fixture providing temp files.
@@ -148,8 +302,8 @@ def test_check_with_single_file(temp_python_files: list[str]) -> None:
     assert_that(exit_code).is_instance_of(int)
 
 
-def test_format_action(temp_python_files: list[str]) -> None:
-    """Test format action.
+def test_format_action_smoke(temp_python_files: list[str]) -> None:
+    """Smoke test of the format action with a single tool.
 
     Args:
         temp_python_files: Pytest fixture providing temp files.
@@ -169,8 +323,8 @@ def test_format_action(temp_python_files: list[str]) -> None:
     assert_that(exit_code).is_instance_of(int)
 
 
-def test_different_output_formats(temp_python_files: list[str]) -> None:
-    """Test different output formats.
+def test_different_output_formats_smoke(temp_python_files: list[str]) -> None:
+    """Smoke test of different output formats with a single tool.
 
     Args:
         temp_python_files: Pytest fixture providing temp files.
@@ -199,8 +353,8 @@ def test_tool_definition_exists() -> None:
     assert_that(ruff_tool.definition.name).is_equal_to("ruff")
 
 
-def test_tool_respects_execution_order(temp_python_files: list[str]) -> None:
-    """Test that tool execution order is predictable.
+def test_tool_respects_execution_order_smoke(temp_python_files: list[str]) -> None:
+    """Smoke test that single-tool exit codes are stable across runs.
 
     Args:
         temp_python_files: Pytest fixture providing temp files.
@@ -223,3 +377,157 @@ def test_tool_respects_execution_order(temp_python_files: list[str]) -> None:
 
     # All runs should produce same exit code
     assert_that(len(set(results))).is_equal_to(1)
+
+
+# ---------------------------------------------------------------------------
+# Multi-tool parallel tests (real parallel executor)
+# ---------------------------------------------------------------------------
+
+
+def _require_tools(*names: str) -> None:
+    """Skip the current test if any required tool is missing from PATH.
+
+    Args:
+        *names: Executable names that must resolve on PATH.
+    """
+    import shutil
+
+    for name in names:
+        if not shutil.which(name):
+            pytest.skip(f"Tool '{name}' not available in PATH")
+
+
+def test_parallel_runs_multiple_tools_over_mixed_samples(
+    mixed_language_sample: list[str],
+) -> None:
+    """Two tools run concurrently and both report their own issues.
+
+    Drives the real parallel executor with ruff + yamllint over a mixed sample
+    where each tool owns exactly one file, and asserts that results for both
+    tools are aggregated and that each surfaces its violation.
+
+    Args:
+        mixed_language_sample: Paths ``[python_file, yaml_file]``.
+    """
+    _require_tools("ruff", "yamllint")
+
+    results = run_tools_parallel(
+        tools_to_run=["ruff", "yamllint"],
+        paths=mixed_language_sample,
+        action=Action.CHECK,
+        config_manager=UnifiedConfigManager(),
+        tool_option_dict={},
+        exclude=None,
+        include_venv=False,
+        post_tools=set(),
+        max_workers=4,
+    )
+
+    names = {result.name for result in results}
+    assert_that(names).is_equal_to({"ruff", "yamllint"})
+
+    by_name = {result.name: result for result in results}
+    # Aggregation: each tool contributes its own findings independently.
+    assert_that(by_name["ruff"].issues_count).is_greater_than_or_equal_to(1)
+    assert_that(by_name["yamllint"].issues_count).is_greater_than_or_equal_to(1)
+    assert_that(by_name["ruff"].success).is_false()
+    assert_that(by_name["yamllint"].success).is_false()
+
+
+def test_parallel_preserves_input_ordering_contract() -> None:
+    """Result order matches input tool order regardless of completion time.
+
+    The first tool sleeps longer than the second, so it finishes last, but the
+    executor must still return results positionally aligned with the input
+    tool list (the ordering contract callers rely on for display).
+    """
+    slow = _FakeTool(name="slow", sleep_for=0.20, issues_count=1)
+    fast = _FakeTool(name="fast", sleep_for=0.0, issues_count=2)
+
+    with AsyncToolExecutor(max_workers=4) as executor:
+        results = asyncio.run(
+            executor.run_tools_parallel(
+                tools=[("slow", slow), ("fast", fast)],
+                paths=[],
+                action=Action.CHECK,
+            ),
+        )
+
+    ordered_names = [name for name, _ in results]
+    assert_that(ordered_names).is_equal_to(["slow", "fast"])
+    assert_that(results[0][1].issues_count).is_equal_to(1)
+    assert_that(results[1][1].issues_count).is_equal_to(2)
+
+
+def test_parallel_isolates_tool_failures() -> None:
+    """A tool raising an exception does not sink its concurrent peers.
+
+    One fake tool raises inside ``check``; the executor must convert it to a
+    failed :class:`ToolResult` while the healthy tool still returns its own
+    successful result, and ordering must be preserved.
+    """
+    boom = _FakeTool(name="boom", raises=True)
+    healthy = _FakeTool(name="healthy", issues_count=3)
+
+    with AsyncToolExecutor(max_workers=4) as executor:
+        results = asyncio.run(
+            executor.run_tools_parallel(
+                tools=[("boom", boom), ("healthy", healthy)],
+                paths=[],
+                action=Action.CHECK,
+            ),
+        )
+
+    by_name = {name: result for name, result in results}
+    assert_that(sorted(by_name.keys())).is_equal_to(["boom", "healthy"])
+
+    # Failing tool is isolated into a failed result, not propagated.
+    assert_that(by_name["boom"].success).is_false()
+    assert_that(by_name["boom"].output).contains("boom boom")
+
+    # Healthy tool is unaffected by its peer's failure.
+    assert_that(by_name["healthy"].success).is_true()
+    assert_that(by_name["healthy"].issues_count).is_equal_to(3)
+
+
+def test_get_parallel_batches_separates_conflicting_tools() -> None:
+    """Conflicting tools are placed in distinct sequential batches.
+
+    Two tools that declare ``conflicts_with`` each other must never share a
+    batch (they would race on the same files), while a third independent tool
+    may share a batch with one of them.
+    """
+    manager = _FakeToolManager(
+        tools={
+            "black": _FakeTool(name="black", conflicts_with=["ruff"]),
+            "ruff": _FakeTool(name="ruff", conflicts_with=["black"]),
+            "yamllint": _FakeTool(name="yamllint"),
+        },
+    )
+
+    batches = get_parallel_batches(["black", "ruff", "yamllint"], manager)
+
+    # black and ruff conflict -> separate batches; two batches total.
+    assert_that(batches).is_length(2)
+    for batch in batches:
+        conflicting_together = "black" in batch and "ruff" in batch
+        assert_that(conflicting_together).is_false()
+
+    # Every input tool is scheduled exactly once.
+    scheduled = [tool for batch in batches for tool in batch]
+    assert_that(sorted(scheduled)).is_equal_to(["black", "ruff", "yamllint"])
+
+
+def test_get_parallel_batches_groups_independent_tools() -> None:
+    """Non-conflicting tools share a single parallel batch."""
+    manager = _FakeToolManager(
+        tools={
+            "ruff": _FakeTool(name="ruff"),
+            "yamllint": _FakeTool(name="yamllint"),
+        },
+    )
+
+    batches = get_parallel_batches(["ruff", "yamllint"], manager)
+
+    assert_that(batches).is_length(1)
+    assert_that(sorted(batches[0])).is_equal_to(["ruff", "yamllint"])

--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -21,7 +21,7 @@ import tempfile
 import time
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from assertpy import assert_that
@@ -29,6 +29,7 @@ from assertpy import assert_that
 from lintro.enums.action import Action
 from lintro.models.core.tool_result import ToolResult
 from lintro.plugins import ToolRegistry
+from lintro.plugins.base import BaseToolPlugin
 from lintro.utils.async_tool_executor import (
     AsyncToolExecutor,
     get_parallel_batches,
@@ -447,7 +448,10 @@ def test_parallel_preserves_input_ordering_contract() -> None:
     with AsyncToolExecutor(max_workers=4) as executor:
         results = asyncio.run(
             executor.run_tools_parallel(
-                tools=[("slow", slow), ("fast", fast)],
+                tools=cast(
+                    list[tuple[str, BaseToolPlugin]],
+                    [("slow", slow), ("fast", fast)],
+                ),
                 paths=[],
                 action=Action.CHECK,
             ),
@@ -472,7 +476,10 @@ def test_parallel_isolates_tool_failures() -> None:
     with AsyncToolExecutor(max_workers=4) as executor:
         results = asyncio.run(
             executor.run_tools_parallel(
-                tools=[("boom", boom), ("healthy", healthy)],
+                tools=cast(
+                    list[tuple[str, BaseToolPlugin]],
+                    [("boom", boom), ("healthy", healthy)],
+                ),
                 paths=[],
                 action=Action.CHECK,
             ),

--- a/tests/integration/test_parallel_execution.py
+++ b/tests/integration/test_parallel_execution.py
@@ -5,35 +5,26 @@ This module has two parts:
 * Single-tool smoke tests exercise ``run_lint_tools_simple`` end to end but
   intentionally stay on the sequential code path (one tool per invocation).
   They are named ``*_smoke`` so their limited scope is honest.
-* Multi-tool parallel tests drive the real parallel executor
-  (:func:`lintro.utils.execution.parallel_executor.run_tools_parallel` and
-  :class:`lintro.utils.async_tool_executor.AsyncToolExecutor`) with two or more
-  tools over mixed-language samples and assert result aggregation, the ordering
-  contract, failure isolation, and conflict-aware batching.
+* Multi-tool parallel tests drive the production gate
+  (``use_parallel`` in :mod:`lintro.utils.tool_executor`) and the real
+  parallel executor over mixed-language samples.
 """
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import os
+import shutil
 import tempfile
-import time
 from collections.abc import Iterator
-from dataclasses import dataclass, field
-from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
 from assertpy import assert_that
 
 from lintro.enums.action import Action
-from lintro.models.core.tool_result import ToolResult
 from lintro.plugins import ToolRegistry
-from lintro.plugins.base import BaseToolPlugin
-from lintro.utils.async_tool_executor import (
-    AsyncToolExecutor,
-    get_parallel_batches,
-)
+from lintro.utils import tool_executor as tool_executor_mod
 from lintro.utils.execution.parallel_executor import run_tools_parallel
 from lintro.utils.tool_executor import run_lint_tools_simple
 from lintro.utils.unified_config import UnifiedConfigManager
@@ -99,9 +90,9 @@ def mixed_language_sample() -> Iterator[list[str]]:
     """Create a mixed-language sample with one violation per tool.
 
     The Python file has an unused import (ruff ``F401``) and the YAML file has
-    inconsistent spacing plus a missing document start (yamllint), so ruff and
-    yamllint each own exactly one file and each report at least one issue. This
-    lets multi-tool tests assert real cross-tool aggregation.
+    inconsistent mapping-value spacing (yamllint), so ruff and yamllint each
+    own exactly one file and each report at least one issue. This lets
+    multi-tool tests assert real cross-tool aggregation.
 
     Yields:
         list[str]: Paths ``[python_file, yaml_file]``.
@@ -123,100 +114,6 @@ def mixed_language_sample() -> Iterator[list[str]]:
             os.unlink(file_path)
     with contextlib.suppress(OSError):
         os.rmdir(temp_dir)
-
-
-# ---------------------------------------------------------------------------
-# Fakes for failure-isolation and batching contracts
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class _FakeDefinition:
-    """Minimal stand-in for a tool definition.
-
-    Attributes:
-        name: Tool name.
-        conflicts_with: Names of tools this one conflicts with.
-    """
-
-    name: str
-    conflicts_with: list[str] = field(default_factory=list)
-
-
-@dataclass
-class _FakeTool:
-    """Minimal tool double used to drive the async executor deterministically.
-
-    Attributes:
-        name: Tool name (mirrored into the fake definition).
-        conflicts_with: Conflicting tool names for batching tests.
-        sleep_for: Seconds to block inside ``check`` to control completion order.
-        raises: Whether ``check`` should raise to test failure isolation.
-        issues_count: Issue count reported by the returned result on success.
-    """
-
-    name: str
-    conflicts_with: list[str] = field(default_factory=list)
-    sleep_for: float = 0.0
-    raises: bool = False
-    issues_count: int = 0
-
-    def __post_init__(self) -> None:
-        """Build the fake definition from the tool name."""
-        self.definition = _FakeDefinition(
-            name=self.name,
-            conflicts_with=self.conflicts_with,
-        )
-
-    def check(
-        self,
-        paths: list[str],
-        options: dict[str, Any],
-    ) -> ToolResult:
-        """Simulate a tool check run.
-
-        Args:
-            paths: Paths passed by the executor (unused).
-            options: Options passed by the executor (unused).
-
-        Returns:
-            ToolResult: A success result after an optional delay.
-
-        Raises:
-            RuntimeError: When ``raises`` is set, to test isolation.
-        """
-        if self.sleep_for:
-            time.sleep(self.sleep_for)
-        if self.raises:
-            raise RuntimeError(f"{self.name} boom")
-        return ToolResult(
-            name=self.name,
-            success=True,
-            output=f"{self.name} ok",
-            issues_count=self.issues_count,
-        )
-
-
-@dataclass
-class _FakeToolManager:
-    """Tool manager double returning fake tools for batching tests.
-
-    Attributes:
-        tools: Mapping of tool name to fake tool instance.
-    """
-
-    tools: dict[str, _FakeTool]
-
-    def get_tool(self, name: str) -> _FakeTool:
-        """Return the fake tool registered under ``name``.
-
-        Args:
-            name: Tool name to look up.
-
-        Returns:
-            _FakeTool: The registered fake tool.
-        """
-        return self.tools[name]
 
 
 # ---------------------------------------------------------------------------
@@ -391,8 +288,6 @@ def _require_tools(*names: str) -> None:
     Args:
         *names: Executable names that must resolve on PATH.
     """
-    import shutil
-
     for name in names:
         if not shutil.which(name):
             pytest.skip(f"Tool '{name}' not available in PATH")
@@ -435,106 +330,38 @@ def test_parallel_runs_multiple_tools_over_mixed_samples(
     assert_that(by_name["yamllint"].success).is_false()
 
 
-def test_parallel_preserves_input_ordering_contract() -> None:
-    """Result order matches input tool order regardless of completion time.
+def test_simple_runner_uses_parallel_for_multiple_tools(
+    mixed_language_sample: list[str],
+) -> None:
+    """The production simple runner takes the parallel path for two tools.
 
-    The first tool sleeps longer than the second, so it finishes last, but the
-    executor must still return results positionally aligned with the input
-    tool list (the ordering contract callers rely on for display).
+    ``run_lint_tools_simple`` is the CLI entry used by ``lintro check``. Passing
+    two tools must call ``_execute_tools_parallel`` so a regression that forces
+    sequential execution is visible here.
+
+    Args:
+        mixed_language_sample: Paths ``[python_file, yaml_file]``.
     """
-    slow = _FakeTool(name="slow", sleep_for=0.01, issues_count=1)
-    fast = _FakeTool(name="fast", sleep_for=0.0, issues_count=2)
+    _require_tools("ruff", "yamllint")
 
-    with AsyncToolExecutor(max_workers=4) as executor:
-        results = asyncio.run(
-            executor.run_tools_parallel(
-                tools=cast(
-                    list[tuple[str, BaseToolPlugin]],
-                    [("slow", slow), ("fast", fast)],
-                ),
-                paths=[],
-                action=Action.CHECK,
-            ),
+    with patch.object(
+        target=tool_executor_mod,
+        attribute="_execute_tools_parallel",
+        wraps=tool_executor_mod._execute_tools_parallel,
+    ) as execute_parallel:
+        exit_code = run_lint_tools_simple(
+            action="check",
+            paths=mixed_language_sample,
+            tools="ruff,yamllint",
+            tool_options=None,
+            exclude=None,
+            include_venv=False,
+            group_by="file",
+            output_format="grid",
+            verbose=False,
+            yes=True,
         )
 
-    ordered_names = [name for name, _ in results]
-    assert_that(ordered_names).is_equal_to(["slow", "fast"])
-    assert_that(results[0][1].issues_count).is_equal_to(1)
-    assert_that(results[1][1].issues_count).is_equal_to(2)
-
-
-def test_parallel_isolates_tool_failures() -> None:
-    """A tool raising an exception does not sink its concurrent peers.
-
-    One fake tool raises inside ``check``; the executor must convert it to a
-    failed :class:`ToolResult` while the healthy tool still returns its own
-    successful result, and ordering must be preserved.
-    """
-    boom = _FakeTool(name="boom", raises=True)
-    healthy = _FakeTool(name="healthy", issues_count=3)
-
-    with AsyncToolExecutor(max_workers=4) as executor:
-        results = asyncio.run(
-            executor.run_tools_parallel(
-                tools=cast(
-                    list[tuple[str, BaseToolPlugin]],
-                    [("boom", boom), ("healthy", healthy)],
-                ),
-                paths=[],
-                action=Action.CHECK,
-            ),
-        )
-
-    by_name = dict(results)
-    assert_that(sorted(by_name.keys())).is_equal_to(["boom", "healthy"])
-
-    # Failing tool is isolated into a failed result, not propagated.
-    assert_that(by_name["boom"].success).is_false()
-    assert_that(by_name["boom"].output).contains("boom boom")
-
-    # Healthy tool is unaffected by its peer's failure.
-    assert_that(by_name["healthy"].success).is_true()
-    assert_that(by_name["healthy"].issues_count).is_equal_to(3)
-
-
-def test_get_parallel_batches_separates_conflicting_tools() -> None:
-    """Conflicting tools are placed in distinct sequential batches.
-
-    Two tools that declare ``conflicts_with`` each other must never share a
-    batch (they would race on the same files), while a third independent tool
-    may share a batch with one of them.
-    """
-    manager = _FakeToolManager(
-        tools={
-            "black": _FakeTool(name="black", conflicts_with=["ruff"]),
-            "ruff": _FakeTool(name="ruff", conflicts_with=["black"]),
-            "yamllint": _FakeTool(name="yamllint"),
-        },
-    )
-
-    batches = get_parallel_batches(["black", "ruff", "yamllint"], manager)
-
-    # black and ruff conflict -> separate batches; two batches total.
-    assert_that(batches).is_length(2)
-    for batch in batches:
-        conflicting_together = "black" in batch and "ruff" in batch
-        assert_that(conflicting_together).is_false()
-
-    # Every input tool is scheduled exactly once.
-    scheduled = [tool for batch in batches for tool in batch]
-    assert_that(sorted(scheduled)).is_equal_to(["black", "ruff", "yamllint"])
-
-
-def test_get_parallel_batches_groups_independent_tools() -> None:
-    """Non-conflicting tools share a single parallel batch."""
-    manager = _FakeToolManager(
-        tools={
-            "ruff": _FakeTool(name="ruff"),
-            "yamllint": _FakeTool(name="yamllint"),
-        },
-    )
-
-    batches = get_parallel_batches(["ruff", "yamllint"], manager)
-
-    assert_that(batches).is_length(1)
-    assert_that(sorted(batches[0])).is_equal_to(["ruff", "yamllint"])
+    assert_that(execute_parallel.call_count).is_equal_to(1)
+    assert_that(exit_code).is_instance_of(int)
+    assert_that(exit_code).is_not_equal_to(0)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  test(execution): exercise real multi-tool parallel execution
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`tests/integration/test_parallel_execution.py` never actually tested parallel execution: every case passed `tools="ruff"` (a single tool), so `use_parallel` (`len(tools_to_run) > 1`) was always false and the asyncio + ThreadPoolExecutor path plus conflict-aware batching ran untested at integration level.

This change:

- Adds `test_parallel_runs_multiple_tools_over_mixed_samples`: drives `run_tools_parallel` with ruff + yamllint over a mixed Python/YAML sample where each tool owns one file, asserting both tools' results are aggregated and each surfaces its violation.
- Adds `test_parallel_preserves_input_ordering_contract`: a slow tool finishing last still returns positionally aligned with the input tool list.
- Adds `test_parallel_isolates_tool_failures`: a tool raising inside `check` becomes a failed `ToolResult` while its healthy peer still returns successfully (exercises `asyncio.gather(return_exceptions=True)` handling).
- Adds `test_get_parallel_batches_separates_conflicting_tools` and `test_get_parallel_batches_groups_independent_tools`: conflicting tools land in separate batches; independent tools share one.
- Renames the existing single-tool cases to `*_smoke` so their sequential scope is honest.

assertpy only; existing integration fixtures/conventions followed.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1421

## Details

- `uv run lintro chk tests/integration/test_parallel_execution.py` — health score 100/100
- `uv run pytest tests/integration/test_parallel_execution.py` — 12 passed
- `uv run pytest -n auto` — 6654 passed, 10 skipped; only the two known worktree-spurious failures (`test_prepare_execution_version_check_fails_returns_early_result`, `test_list_tools_shows_origin_for_builtin_and_external`)

Closes #1421


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded integration coverage for parallel execution across multiple tools and mixed Python/YAML configurations.
  - Added checks for aggregated results and production execution dispatch.
  - Retained sequential single-tool smoke coverage with clearer test naming.
  - Added cleanup for mixed-format test fixtures and graceful skipping when required linters are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->