### PR TITLE
feat(cli): scope no-config first run to detected languages

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,11 +41,17 @@ The configuration system works in a specific order:
 
 1. **Execution Tier** - Determines which tools run and in what order
    - `enabled_tools`: Empty list means all enabled tools run **when a config
-     file is present**. A no-config first run scopes tools to detected
-     languages (use `--tools all` or `lintro init` for the full set). An
-     explicit named `--tools` list on the CLI bypasses this allowlist; default
-     runs and `--tools all`
-     remain filtered by it.
+     file is present** (`.lintro-config.yaml` or a **non-empty**
+     `[tool.lintro]` table in `pyproject.toml`). A no-config first run
+     scopes tools to languages detected from manifests **and** source files
+     (a directory of `*.py` / `*.js` with no `pyproject.toml` /
+     `package.json` still selects ruff/prettier). Use `--tools all` or
+     `lintro init` for the full registry. An empty `[tool.lintro]` table is
+     not a config, so language scoping still applies. An explicit named
+     `--tools` list on the CLI bypasses this allowlist; default runs and
+     `--tools all` remain filtered by it. This is a feat/minor default
+     change: kitchen-sink CI that relied on the unscoped no-config toolset
+     should pass `--tools all` or add a config file.
    - `tool_order`: Controls execution order (priority, alphabetical, or custom)
    - `fail_fast`: Whether to stop on first tool failure
    - `parallel`: Whether to run tools in parallel (default: `true`)
@@ -102,7 +108,7 @@ Create a `.lintro-config.yaml` in your project root:
 ```yaml
 # Tier 1: EXECUTION - What tools run and how
 execution:
-  enabled_tools: [] # Empty = all enabled tools run
+  enabled_tools: [] # Empty = all enabled tools (config present); no-config first run is language-scoped
   tool_order: priority # priority | alphabetical | [custom list]
   fail_fast: false
   parallel: true # Run tools in parallel (default: true)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,7 +50,10 @@ The configuration system works in a specific order:
      CLI bypasses this allowlist; default runs and `--tools all` remain filtered by it.
      This is a feat/minor default change: kitchen-sink CI that relied on the unscoped
      no-config toolset should pass `--tools all` or add a config file. Detection uses
-     the current working directory (not the scan paths passed to chk/fmt). Nested
+     the chk/fmt scan paths (a file uses its parent directory; multiple paths are
+     unioned). When no paths are given the default is `.` (the current working
+     directory). Tools that are not in the language map (for example `commitlint`) are
+     still selected when their native config file is present at a scan root. Nested
      YAML/Markdown/shell files count; a lone root `README.md` does not enable Markdown
      tools.
    - `tool_order`: Controls execution order (priority, alphabetical, or custom)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,7 +49,10 @@ The configuration system works in a specific order:
      config, so language scoping still applies. An explicit named `--tools` list on the
      CLI bypasses this allowlist; default runs and `--tools all` remain filtered by it.
      This is a feat/minor default change: kitchen-sink CI that relied on the unscoped
-     no-config toolset should pass `--tools all` or add a config file.
+     no-config toolset should pass `--tools all` or add a config file. Detection uses
+     the current working directory (not the scan paths passed to chk/fmt). Nested
+     YAML/Markdown/shell files count; a lone root `README.md` does not enable Markdown
+     tools.
    - `tool_order`: Controls execution order (priority, alphabetical, or custom)
    - `fail_fast`: Whether to stop on first tool failure
    - `parallel`: Whether to run tools in parallel (default: `true`)
@@ -349,7 +352,7 @@ lintro check --group-by [file|code|none|auto|category] # Group issues
 
 # Tool selection
 lintro check --tools ruff,prettier           # Run specific tools only
-lintro check --all                           # Run all available tools
+lintro check --tools all                     # Run all available tools
 
 # File filtering
 lintro check --exclude "*.pyc,venv"          # Exclude patterns
@@ -2985,7 +2988,7 @@ lintro check --exclude "venv,node_modules,migrations"
 lintro check --tools ruff
 
 # Full analysis for main branch
-lintro check --all --output full-report.txt
+lintro check --tools all --output full-report.txt
 ```
 
 ### Custom Output Formats
@@ -3067,7 +3070,7 @@ check: lint
 
 # Comprehensive quality report
 quality:
-	lintro check --all --output quality-report.txt
+	lintro check --tools all --output quality-report.txt
 	@echo "Full quality report saved to quality-report.txt"
 
 # Tool installation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,8 +40,11 @@ configure specific commands rather than tool resolution.
 The configuration system works in a specific order:
 
 1. **Execution Tier** - Determines which tools run and in what order
-   - `enabled_tools`: Empty list means all enabled tools run. An explicit named
-     `--tools` list on the CLI bypasses this allowlist; default runs and `--tools all`
+   - `enabled_tools`: Empty list means all enabled tools run **when a config
+     file is present**. A no-config first run scopes tools to detected
+     languages (use `--tools all` or `lintro init` for the full set). An
+     explicit named `--tools` list on the CLI bypasses this allowlist; default
+     runs and `--tools all`
      remain filtered by it.
    - `tool_order`: Controls execution order (priority, alphabetical, or custom)
    - `fail_fast`: Whether to stop on first tool failure

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,18 +40,16 @@ configure specific commands rather than tool resolution.
 The configuration system works in a specific order:
 
 1. **Execution Tier** - Determines which tools run and in what order
-   - `enabled_tools`: Empty list means all enabled tools run **when a config
-     file is present** (`.lintro-config.yaml` or a **non-empty**
-     `[tool.lintro]` table in `pyproject.toml`). A no-config first run
-     scopes tools to languages detected from manifests **and** source files
-     (a directory of `*.py` / `*.js` with no `pyproject.toml` /
-     `package.json` still selects ruff/prettier). Use `--tools all` or
-     `lintro init` for the full registry. An empty `[tool.lintro]` table is
-     not a config, so language scoping still applies. An explicit named
-     `--tools` list on the CLI bypasses this allowlist; default runs and
-     `--tools all` remain filtered by it. This is a feat/minor default
-     change: kitchen-sink CI that relied on the unscoped no-config toolset
-     should pass `--tools all` or add a config file.
+   - `enabled_tools`: Empty list means all enabled tools run **when a config file is
+     present** (`.lintro-config.yaml` or a **non-empty** `[tool.lintro]` table in
+     `pyproject.toml`). A no-config first run scopes tools to languages detected from
+     manifests **and** source files (a directory of `*.py` / `*.js` with no
+     `pyproject.toml` / `package.json` still selects ruff/prettier). Use `--tools all`
+     or `lintro init` for the full registry. An empty `[tool.lintro]` table is not a
+     config, so language scoping still applies. An explicit named `--tools` list on the
+     CLI bypasses this allowlist; default runs and `--tools all` remain filtered by it.
+     This is a feat/minor default change: kitchen-sink CI that relied on the unscoped
+     no-config toolset should pass `--tools all` or add a config file.
    - `tool_order`: Controls execution order (priority, alphabetical, or custom)
    - `fail_fast`: Whether to stop on first tool failure
    - `parallel`: Whether to run tools in parallel (default: `true`)

--- a/lintro/cli_utils/commands/check.py
+++ b/lintro/cli_utils/commands/check.py
@@ -27,7 +27,11 @@ DEFAULT_ACTION: str = "check"
 @click.option(
     "--tools",
     type=str,
-    help='Comma-separated list of tools to run. Use "all" to run all available tools.',
+    help=(
+        "Comma-separated list of tools to run. Omit to use the workspace "
+        "config or, with no config, the language-detected toolset. Use "
+        '"all" to run every available tool.'
+    ),
 )
 @click.option(
     "--tool-options",

--- a/lintro/cli_utils/commands/format.py
+++ b/lintro/cli_utils/commands/format.py
@@ -19,7 +19,11 @@ DEFAULT_ACTION: str = "fmt"
 @click.option(
     "--tools",
     default=None,
-    help="Comma-separated list of tools to run (e.g., ruff,black) or 'all'.",
+    help=(
+        "Comma-separated list of tools to run (e.g., ruff,black). Omit to "
+        "use the workspace config or, with no config, the language-detected "
+        "toolset. Use 'all' to run every available tool."
+    ),
 )
 @click.option(
     "--tool-options",

--- a/lintro/config/execution_config.py
+++ b/lintro/config/execution_config.py
@@ -25,8 +25,11 @@ class ExecutionConfig(BaseModel):
     Attributes:
         model_config: Pydantic model configuration.
         enabled_tools: List of tool names to run on default (no ``--tools``)
-            and ``--tools all`` runs. If empty/None, all tools run. An
-            explicit comma-separated ``--tools`` list bypasses this allowlist.
+            and ``--tools all`` runs. If empty/None and a config file is
+            present, all tools run. A no-config first run is instead scoped
+            to detected languages (use ``--tools all`` or ``lintro init``
+            for the full set). An explicit comma-separated ``--tools`` list
+            bypasses this allowlist.
         tool_order: Execution order strategy. One of:
             - "priority": Use default priority (formatters before linters)
             - "alphabetical": Alphabetical order

--- a/lintro/mcp/toolkits/lint.py
+++ b/lintro/mcp/toolkits/lint.py
@@ -181,7 +181,11 @@ def _check_handler(
             # Selection is resolved up front because ``execute_run`` folds a
             # bad tool name into a console message and an early-exit artifact,
             # which would reach the agent as "a run with no findings".
-            resolve_tools_to_run(tools=tools, action=Action.CHECK)
+            resolve_tools_to_run(
+                tools=tools,
+                action=Action.CHECK,
+                scan_roots=paths,
+            )
             artifact = run_lintro(action=Action.CHECK, paths=paths, tools=tools)
         return _run_payload(
             artifact=artifact,
@@ -211,7 +215,11 @@ def _format_handler(
         dry_run = bool(arguments.get("dry_run", True))
 
         with workspace_session(workspace=workspace):
-            to_run = resolve_tools_to_run(tools=tools, action=Action.FIX)
+            to_run = resolve_tools_to_run(
+                tools=tools,
+                action=Action.FIX,
+                scan_roots=paths,
+            )
             snapshot = snapshot_files(paths=paths, tool_names=to_run)
             try:
                 artifact = run_lintro(action=Action.FIX, paths=paths, tools=tools)

--- a/lintro/mcp/toolkits/lint.py
+++ b/lintro/mcp/toolkits/lint.py
@@ -50,7 +50,8 @@ _TOOLS_SCHEMA: Final[dict[str, Any]] = {
     "description": (
         "Subset of lintro tools to run (e.g. ['ruff', 'prettier']). Omit to "
         "use the workspace config or, with no config, the language-detected "
-        "toolset. Advisory AI finders are not selectable here."
+        "toolset. Pass ['all'] for the full registry. Advisory AI finders "
+        "are not selectable here."
     ),
 }
 

--- a/lintro/mcp/toolkits/lint.py
+++ b/lintro/mcp/toolkits/lint.py
@@ -48,9 +48,9 @@ _TOOLS_SCHEMA: Final[dict[str, Any]] = {
     "type": "array",
     "items": {"type": "string"},
     "description": (
-        "Subset of lintro tools to run (e.g. ['ruff', 'prettier']). Defaults "
-        "to every tool enabled for this action by the workspace config. "
-        "Advisory AI finders are not selectable here."
+        "Subset of lintro tools to run (e.g. ['ruff', 'prettier']). Omit to "
+        "use the workspace config or, with no config, the language-detected "
+        "toolset. Advisory AI finders are not selectable here."
     ),
 }
 

--- a/lintro/mcp/toolkits/runner.py
+++ b/lintro/mcp/toolkits/runner.py
@@ -114,7 +114,12 @@ def workspace_session(*, workspace: Path) -> Iterator[None]:
             clear_config_cache()
 
 
-def resolve_tools_to_run(*, tools: list[str] | None, action: Action) -> list[str]:
+def resolve_tools_to_run(
+    *,
+    tools: list[str] | None,
+    action: Action,
+    scan_roots: list[str] | None = None,
+) -> list[str]:
     """Resolve the tool names a run would execute, validating any subset.
 
     Must be called inside :func:`workspace_session`, because tool selection
@@ -124,6 +129,8 @@ def resolve_tools_to_run(*, tools: list[str] | None, action: Action) -> list[str
         tools: Requested tool names, or ``None``/empty for the default set.
         action: The action the run will perform, which decides whether a tool
             that cannot fix is acceptable.
+        scan_roots: Files or directories used for language-scoped first-run
+            selection. ``None`` detects from the workspace cwd.
 
     Returns:
         list[str]: Tool names the run will execute, in execution order.
@@ -141,7 +148,12 @@ def resolve_tools_to_run(*, tools: list[str] | None, action: Action) -> list[str
 
     requested = ",".join(tools) if tools else None
     try:
-        selection = get_tools_to_run(requested, action, ignore_conflicts=False)
+        selection = get_tools_to_run(
+            tools=requested,
+            action=action,
+            ignore_conflicts=False,
+            scan_roots=scan_roots,
+        )
     except ValueError as exc:
         raise McpError(
             code=McpErrorCode.TOOL_UNAVAILABLE,

--- a/lintro/utils/execution/tool_configuration.py
+++ b/lintro/utils/execution/tool_configuration.py
@@ -441,6 +441,12 @@ def get_tools_to_run(
     explicit ``--tools`` list bypasses that allowlist so named tools still
     run; per-tool ``tools.<name>.enabled: false`` continues to apply.
 
+    A no-config default run (``tools`` is None, no config file, no in-memory
+    ``tools:`` section) is additionally scoped to languages detected in the
+    current working directory. Explicit ``--tools all`` and any configured
+    project keep the full registry. Detection uses ``Path.cwd()``, not the
+    scan paths passed to chk/fmt.
+
     Args:
         tools: Comma-separated tool names, "all", or None.
         action: "check", "fmt", or "test".

--- a/lintro/utils/execution/tool_configuration.py
+++ b/lintro/utils/execution/tool_configuration.py
@@ -141,6 +141,8 @@ class ToolsToRunResult:
 
     to_run: list[str] = field(default_factory=list)
     skipped: list[SkippedTool] = field(default_factory=list)
+    detected_languages: list[str] = field(default_factory=list)
+    scoped_by_detection: bool = False
 
 
 def _apply_conflict_resolution(
@@ -332,6 +334,75 @@ def get_tool_lookup_keys(tool_name: str) -> set[str]:
     return {tool_name.lower()}
 
 
+def _detection_scoped_tool_names() -> tuple[list[str], set[str]]:
+    """Compute the language-scoped toolset for a no-config first run.
+
+    Detects the languages present in the current working directory and
+    resolves them to the union of recommended tool names via the manifest
+    registry's language map. Security tools are always included.
+
+    Returns:
+        Tuple of ``(detected_languages, scoped_tool_names)`` where
+        ``detected_languages`` is the sorted list of detected language
+        identifiers and ``scoped_tool_names`` is the lowercase set of tool
+        names applicable to those languages.
+    """
+    from lintro.tools.core.tool_registry import ManifestRegistry
+    from lintro.utils.project_detection import detect_project_languages
+
+    detected_languages = detect_project_languages()
+    registry = ManifestRegistry.load()
+    scoped_tools = registry.tools_for_languages(detected_languages)
+    scoped_names = {t.name.lower() for t in scoped_tools}
+    return detected_languages, scoped_names
+
+
+def format_detection_notice(
+    detected_languages: list[str],
+    to_run: list[str],
+) -> str:
+    """Build the informational line for a language-scoped no-config run.
+
+    Groups the selected tools by the detected language they belong to so the
+    user sees, e.g., ``(python: bandit, black, mypy, ruff)``.
+
+    Args:
+        detected_languages: Languages detected in the project.
+        to_run: Tool names selected for execution.
+
+    Returns:
+        A single-line notice pointing the user at ``lintro init``.
+    """
+    from lintro.tools.core.tool_registry import ManifestRegistry
+
+    registry = ManifestRegistry.load()
+    language_map = registry.language_map
+    run_set = {name.lower() for name in to_run}
+
+    groups: list[str] = []
+    seen: set[str] = set()
+    for lang in detected_languages:
+        mapped = language_map.get(lang.lower(), [])
+        lang_tools = sorted(
+            name for name in mapped if name.lower() in run_set and name not in seen
+        )
+        seen.update(lang_tools)
+        if lang_tools:
+            groups.append(f"{lang}: {', '.join(lang_tools)}")
+
+    # Include any remaining tools (e.g. always-on security tools) not tied to a
+    # detected language so the notice matches what actually runs.
+    remaining = sorted(name for name in to_run if name not in seen)
+    if remaining:
+        groups.append(f"security: {', '.join(remaining)}")
+
+    detail = "; ".join(groups) if groups else "none"
+    return (
+        f"No config found — using detected toolset ({detail}). "
+        "Run 'lintro init' to customize."
+    )
+
+
 def get_tools_to_run(
     tools: str | ToolsValue | None,
     action: str | Action,
@@ -395,16 +466,29 @@ def get_tools_to_run(
     # Get lintro config for enabled/disabled tool checking
     config = lintro_config or get_config()
 
-    if (
-        tools is None
-        or tools == ToolsValue.ALL
-        or (isinstance(tools, str) and tools.lower() == "all")
-    ):
+    is_explicit_all = tools == ToolsValue.ALL or (
+        isinstance(tools, str) and tools.lower() == "all"
+    )
+
+    if tools is None or is_explicit_all:
         # Get all available tools for the action
         if action == Action.FIX:
             available_tools = tool_manager.get_fix_tools()
         else:  # check
             available_tools = tool_manager.get_check_tools()
+
+        # On a no-config default run (``tools`` is None and no config file was
+        # discovered), scope the toolset to the languages actually present in
+        # the project. Tools not applicable to the detected languages are
+        # omitted entirely rather than surfaced as SKIP rows, so a Python-only
+        # project no longer fires (and lists) ~30 irrelevant tools. Explicit
+        # ``--tools all`` and any configured project keep the full behavior.
+        detected_languages: list[str] = []
+        scoped_names: set[str] | None = None
+        scoped_by_detection = False
+        if tools is None and config.config_path is None:
+            detected_languages, scoped_names = _detection_scoped_tool_names()
+            scoped_by_detection = True
 
         to_run: list[str] = []
         skipped: list[SkippedTool] = []
@@ -415,6 +499,9 @@ def get_tools_to_run(
             # (not reported as skipped) because they were never part of this
             # verb's tool set (#1308).
             if _is_advisory_tool(name=name):
+                continue
+            # Silently drop tools that do not apply to detected languages.
+            if scoped_names is not None and name.lower() not in scoped_names:
                 continue
             if not config.is_tool_enabled(name):
                 reason = _get_disabled_reason(config, name)
@@ -428,7 +515,12 @@ def get_tools_to_run(
             ignore_conflicts=ignore_conflicts,
         )
 
-        return ToolsToRunResult(to_run=to_run, skipped=skipped)
+        return ToolsToRunResult(
+            to_run=to_run,
+            skipped=skipped,
+            detected_languages=detected_languages,
+            scoped_by_detection=scoped_by_detection,
+        )
 
     # Parse specific tools (accept hyphen or underscore spellings)
     tool_names: list[str] = [name.strip().lower() for name in tools.split(",")]

--- a/lintro/utils/execution/tool_configuration.py
+++ b/lintro/utils/execution/tool_configuration.py
@@ -7,7 +7,9 @@ and determining which tools to run.
 from __future__ import annotations
 
 import difflib
+from collections.abc import Sequence
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lintro.config.config_loader import get_config
@@ -334,12 +336,112 @@ def get_tool_lookup_keys(tool_name: str) -> set[str]:
     return {tool_name.lower()}
 
 
-def _detection_scoped_tool_names() -> tuple[list[str], set[str]]:
+def _normalize_scan_roots(
+    *,
+    scan_roots: Sequence[str | Path] | None,
+) -> list[Path]:
+    """Resolve chk/fmt scan targets to directories used for language detection.
+
+    Args:
+        scan_roots: Files or directories from chk/fmt. ``None`` or empty
+            falls back to the current working directory. Files use their
+            parent directory.
+
+    Returns:
+        Deduplicated resolved directory paths, preserving first-seen order.
+    """
+    candidates: list[Path] = []
+    if scan_roots:
+        for raw in scan_roots:
+            path = Path(raw).resolve()
+            candidates.append(path.parent if path.is_file() else path)
+    if not candidates:
+        candidates.append(Path.cwd().resolve())
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for path in candidates:
+        if path in seen:
+            continue
+        seen.add(path)
+        unique.append(path)
+    return unique
+
+
+def _mapped_language_tool_names(
+    *,
+    language_map: dict[str, list[str]],
+) -> set[str]:
+    """Collect hyphen/underscore aliases for every language-mapped tool.
+
+    Args:
+        language_map: Manifest ``language_map`` (language → tool names).
+
+    Returns:
+        Lowercase registry keys and aliases covered by the language map.
+    """
+    names: set[str] = set()
+    for tool_list in language_map.values():
+        for name in tool_list:
+            names.update(_tool_name_lookup_candidates(name=name.lower()))
+    return names
+
+
+def _unmapped_native_config_names(
+    *,
+    roots: list[Path],
+    mapped_names: set[str],
+) -> set[str]:
+    """Include unmapped tools when a native config file exists at a scan root.
+
+    Language-mapped tools stay gated on detection. Tools the map does not
+    cover (for example commitlint) still run on a no-config first run when
+    their native config is present, instead of vanishing silently.
+
+    Args:
+        roots: Directories already used for language detection.
+        mapped_names: Tool names (and aliases) present in the language map.
+
+    Returns:
+        Lowercase registry keys and aliases to add to the scoped set.
+    """
+    extra: set[str] = set()
+    for name in tool_manager.get_tool_names():
+        candidates = _tool_name_lookup_candidates(name=name.lower())
+        if name.lower() == ToolName.PYTEST.value.lower():
+            continue
+        if any(candidate in mapped_names for candidate in candidates):
+            continue
+        if _is_advisory_tool(name=name):
+            continue
+        try:
+            tool = tool_manager.get_tool(name)
+        except (KeyError, ValueError):
+            continue
+        native_configs = tool.definition.native_configs
+        if not native_configs:
+            continue
+        if any(
+            any((root / config_name).exists() for config_name in native_configs)
+            for root in roots
+        ):
+            extra.update(candidates)
+    return extra
+
+
+def _detection_scoped_tool_names(
+    *,
+    scan_roots: Sequence[str | Path] | None = None,
+) -> tuple[list[str], set[str]]:
     """Compute the language-scoped toolset for a no-config first run.
 
-    Detects the languages present in the current working directory and
+    Detects the languages present in *scan_roots* (default: cwd) and
     resolves them to the union of recommended tool names via the manifest
-    registry's language map. Security tools are always included.
+    registry's language map. Security tools are always included. Unmapped
+    tools with a native config at a scan root are included as well.
+
+    Args:
+        scan_roots: Files or directories passed to chk/fmt. ``None`` uses
+            the current working directory.
 
     Returns:
         Tuple of ``(detected_languages, scoped_tool_names)`` where
@@ -350,7 +452,11 @@ def _detection_scoped_tool_names() -> tuple[list[str], set[str]]:
     from lintro.tools.core.tool_registry import ManifestRegistry
     from lintro.utils.project_detection import detect_project_languages
 
-    detected_languages = detect_project_languages()
+    roots = _normalize_scan_roots(scan_roots=scan_roots)
+    languages: set[str] = set()
+    for root in roots:
+        languages.update(detect_project_languages(root=root))
+    detected_languages = sorted(languages)
     registry = ManifestRegistry.load()
     scoped_tools = registry.tools_for_languages(detected_languages)
     scoped_names: set[str] = set()
@@ -358,6 +464,14 @@ def _detection_scoped_tool_names() -> tuple[list[str], set[str]]:
         scoped_names.update(
             _tool_name_lookup_candidates(name=tool.name.lower()),
         )
+    scoped_names.update(
+        _unmapped_native_config_names(
+            roots=roots,
+            mapped_names=_mapped_language_tool_names(
+                language_map=registry.language_map,
+            ),
+        ),
+    )
     return detected_languages, scoped_names
 
 
@@ -434,6 +548,7 @@ def get_tools_to_run(
     *,
     ignore_conflicts: bool = False,
     lintro_config: LintroConfig | None = None,
+    scan_roots: Sequence[str | Path] | None = None,
 ) -> ToolsToRunResult:
     """Get the list of tools to run based on the tools string and action.
 
@@ -442,16 +557,20 @@ def get_tools_to_run(
     run; per-tool ``tools.<name>.enabled: false`` continues to apply.
 
     A no-config default run (``tools`` is None, no config file, no in-memory
-    ``tools:`` section) is additionally scoped to languages detected in the
-    current working directory. Explicit ``--tools all`` and any configured
-    project keep the full registry. Detection uses ``Path.cwd()``, not the
-    scan paths passed to chk/fmt.
+    ``tools:`` section) is additionally scoped to languages detected in
+    *scan_roots* (default: the current working directory). Files use their
+    parent directory; multiple roots are unioned. Explicit ``--tools all``
+    and any configured project keep the full registry. Tools that are not
+    in the language map (for example commitlint) are still selected when
+    their native config file is present at a scan root.
 
     Args:
         tools: Comma-separated tool names, "all", or None.
         action: "check", "fmt", or "test".
         ignore_conflicts: If True, skip conflict checking between tools.
         lintro_config: Optional config override; uses global config when omitted.
+        scan_roots: Files or directories to detect languages from. ``None``
+            uses ``Path.cwd()``.
 
     Returns:
         ToolsToRunResult with tools to run and skipped tools with reasons.
@@ -516,7 +635,9 @@ def get_tools_to_run(
         scoped_names: set[str] | None = None
         scoped_by_detection = False
         if tools is None and config.config_path is None and not config.tools:
-            detected_languages, scoped_names = _detection_scoped_tool_names()
+            detected_languages, scoped_names = _detection_scoped_tool_names(
+                scan_roots=scan_roots,
+            )
             scoped_by_detection = True
 
         to_run: list[str] = []

--- a/lintro/utils/execution/tool_configuration.py
+++ b/lintro/utils/execution/tool_configuration.py
@@ -353,7 +353,11 @@ def _detection_scoped_tool_names() -> tuple[list[str], set[str]]:
     detected_languages = detect_project_languages()
     registry = ManifestRegistry.load()
     scoped_tools = registry.tools_for_languages(detected_languages)
-    scoped_names = {t.name.lower() for t in scoped_tools}
+    scoped_names: set[str] = set()
+    for tool in scoped_tools:
+        scoped_names.update(
+            _tool_name_lookup_candidates(name=tool.name.lower()),
+        )
     return detected_languages, scoped_names
 
 
@@ -377,24 +381,45 @@ def format_detection_notice(
 
     registry = ManifestRegistry.load()
     language_map = registry.language_map
-    run_set = {name.lower() for name in to_run}
+    security_names = {
+        candidate
+        for name in language_map.get("security", [])
+        for candidate in _tool_name_lookup_candidates(name=name.lower())
+    }
+    run_aliases: dict[str, str] = {}
+    for name in to_run:
+        for candidate in _tool_name_lookup_candidates(name=name.lower()):
+            run_aliases[candidate] = name
 
     groups: list[str] = []
     seen: set[str] = set()
     for lang in detected_languages:
         mapped = language_map.get(lang.lower(), [])
-        lang_tools = sorted(
-            name for name in mapped if name.lower() in run_set and name not in seen
-        )
-        seen.update(lang_tools)
+        lang_tools: list[str] = []
+        for mapped_name in mapped:
+            for candidate in _tool_name_lookup_candidates(name=mapped_name.lower()):
+                registered = run_aliases.get(candidate)
+                if registered is not None and registered not in seen:
+                    lang_tools.append(registered)
+                    seen.add(registered)
+                    break
+        lang_tools.sort()
         if lang_tools:
             groups.append(f"{lang}: {', '.join(lang_tools)}")
 
-    # Include any remaining tools (e.g. always-on security tools) not tied to a
-    # detected language so the notice matches what actually runs.
     remaining = sorted(name for name in to_run if name not in seen)
     if remaining:
-        groups.append(f"security: {', '.join(remaining)}")
+        if all(
+            any(
+                candidate in security_names
+                for candidate in _tool_name_lookup_candidates(name=name.lower())
+            )
+            for name in remaining
+        ):
+            leftover_label = "security"
+        else:
+            leftover_label = "other"
+        groups.append(f"{leftover_label}: {', '.join(remaining)}")
 
     detail = "; ".join(groups) if groups else "none"
     return (
@@ -477,16 +502,14 @@ def get_tools_to_run(
         else:  # check
             available_tools = tool_manager.get_check_tools()
 
-        # On a no-config default run (``tools`` is None and no config file was
-        # discovered), scope the toolset to the languages actually present in
-        # the project. Tools not applicable to the detected languages are
-        # omitted entirely rather than surfaced as SKIP rows, so a Python-only
-        # project no longer fires (and lists) ~30 irrelevant tools. Explicit
-        # ``--tools all`` and any configured project keep the full behavior.
+        # On a no-config default run (``tools`` is None, no config file, and no
+        # in-memory ``tools:`` section), scope the toolset to languages present
+        # in the project. Explicit ``--tools all`` and any configured project
+        # keep the full behavior.
         detected_languages: list[str] = []
         scoped_names: set[str] | None = None
         scoped_by_detection = False
-        if tools is None and config.config_path is None:
+        if tools is None and config.config_path is None and not config.tools:
             detected_languages, scoped_names = _detection_scoped_tool_names()
             scoped_by_detection = True
 

--- a/lintro/utils/project_detection.py
+++ b/lintro/utils/project_detection.py
@@ -116,6 +116,43 @@ def _is_requirements_file(path: Path) -> bool:
     return path.name.startswith("requirements") or path.parent.name == "requirements"
 
 
+def _is_dotenv_file(path: Path) -> bool:
+    """Return True if *path* is a dotenv file, not direnv or similar.
+
+    Args:
+        path: Candidate file.
+
+    Returns:
+        True for ``.env`` and ``.env.*`` (e.g. ``.env.local``), not ``.envrc``.
+    """
+    name = path.name
+    return name == ".env" or name.startswith(".env.")
+
+
+def _is_yaml_content(path: Path) -> bool:
+    """Return True if *path* is generic YAML, not compose or Actions workflow.
+
+    Args:
+        path: Candidate file.
+
+    Returns:
+        True for first-party YAML that should select yamllint.
+    """
+    if path.suffix.lower() not in {".yaml", ".yml"}:
+        return False
+    if path.name in {
+        ".lintro-config.yaml",
+        ".lintro-config.yml",
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        "compose.yml",
+        "compose.yaml",
+    }:
+        return False
+    parts = set(path.parts)
+    return not (".github" in parts and "workflows" in parts)
+
+
 def detect_project_languages() -> list[str]:
     """Detect all languages and ecosystems in the current project.
 
@@ -192,11 +229,11 @@ def detect_project_languages() -> list[str]:
     ):
         langs.add("typescript")
 
-    if "astro" in all_deps:
+    if "astro" in all_deps or _has_source_files(cwd, ".astro"):
         langs.add("astro")
-    if "svelte" in all_deps:
+    if "svelte" in all_deps or _has_source_files(cwd, ".svelte"):
         langs.add("svelte")
-    if "vue" in all_deps:
+    if "vue" in all_deps or _has_source_files(cwd, ".vue"):
         langs.add("vue")
 
     # Rust
@@ -236,22 +273,8 @@ def detect_project_languages() -> list[str]:
     if _has_source_files(cwd, ".sql"):
         langs.add("sql")
 
-    # YAML (beyond compose / lintro config files — including nested trees).
-    yaml_skip_names = {
-        ".lintro-config.yaml",
-        ".lintro-config.yml",
-        "docker-compose.yml",
-        "docker-compose.yaml",
-        "compose.yml",
-        "compose.yaml",
-    }
-    if _has_project_file(
-        cwd,
-        match=lambda path: (
-            path.suffix.lower() in {".yaml", ".yml"}
-            and path.name not in yaml_skip_names
-        ),
-    ):
+    # YAML (beyond compose / lintro config / Actions workflows).
+    if _has_project_file(cwd, match=_is_yaml_content):
         langs.add("yaml")
 
     # Markdown (more than just a lone README; nested docs/ counts).
@@ -278,10 +301,7 @@ def detect_project_languages() -> list[str]:
         langs.add("html")
     if _has_source_files(cwd, ".css", ".scss", ".sass", ".less"):
         langs.add("css")
-    if _has_project_file(
-        cwd,
-        match=lambda path: path.name.startswith(".env"),
-    ):
+    if _has_project_file(cwd, match=_is_dotenv_file):
         langs.add("dotenv")
 
     # Prose/documentation formats beyond Markdown (vale targets).

--- a/lintro/utils/project_detection.py
+++ b/lintro/utils/project_detection.py
@@ -1,8 +1,8 @@
 """Project language and package manager detection.
 
 Scans the current working directory for language/framework indicators
-and available package managers.  Used by the ``setup`` and ``install``
-commands so that the detection logic lives in a single shared module.
+and available package managers. Used by the ``setup`` and ``install``
+commands and by no-config first-run tool selection.
 
 Usage:
     from lintro.utils.project_detection import detect_project_languages
@@ -23,13 +23,53 @@ _VENDOR_SKIP_DIRS: frozenset[str] = frozenset(
 )
 
 
+def _has_source_files(
+    cwd: Path,
+    *patterns: str,
+    exclude_name_suffix: str | None = None,
+) -> bool:
+    """Return True if any non-vendored file matches one of *patterns*.
+
+    Globs short-circuit on the first match so a large tree is not fully
+    walked. Vendored and generated directories listed in
+    ``_VENDOR_SKIP_DIRS`` are ignored.
+
+    Args:
+        cwd: Project root to scan.
+        *patterns: Glob patterns relative to *cwd*.
+        exclude_name_suffix: Optional filename suffix to skip (e.g. ``.d.ts``).
+
+    Returns:
+        True when at least one matching first-party file exists.
+    """
+    return (
+        next(
+            (
+                path
+                for path in chain.from_iterable(
+                    cwd.glob(pattern) for pattern in patterns
+                )
+                if path.is_file()
+                and not _VENDOR_SKIP_DIRS.intersection(path.parts)
+                and (
+                    exclude_name_suffix is None
+                    or not path.name.endswith(exclude_name_suffix)
+                )
+            ),
+            None,
+        )
+        is not None
+    )
+
+
 def detect_project_languages() -> list[str]:
     """Detect all languages and ecosystems in the current project.
 
     Checks for Python, JavaScript/TypeScript (including Astro, Svelte, Vue),
     Rust, Go, Ruby, Shell, Docker, GitHub Actions, SQL, YAML, Markdown, TOML,
     HTML, CSS, and dotenv files by inspecting manifests, directories, and
-    extensions.
+    source-file extensions. Language tools still run in source-only trees that
+    have no ``pyproject.toml`` / ``package.json`` / ``Cargo.toml``.
 
     Returns:
         Sorted list of lowercase language/ecosystem identifiers.
@@ -37,7 +77,7 @@ def detect_project_languages() -> list[str]:
     cwd = Path.cwd()
     langs: set[str] = set()
 
-    # Python — include requirements-only projects so pip_audit is selected.
+    # Python — manifests, requirements files, or a first-party ``*.py``.
     # Requirements files are discovered recursively (e.g. ``requirements/base.txt``
     # or ``services/api/requirements.txt``); vendored/generated trees are skipped
     # and next() short-circuits so at most one file is visited.
@@ -46,47 +86,20 @@ def detect_project_languages() -> list[str]:
         or (cwd / "setup.py").exists()
         or (cwd / "setup.cfg").exists()
         or (cwd / "Pipfile").exists()
-        or next(
-            (
-                p
-                for p in chain(
-                    cwd.glob("**/requirements*.txt"),
-                    cwd.glob("**/requirements/*.txt"),
-                )
-                if not _VENDOR_SKIP_DIRS.intersection(p.parts)
-            ),
-            None,
+        or _has_source_files(
+            cwd,
+            "**/requirements*.txt",
+            "**/requirements/*.txt",
         )
-        is not None
+        or _has_source_files(cwd, "**/*.py", "**/*.pyi")
     ):
         langs.add("python")
 
-    # JavaScript / TypeScript
-    if (cwd / "package.json").exists():
-        langs.add("javascript")
-
-        # TypeScript detection — next() short-circuits so at most one file
-        # is visited per glob pattern, avoiding a full tree scan.
-        if (
-            (cwd / "tsconfig.json").exists()
-            or next(
-                (
-                    p
-                    for p in cwd.glob("**/*.ts")
-                    if "node_modules" not in p.parts and not p.name.endswith(".d.ts")
-                ),
-                None,
-            )
-            is not None
-            or next(
-                (p for p in cwd.glob("**/*.tsx") if "node_modules" not in p.parts),
-                None,
-            )
-            is not None
-        ):
-            langs.add("typescript")
-
-        # Framework detection from package.json
+    # JavaScript / TypeScript — package.json *or* source files so a folder of
+    # ``.js`` / ``.ts`` without a manifest still selects prettier/oxlint/tsc.
+    has_package_json = (cwd / "package.json").exists()
+    all_deps: dict[str, object] = {}
+    if has_package_json:
         try:
             import json
 
@@ -100,27 +113,49 @@ def detect_project_languages() -> list[str]:
             if not isinstance(dev_deps, dict):
                 dev_deps = {}
             all_deps = {**deps, **dev_deps}
-            if "typescript" in all_deps:
-                langs.add("typescript")
-            if "astro" in all_deps:
-                langs.add("astro")
-            if "svelte" in all_deps:
-                langs.add("svelte")
-            if "vue" in all_deps:
-                langs.add("vue")
         except (ImportError, OSError, ValueError):
-            pass
+            all_deps = {}
+
+    if has_package_json or _has_source_files(
+        cwd,
+        "**/*.js",
+        "**/*.jsx",
+        "**/*.mjs",
+        "**/*.cjs",
+    ):
+        langs.add("javascript")
+
+    if (
+        (cwd / "tsconfig.json").exists()
+        or "typescript" in all_deps
+        or _has_source_files(
+            cwd,
+            "**/*.ts",
+            "**/*.tsx",
+            "**/*.mts",
+            "**/*.cts",
+            exclude_name_suffix=".d.ts",
+        )
+    ):
+        langs.add("typescript")
+
+    if "astro" in all_deps:
+        langs.add("astro")
+    if "svelte" in all_deps:
+        langs.add("svelte")
+    if "vue" in all_deps:
+        langs.add("vue")
 
     # Rust
-    if (cwd / "Cargo.toml").exists():
+    if (cwd / "Cargo.toml").exists() or _has_source_files(cwd, "**/*.rs"):
         langs.add("rust")
 
     # Go
-    if (cwd / "go.mod").exists():
+    if (cwd / "go.mod").exists() or _has_source_files(cwd, "**/*.go"):
         langs.add("go")
 
     # Ruby
-    if (cwd / "Gemfile").exists():
+    if (cwd / "Gemfile").exists() or _has_source_files(cwd, "**/*.rb"):
         langs.add("ruby")
 
     # Shell scripts (root *.sh or .sh files inside scripts/)
@@ -187,46 +222,17 @@ def detect_project_languages() -> list[str]:
         langs.add("toml")
 
     # Markup and stylesheets that language_map already knows about.
-    if (
-        next(
-            (
-                p
-                for p in chain(cwd.glob("**/*.html"), cwd.glob("**/*.htm"))
-                if not _VENDOR_SKIP_DIRS.intersection(p.parts)
-            ),
-            None,
-        )
-        is not None
-    ):
+    if _has_source_files(cwd, "**/*.html", "**/*.htm"):
         langs.add("html")
-    if (
-        next(
-            (
-                p
-                for p in chain(
-                    cwd.glob("**/*.css"),
-                    cwd.glob("**/*.scss"),
-                    cwd.glob("**/*.sass"),
-                    cwd.glob("**/*.less"),
-                )
-                if not _VENDOR_SKIP_DIRS.intersection(p.parts)
-            ),
-            None,
-        )
-        is not None
+    if _has_source_files(
+        cwd,
+        "**/*.css",
+        "**/*.scss",
+        "**/*.sass",
+        "**/*.less",
     ):
         langs.add("css")
-    if (
-        next(
-            (
-                p
-                for p in cwd.glob("**/.env*")
-                if p.is_file() and not _VENDOR_SKIP_DIRS.intersection(p.parts)
-            ),
-            None,
-        )
-        is not None
-    ):
+    if _has_source_files(cwd, "**/.env*"):
         langs.add("dotenv")
 
     # Prose/documentation formats beyond Markdown (vale targets).

--- a/lintro/utils/project_detection.py
+++ b/lintro/utils/project_detection.py
@@ -41,6 +41,52 @@ _VENDOR_SKIP_DIRS: frozenset[str] = frozenset(
     },
 )
 
+# JS/TS toolchain configs that must not count as application source.
+_JS_TOOLING_CONFIG_STEMS: frozenset[str] = frozenset(
+    {
+        "commitlint.config",
+        "eslint.config",
+        "prettier.config",
+        "babel.config",
+        "webpack.config",
+        "vite.config",
+        "vitest.config",
+        "jest.config",
+        "rollup.config",
+        "tailwind.config",
+        "postcss.config",
+        "svelte.config",
+        "astro.config",
+        "next.config",
+        "nuxt.config",
+        "vue.config",
+        "remix.config",
+    },
+)
+_JS_TOOLING_EXACT_NAMES: frozenset[str] = frozenset(
+    {
+        ".eslintrc.js",
+        ".eslintrc.cjs",
+        ".eslintrc.mjs",
+        ".prettierrc.js",
+        ".prettierrc.cjs",
+        ".prettierrc.mjs",
+        ".commitlintrc.js",
+        ".commitlintrc.cjs",
+        ".commitlintrc.mjs",
+        "karma.conf.js",
+        "karma.conf.cjs",
+    },
+)
+_JS_TOOLING_SUFFIXES: tuple[str, ...] = (
+    ".js",
+    ".mjs",
+    ".cjs",
+    ".ts",
+    ".mts",
+    ".cts",
+)
+
 
 def _iter_project_files(cwd: Path) -> Iterator[Path]:
     """Yield first-party files under *cwd*, pruning vendored directories.
@@ -119,16 +165,73 @@ def _is_requirements_file(path: Path) -> bool:
 
 
 def _is_dotenv_file(path: Path) -> bool:
-    """Return True if *path* is a dotenv file, not direnv or similar.
+    """Return True if *path* is a dotenv file, not direnv or a template.
 
     Args:
         path: Candidate file.
 
     Returns:
-        True for ``.env`` and ``.env.*`` (e.g. ``.env.local``), not ``.envrc``.
+        True for ``.env`` and ``.env.<environment>`` (e.g. ``.env.local``),
+        not ``.envrc`` or templates such as ``.env.example``.
     """
     name = path.name
-    return name == ".env" or name.startswith(".env.")
+    if name != ".env" and not name.startswith(".env."):
+        return False
+    lowered = name.lower()
+    return not any(
+        lowered.endswith(suffix)
+        for suffix in (".example", ".sample", ".template", ".dist")
+    )
+
+
+def _is_js_tooling_config(*, path: Path) -> bool:
+    """Return True if *path* is a JS/TS toolchain config, not app source.
+
+    Args:
+        path: Candidate file.
+
+    Returns:
+        True for files such as ``commitlint.config.js`` or ``eslint.config.ts``.
+    """
+    lowered = path.name.lower()
+    if lowered in _JS_TOOLING_EXACT_NAMES:
+        return True
+    for suffix in _JS_TOOLING_SUFFIXES:
+        if lowered.endswith(suffix):
+            stem = lowered[: -len(suffix)]
+            return stem in _JS_TOOLING_CONFIG_STEMS
+    return False
+
+
+def _is_javascript_application_source(path: Path) -> bool:
+    """Return True if *path* is first-party JavaScript application source.
+
+    Args:
+        path: Candidate file.
+
+    Returns:
+        True for ``.js``/``.jsx``/``.mjs``/``.cjs`` that are not toolchain configs.
+    """
+    if _is_js_tooling_config(path=path):
+        return False
+    return path.suffix.lower() in {".js", ".jsx", ".mjs", ".cjs"}
+
+
+def _is_typescript_application_source(path: Path) -> bool:
+    """Return True if *path* is first-party TypeScript application source.
+
+    Args:
+        path: Candidate file.
+
+    Returns:
+        True for ``.ts``/``.tsx``/``.mts``/``.cts`` excluding ``*.d.ts`` and
+        toolchain configs such as ``commitlint.config.ts``.
+    """
+    if path.name.endswith(".d.ts"):
+        return False
+    if _is_js_tooling_config(path=path):
+        return False
+    return path.suffix.lower() in {".ts", ".tsx", ".mts", ".cts"}
 
 
 def _is_yaml_content(path: Path) -> bool:
@@ -164,7 +267,9 @@ def detect_project_languages(*, root: Path | None = None) -> list[str]:
     source-file extensions. Language tools still run in source-only trees that
     have no ``pyproject.toml`` / ``package.json`` / ``Cargo.toml``. Nested
     YAML/Markdown/shell files count; a single root README.md does not enable
-    Markdown tools.
+    Markdown tools. JS/TS toolchain configs (``commitlint.config.js``,
+    ``eslint.config.*``, …) are not treated as application source. Dotenv
+    templates such as ``.env.example`` do not enable dotenv tools.
 
     Args:
         root: Directory (or file, whose parent is used) to scan. ``None``
@@ -213,26 +318,16 @@ def detect_project_languages(*, root: Path | None = None) -> list[str]:
         except (ImportError, OSError, ValueError):
             all_deps = {}
 
-    if has_package_json or _has_source_files(
+    if has_package_json or _has_project_file(
         cwd,
-        ".js",
-        ".jsx",
-        ".mjs",
-        ".cjs",
+        match=_is_javascript_application_source,
     ):
         langs.add("javascript")
 
     if (
         (cwd / "tsconfig.json").exists()
         or "typescript" in all_deps
-        or _has_source_files(
-            cwd,
-            ".ts",
-            ".tsx",
-            ".mts",
-            ".cts",
-            exclude_name_suffix=".d.ts",
-        )
+        or _has_project_file(cwd, match=_is_typescript_application_source)
     ):
         langs.add("typescript")
 

--- a/lintro/utils/project_detection.py
+++ b/lintro/utils/project_detection.py
@@ -27,8 +27,9 @@ def detect_project_languages() -> list[str]:
     """Detect all languages and ecosystems in the current project.
 
     Checks for Python, JavaScript/TypeScript (including Astro, Svelte, Vue),
-    Rust, Go, Ruby, Shell, Docker, GitHub Actions, SQL, YAML, Markdown, and
-    TOML by inspecting manifest files, directory structure, and file extensions.
+    Rust, Go, Ruby, Shell, Docker, GitHub Actions, SQL, YAML, Markdown, TOML,
+    HTML, CSS, and dotenv files by inspecting manifests, directories, and
+    extensions.
 
     Returns:
         Sorted list of lowercase language/ecosystem identifiers.
@@ -184,6 +185,49 @@ def detect_project_languages() -> list[str]:
     ]
     if toml_files:
         langs.add("toml")
+
+    # Markup and stylesheets that language_map already knows about.
+    if (
+        next(
+            (
+                p
+                for p in chain(cwd.glob("**/*.html"), cwd.glob("**/*.htm"))
+                if not _VENDOR_SKIP_DIRS.intersection(p.parts)
+            ),
+            None,
+        )
+        is not None
+    ):
+        langs.add("html")
+    if (
+        next(
+            (
+                p
+                for p in chain(
+                    cwd.glob("**/*.css"),
+                    cwd.glob("**/*.scss"),
+                    cwd.glob("**/*.sass"),
+                    cwd.glob("**/*.less"),
+                )
+                if not _VENDOR_SKIP_DIRS.intersection(p.parts)
+            ),
+            None,
+        )
+        is not None
+    ):
+        langs.add("css")
+    if (
+        next(
+            (
+                p
+                for p in cwd.glob("**/.env*")
+                if p.is_file() and not _VENDOR_SKIP_DIRS.intersection(p.parts)
+            ),
+            None,
+        )
+        is not None
+    ):
+        langs.add("dotenv")
 
     # Prose/documentation formats beyond Markdown (vale targets).
     docs_dir = cwd / "docs"

--- a/lintro/utils/project_detection.py
+++ b/lintro/utils/project_detection.py
@@ -1,13 +1,15 @@
 """Project language and package manager detection.
 
-Scans the current working directory for language/framework indicators
-and available package managers. Used by the ``setup`` and ``install``
-commands and by no-config first-run tool selection.
+Scans a project tree for language/framework indicators and available
+package managers. Used by the ``setup`` and ``install`` commands and by
+no-config first-run tool selection. Pass ``root=`` to inspect a directory
+other than the current working directory.
 
 Usage:
     from lintro.utils.project_detection import detect_project_languages
 
     langs = detect_project_languages()   # ["docker", "python", "typescript"]
+    langs = detect_project_languages(root=Path("src"))
 """
 
 from __future__ import annotations
@@ -47,7 +49,7 @@ def _iter_project_files(cwd: Path) -> Iterator[Path]:
         cwd: Project root to scan.
 
     Yields:
-        File paths that are not inside ``_VENDOR_SKIP_DIRS``.
+        Path: File paths that are not inside ``_VENDOR_SKIP_DIRS``.
     """
     for dirpath, dirnames, filenames in os.walk(cwd, topdown=True):
         dirnames[:] = [name for name in dirnames if name not in _VENDOR_SKIP_DIRS]
@@ -153,22 +155,27 @@ def _is_yaml_content(path: Path) -> bool:
     return not (".github" in parts and "workflows" in parts)
 
 
-def detect_project_languages() -> list[str]:
-    """Detect all languages and ecosystems in the current project.
+def detect_project_languages(*, root: Path | None = None) -> list[str]:
+    """Detect all languages and ecosystems in a project tree.
 
     Checks for Python, JavaScript/TypeScript (including Astro, Svelte, Vue),
     Rust, Go, Ruby, Shell, Docker, GitHub Actions, SQL, YAML, Markdown, TOML,
     HTML, CSS, and dotenv files by inspecting manifests, directories, and
     source-file extensions. Language tools still run in source-only trees that
-    have no ``pyproject.toml`` / ``package.json`` / ``Cargo.toml``. Detection
-    always inspects ``Path.cwd()`` (not the scan paths passed to chk/fmt).
-    Nested YAML/Markdown/shell files count; a single root README.md does not
-    enable Markdown tools.
+    have no ``pyproject.toml`` / ``package.json`` / ``Cargo.toml``. Nested
+    YAML/Markdown/shell files count; a single root README.md does not enable
+    Markdown tools.
+
+    Args:
+        root: Directory (or file, whose parent is used) to scan. ``None``
+            inspects ``Path.cwd()``.
 
     Returns:
         Sorted list of lowercase language/ecosystem identifiers.
     """
-    cwd = Path.cwd()
+    cwd = (root or Path.cwd()).resolve()
+    if cwd.is_file():
+        cwd = cwd.parent
     langs: set[str] = set()
 
     # Python — manifests, requirements files, or a first-party ``*.py``.

--- a/lintro/utils/project_detection.py
+++ b/lintro/utils/project_detection.py
@@ -12,54 +12,108 @@ Usage:
 
 from __future__ import annotations
 
+import os
 import shutil
-from itertools import chain
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
-# Directories that never carry first-party project markers; excluded from the
-# recursive scans below to avoid false positives from vendored/generated trees.
+# Directories that never carry first-party project markers. Pruned during
+# os.walk so vendored/generated trees are not even entered.
 _VENDOR_SKIP_DIRS: frozenset[str] = frozenset(
-    {"node_modules", ".venv", "venv", "vendor", ".git", "__pycache__"},
+    {
+        "node_modules",
+        ".venv",
+        "venv",
+        "vendor",
+        ".git",
+        "__pycache__",
+        "build",
+        "dist",
+        "target",
+        ".tox",
+        "site-packages",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".pytest_cache",
+        "htmlcov",
+    },
 )
+
+
+def _iter_project_files(cwd: Path) -> Iterator[Path]:
+    """Yield first-party files under *cwd*, pruning vendored directories.
+
+    Args:
+        cwd: Project root to scan.
+
+    Yields:
+        File paths that are not inside ``_VENDOR_SKIP_DIRS``.
+    """
+    for dirpath, dirnames, filenames in os.walk(cwd, topdown=True):
+        dirnames[:] = [name for name in dirnames if name not in _VENDOR_SKIP_DIRS]
+        for filename in filenames:
+            yield Path(dirpath) / filename
+
+
+def _has_project_file(
+    cwd: Path,
+    *,
+    match: Callable[[Path], bool],
+) -> bool:
+    """Return True if any first-party file satisfies *match*.
+
+    Args:
+        cwd: Project root to scan.
+        match: Predicate applied to each walked file.
+
+    Returns:
+        True when the first matching file is found.
+    """
+    return any(match(path) for path in _iter_project_files(cwd))
 
 
 def _has_source_files(
     cwd: Path,
-    *patterns: str,
+    *suffixes: str,
     exclude_name_suffix: str | None = None,
 ) -> bool:
-    """Return True if any non-vendored file matches one of *patterns*.
+    """Return True if any first-party file uses one of *suffixes*.
 
-    Globs short-circuit on the first match so a large tree is not fully
-    walked. Vendored and generated directories listed in
-    ``_VENDOR_SKIP_DIRS`` are ignored.
+    Walks the tree with vendored directories pruned. Suffixes include the
+    leading dot (e.g. ``.py``).
 
     Args:
         cwd: Project root to scan.
-        *patterns: Glob patterns relative to *cwd*.
+        *suffixes: Filename suffixes to accept (``".py"``, ``".js"``, …).
         exclude_name_suffix: Optional filename suffix to skip (e.g. ``.d.ts``).
 
     Returns:
         True when at least one matching first-party file exists.
     """
-    return (
-        next(
-            (
-                path
-                for path in chain.from_iterable(
-                    cwd.glob(pattern) for pattern in patterns
-                )
-                if path.is_file()
-                and not _VENDOR_SKIP_DIRS.intersection(path.parts)
-                and (
-                    exclude_name_suffix is None
-                    or not path.name.endswith(exclude_name_suffix)
-                )
-            ),
-            None,
+    suffix_set = {suffix.lower() for suffix in suffixes}
+
+    def _match(path: Path) -> bool:
+        if exclude_name_suffix is not None and path.name.endswith(exclude_name_suffix):
+            return False
+        return path.suffix.lower() in suffix_set or any(
+            path.name.lower().endswith(suffix) for suffix in suffix_set
         )
-        is not None
-    )
+
+    return _has_project_file(cwd, match=_match)
+
+
+def _is_requirements_file(path: Path) -> bool:
+    """Return True if *path* looks like a pip requirements file.
+
+    Args:
+        path: Candidate file.
+
+    Returns:
+        True for ``requirements*.txt`` or ``requirements/*.txt``.
+    """
+    if path.suffix != ".txt":
+        return False
+    return path.name.startswith("requirements") or path.parent.name == "requirements"
 
 
 def detect_project_languages() -> list[str]:
@@ -69,7 +123,10 @@ def detect_project_languages() -> list[str]:
     Rust, Go, Ruby, Shell, Docker, GitHub Actions, SQL, YAML, Markdown, TOML,
     HTML, CSS, and dotenv files by inspecting manifests, directories, and
     source-file extensions. Language tools still run in source-only trees that
-    have no ``pyproject.toml`` / ``package.json`` / ``Cargo.toml``.
+    have no ``pyproject.toml`` / ``package.json`` / ``Cargo.toml``. Detection
+    always inspects ``Path.cwd()`` (not the scan paths passed to chk/fmt).
+    Nested YAML/Markdown/shell files count; a single root README.md does not
+    enable Markdown tools.
 
     Returns:
         Sorted list of lowercase language/ecosystem identifiers.
@@ -86,12 +143,8 @@ def detect_project_languages() -> list[str]:
         or (cwd / "setup.py").exists()
         or (cwd / "setup.cfg").exists()
         or (cwd / "Pipfile").exists()
-        or _has_source_files(
-            cwd,
-            "**/requirements*.txt",
-            "**/requirements/*.txt",
-        )
-        or _has_source_files(cwd, "**/*.py", "**/*.pyi")
+        or _has_project_file(cwd, match=_is_requirements_file)
+        or _has_source_files(cwd, ".py", ".pyi")
     ):
         langs.add("python")
 
@@ -118,10 +171,10 @@ def detect_project_languages() -> list[str]:
 
     if has_package_json or _has_source_files(
         cwd,
-        "**/*.js",
-        "**/*.jsx",
-        "**/*.mjs",
-        "**/*.cjs",
+        ".js",
+        ".jsx",
+        ".mjs",
+        ".cjs",
     ):
         langs.add("javascript")
 
@@ -130,10 +183,10 @@ def detect_project_languages() -> list[str]:
         or "typescript" in all_deps
         or _has_source_files(
             cwd,
-            "**/*.ts",
-            "**/*.tsx",
-            "**/*.mts",
-            "**/*.cts",
+            ".ts",
+            ".tsx",
+            ".mts",
+            ".cts",
             exclude_name_suffix=".d.ts",
         )
     ):
@@ -147,22 +200,19 @@ def detect_project_languages() -> list[str]:
         langs.add("vue")
 
     # Rust
-    if (cwd / "Cargo.toml").exists() or _has_source_files(cwd, "**/*.rs"):
+    if (cwd / "Cargo.toml").exists() or _has_source_files(cwd, ".rs"):
         langs.add("rust")
 
     # Go
-    if (cwd / "go.mod").exists() or _has_source_files(cwd, "**/*.go"):
+    if (cwd / "go.mod").exists() or _has_source_files(cwd, ".go"):
         langs.add("go")
 
     # Ruby
-    if (cwd / "Gemfile").exists() or _has_source_files(cwd, "**/*.rb"):
+    if (cwd / "Gemfile").exists() or _has_source_files(cwd, ".rb"):
         langs.add("ruby")
 
-    # Shell scripts (root *.sh or .sh files inside scripts/)
-    scripts_dir = cwd / "scripts"
-    if next(cwd.glob("*.sh"), None) is not None or (
-        scripts_dir.is_dir() and next(scripts_dir.glob("*.sh"), None) is not None
-    ):
+    # Shell scripts anywhere in the tree (not only root / scripts/).
+    if _has_source_files(cwd, ".sh"):
         langs.add("shell")
 
     # Docker (Dockerfile, docker-compose, and standalone compose files)
@@ -182,57 +232,56 @@ def detect_project_languages() -> list[str]:
     if (cwd / ".github" / "workflows").is_dir():
         langs.add("github_actions")
 
-    # SQL — next() short-circuits so only one file is visited.
-    if (
-        next(
-            (
-                p
-                for p in cwd.glob("**/*.sql")
-                if not _VENDOR_SKIP_DIRS.intersection(p.parts)
-            ),
-            None,
-        )
-        is not None
-    ):
+    # SQL
+    if _has_source_files(cwd, ".sql"):
         langs.add("sql")
 
-    # YAML (beyond config files — actual YAML content)
-    config_names = {
+    # YAML (beyond compose / lintro config files — including nested trees).
+    yaml_skip_names = {
         ".lintro-config.yaml",
         ".lintro-config.yml",
         "docker-compose.yml",
         "docker-compose.yaml",
+        "compose.yml",
+        "compose.yaml",
     }
-    if any(
-        f.name not in config_names for f in chain(cwd.glob("*.yaml"), cwd.glob("*.yml"))
+    if _has_project_file(
+        cwd,
+        match=lambda path: (
+            path.suffix.lower() in {".yaml", ".yml"}
+            and path.name not in yaml_skip_names
+        ),
     ):
         langs.add("yaml")
 
-    # Markdown (more than just README)
-    for md_count, _ in enumerate(cwd.glob("*.md"), 1):
-        if md_count >= 2:
-            langs.add("markdown")
-            break
+    # Markdown (more than just a lone README; nested docs/ counts).
+    md_count = 0
+    for path in _iter_project_files(cwd):
+        if path.suffix.lower() == ".md":
+            md_count += 1
+            if md_count >= 2:
+                langs.add("markdown")
+                break
 
     # TOML (beyond pyproject.toml / Cargo.toml)
-    toml_files = [
-        f for f in cwd.glob("*.toml") if f.name not in ("pyproject.toml", "Cargo.toml")
-    ]
-    if toml_files:
+    if _has_project_file(
+        cwd,
+        match=lambda path: (
+            path.suffix.lower() == ".toml"
+            and path.name not in ("pyproject.toml", "Cargo.toml")
+        ),
+    ):
         langs.add("toml")
 
     # Markup and stylesheets that language_map already knows about.
-    if _has_source_files(cwd, "**/*.html", "**/*.htm"):
+    if _has_source_files(cwd, ".html", ".htm"):
         langs.add("html")
-    if _has_source_files(
-        cwd,
-        "**/*.css",
-        "**/*.scss",
-        "**/*.sass",
-        "**/*.less",
-    ):
+    if _has_source_files(cwd, ".css", ".scss", ".sass", ".less"):
         langs.add("css")
-    if _has_source_files(cwd, "**/.env*"):
+    if _has_project_file(
+        cwd,
+        match=lambda path: path.name.startswith(".env"),
+    ):
         langs.add("dotenv")
 
     # Prose/documentation formats beyond Markdown (vale targets).

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -449,6 +449,7 @@ def execute_run(
             tools,
             ctx.selection_action,
             ignore_conflicts=ignore_conflicts,
+            scan_roots=list(paths),
         )
     except ValueError as e:
         logger.console_output(f"Error: {e}")

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -463,18 +463,18 @@ def execute_run(
 
     # On a no-config first run the toolset is scoped to detected languages;
     # tell the user what was selected and how to customize. Suppressed for
-    # machine-readable output and score-only mode.
+    # machine-readable stdout and score-only mode.
     if (
         tools_result.scoped_by_detection
-        and output_format.lower() not in {"json", "sarif"}
+        and not ctx.clean_stdout_output
         and not ctx.score_only
     ):
         from lintro.utils.execution.tool_configuration import format_detection_notice
 
         logger.console_output(
             text=format_detection_notice(
-                tools_result.detected_languages,
-                tools_to_run,
+                detected_languages=tools_result.detected_languages,
+                to_run=tools_to_run,
             ),
             color="cyan",
         )

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -461,6 +461,24 @@ def execute_run(
     tools_to_run = tools_result.to_run
     skipped_tools = tools_result.skipped
 
+    # On a no-config first run the toolset is scoped to detected languages;
+    # tell the user what was selected and how to customize. Suppressed for
+    # machine-readable output and score-only mode.
+    if (
+        tools_result.scoped_by_detection
+        and output_format.lower() not in {"json", "sarif"}
+        and not ctx.score_only
+    ):
+        from lintro.utils.execution.tool_configuration import format_detection_notice
+
+        logger.console_output(
+            text=format_detection_notice(
+                tools_result.detected_languages,
+                tools_to_run,
+            ),
+            color="cyan",
+        )
+
     if not tools_to_run and not skipped_tools:
         logger.console_output("No tools to run.")
         return finalize_artifact(

--- a/tests/unit/cli/test_check_command.py
+++ b/tests/unit/cli/test_check_command.py
@@ -26,6 +26,7 @@ def test_check_command_help(cli_runner: CliRunner) -> None:
 
     assert_that(result.exit_code).is_equal_to(0)
     assert_that(result.output).contains("Check files")
+    assert_that(result.output).contains("language-detected")
 
 
 def test_check_command_default_paths(

--- a/tests/unit/cli/test_format_command.py
+++ b/tests/unit/cli/test_format_command.py
@@ -26,6 +26,7 @@ def test_format_command_help(cli_runner: CliRunner) -> None:
 
     assert_that(result.exit_code).is_equal_to(0)
     assert_that(result.output).contains("Format")
+    assert_that(result.output).contains("language-detected")
 
 
 def test_format_command_default_paths(

--- a/tests/unit/cli_utils/commands/test_setup_command.py
+++ b/tests/unit/cli_utils/commands/test_setup_command.py
@@ -249,6 +249,63 @@ def test_detect_dotenv(
     assert_that(langs).contains("dotenv")
 
 
+def test_detect_nested_yaml(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detect YAML from a nested file, not only the repo root."""
+    nested = tmp_path / "deploy"
+    nested.mkdir()
+    (nested / "values.yaml").write_text("replicaCount: 1\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).contains("yaml")
+
+
+def test_detect_nested_shell(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detect Shell from a nested ``*.sh`` outside ``scripts/``."""
+    nested = tmp_path / "tools"
+    nested.mkdir()
+    (nested / "release.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).contains("shell")
+
+
+def test_detect_nested_markdown_docs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two nested Markdown files enable Markdown tools; a lone README does not."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    (docs / "changelog.md").write_text("# Changelog\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).contains("markdown")
+
+
+def test_detect_javascript_ignores_dist_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``*.js`` only inside ``dist/`` does not mark JavaScript."""
+    bundled = tmp_path / "dist"
+    bundled.mkdir()
+    (bundled / "app.js").write_text("console.log(1)\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).does_not_contain("javascript")
+
+
 # ── detect_package_managers ──────────────────────────────────────────
 
 

--- a/tests/unit/cli_utils/commands/test_setup_command.py
+++ b/tests/unit/cli_utils/commands/test_setup_command.py
@@ -306,6 +306,57 @@ def test_detect_javascript_ignores_dist_bundle(
     assert_that(langs).does_not_contain("javascript")
 
 
+def test_detect_readme_only_is_not_markdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lone root README.md does not enable Markdown tools."""
+    (tmp_path / "README.md").write_text("# Sample\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).does_not_contain("markdown")
+
+
+def test_detect_dotenv_ignores_envrc(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direnv ``.envrc`` does not select dotenv tools."""
+    (tmp_path / ".envrc").write_text("export FOO=bar\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).does_not_contain("dotenv")
+
+
+def test_detect_vue_via_source_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detect Vue from a lone ``*.vue`` with no package.json."""
+    (tmp_path / "App.vue").write_text("<template></template>\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).contains("vue")
+
+
+def test_detect_github_actions_yaml_is_not_generic_yaml(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Workflow files select GitHub Actions, not generic yamllint YAML."""
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).contains("github_actions")
+    assert_that(langs).does_not_contain("yaml")
+
+
 # ── detect_package_managers ──────────────────────────────────────────
 
 

--- a/tests/unit/cli_utils/commands/test_setup_command.py
+++ b/tests/unit/cli_utils/commands/test_setup_command.py
@@ -330,6 +330,46 @@ def test_detect_dotenv_ignores_envrc(
     assert_that(langs).does_not_contain("dotenv")
 
 
+def test_detect_dotenv_ignores_example_template(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Template dotenv files such as ``.env.example`` do not select dotenv tools.
+
+    Args:
+        tmp_path: Temporary project directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    (tmp_path / ".env.example").write_text("FOO=bar\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).does_not_contain("dotenv")
+
+
+def test_detect_javascript_ignores_toolchain_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Root toolchain configs such as ``eslint.config.js`` are not JS source.
+
+    Args:
+        tmp_path: Temporary project directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    (tmp_path / "main.py").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "eslint.config.js").write_text("export default [];\n", encoding="utf-8")
+    (tmp_path / "commitlint.config.js").write_text(
+        "module.exports = {};\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).contains("python")
+    assert_that(langs).does_not_contain("javascript", "typescript")
+
+
 def test_detect_vue_via_source_file(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/cli_utils/commands/test_setup_command.py
+++ b/tests/unit/cli_utils/commands/test_setup_command.py
@@ -357,6 +357,31 @@ def test_detect_github_actions_yaml_is_not_generic_yaml(
     assert_that(langs).does_not_contain("yaml")
 
 
+def test_detect_languages_from_explicit_root_without_chdir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detect languages from *root* even when cwd has no markers.
+
+    Args:
+        tmp_path: Temporary directories for the project and empty cwd.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    project = tmp_path / "project"
+    empty = tmp_path / "empty"
+    project.mkdir()
+    empty.mkdir()
+    (project / "main.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.chdir(empty)
+
+    langs = detect_project_languages(root=project)
+    assert_that(langs).contains("python")
+    assert_that(
+        detect_project_languages(root=project / "main.py"),
+    ).contains("python")
+    assert_that(detect_project_languages()).does_not_contain("python")
+
+
 # ── detect_package_managers ──────────────────────────────────────────
 
 

--- a/tests/unit/cli_utils/commands/test_setup_command.py
+++ b/tests/unit/cli_utils/commands/test_setup_command.py
@@ -162,6 +162,93 @@ def test_detect_empty_project(
     assert_that(langs).is_empty()
 
 
+def test_detect_python_via_source_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detect Python from a lone ``*.py`` with no project manifest."""
+    (tmp_path / "main.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).contains("python")
+
+
+def test_detect_python_ignores_vendored_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``*.py`` only inside a vendored tree does not mark Python."""
+    vendored = tmp_path / ".venv" / "lib"
+    vendored.mkdir(parents=True)
+    (vendored / "sitecustomize.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).does_not_contain("python")
+
+
+def test_detect_javascript_via_source_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detect JavaScript from a lone ``*.js`` with no package.json."""
+    (tmp_path / "index.js").write_text("console.log(1)\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).contains("javascript")
+    assert_that(langs).does_not_contain("typescript")
+
+
+def test_detect_typescript_via_source_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detect TypeScript from a lone ``*.ts`` with no package.json."""
+    (tmp_path / "index.ts").write_text("export const x = 1\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).contains("typescript")
+
+
+def test_detect_typescript_ignores_declaration_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A vendored-style ``*.d.ts`` alone does not mark TypeScript."""
+    (tmp_path / "index.d.ts").write_text("export {}\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).does_not_contain("typescript")
+
+
+def test_detect_rust_via_source_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detect Rust from a lone ``*.rs`` with no Cargo.toml."""
+    (tmp_path / "main.rs").write_text("fn main() {}\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).contains("rust")
+
+
+def test_detect_dotenv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detect dotenv from a ``.env`` file."""
+    (tmp_path / ".env").write_text("FOO=bar\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    langs = detect_project_languages()
+    assert_that(langs).contains("dotenv")
+
+
 # ── detect_package_managers ──────────────────────────────────────────
 
 

--- a/tests/unit/compatibility/test_compatibility_ruff_black.py
+++ b/tests/unit/compatibility/test_compatibility_ruff_black.py
@@ -157,15 +157,14 @@ def _setup_tools(monkeypatch: pytest.MonkeyPatch) -> tuple[FakeTool, FakeTool]:
     def fake_get_tools(
         _tools: str | None,
         _action: str,
-        *,
-        ignore_conflicts: bool = False,  # noqa: ARG001 — must match caller kwarg name
+        **_kwargs: object,
     ) -> ToolsToRunResult:
         """Return tool names for ruff and black in order.
 
         Args:
             _tools: Optional tool selection string (ignored in tests).
             _action: Runner action being executed (ignored in tests).
-            ignore_conflicts: Whether to ignore tool conflicts (ignored in tests).
+            **_kwargs: Extra get_tools_to_run keywords (ignored in tests).
 
         Returns:
             ToolsToRunResult with ruff and black tools.

--- a/tests/unit/mcp/test_toolkit_lint.py
+++ b/tests/unit/mcp/test_toolkit_lint.py
@@ -109,6 +109,7 @@ def test_lint_tools_schema_describes_language_scoped_default(
     for name in ("lintro_check", "lintro_format"):
         description = specs[name].input_schema["properties"]["tools"]["description"]
         assert_that(description).contains("language-detected")
+        assert_that(description).contains("['all']")
 
 
 def test_lint_tools_are_listed_with_their_annotations(workspace: Path) -> None:

--- a/tests/unit/mcp/test_toolkit_lint.py
+++ b/tests/unit/mcp/test_toolkit_lint.py
@@ -19,6 +19,7 @@ from assertpy import assert_that
 from mcp.client import Client
 from mcp.types import CallToolResult, Tool
 
+from lintro.mcp.toolkits.lint import build_lint_toolkit
 from tests.unit.mcp.session_helpers import payload_from_result, run_in_memory_client
 
 _T = TypeVar("_T")
@@ -94,6 +95,20 @@ def workspace(tmp_path: Path) -> Path:
     """
     (tmp_path / "bad.py").write_text(_UNFORMATTED, encoding="utf-8")
     return tmp_path.resolve()
+
+
+def test_lint_tools_schema_describes_language_scoped_default(
+    tmp_path: Path,
+) -> None:
+    """MCP check/format tools advertise the no-config language-detected default.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+    """
+    specs = {spec.name: spec for spec in build_lint_toolkit(workspace=tmp_path)}
+    for name in ("lintro_check", "lintro_format"):
+        description = specs[name].input_schema["properties"]["tools"]["description"]
+        assert_that(description).contains("language-detected")
 
 
 def test_lint_tools_are_listed_with_their_annotations(workspace: Path) -> None:

--- a/tests/unit/tools/executor/test_execute_render_split.py
+++ b/tests/unit/tools/executor/test_execute_render_split.py
@@ -262,6 +262,114 @@ def test_execute_run_streams_results_through_the_callback(
     assert_that(seen).is_equal_to(["ruff"])
 
 
+def _console_texts(fake_logger: Any) -> str:
+    """Join all console_output text passed to the fake logger.
+
+    Args:
+        fake_logger: FakeLogger instance whose calls were recorded.
+
+    Returns:
+        A single string of all console_output text arguments.
+    """
+    parts: list[str] = []
+    for name, args, kwargs in fake_logger.calls:
+        if name != "console_output":
+            continue
+        if "text" in kwargs:
+            parts.append(str(kwargs["text"]))
+        elif args:
+            parts.append(str(args[0]))
+    return "\n".join(parts)
+
+
+def test_execute_run_prints_detection_notice_on_human_output(
+    monkeypatch: pytest.MonkeyPatch,
+    executor_doubles: None,
+    tmp_path: Path,
+    fake_logger: Any,
+) -> None:
+    """A language-scoped run prints the no-config notice on human output.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        executor_doubles: Neutralized executor collaborators.
+        tmp_path: Temporary directory standing in for the run directory.
+        fake_logger: Console logger double.
+    """
+    monkeypatch.setattr(
+        te,
+        "get_tools_to_run",
+        lambda tools, action, **_kw: ToolsToRunResult(
+            to_run=["ruff"],
+            detected_languages=["python"],
+            scoped_by_detection=True,
+        ),
+    )
+    monkeypatch.setattr(
+        tool_manager,
+        "get_tool",
+        lambda name: _FakeTool(issues_count=0),
+    )
+    ctx = _context(tmp_path=tmp_path, fake_logger=fake_logger)
+
+    _run_execute(ctx=ctx, tools=None)
+
+    assert_that(_console_texts(fake_logger)).contains("No config found")
+    assert_that(_console_texts(fake_logger)).contains("lintro init")
+
+
+@pytest.mark.parametrize(
+    ("output_format", "score_only"),
+    [
+        ("json", False),
+        ("grid", True),
+    ],
+    ids=["json", "score-only"],
+)
+def test_execute_run_hides_detection_notice_on_machine_or_score_output(
+    monkeypatch: pytest.MonkeyPatch,
+    executor_doubles: None,
+    tmp_path: Path,
+    fake_logger: Any,
+    output_format: str,
+    score_only: bool,
+) -> None:
+    """JSON stdout and ``--score`` suppress the language-scope notice.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        executor_doubles: Neutralized executor collaborators.
+        tmp_path: Temporary directory standing in for the run directory.
+        fake_logger: Console logger double.
+        output_format: Output format the run was asked for.
+        score_only: Whether stdout carries only the numeric score.
+    """
+    monkeypatch.setattr(
+        te,
+        "get_tools_to_run",
+        lambda tools, action, **_kw: ToolsToRunResult(
+            to_run=["ruff"],
+            detected_languages=["python"],
+            scoped_by_detection=True,
+        ),
+    )
+    monkeypatch.setattr(
+        tool_manager,
+        "get_tool",
+        lambda name: _FakeTool(issues_count=0),
+    )
+    ctx = _context(
+        tmp_path=tmp_path,
+        fake_logger=fake_logger,
+        output_format=output_format,
+        score_only=score_only,
+    )
+
+    _run_execute(ctx=ctx, tools=None, output_format=output_format)
+
+    assert_that(_console_texts(fake_logger)).does_not_contain("No config found")
+
+
 def test_execute_run_marks_an_unknown_tool_selection_as_early_exit(
     monkeypatch: pytest.MonkeyPatch,
     executor_doubles: None,

--- a/tests/unit/tools/executor/test_execute_render_split.py
+++ b/tests/unit/tools/executor/test_execute_render_split.py
@@ -370,6 +370,45 @@ def test_execute_run_hides_detection_notice_on_machine_or_score_output(
     assert_that(_console_texts(fake_logger)).does_not_contain("No config found")
 
 
+def test_execute_run_forwards_paths_as_scan_roots(
+    monkeypatch: pytest.MonkeyPatch,
+    executor_doubles: None,
+    tmp_path: Path,
+    fake_logger: Any,
+) -> None:
+    """Default chk/fmt runs pass scan paths into language detection.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        executor_doubles: Neutralized executor collaborators.
+        tmp_path: Temporary directory standing in for the run directory.
+        fake_logger: Console logger double.
+    """
+    captured: dict[str, object] = {}
+
+    def fake_get_tools(
+        tools: str | None,
+        action: object,
+        **kwargs: object,
+    ) -> ToolsToRunResult:
+        captured["tools"] = tools
+        captured["scan_roots"] = kwargs.get("scan_roots")
+        return ToolsToRunResult(to_run=["ruff"])
+
+    monkeypatch.setattr(te, "get_tools_to_run", fake_get_tools)
+    monkeypatch.setattr(
+        tool_manager,
+        "get_tool",
+        lambda name: _FakeTool(issues_count=0),
+    )
+    ctx = _context(tmp_path=tmp_path, fake_logger=fake_logger)
+
+    _run_execute(ctx=ctx, tools=None, paths=["src/app.py"])
+
+    assert_that(captured["tools"]).is_none()
+    assert_that(captured["scan_roots"]).is_equal_to(["src/app.py"])
+
+
 def test_execute_run_marks_an_unknown_tool_selection_as_early_exit(
     monkeypatch: pytest.MonkeyPatch,
     executor_doubles: None,

--- a/tests/unit/tools/executor/test_tool_configuration_detection.py
+++ b/tests/unit/tools/executor/test_tool_configuration_detection.py
@@ -1,0 +1,150 @@
+"""Tests for no-config language-scoped tool selection in get_tools_to_run.
+
+Covers issue #1420: a no-config first run should scope the toolset to the
+languages actually present in the project instead of firing every registered
+tool. Explicit ``--tools`` and configured projects keep the full behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+
+from lintro.config.config_loader import clear_config_cache
+from lintro.utils.execution.tool_configuration import (
+    format_detection_notice,
+    get_tools_to_run,
+)
+
+
+def _write_python_project(root: Path) -> None:
+    """Create a minimal Python-only project in *root*.
+
+    Args:
+        root: Directory to populate.
+    """
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "sample"\nversion = "0.0.0"\n',
+        encoding="utf-8",
+    )
+    (root / "main.py").write_text("x = 1\n", encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_cache() -> None:
+    """Reset the config singleton before and after each test."""
+    clear_config_cache()
+    yield
+    clear_config_cache()
+
+
+def test_no_config_python_project_scopes_to_python_tools(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """No-config Python project scopes the toolset to Python-relevant tools.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary project directory.
+    """
+    _write_python_project(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    result = get_tools_to_run(tools=None, action="check")
+
+    assert_that(result.scoped_by_detection).is_true()
+    assert_that(result.detected_languages).contains("python")
+    # Python tools survive scoping.
+    assert_that(result.to_run).contains("ruff", "black", "mypy", "bandit")
+    # Tools for absent languages are dropped entirely (no SKIP wall).
+    assert_that(result.to_run).does_not_contain(
+        "clippy",
+        "rustfmt",
+        "svelte-check",
+        "sqlfluff",
+    )
+    skipped_names = [s.name for s in result.skipped]
+    assert_that(skipped_names).does_not_contain("clippy", "svelte-check")
+
+
+def test_explicit_tools_overrides_detection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Explicit ``--tools`` bypasses language scoping.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary project directory.
+    """
+    _write_python_project(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    result = get_tools_to_run(tools="yamllint", action="check")
+
+    assert_that(result.scoped_by_detection).is_false()
+    assert_that(result.to_run).is_equal_to(["yamllint"])
+
+
+def test_explicit_all_is_not_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Explicit ``--tools all`` runs the full toolset without scoping.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary project directory.
+    """
+    _write_python_project(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    result = get_tools_to_run(tools="all", action="check")
+
+    assert_that(result.scoped_by_detection).is_false()
+    # Non-Python tools remain candidates under explicit "all".
+    assert_that(result.to_run).contains("ruff", "clippy", "sqlfluff")
+
+
+def test_configured_project_not_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A project with a config file keeps the full, unscoped behavior.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary project directory.
+    """
+    _write_python_project(tmp_path)
+    (tmp_path / ".lintro-config.yaml").write_text(
+        "tools:\n  ruff:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    result = get_tools_to_run(tools=None, action="check")
+
+    assert_that(result.scoped_by_detection).is_false()
+    # With a config present, non-Python tools are candidates (enabled by
+    # default), not silently dropped by detection.
+    assert_that(result.to_run).contains("ruff", "clippy", "sqlfluff")
+
+
+def test_format_detection_notice_groups_by_language() -> None:
+    """The notice groups tools by language and points at ``lintro init``."""
+    notice = format_detection_notice(
+        detected_languages=["python"],
+        to_run=["ruff", "black", "mypy", "bandit"],
+    )
+
+    assert_that(notice).contains("No config found")
+    assert_that(notice).contains("python:")
+    assert_that(notice).contains("lintro init")

--- a/tests/unit/tools/executor/test_tool_configuration_detection.py
+++ b/tests/unit/tools/executor/test_tool_configuration_detection.py
@@ -153,3 +153,65 @@ def test_format_detection_notice_groups_by_language() -> None:
     assert_that(notice).contains("No config found")
     assert_that(notice).contains("python:")
     assert_that(notice).contains("lintro init")
+
+
+@pytest.mark.parametrize(
+    ("files", "language", "expected_tool"),
+    [
+        (
+            {"package.json": '{"devDependencies":{"svelte":"4.0.0"}}\n'},
+            "svelte",
+            "svelte-check",
+        ),
+        (
+            {"package.json": '{"devDependencies":{"astro":"4.0.0"}}\n'},
+            "astro",
+            "astro-check",
+        ),
+        (
+            {"package.json": '{"devDependencies":{"vue":"3.0.0"}}\n'},
+            "vue",
+            "vue-tsc",
+        ),
+        ({"index.html": "<html></html>\n"}, "html", "html_validate"),
+        ({"app.css": "body { color: black; }\n"}, "css", "stylelint"),
+    ],
+    ids=["svelte", "astro", "vue", "html", "css"],
+)
+def test_no_config_scopes_hyphenated_and_markup_tools(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    files: dict[str, str],
+    language: str,
+    expected_tool: str,
+) -> None:
+    """Hyphenated checkers and HTML/CSS tools survive no-config scoping.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary project directory.
+        files: Files to write in the temp project.
+        language: Expected detected language identifier.
+        expected_tool: Registered tool name that must remain in ``to_run``.
+    """
+    for relative, contents in files.items():
+        (tmp_path / relative).write_text(contents, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    result = get_tools_to_run(tools=None, action="check")
+
+    assert_that(result.scoped_by_detection).is_true()
+    assert_that(result.detected_languages).contains(language)
+    assert_that(result.to_run).contains(expected_tool)
+
+
+def test_format_detection_notice_aliases_hyphenated_tools() -> None:
+    """Notice grouping matches hyphenated registry names to underscored maps."""
+    notice = format_detection_notice(
+        detected_languages=["svelte"],
+        to_run=["svelte-check", "gitleaks"],
+    )
+
+    assert_that(notice).contains("svelte: svelte-check")
+    assert_that(notice).contains("security: gitleaks")

--- a/tests/unit/tools/executor/test_tool_configuration_detection.py
+++ b/tests/unit/tools/executor/test_tool_configuration_detection.py
@@ -356,3 +356,152 @@ def test_nonempty_tool_lintro_table_is_not_scoped(
 
     assert_that(result.scoped_by_detection).is_false()
     assert_that(result.to_run).contains("ruff", "clippy")
+
+
+def test_scan_roots_scope_when_cwd_has_no_markers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Language scoping uses *scan_roots*, not only the process cwd.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary project and empty cwd directories.
+    """
+    project = tmp_path / "project"
+    empty = tmp_path / "empty"
+    project.mkdir()
+    empty.mkdir()
+    _write_python_project(project)
+    monkeypatch.chdir(empty)
+    clear_config_cache()
+
+    result = get_tools_to_run(
+        tools=None,
+        action="check",
+        scan_roots=[project],
+    )
+
+    assert_that(result.scoped_by_detection).is_true()
+    assert_that(result.detected_languages).contains("python")
+    assert_that(result.to_run).contains("ruff")
+    assert_that(result.to_run).does_not_contain("clippy")
+
+    duplicate = get_tools_to_run(
+        tools=None,
+        action="check",
+        scan_roots=[project, project],
+    )
+    assert_that(duplicate.detected_languages).is_equal_to(result.detected_languages)
+
+
+def test_scan_roots_union_languages_across_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Multiple scan roots union their detected languages.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary Python and Rust trees plus an empty cwd.
+    """
+    python_root = tmp_path / "python"
+    rust_root = tmp_path / "rust"
+    empty = tmp_path / "empty"
+    python_root.mkdir()
+    rust_root.mkdir()
+    empty.mkdir()
+    _write_python_project(python_root)
+    (rust_root / "Cargo.toml").write_text(
+        '[package]\nname = "sample"\nversion = "0.0.0"\nedition = "2021"\n',
+        encoding="utf-8",
+    )
+    (rust_root / "main.rs").write_text("fn main() {}\n", encoding="utf-8")
+    monkeypatch.chdir(empty)
+    clear_config_cache()
+
+    result = get_tools_to_run(
+        tools=None,
+        action="check",
+        scan_roots=[python_root, rust_root],
+    )
+
+    assert_that(result.scoped_by_detection).is_true()
+    assert_that(result.detected_languages).contains("python", "rust")
+    assert_that(result.to_run).contains("ruff", "clippy")
+
+
+def test_file_scan_root_uses_parent_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A file scan target detects languages from its parent directory.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary project and empty cwd directories.
+    """
+    project = tmp_path / "project"
+    empty = tmp_path / "empty"
+    project.mkdir()
+    empty.mkdir()
+    source = project / "main.py"
+    source.write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.chdir(empty)
+    clear_config_cache()
+
+    result = get_tools_to_run(
+        tools=None,
+        action="check",
+        scan_roots=[source],
+    )
+
+    assert_that(result.scoped_by_detection).is_true()
+    assert_that(result.detected_languages).contains("python")
+    assert_that(result.to_run).contains("ruff")
+
+
+def test_commitlint_included_when_native_config_present(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Unmapped tools with a native config survive language-scoped first runs.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary Python project with a commitlint config.
+    """
+    _write_python_project(tmp_path)
+    (tmp_path / "commitlint.config.js").write_text(
+        "module.exports = { extends: ['@commitlint/config-conventional'] };\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    result = get_tools_to_run(tools=None, action="check")
+
+    assert_that(result.scoped_by_detection).is_true()
+    assert_that(result.to_run).contains("commitlint", "ruff")
+    assert_that(result.to_run).does_not_contain("clippy")
+
+
+def test_commitlint_omitted_without_native_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Unmapped tools stay dropped when no native config is present.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary Python project without a commitlint config.
+    """
+    _write_python_project(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    result = get_tools_to_run(tools=None, action="check")
+
+    assert_that(result.scoped_by_detection).is_true()
+    assert_that(result.to_run).contains("ruff")
+    assert_that(result.to_run).does_not_contain("commitlint")

--- a/tests/unit/tools/executor/test_tool_configuration_detection.py
+++ b/tests/unit/tools/executor/test_tool_configuration_detection.py
@@ -483,7 +483,7 @@ def test_commitlint_included_when_native_config_present(
 
     assert_that(result.scoped_by_detection).is_true()
     assert_that(result.to_run).contains("commitlint", "ruff")
-    assert_that(result.to_run).does_not_contain("clippy")
+    assert_that(result.to_run).does_not_contain("clippy", "prettier", "oxlint", "tsc")
 
 
 def test_commitlint_omitted_without_native_config(

--- a/tests/unit/tools/executor/test_tool_configuration_detection.py
+++ b/tests/unit/tools/executor/test_tool_configuration_detection.py
@@ -176,8 +176,9 @@ def test_format_detection_notice_groups_by_language() -> None:
         ({"index.html": "<html></html>\n"}, "html", "html_validate"),
         ({"app.css": "body { color: black; }\n"}, "css", "stylelint"),
         ({".env": "FOO=bar\n"}, "dotenv", "dotenv_linter"),
+        ({"deploy/values.yaml": "replicaCount: 1\n"}, "yaml", "yamllint"),
     ],
-    ids=["svelte", "astro", "vue", "html", "css", "dotenv"],
+    ids=["svelte", "astro", "vue", "html", "css", "dotenv", "nested-yaml"],
 )
 def test_no_config_scopes_hyphenated_and_markup_tools(
     monkeypatch: pytest.MonkeyPatch,
@@ -196,7 +197,9 @@ def test_no_config_scopes_hyphenated_and_markup_tools(
         expected_tool: Registered tool name that must remain in ``to_run``.
     """
     for relative, contents in files.items():
-        (tmp_path / relative).write_text(contents, encoding="utf-8")
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(contents, encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     clear_config_cache()
 

--- a/tests/unit/tools/executor/test_tool_configuration_detection.py
+++ b/tests/unit/tools/executor/test_tool_configuration_detection.py
@@ -151,7 +151,7 @@ def test_format_detection_notice_groups_by_language() -> None:
     )
 
     assert_that(notice).contains("No config found")
-    assert_that(notice).contains("python:")
+    assert_that(notice).contains("python: bandit, black, mypy, ruff")
     assert_that(notice).contains("lintro init")
 
 
@@ -175,8 +175,9 @@ def test_format_detection_notice_groups_by_language() -> None:
         ),
         ({"index.html": "<html></html>\n"}, "html", "html_validate"),
         ({"app.css": "body { color: black; }\n"}, "css", "stylelint"),
+        ({".env": "FOO=bar\n"}, "dotenv", "dotenv_linter"),
     ],
-    ids=["svelte", "astro", "vue", "html", "css"],
+    ids=["svelte", "astro", "vue", "html", "css", "dotenv"],
 )
 def test_no_config_scopes_hyphenated_and_markup_tools(
     monkeypatch: pytest.MonkeyPatch,
@@ -215,3 +216,140 @@ def test_format_detection_notice_aliases_hyphenated_tools() -> None:
 
     assert_that(notice).contains("svelte: svelte-check")
     assert_that(notice).contains("security: gitleaks")
+
+
+def test_no_config_source_only_python_scopes_to_python_tools(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A lone ``*.py`` with no pyproject still selects Python tools.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary project directory.
+    """
+    (tmp_path / "main.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    result = get_tools_to_run(tools=None, action="check")
+
+    assert_that(result.scoped_by_detection).is_true()
+    assert_that(result.detected_languages).contains("python")
+    assert_that(result.to_run).contains("ruff", "black", "mypy", "bandit")
+    assert_that(result.to_run).does_not_contain("clippy", "rustfmt")
+
+
+def test_no_config_source_only_javascript_scopes_to_js_tools(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A lone ``*.js`` with no package.json still selects JS formatters.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary project directory.
+    """
+    (tmp_path / "index.js").write_text("console.log(1)\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    result = get_tools_to_run(tools=None, action="check")
+
+    assert_that(result.scoped_by_detection).is_true()
+    assert_that(result.detected_languages).contains("javascript")
+    assert_that(result.to_run).contains("prettier")
+    assert_that(result.to_run).does_not_contain("ruff", "clippy")
+
+
+def test_no_config_empty_cwd_keeps_security_tools_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An empty directory still scopes, dropping language tools.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary project directory.
+    """
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    result = get_tools_to_run(tools=None, action="check")
+
+    assert_that(result.scoped_by_detection).is_true()
+    assert_that(result.detected_languages).is_empty()
+    assert_that(result.to_run).contains("gitleaks")
+    assert_that(result.to_run).does_not_contain("ruff", "clippy", "prettier")
+
+
+def test_no_config_fmt_action_is_language_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Format (``fmt``) uses the same no-config language allowlist as check.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary project directory.
+    """
+    _write_python_project(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    result = get_tools_to_run(tools=None, action="fmt")
+
+    assert_that(result.scoped_by_detection).is_true()
+    assert_that(result.detected_languages).contains("python")
+    assert_that(result.to_run).contains("black")
+    assert_that(result.to_run).does_not_contain("clippy", "rustfmt")
+
+
+def test_empty_tool_lintro_table_still_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An empty ``[tool.lintro]`` table is not a config, so scoping applies.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary project directory.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "sample"\nversion = "0.0.0"\n\n[tool.lintro]\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "main.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    result = get_tools_to_run(tools=None, action="check")
+
+    assert_that(result.scoped_by_detection).is_true()
+    assert_that(result.to_run).contains("ruff")
+    assert_that(result.to_run).does_not_contain("clippy")
+
+
+def test_nonempty_tool_lintro_table_is_not_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A non-empty ``[tool.lintro]`` table keeps the unscoped toolset.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary project directory.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "sample"\nversion = "0.0.0"\n\n'
+        "[tool.lintro.execution]\nfail_fast = false\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "main.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    result = get_tools_to_run(tools=None, action="check")
+
+    assert_that(result.scoped_by_detection).is_false()
+    assert_that(result.to_run).contains("ruff", "clippy")

--- a/tests/unit/tools/executor/test_tool_configuration_detection.py
+++ b/tests/unit/tools/executor/test_tool_configuration_detection.py
@@ -7,6 +7,7 @@ tool. Explicit ``--tools`` and configured projects keep the full behavior.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -33,8 +34,12 @@ def _write_python_project(root: Path) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _reset_config_cache() -> None:
-    """Reset the config singleton before and after each test."""
+def _reset_config_cache() -> Iterator[None]:
+    """Reset the config singleton before and after each test.
+
+    Yields:
+        None: Control back to the test after cache reset.
+    """
     clear_config_cache()
     yield
     clear_config_cache()

--- a/tests/unit/tools/executor/test_tool_executor_more.py
+++ b/tests/unit/tools/executor/test_tool_executor_more.py
@@ -147,8 +147,7 @@ def test_main_loop_get_tool_raises_appends_failure(
     def fake_get_tools(
         _tools: str | None,
         _action: str,
-        *,
-        ignore_conflicts: bool = False,  # noqa: ARG001 — must match caller kwarg name
+        **_kwargs: object,
     ) -> ToolsToRunResult:
         return ToolsToRunResult(to_run=["ruff", "black"])
 
@@ -213,8 +212,7 @@ def test_write_reports_errors_are_swallowed(monkeypatch: pytest.MonkeyPatch) -> 
     def fake_get_tools(
         _tools: str | None,
         _action: str,
-        *,
-        ignore_conflicts: bool = False,  # noqa: ARG001 — must match caller kwarg name
+        **_kwargs: object,
     ) -> ToolsToRunResult:
         return ToolsToRunResult(to_run=["ruff"])
 
@@ -292,7 +290,7 @@ def test_unknown_post_check_tool_is_skipped(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(
         te,
         "get_tools_to_run",
-        lambda _tools, _action, *, ignore_conflicts=False: ToolsToRunResult(
+        lambda _tools, _action, **_kwargs: ToolsToRunResult(
             to_run=["ruff"],
         ),
         raising=True,
@@ -367,7 +365,7 @@ def test_post_checks_early_filter_removes_black_from_main(
     monkeypatch.setattr(
         te,
         "get_tools_to_run",
-        lambda _tools, _action, *, ignore_conflicts=False: ToolsToRunResult(
+        lambda _tools, _action, **_kwargs: ToolsToRunResult(
             to_run=["ruff", "black"],
         ),
         raising=True,
@@ -468,7 +466,7 @@ def test_all_filtered_results_in_no_tools_warning(
     monkeypatch.setattr(
         te,
         "get_tools_to_run",
-        lambda _tools, _action, *, ignore_conflicts=False: ToolsToRunResult(
+        lambda _tools, _action, **_kwargs: ToolsToRunResult(
             to_run=["black"],
         ),
         raising=True,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(cli): scope no-config first run to detected languages
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Closes #1420.

A brand-new user running `lintro chk .` with no config previously got all ~32 tools fired at once (rust, svelte/vue/astro, sqlfluff, vale, ...) against, say, a single Python file — a wall of PASS/SKIP rows.

This scopes the **no-config default run** (no `--tools`, no `.lintro-config.yaml` discovered) to the languages actually present in the project, reusing the same detection `init` already uses:

- `detect_project_languages()` + `ManifestRegistry.tools_for_languages()` compute the enabled toolset.
- One informational line names the detected toolset and points at `lintro init`, e.g.:
  `No config found — using detected toolset (python: bandit, black, mypy, pydoclint, ruff, semgrep; security: gitleaks, osv_scanner). Run 'lintro init' to customize.`
- Tools not applicable to detected languages are **omitted entirely** (not surfaced as SKIP rows), so there is no 25-row SKIP wall.
- **Escape hatches preserved:** explicit `--tools <names>` and `--tools all` bypass scoping; any project with a config file (`.lintro-config.yaml` or `[tool.lintro]`) keeps the full, unscoped behavior. (Approach A from the issue.)

On a Python-only sample project this drops the run from 32 tools to 8.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1420

## Details

- New `tests/unit/tools/executor/test_tool_configuration_detection.py` (assertpy, real detection in `tmp_path`): Python-only no-config project scopes to Python tools and drops rust/svelte/sql tools; explicit `--tools yamllint` overrides; `--tools all` unscoped; configured project unscoped; notice format.
- `uv run lintro chk` on changed files: clean (health 100/100).
- `uv run pytest -n auto`: 6655 passed, 10 skipped, 1 failed — the failure (`test_prepare_execution_version_check_fails_returns_early_result`) is a known worktree-spurious failure unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detects project languages during default runs, including source-only and nested projects.
  * Limits checks to relevant tools, while preserving native-config tools and security checks.
  * Applies detection across specified scan paths.
  * Displays detected languages and selected tools in human-readable output.
  * Explicit tool selections, `all`, and configured projects continue using the requested toolset.
  * Machine-readable and score-only output remains unchanged.

* **Documentation**
  * Clarified language-detected defaults and the `--tools all` option.

* **Tests**
  * Added coverage for detection, overrides, scan paths, configuration, and notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->