### PR TITLE
docs: format CONTRIBUTING.md with prettier

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 Thanks for your interest in contributing to Lintro!
 
-The full contributor guide lives in [`docs/contributing.md`](docs/contributing.md).
-It covers Conventional Commits, PR titles and version bumps, local development
-setup, testing, and the review process.
+The full contributor guide lives in [`docs/contributing.md`](docs/contributing.md). It
+covers Conventional Commits, PR titles and version bumps, local development setup,
+testing, and the review process.
 
 Please read [`docs/contributing.md`](docs/contributing.md) before opening a pull
 request.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  docs: format CONTRIBUTING.md with prettier
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [x] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

- CONTRIBUTING.md (added in #1455) is prettier-unclean on main; diff-scoped dogfooding missed it, but every full-scope dogfooding run (nightly, PR full-lint) now fails on it — first seen on #1462's updated branch.
- Reformatted with `uv run lintro fmt`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

_No linked issues._

## Details

- `uv run lintro chk CONTRIBUTING.md`: clean.
