### PR TITLE
fix(cli): force UTF-8 stdio under ASCII locales

### DIFF
--- a/lintro/cli.py
+++ b/lintro/cli.py
@@ -30,8 +30,8 @@ def _is_utf8_encoding(encoding: str | None) -> bool:
     try:
         return codecs.lookup(encoding).name == "utf-8"
     except LookupError:
-        normalized = encoding.lower().replace("-", "").replace("_", "")
-        return normalized == "utf8"
+        # Unknown codec name — cannot be a UTF-8 alias.
+        return False
 
 
 def _reconfigure_stream_utf8(stream: TextIO) -> None:

--- a/lintro/cli.py
+++ b/lintro/cli.py
@@ -1,6 +1,8 @@
 """Command-line interface for Lintro."""
 
-from typing import Any, cast
+import contextlib
+import sys
+from typing import Any, TextIO, cast
 
 import click
 from rich.console import Console
@@ -11,6 +13,50 @@ from rich.text import Text
 from lintro import __version__
 from lintro.cli_utils.command_chainer import CommandChainer
 from lintro.utils.logger_setup import setup_cli_logging
+
+
+def _is_utf8_encoding(encoding: str | None) -> bool:
+    """Return whether *encoding* names UTF-8.
+
+    Args:
+        encoding: Encoding name from a text stream, or ``None``.
+
+    Returns:
+        ``True`` when *encoding* is UTF-8 (any common spelling).
+    """
+    if encoding is None:
+        return False
+    return encoding.lower().replace("-", "") == "utf8"
+
+
+def _reconfigure_stream_utf8(stream: TextIO) -> None:
+    """Reconfigure *stream* to UTF-8 when it is not already UTF-8.
+
+    Args:
+        stream: Stdout/stderr (or compatible) text stream.
+    """
+    if _is_utf8_encoding(getattr(stream, "encoding", None)):
+        return
+    reconfigure = getattr(stream, "reconfigure", None)
+    if reconfigure is None:
+        return
+    # Closed streams or non-reconfigurable wrappers — leave as-is.
+    with contextlib.suppress(OSError, ValueError, AttributeError):
+        reconfigure(encoding="utf-8", errors="replace")
+
+
+def ensure_utf8_stdio() -> None:
+    """Force UTF-8 on stdout/stderr for ASCII (and other non-UTF-8) locales.
+
+    Rich help output includes emoji (e.g. the wrench in the banner). Under
+    ASCII locales such as ``en_US.US-ASCII``, writing that output raises
+    ``UnicodeEncodeError``. CPython's UTF-8 mode rescues ``C``/``POSIX`` but
+    not other ASCII locales, and ``PYTHONUTF8``/``PYTHONIOENCODING`` do not
+    reach Nuitka onefile binaries — only an in-process reconfigure does.
+    """
+    _reconfigure_stream_utf8(sys.stdout)
+    _reconfigure_stream_utf8(sys.stderr)
+
 
 # Configure loguru for CLI commands (help, version, etc.)
 # Only WARNING and above will show. DEBUG logs go to file when tool_executor runs.
@@ -235,4 +281,5 @@ cli.add_command(versions_command, name="version")
 
 def main() -> None:
     """Entry point for the CLI."""
+    ensure_utf8_stdio()
     cli()

--- a/lintro/cli.py
+++ b/lintro/cli.py
@@ -1,5 +1,6 @@
 """Command-line interface for Lintro."""
 
+import codecs
 import contextlib
 import sys
 from typing import Any, TextIO, cast
@@ -26,7 +27,11 @@ def _is_utf8_encoding(encoding: str | None) -> bool:
     """
     if encoding is None:
         return False
-    return encoding.lower().replace("-", "") == "utf8"
+    try:
+        return codecs.lookup(encoding).name == "utf-8"
+    except LookupError:
+        normalized = encoding.lower().replace("-", "").replace("_", "")
+        return normalized == "utf8"
 
 
 def _reconfigure_stream_utf8(stream: TextIO) -> None:
@@ -38,10 +43,10 @@ def _reconfigure_stream_utf8(stream: TextIO) -> None:
     if _is_utf8_encoding(getattr(stream, "encoding", None)):
         return
     reconfigure = getattr(stream, "reconfigure", None)
-    if reconfigure is None:
+    if not callable(reconfigure):
         return
     # Closed streams or non-reconfigurable wrappers — leave as-is.
-    with contextlib.suppress(OSError, ValueError, AttributeError):
+    with contextlib.suppress(OSError, ValueError, AttributeError, TypeError):
         reconfigure(encoding="utf-8", errors="replace")
 
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -76,7 +76,7 @@ def _assert_help_succeeds_under_ascii_stdio(*, env: dict[str, str]) -> None:
         subprocess.run(  # nosec B603 - fixed argv run against project CLI; shell=False
             [sys.executable, "-m", "lintro", "--help"],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
             timeout=30,
             env=env,
             check=False,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for CLI module."""
 
+import os
 import subprocess  # nosec B404 - subprocess is used to drive the tool/CLI under test; invocations use shell=False
 import sys
 from unittest.mock import patch
@@ -10,6 +11,52 @@ from click.testing import CliRunner
 
 from lintro.cli import cli
 
+_ASCII_LOCALE = "en_US.US-ASCII"
+
+
+def _scrubbed_ascii_env() -> dict[str, str]:
+    """Build a brew-test-like env that forces ASCII stdio encoding.
+
+    Returns:
+        Minimal environment with ``LC_ALL`` set to an ASCII locale.
+    """
+    path = os.environ.get("PATH", "/usr/bin:/bin")
+    home = os.environ.get("HOME", "/tmp")
+    env: dict[str, str] = {
+        "PATH": path,
+        "HOME": home,
+        "LC_ALL": _ASCII_LOCALE,
+        "LANG": _ASCII_LOCALE,
+    }
+    # Preserve vars needed to find the project venv / uv cache when present.
+    for key in ("VIRTUAL_ENV", "UV_PROJECT_ENVIRONMENT", "UV_CACHE_DIR", "TMPDIR"):
+        value = os.environ.get(key)
+        if value:
+            env[key] = value
+    return env
+
+
+def _ascii_locale_forces_ascii_stdio() -> bool:
+    """Return whether ``en_US.US-ASCII`` makes CPython use ASCII stdio.
+
+    Returns:
+        ``True`` when a subprocess under that locale reports ASCII encoding.
+    """
+    probe = subprocess.run(  # nosec B603 - fixed argv; encoding probe only
+        [
+            sys.executable,
+            "-c",
+            "import sys; print(sys.stdout.encoding or '')",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=_scrubbed_ascii_env(),
+        check=False,
+    )
+    encoding = probe.stdout.strip().lower().replace("-", "")
+    return probe.returncode == 0 and encoding in {"ascii", "usascii"}
+
 
 def test_cli_help() -> None:
     """Test that CLI shows help."""
@@ -17,6 +64,53 @@ def test_cli_help() -> None:
     result = runner.invoke(cli, ["--help"])
     assert_that(result.exit_code).is_equal_to(0)
     assert_that(result.output).contains("Lintro")
+
+
+def _assert_help_succeeds_under_ascii_stdio(*, env: dict[str, str]) -> None:
+    """Assert ``python -m lintro --help`` succeeds with ASCII stdio.
+
+    Args:
+        env: Subprocess environment that forces ASCII stdout encoding.
+    """
+    result = (
+        subprocess.run(  # nosec B603 - fixed argv run against project CLI; shell=False
+            [sys.executable, "-m", "lintro", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+            check=False,
+        )
+    )
+    combined = f"{result.stdout}\n{result.stderr}"
+    assert_that(combined).does_not_contain("UnicodeEncodeError")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("Lintro")
+    assert_that(result.stdout).contains("🔧")
+
+
+def test_cli_help_succeeds_under_ascii_locale() -> None:
+    """Regression #1379: --help must not UnicodeEncodeError under ASCII locales.
+
+    Mirrors brew-test's scrubbed environment (``env -i`` + ``LC_ALL`` ASCII).
+    Skips when the host lacks an effective ``en_US.US-ASCII`` locale.
+    """
+    if not _ascii_locale_forces_ascii_stdio():
+        pytest.skip(f"Locale {_ASCII_LOCALE} does not force ASCII stdio on this host")
+
+    _assert_help_succeeds_under_ascii_stdio(env=_scrubbed_ascii_env())
+
+
+def test_cli_help_succeeds_with_ascii_pythonioencoding() -> None:
+    """Regression #1379: --help survives PYTHONIOENCODING=ascii (portable).
+
+    Covers hosts without ``en_US.US-ASCII`` while still forcing ASCII stdio
+    the same way a non-UTF-8 locale would for the CPython package entry point.
+    """
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "ascii"
+    env.pop("PYTHONUTF8", None)
+    _assert_help_succeeds_under_ascii_stdio(env=env)
 
 
 def test_cli_version() -> None:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -29,7 +29,13 @@ def _scrubbed_ascii_env() -> dict[str, str]:
         "LANG": _ASCII_LOCALE,
     }
     # Preserve vars needed to find the project venv / uv cache when present.
-    for key in ("VIRTUAL_ENV", "UV_PROJECT_ENVIRONMENT", "UV_CACHE_DIR", "TMPDIR"):
+    for key in (
+        "VIRTUAL_ENV",
+        "UV_PROJECT_ENVIRONMENT",
+        "UV_CACHE_DIR",
+        "TMPDIR",
+        "PYTHONPATH",
+    ):
         value = os.environ.get(key)
         if value:
             env[key] = value

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -78,6 +78,8 @@ def test_main_entry_point() -> None:
         patch("lintro.cli.cli") as mock_cli,
     ):
         mock_cli.return_value = None
+        # Fail if cli() runs before UTF-8 stdio is forced.
+        mock_cli.side_effect = lambda: mock_ensure.assert_called_once_with()
         # main() calls cli() which is a Click command
         with contextlib.suppress(SystemExit):
             main()
@@ -92,6 +94,8 @@ def test_main_entry_point() -> None:
         ("UTF-8", True),
         ("utf8", True),
         ("UTF8", True),
+        ("utf_8", True),
+        ("UTF_8", True),
         ("ascii", False),
         ("US-ASCII", False),
         ("latin-1", False),
@@ -102,6 +106,8 @@ def test_main_entry_point() -> None:
         "UTF-8",
         "utf8",
         "UTF8",
+        "utf_8",
+        "UTF_8",
         "ascii",
         "US-ASCII",
         "latin-1",

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -77,7 +77,6 @@ def test_main_entry_point() -> None:
         patch("lintro.cli.ensure_utf8_stdio") as mock_ensure,
         patch("lintro.cli.cli") as mock_cli,
     ):
-        mock_cli.return_value = None
         # Fail if cli() runs before UTF-8 stdio is forced.
         mock_cli.side_effect = lambda: mock_ensure.assert_called_once_with()
         # main() calls cli() which is a Click command

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -3,14 +3,21 @@
 from __future__ import annotations
 
 import contextlib
-from unittest.mock import patch
+import io
+from unittest.mock import MagicMock, patch
 
 import pytest
 from assertpy import assert_that
 from click.testing import CliRunner
 
 from lintro import __version__
-from lintro.cli import LintroGroup, cli, main
+from lintro.cli import (
+    LintroGroup,
+    _is_utf8_encoding,
+    cli,
+    ensure_utf8_stdio,
+    main,
+)
 
 # =============================================================================
 # CLI Entry Point Tests
@@ -65,13 +72,96 @@ def test_cli_invalid_command(cli_runner: CliRunner) -> None:
 
 
 def test_main_entry_point() -> None:
-    """Verify main() entry point calls cli()."""
-    with patch("lintro.cli.cli") as mock_cli:
+    """Verify main() forces UTF-8 stdio then calls cli()."""
+    with (
+        patch("lintro.cli.ensure_utf8_stdio") as mock_ensure,
+        patch("lintro.cli.cli") as mock_cli,
+    ):
         mock_cli.return_value = None
         # main() calls cli() which is a Click command
         with contextlib.suppress(SystemExit):
             main()
+        mock_ensure.assert_called_once_with()
         mock_cli.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("encoding", "expected"),
+    [
+        ("utf-8", True),
+        ("UTF-8", True),
+        ("utf8", True),
+        ("UTF8", True),
+        ("ascii", False),
+        ("US-ASCII", False),
+        ("latin-1", False),
+        (None, False),
+    ],
+    ids=[
+        "utf-8",
+        "UTF-8",
+        "utf8",
+        "UTF8",
+        "ascii",
+        "US-ASCII",
+        "latin-1",
+        "none",
+    ],
+)
+def test_is_utf8_encoding(encoding: str | None, expected: bool) -> None:
+    """Verify UTF-8 encoding name detection.
+
+    Args:
+        encoding: Encoding name under test.
+        expected: Whether the name should be treated as UTF-8.
+    """
+    assert_that(_is_utf8_encoding(encoding)).is_equal_to(expected)
+
+
+def test_ensure_utf8_stdio_reconfigures_ascii_streams() -> None:
+    """ASCII stdout/stderr must be reconfigured to UTF-8."""
+    stdout = MagicMock()
+    stdout.encoding = "ascii"
+    stderr = MagicMock()
+    stderr.encoding = "US-ASCII"
+
+    with (
+        patch("lintro.cli.sys.stdout", stdout),
+        patch("lintro.cli.sys.stderr", stderr),
+    ):
+        ensure_utf8_stdio()
+
+    stdout.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")
+    stderr.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")
+
+
+def test_ensure_utf8_stdio_skips_utf8_streams() -> None:
+    """Already-UTF-8 streams must not be reconfigured."""
+    stdout = MagicMock()
+    stdout.encoding = "utf-8"
+    stderr = MagicMock()
+    stderr.encoding = "UTF-8"
+
+    with (
+        patch("lintro.cli.sys.stdout", stdout),
+        patch("lintro.cli.sys.stderr", stderr),
+    ):
+        ensure_utf8_stdio()
+
+    stdout.reconfigure.assert_not_called()
+    stderr.reconfigure.assert_not_called()
+
+
+def test_ensure_utf8_stdio_tolerates_streams_without_reconfigure() -> None:
+    """Streams lacking reconfigure (e.g. StringIO) must not raise."""
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    with (
+        patch("lintro.cli.sys.stdout", stdout),
+        patch("lintro.cli.sys.stderr", stderr),
+    ):
+        ensure_utf8_stdio()
 
 
 # =============================================================================


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(cli): force UTF-8 stdio under ASCII locales
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Under ASCII locales such as `en_US.US-ASCII` (including Homebrew’s scrubbed
`brew test` environment), Rich help output crashed with `UnicodeEncodeError`
when writing emoji (e.g. 🔧 in the `--help` banner). CPython’s UTF-8 mode
rescues `C`/`POSIX`, but not other ASCII locales, and `PYTHONUTF8` /
`PYTHONIOENCODING` do not reach Nuitka onefile binaries.

`main()` now calls `ensure_utf8_stdio()` to reconfigure stdout/stderr to
UTF-8 (`errors="replace"`) when they are not already UTF-8. The Nuitka
entry path (`lintro/__main__.py` → `main()`) picks this up automatically.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt`, `uv run lintro chk`, `uv run lintro tst`)

## Closes

- Closes #1379

## Details

- Guarded `reconfigure` on stdout/stderr; UTF-8 detection via `codecs.lookup`
  (covers `utf-8` / `utf8` / `utf_8`).
- Regression tests: scrubbed `LC_ALL=en_US.US-ASCII` (skip if locale ineffective)
  and portable `PYTHONIOENCODING=ascii`.
- Unit tests cover encoding detection, reconfigure behavior, and `main()` call order.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `ensure_utf8_stdio()` to `lintro/cli.py`, called at the start of `main()`, which reconfigures `sys.stdout`/`sys.stderr` to UTF-8 when they are not already UTF-8. This fixes `UnicodeEncodeError` crashes when Rich renders emoji (e.g. `🔧`) under ASCII locales that CPython's built-in UTF-8 mode does not cover, including Nuitka onefile binary environments.

- `_is_utf8_encoding` / `_reconfigure_stream_utf8` / `ensure_utf8_stdio` are added to `cli.py`; both the `lintro` console-script entry point and `python -m lintro` path go through `main()` and therefore pick up the fix automatically.
- Two integration regression tests (locale-scrubbed env and portable `PYTHONIOENCODING=ascii`) plus four focused unit tests are added to verify encoding detection, reconfigure behavior, and call ordering inside `main()`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is self-contained, both entry points go through `main()`, and the fix takes effect before Rich ever constructs its Console.

The reconfiguration logic is correct and defensive: it skips streams that are already UTF-8, skips streams without `reconfigure`, and suppresses the expected OS/IO errors. `Console()` is instantiated inside `format_help()` (well after reconfiguration), so it always sees the updated encoding. The new tests cover encoding detection, reconfigure behavior, UTF-8 pass-through, non-reconfigurable streams, and call ordering — both at the unit level and via real subprocesses.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/cli.py | Adds `ensure_utf8_stdio()` and helpers with correct guard logic; `Console()` is instantiated inside `format_help()` (after reconfiguration), so the fix takes effect before Rich ever touches stdout. |
| tests/cli/test_cli.py | Adds two subprocess-level regression tests: one that probes and skips if the locale is ineffective, and one portable `PYTHONIOENCODING=ascii` variant; env construction now preserves `PYTHONPATH` to avoid `ModuleNotFoundError` masking the real failure. |
| tests/unit/cli/test_cli.py | Four well-structured unit tests covering encoding detection, reconfigure call assertions, UTF-8 skip path, and tolerance for streams without `reconfigure`; call-ordering check in `test_main_entry_point` correctly surfaces ordering violations via `AssertionError` (not suppressed by `contextlib.suppress(SystemExit)`). |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cli): address Greptile nits on UTF-8..."](https://github.com/lgtm-hq/py-lintro/commit/5fca2d181dd6ba5f664851c379b5e8c63361cf0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45054326)</sub>

<!-- /greptile_comment -->