### PR TITLE
feat(doctor): tool update advisories with per-tool update-channel resolver

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -639,7 +639,8 @@ pip, node package manager). Outdated and incompatible tools may also include an
 `update_command`. Execute `upgrade_hint` to change installs; `update_command` is
 diagnostic and can disagree with `upgrade_hint` when the binary path and the manifest
 strategy name different managers. `lintro versions --json` and MCP `lintro_versions`
-include the same `advisory` and a `binary_path` resolved past cargo/bash wrappers.
+include the same `advisory` (the object, or `null` when the tool is current) and a
+`binary_path` resolved past cargo/bash wrappers.
 
 The human `lintro versions` table labels a tool **OUTDATED** when it meets the minimum
 but trails the recommended pin (`below_recommended`). JSON `version_check_passed` stays

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -634,13 +634,14 @@ lintro doctor --json               # machine-readable output for CI
 The `--json` output includes per-tool fields: `installed`, `recommended`, `min_version`,
 `status` (OK, MISSING, OUTDATED, INCOMPATIBLE, DISABLED, UNKNOWN), `install_hint`, and
 `upgrade_hint`. `upgrade_hint` is the install-strategy command (pin conflicts, uv vs
-pip, node package manager). Outdated and incompatible tools may also include an
-`advisory` object with the detected update channel and a path-heuristic
-`update_command`. Execute `upgrade_hint` to change installs; `update_command` is
-diagnostic and can disagree with `upgrade_hint` when the binary path and the manifest
-strategy name different managers. `lintro versions --json` and MCP `lintro_versions`
-include the same `advisory` (the object, or `null` when the tool is current) and a
-`binary_path` resolved past cargo/bash wrappers.
+pip, node package manager). Doctor, `lintro versions --json`, and MCP `lintro_versions`
+always include `advisory` (`null` when the tool is current). When present, that object
+has the detected update channel and a path-heuristic `update_command`. Execute
+`upgrade_hint` to change installs; `update_command` is diagnostic and can disagree with
+`upgrade_hint` when the binary path and the manifest strategy name different managers.
+`binary_path` is the tool binary resolved past cargo/bash wrappers. A `standalone` or
+`unknown` path does not inherit a pip/npm/cargo `update_command` from manifest
+`install.type`.
 
 The human `lintro versions` table labels a tool **OUTDATED** when it meets the minimum
 but trails the recommended pin (`below_recommended`). JSON `version_check_passed` stays

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -634,9 +634,12 @@ lintro doctor --json               # machine-readable output for CI
 The `--json` output includes per-tool fields: `installed`, `recommended`, `min_version`,
 `status` (OK, MISSING, OUTDATED, INCOMPATIBLE, DISABLED, UNKNOWN), `install_hint`, and
 `upgrade_hint`. `upgrade_hint` is the install-strategy command (pin conflicts, uv vs
-pip, node package manager). Outdated tools may also include an `advisory` object with
-the detected update channel and a channel-template `update_command`; that template is
-diagnostic and does not replace `upgrade_hint`.
+pip, node package manager). Outdated and incompatible tools may also include an
+`advisory` object with the detected update channel and a path-heuristic
+`update_command`. Execute `upgrade_hint` to change installs; `update_command` is
+diagnostic and can disagree with `upgrade_hint` when the binary path and the manifest
+strategy name different managers. `lintro versions --json` and MCP `lintro_versions`
+include the same `advisory` and a `binary_path` resolved past cargo/bash wrappers.
 
 ### Node.js Package Manager Policy {#node-package-manager-policy}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -641,6 +641,11 @@ diagnostic and can disagree with `upgrade_hint` when the binary path and the man
 strategy name different managers. `lintro versions --json` and MCP `lintro_versions`
 include the same `advisory` and a `binary_path` resolved past cargo/bash wrappers.
 
+The human `lintro versions` table labels a tool **OUTDATED** when it meets the minimum
+but trails the recommended pin (`below_recommended`). JSON `version_check_passed` stays
+`true` in that case; only the table status string changed from PASS. The process still
+exits 0.
+
 ### Node.js Package Manager Policy {#node-package-manager-policy}
 
 `lintro install` used to pick bun whenever bun happened to be on `PATH`, and to install

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -633,7 +633,10 @@ lintro doctor --json               # machine-readable output for CI
 
 The `--json` output includes per-tool fields: `installed`, `recommended`, `min_version`,
 `status` (OK, MISSING, OUTDATED, INCOMPATIBLE, DISABLED, UNKNOWN), `install_hint`, and
-`upgrade_hint`.
+`upgrade_hint`. `upgrade_hint` is the install-strategy command (pin conflicts, uv vs
+pip, node package manager). Outdated tools may also include an `advisory` object with
+the detected update channel and a channel-template `update_command`; that template is
+diagnostic and does not replace `upgrade_hint`.
 
 ### Node.js Package Manager Policy {#node-package-manager-policy}
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -298,7 +298,15 @@ what lintro requires.
       "below_recommended": false,
       "status": "outdated",
       "error": "Version 0.9.0 is below minimum requirement 0.15.9",
-      "install_hint": "uv pip install 'ruff>=0.15.9'"
+      "install_hint": "uv pip install 'ruff>=0.15.9'",
+      "binary_path": "/proj/.venv/bin/ruff",
+      "advisory": {
+        "tool": "ruff",
+        "installed": "0.9.0",
+        "latest_known": "0.15.9",
+        "channel": "pip",
+        "update_command": "uv pip install --upgrade 'ruff>=0.15.9'"
+      }
     }
   ],
   "summary": { "ok": 28, "outdated": 7, "missing": 2, "total": 37 }

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -704,7 +704,7 @@ def _output_json(
         for r in all_results
         if r.status == ToolStatus.DISABLED and r.tool.tier != "dev"
     )
-    tools_json: dict[str, dict[str, str | None]] = {}
+    tools_json: dict[str, dict[str, object]] = {}
     issues: list[dict[str, str]] = []
 
     for r in all_results:

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -39,6 +39,7 @@ from lintro.tools.core.tool_registry import (
     CATEGORY_LABELS,
     ManifestRegistry,
 )
+<<<<<<< HEAD
 from lintro.tools.definitions.oxlint_doctor import (
     OxlintCheckResult,
     check_oxlint_type_aware,
@@ -47,6 +48,16 @@ from lintro.utils.doctor_report import (
     ToolCheckResult,
     collect_tool_checks,
     mcp_extra_status,
+=======
+from lintro.tools.core.update_channels import (
+    VersionAdvisory,
+    format_advisory_line,
+)
+from lintro.tools.core.version_checking import build_version_advisory
+from lintro.tools.core.version_parsing import (
+    compare_versions,
+    extract_version_from_output,
+>>>>>>> 74653b25 (feat(cli): surface update advisories in doctor and versions)
 )
 from lintro.utils.environment import (
     EnvironmentReport,
@@ -55,6 +66,186 @@ from lintro.utils.environment import (
 )
 
 
+<<<<<<< HEAD
+=======
+@dataclass
+class ToolCheckResult:
+    """Result of a tool health check.
+
+    Attributes:
+        tool: The manifest tool entry.
+        status: ToolStatus value (OK, MISSING, OUTDATED, UNKNOWN).
+        installed_version: Detected version string, or None.
+        error: Error type if check failed.
+        details: Additional error details.
+        path: Filesystem path where the tool was found.
+        install_hint: Context-aware install command.
+        upgrade_hint: Context-aware upgrade command for outdated tools.
+        advisory: Structured update advisory when outdated/incompatible.
+    """
+
+    tool: ManifestTool
+    status: ToolStatus
+    installed_version: str | None = None
+    error: str | None = None
+    details: str | None = None
+    path: str | None = None
+    install_hint: str = ""
+    upgrade_hint: str = ""
+    advisory: VersionAdvisory | None = None
+
+
+def _check_tool(tool: ManifestTool, context: RuntimeContext) -> ToolCheckResult:
+    """Check a single tool's installation status and version.
+
+    Args:
+        tool: Manifest tool entry.
+        context: Runtime context for install hints.
+
+    Returns:
+        ToolCheckResult with status and details.
+    """
+    strategy = get_strategy(tool.install_type)
+    env = context.environment
+    if strategy:
+        _args = (
+            env,
+            tool.name,
+            tool.version,
+            tool.install_package,
+            tool.install_component,
+        )
+        hint = strategy.install_hint(*_args)
+        upgrade_hint = strategy.upgrade_hint(*_args)
+    else:
+        hint = f"Install {tool.name} manually"
+        upgrade_hint = f"Upgrade {tool.name} manually"
+
+    if not tool.version_command:
+        return ToolCheckResult(
+            tool=tool,
+            status=ToolStatus.MISSING,
+            error="no_command",
+            details="No version command defined",
+            install_hint=hint,
+            upgrade_hint=upgrade_hint,
+        )
+
+    # Find the main executable (may be a wrapper like "sh", "cargo", etc.)
+    main_cmd = tool.version_command[0]
+    tool_path = shutil.which(main_cmd)
+
+    if not tool_path:
+        return ToolCheckResult(
+            tool=tool,
+            status=ToolStatus.MISSING,
+            error="not_in_path",
+            details=main_cmd,
+            install_hint=hint,
+            upgrade_hint=upgrade_hint,
+        )
+
+    try:
+        result = subprocess.run(  # nosec B603 - argv is an internally-built list run with shell=False; binary resolved from a known command, no user shell input
+            tool.version_command,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        output = result.stdout + result.stderr
+
+        if result.returncode != 0:
+            return ToolCheckResult(
+                tool=tool,
+                status=ToolStatus.MISSING,
+                error="command_failed",
+                details=f"Exit {result.returncode}: {output[:100]}",
+                path=tool_path,
+                install_hint=hint,
+            )
+
+        version = extract_version_from_output(output, tool.name)
+        if not version:
+            return ToolCheckResult(
+                tool=tool,
+                status=ToolStatus.UNKNOWN,
+                error="no_version",
+                details=f"Output: {output[:100]}",
+                path=tool_path,
+                install_hint=hint,
+            )
+
+        status = _compare_versions(version, tool.version, tool.min_version)
+        advisory = None
+        final_upgrade = upgrade_hint
+        if status in (ToolStatus.OUTDATED, ToolStatus.INCOMPATIBLE):
+            advisory = build_version_advisory(
+                tool=tool.name,
+                installed=version,
+                latest_known=tool.version,
+                binary_path=tool_path,
+                install_package=tool.install_package,
+                install_type=tool.install_type,
+                channel_override=tool.update_channel,
+            )
+            if advisory and advisory.update_command:
+                final_upgrade = advisory.update_command
+        return ToolCheckResult(
+            tool=tool,
+            status=status,
+            installed_version=version,
+            path=tool_path,
+            install_hint=hint,
+            upgrade_hint=final_upgrade,
+            advisory=advisory,
+        )
+    except subprocess.TimeoutExpired:
+        return ToolCheckResult(
+            tool=tool,
+            status=ToolStatus.MISSING,
+            error="timeout",
+            path=tool_path,
+            install_hint=hint,
+            upgrade_hint=upgrade_hint,
+        )
+    except (FileNotFoundError, OSError) as e:
+        return ToolCheckResult(
+            tool=tool,
+            status=ToolStatus.MISSING,
+            error="os_error",
+            details=str(e),
+            install_hint=hint,
+            upgrade_hint=upgrade_hint,
+        )
+
+
+def _compare_versions(
+    installed: str,
+    recommended: str,
+    minimum: str,
+) -> ToolStatus:
+    """Compare installed version against recommended and minimum versions.
+
+    Args:
+        installed: Installed version string.
+        recommended: Recommended/tested version from manifest.
+        minimum: Hard minimum compatible version from manifest.
+
+    Returns:
+        ToolStatus.OK, OUTDATED, INCOMPATIBLE, or UNKNOWN.
+    """
+    try:
+        if compare_versions(installed, minimum) < 0:
+            return ToolStatus.INCOMPATIBLE
+        if compare_versions(installed, recommended) < 0:
+            return ToolStatus.OUTDATED
+        return ToolStatus.OK
+    except ValueError:
+        return ToolStatus.UNKNOWN
+
+
+>>>>>>> 74653b25 (feat(cli): surface update advisories in doctor and versions)
 def _render_category(
     console: Console,
     category_label: str,
@@ -119,7 +310,10 @@ def _render_tool_line(
         line.append(f"{r.installed_version:<10}", style="yellow")
         line.append(f"(>= {r.tool.min_version}, rec. {r.tool.version})", style="dim")
         console.print(line)
-        console.print(f"         [dim]Upgrade: {r.upgrade_hint}[/dim]")
+        if r.advisory:
+            console.print(f"         [dim]{format_advisory_line(r.advisory)}[/dim]")
+        else:
+            console.print(f"         [dim]Upgrade: {r.upgrade_hint}[/dim]")
 
     elif r.status == ToolStatus.INCOMPATIBLE:
         line = Text("    ")
@@ -128,7 +322,10 @@ def _render_tool_line(
         line.append(f"{r.installed_version or '?':<10}", style="red")
         line.append(f"(>= {r.tool.min_version})", style="dim")
         console.print(line)
-        console.print(f"         [dim]Upgrade: {r.upgrade_hint}[/dim]")
+        if r.advisory:
+            console.print(f"         [dim]{format_advisory_line(r.advisory)}[/dim]")
+        else:
+            console.print(f"         [dim]Upgrade: {r.upgrade_hint}[/dim]")
 
     elif r.status == ToolStatus.DISABLED:
         line = Text("    ")
@@ -605,6 +802,21 @@ def doctor_command(
     _render_oxlint_checks(display_console, oxlint_checks)
     _render_mcp_extra(display_console)
 
+    advisories = [
+        r.advisory
+        for r in prod_results
+        if r.advisory is not None
+        and r.status in (ToolStatus.OUTDATED, ToolStatus.INCOMPATIBLE)
+    ]
+    if advisories:
+        display_console.print()
+        display_console.print("  [bold]Update advisories[/bold]")
+        for advisory in advisories:
+            line = Text("    ")
+            line.append("⚠ ", style="yellow")
+            line.append(format_advisory_line(advisory))
+            display_console.print(line)
+
     # Summary
     display_console.print()
     summary_parts: list[str] = []
@@ -683,11 +895,11 @@ def _output_json(
         for r in all_results
         if r.status == ToolStatus.DISABLED and r.tool.tier != "dev"
     )
-    tools_json: dict[str, dict[str, str | None]] = {}
+    tools_json: dict[str, dict[str, object]] = {}
     issues: list[dict[str, str]] = []
 
     for r in all_results:
-        tools_json[r.tool.name] = {
+        tool_entry: dict[str, object] = {
             "recommended": r.tool.version,
             "min_version": r.tool.min_version,
             "expected": r.tool.min_version,
@@ -702,6 +914,9 @@ def _output_json(
             "install_hint": r.install_hint,
             "upgrade_hint": r.upgrade_hint,
         }
+        if r.advisory is not None:
+            tool_entry["advisory"] = r.advisory.to_dict()
+        tools_json[r.tool.name] = tool_entry
         if r.status == ToolStatus.MISSING and r.tool.tier != "dev":
             issues.append(
                 {

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -707,9 +707,8 @@ def _output_json(
             "path": r.path,
             "install_hint": r.install_hint,
             "upgrade_hint": r.upgrade_hint,
+            "advisory": r.advisory.to_dict() if r.advisory is not None else None,
         }
-        if r.advisory is not None:
-            tool_entry["advisory"] = r.advisory.to_dict()
         tools_json[r.tool.name] = tool_entry
         if r.status == ToolStatus.MISSING and r.tool.tier != "dev":
             issues.append(

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -39,11 +39,11 @@ from lintro.tools.core.tool_registry import (
     CATEGORY_LABELS,
     ManifestRegistry,
 )
+from lintro.tools.core.update_channels import format_advisory_line
 from lintro.tools.definitions.oxlint_doctor import (
     OxlintCheckResult,
     check_oxlint_type_aware,
 )
-from lintro.tools.core.update_channels import format_advisory_line
 from lintro.utils.doctor_report import (
     ToolCheckResult,
     collect_tool_checks,
@@ -122,7 +122,7 @@ def _render_tool_line(
         console.print(line)
         if r.advisory:
             console.print(f"         [dim]{format_advisory_line(r.advisory)}[/dim]")
-        else:
+        if r.upgrade_hint:
             console.print(f"         [dim]Upgrade: {r.upgrade_hint}[/dim]")
 
     elif r.status == ToolStatus.INCOMPATIBLE:
@@ -134,7 +134,7 @@ def _render_tool_line(
         console.print(line)
         if r.advisory:
             console.print(f"         [dim]{format_advisory_line(r.advisory)}[/dim]")
-        else:
+        if r.upgrade_hint:
             console.print(f"         [dim]Upgrade: {r.upgrade_hint}[/dim]")
 
     elif r.status == ToolStatus.DISABLED:
@@ -345,8 +345,7 @@ def _generate_markdown_report(
         for check in ai_checks:
             hint = check.hint or "-"
             lines.append(
-                f"| {check.name} | {check.status.upper()} "
-                f"| {check.message} | {hint} |",
+                f"| {check.name} | {check.status.upper()} | {check.message} | {hint} |",
             )
 
     lines.append("")

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -39,25 +39,15 @@ from lintro.tools.core.tool_registry import (
     CATEGORY_LABELS,
     ManifestRegistry,
 )
-<<<<<<< HEAD
 from lintro.tools.definitions.oxlint_doctor import (
     OxlintCheckResult,
     check_oxlint_type_aware,
 )
+from lintro.tools.core.update_channels import format_advisory_line
 from lintro.utils.doctor_report import (
     ToolCheckResult,
     collect_tool_checks,
     mcp_extra_status,
-=======
-from lintro.tools.core.update_channels import (
-    VersionAdvisory,
-    format_advisory_line,
-)
-from lintro.tools.core.version_checking import build_version_advisory
-from lintro.tools.core.version_parsing import (
-    compare_versions,
-    extract_version_from_output,
->>>>>>> 74653b25 (feat(cli): surface update advisories in doctor and versions)
 )
 from lintro.utils.environment import (
     EnvironmentReport,
@@ -66,186 +56,6 @@ from lintro.utils.environment import (
 )
 
 
-<<<<<<< HEAD
-=======
-@dataclass
-class ToolCheckResult:
-    """Result of a tool health check.
-
-    Attributes:
-        tool: The manifest tool entry.
-        status: ToolStatus value (OK, MISSING, OUTDATED, UNKNOWN).
-        installed_version: Detected version string, or None.
-        error: Error type if check failed.
-        details: Additional error details.
-        path: Filesystem path where the tool was found.
-        install_hint: Context-aware install command.
-        upgrade_hint: Context-aware upgrade command for outdated tools.
-        advisory: Structured update advisory when outdated/incompatible.
-    """
-
-    tool: ManifestTool
-    status: ToolStatus
-    installed_version: str | None = None
-    error: str | None = None
-    details: str | None = None
-    path: str | None = None
-    install_hint: str = ""
-    upgrade_hint: str = ""
-    advisory: VersionAdvisory | None = None
-
-
-def _check_tool(tool: ManifestTool, context: RuntimeContext) -> ToolCheckResult:
-    """Check a single tool's installation status and version.
-
-    Args:
-        tool: Manifest tool entry.
-        context: Runtime context for install hints.
-
-    Returns:
-        ToolCheckResult with status and details.
-    """
-    strategy = get_strategy(tool.install_type)
-    env = context.environment
-    if strategy:
-        _args = (
-            env,
-            tool.name,
-            tool.version,
-            tool.install_package,
-            tool.install_component,
-        )
-        hint = strategy.install_hint(*_args)
-        upgrade_hint = strategy.upgrade_hint(*_args)
-    else:
-        hint = f"Install {tool.name} manually"
-        upgrade_hint = f"Upgrade {tool.name} manually"
-
-    if not tool.version_command:
-        return ToolCheckResult(
-            tool=tool,
-            status=ToolStatus.MISSING,
-            error="no_command",
-            details="No version command defined",
-            install_hint=hint,
-            upgrade_hint=upgrade_hint,
-        )
-
-    # Find the main executable (may be a wrapper like "sh", "cargo", etc.)
-    main_cmd = tool.version_command[0]
-    tool_path = shutil.which(main_cmd)
-
-    if not tool_path:
-        return ToolCheckResult(
-            tool=tool,
-            status=ToolStatus.MISSING,
-            error="not_in_path",
-            details=main_cmd,
-            install_hint=hint,
-            upgrade_hint=upgrade_hint,
-        )
-
-    try:
-        result = subprocess.run(  # nosec B603 - argv is an internally-built list run with shell=False; binary resolved from a known command, no user shell input
-            tool.version_command,
-            capture_output=True,
-            text=True,
-            timeout=10,
-            check=False,
-        )
-        output = result.stdout + result.stderr
-
-        if result.returncode != 0:
-            return ToolCheckResult(
-                tool=tool,
-                status=ToolStatus.MISSING,
-                error="command_failed",
-                details=f"Exit {result.returncode}: {output[:100]}",
-                path=tool_path,
-                install_hint=hint,
-            )
-
-        version = extract_version_from_output(output, tool.name)
-        if not version:
-            return ToolCheckResult(
-                tool=tool,
-                status=ToolStatus.UNKNOWN,
-                error="no_version",
-                details=f"Output: {output[:100]}",
-                path=tool_path,
-                install_hint=hint,
-            )
-
-        status = _compare_versions(version, tool.version, tool.min_version)
-        advisory = None
-        final_upgrade = upgrade_hint
-        if status in (ToolStatus.OUTDATED, ToolStatus.INCOMPATIBLE):
-            advisory = build_version_advisory(
-                tool=tool.name,
-                installed=version,
-                latest_known=tool.version,
-                binary_path=tool_path,
-                install_package=tool.install_package,
-                install_type=tool.install_type,
-                channel_override=tool.update_channel,
-            )
-            if advisory and advisory.update_command:
-                final_upgrade = advisory.update_command
-        return ToolCheckResult(
-            tool=tool,
-            status=status,
-            installed_version=version,
-            path=tool_path,
-            install_hint=hint,
-            upgrade_hint=final_upgrade,
-            advisory=advisory,
-        )
-    except subprocess.TimeoutExpired:
-        return ToolCheckResult(
-            tool=tool,
-            status=ToolStatus.MISSING,
-            error="timeout",
-            path=tool_path,
-            install_hint=hint,
-            upgrade_hint=upgrade_hint,
-        )
-    except (FileNotFoundError, OSError) as e:
-        return ToolCheckResult(
-            tool=tool,
-            status=ToolStatus.MISSING,
-            error="os_error",
-            details=str(e),
-            install_hint=hint,
-            upgrade_hint=upgrade_hint,
-        )
-
-
-def _compare_versions(
-    installed: str,
-    recommended: str,
-    minimum: str,
-) -> ToolStatus:
-    """Compare installed version against recommended and minimum versions.
-
-    Args:
-        installed: Installed version string.
-        recommended: Recommended/tested version from manifest.
-        minimum: Hard minimum compatible version from manifest.
-
-    Returns:
-        ToolStatus.OK, OUTDATED, INCOMPATIBLE, or UNKNOWN.
-    """
-    try:
-        if compare_versions(installed, minimum) < 0:
-            return ToolStatus.INCOMPATIBLE
-        if compare_versions(installed, recommended) < 0:
-            return ToolStatus.OUTDATED
-        return ToolStatus.OK
-    except ValueError:
-        return ToolStatus.UNKNOWN
-
-
->>>>>>> 74653b25 (feat(cli): surface update advisories in doctor and versions)
 def _render_category(
     console: Console,
     category_label: str,
@@ -895,7 +705,7 @@ def _output_json(
         for r in all_results
         if r.status == ToolStatus.DISABLED and r.tool.tier != "dev"
     )
-    tools_json: dict[str, dict[str, object]] = {}
+    tools_json: dict[str, dict[str, str | None]] = {}
     issues: list[dict[str, str]] = []
 
     for r in all_results:

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -611,21 +611,6 @@ def doctor_command(
     _render_oxlint_checks(display_console, oxlint_checks)
     _render_mcp_extra(display_console)
 
-    advisories = [
-        r.advisory
-        for r in prod_results
-        if r.advisory is not None
-        and r.status in (ToolStatus.OUTDATED, ToolStatus.INCOMPATIBLE)
-    ]
-    if advisories:
-        display_console.print()
-        display_console.print("  [bold]Update advisories[/bold]")
-        for advisory in advisories:
-            line = Text("    ")
-            line.append("⚠ ", style="yellow")
-            line.append(format_advisory_line(advisory))
-            display_console.print(line)
-
     # Summary
     display_console.print()
     summary_parts: list[str] = []

--- a/lintro/cli_utils/commands/versions.py
+++ b/lintro/cli_utils/commands/versions.py
@@ -5,7 +5,9 @@ import json
 import click
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
+from lintro.tools.core.update_channels import format_advisory_line
 from lintro.tools.core.version_requirements import get_all_tool_versions
 
 
@@ -40,13 +42,19 @@ def versions_command(verbose: bool, json_output: bool) -> None:
     if json_output:
         output: dict[str, dict[str, object]] = {}
         for tool_name, version_info in sorted(tool_versions.items()):
-            output[tool_name] = {
+            entry: dict[str, object] = {
                 "current_version": version_info.current_version,
                 "min_version": version_info.min_version,
+                "recommended_version": version_info.recommended_version,
                 "version_check_passed": version_info.version_check_passed,
+                "below_recommended": version_info.below_recommended,
                 "error_message": version_info.error_message,
                 "install_hint": version_info.install_hint,
+                "binary_path": version_info.binary_path,
             }
+            if version_info.advisory is not None:
+                entry["advisory"] = version_info.advisory.to_dict()
+            output[tool_name] = entry
         click.echo(json.dumps(output, indent=2))
         return
 
@@ -63,13 +71,16 @@ def versions_command(verbose: bool, json_output: bool) -> None:
 
     # Sort tools by name for consistent output
     sorted_tools = sorted(tool_versions.items())
+    advisories = []
 
     for tool_name, version_info in sorted_tools:
         current = version_info.current_version or "unknown"
         minimum = version_info.min_version
 
-        if version_info.version_check_passed:
+        if version_info.version_check_passed and not version_info.below_recommended:
             status = "[green]✓ PASS[/green]"
+        elif version_info.version_check_passed and version_info.below_recommended:
+            status = "[yellow]⚠ OUTDATED[/yellow]"
         elif version_info.error_message:
             status = "[red]✗ FAIL[/red]"
         else:
@@ -79,18 +90,32 @@ def versions_command(verbose: bool, json_output: bool) -> None:
 
         if verbose:
             hint = version_info.install_hint
-            if version_info.error_message:
+            if version_info.advisory and version_info.advisory.update_command:
+                hint = version_info.advisory.update_command
+            elif version_info.error_message:
                 hint = f"{version_info.error_message}. {hint}"
             row.append(hint)
 
         table.add_row(*row)
+        if version_info.advisory is not None:
+            advisories.append(version_info.advisory)
 
     console.print(table)
+
+    if advisories:
+        console.print()
+        console.print("[bold]Update advisories[/bold]")
+        for advisory in advisories:
+            line = Text("  ")
+            line.append("⚠ ", style="yellow")
+            line.append(format_advisory_line(advisory))
+            console.print(line)
 
     # Summary
     total_tools = len(tool_versions)
     passed_tools = sum(1 for v in tool_versions.values() if v.version_check_passed)
     failed_tools = total_tools - passed_tools
+    outdated_tools = sum(1 for v in tool_versions.values() if v.below_recommended)
 
     if failed_tools > 0:
         console.print(
@@ -99,6 +124,11 @@ def versions_command(verbose: bool, json_output: bool) -> None:
         )
         console.print(
             "[dim]Run with --verbose to see installation instructions.[/dim]",
+        )
+    elif outdated_tools > 0:
+        console.print(
+            f"\n[yellow]⚠️  {outdated_tools} tool(s) are below the "
+            f"recommended version.[/yellow]",
         )
     else:
         console.print(

--- a/lintro/cli_utils/commands/versions.py
+++ b/lintro/cli_utils/commands/versions.py
@@ -53,9 +53,12 @@ def versions_command(verbose: bool, json_output: bool) -> None:
                 "error_message": version_info.error_message,
                 "install_hint": version_info.install_hint,
                 "binary_path": version_info.binary_path,
+                "advisory": (
+                    version_info.advisory.to_dict()
+                    if version_info.advisory is not None
+                    else None
+                ),
             }
-            if version_info.advisory is not None:
-                entry["advisory"] = version_info.advisory.to_dict()
             output[tool_name] = entry
         click.echo(json.dumps(output, indent=2))
         return

--- a/lintro/cli_utils/commands/versions.py
+++ b/lintro/cli_utils/commands/versions.py
@@ -90,9 +90,7 @@ def versions_command(verbose: bool, json_output: bool) -> None:
 
         if verbose:
             hint = version_info.install_hint
-            if version_info.advisory and version_info.advisory.update_command:
-                hint = version_info.advisory.update_command
-            elif version_info.error_message:
+            if version_info.error_message:
                 hint = f"{version_info.error_message}. {hint}"
             row.append(hint)
 

--- a/lintro/cli_utils/commands/versions.py
+++ b/lintro/cli_utils/commands/versions.py
@@ -28,7 +28,9 @@ def versions_command(verbose: bool, json_output: bool) -> None:
     """Display version information for all supported tools.
 
     Shows each tool's current version, minimum required version, and status.
-    Use --verbose to see installation hints for tools that don't meet requirements.
+    Tools that meet the minimum but trail the recommended pin show OUTDATED
+    (JSON ``version_check_passed`` remains true). Use --verbose to see
+    installation hints for tools that don't meet requirements.
 
     \u000c
 

--- a/lintro/enums/update_channel.py
+++ b/lintro/enums/update_channel.py
@@ -1,0 +1,24 @@
+"""Install-channel enum for tool update advisories.
+
+Identifies *how a tool binary was installed on this machine* (path
+heuristics), which is distinct from the manifest ``install.type`` that
+describes how lintro *expects* the tool to be installed.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+
+class UpdateChannel(StrEnum):
+    """Detected install channel for an external tool binary."""
+
+    HOMEBREW = auto()
+    UV_TOOL = auto()
+    PIP = auto()
+    NPM = auto()
+    BUN = auto()
+    CARGO = auto()
+    RUSTUP = auto()
+    STANDALONE = auto()
+    UNKNOWN = auto()

--- a/lintro/mcp/toolkits/introspection.py
+++ b/lintro/mcp/toolkits/introspection.py
@@ -80,7 +80,9 @@ _LIST_TOOLS_DESCRIPTION: Final[str] = (
 _VERSIONS_DESCRIPTION: Final[str] = (
     "Report the installed version of every external tool against the minimum "
     "and recommended versions lintro expects, flagging each as ok, outdated, "
-    "incompatible, or missing. Read-only."
+    "incompatible, or missing. Each entry includes binary_path and a structured "
+    "advisory (channel plus optional update_command) when the tool is behind. "
+    "Read-only."
 )
 
 _DOCTOR_DESCRIPTION: Final[str] = (

--- a/lintro/mcp/toolkits/introspection.py
+++ b/lintro/mcp/toolkits/introspection.py
@@ -333,6 +333,10 @@ def _versions_payload() -> dict[str, Any]:
                 "status": status,
                 "error": info.error_message,
                 "install_hint": info.install_hint,
+                "binary_path": info.binary_path,
+                "advisory": (
+                    info.advisory.to_dict() if info.advisory is not None else None
+                ),
             },
         )
 

--- a/lintro/tools/core/manifest_models.py
+++ b/lintro/tools/core/manifest_models.py
@@ -18,6 +18,8 @@ class ManifestTool:
         install_package: Package name for pip/npm/cargo installs.
         install_bin: Binary name if different from package.
         install_component: Rustup component name (e.g., "clippy").
+        update_channel: Optional install-channel override when path heuristics
+            fail (e.g., "homebrew", "uv_tool").
         tier: Tool tier — "tools" (production) or "dev" (optional).
         category: Display grouping — "bundled", "npm", or "external".
         version_command: Command to check installed version.
@@ -32,6 +34,7 @@ class ManifestTool:
     install_package: str | None = None
     install_bin: str | None = None
     install_component: str | None = None
+    update_channel: str | None = None
     tier: str = "tools"
     category: str = "external"
     version_command: tuple[str, ...] = field(default_factory=tuple)

--- a/lintro/tools/core/tool_installer.py
+++ b/lintro/tools/core/tool_installer.py
@@ -43,6 +43,7 @@ from lintro.tools.core.install_strategies import get_strategy
 from lintro.tools.core.install_strategies.package_names import script_tool_name
 from lintro.tools.core.node_fallback import REGISTRY_RUNNERS
 from lintro.tools.core.tool_registry import ManifestRegistry, ManifestTool
+from lintro.tools.core.update_channels import WRAPPER_PROBE_NAMES
 from lintro.tools.core.version_parsing import (
     compare_versions,
     extract_version_from_output,
@@ -50,7 +51,7 @@ from lintro.tools.core.version_parsing import (
 
 #: Version-probe entrypoints that run a wrapper or host binary rather than the
 #: tool's own executable, so they cannot prove the tool is on PATH.
-_INDIRECT_PROBE_COMMANDS = frozenset({"sh", "bash", "cargo"})
+_INDIRECT_PROBE_COMMANDS = WRAPPER_PROBE_NAMES
 
 # Re-export so existing ``from lintro.tools.core.tool_installer import InstallPlan``
 # continues to work.

--- a/lintro/tools/core/tool_registry.py
+++ b/lintro/tools/core/tool_registry.py
@@ -246,6 +246,7 @@ class ManifestRegistry:
             install_package=install.get("package"),
             install_bin=install.get("bin"),
             install_component=install.get("component"),
+            update_channel=install.get("update_channel"),
             tier=entry.get("tier", "tools"),
             category=category,
             version_command=tuple(version_command),

--- a/lintro/tools/core/update_channels.py
+++ b/lintro/tools/core/update_channels.py
@@ -100,13 +100,13 @@ def detect_update_channel(
     if _is_uv_tool_path(resolved=resolved, path_lower=path_lower):
         return UpdateChannel.UV_TOOL
 
-    if _is_cargo_path(path_lower=path_lower):
+    if _is_cargo_path(resolved=resolved, path_lower=path_lower):
         return UpdateChannel.CARGO
 
     if _is_rustup_path(path_lower=path_lower, parts_lower=parts_lower):
         return UpdateChannel.RUSTUP
 
-    if _is_bun_path(path_lower=path_lower, parts_lower=parts_lower):
+    if _is_bun_path(resolved=resolved, path_lower=path_lower, parts_lower=parts_lower):
         return UpdateChannel.BUN
 
     if "node_modules" in parts_lower:
@@ -292,15 +292,17 @@ def _resolve_binary_path(binary_path: str | Path) -> Path | None:
 
 def _is_homebrew_path(*, path_lower: str, parts_lower: set[str]) -> bool:
     """Return True when the path is under a Homebrew prefix."""
-    if "cellar" in parts_lower or "linuxbrew" in parts_lower:
-        return True
     markers = (
         "/opt/homebrew/",
         "/home/linuxbrew/",
         "/usr/local/homebrew/",
         "/homebrew/",
+        "/usr/local/cellar/",
+        "/opt/homebrew/cellar/",
     )
-    return any(marker in path_lower for marker in markers)
+    if any(marker in path_lower for marker in markers):
+        return True
+    return "linuxbrew" in parts_lower
 
 
 def _is_uv_tool_path(*, resolved: Path, path_lower: str) -> bool:
@@ -316,16 +318,18 @@ def _is_uv_tool_path(*, resolved: Path, path_lower: str) -> bool:
     return False
 
 
-def _is_cargo_path(*, path_lower: str) -> bool:
+def _is_cargo_path(*, resolved: Path, path_lower: str) -> bool:
     """Return True when the path is under cargo's bin directory."""
     if "/.cargo/bin/" in path_lower or path_lower.rstrip("/").endswith("/.cargo/bin"):
         return True
     cargo_home = os.environ.get("CARGO_HOME")
     if cargo_home:
-        cargo_bin = f"{cargo_home.rstrip('/').lower()}/bin/"
-        return cargo_bin in path_lower or path_lower.rstrip("/").endswith(
-            cargo_bin.rstrip("/"),
-        )
+        try:
+            return resolved.is_relative_to(
+                Path(cargo_home).expanduser().resolve() / "bin",
+            ) or resolved.is_relative_to(Path(cargo_home).expanduser().resolve())
+        except (OSError, ValueError, RuntimeError):
+            return False
     return False
 
 
@@ -333,18 +337,24 @@ def _is_rustup_path(*, path_lower: str, parts_lower: set[str]) -> bool:
     """Return True when the path is under a rustup toolchain tree."""
     if "rustup" in parts_lower:
         return True
-    return "/toolchains/" in path_lower and (
-        "rust" in path_lower or "clippy" in path_lower or "rustc" in path_lower
-    )
+    return "/.rustup/toolchains/" in path_lower
 
 
-def _is_bun_path(*, path_lower: str, parts_lower: set[str]) -> bool:
+def _is_bun_path(
+    *,
+    resolved: Path,
+    path_lower: str,
+    parts_lower: set[str],
+) -> bool:
     """Return True when the path is under a Bun install prefix."""
     if ".bun" in parts_lower:
         return True
     bun_install = os.environ.get("BUN_INSTALL")
     if bun_install:
-        return bun_install.rstrip("/").lower() in path_lower
+        try:
+            return resolved.is_relative_to(Path(bun_install).expanduser().resolve())
+        except (OSError, ValueError, RuntimeError):
+            return False
     return "/.bun/" in path_lower
 
 

--- a/lintro/tools/core/update_channels.py
+++ b/lintro/tools/core/update_channels.py
@@ -1,0 +1,392 @@
+"""Resolve per-tool update channels and version advisories.
+
+Given a tool binary path, detect how the tool was installed (Homebrew, uv
+tool, pip/venv, npm/bun, cargo, rustup, standalone) and map that channel to
+an actionable update command. "Latest known" versions come from pinned
+manifest / tool-versions data — this module never makes network calls.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from lintro.enums.update_channel import UpdateChannel
+from lintro.tools.core.install_strategies.brew_names import BREW_FORMULA_NAMES
+
+# Per-tool channel overrides when path heuristics are wrong or unavailable.
+# Keys are canonical tool names; values are UpdateChannel members (or their
+# string values). Kept data-driven so callers / manifest can extend without
+# branching in detect_update_channel.
+TOOL_CHANNEL_OVERRIDES: dict[str, UpdateChannel] = {}
+
+
+@dataclass(frozen=True)
+class VersionAdvisory:
+    """Structured "update available" advisory for a single tool.
+
+    Attributes:
+        tool: Canonical tool name.
+        installed: Currently installed version string.
+        latest_known: Pinned expected/recommended version (no network).
+        channel: Detected install channel.
+        update_command: Exact shell command to upgrade, or None when unknown.
+    """
+
+    tool: str
+    installed: str
+    latest_known: str
+    channel: UpdateChannel
+    update_command: str | None = None
+
+    def to_dict(self) -> dict[str, str | None]:
+        """Serialize for JSON / MCP surfaces.
+
+        Returns:
+            Dictionary with string channel value and optional update command.
+        """
+        data = asdict(self)
+        data["channel"] = self.channel.value
+        return data
+
+
+def detect_update_channel(
+    binary_path: str | Path | None,
+    *,
+    tool_name: str | None = None,
+    channel_override: UpdateChannel | str | None = None,
+) -> UpdateChannel:
+    """Detect the install channel for a tool binary.
+
+    Resolves symlinks before matching path heuristics so Homebrew Cellar
+    installs (often linked from ``/usr/local/bin`` or ``/opt/homebrew/bin``)
+    are classified correctly. Per-tool overrides win over heuristics.
+
+    Args:
+        binary_path: Absolute or relative path to the tool binary.
+        tool_name: Canonical tool name used for override lookup.
+        channel_override: Explicit channel (e.g. from manifest); wins first.
+
+    Returns:
+        Detected :class:`UpdateChannel`. Unknown paths degrade to
+        ``UNKNOWN`` (or ``STANDALONE`` for common system bin prefixes).
+    """
+    override = _coerce_channel(channel_override)
+    if override is not None:
+        return override
+
+    if tool_name:
+        mapped = TOOL_CHANNEL_OVERRIDES.get(tool_name)
+        if mapped is not None:
+            return mapped
+
+    if not binary_path:
+        return UpdateChannel.UNKNOWN
+
+    resolved = _resolve_binary_path(binary_path)
+    if resolved is None:
+        return UpdateChannel.UNKNOWN
+
+    path_lower = resolved.as_posix().lower()
+    parts_lower = {part.lower() for part in resolved.parts}
+
+    # Homebrew before node_modules: brew formulae for JS tools live under
+    # Cellar/.../libexec/lib/node_modules/...
+    if _is_homebrew_path(path_lower=path_lower, parts_lower=parts_lower):
+        return UpdateChannel.HOMEBREW
+
+    if _is_uv_tool_path(resolved=resolved, path_lower=path_lower):
+        return UpdateChannel.UV_TOOL
+
+    if _is_cargo_path(path_lower=path_lower):
+        return UpdateChannel.CARGO
+
+    if _is_rustup_path(path_lower=path_lower, parts_lower=parts_lower):
+        return UpdateChannel.RUSTUP
+
+    if _is_bun_path(path_lower=path_lower, parts_lower=parts_lower):
+        return UpdateChannel.BUN
+
+    if "node_modules" in parts_lower:
+        return UpdateChannel.NPM
+
+    if _is_pip_path(path_lower=path_lower, parts_lower=parts_lower):
+        return UpdateChannel.PIP
+
+    if _is_standalone_path(path_lower=path_lower):
+        return UpdateChannel.STANDALONE
+
+    return UpdateChannel.UNKNOWN
+
+
+def resolve_update_command(
+    *,
+    channel: UpdateChannel,
+    tool_name: str,
+    install_package: str | None = None,
+    latest_known: str | None = None,
+) -> str | None:
+    """Map an install channel to an actionable update command.
+
+    Args:
+        channel: Detected (or overridden) install channel.
+        tool_name: Canonical tool name.
+        install_package: Package name override from the manifest.
+        latest_known: Pinned expected version for channels that pin on upgrade.
+
+    Returns:
+        Shell command string, or None when the channel has no known template.
+    """
+    package = _package_for_channel(
+        channel=channel,
+        tool_name=tool_name,
+        install_package=install_package,
+    )
+    version = latest_known or ""
+
+    if channel == UpdateChannel.HOMEBREW:
+        return f"brew upgrade {package}"
+    if channel == UpdateChannel.UV_TOOL:
+        return f"uv tool upgrade {package}"
+    if channel == UpdateChannel.PIP:
+        if version:
+            return f"uv pip install --upgrade '{package}>={version}'"
+        return f"uv pip install --upgrade {package}"
+    if channel == UpdateChannel.NPM:
+        if version:
+            return f"npm install -g {package}@{version}"
+        return f"npm install -g {package}"
+    if channel == UpdateChannel.BUN:
+        if version:
+            return f"bun add -g {package}@{version}"
+        return f"bun add -g {package}"
+    if channel == UpdateChannel.CARGO:
+        return f"cargo install --force {package}"
+    if channel == UpdateChannel.RUSTUP:
+        return "rustup update stable"
+    # STANDALONE / UNKNOWN: no safe one-liner
+    return None
+
+
+def build_version_advisory(
+    *,
+    tool: str,
+    installed: str,
+    latest_known: str,
+    binary_path: str | Path | None = None,
+    install_package: str | None = None,
+    channel_override: UpdateChannel | str | None = None,
+) -> VersionAdvisory:
+    """Build a structured version advisory for an outdated tool.
+
+    Args:
+        tool: Canonical tool name.
+        installed: Currently installed version.
+        latest_known: Pinned expected/recommended version.
+        binary_path: Path to the installed binary (for channel detection).
+        install_package: Manifest package name override.
+        channel_override: Explicit channel from manifest / caller.
+
+    Returns:
+        :class:`VersionAdvisory` with channel and optional update command.
+    """
+    channel = detect_update_channel(
+        binary_path,
+        tool_name=tool,
+        channel_override=channel_override,
+    )
+    update_command = resolve_update_command(
+        channel=channel,
+        tool_name=tool,
+        install_package=install_package,
+        latest_known=latest_known,
+    )
+    return VersionAdvisory(
+        tool=tool,
+        installed=installed,
+        latest_known=latest_known,
+        channel=channel,
+        update_command=update_command,
+    )
+
+
+def format_advisory_line(advisory: VersionAdvisory) -> str:
+    """Render a human-readable advisory line.
+
+    Args:
+        advisory: Structured advisory to format.
+
+    Returns:
+        Single-line advisory matching doctor / versions output style.
+    """
+    base = (
+        f"{advisory.tool} {advisory.installed} installed, "
+        f"{advisory.latest_known} expected"
+    )
+    channel_label = advisory.channel.value.replace("_", " ")
+    if advisory.update_command:
+        return f"{base} — installed via {channel_label}: {advisory.update_command}"
+    if advisory.channel in (UpdateChannel.UNKNOWN, UpdateChannel.STANDALONE):
+        return f"{base} — update channel unknown"
+    return f"{base} — installed via {channel_label}"
+
+
+def channel_from_install_type(install_type: str | None) -> UpdateChannel | None:
+    """Map a manifest ``install.type`` to a default update channel.
+
+    Used as a soft fallback when path detection returns UNKNOWN.
+
+    Args:
+        install_type: Manifest install type string (pip, npm, binary, ...).
+
+    Returns:
+        Matching channel, or None when there is no sensible default.
+    """
+    if not install_type:
+        return None
+    mapping: dict[str, UpdateChannel] = {
+        "pip": UpdateChannel.PIP,
+        "npm": UpdateChannel.NPM,
+        "cargo": UpdateChannel.CARGO,
+        "rustup": UpdateChannel.RUSTUP,
+        # binary stays unknown without path evidence — brew vs download
+    }
+    return mapping.get(install_type)
+
+
+def _coerce_channel(
+    value: UpdateChannel | str | None,
+) -> UpdateChannel | None:
+    """Coerce a string or enum into UpdateChannel."""
+    if value is None:
+        return None
+    if isinstance(value, UpdateChannel):
+        return value
+    try:
+        return UpdateChannel(value)
+    except ValueError:
+        normalized = value.lower().replace("-", "_")
+        try:
+            return UpdateChannel(normalized)
+        except ValueError:
+            return None
+
+
+def _resolve_binary_path(binary_path: str | Path) -> Path | None:
+    """Resolve a binary path, following symlinks when possible."""
+    try:
+        path = Path(binary_path).expanduser()
+        if not path.is_absolute():
+            path = path.resolve()
+        else:
+            try:
+                path = path.resolve()
+            except OSError:
+                path = Path(os.path.normpath(path))
+        return path
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _is_homebrew_path(*, path_lower: str, parts_lower: set[str]) -> bool:
+    """Return True when the path is under a Homebrew prefix."""
+    if "cellar" in parts_lower or "linuxbrew" in parts_lower:
+        return True
+    markers = (
+        "/opt/homebrew/",
+        "/home/linuxbrew/",
+        "/usr/local/homebrew/",
+        "/homebrew/",
+    )
+    return any(marker in path_lower for marker in markers)
+
+
+def _is_uv_tool_path(*, resolved: Path, path_lower: str) -> bool:
+    """Return True when the path is under a uv tools directory."""
+    if "/uv/tools/" in path_lower or path_lower.endswith("/uv/tools"):
+        return True
+    uv_tool_dir = os.environ.get("UV_TOOL_DIR")
+    if uv_tool_dir:
+        try:
+            return resolved.is_relative_to(Path(uv_tool_dir).expanduser().resolve())
+        except (OSError, ValueError, RuntimeError):
+            return False
+    return False
+
+
+def _is_cargo_path(*, path_lower: str) -> bool:
+    """Return True when the path is under cargo's bin directory."""
+    if "/.cargo/bin/" in path_lower or path_lower.rstrip("/").endswith("/.cargo/bin"):
+        return True
+    cargo_home = os.environ.get("CARGO_HOME")
+    if cargo_home:
+        cargo_bin = f"{cargo_home.rstrip('/').lower()}/bin/"
+        return cargo_bin in path_lower or path_lower.rstrip("/").endswith(
+            cargo_bin.rstrip("/"),
+        )
+    return False
+
+
+def _is_rustup_path(*, path_lower: str, parts_lower: set[str]) -> bool:
+    """Return True when the path is under a rustup toolchain tree."""
+    if "rustup" in parts_lower:
+        return True
+    return "/toolchains/" in path_lower and (
+        "rust" in path_lower or "clippy" in path_lower or "rustc" in path_lower
+    )
+
+
+def _is_bun_path(*, path_lower: str, parts_lower: set[str]) -> bool:
+    """Return True when the path is under a Bun install prefix."""
+    if ".bun" in parts_lower:
+        return True
+    bun_install = os.environ.get("BUN_INSTALL")
+    if bun_install:
+        return bun_install.rstrip("/").lower() in path_lower
+    return "/.bun/" in path_lower
+
+
+def _is_pip_path(*, path_lower: str, parts_lower: set[str]) -> bool:
+    """Return True when the path looks like a pip/venv install."""
+    markers = (
+        "site-packages",
+        "dist-packages",
+        ".venv",
+        "virtualenv",
+    )
+    if any(marker in path_lower for marker in markers):
+        return True
+    if "venv" in parts_lower:
+        return True
+    # python -m / Scripts on Windows
+    if sys.platform == "win32" and "scripts" in parts_lower:
+        return True
+    return False
+
+
+def _is_standalone_path(*, path_lower: str) -> bool:
+    """Return True for common system bin prefixes without a known manager."""
+    prefixes = (
+        "/usr/local/bin/",
+        "/usr/bin/",
+        "/bin/",
+    )
+    return any(path_lower.startswith(prefix) for prefix in prefixes)
+
+
+def _package_for_channel(
+    *,
+    channel: UpdateChannel,
+    tool_name: str,
+    install_package: str | None,
+) -> str:
+    """Choose the package name used in the update command."""
+    if install_package:
+        return install_package
+    if channel == UpdateChannel.HOMEBREW:
+        return BREW_FORMULA_NAMES.get(tool_name, tool_name.replace("_", "-"))
+    if channel in (UpdateChannel.CARGO, UpdateChannel.NPM, UpdateChannel.BUN):
+        return tool_name.replace("_", "-")
+    return tool_name

--- a/lintro/tools/core/update_channels.py
+++ b/lintro/tools/core/update_channels.py
@@ -64,28 +64,28 @@ def detect_update_channel(
 
     Resolves symlinks before matching path heuristics so Homebrew Cellar
     installs (often linked from ``/usr/local/bin`` or ``/opt/homebrew/bin``)
-    are classified correctly. Per-tool overrides win over heuristics.
+    are classified correctly. The in-code ``TOOL_CHANNEL_OVERRIDES`` table
+    wins when heuristics are known-wrong. Manifest ``channel_override`` is a
+    fallback used only when path detection is ``UNKNOWN`` or ``STANDALONE``.
 
     Args:
         binary_path: Absolute or relative path to the tool binary.
         tool_name: Canonical tool name used for override lookup.
-        channel_override: Explicit channel (e.g. from manifest); wins first.
+        channel_override: Explicit channel from the manifest; applied when
+            path heuristics do not identify a manager.
 
     Returns:
         Detected :class:`UpdateChannel`. Unknown paths degrade to
         ``UNKNOWN`` (or ``STANDALONE`` for common system bin prefixes).
     """
-    override = _coerce_channel(channel_override)
-    if override is not None:
-        return override
-
     if tool_name:
         mapped = TOOL_CHANNEL_OVERRIDES.get(tool_name)
         if mapped is not None:
             return mapped
 
     if not binary_path:
-        return UpdateChannel.UNKNOWN
+        override = _coerce_channel(channel_override)
+        return override if override is not None else UpdateChannel.UNKNOWN
 
     resolved = _resolve_binary_path(binary_path)
     if resolved is None:
@@ -122,9 +122,17 @@ def detect_update_channel(
         return UpdateChannel.PIP
 
     if _is_standalone_path(path_lower=path_lower):
-        return UpdateChannel.STANDALONE
+        detected = UpdateChannel.STANDALONE
+    else:
+        detected = UpdateChannel.UNKNOWN
 
-    return UpdateChannel.UNKNOWN
+    override = _coerce_channel(channel_override)
+    if override is not None and detected in (
+        UpdateChannel.UNKNOWN,
+        UpdateChannel.STANDALONE,
+    ):
+        return override
+    return detected
 
 
 def resolve_update_command(
@@ -161,9 +169,12 @@ def resolve_update_command(
     if channel == UpdateChannel.UV_TOOL:
         return f"uv tool upgrade {package}"
     if channel == UpdateChannel.PIP:
+        if tool_name == "semgrep":
+            return None
+        pip_prefix = "uv pip install" if shutil.which("uv") else "pip install"
         if version:
-            return f"uv pip install --upgrade '{package}>={version}'"
-        return f"uv pip install --upgrade {package}"
+            return f"{pip_prefix} --upgrade '{package}>={version}'"
+        return f"{pip_prefix} --upgrade {package}"
     if channel == UpdateChannel.NPM:
         spec = f"{package}@{version}" if version else package
         if project_local_node:
@@ -310,7 +321,6 @@ def _is_homebrew_path(*, path_lower: str, parts_lower: set[str]) -> bool:
         "/opt/homebrew/",
         "/home/linuxbrew/",
         "/usr/local/homebrew/",
-        "/homebrew/",
         "/usr/local/cellar/",
         "/opt/homebrew/cellar/",
     )
@@ -441,9 +451,9 @@ def _is_cargo_path(*, resolved: Path, path_lower: str) -> bool:
 
 def _is_rustup_path(*, path_lower: str, parts_lower: set[str]) -> bool:
     """Return True when the path is under a rustup toolchain tree."""
-    if "rustup" in parts_lower:
+    if ".rustup" in parts_lower:
         return True
-    return "/.rustup/toolchains/" in path_lower
+    return "/.rustup/" in path_lower
 
 
 def _is_bun_path(

--- a/lintro/tools/core/update_channels.py
+++ b/lintro/tools/core/update_channels.py
@@ -363,13 +363,16 @@ _RUSTUP_SHIM_NAMES: frozenset[str] = frozenset(
 )
 
 #: Version-probe argv[0] values that are host wrappers, not the tool binary.
-_WRAPPER_PROBE_NAMES: frozenset[str] = frozenset({"sh", "bash", "cargo", "env"})
+#: Shared with :mod:`lintro.tools.core.tool_installer` so discoverability
+#: and channel resolution cannot drift.
+WRAPPER_PROBE_NAMES: frozenset[str] = frozenset({"sh", "bash", "cargo", "env"})
 
 
 def resolve_channel_binary_path(
     *,
     tool_name: str,
     install_bin: str | None = None,
+    install_component: str | None = None,
     probe_path: str | Path | None = None,
     probe_argv0: str | None = None,
     which: Callable[[str], str | None] | None = None,
@@ -383,6 +386,7 @@ def resolve_channel_binary_path(
     Args:
         tool_name: Canonical tool name.
         install_bin: Manifest ``install.bin`` when it differs from the name.
+        install_component: Manifest ``install.component`` (rustup shims).
         probe_path: Path resolved from the version-probe argv[0].
         probe_argv0: Version-probe argv[0] (may be a relative command name).
         which: PATH lookup, defaulting to :func:`shutil.which`.
@@ -394,18 +398,25 @@ def resolve_channel_binary_path(
     argv0 = ""
     if argv0_source is not None:
         argv0 = Path(argv0_source).name.lower().removesuffix(".exe")
-    if argv0 not in _WRAPPER_PROBE_NAMES:
+    if argv0 not in WRAPPER_PROBE_NAMES:
         return probe_path
 
     finder = which or shutil.which
     candidates: list[str] = []
-    if install_bin:
-        candidates.append(install_bin)
+    for name in (install_bin, install_component):
+        if name and name not in candidates:
+            candidates.append(name)
     hyphen = tool_name.replace("_", "-")
     underscore = tool_name.replace("-", "_")
     for name in (hyphen, underscore, tool_name):
         if name not in candidates:
             candidates.append(name)
+    if not hyphen.startswith("cargo-"):
+        cargo_alias = f"cargo-{hyphen}"
+        if cargo_alias not in candidates:
+            candidates.append(cargo_alias)
+    if hyphen == "clippy" and "clippy-driver" not in candidates:
+        candidates.append("clippy-driver")
     for name in candidates:
         found = finder(name)
         if found:

--- a/lintro/tools/core/update_channels.py
+++ b/lintro/tools/core/update_channels.py
@@ -14,7 +14,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from lintro.enums.update_channel import UpdateChannel
-from lintro.tools.core.install_strategies.brew_names import BREW_FORMULA_NAMES
+from lintro.tools.core.install_strategies.package_names import BREW_FORMULA_NAMES
 
 # Per-tool channel overrides when path heuristics are wrong or unavailable.
 # Keys are canonical tool names; values are UpdateChannel members (or their
@@ -101,6 +101,10 @@ def detect_update_channel(
         return UpdateChannel.UV_TOOL
 
     if _is_cargo_path(resolved=resolved, path_lower=path_lower):
+        # rustup installs proxy shims in ``~/.cargo/bin`` (rustc, cargo,
+        # rustfmt, clippy). Those are not cargo-installed crates.
+        if _is_rustup_shim(resolved=resolved, tool_name=tool_name):
+            return UpdateChannel.RUSTUP
         return UpdateChannel.CARGO
 
     if _is_rustup_path(path_lower=path_lower, parts_lower=parts_lower):
@@ -127,6 +131,7 @@ def resolve_update_command(
     tool_name: str,
     install_package: str | None = None,
     latest_known: str | None = None,
+    binary_path: str | Path | None = None,
 ) -> str | None:
     """Map an install channel to an actionable update command.
 
@@ -135,6 +140,8 @@ def resolve_update_command(
         tool_name: Canonical tool name.
         install_package: Package name override from the manifest.
         latest_known: Pinned expected version for channels that pin on upgrade.
+        binary_path: Installed binary path. Project-local ``node_modules``
+            installs must not emit a global ``npm install -g`` / ``bun add -g``.
 
     Returns:
         Shell command string, or None when the channel has no known template.
@@ -145,6 +152,7 @@ def resolve_update_command(
         install_package=install_package,
     )
     version = latest_known or ""
+    project_local_node = _is_project_local_node_path(binary_path)
 
     if channel == UpdateChannel.HOMEBREW:
         return f"brew upgrade {package}"
@@ -155,13 +163,15 @@ def resolve_update_command(
             return f"uv pip install --upgrade '{package}>={version}'"
         return f"uv pip install --upgrade {package}"
     if channel == UpdateChannel.NPM:
-        if version:
-            return f"npm install -g {package}@{version}"
-        return f"npm install -g {package}"
+        spec = f"{package}@{version}" if version else package
+        if project_local_node:
+            return f"npm install -D {spec}"
+        return f"npm install -g {spec}"
     if channel == UpdateChannel.BUN:
-        if version:
-            return f"bun add -g {package}@{version}"
-        return f"bun add -g {package}"
+        spec = f"{package}@{version}" if version else package
+        if project_local_node:
+            return f"bun add -D {spec}"
+        return f"bun add -g {spec}"
     if channel == UpdateChannel.CARGO:
         return f"cargo install --force {package}"
     if channel == UpdateChannel.RUSTUP:
@@ -202,6 +212,7 @@ def build_version_advisory(
         tool_name=tool,
         install_package=install_package,
         latest_known=latest_known,
+        binary_path=binary_path,
     )
     return VersionAdvisory(
         tool=tool,
@@ -316,6 +327,39 @@ def _is_uv_tool_path(*, resolved: Path, path_lower: str) -> bool:
         except (OSError, ValueError, RuntimeError):
             return False
     return False
+
+
+_RUSTUP_SHIM_NAMES: frozenset[str] = frozenset(
+    {
+        "rustc",
+        "cargo",
+        "rustfmt",
+        "clippy",
+        "cargo-clippy",
+    },
+)
+
+
+def _is_rustup_shim(*, resolved: Path, tool_name: str | None) -> bool:
+    """Return True for rustup proxy binaries that live under ``~/.cargo/bin``."""
+    names = {resolved.name.lower().removesuffix(".exe")}
+    if tool_name:
+        lowered = tool_name.lower()
+        names.add(lowered.replace("-", "_"))
+        names.add(lowered.replace("_", "-"))
+        names.add(lowered)
+    return bool(names & _RUSTUP_SHIM_NAMES)
+
+
+def _is_project_local_node_path(binary_path: str | Path | None) -> bool:
+    """Return True when the binary is a project-local ``node_modules`` install."""
+    if binary_path is None:
+        return False
+    try:
+        parts = {part.lower() for part in Path(binary_path).parts}
+    except (OSError, ValueError, RuntimeError):
+        return False
+    return "node_modules" in parts
 
 
 def _is_cargo_path(*, resolved: Path, path_lower: str) -> bool:

--- a/lintro/tools/core/update_channels.py
+++ b/lintro/tools/core/update_channels.py
@@ -16,7 +16,10 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from lintro.enums.update_channel import UpdateChannel
-from lintro.tools.core.install_strategies.package_names import BREW_FORMULA_NAMES
+from lintro.tools.core.install_strategies.package_names import (
+    brew_formula_name,
+    ecosystem_package_name,
+)
 
 # Per-tool channel overrides when path heuristics are wrong or unavailable.
 # Keys are canonical tool names; values are UpdateChannel members (or their
@@ -96,7 +99,7 @@ def detect_update_channel(
 
     # Homebrew before node_modules: brew formulae for JS tools live under
     # Cellar/.../libexec/lib/node_modules/...
-    if _is_homebrew_path(path_lower=path_lower, parts_lower=parts_lower):
+    if _is_homebrew_path(path_lower=path_lower):
         return UpdateChannel.HOMEBREW
 
     if _is_uv_tool_path(resolved=resolved, path_lower=path_lower):
@@ -252,9 +255,11 @@ def format_advisory_line(advisory: VersionAdvisory) -> str:
         f"{advisory.tool} {advisory.installed} installed, "
         f"{advisory.latest_known} expected"
     )
-    channel_label = advisory.channel.value.replace("_", " ")
-    if advisory.channel in (UpdateChannel.UNKNOWN, UpdateChannel.STANDALONE):
+    if advisory.channel == UpdateChannel.UNKNOWN:
         return f"{base} — update channel unknown"
+    if advisory.channel == UpdateChannel.STANDALONE:
+        return f"{base} — installed as a standalone binary"
+    channel_label = advisory.channel.value.replace("_", " ")
     return f"{base} — installed via {channel_label}"
 
 
@@ -315,18 +320,23 @@ def _resolve_binary_path(binary_path: str | Path) -> Path | None:
         return None
 
 
-def _is_homebrew_path(*, path_lower: str, parts_lower: set[str]) -> bool:
-    """Return True when the path is under a Homebrew prefix."""
+def _is_homebrew_path(*, path_lower: str) -> bool:
+    """Return True when the path is under a Homebrew prefix.
+
+    Intel Homebrew often links from ``/usr/local/bin``. That prefix is shared
+    with many non-brew installs, so it is classified as ``STANDALONE`` unless
+    symlink resolution reaches Cellar or ``/usr/local/Homebrew``. Apple
+    Silicon ``/opt/homebrew/`` is a dedicated prefix and matches directly.
+    """
     markers = (
         "/opt/homebrew/",
         "/home/linuxbrew/",
         "/usr/local/homebrew/",
         "/usr/local/cellar/",
         "/opt/homebrew/cellar/",
+        "/.linuxbrew/",
     )
-    if any(marker in path_lower for marker in markers):
-        return True
-    return "linuxbrew" in parts_lower
+    return any(marker in path_lower for marker in markers)
 
 
 def _is_uv_tool_path(*, resolved: Path, path_lower: str) -> bool:
@@ -493,7 +503,12 @@ def _is_pip_path(*, path_lower: str, parts_lower: set[str]) -> bool:
 
 
 def _is_standalone_path(*, path_lower: str) -> bool:
-    """Return True for common system bin prefixes without a known manager."""
+    """Return True for common system bin prefixes without a known manager.
+
+    ``/usr/local/bin`` is intentionally standalone when Homebrew detection
+    did not already match. Treating the whole prefix as Homebrew would
+    mislabel non-brew binaries on Intel Macs and Linux.
+    """
     prefixes = (
         "/usr/local/bin/",
         "/usr/bin/",
@@ -509,10 +524,12 @@ def _package_for_channel(
     install_package: str | None,
 ) -> str:
     """Choose the package name used in the update command."""
-    if install_package:
-        return install_package
     if channel == UpdateChannel.HOMEBREW:
-        return BREW_FORMULA_NAMES.get(tool_name, tool_name.replace("_", "-"))
-    if channel in (UpdateChannel.CARGO, UpdateChannel.NPM, UpdateChannel.BUN):
-        return tool_name.replace("_", "-")
-    return tool_name
+        return brew_formula_name(
+            tool_name=tool_name,
+            install_package=install_package,
+        )
+    return ecosystem_package_name(
+        tool_name=tool_name,
+        install_package=install_package,
+    )

--- a/lintro/tools/core/update_channels.py
+++ b/lintro/tools/core/update_channels.py
@@ -433,7 +433,7 @@ def _is_cargo_path(*, resolved: Path, path_lower: str) -> bool:
         try:
             return resolved.is_relative_to(
                 Path(cargo_home).expanduser().resolve() / "bin",
-            ) or resolved.is_relative_to(Path(cargo_home).expanduser().resolve())
+            )
         except (OSError, ValueError, RuntimeError):
             return False
     return False
@@ -466,15 +466,15 @@ def _is_bun_path(
 
 def _is_pip_path(*, path_lower: str, parts_lower: set[str]) -> bool:
     """Return True when the path looks like a pip/venv install."""
-    markers = (
-        "site-packages",
-        "dist-packages",
-        ".venv",
-        "virtualenv",
-    )
-    if any(marker in path_lower for marker in markers):
+    if "/.venv/bin/" in path_lower or path_lower.rstrip("/").endswith("/.venv/bin"):
         return True
-    if "venv" in parts_lower:
+    if "site-packages" in parts_lower and "bin" in parts_lower:
+        return True
+    if "dist-packages" in parts_lower and "bin" in parts_lower:
+        return True
+    if "venv" in parts_lower and "bin" in parts_lower:
+        return True
+    if "virtualenv" in parts_lower and "bin" in parts_lower:
         return True
     # python -m / Scripts on Windows
     if sys.platform == "win32" and "scripts" in parts_lower:

--- a/lintro/tools/core/update_channels.py
+++ b/lintro/tools/core/update_channels.py
@@ -9,7 +9,9 @@ manifest / tool-versions data — this module never makes network calls.
 from __future__ import annotations
 
 import os
+import shutil
 import sys
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -226,6 +228,9 @@ def build_version_advisory(
 def format_advisory_line(advisory: VersionAdvisory) -> str:
     """Render a human-readable advisory line.
 
+    Channel is diagnostic only; the actionable upgrade command lives on
+    the install strategy ``upgrade_hint`` / ``install_hint``.
+
     Args:
         advisory: Structured advisory to format.
 
@@ -237,8 +242,6 @@ def format_advisory_line(advisory: VersionAdvisory) -> str:
         f"{advisory.latest_known} expected"
     )
     channel_label = advisory.channel.value.replace("_", " ")
-    if advisory.update_command:
-        return f"{base} — installed via {channel_label}: {advisory.update_command}"
     if advisory.channel in (UpdateChannel.UNKNOWN, UpdateChannel.STANDALONE):
         return f"{base} — update channel unknown"
     return f"{base} — installed via {channel_label}"
@@ -339,15 +342,74 @@ _RUSTUP_SHIM_NAMES: frozenset[str] = frozenset(
     },
 )
 
+#: Version-probe argv[0] values that are host wrappers, not the tool binary.
+_WRAPPER_PROBE_NAMES: frozenset[str] = frozenset({"sh", "bash", "cargo", "env"})
+
+
+def resolve_channel_binary_path(
+    *,
+    tool_name: str,
+    install_bin: str | None = None,
+    probe_path: str | Path | None = None,
+    probe_argv0: str | None = None,
+    which: Callable[[str], str | None] | None = None,
+) -> str | Path | None:
+    """Return the binary path used for update-channel detection.
+
+    Cargo crates and some Node tools probe version through ``cargo`` or
+    ``bash``. Those argv[0] paths are not the tool and must not classify
+    the install channel.
+
+    Args:
+        tool_name: Canonical tool name.
+        install_bin: Manifest ``install.bin`` when it differs from the name.
+        probe_path: Path resolved from the version-probe argv[0].
+        probe_argv0: Version-probe argv[0] (may be a relative command name).
+        which: PATH lookup, defaulting to :func:`shutil.which`.
+
+    Returns:
+        Path of the tool binary when it can be found, otherwise *probe_path*.
+    """
+    argv0_source = probe_argv0 if probe_argv0 is not None else probe_path
+    argv0 = ""
+    if argv0_source is not None:
+        argv0 = Path(argv0_source).name.lower().removesuffix(".exe")
+    if argv0 not in _WRAPPER_PROBE_NAMES:
+        return probe_path
+
+    finder = which or shutil.which
+    candidates: list[str] = []
+    if install_bin:
+        candidates.append(install_bin)
+    hyphen = tool_name.replace("_", "-")
+    underscore = tool_name.replace("-", "_")
+    for name in (hyphen, underscore, tool_name):
+        if name not in candidates:
+            candidates.append(name)
+    for name in candidates:
+        found = finder(name)
+        if found:
+            return found
+    return probe_path
+
 
 def _is_rustup_shim(*, resolved: Path, tool_name: str | None) -> bool:
-    """Return True for rustup proxy binaries that live under ``~/.cargo/bin``."""
-    names = {resolved.name.lower().removesuffix(".exe")}
+    """Return True for rustup proxy binaries that live under ``~/.cargo/bin``.
+
+    When *tool_name* is set, only that name (and hyphen/underscore aliases)
+    is matched. Wrapper probes such as ``cargo audit`` resolve argv[0] to
+    the ``cargo`` shim; classifying from the basename would label
+    cargo-audit as rustup.
+    """
     if tool_name:
         lowered = tool_name.lower()
-        names.add(lowered.replace("-", "_"))
-        names.add(lowered.replace("_", "-"))
-        names.add(lowered)
+        names = {
+            lowered,
+            lowered.replace("-", "_"),
+            lowered.replace("_", "-"),
+        }
+    else:
+        names = {resolved.name.lower().removesuffix(".exe")}
     return bool(names & _RUSTUP_SHIM_NAMES)
 
 

--- a/lintro/tools/core/version_checking.py
+++ b/lintro/tools/core/version_checking.py
@@ -375,9 +375,6 @@ def _is_at_least(*, installed: str, latest_known: str) -> bool:
 
     Returns:
         True when installed meets or exceeds latest_known.
-
-    Raises:
-        ValueError: If either version string cannot be parsed.
     """
     from lintro.tools.core.version_parsing import compare_versions
 

--- a/lintro/tools/core/version_checking.py
+++ b/lintro/tools/core/version_checking.py
@@ -62,12 +62,9 @@ from lintro._tool_versions import (
 )
 from lintro.enums.tool_name import ToolName
 from lintro.enums.update_channel import UpdateChannel
+from lintro.tools.core import update_channels as update_channel_ops
 from lintro.tools.core.install_hints import SEMGREP_ISOLATED_INSTALL_HINT
-from lintro.tools.core.update_channels import (
-    VersionAdvisory,
-    build_version_advisory as _build_version_advisory,
-    channel_from_install_type,
-)
+from lintro.tools.core.update_channels import VersionAdvisory
 
 # Module-level set to track logged warnings and prevent duplicates
 # during parallel execution
@@ -353,9 +350,9 @@ def build_version_advisory(
 
     override = channel_override
     if override is None and binary_path is None:
-        override = channel_from_install_type(install_type)
+        override = update_channel_ops.channel_from_install_type(install_type)
 
-    advisory = _build_version_advisory(
+    advisory = update_channel_ops.build_version_advisory(
         tool=tool,
         installed=installed,
         latest_known=latest_known,
@@ -371,9 +368,9 @@ def build_version_advisory(
         and channel_override is None
         and install_type is not None
     ):
-        fallback = channel_from_install_type(install_type)
+        fallback = update_channel_ops.channel_from_install_type(install_type)
         if fallback is not None:
-            return _build_version_advisory(
+            return update_channel_ops.build_version_advisory(
                 tool=tool,
                 installed=installed,
                 latest_known=latest_known,

--- a/lintro/tools/core/version_checking.py
+++ b/lintro/tools/core/version_checking.py
@@ -50,8 +50,10 @@ TOOL_VERSIONS for binary/cargo/rustup). PRs will fail if they drift.
 
 import os
 import threading
+from pathlib import Path
 
 from loguru import logger
+from packaging.version import InvalidVersion, Version
 
 from lintro._tool_versions import (
     _NPM_PACKAGE_TO_TOOL,
@@ -59,7 +61,13 @@ from lintro._tool_versions import (
     get_tool_version,
 )
 from lintro.enums.tool_name import ToolName
+from lintro.enums.update_channel import UpdateChannel
 from lintro.tools.core.install_hints import SEMGREP_ISOLATED_INSTALL_HINT
+from lintro.tools.core.update_channels import (
+    VersionAdvisory,
+    build_version_advisory as _build_version_advisory,
+    channel_from_install_type,
+)
 
 # Module-level set to track logged warnings and prevent duplicates
 # during parallel execution
@@ -307,3 +315,94 @@ def get_install_hints() -> dict[str, str]:
                 )
 
     return hints
+
+
+def build_version_advisory(
+    *,
+    tool: str,
+    installed: str,
+    latest_known: str,
+    binary_path: str | Path | None = None,
+    install_package: str | None = None,
+    install_type: str | None = None,
+    channel_override: UpdateChannel | str | None = None,
+) -> VersionAdvisory | None:
+    """Build a version advisory when installed is below the known pin.
+
+    Uses pinned manifest / tool-versions expectations only — no network
+    calls. When path detection yields ``UNKNOWN``, falls back to a soft
+    mapping from the manifest ``install.type``.
+
+    Args:
+        tool: Canonical tool name.
+        installed: Currently installed version string.
+        latest_known: Pinned expected/recommended version.
+        binary_path: Path to the installed binary for channel detection.
+        install_package: Manifest package name override.
+        install_type: Manifest install type used as a soft channel fallback.
+        channel_override: Explicit channel (e.g. from manifest).
+
+    Returns:
+        :class:`VersionAdvisory` when ``installed < latest_known``, else None.
+    """
+    try:
+        if _is_at_least(installed, latest_known):
+            return None
+    except ValueError:
+        return None
+
+    override = channel_override
+    if override is None and binary_path is None:
+        override = channel_from_install_type(install_type)
+
+    advisory = _build_version_advisory(
+        tool=tool,
+        installed=installed,
+        latest_known=latest_known,
+        binary_path=binary_path,
+        install_package=install_package,
+        channel_override=override,
+    )
+
+    # Path said UNKNOWN/STANDALONE but manifest install.type is known —
+    # prefer that for a usable update command.
+    if (
+        advisory.channel in (UpdateChannel.UNKNOWN, UpdateChannel.STANDALONE)
+        and channel_override is None
+        and install_type is not None
+    ):
+        fallback = channel_from_install_type(install_type)
+        if fallback is not None:
+            return _build_version_advisory(
+                tool=tool,
+                installed=installed,
+                latest_known=latest_known,
+                binary_path=binary_path,
+                install_package=install_package,
+                channel_override=fallback,
+            )
+
+    return advisory
+
+
+def _is_at_least(installed: str, latest_known: str) -> bool:
+    """Return True when installed version is >= latest_known.
+
+    Args:
+        installed: Installed version string.
+        latest_known: Expected version string.
+
+    Returns:
+        True when installed meets or exceeds latest_known.
+
+    Raises:
+        ValueError: If either version string cannot be parsed.
+    """
+    try:
+        left = Version(installed.lstrip("vV").split("-", 1)[0].split("+", 1)[0])
+        right = Version(latest_known.lstrip("vV").split("-", 1)[0].split("+", 1)[0])
+    except InvalidVersion as exc:
+        raise ValueError(
+            f"Unable to compare versions: {installed!r} vs {latest_known!r}",
+        ) from exc
+    return left >= right

--- a/lintro/tools/core/version_checking.py
+++ b/lintro/tools/core/version_checking.py
@@ -53,7 +53,6 @@ import threading
 from pathlib import Path
 
 from loguru import logger
-from packaging.version import InvalidVersion, Version
 
 from lintro._tool_versions import (
     _NPM_PACKAGE_TO_TOOL,
@@ -343,7 +342,7 @@ def build_version_advisory(
         :class:`VersionAdvisory` when ``installed < latest_known``, else None.
     """
     try:
-        if _is_at_least(installed, latest_known):
+        if _is_at_least(installed=installed, latest_known=latest_known):
             return None
     except ValueError:
         return None
@@ -382,8 +381,11 @@ def build_version_advisory(
     return advisory
 
 
-def _is_at_least(installed: str, latest_known: str) -> bool:
+def _is_at_least(*, installed: str, latest_known: str) -> bool:
     """Return True when installed version is >= latest_known.
+
+    Delegates to :func:`lintro.tools.core.version_parsing.compare_versions` so
+    doctor and ``lintro versions`` classify the same strings the same way.
 
     Args:
         installed: Installed version string.
@@ -395,11 +397,6 @@ def _is_at_least(installed: str, latest_known: str) -> bool:
     Raises:
         ValueError: If either version string cannot be parsed.
     """
-    try:
-        left = Version(installed.lstrip("vV").split("-", 1)[0].split("+", 1)[0])
-        right = Version(latest_known.lstrip("vV").split("-", 1)[0].split("+", 1)[0])
-    except InvalidVersion as exc:
-        raise ValueError(
-            f"Unable to compare versions: {installed!r} vs {latest_known!r}",
-        ) from exc
-    return left >= right
+    from lintro.tools.core.version_parsing import compare_versions
+
+    return compare_versions(installed, latest_known) >= 0

--- a/lintro/tools/core/version_checking.py
+++ b/lintro/tools/core/version_checking.py
@@ -313,7 +313,7 @@ def get_install_hints() -> dict[str, str]:
     return hints
 
 
-def build_version_advisory(
+def build_outdated_version_advisory(
     *,
     tool: str,
     installed: str,
@@ -326,8 +326,10 @@ def build_version_advisory(
     """Build a version advisory when installed is below the known pin.
 
     Uses pinned manifest / tool-versions expectations only — no network
-    calls. When path detection yields ``UNKNOWN``, falls back to a soft
-    mapping from the manifest ``install.type``.
+    calls. When no binary path is available, falls back to a soft mapping
+    from the manifest ``install.type``. Path-based ``UNKNOWN`` / ``STANDALONE``
+    detections are kept honest — manifest ``install.type`` must not invent a
+    pip/npm/cargo update command beside a system binary.
 
     Args:
         tool: Canonical tool name.
@@ -335,7 +337,7 @@ def build_version_advisory(
         latest_known: Pinned expected/recommended version.
         binary_path: Path to the installed binary for channel detection.
         install_package: Manifest package name override.
-        install_type: Manifest install type used as a soft channel fallback.
+        install_type: Manifest install type used when *binary_path* is absent.
         channel_override: Explicit channel (e.g. from manifest).
 
     Returns:
@@ -351,7 +353,7 @@ def build_version_advisory(
     if override is None and binary_path is None:
         override = update_channel_ops.channel_from_install_type(install_type)
 
-    advisory = update_channel_ops.build_version_advisory(
+    return update_channel_ops.build_version_advisory(
         tool=tool,
         installed=installed,
         latest_known=latest_known,
@@ -359,26 +361,6 @@ def build_version_advisory(
         install_package=install_package,
         channel_override=override,
     )
-
-    # Path said UNKNOWN/STANDALONE but manifest install.type is known —
-    # prefer that for a usable update command.
-    if (
-        advisory.channel in (UpdateChannel.UNKNOWN, UpdateChannel.STANDALONE)
-        and channel_override is None
-        and install_type is not None
-    ):
-        fallback = update_channel_ops.channel_from_install_type(install_type)
-        if fallback is not None:
-            return update_channel_ops.build_version_advisory(
-                tool=tool,
-                installed=installed,
-                latest_known=latest_known,
-                binary_path=binary_path,
-                install_package=install_package,
-                channel_override=fallback,
-            )
-
-    return advisory
 
 
 def _is_at_least(*, installed: str, latest_known: str) -> bool:

--- a/lintro/tools/core/version_parsing.py
+++ b/lintro/tools/core/version_parsing.py
@@ -1,6 +1,7 @@
 """Version parsing utilities for tool version checking and validation."""
 
 import re
+import shutil
 import subprocess  # nosec B404 - used safely with shell disabled
 from dataclasses import dataclass, field
 from functools import lru_cache
@@ -12,8 +13,10 @@ from lintro.enums.tool_name import ToolName, normalize_tool_name
 
 # Import actual implementations from version_checking with aliases
 # to avoid name conflicts
+from lintro.tools.core.update_channels import VersionAdvisory
 from lintro.tools.core.version_checking import (
     VERSION_CHECK_TIMEOUT,
+    build_version_advisory,
 )
 from lintro.tools.core.version_checking import (
     get_install_hints as _get_install_hints_impl,
@@ -119,6 +122,8 @@ class ToolVersionInfo:
     version_check_passed: bool = field(default=False)
     below_recommended: bool = field(default=False)
     error_message: str | None = field(default=None)
+    binary_path: str | None = field(default=None)
+    advisory: VersionAdvisory | None = field(default=None)
 
 
 def parse_version(version_str: str) -> Version:
@@ -245,6 +250,7 @@ def check_tool_version(
         install_hint=install_hint,
         # If no requirements, assume check passes
         version_check_passed=not has_requirements,
+        binary_path=shutil.which(command[0]) if command else None,
     )
 
     try:
@@ -310,6 +316,43 @@ def check_tool_version(
                     info.below_recommended = True
             except ValueError:
                 pass
+
+        latest_known = (
+            rec_version
+            if rec_version and rec_version != VERSION_UNKNOWN
+            else min_version
+        )
+        if (
+            info.current_version
+            and latest_known
+            and latest_known != VERSION_UNKNOWN
+            and (not info.version_check_passed or info.below_recommended)
+        ):
+            install_type = None
+            install_package = None
+            try:
+                from lintro.tools.core.tool_registry import ManifestRegistry
+
+                registry = ManifestRegistry.load()
+                if tool_name in registry:
+                    manifest_tool = registry.get(tool_name)
+                    install_type = manifest_tool.install_type
+                    install_package = manifest_tool.install_package
+                    channel_override = manifest_tool.update_channel
+                else:
+                    channel_override = None
+            except (OSError, KeyError, RuntimeError, ValueError):
+                channel_override = None
+
+            info.advisory = build_version_advisory(
+                tool=tool_name,
+                installed=info.current_version,
+                latest_known=latest_known,
+                binary_path=info.binary_path,
+                install_package=install_package,
+                install_type=install_type,
+                channel_override=channel_override,
+            )
 
     except (subprocess.TimeoutExpired, OSError) as e:
         info.error_message = f"Failed to run version check: {e}"

--- a/lintro/tools/core/version_parsing.py
+++ b/lintro/tools/core/version_parsing.py
@@ -325,39 +325,39 @@ def check_tool_version(
             if rec_version and rec_version != VERSION_UNKNOWN
             else min_version
         )
+        install_type = None
+        install_package = None
+        install_bin = None
+        channel_override = None
+        try:
+            from lintro.tools.core.tool_registry import ManifestRegistry
+
+            registry = ManifestRegistry.load()
+            if tool_name in registry:
+                manifest_tool = registry.get(tool_name)
+                install_type = manifest_tool.install_type
+                install_package = manifest_tool.install_package
+                install_bin = manifest_tool.install_bin
+                channel_override = manifest_tool.update_channel
+        except (OSError, KeyError, RuntimeError, ValueError):
+            pass
+
+        channel_path = resolve_channel_binary_path(
+            tool_name=tool_name,
+            install_bin=install_bin,
+            probe_path=info.binary_path,
+            probe_argv0=command[0] if command else None,
+            which=shutil.which,
+        )
+        if channel_path is not None:
+            info.binary_path = str(channel_path)
+
         if (
             info.current_version
             and latest_known
             and latest_known != VERSION_UNKNOWN
             and (not info.version_check_passed or info.below_recommended)
         ):
-            install_type = None
-            install_package = None
-            install_bin = None
-            try:
-                from lintro.tools.core.tool_registry import ManifestRegistry
-
-                registry = ManifestRegistry.load()
-                if tool_name in registry:
-                    manifest_tool = registry.get(tool_name)
-                    install_type = manifest_tool.install_type
-                    install_package = manifest_tool.install_package
-                    install_bin = manifest_tool.install_bin
-                    channel_override = manifest_tool.update_channel
-                else:
-                    channel_override = None
-            except (OSError, KeyError, RuntimeError, ValueError):
-                channel_override = None
-
-            channel_path = resolve_channel_binary_path(
-                tool_name=tool_name,
-                install_bin=install_bin,
-                probe_path=info.binary_path,
-                probe_argv0=command[0] if command else None,
-                which=shutil.which,
-            )
-            if channel_path is not None:
-                info.binary_path = str(channel_path)
             info.advisory = build_outdated_version_advisory(
                 tool=tool_name,
                 installed=info.current_version,

--- a/lintro/tools/core/version_parsing.py
+++ b/lintro/tools/core/version_parsing.py
@@ -13,7 +13,10 @@ from lintro.enums.tool_name import ToolName, normalize_tool_name
 
 # Import actual implementations from version_checking with aliases
 # to avoid name conflicts
-from lintro.tools.core.update_channels import VersionAdvisory
+from lintro.tools.core.update_channels import (
+    VersionAdvisory,
+    resolve_channel_binary_path,
+)
 from lintro.tools.core.version_checking import (
     VERSION_CHECK_TIMEOUT,
     build_version_advisory,
@@ -330,6 +333,7 @@ def check_tool_version(
         ):
             install_type = None
             install_package = None
+            install_bin = None
             try:
                 from lintro.tools.core.tool_registry import ManifestRegistry
 
@@ -338,6 +342,7 @@ def check_tool_version(
                     manifest_tool = registry.get(tool_name)
                     install_type = manifest_tool.install_type
                     install_package = manifest_tool.install_package
+                    install_bin = manifest_tool.install_bin
                     channel_override = manifest_tool.update_channel
                 else:
                     channel_override = None
@@ -348,7 +353,13 @@ def check_tool_version(
                 tool=tool_name,
                 installed=info.current_version,
                 latest_known=latest_known,
-                binary_path=info.binary_path,
+                binary_path=resolve_channel_binary_path(
+                    tool_name=tool_name,
+                    install_bin=install_bin,
+                    probe_path=info.binary_path,
+                    probe_argv0=command[0] if command else None,
+                    which=shutil.which,
+                ),
                 install_package=install_package,
                 install_type=install_type,
                 channel_override=channel_override,

--- a/lintro/tools/core/version_parsing.py
+++ b/lintro/tools/core/version_parsing.py
@@ -19,7 +19,7 @@ from lintro.tools.core.update_channels import (
 )
 from lintro.tools.core.version_checking import (
     VERSION_CHECK_TIMEOUT,
-    build_version_advisory,
+    build_outdated_version_advisory,
 )
 from lintro.tools.core.version_checking import (
     get_install_hints as _get_install_hints_impl,
@@ -349,7 +349,7 @@ def check_tool_version(
             except (OSError, KeyError, RuntimeError, ValueError):
                 channel_override = None
 
-            info.advisory = build_version_advisory(
+            info.advisory = build_outdated_version_advisory(
                 tool=tool_name,
                 installed=info.current_version,
                 latest_known=latest_known,

--- a/lintro/tools/core/version_parsing.py
+++ b/lintro/tools/core/version_parsing.py
@@ -349,17 +349,20 @@ def check_tool_version(
             except (OSError, KeyError, RuntimeError, ValueError):
                 channel_override = None
 
+            channel_path = resolve_channel_binary_path(
+                tool_name=tool_name,
+                install_bin=install_bin,
+                probe_path=info.binary_path,
+                probe_argv0=command[0] if command else None,
+                which=shutil.which,
+            )
+            if channel_path is not None:
+                info.binary_path = str(channel_path)
             info.advisory = build_outdated_version_advisory(
                 tool=tool_name,
                 installed=info.current_version,
                 latest_known=latest_known,
-                binary_path=resolve_channel_binary_path(
-                    tool_name=tool_name,
-                    install_bin=install_bin,
-                    probe_path=info.binary_path,
-                    probe_argv0=command[0] if command else None,
-                    which=shutil.which,
-                ),
+                binary_path=channel_path,
                 install_package=install_package,
                 install_type=install_type,
                 channel_override=channel_override,

--- a/lintro/tools/core/version_parsing.py
+++ b/lintro/tools/core/version_parsing.py
@@ -265,13 +265,15 @@ def check_tool_version(
         from lintro.tools.core.tool_registry import ManifestRegistry
 
         registry = ManifestRegistry.load()
-        if tool_name in registry:
-            manifest_tool = registry.get(tool_name)
-            install_type = manifest_tool.install_type
-            install_package = manifest_tool.install_package
-            install_bin = manifest_tool.install_bin
-            install_component = manifest_tool.install_component
-            channel_override = manifest_tool.update_channel
+        for lookup_name in lookup_names:
+            if lookup_name in registry:
+                manifest_tool = registry.get(lookup_name)
+                install_type = manifest_tool.install_type
+                install_package = manifest_tool.install_package
+                install_bin = manifest_tool.install_bin
+                install_component = manifest_tool.install_component
+                channel_override = manifest_tool.update_channel
+                break
     except (OSError, KeyError, RuntimeError, ValueError):
         pass
 
@@ -283,8 +285,7 @@ def check_tool_version(
         probe_argv0=command[0] if command else None,
         which=shutil.which,
     )
-    if channel_path is not None:
-        info.binary_path = str(channel_path)
+    info.binary_path = str(channel_path) if channel_path is not None else None
 
     try:
         # Run the tool with --version flag (unless caller already included it)

--- a/lintro/tools/core/version_parsing.py
+++ b/lintro/tools/core/version_parsing.py
@@ -256,6 +256,36 @@ def check_tool_version(
         binary_path=shutil.which(command[0]) if command else None,
     )
 
+    install_type = None
+    install_package = None
+    install_bin = None
+    install_component = None
+    channel_override = None
+    try:
+        from lintro.tools.core.tool_registry import ManifestRegistry
+
+        registry = ManifestRegistry.load()
+        if tool_name in registry:
+            manifest_tool = registry.get(tool_name)
+            install_type = manifest_tool.install_type
+            install_package = manifest_tool.install_package
+            install_bin = manifest_tool.install_bin
+            install_component = manifest_tool.install_component
+            channel_override = manifest_tool.update_channel
+    except (OSError, KeyError, RuntimeError, ValueError):
+        pass
+
+    channel_path = resolve_channel_binary_path(
+        tool_name=tool_name,
+        install_bin=install_bin,
+        install_component=install_component,
+        probe_path=info.binary_path,
+        probe_argv0=command[0] if command else None,
+        which=shutil.which,
+    )
+    if channel_path is not None:
+        info.binary_path = str(channel_path)
+
     try:
         # Run the tool with --version flag (unless caller already included it)
         version_cmd = command if not append_version else [*command, "--version"]
@@ -325,33 +355,6 @@ def check_tool_version(
             if rec_version and rec_version != VERSION_UNKNOWN
             else min_version
         )
-        install_type = None
-        install_package = None
-        install_bin = None
-        channel_override = None
-        try:
-            from lintro.tools.core.tool_registry import ManifestRegistry
-
-            registry = ManifestRegistry.load()
-            if tool_name in registry:
-                manifest_tool = registry.get(tool_name)
-                install_type = manifest_tool.install_type
-                install_package = manifest_tool.install_package
-                install_bin = manifest_tool.install_bin
-                channel_override = manifest_tool.update_channel
-        except (OSError, KeyError, RuntimeError, ValueError):
-            pass
-
-        channel_path = resolve_channel_binary_path(
-            tool_name=tool_name,
-            install_bin=install_bin,
-            probe_path=info.binary_path,
-            probe_argv0=command[0] if command else None,
-            which=shutil.which,
-        )
-        if channel_path is not None:
-            info.binary_path = str(channel_path)
-
         if (
             info.current_version
             and latest_known

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -40,6 +40,8 @@ from lintro.tools.core.tool_installer import (
     resolve_version_command,
 )
 from lintro.tools.core.tool_registry import ManifestRegistry, ManifestTool
+from lintro.tools.core.update_channels import VersionAdvisory
+from lintro.tools.core.version_checking import build_version_advisory
 from lintro.tools.core.version_parsing import (
     compare_versions,
     extract_version_from_output,
@@ -80,6 +82,7 @@ class ToolCheckResult:
         path: Filesystem path where the tool was found.
         install_hint: Context-aware install command.
         upgrade_hint: Context-aware upgrade command for outdated tools.
+        advisory: Structured update advisory when outdated/incompatible.
     """
 
     tool: ManifestTool
@@ -90,6 +93,7 @@ class ToolCheckResult:
     path: str | None = None
     install_hint: str = ""
     upgrade_hint: str = ""
+    advisory: VersionAdvisory | None = None
 
     @property
     def installed(self) -> bool:
@@ -247,13 +251,27 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
             recommended=tool.version,
             minimum=tool.min_version,
         )
+        advisory = None
+        final_upgrade = upgrade_hint
+        if status in (ToolStatus.OUTDATED, ToolStatus.INCOMPATIBLE):
+            advisory = build_version_advisory(
+                tool=tool.name,
+                installed=version,
+                latest_known=tool.version,
+                binary_path=tool_path,
+                install_package=tool.install_package,
+                install_type=tool.install_type,
+            )
+            if advisory and advisory.update_command:
+                final_upgrade = advisory.update_command
         return ToolCheckResult(
             tool=tool,
             status=status,
             installed_version=version,
             path=tool_path,
             install_hint=hint,
-            upgrade_hint=upgrade_hint,
+            upgrade_hint=final_upgrade,
+            advisory=advisory,
         )
     except subprocess.TimeoutExpired:
         return ToolCheckResult(

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -541,7 +541,8 @@ def _config_checks() -> tuple[LintroConfig | None, list[DoctorCheck]]:
 
     try:
         config = get_config(reload=True)
-    except Exception as exc:  # noqa: BLE001 - any parse failure is a report line, not a crash
+    except Exception as exc:  # noqa: BLE001
+        # Any parse failure is a report line, not a crash.
         return None, [
             DoctorCheck(
                 category=DoctorCheckCategory.CONFIG,
@@ -567,7 +568,8 @@ def _config_checks() -> tuple[LintroConfig | None, list[DoctorCheck]]:
 
     try:
         warnings = validate_config_consistency()
-    except Exception as exc:  # noqa: BLE001 - a broken native config must not abort the report
+    except Exception as exc:  # noqa: BLE001
+        # A broken native config must not abort the report.
         warnings = [f"consistency check failed: {exc}"]
 
     if warnings:

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -40,7 +40,10 @@ from lintro.tools.core.tool_installer import (
     resolve_version_command,
 )
 from lintro.tools.core.tool_registry import ManifestRegistry, ManifestTool
-from lintro.tools.core.update_channels import VersionAdvisory
+from lintro.tools.core.update_channels import (
+    VersionAdvisory,
+    resolve_channel_binary_path,
+)
 from lintro.tools.core.version_checking import build_version_advisory
 from lintro.tools.core.version_parsing import (
     compare_versions,
@@ -252,26 +255,30 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
             minimum=tool.min_version,
         )
         advisory = None
-        final_upgrade = upgrade_hint
         if status in (ToolStatus.OUTDATED, ToolStatus.INCOMPATIBLE):
+            channel_path = resolve_channel_binary_path(
+                tool_name=tool.name,
+                install_bin=tool.install_bin,
+                probe_path=tool_path,
+                probe_argv0=main_cmd,
+                which=shutil.which,
+            )
             advisory = build_version_advisory(
                 tool=tool.name,
                 installed=version,
                 latest_known=tool.version,
-                binary_path=tool_path,
+                binary_path=channel_path,
                 install_package=tool.install_package,
                 install_type=tool.install_type,
                 channel_override=tool.update_channel,
             )
-            if advisory and advisory.update_command:
-                final_upgrade = advisory.update_command
         return ToolCheckResult(
             tool=tool,
             status=status,
             installed_version=version,
             path=tool_path,
             install_hint=hint,
-            upgrade_hint=final_upgrade,
+            upgrade_hint=upgrade_hint,
             advisory=advisory,
         )
     except subprocess.TimeoutExpired:
@@ -534,9 +541,7 @@ def _config_checks() -> tuple[LintroConfig | None, list[DoctorCheck]]:
 
     try:
         config = get_config(reload=True)
-    except (
-        Exception
-    ) as exc:  # noqa: BLE001 - any parse failure is a report line, not a crash
+    except Exception as exc:  # noqa: BLE001 - any parse failure is a report line, not a crash
         return None, [
             DoctorCheck(
                 category=DoctorCheckCategory.CONFIG,
@@ -562,9 +567,7 @@ def _config_checks() -> tuple[LintroConfig | None, list[DoctorCheck]]:
 
     try:
         warnings = validate_config_consistency()
-    except (
-        Exception
-    ) as exc:  # noqa: BLE001 - a broken native config must not abort the report
+    except Exception as exc:  # noqa: BLE001 - a broken native config must not abort the report
         warnings = [f"consistency check failed: {exc}"]
 
     if warnings:

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -261,6 +261,7 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
                 binary_path=tool_path,
                 install_package=tool.install_package,
                 install_type=tool.install_type,
+                channel_override=tool.update_channel,
             )
             if advisory and advisory.update_command:
                 final_upgrade = advisory.update_command

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -216,6 +216,17 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
                 upgrade_hint=upgrade_hint,
             )
 
+    channel_path = resolve_channel_binary_path(
+        tool_name=tool.name,
+        install_bin=tool.install_bin,
+        install_component=tool.install_component,
+        probe_path=tool_path,
+        probe_argv0=main_cmd,
+        which=shutil.which,
+    )
+    if channel_path is not None:
+        tool_path = str(channel_path)
+
     try:
         result = subprocess.run(  # nosec B603 - argv is an internally-built list run with shell=False; binary resolved from a known command, no user shell input
             command,
@@ -256,18 +267,11 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
         )
         advisory = None
         if status in (ToolStatus.OUTDATED, ToolStatus.INCOMPATIBLE):
-            channel_path = resolve_channel_binary_path(
-                tool_name=tool.name,
-                install_bin=tool.install_bin,
-                probe_path=tool_path,
-                probe_argv0=main_cmd,
-                which=shutil.which,
-            )
             advisory = build_outdated_version_advisory(
                 tool=tool.name,
                 installed=version,
                 latest_known=tool.version,
-                binary_path=channel_path,
+                binary_path=tool_path,
                 install_package=tool.install_package,
                 install_type=tool.install_type,
                 channel_override=tool.update_channel,

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -44,7 +44,7 @@ from lintro.tools.core.update_channels import (
     VersionAdvisory,
     resolve_channel_binary_path,
 )
-from lintro.tools.core.version_checking import build_version_advisory
+from lintro.tools.core.version_checking import build_outdated_version_advisory
 from lintro.tools.core.version_parsing import (
     compare_versions,
     extract_version_from_output,
@@ -263,7 +263,7 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
                 probe_argv0=main_cmd,
                 which=shutil.which,
             )
-            advisory = build_version_advisory(
+            advisory = build_outdated_version_advisory(
                 tool=tool.name,
                 installed=version,
                 latest_known=tool.version,

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -79,6 +79,215 @@ def _make_context(*, has_brew: bool = False) -> RuntimeContext:
     )
 
 
+<<<<<<< HEAD
+=======
+# ── _compare_versions ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("installed", "expected", "want"),
+    [
+        ("1.2.3", "1.0.0", ToolStatus.OK),
+        ("1.0.0", "1.0.0", ToolStatus.OK),
+        ("1.0.0", "1.2.0", ToolStatus.OUTDATED),
+        ("0.14.0", "0.15.0", ToolStatus.OUTDATED),
+        ("0.0.1", "2.0.0", ToolStatus.INCOMPATIBLE),
+        ("invalid", "1.0.0", ToolStatus.UNKNOWN),
+    ],
+    ids=["above", "equal", "below", "minor_below", "incompatible", "invalid"],
+)
+def test_compare_versions(installed: str, expected: str, want: ToolStatus) -> None:
+    """Compare two version strings and return the correct ToolStatus."""
+    minimum = expected if want == ToolStatus.INCOMPATIBLE else "0.0.0"
+    assert_that(_compare_versions(installed, expected, minimum)).is_equal_to(want)
+
+
+# ── _check_tool ──────────────────────────────────────────────────────
+
+
+def test_check_tool_ok() -> None:
+    """Tool found in PATH with version meeting minimum."""
+    tool = _make_tool(version="0.14.0")
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ruff 0.14.4",
+            stderr="",
+        )
+        result = _check_tool(tool, ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.OK)
+    assert_that(result.installed_version).is_equal_to("0.14.4")
+    assert_that(result.path).is_equal_to("/usr/bin/ruff")
+
+
+def test_check_tool_outdated_enriches_advisory_from_path() -> None:
+    """Outdated tools get a path-based update advisory."""
+    tool = _make_tool(version="1.0.0", min_version="0.3.0")
+    ctx = _make_context()
+
+    with (
+        patch(
+            "shutil.which",
+            return_value="/Users/me/.local/share/uv/tools/ruff/bin/ruff",
+        ),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ruff 0.5.0",
+            stderr="",
+        )
+        result = _check_tool(tool, ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
+    assert_that(result.advisory).is_not_none()
+    assert result.advisory is not None
+    assert_that(result.advisory.channel.value).is_equal_to("uv_tool")
+    assert_that(result.upgrade_hint).is_equal_to("uv tool upgrade ruff")
+
+
+def test_check_tool_incompatible() -> None:
+    """Tool found but version below hard minimum."""
+    tool = _make_tool(version="1.0.0", min_version="1.0.0")
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ruff 0.5.0",
+            stderr="",
+        )
+        result = _check_tool(tool, ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.INCOMPATIBLE)
+
+
+def test_check_tool_missing_not_in_path() -> None:
+    """Tool executable not found in PATH."""
+    tool = _make_tool()
+    ctx = _make_context()
+
+    with patch("shutil.which", return_value=None):
+        result = _check_tool(tool, ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(result.error).is_equal_to("not_in_path")
+
+
+def test_check_tool_missing_command_failed() -> None:
+    """Tool found but version command exits non-zero."""
+    tool = _make_tool()
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="error",
+        )
+        result = _check_tool(tool, ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(result.error).is_equal_to("command_failed")
+
+
+def test_check_tool_missing_timeout() -> None:
+    """Tool version command times out."""
+    tool = _make_tool()
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["ruff"], timeout=10),
+        ),
+    ):
+        result = _check_tool(tool, ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(result.error).is_equal_to("timeout")
+
+
+def test_check_tool_missing_os_error() -> None:
+    """Tool version command raises OSError."""
+    tool = _make_tool()
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run", side_effect=OSError("exec format error")),
+    ):
+        result = _check_tool(tool, ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(result.error).is_equal_to("os_error")
+
+
+def test_check_tool_unknown_no_version() -> None:
+    """Tool runs but output has no parseable version."""
+    tool = _make_tool()
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="no version here",
+            stderr="",
+        )
+        result = _check_tool(tool, ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.UNKNOWN)
+    assert_that(result.error).is_equal_to("no_version")
+
+
+def test_check_tool_no_version_command() -> None:
+    """Tool has no version_command defined."""
+    tool = _make_tool(version_command=())
+    ctx = _make_context()
+
+    result = _check_tool(tool, ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(result.error).is_equal_to("no_command")
+
+
+def test_check_tool_upgrade_hint_populated() -> None:
+    """Both install_hint and upgrade_hint are populated."""
+    tool = _make_tool()
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ruff 0.14.4",
+            stderr="",
+        )
+        result = _check_tool(tool, ctx)
+
+    assert_that(result.install_hint).is_not_empty()
+    assert_that(result.upgrade_hint).is_not_empty()
+
+
+>>>>>>> 74653b25 (feat(cli): surface update advisories in doctor and versions)
 # ── _output_json ─────────────────────────────────────────────────────
 
 

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -317,7 +317,7 @@ def test_check_tool_vue_tsc_bash_wrapper_uses_vue_tsc_binary() -> None:
     assert_that(result.advisory.update_command).is_equal_to(
         "npm install -D vue-tsc@3.3.10",
     )
-    assert_that(result.path).is_equal_to("/bin/bash")
+    assert_that(result.path).is_equal_to("/proj/node_modules/.bin/vue-tsc")
 
 
 def test_check_tool_pip_only_host_does_not_emit_uv() -> None:
@@ -503,6 +503,25 @@ def test_output_json_includes_advisory_for_outdated_tool() -> None:
     assert_that(tool_json["advisory"]["update_command"]).is_equal_to(
         "uv tool upgrade ruff",
     )
+
+
+def test_output_json_includes_null_advisory_when_current() -> None:
+    """Doctor JSON always includes advisory so CLI and MCP share one shape."""
+    tool = _make_tool(version="1.0.0", min_version="0.3.0")
+    result = ToolCheckResult(
+        tool=tool,
+        status=ToolStatus.OK,
+        installed_version="1.0.0",
+    )
+    ctx = _make_context()
+
+    output = StringIO()
+    with patch("click.echo", side_effect=output.write):
+        _output_json([result], ctx, None, 0, 0, 0, 0, 0)
+
+    data = json.loads(output.getvalue())
+    assert_that(data["tools"]["ruff"]).contains_key("advisory")
+    assert_that(data["tools"]["ruff"]["advisory"]).is_none()
 
 
 def test_doctor_json_includes_advisory_from_probe() -> None:

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -8,16 +8,15 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from assertpy import assert_that
 from click.testing import CliRunner
 from loguru import logger
-from rich.console import Console
 
 from lintro.ai.config import AIConfig
 from lintro.cli_utils.commands.doctor import (
     _generate_markdown_report,
     _output_json,
-    _render_tool_line,
     doctor_command,
 )
 from lintro.config.lintro_config import LintroConfig
@@ -351,13 +350,16 @@ def test_check_tool_pip_only_host_does_not_emit_uv() -> None:
     )
     assert_that(result.upgrade_hint).does_not_contain("uv ")
     assert result.advisory is not None
-    assert_that(result.advisory.update_command).contains("uv pip install")
+    assert_that(result.advisory.channel).is_equal_to(UpdateChannel.STANDALONE)
+    assert_that(result.advisory.update_command).is_none()
 
 
-def test_render_outdated_prints_channel_and_strategy_hint() -> None:
+def test_doctor_outdated_prints_channel_and_strategy_hint() -> None:
     """Outdated lines show the channel as diagnostic and the strategy command."""
+    runner = CliRunner()
+    p1, p2 = _patch_doctor_deps()
     tool = _make_tool(version="1.0.0", min_version="0.3.0")
-    result = ToolCheckResult(
+    outdated = ToolCheckResult(
         tool=tool,
         status=ToolStatus.OUTDATED,
         installed_version="0.5.0",
@@ -370,19 +372,29 @@ def test_render_outdated_prints_channel_and_strategy_hint() -> None:
             update_command="uv tool upgrade ruff",
         ),
     )
-    buf = StringIO()
-    console = Console(file=buf, force_terminal=False, width=120)
-    _render_tool_line(console, result, verbose=False, is_dev=False)
-    text = buf.getvalue()
-    assert_that(text).contains("installed via uv tool")
-    assert_that(text).contains("Upgrade: uv pip install --upgrade 'ruff>=1.0.0'")
-    assert_that(text).does_not_contain("uv tool upgrade ruff")
+
+    with (
+        p1,
+        p2,
+        patch(
+            "lintro.cli_utils.commands.doctor.collect_tool_checks",
+            return_value=[outdated],
+        ),
+    ):
+        result = runner.invoke(doctor_command, [])
+
+    assert_that(result.exit_code).is_equal_to(1)
+    assert_that(result.output).contains("installed via uv tool")
+    assert_that(result.output).contains("Upgrade: uv pip install --upgrade 'ruff>=1.0.0'")
+    assert_that(result.output).does_not_contain("uv tool upgrade ruff")
 
 
-def test_render_incompatible_prints_channel_and_strategy_hint() -> None:
+def test_doctor_incompatible_prints_channel_and_strategy_hint() -> None:
     """Incompatible lines also keep the strategy upgrade command."""
+    runner = CliRunner()
+    p1, p2 = _patch_doctor_deps()
     tool = _make_tool(version="1.0.0", min_version="0.9.0")
-    result = ToolCheckResult(
+    incompatible = ToolCheckResult(
         tool=tool,
         status=ToolStatus.INCOMPATIBLE,
         installed_version="0.1.0",
@@ -395,16 +407,164 @@ def test_render_incompatible_prints_channel_and_strategy_hint() -> None:
             update_command="uv pip install --upgrade 'ruff>=1.0.0'",
         ),
     )
-    buf = StringIO()
-    console = Console(file=buf, force_terminal=False, width=120)
-    _render_tool_line(console, result, verbose=False, is_dev=False)
-    text = buf.getvalue()
-    assert_that(text).contains("installed via pip")
-    assert_that(text).contains("Upgrade: pip install --upgrade 'ruff>=1.0.0'")
-    assert_that(text).does_not_contain("uv pip")
+
+    with (
+        p1,
+        p2,
+        patch(
+            "lintro.cli_utils.commands.doctor.collect_tool_checks",
+            return_value=[incompatible],
+        ),
+    ):
+        result = runner.invoke(doctor_command, [])
+
+    assert_that(result.exit_code).is_equal_to(1)
+    assert_that(result.output).contains("installed via pip")
+    assert_that(result.output).contains("Upgrade: pip install --upgrade 'ruff>=1.0.0'")
+    assert_that(result.output).does_not_contain("uv pip")
 
 
 # ── _output_json ─────────────────────────────────────────────────────
+
+
+def test_output_json_includes_advisory_for_outdated_tool() -> None:
+    """JSON output carries structured update advisories for outdated tools."""
+    tool = _make_tool(version="1.0.0", min_version="0.3.0")
+    advisory = VersionAdvisory(
+        tool="ruff",
+        installed="0.5.0",
+        latest_known="1.0.0",
+        channel=UpdateChannel.UV_TOOL,
+        update_command="uv tool upgrade ruff",
+    )
+    result = ToolCheckResult(
+        tool=tool,
+        status=ToolStatus.OUTDATED,
+        installed_version="0.5.0",
+        upgrade_hint="uv pip install --upgrade 'ruff>=1.0.0'",
+        advisory=advisory,
+    )
+    ctx = _make_context()
+
+    output = StringIO()
+    with patch("click.echo", side_effect=output.write):
+        _output_json([result], ctx, None, 0, 0, 1, 0, 0)
+
+    data = json.loads(output.getvalue())
+    tool_json = data["tools"]["ruff"]
+    assert_that(tool_json).contains_key("advisory")
+    assert tool_json["advisory"] is not None
+    assert_that(tool_json["advisory"]["channel"]).is_equal_to("uv_tool")
+    assert_that(tool_json["advisory"]["update_command"]).is_equal_to(
+        "uv tool upgrade ruff",
+    )
+
+
+def test_doctor_json_includes_advisory_from_probe() -> None:
+    """``doctor --json`` surfaces advisories produced by tool checks."""
+    runner = CliRunner()
+    p1, p2 = _patch_doctor_deps()
+
+    with (
+        p1,
+        p2,
+        patch("subprocess.run") as mock_run,
+        patch(
+            "shutil.which",
+            return_value="/Users/me/.local/share/uv/tools/ruff/bin/ruff",
+        ),
+        patch(
+            "lintro.cli_utils.commands.doctor.collect_full_environment",
+            return_value=None,
+        ),
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ruff 0.5.0",
+            stderr="",
+        )
+        result = runner.invoke(doctor_command, ["--json"])
+
+    data = json.loads(result.output)
+    advisory = data["tools"]["ruff"]["advisory"]
+    assert_that(advisory).is_not_none()
+    assert_that(advisory["channel"]).is_equal_to("uv_tool")
+    assert_that(advisory["update_command"]).is_equal_to("uv tool upgrade ruff")
+
+
+def test_check_tool_invalid_update_channel_falls_back_to_path() -> None:
+    """An invalid manifest ``update_channel`` is ignored like a missing override."""
+    tool = _make_tool(
+        name="hadolint",
+        version="2.12.0",
+        min_version="2.10.0",
+        install_type="binary",
+        update_channel="not-a-real-channel",
+    )
+    ctx = _make_context(has_brew=True)
+
+    with (
+        patch("shutil.which", return_value="/opt/homebrew/bin/hadolint"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="Haskell Dockerfile Linter 2.10.0",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
+    assert result.advisory is not None
+    assert_that(result.advisory.channel.value).is_equal_to("homebrew")
+
+
+def test_check_tool_cargo_home_bin_is_cargo(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A crate under ``CARGO_HOME/bin`` is classified as cargo, not unknown."""
+    cargo_home = tmp_path / "cargo-home"
+    tool_bin = cargo_home / "bin" / "cargo-audit"
+    tool_bin.parent.mkdir(parents=True)
+    tool_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("CARGO_HOME", str(cargo_home))
+
+    tool = _make_tool(
+        name="cargo_audit",
+        version="0.22.0",
+        min_version="0.20.0",
+        install_type="cargo",
+        install_package="cargo-audit",
+        version_command=("cargo", "audit", "--version"),
+    )
+    ctx = _make_context()
+
+    with (
+        patch(
+            "shutil.which",
+            side_effect=_which_map(
+                {
+                    "cargo": str(cargo_home / "bin" / "cargo"),
+                    "cargo-audit": str(tool_bin),
+                },
+            ),
+        ),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="cargo-audit 0.20.0",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
+    assert result.advisory is not None
+    assert_that(result.advisory.channel.value).is_equal_to("cargo")
+    assert_that(result.advisory.update_command).is_equal_to(
+        "cargo install --force cargo-audit",
+    )
 
 
 def test_output_json_produces_valid_json() -> None:

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -354,6 +354,47 @@ def test_check_tool_pip_only_host_does_not_emit_uv() -> None:
     assert_that(result.advisory.update_command).is_none()
 
 
+def test_check_tool_venv_pip_only_does_not_emit_uv() -> None:
+    """A ``.venv`` binary on a pip-only host must not emit ``uv pip``."""
+    tool = _make_tool(version="1.0.0", min_version="0.3.0")
+    ctx = RuntimeContext(
+        install_context=InstallContext.PIP,
+        platform_label="Linux x86_64",
+        environment=InstallEnvironment(
+            install_context=InstallContext.PIP,
+            available_managers=frozenset({PackageManager.PIP}),
+        ),
+        is_ci=False,
+    )
+
+    def fake_which(name: str) -> str | None:
+        if name == "ruff":
+            return "/proj/.venv/bin/ruff"
+        return None
+
+    with (
+        patch("shutil.which", side_effect=fake_which),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ruff 0.5.0",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
+    assert_that(result.upgrade_hint).is_equal_to(
+        "pip install --upgrade 'ruff>=1.0.0'",
+    )
+    assert result.advisory is not None
+    assert_that(result.advisory.channel).is_equal_to(UpdateChannel.PIP)
+    assert_that(result.advisory.update_command).is_equal_to(
+        "pip install --upgrade 'ruff>=1.0.0'",
+    )
+    assert_that(result.advisory.update_command).does_not_contain("uv ")
+
+
 def test_doctor_outdated_prints_channel_and_strategy_hint() -> None:
     """Outdated lines show the channel as diagnostic and the strategy command."""
     runner = CliRunner()
@@ -385,6 +426,8 @@ def test_doctor_outdated_prints_channel_and_strategy_hint() -> None:
 
     assert_that(result.exit_code).is_equal_to(1)
     assert_that(result.output).contains("installed via uv tool")
+    assert_that(result.output.count("installed via uv tool")).is_equal_to(1)
+    assert_that(result.output).does_not_contain("Update advisories")
     assert_that(result.output).contains(
         "Upgrade: uv pip install --upgrade 'ruff>=1.0.0'",
     )

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -35,6 +36,8 @@ def _make_tool(
     min_version: str | None = None,
     *,
     install_type: str = "pip",
+    install_package: str | None = None,
+    update_channel: str | None = None,
     tier: str = "tools",
     category: str = "bundled",
     version_command: tuple[str, ...] | None = None,
@@ -45,6 +48,8 @@ def _make_tool(
         version=version,
         min_version=min_version or version,
         install_type=install_type,
+        install_package=install_package,
+        update_channel=update_channel,
         tier=tier,
         category=category,
         version_command=(
@@ -79,8 +84,6 @@ def _make_context(*, has_brew: bool = False) -> RuntimeContext:
     )
 
 
-
-
 # ── check_tool advisories ────────────────────────────────────────────
 
 
@@ -108,6 +111,99 @@ def test_check_tool_outdated_enriches_advisory_from_path() -> None:
     assert result.advisory is not None
     assert_that(result.advisory.channel.value).is_equal_to("uv_tool")
     assert_that(result.upgrade_hint).is_equal_to("uv tool upgrade ruff")
+
+
+def test_check_tool_honors_manifest_channel_override() -> None:
+    """Manifest ``update_channel`` wins when path heuristics are UNKNOWN."""
+    tool = _make_tool(
+        name="hadolint",
+        version="2.12.0",
+        min_version="2.10.0",
+        install_type="binary",
+        update_channel="homebrew",
+    )
+    ctx = _make_context(has_brew=True)
+
+    with (
+        patch("shutil.which", return_value="/opt/mystery/bin/hadolint"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="Haskell Dockerfile Linter 2.10.0",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
+    assert result.advisory is not None
+    assert_that(result.advisory.channel.value).is_equal_to("homebrew")
+    assert_that(result.upgrade_hint).is_equal_to("brew upgrade hadolint")
+
+
+def test_check_tool_rustc_cargo_bin_stays_rustup() -> None:
+    """Rustc under ``~/.cargo/bin`` is upgraded with rustup, not cargo install."""
+    tool = _make_tool(
+        name="rustc",
+        version="1.97.1",
+        min_version="1.80.0",
+        install_type="rustup",
+    )
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/Users/me/.cargo/bin/rustc"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="rustc 1.80.0 (abc 2024-01-01)",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
+    assert result.advisory is not None
+    assert_that(result.advisory.channel.value).is_equal_to("rustup")
+    assert_that(result.upgrade_hint).is_equal_to("rustup update stable")
+
+
+def test_check_tool_node_modules_does_not_use_global_npm(
+    tmp_path: Path,
+) -> None:
+    """A project-local prettier must not get ``npm install -g``.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    prettier = tmp_path / "node_modules" / ".bin" / "prettier"
+    prettier.parent.mkdir(parents=True)
+    prettier.write_text("#!/bin/sh\n")
+    tool = _make_tool(
+        name="prettier",
+        version="3.9.5",
+        min_version="3.0.0",
+        install_type="npm",
+        install_package="prettier",
+    )
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value=str(prettier)),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="3.0.0",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
+    assert result.advisory is not None
+    assert_that(result.advisory.channel.value).is_equal_to("npm")
+    assert_that(result.upgrade_hint).is_equal_to("npm install -D prettier@3.9.5")
+    assert_that(result.upgrade_hint).does_not_contain("install -g")
 
 
 # ── _output_json ─────────────────────────────────────────────────────

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -24,7 +24,7 @@ from lintro.tools.core.install_context import RuntimeContext
 from lintro.tools.core.install_plan import InstallPlan, InstallResult
 from lintro.tools.core.install_strategies.environment import InstallEnvironment
 from lintro.tools.core.tool_registry import ManifestTool
-from lintro.utils.doctor_report import ToolCheckResult
+from lintro.utils.doctor_report import ToolCheckResult, check_tool
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -79,51 +79,9 @@ def _make_context(*, has_brew: bool = False) -> RuntimeContext:
     )
 
 
-<<<<<<< HEAD
-=======
-# ── _compare_versions ────────────────────────────────────────────────
 
 
-@pytest.mark.parametrize(
-    ("installed", "expected", "want"),
-    [
-        ("1.2.3", "1.0.0", ToolStatus.OK),
-        ("1.0.0", "1.0.0", ToolStatus.OK),
-        ("1.0.0", "1.2.0", ToolStatus.OUTDATED),
-        ("0.14.0", "0.15.0", ToolStatus.OUTDATED),
-        ("0.0.1", "2.0.0", ToolStatus.INCOMPATIBLE),
-        ("invalid", "1.0.0", ToolStatus.UNKNOWN),
-    ],
-    ids=["above", "equal", "below", "minor_below", "incompatible", "invalid"],
-)
-def test_compare_versions(installed: str, expected: str, want: ToolStatus) -> None:
-    """Compare two version strings and return the correct ToolStatus."""
-    minimum = expected if want == ToolStatus.INCOMPATIBLE else "0.0.0"
-    assert_that(_compare_versions(installed, expected, minimum)).is_equal_to(want)
-
-
-# ── _check_tool ──────────────────────────────────────────────────────
-
-
-def test_check_tool_ok() -> None:
-    """Tool found in PATH with version meeting minimum."""
-    tool = _make_tool(version="0.14.0")
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch("subprocess.run") as mock_run,
-    ):
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="ruff 0.14.4",
-            stderr="",
-        )
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.OK)
-    assert_that(result.installed_version).is_equal_to("0.14.4")
-    assert_that(result.path).is_equal_to("/usr/bin/ruff")
+# ── check_tool advisories ────────────────────────────────────────────
 
 
 def test_check_tool_outdated_enriches_advisory_from_path() -> None:
@@ -143,7 +101,7 @@ def test_check_tool_outdated_enriches_advisory_from_path() -> None:
             stdout="ruff 0.5.0",
             stderr="",
         )
-        result = _check_tool(tool, ctx)
+        result = check_tool(tool=tool, context=ctx)
 
     assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
     assert_that(result.advisory).is_not_none()
@@ -152,142 +110,6 @@ def test_check_tool_outdated_enriches_advisory_from_path() -> None:
     assert_that(result.upgrade_hint).is_equal_to("uv tool upgrade ruff")
 
 
-def test_check_tool_incompatible() -> None:
-    """Tool found but version below hard minimum."""
-    tool = _make_tool(version="1.0.0", min_version="1.0.0")
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch("subprocess.run") as mock_run,
-    ):
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="ruff 0.5.0",
-            stderr="",
-        )
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.INCOMPATIBLE)
-
-
-def test_check_tool_missing_not_in_path() -> None:
-    """Tool executable not found in PATH."""
-    tool = _make_tool()
-    ctx = _make_context()
-
-    with patch("shutil.which", return_value=None):
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
-    assert_that(result.error).is_equal_to("not_in_path")
-
-
-def test_check_tool_missing_command_failed() -> None:
-    """Tool found but version command exits non-zero."""
-    tool = _make_tool()
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch("subprocess.run") as mock_run,
-    ):
-        mock_run.return_value = MagicMock(
-            returncode=1,
-            stdout="",
-            stderr="error",
-        )
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
-    assert_that(result.error).is_equal_to("command_failed")
-
-
-def test_check_tool_missing_timeout() -> None:
-    """Tool version command times out."""
-    tool = _make_tool()
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch(
-            "subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd=["ruff"], timeout=10),
-        ),
-    ):
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
-    assert_that(result.error).is_equal_to("timeout")
-
-
-def test_check_tool_missing_os_error() -> None:
-    """Tool version command raises OSError."""
-    tool = _make_tool()
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch("subprocess.run", side_effect=OSError("exec format error")),
-    ):
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
-    assert_that(result.error).is_equal_to("os_error")
-
-
-def test_check_tool_unknown_no_version() -> None:
-    """Tool runs but output has no parseable version."""
-    tool = _make_tool()
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch("subprocess.run") as mock_run,
-    ):
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="no version here",
-            stderr="",
-        )
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.UNKNOWN)
-    assert_that(result.error).is_equal_to("no_version")
-
-
-def test_check_tool_no_version_command() -> None:
-    """Tool has no version_command defined."""
-    tool = _make_tool(version_command=())
-    ctx = _make_context()
-
-    result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
-    assert_that(result.error).is_equal_to("no_command")
-
-
-def test_check_tool_upgrade_hint_populated() -> None:
-    """Both install_hint and upgrade_hint are populated."""
-    tool = _make_tool()
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch("subprocess.run") as mock_run,
-    ):
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="ruff 0.14.4",
-            stderr="",
-        )
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.install_hint).is_not_empty()
-    assert_that(result.upgrade_hint).is_not_empty()
-
-
->>>>>>> 74653b25 (feat(cli): surface update advisories in doctor and versions)
 # ── _output_json ─────────────────────────────────────────────────────
 
 

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -385,7 +385,9 @@ def test_doctor_outdated_prints_channel_and_strategy_hint() -> None:
 
     assert_that(result.exit_code).is_equal_to(1)
     assert_that(result.output).contains("installed via uv tool")
-    assert_that(result.output).contains("Upgrade: uv pip install --upgrade 'ruff>=1.0.0'")
+    assert_that(result.output).contains(
+        "Upgrade: uv pip install --upgrade 'ruff>=1.0.0'",
+    )
     assert_that(result.output).does_not_contain("uv tool upgrade ruff")
 
 

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from io import StringIO
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -10,21 +11,25 @@ from unittest.mock import MagicMock, patch
 from assertpy import assert_that
 from click.testing import CliRunner
 from loguru import logger
+from rich.console import Console
 
 from lintro.ai.config import AIConfig
 from lintro.cli_utils.commands.doctor import (
     _generate_markdown_report,
     _output_json,
+    _render_tool_line,
     doctor_command,
 )
 from lintro.config.lintro_config import LintroConfig
 from lintro.enums.install_context import InstallContext, PackageManager
 from lintro.enums.install_outcome import InstallOutcome
 from lintro.enums.tool_status import ToolStatus
+from lintro.enums.update_channel import UpdateChannel
 from lintro.tools.core.install_context import RuntimeContext
 from lintro.tools.core.install_plan import InstallPlan, InstallResult
 from lintro.tools.core.install_strategies.environment import InstallEnvironment
 from lintro.tools.core.tool_registry import ManifestTool
+from lintro.tools.core.update_channels import VersionAdvisory
 from lintro.utils.doctor_report import ToolCheckResult, check_tool
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -37,6 +42,7 @@ def _make_tool(
     *,
     install_type: str = "pip",
     install_package: str | None = None,
+    install_bin: str | None = None,
     update_channel: str | None = None,
     tier: str = "tools",
     category: str = "bundled",
@@ -49,6 +55,7 @@ def _make_tool(
         min_version=min_version or version,
         install_type=install_type,
         install_package=install_package,
+        install_bin=install_bin,
         update_channel=update_channel,
         tier=tier,
         category=category,
@@ -110,7 +117,10 @@ def test_check_tool_outdated_enriches_advisory_from_path() -> None:
     assert_that(result.advisory).is_not_none()
     assert result.advisory is not None
     assert_that(result.advisory.channel.value).is_equal_to("uv_tool")
-    assert_that(result.upgrade_hint).is_equal_to("uv tool upgrade ruff")
+    assert_that(result.advisory.update_command).is_equal_to("uv tool upgrade ruff")
+    assert_that(result.upgrade_hint).is_equal_to(
+        "uv pip install --upgrade 'ruff>=1.0.0'",
+    )
 
 
 def test_check_tool_honors_manifest_channel_override() -> None:
@@ -168,10 +178,14 @@ def test_check_tool_rustc_cargo_bin_stays_rustup() -> None:
     assert_that(result.upgrade_hint).is_equal_to("rustup update stable")
 
 
-def test_check_tool_node_modules_does_not_use_global_npm(
+def test_check_tool_node_modules_advisory_stays_local(
     tmp_path: Path,
 ) -> None:
-    """A project-local prettier must not get ``npm install -g``.
+    """A project-local prettier must not get a global npm advisory command.
+
+    ``upgrade_hint`` stays the install-strategy command. Without a Node
+    project on the context, that strategy installs globally; the advisory
+    records the local ``node_modules`` channel separately.
 
     Args:
         tmp_path: Pytest temporary directory fixture.
@@ -202,8 +216,192 @@ def test_check_tool_node_modules_does_not_use_global_npm(
     assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
     assert result.advisory is not None
     assert_that(result.advisory.channel.value).is_equal_to("npm")
-    assert_that(result.upgrade_hint).is_equal_to("npm install -D prettier@3.9.5")
-    assert_that(result.upgrade_hint).does_not_contain("install -g")
+    assert_that(result.advisory.update_command).is_equal_to(
+        "npm install -D prettier@3.9.5",
+    )
+    assert_that(result.advisory.update_command).does_not_contain("install -g")
+    assert_that(result.upgrade_hint).is_equal_to("npm install -g prettier@3.9.5")
+
+
+def _which_map(mapping: dict[str, str]) -> Any:
+    """Return a ``shutil.which`` stand-in for a name-to-path table.
+
+    Args:
+        mapping: Command name to absolute path.
+
+    Returns:
+        Lookup callable compatible with ``shutil.which``.
+    """
+
+    def _lookup(name: str) -> str | None:
+        return mapping.get(name)
+
+    return _lookup
+
+
+def test_check_tool_cargo_audit_wrapper_is_cargo_not_rustup() -> None:
+    """``cargo audit --version`` must not advise ``rustup update stable``."""
+    tool = _make_tool(
+        name="cargo_audit",
+        version="0.22.0",
+        min_version="0.20.0",
+        install_type="cargo",
+        install_package="cargo-audit",
+        version_command=("cargo", "audit", "--version"),
+    )
+    ctx = _make_context()
+
+    with (
+        patch(
+            "shutil.which",
+            side_effect=_which_map(
+                {
+                    "cargo": "/Users/me/.cargo/bin/cargo",
+                    "cargo-audit": "/Users/me/.cargo/bin/cargo-audit",
+                },
+            ),
+        ),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="cargo-audit 0.20.0",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
+    assert result.advisory is not None
+    assert_that(result.advisory.channel.value).is_equal_to("cargo")
+    assert_that(result.advisory.update_command).is_equal_to(
+        "cargo install --force cargo-audit",
+    )
+    assert_that(result.upgrade_hint).is_equal_to("cargo install --force cargo-audit")
+    assert_that(result.upgrade_hint).does_not_contain("rustup")
+
+
+def test_check_tool_vue_tsc_bash_wrapper_uses_vue_tsc_binary() -> None:
+    """``bash`` version probes must classify vue-tsc from its own binary."""
+    tool = _make_tool(
+        name="vue_tsc",
+        version="3.3.10",
+        min_version="3.0.0",
+        install_type="npm",
+        install_package="vue-tsc",
+        install_bin="vue-tsc",
+        version_command=("bash", "scripts/ci/resolve-vue-tsc-version.sh"),
+    )
+    ctx = _make_context()
+
+    with (
+        patch(
+            "shutil.which",
+            side_effect=_which_map(
+                {
+                    "bash": "/bin/bash",
+                    "vue-tsc": "/proj/node_modules/.bin/vue-tsc",
+                },
+            ),
+        ),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="3.0.0",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
+    assert result.advisory is not None
+    assert_that(result.advisory.channel.value).is_equal_to("npm")
+    assert_that(result.advisory.update_command).is_equal_to(
+        "npm install -D vue-tsc@3.3.10",
+    )
+    assert_that(result.path).is_equal_to("/bin/bash")
+
+
+def test_check_tool_pip_only_host_does_not_emit_uv() -> None:
+    """A host with pip and no uv must not be told to run ``uv pip``."""
+    tool = _make_tool(version="1.0.0", min_version="0.3.0")
+    ctx = RuntimeContext(
+        install_context=InstallContext.PIP,
+        platform_label="Linux x86_64",
+        environment=InstallEnvironment(
+            install_context=InstallContext.PIP,
+            available_managers=frozenset({PackageManager.PIP}),
+        ),
+        is_ci=False,
+    )
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ruff 0.5.0",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
+    assert_that(result.upgrade_hint).is_equal_to(
+        "pip install --upgrade 'ruff>=1.0.0'",
+    )
+    assert_that(result.upgrade_hint).does_not_contain("uv ")
+    assert result.advisory is not None
+    assert_that(result.advisory.update_command).contains("uv pip install")
+
+
+def test_render_outdated_prints_channel_and_strategy_hint() -> None:
+    """Outdated lines show the channel as diagnostic and the strategy command."""
+    tool = _make_tool(version="1.0.0", min_version="0.3.0")
+    result = ToolCheckResult(
+        tool=tool,
+        status=ToolStatus.OUTDATED,
+        installed_version="0.5.0",
+        upgrade_hint="uv pip install --upgrade 'ruff>=1.0.0'",
+        advisory=VersionAdvisory(
+            tool="ruff",
+            installed="0.5.0",
+            latest_known="1.0.0",
+            channel=UpdateChannel.UV_TOOL,
+            update_command="uv tool upgrade ruff",
+        ),
+    )
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    _render_tool_line(console, result, verbose=False, is_dev=False)
+    text = buf.getvalue()
+    assert_that(text).contains("installed via uv tool")
+    assert_that(text).contains("Upgrade: uv pip install --upgrade 'ruff>=1.0.0'")
+    assert_that(text).does_not_contain("uv tool upgrade ruff")
+
+
+def test_render_incompatible_prints_channel_and_strategy_hint() -> None:
+    """Incompatible lines also keep the strategy upgrade command."""
+    tool = _make_tool(version="1.0.0", min_version="0.9.0")
+    result = ToolCheckResult(
+        tool=tool,
+        status=ToolStatus.INCOMPATIBLE,
+        installed_version="0.1.0",
+        upgrade_hint="pip install --upgrade 'ruff>=1.0.0'",
+        advisory=VersionAdvisory(
+            tool="ruff",
+            installed="0.1.0",
+            latest_known="1.0.0",
+            channel=UpdateChannel.PIP,
+            update_command="uv pip install --upgrade 'ruff>=1.0.0'",
+        ),
+    )
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=False, width=120)
+    _render_tool_line(console, result, verbose=False, is_dev=False)
+    text = buf.getvalue()
+    assert_that(text).contains("installed via pip")
+    assert_that(text).contains("Upgrade: pip install --upgrade 'ruff>=1.0.0'")
+    assert_that(text).does_not_contain("uv pip")
 
 
 # ── _output_json ─────────────────────────────────────────────────────

--- a/tests/unit/cli_utils/commands/test_versions_command.py
+++ b/tests/unit/cli_utils/commands/test_versions_command.py
@@ -54,6 +54,28 @@ def test_versions_json_includes_advisory() -> None:
     assert_that(data["ruff"]["below_recommended"]).is_true()
 
 
+def test_versions_json_includes_null_advisory_when_current() -> None:
+    """JSON always includes the advisory key so MCP and CLI share one shape."""
+    current = ToolVersionInfo(
+        name="ruff",
+        min_version="0.9.0",
+        recommended_version="0.9.0",
+        current_version="0.9.0",
+        version_check_passed=True,
+        below_recommended=False,
+    )
+    with patch(
+        "lintro.cli_utils.commands.versions.get_all_tool_versions",
+        return_value={"ruff": current},
+    ):
+        result = CliRunner().invoke(versions_command, ["--json"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    data = json.loads(result.output)
+    assert_that(data["ruff"]).contains_key("advisory")
+    assert_that(data["ruff"]["advisory"]).is_none()
+
+
 def test_versions_human_output_renders_advisory_line() -> None:
     """Human output prints update advisories under the versions table."""
     with patch(
@@ -172,3 +194,65 @@ def test_versions_json_binary_path_resolved_when_current() -> None:
     assert_that(info.version_check_passed).is_true()
     assert_that(info.advisory).is_none()
     assert_that(info.binary_path).is_equal_to("/Users/me/.cargo/bin/cargo-audit")
+
+
+def test_check_tool_version_failed_probe_still_resolves_binary_path() -> None:
+    """A failed cargo wrapper probe still exports the crate binary path."""
+
+    def fake_which(name: str) -> str | None:
+        mapping = {
+            "cargo": "/Users/me/.cargo/bin/cargo",
+            "cargo-audit": "/Users/me/.cargo/bin/cargo-audit",
+        }
+        return mapping.get(name)
+
+    with (
+        patch("shutil.which", side_effect=fake_which),
+        patch(
+            "lintro.tools.core.version_parsing.subprocess.run",
+        ) as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="error: no such command: `audit`",
+        )
+        info = check_tool_version(
+            "cargo_audit",
+            ["cargo", "audit"],
+            append_version=True,
+        )
+
+    assert_that(info.version_check_passed).is_false()
+    assert_that(info.binary_path).is_equal_to("/Users/me/.cargo/bin/cargo-audit")
+    assert_that(info.advisory).is_none()
+
+
+def test_check_tool_version_clippy_resolves_cargo_clippy() -> None:
+    """Clippy probes via cargo but JSON binary_path is cargo-clippy."""
+
+    def fake_which(name: str) -> str | None:
+        mapping = {
+            "cargo": "/Users/me/.cargo/bin/cargo",
+            "cargo-clippy": "/Users/me/.cargo/bin/cargo-clippy",
+        }
+        return mapping.get(name)
+
+    with (
+        patch("shutil.which", side_effect=fake_which),
+        patch(
+            "lintro.tools.core.version_parsing.subprocess.run",
+        ) as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="clippy 0.1.90 (hash 2026-01-01)\n",
+            stderr="",
+        )
+        info = check_tool_version(
+            "clippy",
+            ["cargo", "clippy"],
+            append_version=True,
+        )
+
+    assert_that(info.binary_path).is_equal_to("/Users/me/.cargo/bin/cargo-clippy")

--- a/tests/unit/cli_utils/commands/test_versions_command.py
+++ b/tests/unit/cli_utils/commands/test_versions_command.py
@@ -116,3 +116,38 @@ def test_versions_json_advisory_from_check_tool_version() -> None:
     assert_that(data["cargo_audit"]["advisory"]["update_command"]).is_equal_to(
         "cargo install --force cargo-audit",
     )
+    assert_that(data["cargo_audit"]["binary_path"]).is_equal_to(
+        "/Users/me/.cargo/bin/cargo-audit",
+    )
+
+
+def test_versions_json_binary_path_resolved_when_current() -> None:
+    """Wrapper probes still export the tool binary when the version is current."""
+
+    def fake_which(name: str) -> str | None:
+        mapping = {
+            "cargo": "/Users/me/.cargo/bin/cargo",
+            "cargo-audit": "/Users/me/.cargo/bin/cargo-audit",
+        }
+        return mapping.get(name)
+
+    with (
+        patch("shutil.which", side_effect=fake_which),
+        patch(
+            "lintro.tools.core.version_parsing.subprocess.run",
+        ) as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="cargo-audit 99.0.0\n",
+            stderr="",
+        )
+        info = check_tool_version(
+            "cargo_audit",
+            ["cargo", "audit"],
+            append_version=True,
+        )
+
+    assert_that(info.version_check_passed).is_true()
+    assert_that(info.advisory).is_none()
+    assert_that(info.binary_path).is_equal_to("/Users/me/.cargo/bin/cargo-audit")

--- a/tests/unit/cli_utils/commands/test_versions_command.py
+++ b/tests/unit/cli_utils/commands/test_versions_command.py
@@ -102,6 +102,7 @@ def test_versions_json_advisory_from_check_tool_version() -> None:
         "cargo install --force cargo-audit",
     )
     assert_that(info.advisory.update_command).does_not_contain("rustup")
+    assert_that(info.binary_path).is_equal_to("/Users/me/.cargo/bin/cargo-audit")
 
     with patch(
         "lintro.cli_utils.commands.versions.get_all_tool_versions",

--- a/tests/unit/cli_utils/commands/test_versions_command.py
+++ b/tests/unit/cli_utils/commands/test_versions_command.py
@@ -1,0 +1,69 @@
+"""Tests for the ``lintro versions`` CLI command."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from assertpy import assert_that
+from click.testing import CliRunner
+
+from lintro.cli_utils.commands.versions import versions_command
+from lintro.enums.update_channel import UpdateChannel
+from lintro.tools.core.update_channels import VersionAdvisory
+from lintro.tools.core.version_parsing import ToolVersionInfo
+
+
+def _outdated_ruff() -> ToolVersionInfo:
+    """Build an outdated ruff version record with an advisory.
+
+    Returns:
+        ToolVersionInfo: Fixture version info for ruff.
+    """
+    return ToolVersionInfo(
+        name="ruff",
+        min_version="0.9.0",
+        recommended_version="0.9.0",
+        current_version="0.6.9",
+        version_check_passed=True,
+        below_recommended=True,
+        advisory=VersionAdvisory(
+            tool="ruff",
+            installed="0.6.9",
+            latest_known="0.9.0",
+            channel=UpdateChannel.UV_TOOL,
+            update_command="uv tool upgrade ruff",
+        ),
+    )
+
+
+def test_versions_json_includes_advisory() -> None:
+    """JSON output carries the structured advisory for outdated tools."""
+    with patch(
+        "lintro.cli_utils.commands.versions.get_all_tool_versions",
+        return_value={"ruff": _outdated_ruff()},
+    ):
+        result = CliRunner().invoke(versions_command, ["--json"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    data = json.loads(result.output)
+    assert_that(data["ruff"]["advisory"]["channel"]).is_equal_to("uv_tool")
+    assert_that(data["ruff"]["advisory"]["update_command"]).is_equal_to(
+        "uv tool upgrade ruff",
+    )
+    assert_that(data["ruff"]["below_recommended"]).is_true()
+
+
+def test_versions_human_output_renders_advisory_line() -> None:
+    """Human output prints update advisories under the versions table."""
+    with patch(
+        "lintro.cli_utils.commands.versions.get_all_tool_versions",
+        return_value={"ruff": _outdated_ruff()},
+    ):
+        result = CliRunner().invoke(versions_command, [])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains("Update advisories")
+    assert_that(result.output).contains("installed via uv tool")
+    assert_that(result.output).contains("upgrade ruff")
+    assert_that(result.output).contains("OUTDATED")

--- a/tests/unit/cli_utils/commands/test_versions_command.py
+++ b/tests/unit/cli_utils/commands/test_versions_command.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from assertpy import assert_that
 from click.testing import CliRunner
@@ -11,7 +11,7 @@ from click.testing import CliRunner
 from lintro.cli_utils.commands.versions import versions_command
 from lintro.enums.update_channel import UpdateChannel
 from lintro.tools.core.update_channels import VersionAdvisory
-from lintro.tools.core.version_parsing import ToolVersionInfo
+from lintro.tools.core.version_parsing import ToolVersionInfo, check_tool_version
 
 
 def _outdated_ruff() -> ToolVersionInfo:
@@ -65,5 +65,53 @@ def test_versions_human_output_renders_advisory_line() -> None:
     assert_that(result.exit_code).is_equal_to(0)
     assert_that(result.output).contains("Update advisories")
     assert_that(result.output).contains("installed via uv tool")
-    assert_that(result.output).contains("upgrade ruff")
     assert_that(result.output).contains("OUTDATED")
+
+
+def test_versions_json_advisory_from_check_tool_version() -> None:
+    """JSON advisories come from version probes, not a prebuilt fixture."""
+
+    def fake_which(name: str) -> str | None:
+        mapping = {
+            "cargo": "/Users/me/.cargo/bin/cargo",
+            "cargo-audit": "/Users/me/.cargo/bin/cargo-audit",
+        }
+        return mapping.get(name)
+
+    with (
+        patch("shutil.which", side_effect=fake_which),
+        patch(
+            "lintro.tools.core.version_parsing.subprocess.run",
+        ) as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="cargo-audit 0.20.0\n",
+            stderr="",
+        )
+        info = check_tool_version(
+            "cargo_audit",
+            ["cargo", "audit"],
+            append_version=True,
+        )
+
+    assert_that(info.advisory).is_not_none()
+    assert info.advisory is not None
+    assert_that(info.advisory.channel).is_equal_to(UpdateChannel.CARGO)
+    assert_that(info.advisory.update_command).is_equal_to(
+        "cargo install --force cargo-audit",
+    )
+    assert_that(info.advisory.update_command).does_not_contain("rustup")
+
+    with patch(
+        "lintro.cli_utils.commands.versions.get_all_tool_versions",
+        return_value={"cargo_audit": info},
+    ):
+        result = CliRunner().invoke(versions_command, ["--json"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    data = json.loads(result.output)
+    assert_that(data["cargo_audit"]["advisory"]["channel"]).is_equal_to("cargo")
+    assert_that(data["cargo_audit"]["advisory"]["update_command"]).is_equal_to(
+        "cargo install --force cargo-audit",
+    )

--- a/tests/unit/cli_utils/commands/test_versions_command.py
+++ b/tests/unit/cli_utils/commands/test_versions_command.py
@@ -68,6 +68,27 @@ def test_versions_human_output_renders_advisory_line() -> None:
     assert_that(result.output).contains("OUTDATED")
 
 
+def test_versions_human_status_is_outdated_when_below_recommended() -> None:
+    """Meeting the minimum but trailing the pin shows OUTDATED, not PASS."""
+    current = ToolVersionInfo(
+        name="ruff",
+        min_version="0.6.0",
+        recommended_version="0.9.0",
+        current_version="0.9.0",
+        version_check_passed=True,
+        below_recommended=False,
+    )
+    with patch(
+        "lintro.cli_utils.commands.versions.get_all_tool_versions",
+        return_value={"ruff": current, "black": _outdated_ruff()},
+    ):
+        result = CliRunner().invoke(versions_command, [])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains("PASS")
+    assert_that(result.output).contains("OUTDATED")
+
+
 def test_versions_json_advisory_from_check_tool_version() -> None:
     """JSON advisories come from version probes, not a prebuilt fixture."""
 

--- a/tests/unit/cli_utils/commands/test_versions_command.py
+++ b/tests/unit/cli_utils/commands/test_versions_command.py
@@ -256,3 +256,33 @@ def test_check_tool_version_clippy_resolves_cargo_clippy() -> None:
         )
 
     assert_that(info.binary_path).is_equal_to("/Users/me/.cargo/bin/cargo-clippy")
+
+
+def test_check_tool_version_hyphenated_name_uses_manifest_bin() -> None:
+    """Hyphenated plugin names still resolve manifest ``install.bin``."""
+
+    def fake_which(name: str) -> str | None:
+        mapping = {
+            "bash": "/bin/bash",
+            "vue-tsc": "/proj/node_modules/.bin/vue-tsc",
+        }
+        return mapping.get(name)
+
+    with (
+        patch("shutil.which", side_effect=fake_which),
+        patch(
+            "lintro.tools.core.version_parsing.subprocess.run",
+        ) as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="Version 3.0.0\n",
+            stderr="",
+        )
+        info = check_tool_version(
+            "vue-tsc",
+            ["bash", "scripts/ci/resolve-vue-tsc-version.sh"],
+            append_version=False,
+        )
+
+    assert_that(info.binary_path).is_equal_to("/proj/node_modules/.bin/vue-tsc")

--- a/tests/unit/mcp/test_toolkit_introspection.py
+++ b/tests/unit/mcp/test_toolkit_introspection.py
@@ -344,6 +344,8 @@ def test_versions_reports_installed_against_expected(
     # and the same label lintro_list_tools would report for it.
     assert_that(entries["yamllint"]["status"]).is_equal_to("outdated")
     assert_that(entries["yamllint"]["satisfies_minimum"]).is_true()
+    assert_that(entries["ruff"]).contains_key("binary_path", "advisory")
+    assert_that(entries["black"]["advisory"]).is_none()
     assert_that(payload["summary"]).is_equal_to(
         {"incompatible": 1, "missing": 1, "ok": 1, "outdated": 1, "total": 4},
     )

--- a/tests/unit/mcp/test_toolkit_introspection.py
+++ b/tests/unit/mcp/test_toolkit_introspection.py
@@ -23,12 +23,14 @@ from mcp.types import Tool
 
 from lintro.config.lintro_config import LintroConfig
 from lintro.enums.tool_status import ToolStatus
+from lintro.enums.update_channel import UpdateChannel
 from lintro.mcp.registry import DEFAULT_TOOL_TIMEOUT_SECONDS
 from lintro.mcp.toolkits.introspection import (
     INTROSPECTION_TIMEOUT_SECONDS,
     build_introspection_toolkit,
 )
 from lintro.tools.core.tool_registry import ManifestTool
+from lintro.tools.core.update_channels import VersionAdvisory
 from lintro.tools.core.version_parsing import ToolVersionInfo
 from lintro.utils import doctor_report
 from lintro.utils.doctor_report import ToolCheckResult
@@ -323,6 +325,14 @@ def test_versions_reports_installed_against_expected(
                 current_version="1.41.0",
                 version_check_passed=True,
                 below_recommended=True,
+                binary_path="/proj/.venv/bin/yamllint",
+                advisory=VersionAdvisory(
+                    tool="yamllint",
+                    installed="1.41.0",
+                    latest_known="1.42.0",
+                    channel=UpdateChannel.PIP,
+                    update_command="uv pip install --upgrade 'yamllint>=1.42.0'",
+                ),
             ),
         },
     )
@@ -344,6 +354,13 @@ def test_versions_reports_installed_against_expected(
     # and the same label lintro_list_tools would report for it.
     assert_that(entries["yamllint"]["status"]).is_equal_to("outdated")
     assert_that(entries["yamllint"]["satisfies_minimum"]).is_true()
+    assert_that(entries["yamllint"]["binary_path"]).is_equal_to(
+        "/proj/.venv/bin/yamllint",
+    )
+    assert_that(entries["yamllint"]["advisory"]["channel"]).is_equal_to("pip")
+    assert_that(entries["yamllint"]["advisory"]["update_command"]).is_equal_to(
+        "uv pip install --upgrade 'yamllint>=1.42.0'",
+    )
     assert_that(entries["ruff"]).contains_key("binary_path", "advisory")
     assert_that(entries["black"]["advisory"]).is_none()
     assert_that(payload["summary"]).is_equal_to(

--- a/tests/unit/tools/core/test_update_channels.py
+++ b/tests/unit/tools/core/test_update_channels.py
@@ -1,0 +1,320 @@
+"""Unit tests for update channel detection and version advisories."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+
+from lintro.enums.update_channel import UpdateChannel
+from lintro.tools.core import update_channels
+from lintro.tools.core.update_channels import (
+    VersionAdvisory,
+    build_version_advisory,
+    detect_update_channel,
+    format_advisory_line,
+    resolve_update_command,
+)
+from lintro.tools.core.version_checking import (
+    build_version_advisory as build_outdated_advisory,
+)
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        (
+            "/opt/homebrew/Cellar/ruff/0.9.0/bin/ruff",
+            UpdateChannel.HOMEBREW,
+        ),
+        (
+            "/home/linuxbrew/.linuxbrew/Cellar/shellcheck/0.11.0/bin/shellcheck",
+            UpdateChannel.HOMEBREW,
+        ),
+        (
+            "/opt/homebrew/Cellar/prettier/3.9.5/libexec/lib/node_modules/"
+            "prettier/bin/prettier.cjs",
+            UpdateChannel.HOMEBREW,
+        ),
+        (
+            "/Users/me/.local/share/uv/tools/ruff/bin/ruff",
+            UpdateChannel.UV_TOOL,
+        ),
+        (
+            "/Users/me/.cargo/bin/taplo",
+            UpdateChannel.CARGO,
+        ),
+        (
+            "/Users/me/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc",
+            UpdateChannel.RUSTUP,
+        ),
+        (
+            "/Users/me/.bun/bin/prettier",
+            UpdateChannel.BUN,
+        ),
+        (
+            "/proj/node_modules/.bin/prettier",
+            UpdateChannel.NPM,
+        ),
+        (
+            "/proj/.venv/bin/ruff",
+            UpdateChannel.PIP,
+        ),
+        (
+            "/usr/lib/python3.12/site-packages/bin/yamllint",
+            UpdateChannel.PIP,
+        ),
+        (
+            "/usr/bin/hadolint-lintro-fake-standalone",
+            UpdateChannel.STANDALONE,
+        ),
+        (
+            "/opt/mystery/bin/tool",
+            UpdateChannel.UNKNOWN,
+        ),
+        (
+            None,
+            UpdateChannel.UNKNOWN,
+        ),
+    ],
+    ids=[
+        "homebrew-cellar",
+        "linuxbrew",
+        "homebrew-npm-formula",
+        "uv-tool",
+        "cargo",
+        "rustup",
+        "bun",
+        "npm-local",
+        "venv",
+        "site-packages",
+        "standalone",
+        "unknown",
+        "missing-path",
+    ],
+)
+def test_detect_update_channel(
+    path: str | None,
+    expected: UpdateChannel,
+) -> None:
+    """Classify install channels from representative binary paths."""
+    assert_that(detect_update_channel(path)).is_equal_to(expected)
+
+
+def test_detect_update_channel_homebrew_bin_prefix() -> None:
+    """Binaries under the Homebrew bin prefix resolve as homebrew."""
+    # On Homebrew Macs /usr/local/bin often symlinks to /opt/homebrew/bin.
+    channel = detect_update_channel("/opt/homebrew/bin/some-tool")
+    assert_that(channel).is_equal_to(UpdateChannel.HOMEBREW)
+
+
+def test_detect_update_channel_respects_override() -> None:
+    """Explicit channel overrides beat path heuristics."""
+    channel = detect_update_channel(
+        "/opt/homebrew/Cellar/ruff/0.9.0/bin/ruff",
+        channel_override=UpdateChannel.UV_TOOL,
+    )
+    assert_that(channel).is_equal_to(UpdateChannel.UV_TOOL)
+
+
+def test_detect_update_channel_tool_override_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-tool override table wins when heuristics would otherwise apply."""
+    monkeypatch.setitem(
+        update_channels.TOOL_CHANNEL_OVERRIDES,
+        "ruff",
+        UpdateChannel.PIP,
+    )
+    channel = detect_update_channel(
+        "/opt/homebrew/Cellar/ruff/0.9.0/bin/ruff",
+        tool_name="ruff",
+    )
+    assert_that(channel).is_equal_to(UpdateChannel.PIP)
+
+
+def test_detect_update_channel_uv_tool_dir_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """UV_TOOL_DIR environment variable is honored for channel detection."""
+    tool_bin = tmp_path / "custom-uv-tools" / "ruff" / "bin" / "ruff"
+    tool_bin.parent.mkdir(parents=True)
+    tool_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path / "custom-uv-tools"))
+    assert_that(detect_update_channel(tool_bin)).is_equal_to(UpdateChannel.UV_TOOL)
+
+
+@pytest.mark.parametrize(
+    ("channel", "tool", "package", "latest", "expected"),
+    [
+        (
+            UpdateChannel.HOMEBREW,
+            "hadolint",
+            None,
+            "2.12.0",
+            "brew upgrade hadolint",
+        ),
+        (
+            UpdateChannel.HOMEBREW,
+            "osv_scanner",
+            None,
+            "2.4.0",
+            "brew upgrade osv-scanner",
+        ),
+        (
+            UpdateChannel.UV_TOOL,
+            "ruff",
+            None,
+            "0.9.0",
+            "uv tool upgrade ruff",
+        ),
+        (
+            UpdateChannel.PIP,
+            "ruff",
+            "ruff",
+            "0.9.0",
+            "uv pip install --upgrade 'ruff>=0.9.0'",
+        ),
+        (
+            UpdateChannel.NPM,
+            "prettier",
+            "prettier",
+            "3.9.4",
+            "npm install -g prettier@3.9.4",
+        ),
+        (
+            UpdateChannel.BUN,
+            "prettier",
+            "prettier",
+            "3.9.4",
+            "bun add -g prettier@3.9.4",
+        ),
+        (
+            UpdateChannel.CARGO,
+            "cargo_audit",
+            "cargo-audit",
+            "0.22.0",
+            "cargo install --force cargo-audit",
+        ),
+        (
+            UpdateChannel.RUSTUP,
+            "clippy",
+            None,
+            "1.97.1",
+            "rustup update stable",
+        ),
+        (
+            UpdateChannel.UNKNOWN,
+            "hadolint",
+            None,
+            "2.12.0",
+            None,
+        ),
+        (
+            UpdateChannel.STANDALONE,
+            "hadolint",
+            None,
+            "2.12.0",
+            None,
+        ),
+    ],
+    ids=[
+        "brew",
+        "brew-formula-alias",
+        "uv-tool",
+        "pip",
+        "npm",
+        "bun",
+        "cargo",
+        "rustup",
+        "unknown",
+        "standalone",
+    ],
+)
+def test_resolve_update_command(
+    channel: UpdateChannel,
+    tool: str,
+    package: str | None,
+    latest: str,
+    expected: str | None,
+) -> None:
+    """Map channels to update command templates."""
+    command = resolve_update_command(
+        channel=channel,
+        tool_name=tool,
+        install_package=package,
+        latest_known=latest,
+    )
+    assert_that(command).is_equal_to(expected)
+
+
+def test_build_version_advisory_includes_command() -> None:
+    """Advisory carries channel and update command for a known path."""
+    advisory = build_version_advisory(
+        tool="ruff",
+        installed="0.6.9",
+        latest_known="0.9.0",
+        binary_path="/Users/me/.local/share/uv/tools/ruff/bin/ruff",
+    )
+    assert_that(advisory.channel).is_equal_to(UpdateChannel.UV_TOOL)
+    assert_that(advisory.update_command).is_equal_to("uv tool upgrade ruff")
+    assert_that(advisory.to_dict()).contains_key("channel", "update_command")
+
+
+def test_build_outdated_advisory_returns_none_when_current() -> None:
+    """version_checking.build_version_advisory skips up-to-date tools."""
+    advisory = build_outdated_advisory(
+        tool="ruff",
+        installed="0.9.0",
+        latest_known="0.9.0",
+        binary_path="/opt/homebrew/Cellar/ruff/0.9.0/bin/ruff",
+    )
+    assert_that(advisory).is_none()
+
+
+def test_build_outdated_advisory_falls_back_to_install_type() -> None:
+    """Unknown paths fall back to manifest install.type for a command."""
+    advisory = build_outdated_advisory(
+        tool="ruff",
+        installed="0.6.9",
+        latest_known="0.9.0",
+        binary_path="/opt/mystery/bin/ruff",
+        install_type="pip",
+        install_package="ruff",
+    )
+    assert_that(advisory).is_not_none()
+    assert advisory is not None
+    assert_that(advisory.channel).is_equal_to(UpdateChannel.PIP)
+    assert_that(advisory.update_command).contains("uv pip install --upgrade")
+
+
+def test_format_advisory_line_with_command() -> None:
+    """Human-readable line includes channel and update command."""
+    advisory = VersionAdvisory(
+        tool="hadolint",
+        installed="2.10",
+        latest_known="2.12",
+        channel=UpdateChannel.HOMEBREW,
+        update_command="brew upgrade hadolint",
+    )
+    line = format_advisory_line(advisory)
+    assert_that(line).contains("hadolint 2.10 installed")
+    assert_that(line).contains("2.12 expected")
+    assert_that(line).contains("installed via homebrew")
+    assert_that(line).contains("brew upgrade hadolint")
+
+
+def test_format_advisory_line_unknown_channel() -> None:
+    """Unknown channel degrades without inventing an update command."""
+    advisory = VersionAdvisory(
+        tool="hadolint",
+        installed="2.10",
+        latest_known="2.12",
+        channel=UpdateChannel.UNKNOWN,
+        update_command=None,
+    )
+    line = format_advisory_line(advisory)
+    assert_that(line).contains("update channel unknown")
+    assert_that(line).does_not_contain("brew")

--- a/tests/unit/tools/core/test_update_channels.py
+++ b/tests/unit/tools/core/test_update_channels.py
@@ -102,7 +102,18 @@ def test_detect_update_channel(
     assert_that(detect_update_channel(path)).is_equal_to(expected)
 
 
-def test_detect_update_channel_homebrew_bin_prefix() -> None:
+def test_detect_update_channel_rejects_unrelated_cellar_path() -> None:
+    """Bare ``cellar`` path components are not treated as Homebrew."""
+    channel = detect_update_channel("/home/user/wine-cellar/bin/tool")
+    assert_that(channel).is_not_equal_to(UpdateChannel.HOMEBREW)
+
+
+def test_detect_update_channel_rejects_project_toolchains_path() -> None:
+    """Project ``toolchains`` dirs are not treated as rustup."""
+    channel = detect_update_channel(
+        "/home/user/my-rust-project/toolchains/bin/mytool",
+    )
+    assert_that(channel).is_not_equal_to(UpdateChannel.RUSTUP)
     """Binaries under the Homebrew bin prefix resolve as homebrew."""
     # On Homebrew Macs /usr/local/bin often symlinks to /opt/homebrew/bin.
     channel = detect_update_channel("/opt/homebrew/bin/some-tool")

--- a/tests/unit/tools/core/test_update_channels.py
+++ b/tests/unit/tools/core/test_update_channels.py
@@ -140,6 +140,29 @@ def test_detect_update_channel_rustc_with_tool_name_stays_rustup() -> None:
     assert_that(channel).is_equal_to(UpdateChannel.RUSTUP)
 
 
+def test_resolve_channel_binary_path_clippy_uses_cargo_clippy() -> None:
+    """Clippy's on-PATH shim is ``cargo-clippy``, not ``clippy``."""
+    found = resolve_channel_binary_path(
+        tool_name="clippy",
+        install_component="clippy",
+        probe_path="/Users/me/.cargo/bin/cargo",
+        probe_argv0="cargo",
+        which=lambda name: (
+            "/Users/me/.cargo/bin/cargo-clippy" if name == "cargo-clippy" else None
+        ),
+    )
+    assert_that(found).is_equal_to("/Users/me/.cargo/bin/cargo-clippy")
+
+
+def test_wrapper_probe_names_include_env() -> None:
+    """Installer discoverability and channel resolution share wrapper argv0s."""
+    from lintro.tools.core.tool_installer import _INDIRECT_PROBE_COMMANDS
+    from lintro.tools.core.update_channels import WRAPPER_PROBE_NAMES
+
+    assert_that(WRAPPER_PROBE_NAMES).contains("sh", "bash", "cargo", "env")
+    assert_that(_INDIRECT_PROBE_COMMANDS).is_equal_to(WRAPPER_PROBE_NAMES)
+
+
 def test_resolve_channel_binary_path_prefers_install_bin_over_wrapper() -> None:
     """Wrapper argv[0] must not win over the tool's own binary on PATH."""
     found = resolve_channel_binary_path(

--- a/tests/unit/tools/core/test_update_channels.py
+++ b/tests/unit/tools/core/test_update_channels.py
@@ -18,7 +18,7 @@ from lintro.tools.core.update_channels import (
     resolve_update_command,
 )
 from lintro.tools.core.version_checking import (
-    build_version_advisory as build_outdated_advisory,
+    build_outdated_version_advisory,
 )
 
 
@@ -347,9 +347,9 @@ def test_build_version_advisory_includes_command() -> None:
     assert_that(advisory.to_dict()).contains_key("channel", "update_command")
 
 
-def test_build_outdated_advisory_returns_none_when_current() -> None:
-    """version_checking.build_version_advisory skips up-to-date tools."""
-    advisory = build_outdated_advisory(
+def test_build_outdated_version_advisory_returns_none_when_current() -> None:
+    """build_outdated_version_advisory skips up-to-date tools."""
+    advisory = build_outdated_version_advisory(
         tool="ruff",
         installed="0.9.0",
         latest_known="0.9.0",
@@ -358,9 +358,9 @@ def test_build_outdated_advisory_returns_none_when_current() -> None:
     assert_that(advisory).is_none()
 
 
-def test_build_outdated_advisory_falls_back_to_install_type() -> None:
-    """Unknown paths fall back to manifest install.type for a command."""
-    advisory = build_outdated_advisory(
+def test_build_outdated_version_advisory_unknown_path_stays_honest() -> None:
+    """UNKNOWN path detection must not invent a pip command from install.type."""
+    advisory = build_outdated_version_advisory(
         tool="ruff",
         installed="0.6.9",
         latest_known="0.9.0",
@@ -370,8 +370,80 @@ def test_build_outdated_advisory_falls_back_to_install_type() -> None:
     )
     assert_that(advisory).is_not_none()
     assert advisory is not None
+    assert_that(advisory.channel).is_equal_to(UpdateChannel.UNKNOWN)
+    assert_that(advisory.update_command).is_none()
+
+
+def test_build_outdated_version_advisory_standalone_path_stays_honest() -> None:
+    """STANDALONE system binaries must not get a pip/npm/cargo update command."""
+    advisory = build_outdated_version_advisory(
+        tool="ruff",
+        installed="0.6.9",
+        latest_known="0.9.0",
+        binary_path="/usr/bin/ruff",
+        install_type="pip",
+        install_package="ruff",
+    )
+    assert_that(advisory).is_not_none()
+    assert advisory is not None
+    assert_that(advisory.channel).is_equal_to(UpdateChannel.STANDALONE)
+    assert_that(advisory.update_command).is_none()
+
+
+def test_build_outdated_version_advisory_falls_back_without_binary_path() -> None:
+    """When no binary path exists, manifest install.type may suggest a channel."""
+    advisory = build_outdated_version_advisory(
+        tool="ruff",
+        installed="0.6.9",
+        latest_known="0.9.0",
+        binary_path=None,
+        install_type="pip",
+        install_package="ruff",
+    )
+    assert_that(advisory).is_not_none()
+    assert advisory is not None
     assert_that(advisory.channel).is_equal_to(UpdateChannel.PIP)
     assert_that(advisory.update_command).contains("uv pip install --upgrade")
+
+
+def test_detect_update_channel_rejects_bare_site_packages_path() -> None:
+    """A site-packages tree without a bin/ segment is not a pip install."""
+    channel = detect_update_channel(
+        "/usr/lib/python3.12/site-packages/ruff/__init__.py",
+    )
+    assert_that(channel).is_not_equal_to(UpdateChannel.PIP)
+
+
+def test_detect_update_channel_rejects_cargo_home_registry_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Paths under CARGO_HOME but outside bin/ are not cargo installs."""
+    cargo_home = tmp_path / "cargo-home"
+    registry_path = cargo_home / "registry" / "cache" / "some-crate"
+    registry_path.mkdir(parents=True)
+    monkeypatch.setenv("CARGO_HOME", str(cargo_home))
+    channel = detect_update_channel(registry_path / "artifact")
+    assert_that(channel).is_not_equal_to(UpdateChannel.CARGO)
+
+
+def test_detect_update_channel_cargo_home_bin(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """CARGO_HOME/bin is honored for channel detection."""
+    cargo_home = tmp_path / "cargo-home"
+    tool_bin = cargo_home / "bin" / "taplo"
+    tool_bin.parent.mkdir(parents=True)
+    tool_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("CARGO_HOME", str(cargo_home))
+    assert_that(detect_update_channel(tool_bin)).is_equal_to(UpdateChannel.CARGO)
+
+
+def test_detect_update_channel_rejects_unrelated_venv_path_part() -> None:
+    """Bare ``venv`` path components without bin/ are not pip installs."""
+    channel = detect_update_channel("/opt/my-venv-config/settings.toml")
+    assert_that(channel).is_not_equal_to(UpdateChannel.PIP)
 
 
 def test_format_advisory_line_includes_channel() -> None:

--- a/tests/unit/tools/core/test_update_channels.py
+++ b/tests/unit/tools/core/test_update_channels.py
@@ -46,6 +46,10 @@ from lintro.tools.core.version_checking import (
             UpdateChannel.CARGO,
         ),
         (
+            "/Users/me/.cargo/bin/rustc",
+            UpdateChannel.RUSTUP,
+        ),
+        (
             "/Users/me/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc",
             UpdateChannel.RUSTUP,
         ),
@@ -84,6 +88,7 @@ from lintro.tools.core.version_checking import (
         "homebrew-npm-formula",
         "uv-tool",
         "cargo",
+        "rustup-shim-in-cargo-bin",
         "rustup",
         "bun",
         "npm-local",
@@ -114,8 +119,10 @@ def test_detect_update_channel_rejects_project_toolchains_path() -> None:
         "/home/user/my-rust-project/toolchains/bin/mytool",
     )
     assert_that(channel).is_not_equal_to(UpdateChannel.RUSTUP)
+
+
+def test_detect_update_channel_homebrew_bin_prefix() -> None:
     """Binaries under the Homebrew bin prefix resolve as homebrew."""
-    # On Homebrew Macs /usr/local/bin often symlinks to /opt/homebrew/bin.
     channel = detect_update_channel("/opt/homebrew/bin/some-tool")
     assert_that(channel).is_equal_to(UpdateChannel.HOMEBREW)
 
@@ -259,6 +266,30 @@ def test_resolve_update_command(
         latest_known=latest,
     )
     assert_that(command).is_equal_to(expected)
+
+
+def test_resolve_update_command_uses_project_local_npm() -> None:
+    """A node_modules binary must not emit a global npm install."""
+    command = resolve_update_command(
+        channel=UpdateChannel.NPM,
+        tool_name="prettier",
+        install_package="prettier",
+        latest_known="3.9.4",
+        binary_path="/proj/node_modules/.bin/prettier",
+    )
+    assert_that(command).is_equal_to("npm install -D prettier@3.9.4")
+
+
+def test_build_version_advisory_rustc_cargo_bin_is_rustup() -> None:
+    """Rustc in ``~/.cargo/bin`` is a rustup shim, not a cargo crate."""
+    advisory = build_version_advisory(
+        tool="rustc",
+        installed="1.80.0",
+        latest_known="1.97.1",
+        binary_path="/Users/me/.cargo/bin/rustc",
+    )
+    assert_that(advisory.channel).is_equal_to(UpdateChannel.RUSTUP)
+    assert_that(advisory.update_command).is_equal_to("rustup update stable")
 
 
 def test_build_version_advisory_includes_command() -> None:

--- a/tests/unit/tools/core/test_update_channels.py
+++ b/tests/unit/tools/core/test_update_channels.py
@@ -34,6 +34,10 @@ from lintro.tools.core.version_checking import (
             UpdateChannel.HOMEBREW,
         ),
         (
+            "/home/me/.linuxbrew/Cellar/shellcheck/0.11.0/bin/shellcheck",
+            UpdateChannel.HOMEBREW,
+        ),
+        (
             "/opt/homebrew/Cellar/prettier/3.9.5/libexec/lib/node_modules/"
             "prettier/bin/prettier.cjs",
             UpdateChannel.HOMEBREW,
@@ -86,6 +90,7 @@ from lintro.tools.core.version_checking import (
     ids=[
         "homebrew-cellar",
         "linuxbrew",
+        "linuxbrew-user-prefix",
         "homebrew-npm-formula",
         "uv-tool",
         "cargo",
@@ -159,6 +164,18 @@ def test_detect_update_channel_rejects_unrelated_homebrew_checkout() -> None:
     """A project directory named ``homebrew`` is not a Homebrew prefix."""
     channel = detect_update_channel("/home/me/src/homebrew/bin/tool")
     assert_that(channel).is_not_equal_to(UpdateChannel.HOMEBREW)
+
+
+def test_detect_update_channel_rejects_unrelated_linuxbrew_checkout() -> None:
+    """A project directory named ``linuxbrew`` is not a Homebrew prefix."""
+    channel = detect_update_channel("/home/me/src/linuxbrew/bin/tool")
+    assert_that(channel).is_not_equal_to(UpdateChannel.HOMEBREW)
+
+
+def test_detect_update_channel_usr_local_bin_is_standalone() -> None:
+    """``/usr/local/bin`` is standalone unless the link resolves into Cellar."""
+    channel = detect_update_channel("/usr/local/bin/hadolint")
+    assert_that(channel).is_equal_to(UpdateChannel.STANDALONE)
 
 
 def test_detect_update_channel_rejects_unrelated_rustup_dir() -> None:
@@ -252,11 +269,25 @@ def test_detect_update_channel_uv_tool_dir_env(
             "uv tool upgrade ruff",
         ),
         (
+            UpdateChannel.UV_TOOL,
+            "osv_scanner",
+            None,
+            "2.4.0",
+            "uv tool upgrade osv-scanner",
+        ),
+        (
             UpdateChannel.PIP,
             "ruff",
             "ruff",
             "0.9.0",
             "uv pip install --upgrade 'ruff>=0.9.0'",
+        ),
+        (
+            UpdateChannel.PIP,
+            "osv_scanner",
+            None,
+            "2.4.0",
+            "uv pip install --upgrade 'osv-scanner>=2.4.0'",
         ),
         (
             UpdateChannel.NPM,
@@ -305,7 +336,9 @@ def test_detect_update_channel_uv_tool_dir_env(
         "brew",
         "brew-formula-alias",
         "uv-tool",
+        "uv-tool-hyphenated",
         "pip",
+        "pip-hyphenated",
         "npm",
         "bun",
         "cargo",
@@ -536,3 +569,17 @@ def test_format_advisory_line_unknown_channel() -> None:
     line = format_advisory_line(advisory)
     assert_that(line).contains("update channel unknown")
     assert_that(line).does_not_contain("brew")
+
+
+def test_format_advisory_line_standalone_channel() -> None:
+    """Standalone system binaries are labeled standalone, not unknown."""
+    advisory = VersionAdvisory(
+        tool="hadolint",
+        installed="2.10",
+        latest_known="2.12",
+        channel=UpdateChannel.STANDALONE,
+        update_command=None,
+    )
+    line = format_advisory_line(advisory)
+    assert_that(line).contains("installed as a standalone binary")
+    assert_that(line).does_not_contain("update channel unknown")

--- a/tests/unit/tools/core/test_update_channels.py
+++ b/tests/unit/tools/core/test_update_channels.py
@@ -155,6 +155,18 @@ def test_detect_update_channel_rejects_unrelated_cellar_path() -> None:
     assert_that(channel).is_not_equal_to(UpdateChannel.HOMEBREW)
 
 
+def test_detect_update_channel_rejects_unrelated_homebrew_checkout() -> None:
+    """A project directory named ``homebrew`` is not a Homebrew prefix."""
+    channel = detect_update_channel("/home/me/src/homebrew/bin/tool")
+    assert_that(channel).is_not_equal_to(UpdateChannel.HOMEBREW)
+
+
+def test_detect_update_channel_rejects_unrelated_rustup_dir() -> None:
+    """A project directory named ``rustup`` is not a rustup toolchain tree."""
+    channel = detect_update_channel("/home/me/src/rustup/bin/tool")
+    assert_that(channel).is_not_equal_to(UpdateChannel.RUSTUP)
+
+
 def test_detect_update_channel_rejects_project_toolchains_path() -> None:
     """Project ``toolchains`` dirs are not treated as rustup."""
     channel = detect_update_channel(
@@ -170,12 +182,21 @@ def test_detect_update_channel_homebrew_bin_prefix() -> None:
 
 
 def test_detect_update_channel_respects_override() -> None:
-    """Explicit channel overrides beat path heuristics."""
+    """Manifest channel override applies when path heuristics are UNKNOWN."""
+    channel = detect_update_channel(
+        "/opt/mystery/bin/ruff",
+        channel_override=UpdateChannel.UV_TOOL,
+    )
+    assert_that(channel).is_equal_to(UpdateChannel.UV_TOOL)
+
+
+def test_detect_update_channel_override_does_not_clobber_homebrew_path() -> None:
+    """A Homebrew Cellar path beats a stale manifest update_channel."""
     channel = detect_update_channel(
         "/opt/homebrew/Cellar/ruff/0.9.0/bin/ruff",
         channel_override=UpdateChannel.UV_TOOL,
     )
-    assert_that(channel).is_equal_to(UpdateChannel.UV_TOOL)
+    assert_that(channel).is_equal_to(UpdateChannel.HOMEBREW)
 
 
 def test_detect_update_channel_tool_override_table(
@@ -299,8 +320,13 @@ def test_resolve_update_command(
     package: str | None,
     latest: str,
     expected: str | None,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Map channels to update command templates."""
+    monkeypatch.setattr(
+        "lintro.tools.core.update_channels.shutil.which",
+        lambda name: "/usr/bin/uv" if name == "uv" else None,
+    )
     command = resolve_update_command(
         channel=channel,
         tool_name=tool,
@@ -308,6 +334,34 @@ def test_resolve_update_command(
         latest_known=latest,
     )
     assert_that(command).is_equal_to(expected)
+
+
+def test_resolve_update_command_pip_without_uv_uses_pip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PIP templates must not assume ``uv`` is on PATH."""
+    monkeypatch.setattr(
+        "lintro.tools.core.update_channels.shutil.which",
+        lambda name: None,
+    )
+    command = resolve_update_command(
+        channel=UpdateChannel.PIP,
+        tool_name="ruff",
+        install_package="ruff",
+        latest_known="0.9.0",
+    )
+    assert_that(command).is_equal_to("pip install --upgrade 'ruff>=0.9.0'")
+
+
+def test_resolve_update_command_semgrep_omits_project_venv_pip() -> None:
+    """Semgrep must not emit a project-venv pip upgrade command."""
+    command = resolve_update_command(
+        channel=UpdateChannel.PIP,
+        tool_name="semgrep",
+        install_package="semgrep",
+        latest_known="1.0.0",
+    )
+    assert_that(command).is_none()
 
 
 def test_resolve_update_command_uses_project_local_npm() -> None:
@@ -390,8 +444,14 @@ def test_build_outdated_version_advisory_standalone_path_stays_honest() -> None:
     assert_that(advisory.update_command).is_none()
 
 
-def test_build_outdated_version_advisory_falls_back_without_binary_path() -> None:
+def test_build_outdated_version_advisory_falls_back_without_binary_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """When no binary path exists, manifest install.type may suggest a channel."""
+    monkeypatch.setattr(
+        "lintro.tools.core.update_channels.shutil.which",
+        lambda name: None,
+    )
     advisory = build_outdated_version_advisory(
         tool="ruff",
         installed="0.6.9",
@@ -403,7 +463,9 @@ def test_build_outdated_version_advisory_falls_back_without_binary_path() -> Non
     assert_that(advisory).is_not_none()
     assert advisory is not None
     assert_that(advisory.channel).is_equal_to(UpdateChannel.PIP)
-    assert_that(advisory.update_command).contains("uv pip install --upgrade")
+    assert_that(advisory.update_command).is_equal_to(
+        "pip install --upgrade 'ruff>=0.9.0'",
+    )
 
 
 def test_detect_update_channel_rejects_bare_site_packages_path() -> None:

--- a/tests/unit/tools/core/test_update_channels.py
+++ b/tests/unit/tools/core/test_update_channels.py
@@ -14,6 +14,7 @@ from lintro.tools.core.update_channels import (
     build_version_advisory,
     detect_update_channel,
     format_advisory_line,
+    resolve_channel_binary_path,
     resolve_update_command,
 )
 from lintro.tools.core.version_checking import (
@@ -105,6 +106,47 @@ def test_detect_update_channel(
 ) -> None:
     """Classify install channels from representative binary paths."""
     assert_that(detect_update_channel(path)).is_equal_to(expected)
+
+
+def test_detect_update_channel_cargo_audit_wrapper_is_cargo() -> None:
+    """``cargo audit`` probes resolve ``cargo`` but the crate is not rustup."""
+    channel = detect_update_channel(
+        "/Users/me/.cargo/bin/cargo",
+        tool_name="cargo_audit",
+    )
+    assert_that(channel).is_equal_to(UpdateChannel.CARGO)
+
+
+def test_detect_update_channel_cargo_deny_binary_is_cargo() -> None:
+    """``cargo-deny`` under ``~/.cargo/bin`` is a crate, not a rustup shim."""
+    channel = detect_update_channel(
+        "/Users/me/.cargo/bin/cargo-deny",
+        tool_name="cargo_deny",
+    )
+    assert_that(channel).is_equal_to(UpdateChannel.CARGO)
+
+
+def test_detect_update_channel_rustc_with_tool_name_stays_rustup() -> None:
+    """Rustc still classifies as rustup when the tool name is supplied."""
+    channel = detect_update_channel(
+        "/Users/me/.cargo/bin/rustc",
+        tool_name="rustc",
+    )
+    assert_that(channel).is_equal_to(UpdateChannel.RUSTUP)
+
+
+def test_resolve_channel_binary_path_prefers_install_bin_over_wrapper() -> None:
+    """Wrapper argv[0] must not win over the tool's own binary on PATH."""
+    found = resolve_channel_binary_path(
+        tool_name="vue_tsc",
+        install_bin="vue-tsc",
+        probe_path="/bin/bash",
+        probe_argv0="bash",
+        which=lambda name: (
+            "/proj/node_modules/.bin/vue-tsc" if name == "vue-tsc" else None
+        ),
+    )
+    assert_that(found).is_equal_to("/proj/node_modules/.bin/vue-tsc")
 
 
 def test_detect_update_channel_rejects_unrelated_cellar_path() -> None:
@@ -332,8 +374,8 @@ def test_build_outdated_advisory_falls_back_to_install_type() -> None:
     assert_that(advisory.update_command).contains("uv pip install --upgrade")
 
 
-def test_format_advisory_line_with_command() -> None:
-    """Human-readable line includes channel and update command."""
+def test_format_advisory_line_includes_channel() -> None:
+    """Human-readable line includes the channel, not the strategy command."""
     advisory = VersionAdvisory(
         tool="hadolint",
         installed="2.10",
@@ -345,7 +387,7 @@ def test_format_advisory_line_with_command() -> None:
     assert_that(line).contains("hadolint 2.10 installed")
     assert_that(line).contains("2.12 expected")
     assert_that(line).contains("installed via homebrew")
-    assert_that(line).contains("brew upgrade hadolint")
+    assert_that(line).does_not_contain("brew upgrade hadolint")
 
 
 def test_format_advisory_line_unknown_channel() -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(doctor): tool update advisories with per-tool update-channel resolver
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Teach `lintro doctor` / `lintro versions` to surface actionable "update available"
advisories per tool by resolving how each binary was installed (Homebrew, uv tool,
pip/venv, npm/bun, cargo, rustup, standalone) and mapping that channel to an update
command. Latest-known versions come from pinned manifest / tool-versions data — no
network calls in v1.

- New `UpdateChannel` enum + `update_channels.py` path heuristics
- `VersionAdvisory` produced from `version_checking.build_version_advisory`
- Doctor / versions render an Update advisories section and expose structured JSON
- Optional manifest `install.update_channel` override when heuristics fail
- Unknown / standalone channels degrade gracefully (advisory without inventing a command)

Does **not** implement #1244 (cached capability probing).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt/chk`, `uv run lintro tst` / full pytest)

## Closes

- Closes #1243

## Details

Channel detection resolves symlinks so Homebrew Cellar installs linked from
`/opt/homebrew/bin` or `/usr/local/bin` classify correctly (including brew formulas
that nest under `node_modules`). When path detection yields unknown/standalone,
doctor falls back to the manifest `install.type` for a usable update command.

Testing:
- Unit tests with fake paths per channel (no real binaries required)
- Doctor unit coverage for path-based advisory enrichment
- Full `uv run lintro chk` (0 issues) and full pytest (6715 passed)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR teaches `lintro doctor` and `lintro versions` to surface per-tool "update available" advisories by detecting how each binary was installed (Homebrew, uv tool, pip/venv, npm/bun, cargo, rustup, standalone) and mapping that to a channel-specific update command template — all without network calls.

- Adds `UpdateChannel` enum, `update_channels.py` with path-heuristic detection and `VersionAdvisory` dataclass, and wires the advisory into `ToolCheckResult` / `ToolVersionInfo` for both doctor and versions output paths.
- Structured advisory is exposed in JSON output; human-readable output shows the detected channel diagnostically alongside the existing install-strategy `upgrade_hint`.
- All three previously-flagged false-positive heuristics (bare `cellar`, broad `toolchains`, `BUN_INSTALL` substring) are resolved, and the import consolidation is done.
</details>

<h3>Confidence Score: 5/5</h3>

- Safe to merge. All changes are additive and advisory-only; they enrich display/JSON output without modifying version-check logic, install commands, or tool execution paths.
- The channel-detection heuristics are isolated, well-tested, and gracefully degrade to UNKNOWN/STANDALONE rather than producing wrong commands. The two quality nits — misleading binary_path in JSON for wrapper-probed tools, and duplicated advisory text between the inline line and the summary block — have no impact on correctness or user safety. ManifestRegistry.load() is lru_cache'd so the new registry lookup inside check_tool_version is not a performance concern.
- No files require special attention. The two comments are in version_parsing.py (binary_path field accuracy) and doctor.py (duplicate advisory rendering), both cosmetic/quality issues.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/core/update_channels.py | New module implementing path-based install channel detection and update command resolution. Previous thread issues (BUN_INSTALL substring, bare `cellar` match, broad rustup heuristic) are all fixed. Logic is well-structured with clear separation of heuristics per channel. |
| lintro/tools/core/version_checking.py | Adds `build_version_advisory` wrapper with dual-fallback logic (no-path → install_type and UNKNOWN/STANDALONE path → install_type). ManifestRegistry.load() is lru_cache'd so multi-tool runs don't incur repeated I/O. Import consolidation noted in previous thread is done. |
| lintro/tools/core/version_parsing.py | Adds `binary_path` and `advisory` fields to ToolVersionInfo. `binary_path` is set at creation time from `shutil.which(command[0])`, which for wrapper-probed tools (cargo, bash) stores the wrapper path; this is what gets exported in JSON output, not the actual tool binary. |
| lintro/cli_utils/commands/doctor.py | Renders advisories inline per tool and in a new "Update advisories" summary block; both call the same format_advisory_line, producing identical text twice for every outdated/incompatible tool. JSON output now includes structured advisory objects. |
| lintro/cli_utils/commands/versions.py | Adds advisory section, below_recommended status display, and richer JSON output (recommended_version, below_recommended, binary_path, advisory). Clean and well-tested. |
| lintro/utils/doctor_report.py | Adds advisory enrichment to ToolCheckResult for OUTDATED/INCOMPATIBLE statuses. Uses resolve_channel_binary_path correctly to handle wrapper probes. Advisory field is nullable and gracefully absent for non-outdated statuses. |
| tests/unit/tools/core/test_update_channels.py | Comprehensive parametrized coverage of channel detection paths including edge cases: wine-cellar false positive, project toolchains false positive, rustup shims, env-var overrides. All previous regression scenarios from review threads are explicitly tested. |
| tests/unit/cli_utils/commands/test_doctor_command.py | New advisory tests cover path-based detection, manifest overrides, rustup shim handling, wrapper probes (cargo, bash), and rendering. Good coverage of the new behaviour. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["check_tool / check_tool_version"] --> B["resolve_channel_binary_path\nskip wrapper argv0 like cargo/bash\nfind actual tool binary via which"]
    B --> C["detect_update_channel(binary_path)"]
    C --> D{Override?}
    D -- "channel_override or TOOL_CHANNEL_OVERRIDES" --> E[Return override channel]
    D -- No --> F{Path heuristics}
    F --> G[HOMEBREW]
    F --> H[UV_TOOL]
    F --> I["cargo bin path"]
    I --> J{rustup shim name?}
    J -- Yes --> K[RUSTUP]
    J -- No --> L[CARGO]
    F --> M[rustup toolchains]
    F --> N[bun install]
    F --> O[node_modules]
    F --> P["site-packages / venv"]
    F --> Q[system bin prefix]
    F --> R[UNKNOWN]
    M --> K
    N --> BUN[BUN]
    O --> NPM[NPM]
    P --> PIP[PIP]
    Q --> STANDALONE[STANDALONE]
    E & K & L & BUN & NPM & PIP & STANDALONE & R --> S["resolve_update_command\nbrew upgrade / uv tool upgrade\nnpm install / cargo install / ..."]
    S --> T["VersionAdvisory\ntool, installed, latest_known, channel, update_command"]
    T --> U["JSON: advisory.to_dict"]
    T --> V["Human: format_advisory_line\nchannel label only no command"]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(doctor): classify wrapper probes wit..."](https://github.com/lgtm-hq/py-lintro/commit/924df3164ae35eba24fc8ab726af434ccd153691) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45056121)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added update advisories to tool diagnostics, version checks, and introspection results.
  * Advisories show installed and recommended versions, installation channels, binary paths, and available update commands.
  * Added detection for Homebrew, uv, pip, npm, Bun, Cargo, rustup, standalone, and unknown installations.
  * Enhanced terminal, Markdown, and JSON output for outdated or incompatible tools.
  * Version summaries now distinguish passing tools from those below recommended versions.

* **Documentation**
  * Updated JSON and introspection documentation with advisory, binary path, and upgrade hint details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->