### PR TITLE
feat(tools): cached capability probing and graceful degradation for unavailable tools

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,12 +65,11 @@ The configuration system works in a specific order:
      `astro-check`). Unset by default, in which case Lintro falls back to container
      auto-detection (enabled inside containers, disabled otherwise)
    - `tool_snapshot_ttl`: Seconds to cache tool capability probes under
-     `.lintro-cache/tool-snapshots.json` (default: `600`). Binary path + mtime
-     changes invalidate immediately. Use `lintro check --no-cache` to force a fresh
-     probe.
+     `.lintro-cache/tool-snapshots.json` (default: `600`). Binary path + mtime changes
+     invalidate immediately. Use `lintro check --no-cache` to force a fresh probe.
    - `strict_missing_tools`: When `true`, unavailable tools fail the run (exit 1).
-     Default `false` — missing tools report `status: unavailable` with a
-     remediation hint and do not count as a lint failure.
+     Default `false` — missing tools report `status: unavailable` with a remediation
+     hint and do not count as a lint failure.
 
 2. **Enforce Tier** - Cross-cutting settings injected as CLI flags
    - These settings override native configs via CLI arguments

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,13 @@ The configuration system works in a specific order:
      that need a project dependency tree (`tsc`, `vue-tsc`, `svelte-check`,
      `astro-check`). Unset by default, in which case Lintro falls back to container
      auto-detection (enabled inside containers, disabled otherwise)
+   - `tool_snapshot_ttl`: Seconds to cache tool capability probes under
+     `.lintro-cache/tool-snapshots.json` (default: `600`). Binary path + mtime
+     changes invalidate immediately. Use `lintro check --no-cache` to force a fresh
+     probe.
+   - `strict_missing_tools`: When `true`, unavailable tools fail the run (exit 1).
+     Default `false` — missing tools report `status: unavailable` with a
+     remediation hint and do not count as a lint failure.
 
 2. **Enforce Tier** - Cross-cutting settings injected as CLI flags
    - These settings override native configs via CLI arguments

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,7 +66,10 @@ The configuration system works in a specific order:
      auto-detection (enabled inside containers, disabled otherwise)
    - `tool_snapshot_ttl`: Seconds to cache tool capability probes under
      `.lintro-cache/tool-snapshots.json` (default: `600`). Binary path + mtime changes
-     invalidate immediately. Use `lintro check --no-cache` to force a fresh probe.
+     invalidate immediately. Unavailable (empty-path) entries are re-checked with a
+     `PATH` lookup, so a binary installed inside the TTL window is picked up on the
+     next probe instead of staying cached as missing. Use `lintro check --no-cache`
+     to force a fresh probe.
    - `strict_missing_tools`: When `true`, unavailable tools fail the run (exit 1).
      Default `false` — missing tools report `status: unavailable` with a remediation
      hint and do not count as a lint failure.
@@ -277,6 +280,12 @@ A timed-out tool reports:
   is invented, and the timeout never reaches `summary.total_issues`. Issues legitimately
   detected _before_ the timeout (for example the pre-fix check of a `format` run) are
   still reported.
+
+Every per-tool object also includes `status`, one of `ok`, `failed`, `skipped`, or
+`unavailable` (see `lintro.enums.tool_result_status.ToolResultStatus`). Missing
+binaries set `status: unavailable` and `unavailable: true`; they are not a lint
+failure unless `execution.strict_missing_tools` is enabled. `lintro list-tools`
+table output has a matching Status column.
 
 `summary.timed_out_tools` lists the tools that timed out, in execution order:
 

--- a/lintro/cli_utils/commands/check.py
+++ b/lintro/cli_utils/commands/check.py
@@ -97,7 +97,7 @@ DEFAULT_ACTION: str = "check"
 @click.option(
     "--no-cache",
     is_flag=True,
-    help="Clear incremental cache before running (forces full check)",
+    help="Clear incremental and tool-snapshot caches before running",
 )
 @click.option(
     "--diff",

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -476,6 +476,7 @@ def doctor_command(
 
     # Determine which tools to check (names were validated above). Bound once
     # so the post-fix recheck below cannot drift from the initial selection.
+    # collect_tool_checks warms the shared snapshot cache in parallel.
     probe_tools = partial(
         collect_tool_checks,
         registry=registry,
@@ -634,6 +635,9 @@ def doctor_command(
 
     if fix and has_fixable:
         unresolved = _run_fix(display_console, prod_results, context, registry)
+        from lintro.tools.core.snapshots import clear_snapshot_cache
+
+        clear_snapshot_cache()
         rechecked = probe_tools()
         rechecked_prod = [r for r in rechecked if r.tool.tier != "dev"]
         missing_count = sum(1 for r in rechecked_prod if r.status == ToolStatus.MISSING)

--- a/lintro/cli_utils/commands/list_tools.py
+++ b/lintro/cli_utils/commands/list_tools.py
@@ -3,7 +3,11 @@
 This module provides the core logic for the 'list_tools' command.
 """
 
+from __future__ import annotations
+
 import json as json_lib
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
 
 import click
 from rich.console import Console
@@ -16,6 +20,9 @@ from lintro.plugins.registry import ToolRegistry
 from lintro.tools import tool_manager
 from lintro.utils.console import get_tool_emoji
 from lintro.utils.unified_config import get_tool_priority, is_tool_injectable
+
+if TYPE_CHECKING:
+    from lintro.tools.core.snapshots import ToolSnapshot
 
 
 def _resolve_conflicts(
@@ -318,7 +325,7 @@ def _generate_plain_text_output(
     check_tools: dict[str, BaseToolPlugin],
     fix_tools: dict[str, BaseToolPlugin],
     show_conflicts: bool,
-    snapshots: dict[str, object] | None = None,
+    snapshots: Mapping[str, ToolSnapshot] | None = None,
 ) -> list[str]:
     """Generate plain text output for file writing.
 

--- a/lintro/cli_utils/commands/list_tools.py
+++ b/lintro/cli_utils/commands/list_tools.py
@@ -133,6 +133,42 @@ def list_tools_command(
     )
 
 
+def _snapshot_result_status(
+    snap: ToolSnapshot | None,
+) -> ToolResultStatus:
+    """Map a capability snapshot to the list-tools status vocabulary.
+
+    Args:
+        snap: Cached probe result, or None when no snapshot exists.
+
+    Returns:
+        ToolResultStatus: ``unknown`` when absent or versionless, else
+        ``ok``/``unavailable``.
+    """
+    if snap is None:
+        return ToolResultStatus.UNKNOWN
+    if not snap.available:
+        return ToolResultStatus.UNAVAILABLE
+    if not snap.version:
+        return ToolResultStatus.UNKNOWN
+    return ToolResultStatus.OK
+
+
+def _snapshot_status_display(snap: ToolSnapshot | None) -> str:
+    """Format the human-readable Status column for one tool.
+
+    Args:
+        snap: Cached probe result, or None when no snapshot exists.
+
+    Returns:
+        str: ``unknown``, ``unavailable``, or ``ok (<version>)``.
+    """
+    status = _snapshot_result_status(snap)
+    if status is ToolResultStatus.OK and snap is not None:
+        return f"ok ({snap.version})"
+    return str(status)
+
+
 def list_tools(
     output: str | None,
     show_conflicts: bool,
@@ -144,7 +180,8 @@ def list_tools(
     Table output includes a Status column (``ok (<version>)``, ``unavailable``,
     or ``unknown``). JSON objects include ``status`` using
     :class:`~lintro.enums.tool_result_status.ToolResultStatus` when a
-    capability snapshot is present (``ok`` or ``unavailable``).
+    capability snapshot is present (``ok``, ``unavailable``, or ``unknown``).
+    Missing snapshots omit ``available`` and report ``status: unknown``.
 
     Args:
         output: Output file path.
@@ -178,17 +215,17 @@ def list_tools(
                 "priority": get_tool_priority(tool_name),
                 "syncable": is_tool_injectable(tool_name),
                 "origin": ToolRegistry.get_origin(tool_name),
-                "available": bool(snap.available) if snap else False,
-                "version": snap.version if snap else None,
-                "probe_error": snap.probe_error if snap else None,
             }
             if snap is not None:
+                tool_info["available"] = snap.available
+                tool_info["version"] = snap.version
+                tool_info["probe_error"] = snap.probe_error
                 tool_info["runtime_capabilities"] = snap.capabilities.to_dict()
-                if snap.available:
-                    tool_info["status"] = ToolResultStatus.OK
-                else:
-                    tool_info["status"] = ToolResultStatus.UNAVAILABLE
+                tool_info["status"] = _snapshot_result_status(snap)
+                if not snap.available:
                     tool_info["remediation_hint"] = snap.remediation_hint
+            else:
+                tool_info["status"] = ToolResultStatus.UNKNOWN
 
             # Only include file_patterns in verbose mode (consistent with table output)
             if verbose:
@@ -237,13 +274,7 @@ def list_tools(
         tool_description = plugin.definition.description
         emoji = get_tool_emoji(tool_name)
         snap = lookup_snapshot(snapshots=snapshots, name=tool_name)
-        if snap is None:
-            status_display = "unknown"
-        elif snap.available:
-            version = snap.version or "?"
-            status_display = f"ok ({version})"
-        else:
-            status_display = str(ToolResultStatus.UNAVAILABLE)
+        status_display = _snapshot_status_display(snap)
 
         # Capabilities
         tool_capabilities = _tool_capabilities(
@@ -347,7 +378,6 @@ def _generate_plain_text_output(
     Returns:
         List of output lines.
     """
-    from lintro.enums.tool_result_status import ToolResultStatus
     from lintro.tools.core.snapshots import lookup_snapshot
 
     output_lines: list[str] = []
@@ -372,12 +402,7 @@ def _generate_plain_text_output(
 
         capabilities_display = ", ".join(capabilities) if capabilities else "-"
         snap = lookup_snapshot(snapshots=snapshots, name=tool_name)
-        if snap is None:
-            runtime_status = "unknown"
-        elif snap.available:
-            runtime_status = f"ok ({snap.version or '?'})"
-        else:
-            runtime_status = str(ToolResultStatus.UNAVAILABLE)
+        runtime_status = _snapshot_status_display(snap)
 
         output_lines.append(f"{emoji} {tool_name}: {tool_description}")
         output_lines.append(f"  Status: {runtime_status}")

--- a/lintro/cli_utils/commands/list_tools.py
+++ b/lintro/cli_utils/commands/list_tools.py
@@ -15,6 +15,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from lintro.enums.action import Action
+from lintro.enums.tool_result_status import ToolResultStatus
 from lintro.plugins.base import BaseToolPlugin
 from lintro.plugins.registry import ToolRegistry
 from lintro.tools import tool_manager
@@ -140,13 +141,18 @@ def list_tools(
 ) -> None:
     """List all available tools.
 
+    Table output includes a Status column (``ok (<version>)``, ``unavailable``,
+    or ``unknown``). JSON objects include ``status`` using
+    :class:`~lintro.enums.tool_result_status.ToolResultStatus` when a
+    capability snapshot is present (``ok`` or ``unavailable``).
+
     Args:
         output: Output file path.
         show_conflicts: Whether to show potential conflicts between tools.
         json_output: Output tool list as JSON.
         verbose: Show verbose output including file extensions and patterns.
     """
-    from lintro.tools.core.snapshots import probe_all_tools
+    from lintro.tools.core.snapshots import lookup_snapshot, probe_all_tools
 
     available_tools = tool_manager.get_all_tools()
     check_tools = tool_manager.get_check_tools()
@@ -164,7 +170,7 @@ def list_tools(
                 fix_tools=fix_tools,
             )
 
-            snap = snapshots.get(tool_name.lower())
+            snap = lookup_snapshot(snapshots=snapshots, name=tool_name)
             tool_info: dict[str, object] = {
                 "description": plugin.definition.description,
                 "capabilities": capabilities,
@@ -178,8 +184,10 @@ def list_tools(
             }
             if snap is not None:
                 tool_info["runtime_capabilities"] = snap.capabilities.to_dict()
-                if not snap.available:
-                    tool_info["status"] = "unavailable"
+                if snap.available:
+                    tool_info["status"] = ToolResultStatus.OK
+                else:
+                    tool_info["status"] = ToolResultStatus.UNAVAILABLE
                     tool_info["remediation_hint"] = snap.remediation_hint
 
             # Only include file_patterns in verbose mode (consistent with table output)
@@ -228,14 +236,14 @@ def list_tools(
     for tool_name, plugin in available_tools.items():
         tool_description = plugin.definition.description
         emoji = get_tool_emoji(tool_name)
-        snap = snapshots.get(tool_name.lower())
+        snap = lookup_snapshot(snapshots=snapshots, name=tool_name)
         if snap is None:
             status_display = "unknown"
         elif snap.available:
             version = snap.version or "?"
             status_display = f"ok ({version})"
         else:
-            status_display = "unavailable"
+            status_display = str(ToolResultStatus.UNAVAILABLE)
 
         # Capabilities
         tool_capabilities = _tool_capabilities(
@@ -339,6 +347,9 @@ def _generate_plain_text_output(
     Returns:
         List of output lines.
     """
+    from lintro.enums.tool_result_status import ToolResultStatus
+    from lintro.tools.core.snapshots import lookup_snapshot
+
     output_lines: list[str] = []
     border = "=" * 70
     snapshots = snapshots or {}
@@ -360,13 +371,13 @@ def _generate_plain_text_output(
         )
 
         capabilities_display = ", ".join(capabilities) if capabilities else "-"
-        snap = snapshots.get(tool_name.lower())
+        snap = lookup_snapshot(snapshots=snapshots, name=tool_name)
         if snap is None:
             runtime_status = "unknown"
-        elif getattr(snap, "available", False):
-            runtime_status = f"ok ({getattr(snap, 'version', None) or '?'})"
+        elif snap.available:
+            runtime_status = f"ok ({snap.version or '?'})"
         else:
-            runtime_status = "unavailable"
+            runtime_status = str(ToolResultStatus.UNAVAILABLE)
 
         output_lines.append(f"{emoji} {tool_name}: {tool_description}")
         output_lines.append(f"  Status: {runtime_status}")

--- a/lintro/cli_utils/commands/list_tools.py
+++ b/lintro/cli_utils/commands/list_tools.py
@@ -139,9 +139,12 @@ def list_tools(
         json_output: Output tool list as JSON.
         verbose: Show verbose output including file extensions and patterns.
     """
+    from lintro.tools.core.snapshots import probe_all_tools
+
     available_tools = tool_manager.get_all_tools()
     check_tools = tool_manager.get_check_tools()
     fix_tools = tool_manager.get_fix_tools()
+    snapshots = probe_all_tools(tool_names=list(available_tools.keys()))
 
     # JSON output mode
     if json_output:
@@ -154,6 +157,7 @@ def list_tools(
                 fix_tools=fix_tools,
             )
 
+            snap = snapshots.get(tool_name.lower())
             tool_info: dict[str, object] = {
                 "description": plugin.definition.description,
                 "capabilities": capabilities,
@@ -161,7 +165,15 @@ def list_tools(
                 "priority": get_tool_priority(tool_name),
                 "syncable": is_tool_injectable(tool_name),
                 "origin": ToolRegistry.get_origin(tool_name),
+                "available": bool(snap.available) if snap else False,
+                "version": snap.version if snap else None,
+                "probe_error": snap.probe_error if snap else None,
             }
+            if snap is not None:
+                tool_info["runtime_capabilities"] = snap.capabilities.to_dict()
+                if not snap.available:
+                    tool_info["status"] = "unavailable"
+                    tool_info["remediation_hint"] = snap.remediation_hint
 
             # Only include file_patterns in verbose mode (consistent with table output)
             if verbose:
@@ -193,6 +205,7 @@ def list_tools(
     # Main tools table
     table = Table(title="Tool Details")
     table.add_column("Tool", style="cyan", no_wrap=True)
+    table.add_column("Status", style="yellow")
     table.add_column("Description", style="white", max_width=40)
     table.add_column("Capabilities", style="green")
     table.add_column("Priority", justify="center", style="yellow")
@@ -208,6 +221,14 @@ def list_tools(
     for tool_name, plugin in available_tools.items():
         tool_description = plugin.definition.description
         emoji = get_tool_emoji(tool_name)
+        snap = snapshots.get(tool_name.lower())
+        if snap is None:
+            status_display = "unknown"
+        elif snap.available:
+            version = snap.version or "?"
+            status_display = f"ok ({version})"
+        else:
+            status_display = "unavailable"
 
         # Capabilities
         tool_capabilities = _tool_capabilities(
@@ -227,6 +248,7 @@ def list_tools(
 
         row = [
             f"{emoji} {tool_name}",
+            status_display,
             tool_description,
             caps_display,
             str(priority),
@@ -264,7 +286,9 @@ def list_tools(
     summary_table.add_column("Metric", style="cyan", width=20)
     summary_table.add_column("Count", style="yellow", justify="right")
 
+    available_count = sum(1 for s in snapshots.values() if s.available)
     summary_table.add_row("📊 Total tools", str(len(available_tools)))
+    summary_table.add_row("✅ Runtime available", str(available_count))
     summary_table.add_row("🔍 Check tools", str(len(check_tools)))
     summary_table.add_row("🔧 Fix tools", str(len(fix_tools)))
 
@@ -279,6 +303,7 @@ def list_tools(
                 check_tools=check_tools,
                 fix_tools=fix_tools,
                 show_conflicts=show_conflicts,
+                snapshots=snapshots,
             )
             with open(output, "w", encoding="utf-8") as f:
                 f.write("\n".join(output_lines) + "\n")
@@ -293,6 +318,7 @@ def _generate_plain_text_output(
     check_tools: dict[str, BaseToolPlugin],
     fix_tools: dict[str, BaseToolPlugin],
     show_conflicts: bool,
+    snapshots: dict[str, object] | None = None,
 ) -> list[str]:
     """Generate plain text output for file writing.
 
@@ -301,12 +327,14 @@ def _generate_plain_text_output(
         check_tools: Dictionary of check-capable tools.
         fix_tools: Dictionary of fix-capable tools.
         show_conflicts: Whether to include conflict information.
+        snapshots: Optional capability snapshots keyed by tool name.
 
     Returns:
         List of output lines.
     """
     output_lines: list[str] = []
     border = "=" * 70
+    snapshots = snapshots or {}
 
     output_lines.append(border)
     output_lines.append("Available Tools")
@@ -325,8 +353,16 @@ def _generate_plain_text_output(
         )
 
         capabilities_display = ", ".join(capabilities) if capabilities else "-"
+        snap = snapshots.get(tool_name.lower())
+        if snap is None:
+            runtime_status = "unknown"
+        elif getattr(snap, "available", False):
+            runtime_status = f"ok ({getattr(snap, 'version', None) or '?'})"
+        else:
+            runtime_status = "unavailable"
 
         output_lines.append(f"{emoji} {tool_name}: {tool_description}")
+        output_lines.append(f"  Status: {runtime_status}")
         output_lines.append(f"  Capabilities: {capabilities_display}")
         output_lines.append(f"  Origin: {ToolRegistry.get_origin(tool_name)}")
 

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -187,14 +187,18 @@ def _parse_execution_config(data: dict[str, Any]) -> ExecutionConfig:
             f"got {max_fix_retries}",
         )
 
-    # max_workers and artifacts are optional; when absent, ExecutionConfig
-    # applies its own defaults (CPU count and empty list respectively). Only
-    # forward them when present so the model defaults still win on omission.
+    # max_workers, artifacts, and snapshot settings are optional; when
+    # absent, ExecutionConfig applies its own defaults. Only forward them
+    # when present so the model defaults still win on omission.
     optional_fields: dict[str, Any] = {}
     if "max_workers" in data:
         optional_fields["max_workers"] = data["max_workers"]
     if "artifacts" in data:
         optional_fields["artifacts"] = data["artifacts"]
+    if "tool_snapshot_ttl" in data:
+        optional_fields["tool_snapshot_ttl"] = data["tool_snapshot_ttl"]
+    if "strict_missing_tools" in data:
+        optional_fields["strict_missing_tools"] = data["strict_missing_tools"]
 
     return ExecutionConfig(
         enabled_tools=enabled_tools,

--- a/lintro/config/execution_config.py
+++ b/lintro/config/execution_config.py
@@ -47,6 +47,12 @@ class ExecutionConfig(BaseModel):
             markdown, html, sarif, plain. When ``GITHUB_ACTIONS=true``
             is detected, SARIF is emitted automatically even if this
             list is empty.
+        tool_snapshot_ttl: TTL in seconds for cached tool capability
+            snapshots (default: 600). Binary path+mtime changes invalidate
+            immediately regardless of TTL.
+        strict_missing_tools: When True, unavailable tools fail the run
+            (exit code 1). Default False — missing tools degrade visibly
+            without counting as a lint failure.
     """
 
     model_config = ConfigDict(frozen=False, extra="forbid")
@@ -59,3 +65,5 @@ class ExecutionConfig(BaseModel):
     auto_install_deps: bool | None = None
     max_fix_retries: int = Field(default=3, ge=1, le=10)
     artifacts: list[ArtifactFormat] = Field(default_factory=list)
+    tool_snapshot_ttl: int = Field(default=600, ge=1, le=86400)
+    strict_missing_tools: bool = False

--- a/lintro/enums/tool_name.py
+++ b/lintro/enums/tool_name.py
@@ -51,6 +51,29 @@ class ToolName(StrEnum):
     YAMLLINT = auto()
 
 
+def tool_name_aliases(name: str) -> tuple[str, ...]:
+    """Return hyphen and underscore spellings for a tool name.
+
+    Registry keys mix the two forms (``astro-check`` vs ``astro_check``).
+    Callers that look up tools or snapshots should try every alias.
+
+    Args:
+        name: Raw tool name (any spelling or case).
+
+    Returns:
+        Deduplicated lowercase candidates, requested spelling first.
+    """
+    lowered = name.strip().lower()
+    aliases: list[str] = [lowered]
+    underscored = lowered.replace("-", "_")
+    hyphenated = lowered.replace("_", "-")
+    if underscored not in aliases:
+        aliases.append(underscored)
+    if hyphenated not in aliases:
+        aliases.append(hyphenated)
+    return tuple(aliases)
+
+
 def normalize_tool_name(value: str | ToolName) -> ToolName:
     """Normalize a raw name to ToolName.
 

--- a/lintro/enums/tool_result_status.py
+++ b/lintro/enums/tool_result_status.py
@@ -1,0 +1,43 @@
+"""Per-tool status values in JSON reports and ``list-tools`` output."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lintro.models.core.tool_result import ToolResult
+
+
+class ToolResultStatus(StrEnum):
+    """Status of one tool in a serialized run or ``list-tools`` listing.
+
+    Attributes:
+        OK: The tool ran and succeeded (or is runtime-available).
+        FAILED: The tool ran and failed.
+        SKIPPED: The tool was skipped (version gate, no files, disabled).
+        UNAVAILABLE: The tool binary could not be probed or is missing.
+    """
+
+    OK = auto()
+    FAILED = auto()
+    SKIPPED = auto()
+    UNAVAILABLE = auto()
+
+
+def status_for_tool_result(result: ToolResult) -> ToolResultStatus:
+    """Derive the JSON ``status`` field for a completed tool result.
+
+    Args:
+        result: Tool result from a check/format/test run.
+
+    Returns:
+        ToolResultStatus: ``unavailable``, ``skipped``, ``ok``, or ``failed``.
+    """
+    if getattr(result, "unavailable", False):
+        return ToolResultStatus.UNAVAILABLE
+    if getattr(result, "skipped", False):
+        return ToolResultStatus.SKIPPED
+    if getattr(result, "success", True):
+        return ToolResultStatus.OK
+    return ToolResultStatus.FAILED

--- a/lintro/enums/tool_result_status.py
+++ b/lintro/enums/tool_result_status.py
@@ -5,39 +5,72 @@ from __future__ import annotations
 from enum import StrEnum, auto
 from typing import TYPE_CHECKING
 
+from lintro.enums.tool_run_status import ToolRunStatus, tool_run_status
+from lintro.formatters.formatter import merge_detected_and_remaining
+
 if TYPE_CHECKING:
     from lintro.models.core.tool_result import ToolResult
+
+_RUN_STATUS_TO_RESULT_STATUS: dict[ToolRunStatus, "ToolResultStatus"] = {}
 
 
 class ToolResultStatus(StrEnum):
     """Status of one tool in a serialized run or ``list-tools`` listing.
 
     Attributes:
-        OK: The tool ran and succeeded (or is runtime-available).
-        FAILED: The tool ran and failed.
+        OK: The tool ran and succeeded (or is runtime-available with a version).
+        FAILED: The tool ran and failed, timed out, or reported issues.
         SKIPPED: The tool was skipped (version gate, no files, disabled).
         UNAVAILABLE: The tool binary could not be probed or is missing.
+        UNKNOWN: Capability could not be determined (no snapshot or no version).
     """
 
     OK = auto()
     FAILED = auto()
     SKIPPED = auto()
     UNAVAILABLE = auto()
+    UNKNOWN = auto()
 
 
-def status_for_tool_result(result: ToolResult) -> ToolResultStatus:
+_RUN_STATUS_TO_RESULT_STATUS.update(
+    {
+        ToolRunStatus.PASSED: ToolResultStatus.OK,
+        ToolRunStatus.ISSUES: ToolResultStatus.FAILED,
+        ToolRunStatus.SKIPPED: ToolResultStatus.SKIPPED,
+        ToolRunStatus.TIMED_OUT: ToolResultStatus.FAILED,
+        ToolRunStatus.ERRORED: ToolResultStatus.FAILED,
+    },
+)
+
+
+def status_for_tool_result(
+    result: ToolResult,
+    *,
+    issue_count: int | None = None,
+) -> ToolResultStatus:
     """Derive the JSON ``status`` field for a completed tool result.
+
+    Classification follows :func:`~lintro.enums.tool_run_status.tool_run_status`
+    so timeouts and issue counts are not collapsed into ``ok``/``failed``
+    incorrectly. ``unavailable`` is checked first because it is outside the run
+    status vocabulary.
 
     Args:
         result: Tool result from a check/format/test run.
+        issue_count: Optional precomputed issue count. When omitted, merged
+            initial and remaining issues are counted like
+            :func:`~lintro.utils.json_output.serialize_tool_result`.
 
     Returns:
         ToolResultStatus: ``unavailable``, ``skipped``, ``ok``, or ``failed``.
     """
     if getattr(result, "unavailable", False):
         return ToolResultStatus.UNAVAILABLE
-    if getattr(result, "skipped", False):
-        return ToolResultStatus.SKIPPED
-    if getattr(result, "success", True):
-        return ToolResultStatus.OK
-    return ToolResultStatus.FAILED
+    if issue_count is None:
+        merged_issues = merge_detected_and_remaining(
+            getattr(result, "initial_issues", None),
+            getattr(result, "issues", None),
+        )
+        issue_count = len(merged_issues)
+    run_status = tool_run_status(result=result, issue_count=issue_count)
+    return _RUN_STATUS_TO_RESULT_STATUS[run_status]

--- a/lintro/models/core/tool_result.py
+++ b/lintro/models/core/tool_result.py
@@ -84,6 +84,11 @@ class ToolResult:
     # the human-readable ``output`` string.
     timed_out: bool = field(default=False)
 
+    # Capability-probe degradation: binary missing / probe failed.
+    # Distinct from ``skipped`` (conflict resolution, disabled, etc.) so
+    # consumers can render ``status: unavailable`` without silent omission.
+    unavailable: bool = field(default=False)
+
     # Parser failures (items that could not be parsed from tool output).
     # Omitted from JSON output unless the tool sets this explicitly.
     parse_failures_count: int | None = field(default=None)
@@ -99,6 +104,18 @@ class ToolResult:
         Raises:
             ValueError: If issue counts are inconsistent or skip state is invalid.
         """
+        # Unavailable tools report probe_error via skip_reason without being
+        # marked skipped (skipped is reserved for intentional non-execution).
+        if self.unavailable:
+            if not self.skip_reason:
+                raise ValueError(
+                    "skip_reason is required when unavailable=True",
+                )
+            if self.skipped:
+                raise ValueError(
+                    "unavailable and skipped cannot both be True",
+                )
+
         # Skipped tools are not failures — they just didn't run
         if self.skipped:
             self.success = True
@@ -107,9 +124,9 @@ class ToolResult:
                     "skip_reason is required when skipped=True",
                 )
 
-        if self.skip_reason and not self.skipped:
+        if self.skip_reason and not self.skipped and not self.unavailable:
             raise ValueError(
-                "skip_reason can only be set when skipped=True",
+                "skip_reason can only be set when skipped=True or unavailable=True",
             )
 
         if (

--- a/lintro/plugins/execution_preparation.py
+++ b/lintro/plugins/execution_preparation.py
@@ -186,25 +186,15 @@ def verify_tool_version(
             )
         return None
 
-    # Binary exists and responded but version could not be parsed — proceed
-    if (
-        snapshot.version is None
-        and snapshot.probe_error
-        and "Could not parse version" in snapshot.probe_error
-    ):
-        logger.debug(
-            "Could not parse version for {}, proceeding anyway",
-            definition.name,
-        )
-        return None
+    # Unparseable versions are encoded as version_check_passed=True with a
+    # live binary (see probe_tool), so they never reach this branch.
 
     # Digest-pinned image lag after a manifest version bump: binary exists and
     # is merely older than min_version. Allowlisted tools keep running so
     # integration coverage is not silently reduced to a skip.
     if (
-        snapshot.version is not None
-        and snapshot.probe_error
-        and "below minimum requirement" in snapshot.probe_error
+        snapshot.available
+        and snapshot.version is not None
         and _version_lag_allowed(definition.name)
     ):
         logger.warning(
@@ -232,7 +222,6 @@ def verify_tool_version(
         skipped=True,
         skip_reason=error,
     )
-
 
 
 def prepare_execution(

--- a/lintro/plugins/execution_preparation.py
+++ b/lintro/plugins/execution_preparation.py
@@ -176,12 +176,12 @@ def verify_tool_version(
         )
 
     if snapshot.version_check_passed:
-        if getattr(snapshot, "below_recommended", False):
+        if snapshot.below_recommended:
             logger.warning(
                 "{} {} is below recommended version {} (minimum {} met)",
                 definition.name,
                 snapshot.version,
-                getattr(snapshot, "recommended_version", None),
+                snapshot.recommended_version,
                 snapshot.min_version,
             )
         return None

--- a/lintro/plugins/execution_preparation.py
+++ b/lintro/plugins/execution_preparation.py
@@ -137,6 +137,10 @@ def verify_tool_version(
 ) -> ToolResult | None:
     """Verify that the tool meets minimum version requirements.
 
+    Uses the cached capability snapshot so version data comes from a single
+    probe per binary (path + mtime + TTL). Unavailable tools return an
+    ``unavailable`` result instead of raising mid-run.
+
     When ``LINTRO_ALLOW_VERSION_LAG`` lists the tool (or is ``*``) and the
     binary is present but older than the manifest minimum, proceed with a
     warning instead of skipping. Missing binaries and other hard failures
@@ -152,63 +156,73 @@ def verify_tool_version(
         cwd: Directory the tool will execute in, when known.
 
     Returns:
-        None if version check passes, or a skip result if it fails.
+        None if version check passes, or a skip/unavailable result if it fails.
     """
-    from lintro.tools.core.version_requirements import check_tool_version
+    from lintro.tools.core.snapshots import (
+        get_tool_snapshot,
+        is_strict_missing_tools,
+        snapshot_to_unavailable_result,
+    )
 
-    command = get_executable_command(definition.name, cwd=cwd)
-    version_info = check_tool_version(definition.name, command)
+    # cwd is reserved for future cwd-scoped probing (#1727); snapshots today
+    # resolve the executable via get_executable_command without an explicit cwd.
+    _ = cwd
+    snapshot = get_tool_snapshot(definition.name)
 
-    if version_info.version_check_passed:
-        if version_info.below_recommended:
+    if not snapshot.available:
+        return snapshot_to_unavailable_result(
+            snapshot,
+            strict=is_strict_missing_tools(),
+        )
+
+    if snapshot.version_check_passed:
+        if getattr(snapshot, "below_recommended", False):
             logger.warning(
                 "{} {} is below recommended version {} (minimum {} met)",
                 definition.name,
-                version_info.current_version,
-                version_info.recommended_version,
-                version_info.min_version,
+                snapshot.version,
+                getattr(snapshot, "recommended_version", None),
+                snapshot.min_version,
             )
         return None
 
     # Binary exists and responded but version could not be parsed — proceed
     if (
-        version_info.current_version is None
-        and version_info.error_message
-        and "Could not parse version" in version_info.error_message
+        snapshot.version is None
+        and snapshot.probe_error
+        and "Could not parse version" in snapshot.probe_error
     ):
-        import shutil
-
-        main_cmd = command[0] if command else definition.name
-        if shutil.which(main_cmd):
-            logger.debug(
-                "Could not parse version for {}, proceeding anyway",
-                definition.name,
-            )
-            return None
+        logger.debug(
+            "Could not parse version for {}, proceeding anyway",
+            definition.name,
+        )
+        return None
 
     # Digest-pinned image lag after a manifest version bump: binary exists and
     # is merely older than min_version. Allowlisted tools keep running so
     # integration coverage is not silently reduced to a skip.
     if (
-        version_info.current_version is not None
-        and version_info.error_message
-        and "below minimum requirement" in version_info.error_message
+        snapshot.version is not None
+        and snapshot.probe_error
+        and "below minimum requirement" in snapshot.probe_error
         and _version_lag_allowed(definition.name)
     ):
         logger.warning(
             "{} {} is below minimum {} but allowed via {}; proceeding",
             definition.name,
-            version_info.current_version,
-            version_info.min_version,
+            snapshot.version,
+            snapshot.min_version,
             _ALLOW_VERSION_LAG_ENV,
         )
         return None
 
+    error = snapshot.probe_error or "version check failed"
+    hint = snapshot.remediation_hint or ""
     skip_message = (
-        f"Skipping {definition.name}: {version_info.error_message}. "
-        f"Minimum required: {version_info.min_version}. "
-        f"{version_info.install_hint}"
-    )
+        f"Skipping {definition.name}: {error}. "
+        f"Minimum required: {snapshot.min_version}. "
+        f"{hint}"
+    ).strip()
 
     return ToolResult(
         name=definition.name,
@@ -216,8 +230,9 @@ def verify_tool_version(
         output=skip_message,
         issues_count=0,
         skipped=True,
-        skip_reason=version_info.error_message,
+        skip_reason=error,
     )
+
 
 
 def prepare_execution(

--- a/lintro/plugins/registry.py
+++ b/lintro/plugins/registry.py
@@ -224,26 +224,31 @@ class ToolRegistry:
 
         Returns:
             ``"builtin"`` for tools shipped with lintro, or the distribution
-            name for a third-party plugin. Returns ``"unknown"`` if the tool
+            name for a third-party plugin. Hyphen and underscore spellings
+            resolve to the registered key. Returns ``"unknown"`` if the tool
             has no recorded origin (e.g. registered by legacy code paths).
         """
         with cls._lock:
             cls._ensure_discovered()
-            return cls._origins.get(name.lower(), "unknown")
+            resolved = cls._resolve_registered_name(name=name)
+            if resolved is None:
+                return "unknown"
+            return cls._origins.get(resolved, "unknown")
 
     @classmethod
     def is_registered(cls, name: str) -> bool:
         """Check if a tool is registered.
 
         Args:
-            name: Tool name (case-insensitive).
+            name: Tool name (case-insensitive; hyphen and underscore aliases
+                match the registered key).
 
         Returns:
             True if the tool is registered, False otherwise.
         """
         with cls._lock:
             cls._ensure_discovered()
-            return name.lower() in cls._tools
+            return cls._resolve_registered_name(name=name) is not None
 
     @classmethod
     def clear(cls) -> None:

--- a/lintro/plugins/registry.py
+++ b/lintro/plugins/registry.py
@@ -141,22 +141,36 @@ class ToolRegistry:
             >>> tool = ToolRegistry.get("hadolint")
             >>> result = tool.check(["."], {})
         """
-        name_lower = name.lower()
-
         with cls._lock:
             # Auto-discover tools if not yet done
             cls._ensure_discovered()
+            resolved = cls._resolve_registered_name(name=name)
+            if resolved is None:
+                available = ", ".join(sorted(cls._tools.keys()))
+                raise ValueError(
+                    f"Unknown tool: {name!r}. Available tools: {available or 'none'}",
+                )
+            if resolved not in cls._instances:
+                cls._instances[resolved] = cls._tools[resolved]()
 
-            if name_lower not in cls._instances:
-                if name_lower not in cls._tools:
-                    available = ", ".join(sorted(cls._tools.keys()))
-                    raise ValueError(
-                        f"Unknown tool: {name!r}. "
-                        f"Available tools: {available or 'none'}",
-                    )
-                cls._instances[name_lower] = cls._tools[name_lower]()
+            return cls._instances[resolved]
 
-            return cls._instances[name_lower]
+    @classmethod
+    def _resolve_registered_name(cls, *, name: str) -> str | None:
+        """Map a caller name onto a registered registry key.
+
+        Args:
+            name: Tool name in any hyphen/underscore spelling.
+
+        Returns:
+            The registered lowercase key, or None when no alias matches.
+        """
+        from lintro.enums.tool_name import tool_name_aliases
+
+        for candidate in tool_name_aliases(name):
+            if candidate in cls._tools:
+                return candidate
+        return None
 
     @classmethod
     def get_all(cls) -> dict[str, BaseToolPlugin]:

--- a/lintro/tools/core/snapshots.py
+++ b/lintro/tools/core/snapshots.py
@@ -1,0 +1,720 @@
+"""Cached capability probing for registered Lintro tools.
+
+Probes each tool once (availability, version, capabilities), caches the
+result under ``.lintro-cache/tool-snapshots.json`` keyed on binary path,
+mtime, and lintro version, and exposes snapshots to check/format runners,
+``list-tools``, and ``doctor``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from lintro import __version__ as LINTRO_VERSION
+
+# Default TTL for on-disk snapshot cache (seconds).
+DEFAULT_SNAPSHOT_TTL_SECONDS: int = 600
+
+# Relative cache path under the project / cwd root.
+SNAPSHOT_CACHE_RELPATH: str = ".lintro-cache/tool-snapshots.json"
+
+_cache_lock = threading.Lock()
+_memory_cache: dict[str, ToolSnapshot] | None = None
+_memory_cache_path: Path | None = None
+_memory_probed_at: float | None = None
+_force_fresh: bool = False
+
+
+@dataclass(frozen=True)
+class ToolCapabilities:
+    """Declared / discovered capabilities for a tool.
+
+    Attributes:
+        can_fix: Whether the tool can auto-fix issues.
+        supports_stdin: Whether the tool accepts stdin input.
+        config_found: Whether a native config file was found in the project.
+    """
+
+    can_fix: bool = False
+    supports_stdin: bool = False
+    config_found: bool = False
+
+    def to_dict(self) -> dict[str, bool]:
+        """Serialize capabilities for JSON cache / API output.
+
+        Returns:
+            Dictionary of capability flags.
+        """
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> ToolCapabilities:
+        """Deserialize capabilities from a cache entry.
+
+        Args:
+            data: Raw capabilities dict, or None for defaults.
+
+        Returns:
+            ToolCapabilities instance.
+        """
+        if not data:
+            return cls()
+        return cls(
+            can_fix=bool(data.get("can_fix", False)),
+            supports_stdin=bool(data.get("supports_stdin", False)),
+            config_found=bool(data.get("config_found", False)),
+        )
+
+
+@dataclass(frozen=True)
+class ToolSnapshot:
+    """Cached probe result for a single tool.
+
+    Attributes:
+        name: Canonical tool name.
+        available: True when the binary exists and version probe succeeded.
+        version: Detected version string, or None.
+        capabilities: Capability flags for the tool.
+        probe_error: Error message when unavailable or probe failed.
+        remediation_hint: Install / upgrade hint for the user.
+        binary_path: Resolved executable path (empty when missing).
+        binary_mtime: mtime of the binary when probed (0.0 when missing).
+        version_check_passed: Whether the installed version meets the minimum.
+        min_version: Minimum required version used during the probe.
+    """
+
+    name: str
+    available: bool = False
+    version: str | None = None
+    capabilities: ToolCapabilities = field(default_factory=ToolCapabilities)
+    probe_error: str | None = None
+    remediation_hint: str | None = None
+    binary_path: str = ""
+    binary_mtime: float = 0.0
+    version_check_passed: bool = False
+    min_version: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the snapshot for JSON cache / API output.
+
+        Returns:
+            Dictionary representation of the snapshot.
+        """
+        return {
+            "name": self.name,
+            "available": self.available,
+            "version": self.version,
+            "capabilities": self.capabilities.to_dict(),
+            "probe_error": self.probe_error,
+            "remediation_hint": self.remediation_hint,
+            "binary_path": self.binary_path,
+            "binary_mtime": self.binary_mtime,
+            "version_check_passed": self.version_check_passed,
+            "min_version": self.min_version,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ToolSnapshot:
+        """Deserialize a snapshot from a cache entry.
+
+        Args:
+            data: Raw snapshot dict.
+
+        Returns:
+            ToolSnapshot instance.
+        """
+        return cls(
+            name=str(data.get("name", "")),
+            available=bool(data.get("available", False)),
+            version=data.get("version"),
+            capabilities=ToolCapabilities.from_dict(data.get("capabilities")),
+            probe_error=data.get("probe_error"),
+            remediation_hint=data.get("remediation_hint"),
+            binary_path=str(data.get("binary_path", "") or ""),
+            binary_mtime=float(data.get("binary_mtime", 0.0) or 0.0),
+            version_check_passed=bool(data.get("version_check_passed", False)),
+            min_version=str(data.get("min_version", "") or ""),
+        )
+
+    def cache_key_matches(
+        self,
+        *,
+        binary_path: str,
+        binary_mtime: float,
+    ) -> bool:
+        """Return True when path+mtime still match this snapshot.
+
+        Args:
+            binary_path: Current resolved binary path.
+            binary_mtime: Current binary mtime (0.0 when missing).
+
+        Returns:
+            True if the cache key components still match.
+        """
+        return self.binary_path == binary_path and self.binary_mtime == binary_mtime
+
+
+def set_force_fresh_probes(force: bool) -> None:
+    """Force the next probe cycle to ignore on-disk and memory caches.
+
+    Args:
+        force: When True, probes re-run even if a valid cache exists.
+    """
+    global _force_fresh
+    with _cache_lock:
+        _force_fresh = force
+
+
+def clear_snapshot_cache(*, cache_root: Path | None = None) -> None:
+    """Clear in-memory and on-disk tool snapshot caches.
+
+    Args:
+        cache_root: Directory containing ``.lintro-cache``; defaults to cwd.
+    """
+    global _memory_cache, _memory_cache_path, _memory_probed_at
+    with _cache_lock:
+        _memory_cache = None
+        _memory_cache_path = None
+        _memory_probed_at = None
+        cache_file = _cache_file_path(cache_root=cache_root)
+        if cache_file.exists():
+            try:
+                cache_file.unlink()
+                logger.debug("Deleted tool snapshot cache: {}", cache_file)
+            except OSError as exc:
+                logger.warning("Could not delete snapshot cache {}: {}", cache_file, exc)
+
+
+def get_snapshot_ttl() -> int:
+    """Return the configured snapshot TTL in seconds.
+
+    Returns:
+        TTL from execution config, or the default when config is unavailable.
+    """
+    try:
+        from lintro.config.config_loader import get_config
+
+        ttl = get_config().execution.tool_snapshot_ttl
+        if isinstance(ttl, int) and ttl >= 1:
+            return ttl
+    except (ImportError, OSError, ValueError, AttributeError, RuntimeError):
+        pass
+    return DEFAULT_SNAPSHOT_TTL_SECONDS
+
+
+def is_strict_missing_tools() -> bool:
+    """Return whether missing tools should fail the run.
+
+    Returns:
+        True when ``execution.strict_missing_tools`` is enabled.
+    """
+    try:
+        from lintro.config.config_loader import get_config
+
+        return bool(get_config().execution.strict_missing_tools)
+    except (ImportError, OSError, ValueError, AttributeError, RuntimeError):
+        return False
+
+
+def _cache_file_path(*, cache_root: Path | None = None) -> Path:
+    """Resolve the on-disk snapshot cache path.
+
+    Args:
+        cache_root: Optional project root; defaults to the current working directory.
+
+    Returns:
+        Absolute path to ``tool-snapshots.json``.
+    """
+    root = cache_root if cache_root is not None else Path.cwd()
+    return (root / SNAPSHOT_CACHE_RELPATH).resolve()
+
+
+def _binary_mtime(path: str) -> float:
+    """Return mtime for ``path``, or 0.0 when unavailable.
+
+    Args:
+        path: Filesystem path to the binary.
+
+    Returns:
+        Modification time as a float epoch seconds.
+    """
+    if not path:
+        return 0.0
+    try:
+        return float(os.path.getmtime(path))
+    except OSError:
+        return 0.0
+
+
+def _find_native_config(native_configs: list[str], *, search_root: Path) -> bool:
+    """Return True when any native config file exists under ``search_root``.
+
+    Args:
+        native_configs: Candidate config filenames / relative paths.
+        search_root: Directory to search.
+
+    Returns:
+        True if at least one native config path exists.
+    """
+    for name in native_configs:
+        candidate = search_root / name
+        if candidate.exists():
+            return True
+    return False
+
+
+def _unavailable_snapshot(
+    name: str,
+    *,
+    probe_error: str,
+    remediation_hint: str | None = None,
+    binary_path: str = "",
+    binary_mtime: float = 0.0,
+    capabilities: ToolCapabilities | None = None,
+    min_version: str = "",
+) -> ToolSnapshot:
+    """Build an unavailable snapshot with remediation context.
+
+    Args:
+        name: Tool name.
+        probe_error: Why the tool is unavailable.
+        remediation_hint: Optional install hint.
+        binary_path: Path if partially resolved.
+        binary_mtime: mtime if binary exists but probe failed.
+        capabilities: Optional capability flags.
+        min_version: Minimum version string for display.
+
+    Returns:
+        Unavailable ToolSnapshot.
+    """
+    return ToolSnapshot(
+        name=name,
+        available=False,
+        version=None,
+        capabilities=capabilities or ToolCapabilities(),
+        probe_error=probe_error,
+        remediation_hint=remediation_hint,
+        binary_path=binary_path,
+        binary_mtime=binary_mtime,
+        version_check_passed=False,
+        min_version=min_version,
+    )
+
+
+def probe_tool(
+    tool_name: str,
+    *,
+    search_root: Path | None = None,
+) -> ToolSnapshot:
+    """Probe a single tool's availability, version, and capabilities.
+
+    Args:
+        tool_name: Registered tool name (case-insensitive).
+        search_root: Project root for native-config discovery; defaults to cwd.
+
+    Returns:
+        Fresh ToolSnapshot (not read from cache).
+    """
+    from lintro.plugins.execution_preparation import get_executable_command
+    from lintro.plugins.registry import ToolRegistry
+    from lintro.tools.core.version_checking import get_install_hints
+    from lintro.tools.core.version_parsing import check_tool_version
+
+    root = search_root if search_root is not None else Path.cwd()
+    name = tool_name.lower()
+
+    try:
+        plugin = ToolRegistry.get(name)
+        definition = plugin.definition
+    except (KeyError, ValueError) as exc:
+        return _unavailable_snapshot(
+            name,
+            probe_error=f"Tool not registered: {exc}",
+        )
+
+    can_fix = bool(definition.can_fix)
+    # Stdin support is not yet declared on ToolDefinition; leave False for v1
+    # so the capability surface is present without inventing false positives.
+    supports_stdin = False
+    config_found = _find_native_config(
+        list(definition.native_configs or []),
+        search_root=root,
+    )
+    capabilities = ToolCapabilities(
+        can_fix=can_fix,
+        supports_stdin=supports_stdin,
+        config_found=config_found,
+    )
+
+    install_hints = get_install_hints()
+    remediation = install_hints.get(name) or install_hints.get(
+        name.replace("-", "_"),
+        f"Install {name} and ensure it is on PATH",
+    )
+
+    # In-process tools (e.g. idiom-review) have no external binary and no
+    # version gate — treat them as available without a PATH probe.
+    if definition.version_command is None and definition.min_version is None:
+        return ToolSnapshot(
+            name=name,
+            available=True,
+            version=None,
+            capabilities=capabilities,
+            probe_error=None,
+            remediation_hint=None,
+            binary_path="",
+            binary_mtime=0.0,
+            version_check_passed=True,
+            min_version="",
+        )
+
+    command = get_executable_command(definition.name)
+    main_cmd = command[0] if command else definition.name
+    binary_path = shutil.which(main_cmd) or ""
+    binary_mtime = _binary_mtime(binary_path)
+
+    if not binary_path:
+        return _unavailable_snapshot(
+            name,
+            probe_error=f"{main_cmd} not found in PATH",
+            remediation_hint=remediation,
+            capabilities=capabilities,
+        )
+
+    # Match verify_tool_version's historical probe: use the resolved
+    # executable command (python -m / bunx / cargo wrappers) rather than the
+    # raw manifest version_command, which may name a binary not on PATH.
+    version_info = check_tool_version(
+        definition.name,
+        command,
+        append_version=True,
+    )
+
+    if version_info.current_version is None and version_info.error_message:
+        # Binary exists but version probe failed — still mark unavailable so
+        # consumers can degrade gracefully instead of mid-run errors.
+        parse_ok = "Could not parse version" in (version_info.error_message or "")
+        if parse_ok and binary_path:
+            # Unparseable version with a live binary: treat as available but
+            # note that the version check could not be completed.
+            return ToolSnapshot(
+                name=name,
+                available=True,
+                version=None,
+                capabilities=capabilities,
+                probe_error=version_info.error_message,
+                remediation_hint=remediation,
+                binary_path=binary_path,
+                binary_mtime=binary_mtime,
+                version_check_passed=True,
+                min_version=version_info.min_version,
+            )
+        return _unavailable_snapshot(
+            name,
+            probe_error=version_info.error_message,
+            remediation_hint=remediation,
+            binary_path=binary_path,
+            binary_mtime=binary_mtime,
+            capabilities=capabilities,
+            min_version=version_info.min_version,
+        )
+
+    return ToolSnapshot(
+        name=name,
+        available=True,
+        version=version_info.current_version,
+        capabilities=capabilities,
+        probe_error=(
+            None
+            if version_info.version_check_passed
+            else version_info.error_message
+        ),
+        remediation_hint=remediation,
+        binary_path=binary_path,
+        binary_mtime=binary_mtime,
+        version_check_passed=version_info.version_check_passed,
+        min_version=version_info.min_version,
+    )
+
+
+def _load_disk_cache(
+    cache_file: Path,
+    *,
+    ttl: int,
+) -> dict[str, ToolSnapshot] | None:
+    """Load snapshots from disk when the cache file is valid.
+
+    Args:
+        cache_file: Path to the JSON cache.
+        ttl: Maximum age in seconds.
+
+    Returns:
+        Snapshot map, or None when missing / corrupt / expired / version mismatch.
+    """
+    if not cache_file.exists():
+        return None
+    try:
+        raw = json.loads(cache_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.debug("Corrupt tool snapshot cache {}; re-probing: {}", cache_file, exc)
+        try:
+            cache_file.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return None
+
+    if not isinstance(raw, dict):
+        return None
+    if raw.get("lintro_version") != LINTRO_VERSION:
+        logger.debug("Snapshot cache lintro version mismatch; re-probing")
+        return None
+    probed_at = raw.get("probed_at")
+    if not isinstance(probed_at, (int, float)):
+        return None
+    if time.time() - float(probed_at) > ttl:
+        logger.debug("Snapshot cache TTL expired; re-probing")
+        return None
+
+    snapshots_raw = raw.get("snapshots")
+    if not isinstance(snapshots_raw, dict):
+        return None
+
+    snapshots: dict[str, ToolSnapshot] = {}
+    for name, entry in snapshots_raw.items():
+        if not isinstance(entry, dict):
+            continue
+        try:
+            snap = ToolSnapshot.from_dict(entry)
+        except (TypeError, ValueError, KeyError):
+            continue
+        # Invalidate entries whose binary path/mtime drifted (tool upgrade).
+        if snap.binary_path:
+            if not Path(snap.binary_path).exists():
+                logger.debug(
+                    "Snapshot for {} invalidated; binary missing at {}",
+                    name,
+                    snap.binary_path,
+                )
+                continue
+            current_path = snap.binary_path
+            current_mtime = _binary_mtime(current_path)
+        else:
+            current_path = ""
+            current_mtime = 0.0
+        if not snap.cache_key_matches(
+            binary_path=current_path,
+            binary_mtime=current_mtime,
+        ):
+            logger.debug(
+                "Snapshot for {} invalidated by binary path/mtime change",
+                name,
+            )
+            continue
+        snapshots[name.lower()] = snap
+
+    return snapshots if snapshots else None
+
+
+def _write_disk_cache(
+    cache_file: Path,
+    snapshots: dict[str, ToolSnapshot],
+    *,
+    ttl: int,
+) -> None:
+    """Persist snapshots to disk.
+
+    Args:
+        cache_file: Destination JSON path.
+        snapshots: Snapshot map to write.
+        ttl: TTL recorded in the cache metadata.
+    """
+    payload = {
+        "lintro_version": LINTRO_VERSION,
+        "probed_at": time.time(),
+        "ttl_seconds": ttl,
+        "snapshots": {name: snap.to_dict() for name, snap in snapshots.items()},
+    }
+    try:
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        tmp = cache_file.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        tmp.replace(cache_file)
+    except OSError as exc:
+        logger.debug("Failed to write tool snapshot cache {}: {}", cache_file, exc)
+
+
+def _probe_all_fresh(
+    tool_names: list[str],
+    *,
+    search_root: Path,
+    max_workers: int,
+) -> dict[str, ToolSnapshot]:
+    """Probe tools in parallel and return the snapshot map.
+
+    Args:
+        tool_names: Tool names to probe.
+        search_root: Project root for config discovery.
+        max_workers: Thread pool size.
+
+    Returns:
+        Mapping of tool name → ToolSnapshot.
+    """
+    results: dict[str, ToolSnapshot] = {}
+    if not tool_names:
+        return results
+
+    workers = max(1, min(max_workers, len(tool_names)))
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(probe_tool, name, search_root=search_root): name
+            for name in tool_names
+        }
+        for future in as_completed(futures):
+            name = futures[future]
+            try:
+                results[name.lower()] = future.result()
+            except (OSError, RuntimeError, ValueError) as exc:
+                logger.debug("Probe failed for {}: {}", name, exc)
+                results[name.lower()] = _unavailable_snapshot(
+                    name.lower(),
+                    probe_error=f"Probe failed: {exc}",
+                )
+    return results
+
+
+def probe_all_tools(
+    *,
+    force: bool = False,
+    cache_root: Path | None = None,
+    tool_names: list[str] | None = None,
+) -> dict[str, ToolSnapshot]:
+    """Probe all registered tools (or a subset), using the snapshot cache.
+
+    Args:
+        force: Bypass cache and re-probe.
+        cache_root: Directory for ``.lintro-cache``; defaults to cwd.
+        tool_names: Optional subset of tool names; defaults to all registered.
+
+    Returns:
+        Mapping of tool name → ToolSnapshot.
+    """
+    global _memory_cache, _memory_cache_path, _memory_probed_at, _force_fresh
+
+    from lintro.plugins.discovery import discover_all_tools
+    from lintro.plugins.registry import ToolRegistry
+
+    discover_all_tools()
+    names = tool_names if tool_names is not None else ToolRegistry.get_names()
+    names = [n.lower() for n in names]
+    root = cache_root if cache_root is not None else Path.cwd()
+    cache_file = _cache_file_path(cache_root=root)
+    ttl = get_snapshot_ttl()
+
+    try:
+        from lintro.config.config_loader import get_config
+
+        max_workers = get_config().execution.max_workers
+    except (ImportError, OSError, ValueError, AttributeError, RuntimeError):
+        max_workers = 8
+
+    with _cache_lock:
+        force_effective = force or _force_fresh
+        if (
+            not force_effective
+            and _memory_cache is not None
+            and _memory_cache_path == cache_file
+            and _memory_probed_at is not None
+            and time.time() - _memory_probed_at <= ttl
+            and all(n in _memory_cache for n in names)
+        ):
+            return {n: _memory_cache[n] for n in names}
+
+        if not force_effective:
+            disk = _load_disk_cache(cache_file, ttl=ttl)
+            if disk is not None and all(n in disk for n in names):
+                _memory_cache = disk
+                _memory_cache_path = cache_file
+                _memory_probed_at = time.time()
+                return {n: disk[n] for n in names}
+
+    fresh = _probe_all_fresh(names, search_root=root, max_workers=max_workers)
+
+    with _cache_lock:
+        merged = dict(_memory_cache or {})
+        merged.update(fresh)
+        _memory_cache = merged
+        _memory_cache_path = cache_file
+        _memory_probed_at = time.time()
+        _force_fresh = False
+        _write_disk_cache(cache_file, merged, ttl=ttl)
+        return {n: fresh[n] for n in names if n in fresh}
+
+
+def get_tool_snapshot(
+    tool_name: str,
+    *,
+    force: bool = False,
+    cache_root: Path | None = None,
+) -> ToolSnapshot:
+    """Return a cached or freshly probed snapshot for one tool.
+
+    Args:
+        tool_name: Tool name (case-insensitive).
+        force: Bypass cache for this tool (re-probes all when cache cold).
+        cache_root: Optional cache root directory.
+
+    Returns:
+        ToolSnapshot for the requested tool.
+    """
+    name = tool_name.lower()
+    snapshots = probe_all_tools(
+        force=force,
+        cache_root=cache_root,
+        tool_names=[name],
+    )
+    if name in snapshots:
+        return snapshots[name]
+    return _unavailable_snapshot(name, probe_error="Probe returned no snapshot")
+
+
+def snapshot_to_unavailable_result(
+    snapshot: ToolSnapshot,
+    *,
+    strict: bool | None = None,
+) -> "ToolResult":
+    """Build a ToolResult representing an unavailable tool.
+
+    Args:
+        snapshot: Unavailable (or version-failed) tool snapshot.
+        strict: Override for ``strict_missing_tools``; None reads config.
+
+    Returns:
+        ToolResult with ``unavailable=True`` and remediation context.
+    """
+    from lintro.models.core.tool_result import ToolResult
+
+    strict_missing = is_strict_missing_tools() if strict is None else strict
+    error = snapshot.probe_error or "tool unavailable"
+    hint = snapshot.remediation_hint or ""
+    message = f"{snapshot.name} unavailable: {error}"
+    if hint:
+        message = f"{message}. {hint}"
+
+    return ToolResult(
+        name=snapshot.name,
+        success=not strict_missing,
+        output=message,
+        issues_count=0,
+        unavailable=True,
+        skip_reason=error,
+    )

--- a/lintro/tools/core/snapshots.py
+++ b/lintro/tools/core/snapshots.py
@@ -8,6 +8,7 @@ mtime, and lintro version, and exposes snapshots to check/format runners,
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
@@ -16,11 +17,14 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from lintro import __version__ as LINTRO_VERSION
+from lintro import __version__
+
+if TYPE_CHECKING:
+    from lintro.models.core.tool_result import ToolResult
 
 # Default TTL for on-disk snapshot cache (seconds).
 DEFAULT_SNAPSHOT_TTL_SECONDS: int = 600
@@ -200,7 +204,11 @@ def clear_snapshot_cache(*, cache_root: Path | None = None) -> None:
                 cache_file.unlink()
                 logger.debug("Deleted tool snapshot cache: {}", cache_file)
             except OSError as exc:
-                logger.warning("Could not delete snapshot cache {}: {}", cache_file, exc)
+                logger.warning(
+                    "Could not delete snapshot cache {}: {}",
+                    cache_file,
+                    exc,
+                )
 
 
 def get_snapshot_ttl() -> int:
@@ -526,15 +534,13 @@ def _load_disk_cache(
         raw = json.loads(cache_file.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         logger.debug("Corrupt tool snapshot cache {}; re-probing: {}", cache_file, exc)
-        try:
+        with contextlib.suppress(OSError):
             cache_file.unlink(missing_ok=True)
-        except OSError:
-            pass
         return None
 
     if not isinstance(raw, dict):
         return None
-    if raw.get("lintro_version") != LINTRO_VERSION:
+    if raw.get("lintro_version") != __version__:
         logger.debug("Snapshot cache lintro version mismatch; re-probing")
         return None
     probed_at = raw.get("probed_at")
@@ -598,7 +604,7 @@ def _write_disk_cache(
         ttl: TTL recorded in the cache metadata.
     """
     payload = {
-        "lintro_version": LINTRO_VERSION,
+        "lintro_version": __version__,
         "probed_at": time.time(),
         "ttl_seconds": ttl,
         "snapshots": {name: snap.to_dict() for name, snap in snapshots.items()},
@@ -767,7 +773,7 @@ def snapshot_to_unavailable_result(
     snapshot: ToolSnapshot,
     *,
     strict: bool | None = None,
-) -> "ToolResult":
+) -> ToolResult:
     """Build a ToolResult representing an unavailable tool.
 
     Args:
@@ -786,7 +792,7 @@ def snapshot_to_unavailable_result(
     if hint:
         message = f"{message}. {hint}"
 
-    return ToolResult(
+    result: ToolResult = ToolResult(
         name=snapshot.name,
         success=not strict_missing,
         output=message,
@@ -794,3 +800,4 @@ def snapshot_to_unavailable_result(
         unavailable=True,
         skip_reason=error,
     )
+    return result

--- a/lintro/tools/core/snapshots.py
+++ b/lintro/tools/core/snapshots.py
@@ -383,66 +383,107 @@ def probe_tool(
     binary_path = shutil.which(main_cmd) or ""
     binary_mtime = _binary_mtime(binary_path)
 
-    if not binary_path:
-        return _unavailable_snapshot(
-            name,
-            probe_error=f"{main_cmd} not found in PATH",
-            remediation_hint=remediation,
-            capabilities=capabilities,
-        )
-
-    # Match verify_tool_version's historical probe: use the resolved
-    # executable command (python -m / bunx / cargo wrappers) rather than the
-    # raw manifest version_command, which may name a binary not on PATH.
+    # Always run the version probe — do not gate on shutil.which alone.
+    # Wrappers (bunx/npx/python -m) and test mocks of subprocess.run can
+    # succeed even when the bare binary name is absent from PATH.
     version_info = check_tool_version(
         definition.name,
         command,
         append_version=True,
     )
 
-    if version_info.current_version is None and version_info.error_message:
-        # Binary exists but version probe failed — still mark unavailable so
-        # consumers can degrade gracefully instead of mid-run errors.
-        parse_ok = "Could not parse version" in (version_info.error_message or "")
-        if parse_ok and binary_path:
-            # Unparseable version with a live binary: treat as available but
-            # note that the version check could not be completed.
-            return ToolSnapshot(
-                name=name,
-                available=True,
-                version=None,
-                capabilities=capabilities,
-                probe_error=version_info.error_message,
-                remediation_hint=remediation,
-                binary_path=binary_path,
-                binary_mtime=binary_mtime,
-                version_check_passed=True,
-                min_version=version_info.min_version,
-            )
-        return _unavailable_snapshot(
-            name,
+    if (
+        version_info.current_version is None
+        and version_info.error_message
+        and "Could not parse version" in version_info.error_message
+        and binary_path
+    ):
+        # Unparseable version with a live binary: treat as available but
+        # note that the version check could not be completed.
+        return ToolSnapshot(
+            name=name,
+            available=True,
+            version=None,
+            capabilities=capabilities,
             probe_error=version_info.error_message,
             remediation_hint=remediation,
             binary_path=binary_path,
             binary_mtime=binary_mtime,
-            capabilities=capabilities,
+            version_check_passed=True,
             min_version=version_info.min_version,
         )
 
-    return ToolSnapshot(
-        name=name,
-        available=True,
-        version=version_info.current_version,
-        capabilities=capabilities,
-        probe_error=(
-            None
-            if version_info.version_check_passed
-            else version_info.error_message
-        ),
+    if version_info.version_check_passed:
+        # Tools without a declared minimum still set version_check_passed on
+        # OSError. Treat a failed probe with no parsed version as unavailable
+        # so missing binaries degrade visibly instead of proceeding.
+        if (
+            version_info.current_version is None
+            and version_info.error_message
+            and (
+                "Failed to run version check" in version_info.error_message
+                or "Command failed" in version_info.error_message
+                or "not found" in version_info.error_message.lower()
+            )
+        ):
+            probe_error = (
+                f"{main_cmd} not found in PATH"
+                if not binary_path
+                else version_info.error_message
+            )
+            return _unavailable_snapshot(
+                name,
+                probe_error=probe_error,
+                remediation_hint=remediation,
+                binary_path=binary_path,
+                binary_mtime=binary_mtime,
+                capabilities=capabilities,
+                min_version=version_info.min_version,
+            )
+        return ToolSnapshot(
+            name=name,
+            available=True,
+            version=version_info.current_version,
+            capabilities=capabilities,
+            probe_error=None,
+            remediation_hint=remediation,
+            binary_path=binary_path,
+            binary_mtime=binary_mtime,
+            version_check_passed=True,
+            min_version=version_info.min_version,
+        )
+
+    # Version below minimum: still "available" so consumers can skip with
+    # the same remediation messaging as before.
+    if (
+        version_info.current_version is not None
+        and version_info.error_message
+        and "below minimum" in version_info.error_message
+    ):
+        return ToolSnapshot(
+            name=name,
+            available=True,
+            version=version_info.current_version,
+            capabilities=capabilities,
+            probe_error=version_info.error_message,
+            remediation_hint=remediation,
+            binary_path=binary_path,
+            binary_mtime=binary_mtime,
+            version_check_passed=False,
+            min_version=version_info.min_version,
+        )
+
+    probe_error = version_info.error_message or f"{main_cmd} not found in PATH"
+    if not binary_path and not version_info.error_message:
+        probe_error = f"{main_cmd} not found in PATH"
+
+    return _unavailable_snapshot(
+        name,
+        probe_error=probe_error,
         remediation_hint=remediation,
         binary_path=binary_path,
         binary_mtime=binary_mtime,
-        version_check_passed=version_info.version_check_passed,
+        capabilities=capabilities,
         min_version=version_info.min_version,
     )
 

--- a/lintro/tools/core/snapshots.py
+++ b/lintro/tools/core/snapshots.py
@@ -91,6 +91,8 @@ class ToolSnapshot:
         binary_mtime: mtime of the binary when probed (0.0 when missing).
         version_check_passed: Whether the installed version meets the minimum.
         min_version: Minimum required version used during the probe.
+        recommended_version: Recommended version from requirements, if any.
+        below_recommended: True when installed version is below recommended.
     """
 
     name: str
@@ -103,6 +105,8 @@ class ToolSnapshot:
     binary_mtime: float = 0.0
     version_check_passed: bool = False
     min_version: str = ""
+    recommended_version: str = ""
+    below_recommended: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the snapshot for JSON cache / API output.
@@ -121,6 +125,8 @@ class ToolSnapshot:
             "binary_mtime": self.binary_mtime,
             "version_check_passed": self.version_check_passed,
             "min_version": self.min_version,
+            "recommended_version": self.recommended_version,
+            "below_recommended": self.below_recommended,
         }
 
     @classmethod
@@ -144,6 +150,8 @@ class ToolSnapshot:
             binary_mtime=float(data.get("binary_mtime", 0.0) or 0.0),
             version_check_passed=bool(data.get("version_check_passed", False)),
             min_version=str(data.get("min_version", "") or ""),
+            recommended_version=str(data.get("recommended_version", "") or ""),
+            below_recommended=bool(data.get("below_recommended", False)),
         )
 
     def cache_key_matches(
@@ -376,6 +384,8 @@ def probe_tool(
             binary_mtime=0.0,
             version_check_passed=True,
             min_version="",
+            recommended_version="",
+            below_recommended=False,
         )
 
     command = get_executable_command(definition.name)
@@ -391,6 +401,8 @@ def probe_tool(
         command,
         append_version=True,
     )
+    recommended = version_info.recommended_version or ""
+    below_rec = bool(version_info.below_recommended)
 
     if (
         version_info.current_version is None
@@ -411,6 +423,8 @@ def probe_tool(
             binary_mtime=binary_mtime,
             version_check_passed=True,
             min_version=version_info.min_version,
+            recommended_version=recommended,
+            below_recommended=below_rec,
         )
 
     if version_info.version_check_passed:
@@ -451,6 +465,8 @@ def probe_tool(
             binary_mtime=binary_mtime,
             version_check_passed=True,
             min_version=version_info.min_version,
+            recommended_version=recommended,
+            below_recommended=below_rec,
         )
 
     # Version below minimum: still "available" so consumers can skip with
@@ -471,6 +487,8 @@ def probe_tool(
             binary_mtime=binary_mtime,
             version_check_passed=False,
             min_version=version_info.min_version,
+            recommended_version=recommended,
+            below_recommended=below_rec,
         )
 
     probe_error = version_info.error_message or f"{main_cmd} not found in PATH"
@@ -624,7 +642,7 @@ def _probe_all_fresh(
             name = futures[future]
             try:
                 results[name.lower()] = future.result()
-            except (OSError, RuntimeError, ValueError) as exc:
+            except Exception as exc:  # noqa: BLE001 - keep probing other tools
                 logger.debug("Probe failed for {}: {}", name, exc)
                 results[name.lower()] = _unavailable_snapshot(
                     name.lower(),
@@ -668,6 +686,7 @@ def probe_all_tools(
     except (ImportError, OSError, ValueError, AttributeError, RuntimeError):
         max_workers = 8
 
+    force_effective = False
     with _cache_lock:
         force_effective = force or _force_fresh
         if (
@@ -680,13 +699,27 @@ def probe_all_tools(
         ):
             return {n: _memory_cache[n] for n in names}
 
-        if not force_effective:
-            disk = _load_disk_cache(cache_file, ttl=ttl)
-            if disk is not None and all(n in disk for n in names):
-                _memory_cache = disk
-                _memory_cache_path = cache_file
-                _memory_probed_at = time.time()
-                return {n: disk[n] for n in names}
+    # Disk I/O outside the lock so slow mounts do not block other callers.
+    disk: dict[str, ToolSnapshot] | None = None
+    if not force_effective:
+        disk = _load_disk_cache(cache_file, ttl=ttl)
+
+    with _cache_lock:
+        # Re-check memory: another thread may have filled the cache.
+        if (
+            not force_effective
+            and _memory_cache is not None
+            and _memory_cache_path == cache_file
+            and _memory_probed_at is not None
+            and time.time() - _memory_probed_at <= ttl
+            and all(n in _memory_cache for n in names)
+        ):
+            return {n: _memory_cache[n] for n in names}
+        if disk is not None and all(n in disk for n in names):
+            _memory_cache = disk
+            _memory_cache_path = cache_file
+            _memory_probed_at = time.time()
+            return {n: disk[n] for n in names}
 
     fresh = _probe_all_fresh(names, search_root=root, max_workers=max_workers)
 
@@ -697,8 +730,10 @@ def probe_all_tools(
         _memory_cache_path = cache_file
         _memory_probed_at = time.time()
         _force_fresh = False
-        _write_disk_cache(cache_file, merged, ttl=ttl)
-        return {n: fresh[n] for n in names if n in fresh}
+        to_write = dict(merged)
+
+    _write_disk_cache(cache_file, to_write, ttl=ttl)
+    return {n: fresh[n] for n in names if n in fresh}
 
 
 def get_tool_snapshot(

--- a/lintro/tools/core/snapshots.py
+++ b/lintro/tools/core/snapshots.py
@@ -205,8 +205,11 @@ def _is_cached_snapshot_fresh(snap: ToolSnapshot) -> bool:
 
     Available snapshots with a binary path are keyed on path + mtime.
     In-process tools (available, empty path) stay valid until TTL.
-    Unavailable empty-path snapshots are re-checked with ``shutil.which`` so
-    a binary installed inside the TTL window is not served as missing.
+    Unavailable empty-path snapshots are re-checked with ``shutil.which`` on
+    the resolved executable (``get_executable_command()[0]``) so a binary
+    installed inside the TTL window is not served as missing. Alias-only PATH
+    checks miss tools whose command name differs from the lintro tool name
+    (e.g. ``markdownlint-cli2`` for ``markdownlint``).
     """
     if snap.binary_path:
         if not Path(snap.binary_path).exists():
@@ -217,9 +220,11 @@ def _is_cached_snapshot_fresh(snap: ToolSnapshot) -> bool:
         )
     if snap.available:
         return True
-    from lintro.enums.tool_name import tool_name_aliases
+    from lintro.plugins.execution_preparation import get_executable_command
 
-    return all(shutil.which(alias) is None for alias in tool_name_aliases(snap.name))
+    command = get_executable_command(snap.name)
+    main_cmd = command[0] if command else snap.name
+    return shutil.which(main_cmd) is None
 
 
 def set_force_fresh_probes(force: bool) -> None:

--- a/lintro/tools/core/snapshots.py
+++ b/lintro/tools/core/snapshots.py
@@ -12,6 +12,7 @@ import contextlib
 import json
 import os
 import shutil
+import tempfile
 import threading
 import time
 from collections.abc import Mapping
@@ -232,17 +233,24 @@ def set_force_fresh_probes(force: bool) -> None:
         _force_fresh = force
 
 
-def clear_snapshot_cache(*, cache_root: Path | None = None) -> None:
-    """Clear in-memory and on-disk tool snapshot caches.
+def clear_snapshot_cache(
+    *,
+    cache_root: Path | None = None,
+    include_disk: bool = True,
+) -> None:
+    """Clear in-memory and optionally on-disk tool snapshot caches.
 
     Args:
         cache_root: Directory containing ``.lintro-cache``; defaults to cwd.
+        include_disk: When False, only the in-process memory cache is reset.
     """
     global _memory_cache, _memory_cache_path, _memory_probed_at
     with _cache_lock:
         _memory_cache = None
         _memory_cache_path = None
         _memory_probed_at = None
+        if not include_disk:
+            return
         cache_file = _cache_file_path(cache_root=cache_root)
         if cache_file.exists():
             try:
@@ -639,9 +647,17 @@ def _write_disk_cache(
     }
     try:
         cache_file.parent.mkdir(parents=True, exist_ok=True)
-        tmp = cache_file.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
-        tmp.replace(cache_file)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=cache_file.parent,
+            delete=False,
+            prefix=f"{cache_file.stem}.",
+            suffix=".tmp",
+        ) as handle:
+            handle.write(json.dumps(payload, indent=2, sort_keys=True))
+            tmp_path = Path(handle.name)
+        tmp_path.replace(cache_file)
     except OSError as exc:
         logger.debug("Failed to write tool snapshot cache {}: {}", cache_file, exc)
 
@@ -796,6 +812,8 @@ def probe_all_tools(
     fresh = _probe_all_fresh(names, search_root=root, max_workers=max_workers)
 
     with _cache_lock:
+        if _memory_cache_path != cache_file:
+            _memory_cache = None
         merged = dict(_memory_cache or {})
         merged.update(fresh)
         _memory_cache = merged

--- a/lintro/tools/core/snapshots.py
+++ b/lintro/tools/core/snapshots.py
@@ -14,6 +14,7 @@ import os
 import shutil
 import threading
 import time
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -174,6 +175,50 @@ class ToolSnapshot:
             True if the cache key components still match.
         """
         return self.binary_path == binary_path and self.binary_mtime == binary_mtime
+
+
+def lookup_snapshot(
+    snapshots: Mapping[str, ToolSnapshot],
+    name: str,
+) -> ToolSnapshot | None:
+    """Return a snapshot for ``name``, trying hyphen and underscore aliases.
+
+    Args:
+        snapshots: Map keyed by tool name.
+        name: Requested tool name (manifest or registry spelling).
+
+    Returns:
+        Matching snapshot, or None when no alias hits.
+    """
+    from lintro.enums.tool_name import tool_name_aliases
+
+    for candidate in tool_name_aliases(name):
+        snap = snapshots.get(candidate)
+        if snap is not None:
+            return snap
+    return None
+
+
+def _is_cached_snapshot_fresh(snap: ToolSnapshot) -> bool:
+    """Return True when a cached snapshot should still be served.
+
+    Available snapshots with a binary path are keyed on path + mtime.
+    In-process tools (available, empty path) stay valid until TTL.
+    Unavailable empty-path snapshots are re-checked with ``shutil.which`` so
+    a binary installed inside the TTL window is not served as missing.
+    """
+    if snap.binary_path:
+        if not Path(snap.binary_path).exists():
+            return False
+        return snap.cache_key_matches(
+            binary_path=snap.binary_path,
+            binary_mtime=_binary_mtime(snap.binary_path),
+        )
+    if snap.available:
+        return True
+    from lintro.enums.tool_name import tool_name_aliases
+
+    return all(shutil.which(alias) is None for alias in tool_name_aliases(snap.name))
 
 
 def set_force_fresh_probes(force: bool) -> None:
@@ -562,26 +607,9 @@ def _load_disk_cache(
             snap = ToolSnapshot.from_dict(entry)
         except (TypeError, ValueError, KeyError):
             continue
-        # Invalidate entries whose binary path/mtime drifted (tool upgrade).
-        if snap.binary_path:
-            if not Path(snap.binary_path).exists():
-                logger.debug(
-                    "Snapshot for {} invalidated; binary missing at {}",
-                    name,
-                    snap.binary_path,
-                )
-                continue
-            current_path = snap.binary_path
-            current_mtime = _binary_mtime(current_path)
-        else:
-            current_path = ""
-            current_mtime = 0.0
-        if not snap.cache_key_matches(
-            binary_path=current_path,
-            binary_mtime=current_mtime,
-        ):
+        if not _is_cached_snapshot_fresh(snap):
             logger.debug(
-                "Snapshot for {} invalidated by binary path/mtime change",
+                "Snapshot for {} invalidated by path/mtime or PATH change",
                 name,
             )
             continue
@@ -657,6 +685,32 @@ def _probe_all_fresh(
     return results
 
 
+def _memory_hits_for(
+    names: list[str],
+    *,
+    cache_file: Path,
+    ttl: int,
+) -> dict[str, ToolSnapshot] | None:
+    """Return memory snapshots when they still cover ``names``.
+
+    Must be called while holding ``_cache_lock``.
+    """
+    if (
+        _memory_cache is None
+        or _memory_cache_path != cache_file
+        or _memory_probed_at is None
+        or time.time() - _memory_probed_at > ttl
+    ):
+        return None
+    hits: dict[str, ToolSnapshot] = {}
+    for name in names:
+        snap = lookup_snapshot(snapshots=_memory_cache, name=name)
+        if snap is None or not _is_cached_snapshot_fresh(snap):
+            return None
+        hits[name] = snap
+    return hits
+
+
 def probe_all_tools(
     *,
     force: bool = False,
@@ -695,15 +749,19 @@ def probe_all_tools(
     force_effective = False
     with _cache_lock:
         force_effective = force or _force_fresh
-        if (
-            not force_effective
-            and _memory_cache is not None
-            and _memory_cache_path == cache_file
-            and _memory_probed_at is not None
-            and time.time() - _memory_probed_at <= ttl
-            and all(n in _memory_cache for n in names)
-        ):
-            return {n: _memory_cache[n] for n in names}
+        if _force_fresh:
+            # Consume the flag at cycle start so a later set during the
+            # probe is not wiped when this cycle used force=True from the
+            # caller.
+            _force_fresh = False
+        if not force_effective:
+            hits = _memory_hits_for(
+                names,
+                cache_file=cache_file,
+                ttl=ttl,
+            )
+            if hits is not None:
+                return hits
 
     # Disk I/O outside the lock so slow mounts do not block other callers.
     disk: dict[str, ToolSnapshot] | None = None
@@ -712,20 +770,28 @@ def probe_all_tools(
 
     with _cache_lock:
         # Re-check memory: another thread may have filled the cache.
-        if (
-            not force_effective
-            and _memory_cache is not None
-            and _memory_cache_path == cache_file
-            and _memory_probed_at is not None
-            and time.time() - _memory_probed_at <= ttl
-            and all(n in _memory_cache for n in names)
-        ):
-            return {n: _memory_cache[n] for n in names}
-        if disk is not None and all(n in disk for n in names):
-            _memory_cache = disk
-            _memory_cache_path = cache_file
-            _memory_probed_at = time.time()
-            return {n: disk[n] for n in names}
+        if not force_effective:
+            hits = _memory_hits_for(
+                names,
+                cache_file=cache_file,
+                ttl=ttl,
+            )
+            if hits is not None:
+                return hits
+        if disk is not None:
+            disk_hits: dict[str, ToolSnapshot] = {}
+            disk_complete = True
+            for name in names:
+                snap = lookup_snapshot(snapshots=disk, name=name)
+                if snap is None:
+                    disk_complete = False
+                    break
+                disk_hits[name] = snap
+            if disk_complete:
+                _memory_cache = disk
+                _memory_cache_path = cache_file
+                _memory_probed_at = time.time()
+                return disk_hits
 
     fresh = _probe_all_fresh(names, search_root=root, max_workers=max_workers)
 
@@ -735,7 +801,6 @@ def probe_all_tools(
         _memory_cache = merged
         _memory_cache_path = cache_file
         _memory_probed_at = time.time()
-        _force_fresh = False
         to_write = dict(merged)
 
     _write_disk_cache(cache_file, to_write, ttl=ttl)

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -137,12 +137,23 @@ def tool_status_for_versions(
         return ToolStatus.UNKNOWN
 
 
-def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResult:
+def check_tool(
+    *,
+    tool: ManifestTool,
+    context: RuntimeContext,
+    snapshot: object | None = None,
+) -> ToolCheckResult:
     """Check a single tool's installation status and version.
+
+    When a capability ``snapshot`` is provided (from the shared probe cache),
+    version/availability come from that snapshot instead of an ad-hoc
+    subprocess. Direct subprocess probing remains as a fallback for unit
+    tests and environments where the snapshot layer is unavailable.
 
     Args:
         tool: Manifest tool entry.
         context: Runtime context for install hints.
+        snapshot: Optional ToolSnapshot from the shared probe cache.
 
     Returns:
         ToolCheckResult with status and details.
@@ -162,6 +173,46 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
     else:
         hint = f"Install {tool.name} manually"
         upgrade_hint = f"Upgrade {tool.name} manually"
+
+    if snapshot is not None:
+        available = bool(getattr(snapshot, "available", False))
+        version = getattr(snapshot, "version", None)
+        binary_path = getattr(snapshot, "binary_path", "") or None
+        probe_error = getattr(snapshot, "probe_error", None)
+        remediation = getattr(snapshot, "remediation_hint", None) or hint
+        if not available:
+            return ToolCheckResult(
+                tool=tool,
+                status=ToolStatus.MISSING,
+                error="probe_failed",
+                details=probe_error or "unavailable",
+                path=binary_path,
+                install_hint=remediation,
+                upgrade_hint=upgrade_hint,
+            )
+        if not version:
+            return ToolCheckResult(
+                tool=tool,
+                status=ToolStatus.UNKNOWN,
+                error="no_version",
+                details=probe_error or "no version",
+                path=binary_path,
+                install_hint=hint,
+                upgrade_hint=upgrade_hint,
+            )
+        status = tool_status_for_versions(
+            installed=version,
+            recommended=tool.version,
+            minimum=tool.min_version,
+        )
+        return ToolCheckResult(
+            tool=tool,
+            status=status,
+            installed_version=version,
+            path=binary_path,
+            install_hint=hint,
+            upgrade_hint=upgrade_hint,
+        )
 
     if not tool.version_command:
         return ToolCheckResult(
@@ -306,28 +357,54 @@ def collect_tool_checks(
     Returns:
         list[ToolCheckResult]: One result per selected tool, in manifest order.
     """
+    from lintro.tools.core.snapshots import probe_all_tools
+
     if tool_names:
+        tools = [registry.get(name) for name in tool_names]
+        snapshots = probe_all_tools(tool_names=[t.name for t in tools])
         return [
-            check_tool(tool=registry.get(name), context=context) for name in tool_names
+            check_tool(
+                tool=tool,
+                context=context,
+                snapshot=snapshots.get(tool.name.lower()),
+            )
+            for tool in tools
         ]
 
     all_tools = list(registry.all_tools(include_dev=True))
     if check_all or config is None:
-        return [check_tool(tool=tool, context=context) for tool in all_tools]
-
-    return [
-        (
-            check_tool(tool=tool, context=context)
-            if config.is_tool_enabled(tool.name)
-            else ToolCheckResult(
+        snapshots = probe_all_tools(tool_names=[t.name for t in all_tools])
+        return [
+            check_tool(
                 tool=tool,
-                status=ToolStatus.DISABLED,
-                install_hint="",
-                upgrade_hint="",
+                context=context,
+                snapshot=snapshots.get(tool.name.lower()),
             )
-        )
-        for tool in all_tools
-    ]
+            for tool in all_tools
+        ]
+
+    enabled = [tool for tool in all_tools if config.is_tool_enabled(tool.name)]
+    snapshots = probe_all_tools(tool_names=[t.name for t in enabled]) if enabled else {}
+    results: list[ToolCheckResult] = []
+    for tool in all_tools:
+        if config.is_tool_enabled(tool.name):
+            results.append(
+                check_tool(
+                    tool=tool,
+                    context=context,
+                    snapshot=snapshots.get(tool.name.lower()),
+                ),
+            )
+        else:
+            results.append(
+                ToolCheckResult(
+                    tool=tool,
+                    status=ToolStatus.DISABLED,
+                    install_hint="",
+                    upgrade_hint="",
+                ),
+            )
+    return results
 
 
 def mcp_extra_status() -> dict[str, str]:

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -48,6 +48,7 @@ from lintro.tools.core.version_parsing import (
 if TYPE_CHECKING:
     from lintro.config.lintro_config import LintroConfig
     from lintro.tools.core.install_context import RuntimeContext
+    from lintro.tools.core.snapshots import ToolSnapshot
 
 __all__ = [
     "DoctorCheck",
@@ -328,6 +329,25 @@ def check_tool(
         )
 
 
+def _snapshot_for_tool(
+    *,
+    snapshots: dict[str, ToolSnapshot],
+    name: str,
+) -> ToolSnapshot | None:
+    """Look up a capability snapshot, accepting hyphen/underscore aliases.
+
+    Args:
+        snapshots: Map returned by ``probe_all_tools``.
+        name: Manifest or registry tool name.
+
+    Returns:
+        Matching snapshot, or None.
+    """
+    from lintro.tools.core.snapshots import lookup_snapshot
+
+    return lookup_snapshot(snapshots=snapshots, name=name)
+
+
 def collect_tool_checks(
     *,
     registry: ManifestRegistry,
@@ -366,7 +386,7 @@ def collect_tool_checks(
             check_tool(
                 tool=tool,
                 context=context,
-                snapshot=snapshots.get(tool.name.lower()),
+                snapshot=_snapshot_for_tool(snapshots=snapshots, name=tool.name),
             )
             for tool in tools
         ]
@@ -378,7 +398,7 @@ def collect_tool_checks(
             check_tool(
                 tool=tool,
                 context=context,
-                snapshot=snapshots.get(tool.name.lower()),
+                snapshot=_snapshot_for_tool(snapshots=snapshots, name=tool.name),
             )
             for tool in all_tools
         ]
@@ -392,7 +412,10 @@ def collect_tool_checks(
                 check_tool(
                     tool=tool,
                     context=context,
-                    snapshot=snapshots.get(tool.name.lower()),
+                    snapshot=_snapshot_for_tool(
+                        snapshots=snapshots,
+                        name=tool.name,
+                    ),
                 ),
             )
         else:
@@ -592,9 +615,8 @@ def _config_checks() -> tuple[LintroConfig | None, list[DoctorCheck]]:
 
     try:
         config = get_config(reload=True)
-    except (
-        Exception
-    ) as exc:  # noqa: BLE001 - any parse failure is a report line, not a crash
+    except Exception as exc:  # noqa: BLE001
+        # Any parse failure is a report line, not a crash.
         return None, [
             DoctorCheck(
                 category=DoctorCheckCategory.CONFIG,
@@ -620,9 +642,8 @@ def _config_checks() -> tuple[LintroConfig | None, list[DoctorCheck]]:
 
     try:
         warnings = validate_config_consistency()
-    except (
-        Exception
-    ) as exc:  # noqa: BLE001 - a broken native config must not abort the report
+    except Exception as exc:  # noqa: BLE001
+        # A broken native config must not abort the report.
         warnings = [f"consistency check failed: {exc}"]
 
     if warnings:

--- a/lintro/utils/execution/exit_codes.py
+++ b/lintro/utils/execution/exit_codes.py
@@ -37,7 +37,8 @@ def determine_exit_code(
     exit_code = DEFAULT_EXIT_CODE_SUCCESS
 
     # Check for tool failures first (applies to all actions)
-    # Exclude skipped tools — they didn't fail, they just didn't run
+    # Exclude skipped / unavailable tools — they didn't fail unless strict
+    # mode marked unavailable with success=False.
     if any(
         not getattr(r, "success", True)
         for r in all_results
@@ -80,8 +81,8 @@ def aggregate_tool_results(
     total_remaining = 0
 
     for result in results:
-        # Exclude skipped tools from totals
-        if getattr(result, "skipped", False):
+        # Exclude skipped / unavailable tools from totals
+        if getattr(result, "skipped", False) or getattr(result, "unavailable", False):
             continue
         total_issues += getattr(result, "issues_count", 0)
 

--- a/lintro/utils/file_cache.py
+++ b/lintro/utils/file_cache.py
@@ -209,7 +209,7 @@ class ToolCache:
 
 
 def clear_all_caches() -> None:
-    """Clear all tool caches."""
+    """Clear all tool caches (incremental fingerprints + capability snapshots)."""
     if CACHE_DIR.exists():
         for cache_file in CACHE_DIR.glob("*.json"):
             try:
@@ -220,6 +220,14 @@ def clear_all_caches() -> None:
         logger.info("Cleared all incremental check caches")
     else:
         logger.debug("No cache directory to clear")
+
+    try:
+        from lintro.tools.core.snapshots import clear_snapshot_cache, set_force_fresh_probes
+
+        clear_snapshot_cache()
+        set_force_fresh_probes(True)
+    except ImportError:
+        pass
 
 
 def get_cache_stats() -> dict[str, int]:

--- a/lintro/utils/json_output.py
+++ b/lintro/utils/json_output.py
@@ -119,7 +119,7 @@ def serialize_tool_result(
     )
     data: dict[str, Any] = {
         "tool": result.name,
-        "success": getattr(result, "success", True),
+        "success": getattr(result, "success", False),
         "issues_count": len(merged_issues),
         "skipped": getattr(result, "skipped", False),
         "skip_reason": getattr(result, "skip_reason", None),

--- a/lintro/utils/json_output.py
+++ b/lintro/utils/json_output.py
@@ -17,6 +17,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from lintro.enums.action import Action, normalize_action
+from lintro.enums.tool_result_status import status_for_tool_result
 from lintro.formatters.formatter import merge_detected_and_remaining
 from lintro.models.core.tool_result import ToolResult
 from lintro.utils.tool_metadata import normalize_tool_metadata
@@ -107,7 +108,10 @@ def serialize_tool_result(
         ``issues_count``, ``skipped``, ``skip_reason``, ``timed_out`` and
         ``output``; plus ``parse_failures_count`` when set,
         ``fixed``/``remaining`` in FIX mode, normalized ``metadata`` when
-        present, and ``issues`` when any exist.
+        present, and ``issues`` when any exist. ``status`` is always one of
+        ``ok``, ``failed``, ``skipped``, or ``unavailable``
+        (:class:`~lintro.enums.tool_result_status.ToolResultStatus`).
+        Unavailable tools also set ``unavailable: true``.
     """
     merged_issues = merge_detected_and_remaining(
         getattr(result, "initial_issues", None),
@@ -123,12 +127,8 @@ def serialize_tool_result(
         "output": getattr(result, "output", ""),
     }
     if getattr(result, "unavailable", False):
-        data["status"] = "unavailable"
         data["unavailable"] = True
-    elif getattr(result, "skipped", False):
-        data["status"] = "skipped"
-    else:
-        data["status"] = "ok" if data["success"] else "failed"
+    data["status"] = status_for_tool_result(result)
     if result.parse_failures_count is not None:
         data["parse_failures_count"] = result.parse_failures_count
     if action == Action.FIX:

--- a/lintro/utils/json_output.py
+++ b/lintro/utils/json_output.py
@@ -122,6 +122,13 @@ def serialize_tool_result(
         "timed_out": bool(getattr(result, "timed_out", False)),
         "output": getattr(result, "output", ""),
     }
+    if getattr(result, "unavailable", False):
+        data["status"] = "unavailable"
+        data["unavailable"] = True
+    elif getattr(result, "skipped", False):
+        data["status"] = "skipped"
+    else:
+        data["status"] = "ok" if data["success"] else "failed"
     if result.parse_failures_count is not None:
         data["parse_failures_count"] = result.parse_failures_count
     if action == Action.FIX:

--- a/lintro/utils/summary_tables.py
+++ b/lintro/utils/summary_tables.py
@@ -147,17 +147,22 @@ def _is_no_files_result(output: object) -> bool:
 
 
 def _is_result_skipped(result: object) -> tuple[bool, str]:
-    """Check if a tool result represents a skipped tool.
+    """Check if a tool result represents a skipped or unavailable tool.
 
-    Uses the first-class ``skipped`` field if available, falling back to
-    legacy output string matching for backward compatibility.
+    Uses the first-class ``unavailable`` / ``skipped`` fields if available,
+    falling back to legacy output string matching for backward compatibility.
 
     Args:
         result: Tool result object.
 
     Returns:
-        Tuple of (is_skipped, skip_reason).
+        Tuple of (is_non_run, reason). Unavailable tools are treated as
+        non-run so they appear in the summary instead of being silent.
     """
+    if getattr(result, "unavailable", False):
+        reason = getattr(result, "skip_reason", None) or ""
+        return True, reason or "unavailable"
+
     # First-class field (preferred)
     skipped = getattr(result, "skipped", False)
     if skipped:
@@ -175,6 +180,22 @@ def _is_result_skipped(result: object) -> tuple[bool, str]:
         return True, _extract_skip_reason(result_output)
 
     return False, ""
+
+
+def _non_run_status_label(result: object, reason: str) -> str:
+    """Format the summary-table status cell for skipped/unavailable tools.
+
+    Args:
+        result: Tool result object.
+        reason: Human-readable reason string (unused; notes column shows it).
+
+    Returns:
+        Colored status label string.
+    """
+    del reason  # notes column carries the reason
+    if getattr(result, "unavailable", False):
+        return f"{_YELLOW}⚠️  UNAVAIL{_RESET}"
+    return f"{_YELLOW}⏭️  SKIP{_RESET}"
 
 
 def count_affected_files(tool_results: Sequence[object]) -> int:
@@ -276,7 +297,7 @@ def print_summary_table(
                     summary_data.append(
                         [
                             tool_display,
-                            f"{_YELLOW}⏭️  SKIP{_RESET}",
+                            _non_run_status_label(result, skip_reason),
                             "-",
                             "-",
                             "-",
@@ -327,7 +348,7 @@ def print_summary_table(
                     summary_data.append(
                         [
                             tool_display,
-                            f"{_YELLOW}⏭️  SKIP{_RESET}",
+                            _non_run_status_label(result, skip_reason),
                             "-",
                             "-",
                             "-",
@@ -366,7 +387,7 @@ def print_summary_table(
                     summary_data.append(
                         [
                             tool_display,
-                            f"{_YELLOW}⏭️  SKIP{_RESET}",
+                            _non_run_status_label(result, skip_reason),
                             "-",  # Fixed
                             "-",  # AI-Applied
                             "-",  # AI-Resolved
@@ -467,7 +488,7 @@ def print_summary_table(
                     summary_data.append(
                         [
                             tool_display,
-                            f"{_YELLOW}⏭️  SKIP{_RESET}",
+                            _non_run_status_label(result, skip_reason),
                             "-",  # Issues
                             f"{_YELLOW}{skip_reason}{_RESET}" if skip_reason else "",
                         ],

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -480,6 +480,13 @@ def execute_run(
             color="cyan",
         )
 
+    # Warm the shared capability snapshot cache in parallel so per-tool
+    # verify_tool_version calls hit memory/disk instead of re-probing.
+    if tools_to_run:
+        from lintro.tools.core.snapshots import probe_all_tools
+
+        probe_all_tools(tool_names=list(tools_to_run))
+
     if not tools_to_run and not skipped_tools:
         logger.console_output("No tools to run.")
         return finalize_artifact(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,18 @@ def _discover_tools() -> None:
     discover_all_tools()
 
 
+@pytest.fixture(autouse=True)
+def _clear_tool_snapshot_cache() -> Iterator[None]:
+    """Clear capability-probe caches so tests do not share stale snapshots."""
+    from lintro.tools.core.snapshots import clear_snapshot_cache, set_force_fresh_probes
+
+    clear_snapshot_cache()
+    set_force_fresh_probes(False)
+    yield
+    clear_snapshot_cache()
+    set_force_fresh_probes(False)
+
+
 """Shared fixtures used across tests in this repository."""
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,10 +34,10 @@ def _clear_tool_snapshot_cache() -> Iterator[None]:
     """Clear capability-probe caches so tests do not share stale snapshots."""
     from lintro.tools.core.snapshots import clear_snapshot_cache, set_force_fresh_probes
 
-    clear_snapshot_cache()
+    clear_snapshot_cache(include_disk=False)
     set_force_fresh_probes(False)
     yield
-    clear_snapshot_cache()
+    clear_snapshot_cache(include_disk=False)
     set_force_fresh_probes(False)
 
 

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -381,6 +381,32 @@ def test_doctor_post_fix_blocks_only_non_retryable_outcomes() -> None:
     )
 
 
+def test_doctor_fix_clears_snapshot_cache_after_install() -> None:
+    """``--fix`` clears the capability cache before re-probing tools."""
+    runner = CliRunner()
+    p1, p2 = _patch_doctor_deps()
+
+    with (
+        p1,
+        p2,
+        patch("shutil.which", return_value=None),
+        patch(
+            "lintro.tools.core.snapshots.probe_all_tools",
+            return_value=_missing_snapshots(),
+        ),
+        patch(
+            "lintro.cli_utils.commands.doctor._run_fix",
+            return_value=[],
+        ),
+        patch(
+            "lintro.tools.core.snapshots.clear_snapshot_cache",
+        ) as mock_clear,
+    ):
+        runner.invoke(doctor_command, ["--fix"])
+
+    mock_clear.assert_called_once()
+
+
 def test_doctor_post_fix_quick_fix_skips_tools_that_did_not_resolve() -> None:
     """After --fix, a tool whose command did not resolve it is not re-suggested."""
     runner = CliRunner()

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -349,6 +349,10 @@ def test_doctor_post_fix_blocks_only_non_retryable_outcomes() -> None:
         p2,
         patch("shutil.which", return_value=None),
         patch(
+            "lintro.tools.core.snapshots.probe_all_tools",
+            return_value=_missing_snapshots(),
+        ),
+        patch(
             "lintro.tools.core.tool_installer.ToolInstaller.plan",
             return_value=plan,
         ),
@@ -387,6 +391,10 @@ def test_doctor_post_fix_quick_fix_skips_tools_that_did_not_resolve() -> None:
         p2,
         patch("shutil.which", return_value=None),
         patch(
+            "lintro.tools.core.snapshots.probe_all_tools",
+            return_value=_missing_snapshots(),
+        ),
+        patch(
             "lintro.cli_utils.commands.doctor._run_fix",
             return_value=["ruff"],
         ) as mock_fix,
@@ -405,7 +413,15 @@ def test_doctor_quick_fix_lists_missing_tool_before_any_fix() -> None:
     runner = CliRunner()
     p1, p2 = _patch_doctor_deps()
 
-    with p1, p2, patch("shutil.which", return_value=None):
+    with (
+        p1,
+        p2,
+        patch("shutil.which", return_value=None),
+        patch(
+            "lintro.tools.core.snapshots.probe_all_tools",
+            return_value=_missing_snapshots(),
+        ),
+    ):
         result = runner.invoke(doctor_command, [])
 
     assert_that(result.output).contains("Quick fix: lintro install ruff")

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -187,6 +187,44 @@ def _patch_doctor_deps() -> tuple[Any, Any]:
     )
 
 
+def _ok_snapshots() -> dict[str, Any]:
+    """Return a probe_all_tools result for a healthy ruff install."""
+    from lintro.tools.core.snapshots import ToolCapabilities, ToolSnapshot
+
+    return {
+        "ruff": ToolSnapshot(
+            name="ruff",
+            available=True,
+            version="0.14.4",
+            capabilities=ToolCapabilities(can_fix=True),
+            binary_path="/usr/bin/ruff",
+            binary_mtime=1.0,
+            version_check_passed=True,
+            min_version="0.14.0",
+        ),
+    }
+
+
+def _missing_snapshots() -> dict[str, Any]:
+    """Return a probe_all_tools result for a missing ruff binary."""
+    from lintro.tools.core.snapshots import ToolCapabilities, ToolSnapshot
+
+    return {
+        "ruff": ToolSnapshot(
+            name="ruff",
+            available=False,
+            version=None,
+            capabilities=ToolCapabilities(),
+            probe_error="ruff not found in PATH",
+            remediation_hint="Install ruff",
+            binary_path="",
+            binary_mtime=0.0,
+            version_check_passed=False,
+            min_version="0.14.0",
+        ),
+    }
+
+
 def test_doctor_all_ok_exit_0() -> None:
     """Exit code 0 when all tools pass."""
     runner = CliRunner()
@@ -195,10 +233,11 @@ def test_doctor_all_ok_exit_0() -> None:
     with (
         p1,
         p2,
-        patch("subprocess.run") as mock_run,
-        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch(
+            "lintro.tools.core.snapshots.probe_all_tools",
+            return_value=_ok_snapshots(),
+        ),
     ):
-        mock_run.return_value = MagicMock(returncode=0, stdout="ruff 0.14.4", stderr="")
         result = runner.invoke(doctor_command, [])
 
     assert_that(result.exit_code).is_equal_to(0)
@@ -209,7 +248,14 @@ def test_doctor_missing_tool_exit_1() -> None:
     runner = CliRunner()
     p1, p2 = _patch_doctor_deps()
 
-    with p1, p2, patch("shutil.which", return_value=None):
+    with (
+        p1,
+        p2,
+        patch(
+            "lintro.tools.core.snapshots.probe_all_tools",
+            return_value=_missing_snapshots(),
+        ),
+    ):
         result = runner.invoke(doctor_command, [])
 
     assert_that(result.exit_code).is_equal_to(1)
@@ -223,14 +269,15 @@ def test_doctor_json_output_valid() -> None:
     with (
         p1,
         p2,
-        patch("subprocess.run") as mock_run,
-        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch(
+            "lintro.tools.core.snapshots.probe_all_tools",
+            return_value=_ok_snapshots(),
+        ),
         patch(
             "lintro.cli_utils.commands.doctor.collect_full_environment",
             return_value=None,
         ),
     ):
-        mock_run.return_value = MagicMock(returncode=0, stdout="ruff 0.14.4", stderr="")
         result = runner.invoke(doctor_command, ["--json"])
 
     data = json.loads(result.output)
@@ -245,14 +292,15 @@ def test_doctor_fix_incompatible_with_json() -> None:
     with (
         p1,
         p2,
-        patch("subprocess.run") as mock_run,
-        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch(
+            "lintro.tools.core.snapshots.probe_all_tools",
+            return_value=_ok_snapshots(),
+        ),
         patch(
             "lintro.cli_utils.commands.doctor.collect_full_environment",
             return_value=MagicMock(),
         ),
     ):
-        mock_run.return_value = MagicMock(returncode=0, stdout="ruff 0.14.4", stderr="")
         result = runner.invoke(doctor_command, ["--fix", "--json"])
 
     assert_that(result.exit_code).is_not_equal_to(0)
@@ -371,10 +419,11 @@ def test_doctor_tools_filter_known_tool() -> None:
     with (
         p1,
         p2,
-        patch("subprocess.run") as mock_run,
-        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch(
+            "lintro.tools.core.snapshots.probe_all_tools",
+            return_value=_ok_snapshots(),
+        ),
     ):
-        mock_run.return_value = MagicMock(returncode=0, stdout="ruff 0.14.4", stderr="")
         result = runner.invoke(doctor_command, ["--tools", "ruff"])
 
     assert_that(result.exit_code).is_equal_to(0)

--- a/tests/unit/cli_utils/commands/test_list_tools_snapshots.py
+++ b/tests/unit/cli_utils/commands/test_list_tools_snapshots.py
@@ -1,0 +1,161 @@
+"""Tests for list-tools capability snapshot JSON output."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.enums.tool_result_status import ToolResultStatus
+from lintro.tools.core.snapshots import ToolCapabilities, ToolSnapshot
+
+
+def _snapshot(
+    *,
+    name: str = "ruff",
+    available: bool = True,
+    version: str | None = "0.14.0",
+) -> ToolSnapshot:
+    """Build a minimal ToolSnapshot for list-tools tests."""
+    return ToolSnapshot(
+        name=name,
+        available=available,
+        version=version,
+        capabilities=ToolCapabilities(can_fix=True),
+        probe_error=None if available else "not found",
+        remediation_hint="Install ruff",
+        binary_path="/usr/bin/ruff" if available else "",
+        binary_mtime=1.0 if available else 0.0,
+        version_check_passed=available,
+        min_version="0.1.0",
+    )
+
+
+def test_list_tools_json_missing_snapshot_reports_unknown_not_unavailable() -> None:
+    """Missing snapshots omit ``available`` and use ``status: unknown``."""
+    from lintro.cli_utils.commands.list_tools import list_tools
+
+    plugin = MagicMock()
+    plugin.definition.description = "Fast linter"
+    plugin.definition.execution_class.value = "subprocess"
+    plugin.definition.file_patterns = []
+    plugin.definition.conflicts_with = []
+
+    with (
+        patch(
+            "lintro.cli_utils.commands.list_tools.tool_manager.get_all_tools",
+            return_value={"ruff": plugin},
+        ),
+        patch(
+            "lintro.cli_utils.commands.list_tools.tool_manager.get_check_tools",
+            return_value={"ruff": plugin},
+        ),
+        patch(
+            "lintro.cli_utils.commands.list_tools.tool_manager.get_fix_tools",
+            return_value={"ruff": plugin},
+        ),
+        patch(
+            "lintro.tools.core.snapshots.probe_all_tools",
+            return_value={},
+        ),
+        patch("lintro.cli_utils.commands.list_tools.click.echo") as mock_echo,
+    ):
+        list_tools(
+            output=None,
+            show_conflicts=False,
+            json_output=True,
+        )
+
+    payload = json.loads(mock_echo.call_args[0][0])
+    assert_that(payload["ruff"]).does_not_contain_key("available")
+    assert_that(payload["ruff"]["status"]).is_equal_to(ToolResultStatus.UNKNOWN)
+
+
+def test_list_tools_json_available_without_version_reports_unknown() -> None:
+    """An available tool with no parsed version shows ``unknown``, not ``ok (?)``."""
+    from lintro.cli_utils.commands.list_tools import list_tools
+
+    plugin = MagicMock()
+    plugin.definition.description = "In-process tool"
+    plugin.definition.execution_class.value = "in_process"
+    plugin.definition.file_patterns = []
+    plugin.definition.conflicts_with = []
+
+    snap = _snapshot(name="idiom-review", version=None)
+
+    with (
+        patch(
+            "lintro.cli_utils.commands.list_tools.tool_manager.get_all_tools",
+            return_value={"idiom-review": plugin},
+        ),
+        patch(
+            "lintro.cli_utils.commands.list_tools.tool_manager.get_check_tools",
+            return_value={"idiom-review": plugin},
+        ),
+        patch(
+            "lintro.cli_utils.commands.list_tools.tool_manager.get_fix_tools",
+            return_value={},
+        ),
+        patch(
+            "lintro.tools.core.snapshots.probe_all_tools",
+            return_value={"idiom-review": snap},
+        ),
+        patch("lintro.cli_utils.commands.list_tools.click.echo") as mock_echo,
+    ):
+        list_tools(
+            output=None,
+            show_conflicts=False,
+            json_output=True,
+        )
+
+    payload = json.loads(mock_echo.call_args[0][0])
+    assert_that(payload["idiom-review"]["available"]).is_true()
+    assert_that(payload["idiom-review"]["status"]).is_equal_to(ToolResultStatus.UNKNOWN)
+    assert_that(payload["idiom-review"]["version"]).is_none()
+
+
+def test_list_tools_json_unavailable_snapshot_sets_status_and_available() -> None:
+    """Unavailable snapshots keep ``available: false`` and remediation hints."""
+    from lintro.cli_utils.commands.list_tools import list_tools
+
+    plugin = MagicMock()
+    plugin.definition.description = "Docker linter"
+    plugin.definition.execution_class.value = "subprocess"
+    plugin.definition.file_patterns = []
+    plugin.definition.conflicts_with = []
+
+    snap = _snapshot(name="hadolint", available=False, version=None)
+
+    with (
+        patch(
+            "lintro.cli_utils.commands.list_tools.tool_manager.get_all_tools",
+            return_value={"hadolint": plugin},
+        ),
+        patch(
+            "lintro.cli_utils.commands.list_tools.tool_manager.get_check_tools",
+            return_value={"hadolint": plugin},
+        ),
+        patch(
+            "lintro.cli_utils.commands.list_tools.tool_manager.get_fix_tools",
+            return_value={},
+        ),
+        patch(
+            "lintro.tools.core.snapshots.probe_all_tools",
+            return_value={"hadolint": snap},
+        ),
+        patch("lintro.cli_utils.commands.list_tools.click.echo") as mock_echo,
+    ):
+        list_tools(
+            output=None,
+            show_conflicts=False,
+            json_output=True,
+        )
+
+    payload = json.loads(mock_echo.call_args[0][0])
+    assert_that(payload["hadolint"]["available"]).is_false()
+    assert_that(payload["hadolint"]["status"]).is_equal_to(
+        ToolResultStatus.UNAVAILABLE,
+    )
+    assert_that(payload["hadolint"]["remediation_hint"]).is_equal_to("Install ruff")

--- a/tests/unit/enums/test_tool_name.py
+++ b/tests/unit/enums/test_tool_name.py
@@ -83,3 +83,11 @@ def test_tool_name_aliases_include_hyphen_and_underscore() -> None:
         ("astro-check", "astro_check"),
     )
     assert_that(tool_name_aliases("ruff")).is_equal_to(("ruff",))
+
+
+def test_tool_name_aliases_empty_input() -> None:
+    """Empty or whitespace-only names yield a single empty alias."""
+    from lintro.enums.tool_name import tool_name_aliases
+
+    assert_that(tool_name_aliases("")).is_equal_to(("",))
+    assert_that(tool_name_aliases("   ")).is_equal_to(("",))

--- a/tests/unit/enums/test_tool_name.py
+++ b/tests/unit/enums/test_tool_name.py
@@ -70,3 +70,16 @@ def test_normalize_tool_name_invalid_raises() -> None:
     """normalize_tool_name raises ValueError for unknown tool."""
     with pytest.raises(ValueError, match="Unknown tool name"):
         normalize_tool_name("nonexistent")
+
+
+def test_tool_name_aliases_include_hyphen_and_underscore() -> None:
+    """tool_name_aliases returns both spellings without duplicates."""
+    from lintro.enums.tool_name import tool_name_aliases
+
+    assert_that(tool_name_aliases("astro_check")).is_equal_to(
+        ("astro_check", "astro-check"),
+    )
+    assert_that(tool_name_aliases("astro-check")).is_equal_to(
+        ("astro-check", "astro_check"),
+    )
+    assert_that(tool_name_aliases("ruff")).is_equal_to(("ruff",))

--- a/tests/unit/enums/test_tool_result_status.py
+++ b/tests/unit/enums/test_tool_result_status.py
@@ -16,6 +16,7 @@ def test_tool_result_status_values() -> None:
     assert_that(ToolResultStatus.FAILED).is_equal_to("failed")
     assert_that(ToolResultStatus.SKIPPED).is_equal_to("skipped")
     assert_that(ToolResultStatus.UNAVAILABLE).is_equal_to("unavailable")
+    assert_that(ToolResultStatus.UNKNOWN).is_equal_to("unknown")
 
 
 def test_status_for_tool_result_precedence() -> None:
@@ -52,6 +53,41 @@ def test_status_for_tool_result_precedence() -> None:
     assert_that(status_for_tool_result(ok)).is_equal_to(ToolResultStatus.OK)
 
 
+def test_status_for_tool_result_timed_out_maps_to_failed() -> None:
+    """Timeouts classify as failed while ``timed_out`` carries detail."""
+    timed_out = ToolResult(
+        name="mypy",
+        success=False,
+        output="timed out",
+        timed_out=True,
+    )
+
+    assert_that(status_for_tool_result(timed_out)).is_equal_to(
+        ToolResultStatus.FAILED,
+    )
+
+
+def test_status_for_tool_result_issues_map_to_failed() -> None:
+    """Issue counts classify as failed even when success is ambiguous."""
+    with_issues = ToolResult(
+        name="ruff",
+        success=False,
+        output="",
+        issues_count=2,
+    )
+
+    assert_that(
+        status_for_tool_result(with_issues, issue_count=2),
+    ).is_equal_to(ToolResultStatus.FAILED)
+
+
+def test_status_for_tool_result_missing_success_defaults_to_failed() -> None:
+    """Missing ``success`` fails closed like ToolResult's default."""
+    bare = ToolResult(name="ruff", output="")
+
+    assert_that(status_for_tool_result(bare)).is_equal_to(ToolResultStatus.FAILED)
+
+
 def test_serialize_tool_result_status_uses_shared_enum() -> None:
     """JSON status is the ToolResultStatus value, not a local literal."""
     result = ToolResult(
@@ -64,3 +100,18 @@ def test_serialize_tool_result_status_uses_shared_enum() -> None:
     data = serialize_tool_result(result, action=Action.CHECK)
     assert_that(data["status"]).is_equal_to(ToolResultStatus.UNAVAILABLE)
     assert_that(data["unavailable"]).is_true()
+
+
+def test_serialize_tool_result_timed_out_status_is_failed() -> None:
+    """Timed-out tools serialize ``status: failed`` with ``timed_out: true``."""
+    result = ToolResult(
+        name="mypy",
+        success=False,
+        output="timed out",
+        timed_out=True,
+    )
+    data = serialize_tool_result(result, action=Action.CHECK)
+
+    assert_that(data["status"]).is_equal_to(ToolResultStatus.FAILED)
+    assert_that(data["timed_out"]).is_true()
+    assert_that(data["success"]).is_false()

--- a/tests/unit/enums/test_tool_result_status.py
+++ b/tests/unit/enums/test_tool_result_status.py
@@ -1,0 +1,66 @@
+"""Tests for per-tool JSON / list-tools status values."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.enums.action import Action
+from lintro.enums.tool_result_status import ToolResultStatus, status_for_tool_result
+from lintro.models.core.tool_result import ToolResult
+from lintro.utils.json_output import serialize_tool_result
+
+
+def test_tool_result_status_values() -> None:
+    """Enum values match the JSON contract."""
+    assert_that(ToolResultStatus.OK).is_equal_to("ok")
+    assert_that(ToolResultStatus.FAILED).is_equal_to("failed")
+    assert_that(ToolResultStatus.SKIPPED).is_equal_to("skipped")
+    assert_that(ToolResultStatus.UNAVAILABLE).is_equal_to("unavailable")
+
+
+def test_status_for_tool_result_precedence() -> None:
+    """Unavailable wins over skipped and success flags."""
+    unavailable = ToolResult(
+        name="ghost",
+        success=True,
+        output="",
+        unavailable=True,
+        skip_reason="not found",
+    )
+    skipped = ToolResult(
+        name="ruff",
+        success=True,
+        output="",
+        skipped=True,
+        skip_reason="no files",
+    )
+    failed = ToolResult(
+        name="ruff",
+        success=False,
+        output="",
+    )
+    ok = ToolResult(
+        name="ruff",
+        success=True,
+        output="",
+    )
+    assert_that(status_for_tool_result(unavailable)).is_equal_to(
+        ToolResultStatus.UNAVAILABLE,
+    )
+    assert_that(status_for_tool_result(skipped)).is_equal_to(ToolResultStatus.SKIPPED)
+    assert_that(status_for_tool_result(failed)).is_equal_to(ToolResultStatus.FAILED)
+    assert_that(status_for_tool_result(ok)).is_equal_to(ToolResultStatus.OK)
+
+
+def test_serialize_tool_result_status_uses_shared_enum() -> None:
+    """JSON status is the ToolResultStatus value, not a local literal."""
+    result = ToolResult(
+        name="ghost",
+        success=True,
+        output="ghost unavailable",
+        unavailable=True,
+        skip_reason="not found",
+    )
+    data = serialize_tool_result(result, action=Action.CHECK)
+    assert_that(data["status"]).is_equal_to(ToolResultStatus.UNAVAILABLE)
+    assert_that(data["unavailable"]).is_true()

--- a/tests/unit/mcp/test_toolkit_introspection.py
+++ b/tests/unit/mcp/test_toolkit_introspection.py
@@ -107,7 +107,7 @@ def stub_probes(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         doctor_report,
         "check_tool",
-        lambda *, tool, context: ToolCheckResult(
+        lambda *, tool, context, snapshot=None: ToolCheckResult(
             tool=tool,
             status=ToolStatus.OK,
             installed_version=tool.version,

--- a/tests/unit/plugins/base/test_execution.py
+++ b/tests/unit/plugins/base/test_execution.py
@@ -328,11 +328,19 @@ def test_prepare_execution_version_check_fails_returns_early_result(
         success=True,
         output="Version check failed",
         issues_count=0,
+        skipped=True,
+        skip_reason="Version check failed",
     )
 
-    with patch(
-        "lintro.plugins.execution_preparation.verify_tool_version",
-        return_value=skip_result,
+    with (
+        patch(
+            "lintro.plugins.execution_preparation.discover_files",
+            return_value=["/tmp/sample.py"],
+        ),
+        patch(
+            "lintro.plugins.execution_preparation.verify_tool_version",
+            return_value=skip_result,
+        ),
     ):
         ctx = fake_tool_plugin._prepare_execution(["."], {})
 

--- a/tests/unit/plugins/base/test_subprocess.py
+++ b/tests/unit/plugins/base/test_subprocess.py
@@ -308,17 +308,22 @@ def test_verify_tool_version_below_min_allowed_via_env(
         fake_tool_plugin: Fixture providing a FakeToolPlugin instance.
         monkeypatch: Pytest monkeypatch fixture.
     """
-    monkeypatch.setenv("LINTRO_ALLOW_VERSION_LAG", fake_tool_plugin.definition.name)
-    with patch("lintro.tools.core.version_requirements.check_tool_version") as mock:
-        mock.return_value = MagicMock(
-            version_check_passed=False,
-            current_version="0.9.0",
-            error_message="Version 0.9.0 is below minimum requirement 1.0.0",
-            min_version="1.0.0",
-            install_hint="pip install tool",
-            below_recommended=False,
-        )
+    from lintro.tools.core.snapshots import ToolCapabilities, ToolSnapshot
 
+    monkeypatch.setenv("LINTRO_ALLOW_VERSION_LAG", fake_tool_plugin.definition.name)
+    snap = ToolSnapshot(
+        name=fake_tool_plugin.definition.name,
+        available=True,
+        version="0.9.0",
+        capabilities=ToolCapabilities(),
+        probe_error="any prose; lag uses structured flags",
+        version_check_passed=False,
+        min_version="1.0.0",
+    )
+    with patch(
+        "lintro.tools.core.snapshots.get_tool_snapshot",
+        return_value=snap,
+    ):
         result = fake_tool_plugin._verify_tool_version()
 
         assert_that(result).is_none()
@@ -334,17 +339,29 @@ def test_verify_tool_version_missing_binary_not_allowed_via_env(
         fake_tool_plugin: Fixture providing a FakeToolPlugin instance.
         monkeypatch: Pytest monkeypatch fixture.
     """
-    monkeypatch.setenv("LINTRO_ALLOW_VERSION_LAG", fake_tool_plugin.definition.name)
-    with patch("lintro.tools.core.version_requirements.check_tool_version") as mock:
-        mock.return_value = MagicMock(
-            version_check_passed=False,
-            current_version=None,
-            error_message="Tool not found",
-            min_version="1.0.0",
-            install_hint="pip install tool",
-        )
+    from lintro.tools.core.snapshots import ToolCapabilities, ToolSnapshot
 
+    monkeypatch.setenv("LINTRO_ALLOW_VERSION_LAG", fake_tool_plugin.definition.name)
+    snap = ToolSnapshot(
+        name=fake_tool_plugin.definition.name,
+        available=False,
+        version=None,
+        capabilities=ToolCapabilities(),
+        probe_error="fake-tool not found in PATH",
+        version_check_passed=False,
+        min_version="1.0.0",
+    )
+    with (
+        patch(
+            "lintro.tools.core.snapshots.get_tool_snapshot",
+            return_value=snap,
+        ),
+        patch(
+            "lintro.tools.core.snapshots.is_strict_missing_tools",
+            return_value=False,
+        ),
+    ):
         result = fake_tool_plugin._verify_tool_version()
 
         assert_that(result).is_not_none()
-        assert_that(result.output).contains("Skipping")  # type: ignore[union-attr]
+        assert_that(result.unavailable).is_true()  # type: ignore[union-attr]

--- a/tests/unit/plugins/base/test_subprocess.py
+++ b/tests/unit/plugins/base/test_subprocess.py
@@ -247,9 +247,20 @@ def test_verify_tool_version_passes_returns_none(
     Args:
         fake_tool_plugin: Fixture providing a FakeToolPlugin instance.
     """
-    with patch("lintro.tools.core.version_requirements.check_tool_version") as mock:
-        mock.return_value = MagicMock(version_check_passed=True)
+    from lintro.tools.core.snapshots import ToolCapabilities, ToolSnapshot
 
+    snap = ToolSnapshot(
+        name="fake-tool",
+        available=True,
+        version="1.0.0",
+        capabilities=ToolCapabilities(),
+        version_check_passed=True,
+        min_version="1.0.0",
+    )
+    with patch(
+        "lintro.tools.core.snapshots.get_tool_snapshot",
+        return_value=snap,
+    ):
         result = fake_tool_plugin._verify_tool_version()
 
         assert_that(result).is_none()
@@ -263,15 +274,22 @@ def test_verify_tool_version_fails_returns_skip_result(
     Args:
         fake_tool_plugin: Fixture providing a FakeToolPlugin instance.
     """
-    with patch("lintro.tools.core.version_requirements.check_tool_version") as mock:
-        mock.return_value = MagicMock(
-            version_check_passed=False,
-            current_version="0.9.0",
-            error_message="Version 0.9.0 is below minimum requirement 1.0.0",
-            min_version="1.0.0",
-            install_hint="pip install tool",
-        )
+    from lintro.tools.core.snapshots import ToolCapabilities, ToolSnapshot
 
+    snap = ToolSnapshot(
+        name="fake-tool",
+        available=True,
+        version="0.1.0",
+        capabilities=ToolCapabilities(),
+        probe_error="Version too old",
+        remediation_hint="pip install tool",
+        version_check_passed=False,
+        min_version="1.0.0",
+    )
+    with patch(
+        "lintro.tools.core.snapshots.get_tool_snapshot",
+        return_value=snap,
+    ):
         result = fake_tool_plugin._verify_tool_version()
 
         assert_that(result).is_not_none()

--- a/tests/unit/plugins/test_execution_preparation.py
+++ b/tests/unit/plugins/test_execution_preparation.py
@@ -74,48 +74,32 @@ def test_version_lag_disallowed_when_unset(monkeypatch: pytest.MonkeyPatch) -> N
     assert_that(_version_lag_allowed("trufflehog")).is_false()
 
 
-def test_verify_tool_version_resolves_from_the_execution_cwd() -> None:
-    """The version check must resolve the binary the run will actually use.
+def test_verify_tool_version_uses_cached_snapshot() -> None:
+    """Version gates read ToolSnapshot flags, not a live subprocess probe.
 
-    Verification previously resolved from the process working directory while
-    execution resolved from the target project. A missing or outdated
-    process-visible binary could then skip the run even though the target had
-    a valid lockfile-pinned install — and the reverse, passing on a binary
-    that never executes (#1727).
-
+    cwd-scoped binary resolution is reserved for #1727; snapshots currently
+    resolve via ``get_tool_snapshot`` without an execution cwd.
     """
     from unittest.mock import patch
 
     from lintro.plugins.execution_preparation import verify_tool_version
-
-    seen: dict[str, object] = {}
-
-    def _capture(tool_name: str, cwd: object = None) -> list[str]:
-        seen["cwd"] = cwd
-        return ["html-validate"]
+    from lintro.tools.core.snapshots import ToolCapabilities, ToolSnapshot
 
     definition = type("Def", (), {"name": "html_validate"})()
+    snap = ToolSnapshot(
+        name="html_validate",
+        available=True,
+        version="1.0.0",
+        capabilities=ToolCapabilities(),
+        version_check_passed=True,
+        min_version="1.0.0",
+    )
 
-    with (
-        patch(
-            "lintro.plugins.execution_preparation.get_executable_command",
-            side_effect=_capture,
-        ),
-        patch(
-            "lintro.tools.core.version_requirements.check_tool_version",
-        ) as mock_check,
-    ):
-        mock_check.return_value = type(
-            "Info",
-            (),
-            {
-                "version_check_passed": True,
-                "below_recommended": False,
-                "current_version": "1.0.0",
-                "recommended_version": "1.0.0",
-                "min_version": "1.0.0",
-            },
-        )()
-        verify_tool_version(definition, cwd="/tmp/target-project")
+    with patch(
+        "lintro.tools.core.snapshots.get_tool_snapshot",
+        return_value=snap,
+    ) as mock_snap:
+        result = verify_tool_version(definition, cwd="/tmp/target-project")
 
-    assert_that(seen.get("cwd")).is_equal_to("/tmp/target-project")
+    assert_that(result).is_none()
+    mock_snap.assert_called_once_with("html_validate")

--- a/tests/unit/plugins/test_registry.py
+++ b/tests/unit/plugins/test_registry.py
@@ -117,6 +117,14 @@ def test_get_is_case_insensitive(tool_name_variant: str) -> None:
     assert_that(tool.definition.name.lower()).is_equal_to("ruff")
 
 
+def test_get_accepts_underscore_alias_for_hyphenated_tool() -> None:
+    """Manifest underscore names resolve hyphen-registered plugins."""
+    tool = ToolRegistry.get("astro_check")
+
+    assert_that(tool).is_not_none()
+    assert_that(tool.definition.name.lower()).is_equal_to("astro-check")
+
+
 # =============================================================================
 # Tests for ToolRegistry.get_all
 # =============================================================================

--- a/tests/unit/plugins/test_registry.py
+++ b/tests/unit/plugins/test_registry.py
@@ -252,6 +252,22 @@ def test_is_registered_returns_correct_boolean(tool_name: str, expected: bool) -
     assert_that(result).is_equal_to(expected)
 
 
+def test_is_registered_and_get_origin_resolve_underscore_alias(
+    clean_registry: None,
+) -> None:
+    """Hyphenated registry keys are visible via underscore aliases.
+
+    Args:
+        clean_registry: Fixture to ensure clean registry state.
+    """
+    plugin_class = create_fake_plugin(name="alias-origin-tool")
+    ToolRegistry.register(plugin_class=plugin_class, origin="testdist")
+
+    assert_that(ToolRegistry.is_registered("alias_origin_tool")).is_true()
+    assert_that(ToolRegistry.get_origin("alias_origin_tool")).is_equal_to("testdist")
+    assert_that(ToolRegistry.get_origin("missing_tool")).is_equal_to("unknown")
+
+
 # =============================================================================
 # Tests for ToolRegistry.clear
 # =============================================================================

--- a/tests/unit/tools/core/test_snapshots.py
+++ b/tests/unit/tools/core/test_snapshots.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 import time
-from pathlib import Path
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -362,6 +362,7 @@ def test_verify_tool_version_uses_unavailable_snapshot() -> None:
         result = verify_tool_version(definition)
 
     assert_that(result).is_not_none()
+    assert result is not None
     assert_that(result.unavailable).is_true()
     assert_that(result.success).is_true()
 

--- a/tests/unit/tools/core/test_snapshots.py
+++ b/tests/unit/tools/core/test_snapshots.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
+from collections.abc import Iterator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -25,7 +26,10 @@ from lintro.tools.core.snapshots import (
 
 
 @pytest.fixture(autouse=True)
-def _reset_snapshot_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def _reset_snapshot_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
     """Isolate snapshot cache to a temp directory for every test."""
     monkeypatch.chdir(tmp_path)
     clear_snapshot_cache(cache_root=tmp_path)
@@ -360,6 +364,36 @@ def test_verify_tool_version_uses_unavailable_snapshot() -> None:
     assert_that(result).is_not_none()
     assert_that(result.unavailable).is_true()
     assert_that(result.success).is_true()
+
+
+def test_verify_tool_version_warns_when_below_recommended() -> None:
+    """Below-recommended versions still pass but emit a warning."""
+    from lintro.plugins.execution_preparation import verify_tool_version
+    from lintro.plugins.protocol import ToolDefinition
+
+    snap = ToolSnapshot(
+        name="ruff",
+        available=True,
+        version="0.10.0",
+        version_check_passed=True,
+        min_version="0.9.0",
+        recommended_version="0.14.0",
+        below_recommended=True,
+    )
+    definition = ToolDefinition(name="ruff", description="lint")
+
+    with (
+        patch(
+            "lintro.tools.core.snapshots.get_tool_snapshot",
+            return_value=snap,
+        ),
+        patch("lintro.plugins.execution_preparation.logger") as mock_logger,
+    ):
+        result = verify_tool_version(definition)
+
+    assert_that(result).is_none()
+    mock_logger.warning.assert_called_once()
+    assert_that(str(mock_logger.warning.call_args)).contains("below recommended")
 
 
 def test_serialize_tool_result_emits_unavailable_status() -> None:

--- a/tests/unit/tools/core/test_snapshots.py
+++ b/tests/unit/tools/core/test_snapshots.py
@@ -1,0 +1,380 @@
+"""Tests for cached tool capability probing (issue #1244)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.tools.core.snapshots import (
+    DEFAULT_SNAPSHOT_TTL_SECONDS,
+    ToolCapabilities,
+    ToolSnapshot,
+    clear_snapshot_cache,
+    get_tool_snapshot,
+    probe_all_tools,
+    probe_tool,
+    set_force_fresh_probes,
+    snapshot_to_unavailable_result,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_snapshot_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate snapshot cache to a temp directory for every test."""
+    monkeypatch.chdir(tmp_path)
+    clear_snapshot_cache(cache_root=tmp_path)
+    set_force_fresh_probes(False)
+    yield
+    clear_snapshot_cache(cache_root=tmp_path)
+    set_force_fresh_probes(False)
+
+
+def _fake_snapshot(
+    name: str = "ruff",
+    *,
+    available: bool = True,
+    version: str | None = "0.14.0",
+    binary_path: str = "/usr/bin/ruff",
+    binary_mtime: float = 100.0,
+    probe_error: str | None = None,
+) -> ToolSnapshot:
+    """Build a ToolSnapshot for tests."""
+    return ToolSnapshot(
+        name=name,
+        available=available,
+        version=version,
+        capabilities=ToolCapabilities(can_fix=True, config_found=False),
+        probe_error=probe_error,
+        remediation_hint="Install ruff",
+        binary_path=binary_path if available else "",
+        binary_mtime=binary_mtime if available else 0.0,
+        version_check_passed=available,
+        min_version="0.1.0",
+    )
+
+
+def test_tool_snapshot_roundtrip_dict() -> None:
+    """ToolSnapshot serializes and deserializes without data loss."""
+    snap = _fake_snapshot()
+    restored = ToolSnapshot.from_dict(snap.to_dict())
+    assert_that(restored.name).is_equal_to(snap.name)
+    assert_that(restored.available).is_true()
+    assert_that(restored.version).is_equal_to("0.14.0")
+    assert_that(restored.capabilities.can_fix).is_true()
+    assert_that(restored.binary_mtime).is_equal_to(100.0)
+
+
+def test_cache_hit_within_ttl_skips_reprobe(tmp_path: Path) -> None:
+    """Second probe_all_tools within TTL must not re-run subprocess probes."""
+    call_count = {"n": 0}
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        call_count["n"] += 1
+        binary = tmp_path / f"{name}.bin"
+        binary.write_text("x")
+        return _fake_snapshot(
+            name,
+            binary_path=str(binary),
+            binary_mtime=binary.stat().st_mtime,
+        )
+
+    with patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe):
+        with patch(
+            "lintro.plugins.discovery.discover_all_tools",
+            return_value=None,
+        ):
+            with patch(
+                "lintro.plugins.registry.ToolRegistry.get_names",
+                return_value=["ruff", "black"],
+            ):
+                first = probe_all_tools(cache_root=tmp_path)
+                second = probe_all_tools(cache_root=tmp_path)
+
+    assert_that(call_count["n"]).is_equal_to(2)
+    assert_that(first).contains_key("ruff", "black")
+    assert_that(second["ruff"].version).is_equal_to(first["ruff"].version)
+    cache_file = tmp_path / ".lintro-cache" / "tool-snapshots.json"
+    assert_that(cache_file.exists()).is_true()
+
+
+def test_mtime_bump_invalidates_cache(tmp_path: Path) -> None:
+    """Changing binary mtime invalidates the cached snapshot for that tool."""
+    from lintro import __version__ as lintro_version
+
+    binary = tmp_path / "ruff.bin"
+    binary.write_text("v1")
+    snap = _fake_snapshot(
+        "ruff",
+        binary_path=str(binary),
+        binary_mtime=binary.stat().st_mtime,
+    )
+    cache_file = tmp_path / ".lintro-cache" / "tool-snapshots.json"
+    cache_file.parent.mkdir(parents=True)
+    cache_file.write_text(
+        json.dumps(
+            {
+                "lintro_version": lintro_version,
+                "probed_at": time.time(),
+                "ttl_seconds": DEFAULT_SNAPSHOT_TTL_SECONDS,
+                "snapshots": {"ruff": snap.to_dict()},
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    # Bump mtime so the cache key no longer matches.
+    time.sleep(0.05)
+    binary.write_text("v2")
+
+    call_count = {"n": 0}
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        call_count["n"] += 1
+        return _fake_snapshot(
+            name,
+            version="0.15.0",
+            binary_path=str(binary),
+            binary_mtime=binary.stat().st_mtime,
+        )
+
+    with patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe):
+        with patch(
+            "lintro.plugins.discovery.discover_all_tools",
+            return_value=None,
+        ):
+            with patch(
+                "lintro.plugins.registry.ToolRegistry.get_names",
+                return_value=["ruff"],
+            ):
+                result = probe_all_tools(cache_root=tmp_path)
+
+    assert_that(call_count["n"]).is_equal_to(1)
+    assert_that(result["ruff"].version).is_equal_to("0.15.0")
+
+
+def test_missing_binary_yields_unavailable_snapshot() -> None:
+    """Missing binary produces available=false with remediation hint."""
+    definition = MagicMock()
+    definition.name = "missingtool"
+    definition.can_fix = False
+    definition.native_configs = []
+    definition.version_command = ["missingtool", "--version"]
+
+    plugin = MagicMock()
+    plugin.definition = definition
+
+    with (
+        patch("lintro.plugins.registry.ToolRegistry.get", return_value=plugin),
+        patch(
+            "lintro.plugins.execution_preparation.get_executable_command",
+            return_value=["missingtool"],
+        ),
+        patch("shutil.which", return_value=None),
+        patch(
+            "lintro.tools.core.version_checking.get_install_hints",
+            return_value={"missingtool": "Install missingtool via brew"},
+        ),
+    ):
+        snap = probe_tool("missingtool")
+
+    assert_that(snap.available).is_false()
+    assert_that(snap.probe_error).contains("not found in PATH")
+    assert_that(snap.remediation_hint).contains("Install missingtool")
+
+    result = snapshot_to_unavailable_result(snap, strict=False)
+    assert_that(result.unavailable).is_true()
+    assert_that(result.success).is_true()
+    assert_that(result.output).contains("unavailable")
+
+
+def test_strict_missing_marks_unavailable_as_failure() -> None:
+    """strict_missing_tools makes unavailable results fail the run."""
+    snap = _fake_snapshot(
+        available=False,
+        version=None,
+        probe_error="not found",
+        binary_path="",
+        binary_mtime=0.0,
+    )
+    result = snapshot_to_unavailable_result(snap, strict=True)
+    assert_that(result.unavailable).is_true()
+    assert_that(result.success).is_false()
+
+
+def test_corrupt_cache_recovers_with_reprobe(tmp_path: Path) -> None:
+    """Corrupt cache file is deleted and probing proceeds."""
+    cache_file = tmp_path / ".lintro-cache" / "tool-snapshots.json"
+    cache_file.parent.mkdir(parents=True)
+    cache_file.write_text("{not-json", encoding="utf-8")
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        binary = tmp_path / f"{name}.bin"
+        binary.write_text("x")
+        return _fake_snapshot(
+            name,
+            binary_path=str(binary),
+            binary_mtime=binary.stat().st_mtime,
+        )
+
+    with patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe):
+        with patch(
+            "lintro.plugins.discovery.discover_all_tools",
+            return_value=None,
+        ):
+            with patch(
+                "lintro.plugins.registry.ToolRegistry.get_names",
+                return_value=["ruff"],
+            ):
+                result = probe_all_tools(cache_root=tmp_path)
+
+    assert_that(result).contains_key("ruff")
+    assert_that(result["ruff"].available).is_true()
+    # Cache should have been rewritten as valid JSON
+    data = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert_that(data).contains_key("snapshots")
+
+
+def test_parallel_probe_correctness(tmp_path: Path) -> None:
+    """Parallel probing returns a snapshot for every requested tool."""
+    seen: list[str] = []
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        seen.append(name)
+        binary = tmp_path / f"{name}.bin"
+        binary.write_text(name)
+        return _fake_snapshot(
+            name,
+            binary_path=str(binary),
+            binary_mtime=binary.stat().st_mtime,
+        )
+
+    names = [f"tool{i}" for i in range(8)]
+    with patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe):
+        with patch(
+            "lintro.plugins.discovery.discover_all_tools",
+            return_value=None,
+        ):
+            with patch(
+                "lintro.plugins.registry.ToolRegistry.get_names",
+                return_value=names,
+            ):
+                result = probe_all_tools(cache_root=tmp_path, force=True)
+
+    assert_that(sorted(seen)).is_equal_to(sorted(names))
+    assert_that(sorted(result.keys())).is_equal_to(sorted(names))
+    for name in names:
+        assert_that(result[name].available).is_true()
+
+
+def test_force_fresh_bypasses_memory_cache(tmp_path: Path) -> None:
+    """force=True re-probes even when memory cache is warm."""
+    call_count = {"n": 0}
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        call_count["n"] += 1
+        binary = tmp_path / f"{name}.bin"
+        binary.write_text("x")
+        return _fake_snapshot(
+            name,
+            version=f"0.{call_count['n']}.0",
+            binary_path=str(binary),
+            binary_mtime=binary.stat().st_mtime,
+        )
+
+    with patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe):
+        with patch(
+            "lintro.plugins.discovery.discover_all_tools",
+            return_value=None,
+        ):
+            with patch(
+                "lintro.plugins.registry.ToolRegistry.get_names",
+                return_value=["ruff"],
+            ):
+                probe_all_tools(cache_root=tmp_path)
+                forced = probe_all_tools(cache_root=tmp_path, force=True)
+
+    assert_that(call_count["n"]).is_equal_to(2)
+    assert_that(forced["ruff"].version).is_equal_to("0.2.0")
+
+
+def test_get_tool_snapshot_returns_named_entry(tmp_path: Path) -> None:
+    """get_tool_snapshot returns the snapshot for the requested tool."""
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        binary = tmp_path / f"{name}.bin"
+        binary.write_text("x")
+        return _fake_snapshot(
+            name,
+            binary_path=str(binary),
+            binary_mtime=binary.stat().st_mtime,
+        )
+
+    with patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe):
+        with patch(
+            "lintro.plugins.discovery.discover_all_tools",
+            return_value=None,
+        ):
+            with patch(
+                "lintro.plugins.registry.ToolRegistry.get_names",
+                return_value=["ruff"],
+            ):
+                snap = get_tool_snapshot("ruff", cache_root=tmp_path)
+
+    assert_that(snap.name).is_equal_to("ruff")
+    assert_that(snap.available).is_true()
+
+
+def test_verify_tool_version_uses_unavailable_snapshot() -> None:
+    """verify_tool_version returns unavailable result when snapshot is down."""
+    from lintro.plugins.execution_preparation import verify_tool_version
+    from lintro.plugins.protocol import ToolDefinition
+
+    snap = _fake_snapshot(
+        "ghost",
+        available=False,
+        version=None,
+        probe_error="ghost not found in PATH",
+        binary_path="",
+        binary_mtime=0.0,
+    )
+    definition = ToolDefinition(name="ghost", description="missing")
+
+    with (
+        patch(
+            "lintro.tools.core.snapshots.get_tool_snapshot",
+            return_value=snap,
+        ),
+        patch(
+            "lintro.tools.core.snapshots.is_strict_missing_tools",
+            return_value=False,
+        ),
+    ):
+        result = verify_tool_version(definition)
+
+    assert_that(result).is_not_none()
+    assert_that(result.unavailable).is_true()
+    assert_that(result.success).is_true()
+
+
+def test_serialize_tool_result_emits_unavailable_status() -> None:
+    """JSON serialization includes status=unavailable for degraded tools."""
+    from lintro.enums.action import Action
+    from lintro.models.core.tool_result import ToolResult
+    from lintro.utils.json_output import serialize_tool_result
+
+    result = ToolResult(
+        name="ghost",
+        success=True,
+        output="ghost unavailable: not found",
+        unavailable=True,
+        skip_reason="not found",
+    )
+    data: dict[str, Any] = serialize_tool_result(result, action=Action.CHECK)
+    assert_that(data["status"]).is_equal_to("unavailable")
+    assert_that(data["unavailable"]).is_true()

--- a/tests/unit/tools/core/test_snapshots.py
+++ b/tests/unit/tools/core/test_snapshots.py
@@ -411,5 +411,263 @@ def test_serialize_tool_result_emits_unavailable_status() -> None:
         skip_reason="not found",
     )
     data: dict[str, Any] = serialize_tool_result(result, action=Action.CHECK)
-    assert_that(data["status"]).is_equal_to("unavailable")
+    from lintro.enums.tool_result_status import ToolResultStatus
+
+    assert_that(data["status"]).is_equal_to(ToolResultStatus.UNAVAILABLE)
     assert_that(data["unavailable"]).is_true()
+
+
+def _write_snapshot_cache(
+    tmp_path: Path,
+    snap: ToolSnapshot,
+) -> Path:
+    """Write a one-entry on-disk snapshot cache for tests."""
+    from lintro import __version__ as lintro_version
+
+    cache_file = tmp_path / ".lintro-cache" / "tool-snapshots.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(
+        json.dumps(
+            {
+                "lintro_version": lintro_version,
+                "probed_at": time.time(),
+                "ttl_seconds": DEFAULT_SNAPSHOT_TTL_SECONDS,
+                "snapshots": {snap.name: snap.to_dict()},
+            },
+        ),
+        encoding="utf-8",
+    )
+    return cache_file
+
+
+def test_unavailable_disk_cache_kept_while_binary_missing(tmp_path: Path) -> None:
+    """Still-missing tools stay cached until PATH grows a hit."""
+    snap = _fake_snapshot(
+        "ruff",
+        available=False,
+        version=None,
+        probe_error="ruff not found in PATH",
+        binary_path="",
+        binary_mtime=0.0,
+    )
+    _write_snapshot_cache(tmp_path, snap)
+    call_count = {"n": 0}
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        call_count["n"] += 1
+        return snap
+
+    with (
+        patch("lintro.tools.core.snapshots.shutil.which", return_value=None),
+        patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe),
+        patch("lintro.plugins.discovery.discover_all_tools", return_value=None),
+        patch(
+            "lintro.plugins.registry.ToolRegistry.get_names",
+            return_value=["ruff"],
+        ),
+    ):
+        result = probe_all_tools(cache_root=tmp_path)
+
+    assert_that(call_count["n"]).is_equal_to(0)
+    assert_that(result["ruff"].available).is_false()
+
+
+def test_unavailable_cache_invalidates_when_binary_appears(tmp_path: Path) -> None:
+    """A PATH hit after an unavailable cache write forces a re-probe."""
+    snap = _fake_snapshot(
+        "ruff",
+        available=False,
+        version=None,
+        probe_error="ruff not found in PATH",
+        binary_path="",
+        binary_mtime=0.0,
+    )
+    _write_snapshot_cache(tmp_path, snap)
+    binary = tmp_path / "ruff"
+    binary.write_text("x")
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        return _fake_snapshot(
+            name,
+            version="0.15.0",
+            binary_path=str(binary),
+            binary_mtime=binary.stat().st_mtime,
+        )
+
+    with (
+        patch("lintro.tools.core.snapshots.shutil.which", return_value=str(binary)),
+        patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe),
+        patch("lintro.plugins.discovery.discover_all_tools", return_value=None),
+        patch(
+            "lintro.plugins.registry.ToolRegistry.get_names",
+            return_value=["ruff"],
+        ),
+    ):
+        result = probe_all_tools(cache_root=tmp_path)
+
+    assert_that(result["ruff"].available).is_true()
+    assert_that(result["ruff"].version).is_equal_to("0.15.0")
+
+
+def test_memory_unavailable_invalidates_when_which_hits(tmp_path: Path) -> None:
+    """In-process memory hits re-probe when a missing binary appears."""
+    call_count = {"n": 0}
+    which_path: dict[str, str | None] = {"v": None}
+
+    def fake_which(_cmd: str) -> str | None:
+        return which_path["v"]
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        call_count["n"] += 1
+        if which_path["v"]:
+            binary = tmp_path / f"{name}.bin"
+            binary.write_text("x")
+            return _fake_snapshot(
+                name,
+                binary_path=str(binary),
+                binary_mtime=binary.stat().st_mtime,
+            )
+        return _fake_snapshot(
+            name,
+            available=False,
+            version=None,
+            probe_error="not found",
+            binary_path="",
+            binary_mtime=0.0,
+        )
+
+    with (
+        patch("lintro.tools.core.snapshots.shutil.which", side_effect=fake_which),
+        patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe),
+        patch("lintro.plugins.discovery.discover_all_tools", return_value=None),
+        patch(
+            "lintro.plugins.registry.ToolRegistry.get_names",
+            return_value=["ruff"],
+        ),
+    ):
+        first = probe_all_tools(cache_root=tmp_path)
+        which_path["v"] = "/usr/bin/ruff"
+        second = probe_all_tools(cache_root=tmp_path)
+
+    assert_that(first["ruff"].available).is_false()
+    assert_that(call_count["n"]).is_equal_to(2)
+    assert_that(second["ruff"].available).is_true()
+
+
+def test_force_fresh_set_during_probe_survives_caller_force(tmp_path: Path) -> None:
+    """A force-fresh flag set during a forced probe is not cleared afterwards."""
+    call_count = {"n": 0}
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        call_count["n"] += 1
+        set_force_fresh_probes(True)
+        binary = tmp_path / f"{name}.bin"
+        binary.write_text("x")
+        return _fake_snapshot(
+            name,
+            version=f"0.{call_count['n']}.0",
+            binary_path=str(binary),
+            binary_mtime=binary.stat().st_mtime,
+        )
+
+    with (
+        patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe),
+        patch("lintro.plugins.discovery.discover_all_tools", return_value=None),
+        patch(
+            "lintro.plugins.registry.ToolRegistry.get_names",
+            return_value=["ruff"],
+        ),
+    ):
+        probe_all_tools(cache_root=tmp_path, force=True)
+        second = probe_all_tools(cache_root=tmp_path)
+
+    assert_that(call_count["n"]).is_equal_to(2)
+    assert_that(second["ruff"].version).is_equal_to("0.2.0")
+
+
+def test_lookup_snapshot_accepts_hyphen_or_underscore() -> None:
+    """Snapshot maps keyed by registry spelling resolve manifest names."""
+    from lintro.tools.core.snapshots import lookup_snapshot
+
+    snap = _fake_snapshot("astro-check")
+    found = lookup_snapshot(
+        snapshots={"astro-check": snap},
+        name="astro_check",
+    )
+    assert_that(found).is_equal_to(snap)
+
+
+def test_lookup_snapshot_returns_none_for_unknown_name() -> None:
+    """Unknown names do not invent a snapshot."""
+    from lintro.tools.core.snapshots import lookup_snapshot
+
+    assert_that(
+        lookup_snapshot(snapshots={}, name="ghost"),
+    ).is_none()
+
+
+def test_in_process_empty_path_snapshot_stays_cached(tmp_path: Path) -> None:
+    """Available tools with no binary (in-process) remain valid until TTL."""
+    snap = ToolSnapshot(
+        name="idiom-review",
+        available=True,
+        version=None,
+        capabilities=ToolCapabilities(),
+        binary_path="",
+        binary_mtime=0.0,
+        version_check_passed=True,
+    )
+    _write_snapshot_cache(tmp_path, snap)
+    call_count = {"n": 0}
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        call_count["n"] += 1
+        return snap
+
+    with (
+        patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe),
+        patch("lintro.plugins.discovery.discover_all_tools", return_value=None),
+        patch(
+            "lintro.plugins.registry.ToolRegistry.get_names",
+            return_value=["idiom-review"],
+        ),
+    ):
+        result = probe_all_tools(cache_root=tmp_path)
+
+    assert_that(call_count["n"]).is_equal_to(0)
+    assert_that(result["idiom-review"].available).is_true()
+
+
+def test_missing_cached_binary_path_invalidates(tmp_path: Path) -> None:
+    """A cached path that disappeared on disk forces a re-probe."""
+    gone = tmp_path / "gone.bin"
+    snap = _fake_snapshot(
+        "ruff",
+        binary_path=str(gone),
+        binary_mtime=1.0,
+    )
+    _write_snapshot_cache(tmp_path, snap)
+    call_count = {"n": 0}
+    binary = tmp_path / "ruff.bin"
+    binary.write_text("x")
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        call_count["n"] += 1
+        return _fake_snapshot(
+            name,
+            binary_path=str(binary),
+            binary_mtime=binary.stat().st_mtime,
+        )
+
+    with (
+        patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe),
+        patch("lintro.plugins.discovery.discover_all_tools", return_value=None),
+        patch(
+            "lintro.plugins.registry.ToolRegistry.get_names",
+            return_value=["ruff"],
+        ),
+    ):
+        result = probe_all_tools(cache_root=tmp_path)
+
+    assert_that(call_count["n"]).is_equal_to(1)
+    assert_that(result["ruff"].binary_path).is_equal_to(str(binary))

--- a/tests/unit/tools/core/test_snapshots.py
+++ b/tests/unit/tools/core/test_snapshots.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from collections.abc import Iterator
 from pathlib import Path
@@ -133,8 +134,9 @@ def test_mtime_bump_invalidates_cache(tmp_path: Path) -> None:
     )
 
     # Bump mtime so the cache key no longer matches.
-    time.sleep(0.05)
     binary.write_text("v2")
+    bumped_mtime = snap.binary_mtime + 100.0
+    os.utime(binary, (bumped_mtime, bumped_mtime))
 
     call_count = {"n": 0}
 
@@ -583,6 +585,44 @@ def test_force_fresh_set_during_probe_survives_caller_force(tmp_path: Path) -> N
 
     assert_that(call_count["n"]).is_equal_to(2)
     assert_that(second["ruff"].version).is_equal_to("0.2.0")
+
+
+def test_probe_all_tools_discards_memory_cache_when_cache_root_changes(
+    tmp_path: Path,
+) -> None:
+    """Memory snapshots from one cache root must not merge into another."""
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    call_count = {"n": 0}
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        call_count["n"] += 1
+        binary = (search_root or tmp_path) / f"{name}.bin"
+        binary.parent.mkdir(parents=True, exist_ok=True)
+        binary.write_text("x")
+        version = "0.1.0" if search_root == root_a else "0.9.0"
+        return _fake_snapshot(
+            name,
+            version=version,
+            binary_path=str(binary),
+            binary_mtime=binary.stat().st_mtime,
+        )
+
+    with patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe):
+        with patch(
+            "lintro.plugins.discovery.discover_all_tools",
+            return_value=None,
+        ):
+            with patch(
+                "lintro.plugins.registry.ToolRegistry.get_names",
+                return_value=["ruff"],
+            ):
+                first = probe_all_tools(cache_root=root_a)
+                second = probe_all_tools(cache_root=root_b)
+
+    assert_that(first["ruff"].version).is_equal_to("0.1.0")
+    assert_that(second["ruff"].version).is_equal_to("0.9.0")
+    assert_that(call_count["n"]).is_equal_to(2)
 
 
 def test_lookup_snapshot_accepts_hyphen_or_underscore() -> None:

--- a/tests/unit/tools/core/test_snapshots.py
+++ b/tests/unit/tools/core/test_snapshots.py
@@ -511,12 +511,62 @@ def test_unavailable_cache_invalidates_when_binary_appears(tmp_path: Path) -> No
     assert_that(result["ruff"].version).is_equal_to("0.15.0")
 
 
+def test_unavailable_cache_invalidates_on_resolved_executable(
+    tmp_path: Path,
+) -> None:
+    """Freshness uses the resolved command, not hyphen/underscore aliases."""
+    snap = _fake_snapshot(
+        "markdownlint",
+        available=False,
+        version=None,
+        probe_error="markdownlint-cli2 not found in PATH",
+        binary_path="",
+        binary_mtime=0.0,
+    )
+    _write_snapshot_cache(tmp_path, snap)
+    binary = tmp_path / "markdownlint-cli2"
+    binary.write_text("x")
+    which_cmds: list[str] = []
+
+    def fake_which(cmd: str, **_kwargs: object) -> str | None:
+        which_cmds.append(cmd)
+        if cmd == "markdownlint-cli2":
+            return str(binary)
+        return None
+
+    def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:
+        return _fake_snapshot(
+            name,
+            version="0.21.0",
+            binary_path=str(binary),
+            binary_mtime=binary.stat().st_mtime,
+        )
+
+    with (
+        patch(
+            "lintro.plugins.execution_preparation.get_executable_command",
+            return_value=["markdownlint-cli2"],
+        ),
+        patch("lintro.tools.core.snapshots.shutil.which", side_effect=fake_which),
+        patch("lintro.tools.core.snapshots.probe_tool", side_effect=fake_probe),
+        patch("lintro.plugins.discovery.discover_all_tools", return_value=None),
+        patch(
+            "lintro.plugins.registry.ToolRegistry.get_names",
+            return_value=["markdownlint"],
+        ),
+    ):
+        result = probe_all_tools(cache_root=tmp_path)
+
+    assert_that(which_cmds).contains("markdownlint-cli2")
+    assert_that(result["markdownlint"].available).is_true()
+
+
 def test_memory_unavailable_invalidates_when_which_hits(tmp_path: Path) -> None:
     """In-process memory hits re-probe when a missing binary appears."""
     call_count = {"n": 0}
     which_path: dict[str, str | None] = {"v": None}
 
-    def fake_which(_cmd: str) -> str | None:
+    def fake_which(_cmd: str, **_kwargs: object) -> str | None:
         return which_path["v"]
 
     def fake_probe(name: str, *, search_root: Path | None = None) -> ToolSnapshot:

--- a/tests/unit/utils/test_doctor_report.py
+++ b/tests/unit/utils/test_doctor_report.py
@@ -258,6 +258,10 @@ def test_disabled_tools_are_reported_rather_than_dropped(
             status=ToolStatus.OK,
         ),
     )
+    monkeypatch.setattr(
+        "lintro.tools.core.snapshots.probe_all_tools",
+        lambda **_kwargs: {},
+    )
 
     results = collect_tool_checks(
         registry=registry,
@@ -289,6 +293,10 @@ def test_named_tools_are_probed_even_when_disabled(
             tool=tool,
             status=ToolStatus.OK,
         ),
+    )
+    monkeypatch.setattr(
+        "lintro.tools.core.snapshots.probe_all_tools",
+        lambda **_kwargs: {},
     )
 
     results = collect_tool_checks(

--- a/tests/unit/utils/test_doctor_report.py
+++ b/tests/unit/utils/test_doctor_report.py
@@ -253,7 +253,10 @@ def test_disabled_tools_are_reported_rather_than_dropped(
     monkeypatch.setattr(
         doctor_report,
         "check_tool",
-        lambda *, tool, context: ToolCheckResult(tool=tool, status=ToolStatus.OK),
+        lambda *, tool, context, snapshot=None: ToolCheckResult(
+            tool=tool,
+            status=ToolStatus.OK,
+        ),
     )
 
     results = collect_tool_checks(
@@ -282,7 +285,10 @@ def test_named_tools_are_probed_even_when_disabled(
     monkeypatch.setattr(
         doctor_report,
         "check_tool",
-        lambda *, tool, context: ToolCheckResult(tool=tool, status=ToolStatus.OK),
+        lambda *, tool, context, snapshot=None: ToolCheckResult(
+            tool=tool,
+            status=ToolStatus.OK,
+        ),
     )
 
     results = collect_tool_checks(
@@ -746,6 +752,79 @@ def test_check_tool_does_not_treat_bunx_fallback_as_installed() -> None:
 
     assert_that(result.status).is_equal_to(ToolStatus.MISSING)
     assert_that(result.error).is_equal_to("not_in_path")
+
+
+def test_check_tool_snapshot_unavailable_maps_to_missing() -> None:
+    """An unavailable capability snapshot is reported as MISSING."""
+    from lintro.tools.core.snapshots import ToolCapabilities, ToolSnapshot
+
+    tool = _make_tool(name="rustc", install_type="rustup")
+    snap = ToolSnapshot(
+        name="rustc",
+        available=False,
+        version=None,
+        capabilities=ToolCapabilities(),
+        probe_error="rustc not found in PATH",
+        remediation_hint="rustup toolchain install stable",
+        binary_path="",
+        binary_mtime=0.0,
+        version_check_passed=False,
+        min_version="1.80.0",
+    )
+    result = check_tool(
+        tool=tool,
+        context=_make_context(),
+        snapshot=snap,
+    )
+    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(result.details).contains("not found")
+    assert_that(result.install_hint).contains("rustup")
+
+
+def test_collect_tool_checks_resolves_hyphenated_snapshot_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manifest underscore names resolve snapshots keyed by registry hyphens."""
+    from lintro.tools.core.snapshots import ToolCapabilities, ToolSnapshot
+
+    registry = ManifestRegistry(
+        tools={"astro_check": _make_tool("astro_check")},
+        language_map={},
+        profiles={},
+    )
+    snap = ToolSnapshot(
+        name="astro-check",
+        available=False,
+        version=None,
+        capabilities=ToolCapabilities(),
+        probe_error="astro not found in PATH",
+        remediation_hint="npm i -D astro",
+        binary_path="",
+        binary_mtime=0.0,
+        version_check_passed=False,
+        min_version="5.0.0",
+    )
+
+    def _fake_probe(
+        *,
+        tool_names: list[str] | None = None,
+        **_kwargs: object,
+    ) -> dict[str, ToolSnapshot]:
+        assert_that(tool_names).contains("astro_check")
+        return {"astro-check": snap}
+
+    monkeypatch.setattr(
+        "lintro.tools.core.snapshots.probe_all_tools",
+        _fake_probe,
+    )
+    results = collect_tool_checks(
+        registry=registry,
+        context=_make_context(),
+        tool_names=["astro_check"],
+    )
+    assert_that(results).is_length(1)
+    assert_that(results[0].status).is_equal_to(ToolStatus.MISSING)
+    assert_that(results[0].tool.name).is_equal_to("astro_check")
 
 
 # ── optional MCP extra ───────────────────────────────────────────────


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(tools): cached capability probing and graceful degradation for unavailable tools
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Probe each configured tool's capabilities once (availability, version, can_fix /
config discovery), cache the result under `.lintro-cache/tool-snapshots.json` keyed
on `(binary_path, binary_mtime, lintro_version)` with a configurable TTL (default
600s), and represent missing/broken tools as degraded-but-visible
`status: unavailable` snapshots instead of mid-run errors or silent skips.

- New `lintro/tools/core/snapshots.py` with parallel probing via ThreadPoolExecutor
- `verify_tool_version` / check·format runners, `list-tools`, and `doctor` consume
  snapshots instead of ad-hoc probes
- Config: `execution.tool_snapshot_ttl`, `execution.strict_missing_tools`
- `lintro check --no-cache` also clears tool-snapshot caches
- In-process tools without a binary (e.g. idiom-review) stay available without PATH probes

Does **not** re-implement #1243 update-channel advisories (kept scoped to #1244).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt/chk`, full pytest: 6694 passed)

## Closes

- Closes #1244

## Details

Testing:
- Unit coverage for cache hit/TTL, mtime invalidation, corrupt-cache recovery,
  parallel probe correctness, unavailable ToolResult JSON `status`, and doctor
  snapshot wiring
- Full `uv run lintro chk` (0 issues) and full pytest (6694 passed, 7 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cached tool capability checks with configurable expiration.
  * Tool names now recognize hyphenated and underscored variants.
  * `list-tools` now reports availability, versions, statuses, capabilities, and remediation guidance.
  * Added optional strict handling for unavailable tools.
* **Bug Fixes**
  * Tool checks and doctor results now refresh correctly after fixes or cache invalidation.
  * JSON and summary outputs distinguish successful, failed, skipped, and unavailable tools.
* **Documentation**
  * Documented tool snapshot caching, strict mode, unavailable-tool behavior, and expanded report formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a parallel capability-probing layer (`lintro/tools/core/snapshots.py`) that probes each configured tool once per run, caches results in `.lintro-cache/tool-snapshots.json` keyed on binary path + mtime + lintro version (TTL 600 s by default), and replaces ad-hoc subprocess probes in `verify_tool_version`, `doctor`, and `list-tools` with snapshot lookups. Missing tools now degrade to `status: unavailable` with a remediation hint instead of causing mid-run errors or silent skips.

- **New `snapshots.py`**: double-checked locking for thread safety, atomic disk writes via tmp-rename, mtime-based per-entry invalidation, and `shutil.which` re-check for newly-installed binaries within the TTL window; `probe_all_tools` uses a `ThreadPoolExecutor` and broad `except Exception` to guarantee graceful degradation for every tool.
- **`ToolResult.unavailable`** and **`ToolResultStatus`** enum added; `verify_tool_version` returns an `unavailable` result for missing binaries and preserves the `below_recommended` warning for low-but-passing versions; `strict_missing_tools` config option lets teams opt into exit-1 on missing tools.
- **Registry, `list-tools`, doctor, summary tables, JSON output, and `--no-cache`** all wired to consume snapshots, with hyphen/underscore alias resolution throughout.
</details>

<h3>Confidence Score: 5/5</h3>

- Safe to merge; the changes are well-scoped, additive (new unavailable field and status enum are backward-compatible), and the core caching logic is correct for the typical single-project-per-process invocation pattern.
- The threading model is sound — disk I/O was explicitly moved outside the lock, broad exception handling prevents any single tool probe from aborting the run, and per-entry mtime validation prevents stale cache hits. The two issues found are confined to uncommon scenarios (NFS mounts where shutil.which inside the lock matters, and multi-project-per-process usage where memory cache contamination occurs); neither affects correctness in the standard single-project workflow.
- lintro/tools/core/snapshots.py — the _memory_hits_for and final merge sections warrant a second look for the filesystem-ops-inside-lock and cross-project cache contamination edge cases.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/core/snapshots.py | New 868-line module implementing the snapshot cache. Core logic is sound — double-checked locking for thread safety, atomic disk writes via tmp+rename, and proper TTL/mtime invalidation. Two subtle issues: filesystem calls (Path.exists, shutil.which) inside _cache_lock, and stale memory entries from a previous cache_root merging into a new project's disk file. |
| lintro/plugins/execution_preparation.py | verify_tool_version now reads from the shared snapshot cache instead of running a live subprocess probe. The below_recommended warning is preserved, and the version-lag allowlist logic is correctly adapted. The cwd parameter is intentionally deferred (documented via comment and #1727). |
| lintro/models/core/tool_result.py | Adds unavailable field with correct validation: requires skip_reason, prohibits co-occurrence with skipped, and does not force success=True (allowing strict mode to set success=False). |
| lintro/enums/tool_result_status.py | New StrEnum with ok/failed/skipped/unavailable values and a status_for_tool_result helper. Precedence order (unavailable > skipped > ok/failed) matches intent. |
| lintro/utils/doctor_report.py | check_tool gains an optional snapshot parameter; when provided it short-circuits the live subprocess probe. collect_tool_checks now batch-probes tools before iterating, correctly handling enabled/disabled splits. Disabled tools are still excluded from probing. |
| lintro/utils/json_output.py | Adds status and unavailable fields to every serialized tool result using the shared ToolResultStatus enum. Clean integration with no backward-compat issues since status is additive. |
| lintro/utils/file_cache.py | clear_all_caches now also clears the snapshot cache and sets force_fresh, ensuring --no-cache properly invalidates both the incremental fingerprint cache and the tool-snapshot cache. |
| lintro/cli_utils/commands/list_tools.py | probe_all_tools is called once before table rendering; lookup_snapshot handles hyphen/underscore aliases. The new Status column and JSON runtime_capabilities/status fields are consistently added to both table and plain-text modes. |
| lintro/cli_utils/commands/doctor.py | clear_snapshot_cache is correctly called before the post-fix recheck so stale cached snapshots don't mask a successful tool install. |
| lintro/plugins/registry.py | Adds _resolve_registered_name to accept both hyphen and underscore spellings via tool_name_aliases. The lock is correctly held for the full get() operation. |
| tests/unit/tools/core/test_snapshots.py | 673-line test suite covering cache hit/miss, TTL expiry, mtime invalidation, corrupt cache recovery, parallel correctness, unavailable snapshots, strict mode, and doctor wiring. Return type annotation on the autouse fixture is correctly Iterator[None]. |
| lintro/config/execution_config.py | Adds tool_snapshot_ttl (int, 1–86400 s, default 600) and strict_missing_tools (bool, default False) fields with appropriate Pydantic constraints. |
| lintro/utils/summary_tables.py | _is_result_skipped now also returns True for unavailable tools; _non_run_status_label renders a distinct UNAVAIL label. All four status-cell call sites are updated consistently. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[probe_all_tools called] --> B{force or _force_fresh?}
    B -- yes --> F
    B -- no --> C{Memory cache hit?\n_memory_hits_for}
    C -- hit --> RET1[Return cached snapshots]
    C -- miss --> D[Load disk cache\noutside lock]
    D --> E{Re-check memory\ninside lock}
    E -- hit --> RET2[Return memory snapshots]
    E -- miss --> G{Disk cache complete?}
    G -- yes --> H[Populate memory cache\nReturn disk snapshots]
    G -- no --> F[_probe_all_fresh\nThreadPoolExecutor]
    F --> I[probe_tool per tool\nversion check + shutil.which]
    I --> J{Tool available?}
    J -- yes --> K[ToolSnapshot available=True\nbinary_path + mtime]
    J -- no --> L[ToolSnapshot available=False\nprobe_error + remediation_hint]
    K --> M[Merge into _memory_cache\nWrite disk cache atomic]
    L --> M
    M --> N[Return fresh snapshots]

    subgraph Consumers
        O[verify_tool_version\nexecution_preparation.py]
        P[collect_tool_checks\ndoctor_report.py]
        Q[list_tools command]
        R[tool_executor warm-up]
    end

    N --> O
    N --> P
    N --> Q
    N --> R
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(tools): invalidate missing-tool cach..."](https://github.com/lgtm-hq/py-lintro/commit/9122d2680d8a3ce32aa0b26c2acb0bb069c99c7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45068173)</sub>

**Context used:**

- Knowledge Base — [Plugin Execution](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/py-lintro/-/docs/plugin-execution.md)

<!-- /greptile_comment -->