### PR TITLE
perf(cli): cut cold-start via lazy imports

### DIFF
--- a/lintro/ai/__init__.py
+++ b/lintro/ai/__init__.py
@@ -10,13 +10,33 @@ Features:
     - Fix generation for issues that native tools can't auto-fix
     - Interactive suggestion review mode
     - Triage guidance for suppressing vs fixing issues
+
+Exports are resolved lazily so importing leaf modules (e.g.
+``lintro.ai.config``) does not pull the full AI surface at cold start.
 """
 
-from lintro.ai.availability import is_ai_available, require_ai
-from lintro.ai.config import AIConfig
-from lintro.ai.enums import ConfidenceLevel, RiskLevel
-from lintro.ai.models import AIResult
-from lintro.ai.provider_enum import AIProvider
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lintro.ai.availability import is_ai_available as is_ai_available
+    from lintro.ai.availability import require_ai as require_ai
+    from lintro.ai.config import AIConfig as AIConfig
+    from lintro.ai.enums import ConfidenceLevel as ConfidenceLevel
+    from lintro.ai.enums import RiskLevel as RiskLevel
+    from lintro.ai.models import AIResult as AIResult
+    from lintro.ai.provider_enum import AIProvider as AIProvider
+
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "AIConfig": ("lintro.ai.config", "AIConfig"),
+    "AIProvider": ("lintro.ai.provider_enum", "AIProvider"),
+    "AIResult": ("lintro.ai.models", "AIResult"),
+    "ConfidenceLevel": ("lintro.ai.enums", "ConfidenceLevel"),
+    "RiskLevel": ("lintro.ai.enums", "RiskLevel"),
+    "is_ai_available": ("lintro.ai.availability", "is_ai_available"),
+    "require_ai": ("lintro.ai.availability", "require_ai"),
+}
 
 __all__ = [
     "AIConfig",
@@ -27,3 +47,25 @@ __all__ = [
     "is_ai_available",
     "require_ai",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve public AI exports on first access.
+
+    Args:
+        name: Attribute name being accessed.
+
+    Returns:
+        The lazily imported attribute.
+
+    Raises:
+        AttributeError: If ``name`` is not a public export.
+    """
+    if name not in _LAZY_EXPORTS:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+    module_name, attr_name = _LAZY_EXPORTS[name]
+    module = __import__(module_name, fromlist=[attr_name])
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value

--- a/lintro/ai/__init__.py
+++ b/lintro/ai/__init__.py
@@ -69,3 +69,12 @@ def __getattr__(name: str) -> Any:
     value = getattr(module, attr_name)
     globals()[name] = value
     return value
+
+
+def __dir__() -> list[str]:
+    """Return available attributes including lazy exports.
+
+    Returns:
+        Sorted names from module globals and ``__all__``.
+    """
+    return sorted(set(globals()) | set(__all__))

--- a/lintro/ai/review/__init__.py
+++ b/lintro/ai/review/__init__.py
@@ -4,34 +4,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from lintro.ai.review.checklist import BUILTIN_CHECKLIST_ITEMS
-from lintro.ai.review.checklist_registry import get_all_checklist_items
-from lintro.ai.review.checklist_selector import (
-    format_checklist_for_prompt,
-    select_checklist_items,
-)
-from lintro.ai.review.enums import FileDomain, ReviewCategory
-from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
-from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
-from lintro.ai.review.exceptions import ReviewContextError
-from lintro.ai.review.group_labels import (
-    REL_DIRECTORY_PREFIX,
-    REL_SINGLE_FILE,
-    REL_SOURCE_TEST,
-    REL_WORKFLOW_SCRIPT_TEST,
-    RelationshipLabel,
-)
-from lintro.ai.review.models import (
-    ChangedFile,
-    ChecklistItem,
-    ChunkingResult,
-    FileClassification,
-    PRMetadata,
-    ReviewChunk,
-    ReviewContext,
-)
-
 if TYPE_CHECKING:
+    from lintro.ai.review.checklist import (
+        BUILTIN_CHECKLIST_ITEMS as BUILTIN_CHECKLIST_ITEMS,
+    )
+    from lintro.ai.review.checklist_registry import (
+        get_all_checklist_items as get_all_checklist_items,
+    )
+    from lintro.ai.review.checklist_selector import (
+        format_checklist_for_prompt as format_checklist_for_prompt,
+    )
+    from lintro.ai.review.checklist_selector import (
+        select_checklist_items as select_checklist_items,
+    )
     from lintro.ai.review.chunker.grouping import (
         chunk_review_context as chunk_review_context,
     )
@@ -50,6 +35,31 @@ if TYPE_CHECKING:
     from lintro.ai.review.context import (
         split_unified_diff_by_file as split_unified_diff_by_file,
     )
+    from lintro.ai.review.enums import FileDomain as FileDomain
+    from lintro.ai.review.enums import ReviewCategory as ReviewCategory
+    from lintro.ai.review.enums.changed_file_status import (
+        ChangedFileStatus as ChangedFileStatus,
+    )
+    from lintro.ai.review.enums.review_context_error_code import (
+        ReviewContextErrorCode as ReviewContextErrorCode,
+    )
+    from lintro.ai.review.exceptions import ReviewContextError as ReviewContextError
+    from lintro.ai.review.group_labels import (
+        REL_DIRECTORY_PREFIX as REL_DIRECTORY_PREFIX,
+    )
+    from lintro.ai.review.group_labels import REL_SINGLE_FILE as REL_SINGLE_FILE
+    from lintro.ai.review.group_labels import REL_SOURCE_TEST as REL_SOURCE_TEST
+    from lintro.ai.review.group_labels import (
+        REL_WORKFLOW_SCRIPT_TEST as REL_WORKFLOW_SCRIPT_TEST,
+    )
+    from lintro.ai.review.group_labels import RelationshipLabel as RelationshipLabel
+    from lintro.ai.review.models import ChangedFile as ChangedFile
+    from lintro.ai.review.models import ChecklistItem as ChecklistItem
+    from lintro.ai.review.models import ChunkingResult as ChunkingResult
+    from lintro.ai.review.models import FileClassification as FileClassification
+    from lintro.ai.review.models import PRMetadata as PRMetadata
+    from lintro.ai.review.models import ReviewChunk as ReviewChunk
+    from lintro.ai.review.models import ReviewContext as ReviewContext
     from lintro.ai.review.pipeline import (
         prepare_review_chunks as prepare_review_chunks,
     )
@@ -58,6 +68,36 @@ if TYPE_CHECKING:
     )
 
 _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "BUILTIN_CHECKLIST_ITEMS": (
+        "lintro.ai.review.checklist",
+        "BUILTIN_CHECKLIST_ITEMS",
+    ),
+    "ChangedFile": ("lintro.ai.review.models", "ChangedFile"),
+    "ChangedFileStatus": (
+        "lintro.ai.review.enums.changed_file_status",
+        "ChangedFileStatus",
+    ),
+    "ChecklistItem": ("lintro.ai.review.models", "ChecklistItem"),
+    "ChunkingResult": ("lintro.ai.review.models", "ChunkingResult"),
+    "FileClassification": ("lintro.ai.review.models", "FileClassification"),
+    "FileDomain": ("lintro.ai.review.enums", "FileDomain"),
+    "PRMetadata": ("lintro.ai.review.models", "PRMetadata"),
+    "REL_DIRECTORY_PREFIX": ("lintro.ai.review.group_labels", "REL_DIRECTORY_PREFIX"),
+    "REL_SINGLE_FILE": ("lintro.ai.review.group_labels", "REL_SINGLE_FILE"),
+    "REL_SOURCE_TEST": ("lintro.ai.review.group_labels", "REL_SOURCE_TEST"),
+    "REL_WORKFLOW_SCRIPT_TEST": (
+        "lintro.ai.review.group_labels",
+        "REL_WORKFLOW_SCRIPT_TEST",
+    ),
+    "RelationshipLabel": ("lintro.ai.review.group_labels", "RelationshipLabel"),
+    "ReviewCategory": ("lintro.ai.review.enums", "ReviewCategory"),
+    "ReviewChunk": ("lintro.ai.review.models", "ReviewChunk"),
+    "ReviewContext": ("lintro.ai.review.models", "ReviewContext"),
+    "ReviewContextError": ("lintro.ai.review.exceptions", "ReviewContextError"),
+    "ReviewContextErrorCode": (
+        "lintro.ai.review.enums.review_context_error_code",
+        "ReviewContextErrorCode",
+    ),
     "chunk_review_context": (
         "lintro.ai.review.chunker.grouping",
         "chunk_review_context",
@@ -69,6 +109,14 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "collect_review_context": (
         "lintro.ai.review.context.collection",
         "collect_review_context",
+    ),
+    "format_checklist_for_prompt": (
+        "lintro.ai.review.checklist_selector",
+        "format_checklist_for_prompt",
+    ),
+    "get_all_checklist_items": (
+        "lintro.ai.review.checklist_registry",
+        "get_all_checklist_items",
     ),
     "parse_changed_files": (
         "lintro.ai.review.context.diff_parse",
@@ -82,6 +130,10 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "resolve_default_base_branch": (
         "lintro.ai.review.context.collection",
         "resolve_default_base_branch",
+    ),
+    "select_checklist_items": (
+        "lintro.ai.review.checklist_selector",
+        "select_checklist_items",
     ),
     "split_unified_diff_by_file": (
         "lintro.ai.review.context.diff_parse",
@@ -129,4 +181,6 @@ def __getattr__(name: str) -> Any:
         raise AttributeError(msg)
     module_name, attr_name = _LAZY_EXPORTS[name]
     module = __import__(module_name, fromlist=[attr_name])
-    return getattr(module, attr_name)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value

--- a/lintro/ai/review/__init__.py
+++ b/lintro/ai/review/__init__.py
@@ -184,3 +184,12 @@ def __getattr__(name: str) -> Any:
     value = getattr(module, attr_name)
     globals()[name] = value
     return value
+
+
+def __dir__() -> list[str]:
+    """Return available attributes including lazy exports.
+
+    Returns:
+        Sorted names from module globals and ``__all__``.
+    """
+    return sorted(set(globals()) | set(__all__))

--- a/lintro/cli.py
+++ b/lintro/cli.py
@@ -6,7 +6,7 @@ import codecs
 import contextlib
 import importlib
 import sys
-from typing import Any, TextIO, cast
+from typing import Any, TextIO
 
 import click
 
@@ -247,9 +247,13 @@ class LintroGroup(click.Group):
                 "a non-command object"
             )
             raise ValueError(msg)
+        # Click auto-names ``format_command`` as ``format-command``; register
+        # the name users type so ``get_command`` and man pages stay aligned.
         canonical = _CANONICAL_NAMES.get(cmd_name, cmd_name)
-        cast(Any, cmd_object)._canonical_name = canonical
+        cmd_object.name = canonical
         self.add_command(cmd_object, name=cmd_name)
+        if cmd_name != canonical:
+            self.add_command(cmd_object, name=canonical)
         return cmd_object
 
     def format_help(

--- a/lintro/cli.py
+++ b/lintro/cli.py
@@ -1,20 +1,16 @@
 """Command-line interface for Lintro."""
 
+from __future__ import annotations
+
 import codecs
 import contextlib
+import importlib
 import sys
 from typing import Any, TextIO, cast
 
 import click
-from rich.console import Console
-from rich.panel import Panel
-from rich.table import Table
-from rich.text import Text
 
 from lintro import __version__
-from lintro.cli_utils.command_chainer import CommandChainer
-from lintro.utils.logger_setup import setup_cli_logging
-
 
 def _is_utf8_encoding(encoding: str | None) -> bool:
     """Return whether *encoding* names UTF-8.
@@ -63,39 +59,189 @@ def ensure_utf8_stdio() -> None:
     _reconfigure_stream_utf8(sys.stderr)
 
 
-# Configure loguru for CLI commands (help, version, etc.)
-# Only WARNING and above will show. DEBUG logs go to file when tool_executor runs.
-setup_cli_logging()
 
-# E402: Module level imports below setup_cli_logging() are intentional.
-# Logging must be configured BEFORE importing modules that use loguru,
-# otherwise log messages during import get silently dropped or misconfigured.
-from lintro.cli_utils.commands.badge import badge_command  # noqa: E402
-from lintro.cli_utils.commands.check import check_command  # noqa: E402
-from lintro.cli_utils.commands.completions import completions_command  # noqa: E402
-from lintro.cli_utils.commands.config import config_command  # noqa: E402
-from lintro.cli_utils.commands.doctor import doctor_command  # noqa: E402
-from lintro.cli_utils.commands.format import format_command  # noqa: E402
-from lintro.cli_utils.commands.init import init_command  # noqa: E402
-from lintro.cli_utils.commands.install import install_command  # noqa: E402
-from lintro.cli_utils.commands.licenses import licenses_command  # noqa: E402
-from lintro.cli_utils.commands.list_tools import list_tools_command  # noqa: E402
-from lintro.cli_utils.commands.mcp import mcp_command  # noqa: E402
-from lintro.cli_utils.commands.review import review_command  # noqa: E402
-from lintro.cli_utils.commands.setup import setup_command  # noqa: E402
-from lintro.cli_utils.commands.test import test_command  # noqa: E402
-from lintro.cli_utils.commands.versions import versions_command  # noqa: E402
-from lintro.tools.core.runtime_discovery import clear_discovery_cache  # noqa: E402
-from lintro.utils.config import clear_pyproject_cache  # noqa: E402
+# Canonical command name -> "module.path.attr" for lazy loading.
+# Aliases point at the same import path as their canonical command.
+_LAZY_SUBCOMMANDS: dict[str, str] = {
+    "badge": "lintro.cli_utils.commands.badge.badge_command",
+    "check": "lintro.cli_utils.commands.check.check_command",
+    "chk": "lintro.cli_utils.commands.check.check_command",
+    "lint": "lintro.cli_utils.commands.check.check_command",
+    "completions": "lintro.cli_utils.commands.completions.completions_command",
+    "comp": "lintro.cli_utils.commands.completions.completions_command",
+    "config": "lintro.cli_utils.commands.config.config_command",
+    "cfg": "lintro.cli_utils.commands.config.config_command",
+    "doctor": "lintro.cli_utils.commands.doctor.doctor_command",
+    "format": "lintro.cli_utils.commands.format.format_command",
+    "fmt": "lintro.cli_utils.commands.format.format_command",
+    "fix": "lintro.cli_utils.commands.format.format_command",
+    "init": "lintro.cli_utils.commands.init.init_command",
+    "install": "lintro.cli_utils.commands.install.install_command",
+    "ins": "lintro.cli_utils.commands.install.install_command",
+    "licenses": "lintro.cli_utils.commands.licenses.licenses_command",
+    "lic": "lintro.cli_utils.commands.licenses.licenses_command",
+    "list-tools": "lintro.cli_utils.commands.list_tools.list_tools_command",
+    "ls": "lintro.cli_utils.commands.list_tools.list_tools_command",
+    "tools": "lintro.cli_utils.commands.list_tools.list_tools_command",
+    "mcp": "lintro.cli_utils.commands.mcp.mcp_command",
+    "review": "lintro.cli_utils.commands.review.review_command",
+    "rev": "lintro.cli_utils.commands.review.review_command",
+    "setup": "lintro.cli_utils.commands.setup.setup_command",
+    "su": "lintro.cli_utils.commands.setup.setup_command",
+    "test": "lintro.cli_utils.commands.test.test_command",
+    "tst": "lintro.cli_utils.commands.test.test_command",
+    "versions": "lintro.cli_utils.commands.versions.versions_command",
+    "ver": "lintro.cli_utils.commands.versions.versions_command",
+    "version": "lintro.cli_utils.commands.versions.versions_command",
+}
+
+# Alias -> canonical name for help rendering.
+_CANONICAL_NAMES: dict[str, str] = {
+    "badge": "badge",
+    "check": "check",
+    "chk": "check",
+    "lint": "check",
+    "completions": "completions",
+    "comp": "completions",
+    "config": "config",
+    "cfg": "config",
+    "doctor": "doctor",
+    "format": "format",
+    "fmt": "format",
+    "fix": "format",
+    "init": "init",
+    "install": "install",
+    "ins": "install",
+    "licenses": "licenses",
+    "lic": "licenses",
+    "list-tools": "list-tools",
+    "ls": "list-tools",
+    "tools": "list-tools",
+    "mcp": "mcp",
+    "review": "review",
+    "rev": "review",
+    "setup": "setup",
+    "su": "setup",
+    "test": "test",
+    "tst": "test",
+    "versions": "versions",
+    "ver": "versions",
+    "version": "versions",
+}
+
+# Canonical command -> short help for ``--help`` without importing subcommands.
+_COMMAND_SHORT_HELP: dict[str, str] = {
+    "badge": "Generate a shields.io markdown badge for the project health score.",
+    "check": "Check files for issues using the specified tools.",
+    "completions": "Print shell completion scripts for bash, zsh, or fish.",
+    "config": "Display Lintro configuration status.",
+    "doctor": "Check tool installation status and version compatibility.",
+    "format": "Format code using configured formatting tools.",
+    "init": "Initialize Lintro for this project.",
+    "install": "Install or upgrade external tools used by lintro.",
+    "licenses": "Check dependency licenses for policy compliance.",
+    "list-tools": "List all available tools and their configurations.",
+    "mcp": "Start the lintro MCP server on stdio.",
+    "review": "Run AI-powered diff-based code review.",
+    "setup": "Set up lintro for your project.",
+    "test": "Run tests using pytest.",
+    "versions": "Display version information for all supported tools.",
+}
 
 
 class LintroGroup(click.Group):
-    """Custom Click group with enhanced help rendering and command chaining.
+    """Custom Click group with lazy subcommands, aliases, and chaining.
 
-    This group prints command aliases alongside their canonical names to make
-    the CLI help output more discoverable. It also supports command chaining
-    with comma-separated commands (e.g., lintro fmt , chk , tst).
+    Subcommands are imported on first use so ``lintro --version`` / ``--help``
+    do not pay for check/format/tool_executor/plugin import costs.
     """
+
+    def __init__(
+        self,
+        *args: Any,
+        lazy_subcommands: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the group with optional lazy subcommand map.
+
+        Args:
+            *args: Positional args forwarded to ``click.Group``.
+            lazy_subcommands: Map of command name -> ``module.attr`` import path.
+            **kwargs: Keyword args forwarded to ``click.Group``.
+        """
+        super().__init__(*args, **kwargs)
+        self.lazy_subcommands = lazy_subcommands or {}
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        """List registered and lazy subcommand names.
+
+        Args:
+            ctx: Click context.
+
+        Returns:
+            Combined command name list.
+        """
+        base = list(super().list_commands(ctx))
+        lazy = list(self.lazy_subcommands.keys())
+        # Preserve insertion order while deduplicating.
+        seen: set[str] = set()
+        result: list[str] = []
+        for name in base + lazy:
+            if name not in seen:
+                seen.add(name)
+                result.append(name)
+        return result
+
+    def get_command(
+        self,
+        ctx: click.Context,
+        cmd_name: str,
+    ) -> click.Command | None:
+        """Resolve a command, importing lazy subcommands on demand.
+
+        Args:
+            ctx: Click context.
+            cmd_name: Command or alias name.
+
+        Returns:
+            The Click command, or None if unknown.
+        """
+        if cmd_name in self.lazy_subcommands:
+            return self._lazy_load(cmd_name)
+        return super().get_command(ctx, cmd_name)
+
+    def _lazy_load(self, cmd_name: str) -> click.Command:
+        """Import and return a lazily registered subcommand.
+
+        Args:
+            cmd_name: Command or alias name present in ``lazy_subcommands``.
+
+        Returns:
+            The loaded Click command object.
+
+        Raises:
+            ValueError: If the import path does not resolve to a Click command.
+        """
+        # Cache under the requested name so aliases do not re-import/mutate.
+        existing = self.commands.get(cmd_name)
+        if existing is not None:
+            return existing
+
+        import_path = self.lazy_subcommands[cmd_name]
+        modname, attr_name = import_path.rsplit(".", 1)
+        # Safe: import paths are a fixed internal whitelist in _LAZY_SUBCOMMANDS.
+        module = importlib.import_module(modname)  # nosemgrep: non-literal-import
+        cmd_object = getattr(module, attr_name)
+        if not isinstance(cmd_object, click.Command):
+            msg = (
+                f"Lazy loading of {import_path} failed by returning "
+                "a non-command object"
+            )
+            raise ValueError(msg)
+        canonical = _CANONICAL_NAMES.get(cmd_name, cmd_name)
+        cast(Any, cmd_object)._canonical_name = canonical
+        self.add_command(cmd_object, name=cmd_name)
+        return cmd_object
 
     def format_help(
         self,
@@ -108,6 +254,11 @@ class LintroGroup(click.Group):
             ctx: click.Context: The Click context.
             formatter: click.HelpFormatter: The help formatter (unused, we use Rich).
         """
+        from rich.console import Console
+        from rich.panel import Panel
+        from rich.table import Table
+        from rich.text import Text
+
         console = Console()
 
         # Header panel
@@ -130,30 +281,25 @@ class LintroGroup(click.Group):
         console.print("  lintro COMMAND1 , COMMAND2 , ...  [dim](chain commands)[/dim]")
         console.print()
 
-        # Commands table
+        # Commands table from static metadata — do not import subcommands.
         commands = self.list_commands(ctx)
-        canonical_map: dict[str, tuple[click.Command, list[str]]] = {}
+        canonical_map: dict[str, list[str]] = {}
         for name in commands:
-            cmd = self.get_command(ctx, name)
-            if cmd is None:
-                continue
-            cmd_any = cast(Any, cmd)
-            if not hasattr(cmd_any, "_canonical_name"):
-                cmd_any._canonical_name = name
-            canonical = cast(str, getattr(cmd_any, "_canonical_name", name))
+            canonical = _CANONICAL_NAMES.get(name, name)
             if canonical not in canonical_map:
-                canonical_map[canonical] = (cmd, [])
+                canonical_map[canonical] = []
             if name != canonical:
-                canonical_map[canonical][1].append(name)
+                canonical_map[canonical].append(name)
 
         table = Table(title="Commands", show_header=True, header_style="bold cyan")
         table.add_column("Command", style="cyan", no_wrap=True)
         table.add_column("Alias", style="yellow", no_wrap=True)
         table.add_column("Description", style="white")
 
-        for canonical, (cmd, aliases) in sorted(canonical_map.items()):
+        for canonical, aliases in sorted(canonical_map.items()):
             alias_str = ", ".join(aliases) if aliases else "-"
-            table.add_row(canonical, alias_str, cmd.get_short_help_str())
+            description = _COMMAND_SHORT_HELP.get(canonical, "")
+            table.add_row(canonical, alias_str, description)
 
         console.print(table)
         console.print()
@@ -206,6 +352,13 @@ class LintroGroup(click.Group):
         Raises:
             SystemExit: If a command exits with a non-zero exit code.
         """
+        from lintro.cli_utils.command_chainer import CommandChainer
+        from lintro.tools.core.runtime_discovery import clear_discovery_cache
+        from lintro.utils.config import clear_pyproject_cache
+        from lintro.utils.logger_setup import setup_cli_logging
+
+        setup_cli_logging()
+
         # Clear caches at start of each invocation to ensure fresh tool
         # detection and pyproject.toml loading across working directories
         clear_discovery_cache()
@@ -234,6 +387,7 @@ class LintroGroup(click.Group):
 
 @click.group(
     cls=LintroGroup,
+    lazy_subcommands=_LAZY_SUBCOMMANDS,
     invoke_without_command=True,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
@@ -241,57 +395,6 @@ class LintroGroup(click.Group):
 def cli() -> None:
     """Lintro: Unified CLI for code formatting, linting, and quality assurance."""
     pass
-
-
-# Register canonical commands and set _canonical_name for help
-cast(Any, badge_command)._canonical_name = "badge"
-cast(Any, check_command)._canonical_name = "check"
-cast(Any, completions_command)._canonical_name = "completions"
-cast(Any, config_command)._canonical_name = "config"
-cast(Any, doctor_command)._canonical_name = "doctor"
-cast(Any, format_command)._canonical_name = "format"
-cast(Any, init_command)._canonical_name = "init"
-cast(Any, install_command)._canonical_name = "install"
-cast(Any, licenses_command)._canonical_name = "licenses"
-cast(Any, setup_command)._canonical_name = "setup"
-cast(Any, test_command)._canonical_name = "test"
-cast(Any, list_tools_command)._canonical_name = "list-tools"
-cast(Any, mcp_command)._canonical_name = "mcp"
-cast(Any, review_command)._canonical_name = "review"
-cast(Any, versions_command)._canonical_name = "versions"
-
-cli.add_command(badge_command, name="badge")
-cli.add_command(check_command, name="check")
-cli.add_command(completions_command, name="completions")
-cli.add_command(config_command, name="config")
-cli.add_command(doctor_command, name="doctor")
-cli.add_command(format_command, name="format")
-cli.add_command(init_command, name="init")
-cli.add_command(install_command, name="install")
-cli.add_command(licenses_command, name="licenses")
-cli.add_command(setup_command, name="setup")
-cli.add_command(test_command, name="test")
-cli.add_command(list_tools_command, name="list-tools")
-cli.add_command(mcp_command, name="mcp")
-cli.add_command(review_command, name="review")
-cli.add_command(versions_command, name="versions")
-
-# Register aliases
-cli.add_command(check_command, name="chk")
-cli.add_command(check_command, name="lint")
-cli.add_command(completions_command, name="comp")
-cli.add_command(config_command, name="cfg")
-cli.add_command(format_command, name="fmt")
-cli.add_command(format_command, name="fix")
-cli.add_command(test_command, name="tst")
-cli.add_command(list_tools_command, name="ls")
-cli.add_command(list_tools_command, name="tools")
-cli.add_command(install_command, name="ins")
-cli.add_command(licenses_command, name="lic")
-cli.add_command(setup_command, name="su")
-cli.add_command(review_command, name="rev")
-cli.add_command(versions_command, name="ver")
-cli.add_command(versions_command, name="version")
 
 
 def main() -> None:

--- a/lintro/cli.py
+++ b/lintro/cli.py
@@ -12,6 +12,7 @@ import click
 
 from lintro import __version__
 
+
 def _is_utf8_encoding(encoding: str | None) -> bool:
     """Return whether *encoding* names UTF-8.
 
@@ -57,7 +58,6 @@ def ensure_utf8_stdio() -> None:
     """
     _reconfigure_stream_utf8(sys.stdout)
     _reconfigure_stream_utf8(sys.stderr)
-
 
 
 # Canonical command name -> "module.path.attr" for lazy loading.
@@ -129,20 +129,29 @@ _CANONICAL_NAMES: dict[str, str] = {
     "version": "versions",
 }
 
+# Longest short-help string rendered without truncation. Well above every entry
+# in ``_COMMAND_SHORT_HELP``, so the sync test compares full sentences rather
+# than Click's ellipsis-truncated form.
+SHORT_HELP_LIMIT: int = 200
+
 # Canonical command -> short help for ``--help`` without importing subcommands.
+#
+# Each value must equal ``cmd.get_short_help_str(limit=SHORT_HELP_LIMIT)`` for
+# the command it names; ``tests/unit/cli/test_lazy_subcommands.py`` fails the
+# build when a subcommand's docstring and this table drift apart.
 _COMMAND_SHORT_HELP: dict[str, str] = {
     "badge": "Generate a shields.io markdown badge for the project health score.",
     "check": "Check files for issues using the specified tools.",
-    "completions": "Print shell completion scripts for bash, zsh, or fish.",
+    "completions": "Print a shell completion script for bash, zsh, or fish.",
     "config": "Display Lintro configuration status.",
     "doctor": "Check tool installation status and version compatibility.",
     "format": "Format code using configured formatting tools.",
-    "init": "Initialize Lintro for this project.",
+    "init": "Initialize Lintro configuration for your project.",
     "install": "Install or upgrade external tools used by lintro.",
     "licenses": "Check dependency licenses for policy compliance.",
     "list-tools": "List all available tools and their configurations.",
     "mcp": "Start the lintro MCP server on stdio.",
-    "review": "Run AI-powered diff-based code review.",
+    "review": "Run AI-powered diff-based code review, plus advisory AI finders.",
     "setup": "Set up lintro for your project.",
     "test": "Run tests using pytest.",
     "versions": "Display version information for all supported tools.",

--- a/lintro/cli_utils/command_chainer.py
+++ b/lintro/cli_utils/command_chainer.py
@@ -14,7 +14,8 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import click
-from loguru import logger
+
+from lintro.utils.lazy_logger import logger
 
 if TYPE_CHECKING:
     pass

--- a/lintro/cli_utils/commands/__init__.py
+++ b/lintro/cli_utils/commands/__init__.py
@@ -14,7 +14,11 @@ if TYPE_CHECKING:
     )
     from lintro.cli_utils.commands.format import (
         format_code as format_code,
+    )
+    from lintro.cli_utils.commands.format import (
         format_code_legacy as format_code_legacy,
+    )
+    from lintro.cli_utils.commands.format import (
         format_command as format_command,
     )
     from lintro.cli_utils.commands.init import init_command as init_command

--- a/lintro/cli_utils/commands/__init__.py
+++ b/lintro/cli_utils/commands/__init__.py
@@ -1,17 +1,50 @@
-"""CLI command modules for lintro."""
+"""CLI command modules for lintro.
 
-from .check import check_command
-from .completions import completions_command
-from .format import format_code, format_code_legacy, format_command
-from .init import init_command
-from .list_tools import list_tools
+Subcommand modules are imported on demand so ``import lintro.cli`` stays light.
+"""
+
+from __future__ import annotations
+
+from typing import Any
 
 __all__ = [
-    "check_command",
-    "completions_command",
-    "format_command",
-    "format_code",
-    "format_code_legacy",
-    "init_command",
-    "list_tools",
+    "check_command",  # noqa: F822 - resolved via module __getattr__
+    "completions_command",  # noqa: F822 - resolved via module __getattr__
+    "format_command",  # noqa: F822 - resolved via module __getattr__
+    "format_code",  # noqa: F822 - resolved via module __getattr__
+    "format_code_legacy",  # noqa: F822 - resolved via module __getattr__
+    "init_command",  # noqa: F822 - resolved via module __getattr__
+    "list_tools",  # noqa: F822 - resolved via module __getattr__
 ]
+
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "check_command": ("lintro.cli_utils.commands.check", "check_command"),
+    "completions_command": ("lintro.cli_utils.commands.completions", "completions_command"),
+    "format_command": ("lintro.cli_utils.commands.format", "format_command"),
+    "format_code": ("lintro.cli_utils.commands.format", "format_code"),
+    "format_code_legacy": ("lintro.cli_utils.commands.format", "format_code_legacy"),
+    "init_command": ("lintro.cli_utils.commands.init", "init_command"),
+    "list_tools": ("lintro.cli_utils.commands.list_tools", "list_tools"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve command exports on first access.
+
+    Args:
+        name: Attribute name being accessed.
+
+    Returns:
+        The lazily imported attribute.
+
+    Raises:
+        AttributeError: If ``name`` is not a public export.
+    """
+    if name not in _LAZY_EXPORTS:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+    module_name, attr_name = _LAZY_EXPORTS[name]
+    module = __import__(module_name, fromlist=[attr_name])
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value

--- a/lintro/cli_utils/commands/__init__.py
+++ b/lintro/cli_utils/commands/__init__.py
@@ -19,7 +19,10 @@ __all__ = [
 
 _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "check_command": ("lintro.cli_utils.commands.check", "check_command"),
-    "completions_command": ("lintro.cli_utils.commands.completions", "completions_command"),
+    "completions_command": (
+        "lintro.cli_utils.commands.completions",
+        "completions_command",
+    ),
     "format_command": ("lintro.cli_utils.commands.format", "format_command"),
     "format_code": ("lintro.cli_utils.commands.format", "format_code"),
     "format_code_legacy": ("lintro.cli_utils.commands.format", "format_code_legacy"),

--- a/lintro/cli_utils/commands/__init__.py
+++ b/lintro/cli_utils/commands/__init__.py
@@ -5,16 +5,29 @@ Subcommand modules are imported on demand so ``import lintro.cli`` stays light.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lintro.cli_utils.commands.check import check_command as check_command
+    from lintro.cli_utils.commands.completions import (
+        completions_command as completions_command,
+    )
+    from lintro.cli_utils.commands.format import (
+        format_code as format_code,
+        format_code_legacy as format_code_legacy,
+        format_command as format_command,
+    )
+    from lintro.cli_utils.commands.init import init_command as init_command
+    from lintro.cli_utils.commands.list_tools import list_tools as list_tools
 
 __all__ = [
-    "check_command",  # noqa: F822 - resolved via module __getattr__
-    "completions_command",  # noqa: F822 - resolved via module __getattr__
-    "format_command",  # noqa: F822 - resolved via module __getattr__
-    "format_code",  # noqa: F822 - resolved via module __getattr__
-    "format_code_legacy",  # noqa: F822 - resolved via module __getattr__
-    "init_command",  # noqa: F822 - resolved via module __getattr__
-    "list_tools",  # noqa: F822 - resolved via module __getattr__
+    "check_command",
+    "completions_command",
+    "format_command",
+    "format_code",
+    "format_code_legacy",
+    "init_command",
+    "list_tools",
 ]
 
 _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
@@ -51,3 +64,12 @@ def __getattr__(name: str) -> Any:
     value = getattr(module, attr_name)
     globals()[name] = value
     return value
+
+
+def __dir__() -> list[str]:
+    """Return available attributes including lazy exports.
+
+    Returns:
+        Sorted names from module globals and ``__all__``.
+    """
+    return sorted(set(globals()) | set(__all__))

--- a/lintro/cli_utils/commands/mcp.py
+++ b/lintro/cli_utils/commands/mcp.py
@@ -21,6 +21,8 @@ def mcp_command(workspace: Path | None) -> None:
     Requires the optional ``lintro[mcp]`` extra. Agents connect over stdio and
     discover tools such as ``lintro_ping``.
 
+    \u000c
+
     Args:
         workspace: Workspace root directory; defaults to the process cwd.
 

--- a/lintro/config/__init__.py
+++ b/lintro/config/__init__.py
@@ -11,41 +11,94 @@ Key components:
 - EnforceConfig: Cross-cutting settings enforced via CLI
 - ConfigLoader: Loads .lintro-config.yaml
 - ToolConfigGenerator: CLI injection and defaults generation
+
+Exports are resolved lazily so importing a single config submodule does not
+pull the AI/review config chain at cold start.
 """
 
-from lintro.config.config_loader import (
-    clear_config_cache,
-    get_config,
-    get_default_config,
-    load_config,
-)
-from lintro.config.lintro_config import (
-    EnforceConfig,
-    ExecutionConfig,
-    LintroConfig,
-    LintroToolConfig,
-)
-from lintro.config.tool_config_generator import (
-    generate_defaults_config,
-    get_defaults_injection_args,
-    get_enforce_cli_args,
-    has_native_config,
-)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lintro.config.config_loader import clear_config_cache as clear_config_cache
+    from lintro.config.config_loader import get_config as get_config
+    from lintro.config.config_loader import get_default_config as get_default_config
+    from lintro.config.config_loader import load_config as load_config
+    from lintro.config.lintro_config import EnforceConfig as EnforceConfig
+    from lintro.config.lintro_config import ExecutionConfig as ExecutionConfig
+    from lintro.config.lintro_config import LintroConfig as LintroConfig
+    from lintro.config.lintro_config import LintroToolConfig as LintroToolConfig
+    from lintro.config.tool_config_generator import (
+        generate_defaults_config as generate_defaults_config,
+    )
+    from lintro.config.tool_config_generator import (
+        get_defaults_injection_args as get_defaults_injection_args,
+    )
+    from lintro.config.tool_config_generator import (
+        get_enforce_cli_args as get_enforce_cli_args,
+    )
+    from lintro.config.tool_config_generator import (
+        has_native_config as has_native_config,
+    )
+
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "EnforceConfig": ("lintro.config.lintro_config", "EnforceConfig"),
+    "ExecutionConfig": ("lintro.config.lintro_config", "ExecutionConfig"),
+    "LintroConfig": ("lintro.config.lintro_config", "LintroConfig"),
+    "LintroToolConfig": ("lintro.config.lintro_config", "LintroToolConfig"),
+    "clear_config_cache": ("lintro.config.config_loader", "clear_config_cache"),
+    "generate_defaults_config": (
+        "lintro.config.tool_config_generator",
+        "generate_defaults_config",
+    ),
+    "get_config": ("lintro.config.config_loader", "get_config"),
+    "get_default_config": ("lintro.config.config_loader", "get_default_config"),
+    "get_defaults_injection_args": (
+        "lintro.config.tool_config_generator",
+        "get_defaults_injection_args",
+    ),
+    "get_enforce_cli_args": (
+        "lintro.config.tool_config_generator",
+        "get_enforce_cli_args",
+    ),
+    "has_native_config": ("lintro.config.tool_config_generator", "has_native_config"),
+    "load_config": ("lintro.config.config_loader", "load_config"),
+}
 
 __all__ = [
-    # Config dataclasses
     "EnforceConfig",
     "ExecutionConfig",
     "LintroConfig",
     "LintroToolConfig",
-    # Config loading
     "clear_config_cache",
     "get_config",
     "get_default_config",
     "load_config",
-    # New tiered model functions
     "get_enforce_cli_args",
     "has_native_config",
     "generate_defaults_config",
     "get_defaults_injection_args",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve public config exports on first access.
+
+    Args:
+        name: Attribute name being accessed.
+
+    Returns:
+        The lazily imported attribute.
+
+    Raises:
+        AttributeError: If ``name`` is not a public export.
+    """
+    if name not in _LAZY_EXPORTS:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+    module_name, attr_name = _LAZY_EXPORTS[name]
+    module = __import__(module_name, fromlist=[attr_name])
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value

--- a/lintro/config/__init__.py
+++ b/lintro/config/__init__.py
@@ -102,3 +102,12 @@ def __getattr__(name: str) -> Any:
     value = getattr(module, attr_name)
     globals()[name] = value
     return value
+
+
+def __dir__() -> list[str]:
+    """Return available attributes including lazy exports.
+
+    Returns:
+        Sorted names from module globals and ``__all__``.
+    """
+    return sorted(set(globals()) | set(__all__))

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -16,8 +16,6 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-from lintro.utils.lazy_logger import logger
-
 from lintro.config.lintro_config import (
     EnforceConfig,
     ExecutionConfig,
@@ -32,6 +30,7 @@ from lintro.config.review_config import (
 )
 from lintro.config.score_config import ScoreConfig
 from lintro.enums.config_key import ConfigKey
+from lintro.utils.lazy_logger import logger
 from lintro.utils.path_utils import find_file_upward
 
 try:

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -16,7 +16,7 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-from loguru import logger
+from lintro.utils.lazy_logger import logger
 
 from lintro.config.lintro_config import (
     EnforceConfig,

--- a/lintro/plugins/__init__.py
+++ b/lintro/plugins/__init__.py
@@ -43,17 +43,45 @@ Example:
     >>> result = tool.check(["."], {})
 """
 
-from lintro.plugins.file_processor import AggregatedResult, FileProcessingResult
-from lintro.plugins.protocol import (
-    LINTRO_PLUGIN_API_VERSION,
-    LintroPlugin,
-    ToolDefinition,
-    is_compatible_api_version,
-)
-from lintro.plugins.registry import ToolRegistry, register_tool
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lintro.plugins.file_processor import AggregatedResult as AggregatedResult
+    from lintro.plugins.file_processor import (
+        FileProcessingResult as FileProcessingResult,
+    )
+    from lintro.plugins.protocol import (
+        LINTRO_PLUGIN_API_VERSION as LINTRO_PLUGIN_API_VERSION,
+    )
+    from lintro.plugins.protocol import LintroPlugin as LintroPlugin
+    from lintro.plugins.protocol import ToolDefinition as ToolDefinition
+    from lintro.plugins.protocol import (
+        is_compatible_api_version as is_compatible_api_version,
+    )
+    from lintro.plugins.registry import ToolRegistry as ToolRegistry
+    from lintro.plugins.registry import register_tool as register_tool
 
 # BaseToolPlugin is imported lazily to avoid circular imports
 # Use: from lintro.plugins.base import BaseToolPlugin
+
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "LINTRO_PLUGIN_API_VERSION": (
+        "lintro.plugins.protocol",
+        "LINTRO_PLUGIN_API_VERSION",
+    ),
+    "AggregatedResult": ("lintro.plugins.file_processor", "AggregatedResult"),
+    "FileProcessingResult": ("lintro.plugins.file_processor", "FileProcessingResult"),
+    "LintroPlugin": ("lintro.plugins.protocol", "LintroPlugin"),
+    "ToolDefinition": ("lintro.plugins.protocol", "ToolDefinition"),
+    "ToolRegistry": ("lintro.plugins.registry", "ToolRegistry"),
+    "is_compatible_api_version": (
+        "lintro.plugins.protocol",
+        "is_compatible_api_version",
+    ),
+    "register_tool": ("lintro.plugins.registry", "register_tool"),
+}
 
 __all__ = [
     "LINTRO_PLUGIN_API_VERSION",
@@ -65,3 +93,25 @@ __all__ = [
     "is_compatible_api_version",
     "register_tool",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve plugin package exports on first access.
+
+    Args:
+        name: Attribute name being accessed.
+
+    Returns:
+        The lazily imported attribute.
+
+    Raises:
+        AttributeError: If ``name`` is not a public export.
+    """
+    if name not in _LAZY_EXPORTS:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+    module_name, attr_name = _LAZY_EXPORTS[name]
+    module = __import__(module_name, fromlist=[attr_name])
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value

--- a/lintro/plugins/__init__.py
+++ b/lintro/plugins/__init__.py
@@ -115,3 +115,12 @@ def __getattr__(name: str) -> Any:
     value = getattr(module, attr_name)
     globals()[name] = value
     return value
+
+
+def __dir__() -> list[str]:
+    """Return available attributes including lazy exports.
+
+    Returns:
+        Sorted names from module globals and ``__all__``.
+    """
+    return sorted(set(globals()) | set(__all__))

--- a/lintro/tools/__init__.py
+++ b/lintro/tools/__init__.py
@@ -2,21 +2,58 @@
 
 This module provides the plugin-based tool system for Lintro.
 Tools are automatically discovered and registered via the plugin registry.
+Exports resolve lazily so importing sibling tool helpers does not pull the
+full plugin/base/config chain at cold start.
 """
 
-from lintro.enums.tool_type import ToolType
-from lintro.plugins import LintroPlugin, ToolDefinition, ToolRegistry
-from lintro.tools.core.tool_manager import ToolManager
+from __future__ import annotations
 
-# Create global tool manager instance
-tool_manager = ToolManager()
+from typing import TYPE_CHECKING, Any
 
-# Consolidated exports
+if TYPE_CHECKING:
+    from lintro.enums.tool_type import ToolType as ToolType
+    from lintro.plugins import LintroPlugin as LintroPlugin
+    from lintro.plugins import ToolDefinition as ToolDefinition
+    from lintro.plugins import ToolRegistry as ToolRegistry
+    from lintro.tools.core.tool_manager import ToolManager as ToolManager
+    from lintro.tools.core.tool_manager import tool_manager as tool_manager
+
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "LintroPlugin": ("lintro.plugins", "LintroPlugin"),
+    "ToolDefinition": ("lintro.plugins", "ToolDefinition"),
+    "ToolRegistry": ("lintro.plugins", "ToolRegistry"),
+    "ToolType": ("lintro.enums.tool_type", "ToolType"),
+    "ToolManager": ("lintro.tools.core.tool_manager", "ToolManager"),
+    "tool_manager": ("lintro.tools.core.tool_manager", "tool_manager"),
+}
+
 __all__ = [
     "LintroPlugin",
     "ToolDefinition",
     "ToolRegistry",
     "ToolType",
     "ToolManager",
-    "tool_manager",
+    "tool_manager",  # noqa: F822 - resolved via module __getattr__
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve tool package exports on first access.
+
+    Args:
+        name: Attribute name being accessed.
+
+    Returns:
+        The lazily imported attribute.
+
+    Raises:
+        AttributeError: If ``name`` is not a public export.
+    """
+    if name not in _LAZY_EXPORTS:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+    module_name, attr_name = _LAZY_EXPORTS[name]
+    module = __import__(module_name, fromlist=[attr_name])
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value

--- a/lintro/tools/__init__.py
+++ b/lintro/tools/__init__.py
@@ -33,7 +33,7 @@ __all__ = [
     "ToolRegistry",
     "ToolType",
     "ToolManager",
-    "tool_manager",  # noqa: F822 - resolved via module __getattr__
+    "tool_manager",
 ]
 
 
@@ -57,3 +57,12 @@ def __getattr__(name: str) -> Any:
     value = getattr(module, attr_name)
     globals()[name] = value
     return value
+
+
+def __dir__() -> list[str]:
+    """Return available attributes including lazy exports.
+
+    Returns:
+        Sorted names from module globals and ``__all__``.
+    """
+    return sorted(set(globals()) | set(__all__))

--- a/lintro/tools/core/tool_manager.py
+++ b/lintro/tools/core/tool_manager.py
@@ -205,3 +205,7 @@ class ToolManager:
         """
         self._ensure_initialized()
         return ToolRegistry.is_registered(name)
+
+
+# Process-wide singleton used by CLI execution paths.
+tool_manager = ToolManager()

--- a/lintro/utils/execution/tool_configuration.py
+++ b/lintro/utils/execution/tool_configuration.py
@@ -16,7 +16,7 @@ from lintro.config.config_loader import get_config
 from lintro.enums.action import Action, normalize_action
 from lintro.enums.tool_name import ToolName
 from lintro.enums.tools_value import ToolsValue
-from lintro.tools import tool_manager
+from lintro.tools.core.tool_manager import tool_manager
 from lintro.utils.unified_config import UnifiedConfigManager
 
 if TYPE_CHECKING:

--- a/lintro/utils/lazy_logger.py
+++ b/lintro/utils/lazy_logger.py
@@ -1,0 +1,52 @@
+"""Lazy loguru proxy for cold-start sensitive import paths.
+
+Importing ``loguru`` costs ~20-25ms. Modules on the ``lintro --version`` /
+``import lintro.cli`` path should import ``logger`` from here instead of
+``from loguru import logger`` so loguru loads only on first log call.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+
+class _LazyLogger:
+    """Proxy that imports loguru on first attribute access."""
+
+    _logger: Any | None = None
+
+    def _get_logger(self) -> Any:
+        """Return the real loguru logger, importing it on first use.
+
+        Returns:
+            The loguru logger instance.
+        """
+        if type(self)._logger is None:
+            from loguru import logger as real_logger
+
+            type(self)._logger = real_logger
+        return cast(Any, type(self)._logger)
+
+    def __getattr__(self, name: str) -> Any:
+        """Forward attribute access to the real loguru logger.
+
+        Args:
+            name: Attribute name requested by the caller.
+
+        Returns:
+            The attribute from the real loguru logger.
+        """
+        return getattr(self._get_logger(), name)
+
+    def __bool__(self) -> bool:
+        """Treat the proxy as truthy like the real logger.
+
+        Returns:
+            Always True.
+        """
+        return True
+
+
+logger = _LazyLogger()
+
+__all__ = ["logger"]

--- a/lintro/utils/lazy_logger.py
+++ b/lintro/utils/lazy_logger.py
@@ -7,6 +7,7 @@ Importing ``loguru`` costs ~20-25ms. Modules on the ``lintro --version`` /
 
 from __future__ import annotations
 
+import threading
 from typing import Any, cast
 
 
@@ -14,6 +15,9 @@ class _LazyLogger:
     """Proxy that imports loguru on first attribute access."""
 
     _logger: Any | None = None
+    #: Guards the check-then-set of ``_logger`` so free-threaded builds (no GIL)
+    #: cannot race two concurrent loguru imports into the class attribute.
+    _lock: threading.Lock = threading.Lock()
 
     def _get_logger(self) -> Any:
         """Return the real loguru logger, importing it on first use.
@@ -21,11 +25,15 @@ class _LazyLogger:
         Returns:
             The loguru logger instance.
         """
-        if type(self)._logger is None:
-            from loguru import logger as real_logger
+        cached = type(self)._logger
+        if cached is not None:
+            return cast(Any, cached)
+        with type(self)._lock:
+            if type(self)._logger is None:
+                from loguru import logger as real_logger
 
-            type(self)._logger = real_logger
-        return cast(Any, type(self)._logger)
+                type(self)._logger = real_logger
+            return cast(Any, type(self)._logger)
 
     def __getattr__(self, name: str) -> Any:
         """Forward attribute access to the real loguru logger.

--- a/lintro/utils/logger_setup.py
+++ b/lintro/utils/logger_setup.py
@@ -6,8 +6,6 @@ Provides centralized logging setup for both CLI and tool execution contexts.
 import sys
 from pathlib import Path
 
-from loguru import logger
-
 
 def setup_cli_logging() -> None:
     """Configure minimal logging for CLI commands (help, version, etc.).
@@ -15,6 +13,8 @@ def setup_cli_logging() -> None:
     Only shows WARNING and ERROR level messages on console.
     No file logging - this is for lightweight CLI operations.
     """
+    from loguru import logger
+
     logger.remove()
     logger.add(
         sys.stderr,
@@ -31,6 +31,8 @@ def setup_execution_logging(run_dir: Path, debug: bool = False) -> None:
         run_dir: Directory for log files.
         debug: If True, show DEBUG messages on console. Otherwise only WARNING+.
     """
+    from loguru import logger
+
     logger.remove()
 
     # Console handler - DEBUG if flag set, else WARNING only

--- a/scripts/generate-man-page.py
+++ b/scripts/generate-man-page.py
@@ -34,6 +34,20 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def populate_lazy_commands(ctx: click.Context) -> None:
+    """Force-load lazy subcommands into ``ctx.command.commands``.
+
+    click-man reads ``Group.commands``, which stays empty until
+    ``get_command`` materializes each lazy entry. An empty mapping is
+    falsy, so the COMMANDS section would otherwise be omitted.
+
+    Args:
+        ctx: Click context wrapping the lintro CLI group.
+    """
+    for name in cli.list_commands(ctx):
+        cli.get_command(ctx, name)
+
+
 def render_man_page(date: str | None = None) -> str:
     """Render the lintro man page text.
 
@@ -44,6 +58,7 @@ def render_man_page(date: str | None = None) -> str:
         The rendered man page text.
     """
     ctx = click.Context(cli, info_name="lintro")
+    populate_lazy_commands(ctx)
     return str(generate_man_page(ctx, version=__version__, date=date))
 
 

--- a/tests/scripts/test_generate_man_page.py
+++ b/tests/scripts/test_generate_man_page.py
@@ -1,0 +1,77 @@
+"""Tests for scripts/generate-man-page.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import click
+import pytest
+from assertpy import assert_that
+
+from lintro.cli import cli
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "generate-man-page.py"
+_REQUIRED_COMMANDS: tuple[str, ...] = ("check", "format", "list-tools", "versions")
+
+
+def _load_module() -> ModuleType:
+    """Load generate-man-page.py as an importable test module.
+
+    Returns:
+        The loaded generator module.
+
+    Raises:
+        RuntimeError: If the module spec or loader cannot be resolved.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "generate_man_page_script",
+        _SCRIPT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        msg = f"Unable to load module from {_SCRIPT_PATH}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def module() -> ModuleType:
+    """Provide the loaded man-page generator module.
+
+    Returns:
+        The loaded generator module.
+    """
+    return _load_module()
+
+
+def test_populate_lazy_commands_fills_group_commands(module: ModuleType) -> None:
+    """Force-loading lazy subcommands populates ``cli.commands``.
+
+    Args:
+        module: Loaded generate-man-page module.
+    """
+    ctx = click.Context(cli, info_name="lintro")
+    module.populate_lazy_commands(ctx)
+    for name in _REQUIRED_COMMANDS:
+        assert_that(cli.commands).contains_key(name)
+        assert_that(cli.list_commands(ctx)).contains(name)
+        loaded = cli.get_command(ctx, name)
+        assert loaded is not None
+        assert_that(loaded.name).is_equal_to(name)
+
+
+def test_render_man_page_includes_canonical_commands(module: ModuleType) -> None:
+    """The rendered man page lists canonical commands such as check and format.
+
+    Args:
+        module: Loaded generate-man-page module.
+    """
+    text = module.render_man_page()
+    assert_that(text).contains(".SH COMMANDS")
+    for name in _REQUIRED_COMMANDS:
+        assert_that(text).contains(name)
+        assert_that(cli.commands).contains_key(name)

--- a/tests/unit/ai/review/test_package_exports.py
+++ b/tests/unit/ai/review/test_package_exports.py
@@ -22,7 +22,7 @@ def test_package_exports_resolve(export_name: str) -> None:
 
 
 def test_lazy_exports_match_implementation() -> None:
-    """Lazy exports resolve to callables defined in their source modules."""
+    """Lazy exports resolve to objects defined in their source modules."""
     importlib.reload(review_pkg)
     for export_name, (module_name, attr_name) in review_pkg._LAZY_EXPORTS.items():
         vars(review_pkg).pop(export_name, None)
@@ -30,8 +30,10 @@ def test_lazy_exports_match_implementation() -> None:
             del sys.modules[module_name]
         assert_that(module_name in sys.modules).is_false()
         resolved = getattr(review_pkg, export_name)
-        assert_that(resolved.__module__).is_equal_to(module_name)
-        assert_that(resolved.__name__).is_equal_to(attr_name)
+        # getattr loads the source module via the package __getattr__ map.
+        assert_that(module_name in sys.modules).is_true()
+        source_module = sys.modules[module_name]
+        assert_that(resolved).is_equal_to(getattr(source_module, attr_name))
 
 
 def test_package_exports_include_changed_file_status() -> None:
@@ -42,34 +44,9 @@ def test_package_exports_include_changed_file_status() -> None:
 
 
 def test_lazy_export_names_match_runtime_map() -> None:
-    """Lazy export names are derived from the runtime lazy-import map."""
+    """Public exports are exactly the runtime lazy-import map keys."""
     importlib.reload(review_pkg)
-    static_exports = {
-        "BUILTIN_CHECKLIST_ITEMS",
-        "ChangedFile",
-        "ChangedFileStatus",
-        "ChecklistItem",
-        "ChunkingResult",
-        "FileClassification",
-        "FileDomain",
-        "PRMetadata",
-        "REL_DIRECTORY_PREFIX",
-        "REL_SINGLE_FILE",
-        "REL_SOURCE_TEST",
-        "REL_WORKFLOW_SCRIPT_TEST",
-        "RelationshipLabel",
-        "ReviewCategory",
-        "ReviewChunk",
-        "ReviewContext",
-        "ReviewContextError",
-        "ReviewContextErrorCode",
-        "format_checklist_for_prompt",
-        "get_all_checklist_items",
-        "select_checklist_items",
-    }
-    assert_that(set(review_pkg.__all__)).is_equal_to(
-        static_exports | set(review_pkg._LAZY_EXPORTS),
-    )
+    assert_that(set(review_pkg.__all__)).is_equal_to(set(review_pkg._LAZY_EXPORTS))
 
 
 def test_type_checking_lazy_exports_match_runtime_map() -> None:

--- a/tests/unit/ai/review/test_package_exports.py
+++ b/tests/unit/ai/review/test_package_exports.py
@@ -5,12 +5,53 @@ from __future__ import annotations
 import ast
 import importlib
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 from assertpy import assert_that
 
 import lintro.ai.review as review_pkg
+
+_REVIEW_PACKAGE = "lintro.ai.review"
+
+
+def _review_module_names() -> list[str]:
+    """Return the currently imported ``lintro.ai.review`` module names.
+
+    Returns:
+        The package itself plus every imported submodule.
+    """
+    return [
+        name
+        for name in list(sys.modules)
+        if name == _REVIEW_PACKAGE or name.startswith(f"{_REVIEW_PACKAGE}.")
+    ]
+
+
+@pytest.fixture(autouse=True)
+def restore_review_modules() -> Iterator[None]:
+    """Undo the ``sys.modules`` surgery these tests perform.
+
+    ``test_lazy_exports_match_implementation`` deletes every lazy-export source
+    module and lets the package re-import it. Re-importing a module defines
+    *new* class objects, so a module that already imported, say,
+    ``ReviewContextError`` eagerly keeps the old class and its ``except``
+    clauses silently stop matching for the rest of the session. Restoring the
+    original modules — and the package globals that cache their attributes —
+    keeps that damage inside this file.
+
+    Yields:
+        None: Control returns to the test while the snapshot is held.
+    """
+    tracked = {name: sys.modules[name] for name in _review_module_names()}
+    package_globals = dict(vars(review_pkg))
+    try:
+        yield
+    finally:
+        sys.modules.update(tracked)
+        vars(review_pkg).clear()
+        vars(review_pkg).update(package_globals)
 
 
 @pytest.mark.parametrize("export_name", review_pkg.__all__)

--- a/tests/unit/ai/review/test_package_exports.py
+++ b/tests/unit/ai/review/test_package_exports.py
@@ -90,6 +90,12 @@ def test_lazy_export_names_match_runtime_map() -> None:
     assert_that(set(review_pkg.__all__)).is_equal_to(set(review_pkg._LAZY_EXPORTS))
 
 
+def test_dir_includes_lazy_export_names() -> None:
+    """``dir()`` lists lazy exports before they have been accessed."""
+    importlib.reload(review_pkg)
+    assert_that(set(review_pkg.__all__).issubset(set(dir(review_pkg)))).is_true()
+
+
 def test_type_checking_lazy_exports_match_runtime_map() -> None:
     """TYPE_CHECKING imports stay aligned with the lazy export map."""
     source = Path(review_pkg.__file__).read_text(encoding="utf-8")

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -8,42 +8,12 @@ import pytest
 from assertpy import assert_that
 from click.testing import CliRunner
 
-from lintro.cli import cli
+from lintro.cli import _COMMAND_SHORT_HELP, cli
 
-SUBCOMMANDS: tuple[str, ...] = (
-    "badge",
-    "check",
-    "completions",
-    "config",
-    "doctor",
-    "format",
-    "init",
-    "install",
-    "licenses",
-    "list-tools",
-    "review",
-    "setup",
-    "test",
-    "versions",
-)
-
-# Human-facing summary phrases that must survive Click's \\f truncation.
-SUBCOMMAND_SUMMARY_PHRASES: dict[str, str] = {
-    "badge": "Generate a shields.io markdown badge for the project health score.",
-    "check": "Check files for issues using the specified tools.",
-    "completions": "Print a shell completion script for bash, zsh, or fish.",
-    "config": "Display Lintro configuration status.",
-    "doctor": "Check tool installation status and version compatibility.",
-    "format": "Format code using configured formatting tools.",
-    "init": "Initialize Lintro configuration for your project.",
-    "install": "Install or upgrade external tools used by lintro.",
-    "licenses": "Check dependency licenses for policy compliance.",
-    "list-tools": "List all available tools and their configurations.",
-    "review": "Run AI-powered diff-based code review, plus advisory AI finders.",
-    "setup": "Set up lintro for your project.",
-    "test": "Run tests using pytest.",
-    "versions": "Display version information for all supported tools.",
-}
+# Derived from the CLI short-help table so root help and subcommand help
+# cannot drift apart. Includes every canonical command (mcp included).
+SUBCOMMAND_SUMMARY_PHRASES: dict[str, str] = dict(_COMMAND_SHORT_HELP)
+SUBCOMMANDS: tuple[str, ...] = tuple(sorted(SUBCOMMAND_SUMMARY_PHRASES))
 
 _DOCSTRING_SECTION_RE = re.compile(
     r"^\s*(Args|Raises|Returns|Note|Notes|Example|Examples|Yields|Attributes"

--- a/tests/unit/cli/test_lazy_subcommands.py
+++ b/tests/unit/cli/test_lazy_subcommands.py
@@ -97,12 +97,24 @@ def test_short_help_entries_fit_the_render_limit() -> None:
         )
 
 
+def _plain_text(text: str) -> str:
+    """Collapse Rich table glyphs so wrapped descriptions can be matched.
+
+    Args:
+        text: Rich-formatted help text or a description string.
+
+    Returns:
+        Whitespace-normalized alphanumeric words.
+    """
+    return " ".join("".join(ch if ch.isalnum() else " " for ch in text).split())
+
+
 def test_root_help_lists_canonical_names_aliases_and_descriptions() -> None:
     """``lintro --help`` shows each canonical name, alias, and description."""
     runner = CliRunner()
     result = runner.invoke(cli, ["--help"])
     assert_that(result.exit_code).is_equal_to(0)
-    normalized = " ".join(result.output.split())
+    haystack = _plain_text(result.output)
     for name, canonical in _CANONICAL_NAMES.items():
         assert_that(result.output).contains(name)
-        assert_that(normalized).contains(_COMMAND_SHORT_HELP[canonical])
+        assert_that(haystack).contains(_plain_text(_COMMAND_SHORT_HELP[canonical]))

--- a/tests/unit/cli/test_lazy_subcommands.py
+++ b/tests/unit/cli/test_lazy_subcommands.py
@@ -2,42 +2,26 @@
 
 ``lintro --help`` renders its Commands table from static metadata so it never
 imports a subcommand. That trades an import for three hand-maintained tables,
-which these tests keep aligned with each other and with the real commands.
+which these tests keep aligned with each other, with the real commands, and
+with the user-visible help text.
 """
 
 from __future__ import annotations
 
-import importlib
-from typing import cast
-
 import click
 import pytest
 from assertpy import assert_that
+from click.testing import CliRunner
 
 from lintro.cli import (
     _CANONICAL_NAMES,
     _COMMAND_SHORT_HELP,
     _LAZY_SUBCOMMANDS,
     SHORT_HELP_LIMIT,
+    cli,
 )
 
 _CANONICAL_COMMANDS: tuple[str, ...] = tuple(sorted(set(_CANONICAL_NAMES.values())))
-
-
-def _load_command(canonical: str) -> click.Command:
-    """Import the Click command backing a canonical command name.
-
-    Args:
-        canonical: Canonical command name present in ``_LAZY_SUBCOMMANDS``.
-
-    Returns:
-        The imported Click command object.
-    """
-    module_name, attr_name = _LAZY_SUBCOMMANDS[canonical].rsplit(".", 1)
-    return cast(
-        click.Command,
-        getattr(importlib.import_module(module_name), attr_name),
-    )
 
 
 def test_lazy_and_canonical_tables_cover_the_same_names() -> None:
@@ -64,15 +48,30 @@ def test_aliases_share_the_canonical_import_path() -> None:
 
 
 @pytest.mark.parametrize("canonical", _CANONICAL_COMMANDS)
-def test_lazy_import_path_resolves_to_a_click_command(canonical: str) -> None:
-    """Every import path resolves to a Click command with the expected name.
+def test_get_command_registers_canonical_name(canonical: str) -> None:
+    """``get_command`` resolves the name users type, not Click's auto-name.
 
     Args:
         canonical: Canonical command name under test.
     """
-    command = _load_command(canonical)
+    ctx = click.Context(cli)
+    command = cli.get_command(ctx, canonical)
     assert_that(isinstance(command, click.Command)).is_true()
+    assert command is not None
     assert_that(command.name).is_equal_to(canonical)
+    assert_that(cli.list_commands(ctx)).contains(canonical)
+    assert_that(cli.commands).contains_key(canonical)
+
+
+def test_aliases_resolve_to_the_canonical_command_object() -> None:
+    """Aliases and canonical names resolve to the same loaded command."""
+    ctx = click.Context(cli)
+    for name, canonical in _CANONICAL_NAMES.items():
+        loaded = cli.get_command(ctx, name)
+        canonical_cmd = cli.get_command(ctx, canonical)
+        assert_that(loaded).is_same_as(canonical_cmd)
+        assert loaded is not None
+        assert_that(loaded.name).is_equal_to(canonical)
 
 
 @pytest.mark.parametrize("canonical", _CANONICAL_COMMANDS)
@@ -82,7 +81,9 @@ def test_static_short_help_matches_the_command(canonical: str) -> None:
     Args:
         canonical: Canonical command name under test.
     """
-    command = _load_command(canonical)
+    ctx = click.Context(cli)
+    command = cli.get_command(ctx, canonical)
+    assert command is not None
     assert_that(_COMMAND_SHORT_HELP[canonical]).is_equal_to(
         command.get_short_help_str(limit=SHORT_HELP_LIMIT),
     )
@@ -94,3 +95,14 @@ def test_short_help_entries_fit_the_render_limit() -> None:
         assert_that(len(short_help)).described_as(canonical).is_less_than_or_equal_to(
             SHORT_HELP_LIMIT,
         )
+
+
+def test_root_help_lists_canonical_names_aliases_and_descriptions() -> None:
+    """``lintro --help`` shows each canonical name, alias, and description."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert_that(result.exit_code).is_equal_to(0)
+    normalized = " ".join(result.output.split())
+    for name, canonical in _CANONICAL_NAMES.items():
+        assert_that(result.output).contains(name)
+        assert_that(normalized).contains(_COMMAND_SHORT_HELP[canonical])

--- a/tests/unit/cli/test_lazy_subcommands.py
+++ b/tests/unit/cli/test_lazy_subcommands.py
@@ -1,0 +1,92 @@
+"""Guards for the lazy-subcommand tables in :mod:`lintro.cli`.
+
+``lintro --help`` renders its Commands table from static metadata so it never
+imports a subcommand. That trades an import for three hand-maintained tables,
+which these tests keep aligned with each other and with the real commands.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import click
+import pytest
+from assertpy import assert_that
+
+from lintro.cli import (
+    _CANONICAL_NAMES,
+    _COMMAND_SHORT_HELP,
+    _LAZY_SUBCOMMANDS,
+    SHORT_HELP_LIMIT,
+)
+
+_CANONICAL_COMMANDS: tuple[str, ...] = tuple(sorted(set(_CANONICAL_NAMES.values())))
+
+
+def _load_command(canonical: str) -> click.Command:
+    """Import the Click command backing a canonical command name.
+
+    Args:
+        canonical: Canonical command name present in ``_LAZY_SUBCOMMANDS``.
+
+    Returns:
+        The imported Click command object.
+    """
+    module_name, attr_name = _LAZY_SUBCOMMANDS[canonical].rsplit(".", 1)
+    return getattr(importlib.import_module(module_name), attr_name)
+
+
+def test_lazy_and_canonical_tables_cover_the_same_names() -> None:
+    """Every lazy command name has a canonical name, and vice versa."""
+    assert_that(set(_LAZY_SUBCOMMANDS)).is_equal_to(set(_CANONICAL_NAMES))
+
+
+def test_canonical_names_have_short_help() -> None:
+    """Canonical command names and short-help keys match exactly."""
+    assert_that(set(_CANONICAL_NAMES.values())).is_equal_to(set(_COMMAND_SHORT_HELP))
+
+
+def test_canonical_names_are_self_mapping() -> None:
+    """Each canonical name maps to itself, so aliases resolve to a real command."""
+    for canonical in _CANONICAL_COMMANDS:
+        assert_that(_CANONICAL_NAMES).contains_key(canonical)
+        assert_that(_CANONICAL_NAMES[canonical]).is_equal_to(canonical)
+
+
+def test_aliases_share_the_canonical_import_path() -> None:
+    """An alias imports the same object as the command it aliases."""
+    for name, canonical in _CANONICAL_NAMES.items():
+        assert_that(_LAZY_SUBCOMMANDS[name]).is_equal_to(_LAZY_SUBCOMMANDS[canonical])
+
+
+@pytest.mark.parametrize("canonical", _CANONICAL_COMMANDS)
+def test_lazy_import_path_resolves_to_a_click_command(canonical: str) -> None:
+    """Every import path resolves to a Click command with the expected name.
+
+    Args:
+        canonical: Canonical command name under test.
+    """
+    command = _load_command(canonical)
+    assert_that(isinstance(command, click.Command)).is_true()
+    assert_that(command.name).is_equal_to(canonical)
+
+
+@pytest.mark.parametrize("canonical", _CANONICAL_COMMANDS)
+def test_static_short_help_matches_the_command(canonical: str) -> None:
+    """The static help table matches what Click would render at runtime.
+
+    Args:
+        canonical: Canonical command name under test.
+    """
+    command = _load_command(canonical)
+    assert_that(_COMMAND_SHORT_HELP[canonical]).is_equal_to(
+        command.get_short_help_str(limit=SHORT_HELP_LIMIT),
+    )
+
+
+def test_short_help_entries_fit_the_render_limit() -> None:
+    """No table entry is long enough to be truncated when rendered."""
+    for canonical, short_help in _COMMAND_SHORT_HELP.items():
+        assert_that(len(short_help)).described_as(canonical).is_less_than_or_equal_to(
+            SHORT_HELP_LIMIT,
+        )

--- a/tests/unit/cli/test_lazy_subcommands.py
+++ b/tests/unit/cli/test_lazy_subcommands.py
@@ -8,6 +8,7 @@ which these tests keep aligned with each other and with the real commands.
 from __future__ import annotations
 
 import importlib
+from typing import cast
 
 import click
 import pytest
@@ -33,7 +34,10 @@ def _load_command(canonical: str) -> click.Command:
         The imported Click command object.
     """
     module_name, attr_name = _LAZY_SUBCOMMANDS[canonical].rsplit(".", 1)
-    return getattr(importlib.import_module(module_name), attr_name)
+    return cast(
+        click.Command,
+        getattr(importlib.import_module(module_name), attr_name),
+    )
 
 
 def test_lazy_and_canonical_tables_cover_the_same_names() -> None:

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -1567,7 +1567,10 @@ def test_full_review_json_merges_advisory_key() -> None:
         result = runner.invoke(cli, ["review", "--output", "json"])
 
     assert_that(result.exit_code).is_equal_to(0)
-    payload = json.loads(result.output)
+    # Parse stdout only: loguru now binds its handler at invoke time, so CLI
+    # warnings land in the runner's captured stderr and would corrupt
+    # ``result.output`` (which merges both streams).
+    payload = json.loads(result.stdout)
     assert_that(payload["summary"]).is_equal_to("ok")
     assert_that(payload["advisory"][0]["tool"]).is_equal_to("idiom-review")
 

--- a/tests/unit/mcp/test_cli_command.py
+++ b/tests/unit/mcp/test_cli_command.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
+import click
 from assertpy import assert_that
 from click.testing import CliRunner
 
@@ -13,8 +14,15 @@ from lintro.cli_utils.commands.mcp import mcp_command
 
 
 def test_mcp_command_is_registered_on_the_cli() -> None:
-    """``mcp`` is exposed as a top-level lintro command."""
-    assert_that(cli.commands).contains_key("mcp")
+    """``mcp`` is exposed as a top-level lintro command.
+
+    Subcommands load lazily, so ``cli.commands`` is empty until one is
+    resolved; go through the public listing/lookup API instead.
+    """
+    ctx = click.Context(cli)
+
+    assert_that(cli.list_commands(ctx)).contains("mcp")
+    assert_that(cli.get_command(ctx, "mcp")).is_same_as(mcp_command)
 
 
 def test_mcp_command_defaults_workspace_to_cwd(tmp_path: Path) -> None:

--- a/tests/unit/test_cold_start_imports.py
+++ b/tests/unit/test_cold_start_imports.py
@@ -1,0 +1,105 @@
+"""Cold-start import budget guards for issue #1305."""
+
+from __future__ import annotations
+
+import re
+import subprocess  # nosec B404 - subprocess used only with fixed sys.executable -c argv in tests
+import sys
+
+from assertpy import assert_that
+
+# Modules that must stay out of ``import lintro.cli`` / --version cold path.
+_FORBIDDEN_AFTER_CLI_IMPORT = (
+    "lintro.ai.review",
+    "lintro.ai.review.checklist",
+    "lintro.utils.tool_executor",
+    "lintro.plugins.base",
+    "lintro.tools.definitions.ruff",
+    "lintro.cli_utils.commands.check",
+    "rich",
+    "pydantic",
+    "loguru",
+)
+
+
+def test_import_lintro_cli_avoids_heavy_modules() -> None:
+    """``import lintro.cli`` must not pull AI/review/plugins/tool trees.
+
+    Runs in a subprocess so the assertion is independent of whatever the
+    pytest process has already imported.
+    """
+    forbidden_repr = ", ".join(repr(name) for name in _FORBIDDEN_AFTER_CLI_IMPORT)
+    script = f"""
+import sys
+import lintro.cli  # noqa: F401
+forbidden = [{forbidden_repr}]
+loaded = [name for name in forbidden if name in sys.modules]
+if loaded:
+    raise SystemExit("unexpected modules after import lintro.cli: " + ", ".join(loaded))
+"""
+    result = subprocess.run(  # nosec B603 - fixed argv: sys.executable -c with literal script; shell=False
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stderr).is_equal_to("")
+
+
+def test_lintro_version_avoids_heavy_modules() -> None:
+    """``lintro --version`` must not import check/AI/plugin trees or rich.
+
+    Uses Click's programmatic invocation so the assertion stays in-process of
+    the subprocess under test without requiring a PATH entry for ``lintro``.
+    """
+    forbidden_repr = ", ".join(repr(name) for name in _FORBIDDEN_AFTER_CLI_IMPORT)
+    script = f"""
+import sys
+from lintro.cli import cli
+cli.main(args=["--version"], standalone_mode=False)
+forbidden = [{forbidden_repr}]
+loaded = [name for name in forbidden if name in sys.modules]
+if loaded:
+    raise SystemExit(
+        "unexpected modules after lintro --version: " + ", ".join(loaded)
+    )
+"""
+    result = subprocess.run(  # nosec B603 - fixed argv: sys.executable -c with literal script; shell=False
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stderr).is_equal_to("")
+    assert_that(bool(re.search(r"\d+\.\d+\.\d+", result.stdout))).is_true()
+
+
+def test_import_config_loader_avoids_ai_review() -> None:
+    """``import lintro.config.config_loader`` must not import AI review.
+
+    pydantic may still load via other config models; AI review must not.
+    """
+    script = """
+import sys
+import lintro.config.config_loader  # noqa: F401
+forbidden = [
+    "lintro.ai.review",
+    "lintro.ai.review.checklist",
+    "lintro.ai.config",
+]
+loaded = [name for name in forbidden if name in sys.modules]
+if loaded:
+    raise SystemExit(
+        "unexpected modules after import config_loader: " + ", ".join(loaded)
+    )
+"""
+    result = subprocess.run(  # nosec B603 - fixed argv: sys.executable -c with literal script; shell=False
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stderr).is_equal_to("")

--- a/tests/unit/test_cold_start_imports.py
+++ b/tests/unit/test_cold_start_imports.py
@@ -76,6 +76,50 @@ if loaded:
     assert_that(bool(re.search(r"\d+\.\d+\.\d+", result.stdout))).is_true()
 
 
+# ``lintro --help`` may import rich to render the Commands table, but must
+# not pull subcommand or tool-executor modules.
+_FORBIDDEN_AFTER_HELP = (
+    "lintro.ai.review",
+    "lintro.ai.review.checklist",
+    "lintro.utils.tool_executor",
+    "lintro.plugins.base",
+    "lintro.tools.definitions.ruff",
+    "lintro.cli_utils.commands.check",
+    "lintro.cli_utils.commands.format",
+)
+
+
+def test_lintro_help_avoids_heavy_modules() -> None:
+    """``lintro --help`` must not import check/format/tool_executor.
+
+    Uses Click's programmatic invocation so the assertion stays in-process of
+    the subprocess under test without requiring a PATH entry for ``lintro``.
+    Rich is allowed because ``format_help`` renders the static Commands table.
+    """
+    forbidden_repr = ", ".join(repr(name) for name in _FORBIDDEN_AFTER_HELP)
+    script = f"""
+import sys
+from lintro.cli import cli
+cli.main(args=["--help"], standalone_mode=False)
+forbidden = [{forbidden_repr}]
+loaded = [name for name in forbidden if name in sys.modules]
+if loaded:
+    raise SystemExit(
+        "unexpected modules after lintro --help: " + ", ".join(loaded)
+    )
+"""
+    result = subprocess.run(  # nosec B603 - fixed argv: sys.executable -c with literal script; shell=False
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stderr).is_equal_to("")
+    assert_that(result.stdout).contains("check")
+    assert_that(result.stdout).contains("format")
+
+
 def test_import_config_loader_avoids_ai_review() -> None:
     """``import lintro.config.config_loader`` must not import AI review.
 

--- a/tests/unit/test_lazy_package_exports.py
+++ b/tests/unit/test_lazy_package_exports.py
@@ -1,0 +1,39 @@
+"""Guards that lazy package ``__all__`` stays aligned with ``_LAZY_EXPORTS``."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from assertpy import assert_that
+
+_LAZY_PACKAGES: tuple[str, ...] = (
+    "lintro.ai",
+    "lintro.ai.review",
+    "lintro.config",
+    "lintro.plugins",
+    "lintro.tools",
+    "lintro.cli_utils.commands",
+)
+
+
+@pytest.mark.parametrize("package_name", _LAZY_PACKAGES)
+def test_all_matches_lazy_exports(package_name: str) -> None:
+    """Public ``__all__`` is exactly the runtime lazy-import map.
+
+    Args:
+        package_name: Import path of a PEP 562 lazy package.
+    """
+    package = importlib.import_module(package_name)
+    assert_that(set(package.__all__)).is_equal_to(set(package._LAZY_EXPORTS))
+
+
+@pytest.mark.parametrize("package_name", _LAZY_PACKAGES)
+def test_dir_includes_lazy_export_names(package_name: str) -> None:
+    """``dir()`` includes every lazy export without requiring first access.
+
+    Args:
+        package_name: Import path of a PEP 562 lazy package.
+    """
+    package = importlib.import_module(package_name)
+    assert_that(set(package.__all__).issubset(set(dir(package)))).is_true()

--- a/tests/unit/utils/test_logger_setup.py
+++ b/tests/unit/utils/test_logger_setup.py
@@ -14,7 +14,7 @@ from lintro.utils.logger_setup import setup_cli_logging, setup_execution_logging
 # =============================================================================
 
 
-@patch("lintro.utils.logger_setup.logger")
+@patch("loguru.logger")
 def test_setup_cli_logging_removes_handlers(mock_logger: MagicMock) -> None:
     """setup_cli_logging removes existing handlers.
 
@@ -26,7 +26,7 @@ def test_setup_cli_logging_removes_handlers(mock_logger: MagicMock) -> None:
     mock_logger.remove.assert_called_once()
 
 
-@patch("lintro.utils.logger_setup.logger")
+@patch("loguru.logger")
 def test_setup_cli_logging_adds_stderr_handler(mock_logger: MagicMock) -> None:
     """setup_cli_logging adds stderr handler.
 
@@ -46,7 +46,7 @@ def test_setup_cli_logging_adds_stderr_handler(mock_logger: MagicMock) -> None:
 # =============================================================================
 
 
-@patch("lintro.utils.logger_setup.logger")
+@patch("loguru.logger")
 def test_setup_execution_logging_removes_handlers(
     mock_logger: MagicMock,
     tmp_path: Path,
@@ -62,7 +62,7 @@ def test_setup_execution_logging_removes_handlers(
     mock_logger.remove.assert_called_once()
 
 
-@patch("lintro.utils.logger_setup.logger")
+@patch("loguru.logger")
 def test_setup_execution_logging_adds_console_and_file_handlers(
     mock_logger: MagicMock,
     tmp_path: Path,
@@ -79,7 +79,7 @@ def test_setup_execution_logging_adds_console_and_file_handlers(
     assert_that(mock_logger.add.call_count).is_equal_to(2)
 
 
-@patch("lintro.utils.logger_setup.logger")
+@patch("loguru.logger")
 def test_setup_execution_logging_debug_false_uses_warning(
     mock_logger: MagicMock,
     tmp_path: Path,
@@ -97,7 +97,7 @@ def test_setup_execution_logging_debug_false_uses_warning(
     assert_that(first_call.kwargs["level"]).is_equal_to("WARNING")
 
 
-@patch("lintro.utils.logger_setup.logger")
+@patch("loguru.logger")
 def test_setup_execution_logging_debug_true_uses_debug(
     mock_logger: MagicMock,
     tmp_path: Path,
@@ -115,7 +115,7 @@ def test_setup_execution_logging_debug_true_uses_debug(
     assert_that(first_call.kwargs["level"]).is_equal_to("DEBUG")
 
 
-@patch("lintro.utils.logger_setup.logger")
+@patch("loguru.logger")
 def test_setup_execution_logging_file_handler_uses_debug(
     mock_logger: MagicMock,
     tmp_path: Path,
@@ -133,7 +133,7 @@ def test_setup_execution_logging_file_handler_uses_debug(
     assert_that(second_call.kwargs["level"]).is_equal_to("DEBUG")
 
 
-@patch("lintro.utils.logger_setup.logger")
+@patch("loguru.logger")
 def test_setup_execution_logging_creates_run_dir(
     mock_logger: MagicMock,
     tmp_path: Path,


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  perf(cli): cut cold-start via lazy imports
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Cut CLI cold-start from ~0.5s toward ~0.1s by deferring AI/config/review
package exports, registering builtin plugins as name→module metadata until
selected, and loading Click subcommands on demand.

### Before / after (Apple Silicon)

| Metric | Before | After |
| --- | --- | --- |
| `time uv run lintro --version` | ~0.45–0.53s | ~0.09s |
| `import lintro.cli` | ~0.31s cumulative | ~0.014–0.021s |

`python -X importtime -c "import lintro.cli"` no longer pulls
`lintro.utils.tool_executor`, `lintro.ai.review`, plugin definitions, or
loguru/pydantic on the version path.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt/chk/tst`)

## Closes

- Closes #1305

## Details

- Lazy `__getattr__` exports for `lintro.ai`, `lintro.ai.review`, `lintro.config`,
  `lintro.plugins`, and `lintro.tools`
- Deferred builtin tool registry (`register_deferred` / `_materialize`)
- Click lazy-group pattern in `lintro/cli.py`; static `--help` metadata so help
  does not import subcommands
- Thin `lazy_logger` facade + deferred loguru setup on the cold path
- Regression tests assert forbidden heavy modules stay out of
  `import lintro.cli` and `lintro --version`

Does not implement #1379 UTF-8 stdio work; `cli.py` changes are limited to
lazy-import cold-start behavior.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR cuts CLI cold-start time from ~0.5 s to ~0.09 s by applying three techniques across 19 files: module `__getattr__` lazy exports in `lintro.ai`, `lintro.config`, `lintro.plugins`, and `lintro.tools`; a `LintroGroup` that defers Click subcommand imports until the command is actually invoked; and a `_LazyLogger` proxy that defers the ~20 ms loguru import until the first log call.

- `lintro/cli.py` replaces fifteen eager module-level imports with `_LAZY_SUBCOMMANDS` / `_CANONICAL_NAMES` / `_COMMAND_SHORT_HELP` static tables, and moves `setup_cli_logging()` from module level into `LintroGroup.invoke()`.
- `lintro/utils/lazy_logger.py` introduces a thread-safe proxy (double-checked locking) so modules like `command_chainer` and `config_loader` no longer pull loguru at import time.
- New subprocess-based tests in `test_cold_start_imports.py` and table-consistency tests in `test_lazy_subcommands.py` guard the cold-start budget going forward.
</details>

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one ordering fix: runtime_discovery.py still eagerly imports loguru at module level but is imported inside invoke() before setup_cli_logging() runs, reversing the intentional constraint from the original code.
- The cold-start path (import lintro.cli, --version) is clean and well-tested. The issue is in the real-command path: invoke() imports runtime_discovery (which has from loguru import logger at module level) before calling setup_cli_logging(), so loguru initialises with its default DEBUG handler for the brief window before reconfiguration. The original cli.py had an explicit E402 comment documenting that this ordering was intentional — the new code quietly reverses it without migrating runtime_discovery to lazy_logger. Nothing currently logs during that window, so observable behaviour is unchanged today, but the constraint is broken and will silently bite the next person who adds a module-level debug log to runtime_discovery or any module it imports.
- lintro/cli.py (invoke() import ordering) and lintro/tools/core/runtime_discovery.py (not migrated to lazy_logger)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/cli.py | Major refactor: subcommands are now lazily loaded via LintroGroup and three static tables. setup_cli_logging() moved from module-level into invoke(), but runtime_discovery (still an eager loguru importer) is imported before setup_cli_logging() runs, reversing an explicit ordering constraint from the original code. |
| lintro/utils/lazy_logger.py | New file: thread-safe loguru proxy using double-checked locking. Correct for normal attribute access; dunder methods on the type cannot be proxied via __getattr__, which is an undocumented limitation. |
| lintro/tools/core/runtime_discovery.py | Not in the PR diff but directly affected: still contains a module-level `from loguru import logger` that was not migrated to lazy_logger, causing loguru to be initialised before setup_cli_logging() runs on first command invocation. |
| lintro/ai/__init__.py | Converted from eager imports to module __getattr__ lazy pattern with globals() caching. TYPE_CHECKING block preserves IDE/type-checker visibility. Clean implementation. |
| lintro/utils/logger_setup.py | loguru import deferred into setup_cli_logging() and setup_execution_logging() function bodies. Test patches updated from module-attribute to loguru.logger accordingly. |
| tests/unit/test_cold_start_imports.py | New subprocess-based cold-start regression tests. Correctly scoped to import and --version paths. Missing a guard for the real-command invocation path where runtime_discovery (an eager loguru importer) fires. |
| tests/unit/cli/test_lazy_subcommands.py | New guard tests for the three static tables (_LAZY_SUBCOMMANDS, _CANONICAL_NAMES, _COMMAND_SHORT_HELP). Parametrized by canonical name and verifies import paths, help text sync, and alias consistency. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as lintro CLI (cli.py)
    participant LG as LintroGroup
    participant Lazy as _LAZY_SUBCOMMANDS
    participant Sub as Subcommand Module
    participant Loguru as loguru

    User->>CLI: lintro --version
    CLI-->>User: version string (loguru never imported)

    User->>CLI: lintro check [args]
    CLI->>LG: invoke(ctx)
    LG->>LG: import runtime_discovery
    Note over LG,Loguru: runtime_discovery has module-level<br/>from loguru import logger → loguru<br/>initialised with DEFAULT handler
    LG->>LG: import setup_cli_logging
    LG->>Loguru: setup_cli_logging() → remove()+add(WARNING)
    LG->>Lazy: get_command("check")
    Lazy->>Sub: importlib.import_module("lintro.cli_utils.commands.check")
    Sub-->>Lazy: check_command object
    Lazy-->>LG: click.Command
    LG->>Sub: sub.invoke(ctx)
    Sub-->>User: output
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test(ai): restore review modules after l..."](https://github.com/lgtm-hq/py-lintro/commit/8f6dcbad8b424b88f708cf5fb55eb93506a8f870) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45072743)</sub>

<!-- /greptile_comment -->