### PR TITLE
fix(deps): exclude test_samples fixtures from Renovate tracking

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,11 @@
   ],
   "packageRules": [
     {
+      "description": "test_samples are fixed tool-test inputs; never update them",
+      "matchFileNames": ["test_samples/**"],
+      "enabled": false
+    },
+    {
       "description": "Hold prettier 3.9.5+ until Docker integration prettier fixtures are updated",
       "matchPackageNames": ["prettier"],
       "allowedVersions": "<=3.9.4"

--- a/test_samples/tools/config/docker/Dockerfile.python311
+++ b/test_samples/tools/config/docker/Dockerfile.python311
@@ -1,1 +1,1 @@
-FROM python:3.11@sha256:13f0881a239ca0d27fb8b2539536ace85f7d680a707bfaa178571e1dbfe85a91
+FROM python:3.11

--- a/test_samples/tools/config/docker/Dockerfile.python311_slim
+++ b/test_samples/tools/config/docker/Dockerfile.python311_slim
@@ -1,1 +1,1 @@
-FROM python:3.11-slim@sha256:db3ff2e1800a8581e2c48a27c3995339d47bdf046da21c7627accd3d51053a93
+FROM python:3.11-slim

--- a/test_samples/tools/config/docker/Dockerfile.simple
+++ b/test_samples/tools/config/docker/Dockerfile.simple
@@ -1,1 +1,1 @@
-FROM python@sha256:311ea5bb79f1a238ee9e38f8d5f09cb3b4b244575cf49e27cf365ea7e60f11d4
+FROM python

--- a/test_samples/tools/config/docker/Dockerfile.with_apt_update
+++ b/test_samples/tools/config/docker/Dockerfile.with_apt_update
@@ -1,2 +1,2 @@
-FROM python@sha256:311ea5bb79f1a238ee9e38f8d5f09cb3b4b244575cf49e27cf365ea7e60f11d4
+FROM python
 RUN apt-get update


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [x] fix / perf (patch)

## What's Changing

Renovate's PR #1472 digest-pinned the base images in four `test_samples/tools/config/docker/Dockerfile.*` fixtures. Those files are fixed tool-test inputs — `Dockerfile.simple` deliberately uses an untagged base and `Dockerfile.with_apt_update` deliberately triggers apt-get findings — so "correcting" them changes what the tests exercise and invites endless digest churn.

- Add a `packageRules` entry in `renovate.json` disabling all updates for `test_samples/**` (a package rule instead of top-level `ignorePaths` so the org preset's `ignorePaths` is not clobbered).
- Revert the four fixture Dockerfiles to their pre-#1472 unpinned forms.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (fixture revert restores existing coverage; no new tests needed)
- [ ] Docs updated if user-facing (not user-facing)
- [x] Local CI passed (full pytest suite: 6725 passed, 10 skipped)

## Closes

- Closes #1501
- Relates to #1472

## Details

The two initially failing integration tests (markdownlint parity, commitlint bad-last-commit) were a fresh-worktree environment artifact (missing `node_modules`); both pass after `bun install`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation settings to exclude selected test sample files from automated updates.
  * Revised sample Docker configurations to reference Python base images by tags instead of fixed image digests.
  * Updated Python, slim Python, and package-installation examples consistently across the sample configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes Renovate digest-pinning four test fixture Dockerfiles that should remain in their deliberately unpinned forms, and adds a `packageRules` entry to prevent recurrence. The approach of using `packageRules` with `matchFileNames` rather than top-level `ignorePaths` is correct and avoids clobbering any inherited `ignorePaths` from the org preset.

- **`renovate.json`**: A new `packageRules` entry with `matchFileNames: ["test_samples/**"]` and `enabled: false` is placed first in the array, ensuring Renovate never opens update PRs for any file under `test_samples/`. Because no subsequent rule explicitly sets `enabled: true`, the disable cannot be silently overridden by other matching rules.
- **Four fixture Dockerfiles**: Digest-pinned `FROM` lines added by PR #1472 are reverted to their pre-#1472 forms — bare tags (`python:3.11`, `python:3.11-slim`) or the untagged `python` base — restoring the exact inputs the Hadolint/Docker integration tests depend on.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the renovate config change is narrowly scoped and the Dockerfile reversions restore known-good fixture content.

The renovate.json rule correctly uses matchFileNames with a packageRules entry (not ignorePaths) so it composes safely with org-level presets, and enabled: false is not overridden by any subsequent rule. The four Dockerfile changes are pure reversions to the fixtures' original single-line forms with no logic impact beyond test inputs.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Adds a packageRules entry disabling all Renovate updates for files matching test_samples/**, preventing Renovate from modifying intentionally-unpinned fixture Dockerfiles in the future. |
| test_samples/tools/config/docker/Dockerfile.python311 | Reverts Renovate digest-pinned FROM line back to the original unpinned form FROM python:3.11, restoring the fixture's intended test content. |
| test_samples/tools/config/docker/Dockerfile.python311_slim | Reverts Renovate digest-pinned FROM line back to FROM python:3.11-slim, restoring the fixture's original unpinned form. |
| test_samples/tools/config/docker/Dockerfile.simple | Reverts FROM python@sha256:... back to bare FROM python, restoring the deliberately untagged base that this fixture is meant to exercise. |
| test_samples/tools/config/docker/Dockerfile.with_apt_update | Reverts FROM python@sha256:... back to bare FROM python while preserving the RUN apt-get update line that triggers the apt-get finding this fixture is designed to test. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Renovate scans repo for updates] --> B{Does file match\ntest_samples/**?}
    B -- Yes --> C[packageRules: enabled=false\nNo PR opened]
    B -- No --> D{Is file a tracked\ndependency source?}
    D -- Yes --> E[Normal Renovate update flow]
    D -- No --> F[Ignored / no action]

    subgraph "Reverted fixtures (test inputs)"
        G[Dockerfile.simple\nFROM python]
        H[Dockerfile.with_apt_update\nFROM python + apt-get]
        I[Dockerfile.python311\nFROM python:3.11]
        J[Dockerfile.python311_slim\nFROM python:3.11-slim]
    end

    C -.->|protects| G
    C -.->|protects| H
    C -.->|protects| I
    C -.->|protects| J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Renovate scans repo for updates] --> B{Does file match\ntest_samples/**?}
    B -- Yes --> C[packageRules: enabled=false\nNo PR opened]
    B -- No --> D{Is file a tracked\ndependency source?}
    D -- Yes --> E[Normal Renovate update flow]
    D -- No --> F[Ignored / no action]

    subgraph "Reverted fixtures (test inputs)"
        G[Dockerfile.simple\nFROM python]
        H[Dockerfile.with_apt_update\nFROM python + apt-get]
        I[Dockerfile.python311\nFROM python:3.11]
        J[Dockerfile.python311_slim\nFROM python:3.11-slim]
    end

    C -.->|protects| G
    C -.->|protects| H
    C -.->|protects| I
    C -.->|protects| J
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: re-trigger Docker Integration Tests ..."](https://github.com/lgtm-hq/py-lintro/commit/6b4d9a2f195d89afb96d2b71991450e780d7d6cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45319834)</sub>

<!-- /greptile_comment -->