### PR TITLE
fix(pip-audit): continue auditing remaining targets after a per-target timeout

### DIFF
--- a/lintro/tools/definitions/pip_audit.py
+++ b/lintro/tools/definitions/pip_audit.py
@@ -315,13 +315,14 @@ class PipAuditPlugin(BaseToolPlugin):
                     cwd=target_cwd,
                 )
             except subprocess.TimeoutExpired:
-                # Preserve findings already collected from earlier targets: a
-                # later timeout must not erase vulnerabilities pip-audit already
-                # reported. Mark the scan unsuccessful and fall through to the
-                # aggregation path rather than returning a clean-looking result.
+                # A slow target must not end the scan: record the timeout as a
+                # failure for this target and keep auditing the rest, so a
+                # timeout can never silently skip coverage of later targets.
                 all_success = False
-                output_chunks.append(f"pip-audit timed out after {timeout}s")
-                break
+                output_chunks.append(
+                    f"pip-audit timed out after {timeout}s for {source}",
+                )
+                continue
 
             # pip-audit writes its JSON report to stdout; parse stdout only so a
             # stderr warning cannot corrupt parsing (see #1043).

--- a/tests/unit/tools/pip_audit/test_pip_audit_plugin.py
+++ b/tests/unit/tools/pip_audit/test_pip_audit_plugin.py
@@ -542,3 +542,54 @@ def test_check_timeout_preserves_earlier_findings(
     assert_that(result.success).is_false()
     assert_that(result.issues_count).is_equal_to(1)
     assert_that(result.output).contains("timed out")
+
+
+def test_check_timeout_continues_to_remaining_targets(
+    pip_audit_plugin: PipAuditPlugin,
+    tmp_path: Path,
+) -> None:
+    """An early target timing out must not skip auditing later targets.
+
+    Args:
+        pip_audit_plugin: The plugin instance.
+        tmp_path: Temporary directory path.
+    """
+    first = tmp_path / "a"
+    first.mkdir()
+    (first / "requirements.txt").write_text("packaging==25.0\n")
+    second = tmp_path / "b"
+    second.mkdir()
+    (second / "requirements.txt").write_text("jinja2==2.4.1\n")
+
+    calls: list[SubprocessResult | TimeoutExpired] = [
+        TimeoutExpired(cmd=["pip-audit"], timeout=120),
+        _proc(success=False, stdout=_VULN_OUTPUT),
+    ]
+
+    def _side_effect(cmd: list[str], **kwargs: object) -> SubprocessResult:
+        result = calls.pop(0)
+        if isinstance(result, TimeoutExpired):
+            raise result
+        return result
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            pip_audit_plugin,
+            "_run_subprocess_result",
+            side_effect=_side_effect,
+        ):
+            result = pip_audit_plugin.check(
+                [
+                    str(first / "requirements.txt"),
+                    str(second / "requirements.txt"),
+                ],
+                {},
+            )
+
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_equal_to(1)
+    assert_that(result.output).contains("timed out")
+    assert_that(result.output).contains(str(first / "requirements.txt"))


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [x] fix / perf (patch)

## What's Changing

In the pip-audit check loop, a `subprocess.TimeoutExpired` on one target used `break`, so every remaining requirements file / project manifest was silently never audited — a coverage gap for a security scanner (greptile P1 raised on #1145, which merged before the thread was addressed).

- Replace the `break` with per-target aggregation: record the timeout (now naming the timed-out target's source), mark the scan unsuccessful, and `continue` to the next target — mirroring the multi-module timeout handling adopted for golangci-lint on #1148.
- Add regression test `test_check_timeout_continues_to_remaining_targets`: first target times out, second target's vulnerability must still be reported and the timed-out source must be named in the output.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing (behavioral fix, no doc surface)
- [x] Local CI passed (full pytest suite: 6726 passed, 10 skipped)

## Closes

- Closes #1502
- Relates to #1145

## Details

The existing `test_check_timeout_preserves_earlier_findings` covers the mirror case (later target times out); together they pin both directions of the aggregation. The two initially failing integration tests in the fresh worktree (markdownlint parity, commitlint) were missing-`node_modules` artifacts; both pass after `bun install`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a coverage gap in the pip-audit check loop: a `subprocess.TimeoutExpired` on any single target previously broke out of the loop entirely, silently skipping all remaining requirements files or project manifests. The fix replaces `break` with `continue` so every target is audited independently, and extends the timeout message to name the specific timed-out source.

- The production change is a two-line delta in `pip_audit.py`: `break` → `continue` and the timeout message gains `for {source}` for traceability.
- A new regression test pins the forward direction (early timeout does not skip later targets); together with the existing `test_check_timeout_preserves_earlier_findings` test, both orderings are now covered.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-line surgical fix in a well-isolated exception handler, and the new test directly exercises the corrected path.

The `break` → `continue` swap is exactly scoped to the timeout case. All other aggregation paths (issues list, all_success flag, output_chunks) are untouched. The new test confirms that a timed-out first target does not prevent the second target's vulnerability from being reported, and the timed-out source name appears in the output. The pre-existing `test_check_timeout_preserves_earlier_findings` test continues to cover the reverse ordering, so both directions of multi-target timeout behaviour are pinned.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/definitions/pip_audit.py | Replaces `break` with `continue` in the TimeoutExpired handler and adds the timed-out source to the message; all surrounding aggregation logic is unchanged. |
| tests/unit/tools/pip_audit/test_pip_audit_plugin.py | Adds `test_check_timeout_continues_to_remaining_targets` which mocks the first target as timing out and the second as returning a vulnerability, asserting both the timed-out source name and the downstream issue are reported. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[check called with N targets] --> B[for target in targets]
    B --> C[run pip-audit subprocess]
    C -->|success| D[parse JSON output]
    C -->|TimeoutExpired - OLD| E_OLD[break — remaining targets skipped]
    C -->|TimeoutExpired - NEW| E_NEW[record timeout message with source\nall_success = False\ncontinue to next target]
    D --> F[extend issues list]
    F --> G{more targets?}
    E_NEW --> G
    G -->|yes| B
    G -->|no| H[build ToolResult with all issues]
    E_OLD -.->|silent gap| SKIP[remaining targets never audited]

    style E_OLD fill:#f88,stroke:#c00
    style SKIP fill:#f88,stroke:#c00
    style E_NEW fill:#8d8,stroke:#060
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[check called with N targets] --> B[for target in targets]
    B --> C[run pip-audit subprocess]
    C -->|success| D[parse JSON output]
    C -->|TimeoutExpired - OLD| E_OLD[break — remaining targets skipped]
    C -->|TimeoutExpired - NEW| E_NEW[record timeout message with source\nall_success = False\ncontinue to next target]
    D --> F[extend issues list]
    F --> G{more targets?}
    E_NEW --> G
    G -->|yes| B
    G -->|no| H[build ToolResult with all issues]
    E_OLD -.->|silent gap| SKIP[remaining targets never audited]

    style E_OLD fill:#f88,stroke:#c00
    style SKIP fill:#f88,stroke:#c00
    style E_NEW fill:#8d8,stroke:#060
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pip-audit): continue auditing remain..."](https://github.com/lgtm-hq/py-lintro/commit/c18d42b49905d48a3f8c39469f3adf486b503f0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45319857)</sub>

<!-- /greptile_comment -->