### PR TITLE
fix(ci): retry setup-uv in binary builds and disable matrix fail-fast

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -62,6 +62,7 @@ jobs:
     permissions:
       contents: write
     strategy:
+      fail-fast: false
       matrix:
         arch: >-
           ${{
@@ -101,6 +102,17 @@ jobs:
           python-version: '3.14'
 
       - name: Install uv
+        id: setup-uv
+        continue-on-error: true
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: 'latest'
+
+      # First connections after the harden-runner network extension activates
+      # can stall past setup-uv's manifest-fetch timeout (macOS especially);
+      # one retry runs on a warm network path. See #1513.
+      - name: Install uv (retry)
+        if: steps.setup-uv.outcome == 'failure'
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: 'latest'
@@ -171,6 +183,7 @@ jobs:
     permissions:
       contents: write
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: x64
@@ -209,6 +222,17 @@ jobs:
           python-version: '3.14'
 
       - name: Install uv
+        id: setup-uv
+        continue-on-error: true
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: 'latest'
+
+      # First connections after the harden-runner network extension activates
+      # can stall past setup-uv's manifest-fetch timeout (macOS especially);
+      # one retry runs on a warm network path. See #1513.
+      - name: Install uv (retry)
+        if: steps.setup-uv.outcome == 'failure'
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: 'latest'

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -228,8 +228,8 @@ jobs:
         with:
           version: 'latest'
 
-      # First connections after the harden-runner network extension activates
-      # can stall past setup-uv's manifest-fetch timeout (macOS especially);
+      # First connections after harden-runner's egress filtering activates
+      # can stall past setup-uv's manifest-fetch timeout;
       # one retry runs on a warm network path. See #1513.
       - name: Install uv (retry)
         if: steps.setup-uv.outcome == 'failure'


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [x] fix / perf (patch)

## What's Changing

Every recent release's first attempt died in `Build macOS Binary (arm64)` at **Install uv** (v0.80.5, v0.80.9 ×2, v0.80.11), shipping only after manual reruns. Diagnosis from the harden-runner agent log: the macOS network extension finishes activating seconds before `setup-uv` fetches its version manifest from `raw.githubusercontent.com`; the first TLS connection through the fresh content filter stalls ~4s, losing the race against setup-uv's ~5s fetch timeout ("The operation was aborted due to timeout"). Reruns pass because the extension is warm by then.

- Add a YAML-only retry for Install uv in both build jobs: first attempt `continue-on-error` with an id, identical second attempt gated on `outcome == 'failure'` — the retry runs on a warm network path.
- `fail-fast: false` on both build matrices so one arch's transient failure no longer cancels the sibling legs (reruns then only rebuild what actually failed).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (workflow-only change; no unit-test surface)
- [ ] Docs updated if user-facing (not user-facing)
- [x] Local CI passed (lintro chk 100/100 incl. actionlint on the workflow)

## Closes

- Closes #1513

## Details

Same pinned SHA reused for the retry step. Applied to both macOS and Linux build jobs — Linux x64 also failed on v0.80.11 (runner shutdown mid-Nuitka-compile, genuine infra), which fail-fast turned into a full-matrix cancellation; with fail-fast off such failures stay contained to one leg.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS and Linux binary build reliability by adding a retry for tool installation when network stalls occur.
  * Updated build jobs to continue independently if one platform’s build fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR addresses recurring transient failures in binary builds caused by `setup-uv` timing out while fetching its manifest during harden-runner network extension activation. It adds a YAML-only retry pattern and disables matrix `fail-fast` on both build jobs.

- Adds `continue-on-error: true` + `id: setup-uv` to the first `Install uv` step in both `build-macos` and `build-linux`, with an identical retry step gated on `steps.setup-uv.outcome == 'failure'` — the idiomatic GitHub Actions single-retry pattern, correctly using `outcome` (not `conclusion`) to detect the actual failure.
- Adds `fail-fast: false` to both matrix strategies so a transient failure in one architecture leg no longer cancels sibling legs, and only the actually-failed leg needs a re-run.
</details>


<h3>Confidence Score: 5/5</h3>

The workflow change is safe to merge — it adds resilience against a documented transient infra failure without altering any build logic.

The retry pattern correctly uses `outcome` (not `conclusion`) to detect actual failure under `continue-on-error: true`, the retry step itself has no `continue-on-error` so a double failure still fails the job, and `fail-fast: false` is scoped precisely to the two build matrices. No build steps, scripts, or downstream jobs are affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-binary.yml | Adds fail-fast: false and a single-retry pattern for setup-uv in both build-macos and build-linux jobs; retry logic uses correct outcome == 'failure' idiom and Linux job comment is properly worded without the macOS-specific framing. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Install uv\ncontinue-on-error: true\nid: setup-uv] --> B{outcome == 'failure'?}
    B -- No --> D[Install dependencies\nuv sync ...]
    B -- Yes --> C[Install uv retry\nno continue-on-error]
    C -- success --> D
    C -- failure --> E[Job fails]
    D --> F[Build binary]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Install uv\ncontinue-on-error: true\nid: setup-uv] --> B{outcome == 'failure'?}
    B -- No --> D[Install dependencies\nuv sync ...]
    B -- Yes --> C[Install uv retry\nno continue-on-error]
    C -- success --> D
    C -- failure --> E[Job fails]
    D --> F[Build binary]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/build-binary.yml`, line 224-246 ([link](https://github.com/lgtm-hq/py-lintro/blob/db8304658ced01a813e5a1034d3fe0014fb1c700/.github/workflows/build-binary.yml#L224-L246)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The comment was copied from the macOS job. Consider softening the platform-specific wording so it reads accurately inside the Linux job context.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fbuild-binary.yml%0ALine%3A%20224-246%0A%0AComment%3A%0AThe%20comment%20was%20copied%20from%20the%20macOS%20job.%20Consider%20softening%20the%20platform-specific%20wording%20so%20it%20reads%20accurately%20inside%20the%20Linux%20job%20context.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Install%20uv%0A%20%20%20%20%20%20%20%20id%3A%20setup-uv%0A%20%20%20%20%20%20%20%20continue-on-error%3A%20true%0A%20%20%20%20%20%20%20%20uses%3A%20astral-sh%2Fsetup-uv%4011f9893b081a58869d3b5fccaea48c9e9e46f990%20%23%20v8.3.2%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20version%3A%20'latest'%0A%0A%20%20%20%20%20%20%23%20First%20connections%20after%20the%20harden-runner%20network%20extension%20activates%0A%20%20%20%20%20%20%23%20can%20stall%20past%20setup-uv's%20manifest-fetch%20timeout%3B%0A%20%20%20%20%20%20%23%20one%20retry%20runs%20on%20a%20warm%20network%20path.%20See%20%231513.%0A%20%20%20%20%20%20-%20name%3A%20Install%20uv%20%28retry%29%0A%20%20%20%20%20%20%20%20if%3A%20steps.setup-uv.outcome%20%3D%3D%20'failure'%0A%20%20%20%20%20%20%20%20uses%3A%20astral-sh%2Fsetup-uv%4011f9893b081a58869d3b5fccaea48c9e9e46f990%20%23%20v8.3.2%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20version%3A%20'latest'%0A%0A%20%20%20%20%20%20-%20name%3A%20Install%20dependencies%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20uv%20sync%20--group%20build%20--group%20dev%0A%0A%20%20%20%20%20%20-%20name%3A%20Build%20binary%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20HOST_ARCH%3D%22%24%7B%7B%20matrix.arch%20%3D%3D%20'x64'%20%26%26%20'x86_64'%20%7C%7C%20'arm64'%20%7D%7D%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=1514&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fbuild-binary.yml%0ALine%3A%20224-246%0A%0AComment%3A%0AThe%20comment%20was%20copied%20from%20the%20macOS%20job.%20Consider%20softening%20the%20platform-specific%20wording%20so%20it%20reads%20accurately%20inside%20the%20Linux%20job%20context.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Install%20uv%0A%20%20%20%20%20%20%20%20id%3A%20setup-uv%0A%20%20%20%20%20%20%20%20continue-on-error%3A%20true%0A%20%20%20%20%20%20%20%20uses%3A%20astral-sh%2Fsetup-uv%4011f9893b081a58869d3b5fccaea48c9e9e46f990%20%23%20v8.3.2%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20version%3A%20'latest'%0A%0A%20%20%20%20%20%20%23%20First%20connections%20after%20the%20harden-runner%20network%20extension%20activates%0A%20%20%20%20%20%20%23%20can%20stall%20past%20setup-uv's%20manifest-fetch%20timeout%3B%0A%20%20%20%20%20%20%23%20one%20retry%20runs%20on%20a%20warm%20network%20path.%20See%20%231513.%0A%20%20%20%20%20%20-%20name%3A%20Install%20uv%20%28retry%29%0A%20%20%20%20%20%20%20%20if%3A%20steps.setup-uv.outcome%20%3D%3D%20'failure'%0A%20%20%20%20%20%20%20%20uses%3A%20astral-sh%2Fsetup-uv%4011f9893b081a58869d3b5fccaea48c9e9e46f990%20%23%20v8.3.2%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20version%3A%20'latest'%0A%0A%20%20%20%20%20%20-%20name%3A%20Install%20dependencies%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20uv%20sync%20--group%20build%20--group%20dev%0A%0A%20%20%20%20%20%20-%20name%3A%20Build%20binary%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20HOST_ARCH%3D%22%24%7B%7B%20matrix.arch%20%3D%3D%20'x64'%20%26%26%20'x86_64'%20%7C%7C%20'arm64'%20%7D%7D%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fpy-lintro&pr=1514&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F1513-setup-uv-retry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1513-setup-uv-retry%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fbuild-binary.yml%0ALine%3A%20224-246%0A%0AComment%3A%0AThe%20comment%20was%20copied%20from%20the%20macOS%20job.%20Consider%20softening%20the%20platform-specific%20wording%20so%20it%20reads%20accurately%20inside%20the%20Linux%20job%20context.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Install%20uv%0A%20%20%20%20%20%20%20%20id%3A%20setup-uv%0A%20%20%20%20%20%20%20%20continue-on-error%3A%20true%0A%20%20%20%20%20%20%20%20uses%3A%20astral-sh%2Fsetup-uv%4011f9893b081a58869d3b5fccaea48c9e9e46f990%20%23%20v8.3.2%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20version%3A%20'latest'%0A%0A%20%20%20%20%20%20%23%20First%20connections%20after%20the%20harden-runner%20network%20extension%20activates%0A%20%20%20%20%20%20%23%20can%20stall%20past%20setup-uv's%20manifest-fetch%20timeout%3B%0A%20%20%20%20%20%20%23%20one%20retry%20runs%20on%20a%20warm%20network%20path.%20See%20%231513.%0A%20%20%20%20%20%20-%20name%3A%20Install%20uv%20%28retry%29%0A%20%20%20%20%20%20%20%20if%3A%20steps.setup-uv.outcome%20%3D%3D%20'failure'%0A%20%20%20%20%20%20%20%20uses%3A%20astral-sh%2Fsetup-uv%4011f9893b081a58869d3b5fccaea48c9e9e46f990%20%23%20v8.3.2%0A%20%20%20%20%20%20%20%20with%3A%0A%20%20%20%20%20%20%20%20%20%20version%3A%20'latest'%0A%0A%20%20%20%20%20%20-%20name%3A%20Install%20dependencies%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20uv%20sync%20--group%20build%20--group%20dev%0A%0A%20%20%20%20%20%20-%20name%3A%20Build%20binary%0A%20%20%20%20%20%20%20%20run%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20HOST_ARCH%3D%22%24%7B%7B%20matrix.arch%20%3D%3D%20'x64'%20%26%26%20'x86_64'%20%7C%7C%20'arm64'%20%7D%7D%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fpy-lintro&pr=1514&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["docs(ci): drop macOS framing from Linux ..."](https://github.com/lgtm-hq/py-lintro/commit/01f7e60cb26ebf2e61c956616bdbdd9bfc32bf63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45322956)</sub>

<!-- /greptile_comment -->