### PR TITLE
feat(commitlint): add root commitlint.config.js extending config-conventional

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -756,6 +756,7 @@ _PIPELINE_RELEVANT_TOP_LEVEL: frozenset[str] = frozenset(
         "apps",
         "benchmarks",
         "bun.lock",
+        "commitlint.config.js",
         "docker",
         "docker-compose.yml",
         "Dockerfile",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(commitlint): add root commitlint.config.js extending config-conventional
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Adds `commitlint.config.js` at the repository root, extending
`@commitlint/config-conventional`. Both packages are already pinned in
`package.json`, so no new dependencies are introduced.

Without this file, the CommitlintPlugin self-skips. With it present, the
plugin validates the latest commit message against Conventional Commits.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1493

## Details

Single-file addition:

```js
module.exports = { extends: ['@commitlint/config-conventional'] };
```
