### PR TITLE
refactor(idiom-review): remove dead DEFAULT_ENABLED ClassVar

### DIFF
--- a/lintro/tools/definitions/idiom_review.py
+++ b/lintro/tools/definitions/idiom_review.py
@@ -9,8 +9,9 @@ detected by a syntax-matching linter. Two modes are offered:
 * **duplication** (Mode 2) — flag the same utility logic reimplemented
   across files, invisible to any per-file linter.
 
-The tool ships disabled by default (``DEFAULT_ENABLED = False``): it is a
-no-op unless the user opts in via ``tools.idiom-review`` config or
+The tool ships disabled by default via the ``enabled: False`` option in
+``default_options``: ``check()`` returns a skipped result immediately unless
+the caller opts in via ``tools.idiom-review`` config or
 ``--tool-options idiom-review:enabled=true``. When no AI provider is
 available (missing SDK, key, or credits) it degrades gracefully to a
 skipped result rather than failing the run.
@@ -19,7 +20,7 @@ skipped result rather than failing the run.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar, cast
+from typing import cast
 
 from loguru import logger
 
@@ -69,9 +70,6 @@ def _confidence_rank(value: str) -> int:
 @dataclass
 class IdiomReviewPlugin(BaseToolPlugin):
     """AI idiom-review plugin (idiomatic-miss + cross-file duplication)."""
-
-    #: Ships disabled: only runs when explicitly opted in.
-    DEFAULT_ENABLED: ClassVar[bool] = False
 
     @property
     def definition(self) -> ToolDefinition:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(idiom-review): remove dead DEFAULT_ENABLED ClassVar
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`IdiomReviewPlugin` carried a `DEFAULT_ENABLED: ClassVar[bool] = False`
that was never read by the framework. The real opt-in gate is the
`enabled: False` entry in `default_options`, enforced in `check()`.

- Remove dead ClassVar and unused `ClassVar` import
- Rewrite module docstring to describe the real opt-in gate

Behavior unchanged.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1494

## Details

_See What’s Changing._
