### PR TITLE
fix(manifest): drop formatter tag from dotenv-linter entry

### DIFF
--- a/lintro/tools/manifest.json
+++ b/lintro/tools/manifest.json
@@ -173,7 +173,7 @@
       "category": "external",
       "version_command": ["dotenv-linter", "--version"],
       "languages": ["dotenv"],
-      "tags": ["linter", "formatter"]
+      "tags": ["linter"]
     },
     {
       "name": "gitleaks",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(manifest): drop formatter tag from dotenv-linter entry
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`DotenvLinterPlugin` declares `tool_type=ToolType.LINTER`, but the
manifest listed `"tags": ["linter", "formatter"]`. Drop `"formatter"` so
manifest tags match `ToolType.LINTER`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1495

## Details

_See What’s Changing._
