### PR TITLE
feat(vale): add repo-root .vale.ini for prose linting

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,11 @@
+# Repo-root Vale configuration (issue #1492).
+# Uses only Vale's built-in style — no vale sync or network access needed.
+#
+# MinAlertLevel = error: warning- and suggestion-level rules are skipped to
+# avoid false positives on technical terms, tool names (ruff, mypy, pydoclint,
+# etc.), CLI command snippets, and code blocks throughout the docs.
+# Vale.Repetition (error) still catches repeated-word mistakes.
+MinAlertLevel = error
+
+[*.md]
+BasedOnStyles = Vale

--- a/.vale.ini
+++ b/.vale.ini
@@ -9,3 +9,9 @@ MinAlertLevel = error
 
 [*.md]
 BasedOnStyles = Vale
+# Vale.Spelling is an error-level rule in the built-in style, so MinAlertLevel
+# alone does not filter it. Disable it explicitly: the docs are full of tool
+# names, CLI snippets, and technical jargon that a dictionary-free spell check
+# reports as thousands of false positives. Repetition and the other error-level
+# Vale rules still run.
+Vale.Spelling = NO

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -752,6 +752,7 @@ _PIPELINE_RELEVANT_TOP_LEVEL: frozenset[str] = frozenset(
         ".pre-commit-hooks.yaml",
         ".prettierignore",
         ".prettierrc.json",
+        ".vale.ini",
         ".yamllint",
         "apps",
         "benchmarks",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(vale): add repo-root .vale.ini for prose linting
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Adds a repo-root `.vale.ini` using only the built-in Vale style (no
`vale sync` / network — dogfood jobs run with egress blocked). Uses
`MinAlertLevel = error` so warning/suggestion spelling noise on technical
terms does not fail CI, while `Vale.Repetition` still catches repeated words.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1492

## Details

_See What’s Changing._
