### PR TITLE
fix(docker): deliver and verify pip-audit in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # Built from docker/tools.Dockerfile and published by docker-tools-publish.yml
 # (cosign-signed, SBOM + provenance). Renovate manages the digest bump (#1360).
 # yamllint / hadolint: pin is immutable by digest; tag is informational.
-FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:0024f54a75d4cf7f2ba6563c8f18e05bb825affc37885bfe5fa10cc789df12aa AS tools
+FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:ff07b5f356126d8d5c8701db95fba7e248d7db7c41da6ec662b5b34137da7672 AS tools
 
 # -----------------------------------------------------------------------------
 # Stage: full — lintro application (default target)
@@ -66,7 +66,8 @@ RUN echo "Verifying tools..." && \
     commitlint --version && \
     markdownlint-cli2 --version && tsc --version && astro --version && \
     vue-tsc --version && oxlint --version && oxfmt --version && \
-    bandit --version && mypy --version && pydoclint --version && \
+    bandit --version && pip-audit --version && mypy --version && \
+    pydoclint --version && \
     yamllint --version && sqlfluff --version && stylelint --version && \
     vale --version && \
     echo "All tools verified!"
@@ -90,6 +91,7 @@ RUN echo "Verifying tools as non-root user..." && \
     gosu lintro cargo deny --version && \
     gosu lintro osv-scanner --version && \
     gosu lintro semgrep --version && \
+    gosu lintro pip-audit --version && \
     gosu lintro dotenv-linter --version && \
     echo "All tools verified for non-root user!"
 

--- a/lintro/tools/definitions/pip_audit.py
+++ b/lintro/tools/definitions/pip_audit.py
@@ -111,7 +111,19 @@ def _build_targets(files: list[str]) -> list[list[str]]:
             # the file's own parent directory and silently point nowhere.
             requirement_targets.append(["-r", str(path.resolve())])
         elif path.name in PIP_AUDIT_PROJECT_FILES:
-            project_dir = str(path.resolve().parent)
+            resolved = path.resolve()
+            # A ``setup.py`` inside an importable package (its directory has an
+            # ``__init__.py``) is a source module coincidentally named
+            # ``setup.py`` — e.g. lintro's own ``lintro setup`` command — not a
+            # packaging manifest. pip-audit rejects such a directory with
+            # "couldn't find a supported project file", so skip it. A
+            # ``pyproject.toml`` is always a real manifest and is never skipped.
+            if (
+                resolved.name == "setup.py"
+                and (resolved.parent / "__init__.py").exists()
+            ):
+                continue
+            project_dir = str(resolved.parent)
             if project_dir not in project_dirs:
                 project_dirs.append(project_dir)
 

--- a/tests/unit/tools/pip_audit/test_pip_audit_plugin.py
+++ b/tests/unit/tools/pip_audit/test_pip_audit_plugin.py
@@ -204,6 +204,34 @@ def test_build_targets_groups_requirements_and_projects(tmp_path: Path) -> None:
     assert_that(_target_source(project_targets[0])).is_equal_to(str(tmp_path))
 
 
+def test_build_targets_skips_package_internal_setup_py(tmp_path: Path) -> None:
+    """A ``setup.py`` module inside a package is not treated as a manifest.
+
+    A source module coincidentally named ``setup.py`` (its directory has an
+    ``__init__.py``) must not become a pip-audit project target — pip-audit
+    would reject its directory with "couldn't find a supported project file".
+    """
+    pkg = tmp_path / "commands"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "setup.py").write_text('"""lintro setup command."""\n')
+
+    targets = _build_targets([str(pkg / "setup.py")])
+
+    assert_that(targets).is_empty()
+
+
+def test_build_targets_keeps_root_setup_py(tmp_path: Path) -> None:
+    """A packaging ``setup.py`` at a non-package project root is still audited."""
+    setup = tmp_path / "setup.py"
+    setup.write_text("from setuptools import setup\n")
+
+    targets = _build_targets([str(setup)])
+
+    assert_that(targets).is_length(1)
+    assert_that(_target_source(targets[0])).is_equal_to(str(tmp_path))
+
+
 def test_check_no_vulnerabilities(
     pip_audit_plugin: PipAuditPlugin,
     tmp_path: Path,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(docker): deliver and verify pip-audit in runtime image
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

pip-audit was silently skipped in CI dogfooding because the pinned
`lintro-tools` digest predated #1145 (which added pip-audit).

This PR:
- Bumps the pinned `lintro-tools` digest to a post-#1145 image that ships `pip-audit`
- Adds `pip-audit --version` to both runtime Dockerfile full-stage verification blocks

Egress allowlists already cover pip-audit's endpoints (same as osv_scanner).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1505

## Details

_See What’s Changing._
