### PR TITLE
feat(pip_audit): close parity gaps with osv_scanner

### DIFF
--- a/apps/site/src/data/services.ts
+++ b/apps/site/src/data/services.ts
@@ -80,4 +80,10 @@ export const services = {
     url: 'https://google.github.io/osv-scanner/',
     description: 'Vulnerability scanning',
   },
+  pipAudit: {
+    id: 'pip-audit',
+    name: 'pip-audit',
+    url: 'https://github.com/pypa/pip-audit',
+    description: 'Python dependency vulnerability scanning',
+  },
 } as const satisfies Record<string, ServiceLink>;

--- a/apps/site/src/data/sidebar-nav.ts
+++ b/apps/site/src/data/sidebar-nav.ts
@@ -62,6 +62,7 @@ export const NAV_GROUP_BY_ID: Partial<Record<string, string>> = {
   'tools/actionlint': 'ci-ops',
   'tools/hadolint': 'ci-ops',
   'tools/osv-scanner': 'security',
+  'tools/pip-audit': 'security',
   'architecture/architecture': 'design',
   'architecture/vision': 'design',
   'architecture/roadmap': 'design',

--- a/lintro/utils/config_constants.py
+++ b/lintro/utils/config_constants.py
@@ -102,5 +102,6 @@ DEFAULT_TOOL_PRIORITIES: dict[str, int] = {
     ToolName.MYPY: 82,
     ToolName.TSC: 82,
     ToolName.OSV_SCANNER: 90,
+    ToolName.PIP_AUDIT: 90,
     ToolName.PYTEST: 100,
 }

--- a/scripts/ci/site/migrate-docs-content.py
+++ b/scripts/ci/site/migrate-docs-content.py
@@ -82,6 +82,7 @@ DOC_NAV: dict[str, tuple[str, str | None]] = {
     "tools/mypy": ("mypy", "python"),
     "tools/osv-scanner": ("osv-scanner", "security"),
     "tools/oxc": ("oxc", "js-ts"),
+    "tools/pip-audit": ("pip-audit", "security"),
     "tools/prettier": ("prettier", "js-ts"),
     "tools/pydoclint": ("pydoclint", "python"),
     "tools/pytest": ("pytest", "python"),

--- a/test_samples/tools/security/pip_audit/pip_audit_violations.txt
+++ b/test_samples/tools/security/pip_audit/pip_audit_violations.txt
@@ -1,6 +1,10 @@
 # Sample requirements file pinning packages with known vulnerabilities.
 # Used for manual testing and integration checks (requires network access to
 # the PyPI Advisory Database / OSV).
+# Versions are pinned to releases that both ship wheels (so pip-audit can
+# resolve them without building from source on modern Python) and carry known
+# advisories, so `pip-audit --strict` reports vulnerabilities instead of
+# failing to build.
 # See: lintro check test_samples/ --tools pip_audit
-jinja2==2.4.1
+jinja2==2.11.2
 requests==2.19.0

--- a/tests/integration/tools/pip_audit/__init__.py
+++ b/tests/integration/tools/pip_audit/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for pip_audit tool."""

--- a/tests/integration/tools/pip_audit/conftest.py
+++ b/tests/integration/tools/pip_audit/conftest.py
@@ -1,0 +1,67 @@
+"""Pytest configuration for pip_audit integration tests."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+def _find_project_root() -> Path:
+    """Find project root by looking for pyproject.toml.
+
+    Returns:
+        Path to the project root directory.
+
+    Raises:
+        RuntimeError: If pyproject.toml is not found in any parent directory.
+    """
+    path = Path(__file__).resolve()
+    for parent in path.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError("pyproject.toml not found in parent directories")
+
+
+# Paths to test samples
+SAMPLE_DIR = _find_project_root() / "test_samples"
+PIP_AUDIT_SAMPLES = SAMPLE_DIR / "tools" / "security" / "pip_audit"
+VIOLATION_SAMPLE = PIP_AUDIT_SAMPLES / "pip_audit_violations.txt"
+CLEAN_SAMPLE = PIP_AUDIT_SAMPLES / "pip_audit_clean.txt"
+
+
+@pytest.fixture
+def pip_audit_violation_file(tmp_path: Path) -> str:
+    """Copy the pip-audit violation sample to a temp directory.
+
+    The destination is named ``requirements.txt`` so pip-audit's
+    ``requirements*.txt`` discovery recognises it as a lockfile.
+
+    Args:
+        tmp_path: Pytest fixture providing a temporary directory.
+
+    Returns:
+        Path to the copied file as a string.
+    """
+    dst = tmp_path / "requirements.txt"
+    shutil.copy(VIOLATION_SAMPLE, dst)
+    return str(dst)
+
+
+@pytest.fixture
+def pip_audit_clean_file(tmp_path: Path) -> str:
+    """Copy the pip-audit clean sample to a temp directory.
+
+    The destination is named ``requirements.txt`` so pip-audit's
+    ``requirements*.txt`` discovery recognises it as a lockfile.
+
+    Args:
+        tmp_path: Pytest fixture providing a temporary directory.
+
+    Returns:
+        Path to the copied file as a string.
+    """
+    dst = tmp_path / "requirements.txt"
+    shutil.copy(CLEAN_SAMPLE, dst)
+    return str(dst)

--- a/tests/integration/tools/pip_audit/test_check.py
+++ b/tests/integration/tools/pip_audit/test_check.py
@@ -1,0 +1,87 @@
+"""Integration tests for PipAuditPlugin check command.
+
+pip-audit queries the PyPI Advisory Database / OSV over the network, so these
+tests require both the ``pip-audit`` binary and network access. They are
+skipped when the binary is absent.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from assertpy import assert_that
+
+if TYPE_CHECKING:
+    from lintro.plugins.base import BaseToolPlugin
+
+# Skip all tests if pip-audit is not installed
+pytestmark = pytest.mark.skipif(
+    shutil.which("pip-audit") is None,
+    reason="pip-audit not installed",
+)
+
+
+def test_check_file_with_vulnerabilities(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    pip_audit_violation_file: str,
+) -> None:
+    """Verify pip-audit detects vulnerabilities in known-vulnerable packages.
+
+    Uses the pip_audit_violations.txt fixture which pins packages with
+    historically known vulnerabilities (jinja2==2.11.2, requests==2.19.0).
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        pip_audit_violation_file: Path to vulnerable lockfile from test_samples.
+    """
+    plugin = get_plugin("pip_audit")
+    result = plugin.check([pip_audit_violation_file], {})
+
+    assert_that(result).is_not_none()
+    assert_that(result.name).is_equal_to("pip_audit")
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_greater_than(0)
+
+
+def test_check_clean_file(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    pip_audit_clean_file: str,
+) -> None:
+    """Verify pip-audit passes on a lockfile with no known vulnerabilities.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        pip_audit_clean_file: Path to clean lockfile from test_samples.
+    """
+    plugin = get_plugin("pip_audit")
+    result = plugin.check([pip_audit_clean_file], {})
+
+    assert_that(result).is_not_none()
+    assert_that(result.name).is_equal_to("pip_audit")
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+
+
+def test_check_empty_directory(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    tmp_path: Path,
+) -> None:
+    """Verify pip-audit check handles empty directories gracefully.
+
+    With no requirements or project files present, pip-audit has nothing to
+    audit and reports a clean, successful result with no vulnerabilities.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        tmp_path: Pytest fixture providing a temporary directory.
+    """
+    plugin = get_plugin("pip_audit")
+    result = plugin.check([str(tmp_path)], {})
+
+    assert_that(result).is_not_none()
+    assert_that(result.name).is_equal_to("pip_audit")
+    assert_that(result.issues_count).is_equal_to(0)

--- a/tests/integration/tools/pip_audit/test_check.py
+++ b/tests/integration/tools/pip_audit/test_check.py
@@ -84,4 +84,5 @@ def test_check_empty_directory(
 
     assert_that(result).is_not_none()
     assert_that(result.name).is_equal_to("pip_audit")
+    assert_that(result.success).is_true()
     assert_that(result.issues_count).is_equal_to(0)

--- a/tests/integration/tools/pip_audit/test_definition.py
+++ b/tests/integration/tools/pip_audit/test_definition.py
@@ -1,0 +1,43 @@
+"""Integration tests for PipAuditPlugin definition."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import pytest
+from assertpy import assert_that
+
+if TYPE_CHECKING:
+    from lintro.plugins.base import BaseToolPlugin
+
+
+@pytest.mark.parametrize(
+    ("attr", "expected"),
+    [
+        ("name", "pip_audit"),
+        ("can_fix", False),
+        ("priority", 90),
+    ],
+    ids=["name", "can_fix", "priority"],
+)
+def test_definition_attributes(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    attr: str,
+    expected: object,
+) -> None:
+    """Verify PipAuditPlugin definition has correct attribute values."""
+    plugin = get_plugin("pip_audit")
+    assert_that(getattr(plugin.definition, attr)).is_equal_to(expected)
+
+
+def test_definition_file_patterns_include_requirements(
+    get_plugin: Callable[[str], BaseToolPlugin],
+) -> None:
+    """Verify PipAuditPlugin discovers requirements and project manifests."""
+    plugin = get_plugin("pip_audit")
+    assert_that(plugin.definition.file_patterns).contains(
+        "requirements*.txt",
+        "pyproject.toml",
+        "setup.py",
+    )

--- a/tests/integration/tools/pip_audit/test_options.py
+++ b/tests/integration/tools/pip_audit/test_options.py
@@ -1,0 +1,51 @@
+"""Integration tests for PipAuditPlugin.set_options method."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import pytest
+from assertpy import assert_that
+
+if TYPE_CHECKING:
+    from lintro.plugins.base import BaseToolPlugin
+
+
+@pytest.mark.parametrize(
+    ("option_name", "option_value", "expected"),
+    [
+        ("timeout", 30, 30),
+        ("timeout", 60, 60),
+        ("timeout", 300, 300),
+    ],
+    ids=["timeout_30", "timeout_60", "timeout_300"],
+)
+def test_set_options_timeout(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    option_name: str,
+    option_value: object,
+    expected: object,
+) -> None:
+    """Verify PipAuditPlugin.set_options correctly sets timeout."""
+    plugin = get_plugin("pip_audit")
+    plugin.set_options(**{option_name: option_value})
+    assert_that(plugin.options.get(option_name)).is_equal_to(expected)
+
+
+def test_invalid_timeout(
+    get_plugin: Callable[[str], BaseToolPlugin],
+) -> None:
+    """Verify PipAuditPlugin.set_options rejects negative timeout values."""
+    plugin = get_plugin("pip_audit")
+    with pytest.raises(ValueError, match="must be non-negative"):
+        plugin.set_options(timeout=-1)
+
+
+def test_invalid_timeout_type(
+    get_plugin: Callable[[str], BaseToolPlugin],
+) -> None:
+    """Verify PipAuditPlugin.set_options rejects non-numeric timeout values."""
+    plugin = get_plugin("pip_audit")
+    with pytest.raises(ValueError, match="must be a number"):
+        plugin.set_options(timeout="fast")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(pip_audit): close parity gaps with osv_scanner
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Closes pip-audit parity gaps vs osv_scanner:

- Add `ToolName.PIP_AUDIT: 90` to `DEFAULT_TOOL_PRIORITIES`
- Add `tests/integration/tools/pip_audit/` mirroring osv_scanner
- Register site nav/services for pip-audit (page generated from existing analysis doc)

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1506

## Details

_See What’s Changing._
