### PR TITLE
feat(oxlint): add type-aware linting support with doctor checks

### DIFF
--- a/docs/tool-analysis/README.md
+++ b/docs/tool-analysis/README.md
@@ -37,7 +37,7 @@ implementations with the core tools themselves.
 **Fast Rust-based JavaScript/TypeScript Linter and Formatter**
 
 - ✅ **Preserved**: Linting, formatting, auto-fix, native config discovery, JSON output
-- ⚠️ **Limited**: Plugin control, stdin piping, type-aware linting
+- ⚠️ **Limited**: Plugin control, stdin piping
 - 🚀 **Enhanced**: Normalized issues, unified API, much faster than traditional tools
 
 ### [Yamllint Analysis](./yamllint-analysis.md)

--- a/docs/tool-analysis/oxc-analysis.md
+++ b/docs/tool-analysis/oxc-analysis.md
@@ -41,6 +41,8 @@ This analysis compares Lintro's wrapper implementations with the core tools.
 - `verbose_fix_output`: Include raw output in fix results
 - `config`: Path to Oxlint config file (--config)
 - `tsconfig`: Path to tsconfig.json for TypeScript support (--tsconfig)
+- `type_aware`: Enable type-aware linting (--type-aware); see
+  [Type-aware linting](#type-aware-linting-oxlint)
 - `allow`: Rules to allow/turn off (--allow)
 - `deny`: Rules to deny/report as errors (--deny)
 - `warn`: Rules to warn on (--warn)
@@ -78,6 +80,67 @@ oxlint_plugin.set_options(quiet=True, exclude_patterns=["node_modules"])
 | **jsx-a11y**            | Accessibility rules for JSX   |
 | **unicorn**             | Various helpful rules         |
 | **import**              | Import/export validation      |
+
+### Type-aware linting (Oxlint)
+
+Oxlint supports **type-aware** linting via `--type-aware`. Lintro exposes this as
+the boolean `type_aware` option, which appends `--type-aware` to the underlying
+command:
+
+```python
+oxlint_plugin = get_plugin("oxlint")
+oxlint_plugin.set_options(type_aware=True)
+result = oxlint_plugin.check(["src/"])
+```
+
+**Requirements:**
+
+- **`oxlint-tsgolint`**: the type-aware companion binary must be resolvable, either
+  from the project's `node_modules` or via `bunx`. Install it with
+  `bun add -d oxlint-tsgolint@latest`.
+- **TypeScript >= 7.0**: type-aware rules rely on the TypeScript-Go (`tsgolint`)
+  toolchain and require TypeScript 7.0 or newer.
+- **No legacy `tsconfig` `baseUrl`**: projects that depend on the legacy
+  `compilerOptions.baseUrl` path resolution are not supported by the type-aware
+  backend; migrate to `paths`/relative imports first.
+
+**Status:** type-aware linting is currently **alpha** in oxlint. Rules that require
+type information live under the `typescript/*` rule namespace.
+
+`lintro doctor` verifies these prerequisites automatically whenever type-aware
+linting is enabled — either through the `type_aware` option or via
+`options.typeAware` in the discovered `.oxlintrc.json`. When `oxlint-tsgolint`
+cannot be resolved it emits the hint `bun add -d oxlint-tsgolint@latest`, and it
+flags TypeScript installs older than 7.0 as incompatible.
+
+Example `.oxlintrc.json` enabling type-aware linting:
+
+```json
+{
+  "options": {
+    "typeAware": true
+  },
+  "rules": {
+    "typescript/no-floating-promises": "error"
+  }
+}
+```
+
+### JavaScript plugins (Oxlint)
+
+Oxlint can load **ESLint v9+ JavaScript plugins** declared in `.oxlintrc.json`.
+These plugins pass through Lintro unchanged: Lintro does not intercept, rewrite, or
+re-declare plugin configuration, so any plugins listed in your `.oxlintrc.json`
+`plugins`/`jsPlugins` arrays are honored exactly as oxlint resolves them. This is a
+documentation-only guarantee — there is no Lintro-specific code path for JS plugins;
+configure them natively:
+
+```json
+{
+  "plugins": ["react", "unicorn"],
+  "jsPlugins": ["eslint-plugin-example"]
+}
+```
 
 ---
 
@@ -297,7 +360,7 @@ invocation in a linting/formatting workflow.
 | `--max-warnings`    | ❌ Not exposed | Use CI exit codes instead                             |
 | `--print-config`    | ❌ Not exposed | Debugging tool, use `oxlint --print-config` directly  |
 | `--threads`         | ❌ Not exposed | Auto-tuned, rarely needs manual control               |
-| `--type-aware`      | ❌ Not exposed | Advanced feature, may add in future                   |
+| `--type-aware`      | ✅ Supported   | Type-aware linting via the `type_aware` option        |
 | `--lsp`             | ❌ Not exposed | LSP mode not applicable to CLI wrapper                |
 | `--watch`           | ❌ Not exposed | Development workflow, not batch processing            |
 | Non-JSON formats    | ❌ Not exposed | Lintro normalizes all output to structured format     |
@@ -384,7 +447,6 @@ oxlint --watch src/
 1. Plugin enable/disable flags at runtime (`--react-perf-plugin`, etc.)
 2. Watch mode integration
 3. Cache control options
-4. Type-aware linting support (`--type-aware`)
 
 ### Oxfmt Enhancements
 

--- a/docs/tool-analysis/oxc-analysis.md
+++ b/docs/tool-analysis/oxc-analysis.md
@@ -83,9 +83,8 @@ oxlint_plugin.set_options(quiet=True, exclude_patterns=["node_modules"])
 
 ### Type-aware linting (Oxlint)
 
-Oxlint supports **type-aware** linting via `--type-aware`. Lintro exposes this as
-the boolean `type_aware` option, which appends `--type-aware` to the underlying
-command:
+Oxlint supports **type-aware** linting via `--type-aware`. Lintro exposes this as the
+boolean `type_aware` option, which appends `--type-aware` to the underlying command:
 
 ```python
 oxlint_plugin = get_plugin("oxlint")
@@ -95,23 +94,23 @@ result = oxlint_plugin.check(["src/"])
 
 **Requirements:**
 
-- **`oxlint-tsgolint`**: the type-aware companion binary must be resolvable, either
-  from the project's `node_modules` or via `bunx`. Install it with
+- **`oxlint-tsgolint`**: the type-aware companion binary must be resolvable, either from
+  the project's `node_modules` or via `bunx`. Install it with
   `bun add -d oxlint-tsgolint@latest`.
 - **TypeScript >= 7.0**: type-aware rules rely on the TypeScript-Go (`tsgolint`)
   toolchain and require TypeScript 7.0 or newer.
 - **No legacy `tsconfig` `baseUrl`**: projects that depend on the legacy
-  `compilerOptions.baseUrl` path resolution are not supported by the type-aware
-  backend; migrate to `paths`/relative imports first.
+  `compilerOptions.baseUrl` path resolution are not supported by the type-aware backend;
+  migrate to `paths`/relative imports first.
 
-**Status:** type-aware linting is currently **alpha** in oxlint. Rules that require
-type information live under the `typescript/*` rule namespace.
+**Status:** type-aware linting is currently **alpha** in oxlint. Rules that require type
+information live under the `typescript/*` rule namespace.
 
-`lintro doctor` verifies these prerequisites automatically whenever type-aware
-linting is enabled — either through the `type_aware` option or via
-`options.typeAware` in the discovered `.oxlintrc.json`. When `oxlint-tsgolint`
-cannot be resolved it emits the hint `bun add -d oxlint-tsgolint@latest`, and it
-flags TypeScript installs older than 7.0 as incompatible.
+`lintro doctor` verifies these prerequisites automatically whenever type-aware linting
+is enabled — either through the `type_aware` option or via `options.typeAware` in the
+discovered `.oxlintrc.json`. When `oxlint-tsgolint` cannot be resolved it emits the hint
+`bun add -d oxlint-tsgolint@latest`, and it flags TypeScript installs older than 7.0 as
+incompatible.
 
 Example `.oxlintrc.json` enabling type-aware linting:
 
@@ -128,9 +127,9 @@ Example `.oxlintrc.json` enabling type-aware linting:
 
 ### JavaScript plugins (Oxlint)
 
-Oxlint can load **ESLint v9+ JavaScript plugins** declared in `.oxlintrc.json`.
-These plugins pass through Lintro unchanged: Lintro does not intercept, rewrite, or
-re-declare plugin configuration, so any plugins listed in your `.oxlintrc.json`
+Oxlint can load **ESLint v9+ JavaScript plugins** declared in `.oxlintrc.json`. These
+plugins pass through Lintro unchanged: Lintro does not intercept, rewrite, or re-declare
+plugin configuration, so any plugins listed in your `.oxlintrc.json`
 `plugins`/`jsPlugins` arrays are honored exactly as oxlint resolves them. This is a
 documentation-only guarantee — there is no Lintro-specific code path for JS plugins;
 configure them natively:

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -846,14 +846,14 @@ def _output_json(
                 },
             )
 
-    for check in oxlint_checks or []:
-        if _oxlint_check_is_failure(check):
+    for oxlint_check in oxlint_checks or []:
+        if _oxlint_check_is_failure(oxlint_check):
             issues.append(
                 {
-                    "tool": check.name,
+                    "tool": oxlint_check.name,
                     "severity": "error",
-                    "message": check.message,
-                    "install_hint": check.hint,
+                    "message": oxlint_check.message,
+                    "install_hint": oxlint_check.hint,
                 },
             )
 

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -29,6 +29,10 @@ from lintro.tools.core.version_parsing import (
     compare_versions,
     extract_version_from_output,
 )
+from lintro.tools.definitions.oxlint_doctor import (
+    OxlintCheckResult,
+    check_oxlint_type_aware,
+)
 from lintro.utils.environment import (
     EnvironmentReport,
     collect_full_environment,
@@ -341,6 +345,48 @@ def _render_ai_checks(console: Console, checks: list[AICheckResult]) -> None:
             console.print(f"         [dim]{check.hint}[/dim]")
 
 
+def _oxlint_check_is_failure(check: OxlintCheckResult) -> bool:
+    return check.status in (
+        ToolStatus.MISSING,
+        ToolStatus.INCOMPATIBLE,
+    )
+
+
+def _render_oxlint_checks(console: Console, checks: list[OxlintCheckResult]) -> None:
+    """Render oxlint type-aware dependency checks.
+
+    Args:
+        console: Rich console for output.
+        checks: Oxlint type-aware check results (empty renders nothing).
+    """
+    if not checks:
+        return
+
+    ok_count = sum(1 for check in checks if check.status == ToolStatus.OK)
+    console.print()
+    header = Text("  Oxlint type-aware ", style="bold")
+    header.append(f"({ok_count}/{len(checks)} OK)", style="dim")
+    console.print(header)
+
+    for check in checks:
+        line = Text("    ")
+        if check.status == ToolStatus.OK:
+            line.append("[OK] ", style="green")
+            line.append(f"{check.name:<30}", style="cyan")
+            line.append(check.message, style="dim")
+        elif check.status in (ToolStatus.MISSING, ToolStatus.INCOMPATIBLE):
+            line.append("[!!] ", style="red bold")
+            line.append(f"{check.name:<30}", style="cyan")
+            line.append(check.message, style="red")
+        else:
+            line.append("[??] ", style="yellow")
+            line.append(f"{check.name:<30}", style="cyan")
+            line.append(check.message, style="dim")
+        console.print(line)
+        if check.hint:
+            console.print(f"         [dim]{check.hint}[/dim]")
+
+
 def _generate_markdown_report(
     env: EnvironmentReport,
     context: RuntimeContext,
@@ -485,6 +531,12 @@ def doctor_command(
     ai_checks = check_ai_configuration(config.ai)
     ai_failure_count = sum(1 for check in ai_checks if _ai_check_is_failure(check))
 
+    oxlint_type_aware = bool(config.get_tool_defaults("oxlint").get("type_aware"))
+    oxlint_checks = check_oxlint_type_aware(option_enabled=oxlint_type_aware)
+    oxlint_failure_count = sum(
+        1 for check in oxlint_checks if _oxlint_check_is_failure(check)
+    )
+
     # Determine which tools to check
     if tools:
         tool_names = [t.strip() for t in tools.split(",") if t.strip()]
@@ -572,6 +624,7 @@ def doctor_command(
             or incompatible_count > 0
             or unknown_count > 0
             or ai_failure_count > 0
+            or oxlint_failure_count > 0
         ):
             sys.exit(1)
         return
@@ -588,6 +641,7 @@ def doctor_command(
             incompatible_count,
             unknown_count,
             ai_checks=ai_checks,
+            oxlint_checks=oxlint_checks,
         )
         if (
             missing_count > 0
@@ -595,6 +649,7 @@ def doctor_command(
             or incompatible_count > 0
             or unknown_count > 0
             or ai_failure_count > 0
+            or oxlint_failure_count > 0
         ):
             sys.exit(1)
         return
@@ -638,6 +693,7 @@ def doctor_command(
         )
 
     _render_ai_checks(display_console, ai_checks)
+    _render_oxlint_checks(display_console, oxlint_checks)
 
     # Summary
     display_console.print()
@@ -697,6 +753,7 @@ def doctor_command(
         or incompatible_count > 0
         or unknown_count > 0
         or ai_failure_count > 0
+        or oxlint_failure_count > 0
     ):
         raise SystemExit(1)
 
@@ -712,6 +769,7 @@ def _output_json(
     unknown_count: int,
     *,
     ai_checks: list[AICheckResult] | None = None,
+    oxlint_checks: list[OxlintCheckResult] | None = None,
 ) -> None:
     """Output doctor results as JSON."""
     disabled_count = sum(
@@ -788,6 +846,27 @@ def _output_json(
                 },
             )
 
+    for check in oxlint_checks or []:
+        if _oxlint_check_is_failure(check):
+            issues.append(
+                {
+                    "tool": check.name,
+                    "severity": "error",
+                    "message": check.message,
+                    "install_hint": check.hint,
+                },
+            )
+
+    oxlint_json = [
+        {
+            "name": check.name,
+            "status": check.status.value,
+            "message": check.message,
+            "hint": check.hint,
+        }
+        for check in (oxlint_checks or [])
+    ]
+
     ai_json = [
         {
             "name": check.name,
@@ -807,6 +886,7 @@ def _output_json(
         "tools": tools_json,
         "issues": issues,
         "ai": ai_json,
+        "oxlint": oxlint_json,
         "summary": {
             "total": (
                 ok_count

--- a/lintro/tools/definitions/oxlint.py
+++ b/lintro/tools/definitions/oxlint.py
@@ -97,6 +97,7 @@ class OxlintPlugin(BaseToolPlugin):
         verbose_fix_output: bool | None = None,
         config: str | None = None,
         tsconfig: str | None = None,
+        type_aware: bool | None = None,
         allow: list[str] | str | None = None,
         deny: list[str] | str | None = None,
         warn: list[str] | str | None = None,
@@ -112,6 +113,8 @@ class OxlintPlugin(BaseToolPlugin):
             verbose_fix_output: If True, include raw Oxlint output in fix().
             config: Path to Oxlint config file (--config).
             tsconfig: Path to tsconfig.json for TypeScript support (--tsconfig).
+            type_aware: If True, enable type-aware linting (--type-aware).
+                Requires ``oxlint-tsgolint`` and TypeScript >= 7.0.
             allow: Rules to allow/turn off (--allow). Can be string or list.
             deny: Rules to deny/report as errors (--deny). Can be string or list.
             warn: Rules to warn on (--warn). Can be string or list.
@@ -123,6 +126,7 @@ class OxlintPlugin(BaseToolPlugin):
         validate_bool(verbose_fix_output, "verbose_fix_output")
         validate_str(config, "config")
         validate_str(tsconfig, "tsconfig")
+        validate_bool(type_aware, "type_aware")
 
         # Normalize rule lists (accept string or list)
         allow_list = normalize_str_or_list(allow, "allow")
@@ -139,6 +143,7 @@ class OxlintPlugin(BaseToolPlugin):
             verbose_fix_output=verbose_fix_output,
             config=config,
             tsconfig=tsconfig,
+            type_aware=type_aware,
             allow=allow_list,
             deny=deny_list,
             warn=warn_list,
@@ -213,6 +218,10 @@ class OxlintPlugin(BaseToolPlugin):
         tsconfig = options.get("tsconfig")
         if tsconfig:
             args.extend(["--tsconfig", str(tsconfig)])
+
+        # Type-aware linting (requires oxlint-tsgolint + TypeScript >= 7.0)
+        if options.get("type_aware"):
+            args.append("--type-aware")
 
         # Rule severity options
         allow_rules = options.get("allow")

--- a/lintro/tools/definitions/oxlint_doctor.py
+++ b/lintro/tools/definitions/oxlint_doctor.py
@@ -122,7 +122,8 @@ def _detect_typescript_version() -> str | None:
             )
             if result.returncode == 0:
                 match = re.search(
-                    r"(\d+\.\d+(?:\.\d+)?)", result.stdout + result.stderr
+                    r"(\d+\.\d+(?:\.\d+)?)",
+                    result.stdout + result.stderr,
                 )
                 if match:
                     return match.group(1)
@@ -210,7 +211,9 @@ def check_oxlint_type_aware(*, option_enabled: bool = False) -> list[OxlintCheck
                     OxlintCheckResult(
                         name="oxlint.type-aware.typescript",
                         status=ToolStatus.OK,
-                        message=f"TypeScript {ts_version} (>= {TYPESCRIPT_MIN_VERSION})",
+                        message=(
+                            f"TypeScript {ts_version} " f"(>= {TYPESCRIPT_MIN_VERSION})"
+                        ),
                     ),
                 )
 

--- a/lintro/tools/definitions/oxlint_doctor.py
+++ b/lintro/tools/definitions/oxlint_doctor.py
@@ -21,7 +21,7 @@ from loguru import logger
 
 from lintro.enums.tool_status import ToolStatus
 from lintro.tools.core.version_parsing import compare_versions
-from lintro.utils.native_parsers import _load_native_tool_config
+from lintro.utils.native_parsers import load_native_tool_config
 
 __all__ = [
     "OxlintCheckResult",
@@ -60,7 +60,7 @@ def oxlintrc_type_aware_enabled() -> bool:
         bool: True if the discovered oxlint native config sets
             ``options.typeAware`` to a truthy value.
     """
-    config = _load_native_tool_config("oxlint")
+    config = load_native_tool_config("oxlint")
     options = config.get("options")
     if isinstance(options, dict):
         return bool(options.get("typeAware"))
@@ -86,6 +86,9 @@ def _resolve_tsgolint() -> str | None:
         return found
 
     if shutil.which("bunx"):
+        # Display-only: this space-joined string documents the bunx fallback
+        # command for doctor output. It must NOT be passed to subprocess as a
+        # single argument; split it (e.g. ``shlex.split``) before use.
         return "bunx oxlint-tsgolint"
 
     return None

--- a/lintro/tools/definitions/oxlint_doctor.py
+++ b/lintro/tools/definitions/oxlint_doctor.py
@@ -1,0 +1,217 @@
+"""Doctor checks for oxlint type-aware linting support.
+
+Type-aware linting (``oxlint --type-aware``) is an alpha feature that requires
+the ``oxlint-tsgolint`` companion binary and a modern TypeScript toolchain
+(``typescript`` >= 7.0). These checks surface actionable diagnostics from
+``lintro doctor`` when type-aware linting is enabled, either via the ``oxlint``
+``type_aware`` option or via ``options.typeAware`` in the discovered
+``.oxlintrc.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess  # nosec B404 - argv lists run with shell=False for version checks
+from dataclasses import dataclass
+from pathlib import Path
+
+from loguru import logger
+
+from lintro.enums.tool_status import ToolStatus
+from lintro.tools.core.version_parsing import compare_versions
+from lintro.utils.native_parsers import _load_native_tool_config
+
+__all__ = [
+    "OxlintCheckResult",
+    "check_oxlint_type_aware",
+    "oxlintrc_type_aware_enabled",
+]
+
+# Install hint emitted when the type-aware companion binary is unresolvable.
+TSGOLINT_INSTALL_HINT = "bun add -d oxlint-tsgolint@latest"
+
+# Minimum TypeScript version required for oxlint type-aware linting.
+TYPESCRIPT_MIN_VERSION = "7.0.0"
+
+
+@dataclass(frozen=True)
+class OxlintCheckResult:
+    """Result of a single oxlint type-aware dependency check.
+
+    Attributes:
+        name: Stable identifier for the check (e.g. ``oxlint.type-aware.tsgolint``).
+        status: ToolStatus value (OK, MISSING, INCOMPATIBLE, UNKNOWN).
+        message: Human-readable status message.
+        hint: Optional actionable remediation hint.
+    """
+
+    name: str
+    status: ToolStatus
+    message: str
+    hint: str = ""
+
+
+def oxlintrc_type_aware_enabled() -> bool:
+    """Return True when ``options.typeAware`` is enabled in ``.oxlintrc.json``.
+
+    Returns:
+        bool: True if the discovered oxlint native config sets
+            ``options.typeAware`` to a truthy value.
+    """
+    config = _load_native_tool_config("oxlint")
+    options = config.get("options")
+    if isinstance(options, dict):
+        return bool(options.get("typeAware"))
+    return False
+
+
+def _resolve_tsgolint() -> str | None:
+    """Resolve the ``oxlint-tsgolint`` companion binary.
+
+    Resolution order mirrors how oxlint locates the binary: a project-local
+    ``node_modules`` install first, then a binary on ``PATH``, then a ``bunx``
+    fallback.
+
+    Returns:
+        str | None: A resolved command/path, or None when unresolvable.
+    """
+    local = Path("node_modules") / ".bin" / "oxlint-tsgolint"
+    if local.exists():
+        return str(local)
+
+    found = shutil.which("oxlint-tsgolint")
+    if found:
+        return found
+
+    if shutil.which("bunx"):
+        return "bunx oxlint-tsgolint"
+
+    return None
+
+
+def _detect_typescript_version() -> str | None:
+    """Detect the available TypeScript version.
+
+    Prefers the project-local ``node_modules/typescript`` install, then falls
+    back to a ``tsc --version`` invocation.
+
+    Returns:
+        str | None: The detected TypeScript version, or None when unknown.
+    """
+    pkg = Path("node_modules") / "typescript" / "package.json"
+    if pkg.exists():
+        try:
+            data = json.loads(pkg.read_text(encoding="utf-8"))
+            version = data.get("version")
+            if isinstance(version, str) and version:
+                return version
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.debug(f"[oxlint doctor] Could not read typescript package: {exc}")
+
+    tsc = shutil.which("tsc")
+    if tsc:
+        try:
+            result = subprocess.run(  # nosec B603 - resolved binary, shell=False
+                [tsc, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if result.returncode == 0:
+                match = re.search(
+                    r"(\d+\.\d+(?:\.\d+)?)", result.stdout + result.stderr
+                )
+                if match:
+                    return match.group(1)
+        except (subprocess.SubprocessError, OSError) as exc:
+            logger.debug(f"[oxlint doctor] tsc --version failed: {exc}")
+
+    return None
+
+
+def check_oxlint_type_aware(*, option_enabled: bool = False) -> list[OxlintCheckResult]:
+    """Run oxlint type-aware dependency checks when the feature is enabled.
+
+    The feature is considered enabled when ``option_enabled`` is True (the
+    ``oxlint`` ``type_aware`` option) OR when ``options.typeAware`` is set in the
+    discovered ``.oxlintrc.json``.
+
+    Args:
+        option_enabled: Whether the ``type_aware`` option is enabled for oxlint.
+
+    Returns:
+        list[OxlintCheckResult]: Check results (empty when type-aware linting is
+            not enabled).
+    """
+    if not (option_enabled or oxlintrc_type_aware_enabled()):
+        return []
+
+    results: list[OxlintCheckResult] = []
+
+    resolved = _resolve_tsgolint()
+    if resolved is None:
+        results.append(
+            OxlintCheckResult(
+                name="oxlint.type-aware.tsgolint",
+                status=ToolStatus.MISSING,
+                message="oxlint-tsgolint not resolvable (node_modules / bunx)",
+                hint=TSGOLINT_INSTALL_HINT,
+            ),
+        )
+    else:
+        results.append(
+            OxlintCheckResult(
+                name="oxlint.type-aware.tsgolint",
+                status=ToolStatus.OK,
+                message=f"oxlint-tsgolint resolved ({resolved})",
+            ),
+        )
+
+    ts_version = _detect_typescript_version()
+    if ts_version is None:
+        results.append(
+            OxlintCheckResult(
+                name="oxlint.type-aware.typescript",
+                status=ToolStatus.MISSING,
+                message="TypeScript not found (>= 7.0 required)",
+                hint="bun add -d typescript@latest",
+            ),
+        )
+    else:
+        try:
+            below_min = compare_versions(ts_version, TYPESCRIPT_MIN_VERSION) < 0
+        except ValueError:
+            results.append(
+                OxlintCheckResult(
+                    name="oxlint.type-aware.typescript",
+                    status=ToolStatus.UNKNOWN,
+                    message=f"Could not parse TypeScript version '{ts_version}'",
+                    hint="bun add -d typescript@latest",
+                ),
+            )
+        else:
+            if below_min:
+                results.append(
+                    OxlintCheckResult(
+                        name="oxlint.type-aware.typescript",
+                        status=ToolStatus.INCOMPATIBLE,
+                        message=(
+                            f"TypeScript {ts_version} < {TYPESCRIPT_MIN_VERSION} "
+                            "required for type-aware linting"
+                        ),
+                        hint="bun add -d typescript@latest",
+                    ),
+                )
+            else:
+                results.append(
+                    OxlintCheckResult(
+                        name="oxlint.type-aware.typescript",
+                        status=ToolStatus.OK,
+                        message=f"TypeScript {ts_version} (>= {TYPESCRIPT_MIN_VERSION})",
+                    ),
+                )
+
+    return results

--- a/lintro/utils/native_parsers.py
+++ b/lintro/utils/native_parsers.py
@@ -261,3 +261,9 @@ def _load_native_tool_config(tool_name: str) -> dict[str, Any]:
         return {}
 
     return {}
+
+
+# Public alias for cross-module use. Prefer this name over the underscore-prefixed
+# ``_load_native_tool_config`` when importing from other modules; the private name
+# is retained for backward compatibility with existing internal callers and tests.
+load_native_tool_config = _load_native_tool_config

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -476,6 +476,40 @@ def test_doctor_tools_filter_known_tool() -> None:
     assert_that(result.output).contains("ruff")
 
 
+def test_doctor_oxlint_type_aware_failure_exit_1() -> None:
+    """A failing oxlint type-aware check causes exit 1 and shows the hint."""
+    from lintro.tools.definitions.oxlint_doctor import OxlintCheckResult
+
+    runner = CliRunner()
+    p1, p2 = _patch_doctor_deps()
+
+    failing = [
+        OxlintCheckResult(
+            name="oxlint.type-aware.tsgolint",
+            status=ToolStatus.MISSING,
+            message="oxlint-tsgolint not resolvable (node_modules / bunx)",
+            hint="bun add -d oxlint-tsgolint@latest",
+        ),
+    ]
+
+    with (
+        p1,
+        p2,
+        patch("subprocess.run") as mock_run,
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch(
+            "lintro.cli_utils.commands.doctor.check_oxlint_type_aware",
+            return_value=failing,
+        ),
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout="ruff 0.14.4", stderr="")
+        result = runner.invoke(doctor_command, [])
+
+    assert_that(result.exit_code).is_equal_to(1)
+    assert_that(result.output).contains("Oxlint type-aware")
+    assert_that(result.output).contains("bun add -d oxlint-tsgolint@latest")
+
+
 def test_doctor_unknown_tool_name_exit_1() -> None:
     """--tools with unknown name prints error and exits 1."""
     runner = CliRunner()

--- a/tests/unit/tools/oxlint/test_set_options.py
+++ b/tests/unit/tools/oxlint/test_set_options.py
@@ -61,6 +61,31 @@ def test_tsconfig_rejects_non_string(oxlint_plugin: OxlintPlugin) -> None:
 
 
 # =============================================================================
+# Tests for the type_aware option validation
+# =============================================================================
+
+
+def test_type_aware_accepts_bool(oxlint_plugin: OxlintPlugin) -> None:
+    """type_aware option accepts a boolean value.
+
+    Args:
+        oxlint_plugin: The OxlintPlugin instance to test.
+    """
+    oxlint_plugin.set_options(type_aware=True)
+    assert_that(oxlint_plugin.options.get("type_aware")).is_true()
+
+
+def test_type_aware_rejects_non_bool(oxlint_plugin: OxlintPlugin) -> None:
+    """type_aware option rejects non-boolean values.
+
+    Args:
+        oxlint_plugin: The OxlintPlugin instance to test.
+    """
+    with pytest.raises(ValueError, match="type_aware must be a boolean"):
+        oxlint_plugin.set_options(type_aware="yes")  # type: ignore[arg-type]
+
+
+# =============================================================================
 # Tests for rule list options (allow, deny, warn)
 # =============================================================================
 
@@ -219,6 +244,38 @@ def test_build_args_rule_options_add_flags(
     args = oxlint_plugin._build_oxlint_args(oxlint_plugin.options)
     for rule in rules:
         assert_that(args).contains(flag, rule)
+
+
+def test_build_args_type_aware_adds_flag(oxlint_plugin: OxlintPlugin) -> None:
+    """type_aware=True adds the --type-aware flag.
+
+    Args:
+        oxlint_plugin: The OxlintPlugin instance to test.
+    """
+    oxlint_plugin.set_options(type_aware=True)
+    args = oxlint_plugin._build_oxlint_args(oxlint_plugin.options)
+    assert_that(args).contains("--type-aware")
+
+
+def test_build_args_type_aware_absent_by_default(oxlint_plugin: OxlintPlugin) -> None:
+    """--type-aware is absent when type_aware is not set.
+
+    Args:
+        oxlint_plugin: The OxlintPlugin instance to test.
+    """
+    args = oxlint_plugin._build_oxlint_args(oxlint_plugin.options)
+    assert_that(args).does_not_contain("--type-aware")
+
+
+def test_build_args_type_aware_false_omits_flag(oxlint_plugin: OxlintPlugin) -> None:
+    """--type-aware is omitted when type_aware is explicitly False.
+
+    Args:
+        oxlint_plugin: The OxlintPlugin instance to test.
+    """
+    oxlint_plugin.set_options(type_aware=False)
+    args = oxlint_plugin._build_oxlint_args(oxlint_plugin.options)
+    assert_that(args).does_not_contain("--type-aware")
 
 
 def test_build_args_multiple_options_combine(oxlint_plugin: OxlintPlugin) -> None:

--- a/tests/unit/tools/oxlint/test_type_aware_doctor.py
+++ b/tests/unit/tools/oxlint/test_type_aware_doctor.py
@@ -1,0 +1,234 @@
+"""Tests for oxlint type-aware doctor checks."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from assertpy import assert_that
+
+from lintro.enums.tool_status import ToolStatus
+from lintro.tools.definitions import oxlint_doctor
+from lintro.tools.definitions.oxlint_doctor import (
+    TSGOLINT_INSTALL_HINT,
+    check_oxlint_type_aware,
+    oxlintrc_type_aware_enabled,
+)
+
+MODULE = "lintro.tools.definitions.oxlint_doctor"
+
+
+def _status(results: list, name: str) -> ToolStatus:
+    """Return the status for the check with the given name.
+
+    Args:
+        results: List of OxlintCheckResult.
+        name: The check name to look up.
+
+    Returns:
+        ToolStatus: The status for the matching check.
+    """
+    return next(r.status for r in results if r.name == name)
+
+
+# =============================================================================
+# oxlintrc_type_aware_enabled
+# =============================================================================
+
+
+def test_oxlintrc_type_aware_enabled_true() -> None:
+    """options.typeAware=true in .oxlintrc.json enables type-aware."""
+    with patch(
+        f"{MODULE}._load_native_tool_config",
+        return_value={"options": {"typeAware": True}},
+    ):
+        assert_that(oxlintrc_type_aware_enabled()).is_true()
+
+
+def test_oxlintrc_type_aware_enabled_false_when_absent() -> None:
+    """Missing options.typeAware does not enable type-aware."""
+    with patch(f"{MODULE}._load_native_tool_config", return_value={"rules": {}}):
+        assert_that(oxlintrc_type_aware_enabled()).is_false()
+
+
+def test_oxlintrc_type_aware_enabled_non_dict_options() -> None:
+    """Non-dict options key does not enable type-aware."""
+    with patch(
+        f"{MODULE}._load_native_tool_config",
+        return_value={"options": "nope"},
+    ):
+        assert_that(oxlintrc_type_aware_enabled()).is_false()
+
+
+# =============================================================================
+# check_oxlint_type_aware - disabled
+# =============================================================================
+
+
+def test_check_returns_empty_when_disabled() -> None:
+    """No checks are produced when type-aware is not enabled anywhere."""
+    with patch(f"{MODULE}.oxlintrc_type_aware_enabled", return_value=False):
+        results = check_oxlint_type_aware(option_enabled=False)
+    assert_that(results).is_empty()
+
+
+# =============================================================================
+# check_oxlint_type_aware - tsgolint resolution
+# =============================================================================
+
+
+def test_check_tsgolint_present_reports_ok() -> None:
+    """Resolvable oxlint-tsgolint reports OK."""
+    with (
+        patch(f"{MODULE}.oxlintrc_type_aware_enabled", return_value=False),
+        patch(f"{MODULE}._resolve_tsgolint", return_value="node_modules/.bin/x"),
+        patch(f"{MODULE}._detect_typescript_version", return_value="7.1.0"),
+    ):
+        results = check_oxlint_type_aware(option_enabled=True)
+
+    assert_that(_status(results, "oxlint.type-aware.tsgolint")).is_equal_to(
+        ToolStatus.OK,
+    )
+
+
+def test_check_tsgolint_missing_reports_hint() -> None:
+    """Unresolvable oxlint-tsgolint reports MISSING with install hint."""
+    with (
+        patch(f"{MODULE}.oxlintrc_type_aware_enabled", return_value=False),
+        patch(f"{MODULE}._resolve_tsgolint", return_value=None),
+        patch(f"{MODULE}._detect_typescript_version", return_value="7.1.0"),
+    ):
+        results = check_oxlint_type_aware(option_enabled=True)
+
+    tsgolint = next(r for r in results if r.name == "oxlint.type-aware.tsgolint")
+    assert_that(tsgolint.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(tsgolint.hint).is_equal_to(TSGOLINT_INSTALL_HINT)
+
+
+def test_check_enabled_via_oxlintrc_only() -> None:
+    """options.typeAware alone (option disabled) still triggers checks."""
+    with (
+        patch(f"{MODULE}.oxlintrc_type_aware_enabled", return_value=True),
+        patch(f"{MODULE}._resolve_tsgolint", return_value=None),
+        patch(f"{MODULE}._detect_typescript_version", return_value="7.1.0"),
+    ):
+        results = check_oxlint_type_aware(option_enabled=False)
+
+    assert_that(results).is_not_empty()
+    assert_that(_status(results, "oxlint.type-aware.tsgolint")).is_equal_to(
+        ToolStatus.MISSING,
+    )
+
+
+# =============================================================================
+# check_oxlint_type_aware - TypeScript version
+# =============================================================================
+
+
+def test_check_typescript_ok() -> None:
+    """TypeScript >= 7.0 reports OK."""
+    with (
+        patch(f"{MODULE}.oxlintrc_type_aware_enabled", return_value=False),
+        patch(f"{MODULE}._resolve_tsgolint", return_value="tsgolint"),
+        patch(f"{MODULE}._detect_typescript_version", return_value="7.0.0"),
+    ):
+        results = check_oxlint_type_aware(option_enabled=True)
+
+    assert_that(_status(results, "oxlint.type-aware.typescript")).is_equal_to(
+        ToolStatus.OK,
+    )
+
+
+def test_check_typescript_incompatible() -> None:
+    """TypeScript < 7.0 reports INCOMPATIBLE."""
+    with (
+        patch(f"{MODULE}.oxlintrc_type_aware_enabled", return_value=False),
+        patch(f"{MODULE}._resolve_tsgolint", return_value="tsgolint"),
+        patch(f"{MODULE}._detect_typescript_version", return_value="5.6.2"),
+    ):
+        results = check_oxlint_type_aware(option_enabled=True)
+
+    assert_that(_status(results, "oxlint.type-aware.typescript")).is_equal_to(
+        ToolStatus.INCOMPATIBLE,
+    )
+
+
+def test_check_typescript_missing() -> None:
+    """Absent TypeScript reports MISSING."""
+    with (
+        patch(f"{MODULE}.oxlintrc_type_aware_enabled", return_value=False),
+        patch(f"{MODULE}._resolve_tsgolint", return_value="tsgolint"),
+        patch(f"{MODULE}._detect_typescript_version", return_value=None),
+    ):
+        results = check_oxlint_type_aware(option_enabled=True)
+
+    assert_that(_status(results, "oxlint.type-aware.typescript")).is_equal_to(
+        ToolStatus.MISSING,
+    )
+
+
+def test_check_typescript_unparseable_is_unknown() -> None:
+    """An unparseable TypeScript version reports UNKNOWN."""
+    with (
+        patch(f"{MODULE}.oxlintrc_type_aware_enabled", return_value=False),
+        patch(f"{MODULE}._resolve_tsgolint", return_value="tsgolint"),
+        patch(f"{MODULE}._detect_typescript_version", return_value="not-a-version"),
+    ):
+        results = check_oxlint_type_aware(option_enabled=True)
+
+    assert_that(_status(results, "oxlint.type-aware.typescript")).is_equal_to(
+        ToolStatus.UNKNOWN,
+    )
+
+
+# =============================================================================
+# Resolver behavior
+# =============================================================================
+
+
+def test_resolve_tsgolint_prefers_node_modules(tmp_path, monkeypatch) -> None:
+    """node_modules/.bin/oxlint-tsgolint is preferred when present.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.chdir(tmp_path)
+    bin_dir = tmp_path / "node_modules" / ".bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "oxlint-tsgolint").write_text("#!/bin/sh\n")
+
+    resolved = oxlint_doctor._resolve_tsgolint()
+    assert_that(resolved).contains("oxlint-tsgolint")
+
+
+def test_resolve_tsgolint_bunx_fallback(tmp_path, monkeypatch) -> None:
+    """Bunx is used as a fallback when no local/PATH binary exists.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    def _which(name: str) -> str | None:
+        return "/usr/bin/bunx" if name == "bunx" else None
+
+    with patch(f"{MODULE}.shutil.which", side_effect=_which):
+        resolved = oxlint_doctor._resolve_tsgolint()
+
+    assert_that(resolved).is_equal_to("bunx oxlint-tsgolint")
+
+
+def test_resolve_tsgolint_none_when_unavailable(tmp_path, monkeypatch) -> None:
+    """None is returned when nothing resolves.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    with patch(f"{MODULE}.shutil.which", return_value=None):
+        resolved = oxlint_doctor._resolve_tsgolint()
+
+    assert_that(resolved).is_none()

--- a/tests/unit/tools/oxlint/test_type_aware_doctor.py
+++ b/tests/unit/tools/oxlint/test_type_aware_doctor.py
@@ -41,7 +41,7 @@ def _status(results: list[OxlintCheckResult], name: str) -> ToolStatus:
 def test_oxlintrc_type_aware_enabled_true() -> None:
     """options.typeAware=true in .oxlintrc.json enables type-aware."""
     with patch(
-        f"{MODULE}._load_native_tool_config",
+        f"{MODULE}.load_native_tool_config",
         return_value={"options": {"typeAware": True}},
     ):
         assert_that(oxlintrc_type_aware_enabled()).is_true()
@@ -49,14 +49,14 @@ def test_oxlintrc_type_aware_enabled_true() -> None:
 
 def test_oxlintrc_type_aware_enabled_false_when_absent() -> None:
     """Missing options.typeAware does not enable type-aware."""
-    with patch(f"{MODULE}._load_native_tool_config", return_value={"rules": {}}):
+    with patch(f"{MODULE}.load_native_tool_config", return_value={"rules": {}}):
         assert_that(oxlintrc_type_aware_enabled()).is_false()
 
 
 def test_oxlintrc_type_aware_enabled_non_dict_options() -> None:
     """Non-dict options key does not enable type-aware."""
     with patch(
-        f"{MODULE}._load_native_tool_config",
+        f"{MODULE}.load_native_tool_config",
         return_value={"options": "nope"},
     ):
         assert_that(oxlintrc_type_aware_enabled()).is_false()

--- a/tests/unit/tools/oxlint/test_type_aware_doctor.py
+++ b/tests/unit/tools/oxlint/test_type_aware_doctor.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from assertpy import assert_that
 
 from lintro.enums.tool_status import ToolStatus
 from lintro.tools.definitions import oxlint_doctor
 from lintro.tools.definitions.oxlint_doctor import (
     TSGOLINT_INSTALL_HINT,
+    OxlintCheckResult,
     check_oxlint_type_aware,
     oxlintrc_type_aware_enabled,
 )
@@ -17,7 +20,7 @@ from lintro.tools.definitions.oxlint_doctor import (
 MODULE = "lintro.tools.definitions.oxlint_doctor"
 
 
-def _status(results: list, name: str) -> ToolStatus:
+def _status(results: list[OxlintCheckResult], name: str) -> ToolStatus:
     """Return the status for the check with the given name.
 
     Args:
@@ -185,7 +188,10 @@ def test_check_typescript_unparseable_is_unknown() -> None:
 # =============================================================================
 
 
-def test_resolve_tsgolint_prefers_node_modules(tmp_path, monkeypatch) -> None:
+def test_resolve_tsgolint_prefers_node_modules(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """node_modules/.bin/oxlint-tsgolint is preferred when present.
 
     Args:
@@ -201,7 +207,10 @@ def test_resolve_tsgolint_prefers_node_modules(tmp_path, monkeypatch) -> None:
     assert_that(resolved).contains("oxlint-tsgolint")
 
 
-def test_resolve_tsgolint_bunx_fallback(tmp_path, monkeypatch) -> None:
+def test_resolve_tsgolint_bunx_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Bunx is used as a fallback when no local/PATH binary exists.
 
     Args:
@@ -219,7 +228,10 @@ def test_resolve_tsgolint_bunx_fallback(tmp_path, monkeypatch) -> None:
     assert_that(resolved).is_equal_to("bunx oxlint-tsgolint")
 
 
-def test_resolve_tsgolint_none_when_unavailable(tmp_path, monkeypatch) -> None:
+def test_resolve_tsgolint_none_when_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """None is returned when nothing resolves.
 
     Args:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(oxlint): add type-aware linting support with doctor checks
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Adds first-class oxlint type-aware linting plus doctor checks and docs:

- `type_aware` option appends `--type-aware` (default off)
- Doctor verifies `oxlint-tsgolint` and TypeScript >= 7.0 when enabled via option or `.oxlintrc.json` `options.typeAware`
- Docs for type-aware mode and JS-plugin passthrough

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1517

## Details

_See What’s Changing._
