### PR TITLE
docs: add idiom-review documentation across README, configuration, and tool analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,13 @@ system.
 <td>-</td>
 <td><code>pipx install semgrep</code><br><code>pip install semgrep</code><br><code>brew install semgrep</code></td>
 </tr>
+<tr><th colspan="4">AI Tools</th></tr>
+<tr>
+<td><a href="docs/ai-features.md#ai-idiom-review-idiom-review-tool"><img src="https://img.shields.io/badge/idiom--review-6941c6?logo=openai&logoColor=white" alt="idiom-review"></a></td>
+<td>🤖 AI · Multi-language</td>
+<td>-</td>
+<td><code>uv pip install 'lintro[ai]'</code> + API key</td>
+</tr>
 </tbody>
 </table>
 

--- a/apps/site/src/data/sidebar-nav.ts
+++ b/apps/site/src/data/sidebar-nav.ts
@@ -61,6 +61,7 @@ export const NAV_GROUP_BY_ID: Partial<Record<string, string>> = {
   'tools/markdownlint': 'config',
   'tools/actionlint': 'ci-ops',
   'tools/hadolint': 'ci-ops',
+  'tools/idiom-review': 'python',
   'tools/osv-scanner': 'security',
   'architecture/architecture': 'design',
   'architecture/vision': 'design',

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2367,10 +2367,10 @@ ai:
 
 ### Idiom Review Tool (`idiom-review`)
 
-The `idiom-review` tool uses AI to find issues that syntax-matching linters cannot:
-code that is syntactically correct but non-idiomatic or redundantly duplicated across
-files. Unlike the AI summary and `--fix` flows, it is a first-class `ToolDefinition`
-plugin that runs as part of the normal `lintro check` pipeline — distinct from the
+The `idiom-review` tool uses AI to find issues that syntax-matching linters cannot: code
+that is syntactically correct but non-idiomatic or redundantly duplicated across files.
+Unlike the AI summary and `--fix` flows, it is a first-class `ToolDefinition` plugin
+that runs as part of the normal `lintro check` pipeline — distinct from the
 `lintro review` diff-review command.
 
 **Install:**
@@ -2381,19 +2381,19 @@ export ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI_API_KEY for OpenAI
 ```
 
 The tool is **disabled by default** and is a no-op until explicitly opted in. When no AI
-provider is available (missing SDK, key, or credits), it degrades gracefully to a skipped
-result rather than failing the run. Findings are cached by content hash under
+provider is available (missing SDK, key, or credits), it degrades gracefully to a
+skipped result rather than failing the run. Findings are cached by content hash under
 `.lintro-cache/idiom`, so unchanged files cost nothing on repeat runs.
 
 **Options:**
 
-| Option           | Type   | Default     | Description                                          |
-| ---------------- | ------ | ----------- | ---------------------------------------------------- |
-| `enabled`        | bool   | `false`     | Opt-in gate — must be `true` to run                  |
-| `mode`           | string | `per-file`  | `per-file` · `duplication` · `both`                  |
-| `min_confidence` | string | `medium`    | Drop findings below this level (`low`/`medium`/`high`) |
-| `max_files`      | int    | `25`        | Cap on files reviewed per run (cost bound)           |
-| `language`       | string | (auto)      | Restrict review to a specific language               |
+| Option           | Type   | Default    | Description                                            |
+| ---------------- | ------ | ---------- | ------------------------------------------------------ |
+| `enabled`        | bool   | `false`    | Opt-in gate — must be `true` to run                    |
+| `mode`           | string | `per-file` | `per-file` · `duplication` · `both`                    |
+| `min_confidence` | string | `medium`   | Drop findings below this level (`low`/`medium`/`high`) |
+| `max_files`      | int    | `25`       | Cap on files reviewed per run (cost bound)             |
+| `language`       | string | (auto)     | Restrict review to a specific language                 |
 
 **Modes:**
 
@@ -2414,10 +2414,10 @@ ai:
 tools:
   idiom-review:
     options:
-      enabled: true        # opt-in gate (default: false)
-      mode: per-file       # per-file | duplication | both
+      enabled: true # opt-in gate (default: false)
+      mode: per-file # per-file | duplication | both
       min_confidence: medium
-      max_files: 25        # cap files reviewed per run (cost bound)
+      max_files: 25 # cap files reviewed per run (cost bound)
 ```
 
 Or enable ad hoc from the CLI without modifying config:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2423,7 +2423,7 @@ tools:
 Or enable ad hoc from the CLI without modifying config:
 
 ```bash
-lintro chk --tools idiom-review --tool-options idiom-review:enabled=true
+lintro check --tools idiom-review --tool-options idiom-review:enabled=true
 ```
 
 ## Advanced Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2365,6 +2365,67 @@ ai:
 | `retry_max_delay`       | float  | `30.0`      | Maximum retry delay in seconds (min 1.0)         |
 | `retry_backoff_factor`  | float  | `2.0`       | Retry delay multiplier (min 1.0)                 |
 
+### Idiom Review Tool (`idiom-review`)
+
+The `idiom-review` tool uses AI to find issues that syntax-matching linters cannot:
+code that is syntactically correct but non-idiomatic or redundantly duplicated across
+files. Unlike the AI summary and `--fix` flows, it is a first-class `ToolDefinition`
+plugin that runs as part of the normal `lintro check` pipeline — distinct from the
+`lintro review` diff-review command.
+
+**Install:**
+
+```bash
+uv pip install 'lintro[ai]'
+export ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI_API_KEY for OpenAI
+```
+
+The tool is **disabled by default** and is a no-op until explicitly opted in. When no AI
+provider is available (missing SDK, key, or credits), it degrades gracefully to a skipped
+result rather than failing the run. Findings are cached by content hash under
+`.lintro-cache/idiom`, so unchanged files cost nothing on repeat runs.
+
+**Options:**
+
+| Option           | Type   | Default     | Description                                          |
+| ---------------- | ------ | ----------- | ---------------------------------------------------- |
+| `enabled`        | bool   | `false`     | Opt-in gate — must be `true` to run                  |
+| `mode`           | string | `per-file`  | `per-file` · `duplication` · `both`                  |
+| `min_confidence` | string | `medium`    | Drop findings below this level (`low`/`medium`/`high`) |
+| `max_files`      | int    | `25`        | Cap on files reviewed per run (cost bound)           |
+| `language`       | string | (auto)      | Restrict review to a specific language               |
+
+**Modes:**
+
+- **`per-file`** — flags idiomatic misses per file (e.g. verbose loops instead of
+  `any()`/`all()` comprehensions).
+- **`duplication`** — flags the same utility logic reimplemented across files, invisible
+  to per-file linters, with a suggested extraction point.
+- **`both`** — runs both modes in one pass.
+
+**Usage example:**
+
+```yaml
+# .lintro-config.yaml
+ai:
+  enabled: true
+  provider: anthropic
+  transport: api
+tools:
+  idiom-review:
+    options:
+      enabled: true        # opt-in gate (default: false)
+      mode: per-file       # per-file | duplication | both
+      min_confidence: medium
+      max_files: 25        # cap files reviewed per run (cost bound)
+```
+
+Or enable ad hoc from the CLI without modifying config:
+
+```bash
+lintro chk --tools idiom-review --tool-options idiom-review:enabled=true
+```
+
 ## Advanced Configuration
 
 ### Tool Conflicts and Priorities

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2393,7 +2393,7 @@ skipped result rather than failing the run. Findings are cached by content hash 
 | `mode`           | string | `per-file` | `per-file` · `duplication` · `both`                    |
 | `min_confidence` | string | `medium`   | Drop findings below this level (`low`/`medium`/`high`) |
 | `max_files`      | int    | `25`       | Cap on files reviewed per run (cost bound)             |
-| `language`       | string | (auto)     | Restrict review to a specific language                 |
+| `language`       | string | `python`   | Language to review; set explicitly for other languages |
 
 **Modes:**
 

--- a/docs/tool-analysis/README.md
+++ b/docs/tool-analysis/README.md
@@ -110,7 +110,7 @@ implementations with the core tools themselves.
 
 ### [Idiom Review Analysis](./idiom-review-analysis.md)
 
-**AI-Powered Idiomatic Code Reviewer (built-in plugin)**
+### AI-Powered Idiomatic Code Reviewer (built-in plugin)
 
 - ✅ **Preserved**: Native `ToolDefinition` plugin, shared AI provider abstraction,
   content-hash caching, cost controls

--- a/docs/tool-analysis/README.md
+++ b/docs/tool-analysis/README.md
@@ -108,6 +108,16 @@ implementations with the core tools themselves.
 - ⚠️ **Limited**: No impact analysis or mutation testing; plugin install not managed
 - 🚀 **Enhanced**: Coverage helpers, parallel presets, plugin/marker/fixture listings
 
+### [Idiom Review Analysis](./idiom-review-analysis.md)
+
+**AI-Powered Idiomatic Code Reviewer (built-in plugin)**
+
+- ✅ **Preserved**: Native `ToolDefinition` plugin, shared AI provider abstraction,
+  content-hash caching, cost controls
+- ⚠️ **Limitations**: No auto-fix, non-deterministic, API cost per uncached file
+- 🚀 **Notes**: No external binary; participates in `--diff` scoping; graceful skip on
+  provider unavailability
+
 ## Analysis Framework
 
 Each analysis follows a consistent structure:

--- a/docs/tool-analysis/idiom-review-analysis.md
+++ b/docs/tool-analysis/idiom-review-analysis.md
@@ -5,12 +5,12 @@
 `idiom-review` is a first-class `ToolDefinition` plugin that uses the configured AI
 provider to find issues that syntax-matching linters structurally cannot. It is
 **distinct from the `lintro review` diff-review command** — it participates in the
-normal `lintro check` pipeline like any other tool and produces standard
-`ToolResult` / `Issue` objects.
+normal `lintro check` pipeline like any other tool and produces standard `ToolResult` /
+`Issue` objects.
 
 It has no external binary; all work is done through the existing AI provider
-abstraction, respecting the same retry, fallback, and cost-budget controls used by
-other AI features.
+abstraction, respecting the same retry, fallback, and cost-budget controls used by other
+AI features.
 
 ## Core Tool Capabilities
 
@@ -19,8 +19,7 @@ native to Lintro. Its capabilities are:
 
 - **Two analysis modes:**
   - **`per-file`** (Mode 1) — finds idiomatic misses per file: correct but verbose code
-    (e.g. `found = False; for x in items: ...` instead of
-    `any(cond for x in items)`).
+    (e.g. `found = False; for x in items: ...` instead of `any(cond for x in items)`).
   - **`duplication`** (Mode 2) — finds the same utility logic reimplemented across
     multiple files, invisible to per-file linters, with a suggested extraction point.
   - **`both`** — runs both modes in a single pass.
@@ -56,8 +55,8 @@ native to Lintro. Its capabilities are:
   configured AI provider
 - ⚠️ **Non-deterministic** — AI responses may vary across runs for the same input;
   caching mitigates this for unchanged files
-- ⚠️ **API cost** — each uncached file incurs one or more API calls; use `max_files`
-  and caching to bound costs in large repos
+- ⚠️ **API cost** — each uncached file incurs one or more API calls; use `max_files` and
+  caching to bound costs in large repos
 
 ### 🚀 Enhancements vs. a hypothetical standalone tool
 
@@ -98,8 +97,8 @@ lintro chk --tools idiom-review \
 
 ## Configuration Strategy
 
-- Requires `ai.enabled: true` and a valid API key in the environment before any
-  analysis runs.
+- Requires `ai.enabled: true` and a valid API key in the environment before any analysis
+  runs.
 - Tool-level `enabled` option (default `false`) acts as a second opt-in gate so that
   `lintro chk` does not silently incur API costs.
 - `max_files` (default 25) is the primary cost-control knob for large repos.

--- a/docs/tool-analysis/idiom-review-analysis.md
+++ b/docs/tool-analysis/idiom-review-analysis.md
@@ -1,0 +1,122 @@
+# Idiom Review Tool Analysis
+
+## Overview
+
+`idiom-review` is a first-class `ToolDefinition` plugin that uses the configured AI
+provider to find issues that syntax-matching linters structurally cannot. It is
+**distinct from the `lintro review` diff-review command** — it participates in the
+normal `lintro check` pipeline like any other tool and produces standard
+`ToolResult` / `Issue` objects.
+
+It has no external binary; all work is done through the existing AI provider
+abstraction, respecting the same retry, fallback, and cost-budget controls used by
+other AI features.
+
+## Core Tool Capabilities
+
+Unlike conventional linters, `idiom-review` has no upstream CLI equivalent — it is
+native to Lintro. Its capabilities are:
+
+- **Two analysis modes:**
+  - **`per-file`** (Mode 1) — finds idiomatic misses per file: correct but verbose code
+    (e.g. `found = False; for x in items: ...` instead of
+    `any(cond for x in items)`).
+  - **`duplication`** (Mode 2) — finds the same utility logic reimplemented across
+    multiple files, invisible to per-file linters, with a suggested extraction point.
+  - **`both`** — runs both modes in a single pass.
+- **Opt-in gate** — disabled by default (`enabled: false`); a no-op until explicitly
+  opted in.
+- **Content-hash caching** — findings cached under `.lintro-cache/idiom`; unchanged
+  files cost no API calls on repeat runs.
+- **Cost bound** — `max_files` caps the number of files reviewed per run.
+- **Confidence filter** — `min_confidence` drops low-quality findings before reporting.
+- **Language filter** — optional `language` option restricts the review scope.
+- **Graceful degradation** — when no AI provider is available (missing SDK, API key, or
+  exhausted credits), the tool produces a skipped result rather than failing the run.
+
+## Lintro Implementation Analysis
+
+### ✅ Preserved / Implemented Features
+
+- ✅ Integrates with the standard `ToolDefinition` plugin interface — `check()` returns
+  a `ToolResult` with structured `Issue` objects
+- ✅ Uses the shared AI provider abstraction (retry, backoff, timeout, cost display)
+- ✅ Respects `ai.enabled`, `ai.provider`, `ai.model`, and `ai.api_key_env` from the
+  top-level AI config
+- ✅ Content-hash caching avoids redundant API calls for unchanged files
+- ✅ `max_files` and `min_confidence` options provide cost and quality controls
+- ✅ `mode` selects per-file, duplication, or both analysis strategies
+- ✅ Graceful skip when provider is unavailable — run still passes
+
+### ⚠️ Limitations / Notes
+
+- ⚠️ **No auto-fix** — AI findings are reported as issues; fixes are not applied
+  automatically (use `--fix` for AI-assisted fix suggestions on other tools)
+- ⚠️ **No external binary** — cannot be run outside of Lintro; depends entirely on the
+  configured AI provider
+- ⚠️ **Non-deterministic** — AI responses may vary across runs for the same input;
+  caching mitigates this for unchanged files
+- ⚠️ **API cost** — each uncached file incurs one or more API calls; use `max_files`
+  and caching to bound costs in large repos
+
+### 🚀 Enhancements vs. a hypothetical standalone tool
+
+- Unified `ToolResult` / `Issue` output compatible with all Lintro output formats (grid,
+  JSON, HTML, CSV, Markdown)
+- Participates in `--diff` scoping — only files changed vs. the base ref are reviewed
+  when `--diff` is active
+- No external binary to install or update; versioned with Lintro itself
+
+## Usage Comparison
+
+### Direct AI call (no Lintro)
+
+Without Lintro, reproducing this analysis would require writing custom prompt
+orchestration, caching, retry logic, and result parsing.
+
+### Lintro wrapper
+
+```bash
+# Ad-hoc run (opt-in via CLI, no config change needed)
+lintro chk --tools idiom-review --tool-options idiom-review:enabled=true
+
+# Persistent opt-in via config
+# .lintro-config.yaml:
+# tools:
+#   idiom-review:
+#     options:
+#       enabled: true
+#       mode: per-file
+#       min_confidence: medium
+#       max_files: 25
+lintro chk --tools idiom-review
+
+# Duplication mode across the whole repo
+lintro chk --tools idiom-review \
+  --tool-options idiom-review:enabled=true,idiom-review:mode=duplication
+```
+
+## Configuration Strategy
+
+- Requires `ai.enabled: true` and a valid API key in the environment before any
+  analysis runs.
+- Tool-level `enabled` option (default `false`) acts as a second opt-in gate so that
+  `lintro chk` does not silently incur API costs.
+- `max_files` (default 25) is the primary cost-control knob for large repos.
+- `min_confidence` (default `medium`) filters noisy low-confidence findings.
+- Caching is automatic; clear `.lintro-cache/idiom` to force a full re-analysis.
+
+See [AI Configuration](../configuration.md#idiom-review-tool-idiom-review) and
+[AI Features Guide](../ai-features.md#ai-idiom-review-idiom-review-tool) for full
+configuration reference.
+
+## Recommendations
+
+- Enable `idiom-review` selectively in CI on changed files only (combine with `--diff`)
+  to keep API costs bounded.
+- Start with `mode: per-file` and a low `max_files` limit to evaluate finding quality
+  before enabling `duplication` mode on large repos.
+- Use `min_confidence: high` in automated pipelines to reduce false positives; reserve
+  `medium` for interactive developer runs where human review filters noise.
+- Do not rely on `idiom-review` as a replacement for conventional linters — it
+  complements them by surfacing structural patterns those linters cannot detect.

--- a/scripts/ci/site/migrate-docs-content.py
+++ b/scripts/ci/site/migrate-docs-content.py
@@ -78,6 +78,7 @@ DOC_NAV: dict[str, tuple[str, str | None]] = {
     "tools/cargo-deny": ("cargo-deny", "rust"),
     "tools/clippy": ("clippy", "rust"),
     "tools/hadolint": ("hadolint", "ci-ops"),
+    "tools/idiom-review": ("idiom-review", "python"),
     "tools/markdownlint": ("markdownlint", "config"),
     "tools/mypy": ("mypy", "python"),
     "tools/osv-scanner": ("osv-scanner", "security"),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  docs: add idiom-review documentation across README, configuration, and tool analysis
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [x] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Documents the `idiom-review` AI plugin across standard doc surfaces:

- README Supported Tools (AI Tools section)
- `docs/configuration.md` options/install section
- `docs/tool-analysis/idiom-review-analysis.md` (new)
- Site nav/migrate wiring for the analysis page

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1496

## Details

_See What’s Changing._
