### PR TITLE
feat(ci): fail dogfooding when an enabled tool silently skips

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -598,6 +598,94 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  # No-silent-skip gate (#1510, epic #1508): the dogfooding jobs above run an
+  # external reusable workflow (no place to add a post-lint step), so this
+  # dedicated job re-derives the structured skip state from the same image and
+  # fails when an enabled tool silently skips for a reason not in the committed
+  # allowlist. Runs whenever a CI image exists (not docs-only) so both the
+  # full-repo and changed-files PR paths are covered.
+  dogfood-skip-gate:
+    name: 🚦 Dogfood No-Silent-Skip Gate
+    needs: [changes, docker-build, dogfooding-lint, dogfooding-lint-changed]
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.changes.outputs.pipeline != 'false' &&
+      needs.docker-build.result == 'success'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read # pull the CI lint image from GHCR
+    timeout-minutes: 30
+    steps:
+      - name: Harden Runner
+        # Same allowlist as dogfooding-lint-changed: the container sets
+        # LINTRO_AUTO_INSTALL_DEPS=1 and may fetch project deps before linting.
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            release-assets.githubusercontent.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pipelines.actions.githubusercontent.com:443
+            github-releases.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            docker.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            static.rust-lang.org:443
+            bun.sh:443
+            astral.sh:443
+            releases.astral.sh:443
+            sh.rustup.rs:443
+            deb.debian.org:80
+            registry.npmjs.org:443
+            crates.io:443
+            static.crates.io:443
+            index.crates.io:443
+            semgrep.dev:443
+            metrics.semgrep.dev:443
+            api.osv.dev:443
+            api.deps.dev:443
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Log in to GitHub Container Registry
+        if: needs.docker-build.outputs.is-fork != 'true'
+        # yamllint disable-line rule:line-length
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for silent tool skips
+        env:
+          # Same tool coverage as the dogfooding run so skip behaviour matches.
+          TOOL_OPTIONS: >-
+            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,osv_scanner:check_suppressions=false
+          # Same image selection as dogfooding-lint: CI-built image for
+          # same-repo PRs, pinned release digest for forks (no CI push).
+          # Pinned digest — keep in sync with pyproject.toml lintro pin
+          LINTRO_IMAGE: >-
+            ${{ needs.docker-build.outputs.is-fork == 'true'
+            && format(
+              'ghcr.io/lgtm-hq/py-lintro@sha256:{0}',
+              '0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c'
+            )
+            || format('ghcr.io/lgtm-hq/py-lintro:ci-{0}', github.run_id) }}
+        run: scripts/ci/dogfood-skip-gate.sh
+
   dogfooding-pr-comment:
     # Comments with the outputs of whichever dogfooding job ran (full or
     # changed-files — they are mutually exclusive per run, see #1361).

--- a/.github/workflows/dogfood-nightly.yml
+++ b/.github/workflows/dogfood-nightly.yml
@@ -45,10 +45,86 @@ jobs:
       lintro-image: >-
         ghcr.io/lgtm-hq/py-lintro@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c
 
-  notify-failure:
+  # No-silent-skip gate (#1510, epic #1508): dogfood-full runs an external
+  # reusable workflow, so this dedicated job re-derives the structured skip
+  # state from the same pinned image and fails when an enabled tool silently
+  # skips for a reason not covered by the committed allowlist.
+  dogfood-skip-gate:
+    name: 🚦 Dogfood No-Silent-Skip Gate
     needs: [dogfood-full]
+    # Run even when dogfood-full failed on real issues — a silent skip is an
+    # independent regression class — but not when it was cancelled.
+    if: always() && !cancelled()
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read # pull the pinned release image from GHCR
+    timeout-minutes: 30
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            release-assets.githubusercontent.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pipelines.actions.githubusercontent.com:443
+            github-releases.githubusercontent.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            docker.io:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            static.rust-lang.org:443
+            bun.sh:443
+            astral.sh:443
+            releases.astral.sh:443
+            sh.rustup.rs:443
+            deb.debian.org:80
+            registry.npmjs.org:443
+            crates.io:443
+            static.crates.io:443
+            index.crates.io:443
+            semgrep.dev:443
+            metrics.semgrep.dev:443
+            api.osv.dev:443
+            api.deps.dev:443
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Log in to GitHub Container Registry
+        # yamllint disable-line rule:line-length
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for silent tool skips
+        env:
+          # Same tool coverage as dogfood-full so skip behaviour matches.
+          TOOL_OPTIONS: >-
+            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,osv_scanner:check_suppressions=false
+          # Same pinned release image dogfood-full lints with.
+          # Pinned digest — keep in sync with pyproject.toml lintro pin
+          LINTRO_IMAGE: >-
+            ghcr.io/lgtm-hq/py-lintro@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c
+        run: scripts/ci/dogfood-skip-gate.sh
+
+  notify-failure:
+    needs: [dogfood-full, dogfood-skip-gate]
     # Main-only: a manual dispatch from a feature branch must not open or
-    # ping the main-failure issue for the dogfood-nightly key.
+    # ping the main-failure issue for the dogfood-nightly key. Fires when the
+    # full lint OR the no-silent-skip gate regresses.
     if: failure() && github.ref == 'refs/heads/main'
     # Deduplicated failure issue (same mechanism as the release workflows):
     # first failure opens `fix(ci): main workflow failed: dogfood-nightly`,

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -72,7 +72,6 @@ jobs:
         files.pythonhosted.org:443
         test.pypi.org:443
         upload.pypi.org:443
-        upload.test.pypi.org:443
         astral.sh:443
         releases.astral.sh:443
     permissions:
@@ -115,7 +114,6 @@ jobs:
         files.pythonhosted.org:443
         test.pypi.org:443
         upload.pypi.org:443
-        upload.test.pypi.org:443
         astral.sh:443
         releases.astral.sh:443
     permissions:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -105,6 +105,8 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `resolve-pipeline-relevance.sh`      | Resolve heavy-pipeline path relevance and set `pipeline` output       | `./scripts/ci/resolve-pipeline-relevance.sh --help`                                |
 | `release-bump-only.sh`               | Classify automated version-bump PRs via diff allowlist (#1362)        | `./scripts/ci/release-bump-only.sh --help`                                         |
 | `dogfood-changed-files.sh`           | Lint only PR-changed files via lintro Docker (full-repo fallback)     | `./scripts/ci/dogfood-changed-files.sh --help`                                     |
+| `dogfood-skip-gate.sh`               | Fail dogfood CI on non-allowlisted skipped tools                      | `LINTRO_IMAGE=<image> ./scripts/ci/dogfood-skip-gate.sh`                           |
+| `check-dogfood-skips.py`             | Validate dogfood skip JSON against the committed allowlist            | `python3 scripts/ci/check-dogfood-skips.py --help`                                 |
 | `evaluate-test-gate.sh`              | Evaluate upstream compat/coverage results for required-check gate     | `COMPAT_RESULT=success COVERAGE_RESULT=success ./scripts/ci/evaluate-test-gate.sh` |
 | `fail-on-security-audit.sh`          | Fail CI when security audit finds vulnerabilities                     | `./scripts/ci/fail-on-security-audit.sh`                                           |
 | `free-disk-space.sh`                 | Free disk space on CI runner for Docker builds                        | `./scripts/ci/free-disk-space.sh`                                                  |

--- a/scripts/ci/check-dogfood-skips.py
+++ b/scripts/ci/check-dogfood-skips.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+"""Fail dogfooding CI when an enabled tool silently skips.
+
+A SKIP is indistinguishable from a PASS in job status, so a wrapped tool can
+be dead for weeks (missing binary) or forever (missing config) without anyone
+noticing. This gate parses lintro's structured JSON output
+(``lintro chk --output-format json``) and exits non-zero when any enabled tool
+reports ``skipped: true`` for a reason that is not covered by the committed
+allowlist (``scripts/ci/dogfood-skip-allowlist.yaml``).
+
+Skip reasons are classified into one of:
+
+- ``binary_missing`` — the tool binary is absent or its version check failed.
+  This is an *image bug*: the tool should be installed in the CI tools image.
+  It is **never permanently allowlistable** and may only be tolerated via an
+  ``interim`` entry that carries a tracking issue (which emits a loud warning).
+- ``no_config`` — the tool has no resolvable configuration in the repo, so it
+  self-skips (e.g. stylelint/vale/commitlint). Allowlistable via the file.
+- ``opt_in_disabled`` — an opt-in tool (idiom-review) is disabled by default.
+  Allowlistable via the file.
+- ``other`` — an unrecognised skip reason; treated like ``no_config`` for
+  allowlisting purposes (must be explicitly listed to be tolerated).
+
+Usage:
+    python3 scripts/ci/check-dogfood-skips.py \
+        --report results.json \
+        --allowlist scripts/ci/dogfood-skip-allowlist.yaml
+
+    # or read the JSON report from stdin
+    lintro chk --output-format json . | \
+        python3 scripts/ci/check-dogfood-skips.py \
+            --allowlist scripts/ci/dogfood-skip-allowlist.yaml
+
+Exit codes:
+    0 — no non-allowlisted skips (gate passes)
+    1 — one or more non-allowlisted skips (gate fails)
+    2 — usage / configuration error (bad args, unreadable report or allowlist,
+        or an allowlist that violates the schema)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class SkipClass(StrEnum):
+    """Classification of a tool skip reason."""
+
+    BINARY_MISSING = "binary_missing"
+    NO_CONFIG = "no_config"
+    OPT_IN_DISABLED = "opt_in_disabled"
+    OTHER = "other"
+
+
+# Classes that a *permanent* allowlist entry is allowed to cover. A missing
+# binary is an image bug, so it is deliberately excluded here — it may only be
+# tolerated as a tracked ``interim`` entry.
+PERMANENT_ALLOWLISTABLE: frozenset[SkipClass] = frozenset(
+    {SkipClass.NO_CONFIG, SkipClass.OPT_IN_DISABLED},
+)
+
+
+class AllowlistError(ValueError):
+    """Raised when the allowlist file is malformed or violates the schema."""
+
+
+def normalize_tool_name(name: str) -> str:
+    """Return a canonical key for a tool name.
+
+    lintro emits some tools with hyphens (``idiom-review``, ``svelte-check``)
+    and others with underscores (``pip_audit``, ``osv_scanner``). Normalising
+    both to a single form lets the allowlist match regardless of the spelling
+    used in the file.
+
+    Args:
+        name: Tool name as it appears in JSON output or the allowlist.
+
+    Returns:
+        Lower-cased name with hyphens folded to underscores.
+    """
+    return name.strip().lower().replace("-", "_")
+
+
+def classify_skip_reason(reason: str | None) -> SkipClass:
+    """Classify a skip reason string into a :class:`SkipClass`.
+
+    Matching is case-insensitive and substring-based, checked in priority
+    order so the most dangerous class (a missing binary) wins.
+
+    Args:
+        reason: The ``skip_reason`` string from a lintro tool result.
+
+    Returns:
+        The classified :class:`SkipClass`. An empty/None reason is treated as
+        ``other`` (an unexplained skip is never silently tolerated).
+    """
+    text = (reason or "").lower()
+    if not text:
+        return SkipClass.OTHER
+
+    binary_markers = (
+        "version check",
+        "no such file or directory",
+        "command not found",
+        "not found in path",
+        "is not installed",
+        "not installed",
+        "executable not found",
+    )
+    if any(marker in text for marker in binary_markers):
+        return SkipClass.BINARY_MISSING
+
+    opt_in_markers = (
+        "disabled by default",
+        "opt-in",
+        "opt in",
+        "disabled (opt-in",
+    )
+    if any(marker in text for marker in opt_in_markers):
+        return SkipClass.OPT_IN_DISABLED
+
+    config_markers = (
+        "no config",
+        "no configuration",
+        "configuration found",
+        "configuration provided",
+        "config found",
+        ".vale.ini",
+    )
+    if any(marker in text for marker in config_markers):
+        return SkipClass.NO_CONFIG
+
+    return SkipClass.OTHER
+
+
+@dataclass(frozen=True)
+class AllowlistEntry:
+    """A single allowlist rule for a tool skip."""
+
+    tool: str
+    reason_class: SkipClass
+    rationale: str
+    interim: bool
+    issue: int | None = None
+
+
+@dataclass
+class Allowlist:
+    """A parsed skip allowlist, keyed by normalized tool name."""
+
+    entries: dict[str, AllowlistEntry] = field(default_factory=dict)
+
+    def get(self, tool: str) -> AllowlistEntry | None:
+        """Return the entry for ``tool`` (normalized), or None."""
+        return self.entries.get(normalize_tool_name(tool))
+
+
+def _parse_entry(raw: Any, *, interim: bool) -> AllowlistEntry:
+    """Validate and build one :class:`AllowlistEntry` from raw YAML data.
+
+    Args:
+        raw: A single mapping from the allowlist ``allowlist``/``interim`` list.
+        interim: Whether this entry came from the ``interim`` section.
+
+    Returns:
+        The validated allowlist entry.
+
+    Raises:
+        AllowlistError: If required fields are missing or invalid.
+    """
+    if not isinstance(raw, dict):
+        raise AllowlistError(f"allowlist entry must be a mapping, got {type(raw)!r}")
+
+    tool = raw.get("tool")
+    if not isinstance(tool, str) or not tool.strip():
+        raise AllowlistError(f"allowlist entry missing a non-empty 'tool': {raw!r}")
+
+    reason_raw = raw.get("reason_class")
+    valid = ", ".join(c.value for c in SkipClass)
+    if not isinstance(reason_raw, str):
+        raise AllowlistError(
+            f"{tool}: 'reason_class' is required (expected one of: {valid})",
+        )
+    try:
+        reason_class = SkipClass(reason_raw)
+    except ValueError as exc:
+        raise AllowlistError(
+            f"{tool}: invalid reason_class {reason_raw!r} (expected one of: {valid})",
+        ) from exc
+
+    rationale = raw.get("rationale")
+    if not isinstance(rationale, str) or not rationale.strip():
+        raise AllowlistError(f"{tool}: 'rationale' is required and must be non-empty")
+
+    issue = raw.get("issue")
+    if issue is not None and not isinstance(issue, int):
+        raise AllowlistError(f"{tool}: 'issue' must be an integer when set")
+
+    if interim:
+        # Interim tolerations are temporary and must be traceable to a
+        # tracking issue so they get removed once remediated.
+        if issue is None:
+            raise AllowlistError(
+                f"{tool}: interim entries must reference a tracking 'issue'",
+            )
+    elif reason_class not in PERMANENT_ALLOWLISTABLE:
+        # A missing binary is an image bug and must never be masked
+        # permanently; it can only be tolerated as a tracked interim entry.
+        allowed = ", ".join(sorted(c.value for c in PERMANENT_ALLOWLISTABLE))
+        raise AllowlistError(
+            f"{tool}: reason_class {reason_class.value!r} is not permanently "
+            f"allowlistable (permanent entries allow: {allowed}); move it to the "
+            "'interim' section with a tracking issue",
+        )
+
+    return AllowlistEntry(
+        tool=normalize_tool_name(tool),
+        reason_class=reason_class,
+        rationale=rationale.strip(),
+        interim=interim,
+        issue=issue,
+    )
+
+
+def load_allowlist(data: Any) -> Allowlist:
+    """Build an :class:`Allowlist` from parsed YAML data.
+
+    Args:
+        data: The parsed YAML document. ``None`` (empty file) yields an empty
+            allowlist.
+
+    Returns:
+        The parsed and validated allowlist.
+
+    Raises:
+        AllowlistError: If the document shape or any entry is invalid, or if a
+            tool appears in more than one entry.
+    """
+    if data is None:
+        return Allowlist()
+    if not isinstance(data, dict):
+        raise AllowlistError("allowlist root must be a mapping")
+
+    entries: dict[str, AllowlistEntry] = {}
+    for section, interim in (("allowlist", False), ("interim", True)):
+        raw_list = data.get(section) or []
+        if not isinstance(raw_list, list):
+            raise AllowlistError(f"'{section}' must be a list when present")
+        for raw in raw_list:
+            entry = _parse_entry(raw, interim=interim)
+            if entry.tool in entries:
+                raise AllowlistError(
+                    f"{entry.tool}: duplicate allowlist entry (each tool may "
+                    "appear at most once across 'allowlist' and 'interim')",
+                )
+            entries[entry.tool] = entry
+    return Allowlist(entries=entries)
+
+
+@dataclass(frozen=True)
+class SkipFinding:
+    """The outcome of evaluating one skipped tool against the allowlist."""
+
+    tool: str
+    reason: str
+    skip_class: SkipClass
+    allowed: bool
+    message: str
+    is_warning: bool = False
+
+
+def _extract_results(payload: Any) -> list[dict[str, Any]]:
+    """Return the list of per-tool result dicts from a lintro JSON payload.
+
+    Args:
+        payload: The parsed ``lintro chk --output-format json`` document.
+
+    Returns:
+        The ``results`` list.
+
+    Raises:
+        ValueError: If the payload is not the expected shape.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("lintro report must be a JSON object")
+    results = payload.get("results")
+    if not isinstance(results, list):
+        raise ValueError("lintro report is missing a 'results' array")
+    return [entry for entry in results if isinstance(entry, dict)]
+
+
+def evaluate_skips(payload: Any, allowlist: Allowlist) -> list[SkipFinding]:
+    """Evaluate every skipped tool in a lintro report against the allowlist.
+
+    Args:
+        payload: Parsed lintro JSON report.
+        allowlist: The parsed allowlist.
+
+    Returns:
+        One :class:`SkipFinding` per skipped tool, in report order.
+    """
+    findings: list[SkipFinding] = []
+    for result in _extract_results(payload):
+        if not result.get("skipped"):
+            continue
+        tool = str(result.get("tool") or "unknown")
+        reason = result.get("skip_reason")
+        reason_str = reason if isinstance(reason, str) else ""
+        skip_class = classify_skip_reason(reason_str)
+        entry = allowlist.get(tool)
+
+        if entry is None:
+            findings.append(
+                SkipFinding(
+                    tool=tool,
+                    reason=reason_str,
+                    skip_class=skip_class,
+                    allowed=False,
+                    message=(
+                        f"{tool}: skipped ({skip_class.value}) with no allowlist "
+                        f"entry — reason: {reason_str or '<none>'}"
+                    ),
+                ),
+            )
+            continue
+
+        if entry.reason_class != skip_class:
+            findings.append(
+                SkipFinding(
+                    tool=tool,
+                    reason=reason_str,
+                    skip_class=skip_class,
+                    allowed=False,
+                    message=(
+                        f"{tool}: skipped as {skip_class.value} but allowlisted for "
+                        f"{entry.reason_class.value} — re-triage the skip reason: "
+                        f"{reason_str or '<none>'}"
+                    ),
+                ),
+            )
+            continue
+
+        # Allowlisted skip. Interim binary-missing tolerations are surfaced as
+        # loud warnings so an image bug can never be masked silently forever.
+        issue_ref = f" (see #{entry.issue})" if entry.issue is not None else ""
+        if entry.interim:
+            findings.append(
+                SkipFinding(
+                    tool=tool,
+                    reason=reason_str,
+                    skip_class=skip_class,
+                    allowed=True,
+                    is_warning=True,
+                    message=(
+                        f"{tool}: interim-allowlisted skip ({skip_class.value})"
+                        f"{issue_ref} — {entry.rationale}"
+                    ),
+                ),
+            )
+        else:
+            findings.append(
+                SkipFinding(
+                    tool=tool,
+                    reason=reason_str,
+                    skip_class=skip_class,
+                    allowed=True,
+                    message=(
+                        f"{tool}: allowlisted skip ({skip_class.value}) — "
+                        f"{entry.rationale}"
+                    ),
+                ),
+            )
+    return findings
+
+
+def _read_report(report_arg: str | None) -> Any:
+    """Read and parse the lintro JSON report from a file or stdin.
+
+    Args:
+        report_arg: Path to the report file, or ``None``/``-`` for stdin.
+
+    Returns:
+        The parsed JSON document.
+
+    Raises:
+        ValueError: On unreadable or malformed input.
+    """
+    if report_arg in (None, "-"):
+        raw = sys.stdin.read()
+    else:
+        raw = Path(report_arg).read_text(encoding="utf-8")
+    if not raw.strip():
+        raise ValueError("lintro report is empty")
+    return json.loads(raw)
+
+
+def _print_report(findings: list[SkipFinding]) -> None:
+    """Print a human-readable summary of skip findings to stdout/stderr."""
+    allowed = [f for f in findings if f.allowed and not f.is_warning]
+    warnings = [f for f in findings if f.allowed and f.is_warning]
+    violations = [f for f in findings if not f.allowed]
+
+    print("Dogfood no-silent-skip gate")
+    print(f"  skipped tools : {len(findings)}")
+    print(f"  allowlisted   : {len(allowed)}")
+    print(f"  interim/warn  : {len(warnings)}")
+    print(f"  violations    : {len(violations)}")
+
+    for finding in allowed:
+        print(f"  OK    {finding.message}")
+    for finding in warnings:
+        print(f"  WARN  {finding.message}", file=sys.stderr)
+    for finding in violations:
+        print(f"  FAIL  {finding.message}", file=sys.stderr)
+
+
+def run(report_arg: str | None, allowlist_arg: str) -> int:
+    """Run the gate and return the process exit code.
+
+    Args:
+        report_arg: Path to the lintro JSON report, or ``None``/``-`` for stdin.
+        allowlist_arg: Path to the allowlist YAML file.
+
+    Returns:
+        Exit code: 0 (pass), 1 (violations), or 2 (usage/config error).
+    """
+    try:
+        payload = _read_report(report_arg)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: failed to read lintro report: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        allowlist_data = yaml.safe_load(
+            Path(allowlist_arg).read_text(encoding="utf-8"),
+        )
+    except (OSError, yaml.YAMLError) as exc:
+        print(f"error: failed to read allowlist: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        allowlist = load_allowlist(allowlist_data)
+    except AllowlistError as exc:
+        print(f"error: invalid allowlist: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        findings = evaluate_skips(payload, allowlist)
+    except ValueError as exc:
+        print(f"error: malformed lintro report: {exc}", file=sys.stderr)
+        return 2
+
+    _print_report(findings)
+
+    violations = [f for f in findings if not f.allowed]
+    if violations:
+        print(
+            f"\nGate failed: {len(violations)} enabled tool(s) silently skipped. "
+            "Install the missing tool in the image, add the missing config, or "
+            "(for tracked work) add an interim allowlist entry with an issue link.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nGate passed: no non-allowlisted skips.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Args:
+        argv: Optional argument list (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Process exit code.
+    """
+    parser = argparse.ArgumentParser(
+        description="Fail dogfooding CI when an enabled tool silently skips.",
+    )
+    parser.add_argument(
+        "--report",
+        default=None,
+        help="Path to the lintro JSON report (default: read from stdin).",
+    )
+    parser.add_argument(
+        "--allowlist",
+        default="scripts/ci/dogfood-skip-allowlist.yaml",
+        help="Path to the skip allowlist YAML file.",
+    )
+    args = parser.parse_args(argv)
+    return run(args.report, args.allowlist)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check-dogfood-skips.py
+++ b/scripts/ci/check-dogfood-skips.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -94,8 +95,8 @@ def normalize_tool_name(name: str) -> str:
 def classify_skip_reason(reason: str | None) -> SkipClass:
     """Classify a skip reason string into a :class:`SkipClass`.
 
-    Matching is case-insensitive and substring-based, checked in priority
-    order so the most dangerous class (a missing binary) wins.
+    Matching is case-insensitive and pattern-based, checked in priority order
+    so the most dangerous class (a missing binary) wins.
 
     Args:
         reason: The ``skip_reason`` string from a lintro tool result.
@@ -108,16 +109,17 @@ def classify_skip_reason(reason: str | None) -> SkipClass:
     if not text:
         return SkipClass.OTHER
 
-    binary_markers = (
-        "version check",
-        "no such file or directory",
-        "command not found",
-        "not found in path",
-        "is not installed",
-        "not installed",
-        "executable not found",
+    binary_patterns = (
+        r"\bfailed to run version check\b",
+        r"\bversion check failed\b",
+        r"\bno such file or directory\b",
+        r"\bcommand not found\b",
+        r"\bnot found in path\b",
+        r"\bis not installed\b",
+        r"\bnot installed\b",
+        r"\bexecutable not found\b",
     )
-    if any(marker in text for marker in binary_markers):
+    if any(re.search(pattern, text) for pattern in binary_patterns):
         return SkipClass.BINARY_MISSING
 
     opt_in_markers = (
@@ -129,15 +131,13 @@ def classify_skip_reason(reason: str | None) -> SkipClass:
     if any(marker in text for marker in opt_in_markers):
         return SkipClass.OPT_IN_DISABLED
 
-    config_markers = (
-        "no config",
-        "no configuration",
-        "configuration found",
-        "configuration provided",
-        "config found",
-        ".vale.ini",
+    config_patterns = (
+        r"\bno\b.*\bconfig(?:uration)?\b.*\b(?:found|provided)\b",
+        r"\bno\b.*\bconfig(?:uration)?\b",
+        r"\bconfig(?:uration)?(?: file)?\b.*\b(?:not found|missing|required)\b",
+        r"\b\.vale\.ini\b.*\b(?:not found|missing|required)\b",
     )
-    if any(marker in text for marker in config_markers):
+    if any(re.search(pattern, text) for pattern in config_patterns):
         return SkipClass.NO_CONFIG
 
     return SkipClass.OTHER

--- a/scripts/ci/check-dogfood-skips.py
+++ b/scripts/ci/check-dogfood-skips.py
@@ -20,8 +20,9 @@ Skip reasons are classified into one of:
   self-skips (e.g. stylelint/vale/commitlint). Allowlistable via the file.
 - ``opt_in_disabled`` — an opt-in tool (idiom-review) is disabled by default.
   Allowlistable via the file.
-- ``other`` — an unrecognised skip reason; treated like ``no_config`` for
-  allowlisting purposes (must be explicitly listed to be tolerated).
+- ``other`` — an unrecognised skip reason. Not permanently allowlistable
+  (like ``binary_missing``); it must be explicitly tolerated via an
+  ``interim`` entry with a tracking issue.
 
 Usage:
     python3 scripts/ci/check-dogfood-skips.py \

--- a/scripts/ci/dogfood-skip-allowlist.yaml
+++ b/scripts/ci/dogfood-skip-allowlist.yaml
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+#
+# Dogfood no-silent-skip allowlist (issue #1510, epic #1508).
+#
+# scripts/ci/check-dogfood-skips.py fails CI when an enabled tool reports
+# `skipped: true` in `lintro chk --output-format json` output for a reason not
+# covered here. Every skip is classified into one of:
+#
+#   binary_missing  - tool binary absent / version check failed. An IMAGE BUG.
+#                     Never permanently allowlistable; may only be tolerated as
+#                     a tracked `interim` entry (which emits a loud warning).
+#   no_config       - no resolvable config in the repo, so the tool self-skips.
+#   opt_in_disabled - an opt-in tool is disabled by default.
+#   other           - unrecognised skip reason.
+#
+# Two sections:
+#   allowlist  Permanent, intentional skips. Only `no_config` /
+#              `opt_in_disabled` are permitted here.
+#   interim    Temporary tolerations pending remediation. Each MUST carry a
+#              tracking `issue` and is reported as a WARNING. Delete the entry
+#              once the issue closes and the tool runs for real.
+#
+# Fields (per entry): tool, reason_class, rationale, and (interim only) issue.
+---
+allowlist:
+  - tool: idiom-review
+    reason_class: opt_in_disabled
+    rationale: >-
+      idiom-review is an opt-in AI reviewer. CI has no AI provider/API key, so
+      it stays disabled by design rather than being a regression.
+
+interim:
+  # TODO(1491): add a root stylelint config so the site CSS is linted for real
+  # instead of hitting the "no configuration found" skip path.
+  - tool: stylelint
+    reason_class: no_config
+    issue: 1491
+    rationale: >-
+      TODO(1491): repo has no stylelint config, so stylelint self-skips and
+      apps/site CSS is unlinted. Remove once a root .stylelintrc lands.
+
+  # TODO(1492): add a root .vale.ini so repo docs are prose-linted for real.
+  - tool: vale
+    reason_class: no_config
+    issue: 1492
+    rationale: >-
+      TODO(1492): repo has no root .vale.ini (the only one is under
+      test_samples/, which is ignored), so vale self-skips. Remove once a root
+      .vale.ini lands.
+
+  # TODO(1493): wire commitlint config, or document the PR-title check as the
+  # canonical gate, so commitlint stops silently self-skipping.
+  - tool: commitlint
+    reason_class: no_config
+    issue: 1493
+    rationale: >-
+      TODO(1493): repo ships no commitlint config, so the plugin self-skips.
+      Remove once the config is added or the PR-title check is documented as
+      canonical.
+
+  # TODO(1505): pip-audit was absent from the pinned tools image, so it skipped
+  # on a failed version check (a missing binary / image bug). Interim toleration
+  # keeps the gate green until the image bump + Dockerfile verification land; a
+  # missing binary is otherwise never allowlistable.
+  - tool: pip_audit
+    reason_class: binary_missing
+    issue: 1505
+    rationale: >-
+      TODO(1505): pip-audit missing from the pinned tools image (silent SKIP).
+      Interim only — remove once the tools-image bump and the Dockerfile
+      `pip-audit --version` verification land so it can never regress silently.

--- a/scripts/ci/dogfood-skip-allowlist.yaml
+++ b/scripts/ci/dogfood-skip-allowlist.yaml
@@ -70,3 +70,13 @@ interim:
       TODO(1505): pip-audit missing from the pinned tools image (silent SKIP).
       Interim only — remove once the tools-image bump and the Dockerfile
       `pip-audit --version` verification land so it can never regress silently.
+
+  # TODO(1510): decide whether the repository should run raw tsc in dogfood CI
+  # or keep delegating site TypeScript checks to astro-check/vue-tsc.
+  - tool: tsc
+    reason_class: other
+    issue: 1510
+    rationale: >-
+      TODO(1510): tsc currently self-skips because repository TypeScript
+      coverage is delegated to astro-check/vue-tsc. Interim only — remove once
+      dogfood CI either runs tsc directly or disables it explicitly.

--- a/scripts/ci/dogfood-skip-gate.sh
+++ b/scripts/ci/dogfood-skip-gate.sh
@@ -97,14 +97,15 @@ declare -a lintro_args=(chk .)
 if [[ -n "$TOOL_OPTIONS" ]]; then
 	lintro_args+=(--tool-options "$TOOL_OPTIONS")
 fi
-lintro_args+=(--output-format json)
+lintro_args+=(--output-format json --output "$REPORT_JSON")
 
 # lintro exits non-zero when it finds real issues; the gate only cares about
-# skips, so capture stdout (pure JSON for machine formats) and ignore the exit
-# code. Warnings go to stderr and are streamed to the log.
+# skips, so ask lintro to write the machine-readable report directly. Stdout can
+# contain operational messages from the CLI and must not be parsed as JSON.
 log_info "Running lintro check (JSON) in container to derive skip state..."
+rm -f "$REPORT_JSON" "${REPORT_JSON}.stdout"
 set +e
-"${docker_args[@]}" "${LINTRO_IMAGE}" "${lintro_args[@]}" >"$REPORT_JSON"
+"${docker_args[@]}" "${LINTRO_IMAGE}" "${lintro_args[@]}" >"${REPORT_JSON}.stdout"
 lintro_exit_code=$?
 set -e
 log_info "lintro exited ${lintro_exit_code} (ignored; gate checks skips only)"

--- a/scripts/ci/dogfood-skip-gate.sh
+++ b/scripts/ci/dogfood-skip-gate.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+set -euo pipefail
+
+# dogfood-skip-gate.sh
+#
+# No-silent-skip gate (issue #1510). Runs lintro chk inside the pinned
+# py-lintro Docker image with `--output-format json` over the whole repo,
+# then runs scripts/ci/check-dogfood-skips.py to fail when an enabled tool
+# silently skips for a reason not covered by the committed allowlist.
+#
+# This runs AFTER the dogfooding lint job as a dedicated gate: the dogfood
+# jobs use an external reusable workflow (no place to add a step), so the gate
+# re-derives the structured skip state from the same image. Only the `skipped`
+# state matters here — real lint issues are gated by the dogfood job itself, so
+# lintro's own exit code is intentionally ignored.
+#
+# Usage:
+#   LINTRO_IMAGE=ghcr.io/lgtm-hq/py-lintro:ci-123 scripts/ci/dogfood-skip-gate.sh
+#
+# Environment:
+#   LINTRO_IMAGE   Required. Pinned py-lintro image (CI tag or digest).
+#   TOOL_OPTIONS   Optional. lintro --tool-options string (match the dogfood
+#                  run so tool coverage — and thus skip behaviour — is identical).
+#   ALLOWLIST      Optional. Allowlist path (default:
+#                  scripts/ci/dogfood-skip-allowlist.yaml).
+#   REPORT_JSON    Optional. Where to write the JSON report (default:
+#                  dogfood-skip-report.json).
+#   MAP_HOST_USER  Optional. true maps host UID/GID into the container
+#                  (default: true on GitHub Actions).
+
+show_help() {
+	cat <<'EOF'
+Usage:
+  LINTRO_IMAGE=<image> scripts/ci/dogfood-skip-gate.sh
+
+Run lintro chk (JSON) in Docker and fail on non-allowlisted tool skips.
+
+Environment:
+  LINTRO_IMAGE   Required. Pinned py-lintro image (CI tag or digest).
+  TOOL_OPTIONS   Optional. lintro --tool-options string.
+  ALLOWLIST      Optional. Allowlist YAML (default: scripts/ci/dogfood-skip-allowlist.yaml).
+  REPORT_JSON    Optional. JSON report output path (default: dogfood-skip-report.json).
+  MAP_HOST_USER  Optional. true maps host UID/GID into the container.
+
+Exit codes:
+  0  no non-allowlisted skips
+  1  one or more non-allowlisted skips
+  2  usage / configuration error, or the lintro run produced no JSON
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	show_help
+	exit 0
+fi
+
+: "${LINTRO_IMAGE:?LINTRO_IMAGE is required}"
+: "${TOOL_OPTIONS:=}"
+: "${ALLOWLIST:=scripts/ci/dogfood-skip-allowlist.yaml}"
+: "${REPORT_JSON:=dogfood-skip-report.json}"
+: "${MAP_HOST_USER:=}"
+if [[ -z "${MAP_HOST_USER}" ]] && [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+	MAP_HOST_USER=true
+fi
+
+log_info() { echo "[INFO] $*"; }
+log_error() { echo "[ERROR] $*" >&2; }
+
+# Pull explicitly so a registry failure surfaces as a clear gate error rather
+# than an empty report.
+log_info "Pulling Lintro image: ${LINTRO_IMAGE}"
+set +e
+docker pull "$LINTRO_IMAGE"
+pull_exit_code=$?
+set -e
+if [[ "$pull_exit_code" -ne 0 ]]; then
+	log_error "Failed to pull Lintro image ${LINTRO_IMAGE} (exit ${pull_exit_code})"
+	exit 2
+fi
+
+# Same container invocation as the dogfood run (host-UID mapping keeps the
+# workspace mount writable on GitHub Actions).
+declare -a docker_args=(
+	docker run --rm
+	-e HOME=/tmp
+	-e LINTRO_AUTO_INSTALL_DEPS=1
+	-v "$(pwd):/code"
+	-w /code
+)
+if [[ "$MAP_HOST_USER" == "true" ]]; then
+	docker_args+=(--user "$(id -u):$(id -g)")
+fi
+
+declare -a lintro_args=(chk .)
+if [[ -n "$TOOL_OPTIONS" ]]; then
+	lintro_args+=(--tool-options "$TOOL_OPTIONS")
+fi
+lintro_args+=(--output-format json)
+
+# lintro exits non-zero when it finds real issues; the gate only cares about
+# skips, so capture stdout (pure JSON for machine formats) and ignore the exit
+# code. Warnings go to stderr and are streamed to the log.
+log_info "Running lintro check (JSON) in container to derive skip state..."
+set +e
+"${docker_args[@]}" "${LINTRO_IMAGE}" "${lintro_args[@]}" >"$REPORT_JSON"
+lintro_exit_code=$?
+set -e
+log_info "lintro exited ${lintro_exit_code} (ignored; gate checks skips only)"
+
+if [[ ! -s "$REPORT_JSON" ]]; then
+	log_error "lintro produced no JSON report at ${REPORT_JSON}; cannot gate skips"
+	exit 2
+fi
+
+# Run the checker inside the image: it ships PyYAML, so no host Python deps are
+# needed. The workspace is mounted at /code, so the report and allowlist are
+# both visible there.
+log_info "Checking skips against ${ALLOWLIST}..."
+"${docker_args[@]}" --entrypoint python3 "${LINTRO_IMAGE}" \
+	/code/scripts/ci/check-dogfood-skips.py \
+	--report "/code/${REPORT_JSON}" \
+	--allowlist "/code/${ALLOWLIST}"

--- a/tests/scripts/test_check_dogfood_skips.py
+++ b/tests/scripts/test_check_dogfood_skips.py
@@ -454,7 +454,8 @@ def test_committed_allowlist_is_valid_and_seeds_expected_tools() -> None:
     )
     data = yaml.safe_load(allowlist_path.read_text(encoding="utf-8"))
     allowlist = mod.load_allowlist(data)
-    for tool in ("idiom-review", "stylelint", "vale", "commitlint", "pip_audit"):
+    for tool in ("idiom-review", "stylelint", "vale", "commitlint", "pip_audit", "tsc"):
         assert_that(allowlist.get(tool)).is_not_none()
     assert_that(allowlist.get("idiom-review").interim).is_false()
     assert_that(allowlist.get("pip_audit").issue).is_equal_to(1505)
+    assert_that(allowlist.get("tsc").issue).is_equal_to(1510)

--- a/tests/scripts/test_check_dogfood_skips.py
+++ b/tests/scripts/test_check_dogfood_skips.py
@@ -80,10 +80,28 @@ def test_classify_binary_missing_from_version_check() -> None:
     )
 
 
+def test_classify_version_check_without_failure_is_other() -> None:
+    """A bare version-check mention is not enough to imply a missing binary."""
+    reason = "Skipping tool because version check is disabled by configuration"
+    assert_that(mod.classify_skip_reason(reason)).is_equal_to(mod.SkipClass.OTHER)
+
+
 def test_classify_no_config_from_stylelint_reason() -> None:
     """A "no configuration found" reason classifies as no_config."""
     reason = "Skipping stylelint: no stylelint configuration found (e.g. .stylelintrc)."
     assert_that(mod.classify_skip_reason(reason)).is_equal_to(mod.SkipClass.NO_CONFIG)
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "Skipping tool because configuration found is true",
+        "Skipping tool because configuration provided by the user is invalid",
+    ],
+)
+def test_classify_positive_configuration_mentions_are_other(reason: str) -> None:
+    """Positive config phrases do not imply a no-config skip."""
+    assert_that(mod.classify_skip_reason(reason)).is_equal_to(mod.SkipClass.OTHER)
 
 
 def test_classify_opt_in_disabled_from_idiom_review_reason() -> None:

--- a/tests/scripts/test_check_dogfood_skips.py
+++ b/tests/scripts/test_check_dogfood_skips.py
@@ -1,0 +1,442 @@
+"""Tests for check-dogfood-skips.py (dogfood no-silent-skip gate, #1510)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+import yaml
+from assertpy import assert_that
+
+
+def _load_module() -> ModuleType:
+    """Load check-dogfood-skips.py as an importable test module."""
+    script_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "ci"
+        / "check-dogfood-skips.py"
+    )
+    spec = importlib.util.spec_from_file_location("check_dogfood_skips", script_path)
+    if spec is None or spec.loader is None:
+        msg = f"Unable to load module from {script_path}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclass annotations (evaluated lazily under
+    # ``from __future__ import annotations``) can resolve via sys.modules.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module()
+
+
+def _skip_result(tool: str, reason: str) -> dict[str, Any]:
+    """Build a skipped tool result dict for a lintro JSON report."""
+    return {
+        "tool": tool,
+        "success": True,
+        "issues_count": 0,
+        "skipped": True,
+        "skip_reason": reason,
+        "output": f"Skipping {tool}",
+    }
+
+
+def _report(*results: dict[str, Any]) -> dict[str, Any]:
+    """Wrap tool result dicts in a lintro JSON report envelope."""
+    return {"results": list(results), "summary": {"total_issues": 0}}
+
+
+def _allowlist(
+    allowlist: list[dict[str, Any]] | None,
+    interim: list[dict[str, Any]] | None,
+) -> Any:
+    """Build an allowlist object from raw section lists."""
+    data: dict[str, Any] = {}
+    if allowlist is not None:
+        data["allowlist"] = allowlist
+    if interim is not None:
+        data["interim"] = interim
+    return mod.load_allowlist(data)
+
+
+# --------------------------------------------------------------------------
+# Skip-reason classification
+# --------------------------------------------------------------------------
+
+
+def test_classify_binary_missing_from_version_check() -> None:
+    """A failed version check / missing binary classifies as binary_missing."""
+    reason = "Failed to run version check: [Errno 2] No such file or directory: 'vale'"
+    assert_that(mod.classify_skip_reason(reason)).is_equal_to(
+        mod.SkipClass.BINARY_MISSING,
+    )
+
+
+def test_classify_no_config_from_stylelint_reason() -> None:
+    """A "no configuration found" reason classifies as no_config."""
+    reason = "Skipping stylelint: no stylelint configuration found (e.g. .stylelintrc)."
+    assert_that(mod.classify_skip_reason(reason)).is_equal_to(mod.SkipClass.NO_CONFIG)
+
+
+def test_classify_opt_in_disabled_from_idiom_review_reason() -> None:
+    """The idiom-review opt-in reason classifies as opt_in_disabled."""
+    reason = "idiom-review is disabled by default; enable it via tools.idiom-review"
+    assert_that(mod.classify_skip_reason(reason)).is_equal_to(
+        mod.SkipClass.OPT_IN_DISABLED,
+    )
+
+
+def test_classify_empty_reason_is_other() -> None:
+    """An empty or missing reason never silently classifies as tolerable."""
+    assert_that(mod.classify_skip_reason("")).is_equal_to(mod.SkipClass.OTHER)
+    assert_that(mod.classify_skip_reason(None)).is_equal_to(mod.SkipClass.OTHER)
+
+
+def test_classify_unrecognised_reason_is_other() -> None:
+    """An unrecognised reason classifies as other, not a known class."""
+    assert_that(mod.classify_skip_reason("some brand new reason")).is_equal_to(
+        mod.SkipClass.OTHER,
+    )
+
+
+# --------------------------------------------------------------------------
+# Tool-name normalization
+# --------------------------------------------------------------------------
+
+
+def test_normalize_tool_name_folds_hyphens_and_case() -> None:
+    """Hyphen and underscore spellings normalize to the same key."""
+    assert_that(mod.normalize_tool_name("idiom-review")).is_equal_to("idiom_review")
+    assert_that(mod.normalize_tool_name("PIP_AUDIT")).is_equal_to("pip_audit")
+
+
+# --------------------------------------------------------------------------
+# Allowlist parsing / validation
+# --------------------------------------------------------------------------
+
+
+def test_load_allowlist_none_yields_empty() -> None:
+    """An empty (None) document yields an allowlist with no entries."""
+    allowlist = mod.load_allowlist(None)
+    assert_that(allowlist.entries).is_empty()
+
+
+def test_permanent_entry_rejects_binary_missing_class() -> None:
+    """binary_missing is never permitted in the permanent allowlist section."""
+    with pytest.raises(mod.AllowlistError) as exc:
+        _allowlist(
+            allowlist=[
+                {
+                    "tool": "pip_audit",
+                    "reason_class": "binary_missing",
+                    "rationale": "nope",
+                },
+            ],
+            interim=None,
+        )
+    assert_that(str(exc.value)).contains("not permanently allowlistable")
+
+
+def test_interim_entry_requires_issue() -> None:
+    """Interim tolerations must reference a tracking issue."""
+    with pytest.raises(mod.AllowlistError) as exc:
+        _allowlist(
+            allowlist=None,
+            interim=[
+                {
+                    "tool": "stylelint",
+                    "reason_class": "no_config",
+                    "rationale": "missing config",
+                },
+            ],
+        )
+    assert_that(str(exc.value)).contains("must reference a tracking 'issue'")
+
+
+def test_interim_entry_allows_binary_missing_with_issue() -> None:
+    """binary_missing IS tolerable as an interim entry with a tracking issue."""
+    allowlist = _allowlist(
+        allowlist=None,
+        interim=[
+            {
+                "tool": "pip_audit",
+                "reason_class": "binary_missing",
+                "issue": 1505,
+                "rationale": "interim until image bump",
+            },
+        ],
+    )
+    entry = allowlist.get("pip-audit")
+    assert_that(entry).is_not_none()
+    assert_that(entry.interim).is_true()
+    assert_that(entry.issue).is_equal_to(1505)
+
+
+def test_duplicate_tool_entry_is_rejected() -> None:
+    """A tool may appear at most once across allowlist + interim."""
+    with pytest.raises(mod.AllowlistError) as exc:
+        _allowlist(
+            allowlist=[
+                {
+                    "tool": "vale",
+                    "reason_class": "no_config",
+                    "rationale": "x",
+                },
+            ],
+            interim=[
+                {
+                    "tool": "vale",
+                    "reason_class": "no_config",
+                    "issue": 1492,
+                    "rationale": "y",
+                },
+            ],
+        )
+    assert_that(str(exc.value)).contains("duplicate allowlist entry")
+
+
+def test_invalid_reason_class_is_rejected() -> None:
+    """An unknown reason_class value fails allowlist validation."""
+    with pytest.raises(mod.AllowlistError):
+        _allowlist(
+            allowlist=[
+                {"tool": "vale", "reason_class": "bogus", "rationale": "x"},
+            ],
+            interim=None,
+        )
+
+
+# --------------------------------------------------------------------------
+# Skip evaluation against the allowlist
+# --------------------------------------------------------------------------
+
+
+def test_binary_missing_without_entry_is_violation() -> None:
+    """A missing-binary skip with no allowlist entry is a hard violation."""
+    payload = _report(
+        _skip_result(
+            "osv_scanner",
+            "Failed to run version check: No such file or directory: 'osv-scanner'",
+        ),
+    )
+    findings = mod.evaluate_skips(payload, mod.load_allowlist(None))
+    assert_that(findings).is_length(1)
+    assert_that(findings[0].allowed).is_false()
+    assert_that(findings[0].skip_class).is_equal_to(mod.SkipClass.BINARY_MISSING)
+
+
+def test_no_config_skip_is_allowed_when_interim_listed() -> None:
+    """A no_config skip listed as interim is allowed (as a warning)."""
+    payload = _report(
+        _skip_result(
+            "stylelint",
+            "Skipping stylelint: no stylelint configuration found.",
+        ),
+    )
+    allowlist = _allowlist(
+        allowlist=None,
+        interim=[
+            {
+                "tool": "stylelint",
+                "reason_class": "no_config",
+                "issue": 1491,
+                "rationale": "interim",
+            },
+        ],
+    )
+    findings = mod.evaluate_skips(payload, allowlist)
+    assert_that(findings).is_length(1)
+    assert_that(findings[0].allowed).is_true()
+    assert_that(findings[0].is_warning).is_true()
+
+
+def test_opt_in_permanent_allowlist_is_allowed_without_warning() -> None:
+    """An opt_in_disabled permanent entry is allowed and is not a warning."""
+    payload = _report(
+        _skip_result(
+            "idiom-review",
+            "idiom-review is disabled by default; enable it via tools.idiom-review",
+        ),
+    )
+    allowlist = _allowlist(
+        allowlist=[
+            {
+                "tool": "idiom-review",
+                "reason_class": "opt_in_disabled",
+                "rationale": "no API key in CI",
+            },
+        ],
+        interim=None,
+    )
+    findings = mod.evaluate_skips(payload, allowlist)
+    assert_that(findings).is_length(1)
+    assert_that(findings[0].allowed).is_true()
+    assert_that(findings[0].is_warning).is_false()
+
+
+def test_class_mismatch_is_violation() -> None:
+    """A skip whose class differs from its allowlist entry is a violation."""
+    payload = _report(
+        _skip_result(
+            "vale",
+            "Failed to run version check: No such file or directory: 'vale'",
+        ),
+    )
+    allowlist = _allowlist(
+        allowlist=None,
+        interim=[
+            {
+                "tool": "vale",
+                "reason_class": "no_config",
+                "issue": 1492,
+                "rationale": "interim",
+            },
+        ],
+    )
+    findings = mod.evaluate_skips(payload, allowlist)
+    assert_that(findings).is_length(1)
+    assert_that(findings[0].allowed).is_false()
+    assert_that(findings[0].message).contains("re-triage")
+
+
+def test_non_skipped_tools_are_ignored() -> None:
+    """Tools that ran (skipped=false) produce no findings."""
+    payload = _report(
+        {
+            "tool": "ruff",
+            "success": True,
+            "issues_count": 0,
+            "skipped": False,
+            "skip_reason": None,
+            "output": "ok",
+        },
+    )
+    findings = mod.evaluate_skips(payload, mod.load_allowlist(None))
+    assert_that(findings).is_empty()
+
+
+def test_extract_results_rejects_missing_results_key() -> None:
+    """A payload without a results array is a malformed report."""
+    with pytest.raises(ValueError):
+        mod.evaluate_skips({"summary": {}}, mod.load_allowlist(None))
+
+
+# --------------------------------------------------------------------------
+# End-to-end run() exit codes
+# --------------------------------------------------------------------------
+
+
+def test_run_passes_on_green_report(tmp_path: Path) -> None:
+    """run() exits 0 when every skip is allowlisted."""
+    report = tmp_path / "report.json"
+    report.write_text(
+        json.dumps(
+            _report(
+                _skip_result(
+                    "idiom-review",
+                    "idiom-review is disabled by default; enable it via config",
+                ),
+                _skip_result(
+                    "stylelint",
+                    "Skipping stylelint: no stylelint configuration found.",
+                ),
+            ),
+        ),
+        encoding="utf-8",
+    )
+    allowlist = tmp_path / "allow.yaml"
+    allowlist.write_text(
+        yaml.safe_dump(
+            {
+                "allowlist": [
+                    {
+                        "tool": "idiom-review",
+                        "reason_class": "opt_in_disabled",
+                        "rationale": "no API key in CI",
+                    },
+                ],
+                "interim": [
+                    {
+                        "tool": "stylelint",
+                        "reason_class": "no_config",
+                        "issue": 1491,
+                        "rationale": "interim",
+                    },
+                ],
+            },
+        ),
+        encoding="utf-8",
+    )
+    assert_that(mod.run(str(report), str(allowlist))).is_equal_to(0)
+
+
+def test_run_fails_on_unlisted_skip(tmp_path: Path) -> None:
+    """run() exits 1 when a skip is not covered by the allowlist."""
+    report = tmp_path / "report.json"
+    report.write_text(
+        json.dumps(
+            _report(
+                _skip_result(
+                    "gitleaks",
+                    "Failed to run version check: No such file or directory: 'gitleaks'",
+                ),
+            ),
+        ),
+        encoding="utf-8",
+    )
+    allowlist = tmp_path / "allow.yaml"
+    allowlist.write_text("allowlist: []\n", encoding="utf-8")
+    assert_that(mod.run(str(report), str(allowlist))).is_equal_to(1)
+
+
+def test_run_returns_config_error_on_bad_report(tmp_path: Path) -> None:
+    """run() exits 2 when the report file is missing or unparseable."""
+    allowlist = tmp_path / "allow.yaml"
+    allowlist.write_text("allowlist: []\n", encoding="utf-8")
+    assert_that(mod.run(str(tmp_path / "nope.json"), str(allowlist))).is_equal_to(2)
+
+
+def test_run_returns_config_error_on_invalid_allowlist(tmp_path: Path) -> None:
+    """run() exits 2 when the allowlist violates the schema."""
+    report = tmp_path / "report.json"
+    report.write_text(json.dumps(_report()), encoding="utf-8")
+    allowlist = tmp_path / "allow.yaml"
+    allowlist.write_text(
+        yaml.safe_dump(
+            {
+                "allowlist": [
+                    {
+                        "tool": "pip_audit",
+                        "reason_class": "binary_missing",
+                        "rationale": "not allowed permanently",
+                    },
+                ],
+            },
+        ),
+        encoding="utf-8",
+    )
+    assert_that(mod.run(str(report), str(allowlist))).is_equal_to(2)
+
+
+def test_committed_allowlist_is_valid_and_seeds_expected_tools() -> None:
+    """The committed allowlist parses and seeds the tracked tools."""
+    allowlist_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "ci"
+        / "dogfood-skip-allowlist.yaml"
+    )
+    data = yaml.safe_load(allowlist_path.read_text(encoding="utf-8"))
+    allowlist = mod.load_allowlist(data)
+    for tool in ("idiom-review", "stylelint", "vale", "commitlint", "pip_audit"):
+        assert_that(allowlist.get(tool)).is_not_none()
+    assert_that(allowlist.get("idiom-review").interim).is_false()
+    assert_that(allowlist.get("pip_audit").issue).is_equal_to(1505)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ci): fail dogfooding when an enabled tool silently skips
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Adds a no-silent-skip gate to dogfooding so an enabled tool that SKIP's cannot masquerade as a green PASS.

- `scripts/ci/check-dogfood-skips.py` — classify skips from lintro JSON (`binary_missing` / `no_config` / `opt_in_disabled` / `other`) and fail on non-allowlisted skips
- `scripts/ci/dogfood-skip-allowlist.yaml` — permanent `idiom-review`; interim entries for stylelint/vale/commitlint/pip_audit with TODO + issue links
- `scripts/ci/dogfood-skip-gate.sh` — re-derives JSON skip state from the pinned image and runs the checker
- Wires SHA-pinned `dogfood-skip-gate` job into `docker-ci.yml` and `dogfood-nightly.yml`
- Unit tests for classification, allowlist matching, and never-allowlistable class

`binary_missing` is never permanently allowlistable (interim-only with issue link + WARN).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1510

## Details

Part of epic #1508. 23 new unit tests green; `lintro fmt`/`chk` clean on changed files.
