### PR TITLE
refactor(core): migrate os.path usage to pathlib in core modules

### DIFF
--- a/lintro/tools/core/install_context.py
+++ b/lintro/tools/core/install_context.py
@@ -19,6 +19,7 @@ import os
 import platform
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 from lintro.enums.install_context import CISystem, InstallContext
 from lintro.tools.core.install_strategies.environment import InstallEnvironment
@@ -63,7 +64,7 @@ def _detect_install_context() -> InstallContext:
     """Detect how lintro was installed based on the executable path."""
     # Docker: check for Docker indicators
     if (
-        os.path.exists("/.dockerenv")
+        Path("/.dockerenv").exists()
         or os.environ.get("LINTRO_DOCKER") == "1"
         or os.environ.get("CONTAINER") == "docker"
     ):
@@ -71,8 +72,8 @@ def _detect_install_context() -> InstallContext:
 
     # Resolve symlinks so pip installs under /opt/homebrew/lib aren't
     # misclassified as Homebrew formula installs.
-    exe_path = os.path.realpath(sys.executable)
-    install_path = os.path.realpath(__file__)
+    exe_path = str(Path(sys.executable).resolve(strict=False))
+    install_path = str(Path(__file__).resolve(strict=False))
 
     # npm binary: the launcher resolves the platform package, so the running
     # executable lives under node_modules/@lgtm-hq/lintro-<platform>/. Check before
@@ -99,18 +100,19 @@ def _detect_install_context() -> InstallContext:
             continue
         if "lintro-full" in lower:
             return InstallContext.HOMEBREW_FULL
-        name = os.path.basename(lower)
-        parent = os.path.basename(os.path.dirname(lower))
+        lower_path = Path(lower)
+        name = lower_path.name
+        parent = lower_path.parent.name
         if name == "lintro" and parent in {"bin", "sbin"}:
             return InstallContext.HOMEBREW_BIN
 
     # Development: running from a git checkout
     # install_path is lintro/tools/core/install_context.py — 4 levels to repo root
-    source_root = os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.dirname(install_path))),
-    )
-    # Use os.path.exists (not isdir) to also detect .git files (worktrees/submodules)
-    if os.path.exists(os.path.join(source_root, ".git")):
+    source_root = Path(install_path)
+    for _ in range(4):
+        source_root = source_root.parent
+    # Use exists (not is_dir) to also detect .git files (worktrees/submodules)
+    if (source_root / ".git").exists():
         return InstallContext.DEVELOPMENT
 
     # Default: pip/uv install

--- a/lintro/tools/core/line_length_checker.py
+++ b/lintro/tools/core/line_length_checker.py
@@ -8,10 +8,10 @@ making the architecture more modular.
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import subprocess  # nosec B404 - used safely with shell disabled
 from dataclasses import dataclass
+from pathlib import Path
 
 from loguru import logger
 
@@ -36,6 +36,67 @@ class LineLengthViolation:
     column: int
     message: str
     code: str = "E501"
+
+
+def _absolute_path_without_resolving(path: Path) -> str:
+    """Return an absolute path without resolving symlinks.
+
+    Args:
+        path: Path to convert.
+
+    Returns:
+        Absolute path with ``..`` segments normalized, matching
+        ``os.path.abspath`` semantics without following symlinks.
+    """
+    absolute_path = path if path.is_absolute() else Path.cwd() / path
+    normalized_parts: list[str] = []
+
+    for part in absolute_path.parts:
+        if part in {absolute_path.anchor, ""}:
+            continue
+        if part == "..":
+            if normalized_parts:
+                normalized_parts.pop()
+            continue
+        normalized_parts.append(part)
+
+    if absolute_path.anchor:
+        return str(Path(absolute_path.anchor, *normalized_parts))
+    return str(Path(*normalized_parts))
+
+
+def _file_arg_path(file_path: str, cwd: str | None) -> str:
+    """Return the path to pass to Ruff for an input file.
+
+    Args:
+        file_path: User-provided file path.
+        cwd: Working directory for relative paths.
+
+    Returns:
+        Absolute path for relative inputs, or the original absolute path.
+    """
+    path = Path(file_path)
+    if cwd and not path.is_absolute():
+        return _absolute_path_without_resolving(Path(cwd) / path)
+    if not path.is_absolute():
+        return _absolute_path_without_resolving(path)
+    return file_path
+
+
+def _ruff_output_path(file_path: str, cwd: str | None) -> str:
+    """Return a normalized violation path from Ruff output.
+
+    Args:
+        file_path: Filename reported by Ruff.
+        cwd: Working directory Ruff ran in.
+
+    Returns:
+        Absolute path for relative Ruff output when ``cwd`` is available.
+    """
+    path = Path(file_path)
+    if cwd and not path.is_absolute():
+        return _absolute_path_without_resolving(Path(cwd) / path)
+    return file_path
 
 
 def check_line_length_violations(
@@ -82,16 +143,7 @@ def check_line_length_violations(
     # Convert relative paths to absolute paths
     abs_files: list[str] = []
     for file_path in files:
-        if cwd and not os.path.isabs(file_path):
-            abs_files.append(os.path.abspath(os.path.join(cwd, file_path)))
-        else:
-            abs_files.append(
-                (
-                    os.path.abspath(file_path)
-                    if not os.path.isabs(file_path)
-                    else file_path
-                ),
-            )
+        abs_files.append(_file_arg_path(file_path, cwd))
 
     # Build the Ruff command
     cmd: list[str] = [
@@ -135,9 +187,7 @@ def check_line_length_violations(
         violations: list[LineLengthViolation] = []
         for issue in issues_data:
             # Ruff JSON format has: filename, row, column, message, code
-            file_path = issue.get("filename", "")
-            if not os.path.isabs(file_path) and cwd:
-                file_path = os.path.abspath(os.path.join(cwd, file_path))
+            file_path = _ruff_output_path(issue.get("filename", ""), cwd)
 
             # Handle both old and new Ruff JSON formats
             line = issue.get("location", {}).get("row") or issue.get("row", 0)

--- a/lintro/tools/core/line_length_checker.py
+++ b/lintro/tools/core/line_length_checker.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 from loguru import logger
 
+from lintro.utils.path_utils import absolute_path_without_resolving
+
 
 @dataclass
 class LineLengthViolation:
@@ -38,33 +40,6 @@ class LineLengthViolation:
     code: str = "E501"
 
 
-def _absolute_path_without_resolving(path: Path) -> str:
-    """Return an absolute path without resolving symlinks.
-
-    Args:
-        path: Path to convert.
-
-    Returns:
-        Absolute path with ``..`` segments normalized, matching
-        ``os.path.abspath`` semantics without following symlinks.
-    """
-    absolute_path = path if path.is_absolute() else Path.cwd() / path
-    normalized_parts: list[str] = []
-
-    for part in absolute_path.parts:
-        if part in {absolute_path.anchor, ""}:
-            continue
-        if part == "..":
-            if normalized_parts:
-                normalized_parts.pop()
-            continue
-        normalized_parts.append(part)
-
-    if absolute_path.anchor:
-        return str(Path(absolute_path.anchor, *normalized_parts))
-    return str(Path(*normalized_parts))
-
-
 def _file_arg_path(file_path: str, cwd: str | None) -> str:
     """Return the path to pass to Ruff for an input file.
 
@@ -77,9 +52,9 @@ def _file_arg_path(file_path: str, cwd: str | None) -> str:
     """
     path = Path(file_path)
     if cwd and not path.is_absolute():
-        return _absolute_path_without_resolving(Path(cwd) / path)
+        return absolute_path_without_resolving(Path(cwd) / path)
     if not path.is_absolute():
-        return _absolute_path_without_resolving(path)
+        return absolute_path_without_resolving(path)
     return file_path
 
 
@@ -95,7 +70,7 @@ def _ruff_output_path(file_path: str, cwd: str | None) -> str:
     """
     path = Path(file_path)
     if cwd and not path.is_absolute():
-        return _absolute_path_without_resolving(Path(cwd) / path)
+        return absolute_path_without_resolving(Path(cwd) / path)
     return file_path
 
 

--- a/lintro/utils/git_diff.py
+++ b/lintro/utils/git_diff.py
@@ -24,6 +24,8 @@ import subprocess  # nosec B404 - subprocess is the core mechanism for invoking 
 from functools import lru_cache
 from pathlib import Path
 
+from lintro.utils.path_utils import absolute_path_without_resolving
+
 # Sentinel used by the ``--diff`` CLI option to mean "flag supplied without an
 # explicit base"; resolved to the repository's default base ref at runtime.
 DIFF_DEFAULT_SENTINEL: str = "\x00lintro-diff-default\x00"
@@ -42,33 +44,6 @@ _GIT_TIMEOUT_SECONDS: float = 30.0
 
 class DiffResolutionError(Exception):
     """Raised when an explicit ``--diff`` base ref cannot be resolved."""
-
-
-def _absolute_path_without_resolving(path: Path) -> str:
-    """Return an absolute path without resolving symlinks.
-
-    Args:
-        path: Path to convert.
-
-    Returns:
-        Absolute path with ``..`` segments normalized, matching
-        ``os.path.abspath`` semantics without following symlinks.
-    """
-    absolute_path = path if path.is_absolute() else Path.cwd() / path
-    normalized_parts: list[str] = []
-
-    for part in absolute_path.parts:
-        if part in {absolute_path.anchor, ""}:
-            continue
-        if part == "..":
-            if normalized_parts:
-                normalized_parts.pop()
-            continue
-        normalized_parts.append(part)
-
-    if absolute_path.anchor:
-        return str(Path(absolute_path.anchor, *normalized_parts))
-    return str(Path(*normalized_parts))
 
 
 def _run_git(args: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
@@ -262,7 +237,7 @@ def get_changed_files(base: str, cwd: str = ".") -> frozenset[str]:
     Raises:
         DiffResolutionError: When ``base`` does not resolve to a commit.
     """
-    root = _repo_root(cwd) or _absolute_path_without_resolving(Path(cwd))
+    root = _repo_root(cwd) or absolute_path_without_resolving(Path(cwd))
 
     if not _ref_exists(base, cwd):
         raise DiffResolutionError(
@@ -278,7 +253,7 @@ def get_changed_files(base: str, cwd: str = ".") -> frozenset[str]:
 
     changed: set[str] = set()
     for name in names:
-        abs_path = _absolute_path_without_resolving(Path(root) / name)
+        abs_path = absolute_path_without_resolving(Path(root) / name)
         # Drop deletions / rename sources that no longer exist on disk.
         if Path(abs_path).is_file():
             changed.add(abs_path)
@@ -303,4 +278,4 @@ def filter_files_by_diff(
     changed = get_changed_files(base, cwd)
     if not changed:
         return []
-    return [f for f in files if _absolute_path_without_resolving(Path(f)) in changed]
+    return [f for f in files if absolute_path_without_resolving(Path(f)) in changed]

--- a/lintro/utils/git_diff.py
+++ b/lintro/utils/git_diff.py
@@ -19,10 +19,10 @@ produce phantom paths that would break downstream tools.
 
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess  # nosec B404 - subprocess is the core mechanism for invoking git; all invocations use shell=False
 from functools import lru_cache
+from pathlib import Path
 
 # Sentinel used by the ``--diff`` CLI option to mean "flag supplied without an
 # explicit base"; resolved to the repository's default base ref at runtime.
@@ -42,6 +42,33 @@ _GIT_TIMEOUT_SECONDS: float = 30.0
 
 class DiffResolutionError(Exception):
     """Raised when an explicit ``--diff`` base ref cannot be resolved."""
+
+
+def _absolute_path_without_resolving(path: Path) -> str:
+    """Return an absolute path without resolving symlinks.
+
+    Args:
+        path: Path to convert.
+
+    Returns:
+        Absolute path with ``..`` segments normalized, matching
+        ``os.path.abspath`` semantics without following symlinks.
+    """
+    absolute_path = path if path.is_absolute() else Path.cwd() / path
+    normalized_parts: list[str] = []
+
+    for part in absolute_path.parts:
+        if part in {absolute_path.anchor, ""}:
+            continue
+        if part == "..":
+            if normalized_parts:
+                normalized_parts.pop()
+            continue
+        normalized_parts.append(part)
+
+    if absolute_path.anchor:
+        return str(Path(absolute_path.anchor, *normalized_parts))
+    return str(Path(*normalized_parts))
 
 
 def _run_git(args: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
@@ -235,7 +262,7 @@ def get_changed_files(base: str, cwd: str = ".") -> frozenset[str]:
     Raises:
         DiffResolutionError: When ``base`` does not resolve to a commit.
     """
-    root = _repo_root(cwd) or os.path.abspath(cwd)
+    root = _repo_root(cwd) or _absolute_path_without_resolving(Path(cwd))
 
     if not _ref_exists(base, cwd):
         raise DiffResolutionError(
@@ -251,9 +278,9 @@ def get_changed_files(base: str, cwd: str = ".") -> frozenset[str]:
 
     changed: set[str] = set()
     for name in names:
-        abs_path = os.path.abspath(os.path.join(root, name))
+        abs_path = _absolute_path_without_resolving(Path(root) / name)
         # Drop deletions / rename sources that no longer exist on disk.
-        if os.path.isfile(abs_path):
+        if Path(abs_path).is_file():
             changed.add(abs_path)
     return frozenset(changed)
 
@@ -276,4 +303,4 @@ def filter_files_by_diff(
     changed = get_changed_files(base, cwd)
     if not changed:
         return []
-    return [f for f in files if os.path.abspath(f) in changed]
+    return [f for f in files if _absolute_path_without_resolving(Path(f)) in changed]

--- a/lintro/utils/path_utils.py
+++ b/lintro/utils/path_utils.py
@@ -15,6 +15,31 @@ from loguru import logger
 _IGNORE_SEARCH_MAX_DEPTH = 20
 
 
+def absolute_path_without_resolving(path: Path) -> str:
+    """Return an absolute path without resolving symlinks.
+
+    Args:
+        path: Path to convert.
+
+    Returns:
+        Absolute path with ``..`` segments normalized, matching
+        ``os.path.abspath`` semantics without following symlinks.
+    """
+    absolute_path = path if path.is_absolute() else Path.cwd() / path
+    normalized_parts: list[str] = []
+
+    for part in absolute_path.parts:
+        if part in {absolute_path.anchor, ""}:
+            continue
+        if part == "..":
+            if normalized_parts:
+                normalized_parts.pop()
+            continue
+        normalized_parts.append(part)
+
+    return str(Path(absolute_path.anchor, *normalized_parts))
+
+
 def find_file_upward(
     start: Path,
     filenames: Sequence[str],

--- a/tests/unit/tools/core/test_install_context.py
+++ b/tests/unit/tools/core/test_install_context.py
@@ -84,7 +84,7 @@ def test_runtime_context_environment_reflects_managers() -> None:
 def test_detect_docker_via_dockerenv() -> None:
     """Detect Docker context when /.dockerenv file exists."""
     with patch(
-        "lintro.tools.core.install_context.os.path.exists",
+        "lintro.tools.core.install_context.Path.exists",
         return_value=True,
     ):
         result = _detect_install_context()
@@ -98,7 +98,7 @@ def test_detect_docker_via_env_var(
     """Detect Docker context via LINTRO_DOCKER=1 env var."""
     monkeypatch.setenv("LINTRO_DOCKER", "1")
     with patch(
-        "lintro.tools.core.install_context.os.path.exists",
+        "lintro.tools.core.install_context.Path.exists",
         return_value=False,
     ):
         result = _detect_install_context()
@@ -117,7 +117,7 @@ def test_detect_docker_via_container_env_var(
     monkeypatch.delenv("LINTRO_DOCKER", raising=False)
     monkeypatch.setenv("CONTAINER", "docker")
     with patch(
-        "lintro.tools.core.install_context.os.path.exists",
+        "lintro.tools.core.install_context.Path.exists",
         return_value=False,
     ):
         result = _detect_install_context()
@@ -134,7 +134,7 @@ def test_detect_pip_default(
 
     with (
         patch(
-            "lintro.tools.core.install_context.os.path.exists",
+            "lintro.tools.core.install_context.Path.exists",
             return_value=False,
         ),
         patch(
@@ -203,7 +203,7 @@ def test_detect_homebrew_install_context(
 
     with (
         patch(
-            "lintro.tools.core.install_context.os.path.exists",
+            "lintro.tools.core.install_context.Path.exists",
             return_value=False,
         ),
         patch(
@@ -216,8 +216,9 @@ def test_detect_homebrew_install_context(
             executable,
         ),
         patch(
-            "lintro.tools.core.install_context.os.path.realpath",
-            side_effect=lambda path: path,
+            "lintro.tools.core.install_context.Path.resolve",
+            autospec=True,
+            side_effect=lambda self, strict=False: self,
         ),
     ):
         result = _detect_install_context()
@@ -255,7 +256,7 @@ def test_detect_npm_bin_install_context(
 
     with (
         patch(
-            "lintro.tools.core.install_context.os.path.exists",
+            "lintro.tools.core.install_context.Path.exists",
             return_value=False,
         ),
         patch(
@@ -268,8 +269,9 @@ def test_detect_npm_bin_install_context(
             executable,
         ),
         patch(
-            "lintro.tools.core.install_context.os.path.realpath",
-            side_effect=lambda path: path,
+            "lintro.tools.core.install_context.Path.resolve",
+            autospec=True,
+            side_effect=lambda self, strict=False: self,
         ),
     ):
         result = _detect_install_context()

--- a/tests/unit/tools/core/test_line_length_checker.py
+++ b/tests/unit/tools/core/test_line_length_checker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess  # nosec B404 - subprocess is used to drive the tool/CLI under test; invocations use shell=False
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -213,6 +214,30 @@ def test_check_line_length_relative_paths_converted_to_absolute(
     cmd = call_args[0][0]
     assert_that(cmd).contains("/project/src/module.py")
     assert_that(cmd).contains("/project/tests/test_module.py")
+
+
+def test_check_line_length_cwd_symlink_is_not_resolved(
+    tmp_path: Path,
+    mock_ruff_available: MagicMock,
+    mock_subprocess: MagicMock,
+) -> None:
+    """Relative input paths preserve ``abspath`` symlink semantics.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        mock_ruff_available: Mock fixture ensuring ruff is available.
+        mock_subprocess: Mock fixture for subprocess operations.
+    """
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    symlink_dir = tmp_path / "link"
+    symlink_dir.symlink_to(real_dir, target_is_directory=True)
+
+    check_line_length_violations(files=["src/module.py"], cwd=str(symlink_dir))
+
+    cmd = mock_subprocess.call_args[0][0]
+    assert_that(cmd).contains(str(symlink_dir / "src" / "module.py"))
+    assert_that(cmd).does_not_contain(str(real_dir / "src" / "module.py"))
 
 
 def test_check_line_length_old_ruff_json_format(

--- a/tests/unit/utils/test_git_diff.py
+++ b/tests/unit/utils/test_git_diff.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 from assertpy import assert_that
 
+import lintro.utils.git_diff as git_diff
 from lintro.utils.git_diff import (
     DIFF_DEFAULT_SENTINEL,
     DiffResolutionError,
@@ -117,6 +118,38 @@ def test_get_changed_files_includes_working_tree_and_untracked(
     changed = get_changed_files("main", str(git_repo))
 
     assert_that(_names(changed)).is_equal_to(["a.py", "c.py"])
+
+
+def test_get_changed_files_fallback_root_preserves_cwd_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fallback absolute root keeps ``abspath`` symlink semantics.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    real_repo = tmp_path / "real"
+    real_repo.mkdir()
+    symlink_repo = tmp_path / "link"
+    symlink_repo.symlink_to(real_repo, target_is_directory=True)
+    (symlink_repo / "changed.py").write_text("x = 1\n")
+
+    monkeypatch.setattr(git_diff, "_repo_root", lambda cwd: None)
+    monkeypatch.setattr(git_diff, "_ref_exists", lambda base, cwd: True)
+    monkeypatch.setattr(
+        git_diff,
+        "_merge_base_diff_names",
+        lambda base, cwd: ["changed.py"],
+    )
+    monkeypatch.setattr(git_diff, "_worktree_diff_names", lambda cwd, *, cached: [])
+    monkeypatch.setattr(git_diff, "_untracked_names", lambda cwd: [])
+
+    changed = get_changed_files("main", str(symlink_repo))
+
+    assert_that(changed).contains(str(symlink_repo / "changed.py"))
+    assert_that(changed).does_not_contain(str(real_repo / "changed.py"))
 
 
 def test_get_changed_files_staged_change(git_repo: Path) -> None:

--- a/tests/unit/utils/test_path_utils.py
+++ b/tests/unit/utils/test_path_utils.py
@@ -10,11 +10,34 @@ import pytest
 from assertpy import assert_that
 
 from lintro.utils.path_utils import (
+    absolute_path_without_resolving,
     find_file_upward,
     find_lintro_ignore,
     load_lintro_ignore,
     normalize_file_path_for_display,
 )
+
+# =============================================================================
+# Tests for absolute_path_without_resolving
+# =============================================================================
+
+
+def test_absolute_path_without_resolving_preserves_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Normalize relative segments without resolving symlink components."""
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    symlink_dir = tmp_path / "link"
+    symlink_dir.symlink_to(real_dir, target_is_directory=True)
+    monkeypatch.chdir(tmp_path)
+
+    result = absolute_path_without_resolving(Path("link") / ".." / "link" / "file.py")
+
+    assert_that(result).is_equal_to(str(symlink_dir / "file.py"))
+    assert_that(result).does_not_contain(str(real_dir))
+
 
 # =============================================================================
 # Tests for find_file_upward


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(core): migrate os.path usage to pathlib in core modules
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Migrate remaining `os.path` usage to `pathlib` in three core modules, preserving abspath vs realpath/symlink semantics:

- `lintro/tools/core/line_length_checker.py`
- `lintro/tools/core/install_context.py`
- `lintro/utils/git_diff.py`

Adds focused symlink-semantics tests where behavior was previously untested.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1349

## Details

Full suite green locally: `6483 passed, 270 skipped`. `lintro fmt`/`chk` clean.
