### PR TITLE
fix(output): gate ASCII art on TTY and add --no-art

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -72,7 +72,6 @@ jobs:
         files.pythonhosted.org:443
         test.pypi.org:443
         upload.pypi.org:443
-        upload.test.pypi.org:443
         astral.sh:443
         releases.astral.sh:443
     permissions:
@@ -115,7 +114,6 @@ jobs:
         files.pythonhosted.org:443
         test.pypi.org:443
         upload.pypi.org:443
-        upload.test.pypi.org:443
         astral.sh:443
         releases.astral.sh:443
     permissions:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -231,6 +231,32 @@ In `--output-format json` the score is added **additively** under
 }
 ```
 
+### Output Presentation
+
+Purely cosmetic console output is controlled by the `output` section. These settings
+never affect machine-readable documents (JSON/SARIF) or on-disk artifacts.
+
+```yaml
+# .lintro-config.yaml
+output:
+  art: true # Show decorative ASCII art after a run (default: true)
+```
+
+The decorative ASCII art printed after `check`/`fmt` is only emitted to an interactive
+terminal. It is always suppressed when:
+
+- stdout is not a TTY (piped output, CI logs, redirected files), or
+- `output.art: false` is set in config, or
+- the `--no-art` flag is passed to `lintro check` / `lintro fmt`.
+
+The art is never written to `.lintro/run-*/report.md`, `console.log`, or any
+`--output-format` stream regardless of these settings.
+
+```bash
+lintro check --no-art   # suppress art for this run only
+lintro fmt --no-art
+```
+
 ### Command-Line Options
 
 #### Global Options

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -247,14 +247,14 @@ terminal. It is always suppressed when:
 
 - stdout is not a TTY (piped output, CI logs, redirected files), or
 - `output.art: false` is set in config, or
-- the `--no-art` flag is passed to `lintro check` / `lintro fmt`.
+- the `--no-art` flag is passed to `lintro check` / `lintro format`.
 
 The art is never written to `.lintro/run-*/report.md`, `console.log`, or any
 `--output-format` stream regardless of these settings.
 
 ```bash
 lintro check --no-art   # suppress art for this run only
-lintro fmt --no-art
+lintro format --no-art
 ```
 
 ### Command-Line Options

--- a/lintro/cli_utils/commands/check.py
+++ b/lintro/cli_utils/commands/check.py
@@ -153,6 +153,11 @@ DEFAULT_ACTION: str = "check"
     default=None,
     help="Exit 1 if the health score is below this threshold (0-100).",
 )
+@click.option(
+    "--no-art",
+    is_flag=True,
+    help="Suppress the decorative ASCII art printed after the run.",
+)
 def check_command(
     paths: tuple[str, ...],
     tools: str | None,
@@ -177,6 +182,7 @@ def check_command(
     transport: str | None,
     score: bool,
     fail_under: float | None,
+    no_art: bool,
 ) -> None:
     """Check files for issues using the specified tools.
 
@@ -206,6 +212,7 @@ def check_command(
         transport: str | None: Override AI transport (``api`` or ``cli``).
         score: bool: Print only the health score, suppressing the summary.
         fail_under: float | None: Exit 1 if the health score is below this value.
+        no_art: bool: Suppress the decorative ASCII art printed after the run.
 
     Raises:
         SystemExit: Process exit with the aggregated exit code from tools.
@@ -253,6 +260,7 @@ def check_command(
         transport=transport,
         score=score,
         fail_under=fail_under,
+        no_art=no_art,
     )
 
     # Exit with code only; CLI uses this as process exit code and avoids any

--- a/lintro/cli_utils/commands/format.py
+++ b/lintro/cli_utils/commands/format.py
@@ -117,6 +117,11 @@ DEFAULT_ACTION: str = "fmt"
         "would be fixed and 1 when fixes are available (useful for CI checks)."
     ),
 )
+@click.option(
+    "--no-art",
+    is_flag=True,
+    help="Suppress the decorative ASCII art printed after the run.",
+)
 def format_command(
     ctx: click.Context,
     paths: tuple[str, ...],
@@ -136,6 +141,7 @@ def format_command(
     auto_install: bool,
     yes: bool,
     dry_run: bool,
+    no_art: bool,
 ) -> None:
     """Format code using configured formatting tools.
 
@@ -164,6 +170,7 @@ def format_command(
         auto_install: bool: Whether to auto-install Node.js deps if missing.
         yes: bool: Skip confirmation prompt and proceed immediately.
         dry_run: bool: Preview would-be fixes without modifying any files.
+        no_art: bool: Suppress the decorative ASCII art printed after the run.
     """
     # Default to current directory if no paths provided
     normalized_paths: list[str] = list(paths) if paths else list(DEFAULT_PATHS)
@@ -188,6 +195,7 @@ def format_command(
         auto_install=auto_install,
         yes=yes,
         dry_run=dry_run,
+        no_art=no_art,
     )
 
     # Exit with code from tool execution.

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -411,11 +411,13 @@ def _parse_output_config(data: Any) -> OutputConfig:
         ValueError: When the output section is not a mapping or ``art`` is not
             a boolean.
     """
-    if not data:
+    if data is None:
         return OutputConfig()
     if not isinstance(data, dict):
         msg = f"output config must be a mapping, got {type(data).__name__}"
         raise ValueError(msg)
+    if not data:
+        return OutputConfig()
 
     known_fields = set(OutputConfig.model_fields)
     unknown = set(data) - known_fields

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -24,6 +24,7 @@ from lintro.config.lintro_config import (
     ExecutionConfig,
     LintroConfig,
     LintroToolConfig,
+    OutputConfig,
 )
 from lintro.config.review_config import (
     ReviewChecklistConfig,
@@ -397,6 +398,42 @@ def _parse_review_config(data: Any) -> ReviewConfig:
     return ReviewConfig(**filtered)
 
 
+def _parse_output_config(data: Any) -> OutputConfig:
+    """Parse the console output configuration section.
+
+    Args:
+        data: Raw ``output`` section from config.
+
+    Returns:
+        OutputConfig: Parsed output configuration.
+
+    Raises:
+        ValueError: When the output section is not a mapping or ``art`` is not
+            a boolean.
+    """
+    if not data:
+        return OutputConfig()
+    if not isinstance(data, dict):
+        msg = f"output config must be a mapping, got {type(data).__name__}"
+        raise ValueError(msg)
+
+    known_fields = set(OutputConfig.model_fields)
+    unknown = set(data) - known_fields
+    if unknown:
+        logger.warning(
+            "Unknown output config keys ignored: {}",
+            ", ".join(sorted(unknown)),
+        )
+    filtered = {key: value for key, value in data.items() if key in known_fields}
+
+    art = filtered.get("art")
+    if art is not None and not isinstance(art, bool):
+        msg = f"output.art must be a boolean, got {type(art).__name__}"
+        raise ValueError(msg)
+
+    return OutputConfig(**filtered)
+
+
 def _parse_score_config(data: Any) -> ScoreConfig:
     """Parse the health score configuration section.
 
@@ -445,6 +482,7 @@ def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
         "ai": {},
         "review": {},
         "score": {},
+        "output": {},
     }
 
     # Inline import: ToolName is a static StrEnum that does not trigger
@@ -503,6 +541,8 @@ def _convert_pyproject_to_config(data: dict[str, Any]) -> dict[str, Any]:
             result["review"] = value
         elif key_lower == "score" and isinstance(value, dict):
             result["score"] = value
+        elif key_lower == "output" and isinstance(value, dict):
+            result["output"] = value
 
     return result
 
@@ -570,6 +610,7 @@ def load_config(
     ai_config = _parse_ai_config(data.get("ai", {}))
     review_config = _parse_review_config(data.get("review", {}))
     score_config = _parse_score_config(data.get("score", {}))
+    output_config = _parse_output_config(data.get("output", {}))
 
     return LintroConfig(
         execution=execution_config,
@@ -579,6 +620,7 @@ def load_config(
         ai=ai_config,
         review=review_config,
         score=score_config,
+        output=output_config,
         config_path=resolved_path,
     )
 

--- a/lintro/config/lintro_config.py
+++ b/lintro/config/lintro_config.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from lintro.ai.config import AIConfig
 from lintro.config.enforce_config import EnforceConfig
 from lintro.config.execution_config import ExecutionConfig
+from lintro.config.output_config import OutputConfig
 from lintro.config.review_config import ReviewConfig
 from lintro.config.score_config import ScoreConfig
 from lintro.config.tool_config import LintroToolConfig
@@ -17,6 +18,7 @@ __all__ = [
     "ExecutionConfig",
     "LintroConfig",
     "LintroToolConfig",
+    "OutputConfig",
     "ReviewConfig",
     "ScoreConfig",
 ]
@@ -43,6 +45,7 @@ class LintroConfig(BaseModel):
         ai: AI-powered features configuration (optional, disabled by default).
         review: Diff review command configuration (checklist items).
         score: Health score weights and scale (0-100 metric).
+        output: Console output presentation settings (e.g. ASCII art toggle).
         config_path: Path to the config file (set by loader).
     """
 
@@ -55,6 +58,7 @@ class LintroConfig(BaseModel):
     ai: AIConfig = Field(default_factory=AIConfig)
     review: ReviewConfig = Field(default_factory=ReviewConfig)
     score: ScoreConfig = Field(default_factory=ScoreConfig)
+    output: OutputConfig = Field(default_factory=OutputConfig)
     config_path: str | None = None
 
     def get_tool_config(self, tool_name: str) -> LintroToolConfig:

--- a/lintro/config/output_config.py
+++ b/lintro/config/output_config.py
@@ -1,0 +1,22 @@
+"""Output configuration model."""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class OutputConfig(BaseModel):
+    """Console output presentation settings.
+
+    Controls purely cosmetic aspects of the console output that do not affect
+    the machine-readable result documents (JSON/SARIF) or on-disk artifacts.
+
+    Attributes:
+        model_config: Pydantic model configuration.
+        art: Whether decorative ASCII art may be printed after a run. Even
+            when ``True`` the art is only emitted to an interactive TTY and is
+            never written to ``report.md`` or any ``--output-format`` stream.
+            Set to ``False`` (or pass ``--no-art``) to suppress it entirely.
+    """
+
+    model_config = ConfigDict(frozen=False, extra="forbid")
+
+    art: bool = True

--- a/lintro/utils/console/__init__.py
+++ b/lintro/utils/console/__init__.py
@@ -26,6 +26,7 @@ def create_logger(
     run_dir: Path | None = None,
     *,
     route_stderr: bool = False,
+    art_enabled: bool = True,
     **kwargs: Any,
 ) -> ThreadSafeConsoleLogger:
     """Create a new ThreadSafeConsoleLogger instance.
@@ -34,12 +35,18 @@ def create_logger(
         run_dir: Optional run directory path for output location display.
         route_stderr: When True, decorative console output is routed to stderr
             so stdout carries only the final machine-readable document.
+        art_enabled: When True (default), decorative ASCII art may be printed
+            to an interactive TTY. When False, art is suppressed entirely.
         **kwargs: Additional arguments (ignored for backward compatibility).
 
     Returns:
         ThreadSafeConsoleLogger: A new instance of ThreadSafeConsoleLogger.
     """
-    return ThreadSafeConsoleLogger(run_dir=run_dir, route_stderr=route_stderr)
+    return ThreadSafeConsoleLogger(
+        run_dir=run_dir,
+        route_stderr=route_stderr,
+        art_enabled=art_enabled,
+    )
 
 
 __all__ = [

--- a/lintro/utils/console/logger.py
+++ b/lintro/utils/console/logger.py
@@ -7,6 +7,7 @@ with thread-safe message tracking for parallel execution.
 from __future__ import annotations
 
 import re
+import sys
 import threading
 from collections.abc import Sequence
 from pathlib import Path
@@ -445,6 +446,7 @@ class ThreadSafeConsoleLogger:
             console_output_func=self._emit_untracked,
             issue_count=total_issues,
             enabled=self.art_enabled,
+            output_stream=sys.stderr if self.route_stderr else sys.stdout,
         )
 
     def print_lintro_header(self) -> None:

--- a/lintro/utils/console/logger.py
+++ b/lintro/utils/console/logger.py
@@ -44,6 +44,7 @@ class ThreadSafeConsoleLogger:
         run_dir: Path | None = None,
         *,
         route_stderr: bool = False,
+        art_enabled: bool = True,
     ) -> None:
         """Initialize the ThreadSafeConsoleLogger.
 
@@ -53,9 +54,13 @@ class ThreadSafeConsoleLogger:
                 to stderr instead of stdout. Used for machine-readable output
                 formats (JSON/SARIF) so stdout carries only the final
                 parseable document.
+            art_enabled: When True (default), decorative ASCII art may be
+                printed to an interactive TTY. When False (config
+                ``output.art: false`` or ``--no-art``), art is suppressed.
         """
         self.run_dir = run_dir
         self.route_stderr = route_stderr
+        self.art_enabled = art_enabled
         self._messages: list[str] = []
         self._lock = threading.Lock()
 
@@ -408,18 +413,38 @@ class ThreadSafeConsoleLogger:
             total_remaining=total_remaining,
         )
 
+    def _emit_untracked(self, text: str) -> None:
+        """Write text to the console without tracking it in the buffer.
+
+        Decorative output such as ASCII art must reach an interactive
+        terminal but must never be captured into ``self._messages``, which
+        backs ``console.log`` and the ``report.md`` console dump. Writing
+        directly with :func:`click.echo` keeps the art off those
+        machine-facing artifacts.
+
+        Args:
+            text: Text to display on the console.
+        """
+        click.echo(text, err=self.route_stderr)
+
     def _print_ascii_art(
         self,
         total_issues: int,
     ) -> None:
         """Print ASCII art based on the number of issues.
 
+        Art is emitted via an untracked writer so it never lands in the
+        captured console buffer (``report.md`` / ``console.log``), and only
+        when enabled and stdout is an interactive TTY (enforced by
+        :func:`print_ascii_art`).
+
         Args:
             total_issues: The total number of issues found.
         """
         print_ascii_art(
-            console_output_func=self.console_output,
+            console_output_func=self._emit_untracked,
             issue_count=total_issues,
+            enabled=self.art_enabled,
         )
 
     def print_lintro_header(self) -> None:

--- a/lintro/utils/display_helpers.py
+++ b/lintro/utils/display_helpers.py
@@ -3,6 +3,7 @@
 Contains ASCII art display functions and styling constants.
 """
 
+import sys
 from collections.abc import Callable
 
 from loguru import logger
@@ -18,13 +19,30 @@ INFO_BORDER_LENGTH: int = 40
 def print_ascii_art(
     console_output_func: Callable[..., None],
     issue_count: int,
+    *,
+    enabled: bool = True,
 ) -> None:
-    """Print ASCII art based on the issue count.
+    """Print decorative ASCII art based on the issue count.
+
+    The art is purely cosmetic, so it is only emitted to an interactive
+    terminal. It is suppressed when ``enabled`` is ``False`` (config
+    ``output.art: false`` or the ``--no-art`` flag) and whenever stdout is not
+    a TTY (piped output, CI logs, or captured report streams). This keeps the
+    non-ASCII braille blob out of ``report.md`` and any ``--output-format``
+    document.
 
     Args:
-        console_output_func: Function to output text to console
-        issue_count: The number of issues (remaining, fixed, or total)
+        console_output_func: Function to output text to console.
+        issue_count: The number of issues (remaining, fixed, or total).
+        enabled: Whether art display is enabled by config/CLI. Defaults to
+            ``True``.
     """
+    if not enabled:
+        return
+
+    if not sys.stdout.isatty():
+        return
+
     try:
         if issue_count == 0:
             ascii_art = read_ascii_art(filename="success.txt")

--- a/lintro/utils/display_helpers.py
+++ b/lintro/utils/display_helpers.py
@@ -5,6 +5,7 @@ Contains ASCII art display functions and styling constants.
 
 import sys
 from collections.abc import Callable
+from typing import TextIO
 
 from loguru import logger
 
@@ -21,26 +22,29 @@ def print_ascii_art(
     issue_count: int,
     *,
     enabled: bool = True,
+    output_stream: TextIO | None = None,
 ) -> None:
     """Print decorative ASCII art based on the issue count.
 
     The art is purely cosmetic, so it is only emitted to an interactive
     terminal. It is suppressed when ``enabled`` is ``False`` (config
-    ``output.art: false`` or the ``--no-art`` flag) and whenever stdout is not
-    a TTY (piped output, CI logs, or captured report streams). This keeps the
-    non-ASCII braille blob out of ``report.md`` and any ``--output-format``
-    document.
+    ``output.art: false`` or the ``--no-art`` flag) and whenever the target
+    stream is not a TTY (piped output, CI logs, or captured report streams).
+    This keeps the non-ASCII braille blob out of ``report.md`` and any
+    ``--output-format`` document.
 
     Args:
         console_output_func: Function to output text to console.
         issue_count: The number of issues (remaining, fixed, or total).
         enabled: Whether art display is enabled by config/CLI. Defaults to
             ``True``.
+        output_stream: Stream used for the TTY gate. Defaults to stdout.
     """
     if not enabled:
         return
 
-    if not sys.stdout.isatty():
+    target_stream = output_stream or sys.stdout
+    if not target_stream.isatty():
         return
 
     try:

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -480,6 +480,7 @@ def run_lint_tools_simple(
     score: bool = False,
     fail_under: float | None = None,
     diff_base: str | None = None,
+    no_art: bool = False,
 ) -> int:
     """Simplified runner using Loguru-based logging with rich formatting.
 
@@ -523,6 +524,9 @@ def run_lint_tools_simple(
             files; :data:`~lintro.utils.git_diff.DIFF_DEFAULT_SENTINEL` resolves
             the repository default base; any other value is used as the base
             ref. Non-git directories fall back to a full scan with a warning.
+        no_art: When True, suppress decorative ASCII art regardless of the
+            ``output.art`` config value. Art is also suppressed automatically
+            when ``output.art`` is ``False`` or stdout is not a TTY.
 
     Returns:
         Exit code (0 for success, 1 for failures).
@@ -562,9 +566,18 @@ def run_lint_tools_simple(
     # Score-only takes priority over machine-readable formats so
     # ``--score --output-format json`` still prints only the numeric score.
     score_only = bool(score)
+
+    # Resolve whether decorative ASCII art may be shown. Either the ``--no-art``
+    # flag or ``output.art: false`` in config disables it; the TTY guard in
+    # print_ascii_art still applies on top of this.
+    from lintro.config.config_loader import get_config as _get_config
+
+    art_enabled = bool(_get_config().output.art) and not no_art
+
     logger = create_logger(
         run_dir=output_manager.run_dir,
         route_stderr=machine_readable_output or score_only,
+        art_enabled=art_enabled,
     )
 
     # Get tools to run (now returns ToolsToRunResult with skip info)

--- a/tests/unit/cli/test_cli_lintro_group.py
+++ b/tests/unit/cli/test_cli_lintro_group.py
@@ -136,6 +136,26 @@ def test_invoke_with_comma_separated_commands() -> None:
         )
 
 
+def test_invoke_forwards_no_art_flag() -> None:
+    """Test that chained commands forward the enabled --no-art flag."""
+    runner = CliRunner()
+    with (
+        patch("lintro.cli_utils.commands.check.run_lint_tools_simple") as mock_check,
+        patch("lintro.cli_utils.commands.format.run_lint_tools_simple") as mock_fmt,
+    ):
+        mock_check.return_value = 0
+        mock_fmt.return_value = 0
+
+        result = runner.invoke(
+            cli,
+            ["check", "--no-art", ".", ",", "format", "--no-art", "."],
+        )
+
+        assert_that(result.exit_code).is_equal_to(0)
+        assert_that(mock_check.call_args.kwargs["no_art"]).is_true()
+        assert_that(mock_fmt.call_args.kwargs["no_art"]).is_true()
+
+
 def test_invoke_aggregates_exit_codes_success() -> None:
     """Test that invoke aggregates exit codes from chained commands."""
     runner = CliRunner()

--- a/tests/unit/cli/test_cli_lintro_group.py
+++ b/tests/unit/cli/test_cli_lintro_group.py
@@ -111,6 +111,7 @@ def test_invoke_with_comma_separated_commands() -> None:
             transport=None,
             score=False,
             fail_under=None,
+            no_art=False,
         )
         mock_fmt.assert_any_call(
             action="fmt",
@@ -131,6 +132,7 @@ def test_invoke_with_comma_separated_commands() -> None:
             auto_install=False,
             yes=False,
             dry_run=False,
+            no_art=False,
         )
 
 

--- a/tests/unit/config/test_output_config.py
+++ b/tests/unit/config/test_output_config.py
@@ -55,6 +55,33 @@ def test_output_art_rejects_non_boolean(
         load_config(config_path=config_file)
 
 
+@pytest.mark.parametrize(
+    ("raw_output", "expected_type"),
+    [
+        ("false", "bool"),
+        ("[]", "list"),
+        ('""', "str"),
+    ],
+)
+def test_output_rejects_falsey_non_mapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    raw_output: str,
+    expected_type: str,
+) -> None:
+    """False-y non-mapping ``output`` sections raise the mapping error."""
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text(f"output: {raw_output}\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    with pytest.raises(
+        ValueError,
+        match=escape(f"output config must be a mapping, got {expected_type}"),
+    ):
+        load_config(config_path=config_file)
+
+
 def test_output_unknown_keys_are_ignored(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/config/test_output_config.py
+++ b/tests/unit/config/test_output_config.py
@@ -1,0 +1,73 @@
+"""Tests for output (console presentation) configuration parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from re import escape
+
+import pytest
+from assertpy import assert_that
+
+from lintro.config.config_loader import clear_config_cache, load_config
+
+
+def test_output_art_defaults_to_true_when_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A config without an ``output`` section defaults ``output.art`` to True."""
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text("execution:\n  parallel: false\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    config = load_config(config_path=config_file)
+
+    assert_that(config.output.art).is_true()
+
+
+def test_output_art_can_be_disabled_via_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``output.art: false`` is parsed into the loaded configuration."""
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text("output:\n  art: false\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    config = load_config(config_path=config_file)
+
+    assert_that(config.output.art).is_false()
+
+
+def test_output_art_rejects_non_boolean(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-boolean ``output.art`` value raises a clear error."""
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text("output:\n  art: nope\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    with pytest.raises(ValueError, match=escape("output.art must be a boolean")):
+        load_config(config_path=config_file)
+
+
+def test_output_unknown_keys_are_ignored(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown keys under ``output`` are ignored, not fatal."""
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text(
+        "output:\n  art: true\n  bogus: 1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    config = load_config(config_path=config_file)
+
+    assert_that(config.output.art).is_true()

--- a/tests/unit/utils/console/summary/test_delegation.py
+++ b/tests/unit/utils/console/summary/test_delegation.py
@@ -7,6 +7,7 @@ including summary table, final status, and ASCII art delegation.
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -338,6 +339,7 @@ def test_print_ascii_art_delegates_correctly() -> None:
             console_output_func=logger._emit_untracked,
             issue_count=5,
             enabled=True,
+            output_stream=sys.stdout,
         )
 
 
@@ -360,6 +362,7 @@ def test_print_ascii_art_various_counts(issue_count: int) -> None:
             console_output_func=logger._emit_untracked,
             issue_count=issue_count,
             enabled=True,
+            output_stream=sys.stdout,
         )
 
 
@@ -378,6 +381,21 @@ def test_print_ascii_art_delegates_disabled_flag() -> None:
             console_output_func=logger._emit_untracked,
             issue_count=0,
             enabled=False,
+            output_stream=sys.stdout,
+        )
+
+
+def test_print_ascii_art_uses_stderr_tty_gate_when_routed() -> None:
+    """Verify stderr routing checks stderr for interactive output."""
+    logger = ThreadSafeConsoleLogger(route_stderr=True)
+
+    with patch("lintro.utils.console.logger.print_ascii_art") as mock_print:
+        logger._print_ascii_art(0)
+        mock_print.assert_called_once_with(
+            console_output_func=logger._emit_untracked,
+            issue_count=0,
+            enabled=True,
+            output_stream=sys.stderr,
         )
 
 

--- a/tests/unit/utils/console/summary/test_delegation.py
+++ b/tests/unit/utils/console/summary/test_delegation.py
@@ -325,16 +325,19 @@ def test_print_final_status_format_various_counts(
 def test_print_ascii_art_delegates_correctly() -> None:
     """Verify _print_ascii_art delegates with correct parameters.
 
-    The method should pass the console output function and issue count
-    to the module-level print_ascii_art function.
+    The method should pass the untracked console writer, issue count, and
+    the resolved ``enabled`` flag to the module-level print_ascii_art
+    function. Art must use the untracked writer so it never lands in the
+    captured buffer backing report.md/console.log.
     """
     logger = ThreadSafeConsoleLogger()
 
     with patch("lintro.utils.console.logger.print_ascii_art") as mock_print:
         logger._print_ascii_art(5)
         mock_print.assert_called_once_with(
-            console_output_func=logger.console_output,
+            console_output_func=logger._emit_untracked,
             issue_count=5,
+            enabled=True,
         )
 
 
@@ -354,8 +357,27 @@ def test_print_ascii_art_various_counts(issue_count: int) -> None:
     with patch("lintro.utils.console.logger.print_ascii_art") as mock_print:
         logger._print_ascii_art(issue_count)
         mock_print.assert_called_once_with(
-            console_output_func=logger.console_output,
+            console_output_func=logger._emit_untracked,
             issue_count=issue_count,
+            enabled=True,
+        )
+
+
+def test_print_ascii_art_delegates_disabled_flag() -> None:
+    """Verify _print_ascii_art forwards a disabled art flag.
+
+    When the logger is constructed with ``art_enabled=False`` (config
+    ``output.art: false`` or ``--no-art``), the disabled state must be passed
+    through so no art is emitted.
+    """
+    logger = ThreadSafeConsoleLogger(art_enabled=False)
+
+    with patch("lintro.utils.console.logger.print_ascii_art") as mock_print:
+        logger._print_ascii_art(0)
+        mock_print.assert_called_once_with(
+            console_output_func=logger._emit_untracked,
+            issue_count=0,
+            enabled=False,
         )
 
 

--- a/tests/unit/utils/console/summary/test_execution_summary.py
+++ b/tests/unit/utils/console/summary/test_execution_summary.py
@@ -6,6 +6,7 @@ including tests for CHECK and FIX action handling.
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -19,6 +20,9 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from tests.unit.utils.conftest import FakeToolResult
+
+# Braille block used by the decorative ASCII art (U+2800..U+28FF).
+_BRAILLE_RE = re.compile(r"[\u2800-\u28ff]")
 
 
 # =============================================================================
@@ -336,6 +340,89 @@ def test_execution_summary_fix_handles_string_sentinel_remaining(
     ):
         # Should not raise or add string sentinel to numeric total
         logger.print_execution_summary(Action.FIX, results)
+
+
+# =============================================================================
+# ASCII Art Gating - Buffer / TTY / Toggle
+# =============================================================================
+
+
+def test_art_never_enters_tracked_buffer_on_tty(
+    fake_tool_result_factory: Callable[..., FakeToolResult],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Verify braille art reaches the TTY but never the captured buffer.
+
+    ``report.md`` and ``console.log`` are rendered from ``get_buffer()``. Art
+    must be emitted via the untracked writer so those machine-facing artifacts
+    stay free of the non-ASCII braille blob, even during an interactive run.
+
+    Args:
+        fake_tool_result_factory: Factory for creating FakeToolResult instances.
+        capsys: Pytest capture fixture for stdout/stderr.
+    """
+    logger = ThreadSafeConsoleLogger()
+    results = [fake_tool_result_factory(success=False, issues_count=3)]
+
+    with patch(
+        "lintro.utils.display_helpers.sys.stdout.isatty",
+        return_value=True,
+    ):
+        logger.print_execution_summary(Action.CHECK, results)
+
+    captured = capsys.readouterr()
+    # Art is emitted to the terminal on a TTY...
+    assert_that(bool(_BRAILLE_RE.search(captured.out))).is_true()
+    # ...but must not leak into the tracked buffer backing report.md.
+    assert_that(bool(_BRAILLE_RE.search(logger.get_buffer()))).is_false()
+
+
+def test_art_suppressed_in_buffer_and_stdout_when_not_tty(
+    fake_tool_result_factory: Callable[..., FakeToolResult],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Verify no braille art on stdout or in the buffer when not a TTY.
+
+    Args:
+        fake_tool_result_factory: Factory for creating FakeToolResult instances.
+        capsys: Pytest capture fixture for stdout/stderr.
+    """
+    logger = ThreadSafeConsoleLogger()
+    results = [fake_tool_result_factory(success=False, issues_count=3)]
+
+    with patch(
+        "lintro.utils.display_helpers.sys.stdout.isatty",
+        return_value=False,
+    ):
+        logger.print_execution_summary(Action.CHECK, results)
+
+    captured = capsys.readouterr()
+    assert_that(bool(_BRAILLE_RE.search(captured.out))).is_false()
+    assert_that(bool(_BRAILLE_RE.search(logger.get_buffer()))).is_false()
+
+
+def test_art_suppressed_when_art_disabled_even_on_tty(
+    fake_tool_result_factory: Callable[..., FakeToolResult],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Verify ``art_enabled=False`` suppresses art on an interactive TTY.
+
+    Args:
+        fake_tool_result_factory: Factory for creating FakeToolResult instances.
+        capsys: Pytest capture fixture for stdout/stderr.
+    """
+    logger = ThreadSafeConsoleLogger(art_enabled=False)
+    results = [fake_tool_result_factory(success=False, issues_count=3)]
+
+    with patch(
+        "lintro.utils.display_helpers.sys.stdout.isatty",
+        return_value=True,
+    ):
+        logger.print_execution_summary(Action.CHECK, results)
+
+    captured = capsys.readouterr()
+    assert_that(bool(_BRAILLE_RE.search(captured.out))).is_false()
+    assert_that(bool(_BRAILLE_RE.search(logger.get_buffer()))).is_false()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/utils/test_display_helpers.py
+++ b/tests/unit/utils/test_display_helpers.py
@@ -72,9 +72,11 @@ def console_capture() -> Generator[tuple[list[str], Callable[..., None]], None, 
         ),
     ],
 )
+@patch("lintro.utils.display_helpers.sys.stdout.isatty", return_value=True)
 @patch("lintro.utils.display_helpers.read_ascii_art")
 def test_print_ascii_art_selects_correct_file(
     mock_read: MagicMock,
+    _mock_isatty: MagicMock,
     console_capture: tuple[list[str], Callable[..., None]],
     issue_count: int,
     expected_file: str,
@@ -85,6 +87,7 @@ def test_print_ascii_art_selects_correct_file(
 
     Args:
         mock_read: Mock for read_ascii_art function.
+        _mock_isatty: Mock forcing stdout.isatty() to True (interactive).
         console_capture: Fixture providing output capture.
         issue_count: Number of issues to simulate.
         expected_file: Expected filename to be loaded.
@@ -101,15 +104,18 @@ def test_print_ascii_art_selects_correct_file(
     assert_that(output[0]).contains(expected_in_output)
 
 
+@patch("lintro.utils.display_helpers.sys.stdout.isatty", return_value=True)
 @patch("lintro.utils.display_helpers.read_ascii_art")
 def test_print_ascii_art_no_output_when_empty(
     mock_read: MagicMock,
+    _mock_isatty: MagicMock,
     console_capture: tuple[list[str], Callable[..., None]],
 ) -> None:
     """Verify no output is produced when ASCII art is empty.
 
     Args:
         mock_read: Mock for read_ascii_art function.
+        _mock_isatty: Mock forcing stdout.isatty() to True (interactive).
         console_capture: Fixture providing output capture.
     """
     output, mock_console = console_capture
@@ -120,15 +126,18 @@ def test_print_ascii_art_no_output_when_empty(
     assert_that(output).is_empty()
 
 
+@patch("lintro.utils.display_helpers.sys.stdout.isatty", return_value=True)
 @patch("lintro.utils.display_helpers.read_ascii_art")
 def test_print_ascii_art_handles_exception_gracefully(
     mock_read: MagicMock,
+    _mock_isatty: MagicMock,
     console_capture: tuple[list[str], Callable[..., None]],
 ) -> None:
     """Verify exceptions are handled gracefully without crashing.
 
     Args:
         mock_read: Mock for read_ascii_art function.
+        _mock_isatty: Mock forcing stdout.isatty() to True (interactive).
         console_capture: Fixture providing output capture.
     """
     output, mock_console = console_capture
@@ -138,6 +147,58 @@ def test_print_ascii_art_handles_exception_gracefully(
     print_ascii_art(mock_console, issue_count=0)
 
     assert_that(output).is_empty()
+
+
+@patch("lintro.utils.display_helpers.sys.stdout.isatty", return_value=False)
+@patch("lintro.utils.display_helpers.read_ascii_art")
+def test_print_ascii_art_suppressed_when_not_a_tty(
+    mock_read: MagicMock,
+    _mock_isatty: MagicMock,
+    console_capture: tuple[list[str], Callable[..., None]],
+) -> None:
+    """Verify no art is emitted (or even loaded) when stdout is not a TTY.
+
+    Piped output, CI logs, and captured report streams are non-interactive,
+    so the braille art must be gated out entirely.
+
+    Args:
+        mock_read: Mock for read_ascii_art function.
+        _mock_isatty: Mock forcing stdout.isatty() to False (non-interactive).
+        console_capture: Fixture providing output capture.
+    """
+    output, mock_console = console_capture
+    mock_read.return_value = ["⣿⣿⣿", "⣿ ⣿"]
+
+    print_ascii_art(mock_console, issue_count=0)
+
+    assert_that(output).is_empty()
+    mock_read.assert_not_called()
+
+
+@patch("lintro.utils.display_helpers.sys.stdout.isatty", return_value=True)
+@patch("lintro.utils.display_helpers.read_ascii_art")
+def test_print_ascii_art_suppressed_when_disabled(
+    mock_read: MagicMock,
+    _mock_isatty: MagicMock,
+    console_capture: tuple[list[str], Callable[..., None]],
+) -> None:
+    """Verify no art is emitted when explicitly disabled, even on a TTY.
+
+    ``enabled=False`` models config ``output.art: false`` and the
+    ``--no-art`` flag; it must win over an interactive terminal.
+
+    Args:
+        mock_read: Mock for read_ascii_art function.
+        _mock_isatty: Mock forcing stdout.isatty() to True (interactive).
+        console_capture: Fixture providing output capture.
+    """
+    output, mock_console = console_capture
+    mock_read.return_value = ["⣿⣿⣿", "⣿ ⣿"]
+
+    print_ascii_art(mock_console, issue_count=0, enabled=False)
+
+    assert_that(output).is_empty()
+    mock_read.assert_not_called()
 
 
 # --- Tests for print_final_status ---

--- a/tests/unit/utils/test_display_helpers.py
+++ b/tests/unit/utils/test_display_helpers.py
@@ -175,6 +175,23 @@ def test_print_ascii_art_suppressed_when_not_a_tty(
     mock_read.assert_not_called()
 
 
+@patch("lintro.utils.display_helpers.read_ascii_art")
+def test_print_ascii_art_checks_requested_output_stream(
+    mock_read: MagicMock,
+    console_capture: tuple[list[str], Callable[..., None]],
+) -> None:
+    """Verify the TTY gate uses the explicitly routed output stream."""
+    output, mock_console = console_capture
+    output_stream = MagicMock()
+    output_stream.isatty.return_value = False
+
+    print_ascii_art(mock_console, issue_count=0, output_stream=output_stream)
+
+    output_stream.isatty.assert_called_once_with()
+    assert_that(output).is_empty()
+    mock_read.assert_not_called()
+
+
 @patch("lintro.utils.display_helpers.sys.stdout.isatty", return_value=True)
 @patch("lintro.utils.display_helpers.read_ascii_art")
 def test_print_ascii_art_suppressed_when_disabled(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(output): gate ASCII art on TTY and add --no-art
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

ASCII art printed unconditionally after chk/fmt runs, polluting CI logs, redirected output, and on-disk `report.md`.

- Gate `print_ascii_art()` on `sys.stdout.isatty()`.
- Add `output.art` config (default true) and `--no-art` CLI flag on chk/fmt.
- Emit art through an untracked writer so it never enters `report.md` / captured buffers.
- Document the new config option.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1416

## Details

Unit suite verified locally for utils/config/cli (`1058 passed`). Full `lintro fmt`/`chk` green before push.
