### PR TITLE
fix(output): stop routing bandit no-files message through JSON parser

### DIFF
--- a/lintro/tools/definitions/bandit.py
+++ b/lintro/tools/definitions/bandit.py
@@ -421,11 +421,14 @@ class BanditPlugin(BaseToolPlugin):
                 "No .py/.pyi files found" in output
                 or "No .py/.pyi files found" in stderr_output
             ):
-                logger.debug("[bandit] No Python files found to check")
+                # Informational, non-JSON output. Keep ``output`` empty so the
+                # display layer never routes this through the JSON parser and
+                # emits parse-error noise for a clean, zero-issue pass (#1534).
+                logger.debug("[bandit] No .py/.pyi files found to check")
                 return ToolResult(
                     name=self.definition.name,
                     success=True,
-                    output="No .py/.pyi files found to check.",
+                    output=None,
                     issues_count=0,
                 )
 
@@ -447,11 +450,14 @@ class BanditPlugin(BaseToolPlugin):
                         output=stderr_output or "Bandit failed with non-zero exit code",
                         issues_count=0,
                     )
-                logger.debug("[bandit] Empty output received")
+                # Informational, non-JSON output. Keep ``output`` empty so a
+                # clean, zero-issue pass is never routed through the JSON
+                # parser and reported as parse-error noise (#1534).
+                logger.debug("[bandit] Empty output received; treating as clean pass")
                 return ToolResult(
                     name=self.definition.name,
                     success=True,
-                    output="Bandit ran successfully and found no issues",
+                    output=None,
                     issues_count=0,
                 )
 

--- a/lintro/utils/output/file_writer.py
+++ b/lintro/utils/output/file_writer.py
@@ -425,6 +425,9 @@ def format_tool_output(
     output: str,
     output_format: str | OutputFormat = "grid",
     issues: Sequence[BaseIssue] | None = None,
+    *,
+    success: bool | None = None,
+    issues_count: int | None = None,
 ) -> str:
     """Format tool output using the specified format.
 
@@ -433,6 +436,12 @@ def format_tool_output(
         output: str: Raw output from the tool.
         output_format: str: Output format (plain, grid, markdown, html, json, csv).
         issues: Sequence[BaseIssue] | None: List of parsed issue objects (optional).
+        success: bool | None: Whether the tool run succeeded. When a run is a
+            success with zero issues, informational (non-JSON) tool output is
+            returned as-is instead of being re-parsed, avoiding parse-error
+            noise for clean passes (#1534).
+        issues_count: int | None: The tool-reported issue count, used together
+            with ``success`` to detect a clean zero-issue pass.
 
     Returns:
         str: Formatted output string.
@@ -463,6 +472,14 @@ def format_tool_output(
 
     if not output or not output.strip():
         return "No issues found."
+
+    # A successful, zero-issue run with no parsed issues carries only
+    # informational (non-JSON) text. Return it verbatim rather than feeding it
+    # to the JSON parser, which would raise and print parse-error noise for a
+    # clean pass (#1534). Real failures (success is False) still get parsed so
+    # unparseable diagnostic output surfaces as an error (#1044).
+    if success and issues_count == 0:
+        return output
 
     # Try to parse the output using registered parser (O(1) lookup)
     # Note: pytest output is already formatted by build_output_with_failures

--- a/lintro/utils/output/file_writer.py
+++ b/lintro/utils/output/file_writer.py
@@ -436,8 +436,8 @@ def format_tool_output(
         output: str: Raw output from the tool.
         output_format: str: Output format (plain, grid, markdown, html, json, csv).
         issues: Sequence[BaseIssue] | None: List of parsed issue objects (optional).
-        success: bool | None: Whether the tool run succeeded. When a run is a
-            success with zero issues, informational (non-JSON) tool output is
+        success: bool | None: Whether the tool run succeeded. When a Bandit
+            run succeeds with zero issues, informational (non-JSON) output is
             returned as-is instead of being re-parsed, avoiding parse-error
             noise for clean passes (#1534).
         issues_count: int | None: The tool-reported issue count, used together
@@ -473,12 +473,12 @@ def format_tool_output(
     if not output or not output.strip():
         return "No issues found."
 
-    # A successful, zero-issue run with no parsed issues carries only
+    # A successful, zero-issue Bandit run with no parsed issues may carry only
     # informational (non-JSON) text. Return it verbatim rather than feeding it
     # to the JSON parser, which would raise and print parse-error noise for a
     # clean pass (#1534). Real failures (success is False) still get parsed so
     # unparseable diagnostic output surfaces as an error (#1044).
-    if success and issues_count == 0:
+    if tool_name == ToolName.BANDIT.value and success and issues_count == 0:
         return output
 
     # Try to parse the output using registered parser (O(1) lookup)

--- a/lintro/utils/output/parser_registration.py
+++ b/lintro/utils/output/parser_registration.py
@@ -81,10 +81,7 @@ class ParserError(Exception):
 # a successful, zero-issue run. These are not diagnostic output and must not be
 # treated as parse failures (#1534). Real unparseable bandit output (e.g. from
 # an actual bandit run) is still surfaced as an error to preserve #1044.
-_BANDIT_INFORMATIONAL_SENTINELS: tuple[str, ...] = (
-    "No .py/.pyi files found",
-    "Bandit ran successfully and found no issues",
-)
+_BANDIT_INFORMATIONAL_SENTINELS: tuple[str, ...] = ("No .py/.pyi files found",)
 
 
 def _parse_bandit_output(output: str) -> list[Any]:

--- a/lintro/utils/output/parser_registration.py
+++ b/lintro/utils/output/parser_registration.py
@@ -77,6 +77,16 @@ class ParserError(Exception):
     """
 
 
+# Informational, non-JSON messages that Lintro's bandit wrapper may surface for
+# a successful, zero-issue run. These are not diagnostic output and must not be
+# treated as parse failures (#1534). Real unparseable bandit output (e.g. from
+# an actual bandit run) is still surfaced as an error to preserve #1044.
+_BANDIT_INFORMATIONAL_SENTINELS: tuple[str, ...] = (
+    "No .py/.pyi files found",
+    "Bandit ran successfully and found no issues",
+)
+
+
 def _parse_bandit_output(output: str) -> list[Any]:
     """Parse Bandit output, handling JSON format.
 
@@ -89,6 +99,11 @@ def _parse_bandit_output(output: str) -> list[Any]:
     Raises:
         ParserError: If the output cannot be parsed as valid JSON.
     """
+    # Treat known informational, non-JSON sentinels as "no issues" rather than a
+    # parse failure so a clean pass never emits parse-error noise (#1534).
+    if any(sentinel in output for sentinel in _BANDIT_INFORMATIONAL_SENTINELS):
+        return []
+
     try:
         return parse_bandit_output(bandit_data=json.loads(output))
     except (json.JSONDecodeError, KeyError, TypeError, ValueError) as e:

--- a/lintro/utils/post_checks.py
+++ b/lintro/utils/post_checks.py
@@ -235,6 +235,8 @@ def execute_post_checks(
                         output=output or "",
                         output_format=output_fmt_enum.value,
                         issues=issues,
+                        success=getattr(result, "success", None),
+                        issues_count=issues_count,
                     )
 
                 if not json_output_mode:

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -236,6 +236,8 @@ def _display_fix_result(
             output=result.output or "",
             output_format=output_format,
             issues=list(result.issues) if result.issues else None,
+            success=result.success,
+            issues_count=result.issues_count,
         )
     if result.output and raw_output:
         display_output = result.output

--- a/tests/unit/tools/bandit/test_bandit_no_files_output.py
+++ b/tests/unit/tools/bandit/test_bandit_no_files_output.py
@@ -1,0 +1,86 @@
+"""Unit tests for Bandit clean-pass output not carrying informational text (#1534)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import (
+    CompletedProcess,
+)  # nosec B404 - subprocess is used to drive the tool/CLI under test; invocations use shell=False
+from unittest.mock import patch
+
+from assertpy import assert_that
+
+from lintro.tools.definitions.bandit import BanditPlugin
+
+
+def test_check_no_python_files_returns_empty_output(tmp_path: Path) -> None:
+    """A bandit "no .py/.pyi files" result must not carry informational output.
+
+    When bandit reports no Python files, the ToolResult must be a clean pass
+    with empty ``output`` so the display layer never routes an informational
+    string through the JSON parser (#1534).
+
+    Args:
+        tmp_path: Temporary directory path for the target file.
+    """
+    py_file = tmp_path / "mod.py"
+    py_file.write_text("x = 1\n")
+    plugin = BanditPlugin()
+
+    completed: CompletedProcess[str] = CompletedProcess(
+        args=["bandit"],
+        returncode=0,
+        stdout="",
+        stderr="No .py/.pyi files found to check.",
+    )
+
+    with (
+        patch(
+            "lintro.plugins.execution_preparation.verify_tool_version",
+            return_value=None,
+        ),
+        patch(
+            "lintro.tools.definitions.bandit.subprocess.run",
+            return_value=completed,
+        ),
+    ):
+        result = plugin.check([str(py_file)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.output).is_none()
+    assert_that(result.parse_failures_count or 0).is_equal_to(0)
+
+
+def test_check_empty_output_clean_pass_has_empty_output(tmp_path: Path) -> None:
+    """An empty-stdout clean bandit run must not carry informational output.
+
+    Args:
+        tmp_path: Temporary directory path for the target file.
+    """
+    py_file = tmp_path / "mod.py"
+    py_file.write_text("x = 1\n")
+    plugin = BanditPlugin()
+
+    completed: CompletedProcess[str] = CompletedProcess(
+        args=["bandit"],
+        returncode=0,
+        stdout="",
+        stderr="",
+    )
+
+    with (
+        patch(
+            "lintro.plugins.execution_preparation.verify_tool_version",
+            return_value=None,
+        ),
+        patch(
+            "lintro.tools.definitions.bandit.subprocess.run",
+            return_value=completed,
+        ),
+    ):
+        result = plugin.check([str(py_file)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.output).is_none()

--- a/tests/unit/utils/output/test_file_writer_format.py
+++ b/tests/unit/utils/output/test_file_writer_format.py
@@ -220,6 +220,46 @@ def test_format_tool_output_handles_invalid_bandit_json() -> None:
     assert_that(result).contains(bandit_output)
 
 
+def test_format_tool_output_skips_reparse_for_clean_pass() -> None:
+    """Verify informational output on a clean pass is not routed through parser.
+
+    A successful, zero-issue run whose ``output`` is a non-JSON informational
+    string must be returned verbatim instead of raising a parse error (#1534).
+    """
+    informational = "No .py/.pyi files found to check."
+
+    result = format_tool_output(
+        "bandit",
+        informational,
+        output_format="plain",
+        success=True,
+        issues_count=0,
+    )
+
+    assert_that(result).is_equal_to(informational)
+    assert_that(result).does_not_contain("Error:")
+
+
+def test_format_tool_output_still_errors_on_failed_bandit_run() -> None:
+    """Verify a failed bandit run with unparseable output still surfaces an error.
+
+    The clean-pass skip must not weaken the #1044 guarantee: real unparseable
+    bandit output from a failed run must still be reported as an error.
+    """
+    bandit_output = "not valid json { broken"
+
+    result = format_tool_output(
+        "bandit",
+        bandit_output,
+        output_format="plain",
+        success=False,
+        issues_count=0,
+    )
+
+    assert_that(result).contains("Error:")
+    assert_that(result).contains("Failed to parse Bandit output")
+
+
 @pytest.mark.parametrize(
     ("output_format_str",),
     [

--- a/tests/unit/utils/output/test_file_writer_format.py
+++ b/tests/unit/utils/output/test_file_writer_format.py
@@ -7,6 +7,7 @@ tool outputs into various display formats.
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 import pytest
 from assertpy import assert_that
@@ -238,6 +239,26 @@ def test_format_tool_output_skips_reparse_for_clean_pass() -> None:
 
     assert_that(result).is_equal_to(informational)
     assert_that(result).does_not_contain("Error:")
+
+
+def test_format_tool_output_clean_pass_shortcut_is_bandit_specific() -> None:
+    """Verify other tools still use parser dispatch for clean-pass output."""
+    informational = "informational output"
+
+    with patch(
+        "lintro.utils.output.file_writer.ParserRegistry.parse",
+        return_value=[],
+    ) as mock_parse:
+        result = format_tool_output(
+            "ruff",
+            informational,
+            output_format="plain",
+            success=True,
+            issues_count=0,
+        )
+
+    mock_parse.assert_called_once_with("ruff", informational)
+    assert_that(result).is_equal_to(informational)
 
 
 def test_format_tool_output_still_errors_on_failed_bandit_run() -> None:

--- a/tests/unit/utils/output/test_parser_registration_bandit.py
+++ b/tests/unit/utils/output/test_parser_registration_bandit.py
@@ -1,0 +1,54 @@
+"""Unit tests for the bandit parser registration (#1534, #1044)."""
+
+from __future__ import annotations
+
+import pytest
+from assertpy import assert_that
+
+from lintro.utils.output.parser_registration import (
+    ParserError,
+    _parse_bandit_output,
+)
+
+
+@pytest.mark.parametrize(
+    ("informational",),
+    [
+        ("No .py/.pyi files found to check.",),
+        ("No .py/.pyi files found",),
+        ("Bandit ran successfully and found no issues",),
+    ],
+    ids=["no-files-message", "no-files-sentinel", "clean-pass-sentinel"],
+)
+def test_parse_bandit_output_treats_sentinels_as_no_issues(
+    informational: str,
+) -> None:
+    """Verify informational sentinels parse to an empty issue list, not an error.
+
+    Args:
+        informational: A non-JSON informational message from a clean run.
+    """
+    issues = _parse_bandit_output(informational)
+
+    assert_that(issues).is_instance_of(list)
+    assert_that(issues).is_empty()
+
+
+def test_parse_bandit_output_raises_on_real_unparseable_output() -> None:
+    """Verify genuine unparseable bandit output still raises ParserError (#1044)."""
+    assert_that(_parse_bandit_output).raises(ParserError).when_called_with(
+        "not valid json { broken",
+    )
+
+
+def test_parse_bandit_output_parses_valid_json() -> None:
+    """Verify valid bandit JSON is parsed into issue objects."""
+    bandit_output = (
+        '{"results": [{"filename": "src/main.py", "line_number": 10, '
+        '"test_id": "B101", "issue_text": "Security issue", '
+        '"issue_severity": "HIGH", "issue_confidence": "HIGH"}]}'
+    )
+
+    issues = _parse_bandit_output(bandit_output)
+
+    assert_that(issues).is_length(1)

--- a/tests/unit/utils/output/test_parser_registration_bandit.py
+++ b/tests/unit/utils/output/test_parser_registration_bandit.py
@@ -16,9 +16,8 @@ from lintro.utils.output.parser_registration import (
     [
         ("No .py/.pyi files found to check.",),
         ("No .py/.pyi files found",),
-        ("Bandit ran successfully and found no issues",),
     ],
-    ids=["no-files-message", "no-files-sentinel", "clean-pass-sentinel"],
+    ids=["no-files-message", "no-files-sentinel"],
 )
 def test_parse_bandit_output_treats_sentinels_as_no_issues(
     informational: str,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(output): stop routing bandit no-files message through JSON parser
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

When bandit finds no `.py`/`.pyi` files, its informational non-JSON output was fed through the JSON parser, printing spurious `Failed to parse Bandit output` noise on a clean zero-issue pass.

- Return no-files / empty-output clean passes with `output=None` (debug log kept).
- Treat known informational sentinels as empty findings in `_parse_bandit_output`.
- Skip re-parse in `format_tool_output` for successful zero-issue results.
- Preserve #1044 fail-closed behavior for real unparseable failed bandit runs.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1534

## Details

Unit suite green locally (`5847 passed, 7 skipped`). `lintro chk .` reports 100/100.
