### PR TITLE
feat(docker): bundle pinned Go toolchain in lintro-tools image

### DIFF
--- a/.github/workflows/docker-tools-publish.yml
+++ b/.github/workflows/docker-tools-publish.yml
@@ -103,7 +103,8 @@ jobs:
       # non-empty value must include the docker preset baseline. The
       # sigstore hosts cover cosign keyless signing in the merge job;
       # get.trivy.dev serves the Trivy binary download and mirror.gcr.io is
-      # the Trivy vulnerability DB fallback.
+      # the Trivy vulnerability DB fallback. dl.google.com serves the
+      # bundled Go toolchain tarball + checksum (#1500).
       allowed-endpoints-mode: replace
       allowed-endpoints: >
         github.com:443
@@ -125,6 +126,7 @@ jobs:
         pypi.org:443
         files.pythonhosted.org:443
         static.rust-lang.org:443
+        dl.google.com:443
         bun.sh:443
         astral.sh:443
         releases.astral.sh:443

--- a/docker/tools.Dockerfile
+++ b/docker/tools.Dockerfile
@@ -100,7 +100,7 @@ RUN ARCH=$(uname -m) && \
 # Multi-arch with SHA256 verification, mirroring the bun/uv blocks. The
 # checksum is fetched from the vendor sibling ".sha256" so Renovate only needs
 # to bump GO_VERSION (no hand-maintained hashes to drift).
-# hadolint ignore=DL3003,SC2086
+# hadolint ignore=SC2086
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then GO_ARCH="amd64"; \
     elif [ "$ARCH" = "aarch64" ]; then GO_ARCH="arm64"; \

--- a/docker/tools.Dockerfile
+++ b/docker/tools.Dockerfile
@@ -24,6 +24,7 @@ FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea5
 
 ARG BUN_VERSION=1.3.14
 ARG UV_VERSION=0.11.29
+ARG GO_VERSION=1.26.5
 
 LABEL maintainer="lgtm-hq"
 LABEL org.opencontainers.image.source="https://github.com/lgtm-hq/py-lintro"
@@ -36,7 +37,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     BUN_INSTALL="/opt/bun" \
     CARGO_HOME="/opt/cargo" \
     RUSTUP_HOME="/opt/rustup" \
-    PATH="/usr/local/bin:/opt/cargo/bin:/opt/bun/bin:${PATH}"
+    GOTOOLCHAIN=local \
+    PATH="/usr/local/go/bin:/usr/local/bin:/opt/cargo/bin:/opt/bun/bin:${PATH}"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -92,6 +94,25 @@ RUN ARCH=$(uname -m) && \
     chmod +x /usr/local/bin/uv && \
     rm -rf /tmp/uv*
 
+# Bundle a pinned Go toolchain so Go-based linters (e.g. golangci-lint) have a
+# working compiler. GOTOOLCHAIN=local (set above) keeps this toolchain
+# authoritative — Go never auto-downloads a different version at runtime.
+# Multi-arch with SHA256 verification, mirroring the bun/uv blocks. The
+# checksum is fetched from the vendor sibling ".sha256" so Renovate only needs
+# to bump GO_VERSION (no hand-maintained hashes to drift).
+# hadolint ignore=DL3003,SC2086
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then GO_ARCH="amd64"; \
+    elif [ "$ARCH" = "aarch64" ]; then GO_ARCH="arm64"; \
+    else echo "Unsupported arch: $ARCH" && exit 1; fi && \
+    GO_TAR="go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" && \
+    GO_URL="https://dl.google.com/go/${GO_TAR}" && \
+    curl -fsSL "$GO_URL" -o "/tmp/${GO_TAR}" && \
+    curl -fsSL "${GO_URL}.sha256" -o "/tmp/${GO_TAR}.sha256" && \
+    echo "$(cat /tmp/${GO_TAR}.sha256)  /tmp/${GO_TAR}" | sha256sum -c - && \
+    tar -C /usr/local -xzf "/tmp/${GO_TAR}" && \
+    rm -rf /tmp/go*
+
 COPY lintro/ /app/lintro/
 COPY scripts/ /app/scripts/
 COPY package.json /app/package.json
@@ -112,7 +133,8 @@ RUN chgrp -R tools /opt/cargo /opt/rustup /opt/bun && \
     chmod -R a+rX /opt/cargo /opt/rustup /opt/bun
 
 RUN echo "=== Verifying all tools ===" && \
-    bun --version && uv --version && cargo --version && rustc --version && \
+    bun --version && uv --version && go version && \
+    cargo --version && rustc --version && \
     rustfmt --version && cargo clippy --version && cargo audit --version && \
     cargo deny --version && actionlint --version && bandit --version && \
     black --version && commitlint --version && gitleaks version && \

--- a/renovate.json
+++ b/renovate.json
@@ -198,6 +198,18 @@
       "packageNameTemplate": "astral-sh/uv"
     },
     {
+      "description": "Bundled Go toolchain in the lintro-tools image (checksum fetched at build time, so only the version pins here)",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "docker/tools.Dockerfile"
+      ],
+      "matchStrings": [
+        "ARG GO_VERSION=(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "golang-version",
+      "packageNameTemplate": "golang"
+    },
+    {
       "customType": "regex",
       "managerFilePatterns": [
         "/^\\.github/workflows/sbom-on-main\\.yml$/"


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (present tense):

  ```text
  feat(docker): bundle pinned Go toolchain in lintro-tools image
  ```

- Type:
  - [x] feat (minor)

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Bundles a pinned Go SDK in the `lintro-tools` base image so Go-based linters
(e.g. `golangci-lint`) have a working compiler. The image could previously carry
the `golangci-lint` binary but no Go toolchain, so its analyzers could not run.

The Go install block mirrors the existing `BUN_VERSION`/`UV_VERSION` pinned-ARG
blocks exactly: multi-arch (amd64/arm64), SHA256 checksum verification, and a
Renovate custom manager for version bumps.

### Changes Made

- Add `ARG GO_VERSION=1.26.5`; download `go${GO_VERSION}.linux-${arch}.tar.gz`
  from `dl.google.com`, verify its SHA256 against the vendor `.sha256` sibling,
  and extract to `/usr/local/go`; add `/usr/local/go/bin` to `PATH`.
- Set `GOTOOLCHAIN=local` so the pinned toolchain is authoritative and Go never
  auto-downloads a different version at runtime.
- Extend the image's inline verification step to run `go version` alongside the
  existing tool checks.
- Add a Renovate custom manager (`golang-version` datasource) so `GO_VERSION`
  receives bump PRs, mirroring the BUN/UV managers. The checksum is fetched at
  build time from the vendor `.sha256` sibling, so there are **no hand-maintained
  hashes to drift** — Renovate only bumps the single `GO_VERSION` pin.

### Image-size impact

The Go SDK adds roughly **150–500 MB** (extracted) to the `lintro-tools` image.
This is the accepted trade-off per the issue discussion — the tools layer is
built weekly/on-change and stays off the per-PR build path, and without it
Go-based analyzers cannot function inside the image.

### Scope

Per the issue prompt, this touches only `docker/tools.Dockerfile` and
`renovate.json`. The root app `Dockerfile` is intentionally **not** modified
(coordinated separately with #1360).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1500

## Details

**Verification**

- `uv run lintro fmt` then `uv run lintro chk`: clean (health score 100/100, 0 issues).
- Full test suite (`uv run pytest --maxfail=0`): **6799 passed, 10 skipped, 1
  failed**. The single failure — `test_commitlint_detects_bad_last_commit` — is a
  pre-existing local-environment issue (the locally installed commitlint is
  21.2.0, below the repo's required minimum 21.2.1, so lintro skips it and the
  test expecting it to run fails). It is unrelated to this change, which touches
  no Python and no commitlint; CI runs the pinned commitlint version.
- Docker was **not available locally**, so the multi-arch image build could not
  be exercised here. CI (`docker-tools-publish.yml`) validates the build and the
  `go version` verification step. Go 1.26.5 and its amd64/arm64 checksums were
  confirmed current against `https://go.dev/dl/?mode=json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pinned Go toolchain to the development tools environment.
  * Added support for installing Go across supported CPU architectures.
  * Go is now included in environment path configuration and tool version checks.

* **Chores**
  * Added automated tracking for Go toolchain version updates to help keep the included version current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bundles a pinned Go toolchain into the `lintro-tools` Docker image so Go-based linters like `golangci-lint` have a working compiler. It mirrors the existing pattern for Bun and UV: multi-arch (amd64/arm64) download from `dl.google.com`, SHA256 verification, `GOTOOLCHAIN=local` to pin the toolchain, and a Renovate custom manager for automated version bumps.

- Adds `ARG GO_VERSION=1.26.5` with a `dl.google.com` download-and-verify block in `tools.Dockerfile`, extracting to `/usr/local/go` and adding it to `PATH`.
- Extends the build-time tool-verification step (`go version`) and adds `dl.google.com:443` to the egress allowlist in the workflow.
- Adds a Renovate `custom.regex` manager using the `golang-version` datasource to keep `GO_VERSION` automatically updated.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge for the Docker image functionality; the Go toolchain installs and verifies correctly at build time. The Renovate manager config needs one word changed before GO_VERSION will receive automated bump PRs.

The Dockerfile and workflow changes are correct and well-constructed. The only issue is in renovate.json: the golang-version datasource lookup uses packageName "golang" where "go" is the expected value, which would cause the automated GO_VERSION bump PRs to never fire. The image itself builds and runs correctly regardless of this config error.

renovate.json — the packageNameTemplate value for the golang-version datasource custom manager needs to be "go" instead of "golang".

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docker/tools.Dockerfile | Adds Go toolchain install block (download, SHA256 verify, extract) mirroring the existing bun/uv patterns; sets GOTOOLCHAIN=local and prepends /usr/local/go/bin to PATH; adds go version to the build-time verification step. Logic is sound. |
| renovate.json | Adds a custom regex manager for GO_VERSION using datasource=golang-version with packageNameTemplate="golang"; the golang-version datasource expects packageName="go", so the bump PRs may silently never fire. |
| .github/workflows/docker-tools-publish.yml | Adds dl.google.com:443 to the egress allowlist and updates the inline comment to reference the new Go toolchain download. Change is minimal and correct. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant DG as dl.google.com
    participant DR as Docker Build

    GH->>DR: docker buildx build (linux/amd64, linux/arm64)
    DR->>DG: "GET go1.26.5.linux-{arch}.tar.gz"
    DG-->>DR: tarball
    DR->>DG: "GET go1.26.5.linux-{arch}.tar.gz.sha256"
    DG-->>DR: hex checksum
    DR->>DR: sha256sum -c (verify)
    DR->>DR: tar -C /usr/local -xzf (extract)
    DR->>DR: go version (build-time verify)
    DR-->>GH: image layer with /usr/local/go

    participant RV as Renovate Bot
    RV->>RV: "match ARG GO_VERSION=x.y.z in tools.Dockerfile"
    RV->>RV: "golang-version datasource lookup (packageName=golang ⚠️)"
    RV-->>GH: bump PR (if datasource resolves correctly)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant DG as dl.google.com
    participant DR as Docker Build

    GH->>DR: docker buildx build (linux/amd64, linux/arm64)
    DR->>DG: "GET go1.26.5.linux-{arch}.tar.gz"
    DG-->>DR: tarball
    DR->>DG: "GET go1.26.5.linux-{arch}.tar.gz.sha256"
    DG-->>DR: hex checksum
    DR->>DR: sha256sum -c (verify)
    DR->>DR: tar -C /usr/local -xzf (extract)
    DR->>DR: go version (build-time verify)
    DR-->>GH: image layer with /usr/local/go

    participant RV as Renovate Bot
    RV->>RV: "match ARG GO_VERSION=x.y.z in tools.Dockerfile"
    RV->>RV: "golang-version datasource lookup (packageName=golang ⚠️)"
    RV-->>GH: bump PR (if datasource resolves correctly)
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): allow dl.google.com in tools-im..."](https://github.com/lgtm-hq/py-lintro/commit/9a5cd3b679ac90bdfda7c722d86766c2443f9612) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45592932)</sub>

<!-- /greptile_comment -->