### PR TITLE
fix(markdownlint): forward nested defaults.markdownlint rule options

### DIFF
--- a/lintro/config/tool_config_generator.py
+++ b/lintro/config/tool_config_generator.py
@@ -72,6 +72,14 @@ TOOL_CONFIG_FORMATS: dict[str, ConfigFormat] = {
     "prettier": ConfigFormat.JSON,
 }
 
+# Tools whose native config format nests all settings under a top-level key.
+# markdownlint-cli2 config files (e.g. ``.markdownlint-cli2.jsonc``) require rule
+# options to live under a ``"config"`` object; options written at the top level are
+# silently ignored. Mapping a tool here wraps its generated defaults accordingly.
+TOOL_CONFIG_WRAPPER_KEYS: dict[str, str] = {
+    "markdownlint": "config",
+}
+
 # Key mappings for tools that use different naming conventions in their native configs.
 # Maps lintro config keys (snake_case) to native tool keys (often camelCase).
 NATIVE_KEY_MAPPINGS: dict[str, dict[str, str]] = {
@@ -391,6 +399,15 @@ def _write_defaults_config(
 
     # Transform keys to native format before writing
     native_defaults = _transform_keys_for_native_config(defaults, tool_lower)
+
+    # Some tools nest all settings under a top-level key in their native config
+    # format (e.g. markdownlint-cli2 requires rule options under "config").
+    wrapper_key = TOOL_CONFIG_WRAPPER_KEYS.get(tool_lower)
+    if wrapper_key is not None:
+        native_defaults = {wrapper_key: native_defaults}
+        logger.debug(
+            f"Wrapped {tool_name} defaults under top-level '{wrapper_key}' key",
+        )
 
     if config_format == ConfigFormat.YAML:
         if yaml is None:

--- a/tests/config/test_tool_config_generator.py
+++ b/tests/config/test_tool_config_generator.py
@@ -1,5 +1,6 @@
 """Tests for tool_config_generator module."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,7 @@ from lintro.config.enforce_config import EnforceConfig
 from lintro.config.lintro_config import LintroConfig
 from lintro.config.tool_config_generator import (
     NATIVE_KEY_MAPPINGS,
+    TOOL_CONFIG_WRAPPER_KEYS,
     _convert_python_version_for_mypy,
     _transform_keys_for_native_config,
     _write_defaults_config,
@@ -156,6 +158,79 @@ def test_generic_tool_config_uses_json_suffix() -> None:
         assert_that(config_path.exists()).is_true()
     finally:
         config_path.unlink(missing_ok=True)
+
+
+def test_markdownlint_has_config_wrapper_key() -> None:
+    """Markdownlint must be registered to wrap defaults under 'config'."""
+    assert_that(TOOL_CONFIG_WRAPPER_KEYS).contains_key("markdownlint")
+    assert_that(TOOL_CONFIG_WRAPPER_KEYS["markdownlint"]).is_equal_to("config")
+
+
+def test_markdownlint_defaults_wrapped_under_config() -> None:
+    """Markdownlint rule options must be nested under a top-level 'config' key.
+
+    Regression for #1549: markdownlint-cli2 silently ignores rule options that
+    are not wrapped under 'config', so nested defaults (e.g. MD024.siblings_only)
+    were never applied.
+    """
+    config_path = _write_defaults_config(
+        defaults={"MD024": {"siblings_only": True}},
+        tool_name="markdownlint",
+        config_format=ConfigFormat.JSON,
+    )
+
+    try:
+        parsed = json.loads(config_path.read_text(encoding="utf-8"))
+        assert_that(parsed).contains_key("config")
+        assert_that(parsed).does_not_contain_key("MD024")
+        assert_that(parsed["config"]).contains_key("MD024")
+        assert_that(parsed["config"]["MD024"]).is_equal_to({"siblings_only": True})
+    finally:
+        config_path.unlink(missing_ok=True)
+
+
+def test_non_wrapped_tool_defaults_stay_top_level() -> None:
+    """Tools without a wrapper key keep their defaults at the top level."""
+    config_path = _write_defaults_config(
+        defaults={"printWidth": 100},
+        tool_name="prettier",
+        config_format=ConfigFormat.JSON,
+    )
+
+    try:
+        parsed = json.loads(config_path.read_text(encoding="utf-8"))
+        assert_that(parsed).contains_key("printWidth")
+        assert_that(parsed).does_not_contain_key("config")
+    finally:
+        config_path.unlink(missing_ok=True)
+
+
+def test_generate_defaults_config_forwards_nested_markdownlint_rules(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: nested markdownlint defaults reach the generated config file.
+
+    Regression for #1549 covering the full ``generate_defaults_config`` path,
+    including native-config discovery (none present in ``tmp_path``).
+    """
+    monkeypatch.chdir(tmp_path)
+    lintro_config = LintroConfig(
+        defaults={"markdownlint": {"MD024": {"siblings_only": True}}},
+    )
+
+    config_path = generate_defaults_config(
+        tool_name="markdownlint",
+        lintro_config=lintro_config,
+    )
+
+    assert_that(config_path).is_not_none()
+    if config_path is not None:
+        try:
+            parsed = json.loads(config_path.read_text(encoding="utf-8"))
+            assert_that(parsed["config"]["MD024"]["siblings_only"]).is_true()
+        finally:
+            config_path.unlink(missing_ok=True)
 
 
 # =============================================================================


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(markdownlint): forward nested defaults.markdownlint rule options
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Rule-scoped options declared under `defaults.markdownlint` in
`.lintro-config.yaml` (e.g. `MD024: {siblings_only: true}`,
`MD013: {line_length: 88}`) were silently ignored. Lintro generates a
temporary `.markdownlint-cli2.jsonc` and passes it via `--config`, but it wrote
the rule options at the top level. markdownlint-cli2 requires rule options to be
nested under a `"config"` key, so the top-level entries were unrecognized and
dropped — findings behaved as if rule defaults were in effect, even though the
config appeared valid (the sharp "silent ignore" edge from the issue).

The fix wraps generated markdownlint defaults under the `"config"` key, matching
markdownlint-cli2 config semantics and the plugin's own temp-config format.
Nested dict values survive translation.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1549

## Details

- Added `TOOL_CONFIG_WRAPPER_KEYS` (`markdownlint -> "config"`) in
  `lintro/config/tool_config_generator.py`; `_write_defaults_config` wraps the
  native defaults under the wrapper key before serialization. Tools without a
  wrapper key (e.g. prettier, hadolint) are unaffected.
- Regression tests in `tests/config/test_tool_config_generator.py` (assertpy,
  pytest-style):
  - wrapper-key registration,
  - wrapped write for markdownlint (`config.MD024.siblings_only`),
  - unwrapped top-level write for non-wrapped tools,
  - end-to-end `generate_defaults_config` forwarding nested markdownlint rules.

Testing:
- Reproduced against pre-fix code: MD024 fired on sibling headings despite
  `defaults.markdownlint.MD024.siblings_only: true`; after the fix it no longer
  fires (verified with a temp project, no native `.markdownlint.json`).
- `uv run lintro chk`: clean (pre-existing local-only `pip_audit` ensurepip crash
  and a `commitlint` version-skip are environmental, identical on a clean tree).
- Full `uv run pytest`: 6803 passed, 10 skipped; the single failure
  (`test_commitlint_detects_bad_last_commit`) is an unrelated local commitlint
  version mismatch (21.2.0 < required 21.2.1), not touched by this change.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent bug where markdownlint rule options in `defaults.markdownlint` were ignored because `_write_defaults_config` wrote them at the top level of the generated `.markdownlint-cli2.jsonc` config, but markdownlint-cli2 requires rule options to live under a `"config"` key. The fix introduces a `TOOL_CONFIG_WRAPPER_KEYS` registry and wraps markdownlint defaults automatically inside `_write_defaults_config`.

- Adds `TOOL_CONFIG_WRAPPER_KEYS` dict and applies wrapping logic in `_write_defaults_config`; other tools (prettier, hadolint, etc.) are unaffected.
- The pre-existing test `test_markdownlint_config_uses_correct_suffix` was not updated and now passes already-wrapped defaults `{\"config\": {...}}` to `_write_defaults_config`, which will double-wrap them; the test still passes because it only checks the file suffix, masking the regression.
- Four new regression tests cover wrapper-key registration, wrapped vs. unwrapped writes, and an end-to-end path through `generate_defaults_config`.
</details>


<h3>Confidence Score: 3/5</h3>

The core production fix is correct, but the test suite has a latent double-wrapping defect that currently passes silently.

The production logic in tool_config_generator.py is sound and the four new regression tests are well-written. However, the pre-existing test test_markdownlint_config_uses_correct_suffix was not updated: it passes {"config": {"MD013": ...}} as defaults, which the new wrapping logic double-nests into {"config": {"config": {"MD013": ...}}}. The test still passes because it only asserts the file suffix, silently exercising a broken code path.

tests/config/test_tool_config_generator.py — specifically the unchanged test test_markdownlint_config_uses_correct_suffix at line 135.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lintro/config/tool_config_generator.py | Adds TOOL_CONFIG_WRAPPER_KEYS dict and wraps markdownlint defaults under "config" in _write_defaults_config; logic is correct for rule options but wraps all defaults unconditionally, which could silently swallow non-rule top-level markdownlint-cli2 keys. |
| tests/config/test_tool_config_generator.py | Adds four well-structured regression tests for the wrapping behavior, but leaves the pre-existing test_markdownlint_config_uses_correct_suffix unchanged; that test now passes pre-wrapped defaults to _write_defaults_config, producing double-nested output that the test misses because it only checks the file suffix. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["generate_defaults_config(tool_name, lintro_config)"] --> B{has_native_config?}
    B -- yes --> C[return None]
    B -- no --> D["merge builtin + user defaults\n{MD024: {siblings_only: true}}"]
    D --> E["_write_defaults_config(defaults, tool_name, config_format)"]
    E --> F["_transform_keys_for_native_config()\n(e.g. snake_case to camelCase for hadolint)"]
    F --> G{tool in TOOL_CONFIG_WRAPPER_KEYS?}
    G -- no --> H[write defaults as-is]
    G -- yes: markdownlint to config --> I["wrap: {config: native_defaults}\n{config: {MD024: {siblings_only: true}}}"]
    I --> J["json.dumps to .markdownlint-cli2.jsonc"]
    H --> K["json/yaml write to temp file"]
    J --> L[return temp Path]
    K --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["generate_defaults_config(tool_name, lintro_config)"] --> B{has_native_config?}
    B -- yes --> C[return None]
    B -- no --> D["merge builtin + user defaults\n{MD024: {siblings_only: true}}"]
    D --> E["_write_defaults_config(defaults, tool_name, config_format)"]
    E --> F["_transform_keys_for_native_config()\n(e.g. snake_case to camelCase for hadolint)"]
    F --> G{tool in TOOL_CONFIG_WRAPPER_KEYS?}
    G -- no --> H[write defaults as-is]
    G -- yes: markdownlint to config --> I["wrap: {config: native_defaults}\n{config: {MD024: {siblings_only: true}}}"]
    I --> J["json.dumps to .markdownlint-cli2.jsonc"]
    H --> K["json/yaml write to temp file"]
    J --> L[return temp Path]
    K --> L
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/config/test_tool_config_generator.py`, line 135-139 ([link](https://github.com/lgtm-hq/py-lintro/blob/4d41e6e19bf801fed3c0cd5d5fd66bb164682a56/tests/config/test_tool_config_generator.py#L135-L139)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> Update the defaults to pass unwrapped rule options, matching the new contract where `_write_defaults_config` adds the `"config"` wrapper internally. The current pre-wrapped input produces a double-nested `{"config": {"config": {...}}}` file that would be silently rejected by markdownlint-cli2.

   

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fconfig%2Ftest_tool_config_generator.py%0ALine%3A%20135-139%0A%0AComment%3A%0AUpdate%20the%20defaults%20to%20pass%20unwrapped%20rule%20options%2C%20matching%20the%20new%20contract%20where%20%60_write_defaults_config%60%20adds%20the%20%60%22config%22%60%20wrapper%20internally.%20The%20current%20pre-wrapped%20input%20produces%20a%20double-nested%20%60%7B%22config%22%3A%20%7B%22config%22%3A%20%7B...%7D%7D%7D%60%20file%20that%20would%20be%20silently%20rejected%20by%20markdownlint-cli2.%0A%0A%60%60%60suggestion%0A%20%20%20%20config_path%20%3D%20_write_defaults_config%28%0A%20%20%20%20%20%20%20%20defaults%3D%7B%22MD013%22%3A%20%7B%22line_length%22%3A%20100%7D%7D%2C%0A%20%20%20%20%20%20%20%20tool_name%3D%22markdownlint%22%2C%0A%20%20%20%20%20%20%20%20config_format%3DConfigFormat.JSON%2C%0A%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=1554&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fconfig%2Ftest_tool_config_generator.py%0ALine%3A%20135-139%0A%0AComment%3A%0AUpdate%20the%20defaults%20to%20pass%20unwrapped%20rule%20options%2C%20matching%20the%20new%20contract%20where%20%60_write_defaults_config%60%20adds%20the%20%60%22config%22%60%20wrapper%20internally.%20The%20current%20pre-wrapped%20input%20produces%20a%20double-nested%20%60%7B%22config%22%3A%20%7B%22config%22%3A%20%7B...%7D%7D%7D%60%20file%20that%20would%20be%20silently%20rejected%20by%20markdownlint-cli2.%0A%0A%60%60%60suggestion%0A%20%20%20%20config_path%20%3D%20_write_defaults_config%28%0A%20%20%20%20%20%20%20%20defaults%3D%7B%22MD013%22%3A%20%7B%22line_length%22%3A%20100%7D%7D%2C%0A%20%20%20%20%20%20%20%20tool_name%3D%22markdownlint%22%2C%0A%20%20%20%20%20%20%20%20config_format%3DConfigFormat.JSON%2C%0A%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fpy-lintro&pr=1554&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F1549-markdownlint-defaults%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1549-markdownlint-defaults%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fconfig%2Ftest_tool_config_generator.py%0ALine%3A%20135-139%0A%0AComment%3A%0AUpdate%20the%20defaults%20to%20pass%20unwrapped%20rule%20options%2C%20matching%20the%20new%20contract%20where%20%60_write_defaults_config%60%20adds%20the%20%60%22config%22%60%20wrapper%20internally.%20The%20current%20pre-wrapped%20input%20produces%20a%20double-nested%20%60%7B%22config%22%3A%20%7B%22config%22%3A%20%7B...%7D%7D%7D%60%20file%20that%20would%20be%20silently%20rejected%20by%20markdownlint-cli2.%0A%0A%60%60%60suggestion%0A%20%20%20%20config_path%20%3D%20_write_defaults_config%28%0A%20%20%20%20%20%20%20%20defaults%3D%7B%22MD013%22%3A%20%7B%22line_length%22%3A%20100%7D%7D%2C%0A%20%20%20%20%20%20%20%20tool_name%3D%22markdownlint%22%2C%0A%20%20%20%20%20%20%20%20config_format%3DConfigFormat.JSON%2C%0A%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Fpy-lintro&pr=1554&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atests%2Fconfig%2Ftest_tool_config_generator.py%3A135-139%0AUpdate%20the%20defaults%20to%20pass%20unwrapped%20rule%20options%2C%20matching%20the%20new%20contract%20where%20%60_write_defaults_config%60%20adds%20the%20%60%22config%22%60%20wrapper%20internally.%20The%20current%20pre-wrapped%20input%20produces%20a%20double-nested%20%60%7B%22config%22%3A%20%7B%22config%22%3A%20%7B...%7D%7D%7D%60%20file%20that%20would%20be%20silently%20rejected%20by%20markdownlint-cli2.%0A%0A%60%60%60suggestion%0A%20%20%20%20config_path%20%3D%20_write_defaults_config%28%0A%20%20%20%20%20%20%20%20defaults%3D%7B%22MD013%22%3A%20%7B%22line_length%22%3A%20100%7D%7D%2C%0A%20%20%20%20%20%20%20%20tool_name%3D%22markdownlint%22%2C%0A%20%20%20%20%20%20%20%20config_format%3DConfigFormat.JSON%2C%0A%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alintro%2Fconfig%2Ftool_config_generator.py%3A79-81%0A**Wrapping%20swallows%20non-rule%20top-level%20markdownlint-cli2%20options%20silently**%0A%0A%60markdownlint-cli2%60%20config%20files%20support%20several%20top-level%20keys%20besides%20%60%22config%22%60%20%28e.g.%20%60%22customRules%22%60%2C%20%60%22markdownItPlugins%22%60%2C%20%60%22noPatch%22%60%2C%20%60%22noInlineConfig%22%60%29.%20The%20current%20implementation%20wraps%20the%20entire%20%60defaults.markdownlint%60%20dict%20under%20%60%22config%22%60%2C%20so%20if%20a%20user%20ever%20includes%20one%20of%20those%20top-level%20keys%20in%20their%20%60.lintro-config.yaml%60%20under%20%60defaults.markdownlint%60%2C%20it%20will%20be%20buried%20inside%20%60config%60%20and%20silently%20ignored%20by%20the%20tool.%20Consider%20documenting%20that%20only%20per-rule%20options%20%28MD-prefixed%20keys%29%20should%20be%20placed%20under%20%60defaults.markdownlint%60%2C%20or%20handle%20the%20wrapping%20selectively.%0A%0A&pr=1554&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atests%2Fconfig%2Ftest_tool_config_generator.py%3A135-139%0AUpdate%20the%20defaults%20to%20pass%20unwrapped%20rule%20options%2C%20matching%20the%20new%20contract%20where%20%60_write_defaults_config%60%20adds%20the%20%60%22config%22%60%20wrapper%20internally.%20The%20current%20pre-wrapped%20input%20produces%20a%20double-nested%20%60%7B%22config%22%3A%20%7B%22config%22%3A%20%7B...%7D%7D%7D%60%20file%20that%20would%20be%20silently%20rejected%20by%20markdownlint-cli2.%0A%0A%60%60%60suggestion%0A%20%20%20%20config_path%20%3D%20_write_defaults_config%28%0A%20%20%20%20%20%20%20%20defaults%3D%7B%22MD013%22%3A%20%7B%22line_length%22%3A%20100%7D%7D%2C%0A%20%20%20%20%20%20%20%20tool_name%3D%22markdownlint%22%2C%0A%20%20%20%20%20%20%20%20config_format%3DConfigFormat.JSON%2C%0A%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alintro%2Fconfig%2Ftool_config_generator.py%3A79-81%0A**Wrapping%20swallows%20non-rule%20top-level%20markdownlint-cli2%20options%20silently**%0A%0A%60markdownlint-cli2%60%20config%20files%20support%20several%20top-level%20keys%20besides%20%60%22config%22%60%20%28e.g.%20%60%22customRules%22%60%2C%20%60%22markdownItPlugins%22%60%2C%20%60%22noPatch%22%60%2C%20%60%22noInlineConfig%22%60%29.%20The%20current%20implementation%20wraps%20the%20entire%20%60defaults.markdownlint%60%20dict%20under%20%60%22config%22%60%2C%20so%20if%20a%20user%20ever%20includes%20one%20of%20those%20top-level%20keys%20in%20their%20%60.lintro-config.yaml%60%20under%20%60defaults.markdownlint%60%2C%20it%20will%20be%20buried%20inside%20%60config%60%20and%20silently%20ignored%20by%20the%20tool.%20Consider%20documenting%20that%20only%20per-rule%20options%20%28MD-prefixed%20keys%29%20should%20be%20placed%20under%20%60defaults.markdownlint%60%2C%20or%20handle%20the%20wrapping%20selectively.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1554&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F1549-markdownlint-defaults%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1549-markdownlint-defaults%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atests%2Fconfig%2Ftest_tool_config_generator.py%3A135-139%0AUpdate%20the%20defaults%20to%20pass%20unwrapped%20rule%20options%2C%20matching%20the%20new%20contract%20where%20%60_write_defaults_config%60%20adds%20the%20%60%22config%22%60%20wrapper%20internally.%20The%20current%20pre-wrapped%20input%20produces%20a%20double-nested%20%60%7B%22config%22%3A%20%7B%22config%22%3A%20%7B...%7D%7D%7D%60%20file%20that%20would%20be%20silently%20rejected%20by%20markdownlint-cli2.%0A%0A%60%60%60suggestion%0A%20%20%20%20config_path%20%3D%20_write_defaults_config%28%0A%20%20%20%20%20%20%20%20defaults%3D%7B%22MD013%22%3A%20%7B%22line_length%22%3A%20100%7D%7D%2C%0A%20%20%20%20%20%20%20%20tool_name%3D%22markdownlint%22%2C%0A%20%20%20%20%20%20%20%20config_format%3DConfigFormat.JSON%2C%0A%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alintro%2Fconfig%2Ftool_config_generator.py%3A79-81%0A**Wrapping%20swallows%20non-rule%20top-level%20markdownlint-cli2%20options%20silently**%0A%0A%60markdownlint-cli2%60%20config%20files%20support%20several%20top-level%20keys%20besides%20%60%22config%22%60%20%28e.g.%20%60%22customRules%22%60%2C%20%60%22markdownItPlugins%22%60%2C%20%60%22noPatch%22%60%2C%20%60%22noInlineConfig%22%60%29.%20The%20current%20implementation%20wraps%20the%20entire%20%60defaults.markdownlint%60%20dict%20under%20%60%22config%22%60%2C%20so%20if%20a%20user%20ever%20includes%20one%20of%20those%20top-level%20keys%20in%20their%20%60.lintro-config.yaml%60%20under%20%60defaults.markdownlint%60%2C%20it%20will%20be%20buried%20inside%20%60config%60%20and%20silently%20ignored%20by%20the%20tool.%20Consider%20documenting%20that%20only%20per-rule%20options%20%28MD-prefixed%20keys%29%20should%20be%20placed%20under%20%60defaults.markdownlint%60%2C%20or%20handle%20the%20wrapping%20selectively.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1554&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(markdownlint): forward nested defaul..."](https://github.com/lgtm-hq/py-lintro/commit/4d41e6e19bf801fed3c0cd5d5fd66bb164682a56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45593619)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->