### PR TITLE
fix(ci): allow raw.githubusercontent.com in generate-man-page egress allowlist

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -76,6 +76,7 @@ jobs:
             github.com:443
             api.github.com:443
             objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
             pypi.org:443
             files.pythonhosted.org:443
             astral.sh:443


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): allow raw.githubusercontent.com in generate-man-page egress allowlist
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Adds `raw.githubusercontent.com:443` to the `generate-man-page` job's harden-runner `allowed-endpoints` in `.github/workflows/build-binary.yml`, matching the binary-build jobs in the same workflow (which gained it in #1152).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1556

## Details

- `uv run lintro fmt` + `uv run lintro chk`: clean, health score 100/100 (covers yamllint/actionlint on the workflow).
- Full `uv run pytest`: 6799 passed, 10 skipped, 1 failed — the failure is the known pre-existing local-environment commitlint version mismatch (21.2.0 < 21.2.1), unrelated to this workflow-only change.
- Real validation is the next tag-triggered publish run's Generate Man Page job.
