### PR TITLE
fix(ci): tolerate PR-introduced tools in the docker-ci manifest gate

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -921,6 +921,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Full history: the manifest gate diffs the manifest against the
+          # merge-base with the base branch to tolerate a newly-added tool's
+          # missing binary (#1565); a shallow checkout breaks merge-base.
+          fetch-depth: 0
           persist-credentials: false
       - name: Log in to GHCR
         if: >-
@@ -973,9 +977,19 @@ jobs:
         # fork PRs this verifies the tarball-loaded fork-built image (also
         # tagged py-lintro:latest by load-ci-docker-images.sh), so forks gate
         # on the exact image their integration tests run.
+        #
+        # New-binary-tool tolerance (#1565): BASE_REF lets the wrapper compute
+        # the tools this PR newly adds to the manifest (diff vs the merge-base)
+        # and pass them as --allow-missing, so their absent binary in the
+        # digest-pinned base image downgrades to a warning instead of failing
+        # this required check structurally. BASE_REF is empty for non-PR events
+        # (github.base_ref is only set on pull_request), so main pushes keep
+        # full enforcement; the fail-closed diff also yields an empty allowlist
+        # if the merge-base cannot be computed.
         if: needs.changes.outputs.pipeline != 'false'
         env:
           IMAGE: py-lintro:latest
+          BASE_REF: ${{ github.base_ref }}
         run: scripts/ci/verify-image-manifest-tools.sh
       - name: Run Docker integration tests
         if: needs.changes.outputs.pipeline != 'false'

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -133,6 +133,8 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `resolve-vue-tsc-version.sh`         | Read installed vue-tsc version from bun's global install root         | `./scripts/ci/resolve-vue-tsc-version.sh --help`                                   |
 | `verify-manifest-tools.py`           | Verify tools in image match manifest versions                         | `python scripts/ci/verify-manifest-tools.py --help`                                |
 | `verify-image-manifest-tools.sh`     | Run verify-manifest-tools.py inside a container image vs the manifest | `IMAGE=py-lintro:latest scripts/ci/verify-image-manifest-tools.sh`                 |
+| `compute-new-manifest-tools.sh`      | Print tool names a PR adds vs the merge-base (fails closed to empty)  | `BASE_REF=main scripts/ci/compute-new-manifest-tools.sh`                           |
+| `compute-new-manifest-tools.py`      | Diff tool names between an old and new manifest (added names)         | `python scripts/ci/compute-new-manifest-tools.py --help`                           |
 | `generate-tool-versions.py`          | Generate `_generated_versions.py` and sync `manifest.json` versions   | `python scripts/ci/generate-tool-versions.py [--check]`                            |
 | `stage-python-coverage-html.sh`      | Stage flat HTML coverage for GitHub Pages bundling                    | `./scripts/ci/testing/stage-python-coverage-html.sh --help`                        |
 | `render-coverage-json-html.py`       | Render a simple HTML index from CI `coverage.json` for Pages bundling | `python scripts/ci/testing/render-coverage-json-html.py --help`                    |

--- a/scripts/ci/compute-new-manifest-tools.py
+++ b/scripts/ci/compute-new-manifest-tools.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Print tool names present in a new manifest but absent from an old one.
+
+Used by ``compute-new-manifest-tools.sh`` to derive the set of tools a PR
+introduces, so the manifest-vs-image gate can tolerate their (necessarily)
+missing binary in the digest-pinned base image. JSON parsing lives here; git
+resolution (merge-base, ``git show``) lives in the shell wrapper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _tool_names(manifest_path: Path) -> set[str]:
+    """Extract the set of tool names declared in a manifest file.
+
+    A path that does not exist yields an empty set: the "old" side of the diff
+    is absent when the manifest is brand new, in which case every tool in the
+    new manifest counts as added.
+
+    Args:
+        manifest_path: Path to a manifest JSON file.
+
+    Returns:
+        The set of non-empty ``tools[].name`` values.
+
+    Raises:
+        ValueError: When the manifest is not a JSON object or ``tools`` is not
+            a list of objects.
+    """
+    if not manifest_path.exists():
+        return set()
+    data: Any = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"manifest must be a JSON object, got {type(data).__name__}")
+    tools = data.get("tools", [])
+    if not isinstance(tools, list):
+        raise ValueError("manifest tools must be a list")
+    names: set[str] = set()
+    for entry in tools:
+        if not isinstance(entry, dict):
+            raise ValueError("manifest tools[] entries must be objects")
+        name = str(entry.get("name", "")).strip()
+        if name:
+            names.add(name)
+    return names
+
+
+def main() -> int:
+    """Print comma-separated tool names added between the old and new manifest.
+
+    Returns:
+        ``0`` on success (the added-name list, possibly empty, is printed to
+        stdout); ``2`` when either manifest cannot be parsed. Callers treat a
+        non-zero exit as "fail closed": an empty allowlist, full enforcement.
+    """
+    parser = argparse.ArgumentParser(
+        description="Print tool names added between two manifests.",
+    )
+    parser.add_argument(
+        "--old",
+        required=True,
+        help="Path to the base-branch manifest (may not exist -> empty set)",
+    )
+    parser.add_argument(
+        "--new",
+        required=True,
+        help="Path to the current manifest",
+    )
+    args = parser.parse_args()
+
+    try:
+        old_names = _tool_names(Path(args.old))
+        new_names = _tool_names(Path(args.new))
+    except (ValueError, OSError, json.JSONDecodeError) as exc:
+        print(f"Failed to compute new manifest tools: {exc}", file=sys.stderr)
+        return 2
+
+    added = sorted(new_names - old_names)
+    print(",".join(added))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/compute-new-manifest-tools.sh
+++ b/scripts/ci/compute-new-manifest-tools.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+set -euo pipefail
+
+# compute-new-manifest-tools.sh
+#
+# Print the comma-separated set of tool names a PR *introduces* into
+# lintro/tools/manifest.json, computed as the git diff of tool names between
+# the current manifest and the manifest at the merge-base with the PR base
+# branch. The manifest-vs-image gate (verify-image-manifest-tools.sh) feeds
+# this to verify-manifest-tools.py via --allow-missing so a newly-added tool's
+# (necessarily) absent binary in the digest-pinned base image downgrades to a
+# warning instead of structurally failing the required check (#1565). The
+# post-merge tools-image republish + digest bump restores full coverage.
+#
+# Fail CLOSED: any trouble resolving the base ref, merge-base, the old manifest
+# blob, or the name diff prints an EMPTY set. An empty allowlist means full
+# enforcement — the safe default. On main / nightly runs (no BASE_REF, no PR
+# context) the set is likewise empty, so enforcement stays total.
+#
+# Fork PRs: the docker-ci checkout uses fetch-depth 0 and the base ref is a
+# same-repo branch (github.base_ref, e.g. main) whose remote-tracking ref is
+# fetched by the full checkout, so merge-base resolves without needing the
+# fork's own history. If it cannot (shallow/absent base), the fail-closed path
+# yields an empty allowlist and the gate enforces fully.
+#
+# Usage:
+#   BASE_REF=main scripts/ci/compute-new-manifest-tools.sh
+
+show_help() {
+	cat <<'EOF'
+Usage:
+  BASE_REF=<branch> scripts/ci/compute-new-manifest-tools.sh
+
+Print the comma-separated tool names a PR adds to the manifest, diffed against
+the merge-base with the base branch. Fails closed (empty output) on any error.
+
+Environment:
+  BASE_REF   Optional. PR base branch (github.base_ref), e.g. main. When unset
+             or empty (main / nightly runs), the added set is empty.
+  MANIFEST   Optional. Manifest path relative to the repo root
+             (default: lintro/tools/manifest.json).
+
+Output:
+  A single line on stdout: comma-separated added tool names (possibly empty).
+
+Exit codes:
+  0  always (fail-closed: errors print an empty set and still exit 0)
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	show_help
+	exit 0
+fi
+
+: "${BASE_REF:=}"
+: "${MANIFEST:=lintro/tools/manifest.json}"
+
+log_info() { echo "[INFO] $*" >&2; }
+log_warn() { echo "[WARN] $*" >&2; }
+
+# Emit the (possibly empty) allowlist on stdout and exit 0. Every fail-closed
+# path funnels through here so stdout carries exactly one line.
+emit() {
+	printf '%s\n' "${1:-}"
+	exit 0
+}
+
+# No PR context (main push / nightly): full enforcement, empty allowlist.
+if [[ -z "$BASE_REF" ]]; then
+	log_info "No BASE_REF (not a PR context); empty allow-missing set"
+	emit ""
+fi
+
+# Resolve the base ref: prefer the remote-tracking ref (CI checkouts), fall
+# back to a local branch (local runs and tests).
+base_commit=""
+if git rev-parse --verify --quiet "origin/${BASE_REF}^{commit}" >/dev/null 2>&1; then
+	base_commit="origin/${BASE_REF}"
+elif git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+	base_commit="${BASE_REF}"
+fi
+
+if [[ -z "$base_commit" ]]; then
+	log_warn "Base ref '${BASE_REF}' not resolvable; failing closed (empty set)"
+	emit ""
+fi
+
+if ! merge_base="$(git merge-base "$base_commit" HEAD 2>/dev/null)"; then
+	log_warn "merge-base(${base_commit}, HEAD) failed; failing closed (empty set)"
+	emit ""
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+old_manifest="$(mktemp)"
+trap 'rm -f "$old_manifest"' EXIT
+
+# The manifest may not have existed at the merge-base (brand-new manifest); an
+# empty old blob makes compute-new-manifest-tools.py treat every current tool
+# as added, which is the correct fail-open-to-tolerance for that rare case.
+if ! git show "${merge_base}:${MANIFEST}" >"$old_manifest" 2>/dev/null; then
+	log_info "No manifest at merge-base ${merge_base}; treating all tools as new"
+	: >"$old_manifest"
+fi
+
+added=""
+if ! added="$(python3 "${script_dir}/compute-new-manifest-tools.py" \
+	--old "$old_manifest" --new "$MANIFEST" 2>/dev/null)"; then
+	log_warn "Name diff failed; failing closed (empty set)"
+	emit ""
+fi
+
+if [[ -n "$added" ]]; then
+	log_info "Tools newly added by this PR: ${added}"
+else
+	log_info "No tools newly added by this PR"
+fi
+emit "$added"

--- a/scripts/ci/compute-new-manifest-tools.sh
+++ b/scripts/ci/compute-new-manifest-tools.sh
@@ -103,12 +103,12 @@ trap 'rm -f "$old_manifest"' EXIT
 # as added, which is the correct fail-open-to-tolerance for that rare case.
 if ! git show "${merge_base}:${MANIFEST}" >"$old_manifest" 2>/dev/null; then
 	log_info "No manifest at merge-base ${merge_base}; treating all tools as new"
-	: >"$old_manifest"
+	rm -f "$old_manifest"
 fi
 
 added=""
 if ! added="$(python3 "${script_dir}/compute-new-manifest-tools.py" \
-	--old "$old_manifest" --new "$MANIFEST" 2>/dev/null)"; then
+	--old "$old_manifest" --new "$MANIFEST")"; then
 	log_warn "Name diff failed; failing closed (empty set)"
 	emit ""
 fi

--- a/scripts/ci/verify-image-manifest-tools.sh
+++ b/scripts/ci/verify-image-manifest-tools.sh
@@ -39,14 +39,22 @@ Run verify-manifest-tools.py inside a container image, checking the image's
 installed tools against the current repository manifest.
 
 Environment:
-  IMAGE      Required. Image ref to verify (CI tag, local tag, or @sha256
-             digest). Registry refs are auto-pulled by `docker run`.
-  TIERS      Optional. Comma-separated manifest tiers to verify
-             (default: tools).
-  MANIFEST   Optional. Manifest path relative to the repo root
-             (default: lintro/tools/manifest.json).
-  DRY_RUN    Optional. When "1"/"true", print the docker command and exit 0
-             without invoking docker (used by unit tests).
+  IMAGE          Required. Image ref to verify (CI tag, local tag, or @sha256
+                 digest). Registry refs are auto-pulled by `docker run`.
+  TIERS          Optional. Comma-separated manifest tiers to verify
+                 (default: tools).
+  MANIFEST       Optional. Manifest path relative to the repo root
+                 (default: lintro/tools/manifest.json).
+  BASE_REF       Optional. PR base branch (github.base_ref). When set, tools
+                 the PR newly adds to the manifest are computed (diff vs the
+                 merge-base) and passed as --allow-missing, so their absent
+                 binary in the digest-pinned base image downgrades to a
+                 warning instead of failing the gate (#1565). Unset on
+                 main/nightly -> empty allowlist -> full enforcement.
+  ALLOW_MISSING  Optional. Explicit comma-separated allow-missing tool names.
+                 Overrides the BASE_REF-derived set (used by unit tests).
+  DRY_RUN        Optional. When "1"/"true", print the docker command and exit 0
+                 without invoking docker (used by unit tests).
 
 Exit codes:
   0  all verified tiers match the manifest
@@ -63,10 +71,14 @@ fi
 : "${IMAGE:?IMAGE is required (e.g. ghcr.io/lgtm-hq/py-lintro:ci-123)}"
 : "${TIERS:=tools}"
 : "${MANIFEST:=lintro/tools/manifest.json}"
+: "${BASE_REF:=}"
+: "${ALLOW_MISSING:=}"
 : "${DRY_RUN:=}"
 
 log_info() { echo "[INFO] $*"; }
 log_error() { echo "[ERROR] $*" >&2; }
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Resolve the repository root to mount: prefer git, fall back to the script's
 # grandparent (scripts/ci/ -> repo root).
@@ -81,6 +93,14 @@ if [[ ! -f "${repo_root}/${MANIFEST}" ]]; then
 	exit 2
 fi
 
+# Compute the newly-added-tool allowlist (#1565). An explicit ALLOW_MISSING
+# wins (tests); otherwise derive it from BASE_REF via the fail-closed helper.
+# On main/nightly (no BASE_REF) the helper returns empty -> full enforcement.
+if [[ -z "$ALLOW_MISSING" ]]; then
+	ALLOW_MISSING="$(BASE_REF="$BASE_REF" MANIFEST="$MANIFEST" \
+		"${script_dir}/compute-new-manifest-tools.sh")"
+fi
+
 # Bypass the image entrypoint so the container's baked ENV is used verbatim and
 # the checkout is mounted read-only outside /code (the entrypoint's gosu path).
 declare -a docker_args=(
@@ -93,6 +113,10 @@ declare -a docker_args=(
 	--manifest "$MANIFEST"
 	--tiers "$TIERS"
 )
+if [[ -n "$ALLOW_MISSING" ]]; then
+	docker_args+=(--allow-missing "$ALLOW_MISSING")
+	log_info "Tolerating newly-added tool(s): ${ALLOW_MISSING}"
+fi
 
 if [[ "$DRY_RUN" == "1" || "$DRY_RUN" == "true" ]]; then
 	log_info "[DRY-RUN] ${docker_args[*]}"

--- a/scripts/ci/verify-manifest-tools.py
+++ b/scripts/ci/verify-manifest-tools.py
@@ -127,6 +127,34 @@ def _iter_tools(
     return selected
 
 
+# Exit code returned by `_run` when the binary itself cannot be found on PATH
+# (FileNotFoundError). This is the ONLY failure mode tolerated for an
+# allow-missing tool: the tool the PR introduces is not yet baked into the
+# digest-pinned base image, so its binary is simply absent. Any other non-zero
+# exit means the binary IS present but misbehaving, which stays a hard failure
+# even for an allow-missing tool.
+_MISSING_BINARY_EXIT = 127
+
+
+def _parse_allow_missing(values: list[str] | None) -> set[str]:
+    """Parse repeated/comma-separated --allow-missing values into a name set.
+
+    Args:
+        values: Raw ``--allow-missing`` argument values, each of which may
+            itself be a comma-separated list of tool names. ``None`` when the
+            flag was never supplied.
+
+    Returns:
+        The set of tool names whose missing binary should be tolerated.
+    """
+    if not values:
+        return set()
+    names: set[str] = set()
+    for value in values:
+        names.update(part.strip() for part in value.split(",") if part.strip())
+    return names
+
+
 def main() -> int:
     """Verify tools in manifest.json are installed with correct versions."""
     parser = argparse.ArgumentParser()
@@ -140,9 +168,22 @@ def main() -> int:
         default=os.environ.get("LINTRO_MANIFEST_TIERS", "tools"),
         help="Comma-separated tiers to verify (default: tools)",
     )
+    parser.add_argument(
+        "--allow-missing",
+        action="append",
+        default=None,
+        help=(
+            "Tool name(s) whose missing binary downgrades to a warning instead "
+            "of failing. Repeatable and/or comma-separated. Intended for the "
+            "tool a PR introduces, which is not yet in the digest-pinned base "
+            "image. An allow-missing tool that IS present must still "
+            "version-match; every other tool keeps hard-fail behavior."
+        ),
+    )
     args = parser.parse_args()
 
     tiers = [t.strip() for t in args.tiers.split(",")]
+    allow_missing = _parse_allow_missing(args.allow_missing)
     try:
         all_tools = _load_manifest(args.manifest)
     except (ValueError, OSError, json.JSONDecodeError) as exc:
@@ -155,6 +196,7 @@ def main() -> int:
         return 2
 
     failures: list[str] = []
+    warnings: list[str] = []
     for tool in tools:
         name = str(tool.get("name", "")).strip()
         expected = str(tool.get("version", "")).strip()
@@ -170,6 +212,19 @@ def main() -> int:
         code, output = _run(cmd)
         if code != 0:
             cmd_str = " ".join(cmd)
+            # Tolerate ONLY a genuinely-absent binary (127) for a tool the PR
+            # introduces: the digest-pinned base image cannot yet contain it,
+            # so downgrade to a loud warning instead of a hard failure. The
+            # post-merge tools-image republish + digest bump restores full
+            # coverage. Any other exit code means the binary is present but
+            # broken, which stays a failure even for an allow-missing tool.
+            if name in allow_missing and code == _MISSING_BINARY_EXIT:
+                warnings.append(
+                    f"{name}: binary not found in image ({cmd_str}); tolerated "
+                    f"because this tool is newly added by the PR and is not yet "
+                    f"in the digest-pinned base image",
+                )
+                continue
             diagnostic = output.strip()
             message = f"{name}: command failed with exit code {code} ({cmd_str})"
             if diagnostic:
@@ -187,13 +242,27 @@ def main() -> int:
                 f"{name}: version mismatch (expected {expected}, got {actual})",
             )
 
+    if warnings:
+        # GitHub Actions annotation (::warning::) plus a human-readable block so
+        # the tolerated tool is prominent in both the checks UI and raw logs.
+        print("::warning::Tool verification tolerated newly-added tool(s):")
+        for item in warnings:
+            print(f"::warning::{item}")
+        print("Tolerated missing tool(s) (newly added by this PR):")
+        for item in warnings:
+            print(f"  - {item}")
+
     if failures:
         print("Tool verification failed:")
         for item in failures:
             print(f"  - {item}")
         return 1
 
-    print(f"Verified {len(tools)} tool(s) against manifest tiers: {', '.join(tiers)}")
+    tiers_str = ", ".join(tiers)
+    summary = f"Verified {len(tools)} tool(s) against manifest tiers: {tiers_str}"
+    if warnings:
+        summary = f"{summary} ({len(warnings)} newly-added tool(s) tolerated)"
+    print(summary)
     return 0
 
 

--- a/tests/scripts/test_compute_new_manifest_tools.py
+++ b/tests/scripts/test_compute_new_manifest_tools.py
@@ -1,0 +1,262 @@
+"""Tests for the newly-added-manifest-tool computation (#1565).
+
+Covers the pure JSON name-diff helper (``compute-new-manifest-tools.py``) and
+the git-resolution shell wrapper (``compute-new-manifest-tools.sh``), which
+feeds the ``--allow-missing`` allowlist to the manifest-vs-image gate. The
+wrapper is exercised against a real temporary git repository so the merge-base
+and fail-closed paths are covered end to end.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess  # nosec B404 - drives the scripts under test with shell=False
+from pathlib import Path
+from types import ModuleType
+
+from assertpy import assert_that
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PY_SCRIPT = (_REPO_ROOT / "scripts/ci/compute-new-manifest-tools.py").resolve()
+_SH_SCRIPT = (_REPO_ROOT / "scripts/ci/compute-new-manifest-tools.sh").resolve()
+
+
+def _load_module() -> ModuleType:
+    """Load compute-new-manifest-tools.py as an importable module.
+
+    Returns:
+        ModuleType: The loaded module.
+
+    Raises:
+        RuntimeError: When the module spec cannot be created.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "compute_new_manifest_tools",
+        _PY_SCRIPT,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load compute-new-manifest-tools.py module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _manifest(names: list[str]) -> str:
+    """Render a manifest JSON string declaring the given tool names.
+
+    Args:
+        names: Tool names to include.
+
+    Returns:
+        str: The manifest JSON.
+    """
+    return json.dumps(
+        {"version": 2, "tools": [{"name": n, "version": "1.0.0"} for n in names]},
+    )
+
+
+def test_tool_names_missing_file_is_empty() -> None:
+    """A non-existent manifest path yields an empty name set (new-manifest case)."""
+    module = _load_module()
+    names = module._tool_names(Path("/definitely/not/here.json"))  # noqa: SLF001
+    assert_that(names).is_equal_to(set())
+
+
+def test_tool_names_reads_declared_names(tmp_path: Path) -> None:
+    """Declared tool names are extracted, empty/blank names dropped."""
+    module = _load_module()
+    manifest = tmp_path / "m.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "tools": [{"name": "ruff"}, {"name": " "}, {"name": "black"}],
+            },
+        ),
+    )
+    names = module._tool_names(manifest)  # noqa: SLF001
+    assert_that(names).is_equal_to({"ruff", "black"})
+
+
+def _run_py(old: Path, new: Path) -> subprocess.CompletedProcess[str]:
+    """Run the python diff helper.
+
+    Args:
+        old: Old manifest path.
+        new: New manifest path.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed run.
+    """
+    return subprocess.run(  # nosec B603 B607 - fixed argv, shell=False, controlled test
+        ["python3", str(_PY_SCRIPT), "--old", str(old), "--new", str(new)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_py_prints_added_names_sorted(tmp_path: Path) -> None:
+    """Added tool names print comma-separated and sorted."""
+    old = tmp_path / "old.json"
+    new = tmp_path / "new.json"
+    old.write_text(_manifest(["ruff"]))
+    new.write_text(_manifest(["ruff", "terraform", "ansible"]))
+    result = _run_py(old, new)
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("ansible,terraform")
+
+
+def test_py_no_additions_prints_empty(tmp_path: Path) -> None:
+    """No added tools prints an empty line and exits 0."""
+    old = tmp_path / "old.json"
+    new = tmp_path / "new.json"
+    old.write_text(_manifest(["ruff", "black"]))
+    new.write_text(_manifest(["ruff"]))
+    result = _run_py(old, new)
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("")
+
+
+def test_py_invalid_new_manifest_exits_two(tmp_path: Path) -> None:
+    """A malformed current manifest exits 2 (caller fails closed)."""
+    old = tmp_path / "old.json"
+    new = tmp_path / "new.json"
+    old.write_text(_manifest(["ruff"]))
+    new.write_text("not json")
+    result = _run_py(old, new)
+    assert_that(result.returncode).is_equal_to(2)
+
+
+def _git(repo: Path, *args: str) -> None:
+    """Run a git command inside a test repository.
+
+    Args:
+        repo: Repository working directory.
+        *args: Git arguments (without the leading ``git``).
+    """
+    subprocess.run(  # nosec B603 B607 - fixed argv against a real binary; shell=False
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        },
+    )
+
+
+def _write_manifest_file(repo: Path, names: list[str]) -> None:
+    """Write the repo manifest declaring the given tool names.
+
+    Args:
+        repo: Repository root.
+        names: Tool names to declare.
+    """
+    manifest = repo / "lintro" / "tools" / "manifest.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(_manifest(names))
+
+
+def _run_sh(
+    repo: Path,
+    *,
+    base_ref: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run the shell wrapper in a repo with a given BASE_REF.
+
+    Args:
+        repo: Repository to run in (cwd).
+        base_ref: BASE_REF value.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed run.
+    """
+    return subprocess.run(  # nosec B603 - fixed argv against a real binary; shell=False
+        [str(_SH_SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=repo,
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": os.environ.get("HOME", "/tmp"),  # nosec B108 - test fallback
+            "BASE_REF": base_ref,
+        },
+    )
+
+
+def _init_repo_with_base(tmp_path: Path) -> Path:
+    """Create a repo on main with a two-tool manifest committed.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+
+    Returns:
+        Path: The repository root, checked out on a feature branch.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    _write_manifest_file(repo, ["ruff", "black"])
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base manifest")
+    _git(repo, "checkout", "-b", "feature")
+    return repo
+
+
+def test_sh_empty_base_ref_is_empty(tmp_path: Path) -> None:
+    """No BASE_REF (main / nightly) yields an empty allowlist on stdout."""
+    repo = _init_repo_with_base(tmp_path)
+    result = _run_sh(repo, base_ref="")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("")
+
+
+def test_sh_added_tool_is_reported(tmp_path: Path) -> None:
+    """A tool added on the branch is reported as newly-added vs the base."""
+    repo = _init_repo_with_base(tmp_path)
+    _write_manifest_file(repo, ["ruff", "black", "terraform"])
+    _git(repo, "commit", "-am", "add terraform")
+    result = _run_sh(repo, base_ref="main")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("terraform")
+
+
+def test_sh_no_manifest_change_is_empty(tmp_path: Path) -> None:
+    """A branch that does not touch the manifest reports no added tools."""
+    repo = _init_repo_with_base(tmp_path)
+    (repo / "README.md").write_text("docs\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "docs only")
+    result = _run_sh(repo, base_ref="main")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("")
+
+
+def test_sh_unresolvable_base_fails_closed(tmp_path: Path) -> None:
+    """An unresolvable base ref fails closed: empty allowlist, exit 0."""
+    repo = _init_repo_with_base(tmp_path)
+    result = _run_sh(repo, base_ref="does-not-exist")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("")
+
+
+def test_sh_help_exits_zero() -> None:
+    """The wrapper prints help and exits 0."""
+    result = (
+        subprocess.run(  # nosec B603 - fixed argv against a real binary; shell=False
+            [str(_SH_SCRIPT), "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("Usage:")
+    assert_that(result.stdout).contains("BASE_REF")

--- a/tests/scripts/test_compute_new_manifest_tools.py
+++ b/tests/scripts/test_compute_new_manifest_tools.py
@@ -239,6 +239,30 @@ def test_sh_no_manifest_change_is_empty(tmp_path: Path) -> None:
     assert_that(result.stdout.strip()).is_equal_to("")
 
 
+def test_sh_new_manifest_treats_all_as_added(tmp_path: Path) -> None:
+    """No manifest at the merge-base reports every current tool as added.
+
+    Regression test for #1566: ``git show`` failing (no manifest blob at the
+    merge-base) must make the Python helper see a *non-existent* old-manifest
+    path, not an existing-but-empty one -- an empty file fails JSON parsing
+    and flips the result to fail-closed (empty allowlist), the opposite of
+    the documented "brand-new manifest" intent.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    (repo / "README.md").write_text("docs\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base without a manifest")
+    _git(repo, "checkout", "-b", "feature")
+    _write_manifest_file(repo, ["ruff", "terraform"])
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "introduce manifest")
+    result = _run_sh(repo, base_ref="main")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("ruff,terraform")
+
+
 def test_sh_unresolvable_base_fails_closed(tmp_path: Path) -> None:
     """An unresolvable base ref fails closed: empty allowlist, exit 0."""
     repo = _init_repo_with_base(tmp_path)

--- a/tests/scripts/test_verify_image_manifest_tools.py
+++ b/tests/scripts/test_verify_image_manifest_tools.py
@@ -243,3 +243,38 @@ def test_drift_failure_propagates_exit_code(
         extra_env={"DOCKER_RUN_EXIT_CODE": "1"},
     )
     assert_that(result.returncode).is_equal_to(1)
+
+
+def test_explicit_allow_missing_passes_through(
+    image_repo: Path,
+    docker_stub: tuple[Path, Path],
+) -> None:
+    """An explicit ALLOW_MISSING flows through as --allow-missing (#1565)."""
+    bin_dir, args_log = docker_stub
+    result = _run_script(
+        image_repo,
+        bin_dir,
+        args_log,
+        extra_env={"ALLOW_MISSING": "terraform"},
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    run_lines = [
+        line for line in args_log.read_text().splitlines() if line.startswith("run ")
+    ]
+    assert_that(run_lines).is_length(1)
+    assert_that(run_lines[0]).contains("--allow-missing terraform")
+
+
+def test_no_allow_missing_without_base_ref(
+    image_repo: Path,
+    docker_stub: tuple[Path, Path],
+) -> None:
+    """With no BASE_REF and no manifest change, no --allow-missing is passed."""
+    bin_dir, args_log = docker_stub
+    result = _run_script(image_repo, bin_dir, args_log)
+    assert_that(result.returncode).is_equal_to(0)
+    run_lines = [
+        line for line in args_log.read_text().splitlines() if line.startswith("run ")
+    ]
+    assert_that(run_lines).is_length(1)
+    assert_that(run_lines[0]).does_not_contain("--allow-missing")

--- a/tests/scripts/test_verify_manifest_tools.py
+++ b/tests/scripts/test_verify_manifest_tools.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 from types import ModuleType
 
+import pytest
 from assertpy import assert_that
 
 
@@ -87,3 +89,164 @@ def test_non_clippy_versions_require_exact_match() -> None:
     versions_match = module._versions_match  # noqa: SLF001
     assert_that(versions_match("ruff", "1.97.1", "1.97.1")).is_true()
     assert_that(versions_match("ruff", "1.97.1", "1.97.0")).is_false()
+
+
+def test_parse_allow_missing_splits_and_dedupes() -> None:
+    """--allow-missing values are comma-split, trimmed, and de-duplicated."""
+    module = _load_verify_manifest_tools_module()
+
+    parse = module._parse_allow_missing  # noqa: SLF001
+    assert_that(parse(None)).is_equal_to(set())
+    assert_that(parse([])).is_equal_to(set())
+    assert_that(parse(["terraform"])).is_equal_to({"terraform"})
+    assert_that(parse(["a, b ", "b,c", " "])).is_equal_to({"a", "b", "c"})
+
+
+def _write_manifest(
+    tmp_path: Path,
+    *,
+    name: str,
+    version: str,
+    version_command: list[str],
+) -> Path:
+    """Write a single-tool manifest to a temp file.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+        name: Tool name.
+        version: Manifest-declared version.
+        version_command: Command used to probe the installed version.
+
+    Returns:
+        Path: The written manifest file.
+    """
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "tools": [
+                    {
+                        "name": name,
+                        "version": version,
+                        "tier": "tools",
+                        "version_command": version_command,
+                    },
+                ],
+            },
+        ),
+    )
+    return manifest
+
+
+def _run_main(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    argv: list[str],
+) -> int:
+    """Invoke the verifier's main() with a synthetic argv.
+
+    Args:
+        module: The loaded verify-manifest-tools module.
+        monkeypatch: Pytest monkeypatch fixture.
+        argv: Arguments following the program name.
+
+    Returns:
+        int: The main() exit code.
+    """
+    monkeypatch.setattr("sys.argv", ["verify-manifest-tools.py", *argv])
+    # module is loaded dynamically via importlib, so main() is typed as Any.
+    return int(module.main())
+
+
+def test_allow_missing_tool_absent_passes_with_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An allow-missing tool whose binary is absent passes with a loud warning."""
+    module = _load_verify_manifest_tools_module()
+    manifest = _write_manifest(
+        tmp_path,
+        name="brandnew",
+        version="1.0.0",
+        version_command=["definitely-not-a-real-binary-xyz", "--version"],
+    )
+
+    code = _run_main(
+        module,
+        monkeypatch,
+        ["--manifest", str(manifest), "--allow-missing", "brandnew"],
+    )
+
+    assert_that(code).is_equal_to(0)
+    out = capsys.readouterr().out
+    assert_that(out).contains("::warning::")
+    assert_that(out).contains("brandnew")
+
+
+def test_allow_missing_tool_present_version_mismatch_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An allow-missing tool that IS present must still version-match."""
+    module = _load_verify_manifest_tools_module()
+    # `git --version` is a real, present binary that never reports 99.0.0.
+    manifest = _write_manifest(
+        tmp_path,
+        name="git",
+        version="99.0.0",
+        version_command=["git", "--version"],
+    )
+
+    code = _run_main(
+        module,
+        monkeypatch,
+        ["--manifest", str(manifest), "--allow-missing", "git"],
+    )
+
+    assert_that(code).is_equal_to(1)
+
+
+def test_non_allowed_missing_tool_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing binary for a tool NOT in allow-missing is still a hard failure."""
+    module = _load_verify_manifest_tools_module()
+    manifest = _write_manifest(
+        tmp_path,
+        name="brandnew",
+        version="1.0.0",
+        version_command=["definitely-not-a-real-binary-xyz", "--version"],
+    )
+
+    code = _run_main(
+        module,
+        monkeypatch,
+        ["--manifest", str(manifest)],
+    )
+
+    assert_that(code).is_equal_to(1)
+
+
+def test_empty_allow_missing_leaves_behavior_unchanged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty allowlist keeps full enforcement: a present, matching tool passes."""
+    module = _load_verify_manifest_tools_module()
+    # `git --version` -> "git version X.Y.Z"; declare that exact version so the
+    # match succeeds regardless of the runner's git build.
+    _, output = module._run(["git", "--version"])  # noqa: SLF001
+    actual = module._parse_version(output, "git")  # noqa: SLF001
+    manifest = _write_manifest(
+        tmp_path,
+        name="git",
+        version=str(actual),
+        version_command=["git", "--version"],
+    )
+
+    code = _run_main(module, monkeypatch, ["--manifest", str(manifest)])
+
+    assert_that(code).is_equal_to(0)


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `fix(ci): tolerate PR-introduced tools in the docker-ci manifest gate`
- Type:
  - [x] fix / perf (patch)
- Breaking change:
  - [ ] none

## What's Changing

The required `Verify CI image tools against manifest` check runs the freshly
built CI image against the CURRENT manifest. Because that image inherits its
binaries from the digest-pinned `lintro-tools` base image, any PR adding a new
binary tool fails structurally: the pinned base cannot contain a tool the PR is
introducing, and the pin only bumps after merge. That blocks every
new-binary-tool PR on an admin merge (live repro: #1529 / Terraform).

This teaches the gate to tolerate tools the PR itself adds while keeping full
enforcement for everything else:

- **`verify-manifest-tools.py` gains `--allow-missing`** (repeatable and/or
  comma-separated). For those tools ONLY, a genuinely-absent binary (exit 127)
  downgrades to a loud `::warning::` naming the tolerated tool. An allow-missing
  tool that IS present must still version-match; every other tool keeps
  hard-fail behavior (missing binary, version mismatch, parse failure).
- **The newly-added-tool set is computed in script files, not inline workflow
  shell** (stand-ci): `compute-new-manifest-tools.sh` resolves the merge-base
  with the base branch and extracts the old manifest blob;
  `compute-new-manifest-tools.py` diffs tool names (added = new − old). It
  **fails CLOSED** to an empty allowlist on any resolution error (unresolvable
  base ref, merge-base failure, malformed diff), so a broken diff enforces
  fully. On main/nightly (no `BASE_REF`) the set is empty → total enforcement.
- **Wiring:** `verify-image-manifest-tools.sh` derives the allowlist from
  `BASE_REF` and passes it through as `--allow-missing`. `docker-ci.yml` sets
  `BASE_REF: ${{ github.base_ref }}` (empty on non-PR events) on the verify step
  and switches the integration-test checkout to `fetch-depth: 0` so `merge-base`
  resolves — including for fork PRs, where the base ref is a same-repo branch
  whose remote-tracking ref is fetched by the full checkout.

## Fork PRs

The base ref is `github.base_ref` (a same-repo branch, e.g. `main`), fetched by
the `fetch-depth: 0` checkout, so `merge-base` resolves without the fork's own
history. If it cannot, the fail-closed path yields an empty allowlist and the
gate enforces fully.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing (scripts/README.md)
- [x] Local CI passed (full lint + suite green apart from documented local-only
  failures: commitlint version lag, pip-audit ensurepip SIGABRT)

## Closes

- Closes #1565
- Relates to #1529
- Relates to #1528

## Details

Unit tests cover: allow-missing tool absent → pass with warning; allow-missing
tool present but version-mismatched → fail; non-allowed tool missing → fail;
empty allowlist → unchanged behavior; the JSON name diff (added/none/malformed);
and the shell wrapper's git resolution (empty BASE_REF, added tool reported,
no-manifest-change, unresolvable base → fail-closed empty). #1529 should go
green once rebased onto this fix.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a structural CI failure affecting any PR that introduces a new binary tool: the required `Verify CI image tools against manifest` check ran against a digest-pinned base image that, by construction, could not contain a tool being introduced in that very PR.

- **New `--allow-missing` flag in `verify-manifest-tools.py`**: tools in the allowlist that are absent (exit 127) downgrade to a `::warning::` annotation; if the binary IS present, version-matching is still enforced fully.
- **New `compute-new-manifest-tools.{py,sh}`**: derive the set of PR-introduced tools by diffing the manifest against the merge-base; fail closed (empty allowlist) on any resolution error so main/nightly runs and broken diffs keep total enforcement.
- **`verify-image-manifest-tools.sh` wiring + `docker-ci.yml` plumbing**: `BASE_REF` is passed from `github.base_ref` and `fetch-depth: 0` is added to allow `git merge-base` to resolve; all integration-test and unit-test scenarios (including the brand-new-manifest edge case) are covered.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the fail-closed design ensures any git resolution error or parse failure yields an empty allowlist and full enforcement, not a weakened gate.

The change is well-scoped and consistently fail-closed: empty BASE_REF, unresolvable merge-base, malformed manifest diff, and missing Python all produce an empty allowlist. The --allow-missing tolerance is deliberately narrow — only a genuinely absent binary (exit 127) is downgraded; any other failure code and any version mismatch remain hard failures. Issues raised in prior review rounds are both addressed and covered by a dedicated regression test.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/compute-new-manifest-tools.sh | New shell wrapper that computes PR-introduced tool names; correctly uses rm -f (not truncation) when the old manifest doesn't exist at merge-base, and fails closed on any git resolution error. |
| scripts/ci/compute-new-manifest-tools.py | New Python helper that diffs tool name sets between two manifest files; correctly treats a non-existent path as an empty set and propagates parse errors as exit-2 for fail-closed handling by the shell caller. |
| scripts/ci/verify-manifest-tools.py | Adds --allow-missing argument with correct tolerances: only exit-127 (genuinely absent binary) is downgraded to a warning; other non-zero exits and version mismatches remain hard failures even for allow-listed tools. |
| scripts/ci/verify-image-manifest-tools.sh | Wires compute-new-manifest-tools.sh into the docker invocation; explicit ALLOW_MISSING env var takes precedence for tests, falling back to BASE_REF-derived computation for CI runs. |
| .github/workflows/docker-ci.yml | Adds fetch-depth: 0 to the integration-test checkout and passes BASE_REF from github.base_ref to the verify step; empty on non-PR events, preserving full enforcement for main pushes. |
| tests/scripts/test_compute_new_manifest_tools.py | Comprehensive test suite covering the Python name-diff helper and the shell wrapper end-to-end against a real temp git repo; includes regression test for the rm-f-vs-truncation edge case. |
| tests/scripts/test_verify_manifest_tools.py | New tests validate allow-missing semantics: absent binary passes with warning, present-but-mismatched binary still fails, non-listed missing binary still fails, and empty allowlist keeps existing behavior unchanged. |
| tests/scripts/test_verify_image_manifest_tools.py | Two new tests confirm that an explicit ALLOW_MISSING flows through as --allow-missing in the docker command, and that no --allow-missing flag is added when BASE_REF and manifest changes are absent. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): remove old-manifest temp file i..."](https://github.com/lgtm-hq/py-lintro/commit/5d1b1ef25b2a4dab4d62505415b3ece2853c241e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45656019)</sub>

<!-- /greptile_comment -->