### PR TITLE
feat(cli): add lintro badge command for shields.io score

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ bun add -g @lgtm-hq/lintro         # Node / npm — self-contained, no Python
 
 lintro check .                     # Find issues (alias: chk)
 lintro format .                    # Fix issues (alias: fmt)
+lintro badge                       # shields.io health-score badge
 lintro check --output-format grid  # Beautiful output
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,8 +171,8 @@ lintro badge --url            # bare badge URL
 lintro badge --json           # score, tier, color, url, and markdown as JSON
 ```
 
-`lintro badge` runs a score-only check (or accepts `--score N` to skip the run) and
-prints a shields.io snippet such as
+`--json` and `--url` are mutually exclusive. `lintro badge` runs a score-only check (or
+accepts `--score N` to skip the run) and prints a shields.io snippet such as
 `![Lintro Score](https://img.shields.io/badge/lintro-84%2F100-brightgreen)`. Badge color
 follows the tiers below: bright green (75+), yellow (50–74), red (<50).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,8 +173,8 @@ lintro badge --json           # score, tier, color, url, and markdown as JSON
 
 `lintro badge` runs a score-only check (or accepts `--score N` to skip the run) and
 prints a shields.io snippet such as
-`![Lintro Score](https://img.shields.io/badge/lintro-84%2F100-brightgreen)`.
-Badge color follows the tiers below: bright green (75+), yellow (50–74), red (<50).
+`![Lintro Score](https://img.shields.io/badge/lintro-84%2F100-brightgreen)`. Badge color
+follows the tiers below: bright green (75+), yellow (50–74), red (<50).
 
 #### Scoring model
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,7 +165,16 @@ lintro check                  # normal output + health score line at the end
 lintro check --score          # print ONLY the score (for scripts/badges)
 lintro check --fail-under 75  # exit 1 if the score is below 75
 lintro check --output-format json   # score included under summary.health_score
+lintro badge                  # markdown shields.io badge for the score
+lintro badge --style flat     # shields.io style variant
+lintro badge --url            # bare badge URL
+lintro badge --json           # score, tier, color, url, and markdown as JSON
 ```
+
+`lintro badge` runs a score-only check (or accepts `--score N` to skip the run) and
+prints a shields.io snippet such as
+`![Lintro Score](https://img.shields.io/badge/lintro-84%2F100-brightgreen)`.
+Badge color follows the tiers below: bright green (75+), yellow (50–74), red (<50).
 
 #### Scoring model
 

--- a/lintro/ai/transcript.py
+++ b/lintro/ai/transcript.py
@@ -101,6 +101,7 @@ def _infer_command() -> str:
         "versions",
         "licenses",
         "completions",
+        "badge",
     }
     for arg in sys.argv[1:]:
         if arg.startswith("-"):

--- a/lintro/api/core.py
+++ b/lintro/api/core.py
@@ -378,6 +378,7 @@ def check_run(
     transport: str | None = None,
     score: bool = False,
     fail_under: float | None = None,
+    ai_enabled: bool = True,
 ) -> RunArtifact:
     """Check files and return the full run artifact.
 
@@ -408,6 +409,7 @@ def check_run(
         transport: Override AI transport (``api`` or ``cli``).
         score: Print only the health score, suppressing the summary.
         fail_under: Exit non-zero if the health score is below this value.
+        ai_enabled: Whether post-execution AI enhancement may run.
 
     Returns:
         RunArtifact: Everything the run produced.
@@ -436,6 +438,7 @@ def check_run(
         transport=transport,
         score=score,
         fail_under=fail_under,
+        ai_enabled=ai_enabled,
     )
 
 

--- a/lintro/cli.py
+++ b/lintro/cli.py
@@ -70,6 +70,7 @@ setup_cli_logging()
 # E402: Module level imports below setup_cli_logging() are intentional.
 # Logging must be configured BEFORE importing modules that use loguru,
 # otherwise log messages during import get silently dropped or misconfigured.
+from lintro.cli_utils.commands.badge import badge_command  # noqa: E402
 from lintro.cli_utils.commands.check import check_command  # noqa: E402
 from lintro.cli_utils.commands.completions import completions_command  # noqa: E402
 from lintro.cli_utils.commands.config import config_command  # noqa: E402
@@ -243,6 +244,7 @@ def cli() -> None:
 
 
 # Register canonical commands and set _canonical_name for help
+cast(Any, badge_command)._canonical_name = "badge"
 cast(Any, check_command)._canonical_name = "check"
 cast(Any, completions_command)._canonical_name = "completions"
 cast(Any, config_command)._canonical_name = "config"
@@ -258,6 +260,7 @@ cast(Any, mcp_command)._canonical_name = "mcp"
 cast(Any, review_command)._canonical_name = "review"
 cast(Any, versions_command)._canonical_name = "versions"
 
+cli.add_command(badge_command, name="badge")
 cli.add_command(check_command, name="check")
 cli.add_command(completions_command, name="completions")
 cli.add_command(config_command, name="config")

--- a/lintro/cli_utils/commands/badge.py
+++ b/lintro/cli_utils/commands/badge.py
@@ -1,0 +1,165 @@
+"""``lintro badge`` command for shields.io health-score badges."""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+from contextlib import redirect_stdout
+
+import click
+
+from lintro.api import core as api
+from lintro.utils.health_score import (
+    MAX_SCORE,
+    MIN_SCORE,
+    build_shields_badge_markdown,
+    build_shields_badge_url,
+    shields_color_for_tier,
+    tier_for_score,
+)
+
+_SCORE_LINE_RE = re.compile(r"^\d{1,3}$")
+
+_SHIELDS_STYLES: tuple[str, ...] = (
+    "flat",
+    "flat-square",
+    "plastic",
+    "for-the-badge",
+    "social",
+)
+
+
+def _parse_score_output(raw: str) -> int:
+    """Extract the numeric health score from score-only check stdout.
+
+    Prefers the last line that is a bare integer so incidental progress text
+    on stdout does not break parsing.
+
+    Args:
+        raw: Captured stdout from a score-only check run.
+
+    Returns:
+        int: Parsed score in ``[0, 100]``.
+
+    Raises:
+        click.ClickException: If no parseable score line is found or the value
+            is outside the valid range.
+    """
+    candidates = [
+        line.strip()
+        for line in raw.splitlines()
+        if _SCORE_LINE_RE.fullmatch(line.strip())
+    ]
+    if not candidates:
+        raise click.ClickException(
+            "Could not determine health score from check output.",
+        )
+    score = int(candidates[-1])
+    if score < MIN_SCORE or score > MAX_SCORE:
+        raise click.ClickException(
+            f"Health score out of range: {score} (expected {MIN_SCORE}-{MAX_SCORE}).",
+        )
+    return score
+
+
+def resolve_health_score(
+    *,
+    score_override: int | None,
+    paths: tuple[str, ...],
+) -> int:
+    """Resolve the project health score for badge generation.
+
+    When ``score_override`` is set, that value is returned directly (useful for
+    tests and CI snippets). Otherwise a score-only check is run via the public
+    API and the printed score is parsed.
+
+    Args:
+        score_override: Explicit score to use instead of running tools.
+        paths: Paths to check when computing a live score.
+
+    Returns:
+        int: Health score in ``[0, 100]``.
+    """
+    if score_override is not None:
+        return score_override
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        api.check(
+            paths=list(paths) if paths else None,
+            score=True,
+            no_log=True,
+        )
+    return _parse_score_output(buffer.getvalue())
+
+
+@click.command("badge")
+@click.argument("paths", nargs=-1, type=click.Path(exists=True))
+@click.option(
+    "--style",
+    type=click.Choice(_SHIELDS_STYLES, case_sensitive=False),
+    default=None,
+    help="shields.io badge style (e.g. flat).",
+)
+@click.option(
+    "--url",
+    "url_only",
+    is_flag=True,
+    help="Print only the shields.io badge URL.",
+)
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    help="Print badge metadata as JSON.",
+)
+@click.option(
+    "--score",
+    "score_override",
+    type=click.IntRange(MIN_SCORE, MAX_SCORE),
+    default=None,
+    help="Use this score instead of running a check (0-100).",
+)
+def badge_command(
+    paths: tuple[str, ...],
+    style: str | None,
+    url_only: bool,
+    json_output: bool,
+    score_override: int | None,
+) -> None:
+    """Generate a shields.io markdown badge for the project health score.
+
+    Runs a score-only check on the given paths (default ``.``) unless
+    ``--score`` supplies an override. Prints a markdown image by default;
+    use ``--url`` for the bare URL or ``--json`` for structured output.
+
+    Args:
+        paths: File/directory paths to score; empty means the current directory.
+        style: Optional shields.io style query parameter.
+        url_only: Emit only the badge URL.
+        json_output: Emit JSON with score, tier, color, url, and markdown.
+        score_override: Explicit score that skips running tools.
+    """
+    score = resolve_health_score(score_override=score_override, paths=paths)
+    tier = tier_for_score(score)
+    color = shields_color_for_tier(tier)
+    url = build_shields_badge_url(score, style=style)
+    markdown = build_shields_badge_markdown(score, style=style)
+
+    if json_output:
+        payload = {
+            "score": score,
+            "tier": tier.label,
+            "color": color,
+            "url": url,
+            "markdown": markdown,
+        }
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    if url_only:
+        click.echo(url)
+        return
+
+    click.echo(markdown)

--- a/lintro/cli_utils/commands/badge.py
+++ b/lintro/cli_utils/commands/badge.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import io
 import json
-import re
 from contextlib import redirect_stdout
 
 import click
@@ -19,8 +18,6 @@ from lintro.utils.health_score import (
     tier_for_score,
 )
 
-_SCORE_LINE_RE = re.compile(r"^\d{1,3}$")
-
 _SHIELDS_STYLES: tuple[str, ...] = (
     "flat",
     "flat-square",
@@ -28,39 +25,6 @@ _SHIELDS_STYLES: tuple[str, ...] = (
     "for-the-badge",
     "social",
 )
-
-
-def _parse_score_output(raw: str) -> int:
-    """Extract the numeric health score from score-only check stdout.
-
-    Prefers the last line that is a bare integer so incidental progress text
-    on stdout does not break parsing.
-
-    Args:
-        raw: Captured stdout from a score-only check run.
-
-    Returns:
-        int: Parsed score in ``[0, 100]``.
-
-    Raises:
-        click.ClickException: If no parseable score line is found or the value
-            is outside the valid range.
-    """
-    candidates = [
-        line.strip()
-        for line in raw.splitlines()
-        if _SCORE_LINE_RE.fullmatch(line.strip())
-    ]
-    if not candidates:
-        raise click.ClickException(
-            "Could not determine health score from check output.",
-        )
-    score = int(candidates[-1])
-    if score < MIN_SCORE or score > MAX_SCORE:
-        raise click.ClickException(
-            f"Health score out of range: {score} (expected {MIN_SCORE}-{MAX_SCORE}).",
-        )
-    return score
 
 
 def resolve_health_score(
@@ -71,8 +35,9 @@ def resolve_health_score(
     """Resolve the project health score for badge generation.
 
     When ``score_override`` is set, that value is returned directly (useful for
-    tests and CI snippets). Otherwise a score-only check is run via the public
-    API and the printed score is parsed.
+    tests and CI snippets). Otherwise a check is run via :func:`api.check_run`
+    and the score is read from the :class:`~lintro.models.core.run_artifact.RunArtifact`
+    (issue #1823) rather than re-parsing stdout.
 
     Args:
         score_override: Explicit score to use instead of running tools.
@@ -86,12 +51,12 @@ def resolve_health_score(
 
     buffer = io.StringIO()
     with redirect_stdout(buffer):
-        api.check(
+        artifact = api.check_run(
             paths=list(paths) if paths else None,
-            score=True,
             no_log=True,
+            score=True,
         )
-    return _parse_score_output(buffer.getvalue())
+    return artifact.health_score
 
 
 @click.command("badge")
@@ -133,6 +98,7 @@ def badge_command(
     Runs a score-only check on the given paths (default ``.``) unless
     ``--score`` supplies an override. Prints a markdown image by default;
     use ``--url`` for the bare URL or ``--json`` for structured output.
+    \u000c
 
     Args:
         paths: File/directory paths to score; empty means the current directory.

--- a/lintro/cli_utils/commands/badge.py
+++ b/lintro/cli_utils/commands/badge.py
@@ -9,6 +9,7 @@ from contextlib import redirect_stdout
 import click
 
 from lintro.api import core as api
+from lintro.models.core.run_artifact import RunArtifact
 from lintro.utils.health_score import (
     MAX_SCORE,
     MIN_SCORE,
@@ -25,6 +26,24 @@ _SHIELDS_STYLES: tuple[str, ...] = (
     "for-the-badge",
     "social",
 )
+
+
+def _live_score_is_usable(artifact: RunArtifact) -> bool:
+    """Return whether a live check produced a badge-worthy score.
+
+    Args:
+        artifact: Completed check run.
+
+    Returns:
+        bool: ``True`` when at least one tool executed and a health score
+        was computed. Empty, all-skipped, filtered, and early-exit runs are
+        not usable public quality signals.
+    """
+    if artifact.early_exit or artifact.health is None:
+        return False
+    if artifact.main_phase_empty_due_to_filter:
+        return False
+    return any(not result.skipped for result in artifact.tool_results)
 
 
 def resolve_health_score(
@@ -48,7 +67,7 @@ def resolve_health_score(
 
     Raises:
         click.ClickException: If the live check exits before a score is
-            produced (``early_exit`` or missing ``health``).
+            produced, or no tool actually executed (empty / all-skipped).
     """
     if score_override is not None:
         return score_override
@@ -60,9 +79,10 @@ def resolve_health_score(
             no_log=True,
             score=True,
         )
-    if artifact.early_exit or artifact.health is None:
+    if not _live_score_is_usable(artifact):
         raise click.ClickException(
-            "Could not determine health score because the check exited before scoring.",
+            "Could not determine a usable health score because the check "
+            "exited early, was empty, or all tools were skipped.",
         )
     return artifact.health_score
 
@@ -114,7 +134,13 @@ def badge_command(
         url_only: Emit only the badge URL.
         json_output: Emit JSON with score, tier, color, url, and markdown.
         score_override: Explicit score that skips running tools.
+
+    Raises:
+        click.UsageError: If ``--json`` and ``--url`` are passed together.
     """
+    if json_output and url_only:
+        raise click.UsageError("Use --json or --url, not both.")
+
     score = resolve_health_score(score_override=score_override, paths=paths)
     tier = tier_for_score(score)
     color = shields_color_for_tier(tier)

--- a/lintro/cli_utils/commands/badge.py
+++ b/lintro/cli_utils/commands/badge.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import io
 import json
+import re
 from contextlib import redirect_stdout
 
 import click
 
 from lintro.api import core as api
 from lintro.models.core.run_artifact import RunArtifact
+from lintro.models.core.tool_result import ToolResult
 from lintro.utils.health_score import (
     MAX_SCORE,
     MIN_SCORE,
@@ -27,6 +29,28 @@ _SHIELDS_STYLES: tuple[str, ...] = (
     "social",
 )
 
+_NO_FILES_CHECKED_RE = re.compile(r"(?i)no .+files found to check")
+
+
+def _result_checked_any_files(result: ToolResult) -> bool:
+    """Return whether a tool result looks like it actually inspected files.
+
+    Tools that run over an empty path still return ``skipped=False`` and
+    ``success=True`` with a ``"No … files found to check"`` message. That is
+    not a public quality signal — it is the same as never running.
+
+    Args:
+        result: One tool's completed result.
+
+    Returns:
+        bool: ``True`` when the tool was not skipped and did not report an
+        empty file set.
+    """
+    if result.skipped:
+        return False
+    text = f"{result.output or ''}\n{result.formatted_output or ''}"
+    return _NO_FILES_CHECKED_RE.search(text) is None
+
 
 def _live_score_is_usable(artifact: RunArtifact) -> bool:
     """Return whether a live check produced a badge-worthy score.
@@ -35,15 +59,15 @@ def _live_score_is_usable(artifact: RunArtifact) -> bool:
         artifact: Completed check run.
 
     Returns:
-        bool: ``True`` when at least one tool executed and a health score
-        was computed. Empty, all-skipped, filtered, and early-exit runs are
-        not usable public quality signals.
+        bool: ``True`` when at least one tool inspected files and a health
+        score was computed. Empty, all-skipped, filtered, and early-exit
+        runs are not usable public quality signals.
     """
     if artifact.early_exit or artifact.health is None:
         return False
     if artifact.main_phase_empty_due_to_filter:
         return False
-    return any(not result.skipped for result in artifact.tool_results)
+    return any(_result_checked_any_files(result) for result in artifact.tool_results)
 
 
 def resolve_health_score(

--- a/lintro/cli_utils/commands/badge.py
+++ b/lintro/cli_utils/commands/badge.py
@@ -45,6 +45,10 @@ def resolve_health_score(
 
     Returns:
         int: Health score in ``[0, 100]``.
+
+    Raises:
+        click.ClickException: If the live check exits before a score is
+            produced (``early_exit`` or missing ``health``).
     """
     if score_override is not None:
         return score_override
@@ -55,6 +59,10 @@ def resolve_health_score(
             paths=list(paths) if paths else None,
             no_log=True,
             score=True,
+        )
+    if artifact.early_exit or artifact.health is None:
+        raise click.ClickException(
+            "Could not determine health score because the check exited before scoring.",
         )
     return artifact.health_score
 

--- a/lintro/cli_utils/commands/badge.py
+++ b/lintro/cli_utils/commands/badge.py
@@ -48,7 +48,7 @@ def _result_checked_any_files(result: ToolResult) -> bool:
         bool: ``True`` when the tool was not skipped and did not report an
         empty file set.
     """
-    if result.skipped:
+    if result.skipped or result.timed_out:
         return False
     text = f"{result.output or ''}\n{result.formatted_output or ''}"
     return _NO_FILES_CHECKED_RE.search(text) is None
@@ -62,12 +62,11 @@ def _live_score_is_usable(artifact: RunArtifact) -> bool:
 
     Returns:
         bool: ``True`` when at least one tool inspected files and a health
-        score was computed. Empty, all-skipped, filtered, and early-exit
-        runs are not usable public quality signals.
+        score was computed. Empty, all-skipped, timed-out, and early-exit
+        runs are not usable public quality signals. A filter-empty main
+        phase is still usable when post-checks produced a real result.
     """
     if artifact.early_exit or artifact.health is None:
-        return False
-    if artifact.main_phase_empty_due_to_filter:
         return False
     return any(_result_checked_any_files(result) for result in artifact.tool_results)
 
@@ -104,6 +103,7 @@ def resolve_health_score(
             paths=list(paths) if paths else None,
             no_log=True,
             score=True,
+            ai_enabled=False,
         )
     if not _live_score_is_usable(artifact):
         raise click.ClickException(

--- a/lintro/cli_utils/commands/badge.py
+++ b/lintro/cli_utils/commands/badge.py
@@ -29,7 +29,9 @@ _SHIELDS_STYLES: tuple[str, ...] = (
     "social",
 )
 
-_NO_FILES_CHECKED_RE = re.compile(r"(?i)no .+files found to check")
+# Real wrapper messages vary: "No files found to check.", "No Astro files to
+# check.", "No .py/.pyi files found to check.".
+_NO_FILES_CHECKED_RE = re.compile(r"(?i)\bno\b.*\bfiles?\b.*\bto check\b")
 
 
 def _result_checked_any_files(result: ToolResult) -> bool:

--- a/lintro/utils/health_score.py
+++ b/lintro/utils/health_score.py
@@ -292,6 +292,7 @@ def health_score_for_results(
     counts = count_severities(tool_results)
     return compute_health_score_from_config(counts, config)
 
+
 def shields_color_for_tier(tier: ScoreTier) -> str:
     """Return the shields.io color name for a qualitative score tier.
 

--- a/lintro/utils/health_score.py
+++ b/lintro/utils/health_score.py
@@ -47,6 +47,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import auto
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 from lintro.enums.severity_level import SeverityLevel
 from lintro.enums.uppercase_str_enum import UppercaseStrEnum
@@ -290,3 +291,65 @@ def health_score_for_results(
     """
     counts = count_severities(tool_results)
     return compute_health_score_from_config(counts, config)
+
+def shields_color_for_tier(tier: ScoreTier) -> str:
+    """Return the shields.io color name for a qualitative score tier.
+
+    Mapping follows the README badge convention: bright green for healthy
+    projects, yellow for middling scores, and red for critical ones.
+
+    Args:
+        tier: Qualitative :class:`ScoreTier` for the numeric score.
+
+    Returns:
+        str: shields.io color token (``brightgreen``, ``yellow``, or ``red``).
+    """
+    if tier is ScoreTier.GREAT:
+        return "brightgreen"
+    if tier is ScoreTier.NEEDS_WORK:
+        return "yellow"
+    return "red"
+
+
+def build_shields_badge_url(
+    score: int,
+    *,
+    style: str | None = None,
+) -> str:
+    """Build a shields.io static badge URL for a health score.
+
+    Args:
+        score: Integer health score in ``[0, 100]`` (clamped if out of range).
+        style: Optional shields.io style (e.g. ``flat``); omitted when ``None``.
+
+    Returns:
+        str: Absolute shields.io badge URL.
+    """
+    clamped = max(MIN_SCORE, min(MAX_SCORE, score))
+    message = quote(f"{clamped}/100", safe="")
+    color = shields_color_for_tier(tier_for_score(clamped))
+    url = f"https://img.shields.io/badge/lintro-{message}-{color}"
+    if style:
+        url = f"{url}?style={quote(style, safe='')}"
+    return url
+
+
+def build_shields_badge_markdown(
+    score: int,
+    *,
+    style: str | None = None,
+    alt_text: str = "Lintro Score",
+) -> str:
+    """Build a markdown image snippet for a health-score shields.io badge.
+
+    Args:
+        score: Integer health score in ``[0, 100]``.
+        style: Optional shields.io style forwarded to the URL builder.
+        alt_text: Alt text for the markdown image.
+
+    Returns:
+        str: Markdown such as
+        ``![Lintro Score](https://img.shields.io/badge/lintro-84%2F100-brightgreen)``.
+    """
+    url = build_shields_badge_url(score, style=style)
+    return f"![{alt_text}]({url})"

--- a/lintro/utils/health_score.py
+++ b/lintro/utils/health_score.py
@@ -331,7 +331,7 @@ def build_shields_badge_url(
     color = shields_color_for_tier(tier_for_score(clamped))
     url = f"https://img.shields.io/badge/lintro-{message}-{color}"
     if style:
-        url = f"{url}?style={quote(style, safe='')}"
+        url = f"{url}?style={quote(style, safe='-')}"
     return url
 
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -268,6 +268,17 @@ def test_cli_has_versions_command(cli_runner: CliRunner) -> None:
     assert_that(result.exit_code).is_equal_to(0)
 
 
+def test_cli_has_badge_command(cli_runner: CliRunner) -> None:
+    """Verify badge command is registered.
+
+    Args:
+        cli_runner: The Click CLI test runner.
+    """
+    result = cli_runner.invoke(cli, ["badge", "--help"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+
+
 def test_cli_has_list_tools_command(cli_runner: CliRunner) -> None:
     """Verify list-tools command is registered.
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -277,6 +277,9 @@ def test_cli_has_badge_command(cli_runner: CliRunner) -> None:
     result = cli_runner.invoke(cli, ["badge", "--help"])
 
     assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains(
+        "Generate a shields.io markdown badge for the project health score.",
+    )
 
 
 def test_cli_has_list_tools_command(cli_runner: CliRunner) -> None:

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -11,6 +11,7 @@ from click.testing import CliRunner
 from lintro.cli import cli
 
 SUBCOMMANDS: tuple[str, ...] = (
+    "badge",
     "check",
     "completions",
     "config",
@@ -28,6 +29,7 @@ SUBCOMMANDS: tuple[str, ...] = (
 
 # Human-facing summary phrases that must survive Click's \\f truncation.
 SUBCOMMAND_SUMMARY_PHRASES: dict[str, str] = {
+    "badge": "Generate a shields.io markdown badge for the project health score.",
     "check": "Check files for issues using the specified tools.",
     "completions": "Print a shell completion script for bash, zsh, or fish.",
     "config": "Display Lintro configuration status.",

--- a/tests/unit/cli_utils/commands/test_badge_command.py
+++ b/tests/unit/cli_utils/commands/test_badge_command.py
@@ -1,0 +1,155 @@
+"""Tests for the ``lintro badge`` CLI command."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from assertpy import assert_that
+from click.testing import CliRunner
+
+from lintro.cli import cli
+from lintro.cli_utils.commands.badge import (
+    _parse_score_output,
+    badge_command,
+    resolve_health_score,
+)
+
+
+def test_badge_markdown_default() -> None:
+    """Default output is a markdown shields.io image for the score."""
+    runner = CliRunner()
+
+    result = runner.invoke(badge_command, ["--score", "84"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output.strip()).is_equal_to(
+        "![Lintro Score](https://img.shields.io/badge/lintro-84%2F100-brightgreen)",
+    )
+
+
+def test_badge_url_only() -> None:
+    """``--url`` prints the bare shields.io URL."""
+    runner = CliRunner()
+
+    result = runner.invoke(badge_command, ["--score", "60", "--url"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output.strip()).is_equal_to(
+        "https://img.shields.io/badge/lintro-60%2F100-yellow",
+    )
+
+
+def test_badge_style_flat() -> None:
+    """``--style flat`` appends the shields style query parameter."""
+    runner = CliRunner()
+
+    result = runner.invoke(badge_command, ["--score", "84", "--style", "flat", "--url"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output.strip()).is_equal_to(
+        "https://img.shields.io/badge/lintro-84%2F100-brightgreen?style=flat",
+    )
+
+
+def test_badge_json_output() -> None:
+    """``--json`` emits score, tier, color, url, and markdown."""
+    runner = CliRunner()
+
+    result = runner.invoke(badge_command, ["--score", "40", "--json"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    payload = json.loads(result.output)
+    assert_that(payload["score"]).is_equal_to(40)
+    assert_that(payload["tier"]).is_equal_to("critical")
+    assert_that(payload["color"]).is_equal_to("red")
+    assert_that(payload["url"]).is_equal_to(
+        "https://img.shields.io/badge/lintro-40%2F100-red",
+    )
+    assert_that(payload["markdown"]).starts_with("![Lintro Score](")
+
+
+def test_badge_registered_on_cli() -> None:
+    """The root CLI exposes the badge command help."""
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["badge", "--help"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output.lower()).contains("shields")
+
+
+def test_parse_score_output_prefers_last_integer_line() -> None:
+    """Score parsing ignores incidental stdout and takes the last integer."""
+    raw = "Processing files\nProcessing files\n99\n"
+
+    assert_that(_parse_score_output(raw)).is_equal_to(99)
+
+
+def test_parse_score_output_raises_when_missing() -> None:
+    """Missing score lines raise a ClickException."""
+    assert_that(_parse_score_output).raises(click.ClickException).when_called_with(
+        "no score here\n",
+    )
+
+
+def test_parse_score_output_rejects_out_of_range() -> None:
+    """Scores outside 0-100 are rejected."""
+    assert_that(_parse_score_output).raises(click.ClickException).when_called_with(
+        "101\n",
+    )
+
+
+def test_resolve_health_score_uses_override() -> None:
+    """An explicit override skips the live check API."""
+    with patch("lintro.cli_utils.commands.badge.api.check") as mock_check:
+        score = resolve_health_score(score_override=77, paths=())
+
+    assert_that(score).is_equal_to(77)
+    mock_check.assert_not_called()
+
+
+def test_resolve_health_score_runs_check_when_needed() -> None:
+    """Without an override, a score-only API check is invoked."""
+
+    def _fake_check(**_kwargs: object) -> MagicMock:
+        print("88")
+        return MagicMock()
+
+    with patch(
+        "lintro.cli_utils.commands.badge.api.check",
+        side_effect=_fake_check,
+    ) as mock_check:
+        score = resolve_health_score(score_override=None, paths=(".",))
+
+    assert_that(score).is_equal_to(88)
+    mock_check.assert_called_once()
+    assert_that(mock_check.call_args.kwargs["score"]).is_true()
+
+
+@pytest.mark.parametrize(
+    ("score", "color_fragment"),
+    [
+        ("100", "brightgreen"),
+        ("75", "brightgreen"),
+        ("74", "yellow"),
+        ("50", "yellow"),
+        ("49", "red"),
+        ("0", "red"),
+    ],
+)
+def test_badge_color_thresholds(score: str, color_fragment: str) -> None:
+    """Badge color tracks the documented tier thresholds.
+
+    Args:
+        score: Override score passed to the CLI.
+        color_fragment: Expected shields.io color token in the URL.
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(badge_command, ["--score", score, "--url"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains(color_fragment)

--- a/tests/unit/cli_utils/commands/test_badge_command.py
+++ b/tests/unit/cli_utils/commands/test_badge_command.py
@@ -227,6 +227,55 @@ def test_resolve_health_score_rejects_all_skipped_run() -> None:
             resolve_health_score(score_override=None, paths=())
 
 
+def test_resolve_health_score_rejects_no_files_found_run() -> None:
+    """A run that executed but matched no files must not publish 100."""
+    artifact = _scored_artifact(score=100)
+    artifact.tool_results = [
+        ToolResult(
+            name="ruff",
+            success=True,
+            skipped=False,
+            output="No .py/.pyi files found to check.",
+        ),
+        ToolResult(
+            name="yamllint",
+            success=True,
+            skipped=False,
+            output="No YAML files found to check.",
+        ),
+    ]
+
+    with patch(
+        "lintro.cli_utils.commands.badge.api.check_run",
+        return_value=artifact,
+    ):
+        with pytest.raises(click.ClickException):
+            resolve_health_score(score_override=None, paths=())
+
+
+def test_badge_live_no_files_found_prints_no_badge() -> None:
+    """Empty-path live checks exit non-zero and print no shields snippet."""
+    runner = CliRunner()
+    artifact = _scored_artifact(score=100)
+    artifact.tool_results = [
+        ToolResult(
+            name="ruff",
+            success=True,
+            skipped=False,
+            output="No .py/.pyi files found to check.\nNo issues found.",
+        ),
+    ]
+
+    with patch(
+        "lintro.cli_utils.commands.badge.api.check_run",
+        return_value=artifact,
+    ):
+        result = runner.invoke(badge_command, [])
+
+    assert_that(result.exit_code).is_not_equal_to(0)
+    assert_that(result.output).does_not_contain("img.shields.io")
+
+
 def test_resolve_health_score_rejects_filter_empty_run() -> None:
     """A filter-empty run must not publish a perfect 100 badge."""
     artifact = _scored_artifact(score=100)

--- a/tests/unit/cli_utils/commands/test_badge_command.py
+++ b/tests/unit/cli_utils/commands/test_badge_command.py
@@ -3,19 +3,19 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import click
 import pytest
 from assertpy import assert_that
 from click.testing import CliRunner
 
 from lintro.cli import cli
 from lintro.cli_utils.commands.badge import (
-    _parse_score_output,
     badge_command,
     resolve_health_score,
 )
+from lintro.models.core.run_artifact import RunArtifact
+from lintro.utils.health_score import HealthScore, ScoreTier, SeverityCounts
 
 
 def test_badge_markdown_default() -> None:
@@ -81,30 +81,9 @@ def test_badge_registered_on_cli() -> None:
     assert_that(result.output.lower()).contains("shields")
 
 
-def test_parse_score_output_prefers_last_integer_line() -> None:
-    """Score parsing ignores incidental stdout and takes the last integer."""
-    raw = "Processing files\nProcessing files\n99\n"
-
-    assert_that(_parse_score_output(raw)).is_equal_to(99)
-
-
-def test_parse_score_output_raises_when_missing() -> None:
-    """Missing score lines raise a ClickException."""
-    assert_that(_parse_score_output).raises(click.ClickException).when_called_with(
-        "no score here\n",
-    )
-
-
-def test_parse_score_output_rejects_out_of_range() -> None:
-    """Scores outside 0-100 are rejected."""
-    assert_that(_parse_score_output).raises(click.ClickException).when_called_with(
-        "101\n",
-    )
-
-
 def test_resolve_health_score_uses_override() -> None:
     """An explicit override skips the live check API."""
-    with patch("lintro.cli_utils.commands.badge.api.check") as mock_check:
+    with patch("lintro.cli_utils.commands.badge.api.check_run") as mock_check:
         score = resolve_health_score(score_override=77, paths=())
 
     assert_that(score).is_equal_to(77)
@@ -113,20 +92,25 @@ def test_resolve_health_score_uses_override() -> None:
 
 def test_resolve_health_score_runs_check_when_needed() -> None:
     """Without an override, a score-only API check is invoked."""
-
-    def _fake_check(**_kwargs: object) -> MagicMock:
-        print("88")
-        return MagicMock()
+    artifact = RunArtifact(
+        health=HealthScore(
+            score=88,
+            tier=ScoreTier.GREAT,
+            counts=SeverityCounts(),
+            weighted_penalty=0.0,
+        ),
+    )
 
     with patch(
-        "lintro.cli_utils.commands.badge.api.check",
-        side_effect=_fake_check,
+        "lintro.cli_utils.commands.badge.api.check_run",
+        return_value=artifact,
     ) as mock_check:
         score = resolve_health_score(score_override=None, paths=(".",))
 
     assert_that(score).is_equal_to(88)
     mock_check.assert_called_once()
     assert_that(mock_check.call_args.kwargs["score"]).is_true()
+    assert_that(mock_check.call_args.kwargs["no_log"]).is_true()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cli_utils/commands/test_badge_command.py
+++ b/tests/unit/cli_utils/commands/test_badge_command.py
@@ -13,7 +13,6 @@ from click.testing import CliRunner
 
 from lintro.cli import cli
 from lintro.cli_utils.commands.badge import (
-    _SHIELDS_STYLES,
     badge_command,
     resolve_health_score,
 )
@@ -130,6 +129,7 @@ def test_resolve_health_score_runs_check_when_needed() -> None:
     mock_check.assert_called_once()
     assert_that(mock_check.call_args.kwargs["score"]).is_true()
     assert_that(mock_check.call_args.kwargs["no_log"]).is_true()
+    assert_that(mock_check.call_args.kwargs["ai_enabled"]).is_false()
     assert_that(mock_check.call_args.kwargs["paths"]).is_equal_to(["."])
 
 
@@ -297,10 +297,32 @@ def test_badge_live_no_files_found_prints_no_badge() -> None:
     assert_that(result.output).does_not_contain("img.shields.io")
 
 
-def test_resolve_health_score_rejects_filter_empty_run() -> None:
-    """A filter-empty run must not publish a perfect 100 badge."""
-    artifact = _scored_artifact(score=100)
+def test_resolve_health_score_accepts_filter_empty_with_post_checks() -> None:
+    """A filter-empty main phase is usable when a post-check inspected files."""
+    artifact = _scored_artifact(score=88)
     artifact.main_phase_empty_due_to_filter = True
+
+    with patch(
+        "lintro.cli_utils.commands.badge.api.check_run",
+        return_value=artifact,
+    ):
+        score = resolve_health_score(score_override=None, paths=())
+
+    assert_that(score).is_equal_to(88)
+
+
+def test_resolve_health_score_rejects_all_timeout_run() -> None:
+    """An all-timeout run must not publish a perfect 100 badge."""
+    artifact = _scored_artifact(score=100)
+    artifact.tool_results = [
+        ToolResult(
+            name="ruff",
+            success=False,
+            skipped=False,
+            timed_out=True,
+            output="timed out after 30s",
+        ),
+    ]
 
     with patch(
         "lintro.cli_utils.commands.badge.api.check_run",
@@ -340,7 +362,10 @@ def test_badge_live_all_skipped_prints_no_badge() -> None:
     assert_that(result.output).does_not_contain("img.shields.io")
 
 
-@pytest.mark.parametrize("style", list(_SHIELDS_STYLES))
+@pytest.mark.parametrize(
+    "style",
+    ["flat", "flat-square", "plastic", "for-the-badge", "social"],
+)
 def test_badge_style_query_keeps_hyphens(style: str) -> None:
     """Every supported shields style is appended without encoding hyphens.
 

--- a/tests/unit/cli_utils/commands/test_badge_command.py
+++ b/tests/unit/cli_utils/commands/test_badge_command.py
@@ -12,10 +12,12 @@ from click.testing import CliRunner
 
 from lintro.cli import cli
 from lintro.cli_utils.commands.badge import (
+    _SHIELDS_STYLES,
     badge_command,
     resolve_health_score,
 )
 from lintro.models.core.run_artifact import RunArtifact
+from lintro.models.core.tool_result import ToolResult
 from lintro.utils.health_score import HealthScore, ScoreTier, SeverityCounts
 
 
@@ -107,6 +109,9 @@ def _scored_artifact(*, score: int = 88) -> RunArtifact:
             counts=SeverityCounts(),
             weighted_penalty=0.0,
         ),
+        tool_results=[
+            ToolResult(name="ruff", success=True, skipped=False),
+        ],
     )
 
 
@@ -183,6 +188,120 @@ def test_badge_rejects_score_out_of_range() -> None:
     result = runner.invoke(badge_command, ["--score", "101"])
 
     assert_that(result.exit_code).is_not_equal_to(0)
+
+
+def test_badge_rejects_json_and_url_together() -> None:
+    """``--json`` and ``--url`` are mutually exclusive."""
+    runner = CliRunner()
+
+    result = runner.invoke(badge_command, ["--score", "84", "--json", "--url"])
+
+    assert_that(result.exit_code).is_not_equal_to(0)
+    assert_that(result.output.lower()).contains("not both")
+
+
+def test_resolve_health_score_rejects_all_skipped_run() -> None:
+    """An all-skipped run must not publish a perfect 100 badge."""
+    artifact = RunArtifact(
+        health=HealthScore(
+            score=100,
+            tier=ScoreTier.GREAT,
+            counts=SeverityCounts(),
+            weighted_penalty=0.0,
+        ),
+        tool_results=[
+            ToolResult(
+                name="ruff",
+                success=True,
+                skipped=True,
+                skip_reason="no files matched",
+            ),
+        ],
+    )
+
+    with patch(
+        "lintro.cli_utils.commands.badge.api.check_run",
+        return_value=artifact,
+    ):
+        with pytest.raises(click.ClickException):
+            resolve_health_score(score_override=None, paths=())
+
+
+def test_resolve_health_score_rejects_filter_empty_run() -> None:
+    """A filter-empty run must not publish a perfect 100 badge."""
+    artifact = _scored_artifact(score=100)
+    artifact.main_phase_empty_due_to_filter = True
+
+    with patch(
+        "lintro.cli_utils.commands.badge.api.check_run",
+        return_value=artifact,
+    ):
+        with pytest.raises(click.ClickException):
+            resolve_health_score(score_override=None, paths=())
+
+
+def test_badge_live_all_skipped_prints_no_badge() -> None:
+    """Skipped-only live checks exit non-zero and print no shields snippet."""
+    runner = CliRunner()
+    artifact = RunArtifact(
+        health=HealthScore(
+            score=100,
+            tier=ScoreTier.GREAT,
+            counts=SeverityCounts(),
+            weighted_penalty=0.0,
+        ),
+        tool_results=[
+            ToolResult(
+                name="ruff",
+                success=True,
+                skipped=True,
+                skip_reason="no files matched",
+            ),
+        ],
+    )
+
+    with patch(
+        "lintro.cli_utils.commands.badge.api.check_run",
+        return_value=artifact,
+    ):
+        result = runner.invoke(badge_command, [])
+
+    assert_that(result.exit_code).is_not_equal_to(0)
+    assert_that(result.output).does_not_contain("img.shields.io")
+
+
+@pytest.mark.parametrize("style", list(_SHIELDS_STYLES))
+def test_badge_style_query_keeps_hyphens(style: str) -> None:
+    """Every supported shields style is appended without encoding hyphens.
+
+    Args:
+        style: shields.io style token from the CLI choice list.
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(
+        badge_command,
+        ["--score", "84", "--style", style, "--url"],
+    )
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output.strip()).ends_with(f"?style={style}")
+    assert_that(result.output).does_not_contain("%2D")
+
+
+def test_badge_style_flat_square_keeps_hyphen() -> None:
+    """Hyphenated shields styles are not percent-encoded."""
+    runner = CliRunner()
+
+    result = runner.invoke(
+        badge_command,
+        ["--score", "84", "--style", "flat-square", "--url"],
+    )
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output.strip()).is_equal_to(
+        "https://img.shields.io/badge/lintro-84%2F100-brightgreen?style=flat-square",
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cli_utils/commands/test_badge_command.py
+++ b/tests/unit/cli_utils/commands/test_badge_command.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from unittest.mock import patch
 
+import click
 import pytest
 from assertpy import assert_that
 from click.testing import CliRunner
@@ -90,16 +91,28 @@ def test_resolve_health_score_uses_override() -> None:
     mock_check.assert_not_called()
 
 
-def test_resolve_health_score_runs_check_when_needed() -> None:
-    """Without an override, a score-only API check is invoked."""
-    artifact = RunArtifact(
+def _scored_artifact(*, score: int = 88) -> RunArtifact:
+    """Build a scored run artifact for badge tests.
+
+    Args:
+        score: Health score to embed on the artifact.
+
+    Returns:
+        RunArtifact: Artifact with a real health score.
+    """
+    return RunArtifact(
         health=HealthScore(
-            score=88,
+            score=score,
             tier=ScoreTier.GREAT,
             counts=SeverityCounts(),
             weighted_penalty=0.0,
         ),
     )
+
+
+def test_resolve_health_score_runs_check_when_needed() -> None:
+    """Without an override, a score-only API check is invoked."""
+    artifact = _scored_artifact()
 
     with patch(
         "lintro.cli_utils.commands.badge.api.check_run",
@@ -111,6 +124,65 @@ def test_resolve_health_score_runs_check_when_needed() -> None:
     mock_check.assert_called_once()
     assert_that(mock_check.call_args.kwargs["score"]).is_true()
     assert_that(mock_check.call_args.kwargs["no_log"]).is_true()
+    assert_that(mock_check.call_args.kwargs["paths"]).is_equal_to(["."])
+
+
+def test_resolve_health_score_rejects_early_exit() -> None:
+    """An unscored early-exit run must not become a 0/100 badge."""
+    artifact = RunArtifact(early_exit=True, exit_code=1)
+
+    with patch(
+        "lintro.cli_utils.commands.badge.api.check_run",
+        return_value=artifact,
+    ):
+        with pytest.raises(click.ClickException):
+            resolve_health_score(score_override=None, paths=())
+
+
+def test_badge_live_score_prints_markdown_only() -> None:
+    """Without ``--score``, CLI output is the badge markdown (no leaked score)."""
+    runner = CliRunner()
+    artifact = _scored_artifact(score=88)
+
+    def _fake_check_run(**_kwargs: object) -> RunArtifact:
+        print("88")
+        return artifact
+
+    with patch(
+        "lintro.cli_utils.commands.badge.api.check_run",
+        side_effect=_fake_check_run,
+    ):
+        result = runner.invoke(badge_command, [])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output.strip()).is_equal_to(
+        "![Lintro Score](https://img.shields.io/badge/lintro-88%2F100-brightgreen)",
+    )
+    assert_that(result.output).does_not_contain("88\n")
+
+
+def test_badge_live_early_exit_prints_no_badge() -> None:
+    """An early-exit live check exits non-zero and prints no shields snippet."""
+    runner = CliRunner()
+    artifact = RunArtifact(early_exit=True, exit_code=2)
+
+    with patch(
+        "lintro.cli_utils.commands.badge.api.check_run",
+        return_value=artifact,
+    ):
+        result = runner.invoke(badge_command, [])
+
+    assert_that(result.exit_code).is_not_equal_to(0)
+    assert_that(result.output).does_not_contain("img.shields.io")
+
+
+def test_badge_rejects_score_out_of_range() -> None:
+    """Click rejects ``--score`` values outside 0-100."""
+    runner = CliRunner()
+
+    result = runner.invoke(badge_command, ["--score", "101"])
+
+    assert_that(result.exit_code).is_not_equal_to(0)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cli_utils/commands/test_badge_command.py
+++ b/tests/unit/cli_utils/commands/test_badge_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 import click
@@ -238,10 +239,16 @@ def test_resolve_health_score_rejects_no_files_found_run() -> None:
             output="No .py/.pyi files found to check.",
         ),
         ToolResult(
-            name="yamllint",
+            name="cargo_audit",
             success=True,
             skipped=False,
-            output="No YAML files found to check.",
+            output="No files found to check.",
+        ),
+        ToolResult(
+            name="astro-check",
+            success=True,
+            skipped=False,
+            output="No Astro files to check.",
         ),
     ]
 
@@ -251,6 +258,20 @@ def test_resolve_health_score_rejects_no_files_found_run() -> None:
     ):
         with pytest.raises(click.ClickException):
             resolve_health_score(score_override=None, paths=())
+
+
+def test_badge_empty_directory_does_not_publish(tmp_path: Path) -> None:
+    """A real empty directory must not publish a 100/100 badge.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(badge_command, [str(tmp_path)])
+
+    assert_that(result.exit_code).is_not_equal_to(0)
+    assert_that(result.output).does_not_contain("img.shields.io")
 
 
 def test_badge_live_no_files_found_prints_no_badge() -> None:

--- a/tests/utils/test_health_score.py
+++ b/tests/utils/test_health_score.py
@@ -13,10 +13,13 @@ from lintro.utils.health_score import (
     HealthScore,
     ScoreTier,
     SeverityCounts,
+    build_shields_badge_markdown,
+    build_shields_badge_url,
     compute_health_score,
     compute_health_score_from_config,
     count_severities,
     health_score_for_results,
+    shields_color_for_tier,
     tier_for_score,
 )
 
@@ -254,3 +257,37 @@ def test_tier_for_representative_counts(
         expected_tier: Tier the score should fall into.
     """
     assert_that(compute_health_score(counts).tier).is_equal_to(expected_tier)
+
+@pytest.mark.parametrize(
+    ("tier", "expected_color"),
+    [
+        (ScoreTier.GREAT, "brightgreen"),
+        (ScoreTier.NEEDS_WORK, "yellow"),
+        (ScoreTier.CRITICAL, "red"),
+    ],
+)
+def test_shields_color_for_tier(
+    tier: ScoreTier,
+    expected_color: str,
+) -> None:
+    """Each score tier maps to the documented shields.io color.
+
+    Args:
+        tier: Qualitative score tier.
+        expected_color: Expected shields.io color token.
+    """
+    assert_that(shields_color_for_tier(tier)).is_equal_to(expected_color)
+
+
+def test_build_shields_badge_url_and_markdown() -> None:
+    """Badge helpers encode the score and optional style correctly."""
+    url = build_shields_badge_url(84)
+    markdown = build_shields_badge_markdown(84, style="flat")
+
+    assert_that(url).is_equal_to(
+        "https://img.shields.io/badge/lintro-84%2F100-brightgreen",
+    )
+    assert_that(markdown).is_equal_to(
+        "![Lintro Score](https://img.shields.io/badge/lintro-84%2F100-brightgreen"
+        "?style=flat)",
+    )

--- a/tests/utils/test_health_score.py
+++ b/tests/utils/test_health_score.py
@@ -258,6 +258,7 @@ def test_tier_for_representative_counts(
     """
     assert_that(compute_health_score(counts).tier).is_equal_to(expected_tier)
 
+
 @pytest.mark.parametrize(
     ("tier", "expected_color"),
     [

--- a/tests/utils/test_health_score.py
+++ b/tests/utils/test_health_score.py
@@ -284,6 +284,7 @@ def test_build_shields_badge_url_and_markdown() -> None:
     """Badge helpers encode the score and optional style correctly."""
     url = build_shields_badge_url(84)
     markdown = build_shields_badge_markdown(84, style="flat")
+    hyphenated = build_shields_badge_url(84, style="for-the-badge")
 
     assert_that(url).is_equal_to(
         "https://img.shields.io/badge/lintro-84%2F100-brightgreen",
@@ -292,3 +293,5 @@ def test_build_shields_badge_url_and_markdown() -> None:
         "![Lintro Score](https://img.shields.io/badge/lintro-84%2F100-brightgreen"
         "?style=flat)",
     )
+    assert_that(hyphenated).contains("style=for-the-badge")
+    assert_that(hyphenated).does_not_contain("%2D")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(cli): add lintro badge command for shields.io score
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

- New `lintro badge` CLI command with `--style`, `--url`, `--json`, and `--score` override
- Shields color helpers on the health-score module (great → brightgreen, needs-work → yellow, critical → red)
- Docs and unit/CLI tests

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #617

## Details

- `uv run lintro fmt` — clean
- `uv run lintro chk` — 0 issues
- `uv run pytest --maxfail=0` — 6940 passed; 6 env-only failures (markdownlint/rustfmt missing tools)

Closes #617


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `lintro badge` command for generating Shields.io health-score badges.
  * Supports Markdown, URL-only, and JSON output formats.
  * Added configurable badge styles and score overrides.
  * Badge colors reflect health-score tiers, with validation for scores and output options.

* **Documentation**
  * Added Quick Start and configuration guidance.

* **Tests**
  * Added coverage for command registration, output formats, styles, score handling, and color thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->