### PR TITLE
feat(tsc): type-check JSDoc JavaScript when checkJs enabled

### DIFF
--- a/lintro/tools/definitions/_ts_checker_base.py
+++ b/lintro/tools/definitions/_ts_checker_base.py
@@ -488,8 +488,10 @@ class TypeScriptCheckerPlugin(BaseToolPlugin):
         """Optionally skip the check after file discovery.
 
         The default implementation never skips. ``tsc`` overrides this to
-        avoid running on JavaScript-only inputs when no discovered tsconfig
-        enables ``checkJs``.
+        skip JavaScript-only inputs when no discovered tsconfig enables
+        ``checkJs``, no file has ``@ts-check``, and native project
+        selection is not requested. It also drops uncheckable JS from the
+        file set for mixed trees.
 
         Args:
             ctx: Prepared execution context with discovered files.

--- a/lintro/tools/definitions/_ts_checker_base.py
+++ b/lintro/tools/definitions/_ts_checker_base.py
@@ -477,3 +477,27 @@ class TypeScriptCheckerPlugin(BaseToolPlugin):
             Directory to scan for tsconfigs.
         """
         return cwd_path
+
+    def _pre_run_skip(
+        self,
+        ctx: ExecutionContext,
+        paths: list[str],
+        cwd_path: Path,
+        merged_options: dict[str, object],
+    ) -> ToolResult | None:
+        """Optionally skip the check after file discovery.
+
+        The default implementation never skips. ``tsc`` overrides this to
+        avoid running on JavaScript-only inputs when no discovered tsconfig
+        enables ``checkJs``.
+
+        Args:
+            ctx: Prepared execution context with discovered files.
+            paths: Original input paths passed to ``check``.
+            cwd_path: Prepared execution working directory.
+            merged_options: Merged runtime options.
+
+        Returns:
+            A ToolResult to return immediately, or ``None`` to continue.
+        """
+        return None

--- a/lintro/tools/definitions/_ts_checker_base.py
+++ b/lintro/tools/definitions/_ts_checker_base.py
@@ -503,3 +503,23 @@ class TypeScriptCheckerPlugin(BaseToolPlugin):
             A ToolResult to return immediately, or ``None`` to continue.
         """
         return None
+
+    def _use_native_tsconfig_scoping(
+        self,
+        info: Any,
+        files: list[str],
+    ) -> bool:
+        """Return whether to run ``-p`` against the project's tsconfig as-is.
+
+        The default is to honour explicit include/exclude/files (#851).
+        ``tsc`` overrides this so remaining JavaScript (``@ts-check``)
+        is not dropped by native project loading without ``allowJs``.
+
+        Args:
+            info: Resolved tsconfig metadata for the project.
+            files: Absolute file paths assigned to this project.
+
+        Returns:
+            ``True`` to use the tsconfig path directly.
+        """
+        return True

--- a/lintro/tools/definitions/_ts_checker_execution.py
+++ b/lintro/tools/definitions/_ts_checker_execution.py
@@ -287,7 +287,12 @@ def _check_single_project(
             # directly instead of creating a temp tsconfig that overrides
             # include.
             tsconfig_info = resolve_extends_chain(base_tsconfig)
-            if has_explicit_scoping(tsconfig_info):
+            if has_explicit_scoping(
+                tsconfig_info,
+            ) and plugin._use_native_tsconfig_scoping(
+                info=tsconfig_info,
+                files=ctx.files,
+            ):
                 project_path = str(base_tsconfig)
                 logger.info(
                     "[{}] Respecting native tsconfig scoping: {}",
@@ -397,7 +402,14 @@ def _check_multi_project(
             temp_tsconfig: Path | None = None
             project_path: str | None = None
 
-            if tsconfig_info is not None and has_explicit_scoping(tsconfig_info):
+            if (
+                tsconfig_info is not None
+                and has_explicit_scoping(tsconfig_info)
+                and plugin._use_native_tsconfig_scoping(
+                    info=tsconfig_info,
+                    files=project_files,
+                )
+            ):
                 project_path = str(tsconfig_info.path)
             elif tsconfig_info is not None:
                 rel_files = [os.path.relpath(f, project_dir) for f in project_files]

--- a/lintro/tools/definitions/_ts_checker_execution.py
+++ b/lintro/tools/definitions/_ts_checker_execution.py
@@ -76,6 +76,11 @@ def check(
     # Determine project configuration strategy
     cwd_path = Path(ctx.cwd) if ctx.cwd else Path.cwd()
 
+    # Optional per-tool early skip (e.g. tsc JS-only without checkJs).
+    early_skip = plugin._pre_run_skip(ctx, paths, cwd_path, merged_options)
+    if early_skip is not None:
+        return early_skip
+
     # Check if dependencies need installing
     from lintro.utils.node_deps import install_node_deps, should_install_deps
 

--- a/lintro/tools/definitions/tsc.py
+++ b/lintro/tools/definitions/tsc.py
@@ -59,7 +59,11 @@ from lintro.plugins.base import ExecutionContext
 from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.registry import register_tool
 from lintro.tools.definitions._ts_checker_base import TypeScriptCheckerPlugin
-from lintro.utils.tsconfig import discover_tsconfigs, resolve_extends_chain
+from lintro.utils.tsconfig import (
+    create_temp_tsconfig,
+    discover_tsconfigs,
+    resolve_extends_chain,
+)
 from lintro.utils.tsconfig_info import TsconfigInfo
 
 # Constants for Tsc configuration
@@ -286,6 +290,59 @@ class TscPlugin(TypeScriptCheckerPlugin):
             default_timeout=TSC_DEFAULT_TIMEOUT,
         )
 
+    def _create_temp_tsconfig(
+        self,
+        base_tsconfig: Path,
+        files: list[str],
+        cwd: Path,
+    ) -> Path:
+        """Create a temp tsconfig, enabling allowJs when JS files are targeted.
+
+        Native ``tsc -p`` drops JavaScript from the program unless
+        ``allowJs`` is set, which would hide ``// @ts-check`` files and
+        yield TS18003. The skip hook already filtered uncheckable JS, so
+        remaining JS files are ones tsc should load.
+
+        Args:
+            base_tsconfig: Path to the original tsconfig.json to extend.
+            files: File paths to include (relative to *cwd*).
+            cwd: Working directory for resolving paths.
+
+        Returns:
+            Path to the temporary tsconfig.json file.
+        """
+        extra: dict[str, Any] = {}
+        if any(Path(path).suffix.lower() in _JS_EXTENSIONS for path in files):
+            extra["allowJs"] = True
+        return create_temp_tsconfig(
+            base_tsconfig=base_tsconfig,
+            files=files,
+            cwd=cwd,
+            prefix=self._temp_config_prefix,
+            tool_label=self._tool_label,
+            extra_compiler_options=extra,
+        )
+
+    def _use_native_tsconfig_scoping(
+        self,
+        info: TsconfigInfo,
+        files: list[str],
+    ) -> bool:
+        """Use native ``-p`` unless remaining JS would be dropped without allowJs.
+
+        Args:
+            info: Resolved tsconfig for the project.
+            files: Absolute file paths assigned to this project.
+
+        Returns:
+            ``True`` to honour tsconfig include/exclude/files as-is.
+        """
+        has_js = any(Path(path).suffix.lower() in _JS_EXTENSIONS for path in files)
+        if not has_js:
+            return True
+        opts = info.compiler_options
+        return opts.get("allowJs") is True or opts.get("checkJs") is True
+
     def _pre_run_skip(
         self,
         ctx: ExecutionContext,
@@ -337,15 +394,9 @@ class TscPlugin(TypeScriptCheckerPlugin):
             return None
 
         ts_check_js = (
-            set()
-            if gating.check_js
-            else _js_files_with_ts_check(files=ctx.files)
+            set() if gating.check_js else _js_files_with_ts_check(files=ctx.files)
         )
-        if (
-            _is_js_only(files=ctx.files)
-            and not gating.check_js
-            and not ts_check_js
-        ):
+        if _is_js_only(files=ctx.files) and not gating.check_js and not ts_check_js:
             logger.debug(
                 "[tsc] Skipping JS-only check: no tsconfig enables checkJs",
             )

--- a/lintro/tools/definitions/tsc.py
+++ b/lintro/tools/definitions/tsc.py
@@ -14,8 +14,13 @@ File Targeting Behavior:
 
     JavaScript files (``*.js`` / ``*.mjs`` / ``*.cjs`` / ``*.jsx``) are included in
     discovery so JSDoc-typed projects activate the plugin. Native tsc ignores JS
-    unless ``allowJs``/``checkJs`` is set; lintro additionally skips JS-only
-    invocations early when no discovered tsconfig enables ``checkJs``.
+    unless ``allowJs``/``checkJs`` is set or a file starts with ``// @ts-check``.
+    Lintro skips JS-only invocations early only when the *effective* file set is
+    JavaScript-only, no discovered tsconfig enables ``checkJs``, no input has
+    ``@ts-check``, ``extends`` targets are fully resolved, and the caller did
+    not request native project selection (``use_project_files`` / ``project``).
+    When ``checkJs``/``allowJs`` is off, discovered ``.js``/``.jsx`` files are
+    dropped from the tsc file list so mixed TS+JS trees do not hit TS6504.
 
 Example:
     # Check only specific files (default behavior)
@@ -54,23 +59,22 @@ from lintro.plugins.base import ExecutionContext
 from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.registry import register_tool
 from lintro.tools.definitions._ts_checker_base import TypeScriptCheckerPlugin
-from lintro.utils.tsconfig import discover_tsconfigs, enables_check_js
+from lintro.utils.tsconfig import discover_tsconfigs, resolve_extends_chain
+from lintro.utils.tsconfig_info import TsconfigInfo
 
 # Constants for Tsc configuration
 TSC_DEFAULT_TIMEOUT: int = 60
 TSC_DEFAULT_PRIORITY: int = 82  # Same as mypy (type checkers)
+# One ordered table drives discovery globs and suffix frozensets.
+_TS_EXTENSIONS_ORDERED: tuple[str, ...] = (".ts", ".tsx", ".mts", ".cts")
+_JS_EXTENSIONS_ORDERED: tuple[str, ...] = (".js", ".mjs", ".cjs", ".jsx")
+_TS_EXTENSIONS: frozenset[str] = frozenset(_TS_EXTENSIONS_ORDERED)
+_JS_EXTENSIONS: frozenset[str] = frozenset(_JS_EXTENSIONS_ORDERED)
 TSC_FILE_PATTERNS: list[str] = [
-    "*.ts",
-    "*.tsx",
-    "*.mts",
-    "*.cts",
-    "*.js",
-    "*.mjs",
-    "*.cjs",
-    "*.jsx",
+    f"*{ext}" for ext in (*_TS_EXTENSIONS_ORDERED, *_JS_EXTENSIONS_ORDERED)
 ]
-_JS_EXTENSIONS: frozenset[str] = frozenset({".js", ".mjs", ".cjs", ".jsx"})
-_TS_EXTENSIONS: frozenset[str] = frozenset({".ts", ".tsx", ".mts", ".cts"})
+_SKIP_CHECKJS_REASON: str = "checkJs not enabled for JavaScript-only check"
+_TS_CHECK_HEADER_BYTES: int = 8192
 
 # Framework config files that indicate tsc should defer to framework-specific checker
 # Note: vite.config.ts is NOT included for Vue because it's used by many
@@ -89,6 +93,147 @@ FRAMEWORK_CONFIGS: dict[str, tuple[str, list[str]]] = {
         ["svelte.config.js", "svelte.config.ts"],
     ),
 }
+
+
+@dataclass(frozen=True)
+class _JsGating:
+    """Aggregated JavaScript type-check flags from relevant tsconfigs."""
+
+    check_js: bool
+    allow_js: bool
+    unresolved_extends: bool
+
+
+def _is_native_project_mode(merged_options: dict[str, object]) -> bool:
+    """Return whether the caller requested native tsconfig file selection.
+
+    Args:
+        merged_options: Merged runtime options.
+
+    Returns:
+        ``True`` when ``use_project_files`` or ``project`` is set.
+    """
+    if merged_options.get("use_project_files"):
+        return True
+    project = merged_options.get("project")
+    return isinstance(project, str) and bool(project)
+
+
+def _is_js_only(*, files: list[str]) -> bool:
+    """Return whether all discovered files are JavaScript (no TypeScript).
+
+    Args:
+        files: Absolute file paths discovered for the check.
+
+    Returns:
+        ``True`` when every file has a JavaScript extension and none
+        have a TypeScript extension.
+    """
+    if not files:
+        return False
+    has_js = False
+    for filepath in files:
+        suffix = Path(filepath).suffix.lower()
+        if suffix in _TS_EXTENSIONS:
+            return False
+        if suffix in _JS_EXTENSIONS:
+            has_js = True
+    return has_js
+
+
+def _js_files_with_ts_check(*, files: list[str]) -> set[str]:
+    """Return JS paths whose header enables native tsc via ``@ts-check``.
+
+    Args:
+        files: Absolute file paths discovered for the check.
+
+    Returns:
+        Absolute paths of JavaScript files with a header ``@ts-check``.
+    """
+    checked: set[str] = set()
+    for filepath in files:
+        if Path(filepath).suffix.lower() not in _JS_EXTENSIONS:
+            continue
+        if _js_file_has_ts_check(filepath=filepath):
+            checked.add(filepath)
+    return checked
+
+
+def _js_file_has_ts_check(*, filepath: str) -> bool:
+    """Return whether a JS file header contains ``// @ts-check``.
+
+    Mirrors native tsc: the pragma is honoured in the comment/shebang
+    header before the first non-comment statement. ``@ts-nocheck`` wins
+    if both appear in that header.
+
+    Args:
+        filepath: Absolute path of a JavaScript file.
+
+    Returns:
+        ``True`` when the header enables per-file JS type checking.
+    """
+    try:
+        with Path(filepath).open(encoding="utf-8", errors="replace") as handle:
+            header = handle.read(_TS_CHECK_HEADER_BYTES)
+    except OSError:
+        return False
+
+    saw_check = False
+    in_block = False
+    for raw_line in header.splitlines():
+        stripped = raw_line.strip()
+        if in_block:
+            if "@ts-nocheck" in stripped:
+                return False
+            if "@ts-check" in stripped:
+                saw_check = True
+            if "*/" in stripped:
+                in_block = False
+            continue
+        if not stripped or stripped.startswith("#!"):
+            continue
+        if stripped.startswith("/*"):
+            if "@ts-nocheck" in stripped:
+                return False
+            if "@ts-check" in stripped:
+                saw_check = True
+            if "*/" not in stripped:
+                in_block = True
+            continue
+        if stripped.startswith("//"):
+            if "@ts-nocheck" in stripped:
+                return False
+            if "@ts-check" in stripped:
+                saw_check = True
+            continue
+        break
+    return saw_check
+
+
+def _drop_uncheckable_js(
+    *,
+    ctx: ExecutionContext,
+    keep_abs_paths: set[str],
+) -> None:
+    """Drop JavaScript files tsc would reject without allowJs/checkJs.
+
+    TypeScript files and JS files with ``@ts-check`` (in *keep_abs_paths*)
+    are retained. Mutates *ctx* in place.
+
+    Args:
+        ctx: Prepared execution context with discovered files.
+        keep_abs_paths: Absolute JS paths that must still be passed to tsc.
+    """
+    kept_files: list[str] = []
+    kept_rel: list[str] = []
+    for abs_path, rel_path in zip(ctx.files, ctx.rel_files, strict=True):
+        suffix = Path(abs_path).suffix.lower()
+        if suffix in _JS_EXTENSIONS and abs_path not in keep_abs_paths:
+            continue
+        kept_files.append(abs_path)
+        kept_rel.append(rel_path)
+    ctx.files = kept_files
+    ctx.rel_files = kept_rel
 
 
 @register_tool
@@ -148,11 +293,24 @@ class TscPlugin(TypeScriptCheckerPlugin):
         cwd_path: Path,
         merged_options: dict[str, object],
     ) -> ToolResult | None:
-        """Skip JS-only checks when no discovered tsconfig enables checkJs.
+        """Skip JS-only checks that native tsc would not type-check.
 
-        Native tsc ignores JavaScript unless ``checkJs`` is set. Skipping
-        early avoids spurious tsc runs (and node_modules install prompts)
-        for plain JS trees that happen to match the expanded file patterns.
+        Native tsc ignores JavaScript unless ``checkJs`` is set or a file
+        starts with ``// @ts-check``. Skipping early avoids spurious tsc
+        runs (and node_modules install prompts) for plain JS trees that
+        happen to match the expanded file patterns.
+
+        This hook does **not** skip when:
+
+        * ``use_project_files`` or ``project`` is set (native tsconfig
+          file selection may still type-check TypeScript).
+        * An ``extends`` target is unresolved (fail closed so auto-install
+          can populate an npm parent that enables ``checkJs``).
+        * Any discovered JS file has a header ``@ts-check`` pragma.
+
+        When ``checkJs``/``allowJs`` is off, uncheckable JavaScript is
+        dropped from ``ctx.files`` / ``ctx.rel_files`` so mixed TS+JS
+        trees do not pass ``.js`` into a temp tsconfig (TS6504).
 
         Args:
             ctx: Prepared execution context with discovered files.
@@ -161,17 +319,51 @@ class TscPlugin(TypeScriptCheckerPlugin):
             merged_options: Merged runtime options.
 
         Returns:
-            A skipped ToolResult when the invocation is JS-only and no
-            relevant tsconfig enables ``checkJs``; otherwise ``None``.
+            A skipped ToolResult when the *effective* file set is JS-only
+            and nothing would be type-checked; otherwise ``None``.
         """
-        if not self._is_js_only(ctx.files):
-            return None
-        if self._any_check_js_enabled(cwd_path, paths, merged_options):
+        if _is_native_project_mode(merged_options):
             return None
 
-        logger.debug(
-            "[tsc] Skipping JS-only check: no tsconfig enables checkJs",
+        gating = self._js_gating(
+            cwd_path=cwd_path,
+            paths=paths,
+            merged_options=merged_options,
         )
+        if gating.unresolved_extends:
+            logger.debug(
+                "[tsc] Not skipping: unresolved tsconfig extends (fail closed)",
+            )
+            return None
+
+        ts_check_js = (
+            set()
+            if gating.check_js
+            else _js_files_with_ts_check(files=ctx.files)
+        )
+        if (
+            _is_js_only(files=ctx.files)
+            and not gating.check_js
+            and not ts_check_js
+        ):
+            logger.debug(
+                "[tsc] Skipping JS-only check: no tsconfig enables checkJs",
+            )
+            return self._skipped_checkjs_result()
+
+        if not gating.check_js and not gating.allow_js:
+            _drop_uncheckable_js(ctx=ctx, keep_abs_paths=ts_check_js)
+            if not ctx.files:
+                return self._skipped_checkjs_result()
+
+        return None
+
+    def _skipped_checkjs_result(self) -> ToolResult:
+        """Return the standard JS-only / no-checkJs skip result.
+
+        Returns:
+            A successful skipped ToolResult.
+        """
         return ToolResult(
             name=self.definition.name,
             success=True,
@@ -180,41 +372,21 @@ class TscPlugin(TypeScriptCheckerPlugin):
             ),
             issues_count=0,
             skipped=True,
-            skip_reason="checkJs not enabled for JavaScript-only check",
+            skip_reason=_SKIP_CHECKJS_REASON,
         )
 
-    @staticmethod
-    def _is_js_only(files: list[str]) -> bool:
-        """Return whether all discovered files are JavaScript (no TypeScript).
-
-        Args:
-            files: Absolute file paths discovered for the check.
-
-        Returns:
-            ``True`` when every file has a JavaScript extension and none
-            have a TypeScript extension.
-        """
-        if not files:
-            return False
-        has_js = False
-        for filepath in files:
-            suffix = Path(filepath).suffix.lower()
-            if suffix in _TS_EXTENSIONS:
-                return False
-            if suffix in _JS_EXTENSIONS:
-                has_js = True
-        return has_js
-
-    def _any_check_js_enabled(
+    def _js_gating(
         self,
         cwd_path: Path,
         paths: list[str],
         merged_options: dict[str, object],
-    ) -> bool:
-        """Return whether any relevant tsconfig enables ``checkJs``.
+    ) -> _JsGating:
+        """Aggregate checkJs/allowJs/unresolved-extends from relevant tsconfigs.
 
         Honours an explicit ``project`` option when set; otherwise discovers
-        tsconfigs from the same root used by the normal check path.
+        tsconfigs from the same root used by the normal check path. Discovery
+        already returns :func:`~lintro.utils.tsconfig.resolve_extends_chain`
+        results, so compiler options are not walked a second time.
 
         Args:
             cwd_path: Prepared execution working directory.
@@ -222,7 +394,45 @@ class TscPlugin(TypeScriptCheckerPlugin):
             merged_options: Merged runtime options.
 
         Returns:
-            ``True`` if at least one relevant tsconfig enables ``checkJs``.
+            Aggregated JavaScript gating flags.
+        """
+        infos = self._relevant_tsconfigs(
+            cwd_path=cwd_path,
+            paths=paths,
+            merged_options=merged_options,
+        )
+        check_js = False
+        allow_js = False
+        unresolved_extends = False
+        for info in infos:
+            opts = info.compiler_options
+            if opts.get("checkJs") is True:
+                check_js = True
+            if opts.get("allowJs") is True or opts.get("checkJs") is True:
+                allow_js = True
+            if info.unresolved_extends:
+                unresolved_extends = True
+        return _JsGating(
+            check_js=check_js,
+            allow_js=allow_js,
+            unresolved_extends=unresolved_extends,
+        )
+
+    def _relevant_tsconfigs(
+        self,
+        cwd_path: Path,
+        paths: list[str],
+        merged_options: dict[str, object],
+    ) -> list[TsconfigInfo]:
+        """Return tsconfigs that govern this check's JavaScript gating.
+
+        Args:
+            cwd_path: Prepared execution working directory.
+            paths: Original input paths passed to ``check``.
+            merged_options: Merged runtime options.
+
+        Returns:
+            Resolved tsconfig infos (possibly empty).
         """
         explicit_project = merged_options.get("project")
         if isinstance(explicit_project, str) and explicit_project:
@@ -231,17 +441,25 @@ class TscPlugin(TypeScriptCheckerPlugin):
                 project_path = (cwd_path / project_path).resolve()
             else:
                 project_path = project_path.resolve()
-            return project_path.exists() and enables_check_js(project_path)
+            if project_path.exists():
+                return [resolve_extends_chain(project_path)]
+            return []
 
-        discovery_root = self._compute_discovery_root(cwd_path, paths)
-        tsconfigs = discover_tsconfigs(discovery_root, self.exclude_patterns)
-        if any(enables_check_js(info.path) for info in tsconfigs):
-            return True
+        discovery_root = self._compute_discovery_root(
+            cwd_path=cwd_path,
+            paths=paths,
+        )
+        tsconfigs = discover_tsconfigs(
+            root=discovery_root,
+            exclude_patterns=self.exclude_patterns,
+        )
+        if tsconfigs:
+            return tsconfigs
 
-        # Fall back to the nearest candidate tsconfig when discovery finds
-        # nothing (e.g. unusual working-directory layouts).
         nearest = self._find_tsconfig(cwd_path)
-        return nearest is not None and enables_check_js(nearest)
+        if nearest is not None:
+            return [resolve_extends_chain(nearest)]
+        return []
 
     def _get_tsc_command(self, cwd: Path | None = None) -> list[str]:
         """Get the command to run tsc.

--- a/lintro/tools/definitions/tsc.py
+++ b/lintro/tools/definitions/tsc.py
@@ -1,8 +1,9 @@
 """Tsc (TypeScript Compiler) tool definition.
 
 Tsc is the TypeScript compiler which performs static type checking on
-TypeScript files. It helps catch type-related bugs before runtime by
-analyzing type annotations and inferences.
+TypeScript files and, when a project's tsconfig enables ``checkJs``, on
+JSDoc-typed JavaScript as well. It helps catch type-related bugs before
+runtime by analyzing type annotations and inferences.
 
 File Targeting Behavior:
     By default, lintro respects your file selection even when tsconfig.json exists.
@@ -10,6 +11,11 @@ File Targeting Behavior:
     config but overrides the `include` pattern to target only the specified files.
 
     To use native tsconfig.json file selection instead, set `use_project_files=True`.
+
+    JavaScript files (``*.js`` / ``*.mjs`` / ``*.cjs`` / ``*.jsx``) are included in
+    discovery so JSDoc-typed projects activate the plugin. Native tsc ignores JS
+    unless ``allowJs``/``checkJs`` is set; lintro additionally skips JS-only
+    invocations early when no discovered tsconfig enables ``checkJs``.
 
 Example:
     # Check only specific files (default behavior)
@@ -21,8 +27,9 @@ Example:
 Most of the orchestration (command construction, tsconfig discovery, single- and
 multi-project execution, output shaping) lives in the shared
 :class:`lintro.tools.definitions._ts_checker_base.TypeScriptCheckerPlugin` base.
-This module supplies the tsc-specific deltas: the binary command, TypeScript file
-extensions, tsc output parsing, framework detection, and error-message copy.
+This module supplies the tsc-specific deltas: the binary command, TypeScript and
+JavaScript file extensions, tsc output parsing, framework detection, JS-only
+``checkJs`` gating, and error-message copy.
 """
 
 from __future__ import annotations
@@ -37,19 +44,33 @@ from loguru import logger
 from lintro._tool_versions import get_min_version
 from lintro.enums.tool_name import ToolName
 from lintro.enums.tool_type import ToolType
+from lintro.models.core.tool_result import ToolResult
 from lintro.parsers.tsc.tsc_parser import (
     categorize_tsc_issues,
     extract_missing_modules,
     parse_tsc_output,
 )
+from lintro.plugins.base import ExecutionContext
 from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.registry import register_tool
 from lintro.tools.definitions._ts_checker_base import TypeScriptCheckerPlugin
+from lintro.utils.tsconfig import discover_tsconfigs, enables_check_js
 
 # Constants for Tsc configuration
 TSC_DEFAULT_TIMEOUT: int = 60
 TSC_DEFAULT_PRIORITY: int = 82  # Same as mypy (type checkers)
-TSC_FILE_PATTERNS: list[str] = ["*.ts", "*.tsx", "*.mts", "*.cts"]
+TSC_FILE_PATTERNS: list[str] = [
+    "*.ts",
+    "*.tsx",
+    "*.mts",
+    "*.cts",
+    "*.js",
+    "*.mjs",
+    "*.cjs",
+    "*.jsx",
+]
+_JS_EXTENSIONS: frozenset[str] = frozenset({".js", ".mjs", ".cjs", ".jsx"})
+_TS_EXTENSIONS: frozenset[str] = frozenset({".ts", ".tsx", ".mts", ".cts"})
 
 # Framework config files that indicate tsc should defer to framework-specific checker
 # Note: vite.config.ts is NOT included for Vue because it's used by many
@@ -76,16 +97,16 @@ class TscPlugin(TypeScriptCheckerPlugin):
     """TypeScript Compiler (tsc) type checking plugin.
 
     This plugin integrates the TypeScript compiler with Lintro for static
-    type checking of TypeScript files.
+    type checking of TypeScript files and JSDoc-typed JavaScript when
+    ``checkJs`` is enabled.
     """
 
     _tool_label: ClassVar[str] = "tsc"
-    _file_kind: ClassVar[str] = "TypeScript"
-    _no_files_message: ClassVar[str] = "No TypeScript files to check."
+    _file_kind: ClassVar[str] = "TypeScript/JavaScript"
+    _no_files_message: ClassVar[str] = "No TypeScript or JavaScript files to check."
     _temp_config_prefix: ClassVar[str] = ".lintro-tsc-"
     _fix_error_message: ClassVar[str] = (
-        "Tsc cannot automatically fix issues. Type errors require "
-        "manual code changes."
+        "Tsc cannot automatically fix issues. Type errors require manual code changes."
     )
     _tsconfig_candidates: ClassVar[tuple[str, ...]] = ("tsconfig.json",)
 
@@ -98,7 +119,10 @@ class TscPlugin(TypeScriptCheckerPlugin):
         """
         return ToolDefinition(
             name="tsc",
-            description="TypeScript compiler for static type checking",
+            description=(
+                "TypeScript compiler for static type checking "
+                "(including JSDoc JavaScript when checkJs is enabled)"
+            ),
             can_fix=False,
             tool_type=ToolType.LINTER | ToolType.TYPE_CHECKER,
             file_patterns=TSC_FILE_PATTERNS,
@@ -116,6 +140,108 @@ class TscPlugin(TypeScriptCheckerPlugin):
             },
             default_timeout=TSC_DEFAULT_TIMEOUT,
         )
+
+    def _pre_run_skip(
+        self,
+        ctx: ExecutionContext,
+        paths: list[str],
+        cwd_path: Path,
+        merged_options: dict[str, object],
+    ) -> ToolResult | None:
+        """Skip JS-only checks when no discovered tsconfig enables checkJs.
+
+        Native tsc ignores JavaScript unless ``checkJs`` is set. Skipping
+        early avoids spurious tsc runs (and node_modules install prompts)
+        for plain JS trees that happen to match the expanded file patterns.
+
+        Args:
+            ctx: Prepared execution context with discovered files.
+            paths: Original input paths passed to ``check``.
+            cwd_path: Prepared execution working directory.
+            merged_options: Merged runtime options.
+
+        Returns:
+            A skipped ToolResult when the invocation is JS-only and no
+            relevant tsconfig enables ``checkJs``; otherwise ``None``.
+        """
+        if not self._is_js_only(ctx.files):
+            return None
+        if self._any_check_js_enabled(cwd_path, paths, merged_options):
+            return None
+
+        logger.debug(
+            "[tsc] Skipping JS-only check: no tsconfig enables checkJs",
+        )
+        return ToolResult(
+            name=self.definition.name,
+            success=True,
+            output=(
+                "Skipping tsc: JavaScript-only inputs and no tsconfig enables checkJs."
+            ),
+            issues_count=0,
+            skipped=True,
+            skip_reason="checkJs not enabled for JavaScript-only check",
+        )
+
+    @staticmethod
+    def _is_js_only(files: list[str]) -> bool:
+        """Return whether all discovered files are JavaScript (no TypeScript).
+
+        Args:
+            files: Absolute file paths discovered for the check.
+
+        Returns:
+            ``True`` when every file has a JavaScript extension and none
+            have a TypeScript extension.
+        """
+        if not files:
+            return False
+        has_js = False
+        for filepath in files:
+            suffix = Path(filepath).suffix.lower()
+            if suffix in _TS_EXTENSIONS:
+                return False
+            if suffix in _JS_EXTENSIONS:
+                has_js = True
+        return has_js
+
+    def _any_check_js_enabled(
+        self,
+        cwd_path: Path,
+        paths: list[str],
+        merged_options: dict[str, object],
+    ) -> bool:
+        """Return whether any relevant tsconfig enables ``checkJs``.
+
+        Honours an explicit ``project`` option when set; otherwise discovers
+        tsconfigs from the same root used by the normal check path.
+
+        Args:
+            cwd_path: Prepared execution working directory.
+            paths: Original input paths passed to ``check``.
+            merged_options: Merged runtime options.
+
+        Returns:
+            ``True`` if at least one relevant tsconfig enables ``checkJs``.
+        """
+        explicit_project = merged_options.get("project")
+        if isinstance(explicit_project, str) and explicit_project:
+            project_path = Path(explicit_project)
+            if not project_path.is_absolute():
+                project_path = (cwd_path / project_path).resolve()
+            else:
+                project_path = project_path.resolve()
+            return project_path.exists() and enables_check_js(project_path)
+
+        discovery_root = self._compute_discovery_root(cwd_path, paths)
+        tsconfigs = discover_tsconfigs(discovery_root, self.exclude_patterns)
+        if any(enables_check_js(info.path) for info in tsconfigs):
+            return True
+
+        # Fall back to the nearest candidate tsconfig when discovery finds
+        # nothing (e.g. unusual working-directory layouts).
+        nearest = self._find_tsconfig(cwd_path)
+        return nearest is not None and enables_check_js(nearest)
 
     def _get_tsc_command(self, cwd: Path | None = None) -> list[str]:
         """Get the command to run tsc.

--- a/lintro/utils/tsconfig.py
+++ b/lintro/utils/tsconfig.py
@@ -34,6 +34,7 @@ __all__ = [
     "TsconfigInfo",
     "create_temp_tsconfig",
     "discover_tsconfigs",
+    "enables_check_js",
     "has_explicit_scoping",
     "parse_tsconfig",
     "partition_files",
@@ -520,6 +521,80 @@ def partition_files(
         result.append((None, fallback_files))
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Compiler-option helpers
+# ---------------------------------------------------------------------------
+
+
+def enables_check_js(
+    path: Path,
+    *,
+    _seen: set[str] | None = None,
+) -> bool:
+    """Return whether effective ``compilerOptions.checkJs`` is ``true``.
+
+    Walks the ``extends`` chain using TypeScript's per-key override semantics:
+    a child's explicit ``checkJs`` wins; otherwise the nearest parent value is
+    used. Circular ``extends`` graphs are short-circuited.
+
+    Args:
+        path: Path to a tsconfig.json (or extended config) file.
+        _seen: Internal set for cycle detection.
+
+    Returns:
+        ``True`` when the effective ``checkJs`` option is enabled.
+    """
+    return _resolve_check_js_option(path, _seen=_seen) is True
+
+
+def _resolve_check_js_option(
+    path: Path,
+    *,
+    _seen: set[str] | None = None,
+) -> bool | None:
+    """Resolve effective ``checkJs`` from a tsconfig and its extends chain.
+
+    Args:
+        path: Path to a tsconfig file.
+        _seen: Internal set for cycle detection.
+
+    Returns:
+        ``True``/``False`` when ``checkJs`` is set anywhere in the effective
+        chain, or ``None`` when the option is unset.
+    """
+    if _seen is None:
+        _seen = set()
+
+    abs_path = str(path.resolve())
+    if abs_path in _seen:
+        return None
+    _seen.add(abs_path)
+
+    info = parse_tsconfig(path)
+    parent_value: bool | None = None
+    extends_val = info.raw_config.get("extends") if info.raw_config else None
+
+    extends_list: list[str] = []
+    if isinstance(extends_val, str):
+        extends_list = [extends_val]
+    elif isinstance(extends_val, list):
+        extends_list = [v for v in extends_val if isinstance(v, str)]
+
+    for ext in extends_list:
+        parent_path = _resolve_extends_path(ext, info.project_dir)
+        if parent_path is None:
+            continue
+        # Later parents override earlier ones (TS 5.0+ array extends).
+        resolved = _resolve_check_js_option(parent_path, _seen=set(_seen))
+        if resolved is not None:
+            parent_value = resolved
+
+    comp_opts = info.raw_config.get("compilerOptions") if info.raw_config else None
+    if isinstance(comp_opts, dict) and "checkJs" in comp_opts:
+        return bool(comp_opts["checkJs"])
+    return parent_value
 
 
 # ---------------------------------------------------------------------------

--- a/lintro/utils/tsconfig.py
+++ b/lintro/utils/tsconfig.py
@@ -630,6 +630,7 @@ def create_temp_tsconfig(
     *,
     prefix: str = ".lintro-tsc-",
     tool_label: str = "tsc",
+    extra_compiler_options: dict[str, Any] | None = None,
 ) -> Path:
     """Create a temporary tsconfig.json extending a base config.
 
@@ -646,6 +647,8 @@ def create_temp_tsconfig(
         cwd: Working directory for resolving paths.
         prefix: Filename prefix for the temp file.
         tool_label: Label used in log messages (``"tsc"`` or ``"vue-tsc"``).
+        extra_compiler_options: Additional compiler options merged into the
+            temp config (for example ``allowJs`` when JS files are targeted).
 
     Returns:
         Path to the temporary tsconfig.json file.
@@ -663,6 +666,9 @@ def create_temp_tsconfig(
         # Ensure noEmit is set (type checking only)
         "noEmit": True,
     }
+    if extra_compiler_options:
+        compiler_options.update(extra_compiler_options)
+        compiler_options["noEmit"] = True
 
     # Read typeRoots from the base tsconfig once, up-front, and reuse the
     # extracted value in both the main and the read-only-fallback paths

--- a/lintro/utils/tsconfig.py
+++ b/lintro/utils/tsconfig.py
@@ -88,8 +88,26 @@ def parse_tsconfig(path: Path) -> TsconfigInfo:
         files_list=fields["files"],
         references=[Path(r) for r in fields["references"]],
         is_composite=fields["composite"],
+        compiler_options=_compiler_options_from_raw(content),
         raw_config=content,
     )
+
+
+def _compiler_options_from_raw(raw: dict[str, Any] | None) -> dict[str, Any]:
+    """Copy ``compilerOptions`` from a parsed tsconfig dict.
+
+    Args:
+        raw: Parsed tsconfig content, or ``None``.
+
+    Returns:
+        A shallow copy of ``compilerOptions``, or ``{}`` when absent.
+    """
+    if not raw:
+        return {}
+    opts = raw.get("compilerOptions")
+    if isinstance(opts, dict):
+        return dict(opts)
+    return {}
 
 
 # ---------------------------------------------------------------------------
@@ -105,10 +123,13 @@ def resolve_extends_chain(
     """Recursively resolve the ``extends`` chain for a tsconfig.
 
     Walks up the ``extends`` hierarchy to compute the effective
-    ``include``, ``exclude``, and ``files`` fields.  The child's values
-    override the parent's (matching TypeScript semantics).
+    ``include``, ``exclude``, ``files``, and ``compilerOptions`` fields.
+    The child's values override the parent's (matching TypeScript
+    semantics). ``compilerOptions`` is merged per-key; later entries in a
+    TS 5.0+ array ``extends`` list override earlier ones.
 
-    Circular references are detected and short-circuited.
+    Circular references are detected and short-circuited. Unresolvable
+    ``extends`` targets set :attr:`TsconfigInfo.unresolved_extends`.
 
     Args:
         path: Path to the tsconfig.json file.
@@ -146,13 +167,20 @@ def resolve_extends_chain(
     merged_include: list[str] | None = None
     merged_exclude: list[str] | None = None
     merged_files: list[str] | None = None
+    merged_compiler: dict[str, Any] = {}
+    unresolved_extends = False
 
     for ext in extends_list:
-        parent_path = _resolve_extends_path(ext, info.project_dir)
+        parent_path = _resolve_extends_path(
+            extends=ext,
+            base_dir=info.project_dir,
+        )
         if parent_path is None:
+            unresolved_extends = True
             continue
         # Pass a copy so sibling extends branches don't share visited state
         parent_info = resolve_extends_chain(parent_path, _seen=set(_seen))
+        unresolved_extends = unresolved_extends or parent_info.unresolved_extends
         # Parent values become the base (None means parent didn't set it)
         if parent_info.include_patterns is not None:
             merged_include = parent_info.include_patterns
@@ -160,6 +188,7 @@ def resolve_extends_chain(
             merged_exclude = parent_info.exclude_patterns
         if parent_info.files_list is not None:
             merged_files = parent_info.files_list
+        merged_compiler.update(parent_info.compiler_options)
 
     # Child overrides parent if it explicitly set the field ([] clears parent)
     if info.include_patterns is not None:
@@ -168,6 +197,7 @@ def resolve_extends_chain(
         merged_exclude = info.exclude_patterns
     if info.files_list is not None:
         merged_files = info.files_list
+    merged_compiler.update(info.compiler_options)
 
     return TsconfigInfo(
         path=info.path,
@@ -177,6 +207,8 @@ def resolve_extends_chain(
         files_list=merged_files,
         references=info.references,
         is_composite=info.is_composite,
+        compiler_options=merged_compiler,
+        unresolved_extends=unresolved_extends,
         raw_config=info.raw_config,
     )
 
@@ -528,73 +560,26 @@ def partition_files(
 # ---------------------------------------------------------------------------
 
 
-def enables_check_js(
-    path: Path,
-    *,
-    _seen: set[str] | None = None,
-) -> bool:
+def enables_check_js(path: Path) -> bool:
     """Return whether effective ``compilerOptions.checkJs`` is ``true``.
 
-    Walks the ``extends`` chain using TypeScript's per-key override semantics:
-    a child's explicit ``checkJs`` wins; otherwise the nearest parent value is
-    used. Circular ``extends`` graphs are short-circuited.
+    Uses :func:`resolve_extends_chain` so ``checkJs`` follows the same
+    string/array ``extends`` walk, package.json ``tsconfig`` field lookup,
+    and cycle handling as include/exclude/files.
+
+    Unresolved ``extends`` targets do **not** enable ``checkJs``. Callers
+    that skip work based on this result must also inspect
+    :attr:`TsconfigInfo.unresolved_extends` and fail closed (proceed to
+    install / run tsc) when a parent config could not be loaded.
 
     Args:
         path: Path to a tsconfig.json (or extended config) file.
-        _seen: Internal set for cycle detection.
 
     Returns:
         ``True`` when the effective ``checkJs`` option is enabled.
     """
-    return _resolve_check_js_option(path, _seen=_seen) is True
-
-
-def _resolve_check_js_option(
-    path: Path,
-    *,
-    _seen: set[str] | None = None,
-) -> bool | None:
-    """Resolve effective ``checkJs`` from a tsconfig and its extends chain.
-
-    Args:
-        path: Path to a tsconfig file.
-        _seen: Internal set for cycle detection.
-
-    Returns:
-        ``True``/``False`` when ``checkJs`` is set anywhere in the effective
-        chain, or ``None`` when the option is unset.
-    """
-    if _seen is None:
-        _seen = set()
-
-    abs_path = str(path.resolve())
-    if abs_path in _seen:
-        return None
-    _seen.add(abs_path)
-
-    info = parse_tsconfig(path)
-    parent_value: bool | None = None
-    extends_val = info.raw_config.get("extends") if info.raw_config else None
-
-    extends_list: list[str] = []
-    if isinstance(extends_val, str):
-        extends_list = [extends_val]
-    elif isinstance(extends_val, list):
-        extends_list = [v for v in extends_val if isinstance(v, str)]
-
-    for ext in extends_list:
-        parent_path = _resolve_extends_path(ext, info.project_dir)
-        if parent_path is None:
-            continue
-        # Later parents override earlier ones (TS 5.0+ array extends).
-        resolved = _resolve_check_js_option(parent_path, _seen=set(_seen))
-        if resolved is not None:
-            parent_value = resolved
-
-    comp_opts = info.raw_config.get("compilerOptions") if info.raw_config else None
-    if isinstance(comp_opts, dict) and "checkJs" in comp_opts:
-        return bool(comp_opts["checkJs"])
-    return parent_value
+    info = resolve_extends_chain(path)
+    return info.compiler_options.get("checkJs") is True
 
 
 # ---------------------------------------------------------------------------

--- a/lintro/utils/tsconfig_info.py
+++ b/lintro/utils/tsconfig_info.py
@@ -42,5 +42,22 @@ class TsconfigInfo:
     is_composite: bool = False
     """Whether ``compilerOptions.composite`` is ``true``."""
 
+    compiler_options: dict[str, Any] = field(default_factory=dict)
+    """Effective ``compilerOptions`` after the ``extends`` chain is merged.
+
+    Per-key child values override parents (TypeScript semantics). Later
+    entries in a TS 5.0+ array ``extends`` list override earlier ones.
+    ``parse_tsconfig`` stores the local file's options only; use
+    :func:`~lintro.utils.tsconfig.resolve_extends_chain` for the effective set.
+    """
+
+    unresolved_extends: bool = False
+    """Whether any ``extends`` target in the chain could not be resolved.
+
+    Callers that skip work based on inherited compiler options must fail
+    closed when this is ``True`` (the missing parent may live in an
+    as-yet-uninstalled package).
+    """
+
     raw_config: dict[str, Any] = field(default_factory=dict)
     """The parsed JSONC content of the tsconfig file itself."""

--- a/tests/integration/tools/tsc/test_check.py
+++ b/tests/integration/tools/tsc/test_check.py
@@ -56,9 +56,10 @@ def test_definition_attributes(
 
 
 def test_definition_file_patterns(get_plugin: Callable[[str], BaseToolPlugin]) -> None:
-    """Verify TscPlugin definition includes TypeScript file patterns.
+    """Verify TscPlugin definition includes TypeScript and JavaScript patterns.
 
-    Tests that the plugin is configured to handle TypeScript files (*.ts, *.tsx).
+    Tests that the plugin is configured to handle TypeScript files and
+    JSDoc-typed JavaScript (*.js / *.mjs / *.cjs / *.jsx) for checkJs.
 
     Args:
         get_plugin: Fixture factory to get plugin instances.
@@ -66,6 +67,10 @@ def test_definition_file_patterns(get_plugin: Callable[[str], BaseToolPlugin]) -
     tsc_plugin = get_plugin("tsc")
     assert_that(tsc_plugin.definition.file_patterns).contains("*.ts")
     assert_that(tsc_plugin.definition.file_patterns).contains("*.tsx")
+    assert_that(tsc_plugin.definition.file_patterns).contains("*.js")
+    assert_that(tsc_plugin.definition.file_patterns).contains("*.mjs")
+    assert_that(tsc_plugin.definition.file_patterns).contains("*.cjs")
+    assert_that(tsc_plugin.definition.file_patterns).contains("*.jsx")
 
 
 # --- Integration tests for tsc check command ---
@@ -246,4 +251,86 @@ def test_use_project_files_checks_all_files(
     )
 
     # Should find the error in error.ts even though we only passed clean.ts
+    assert_that(result.issues_count).is_greater_than(0)
+
+
+# --- Tests for checkJs / JSDoc JavaScript (issue #1185) ---
+
+
+def test_check_js_with_checkjs_finds_type_errors(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    tmp_path: Path,
+) -> None:
+    """Verify tsc type-checks JSDoc JavaScript when checkJs is enabled.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        tmp_path: Pytest fixture providing a temporary directory.
+    """
+    (tmp_path / "tsconfig.json").write_text(
+        '{"compilerOptions": {"strict": true, "checkJs": true, "allowJs": true, '
+        '"noEmit": true}, "include": ["*.js"]}',
+    )
+    js_file = tmp_path / "bad.js"
+    js_file.write_text(
+        "/** @type {number} */\nconst x = 'not-a-number';\nexport { x };\n",
+    )
+
+    tsc_plugin = get_plugin("tsc")
+    result = tsc_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.skipped).is_false()
+    assert_that(result.issues_count).is_greater_than(0)
+
+
+def test_check_js_without_checkjs_skips(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    tmp_path: Path,
+) -> None:
+    """Verify JS-only projects without checkJs do not activate tsc findings.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        tmp_path: Pytest fixture providing a temporary directory.
+    """
+    (tmp_path / "tsconfig.json").write_text(
+        '{"compilerOptions": {"strict": true, "allowJs": true, "noEmit": true}, '
+        '"include": ["*.js"]}',
+    )
+    js_file = tmp_path / "bad.js"
+    js_file.write_text(
+        "/** @type {number} */\nconst x = 'not-a-number';\nexport { x };\n",
+    )
+
+    tsc_plugin = get_plugin("tsc")
+    result = tsc_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.skipped).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.skip_reason).contains("checkJs")
+
+
+def test_check_mixed_ts_js_with_checkjs(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    tmp_path: Path,
+) -> None:
+    """Verify mixed TS+JS projects with checkJs report JSDoc errors.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        tmp_path: Pytest fixture providing a temporary directory.
+    """
+    (tmp_path / "tsconfig.json").write_text(
+        '{"compilerOptions": {"strict": true, "checkJs": true, "allowJs": true, '
+        '"noEmit": true}, "include": ["*.ts", "*.js"]}',
+    )
+    (tmp_path / "ok.ts").write_text("export const n: number = 1;\n")
+    (tmp_path / "bad.js").write_text(
+        "/** @type {number} */\nconst x = 'not-a-number';\nexport { x };\n",
+    )
+
+    tsc_plugin = get_plugin("tsc")
+    result = tsc_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.skipped).is_false()
     assert_that(result.issues_count).is_greater_than(0)

--- a/tests/integration/tools/tsc/test_check.py
+++ b/tests/integration/tools/tsc/test_check.py
@@ -334,3 +334,87 @@ def test_check_mixed_ts_js_with_checkjs(
 
     assert_that(result.skipped).is_false()
     assert_that(result.issues_count).is_greater_than(0)
+
+
+def test_check_mixed_without_allowjs_no_ts6504(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    tmp_path: Path,
+) -> None:
+    """Mixed TS+JS without allowJs type-checks TS and does not emit TS6504.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        tmp_path: Pytest fixture providing a temporary directory.
+    """
+    (tmp_path / "tsconfig.json").write_text(
+        '{"compilerOptions": {"strict": true, "noEmit": true}}',
+    )
+    (tmp_path / "error.ts").write_text(
+        "const y: number = 'string';\nexport { y };\n",
+    )
+    (tmp_path / "plain.js").write_text("export const x = 1;\n")
+
+    tsc_plugin = get_plugin("tsc")
+    result = tsc_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.skipped).is_false()
+    assert_that(result.issues_count).is_greater_than(0)
+    codes = [getattr(issue, "code", "") for issue in (result.issues or [])]
+    assert_that(codes).does_not_contain("TS6504")
+    output = result.output or ""
+    assert_that("TS6504" in output).is_false()
+
+
+def test_check_ts_check_pragma_without_checkjs(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    tmp_path: Path,
+) -> None:
+    """Native ``// @ts-check`` JS files are type-checked without checkJs.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        tmp_path: Pytest fixture providing a temporary directory.
+    """
+    (tmp_path / "tsconfig.json").write_text(
+        '{"compilerOptions": {"strict": true, "noEmit": true}}',
+    )
+    (tmp_path / "checked.js").write_text(
+        "// @ts-check\n/** @type {number} */\nconst x = 'not-a-number';\n"
+        "export { x };\n",
+    )
+
+    tsc_plugin = get_plugin("tsc")
+    result = tsc_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.skipped).is_false()
+    assert_that(result.issues_count).is_greater_than(0)
+
+
+def test_check_js_path_use_project_files_finds_ts_errors(
+    get_plugin: Callable[[str], BaseToolPlugin],
+    tmp_path: Path,
+) -> None:
+    """JS-only input with use_project_files still type-checks tsconfig TS files.
+
+    Args:
+        get_plugin: Fixture factory to get plugin instances.
+        tmp_path: Pytest fixture providing a temporary directory.
+    """
+    (tmp_path / "tsconfig.json").write_text(
+        '{"compilerOptions": {"strict": true, "noEmit": true}, '
+        '"include": ["*.ts"]}',
+    )
+    (tmp_path / "error.ts").write_text(
+        "const y: number = 'string';\nexport { y };\n",
+    )
+    js_file = tmp_path / "plain.js"
+    js_file.write_text("export const x = 1;\n")
+
+    tsc_plugin = get_plugin("tsc")
+    result = tsc_plugin.check(
+        [str(js_file)],
+        {"use_project_files": True},
+    )
+
+    assert_that(result.skipped).is_false()
+    assert_that(result.issues_count).is_greater_than(0)

--- a/tests/unit/tools/tsc/test_checkjs.py
+++ b/tests/unit/tools/tsc/test_checkjs.py
@@ -1,0 +1,343 @@
+"""Unit tests for tsc checkJs / JSDoc JavaScript activation (issue #1185)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.tools.definitions.tsc import TscPlugin
+from tests.unit.utils.tsconfig_helpers import write_tsconfig
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def js_checkjs_project(tmp_path: Path) -> Path:
+    """JS project with checkJs enabled and a deliberate type error.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+
+    Returns:
+        Path to the project root.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {
+            "compilerOptions": {
+                "strict": True,
+                "checkJs": True,
+                "noEmit": True,
+                "allowJs": True,
+            },
+            "include": ["*.js"],
+        },
+    )
+    (tmp_path / "bad.js").write_text(
+        "/** @type {number} */\nconst x = 'not-a-number';\nexport { x };\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def js_no_checkjs_project(tmp_path: Path) -> Path:
+    """JS project with a tsconfig that does not enable checkJs.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+
+    Returns:
+        Path to the project root.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {
+            "compilerOptions": {
+                "strict": True,
+                "noEmit": True,
+                "allowJs": True,
+            },
+            "include": ["*.js"],
+        },
+    )
+    (tmp_path / "plain.js").write_text(
+        "/** @type {number} */\nconst x = 'not-a-number';\nexport { x };\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def mixed_ts_js_checkjs_project(tmp_path: Path) -> Path:
+    """Mixed TypeScript + JavaScript project with checkJs enabled.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+
+    Returns:
+        Path to the project root.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {
+            "compilerOptions": {
+                "strict": True,
+                "checkJs": True,
+                "noEmit": True,
+                "allowJs": True,
+            },
+            "include": ["*.ts", "*.js"],
+        },
+    )
+    (tmp_path / "ok.ts").write_text(
+        "export const n: number = 1;\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "bad.js").write_text(
+        "/** @type {number} */\nconst x = 'not-a-number';\nexport { x };\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+# =============================================================================
+# Activation / early-skip behavior
+# =============================================================================
+
+
+def test_js_with_checkjs_activates_and_reports_issues(
+    tsc_plugin: TscPlugin,
+    js_checkjs_project: Path,
+) -> None:
+    """JS + checkJs runs tsc and surfaces JSDoc type errors.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        js_checkjs_project: Fixture project with checkJs and a bad .js file.
+    """
+    js_file = js_checkjs_project / "bad.js"
+    tsc_output = (
+        f"{js_file}(2,7): error TS2322: Type 'string' is not assignable "
+        "to type 'number'."
+    )
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            tsc_plugin,
+            "_run_subprocess",
+            return_value=(False, tsc_output),
+        ) as mock_run:
+            result = tsc_plugin.check([str(js_checkjs_project)], {})
+
+    assert_that(result.skipped).is_false()
+    assert_that(result.success).is_false()
+    assert_that(result.issues_count).is_greater_than(0)
+    assert_that(mock_run.called).is_true()
+
+
+def test_js_without_checkjs_skips_early(
+    tsc_plugin: TscPlugin,
+    js_no_checkjs_project: Path,
+) -> None:
+    """JS-only without checkJs skips before invoking tsc.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        js_no_checkjs_project: Fixture project without checkJs.
+    """
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            tsc_plugin,
+            "_run_subprocess",
+            return_value=(True, ""),
+        ) as mock_run:
+            result = tsc_plugin.check([str(js_no_checkjs_project)], {})
+
+    assert_that(result.skipped).is_true()
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.skip_reason).contains("checkJs")
+    assert_that(mock_run.called).is_false()
+
+
+def test_js_only_without_tsconfig_skips_early(
+    tsc_plugin: TscPlugin,
+    tmp_path: Path,
+) -> None:
+    """Bare JS files with no tsconfig do not activate tsc.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        tmp_path: Pytest temporary directory.
+    """
+    js_file = tmp_path / "alone.js"
+    js_file.write_text("export const x = 1;\n", encoding="utf-8")
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            tsc_plugin,
+            "_run_subprocess",
+            return_value=(True, ""),
+        ) as mock_run:
+            result = tsc_plugin.check([str(js_file)], {})
+
+    assert_that(result.skipped).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(mock_run.called).is_false()
+
+
+def test_mixed_ts_js_with_checkjs_runs(
+    tsc_plugin: TscPlugin,
+    mixed_ts_js_checkjs_project: Path,
+) -> None:
+    """Mixed TS+JS with checkJs still invokes tsc (does not early-skip).
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        mixed_ts_js_checkjs_project: Fixture with .ts and .js plus checkJs.
+    """
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            tsc_plugin,
+            "_run_subprocess",
+            return_value=(True, ""),
+        ) as mock_run:
+            result = tsc_plugin.check([str(mixed_ts_js_checkjs_project)], {})
+
+    assert_that(result.skipped).is_false()
+    assert_that(mock_run.called).is_true()
+
+
+def test_checkjs_inherited_via_extends_activates(
+    tsc_plugin: TscPlugin,
+    tmp_path: Path,
+) -> None:
+    """Inherited checkJs through extends still activates JS-only checks.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        tmp_path: Pytest temporary directory.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.base.json",
+        {"compilerOptions": {"checkJs": True, "allowJs": True, "strict": True}},
+    )
+    write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {"extends": "./tsconfig.base.json", "include": ["*.js"]},
+    )
+    (tmp_path / "app.js").write_text(
+        "/** @type {number} */\nconst x = 1;\nexport { x };\n",
+        encoding="utf-8",
+    )
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            tsc_plugin,
+            "_run_subprocess",
+            return_value=(True, ""),
+        ) as mock_run:
+            result = tsc_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.skipped).is_false()
+    assert_that(mock_run.called).is_true()
+
+
+def test_explicit_project_without_checkjs_skips_js_only(
+    tsc_plugin: TscPlugin,
+    tmp_path: Path,
+) -> None:
+    """Explicit project option without checkJs still skips JS-only runs.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        tmp_path: Pytest temporary directory.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {"compilerOptions": {"strict": True}, "include": ["*.js"]},
+    )
+    js_file = tmp_path / "app.js"
+    js_file.write_text("export const x = 1;\n", encoding="utf-8")
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            tsc_plugin,
+            "_run_subprocess",
+            return_value=(True, ""),
+        ) as mock_run:
+            result = tsc_plugin.check(
+                [str(js_file)],
+                {"project": str(tmp_path / "tsconfig.json")},
+            )
+
+    assert_that(result.skipped).is_true()
+    assert_that(mock_run.called).is_false()
+
+
+def test_mjs_and_cjs_patterns_are_discovered(
+    tsc_plugin: TscPlugin,
+    tmp_path: Path,
+) -> None:
+    """*.mjs and *.cjs files are discovered by the tsc plugin patterns.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        tmp_path: Pytest temporary directory.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {
+            "compilerOptions": {"checkJs": True, "allowJs": True},
+            "include": ["*.mjs", "*.cjs"],
+        },
+    )
+    (tmp_path / "mod.mjs").write_text("export const a = 1;\n", encoding="utf-8")
+    (tmp_path / "mod.cjs").write_text("module.exports = { a: 1 };\n", encoding="utf-8")
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        ctx = tsc_plugin._prepare_execution(
+            [str(tmp_path)],
+            dict(tsc_plugin.options),
+            no_files_message="none",
+        )
+
+    assert_that(ctx.should_skip).is_false()
+    suffixes = {Path(f).suffix for f in ctx.files}
+    assert_that(suffixes).contains(".mjs", ".cjs")
+
+
+def test_is_js_only_helpers() -> None:
+    """_is_js_only distinguishes pure-JS from mixed/TS inputs."""
+    assert_that(TscPlugin._is_js_only(["/a/app.js", "/a/lib.mjs"])).is_true()
+    assert_that(TscPlugin._is_js_only(["/a/app.ts"])).is_false()
+    assert_that(TscPlugin._is_js_only(["/a/app.js", "/a/app.ts"])).is_false()
+    assert_that(TscPlugin._is_js_only([])).is_false()
+    assert_that(TscPlugin._is_js_only(["/a/readme.md"])).is_false()

--- a/tests/unit/tools/tsc/test_checkjs.py
+++ b/tests/unit/tools/tsc/test_checkjs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -359,6 +360,55 @@ def test_ts_check_pragma_does_not_skip_js_only(
     assert_that(result.skipped).is_false()
     assert_that(mock_run.called).is_true()
     assert_that(result.issues_count).is_greater_than(0)
+
+
+def test_ts_check_temp_config_enables_allowjs(
+    tsc_plugin: TscPlugin,
+    tmp_path: Path,
+) -> None:
+    """Temp tsconfig sets allowJs so ``@ts-check`` JS files are loaded.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        tmp_path: Pytest temporary directory.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {"compilerOptions": {"strict": True, "noEmit": True}},
+    )
+    (tmp_path / "checked.js").write_text(
+        "// @ts-check\nexport const x = 1;\n",
+        encoding="utf-8",
+    )
+    captured: list[dict[str, object]] = []
+    original_create = tsc_plugin._create_temp_tsconfig
+
+    def _spy_create(*args: Any, **kwargs: Any) -> Path:
+        path = original_create(*args, **kwargs)
+        captured.append(json.loads(path.read_text(encoding="utf-8")))
+        return path
+
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            tsc_plugin,
+            "_create_temp_tsconfig",
+            side_effect=_spy_create,
+        ):
+            with patch.object(
+                tsc_plugin,
+                "_run_subprocess",
+                return_value=(True, ""),
+            ):
+                result = tsc_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.skipped).is_false()
+    assert_that(captured).is_not_empty()
+    compiler_options = captured[0]["compilerOptions"]
+    assert isinstance(compiler_options, dict)
+    assert_that(compiler_options.get("allowJs")).is_true()
 
 
 def test_ts_nocheck_pragma_still_skips_js_only(

--- a/tests/unit/tools/tsc/test_checkjs.py
+++ b/tests/unit/tools/tsc/test_checkjs.py
@@ -3,13 +3,64 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 from assertpy import assert_that
 
 from lintro.tools.definitions.tsc import TscPlugin
 from tests.unit.utils.tsconfig_helpers import write_tsconfig
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _run_check(
+    plugin: TscPlugin,
+    paths: list[str],
+    options: dict[str, object] | None = None,
+    *,
+    subprocess_result: tuple[bool, str] = (True, ""),
+) -> tuple[Any, MagicMock]:
+    """Invoke ``plugin.check`` with version verification and tsc mocked.
+
+    Args:
+        plugin: Plugin under test.
+        paths: Paths passed to ``check``.
+        options: Runtime options passed to ``check``.
+        subprocess_result: Return value for ``_run_subprocess``.
+
+    Returns:
+        A ``(ToolResult, mock_run)`` pair.
+    """
+    mock_run = MagicMock(return_value=subprocess_result)
+    with patch(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        return_value=None,
+    ):
+        with patch.object(
+            plugin,
+            "_run_subprocess",
+            mock_run,
+        ):
+            result = plugin.check(paths, options or {})
+    return result, mock_run
+
+
+def _write_plain_js(path: Path) -> Path:
+    """Write a small JS module at *path*.
+
+    Args:
+        path: Destination file.
+
+    Returns:
+        The written path.
+    """
+    path.write_text("export const x = 1;\n", encoding="utf-8")
+    return path
+
 
 # =============================================================================
 # Fixtures
@@ -126,17 +177,11 @@ def test_js_with_checkjs_activates_and_reports_issues(
         f"{js_file}(2,7): error TS2322: Type 'string' is not assignable "
         "to type 'number'."
     )
-
-    with patch(
-        "lintro.plugins.execution_preparation.verify_tool_version",
-        return_value=None,
-    ):
-        with patch.object(
-            tsc_plugin,
-            "_run_subprocess",
-            return_value=(False, tsc_output),
-        ) as mock_run:
-            result = tsc_plugin.check([str(js_checkjs_project)], {})
+    result, mock_run = _run_check(
+        tsc_plugin,
+        [str(js_checkjs_project)],
+        subprocess_result=(False, tsc_output),
+    )
 
     assert_that(result.skipped).is_false()
     assert_that(result.success).is_false()
@@ -154,16 +199,10 @@ def test_js_without_checkjs_skips_early(
         tsc_plugin: The TscPlugin instance to test.
         js_no_checkjs_project: Fixture project without checkJs.
     """
-    with patch(
-        "lintro.plugins.execution_preparation.verify_tool_version",
-        return_value=None,
-    ):
-        with patch.object(
-            tsc_plugin,
-            "_run_subprocess",
-            return_value=(True, ""),
-        ) as mock_run:
-            result = tsc_plugin.check([str(js_no_checkjs_project)], {})
+    result, mock_run = _run_check(
+        tsc_plugin,
+        [str(js_no_checkjs_project)],
+    )
 
     assert_that(result.skipped).is_true()
     assert_that(result.success).is_true()
@@ -182,19 +221,8 @@ def test_js_only_without_tsconfig_skips_early(
         tsc_plugin: The TscPlugin instance to test.
         tmp_path: Pytest temporary directory.
     """
-    js_file = tmp_path / "alone.js"
-    js_file.write_text("export const x = 1;\n", encoding="utf-8")
-
-    with patch(
-        "lintro.plugins.execution_preparation.verify_tool_version",
-        return_value=None,
-    ):
-        with patch.object(
-            tsc_plugin,
-            "_run_subprocess",
-            return_value=(True, ""),
-        ) as mock_run:
-            result = tsc_plugin.check([str(js_file)], {})
+    js_file = _write_plain_js(tmp_path / "alone.js")
+    result, mock_run = _run_check(tsc_plugin, [str(js_file)])
 
     assert_that(result.skipped).is_true()
     assert_that(result.issues_count).is_equal_to(0)
@@ -211,16 +239,10 @@ def test_mixed_ts_js_with_checkjs_runs(
         tsc_plugin: The TscPlugin instance to test.
         mixed_ts_js_checkjs_project: Fixture with .ts and .js plus checkJs.
     """
-    with patch(
-        "lintro.plugins.execution_preparation.verify_tool_version",
-        return_value=None,
-    ):
-        with patch.object(
-            tsc_plugin,
-            "_run_subprocess",
-            return_value=(True, ""),
-        ) as mock_run:
-            result = tsc_plugin.check([str(mixed_ts_js_checkjs_project)], {})
+    result, mock_run = _run_check(
+        tsc_plugin,
+        [str(mixed_ts_js_checkjs_project)],
+    )
 
     assert_that(result.skipped).is_false()
     assert_that(mock_run.called).is_true()
@@ -244,31 +266,19 @@ def test_checkjs_inherited_via_extends_activates(
         tmp_path / "tsconfig.json",
         {"extends": "./tsconfig.base.json", "include": ["*.js"]},
     )
-    (tmp_path / "app.js").write_text(
-        "/** @type {number} */\nconst x = 1;\nexport { x };\n",
-        encoding="utf-8",
-    )
+    _write_plain_js(tmp_path / "app.js")
 
-    with patch(
-        "lintro.plugins.execution_preparation.verify_tool_version",
-        return_value=None,
-    ):
-        with patch.object(
-            tsc_plugin,
-            "_run_subprocess",
-            return_value=(True, ""),
-        ) as mock_run:
-            result = tsc_plugin.check([str(tmp_path)], {})
+    result, mock_run = _run_check(tsc_plugin, [str(tmp_path)])
 
     assert_that(result.skipped).is_false()
     assert_that(mock_run.called).is_true()
 
 
-def test_explicit_project_without_checkjs_skips_js_only(
+def test_mixed_without_allowjs_omits_js_from_temp_config(
     tsc_plugin: TscPlugin,
     tmp_path: Path,
 ) -> None:
-    """Explicit project option without checkJs still skips JS-only runs.
+    """Mixed TS+JS without allowJs/checkJs keeps .ts and drops .js (no TS6504).
 
     Args:
         tsc_plugin: The TscPlugin instance to test.
@@ -276,10 +286,23 @@ def test_explicit_project_without_checkjs_skips_js_only(
     """
     write_tsconfig(
         tmp_path / "tsconfig.json",
-        {"compilerOptions": {"strict": True}, "include": ["*.js"]},
+        {"compilerOptions": {"strict": True, "noEmit": True}},
     )
-    js_file = tmp_path / "app.js"
-    js_file.write_text("export const x = 1;\n", encoding="utf-8")
+    (tmp_path / "ok.ts").write_text(
+        "export const n: number = 1;\n",
+        encoding="utf-8",
+    )
+    _write_plain_js(tmp_path / "plain.js")
+
+    captured_files: list[str] = []
+    original_create = tsc_plugin._create_temp_tsconfig
+
+    def _spy_create(*args: Any, **kwargs: Any) -> Path:
+        files = kwargs.get("files")
+        if files is None and len(args) >= 2:
+            files = args[1]
+        captured_files.extend(list(files or []))
+        return original_create(*args, **kwargs)
 
     with patch(
         "lintro.plugins.execution_preparation.verify_tool_version",
@@ -287,23 +310,86 @@ def test_explicit_project_without_checkjs_skips_js_only(
     ):
         with patch.object(
             tsc_plugin,
-            "_run_subprocess",
-            return_value=(True, ""),
-        ) as mock_run:
-            result = tsc_plugin.check(
-                [str(js_file)],
-                {"project": str(tmp_path / "tsconfig.json")},
-            )
+            "_create_temp_tsconfig",
+            side_effect=_spy_create,
+        ):
+            with patch.object(
+                tsc_plugin,
+                "_run_subprocess",
+                return_value=(True, ""),
+            ) as mock_run:
+                result = tsc_plugin.check([str(tmp_path)], {})
+
+    assert_that(result.skipped).is_false()
+    assert_that(mock_run.called).is_true()
+    suffixes = {Path(name).suffix.lower() for name in captured_files}
+    assert_that(suffixes).contains(".ts")
+    assert_that(".js" in suffixes).is_false()
+
+
+def test_ts_check_pragma_does_not_skip_js_only(
+    tsc_plugin: TscPlugin,
+    tmp_path: Path,
+) -> None:
+    """JS-only trees with ``// @ts-check`` still invoke tsc without checkJs.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        tmp_path: Pytest temporary directory.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {"compilerOptions": {"strict": True, "noEmit": True}},
+    )
+    (tmp_path / "checked.js").write_text(
+        "// @ts-check\n/** @type {number} */\nconst x = 'nope';\nexport { x };\n",
+        encoding="utf-8",
+    )
+    js_file = tmp_path / "checked.js"
+    tsc_output = (
+        f"{js_file}(3,7): error TS2322: Type 'string' is not assignable "
+        "to type 'number'."
+    )
+    result, mock_run = _run_check(
+        tsc_plugin,
+        [str(tmp_path)],
+        subprocess_result=(False, tsc_output),
+    )
+
+    assert_that(result.skipped).is_false()
+    assert_that(mock_run.called).is_true()
+    assert_that(result.issues_count).is_greater_than(0)
+
+
+def test_ts_nocheck_pragma_still_skips_js_only(
+    tsc_plugin: TscPlugin,
+    tmp_path: Path,
+) -> None:
+    """``@ts-nocheck`` does not keep a JS-only tree alive without checkJs.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        tmp_path: Pytest temporary directory.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {"compilerOptions": {"strict": True, "noEmit": True}},
+    )
+    (tmp_path / "plain.js").write_text(
+        "// @ts-nocheck\nexport const x = 1;\n",
+        encoding="utf-8",
+    )
+    result, mock_run = _run_check(tsc_plugin, [str(tmp_path)])
 
     assert_that(result.skipped).is_true()
     assert_that(mock_run.called).is_false()
 
 
-def test_mjs_and_cjs_patterns_are_discovered(
+def test_unresolved_relative_extends_does_not_skip(
     tsc_plugin: TscPlugin,
     tmp_path: Path,
 ) -> None:
-    """*.mjs and *.cjs files are discovered by the tsc plugin patterns.
+    """Missing extends targets fail closed: JS-only checks are not skipped.
 
     Args:
         tsc_plugin: The TscPlugin instance to test.
@@ -312,32 +398,186 @@ def test_mjs_and_cjs_patterns_are_discovered(
     write_tsconfig(
         tmp_path / "tsconfig.json",
         {
-            "compilerOptions": {"checkJs": True, "allowJs": True},
-            "include": ["*.mjs", "*.cjs"],
+            "extends": "./missing-base.json",
+            "include": ["*.js"],
         },
     )
-    (tmp_path / "mod.mjs").write_text("export const a = 1;\n", encoding="utf-8")
-    (tmp_path / "mod.cjs").write_text("module.exports = { a: 1 };\n", encoding="utf-8")
+    _write_plain_js(tmp_path / "app.js")
 
-    with patch(
-        "lintro.plugins.execution_preparation.verify_tool_version",
-        return_value=None,
-    ):
-        ctx = tsc_plugin._prepare_execution(
-            [str(tmp_path)],
-            dict(tsc_plugin.options),
-            no_files_message="none",
-        )
+    result, mock_run = _run_check(tsc_plugin, [str(tmp_path)])
 
-    assert_that(ctx.should_skip).is_false()
-    suffixes = {Path(f).suffix for f in ctx.files}
-    assert_that(suffixes).contains(".mjs", ".cjs")
+    assert_that(result.skipped).is_false()
+    assert_that(mock_run.called).is_true()
 
 
-def test_is_js_only_helpers() -> None:
-    """_is_js_only distinguishes pure-JS from mixed/TS inputs."""
-    assert_that(TscPlugin._is_js_only(["/a/app.js", "/a/lib.mjs"])).is_true()
-    assert_that(TscPlugin._is_js_only(["/a/app.ts"])).is_false()
-    assert_that(TscPlugin._is_js_only(["/a/app.js", "/a/app.ts"])).is_false()
-    assert_that(TscPlugin._is_js_only([])).is_false()
-    assert_that(TscPlugin._is_js_only(["/a/readme.md"])).is_false()
+def test_unresolved_package_extends_reaches_install_gate(
+    tsc_plugin: TscPlugin,
+    tmp_path: Path,
+) -> None:
+    """Unresolved npm extends does not skip for checkJs before install.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        tmp_path: Pytest temporary directory.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {
+            "extends": "@tsconfig/strictest/tsconfig.json",
+            "include": ["*.js"],
+        },
+    )
+    (tmp_path / "package.json").write_text(
+        '{"name": "demo", "version": "1.0.0"}\n',
+        encoding="utf-8",
+    )
+    _write_plain_js(tmp_path / "app.js")
+
+    result, mock_run = _run_check(tsc_plugin, [str(tmp_path)])
+
+    assert_that(result.skipped).is_true()
+    assert_that(result.skip_reason).is_equal_to("node_modules not found")
+    assert_that(mock_run.called).is_false()
+
+
+def test_js_only_use_project_files_still_invokes_tsc(
+    tsc_plugin: TscPlugin,
+    tmp_path: Path,
+) -> None:
+    """Passing only a JS path with use_project_files still runs native tsc.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        tmp_path: Pytest temporary directory.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {
+            "compilerOptions": {"strict": True, "noEmit": True},
+            "include": ["*.ts"],
+        },
+    )
+    error_file = tmp_path / "error.ts"
+    error_file.write_text(
+        "const y: number = 'string';\nexport { y };\n",
+        encoding="utf-8",
+    )
+    js_file = _write_plain_js(tmp_path / "plain.js")
+    tsc_output = (
+        f"{error_file}(1,7): error TS2322: Type 'string' is not assignable "
+        "to type 'number'."
+    )
+    result, mock_run = _run_check(
+        tsc_plugin,
+        [str(js_file)],
+        {"use_project_files": True},
+        subprocess_result=(False, tsc_output),
+    )
+
+    assert_that(result.skipped).is_false()
+    assert_that(mock_run.called).is_true()
+    assert_that(result.issues_count).is_greater_than(0)
+
+
+def test_js_only_explicit_project_still_invokes_tsc(
+    tsc_plugin: TscPlugin,
+    tmp_path: Path,
+) -> None:
+    """Explicit project option does not skip just because the input is JS.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        tmp_path: Pytest temporary directory.
+    """
+    tsconfig = write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {
+            "compilerOptions": {"strict": True, "noEmit": True},
+            "include": ["*.ts"],
+        },
+    )
+    error_file = tmp_path / "error.ts"
+    error_file.write_text(
+        "const y: number = 'string';\nexport { y };\n",
+        encoding="utf-8",
+    )
+    js_file = _write_plain_js(tmp_path / "plain.js")
+    tsc_output = (
+        f"{error_file}(1,7): error TS2322: Type 'string' is not assignable "
+        "to type 'number'."
+    )
+    result, mock_run = _run_check(
+        tsc_plugin,
+        [str(js_file)],
+        {"project": str(tsconfig)},
+        subprocess_result=(False, tsc_output),
+    )
+
+    assert_that(result.skipped).is_false()
+    assert_that(mock_run.called).is_true()
+    assert_that(result.issues_count).is_greater_than(0)
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [".js", ".mjs", ".cjs", ".jsx"],
+    ids=["js", "mjs", "cjs", "jsx"],
+)
+def test_js_suffix_with_checkjs_invokes_tsc(
+    tsc_plugin: TscPlugin,
+    tmp_path: Path,
+    suffix: str,
+) -> None:
+    """Each JS suffix is discovered and checked when checkJs is enabled.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        tmp_path: Pytest temporary directory.
+        suffix: JavaScript file suffix under test.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {
+            "compilerOptions": {"checkJs": True, "allowJs": True, "noEmit": True},
+            "include": [f"*{suffix}"],
+        },
+    )
+    (tmp_path / f"mod{suffix}").write_text(
+        "export const a = 1;\n",
+        encoding="utf-8",
+    )
+    result, mock_run = _run_check(tsc_plugin, [str(tmp_path)])
+
+    assert_that(result.skipped).is_false()
+    assert_that(mock_run.called).is_true()
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [".js", ".mjs", ".cjs", ".jsx"],
+    ids=["js", "mjs", "cjs", "jsx"],
+)
+def test_js_suffix_without_checkjs_skips(
+    tsc_plugin: TscPlugin,
+    tmp_path: Path,
+    suffix: str,
+) -> None:
+    """Each JS suffix is treated as JS-only skip input without checkJs.
+
+    Args:
+        tsc_plugin: The TscPlugin instance to test.
+        tmp_path: Pytest temporary directory.
+        suffix: JavaScript file suffix under test.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {"compilerOptions": {"strict": True, "noEmit": True}},
+    )
+    (tmp_path / f"mod{suffix}").write_text(
+        "export const a = 1;\n",
+        encoding="utf-8",
+    )
+    result, mock_run = _run_check(tsc_plugin, [str(tmp_path)])
+
+    assert_that(result.skipped).is_true()
+    assert_that(mock_run.called).is_false()

--- a/tests/unit/tools/tsc/test_execution.py
+++ b/tests/unit/tools/tsc/test_execution.py
@@ -145,7 +145,9 @@ def test_check_with_no_typescript_files(
         result = tsc_plugin.check([str(non_ts_file)], {})
 
     assert_that(result.success).is_true()
-    assert_that(result.output).contains("No .ts/.tsx/.mts/.cts files")
+    assert_that(result.output).contains(
+        "No .ts/.tsx/.mts/.cts/.js/.mjs/.cjs/.jsx files",
+    )
 
 
 def test_check_parses_multiple_issues(

--- a/tests/unit/tools/tsc/test_options.py
+++ b/tests/unit/tools/tsc/test_options.py
@@ -59,14 +59,23 @@ def test_definition_tool_type(tsc_plugin: TscPlugin) -> None:
 
 
 def test_definition_file_patterns(tsc_plugin: TscPlugin) -> None:
-    """Plugin handles TypeScript files.
+    """Plugin handles TypeScript and JavaScript files.
 
     Args:
         tsc_plugin: The TscPlugin instance to test.
     """
     patterns = tsc_plugin.definition.file_patterns
     assert_that(patterns).is_equal_to(TSC_FILE_PATTERNS)
-    assert_that(patterns).contains("*.ts", "*.tsx", "*.mts", "*.cts")
+    assert_that(patterns).contains(
+        "*.ts",
+        "*.tsx",
+        "*.mts",
+        "*.cts",
+        "*.js",
+        "*.mjs",
+        "*.cjs",
+        "*.jsx",
+    )
 
 
 def test_definition_native_configs(tsc_plugin: TscPlugin) -> None:

--- a/tests/unit/tools/tsc/test_options.py
+++ b/tests/unit/tools/tsc/test_options.py
@@ -11,7 +11,6 @@ from lintro.enums.tool_type import ToolType
 from lintro.tools.definitions.tsc import (
     TSC_DEFAULT_PRIORITY,
     TSC_DEFAULT_TIMEOUT,
-    TSC_FILE_PATTERNS,
     TscPlugin,
 )
 
@@ -65,7 +64,6 @@ def test_definition_file_patterns(tsc_plugin: TscPlugin) -> None:
         tsc_plugin: The TscPlugin instance to test.
     """
     patterns = tsc_plugin.definition.file_patterns
-    assert_that(patterns).is_equal_to(TSC_FILE_PATTERNS)
     assert_that(patterns).contains(
         "*.ts",
         "*.tsx",

--- a/tests/unit/utils/test_tsconfig_checkjs.py
+++ b/tests/unit/utils/test_tsconfig_checkjs.py
@@ -1,0 +1,86 @@
+"""Unit tests for tsconfig checkJs resolution (issue #1185)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from assertpy import assert_that
+
+from lintro.utils.tsconfig import enables_check_js
+from tests.unit.utils.tsconfig_helpers import write_tsconfig
+
+
+def test_enables_check_js_true(tmp_path: Path) -> None:
+    """Direct checkJs: true is detected.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+    """
+    path = write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {"compilerOptions": {"checkJs": True}},
+    )
+    assert_that(enables_check_js(path)).is_true()
+
+
+def test_enables_check_js_false(tmp_path: Path) -> None:
+    """Explicit checkJs: false is not treated as enabled.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+    """
+    path = write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {"compilerOptions": {"checkJs": False, "allowJs": True}},
+    )
+    assert_that(enables_check_js(path)).is_false()
+
+
+def test_enables_check_js_unset(tmp_path: Path) -> None:
+    """Missing checkJs is not enabled.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+    """
+    path = write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {"compilerOptions": {"strict": True}},
+    )
+    assert_that(enables_check_js(path)).is_false()
+
+
+def test_enables_check_js_via_extends(tmp_path: Path) -> None:
+    """Inherited checkJs from an extended base config is detected.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.base.json",
+        {"compilerOptions": {"checkJs": True}},
+    )
+    path = write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {"extends": "./tsconfig.base.json"},
+    )
+    assert_that(enables_check_js(path)).is_true()
+
+
+def test_enables_check_js_child_overrides_parent(tmp_path: Path) -> None:
+    """Child checkJs: false overrides a parent checkJs: true.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+    """
+    write_tsconfig(
+        tmp_path / "tsconfig.base.json",
+        {"compilerOptions": {"checkJs": True}},
+    )
+    path = write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {
+            "extends": "./tsconfig.base.json",
+            "compilerOptions": {"checkJs": False},
+        },
+    )
+    assert_that(enables_check_js(path)).is_false()

--- a/tests/unit/utils/test_tsconfig_checkjs.py
+++ b/tests/unit/utils/test_tsconfig_checkjs.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from assertpy import assert_that
 
-from lintro.utils.tsconfig import enables_check_js
+from lintro.utils.tsconfig import enables_check_js, resolve_extends_chain
 from tests.unit.utils.tsconfig_helpers import write_tsconfig
 
 
@@ -84,3 +84,86 @@ def test_enables_check_js_child_overrides_parent(tmp_path: Path) -> None:
         },
     )
     assert_that(enables_check_js(path)).is_false()
+
+
+def test_enables_check_js_via_array_extends(tmp_path: Path) -> None:
+    """Array extends merges compilerOptions; later parents override earlier.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+    """
+    write_tsconfig(
+        tmp_path / "base1.json",
+        {"compilerOptions": {"checkJs": False, "strict": True}},
+    )
+    write_tsconfig(
+        tmp_path / "base2.json",
+        {"compilerOptions": {"checkJs": True}},
+    )
+    path = write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {"extends": ["./base1.json", "./base2.json"]},
+    )
+    info = resolve_extends_chain(path)
+    assert_that(enables_check_js(path)).is_true()
+    assert_that(info.compiler_options.get("checkJs")).is_true()
+    assert_that(info.compiler_options.get("strict")).is_true()
+    assert_that(info.unresolved_extends).is_false()
+
+
+def test_enables_check_js_array_extends_later_false_wins(tmp_path: Path) -> None:
+    """A later array-extends parent can disable an earlier checkJs: true.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+    """
+    write_tsconfig(
+        tmp_path / "base1.json",
+        {"compilerOptions": {"checkJs": True}},
+    )
+    write_tsconfig(
+        tmp_path / "base2.json",
+        {"compilerOptions": {"checkJs": False}},
+    )
+    path = write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {"extends": ["./base1.json", "./base2.json"]},
+    )
+    assert_that(enables_check_js(path)).is_false()
+
+
+def test_unresolved_extends_is_flagged(tmp_path: Path) -> None:
+    """Missing extends targets set unresolved_extends and do not enable checkJs.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+    """
+    path = write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {"extends": "@tsconfig/strictest/tsconfig.json"},
+    )
+    info = resolve_extends_chain(path)
+    assert_that(info.unresolved_extends).is_true()
+    assert_that(enables_check_js(path)).is_false()
+
+
+def test_unresolved_array_extends_is_flagged(tmp_path: Path) -> None:
+    """A missing entry in array extends still flags the chain unresolved.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+    """
+    write_tsconfig(
+        tmp_path / "base.json",
+        {"compilerOptions": {"strict": True}},
+    )
+    path = write_tsconfig(
+        tmp_path / "tsconfig.json",
+        {
+            "extends": ["./base.json", "./missing.json"],
+            "compilerOptions": {"checkJs": True},
+        },
+    )
+    info = resolve_extends_chain(path)
+    assert_that(info.unresolved_extends).is_true()
+    assert_that(enables_check_js(path)).is_true()

--- a/tests/unit/utils/test_tsconfig_extends.py
+++ b/tests/unit/utils/test_tsconfig_extends.py
@@ -76,13 +76,18 @@ def test_resolve_circular_extends(tmp_path: Path) -> None:
 
 
 def test_resolve_missing_extends_target(tmp_path: Path) -> None:
-    """Missing extends target is silently skipped."""
+    """Missing extends target is skipped for field merge but flagged.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+    """
     write_tsconfig(
         tmp_path / "tsconfig.json",
         {"extends": "./nonexistent.json", "include": ["src/**/*.ts"]},
     )
     info = resolve_extends_chain(tmp_path / "tsconfig.json")
     assert_that(info.include_patterns).is_equal_to(["src/**/*.ts"])
+    assert_that(info.unresolved_extends).is_true()
 
 
 def test_resolve_array_extends_ts5(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(tsc): type-check JSDoc JavaScript when checkJs enabled
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

- Expand `TSC_FILE_PATTERNS` with `*.js` / `*.mjs` / `*.cjs` / `*.jsx`
- Early-skip JS-only runs when no tsconfig enables `checkJs` (extends-aware)
- Unit/integration coverage for checkJs on/off and mixed TS+JS
- No tool-dispatch restructuring (#806/#807 left untouched)

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1185

## Details

- `uv run lintro fmt` / `uv run lintro chk` — clean for this change
- `uv run pytest --maxfail=0` — 6932 passed; 6 env-only markdownlint/rustfmt failures

Closes #1185

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR expands the tsc integration to discover JSDoc-typed JavaScript and gates JavaScript-only execution on effective `checkJs` configuration.

- Adds JavaScript-family file patterns to the tsc plugin.
- Adds extends-aware `checkJs` resolution and a pre-execution skip hook.
- Adds unit and integration coverage for enabled, disabled, inherited, and mixed-language projects.
</details>

<h3>Confidence Score: 4/5</h3>

The PR should not merge until JavaScript-only discovery can no longer bypass the requested use_project_files project check.

The new early return executes before project-mode dispatch, allowing an input-path classification to suppress TypeScript files that the selected tsconfig is explicitly supposed to check.

**Files Needing Attention:** lintro/tools/definitions/_ts_checker_execution.py, lintro/tools/definitions/tsc.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/tools/definitions/_ts_checker_execution.py | Adds the pre-run hook, but invokes it before project-file mode and can therefore bypass native tsconfig selection. |
| lintro/tools/definitions/tsc.py | Expands discovery to JavaScript and implements JavaScript-only checkJs gating, with the project-mode ordering caveat. |
| lintro/utils/tsconfig.py | Adds recursive effective checkJs resolution across string and array extends chains. |
| tests/unit/tools/tsc/test_checkjs.py | Covers JavaScript activation and skip behavior but omits JavaScript-only input combined with use_project_files. |
| tests/integration/tools/tsc/test_check.py | Adds real tsc coverage for checkJs behavior and documents the native project-selection contract. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Discover TS and JS files] --> B{JavaScript-only inputs?}
    B -- No --> E[Select normal project strategy]
    B -- Yes --> C{Any relevant tsconfig enables checkJs?}
    C -- Yes --> E
    C -- No --> D[Return skipped result]
    E --> F{use_project_files or explicit project?}
    F -- Yes --> G[Run native project selection]
    F -- No --> H[Partition inputs and run temporary projects]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20lgtm-hq%2Fpy-lintro%20PR%20%231570%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=1570&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alintro%2Ftools%2Fdefinitions%2F_ts_checker_execution.py%3A80-82%0A**Project%20selection%20is%20skipped**%0A%0AWhen%20a%20caller%20passes%20only%20a%20JavaScript%20path%20with%20%60use_project_files%3DTrue%60%20and%20the%20tsconfig%20does%20not%20enable%20%60checkJs%60%2C%20this%20early%20return%20runs%20before%20project-mode%20dispatch%2C%20causing%20TypeScript%20errors%20in%20files%20selected%20by%20the%20tsconfig%20to%20be%20silently%20missed.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=1570&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alintro%2Ftools%2Fdefinitions%2F_ts_checker_execution.py%3A80-82%0A**Project%20selection%20is%20skipped**%0A%0AWhen%20a%20caller%20passes%20only%20a%20JavaScript%20path%20with%20%60use_project_files%3DTrue%60%20and%20the%20tsconfig%20does%20not%20enable%20%60checkJs%60%2C%20this%20early%20return%20runs%20before%20project-mode%20dispatch%2C%20causing%20TypeScript%20errors%20in%20files%20selected%20by%20the%20tsconfig%20to%20be%20silently%20missed.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=lgtm-hq%2Fpy-lintro&pr=1570&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22feat%2F1185-tsc-checkjs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F1185-tsc-checkjs%22.%0A%0A%23%23%23%20Issue%201%0Alintro%2Ftools%2Fdefinitions%2F_ts_checker_execution.py%3A80-82%0A**Project%20selection%20is%20skipped**%0A%0AWhen%20a%20caller%20passes%20only%20a%20JavaScript%20path%20with%20%60use_project_files%3DTrue%60%20and%20the%20tsconfig%20does%20not%20enable%20%60checkJs%60%2C%20this%20early%20return%20runs%20before%20project-mode%20dispatch%2C%20causing%20TypeScript%20errors%20in%20files%20selected%20by%20the%20tsconfig%20to%20be%20silently%20missed.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=lgtm-hq%2Fpy-lintro&pr=1570&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(tsc): wire checkJs early-skip throug..."](https://github.com/lgtm-hq/py-lintro/commit/05631124591c58ef313f555e9ef7457faa971121) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54639747)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->