### PR TITLE
feat(ai): add git-checkpoint rollback for fix application

### DIFF
--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -106,16 +106,18 @@ Before an AI fix batch mutates files, lintro captures a snapshot under
 `refs/lintro/checkpoints/<run-id>` using git plumbing on a temporary index
 (`GIT_INDEX_FILE`). This does **not** touch your index, stash, or `HEAD`.
 
-- **Rollback** restores only the files lintro targeted from that checkpoint tree, atomic
-  across the batch. Paths that were not part of the snapshot are never touched.
+- **Rollback** restores only the files lintro targeted from that checkpoint tree. Every
+  blob is read before anything is written, each file is replaced atomically and keeps
+  its mode, and paths that were not part of the snapshot are never touched.
 - **Diff** against the checkpoint shows exactly what lintro changed in the run. When a
   run changed anything, lintro prints the ref so you can run `git diff <ref>` or
   `git checkout <ref> -- <path>` after it exits.
 - **Interactive reject** restores rejected files from the checkpoint tree, not from
   in-memory copies. Files an earlier accepted group already changed are left alone, so
   rejecting one group never discards fixes you just accepted.
-- **Retention** keeps the last N checkpoint refs (default 10) and prunes older ones via
-  `git update-ref -d`.
+- **Retention** keeps the last N checkpoint refs (default 10), pruning older ones via
+  `git update-ref -d` before the new ref is written. `0` keeps only the current run's
+  checkpoint.
 - **Fallback:** outside a git work tree (or in a bare repo), lintro falls back to
   file-content snapshots / the legacy reverse patch under `.lintro-cache/ai`.
 
@@ -475,8 +477,8 @@ ai:
   fix_search_radius: 5
 
   # ── Git checkpoints ───────────────────────────────────────────
-  # Max refs kept under refs/lintro/checkpoints/; 0 prunes all.
-  # (int >= 0, default: 10)
+  # Refs kept under refs/lintro/checkpoints/, this run included.
+  # 0 keeps only the current run. (int >= 0, default: 10)
   checkpoint_retention: 10
 
   # Also checkpoint before `lintro format` mutates files.

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -109,10 +109,12 @@ Before an AI fix batch mutates files, lintro captures a snapshot under
 - **Rollback** restores only the files lintro targeted from that checkpoint tree. Every
   blob is read before anything is written, each file is replaced atomically and keeps
   its mode, and paths that were not part of the snapshot are never touched.
-- **Diff** against the checkpoint shows exactly what lintro changed in the run. When a
-  run changed anything, lintro prints the ref so you can run `git diff <ref>` or
-  `git restore --source=<ref> --worktree -- <path>` after it exits. `restore --worktree`
-  is deliberate: `git checkout <ref> -- <path>` would also rewrite your index.
+- **Diff** against the checkpoint shows how the targeted files differ from their
+  pre-batch state. When a run changed anything, lintro prints the ref so you can run
+  `git diff <ref>` or `git restore --source=<ref> --worktree -- <path>` after it exits.
+  `restore --worktree` is deliberate: `git checkout <ref> -- <path>` would also rewrite
+  your index. This is a diff of the _files_, not an audit trail of lintro alone — an
+  edit you made to a targeted file after capture appears in it too.
 - **Interactive reject** restores rejected files from the checkpoint tree, not from
   in-memory copies. Files an earlier accepted group already changed are left alone, so
   rejecting one group never discards fixes you just accepted.

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -100,6 +100,33 @@ For safe-style groups, pressing `Enter` defaults to accepting the group.
 After the review session, a post-fix AI summary contextualizes what was fixed and what
 remains.
 
+### Git Checkpoints & Rollback
+
+Before an AI fix batch mutates files, lintro captures a snapshot under
+`refs/lintro/checkpoints/<run-id>` using git plumbing on a temporary index
+(`GIT_INDEX_FILE`). This does **not** touch your index, stash, or `HEAD`.
+
+- **Rollback** restores only the files lintro targeted from that checkpoint tree, atomic
+  across the batch. Paths that were not part of the snapshot are never touched.
+- **Diff** against the checkpoint shows exactly what lintro changed in the run. When a
+  run changed anything, lintro prints the ref so you can run `git diff <ref>` or
+  `git checkout <ref> -- <path>` after it exits.
+- **Interactive reject** restores rejected files from the checkpoint tree, not from
+  in-memory copies. Files an earlier accepted group already changed are left alone, so
+  rejecting one group never discards fixes you just accepted.
+- **Retention** keeps the last N checkpoint refs (default 10) and prunes older ones via
+  `git update-ref -d`.
+- **Fallback:** outside a git work tree (or in a bare repo), lintro falls back to
+  file-content snapshots / the legacy reverse patch under `.lintro-cache/ai`.
+
+Optional: set `ai.checkpoint_fmt: true` to capture the same style of checkpoint before
+`lintro format` mutates files. This one is git-only — an in-process snapshot would not
+outlive the run, so nothing is captured outside a git work tree.
+
+> **Semantics:** Rolling back a lintro target overwrites that file with the pre-batch
+> snapshot — including any edits you made to that same file between capture and
+> rollback. Non-target files and your staged/unstaged index state are left alone.
+
 ### AI Fixes in `format`
 
 When running `lintro format`, tools auto-fix what they can. For remaining unfixable
@@ -446,6 +473,15 @@ ai:
   # Max lines above/below target for line-targeted fix search.
   # (int 1–50, default: 5)
   fix_search_radius: 5
+
+  # ── Git checkpoints ───────────────────────────────────────────
+  # Max refs kept under refs/lintro/checkpoints/; 0 prunes all.
+  # (int >= 0, default: 10)
+  checkpoint_retention: 10
+
+  # Also checkpoint before `lintro format` mutates files.
+  # (bool, default: false)
+  checkpoint_fmt: false
 
   # ── Suggestion cache ──────────────────────────────────────────
   # Deduplicate identical fix requests across runs. (bool, default: false)

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -111,7 +111,8 @@ Before an AI fix batch mutates files, lintro captures a snapshot under
   its mode, and paths that were not part of the snapshot are never touched.
 - **Diff** against the checkpoint shows exactly what lintro changed in the run. When a
   run changed anything, lintro prints the ref so you can run `git diff <ref>` or
-  `git checkout <ref> -- <path>` after it exits.
+  `git restore --source=<ref> --worktree -- <path>` after it exits. `restore --worktree`
+  is deliberate: `git checkout <ref> -- <path>` would also rewrite your index.
 - **Interactive reject** restores rejected files from the checkpoint tree, not from
   in-memory copies. Files an earlier accepted group already changed are left alone, so
   rejecting one group never discards fixes you just accepted.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2764,6 +2764,8 @@ ai:
 | `show_cost_estimate`    | bool   | `true`      | Show token/cost info in output                   |
 | `context_lines`         | int    | `15`        | Lines of context sent for fix generation (1-100) |
 | `fix_search_radius`     | int    | `5`         | Line search radius for fix application (1-50)    |
+| `checkpoint_retention`  | int    | `10`        | Max git checkpoint refs to retain                |
+| `checkpoint_fmt`        | bool   | `false`     | Checkpoint before `lintro format` file mutations |
 | `retry_base_delay`      | float  | `1.0`       | Initial retry delay in seconds (min 0.1)         |
 | `retry_max_delay`       | float  | `30.0`      | Maximum retry delay in seconds (min 1.0)         |
 | `retry_backoff_factor`  | float  | `2.0`       | Retry delay multiplier (min 1.0)                 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2764,8 +2764,8 @@ ai:
 | `show_cost_estimate`    | bool   | `true`      | Show token/cost info in output                   |
 | `context_lines`         | int    | `15`        | Lines of context sent for fix generation (1-100) |
 | `fix_search_radius`     | int    | `5`         | Line search radius for fix application (1-50)    |
-| `checkpoint_retention`  | int    | `10`        | Max git checkpoint refs to retain                |
-| `checkpoint_fmt`        | bool   | `false`     | Checkpoint before `lintro format` file mutations |
+| `checkpoint_retention`  | int    | `10`        | Git checkpoint refs kept (>=0; 0 = current only) |
+| `checkpoint_fmt`        | bool   | `false`     | Git checkpoint before `lintro format` mutations  |
 | `retry_base_delay`      | float  | `1.0`       | Initial retry delay in seconds (min 0.1)         |
 | `retry_max_delay`       | float  | `30.0`      | Maximum retry delay in seconds (min 1.0)         |
 | `retry_backoff_factor`  | float  | `2.0`       | Retry delay multiplier (min 1.0)                 |

--- a/lintro/ai/apply.py
+++ b/lintro/ai/apply.py
@@ -12,8 +12,10 @@ from pathlib import Path
 
 from loguru import logger
 
+from lintro.ai.checkpoints import DEFAULT_CHECKPOINT_RETENTION
 from lintro.ai.models import AIFixSuggestion
 from lintro.ai.paths import resolve_workspace_file
+from lintro.ai.undo import UndoState, prepare_fix_batch, restore_undo
 
 
 def _apply_fix(
@@ -142,8 +144,42 @@ def apply_fixes(
     workspace_root: Path,
     auto_apply: bool = False,
     search_radius: int | None = None,
+    undo_state: UndoState | None = None,
+    capture_undo: bool = False,
+    checkpoint_retention: int = DEFAULT_CHECKPOINT_RETENTION,
 ) -> list[AIFixSuggestion]:
-    """Apply suggestions and return only those successfully applied."""
+    """Apply suggestions and return only those successfully applied.
+
+    When ``capture_undo`` is True and ``undo_state`` is omitted, a git
+    checkpoint (or file-snapshot fallback) is captured before the first
+    mutation. Callers that already prepared an :class:`~lintro.ai.undo.UndoState`
+    should pass it via ``undo_state`` and leave ``capture_undo`` False.
+
+    Args:
+        suggestions: Fix suggestions to apply.
+        workspace_root: Root directory limiting writable paths.
+        auto_apply: Reserved for future use; kept for API compatibility.
+        search_radius: Max lines above/below the target line to search.
+        undo_state: Optional pre-captured rollback state for this batch.
+        capture_undo: When True, capture rollback state before mutating.
+        checkpoint_retention: Max git checkpoint refs to retain when capturing.
+
+    Returns:
+        Suggestions that were applied successfully.
+    """
+    if capture_undo and undo_state is None and suggestions:
+        undo_state = prepare_fix_batch(
+            list(suggestions),
+            workspace_root,
+            retention=checkpoint_retention,
+        )
+        if undo_state is not None:
+            logger.debug(
+                "Captured fix-batch undo via {} backend ({} paths)",
+                undo_state.kind,
+                len(undo_state.paths),
+            )
+
     extra: dict[str, int] = {}
     if search_radius is not None:
         extra["search_radius"] = search_radius
@@ -157,3 +193,23 @@ def apply_fixes(
             **extra,
         )
     ]
+
+
+def rollback_applied_paths(
+    undo_state: UndoState,
+    suggestions: Sequence[AIFixSuggestion],
+) -> None:
+    """Restore files for ``suggestions`` from ``undo_state``.
+
+    Used by interactive rejection and callers that need per-file rollback
+    from the checkpoint tree (or file-snapshot fallback), not from
+    in-memory suggestion ``original_code``.
+
+    Args:
+        undo_state: Handle from :func:`~lintro.ai.undo.prepare_fix_batch`.
+        suggestions: Suggestions whose target files should be restored.
+    """
+    paths = [s.file for s in suggestions if s.file]
+    if not paths:
+        return
+    restore_undo(undo_state, paths)

--- a/lintro/ai/apply.py
+++ b/lintro/ai/apply.py
@@ -12,10 +12,10 @@ from pathlib import Path
 
 from loguru import logger
 
-from lintro.ai.checkpoints import DEFAULT_CHECKPOINT_RETENTION
+from lintro.ai.checkpoints import CheckpointError
 from lintro.ai.models import AIFixSuggestion
 from lintro.ai.paths import resolve_workspace_file
-from lintro.ai.undo import UndoState, prepare_fix_batch, restore_undo
+from lintro.ai.undo import UndoState, restore_undo
 
 
 def _apply_fix(
@@ -144,42 +144,22 @@ def apply_fixes(
     workspace_root: Path,
     auto_apply: bool = False,
     search_radius: int | None = None,
-    undo_state: UndoState | None = None,
-    capture_undo: bool = False,
-    checkpoint_retention: int = DEFAULT_CHECKPOINT_RETENTION,
 ) -> list[AIFixSuggestion]:
     """Apply suggestions and return only those successfully applied.
 
-    When ``capture_undo`` is True and ``undo_state`` is omitted, a git
-    checkpoint (or file-snapshot fallback) is captured before the first
-    mutation. Callers that already prepared an :class:`~lintro.ai.undo.UndoState`
-    should pass it via ``undo_state`` and leave ``capture_undo`` False.
+    Rollback state is the caller's responsibility: capture it with
+    :func:`~lintro.ai.undo.prepare_fix_batch` *before* calling this, and undo
+    with :func:`rollback_applied_paths`.
 
     Args:
         suggestions: Fix suggestions to apply.
         workspace_root: Root directory limiting writable paths.
         auto_apply: Reserved for future use; kept for API compatibility.
         search_radius: Max lines above/below the target line to search.
-        undo_state: Optional pre-captured rollback state for this batch.
-        capture_undo: When True, capture rollback state before mutating.
-        checkpoint_retention: Max git checkpoint refs to retain when capturing.
 
     Returns:
         Suggestions that were applied successfully.
     """
-    if capture_undo and undo_state is None and suggestions:
-        undo_state = prepare_fix_batch(
-            list(suggestions),
-            workspace_root,
-            retention=checkpoint_retention,
-        )
-        if undo_state is not None:
-            logger.debug(
-                "Captured fix-batch undo via {} backend ({} paths)",
-                undo_state.kind,
-                len(undo_state.paths),
-            )
-
     extra: dict[str, int] = {}
     if search_radius is not None:
         extra["search_radius"] = search_radius
@@ -198,18 +178,30 @@ def apply_fixes(
 def rollback_applied_paths(
     undo_state: UndoState,
     suggestions: Sequence[AIFixSuggestion],
-) -> None:
+) -> bool:
     """Restore files for ``suggestions`` from ``undo_state``.
 
     Used by interactive rejection and callers that need per-file rollback
     from the checkpoint tree (or file-snapshot fallback), not from
     in-memory suggestion ``original_code``.
 
+    A restore that fails is logged and swallowed: rollback runs inside an
+    interactive session, where crashing would cost the user their running
+    accept/reject state and every group still to review.
+
     Args:
         undo_state: Handle from :func:`~lintro.ai.undo.prepare_fix_batch`.
         suggestions: Suggestions whose target files should be restored.
+
+    Returns:
+        True when every target was restored, False when the restore failed.
     """
     paths = [s.file for s in suggestions if s.file]
     if not paths:
-        return
-    restore_undo(undo_state, paths)
+        return True
+    try:
+        restore_undo(undo_state, paths)
+    except (OSError, CheckpointError) as exc:
+        logger.debug("Checkpoint restore failed for {}: {}", paths, exc)
+        return False
+    return True

--- a/lintro/ai/checkpoints.py
+++ b/lintro/ai/checkpoints.py
@@ -1,0 +1,494 @@
+"""Git-checkpoint snapshots for AI fix (and optional fmt) rollback.
+
+Captures working-tree file state to ``refs/lintro/checkpoints/<run-id>`` using
+git plumbing on a temporary index (``GIT_INDEX_FILE``). Never touches the
+user's index, stash, or ``HEAD``.
+
+Outside a usable git work tree (no git, bare repo, etc.) callers should fall
+back to :mod:`lintro.ai.undo` file-content snapshots.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # nosec B404 - subprocess invokes git with shell=False; args are plumbing only
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from loguru import logger
+
+CHECKPOINT_REF_PREFIX = "refs/lintro/checkpoints/"
+DEFAULT_CHECKPOINT_RETENTION = 10
+_GIT_TIMEOUT_SECONDS = 60.0
+
+
+@dataclass(frozen=True)
+class Checkpoint:
+    """A lintro-managed git tree snapshot.
+
+    Attributes:
+        ref: Full ref name under ``refs/lintro/checkpoints/``.
+        run_id: Unique run identifier embedded in the ref.
+        root: Absolute repository root path.
+        paths: Repo-relative paths included in the snapshot.
+        tree_sha: Object name of the written tree.
+    """
+
+    ref: str
+    run_id: str
+    root: Path
+    paths: tuple[str, ...] = field(default_factory=tuple)
+    tree_sha: str = ""
+
+
+class CheckpointError(Exception):
+    """Raised when a checkpoint capture, restore, or prune operation fails."""
+
+
+def _git_bin() -> str | None:
+    """Return the resolved git binary path, or None if unavailable."""
+    return shutil.which("git")
+
+
+def _run_git(
+    args: list[str],
+    *,
+    cwd: str,
+    env: dict[str, str] | None = None,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command with optional temp-index environment.
+
+    Args:
+        args: Git arguments (without the leading ``git``).
+        cwd: Working directory.
+        env: Optional environment overlay (e.g. ``GIT_INDEX_FILE``).
+        check: When True, raise :class:`CheckpointError` on non-zero exit.
+
+    Returns:
+        Completed process with text stdout/stderr.
+
+    Raises:
+        CheckpointError: When git is missing, times out, or ``check`` fails.
+    """
+    git_bin = _git_bin()
+    if git_bin is None:
+        raise CheckpointError("git is not installed or not on PATH")
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    # Avoid locale/pager interference and never open an editor.
+    full_env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    full_env.setdefault("GIT_OPTIONAL_LOCKS", "0")
+    try:
+        result = subprocess.run(  # nosec B603 - argv is [resolved git binary, *args]; shell=False; plumbing args only
+            [git_bin, *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            check=False,
+            env=full_env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise CheckpointError(
+            f"git {' '.join(args)} timed out after {_GIT_TIMEOUT_SECONDS}s",
+        ) from exc
+    except OSError as exc:
+        raise CheckpointError(f"Failed to run git {' '.join(args)}: {exc}") from exc
+    if check and result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip() or "unknown git error"
+        raise CheckpointError(f"git {' '.join(args)} failed: {stderr}")
+    return result
+
+
+def git_checkpoints_available(workspace_root: Path) -> bool:
+    """Return whether git checkpoints can be used under ``workspace_root``.
+
+    Requires git on ``PATH``, a non-bare work tree, and a readable repo root.
+
+    Args:
+        workspace_root: Project directory to probe.
+
+    Returns:
+        True when capture/restore via git refs is supported.
+    """
+    if _git_bin() is None:
+        return False
+    root = str(workspace_root)
+    try:
+        inside = _run_git(
+            ["rev-parse", "--is-inside-work-tree"],
+            cwd=root,
+        )
+        if inside.returncode != 0 or inside.stdout.strip() != "true":
+            return False
+        bare = _run_git(
+            ["rev-parse", "--is-bare-repository"],
+            cwd=root,
+        )
+        if bare.returncode == 0 and bare.stdout.strip() == "true":
+            return False
+    except CheckpointError:
+        return False
+    return True
+
+
+def _repo_root(workspace_root: Path) -> Path | None:
+    """Resolve the git top-level directory for ``workspace_root``."""
+    try:
+        result = _run_git(
+            ["rev-parse", "--show-toplevel"],
+            cwd=str(workspace_root),
+        )
+    except CheckpointError:
+        return None
+    if result.returncode != 0:
+        return None
+    top = result.stdout.strip()
+    return Path(top) if top else None
+
+
+def _normalize_paths(
+    paths: list[str] | tuple[str, ...],
+    *,
+    root: Path,
+) -> list[str]:
+    """Convert paths to unique repo-relative POSIX strings.
+
+    Args:
+        paths: Absolute or relative path strings (files or directories).
+        root: Repository root.
+
+    Returns:
+        Sorted unique relative paths that exist on disk (files only expanded
+        from directories via a shallow walk of existing files).
+    """
+    root_resolved = root.resolve()
+    rels: set[str] = set()
+    for raw in paths:
+        if not raw:
+            continue
+        candidate = Path(raw)
+        abs_path = (
+            candidate.resolve()
+            if candidate.is_absolute()
+            else (root_resolved / candidate).resolve()
+        )
+        try:
+            rel = abs_path.relative_to(root_resolved)
+        except ValueError:
+            logger.debug("Skipping path outside repo for checkpoint: {}", raw)
+            continue
+        if abs_path.is_dir():
+            for file_path in abs_path.rglob("*"):
+                if file_path.is_file():
+                    try:
+                        rels.add(
+                            file_path.resolve().relative_to(root_resolved).as_posix(),
+                        )
+                    except ValueError:
+                        continue
+        else:
+            # Include missing paths so restore can delete files created later;
+            # capture only adds existing files to the temp index.
+            rels.add(rel.as_posix())
+    return sorted(rels)
+
+
+def _new_run_id() -> str:
+    """Return a sortable unique run id (timestamp + short uuid)."""
+    return f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+
+
+def capture_checkpoint(
+    paths: list[str] | tuple[str, ...],
+    *,
+    workspace_root: Path,
+    run_id: str | None = None,
+    keep: int = DEFAULT_CHECKPOINT_RETENTION,
+) -> Checkpoint | None:
+    """Snapshot target file state to ``refs/lintro/checkpoints/<run-id>``.
+
+    Uses a temporary ``GIT_INDEX_FILE``: ``read-tree HEAD`` (or empty tree),
+    ``add`` target paths (including untracked), ``write-tree``, ``update-ref``.
+    Does not modify the user index, stash, or ``HEAD``.
+
+    Args:
+        paths: Files (and/or directories) to include in the snapshot.
+        workspace_root: Directory inside the repository.
+        run_id: Optional run identifier; generated when omitted.
+        keep: Maximum checkpoint refs to retain after capture (default 10).
+
+    Returns:
+        The created :class:`Checkpoint`, or None when git checkpoints are
+        unavailable or no paths remain after normalization.
+    """
+    if not git_checkpoints_available(workspace_root):
+        return None
+    root = _repo_root(workspace_root)
+    if root is None:
+        return None
+    rel_paths = _normalize_paths(paths, root=root)
+    if not rel_paths:
+        return None
+
+    rid = run_id or _new_run_id()
+    ref = f"{CHECKPOINT_REF_PREFIX}{rid}"
+    cwd = str(root)
+
+    fd, index_path = tempfile.mkstemp(prefix="lintro-git-index-")
+    os.close(fd)
+    index_file = Path(index_path)
+    env = {"GIT_INDEX_FILE": str(index_file)}
+    try:
+        # Start from HEAD when available; otherwise empty tree (unborn branch).
+        head = _run_git(["rev-parse", "--verify", "HEAD"], cwd=cwd)
+        if head.returncode == 0:
+            _run_git(["read-tree", "HEAD"], cwd=cwd, env=env, check=True)
+        else:
+            _run_git(["read-tree", "--empty"], cwd=cwd, env=env, check=True)
+
+        existing = [p for p in rel_paths if (root / p).is_file()]
+        if existing:
+            # ``git add --`` updates only the temp index (via GIT_INDEX_FILE).
+            _run_git(
+                ["add", "-f", "--", *existing],
+                cwd=cwd,
+                env=env,
+                check=True,
+            )
+
+        tree = _run_git(["write-tree"], cwd=cwd, env=env, check=True)
+        tree_sha = tree.stdout.strip()
+        if not tree_sha:
+            logger.debug("write-tree returned empty tree sha")
+            return None
+
+        _run_git(
+            ["update-ref", ref, tree_sha],
+            cwd=cwd,
+            check=True,
+        )
+        logger.debug("Captured AI checkpoint {} ({})", ref, tree_sha)
+    except CheckpointError:
+        logger.debug("Checkpoint capture failed; caller should use file fallback")
+        return None
+    finally:
+        index_file.unlink(missing_ok=True)
+
+    try:
+        prune_checkpoints(workspace_root=root, keep=keep)
+    except CheckpointError as exc:
+        logger.debug("Checkpoint prune skipped: {}", exc)
+
+    return Checkpoint(
+        ref=ref,
+        run_id=rid,
+        root=root,
+        paths=tuple(rel_paths),
+        tree_sha=tree_sha,
+    )
+
+
+def _blob_for_path(
+    *,
+    root: Path,
+    treeish: str,
+    rel_path: str,
+) -> bytes | None:
+    """Return blob bytes for ``rel_path`` at ``treeish``, or None if absent."""
+    exists = _run_git(
+        ["cat-file", "-e", f"{treeish}:{rel_path}"],
+        cwd=str(root),
+    )
+    if exists.returncode != 0:
+        return None
+    git_bin = _git_bin()
+    if git_bin is None:
+        raise CheckpointError("git is not installed or not on PATH")
+    # Binary-safe read (avoid text-mode decoding).
+    raw = subprocess.run(  # nosec B603 - argv is [git, cat-file, -p, tree:path]; shell=False
+        [git_bin, "cat-file", "-p", f"{treeish}:{rel_path}"],
+        cwd=str(root),
+        capture_output=True,
+        timeout=_GIT_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if raw.returncode != 0:
+        raise CheckpointError(
+            f"cat-file -p failed for {rel_path}: "
+            f"{raw.stderr.decode('utf-8', errors='replace')}",
+        )
+    return raw.stdout
+
+
+def restore_checkpoint(
+    checkpoint: Checkpoint,
+    paths: list[str] | tuple[str, ...] | None = None,
+) -> None:
+    """Restore files from a checkpoint tree (atomic across the batch).
+
+    Reads all target blobs first, then writes them with atomic replace so a
+    mid-batch failure does not leave a half-restored set. Paths present on
+    disk but absent from the checkpoint tree are removed (they were created
+    after capture). Paths that remain at the checkpoint content are rewritten
+    from the tree — including when the user edited them between capture and
+    rollback (lintro targets always return to the pre-batch snapshot).
+
+    Args:
+        checkpoint: Checkpoint produced by :func:`capture_checkpoint`.
+        paths: Optional subset of paths to restore; defaults to all paths
+            recorded on the checkpoint.
+
+    Raises:
+        BaseException: Re-raised after cleanup when an atomic write fails.
+    """
+    root = checkpoint.root
+    treeish = checkpoint.tree_sha or checkpoint.ref
+    if paths is None:
+        target_rels = list(checkpoint.paths)
+    else:
+        target_rels = _normalize_paths(list(paths), root=root)
+        # Also accept already-relative paths that were in the checkpoint list.
+        for raw in paths:
+            if raw and raw not in target_rels:
+                target_rels.append(Path(raw).as_posix())
+
+    planned: list[tuple[Path, bytes | None]] = []
+    for rel in target_rels:
+        abs_path = root / rel
+        blob = _blob_for_path(root=root, treeish=treeish, rel_path=rel)
+        planned.append((abs_path, blob))
+
+    # Phase 1 complete — apply all writes/deletes.
+    for abs_path, blob in planned:
+        if blob is None:
+            if abs_path.is_file():
+                abs_path.unlink()
+            continue
+        abs_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(abs_path.parent), suffix=".lintro-restore")
+        try:
+            try:
+                fobj = os.fdopen(fd, "wb")
+            except BaseException:
+                os.close(fd)
+                raise
+            with fobj:
+                fobj.write(blob)
+            Path(tmp).replace(abs_path)
+        except BaseException:
+            Path(tmp).unlink(missing_ok=True)
+            raise
+
+
+def diff_checkpoint(
+    checkpoint: Checkpoint,
+    paths: list[str] | tuple[str, ...] | None = None,
+) -> str:
+    """Return a unified diff of working tree vs the checkpoint for ``paths``.
+
+    This is the accurate post-run "what lintro changed" report for files that
+    were included in the checkpoint.
+
+    Args:
+        checkpoint: Checkpoint to diff against.
+        paths: Optional path subset; defaults to checkpoint paths.
+
+    Returns:
+        Unified diff text (may be empty when nothing changed).
+    """
+    root = checkpoint.root
+    rels = (
+        list(checkpoint.paths)
+        if paths is None
+        else _normalize_paths(list(paths), root=root)
+    )
+    if not rels:
+        return ""
+    treeish = checkpoint.tree_sha or checkpoint.ref
+    # Compare checkpoint tree to the working tree for the given paths.
+    result = _run_git(
+        ["diff", "--no-ext-diff", treeish, "--", *rels],
+        cwd=str(root),
+        check=True,
+    )
+    return result.stdout
+
+
+def list_checkpoint_refs(*, workspace_root: Path) -> list[str]:
+    """List lintro checkpoint refs (oldest first).
+
+    Args:
+        workspace_root: Directory inside the repository.
+
+    Returns:
+        Full ref names sorted lexicographically (timestamp-prefixed run ids).
+    """
+    if not git_checkpoints_available(workspace_root):
+        return []
+    root = _repo_root(workspace_root)
+    if root is None:
+        return []
+    result = _run_git(
+        [
+            "for-each-ref",
+            "--format=%(refname)",
+            "--sort=refname",
+            CHECKPOINT_REF_PREFIX,
+        ],
+        cwd=str(root),
+    )
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def prune_checkpoints(
+    *,
+    workspace_root: Path,
+    keep: int = DEFAULT_CHECKPOINT_RETENTION,
+) -> int:
+    """Delete oldest checkpoint refs beyond ``keep``.
+
+    Args:
+        workspace_root: Directory inside the repository.
+        keep: Number of newest refs to retain. When ``keep <= 0``, all
+            checkpoint refs are deleted.
+
+    Returns:
+        Number of refs deleted.
+    """
+    refs = list_checkpoint_refs(workspace_root=workspace_root)
+    if keep < 0:
+        keep = 0
+    if len(refs) <= keep:
+        return 0
+    to_delete = refs if keep == 0 else refs[: len(refs) - keep]
+    root = _repo_root(workspace_root)
+    if root is None:
+        return 0
+    deleted = 0
+    for ref in to_delete:
+        _run_git(["update-ref", "-d", ref], cwd=str(root), check=True)
+        deleted += 1
+    return deleted
+
+
+__all__ = [
+    "CHECKPOINT_REF_PREFIX",
+    "DEFAULT_CHECKPOINT_RETENTION",
+    "Checkpoint",
+    "CheckpointError",
+    "capture_checkpoint",
+    "diff_checkpoint",
+    "git_checkpoints_available",
+    "list_checkpoint_refs",
+    "prune_checkpoints",
+    "restore_checkpoint",
+]

--- a/lintro/ai/checkpoints.py
+++ b/lintro/ai/checkpoints.py
@@ -55,6 +55,9 @@ class Checkpoint:
         root: Absolute repository root path.
         paths: Repo-relative paths included in the snapshot.
         tree_sha: Object name of the written tree.
+        base: Directory that relative caller paths are resolved against —
+            the ``workspace_root`` passed at capture, which for a CLI run is
+            the invocation directory, not the repository root.
     """
 
     ref: str
@@ -62,6 +65,7 @@ class Checkpoint:
     root: Path
     paths: tuple[str, ...] = field(default_factory=tuple)
     tree_sha: str = ""
+    base: Path | None = None
 
 
 class CheckpointError(Exception):
@@ -232,6 +236,7 @@ def _normalize_paths(
     paths: list[str] | tuple[str, ...],
     *,
     root: Path,
+    base: Path | None = None,
 ) -> list[str]:
     """Convert paths to unique repo-relative POSIX strings.
 
@@ -241,18 +246,23 @@ def _normalize_paths(
 
     Args:
         paths: Absolute or relative path strings (files or directories).
-        root: Repository root.
+        root: Repository root; results are relative to it.
+        base: Directory relative inputs are resolved against. Defaults to
+            ``root``, but a CLI run passes its invocation directory — running
+            ``lintro fmt src/app.py`` from a subdirectory must not snapshot
+            ``<repo>/src/app.py``.
 
     Returns:
         Sorted unique repo-relative POSIX paths.
     """
     root_resolved = root.resolve()
+    base_resolved = base.resolve() if base is not None else root_resolved
     rels: set[str] = set()
     for raw in paths:
         if not raw:
             continue
         candidate = Path(raw)
-        raw_abs = candidate if candidate.is_absolute() else root_resolved / candidate
+        raw_abs = candidate if candidate.is_absolute() else base_resolved / candidate
         raw_abs = Path(os.path.normpath(raw_abs))
         # Resolve the parent, never the leaf: resolving the whole path would
         # rewrite a symlinked target to whatever it points at, and the
@@ -308,7 +318,8 @@ def capture_checkpoint(
     root = _repo_root(workspace_root)
     if root is None:
         return None
-    rel_paths = _normalize_paths(paths, root=root)
+    base = workspace_root.resolve()
+    rel_paths = _normalize_paths(paths, root=root, base=base)
     if not rel_paths:
         return None
 
@@ -391,6 +402,7 @@ def capture_checkpoint(
         root=root,
         paths=tuple(rel_paths),
         tree_sha=tree_sha,
+        base=base,
     )
 
 
@@ -476,7 +488,7 @@ def restore_checkpoint(
     if paths is None:
         target_rels = list(checkpoint.paths)
     else:
-        requested = _normalize_paths(list(paths), root=root)
+        requested = _normalize_paths(list(paths), root=root, base=checkpoint.base)
         target_rels = [rel for rel in requested if rel in known]
         skipped = sorted(set(requested) - known)
         if skipped:
@@ -542,7 +554,11 @@ def diff_checkpoint(
     if paths is None:
         rels = list(checkpoint.paths)
     else:
-        rels = [rel for rel in _normalize_paths(list(paths), root=root) if rel in known]
+        rels = [
+            rel
+            for rel in _normalize_paths(list(paths), root=root, base=checkpoint.base)
+            if rel in known
+        ]
     if not rels:
         return ""
     treeish = checkpoint.tree_sha or checkpoint.ref

--- a/lintro/ai/checkpoints.py
+++ b/lintro/ai/checkpoints.py
@@ -32,6 +32,7 @@ _GIT_ADD_CHUNK = 500
 # Git tree entry modes that are not plain file content.
 _SYMLINK_MODE = "120000"
 _GITLINK_MODE = "160000"
+_TREE_MODE = "040000"
 # Ambient git state that must never leak into these plumbing calls.
 _INHERITED_GIT_VARS = (
     "GIT_DIR",
@@ -336,7 +337,12 @@ def capture_checkpoint(
 
         # A target tracked in HEAD but already gone from the working tree
         # must be recorded as absent, or a rollback would resurrect it.
-        missing = [p for p in rel_paths if not (root / p).exists()]
+        # Anything that exists but is not a regular file (a directory, a
+        # symlink to one, a FIFO) is dropped from the snapshot entirely: it
+        # cannot be captured as a blob, and leaving it in ``paths`` would let
+        # a restore delete a path lintro never touched.
+        missing = [p for p in rel_paths if not os.path.lexists(root / p)]
+        rel_paths = [p for p in rel_paths if p in set(missing) or (root / p).is_file()]
         for start in range(0, len(missing), _GIT_ADD_CHUNK):
             _run_git(
                 [
@@ -414,8 +420,10 @@ def _blob_for_path(
     if entry.returncode != 0 or not entry.stdout.strip():
         return None
     git_mode = entry.stdout.split(" ", 1)[0]
-    if git_mode == _GITLINK_MODE:
-        logger.debug("Skipping submodule entry in checkpoint: {}", rel_path)
+    if git_mode in (_GITLINK_MODE, _TREE_MODE):
+        # A submodule pointer has no blob, and ``cat-file -p`` on a tree
+        # prints a directory listing that must never be written as content.
+        logger.debug("Skipping non-blob entry in checkpoint: {}", rel_path)
         return None
     raw = _run_git(
         ["cat-file", "-p", f"{treeish}:{rel_path}"],
@@ -538,25 +546,29 @@ def diff_checkpoint(
         # ``--no-color`` defends against a user's ``color.ui = always``.
         # ``--no-textconv`` matters as much as ``--no-ext-diff``: a repo's
         # ``diff.*.textconv`` would otherwise run an external program here.
-        result = _run_git(
-            [
-                "diff",
-                "--no-ext-diff",
-                "--no-textconv",
-                "--no-color",
-                "--",
-                *rels,
-            ],
-            cwd=str(root),
-            env=env,
-            check=True,
-            binary=True,
-        )
+        # Chunked for the same argv-limit reason capture chunks ``git add``.
+        chunks: list[bytes] = []
+        for start in range(0, len(rels), _GIT_ADD_CHUNK):
+            result = _run_git(
+                [
+                    "diff",
+                    "--no-ext-diff",
+                    "--no-textconv",
+                    "--no-color",
+                    "--",
+                    *rels[start : start + _GIT_ADD_CHUNK],
+                ],
+                cwd=str(root),
+                env=env,
+                check=True,
+                binary=True,
+            )
+            chunks.append(result.stdout)
     finally:
         index_file.unlink(missing_ok=True)
     # Decoded leniently: a UTF-16 file with a ``diff`` attribute would make
     # strict locale decoding raise outside this module's error contract.
-    diff_text: str = result.stdout.decode("utf-8", errors="replace")
+    diff_text: str = b"".join(chunks).decode("utf-8", errors="replace")
     return diff_text
 
 

--- a/lintro/ai/checkpoints.py
+++ b/lintro/ai/checkpoints.py
@@ -18,14 +18,27 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from loguru import logger
+
+from lintro.ai.paths import atomic_write_bytes
 
 CHECKPOINT_REF_PREFIX = "refs/lintro/checkpoints/"
 DEFAULT_CHECKPOINT_RETENTION = 10
 _GIT_TIMEOUT_SECONDS = 60.0
 # Keep each ``git add`` argv comfortably under platform ARG_MAX limits.
 _GIT_ADD_CHUNK = 500
+# Ambient git state that must never leak into these plumbing calls.
+_INHERITED_GIT_VARS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_NAMESPACE",
+)
 
 
 @dataclass(frozen=True)
@@ -56,13 +69,43 @@ def _git_bin() -> str | None:
     return shutil.which("git")
 
 
+def _git_env(overlay: dict[str, str] | None) -> dict[str, str]:
+    """Build a hardened environment for a git plumbing call.
+
+    Ambient ``GIT_*`` variables are stripped first. When lintro runs inside a
+    git hook, git exports ``GIT_DIR``, ``GIT_INDEX_FILE`` and friends; a
+    plumbing call that inherited them would target the hook's repository and
+    index instead of the one at ``cwd``, breaking this module's promise never
+    to touch the user's index.
+
+    Args:
+        overlay: Variables to set after sanitising (e.g. the temp index).
+
+    Returns:
+        The environment to pass to :func:`subprocess.run`.
+    """
+    full_env = os.environ.copy()
+    for leaked in _INHERITED_GIT_VARS:
+        full_env.pop(leaked, None)
+    if overlay:
+        full_env.update(overlay)
+    # Avoid locale/pager interference and never open an editor.
+    full_env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    full_env.setdefault("GIT_OPTIONAL_LOCKS", "0")
+    # Target paths are literal filenames; ``*``, ``?``, ``[`` and a leading
+    # ``:`` in a filename must not be read as pathspec magic.
+    full_env.setdefault("GIT_LITERAL_PATHSPECS", "1")
+    return full_env
+
+
 def _run_git(
     args: list[str],
     *,
     cwd: str,
     env: dict[str, str] | None = None,
     check: bool = False,
-) -> subprocess.CompletedProcess[str]:
+    binary: bool = False,
+) -> subprocess.CompletedProcess[Any]:
     """Run a git command with optional temp-index environment.
 
     Args:
@@ -70,9 +113,12 @@ def _run_git(
         cwd: Working directory.
         env: Optional environment overlay (e.g. ``GIT_INDEX_FILE``).
         check: When True, raise :class:`CheckpointError` on non-zero exit.
+        binary: When True, return raw ``bytes`` streams instead of decoded
+            text. Required for blob contents, which are not always UTF-8.
 
     Returns:
-        Completed process with text stdout/stderr.
+        Completed process whose stdout/stderr are ``str`` (or ``bytes`` when
+        ``binary`` is set).
 
     Raises:
         CheckpointError: When git is missing, times out, or ``check`` fails.
@@ -80,21 +126,15 @@ def _run_git(
     git_bin = _git_bin()
     if git_bin is None:
         raise CheckpointError("git is not installed or not on PATH")
-    full_env = os.environ.copy()
-    if env:
-        full_env.update(env)
-    # Avoid locale/pager interference and never open an editor.
-    full_env.setdefault("GIT_TERMINAL_PROMPT", "0")
-    full_env.setdefault("GIT_OPTIONAL_LOCKS", "0")
     try:
         result = subprocess.run(  # nosec B603 - argv is [resolved git binary, *args]; shell=False; plumbing args only
             [git_bin, *args],
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=not binary,
             timeout=_GIT_TIMEOUT_SECONDS,
             check=False,
-            env=full_env,
+            env=_git_env(env),
         )
     except subprocess.TimeoutExpired as exc:
         raise CheckpointError(
@@ -103,7 +143,10 @@ def _run_git(
     except OSError as exc:
         raise CheckpointError(f"Failed to run git {' '.join(args)}: {exc}") from exc
     if check and result.returncode != 0:
-        stderr = result.stderr.strip() or result.stdout.strip() or "unknown git error"
+        streams = [result.stderr, result.stdout]
+        if binary:
+            streams = [s.decode("utf-8", errors="replace") for s in streams]
+        stderr = streams[0].strip() or streams[1].strip() or "unknown git error"
         raise CheckpointError(f"git {' '.join(args)} failed: {stderr}")
     return result
 
@@ -246,7 +289,10 @@ def capture_checkpoint(
         paths: Files (and/or directories) to include in the snapshot.
         workspace_root: Directory inside the repository.
         run_id: Optional run identifier; generated when omitted.
-        keep: Maximum checkpoint refs to retain after capture (default 10).
+        keep: Total checkpoint refs to retain, this run's included (default
+            10). Older refs are pruned *before* the new one is written, so
+            the checkpoint a run depends on is never the one pruned — even at
+            ``keep=0``, which keeps only the current run's ref.
 
     Returns:
         The created :class:`Checkpoint`, or None when git checkpoints are
@@ -264,6 +310,13 @@ def capture_checkpoint(
     rid = run_id or _new_run_id()
     ref = f"{CHECKPOINT_REF_PREFIX}{rid}"
     cwd = str(root)
+
+    # Prune first: pruning after the write could delete the ref this very run
+    # is about to hand back to the caller.
+    try:
+        prune_checkpoints(workspace_root=root, keep=max(keep - 1, 0))
+    except CheckpointError as exc:
+        logger.debug("Checkpoint prune skipped: {}", exc)
 
     fd, index_path = tempfile.mkstemp(prefix="lintro-git-index-")
     os.close(fd)
@@ -306,11 +359,6 @@ def capture_checkpoint(
     finally:
         index_file.unlink(missing_ok=True)
 
-    try:
-        prune_checkpoints(workspace_root=root, keep=keep)
-    except CheckpointError as exc:
-        logger.debug("Checkpoint prune skipped: {}", exc)
-
     return Checkpoint(
         ref=ref,
         run_id=rid,
@@ -325,44 +373,52 @@ def _blob_for_path(
     root: Path,
     treeish: str,
     rel_path: str,
-) -> bytes | None:
-    """Return blob bytes for ``rel_path`` at ``treeish``, or None if absent."""
-    exists = _run_git(
-        ["cat-file", "-e", f"{treeish}:{rel_path}"],
+) -> tuple[bytes, int] | None:
+    """Return blob bytes and file mode for ``rel_path`` at ``treeish``.
+
+    Args:
+        root: Repository root.
+        treeish: Tree object (or ref) to read from.
+        rel_path: Repo-relative path inside that tree.
+
+    Returns:
+        ``(contents, permission bits)``, or None when the path is absent from
+        the tree. Git records only ``100644``/``100755`` for regular files, so
+        the mode collapses to ``0o644`` or ``0o755``. A tree entry that git
+        then refuses to read raises :class:`CheckpointError` from
+        :func:`_run_git`.
+    """
+    entry = _run_git(
+        ["ls-tree", "-z", "--", treeish, rel_path],
         cwd=str(root),
     )
-    if exists.returncode != 0:
+    if entry.returncode != 0 or not entry.stdout.strip():
         return None
-    git_bin = _git_bin()
-    if git_bin is None:
-        raise CheckpointError("git is not installed or not on PATH")
-    # Binary-safe read (avoid text-mode decoding).
-    raw = subprocess.run(  # nosec B603 - argv is [git, cat-file, -p, tree:path]; shell=False
-        [git_bin, "cat-file", "-p", f"{treeish}:{rel_path}"],
+    git_mode = entry.stdout.split(" ", 1)[0]
+    mode = 0o755 if git_mode.endswith("755") else 0o644
+    raw = _run_git(
+        ["cat-file", "-p", f"{treeish}:{rel_path}"],
         cwd=str(root),
-        capture_output=True,
-        timeout=_GIT_TIMEOUT_SECONDS,
-        check=False,
+        check=True,
+        binary=True,
     )
-    if raw.returncode != 0:
-        raise CheckpointError(
-            f"cat-file -p failed for {rel_path}: "
-            f"{raw.stderr.decode('utf-8', errors='replace')}",
-        )
-    return raw.stdout
+    return raw.stdout, mode
 
 
 def restore_checkpoint(
     checkpoint: Checkpoint,
     paths: list[str] | tuple[str, ...] | None = None,
 ) -> None:
-    """Restore files from a checkpoint tree (atomic across the batch).
+    """Restore files from a checkpoint tree.
 
-    Reads all target blobs first, then writes them with atomic replace so a
-    mid-batch failure does not leave a half-restored set. Paths present on
-    disk but absent from the checkpoint tree are removed (they were created
-    after capture). Paths that remain at the checkpoint content are rewritten
-    from the tree — including when the user edited them between capture and
+    Every target blob is read before anything is written, so a tree that
+    cannot be read fails the whole rollback without having touched the working
+    tree. Each individual file is then replaced atomically and with its
+    recorded mode; the write phase itself is sequential, so a failure part way
+    through leaves the earlier files already restored. Paths present on disk
+    but absent from the checkpoint tree are removed (they were created after
+    capture). Paths that remain at the checkpoint content are rewritten from
+    the tree — including when the user edited them between capture and
     rollback (lintro targets always return to the pre-batch snapshot).
 
     Only paths recorded on the checkpoint are eligible. Anything else is
@@ -372,10 +428,8 @@ def restore_checkpoint(
     Args:
         checkpoint: Checkpoint produced by :func:`capture_checkpoint`.
         paths: Optional subset of paths to restore; defaults to all paths
-            recorded on the checkpoint.
-
-    Raises:
-        BaseException: Re-raised after cleanup when an atomic write fails.
+            recorded on the checkpoint. A failed write propagates to the
+            caller after the partial temporary file is cleaned up.
     """
     root = checkpoint.root
     treeish = checkpoint.tree_sha or checkpoint.ref
@@ -393,32 +447,21 @@ def restore_checkpoint(
                 skipped,
             )
 
-    planned: list[tuple[Path, bytes | None]] = []
+    planned: list[tuple[Path, tuple[bytes, int] | None]] = []
     for rel in target_rels:
-        abs_path = root / rel
-        blob = _blob_for_path(root=root, treeish=treeish, rel_path=rel)
-        planned.append((abs_path, blob))
+        planned.append(
+            (root / rel, _blob_for_path(root=root, treeish=treeish, rel_path=rel)),
+        )
 
-    # Phase 1 complete — apply all writes/deletes.
+    # Read phase complete — apply all writes/deletes.
     for abs_path, blob in planned:
         if blob is None:
             if abs_path.is_file():
                 abs_path.unlink()
             continue
+        contents, mode = blob
         abs_path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=str(abs_path.parent), suffix=".lintro-restore")
-        try:
-            try:
-                fobj = os.fdopen(fd, "wb")
-            except BaseException:
-                os.close(fd)
-                raise
-            with fobj:
-                fobj.write(blob)
-            Path(tmp).replace(abs_path)
-        except BaseException:
-            Path(tmp).unlink(missing_ok=True)
-            raise
+        atomic_write_bytes(abs_path, contents, fallback_mode=mode)
 
 
 def diff_checkpoint(
@@ -429,6 +472,11 @@ def diff_checkpoint(
 
     This is the accurate post-run "what lintro changed" report for files that
     were included in the checkpoint.
+
+    The diff runs against a throwaway index loaded from the checkpoint tree.
+    A plain ``git diff <tree>`` would consult the *real* index for the
+    working-tree side and so report every untracked target as a deletion,
+    which is precisely backwards for the files this feature exists to protect.
 
     Args:
         checkpoint: Checkpoint to diff against.
@@ -446,14 +494,47 @@ def diff_checkpoint(
     if not rels:
         return ""
     treeish = checkpoint.tree_sha or checkpoint.ref
-    # Compare checkpoint tree to the working tree for the given paths.
-    # ``--no-color`` defends against a user's ``color.ui = always``.
-    result = _run_git(
-        ["diff", "--no-ext-diff", "--no-color", treeish, "--", *rels],
-        cwd=str(root),
-        check=True,
-    )
-    return result.stdout
+
+    fd, index_path = tempfile.mkstemp(prefix="lintro-git-diff-index-")
+    os.close(fd)
+    index_file = Path(index_path)
+    env = {"GIT_INDEX_FILE": str(index_file)}
+    try:
+        _run_git(["read-tree", treeish], cwd=str(root), env=env, check=True)
+        # ``--no-color`` defends against a user's ``color.ui = always``.
+        result = _run_git(
+            ["diff", "--no-ext-diff", "--no-color", "--", *rels],
+            cwd=str(root),
+            env=env,
+            check=True,
+        )
+    finally:
+        index_file.unlink(missing_ok=True)
+    diff_text: str = result.stdout
+    return diff_text
+
+
+def checkpoint_ref_exists(checkpoint: Checkpoint) -> bool:
+    """Return whether a checkpoint's ref is still present.
+
+    A later capture in the same run can prune an earlier ref under a tight
+    retention setting, which would make a printed ``git diff <ref>`` hint fail
+    even though the tree object itself is still reachable.
+
+    Args:
+        checkpoint: Checkpoint to probe.
+
+    Returns:
+        True when the ref still resolves.
+    """
+    try:
+        result = _run_git(
+            ["show-ref", "--verify", "--quiet", checkpoint.ref],
+            cwd=str(checkpoint.root),
+        )
+    except CheckpointError:
+        return False
+    return result.returncode == 0
 
 
 def list_checkpoint_refs(*, workspace_root: Path) -> list[str]:
@@ -526,6 +607,7 @@ __all__ = [
     "Checkpoint",
     "CheckpointError",
     "capture_checkpoint",
+    "checkpoint_ref_exists",
     "diff_checkpoint",
     "git_checkpoints_available",
     "list_checkpoint_refs",

--- a/lintro/ai/checkpoints.py
+++ b/lintro/ai/checkpoints.py
@@ -416,8 +416,10 @@ def _blob_for_path(
     entry = _run_git(
         ["ls-tree", "-z", "--", treeish, rel_path],
         cwd=str(root),
+        check=True,
     )
-    if entry.returncode != 0 or not entry.stdout.strip():
+    if not entry.stdout.strip():
+        # Genuinely absent from the tree: the path was created after capture.
         return None
     git_mode = entry.stdout.split(" ", 1)[0]
     if git_mode in (_GITLINK_MODE, _TREE_MODE):
@@ -442,9 +444,10 @@ def restore_checkpoint(
 
     Every target blob is read before anything is written, so a tree that
     cannot be read fails the whole rollback without having touched the working
-    tree. Each individual file is then replaced atomically and with its
-    recorded mode; the write phase itself is sequential, so a failure part way
-    through leaves the earlier files already restored. Paths present on disk
+    tree. Each individual file is then replaced atomically and with the mode
+    the checkpoint recorded, so a mode the run changed is rolled back too. The
+    write phase itself is sequential, so a failure part way through leaves the
+    earlier files already restored. Paths present on disk
     but absent from the checkpoint tree are removed (they were created after
     capture). Paths that remain at the checkpoint content are rewritten from
     the tree — including when the user edited them between capture and
@@ -462,6 +465,13 @@ def restore_checkpoint(
     """
     root = checkpoint.root
     treeish = checkpoint.tree_sha or checkpoint.ref
+    # Fail before the read phase if the tree object itself is gone: every
+    # subsequent lookup would report "absent", and absent means delete.
+    _run_git(
+        ["rev-parse", "--verify", "--quiet", f"{treeish}^{{tree}}"],
+        cwd=str(root),
+        check=True,
+    )
     known = set(checkpoint.paths)
     if paths is None:
         target_rels = list(checkpoint.paths)
@@ -502,7 +512,7 @@ def restore_checkpoint(
         atomic_write_bytes(
             abs_path,
             contents,
-            fallback_mode=0o755 if git_mode.endswith("755") else 0o644,
+            mode=0o755 if git_mode.endswith("755") else 0o644,
         )
 
 

--- a/lintro/ai/checkpoints.py
+++ b/lintro/ai/checkpoints.py
@@ -29,6 +29,9 @@ DEFAULT_CHECKPOINT_RETENTION = 10
 _GIT_TIMEOUT_SECONDS = 60.0
 # Keep each ``git add`` argv comfortably under platform ARG_MAX limits.
 _GIT_ADD_CHUNK = 500
+# Git tree entry modes that are not plain file content.
+_SYMLINK_MODE = "120000"
+_GITLINK_MODE = "160000"
 # Ambient git state that must never leak into these plumbing calls.
 _INHERITED_GIT_VARS = (
     "GIT_DIR",
@@ -94,7 +97,7 @@ def _git_env(overlay: dict[str, str] | None) -> dict[str, str]:
     full_env.setdefault("GIT_OPTIONAL_LOCKS", "0")
     # Target paths are literal filenames; ``*``, ``?``, ``[`` and a leading
     # ``:`` in a filename must not be read as pathspec magic.
-    full_env.setdefault("GIT_LITERAL_PATHSPECS", "1")
+    full_env["GIT_LITERAL_PATHSPECS"] = "1"
     return full_env
 
 
@@ -248,17 +251,18 @@ def _normalize_paths(
         if not raw:
             continue
         candidate = Path(raw)
-        abs_path = (
-            candidate.resolve()
-            if candidate.is_absolute()
-            else (root_resolved / candidate).resolve()
-        )
+        raw_abs = candidate if candidate.is_absolute() else root_resolved / candidate
+        raw_abs = Path(os.path.normpath(raw_abs))
+        # Resolve the parent, never the leaf: resolving the whole path would
+        # rewrite a symlinked target to whatever it points at, and the
+        # checkpoint would then snapshot (and restore) the wrong file.
+        abs_path = raw_abs.parent.resolve() / raw_abs.name
         try:
             rel = abs_path.relative_to(root_resolved)
         except ValueError:
             logger.debug("Skipping path outside repo for checkpoint: {}", raw)
             continue
-        if abs_path.is_dir():
+        if abs_path.is_dir() and not abs_path.is_symlink():
             rels.update(_expand_directory(root=root_resolved, rel_dir=rel.as_posix()))
         else:
             # Include missing paths so restore can delete files created later;
@@ -330,6 +334,22 @@ def capture_checkpoint(
         else:
             _run_git(["read-tree", "--empty"], cwd=cwd, env=env, check=True)
 
+        # A target tracked in HEAD but already gone from the working tree
+        # must be recorded as absent, or a rollback would resurrect it.
+        missing = [p for p in rel_paths if not (root / p).exists()]
+        for start in range(0, len(missing), _GIT_ADD_CHUNK):
+            _run_git(
+                [
+                    "update-index",
+                    "--force-remove",
+                    "--",
+                    *missing[start : start + _GIT_ADD_CHUNK],
+                ],
+                cwd=cwd,
+                env=env,
+                check=True,
+            )
+
         existing = [p for p in rel_paths if (root / p).is_file()]
         # ``git add --`` updates only the temp index (via GIT_INDEX_FILE).
         # Chunked so a large target set cannot overflow the platform argv limit.
@@ -373,8 +393,8 @@ def _blob_for_path(
     root: Path,
     treeish: str,
     rel_path: str,
-) -> tuple[bytes, int] | None:
-    """Return blob bytes and file mode for ``rel_path`` at ``treeish``.
+) -> tuple[bytes, str] | None:
+    """Return blob bytes and the git mode for ``rel_path`` at ``treeish``.
 
     Args:
         root: Repository root.
@@ -382,11 +402,10 @@ def _blob_for_path(
         rel_path: Repo-relative path inside that tree.
 
     Returns:
-        ``(contents, permission bits)``, or None when the path is absent from
-        the tree. Git records only ``100644``/``100755`` for regular files, so
-        the mode collapses to ``0o644`` or ``0o755``. A tree entry that git
-        then refuses to read raises :class:`CheckpointError` from
-        :func:`_run_git`.
+        ``(contents, git mode)``, or None when the path is absent from the
+        tree or is a submodule pointer, which cannot be restored from a blob.
+        A tree entry that git then refuses to read raises
+        :class:`CheckpointError` from :func:`_run_git`.
     """
     entry = _run_git(
         ["ls-tree", "-z", "--", treeish, rel_path],
@@ -395,14 +414,16 @@ def _blob_for_path(
     if entry.returncode != 0 or not entry.stdout.strip():
         return None
     git_mode = entry.stdout.split(" ", 1)[0]
-    mode = 0o755 if git_mode.endswith("755") else 0o644
+    if git_mode == _GITLINK_MODE:
+        logger.debug("Skipping submodule entry in checkpoint: {}", rel_path)
+        return None
     raw = _run_git(
         ["cat-file", "-p", f"{treeish}:{rel_path}"],
         cwd=str(root),
         check=True,
         binary=True,
     )
-    return raw.stdout, mode
+    return raw.stdout, git_mode
 
 
 def restore_checkpoint(
@@ -447,7 +468,7 @@ def restore_checkpoint(
                 skipped,
             )
 
-    planned: list[tuple[Path, tuple[bytes, int] | None]] = []
+    planned: list[tuple[Path, tuple[bytes, str] | None]] = []
     for rel in target_rels:
         planned.append(
             (root / rel, _blob_for_path(root=root, treeish=treeish, rel_path=rel)),
@@ -456,12 +477,25 @@ def restore_checkpoint(
     # Read phase complete — apply all writes/deletes.
     for abs_path, blob in planned:
         if blob is None:
-            if abs_path.is_file():
-                abs_path.unlink()
+            # ``missing_ok`` because a concurrent delete between the read and
+            # write phases must not abandon the rest of the rollback.
+            abs_path.unlink(missing_ok=True)
             continue
-        contents, mode = blob
+        contents, git_mode = blob
         abs_path.parent.mkdir(parents=True, exist_ok=True)
-        atomic_write_bytes(abs_path, contents, fallback_mode=mode)
+        if git_mode == _SYMLINK_MODE:
+            # The blob of a symlink entry is its target path, not file content.
+            abs_path.unlink(missing_ok=True)
+            abs_path.symlink_to(contents.decode("utf-8", errors="replace"))
+            continue
+        if abs_path.is_symlink():
+            # Never write through a link: that would rewrite its target.
+            abs_path.unlink()
+        atomic_write_bytes(
+            abs_path,
+            contents,
+            fallback_mode=0o755 if git_mode.endswith("755") else 0o644,
+        )
 
 
 def diff_checkpoint(
@@ -502,15 +536,27 @@ def diff_checkpoint(
     try:
         _run_git(["read-tree", treeish], cwd=str(root), env=env, check=True)
         # ``--no-color`` defends against a user's ``color.ui = always``.
+        # ``--no-textconv`` matters as much as ``--no-ext-diff``: a repo's
+        # ``diff.*.textconv`` would otherwise run an external program here.
         result = _run_git(
-            ["diff", "--no-ext-diff", "--no-color", "--", *rels],
+            [
+                "diff",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--no-color",
+                "--",
+                *rels,
+            ],
             cwd=str(root),
             env=env,
             check=True,
+            binary=True,
         )
     finally:
         index_file.unlink(missing_ok=True)
-    diff_text: str = result.stdout
+    # Decoded leniently: a UTF-16 file with a ``diff`` attribute would make
+    # strict locale decoding raise outside this module's error contract.
+    diff_text: str = result.stdout.decode("utf-8", errors="replace")
     return diff_text
 
 

--- a/lintro/ai/checkpoints.py
+++ b/lintro/ai/checkpoints.py
@@ -24,6 +24,8 @@ from loguru import logger
 CHECKPOINT_REF_PREFIX = "refs/lintro/checkpoints/"
 DEFAULT_CHECKPOINT_RETENTION = 10
 _GIT_TIMEOUT_SECONDS = 60.0
+# Keep each ``git add`` argv comfortably under platform ARG_MAX limits.
+_GIT_ADD_CHUNK = 500
 
 
 @dataclass(frozen=True)
@@ -153,6 +155,32 @@ def _repo_root(workspace_root: Path) -> Path | None:
     return Path(top) if top else None
 
 
+def _expand_directory(*, root: Path, rel_dir: str) -> list[str]:
+    """List candidate files under ``rel_dir`` using git's own path filters.
+
+    ``git ls-files -co --exclude-standard`` returns tracked plus untracked
+    files while honouring ``.gitignore``. Walking the directory manually
+    instead would drag ``.git/``, ``.venv/`` and every other ignored tree into
+    the snapshot.
+
+    Args:
+        root: Repository root.
+        rel_dir: Repo-relative directory (``""`` for the root itself).
+
+    Returns:
+        Repo-relative POSIX file paths, or an empty list when git fails.
+    """
+    args = ["ls-files", "-co", "--exclude-standard", "-z", "--"]
+    args.append(rel_dir or ".")
+    try:
+        result = _run_git(args, cwd=str(root))
+    except CheckpointError:
+        return []
+    if result.returncode != 0:
+        return []
+    return [entry for entry in result.stdout.split("\0") if entry]
+
+
 def _normalize_paths(
     paths: list[str] | tuple[str, ...],
     *,
@@ -160,13 +188,16 @@ def _normalize_paths(
 ) -> list[str]:
     """Convert paths to unique repo-relative POSIX strings.
 
+    Directories are expanded through :func:`_expand_directory` so ignored
+    trees never enter a snapshot. Files that do not exist are kept so that a
+    restore can delete paths lintro created after capture.
+
     Args:
         paths: Absolute or relative path strings (files or directories).
         root: Repository root.
 
     Returns:
-        Sorted unique relative paths that exist on disk (files only expanded
-        from directories via a shallow walk of existing files).
+        Sorted unique repo-relative POSIX paths.
     """
     root_resolved = root.resolve()
     rels: set[str] = set()
@@ -185,14 +216,7 @@ def _normalize_paths(
             logger.debug("Skipping path outside repo for checkpoint: {}", raw)
             continue
         if abs_path.is_dir():
-            for file_path in abs_path.rglob("*"):
-                if file_path.is_file():
-                    try:
-                        rels.add(
-                            file_path.resolve().relative_to(root_resolved).as_posix(),
-                        )
-                    except ValueError:
-                        continue
+            rels.update(_expand_directory(root=root_resolved, rel_dir=rel.as_posix()))
         else:
             # Include missing paths so restore can delete files created later;
             # capture only adds existing files to the temp index.
@@ -254,10 +278,11 @@ def capture_checkpoint(
             _run_git(["read-tree", "--empty"], cwd=cwd, env=env, check=True)
 
         existing = [p for p in rel_paths if (root / p).is_file()]
-        if existing:
-            # ``git add --`` updates only the temp index (via GIT_INDEX_FILE).
+        # ``git add --`` updates only the temp index (via GIT_INDEX_FILE).
+        # Chunked so a large target set cannot overflow the platform argv limit.
+        for start in range(0, len(existing), _GIT_ADD_CHUNK):
             _run_git(
-                ["add", "-f", "--", *existing],
+                ["add", "-f", "--", *existing[start : start + _GIT_ADD_CHUNK]],
                 cwd=cwd,
                 env=env,
                 check=True,
@@ -340,6 +365,10 @@ def restore_checkpoint(
     from the tree — including when the user edited them between capture and
     rollback (lintro targets always return to the pre-batch snapshot).
 
+    Only paths recorded on the checkpoint are eligible. Anything else is
+    ignored rather than deleted, so a caller passing an unrelated (or
+    unresolvable) path can never destroy a file that was never snapshotted.
+
     Args:
         checkpoint: Checkpoint produced by :func:`capture_checkpoint`.
         paths: Optional subset of paths to restore; defaults to all paths
@@ -350,14 +379,19 @@ def restore_checkpoint(
     """
     root = checkpoint.root
     treeish = checkpoint.tree_sha or checkpoint.ref
+    known = set(checkpoint.paths)
     if paths is None:
         target_rels = list(checkpoint.paths)
     else:
-        target_rels = _normalize_paths(list(paths), root=root)
-        # Also accept already-relative paths that were in the checkpoint list.
-        for raw in paths:
-            if raw and raw not in target_rels:
-                target_rels.append(Path(raw).as_posix())
+        requested = _normalize_paths(list(paths), root=root)
+        target_rels = [rel for rel in requested if rel in known]
+        skipped = sorted(set(requested) - known)
+        if skipped:
+            logger.debug(
+                "Skipping restore for paths absent from checkpoint {}: {}",
+                checkpoint.ref,
+                skipped,
+            )
 
     planned: list[tuple[Path, bytes | None]] = []
     for rel in target_rels:
@@ -404,17 +438,18 @@ def diff_checkpoint(
         Unified diff text (may be empty when nothing changed).
     """
     root = checkpoint.root
-    rels = (
-        list(checkpoint.paths)
-        if paths is None
-        else _normalize_paths(list(paths), root=root)
-    )
+    known = set(checkpoint.paths)
+    if paths is None:
+        rels = list(checkpoint.paths)
+    else:
+        rels = [rel for rel in _normalize_paths(list(paths), root=root) if rel in known]
     if not rels:
         return ""
     treeish = checkpoint.tree_sha or checkpoint.ref
     # Compare checkpoint tree to the working tree for the given paths.
+    # ``--no-color`` defends against a user's ``color.ui = always``.
     result = _run_git(
-        ["diff", "--no-ext-diff", treeish, "--", *rels],
+        ["diff", "--no-ext-diff", "--no-color", treeish, "--", *rels],
         cwd=str(root),
         check=True,
     )
@@ -475,8 +510,13 @@ def prune_checkpoints(
         return 0
     deleted = 0
     for ref in to_delete:
-        _run_git(["update-ref", "-d", ref], cwd=str(root), check=True)
-        deleted += 1
+        # Tolerate a ref another lintro process already removed; pruning is
+        # best-effort housekeeping and must never fail a fix run.
+        result = _run_git(["update-ref", "-d", ref], cwd=str(root))
+        if result.returncode == 0:
+            deleted += 1
+        else:
+            logger.debug("Could not prune checkpoint ref {}", ref)
     return deleted
 
 

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -245,6 +245,24 @@ class AIConfig(BaseModel):
         ),
     )
 
+    checkpoint_retention: int = Field(
+        default=10,
+        ge=0,
+        description=(
+            "Maximum number of git checkpoint refs to retain under "
+            "refs/lintro/checkpoints/ (oldest pruned). Default 10. "
+            "Used when capturing snapshots before AI fix batches."
+        ),
+    )
+    checkpoint_fmt: bool = Field(
+        default=False,
+        description=(
+            "When True, capture a git checkpoint (or file-snapshot fallback) "
+            "before `lintro fmt` mutates files, enabling the same rollback "
+            "semantics as AI fix batches."
+        ),
+    )
+
     review_allow_unredacted_git_native: bool = Field(
         default=False,
         description=(

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -249,17 +249,18 @@ class AIConfig(BaseModel):
         default=10,
         ge=0,
         description=(
-            "Maximum number of git checkpoint refs to retain under "
-            "refs/lintro/checkpoints/ (oldest pruned). Default 10. "
-            "Used when capturing snapshots before AI fix batches."
+            "Total git checkpoint refs to retain under "
+            "refs/lintro/checkpoints/, this run's included; older refs are "
+            "pruned first. Default 10; 0 keeps only the current run's ref."
         ),
     )
     checkpoint_fmt: bool = Field(
         default=False,
         description=(
-            "When True, capture a git checkpoint (or file-snapshot fallback) "
-            "before `lintro fmt` mutates files, enabling the same rollback "
-            "semantics as AI fix batches."
+            "When True, capture a git checkpoint before `lintro fmt` mutates "
+            "files, so `git diff <ref>` and `git checkout <ref> -- <path>` "
+            "can review or undo the run. Git-only: nothing is captured "
+            "outside a git work tree."
         ),
     )
 

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -258,9 +258,10 @@ class AIConfig(BaseModel):
         default=False,
         description=(
             "When True, capture a git checkpoint before `lintro fmt` mutates "
-            "files, so `git diff <ref>` and `git checkout <ref> -- <path>` "
-            "can review or undo the run. Git-only: nothing is captured "
-            "outside a git work tree."
+            "files, so `git diff <ref>` and "
+            "`git restore --source=<ref> --worktree -- <path>` can review or "
+            "undo the run. Git-only: nothing is captured outside a git work "
+            "tree."
         ),
     )
 

--- a/lintro/ai/interactive.py
+++ b/lintro/ai/interactive.py
@@ -18,7 +18,7 @@ from rich.markup import escape
 from rich.panel import Panel
 from rich.syntax import Syntax
 
-from lintro.ai.apply import apply_fixes
+from lintro.ai.apply import apply_fixes, rollback_applied_paths
 from lintro.ai.display.shared import cost_str, print_code_panel, print_section_header
 from lintro.ai.display.validation import render_validation
 from lintro.ai.enums import RiskLevel
@@ -30,6 +30,7 @@ from lintro.ai.risk import (
     classify_fix_risk,
     is_safe_style_fix,
 )
+from lintro.ai.undo import UndoState
 from lintro.ai.validation import validate_applied_fixes
 
 __all__ = ["apply_fixes", "review_fixes_interactive"]
@@ -236,6 +237,7 @@ def review_fixes_interactive(
     validate_after_group: bool = False,
     workspace_root: Path,
     search_radius: int = 5,
+    undo_state: UndoState | None = None,
 ) -> tuple[int, int, list[AIFixSuggestion]]:
     """Present fix suggestions grouped by error code for review.
 
@@ -243,12 +245,19 @@ def review_fixes_interactive(
     ``[y]accept group / [a]accept group + remaining / [r]eject /
     [d]iffs / [s]kip / [v]toggle per-group validation / [q]uit``
 
+    When ``undo_state`` is provided, rejecting a group restores that group's
+    target files from the pre-batch git checkpoint (or file-snapshot
+    fallback) rather than from in-memory suggestion copies. Restore is
+    idempotent when the files were never mutated.
+
     Args:
         suggestions: Fix suggestions to review.
         validate_after_group: Whether to validate immediately after
             each accepted group.
         workspace_root: Root directory limiting writable paths.
         search_radius: Max lines above/below the target line to search.
+        undo_state: Optional pre-batch checkpoint / snapshot for reject
+            rollback.
 
     Returns:
         Tuple of (accepted_count, rejected_count, applied_suggestions).
@@ -382,6 +391,17 @@ def review_fixes_interactive(
                 accept_all = True
                 console.print("  [dim]Will accept all remaining groups.[/dim]")
         elif choice == ReviewKey.REJECT:
+            if undo_state is not None:
+                # Per-file rejection restores from the checkpoint tree (or
+                # file-snapshot fallback), not from in-memory originals.
+                rollback_applied_paths(undo_state, fixes)
+                # Drop any earlier accepts that touched the same paths.
+                rejected_files = {f.file for f in fixes if f.file}
+                before = len(all_applied)
+                all_applied[:] = [
+                    s for s in all_applied if s.file not in rejected_files
+                ]
+                accepted = max(0, accepted - (before - len(all_applied)))
             rejected += len(fixes)
             console.print(
                 f"  [yellow]✗ Rejected {len(fixes)} "

--- a/lintro/ai/interactive.py
+++ b/lintro/ai/interactive.py
@@ -248,7 +248,8 @@ def review_fixes_interactive(
     When ``undo_state`` is provided, rejecting a group restores that group's
     target files from the pre-batch git checkpoint (or file-snapshot
     fallback) rather than from in-memory suggestion copies. Restore is
-    idempotent when the files were never mutated.
+    idempotent when the files were never mutated, and files already changed
+    by an earlier accepted group are skipped so accepted work survives.
 
     Args:
         suggestions: Fix suggestions to review.
@@ -392,16 +393,15 @@ def review_fixes_interactive(
                 console.print("  [dim]Will accept all remaining groups.[/dim]")
         elif choice == ReviewKey.REJECT:
             if undo_state is not None:
-                # Per-file rejection restores from the checkpoint tree (or
-                # file-snapshot fallback), not from in-memory originals.
-                rollback_applied_paths(undo_state, fixes)
-                # Drop any earlier accepts that touched the same paths.
-                rejected_files = {f.file for f in fixes if f.file}
-                before = len(all_applied)
-                all_applied[:] = [
-                    s for s in all_applied if s.file not in rejected_files
-                ]
-                accepted = max(0, accepted - (before - len(all_applied)))
+                # Rejection restores from the checkpoint tree (or file-snapshot
+                # fallback), not from in-memory originals. Files an earlier
+                # accepted group already changed are left alone: restoring them
+                # would silently discard fixes the user just accepted.
+                accepted_files = {s.file for s in all_applied if s.file}
+                rollback_applied_paths(
+                    undo_state,
+                    [fix for fix in fixes if fix.file not in accepted_files],
+                )
             rejected += len(fixes)
             console.print(
                 f"  [yellow]✗ Rejected {len(fixes)} "

--- a/lintro/ai/interactive.py
+++ b/lintro/ai/interactive.py
@@ -398,10 +398,15 @@ def review_fixes_interactive(
                 # accepted group already changed are left alone: restoring them
                 # would silently discard fixes the user just accepted.
                 accepted_files = {s.file for s in all_applied if s.file}
-                rollback_applied_paths(
+                restored = rollback_applied_paths(
                     undo_state,
                     [fix for fix in fixes if fix.file not in accepted_files],
                 )
+                if not restored:
+                    console.print(
+                        "  [red]⚠ Could not restore this group from the "
+                        "checkpoint; review it by hand.[/red]",
+                    )
             rejected += len(fixes)
             console.print(
                 f"  [yellow]✗ Rejected {len(fixes)} "

--- a/lintro/ai/paths.py
+++ b/lintro/ai/paths.py
@@ -96,6 +96,7 @@ def atomic_write_bytes(
     path: Path,
     data: bytes,
     *,
+    mode: int | None = None,
     fallback_mode: int = 0o644,
 ) -> None:
     """Replace ``path`` with ``data`` atomically, preserving its mode.
@@ -107,16 +108,22 @@ def atomic_write_bytes(
     Args:
         path: Destination file. Its parent must already exist.
         data: Bytes to write.
-        fallback_mode: Permission bits to apply when ``path`` does not exist
-            yet and the caller has no better information.
+        mode: Permission bits to force. Callers restoring a snapshot pass the
+            bits the file had *then*, so a mode the run itself changed is
+            rolled back too. ``None`` keeps whatever ``path`` currently has.
+        fallback_mode: Permission bits to apply when ``mode`` is ``None`` and
+            ``path`` does not exist yet.
 
     Raises:
         BaseException: Re-raised after the partial temporary file is removed,
             so a failed write never leaves debris beside the target.
     """
-    mode = fallback_mode
-    if path.is_file():
-        mode = path.stat().st_mode & 0o7777
+    if mode is None:
+        mode = (
+            path.stat().st_mode & 0o7777
+            if path.is_file() and not path.is_symlink()
+            else fallback_mode
+        )
     fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".lintro-tmp")
     try:
         try:

--- a/lintro/ai/paths.py
+++ b/lintro/ai/paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from pathlib import Path
 
 OUTSIDE_WORKSPACE_SENTINEL = "<outside-workspace>"
@@ -89,3 +90,44 @@ def to_provider_path(file_path: str, workspace_root: Path) -> str:
     if resolved is None:
         return OUTSIDE_WORKSPACE_SENTINEL
     return resolved.relative_to(workspace_root.resolve()).as_posix()
+
+
+def atomic_write_bytes(
+    path: Path,
+    data: bytes,
+    *,
+    fallback_mode: int = 0o644,
+) -> None:
+    """Replace ``path`` with ``data`` atomically, preserving its mode.
+
+    ``tempfile.mkstemp`` creates files as ``0600`` and :meth:`Path.replace`
+    keeps that mode, so a naive write-then-rename silently strips the
+    executable bit and group/other read access from every file it restores.
+
+    Args:
+        path: Destination file. Its parent must already exist.
+        data: Bytes to write.
+        fallback_mode: Permission bits to apply when ``path`` does not exist
+            yet and the caller has no better information.
+
+    Raises:
+        BaseException: Re-raised after the partial temporary file is removed,
+            so a failed write never leaves debris beside the target.
+    """
+    mode = fallback_mode
+    if path.is_file():
+        mode = path.stat().st_mode & 0o7777
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".lintro-tmp")
+    try:
+        try:
+            handle = os.fdopen(fd, "wb")
+        except BaseException:
+            os.close(fd)
+            raise
+        with handle:
+            handle.write(data)
+        os.chmod(tmp, mode)  # noqa: S103 - mirrors the replaced file's own mode
+        Path(tmp).replace(path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise

--- a/lintro/ai/pipeline.py
+++ b/lintro/ai/pipeline.py
@@ -27,7 +27,7 @@ from lintro.ai.refinement import refine_unverified_fixes
 from lintro.ai.risk import is_safe_style_fix
 from lintro.ai.summary import generate_post_fix_summary
 from lintro.ai.telemetry import AITelemetry
-from lintro.ai.undo import prepare_fix_batch
+from lintro.ai.undo import UndoState, diff_undo, prepare_fix_batch
 from lintro.ai.validation import ValidationResult, validate_applied_fixes, verify_fixes
 from lintro.enums.output_format import OutputFormat
 
@@ -189,6 +189,41 @@ def _filter_by_confidence(
     return filtered
 
 
+def _report_checkpoints(
+    undo_states: list[UndoState | None],
+    logger: ThreadSafeConsoleLogger,
+    is_json: bool,
+) -> None:
+    """Print how to inspect or undo what this run changed.
+
+    Only git-backed checkpoints are reported: they outlive the process, so
+    ``git diff <ref>`` and ``git checkout <ref> -- <path>`` remain usable after
+    lintro exits. A checkpoint whose diff is empty changed nothing and is
+    silently skipped.
+
+    Args:
+        undo_states: Rollback handles captured during this run, in order.
+        logger: Console logger.
+        is_json: Whether stdout is reserved for a machine-readable document.
+    """
+    if is_json:
+        return
+    for state in undo_states:
+        if state is None or state.kind != "git" or state.checkpoint is None:
+            continue
+        try:
+            changed = diff_undo(state)
+        except Exception as exc:  # noqa: BLE001 - reporting must never fail a run
+            loguru_logger.debug(f"Checkpoint diff unavailable: {exc}")
+            continue
+        if not changed.strip():
+            continue
+        logger.console_output(
+            f"  AI: checkpoint {state.checkpoint.ref} "
+            "(git diff <ref> to review, git checkout <ref> -- <path> to undo)",
+        )
+
+
 def _apply_or_review(
     all_suggestions: list[AIFixSuggestion],
     ai_config: AIConfig,
@@ -208,6 +243,7 @@ def _apply_or_review(
     safe_failed = 0
     safe_fast_path_applied = False
     retention = ai_config.checkpoint_retention
+    undo_states: list[UndoState | None] = []
 
     # Fast path: auto-apply deterministic style-only fixes when non-interactive.
     if (
@@ -221,6 +257,7 @@ def _apply_or_review(
             workspace_root,
             retention=retention,
         )
+        undo_states.append(undo_state)
         applied_safe = apply_fixes(
             safe_suggestions,
             workspace_root=workspace_root,
@@ -249,6 +286,7 @@ def _apply_or_review(
             workspace_root,
             retention=retention,
         )
+        undo_states.append(undo_state)
         auto_applied = apply_fixes(
             auto_apply_candidates,
             workspace_root=workspace_root,
@@ -272,6 +310,7 @@ def _apply_or_review(
             workspace_root,
             retention=retention,
         )
+        undo_states.append(undo_state)
         accepted_count, rejected_count, interactive_applied = review_fixes_interactive(
             review_candidates,
             validate_after_group=ai_config.validate_after_group,
@@ -283,6 +322,7 @@ def _apply_or_review(
         rejected += rejected_count + safe_failed
         applied_suggestions.extend(interactive_applied)
 
+    _report_checkpoints(undo_states, logger, is_json)
     return applied, rejected, applied_suggestions
 
 

--- a/lintro/ai/pipeline.py
+++ b/lintro/ai/pipeline.py
@@ -198,9 +198,9 @@ def _report_checkpoints(
     """Print how to inspect or undo what this run changed.
 
     Only git-backed checkpoints are reported: they outlive the process, so
-    ``git diff <ref>`` and ``git checkout <ref> -- <path>`` remain usable after
-    lintro exits. A checkpoint whose diff is empty changed nothing and is
-    silently skipped.
+    ``git diff <ref>`` and ``git restore --source=<ref> --worktree -- <path>``
+    remain usable after lintro exits. A checkpoint whose diff is empty changed
+    nothing and is silently skipped.
 
     Args:
         undo_states: Rollback handles captured during this run, in order.
@@ -223,7 +223,8 @@ def _report_checkpoints(
             continue
         logger.console_output(
             f"  AI: checkpoint {state.checkpoint.ref} "
-            "(git diff <ref> to review, git checkout <ref> -- <path> to undo)",
+            "(git diff <ref> to review, "
+            "git restore --source=<ref> --worktree -- <path> to undo)",
         )
 
 
@@ -266,7 +267,6 @@ def _apply_or_review(
             workspace_root=workspace_root,
             auto_apply=True,
             search_radius=ai_config.fix_search_radius,
-            undo_state=undo_state,
         )
         applied_suggestions.extend(applied_safe)
         applied += len(applied_safe)
@@ -295,7 +295,6 @@ def _apply_or_review(
             workspace_root=workspace_root,
             auto_apply=True,
             search_radius=ai_config.fix_search_radius,
-            undo_state=undo_state,
         )
         applied_suggestions.extend(auto_applied)
         applied += len(auto_applied)
@@ -319,7 +318,6 @@ def _apply_or_review(
             validate_after_group=ai_config.validate_after_group,
             workspace_root=workspace_root,
             search_radius=ai_config.fix_search_radius,
-            undo_state=undo_state,
         )
         applied += accepted_count
         rejected += rejected_count + safe_failed

--- a/lintro/ai/pipeline.py
+++ b/lintro/ai/pipeline.py
@@ -12,6 +12,7 @@ from loguru import logger as loguru_logger
 from lintro.ai.apply import apply_fixes
 from lintro.ai.audit import write_audit_log
 from lintro.ai.budget import CostBudget
+from lintro.ai.checkpoints import checkpoint_ref_exists
 from lintro.ai.display import render_fixes, render_summary, render_validation
 from lintro.ai.enums import ConfidenceLevel
 from lintro.ai.fix import generate_fixes_from_params
@@ -210,6 +211,8 @@ def _report_checkpoints(
         return
     for state in undo_states:
         if state is None or state.kind != "git" or state.checkpoint is None:
+            continue
+        if not checkpoint_ref_exists(state.checkpoint):
             continue
         try:
             changed = diff_undo(state)

--- a/lintro/ai/pipeline.py
+++ b/lintro/ai/pipeline.py
@@ -318,6 +318,7 @@ def _apply_or_review(
             validate_after_group=ai_config.validate_after_group,
             workspace_root=workspace_root,
             search_radius=ai_config.fix_search_radius,
+            undo_state=undo_state,
         )
         applied += accepted_count
         rejected += rejected_count + safe_failed

--- a/lintro/ai/pipeline.py
+++ b/lintro/ai/pipeline.py
@@ -27,7 +27,7 @@ from lintro.ai.refinement import refine_unverified_fixes
 from lintro.ai.risk import is_safe_style_fix
 from lintro.ai.summary import generate_post_fix_summary
 from lintro.ai.telemetry import AITelemetry
-from lintro.ai.undo import save_undo_patch
+from lintro.ai.undo import prepare_fix_batch
 from lintro.ai.validation import ValidationResult, validate_applied_fixes, verify_fixes
 from lintro.enums.output_format import OutputFormat
 
@@ -207,6 +207,7 @@ def _apply_or_review(
     risky_suggestions = [s for s in all_suggestions if not is_safe_style_fix(s)]
     safe_failed = 0
     safe_fast_path_applied = False
+    retention = ai_config.checkpoint_retention
 
     # Fast path: auto-apply deterministic style-only fixes when non-interactive.
     if (
@@ -215,12 +216,17 @@ def _apply_or_review(
         and (is_json or not sys.stdin.isatty())
     ):
         safe_fast_path_applied = True
-        save_undo_patch(safe_suggestions, workspace_root)
+        undo_state = prepare_fix_batch(
+            safe_suggestions,
+            workspace_root,
+            retention=retention,
+        )
         applied_safe = apply_fixes(
             safe_suggestions,
             workspace_root=workspace_root,
             auto_apply=True,
             search_radius=ai_config.fix_search_radius,
+            undo_state=undo_state,
         )
         applied_suggestions.extend(applied_safe)
         applied += len(applied_safe)
@@ -238,12 +244,17 @@ def _apply_or_review(
         auto_apply_candidates = (
             risky_suggestions if safe_fast_path_applied else all_suggestions
         )
-        save_undo_patch(auto_apply_candidates, workspace_root)
+        undo_state = prepare_fix_batch(
+            auto_apply_candidates,
+            workspace_root,
+            retention=retention,
+        )
         auto_applied = apply_fixes(
             auto_apply_candidates,
             workspace_root=workspace_root,
             auto_apply=True,
             search_radius=ai_config.fix_search_radius,
+            undo_state=undo_state,
         )
         applied_suggestions.extend(auto_applied)
         applied += len(auto_applied)
@@ -256,12 +267,17 @@ def _apply_or_review(
         review_candidates = (
             risky_suggestions if safe_fast_path_applied else all_suggestions
         )
-        save_undo_patch(review_candidates, workspace_root)
+        undo_state = prepare_fix_batch(
+            review_candidates,
+            workspace_root,
+            retention=retention,
+        )
         accepted_count, rejected_count, interactive_applied = review_fixes_interactive(
             review_candidates,
             validate_after_group=ai_config.validate_after_group,
             workspace_root=workspace_root,
             search_radius=ai_config.fix_search_radius,
+            undo_state=undo_state,
         )
         applied += accepted_count
         rejected += rejected_count + safe_failed

--- a/lintro/ai/undo.py
+++ b/lintro/ai/undo.py
@@ -1,18 +1,69 @@
-"""AI fix undo/rollback via patch files."""
+"""AI fix undo/rollback via git checkpoints or file snapshots.
+
+Prefer git checkpoint refs (:mod:`lintro.ai.checkpoints`) when available.
+Outside a usable git work tree, fall back to in-memory/on-disk file content
+snapshots (and the legacy reverse patch under ``.lintro-cache/ai``).
+"""
 
 from __future__ import annotations
 
 import difflib
 import os
 import tempfile
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
+
+from loguru import logger
+
+from lintro.ai.checkpoints import (
+    DEFAULT_CHECKPOINT_RETENTION,
+    Checkpoint,
+    capture_checkpoint,
+    diff_checkpoint,
+    git_checkpoints_available,
+    restore_checkpoint,
+)
+from lintro.ai.paths import resolve_workspace_file
 
 if TYPE_CHECKING:
     from lintro.ai.models import AIFixSuggestion
 
 UNDO_DIR = ".lintro-cache/ai"
 UNDO_FILE = "last_fixes.patch"
+
+
+@dataclass
+class FileSnapshot:
+    """Content snapshot for non-git rollback.
+
+    Attributes:
+        root: Workspace root used when the snapshot was taken.
+        contents: Map of repo-/workspace-relative path to file bytes, or
+            ``None`` when the path did not exist at capture time.
+    """
+
+    root: Path
+    contents: dict[str, bytes | None] = field(default_factory=dict)
+
+
+@dataclass
+class UndoState:
+    """Rollback handle for one AI fix (or fmt) mutation batch.
+
+    Attributes:
+        kind: ``git`` when a checkpoint ref was captured, else ``file``.
+        checkpoint: Git checkpoint (when ``kind == "git"``).
+        file_snapshot: File-content fallback (when ``kind == "file"``).
+        patch_path: Optional legacy reverse-patch path for compatibility.
+        paths: Target paths recorded at prepare time.
+    """
+
+    kind: Literal["git", "file"]
+    checkpoint: Checkpoint | None = None
+    file_snapshot: FileSnapshot | None = None
+    patch_path: Path | None = None
+    paths: tuple[str, ...] = field(default_factory=tuple)
 
 
 def save_undo_patch(
@@ -73,3 +124,253 @@ def save_undo_patch(
         Path(tmp).unlink(missing_ok=True)
         raise
     return patch_path
+
+
+def _suggestion_paths(suggestions: list[AIFixSuggestion]) -> list[str]:
+    """Return unique suggestion file paths in stable order."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for suggestion in suggestions:
+        path = suggestion.file
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        ordered.append(path)
+    return ordered
+
+
+def _capture_file_snapshot(
+    paths: list[str],
+    *,
+    workspace_root: Path,
+) -> FileSnapshot:
+    """Read current file bytes for fallback rollback."""
+    contents: dict[str, bytes | None] = {}
+    for path in paths:
+        resolved = resolve_workspace_file(path, workspace_root)
+        if resolved is None:
+            contents[path] = None
+            continue
+        if resolved.is_file():
+            contents[path] = resolved.read_bytes()
+        else:
+            contents[path] = None
+    return FileSnapshot(root=workspace_root, contents=contents)
+
+
+def _restore_file_snapshot(
+    snapshot: FileSnapshot,
+    paths: list[str] | None = None,
+) -> None:
+    """Restore files from a :class:`FileSnapshot`."""
+    items = (
+        snapshot.contents.items()
+        if paths is None
+        else ((p, snapshot.contents.get(p)) for p in paths)
+    )
+    for path, data in items:
+        resolved = resolve_workspace_file(path, snapshot.root)
+        if resolved is None:
+            # Fall back to joining under root when the path was relative.
+            candidate = Path(path)
+            resolved = (
+                candidate if candidate.is_absolute() else snapshot.root / candidate
+            )
+        if data is None:
+            if resolved.is_file():
+                resolved.unlink()
+            continue
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(resolved.parent), suffix=".tmp")
+        try:
+            try:
+                fobj = os.fdopen(fd, "wb")
+            except BaseException:
+                os.close(fd)
+                raise
+            with fobj:
+                fobj.write(data)
+            Path(tmp).replace(resolved)
+        except BaseException:
+            Path(tmp).unlink(missing_ok=True)
+            raise
+
+
+def prepare_fix_batch(
+    suggestions: list[AIFixSuggestion],
+    workspace_root: Path,
+    *,
+    retention: int = DEFAULT_CHECKPOINT_RETENTION,
+) -> UndoState | None:
+    """Capture rollback state before an AI fix batch mutates files.
+
+    Prefers a git checkpoint ref. When git checkpoints are unavailable,
+    falls back to a file-content snapshot plus the legacy reverse patch.
+
+    Args:
+        suggestions: Fixes about to be applied.
+        workspace_root: Project root directory.
+        retention: Max git checkpoint refs to keep (default 10).
+
+    Returns:
+        Undo state handle, or None when there is nothing to capture.
+    """
+    if not suggestions:
+        return None
+    paths = _suggestion_paths(suggestions)
+    if not paths:
+        return None
+
+    if git_checkpoints_available(workspace_root):
+        checkpoint = capture_checkpoint(
+            paths,
+            workspace_root=workspace_root,
+            keep=retention,
+        )
+        if checkpoint is not None:
+            # Keep legacy patch for tooling that still reads it.
+            patch_path = save_undo_patch(suggestions, workspace_root)
+            return UndoState(
+                kind="git",
+                checkpoint=checkpoint,
+                patch_path=patch_path,
+                paths=tuple(paths),
+            )
+        logger.debug("Git checkpoint unavailable; using file-snapshot fallback")
+
+    snapshot = _capture_file_snapshot(paths, workspace_root=workspace_root)
+    patch_path = save_undo_patch(suggestions, workspace_root)
+    return UndoState(
+        kind="file",
+        file_snapshot=snapshot,
+        patch_path=patch_path,
+        paths=tuple(paths),
+    )
+
+
+def prepare_path_batch(
+    paths: list[str] | tuple[str, ...],
+    workspace_root: Path,
+    *,
+    retention: int = DEFAULT_CHECKPOINT_RETENTION,
+) -> UndoState | None:
+    """Capture rollback state for arbitrary paths (e.g. ``lintro fmt``).
+
+    Args:
+        paths: Files or directories about to be mutated.
+        workspace_root: Project root directory.
+        retention: Max git checkpoint refs to keep.
+
+    Returns:
+        Undo state handle, or None when capture is not possible / empty.
+    """
+    path_list = [p for p in paths if p]
+    if not path_list:
+        return None
+    if git_checkpoints_available(workspace_root):
+        checkpoint = capture_checkpoint(
+            path_list,
+            workspace_root=workspace_root,
+            keep=retention,
+        )
+        if checkpoint is not None:
+            return UndoState(
+                kind="git",
+                checkpoint=checkpoint,
+                paths=checkpoint.paths,
+            )
+    snapshot = _capture_file_snapshot(path_list, workspace_root=workspace_root)
+    if not snapshot.contents:
+        return None
+    return UndoState(
+        kind="file",
+        file_snapshot=snapshot,
+        paths=tuple(snapshot.contents.keys()),
+    )
+
+
+def restore_undo(
+    state: UndoState,
+    paths: list[str] | tuple[str, ...] | None = None,
+) -> None:
+    """Restore paths from a previously prepared :class:`UndoState`.
+
+    Args:
+        state: Handle from :func:`prepare_fix_batch` or
+            :func:`prepare_path_batch`.
+        paths: Optional subset to restore; defaults to all recorded paths.
+    """
+    path_list = list(paths) if paths is not None else None
+    if state.kind == "git" and state.checkpoint is not None:
+        restore_checkpoint(state.checkpoint, path_list)
+        return
+    if state.file_snapshot is not None:
+        _restore_file_snapshot(state.file_snapshot, path_list)
+
+
+def diff_undo(
+    state: UndoState,
+    paths: list[str] | tuple[str, ...] | None = None,
+) -> str:
+    """Return a unified diff of current files vs the prepared undo state.
+
+    For git checkpoints this is ``git diff <ref> -- <paths>``. For file
+    snapshots a simple unified diff per path is produced.
+
+    Args:
+        state: Handle from prepare helpers.
+        paths: Optional path subset.
+
+    Returns:
+        Unified diff text (empty when unchanged or unavailable).
+    """
+    if state.kind == "git" and state.checkpoint is not None:
+        return diff_checkpoint(state.checkpoint, paths)
+
+    if state.file_snapshot is None:
+        return ""
+    snapshot = state.file_snapshot
+    targets = list(paths) if paths is not None else list(snapshot.contents)
+    chunks: list[str] = []
+    for path in targets:
+        original = snapshot.contents.get(path)
+        resolved = resolve_workspace_file(path, snapshot.root)
+        current: bytes | None
+        if resolved is not None and resolved.is_file():
+            current = resolved.read_bytes()
+        else:
+            current = None
+        if original == current:
+            continue
+        old_text = (
+            original.decode("utf-8", errors="replace").splitlines(keepends=True)
+            if original is not None
+            else []
+        )
+        new_text = (
+            current.decode("utf-8", errors="replace").splitlines(keepends=True)
+            if current is not None
+            else []
+        )
+        chunks.extend(
+            difflib.unified_diff(
+                old_text,
+                new_text,
+                fromfile=f"a/{path}",
+                tofile=f"b/{path}",
+            ),
+        )
+    return "".join(chunks)
+
+
+__all__ = [
+    "UNDO_DIR",
+    "UNDO_FILE",
+    "FileSnapshot",
+    "UndoState",
+    "diff_undo",
+    "prepare_fix_batch",
+    "prepare_path_batch",
+    "restore_undo",
+    "save_undo_patch",
+]

--- a/lintro/ai/undo.py
+++ b/lintro/ai/undo.py
@@ -206,14 +206,7 @@ def _restore_file_snapshot(
                 resolved.unlink()
             continue
         resolved.parent.mkdir(parents=True, exist_ok=True)
-        recorded_mode = snapshot.modes.get(path)
-        if recorded_mode is not None and resolved.is_file():
-            resolved.chmod(recorded_mode)
-        atomic_write_bytes(
-            resolved,
-            data,
-            fallback_mode=recorded_mode if recorded_mode is not None else 0o644,
-        )
+        atomic_write_bytes(resolved, data, mode=snapshot.modes.get(path))
 
 
 def _try_save_undo_patch(

--- a/lintro/ai/undo.py
+++ b/lintro/ai/undo.py
@@ -143,6 +143,22 @@ def _suggestion_paths(suggestions: list[AIFixSuggestion]) -> list[str]:
     return ordered
 
 
+def _snapshot_key(path: str, workspace_root: Path) -> str | None:
+    """Return the workspace-relative POSIX key for ``path``.
+
+    Args:
+        path: Absolute or relative target path.
+        workspace_root: Root directory the path must stay inside.
+
+    Returns:
+        The normalised key, or None when the path escapes the workspace.
+    """
+    resolved = resolve_workspace_file(path, workspace_root)
+    if resolved is None:
+        return None
+    return resolved.relative_to(workspace_root.resolve()).as_posix()
+
+
 def _capture_file_snapshot(
     paths: list[str],
     *,
@@ -150,9 +166,13 @@ def _capture_file_snapshot(
 ) -> FileSnapshot:
     """Read current file bytes for fallback rollback.
 
-    Paths that do not resolve inside ``workspace_root`` are dropped rather
-    than recorded, so ``None`` unambiguously means "did not exist at capture
-    time" and a restore can never write outside the workspace.
+    Entries are keyed by workspace-relative POSIX path, not by the raw
+    suggestion string, so a caller that later spells a target differently
+    (absolute vs relative, ``./x.py`` vs ``x.py``) still matches — the git
+    backend normalises the same way. Paths that do not resolve inside
+    ``workspace_root`` are dropped rather than recorded, so ``None``
+    unambiguously means "did not exist at capture time" and a restore can
+    never write outside the workspace.
 
     Args:
         paths: Target file paths.
@@ -164,16 +184,42 @@ def _capture_file_snapshot(
     contents: dict[str, bytes | None] = {}
     modes: dict[str, int] = {}
     for path in paths:
-        resolved = resolve_workspace_file(path, workspace_root)
-        if resolved is None:
+        key = _snapshot_key(path, workspace_root)
+        if key is None:
             logger.debug("Skipping snapshot of out-of-workspace path: {}", path)
             continue
+        resolved = workspace_root.resolve() / key
         if resolved.is_file():
-            contents[path] = resolved.read_bytes()
-            modes[path] = resolved.stat().st_mode & 0o7777
+            contents[key] = resolved.read_bytes()
+            modes[key] = resolved.stat().st_mode & 0o7777
         else:
-            contents[path] = None
+            contents[key] = None
     return FileSnapshot(root=workspace_root, contents=contents, modes=modes)
+
+
+def _select_keys(
+    paths: list[str] | tuple[str, ...],
+    *,
+    snapshot: FileSnapshot,
+) -> list[str]:
+    """Map requested paths onto the snapshot's normalised keys.
+
+    Args:
+        paths: Caller-supplied subset, in any spelling.
+        snapshot: Snapshot to match against.
+
+    Returns:
+        Recorded keys the request selects, in request order.
+    """
+    selected: list[str] = []
+    for path in paths:
+        key = _snapshot_key(path, snapshot.root)
+        if key is None or key not in snapshot.contents:
+            logger.debug("Skipping path absent from file snapshot: {}", path)
+            continue
+        if key not in selected:
+            selected.append(key)
+    return selected
 
 
 def _restore_file_snapshot(
@@ -191,16 +237,14 @@ def _restore_file_snapshot(
         snapshot: Snapshot captured before the batch.
         paths: Optional subset to restore; defaults to every recorded path.
     """
-    items = (
-        snapshot.contents.items()
+    keys = (
+        list(snapshot.contents)
         if paths is None
-        else ((p, snapshot.contents[p]) for p in paths if p in snapshot.contents)
+        else _select_keys(paths, snapshot=snapshot)
     )
-    for path, data in items:
-        resolved = resolve_workspace_file(path, snapshot.root)
-        if resolved is None:
-            logger.debug("Skipping restore of out-of-workspace path: {}", path)
-            continue
+    for path in keys:
+        data = snapshot.contents[path]
+        resolved = snapshot.root.resolve() / path
         if data is None:
             if resolved.is_file():
                 resolved.unlink()

--- a/lintro/ai/undo.py
+++ b/lintro/ai/undo.py
@@ -24,7 +24,7 @@ from lintro.ai.checkpoints import (
     git_checkpoints_available,
     restore_checkpoint,
 )
-from lintro.ai.paths import resolve_workspace_file
+from lintro.ai.paths import atomic_write_bytes, resolve_workspace_file
 
 if TYPE_CHECKING:
     from lintro.ai.models import AIFixSuggestion
@@ -144,17 +144,26 @@ def _capture_file_snapshot(
     *,
     workspace_root: Path,
 ) -> FileSnapshot:
-    """Read current file bytes for fallback rollback."""
+    """Read current file bytes for fallback rollback.
+
+    Paths that do not resolve inside ``workspace_root`` are dropped rather
+    than recorded, so ``None`` unambiguously means "did not exist at capture
+    time" and a restore can never write outside the workspace.
+
+    Args:
+        paths: Target file paths.
+        workspace_root: Root directory that restores must stay inside.
+
+    Returns:
+        Snapshot of the in-workspace target files.
+    """
     contents: dict[str, bytes | None] = {}
     for path in paths:
         resolved = resolve_workspace_file(path, workspace_root)
         if resolved is None:
-            contents[path] = None
+            logger.debug("Skipping snapshot of out-of-workspace path: {}", path)
             continue
-        if resolved.is_file():
-            contents[path] = resolved.read_bytes()
-        else:
-            contents[path] = None
+        contents[path] = resolved.read_bytes() if resolved.is_file() else None
     return FileSnapshot(root=workspace_root, contents=contents)
 
 
@@ -162,38 +171,33 @@ def _restore_file_snapshot(
     snapshot: FileSnapshot,
     paths: list[str] | None = None,
 ) -> None:
-    """Restore files from a :class:`FileSnapshot`."""
+    """Restore files from a :class:`FileSnapshot`.
+
+    Only paths the snapshot recorded — which are by construction inside the
+    workspace — are written or deleted, matching the containment guarantee
+    :func:`~lintro.ai.apply._apply_fix` and
+    :func:`~lintro.ai.checkpoints.restore_checkpoint` already enforce.
+
+    Args:
+        snapshot: Snapshot captured before the batch.
+        paths: Optional subset to restore; defaults to every recorded path.
+    """
     items = (
         snapshot.contents.items()
         if paths is None
-        else ((p, snapshot.contents.get(p)) for p in paths)
+        else ((p, snapshot.contents[p]) for p in paths if p in snapshot.contents)
     )
     for path, data in items:
         resolved = resolve_workspace_file(path, snapshot.root)
         if resolved is None:
-            # Fall back to joining under root when the path was relative.
-            candidate = Path(path)
-            resolved = (
-                candidate if candidate.is_absolute() else snapshot.root / candidate
-            )
+            logger.debug("Skipping restore of out-of-workspace path: {}", path)
+            continue
         if data is None:
             if resolved.is_file():
                 resolved.unlink()
             continue
         resolved.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=str(resolved.parent), suffix=".tmp")
-        try:
-            try:
-                fobj = os.fdopen(fd, "wb")
-            except BaseException:
-                os.close(fd)
-                raise
-            with fobj:
-                fobj.write(data)
-            Path(tmp).replace(resolved)
-        except BaseException:
-            Path(tmp).unlink(missing_ok=True)
-            raise
+        atomic_write_bytes(resolved, data)
 
 
 def prepare_fix_batch(

--- a/lintro/ai/undo.py
+++ b/lintro/ai/undo.py
@@ -49,7 +49,7 @@ class FileSnapshot:
 
 @dataclass
 class UndoState:
-    """Rollback handle for one AI fix (or fmt) mutation batch.
+    """Rollback handle for one AI fix mutation batch.
 
     Attributes:
         kind: ``git`` when a checkpoint ref was captured, else ``file``.
@@ -248,47 +248,6 @@ def prepare_fix_batch(
     )
 
 
-def prepare_path_batch(
-    paths: list[str] | tuple[str, ...],
-    workspace_root: Path,
-    *,
-    retention: int = DEFAULT_CHECKPOINT_RETENTION,
-) -> UndoState | None:
-    """Capture rollback state for arbitrary paths (e.g. ``lintro fmt``).
-
-    Args:
-        paths: Files or directories about to be mutated.
-        workspace_root: Project root directory.
-        retention: Max git checkpoint refs to keep.
-
-    Returns:
-        Undo state handle, or None when capture is not possible / empty.
-    """
-    path_list = [p for p in paths if p]
-    if not path_list:
-        return None
-    if git_checkpoints_available(workspace_root):
-        checkpoint = capture_checkpoint(
-            path_list,
-            workspace_root=workspace_root,
-            keep=retention,
-        )
-        if checkpoint is not None:
-            return UndoState(
-                kind="git",
-                checkpoint=checkpoint,
-                paths=checkpoint.paths,
-            )
-    snapshot = _capture_file_snapshot(path_list, workspace_root=workspace_root)
-    if not snapshot.contents:
-        return None
-    return UndoState(
-        kind="file",
-        file_snapshot=snapshot,
-        paths=tuple(snapshot.contents.keys()),
-    )
-
-
 def restore_undo(
     state: UndoState,
     paths: list[str] | tuple[str, ...] | None = None,
@@ -296,8 +255,7 @@ def restore_undo(
     """Restore paths from a previously prepared :class:`UndoState`.
 
     Args:
-        state: Handle from :func:`prepare_fix_batch` or
-            :func:`prepare_path_batch`.
+        state: Handle from :func:`prepare_fix_batch`.
         paths: Optional subset to restore; defaults to all recorded paths.
     """
     path_list = list(paths) if paths is not None else None
@@ -318,7 +276,7 @@ def diff_undo(
     snapshots a simple unified diff per path is produced.
 
     Args:
-        state: Handle from prepare helpers.
+        state: Handle from :func:`prepare_fix_batch`.
         paths: Optional path subset.
 
     Returns:
@@ -370,7 +328,6 @@ __all__ = [
     "UndoState",
     "diff_undo",
     "prepare_fix_batch",
-    "prepare_path_batch",
     "restore_undo",
     "save_undo_patch",
 ]

--- a/lintro/ai/undo.py
+++ b/lintro/ai/undo.py
@@ -41,10 +41,14 @@ class FileSnapshot:
         root: Workspace root used when the snapshot was taken.
         contents: Map of repo-/workspace-relative path to file bytes, or
             ``None`` when the path did not exist at capture time.
+        modes: Permission bits recorded per path, so a restore reinstates the
+            mode the file had before the batch rather than whatever it drifted
+            to (or the ``0600`` a fresh temp file would carry).
     """
 
     root: Path
     contents: dict[str, bytes | None] = field(default_factory=dict)
+    modes: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -158,13 +162,18 @@ def _capture_file_snapshot(
         Snapshot of the in-workspace target files.
     """
     contents: dict[str, bytes | None] = {}
+    modes: dict[str, int] = {}
     for path in paths:
         resolved = resolve_workspace_file(path, workspace_root)
         if resolved is None:
             logger.debug("Skipping snapshot of out-of-workspace path: {}", path)
             continue
-        contents[path] = resolved.read_bytes() if resolved.is_file() else None
-    return FileSnapshot(root=workspace_root, contents=contents)
+        if resolved.is_file():
+            contents[path] = resolved.read_bytes()
+            modes[path] = resolved.stat().st_mode & 0o7777
+        else:
+            contents[path] = None
+    return FileSnapshot(root=workspace_root, contents=contents, modes=modes)
 
 
 def _restore_file_snapshot(
@@ -197,7 +206,38 @@ def _restore_file_snapshot(
                 resolved.unlink()
             continue
         resolved.parent.mkdir(parents=True, exist_ok=True)
-        atomic_write_bytes(resolved, data)
+        recorded_mode = snapshot.modes.get(path)
+        if recorded_mode is not None and resolved.is_file():
+            resolved.chmod(recorded_mode)
+        atomic_write_bytes(
+            resolved,
+            data,
+            fallback_mode=recorded_mode if recorded_mode is not None else 0o644,
+        )
+
+
+def _try_save_undo_patch(
+    suggestions: list[AIFixSuggestion],
+    workspace_root: Path,
+) -> Path | None:
+    """Write the legacy reverse patch, tolerating a failure.
+
+    The patch under ``.lintro-cache/ai`` is kept only for tooling that still
+    reads it. A failure to write it must not throw away the checkpoint or
+    snapshot that the fix batch actually depends on for rollback.
+
+    Args:
+        suggestions: Fixes about to be applied.
+        workspace_root: Project root directory.
+
+    Returns:
+        Path to the written patch, or None when it could not be written.
+    """
+    try:
+        return save_undo_patch(suggestions, workspace_root)
+    except OSError as exc:
+        logger.debug("Legacy undo patch not written: {}", exc)
+        return None
 
 
 def prepare_fix_batch(
@@ -232,18 +272,16 @@ def prepare_fix_batch(
             keep=retention,
         )
         if checkpoint is not None:
-            # Keep legacy patch for tooling that still reads it.
-            patch_path = save_undo_patch(suggestions, workspace_root)
             return UndoState(
                 kind="git",
                 checkpoint=checkpoint,
-                patch_path=patch_path,
+                patch_path=_try_save_undo_patch(suggestions, workspace_root),
                 paths=tuple(paths),
             )
         logger.debug("Git checkpoint unavailable; using file-snapshot fallback")
 
     snapshot = _capture_file_snapshot(paths, workspace_root=workspace_root)
-    patch_path = save_undo_patch(suggestions, workspace_root)
+    patch_path = _try_save_undo_patch(suggestions, workspace_root)
     return UndoState(
         kind="file",
         file_snapshot=snapshot,

--- a/lintro/ai/undo.py
+++ b/lintro/ai/undo.py
@@ -292,7 +292,11 @@ def diff_undo(
     if state.file_snapshot is None:
         return ""
     snapshot = state.file_snapshot
-    targets = list(paths) if paths is not None else list(snapshot.contents)
+    targets = (
+        [p for p in paths if p in snapshot.contents]
+        if paths is not None
+        else list(snapshot.contents)
+    )
     chunks: list[str] = []
     for path in targets:
         original = snapshot.contents.get(path)

--- a/lintro/api/pipeline.py
+++ b/lintro/api/pipeline.py
@@ -94,6 +94,52 @@ def _sarif_enrichment(
     return sarif_enrichment_from_results(all_results=artifact.tool_results)
 
 
+def _capture_fmt_checkpoint(*, ctx: RunContext, paths: list[str]) -> None:
+    """Snapshot ``fmt`` targets when ``ai.checkpoint_fmt`` is enabled.
+
+    ``lintro fmt`` rewrites files in place, so the same pre-mutation git
+    checkpoint that guards AI fix batches is offered here behind an opt-in
+    flag. The ref is announced on the console because, unlike the AI fix path,
+    nothing else in a ``fmt`` run holds a handle to it — ``git diff <ref>`` and
+    ``git checkout <ref> -- <path>`` are the user's entry points. Outside a git
+    work tree nothing is captured: an in-memory snapshot would not survive the
+    process, so it would buy nothing for the price of reading every target.
+
+    This lives in the API layer rather than the executor because the executor
+    may not import :mod:`lintro.ai` (issue #724).
+
+    Args:
+        ctx: The run context for this run.
+        paths: Paths the run will format.
+    """
+    from lintro.enums.action import Action as _Action
+
+    ai_config = getattr(ctx.lintro_config, "ai", None)
+    if (
+        ctx.action != _Action.FIX
+        or ctx.dry_run_preview
+        or ai_config is None
+        or not getattr(ai_config, "checkpoint_fmt", False)
+    ):
+        return
+
+    from pathlib import Path
+
+    from lintro.ai.checkpoints import capture_checkpoint
+
+    checkpoint = capture_checkpoint(
+        paths,
+        workspace_root=Path.cwd(),
+        keep=ai_config.checkpoint_retention,
+    )
+    if checkpoint is None or ctx.clean_stdout_output or ctx.score_only:
+        return
+    ctx.logger.console_output(
+        text=f"Captured fmt checkpoint {checkpoint.ref}",
+        color="cyan",
+    )
+
+
 def run_lint_artifact(
     *,
     action: str | Action,
@@ -175,6 +221,7 @@ def run_lint_artifact(
         no_art=no_art,
         dry_run=dry_run,
     )
+    _capture_fmt_checkpoint(ctx=ctx, paths=paths)
     artifact = execute_run(
         ctx=ctx,
         paths=paths,

--- a/lintro/api/pipeline.py
+++ b/lintro/api/pipeline.py
@@ -101,9 +101,10 @@ def _capture_fmt_checkpoint(*, ctx: RunContext, paths: list[str]) -> None:
     checkpoint that guards AI fix batches is offered here behind an opt-in
     flag. The ref is announced on the console because, unlike the AI fix path,
     nothing else in a ``fmt`` run holds a handle to it — ``git diff <ref>`` and
-    ``git checkout <ref> -- <path>`` are the user's entry points. Outside a git
-    work tree nothing is captured: an in-memory snapshot would not survive the
-    process, so it would buy nothing for the price of reading every target.
+    ``git restore --source=<ref> --worktree -- <path>`` are the entry points.
+    Outside a git work tree nothing is captured: an in-memory snapshot would
+    not survive the process, so it would buy nothing for the price of reading
+    every target.
 
     This lives in the API layer rather than the executor because the executor
     may not import :mod:`lintro.ai` (issue #724).

--- a/tests/unit/ai/test_checkpoints.py
+++ b/tests/unit/ai/test_checkpoints.py
@@ -1,0 +1,285 @@
+"""Tests for git-checkpoint capture, restore, diff, and pruning."""
+
+from __future__ import annotations
+
+import os
+import subprocess  # nosec B404 - subprocess drives git in temp test repos; shell=False
+from pathlib import Path
+
+from assertpy import assert_that
+
+from lintro.ai.checkpoints import (
+    CHECKPOINT_REF_PREFIX,
+    capture_checkpoint,
+    diff_checkpoint,
+    git_checkpoints_available,
+    list_checkpoint_refs,
+    prune_checkpoints,
+    restore_checkpoint,
+)
+from lintro.ai.models import AIFixSuggestion
+from lintro.ai.undo import prepare_fix_batch, restore_undo
+
+
+def _run(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return (
+        subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
+            cmd,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    )
+
+
+def _init_git_repo(tmp_path: Path) -> Path:
+    """Create a temp git repo with an initial commit."""
+    _run(["git", "init"], cwd=tmp_path)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path)
+    _run(["git", "config", "user.name", "Test User"], cwd=tmp_path)
+    # Avoid depending on system default branch name.
+    _run(["git", "checkout", "-b", "main"], cwd=tmp_path)
+    tracked = tmp_path / "tracked.py"
+    tracked.write_text("alpha = 1\n", encoding="utf-8")
+    other = tmp_path / "other.py"
+    other.write_text("keep = True\n", encoding="utf-8")
+    _run(["git", "add", "tracked.py", "other.py"], cwd=tmp_path)
+    _run(["git", "commit", "-m", "init"], cwd=tmp_path)
+    return tmp_path
+
+
+def _index_sha(*, cwd: Path) -> str:
+    """Return the sha of the real index tree (user index must stay stable)."""
+    env = os.environ.copy()
+    # Force using the real index (clear any leaked GIT_INDEX_FILE).
+    env.pop("GIT_INDEX_FILE", None)
+    result = (
+        subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
+            ["git", "write-tree"],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+    )
+    return result.stdout.strip()
+
+
+def _staged_diff(*, cwd: Path) -> str:
+    result = (
+        subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
+            ["git", "diff", "--cached"],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    )
+    return result.stdout
+
+
+def _make_suggestion(file: str, original: str, suggested: str) -> AIFixSuggestion:
+    return AIFixSuggestion(
+        file=file,
+        line=1,
+        code="E001",
+        tool_name="ruff",
+        original_code=original,
+        suggested_code=suggested,
+        diff="",
+        explanation="fix",
+    )
+
+
+def test_git_checkpoints_available_true_in_repo(tmp_path: Path) -> None:
+    """Usable non-bare work trees report checkpoints available."""
+    repo = _init_git_repo(tmp_path)
+    assert_that(git_checkpoints_available(repo)).is_true()
+
+
+def test_git_checkpoints_available_false_outside_git(tmp_path: Path) -> None:
+    """Non-git directories cannot use git checkpoints."""
+    assert_that(git_checkpoints_available(tmp_path)).is_false()
+
+
+def test_capture_restore_round_trip_multi_file(tmp_path: Path) -> None:
+    """Capture then restore returns multiple mutated files to prior content."""
+    repo = _init_git_repo(tmp_path)
+    a = repo / "tracked.py"
+    b = repo / "other.py"
+    untracked = repo / "new_file.py"
+    untracked.write_text("untracked = 0\n", encoding="utf-8")
+
+    checkpoint = capture_checkpoint(
+        ["tracked.py", "other.py", "new_file.py"],
+        workspace_root=repo,
+        keep=10,
+    )
+    assert_that(checkpoint).is_not_none()
+    assert_that(checkpoint.ref).starts_with(CHECKPOINT_REF_PREFIX)  # type: ignore[union-attr]
+
+    a.write_text("alpha = 99\n", encoding="utf-8")
+    b.write_text("keep = False\n", encoding="utf-8")
+    untracked.write_text("untracked = 1\n", encoding="utf-8")
+
+    restore_checkpoint(checkpoint)  # type: ignore[arg-type]
+    assert_that(a.read_text(encoding="utf-8")).is_equal_to("alpha = 1\n")
+    assert_that(b.read_text(encoding="utf-8")).is_equal_to("keep = True\n")
+    assert_that(untracked.read_text(encoding="utf-8")).is_equal_to("untracked = 0\n")
+
+
+def test_capture_does_not_touch_dirty_user_index(tmp_path: Path) -> None:
+    """Capture must leave staged/unstaged user index state untouched."""
+    repo = _init_git_repo(tmp_path)
+    tracked = repo / "tracked.py"
+    tracked.write_text("alpha = 2\n", encoding="utf-8")
+    _run(["git", "add", "tracked.py"], cwd=repo)
+    staged_before = _staged_diff(cwd=repo)
+    index_before = _index_sha(cwd=repo)
+    head_before = _run(["git", "rev-parse", "HEAD"], cwd=repo).stdout.strip()
+
+    # Also leave an unstaged edit on another file.
+    other = repo / "other.py"
+    other.write_text("keep = 'dirty'\n", encoding="utf-8")
+
+    checkpoint = capture_checkpoint(
+        ["tracked.py", "other.py"],
+        workspace_root=repo,
+        keep=10,
+    )
+    assert_that(checkpoint).is_not_none()
+
+    assert_that(_staged_diff(cwd=repo)).is_equal_to(staged_before)
+    assert_that(_index_sha(cwd=repo)).is_equal_to(index_before)
+    assert_that(
+        _run(["git", "rev-parse", "HEAD"], cwd=repo).stdout.strip(),
+    ).is_equal_to(
+        head_before,
+    )
+    # Working tree dirty content for non-capture side effects must remain.
+    assert_that(other.read_text(encoding="utf-8")).is_equal_to("keep = 'dirty'\n")
+
+
+def test_restore_does_not_touch_dirty_user_index(tmp_path: Path) -> None:
+    """Restore must not alter the user's staged index."""
+    repo = _init_git_repo(tmp_path)
+    tracked = repo / "tracked.py"
+    tracked.write_text("alpha = 2\n", encoding="utf-8")
+    _run(["git", "add", "tracked.py"], cwd=repo)
+    staged_before = _staged_diff(cwd=repo)
+    index_before = _index_sha(cwd=repo)
+
+    checkpoint = capture_checkpoint(["tracked.py"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    tracked.write_text("alpha = 3\n", encoding="utf-8")
+    restore_checkpoint(checkpoint)  # type: ignore[arg-type]
+
+    assert_that(tracked.read_text(encoding="utf-8")).is_equal_to("alpha = 2\n")
+    assert_that(_staged_diff(cwd=repo)).is_equal_to(staged_before)
+    assert_that(_index_sha(cwd=repo)).is_equal_to(index_before)
+
+
+def test_untracked_target_included_in_checkpoint(tmp_path: Path) -> None:
+    """Untracked target files are snapshotted and restorable."""
+    repo = _init_git_repo(tmp_path)
+    newbie = repo / "scratch.py"
+    newbie.write_text("scratch = 1\n", encoding="utf-8")
+
+    checkpoint = capture_checkpoint(["scratch.py"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    newbie.write_text("scratch = 9\n", encoding="utf-8")
+    restore_checkpoint(checkpoint)  # type: ignore[arg-type]
+    assert_that(newbie.read_text(encoding="utf-8")).is_equal_to("scratch = 1\n")
+
+
+def test_user_edited_between_capture_and_rollback(tmp_path: Path) -> None:
+    """Rollback restores lintro targets even if the user edited them mid-run.
+
+    Semantics: checkpoint rollback always returns targeted paths to the
+    pre-batch snapshot, overwriting intervening user edits on those paths.
+    """
+    repo = _init_git_repo(tmp_path)
+    tracked = repo / "tracked.py"
+    checkpoint = capture_checkpoint(["tracked.py"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+
+    # Simulate lintro mutation, then a user edit on the same file.
+    tracked.write_text("alpha = 'lintro'\n", encoding="utf-8")
+    tracked.write_text("alpha = 'user-edit'\n", encoding="utf-8")
+
+    restore_checkpoint(checkpoint)  # type: ignore[arg-type]
+    assert_that(tracked.read_text(encoding="utf-8")).is_equal_to("alpha = 1\n")
+
+
+def test_diff_reports_lintro_changes(tmp_path: Path) -> None:
+    """diff_checkpoint reflects working-tree changes since capture."""
+    repo = _init_git_repo(tmp_path)
+    tracked = repo / "tracked.py"
+    checkpoint = capture_checkpoint(["tracked.py"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    tracked.write_text("alpha = 42\n", encoding="utf-8")
+
+    diff = diff_checkpoint(checkpoint)  # type: ignore[arg-type]
+    assert_that(diff).contains("alpha = 1")
+    assert_that(diff).contains("alpha = 42")
+
+
+def test_non_git_falls_back_to_file_undo(tmp_path: Path) -> None:
+    """Outside git, prepare_fix_batch uses file-snapshot fallback."""
+    target = tmp_path / "app.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    suggestion = _make_suggestion(str(target), "x = 1\n", "x = 2\n")
+
+    state = prepare_fix_batch([suggestion], tmp_path, retention=10)
+    assert_that(state).is_not_none()
+    assert_that(state.kind).is_equal_to("file")  # type: ignore[union-attr]
+    assert_that(state.checkpoint).is_none()  # type: ignore[union-attr]
+
+    target.write_text("x = 2\n", encoding="utf-8")
+    restore_undo(state)  # type: ignore[arg-type]
+    assert_that(target.read_text(encoding="utf-8")).is_equal_to("x = 1\n")
+
+
+def test_prune_keeps_last_n_refs(tmp_path: Path) -> None:
+    """prune_checkpoints deletes older refs beyond the retention limit."""
+    repo = _init_git_repo(tmp_path)
+    tracked = repo / "tracked.py"
+
+    refs: list[str] = []
+    for i in range(5):
+        tracked.write_text(f"alpha = {i}\n", encoding="utf-8")
+        cp = capture_checkpoint(
+            ["tracked.py"],
+            workspace_root=repo,
+            run_id=f"100{i}-abcd{i:04d}",
+            keep=100,  # disable prune during capture
+        )
+        assert_that(cp).is_not_none()
+        refs.append(cp.ref)  # type: ignore[union-attr]
+
+    listed = list_checkpoint_refs(workspace_root=repo)
+    assert_that(listed).is_length(5)
+
+    deleted = prune_checkpoints(workspace_root=repo, keep=2)
+    assert_that(deleted).is_equal_to(3)
+    remaining = list_checkpoint_refs(workspace_root=repo)
+    assert_that(remaining).is_length(2)
+    assert_that(remaining).is_equal_to(refs[-2:])
+
+
+def test_prepare_fix_batch_uses_git_in_repo(tmp_path: Path) -> None:
+    """prepare_fix_batch prefers git checkpoints inside a repository."""
+    repo = _init_git_repo(tmp_path)
+    suggestion = _make_suggestion("tracked.py", "alpha = 1\n", "alpha = 2\n")
+    state = prepare_fix_batch([suggestion], repo, retention=10)
+    assert_that(state).is_not_none()
+    assert_that(state.kind).is_equal_to("git")  # type: ignore[union-attr]
+    assert_that(state.checkpoint).is_not_none()  # type: ignore[union-attr]
+
+    (repo / "tracked.py").write_text("alpha = 2\n", encoding="utf-8")
+    restore_undo(state, ["tracked.py"])  # type: ignore[arg-type]
+    assert_that((repo / "tracked.py").read_text(encoding="utf-8")).is_equal_to(
+        "alpha = 1\n",
+    )

--- a/tests/unit/ai/test_checkpoints.py
+++ b/tests/unit/ai/test_checkpoints.py
@@ -397,6 +397,7 @@ def test_report_checkpoints_silent_for_json(tmp_path: Path) -> None:
     repo = _init_git_repo(tmp_path)
     suggestion = _make_suggestion("tracked.py", "alpha = 1\n", "alpha = 2\n")
     state = prepare_fix_batch([suggestion], repo, retention=10)
+    assert_that(state).is_not_none()
     (repo / "tracked.py").write_text("alpha = 2\n", encoding="utf-8")
 
     logger = MagicMock()
@@ -558,3 +559,23 @@ def test_restore_preserves_symlink_targets(tmp_path: Path) -> None:
 
     assert_that(link.is_symlink()).is_true()
     assert_that(os.readlink(link)).is_equal_to("tracked.py")
+
+
+def test_symlink_to_directory_is_left_alone(tmp_path: Path) -> None:
+    """A symlink to a directory is not snapshotted and never deleted."""
+    repo = _init_git_repo(tmp_path)
+    (repo / "pkg").mkdir()
+    (repo / "pkg" / "mod.py").write_text("mod = 1\n", encoding="utf-8")
+    link = repo / "pkg-link"
+    link.symlink_to("pkg")
+
+    checkpoint = capture_checkpoint(
+        ["tracked.py", "pkg-link"],
+        workspace_root=repo,
+        keep=10,
+    )
+
+    assert_that(checkpoint).is_not_none()
+    assert_that(list(checkpoint.paths)).does_not_contain("pkg-link")  # type: ignore[union-attr]
+    restore_checkpoint(checkpoint)  # type: ignore[arg-type]
+    assert_that(link.is_symlink()).is_true()

--- a/tests/unit/ai/test_checkpoints.py
+++ b/tests/unit/ai/test_checkpoints.py
@@ -88,16 +88,15 @@ def _index_sha(*, cwd: Path) -> str:
 
 
 def _staged_diff(*, cwd: Path) -> str:
-    result = (
-        subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
-            ["git", "diff", "--cached"],
-            cwd=str(cwd),
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    )
-    return result.stdout
+    """Return the staged diff of the real user index.
+
+    Args:
+        cwd: Repository directory.
+
+    Returns:
+        Output of ``git diff --cached``.
+    """
+    return _run(["git", "diff", "--cached"], cwd=cwd).stdout
 
 
 def _make_suggestion(file: str, original: str, suggested: str) -> AIFixSuggestion:
@@ -510,3 +509,52 @@ def test_capture_ignores_ambient_git_index_file(
 
     assert_that(checkpoint).is_not_none()
     assert_that(hook_index.exists()).is_false()
+
+
+def test_capture_and_restore_filename_with_glob_characters(tmp_path: Path) -> None:
+    """Glob characters in a filename stay literal instead of matching magic."""
+    repo = _init_git_repo(tmp_path)
+    tricky = repo / "weird[1].py"
+    tricky.write_text("value = 1\n", encoding="utf-8")
+
+    checkpoint = capture_checkpoint(["weird[1].py"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    assert_that(list(checkpoint.paths)).contains("weird[1].py")  # type: ignore[union-attr]
+
+    tricky.write_text("value = 2\n", encoding="utf-8")
+    restore_checkpoint(checkpoint)  # type: ignore[arg-type]
+
+    assert_that(tricky.read_text(encoding="utf-8")).is_equal_to("value = 1\n")
+
+
+def test_target_deleted_before_capture_stays_deleted(tmp_path: Path) -> None:
+    """A tracked target already gone at capture is not resurrected."""
+    repo = _init_git_repo(tmp_path)
+    tracked = repo / "tracked.py"
+    tracked.unlink()
+
+    checkpoint = capture_checkpoint(["tracked.py"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    tracked.write_text("alpha = 5\n", encoding="utf-8")
+
+    restore_checkpoint(checkpoint)  # type: ignore[arg-type]
+
+    assert_that(tracked.exists()).is_false()
+
+
+def test_restore_preserves_symlink_targets(tmp_path: Path) -> None:
+    """A symlinked target is restored as a link, not flattened to a file."""
+    repo = _init_git_repo(tmp_path)
+    link = repo / "link.py"
+    link.symlink_to("tracked.py")
+    _run(["git", "add", "link.py"], cwd=repo)
+
+    checkpoint = capture_checkpoint(["link.py"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    link.unlink()
+    link.write_text("clobbered = True\n", encoding="utf-8")
+
+    restore_checkpoint(checkpoint)  # type: ignore[arg-type]
+
+    assert_that(link.is_symlink()).is_true()
+    assert_that(os.readlink(link)).is_equal_to("tracked.py")

--- a/tests/unit/ai/test_checkpoints.py
+++ b/tests/unit/ai/test_checkpoints.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess  # nosec B404 - subprocess drives git in temp test repos; shell=False
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from assertpy import assert_that
 
@@ -18,6 +19,7 @@ from lintro.ai.checkpoints import (
     restore_checkpoint,
 )
 from lintro.ai.models import AIFixSuggestion
+from lintro.ai.pipeline import _report_checkpoints
 from lintro.ai.undo import prepare_fix_batch, restore_undo
 
 
@@ -269,6 +271,75 @@ def test_prune_keeps_last_n_refs(tmp_path: Path) -> None:
     assert_that(remaining).is_equal_to(refs[-2:])
 
 
+def test_restore_ignores_paths_absent_from_checkpoint(tmp_path: Path) -> None:
+    """A path that was never snapshotted must never be deleted by a restore."""
+    repo = _init_git_repo(tmp_path)
+    checkpoint = capture_checkpoint(["tracked.py"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+
+    bystander = repo / "other.py"
+    restore_checkpoint(checkpoint, [str(bystander)])  # type: ignore[arg-type]
+
+    assert_that(bystander.exists()).is_true()
+    assert_that(bystander.read_text(encoding="utf-8")).is_equal_to("keep = True\n")
+
+
+def test_restore_accepts_absolute_target_paths(tmp_path: Path) -> None:
+    """Absolute paths resolve to checkpoint entries instead of being dropped."""
+    repo = _init_git_repo(tmp_path)
+    tracked = repo / "tracked.py"
+    checkpoint = capture_checkpoint(["tracked.py"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    tracked.write_text("alpha = 7\n", encoding="utf-8")
+
+    restore_checkpoint(checkpoint, [str(tracked)])  # type: ignore[arg-type]
+
+    assert_that(tracked.exists()).is_true()
+    assert_that(tracked.read_text(encoding="utf-8")).is_equal_to("alpha = 1\n")
+
+
+def test_restore_deletes_files_created_after_capture(tmp_path: Path) -> None:
+    """Targets that did not exist at capture time are removed on restore."""
+    repo = _init_git_repo(tmp_path)
+    created = repo / "created.py"
+    checkpoint = capture_checkpoint(["created.py"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    created.write_text("made = True\n", encoding="utf-8")
+
+    restore_checkpoint(checkpoint)  # type: ignore[arg-type]
+
+    assert_that(created.exists()).is_false()
+
+
+def test_directory_targets_skip_ignored_and_git_internals(tmp_path: Path) -> None:
+    """Directory expansion honours .gitignore and never walks into .git/."""
+    repo = _init_git_repo(tmp_path)
+    (repo / ".gitignore").write_text("ignored/\n", encoding="utf-8")
+    ignored_dir = repo / "ignored"
+    ignored_dir.mkdir()
+    (ignored_dir / "junk.py").write_text("junk = 1\n", encoding="utf-8")
+
+    checkpoint = capture_checkpoint(["."], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+
+    paths = list(checkpoint.paths)  # type: ignore[union-attr]
+    assert_that(paths).contains("tracked.py")
+    assert_that([p for p in paths if p.startswith(".git/")]).is_empty()
+    assert_that([p for p in paths if p.startswith("ignored/")]).is_empty()
+
+
+def test_diff_ignores_paths_absent_from_checkpoint(tmp_path: Path) -> None:
+    """Diffing an unsnapshotted path yields nothing rather than noise."""
+    repo = _init_git_repo(tmp_path)
+    checkpoint = capture_checkpoint(["tracked.py"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    (repo / "other.py").write_text("keep = 'changed'\n", encoding="utf-8")
+
+    diff = diff_checkpoint(checkpoint, ["other.py"])  # type: ignore[arg-type]
+
+    assert_that(diff).is_empty()
+
+
 def test_prepare_fix_batch_uses_git_in_repo(tmp_path: Path) -> None:
     """prepare_fix_batch prefers git checkpoints inside a repository."""
     repo = _init_git_repo(tmp_path)
@@ -283,3 +354,35 @@ def test_prepare_fix_batch_uses_git_in_repo(tmp_path: Path) -> None:
     assert_that((repo / "tracked.py").read_text(encoding="utf-8")).is_equal_to(
         "alpha = 1\n",
     )
+
+
+def test_report_checkpoints_announces_ref_when_files_changed(tmp_path: Path) -> None:
+    """The post-run report names the ref only when the run changed something."""
+    repo = _init_git_repo(tmp_path)
+    suggestion = _make_suggestion("tracked.py", "alpha = 1\n", "alpha = 2\n")
+    state = prepare_fix_batch([suggestion], repo, retention=10)
+    assert_that(state).is_not_none()
+
+    logger = MagicMock()
+    _report_checkpoints([state], logger, is_json=False)
+    assert_that(logger.console_output.call_count).is_equal_to(0)
+
+    (repo / "tracked.py").write_text("alpha = 2\n", encoding="utf-8")
+    _report_checkpoints([state], logger, is_json=False)
+    assert_that(logger.console_output.call_count).is_equal_to(1)
+    assert_that(logger.console_output.call_args.args[0]).contains(
+        state.checkpoint.ref,  # type: ignore[union-attr]
+    )
+
+
+def test_report_checkpoints_silent_for_json(tmp_path: Path) -> None:
+    """Machine-readable stdout never gains a checkpoint line."""
+    repo = _init_git_repo(tmp_path)
+    suggestion = _make_suggestion("tracked.py", "alpha = 1\n", "alpha = 2\n")
+    state = prepare_fix_batch([suggestion], repo, retention=10)
+    (repo / "tracked.py").write_text("alpha = 2\n", encoding="utf-8")
+
+    logger = MagicMock()
+    _report_checkpoints([state], logger, is_json=True)
+
+    assert_that(logger.console_output.call_count).is_equal_to(0)

--- a/tests/unit/ai/test_checkpoints.py
+++ b/tests/unit/ai/test_checkpoints.py
@@ -7,6 +7,7 @@ import subprocess  # nosec B404 - subprocess drives git in temp test repos; shel
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
 from assertpy import assert_that
 
 from lintro.ai.checkpoints import (
@@ -24,6 +25,22 @@ from lintro.ai.undo import prepare_fix_batch, restore_undo
 
 
 def _run(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run a git command in a temp repo, isolated from developer git config.
+
+    A global ``commit.gpgsign``, ``core.hooksPath`` or ``init.templateDir``
+    would otherwise change how these fixtures behave from machine to machine.
+
+    Args:
+        cmd: Full argv.
+        cwd: Working directory.
+
+    Returns:
+        The completed process.
+    """
+    env = os.environ.copy()
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_CONFIG_SYSTEM"] = os.devnull
+    env.pop("GIT_INDEX_FILE", None)
     return (
         subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
             cmd,
@@ -31,6 +48,7 @@ def _run(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
             capture_output=True,
             text=True,
             check=True,
+            env=env,
         )
     )
 
@@ -386,3 +404,109 @@ def test_report_checkpoints_silent_for_json(tmp_path: Path) -> None:
     _report_checkpoints([state], logger, is_json=True)
 
     assert_that(logger.console_output.call_count).is_equal_to(0)
+
+
+def test_restore_preserves_file_mode(tmp_path: Path) -> None:
+    """A restored file keeps its permission bits, including the exec bit."""
+    repo = _init_git_repo(tmp_path)
+    script = repo / "script.sh"
+    script.write_text("#!/bin/sh\necho one\n", encoding="utf-8")
+    script.chmod(0o755)
+
+    checkpoint = capture_checkpoint(["script.sh"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    script.write_text("#!/bin/sh\necho two\n", encoding="utf-8")
+    restore_checkpoint(checkpoint)  # type: ignore[arg-type]
+
+    assert_that(script.read_text(encoding="utf-8")).contains("echo one")
+    assert_that(script.stat().st_mode & 0o777).is_equal_to(0o755)
+
+
+def test_restore_recreates_deleted_file_with_tree_mode(tmp_path: Path) -> None:
+    """A target deleted after capture comes back with the checkpoint's mode."""
+    repo = _init_git_repo(tmp_path)
+    script = repo / "script.sh"
+    script.write_text("#!/bin/sh\necho one\n", encoding="utf-8")
+    script.chmod(0o755)
+
+    checkpoint = capture_checkpoint(["script.sh"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    script.unlink()
+    restore_checkpoint(checkpoint)  # type: ignore[arg-type]
+
+    assert_that(script.exists()).is_true()
+    assert_that(script.stat().st_mode & 0o777).is_equal_to(0o755)
+
+
+def test_diff_reports_edits_to_untracked_targets(tmp_path: Path) -> None:
+    """An untracked target reads as modified, not deleted, in the diff."""
+    repo = _init_git_repo(tmp_path)
+    scratch = repo / "scratch.py"
+    scratch.write_text("scratch = 1\n", encoding="utf-8")
+    checkpoint = capture_checkpoint(["scratch.py"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    scratch.write_text("scratch = 2\n", encoding="utf-8")
+
+    diff = diff_checkpoint(checkpoint)  # type: ignore[arg-type]
+
+    assert_that(diff).contains("-scratch = 1")
+    assert_that(diff).contains("+scratch = 2")
+    assert_that(diff).does_not_contain("/dev/null")
+
+
+def test_capture_prunes_before_writing_its_own_ref(tmp_path: Path) -> None:
+    """With retention 1 the newest ref survives and older ones are gone."""
+    repo = _init_git_repo(tmp_path)
+    first = capture_checkpoint(
+        ["tracked.py"],
+        workspace_root=repo,
+        run_id="1000-aaaaaaaa",
+        keep=10,
+    )
+    second = capture_checkpoint(
+        ["tracked.py"],
+        workspace_root=repo,
+        run_id="1001-bbbbbbbb",
+        keep=1,
+    )
+
+    refs = list_checkpoint_refs(workspace_root=repo)
+    assert_that(refs).is_equal_to([second.ref])  # type: ignore[union-attr]
+    assert_that(refs).does_not_contain(first.ref)  # type: ignore[union-attr]
+
+
+def test_capture_with_zero_retention_keeps_current_ref(tmp_path: Path) -> None:
+    """``keep=0`` prunes history but never the ref the caller just got back."""
+    repo = _init_git_repo(tmp_path)
+    capture_checkpoint(
+        ["tracked.py"],
+        workspace_root=repo,
+        run_id="1000-aaaaaaaa",
+        keep=10,
+    )
+    current = capture_checkpoint(
+        ["tracked.py"],
+        workspace_root=repo,
+        run_id="1001-bbbbbbbb",
+        keep=0,
+    )
+
+    assert_that(current).is_not_none()
+    assert_that(list_checkpoint_refs(workspace_root=repo)).is_equal_to(
+        [current.ref],  # type: ignore[union-attr]
+    )
+
+
+def test_capture_ignores_ambient_git_index_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A GIT_INDEX_FILE inherited from a git hook must not be honoured."""
+    repo = _init_git_repo(tmp_path)
+    hook_index = tmp_path / "hook-index"
+    monkeypatch.setenv("GIT_INDEX_FILE", str(hook_index))
+
+    checkpoint = capture_checkpoint(["tracked.py"], workspace_root=repo, keep=10)
+
+    assert_that(checkpoint).is_not_none()
+    assert_that(hook_index.exists()).is_false()

--- a/tests/unit/ai/test_checkpoints.py
+++ b/tests/unit/ai/test_checkpoints.py
@@ -12,6 +12,8 @@ from assertpy import assert_that
 
 from lintro.ai.checkpoints import (
     CHECKPOINT_REF_PREFIX,
+    Checkpoint,
+    CheckpointError,
     capture_checkpoint,
     diff_checkpoint,
     git_checkpoints_available,
@@ -579,3 +581,36 @@ def test_symlink_to_directory_is_left_alone(tmp_path: Path) -> None:
     assert_that(list(checkpoint.paths)).does_not_contain("pkg-link")  # type: ignore[union-attr]
     restore_checkpoint(checkpoint)  # type: ignore[arg-type]
     assert_that(link.is_symlink()).is_true()
+
+
+def test_restore_aborts_when_the_tree_is_unreadable(tmp_path: Path) -> None:
+    """An unreadable checkpoint tree fails loudly instead of deleting targets."""
+    repo = _init_git_repo(tmp_path)
+    checkpoint = capture_checkpoint(["tracked.py"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    broken = Checkpoint(
+        ref=checkpoint.ref,  # type: ignore[union-attr]
+        run_id=checkpoint.run_id,  # type: ignore[union-attr]
+        root=repo,
+        paths=checkpoint.paths,  # type: ignore[union-attr]
+        tree_sha="0" * 40,
+    )
+
+    assert_that(restore_checkpoint).raises(CheckpointError).when_called_with(broken)
+    assert_that((repo / "tracked.py").exists()).is_true()
+
+
+def test_restore_reverts_a_mode_the_run_changed(tmp_path: Path) -> None:
+    """The checkpoint's mode wins over whatever the file drifted to."""
+    repo = _init_git_repo(tmp_path)
+    script = repo / "script.sh"
+    script.write_text("#!/bin/sh\necho one\n", encoding="utf-8")
+    script.chmod(0o644)
+
+    checkpoint = capture_checkpoint(["script.sh"], workspace_root=repo, keep=10)
+    assert_that(checkpoint).is_not_none()
+    script.write_text("#!/bin/sh\necho two\n", encoding="utf-8")
+    script.chmod(0o755)
+    restore_checkpoint(checkpoint)  # type: ignore[arg-type]
+
+    assert_that(script.stat().st_mode & 0o777).is_equal_to(0o644)

--- a/tests/unit/ai/test_checkpoints.py
+++ b/tests/unit/ai/test_checkpoints.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import os
-import subprocess  # nosec B404 - subprocess drives git in temp test repos; shell=False
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from assertpy import assert_that
@@ -21,72 +20,38 @@ from lintro.ai.checkpoints import (
     prune_checkpoints,
     restore_checkpoint,
 )
+from lintro.ai.config import AIConfig
 from lintro.ai.models import AIFixSuggestion
-from lintro.ai.pipeline import _report_checkpoints
+from lintro.ai.pipeline import _apply_or_review, _report_checkpoints
 from lintro.ai.undo import prepare_fix_batch, restore_undo
-
-
-def _run(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
-    """Run a git command in a temp repo, isolated from developer git config.
-
-    A global ``commit.gpgsign``, ``core.hooksPath`` or ``init.templateDir``
-    would otherwise change how these fixtures behave from machine to machine.
-
-    Args:
-        cmd: Full argv.
-        cwd: Working directory.
-
-    Returns:
-        The completed process.
-    """
-    env = os.environ.copy()
-    env["GIT_CONFIG_GLOBAL"] = os.devnull
-    env["GIT_CONFIG_SYSTEM"] = os.devnull
-    env.pop("GIT_INDEX_FILE", None)
-    return (
-        subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
-            cmd,
-            cwd=str(cwd),
-            capture_output=True,
-            text=True,
-            check=True,
-            env=env,
-        )
-    )
+from tests.unit.conftest import init_git_repo, run_git
 
 
 def _init_git_repo(tmp_path: Path) -> Path:
-    """Create a temp git repo with an initial commit."""
-    _run(["git", "init"], cwd=tmp_path)
-    _run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path)
-    _run(["git", "config", "user.name", "Test User"], cwd=tmp_path)
-    # Avoid depending on system default branch name.
-    _run(["git", "checkout", "-b", "main"], cwd=tmp_path)
-    tracked = tmp_path / "tracked.py"
-    tracked.write_text("alpha = 1\n", encoding="utf-8")
-    other = tmp_path / "other.py"
-    other.write_text("keep = True\n", encoding="utf-8")
-    _run(["git", "add", "tracked.py", "other.py"], cwd=tmp_path)
-    _run(["git", "commit", "-m", "init"], cwd=tmp_path)
-    return tmp_path
+    """Create a temp git repo with two committed files.
+
+    Args:
+        tmp_path: Pytest temp directory.
+
+    Returns:
+        The repository root.
+    """
+    return init_git_repo(
+        tmp_path,
+        files={"tracked.py": "alpha = 1\n", "other.py": "keep = True\n"},
+    )
 
 
 def _index_sha(*, cwd: Path) -> str:
-    """Return the sha of the real index tree (user index must stay stable)."""
-    env = os.environ.copy()
-    # Force using the real index (clear any leaked GIT_INDEX_FILE).
-    env.pop("GIT_INDEX_FILE", None)
-    result = (
-        subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
-            ["git", "write-tree"],
-            cwd=str(cwd),
-            capture_output=True,
-            text=True,
-            check=True,
-            env=env,
-        )
-    )
-    return result.stdout.strip()
+    """Return the sha of the real index tree (the user index must stay stable).
+
+    Args:
+        cwd: Repository directory.
+
+    Returns:
+        Object name of the tree written from the real index.
+    """
+    return run_git(["git", "write-tree"], cwd=cwd).stdout.strip()
 
 
 def _staged_diff(*, cwd: Path) -> str:
@@ -98,7 +63,7 @@ def _staged_diff(*, cwd: Path) -> str:
     Returns:
         Output of ``git diff --cached``.
     """
-    return _run(["git", "diff", "--cached"], cwd=cwd).stdout
+    return run_git(["git", "diff", "--cached"], cwd=cwd).stdout
 
 
 def _make_suggestion(file: str, original: str, suggested: str) -> AIFixSuggestion:
@@ -156,10 +121,10 @@ def test_capture_does_not_touch_dirty_user_index(tmp_path: Path) -> None:
     repo = _init_git_repo(tmp_path)
     tracked = repo / "tracked.py"
     tracked.write_text("alpha = 2\n", encoding="utf-8")
-    _run(["git", "add", "tracked.py"], cwd=repo)
+    run_git(["git", "add", "tracked.py"], cwd=repo)
     staged_before = _staged_diff(cwd=repo)
     index_before = _index_sha(cwd=repo)
-    head_before = _run(["git", "rev-parse", "HEAD"], cwd=repo).stdout.strip()
+    head_before = run_git(["git", "rev-parse", "HEAD"], cwd=repo).stdout.strip()
 
     # Also leave an unstaged edit on another file.
     other = repo / "other.py"
@@ -175,7 +140,7 @@ def test_capture_does_not_touch_dirty_user_index(tmp_path: Path) -> None:
     assert_that(_staged_diff(cwd=repo)).is_equal_to(staged_before)
     assert_that(_index_sha(cwd=repo)).is_equal_to(index_before)
     assert_that(
-        _run(["git", "rev-parse", "HEAD"], cwd=repo).stdout.strip(),
+        run_git(["git", "rev-parse", "HEAD"], cwd=repo).stdout.strip(),
     ).is_equal_to(
         head_before,
     )
@@ -188,7 +153,7 @@ def test_restore_does_not_touch_dirty_user_index(tmp_path: Path) -> None:
     repo = _init_git_repo(tmp_path)
     tracked = repo / "tracked.py"
     tracked.write_text("alpha = 2\n", encoding="utf-8")
-    _run(["git", "add", "tracked.py"], cwd=repo)
+    run_git(["git", "add", "tracked.py"], cwd=repo)
     staged_before = _staged_diff(cwd=repo)
     index_before = _index_sha(cwd=repo)
 
@@ -550,7 +515,7 @@ def test_restore_preserves_symlink_targets(tmp_path: Path) -> None:
     repo = _init_git_repo(tmp_path)
     link = repo / "link.py"
     link.symlink_to("tracked.py")
-    _run(["git", "add", "link.py"], cwd=repo)
+    run_git(["git", "add", "link.py"], cwd=repo)
 
     checkpoint = capture_checkpoint(["link.py"], workspace_root=repo, keep=10)
     assert_that(checkpoint).is_not_none()
@@ -614,3 +579,32 @@ def test_restore_reverts_a_mode_the_run_changed(tmp_path: Path) -> None:
     restore_checkpoint(checkpoint)  # type: ignore[arg-type]
 
     assert_that(script.stat().st_mode & 0o777).is_equal_to(0o644)
+
+
+def test_interactive_review_receives_the_prepared_undo_state(tmp_path: Path) -> None:
+    """The interactive branch must hand its checkpoint to the review loop.
+
+    Without it, rejecting a group silently skips rollback in production even
+    though the unit tests that pass ``undo_state`` directly still pass.
+    """
+    repo = _init_git_repo(tmp_path)
+    config = AIConfig(auto_apply=False, auto_apply_safe_fixes=False)
+    suggestion = _make_suggestion("tracked.py", "alpha = 1\n", "alpha = 2\n")
+
+    with (
+        patch("lintro.ai.pipeline.sys.stdin.isatty", return_value=True),
+        patch("lintro.ai.pipeline.review_fixes_interactive") as mock_review,
+    ):
+        mock_review.return_value = (0, 0, [])
+        _apply_or_review(
+            [suggestion],
+            config,
+            MagicMock(),
+            is_json=False,
+            workspace_root=repo,
+        )
+
+    assert_that(mock_review.call_count).is_equal_to(1)
+    passed = mock_review.call_args.kwargs.get("undo_state")
+    assert_that(passed).is_not_none()
+    assert_that(passed.kind).is_equal_to("git")  # type: ignore[union-attr]

--- a/tests/unit/ai/test_config.py
+++ b/tests/unit/ai/test_config.py
@@ -329,3 +329,17 @@ def test_explicit_sub_toggle_suppresses_legacy_default(
     assert_that(config.review).is_true()
     deprecations = [w for w in recwarn if issubclass(w.category, DeprecationWarning)]
     assert_that(deprecations).is_empty()
+
+
+def test_checkpoint_defaults() -> None:
+    """Git checkpoint retention defaults to 10; fmt checkpointing is off."""
+    config = AIConfig()
+    assert_that(config.checkpoint_retention).is_equal_to(10)
+    assert_that(config.checkpoint_fmt).is_false()
+
+
+def test_checkpoint_overrides() -> None:
+    """Checkpoint config keys can be overridden."""
+    config = AIConfig(checkpoint_retention=3, checkpoint_fmt=True)
+    assert_that(config.checkpoint_retention).is_equal_to(3)
+    assert_that(config.checkpoint_fmt).is_true()

--- a/tests/unit/ai/test_config.py
+++ b/tests/unit/ai/test_config.py
@@ -343,3 +343,15 @@ def test_checkpoint_overrides() -> None:
     config = AIConfig(checkpoint_retention=3, checkpoint_fmt=True)
     assert_that(config.checkpoint_retention).is_equal_to(3)
     assert_that(config.checkpoint_fmt).is_true()
+
+
+def test_checkpoint_retention_accepts_zero() -> None:
+    """Zero retention is valid and means "keep only the current run"."""
+    assert_that(AIConfig(checkpoint_retention=0).checkpoint_retention).is_equal_to(0)
+
+
+def test_checkpoint_retention_rejects_negative() -> None:
+    """Negative retention is rejected by the ge=0 bound."""
+    assert_that(AIConfig).raises(ValidationError).when_called_with(
+        checkpoint_retention=-1,
+    )

--- a/tests/unit/ai/test_interactive.py
+++ b/tests/unit/ai/test_interactive.py
@@ -446,3 +446,32 @@ def test_review_fixes_interactive_quit_via_keyboard(
     assert_that(accepted).is_equal_to(0)
     # Only the first group was seen before quit
     assert_that(applied).is_empty()
+
+
+@patch("lintro.ai.interactive.sys.stdin.isatty", return_value=True)
+@patch("lintro.ai.interactive.click.getchar", side_effect=["r", "q"])
+def test_reject_restores_from_checkpoint(_mock_getchar, _mock_isatty, tmp_path):
+    """Reject restores target files from the pre-batch undo state."""
+    from lintro.ai.undo import prepare_fix_batch
+
+    f = tmp_path / "app.py"
+    f.write_text("x = 1\n", encoding="utf-8")
+    fix = AIFixSuggestion(
+        file=str(f),
+        line=1,
+        code="E001",
+        original_code="x = 1\n",
+        suggested_code="x = 2\n",
+    )
+    undo_state = prepare_fix_batch([fix], tmp_path)
+    f.write_text("x = 99\n", encoding="utf-8")
+
+    accepted, rejected, applied = review_fixes_interactive(
+        [fix],
+        workspace_root=tmp_path,
+        undo_state=undo_state,
+    )
+    assert_that(rejected).is_equal_to(1)
+    assert_that(accepted).is_equal_to(0)
+    assert_that(applied).is_empty()
+    assert_that(f.read_text(encoding="utf-8")).is_equal_to("x = 1\n")

--- a/tests/unit/ai/test_interactive.py
+++ b/tests/unit/ai/test_interactive.py
@@ -475,3 +475,45 @@ def test_reject_restores_from_checkpoint(_mock_getchar, _mock_isatty, tmp_path):
     assert_that(accepted).is_equal_to(0)
     assert_that(applied).is_empty()
     assert_that(f.read_text(encoding="utf-8")).is_equal_to("x = 1\n")
+
+
+@patch("lintro.ai.interactive.sys.stdin.isatty", return_value=True)
+@patch("lintro.ai.interactive.click.getchar", side_effect=["y", "r"])
+def test_reject_preserves_accepted_fixes_in_shared_file(
+    _mock_getchar,
+    _mock_isatty,
+    tmp_path,
+):
+    """Rejecting a group must not roll back a file an earlier group changed."""
+    from lintro.ai.undo import prepare_fix_batch
+
+    target = tmp_path / "app.py"
+    target.write_text("x = 1\ny = 1\n", encoding="utf-8")
+    accepted_fix = AIFixSuggestion(
+        file=str(target),
+        line=1,
+        code="E001",
+        original_code="x = 1\n",
+        suggested_code="x = 2\n",
+    )
+    rejected_fix = AIFixSuggestion(
+        file=str(target),
+        line=2,
+        code="E002",
+        original_code="y = 1\n",
+        suggested_code="y = 2\n",
+    )
+    undo_state = prepare_fix_batch([accepted_fix, rejected_fix], tmp_path)
+
+    accepted, rejected, applied = review_fixes_interactive(
+        [accepted_fix, rejected_fix],
+        workspace_root=tmp_path,
+        undo_state=undo_state,
+    )
+
+    assert_that(accepted).is_equal_to(1)
+    assert_that(rejected).is_equal_to(1)
+    assert_that(applied).is_length(1)
+    contents = target.read_text(encoding="utf-8")
+    assert_that(contents).contains("x = 2")
+    assert_that(contents).contains("y = 1")

--- a/tests/unit/ai/test_undo.py
+++ b/tests/unit/ai/test_undo.py
@@ -122,7 +122,10 @@ def test_file_fallback_restore_preserves_mode(tmp_path: Path) -> None:
     )
 
     state = prepare_fix_batch([suggestion], tmp_path)
+    assert_that(state).is_not_none()
+    # Simulate a formatter that rewrites the file and drops the exec bit.
     script.write_text("#!/bin/sh\necho two\n", encoding="utf-8")
+    script.chmod(0o600)
     restore_undo(state)  # type: ignore[arg-type]
 
     assert_that(script.read_text(encoding="utf-8")).contains("echo one")

--- a/tests/unit/ai/test_undo.py
+++ b/tests/unit/ai/test_undo.py
@@ -7,7 +7,13 @@ from pathlib import Path
 from assertpy import assert_that
 
 from lintro.ai.models import AIFixSuggestion
-from lintro.ai.undo import UNDO_DIR, UNDO_FILE, save_undo_patch
+from lintro.ai.undo import (
+    UNDO_DIR,
+    UNDO_FILE,
+    prepare_fix_batch,
+    restore_undo,
+    save_undo_patch,
+)
 
 
 def _make_suggestion(
@@ -74,3 +80,50 @@ def test_patch_content_is_valid_unified_diff(tmp_path: Path) -> None:
     assert_that(content).contains("---")
     assert_that(content).contains("+++")
     assert_that(content).contains("@@")
+
+
+def test_file_fallback_never_writes_outside_the_workspace(tmp_path: Path) -> None:
+    """An escaping path is dropped at capture and never restored."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outsider = tmp_path / "outside.py"
+    outsider.write_text("secret = 1\n", encoding="utf-8")
+    suggestion = AIFixSuggestion(
+        file="../outside.py",
+        line=1,
+        code="E001",
+        original_code="secret = 1\n",
+        suggested_code="secret = 2\n",
+    )
+
+    state = prepare_fix_batch([suggestion], workspace)
+
+    assert_that(state).is_not_none()
+    assert_that(state.file_snapshot.contents).is_empty()  # type: ignore[union-attr]
+
+    outsider.write_text("secret = 999\n", encoding="utf-8")
+    restore_undo(state)  # type: ignore[arg-type]
+
+    assert_that(outsider.exists()).is_true()
+    assert_that(outsider.read_text(encoding="utf-8")).is_equal_to("secret = 999\n")
+
+
+def test_file_fallback_restore_preserves_mode(tmp_path: Path) -> None:
+    """The non-git fallback keeps the executable bit on restore."""
+    script = tmp_path / "run.sh"
+    script.write_text("#!/bin/sh\necho one\n", encoding="utf-8")
+    script.chmod(0o755)
+    suggestion = AIFixSuggestion(
+        file="run.sh",
+        line=1,
+        code="E001",
+        original_code="echo one\n",
+        suggested_code="echo two\n",
+    )
+
+    state = prepare_fix_batch([suggestion], tmp_path)
+    script.write_text("#!/bin/sh\necho two\n", encoding="utf-8")
+    restore_undo(state)  # type: ignore[arg-type]
+
+    assert_that(script.read_text(encoding="utf-8")).contains("echo one")
+    assert_that(script.stat().st_mode & 0o777).is_equal_to(0o755)

--- a/tests/unit/ai/test_undo.py
+++ b/tests/unit/ai/test_undo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from assertpy import assert_that
 
 from lintro.ai.models import AIFixSuggestion
@@ -82,7 +83,10 @@ def test_patch_content_is_valid_unified_diff(tmp_path: Path) -> None:
     assert_that(content).contains("@@")
 
 
-def test_file_fallback_never_writes_outside_the_workspace(tmp_path: Path) -> None:
+def test_file_fallback_never_writes_outside_the_workspace(
+    tmp_path: Path,
+    no_git_checkpoints: None,
+) -> None:
     """An escaping path is dropped at capture and never restored."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -108,7 +112,10 @@ def test_file_fallback_never_writes_outside_the_workspace(tmp_path: Path) -> Non
     assert_that(outsider.read_text(encoding="utf-8")).is_equal_to("secret = 999\n")
 
 
-def test_file_fallback_restore_preserves_mode(tmp_path: Path) -> None:
+def test_file_fallback_restore_preserves_mode(
+    tmp_path: Path,
+    no_git_checkpoints: None,
+) -> None:
     """The non-git fallback keeps the executable bit on restore."""
     script = tmp_path / "run.sh"
     script.write_text("#!/bin/sh\necho one\n", encoding="utf-8")
@@ -130,3 +137,20 @@ def test_file_fallback_restore_preserves_mode(tmp_path: Path) -> None:
 
     assert_that(script.read_text(encoding="utf-8")).contains("echo one")
     assert_that(script.stat().st_mode & 0o777).is_equal_to(0o755)
+
+
+@pytest.fixture
+def no_git_checkpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the file-snapshot backend regardless of where tmp_path lives.
+
+    ``prepare_fix_batch`` prefers git whenever the workspace is inside a work
+    tree, so a ``TMPDIR`` under one would silently skip the fallback these
+    tests exist to cover.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        "lintro.ai.undo.git_checkpoints_available",
+        lambda _workspace_root: False,
+    )

--- a/tests/unit/api/test_pipeline_checkpoints.py
+++ b/tests/unit/api/test_pipeline_checkpoints.py
@@ -53,6 +53,7 @@ def _make_ctx(
     dry_run_preview: bool = False,
     checkpoint_fmt: bool = True,
     clean_stdout_output: bool = False,
+    score_only: bool = False,
 ) -> RunContext:
     """Build a RunContext wired to a recording logger and a stub config.
 
@@ -61,6 +62,7 @@ def _make_ctx(
         dry_run_preview: Whether this is a ``fmt --dry-run`` preview.
         checkpoint_fmt: Value of the ``ai.checkpoint_fmt`` toggle.
         clean_stdout_output: Whether stdout carries a machine document.
+        score_only: Whether stdout carries only the numeric health score.
 
     Returns:
         RunContext: A context suitable for the checkpoint hook under test.
@@ -73,7 +75,7 @@ def _make_ctx(
         logger=_RecordingLogger(),
         lintro_config=_ConfigStub(ai=_AIConfigStub(checkpoint_fmt=checkpoint_fmt)),
         clean_stdout_output=clean_stdout_output,
-        score_only=False,
+        score_only=score_only,
     )
 
 
@@ -184,6 +186,21 @@ def test_fmt_checkpoint_quiet_for_machine_output(
     repo = _init_git_repo(tmp_path)
     monkeypatch.chdir(repo)
     ctx = _make_ctx(clean_stdout_output=True)
+
+    _capture_fmt_checkpoint(ctx=ctx, paths=["tracked.py"])
+
+    assert_that(list_checkpoint_refs(workspace_root=repo)).is_length(1)
+    assert_that(ctx.logger.lines).is_empty()
+
+
+def test_fmt_checkpoint_quiet_for_score_only_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A score-only run captures a ref without polluting the score line."""
+    repo = _init_git_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    ctx = _make_ctx(score_only=True)
 
     _capture_fmt_checkpoint(ctx=ctx, paths=["tracked.py"])
 

--- a/tests/unit/api/test_pipeline_checkpoints.py
+++ b/tests/unit/api/test_pipeline_checkpoints.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess  # nosec B404 - subprocess drives git in temp test repos; shell=False
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -10,10 +9,15 @@ from typing import Any
 import pytest
 from assertpy import assert_that
 
-from lintro.ai.checkpoints import CHECKPOINT_REF_PREFIX, list_checkpoint_refs
+from lintro.ai.checkpoints import (
+    CHECKPOINT_REF_PREFIX,
+    capture_checkpoint,
+    list_checkpoint_refs,
+)
 from lintro.api.pipeline import _capture_fmt_checkpoint
 from lintro.enums.action import Action
 from lintro.utils.execution.run_context import RunContext
+from tests.unit.conftest import init_git_repo
 
 
 @dataclass
@@ -88,32 +92,7 @@ def _init_git_repo(tmp_path: Path) -> Path:
     Returns:
         The repository root.
     """
-    for cmd in (
-        ["git", "init"],
-        ["git", "config", "user.email", "test@example.com"],
-        ["git", "config", "user.name", "Test User"],
-        ["git", "checkout", "-b", "main"],
-    ):
-        subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
-            cmd,
-            cwd=str(tmp_path),
-            capture_output=True,
-            check=True,
-        )
-    (tmp_path / "tracked.py").write_text("alpha = 1\n", encoding="utf-8")
-    subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
-        ["git", "add", "tracked.py"],
-        cwd=str(tmp_path),
-        capture_output=True,
-        check=True,
-    )
-    subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
-        ["git", "commit", "-m", "init"],
-        cwd=str(tmp_path),
-        capture_output=True,
-        check=True,
-    )
-    return tmp_path
+    return init_git_repo(tmp_path, files={"tracked.py": "alpha = 1\n"})
 
 
 def test_fmt_checkpoint_captured_and_announced(
@@ -206,3 +185,26 @@ def test_fmt_checkpoint_quiet_for_score_only_output(
 
     assert_that(list_checkpoint_refs(workspace_root=repo)).is_length(1)
     assert_that(ctx.logger.lines).is_empty()
+
+
+def test_fmt_checkpoint_resolves_paths_from_the_invocation_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A relative target is read from the cwd, not from the repository root."""
+    repo = init_git_repo(
+        tmp_path,
+        files={"tracked.py": "alpha = 1\n", "pkg/tracked.py": "beta = 1\n"},
+    )
+    monkeypatch.chdir(repo / "pkg")
+    ctx = _make_ctx()
+
+    _capture_fmt_checkpoint(ctx=ctx, paths=["tracked.py"])
+
+    checkpoint = capture_checkpoint(
+        ["tracked.py"],
+        workspace_root=repo / "pkg",
+        keep=10,
+    )
+    assert_that(checkpoint).is_not_none()
+    assert_that(list(checkpoint.paths)).is_equal_to(["pkg/tracked.py"])  # type: ignore[union-attr]

--- a/tests/unit/api/test_pipeline_checkpoints.py
+++ b/tests/unit/api/test_pipeline_checkpoints.py
@@ -1,0 +1,191 @@
+"""Unit tests for the opt-in ``fmt`` git checkpoint hook (issue #1247)."""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 - subprocess drives git in temp test repos; shell=False
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.checkpoints import CHECKPOINT_REF_PREFIX, list_checkpoint_refs
+from lintro.api.pipeline import _capture_fmt_checkpoint
+from lintro.enums.action import Action
+from lintro.utils.execution.run_context import RunContext
+
+
+@dataclass
+class _RecordingLogger:
+    """Console logger stub that records what would be printed."""
+
+    lines: list[str] = field(default_factory=list)
+
+    def console_output(self, text: str = "", **_kwargs: Any) -> None:
+        """Record one console line.
+
+        Args:
+            text: The line that would be printed.
+            **_kwargs: Styling arguments the real logger accepts.
+        """
+        self.lines.append(text)
+
+
+@dataclass
+class _AIConfigStub:
+    """Minimal stand-in for the ``ai`` section of the config."""
+
+    checkpoint_fmt: bool = True
+    checkpoint_retention: int = 10
+
+
+@dataclass
+class _ConfigStub:
+    """Minimal stand-in for the loaded lintro config."""
+
+    ai: _AIConfigStub | None = field(default_factory=_AIConfigStub)
+
+
+def _make_ctx(
+    *,
+    action: Action = Action.FIX,
+    dry_run_preview: bool = False,
+    checkpoint_fmt: bool = True,
+    clean_stdout_output: bool = False,
+) -> RunContext:
+    """Build a RunContext wired to a recording logger and a stub config.
+
+    Args:
+        action: The action the run executes.
+        dry_run_preview: Whether this is a ``fmt --dry-run`` preview.
+        checkpoint_fmt: Value of the ``ai.checkpoint_fmt`` toggle.
+        clean_stdout_output: Whether stdout carries a machine document.
+
+    Returns:
+        RunContext: A context suitable for the checkpoint hook under test.
+    """
+    return RunContext(
+        action=action,
+        selection_action=Action.FIX,
+        dry_run_preview=dry_run_preview,
+        output_manager=None,
+        logger=_RecordingLogger(),
+        lintro_config=_ConfigStub(ai=_AIConfigStub(checkpoint_fmt=checkpoint_fmt)),
+        clean_stdout_output=clean_stdout_output,
+        score_only=False,
+    )
+
+
+def _init_git_repo(tmp_path: Path) -> Path:
+    """Create a temp git repo with one committed file.
+
+    Args:
+        tmp_path: Pytest temp directory.
+
+    Returns:
+        The repository root.
+    """
+    for cmd in (
+        ["git", "init"],
+        ["git", "config", "user.email", "test@example.com"],
+        ["git", "config", "user.name", "Test User"],
+        ["git", "checkout", "-b", "main"],
+    ):
+        subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
+            cmd,
+            cwd=str(tmp_path),
+            capture_output=True,
+            check=True,
+        )
+    (tmp_path / "tracked.py").write_text("alpha = 1\n", encoding="utf-8")
+    subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
+        ["git", "add", "tracked.py"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
+        ["git", "commit", "-m", "init"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        check=True,
+    )
+    return tmp_path
+
+
+def test_fmt_checkpoint_captured_and_announced(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With ``checkpoint_fmt`` on, a fmt run captures and prints a ref."""
+    repo = _init_git_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    ctx = _make_ctx()
+
+    _capture_fmt_checkpoint(ctx=ctx, paths=["tracked.py"])
+
+    refs = list_checkpoint_refs(workspace_root=repo)
+    assert_that(refs).is_length(1)
+    assert_that(ctx.logger.lines).is_length(1)
+    assert_that(ctx.logger.lines[0]).contains(CHECKPOINT_REF_PREFIX)
+
+
+def test_fmt_checkpoint_skipped_when_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hook is a no-op unless ``ai.checkpoint_fmt`` is enabled."""
+    repo = _init_git_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    ctx = _make_ctx(checkpoint_fmt=False)
+
+    _capture_fmt_checkpoint(ctx=ctx, paths=["tracked.py"])
+
+    assert_that(list_checkpoint_refs(workspace_root=repo)).is_empty()
+    assert_that(ctx.logger.lines).is_empty()
+
+
+def test_fmt_checkpoint_skipped_for_check_and_dry_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nothing is captured for a check run or a fmt dry-run preview."""
+    repo = _init_git_repo(tmp_path)
+    monkeypatch.chdir(repo)
+
+    check_ctx = _make_ctx(action=Action.CHECK)
+    _capture_fmt_checkpoint(ctx=check_ctx, paths=["tracked.py"])
+    dry_ctx = _make_ctx(dry_run_preview=True)
+    _capture_fmt_checkpoint(ctx=dry_ctx, paths=["tracked.py"])
+
+    assert_that(list_checkpoint_refs(workspace_root=repo)).is_empty()
+
+
+def test_fmt_checkpoint_silent_outside_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Outside a git work tree the hook captures nothing and stays quiet."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tracked.py").write_text("alpha = 1\n", encoding="utf-8")
+    ctx = _make_ctx()
+
+    _capture_fmt_checkpoint(ctx=ctx, paths=["tracked.py"])
+
+    assert_that(ctx.logger.lines).is_empty()
+
+
+def test_fmt_checkpoint_quiet_for_machine_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ref is still captured for JSON/score runs, but nothing is printed."""
+    repo = _init_git_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    ctx = _make_ctx(clean_stdout_output=True)
+
+    _capture_fmt_checkpoint(ctx=ctx, paths=["tracked.py"])
+
+    assert_that(list_checkpoint_refs(workspace_root=repo)).is_length(1)
+    assert_that(ctx.logger.lines).is_empty()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,8 @@
 """Shared fixtures for unit tests."""
 
+import os
+import subprocess  # nosec B404 - drives git in temp test repos; shell=False
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -142,3 +145,58 @@ def fake_logger() -> FakeLogger:
         FakeLogger: Configured FakeLogger instance for unit testing.
     """
     return FakeLogger()
+
+
+def run_git(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run a git command in a temp repo, isolated from developer git config.
+
+    A global ``commit.gpgsign``, ``core.hooksPath`` or ``init.templateDir``
+    would otherwise change how these fixtures behave from machine to machine,
+    and an exported ``GIT_INDEX_FILE`` would point git at the wrong index.
+
+    Args:
+        cmd: Full argv, starting with ``git``.
+        cwd: Working directory.
+
+    Returns:
+        The completed process.
+    """
+    env = os.environ.copy()
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_CONFIG_SYSTEM"] = os.devnull
+    for leaked in ("GIT_INDEX_FILE", "GIT_DIR", "GIT_WORK_TREE"):
+        env.pop(leaked, None)
+    return (
+        subprocess.run(  # nosec B603 B607 - fixed git argv in a temp repo; shell=False
+            cmd,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+        )
+    )
+
+
+def init_git_repo(tmp_path: Path, *, files: dict[str, str]) -> Path:
+    """Create a temp git repo on ``main`` with ``files`` committed.
+
+    Args:
+        tmp_path: Directory to turn into a repository.
+        files: Repo-relative path to contents for the initial commit.
+
+    Returns:
+        The repository root.
+    """
+    run_git(["git", "init"], cwd=tmp_path)
+    run_git(["git", "config", "user.email", "test@example.com"], cwd=tmp_path)
+    run_git(["git", "config", "user.name", "Test User"], cwd=tmp_path)
+    # Pin the branch name rather than depending on the host's init.defaultBranch.
+    run_git(["git", "checkout", "-b", "main"], cwd=tmp_path)
+    for rel, contents in files.items():
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(contents, encoding="utf-8")
+    run_git(["git", "add", *files], cwd=tmp_path)
+    run_git(["git", "commit", "-m", "init"], cwd=tmp_path)
+    return tmp_path


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai): add git-checkpoint rollback for fix application
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

- New `lintro/ai/checkpoints.py` — capture, restore, diff, list, prune, all via git plumbing over `subprocess` (no gitpython).
- `lintro/ai/undo.py` — `UndoState` picks a git checkpoint when available and falls back to file-content snapshots outside a git work tree; the legacy reverse patch under `.lintro-cache/ai` is still written.
- `lintro/ai/pipeline.py` — every fix batch (safe fast path, auto-apply, interactive) captures state first, and a run that changed anything prints its checkpoint ref.
- `lintro/ai/interactive.py` — rejecting a group restores from the checkpoint tree, not from in-memory copies.
- `lintro/api/pipeline.py` — opt-in `ai.checkpoint_fmt` captures a checkpoint before `lintro fmt` mutates files.
- Config: `ai.checkpoint_retention` (default 10) and `ai.checkpoint_fmt` (default false), plus docs.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1247

## Details

- `uv run lintro chk` / `uv run lintro fmt` — 0 issues.
- `uv run pytest` — 8608 passed. Tests cover dirty-index, staged state, untracked targets, user-edited-between, absolute paths, glob-magic filenames, symlinks, permission preservation, retention boundaries, and the non-git fallback, over temp git repos.

Closes #1247
