### PR TITLE
feat(cli): add --group-by category for issue grouping

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -203,7 +203,7 @@ lintro fmt, chk, tst
 --output-format grid        # Use grid output (recommended)
 --tools ruff,prettier        # Run specific tools only
 --output results.txt         # Save output to file
---group-by [file|code|none|auto|category]  # Group issues by type
+--group-by [file|code|none|auto|category]  # Group issues (category: check/format)
 --exclude "venv,node_modules" # Exclude patterns
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -203,7 +203,7 @@ lintro fmt, chk, tst
 --output-format grid        # Use grid output (recommended)
 --tools ruff,prettier        # Run specific tools only
 --output results.txt         # Save output to file
---group-by [file|code|auto|category]  # Group issues by type
+--group-by [file|code|none|auto|category]  # Group issues by type
 --exclude "venv,node_modules" # Exclude patterns
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -203,7 +203,7 @@ lintro fmt, chk, tst
 --output-format grid        # Use grid output (recommended)
 --tools ruff,prettier        # Run specific tools only
 --output results.txt         # Save output to file
---group-by [file|code|auto]  # Group issues by type
+--group-by [file|code|auto|category]  # Group issues by type
 --exclude "venv,node_modules" # Exclude patterns
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -338,7 +338,7 @@ lintro format --no-art
 # Output options
 lintro check                  # Use grid formatting
 lintro check --output results.txt            # Save output to file
-lintro check --group-by [file|code|none|auto] # Group issues
+lintro check --group-by [file|code|none|auto|category] # Group issues
 
 # Tool selection
 lintro check --tools ruff,prettier           # Run specific tools only

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -296,7 +296,7 @@ docker compose run --rm lintro check --tools ruff,prettier
 
 - `--tools TEXT` - Comma-separated list of tools (default: all)
 - `--output-format grid` - Format output as a grid table
-- `--group-by [file|code|none|auto]` - How to group issues
+- `--group-by [file|code|none|auto|category]` - How to group issues
 - `--output FILE` - Save output to file
 - `--exclude TEXT` - Patterns to exclude
 - `--include-venv` - Include virtual environment directories

--- a/lintro/api/core.py
+++ b/lintro/api/core.py
@@ -265,7 +265,7 @@ def test(
         include_venv: Whether to include virtual environment directories.
         output: Path to an output file for results.
         output_format: Format for displaying results (grid, json, etc).
-        group_by: How to group issues in output (file, code, none, auto, category).
+        group_by: How to group issues in output (file, code, none, auto).
         verbose: Whether to show verbose output during execution.
         raw_output: Whether to show raw tool output instead of formatted output.
         tool_options: Tool-specific options in ``option=value`` form.

--- a/lintro/api/core.py
+++ b/lintro/api/core.py
@@ -112,7 +112,7 @@ def check(
         include_venv: Whether to include virtual environment directories.
         output: Path to an output file for results.
         output_format: Format for displaying results (grid, json, etc).
-        group_by: How to group issues in output (file, code, none, auto).
+        group_by: How to group issues in output (file, code, none, auto, category).
         ignore_conflicts: Whether to ignore tool configuration conflicts.
         verbose: Whether to show verbose output during execution.
         no_log: Whether to disable logging to file.
@@ -189,7 +189,7 @@ def format(
         tool_options: Tool-specific configuration options.
         exclude: Comma-separated patterns of files/dirs to exclude.
         include_venv: Whether to include virtual environment directories.
-        group_by: How to group issues in output (file, code, none, auto).
+        group_by: How to group issues in output (file, code, none, auto, category).
         output: Path to an output file for results.
         output_format: Format for displaying results (grid, json, etc).
         verbose: Whether to show verbose output during execution.
@@ -265,7 +265,7 @@ def test(
         include_venv: Whether to include virtual environment directories.
         output: Path to an output file for results.
         output_format: Format for displaying results (grid, json, etc).
-        group_by: How to group issues in output (file, code, none, auto).
+        group_by: How to group issues in output (file, code, none, auto, category).
         verbose: Whether to show verbose output during execution.
         raw_output: Whether to show raw tool output instead of formatted output.
         tool_options: Tool-specific options in ``option=value`` form.

--- a/lintro/api/pipeline.py
+++ b/lintro/api/pipeline.py
@@ -233,6 +233,7 @@ def run_lint_artifact(
         debug=debug,
         no_art=no_art,
         dry_run=dry_run,
+        group_by=group_by,
     )
     _capture_fmt_checkpoint(ctx=ctx, paths=paths)
     artifact = execute_run(
@@ -258,6 +259,7 @@ def run_lint_artifact(
             output_format=output_format,
             raw_output=raw_output,
             action=ctx.action,
+            group_by=group_by,
         ),
     )
 

--- a/lintro/cli_utils/commands/check.py
+++ b/lintro/cli_utils/commands/check.py
@@ -59,7 +59,7 @@ DEFAULT_ACTION: str = "check"
 )
 @click.option(
     "--group-by",
-    type=click.Choice(["file", "code", "none", "auto"]),
+    type=click.Choice(["file", "code", "none", "auto", "category"]),
     default="file",
     help="How to group issues in the output",
 )

--- a/lintro/cli_utils/commands/format.py
+++ b/lintro/cli_utils/commands/format.py
@@ -40,7 +40,7 @@ DEFAULT_ACTION: str = "fmt"
 @click.option(
     "--group-by",
     default="auto",
-    type=click.Choice(["file", "code", "none", "auto"]),
+    type=click.Choice(["file", "code", "none", "auto", "category"]),
     help="How to group issues in output.",
 )
 @click.option(

--- a/lintro/cli_utils/commands/test.py
+++ b/lintro/cli_utils/commands/test.py
@@ -58,7 +58,7 @@ def _ensure_pytest_prefix(option_fragment: str) -> str:
 )
 @click.option(
     "--group-by",
-    type=click.Choice(["file", "code", "none", "auto"]),
+    type=click.Choice(["file", "code", "none", "auto", "category"]),
     default="file",
     help="How to group issues in the output",
 )

--- a/lintro/cli_utils/commands/test.py
+++ b/lintro/cli_utils/commands/test.py
@@ -58,7 +58,7 @@ def _ensure_pytest_prefix(option_fragment: str) -> str:
 )
 @click.option(
     "--group-by",
-    type=click.Choice(["file", "code", "none", "auto", "category"]),
+    type=click.Choice(["file", "code", "none", "auto"]),
     default="file",
     help="How to group issues in the output",
 )

--- a/lintro/enums/group_by.py
+++ b/lintro/enums/group_by.py
@@ -14,6 +14,7 @@ class GroupBy(StrEnum):
     CODE = auto()
     NONE = auto()
     AUTO = auto()
+    CATEGORY = auto()
 
 
 def normalize_group_by(value: str | GroupBy) -> GroupBy:

--- a/lintro/enums/issue_category.py
+++ b/lintro/enums/issue_category.py
@@ -1,0 +1,33 @@
+"""Issue concern-category definitions for grouping and taxonomy."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class IssueCategory(StrEnum):
+    """High-level concern categories for lint and security findings.
+
+    Values are title-case display labels used as section headers when
+    ``--group-by category`` is active.
+    """
+
+    SECURITY = "Security"
+    CORRECTNESS = "Correctness"
+    PERFORMANCE = "Performance"
+    STYLE = "Style"
+    ACCESSIBILITY = "Accessibility"
+    DOCUMENTATION = "Documentation"
+    INFRASTRUCTURE = "Infrastructure"
+
+
+# Stable display order for category sections.
+ISSUE_CATEGORY_ORDER: tuple[IssueCategory, ...] = (
+    IssueCategory.SECURITY,
+    IssueCategory.CORRECTNESS,
+    IssueCategory.PERFORMANCE,
+    IssueCategory.STYLE,
+    IssueCategory.ACCESSIBILITY,
+    IssueCategory.DOCUMENTATION,
+    IssueCategory.INFRASTRUCTURE,
+)

--- a/lintro/formatters/__init__.py
+++ b/lintro/formatters/__init__.py
@@ -13,6 +13,7 @@ from lintro.formatters.formatter import (
     UnifiedTableDescriptor,
     format_fix_results,
     format_issues,
+    format_issues_by_category,
     format_issues_with_sections,
     format_tool_result,
 )
@@ -20,6 +21,7 @@ from lintro.formatters.formatter import (
 __all__ = [
     # Unified formatter (primary API)
     "format_issues",
+    "format_issues_by_category",
     "format_issues_with_sections",
     "format_fix_results",
     "format_tool_result",

--- a/lintro/formatters/formatter.py
+++ b/lintro/formatters/formatter.py
@@ -18,13 +18,16 @@ Example:
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
 
 from lintro.enums.display_column import STANDARD_COLUMNS, DisplayColumn
+from lintro.enums.issue_category import ISSUE_CATEGORY_ORDER
 from lintro.enums.output_format import OutputFormat, normalize_output_format
 from lintro.formatters.core.format_registry import TableDescriptor, get_style
 from lintro.parsers.base_issue import BaseIssue
+from lintro.utils.issue_category import enrich_issue_category
 from lintro.utils.path_utils import normalize_file_path_for_display
 
 
@@ -206,6 +209,62 @@ def format_issues(
     rows = descriptor.get_rows(list(issues))
 
     return style.format(columns=cols, rows=rows, tool_name=tool_name)
+
+
+def format_issues_by_category(
+    issues: Sequence[BaseIssue],
+    output_format: OutputFormat | str = OutputFormat.GRID,
+    *,
+    tool_name: str | None = None,
+) -> str:
+    """Format issues grouped into concern-category sections.
+
+    Thin grouping hook for ``--group-by category``. Issues are enriched with
+    a resolved ``category`` and rendered under titled sections. JSON/GitHub
+    formats stay a single table for machine-readable compatibility.
+
+    Args:
+        issues: List of issues (any BaseIssue subclass).
+        output_format: Output format (grid, json, plain, etc.).
+        tool_name: Tool name used for taxonomy fallback and JSON output.
+
+    Returns:
+        Formatted string with category sections (or a single table).
+    """
+    if not issues:
+        return "No issues found."
+
+    normalized_format = normalize_output_format(output_format)
+    buckets: dict[str, list[BaseIssue]] = defaultdict(list)
+    for issue in issues:
+        category = enrich_issue_category(issue, tool_name=tool_name)
+        buckets[category.value].append(issue)
+
+    if normalized_format in {OutputFormat.JSON, OutputFormat.GITHUB}:
+        return format_issues(
+            issues,
+            output_format=normalized_format,
+            tool_name=tool_name,
+        )
+
+    ordered_labels: list[str] = [
+        cat.value for cat in ISSUE_CATEGORY_ORDER if cat.value in buckets
+    ]
+    ordered_labels.extend(
+        sorted(label for label in buckets if label not in ordered_labels),
+    )
+
+    sections: list[str] = []
+    for label in ordered_labels:
+        section_issues = buckets[label]
+        section_output = format_issues(
+            section_issues,
+            output_format=normalized_format,
+            tool_name=tool_name,
+        )
+        sections.append(f"{label} ({len(section_issues)})\n{section_output}")
+
+    return "\n\n".join(sections) if sections else "No issues found."
 
 
 def format_issues_with_sections(

--- a/lintro/formatters/formatter.py
+++ b/lintro/formatters/formatter.py
@@ -220,7 +220,7 @@ def format_issues_by_category(
     """Format issues grouped into concern-category sections.
 
     Thin grouping hook for ``--group-by category``. Issues are enriched with
-    a resolved ``category`` and rendered under titled sections. JSON/GitHub/CSV
+    a resolved ``category`` and rendered under titled sections. JSON/GitHub/CSV/SARIF
     formats stay a single table for machine-readable compatibility.
 
     Args:
@@ -244,6 +244,7 @@ def format_issues_by_category(
         OutputFormat.JSON,
         OutputFormat.GITHUB,
         OutputFormat.CSV,
+        OutputFormat.SARIF,
     }:
         return format_issues(
             issues,

--- a/lintro/formatters/formatter.py
+++ b/lintro/formatters/formatter.py
@@ -220,7 +220,7 @@ def format_issues_by_category(
     """Format issues grouped into concern-category sections.
 
     Thin grouping hook for ``--group-by category``. Issues are enriched with
-    a resolved ``category`` and rendered under titled sections. JSON/GitHub
+    a resolved ``category`` and rendered under titled sections. JSON/GitHub/CSV
     formats stay a single table for machine-readable compatibility.
 
     Args:
@@ -240,7 +240,11 @@ def format_issues_by_category(
         category = enrich_issue_category(issue, tool_name=tool_name)
         buckets[category.value].append(issue)
 
-    if normalized_format in {OutputFormat.JSON, OutputFormat.GITHUB}:
+    if normalized_format in {
+        OutputFormat.JSON,
+        OutputFormat.GITHUB,
+        OutputFormat.CSV,
+    }:
         return format_issues(
             issues,
             output_format=normalized_format,

--- a/lintro/formatters/formatter.py
+++ b/lintro/formatters/formatter.py
@@ -269,7 +269,7 @@ def format_issues_by_category(
         )
         sections.append(f"{label} ({len(section_issues)})\n{section_output}")
 
-    return "\n\n".join(sections) if sections else "No issues found."
+    return "\n\n".join(sections)
 
 
 def format_issues_with_sections(

--- a/lintro/parsers/base_issue.py
+++ b/lintro/parsers/base_issue.py
@@ -40,6 +40,8 @@ class BaseIssue:
         column: Column number where the issue was found (1-based, 0 means unknown).
         message: Human-readable description of the issue.
         doc_url: URL to the rule's documentation page (empty when unavailable).
+        category: Optional concern category (Security, Style, …) used by
+            ``--group-by category``; empty until taxonomy enrichment.
     """
 
     # Default field mapping - subclasses can override specific keys
@@ -48,6 +50,7 @@ class BaseIssue:
         "severity": "severity",
         "fixable": "fixable",
         "message": "message",
+        "category": "category",
     }
 
     DEFAULT_SEVERITY: ClassVar[SeverityLevel] = SeverityLevel.WARNING
@@ -57,6 +60,7 @@ class BaseIssue:
     column: int = field(default=0)
     message: str = field(default="")
     doc_url: str = field(default="", repr=False)
+    category: str = field(default="")
 
     def get_severity(self) -> SeverityLevel:
         """Return the normalized severity for this issue.
@@ -109,7 +113,7 @@ class BaseIssue:
 
         Returns:
             Dictionary with keys: file, line, column, code, message, severity,
-            fixable, doc_url.
+            fixable, doc_url, category.
         """
         # Get the field mapping (supports inheritance)
         field_map = self.DISPLAY_FIELD_MAP
@@ -117,9 +121,11 @@ class BaseIssue:
         # Resolve each mapped field
         fixable_attr = field_map.get("fixable", "fixable")
         message_attr = field_map.get("message", "message")
+        category_attr = field_map.get("category", "category")
 
         fixable_val = getattr(self, fixable_attr, False)
         message_val = getattr(self, message_attr, "") or ""
+        category_val = getattr(self, category_attr, None) or ""
 
         return {
             "file": self.file,
@@ -130,4 +136,5 @@ class BaseIssue:
             "severity": str(self.get_severity()),
             "fixable": "Yes" if fixable_val else "",
             "doc_url": self.doc_url,
+            "category": str(category_val) if category_val else "",
         }

--- a/lintro/parsers/semgrep/semgrep_issue.py
+++ b/lintro/parsers/semgrep/semgrep_issue.py
@@ -18,9 +18,12 @@ class SemgrepIssue(BaseIssue):
         end_line: Ending line number of the issue.
         end_column: Ending column number of the issue.
         severity: Severity level (ERROR, WARNING, INFO).
-        category: Category of the issue (security, correctness, performance, etc.).
         cwe: List of CWE IDs associated with this issue.
         metadata: Additional metadata from the rule.
+
+    Note:
+        ``category`` is inherited from ``BaseIssue`` and populated from Semgrep
+        rule metadata when available.
     """
 
     DISPLAY_FIELD_MAP: ClassVar[dict[str, str]] = {
@@ -33,7 +36,6 @@ class SemgrepIssue(BaseIssue):
     end_line: int = field(default=0)
     end_column: int = field(default=0)
     severity: str = field(default="WARNING")
-    category: str = field(default="")
     cwe: list[str] | None = field(default=None)
     metadata: dict[str, object] | None = field(default=None)
 

--- a/lintro/utils/execution/run_context.py
+++ b/lintro/utils/execution/run_context.py
@@ -40,6 +40,7 @@ class RunContext:
             readable document (json/sarif/csv/markdown), which routes all
             decorative console UI to stderr.
         score_only: Whether stdout must carry only the numeric health score.
+        group_by: How to group issues in formatted and JSON output.
     """
 
     action: Action
@@ -50,3 +51,4 @@ class RunContext:
     lintro_config: Any
     clean_stdout_output: bool
     score_only: bool
+    group_by: str = "auto"

--- a/lintro/utils/execution/run_renderer.py
+++ b/lintro/utils/execution/run_renderer.py
@@ -358,20 +358,7 @@ def _render_stdout_document(
     if fmt == "json":
         import json
 
-        from lintro.enums.group_by import GroupBy, normalize_group_by
-        from lintro.utils.issue_category import enrich_issues_with_categories
         from lintro.utils.json_output import create_json_output
-
-        if normalize_group_by(ctx.group_by) == GroupBy.CATEGORY:
-            for result in all_results:
-                enrich_issues_with_categories(
-                    list(result.issues) if result.issues else None,
-                    tool_name=result.name,
-                )
-                enrich_issues_with_categories(
-                    list(result.initial_issues) if result.initial_issues else None,
-                    tool_name=result.name,
-                )
 
         json_data = create_json_output(
             action=str(artifact.action),
@@ -610,6 +597,12 @@ def render_run(
         if ctx.score_only:
             print(health_score)
         return
+
+    from lintro.enums.group_by import GroupBy, normalize_group_by
+    from lintro.utils.issue_category import enrich_tool_results_with_categories
+
+    if normalize_group_by(ctx.group_by) == GroupBy.CATEGORY:
+        enrich_tool_results_with_categories(artifact.tool_results)
 
     if ctx.score_only:
         # Score-only wins over JSON/SARIF so stdout stays a bare number.

--- a/lintro/utils/execution/run_renderer.py
+++ b/lintro/utils/execution/run_renderer.py
@@ -79,6 +79,7 @@ def _display_fix_result(
     console_output_func: Callable[..., None],
     success_func: Callable[..., None],
     action: Action,
+    group_by: str = "auto",
 ) -> None:
     """Display a single tool result, with initial issue details when available.
 
@@ -93,6 +94,7 @@ def _display_fix_result(
         console_output_func: Function to output text to console.
         success_func: Function to display success message.
         action: The action being performed.
+        group_by: How to group issues in formatted output.
     """
     from lintro.formatters import format_fix_results
     from lintro.utils.output import format_tool_output
@@ -138,6 +140,7 @@ def _display_fix_result(
             issues=list(result.issues) if result.issues else None,
             success=result.success,
             issues_count=result.issues_count,
+            group_by=group_by,
         )
     if result.output and raw_output:
         display_output = result.output
@@ -179,6 +182,7 @@ def make_result_display(
     output_format: str,
     raw_output: bool,
     action: Action,
+    group_by: str = "auto",
 ) -> Callable[[ToolResult], None]:
     """Build the per-tool display callback the execute phase streams through.
 
@@ -191,6 +195,7 @@ def make_result_display(
         output_format: Output format for formatting issues.
         raw_output: Whether to show raw tool output.
         action: The action being performed.
+        group_by: How to group issues in formatted output.
 
     Returns:
         Callable[[ToolResult], None]: Callback that renders one tool result.
@@ -207,6 +212,7 @@ def make_result_display(
             console_output_func=logger.console_output,
             success_func=_success,
             action=action,
+            group_by=group_by,
         )
 
     return _display
@@ -352,7 +358,20 @@ def _render_stdout_document(
     if fmt == "json":
         import json
 
+        from lintro.enums.group_by import GroupBy, normalize_group_by
+        from lintro.utils.issue_category import enrich_issues_with_categories
         from lintro.utils.json_output import create_json_output
+
+        if normalize_group_by(ctx.group_by) == GroupBy.CATEGORY:
+            for result in all_results:
+                enrich_issues_with_categories(
+                    list(result.issues) if result.issues else None,
+                    tool_name=result.name,
+                )
+                enrich_issues_with_categories(
+                    list(result.initial_issues) if result.initial_issues else None,
+                    tool_name=result.name,
+                )
 
         json_data = create_json_output(
             action=str(artifact.action),

--- a/lintro/utils/issue_category.py
+++ b/lintro/utils/issue_category.py
@@ -1,0 +1,280 @@
+"""Taxonomy helpers that map issues to concern categories.
+
+Resolution order:
+1. Existing non-empty ``issue.category`` (normalized when it matches a known label)
+2. Cheap rule-code heuristics (e.g. oxlint ``jsx-a11y`` → Accessibility)
+3. Known tool-name defaults from the issue taxonomy
+4. ``ToolType`` fallback from the tool registry
+5. ``Correctness`` as the final default
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from lintro.enums.issue_category import IssueCategory
+from lintro.enums.tool_type import ToolType
+
+if TYPE_CHECKING:
+    from lintro.parsers.base_issue import BaseIssue
+
+# Tool-name defaults aligned with the category taxonomy in issue #616.
+_TOOL_NAME_CATEGORIES: dict[str, IssueCategory] = {
+    "bandit": IssueCategory.SECURITY,
+    "gitleaks": IssueCategory.SECURITY,
+    "semgrep": IssueCategory.SECURITY,
+    "cargo_audit": IssueCategory.SECURITY,
+    "cargo-audit": IssueCategory.SECURITY,
+    "cargo_deny": IssueCategory.SECURITY,
+    "cargo-deny": IssueCategory.SECURITY,
+    "pip_audit": IssueCategory.SECURITY,
+    "pip-audit": IssueCategory.SECURITY,
+    "osv_scanner": IssueCategory.SECURITY,
+    "osv-scanner": IssueCategory.SECURITY,
+    "mypy": IssueCategory.CORRECTNESS,
+    "tsc": IssueCategory.CORRECTNESS,
+    "vue_tsc": IssueCategory.CORRECTNESS,
+    "vue-tsc": IssueCategory.CORRECTNESS,
+    "svelte_check": IssueCategory.CORRECTNESS,
+    "svelte-check": IssueCategory.CORRECTNESS,
+    "astro_check": IssueCategory.CORRECTNESS,
+    "astro-check": IssueCategory.CORRECTNESS,
+    "clippy": IssueCategory.CORRECTNESS,
+    "black": IssueCategory.STYLE,
+    "prettier": IssueCategory.STYLE,
+    "oxfmt": IssueCategory.STYLE,
+    "rustfmt": IssueCategory.STYLE,
+    "shfmt": IssueCategory.STYLE,
+    "taplo": IssueCategory.STYLE,
+    "pydoclint": IssueCategory.DOCUMENTATION,
+    "markdownlint": IssueCategory.DOCUMENTATION,
+    "vale": IssueCategory.DOCUMENTATION,
+    "hadolint": IssueCategory.INFRASTRUCTURE,
+    "actionlint": IssueCategory.INFRASTRUCTURE,
+    "shellcheck": IssueCategory.INFRASTRUCTURE,
+}
+
+_CATEGORY_ALIASES: dict[str, IssueCategory] = {
+    cat.value.lower(): cat for cat in IssueCategory
+}
+_CATEGORY_ALIASES.update(
+    {
+        "security": IssueCategory.SECURITY,
+        "correctness": IssueCategory.CORRECTNESS,
+        "performance": IssueCategory.PERFORMANCE,
+        "perf": IssueCategory.PERFORMANCE,
+        "style": IssueCategory.STYLE,
+        "formatting": IssueCategory.STYLE,
+        "accessibility": IssueCategory.ACCESSIBILITY,
+        "a11y": IssueCategory.ACCESSIBILITY,
+        "documentation": IssueCategory.DOCUMENTATION,
+        "docs": IssueCategory.DOCUMENTATION,
+        "infrastructure": IssueCategory.INFRASTRUCTURE,
+        "infra": IssueCategory.INFRASTRUCTURE,
+    },
+)
+
+# Ruff/flake8-style performance and complexity codes.
+_RUFF_PERFORMANCE_PREFIXES: tuple[str, ...] = (
+    "PERF",
+    "C90",
+    "PLR091",  # too-many-* complexity rules
+)
+
+_A11Y_PATTERN = re.compile(
+    r"(?:^|[/(._-])(?:jsx-a11y|a11y|eslint-plugin-jsx-a11y)(?:$|[/)._-])",
+    re.IGNORECASE,
+)
+_PERF_PATTERN = re.compile(
+    r"(?:^|[/(._-])(?:perf|performance)(?:$|[/)._-])",
+    re.IGNORECASE,
+)
+_SECURITY_PATTERN = re.compile(
+    r"(?:^|[/(._-])(?:security|sec|snyk|bandit)(?:$|[/)._-])",
+    re.IGNORECASE,
+)
+
+
+def normalize_issue_category(value: str | IssueCategory | None) -> IssueCategory | None:
+    """Normalize a raw category label to ``IssueCategory`` when recognized.
+
+    Args:
+        value: Raw category string, enum, or empty/None.
+
+    Returns:
+        Matching ``IssueCategory``, or ``None`` when unrecognized/empty.
+    """
+    if isinstance(value, IssueCategory):
+        return value
+    if not value:
+        return None
+    return _CATEGORY_ALIASES.get(str(value).strip().lower())
+
+
+def _issue_code(issue: BaseIssue) -> str:
+    """Return the display rule code for an issue.
+
+    Args:
+        issue: Issue to inspect.
+
+    Returns:
+        Rule/code string, or empty when unavailable.
+    """
+    field_map = getattr(issue, "DISPLAY_FIELD_MAP", {}) or {}
+    code_attr = field_map.get("code", "code")
+    return str(getattr(issue, code_attr, None) or getattr(issue, "code", "") or "")
+
+
+def category_from_rule_code(code: str) -> IssueCategory | None:
+    """Map a rule code to a category using cheap heuristics.
+
+    Args:
+        code: Tool rule identifier (e.g. ``jsx-a11y/alt-text``, ``PERF401``).
+
+    Returns:
+        Matched category, or ``None`` when no heuristic applies.
+    """
+    if not code:
+        return None
+    normalized = code.strip()
+    upper = normalized.upper()
+
+    if _A11Y_PATTERN.search(normalized):
+        return IssueCategory.ACCESSIBILITY
+
+    if upper.startswith(_RUFF_PERFORMANCE_PREFIXES) or _PERF_PATTERN.search(normalized):
+        return IssueCategory.PERFORMANCE
+
+    if _SECURITY_PATTERN.search(normalized):
+        return IssueCategory.SECURITY
+
+    return None
+
+
+def category_from_tool_type(tool_type: ToolType) -> IssueCategory:
+    """Derive a default category from a tool's ``ToolType`` flags.
+
+    Args:
+        tool_type: Tool capability flags.
+
+    Returns:
+        Best-fit category for the tool type.
+    """
+    if tool_type & ToolType.SECURITY:
+        return IssueCategory.SECURITY
+    if tool_type & ToolType.TYPE_CHECKER:
+        return IssueCategory.CORRECTNESS
+    if tool_type & ToolType.DOCUMENTATION:
+        return IssueCategory.DOCUMENTATION
+    if tool_type & ToolType.INFRASTRUCTURE:
+        return IssueCategory.INFRASTRUCTURE
+    if tool_type & ToolType.FORMATTER and not (tool_type & ToolType.LINTER):
+        return IssueCategory.STYLE
+    if tool_type & ToolType.FORMATTER:
+        return IssueCategory.STYLE
+    if tool_type & ToolType.LINTER:
+        return IssueCategory.CORRECTNESS
+    return IssueCategory.CORRECTNESS
+
+
+def _tool_type_for_name(tool_name: str | None) -> ToolType | None:
+    """Look up a tool's ``ToolType`` from the registry when available.
+
+    Args:
+        tool_name: Tool identifier.
+
+    Returns:
+        Tool type flags, or ``None`` when the tool is unknown/unavailable.
+    """
+    if not tool_name:
+        return None
+    try:
+        from lintro.plugins.registry import ToolRegistry
+
+        name = tool_name.lower().replace("-", "_")
+        for candidate in (tool_name.lower(), name, tool_name.lower().replace("_", "-")):
+            if ToolRegistry.is_registered(candidate):
+                return ToolRegistry.get(candidate).definition.tool_type
+    except (ImportError, AttributeError, KeyError, RuntimeError, TypeError, ValueError):
+        return None
+    return None
+
+
+def resolve_issue_category(
+    issue: BaseIssue,
+    *,
+    tool_name: str | None = None,
+) -> IssueCategory:
+    """Resolve the concern category for a single issue.
+
+    Args:
+        issue: Issue to categorize.
+        tool_name: Optional tool that produced the issue.
+
+    Returns:
+        Resolved ``IssueCategory``.
+    """
+    existing = normalize_issue_category(getattr(issue, "category", None))
+    if existing is not None:
+        return existing
+
+    from_code = category_from_rule_code(_issue_code(issue))
+    if from_code is not None:
+        return from_code
+
+    if tool_name:
+        tool_key = tool_name.lower()
+        if tool_key in _TOOL_NAME_CATEGORIES:
+            return _TOOL_NAME_CATEGORIES[tool_key]
+        underscore = tool_key.replace("-", "_")
+        if underscore in _TOOL_NAME_CATEGORIES:
+            return _TOOL_NAME_CATEGORIES[underscore]
+
+    tool_type = _tool_type_for_name(tool_name)
+    if tool_type is not None:
+        return category_from_tool_type(tool_type)
+
+    return IssueCategory.CORRECTNESS
+
+
+def enrich_issue_category(
+    issue: BaseIssue,
+    *,
+    tool_name: str | None = None,
+) -> IssueCategory:
+    """Resolve and persist ``issue.category`` when empty.
+
+    Args:
+        issue: Issue to enrich.
+        tool_name: Optional tool that produced the issue.
+
+    Returns:
+        Category assigned to the issue.
+    """
+    category = resolve_issue_category(issue, tool_name=tool_name)
+    current = getattr(issue, "category", "") or ""
+    if not current:
+        issue.category = category.value
+    else:
+        normalized = normalize_issue_category(current)
+        if normalized is not None:
+            issue.category = normalized.value
+    return category
+
+
+def enrich_issues_with_categories(
+    issues: list[BaseIssue] | None,
+    *,
+    tool_name: str | None = None,
+) -> None:
+    """Enrich a list of issues with resolved categories in place.
+
+    Args:
+        issues: Issues to enrich (ignored when None/empty).
+        tool_name: Optional tool that produced the issues.
+    """
+    if not issues:
+        return
+    for issue in issues:
+        enrich_issue_category(issue, tool_name=tool_name)

--- a/lintro/utils/issue_category.py
+++ b/lintro/utils/issue_category.py
@@ -171,8 +171,6 @@ def category_from_tool_type(tool_type: ToolType) -> IssueCategory:
         return IssueCategory.INFRASTRUCTURE
     if tool_type & ToolType.FORMATTER and not (tool_type & ToolType.LINTER):
         return IssueCategory.STYLE
-    if tool_type & ToolType.FORMATTER:
-        return IssueCategory.STYLE
     if tool_type & ToolType.LINTER:
         return IssueCategory.CORRECTNESS
     return IssueCategory.CORRECTNESS

--- a/lintro/utils/issue_category.py
+++ b/lintro/utils/issue_category.py
@@ -11,12 +11,14 @@ Resolution order:
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from lintro.enums.issue_category import IssueCategory
 from lintro.enums.tool_type import ToolType
 
 if TYPE_CHECKING:
+    from lintro.models.core.tool_result import ToolResult
     from lintro.parsers.base_issue import BaseIssue
 
 # Tool-name defaults aligned with the category taxonomy in issue #616.
@@ -82,6 +84,9 @@ _RUFF_PERFORMANCE_PREFIXES: tuple[str, ...] = (
     "PLR091",  # too-many-* complexity rules
 )
 
+# Ruff flake8-bandit security codes (S101, S105, …).
+_RUFF_SECURITY_CODE = re.compile(r"^S\d+")
+
 _A11Y_PATTERN = re.compile(
     r"(?:^|[/(._-])(?:jsx-a11y|a11y|eslint-plugin-jsx-a11y)(?:$|[/)._-])",
     re.IGNORECASE,
@@ -146,7 +151,7 @@ def category_from_rule_code(code: str) -> IssueCategory | None:
     if upper.startswith(_RUFF_PERFORMANCE_PREFIXES) or _PERF_PATTERN.search(normalized):
         return IssueCategory.PERFORMANCE
 
-    if _SECURITY_PATTERN.search(normalized):
+    if _RUFF_SECURITY_CODE.match(upper) or _SECURITY_PATTERN.search(normalized):
         return IssueCategory.SECURITY
 
     return None
@@ -241,7 +246,10 @@ def enrich_issue_category(
     *,
     tool_name: str | None = None,
 ) -> IssueCategory:
-    """Resolve and persist ``issue.category`` when empty.
+    """Resolve and persist the canonical ``issue.category`` label.
+
+    Unrecognized parser labels (for example Semgrep ``best-practice``) are
+    replaced with the resolved enum so console grouping and JSON agree.
 
     Args:
         issue: Issue to enrich.
@@ -251,13 +259,7 @@ def enrich_issue_category(
         Category assigned to the issue.
     """
     category = resolve_issue_category(issue, tool_name=tool_name)
-    current = getattr(issue, "category", "") or ""
-    if not current:
-        issue.category = category.value
-    else:
-        normalized = normalize_issue_category(current)
-        if normalized is not None:
-            issue.category = normalized.value
+    issue.category = category.value
     return category
 
 
@@ -276,3 +278,25 @@ def enrich_issues_with_categories(
         return
     for issue in issues:
         enrich_issue_category(issue, tool_name=tool_name)
+
+
+def enrich_tool_results_with_categories(
+    results: Sequence[ToolResult],
+) -> None:
+    """Enrich every issue on the given tool results with a resolved category.
+
+    Mutates ``issues`` and ``initial_issues`` in place so stdout JSON,
+    ``--output`` files, and side-channel artifacts share the same labels.
+
+    Args:
+        results: Tool results from the completed run.
+    """
+    for result in results:
+        enrich_issues_with_categories(
+            list(result.issues) if result.issues else None,
+            tool_name=result.name,
+        )
+        enrich_issues_with_categories(
+            list(result.initial_issues) if result.initial_issues else None,
+            tool_name=result.name,
+        )

--- a/lintro/utils/json_output.py
+++ b/lintro/utils/json_output.py
@@ -44,6 +44,9 @@ def serialize_issue(issue: "BaseIssue") -> dict[str, Any]:
     doc_url = getattr(issue, "doc_url", "") or ""
     if doc_url:
         data["doc_url"] = doc_url
+    raw_category = getattr(issue, "category", None)
+    if isinstance(raw_category, str) and raw_category:
+        data["category"] = raw_category
     return data
 
 

--- a/lintro/utils/output/file_writer.py
+++ b/lintro/utils/output/file_writer.py
@@ -540,6 +540,12 @@ def format_tool_output(
         return f"Error: {e}\n\nRaw output:\n{output}"
 
     if parsed_issues:
+        if group_by_enum == GroupBy.CATEGORY:
+            return format_issues_by_category(
+                issues=parsed_issues,
+                output_format=output_format,
+                tool_name=tool_name,
+            )
         return format_issues(issues=parsed_issues, output_format=output_format)
 
     # Fallback: return the raw output

--- a/lintro/utils/output/file_writer.py
+++ b/lintro/utils/output/file_writer.py
@@ -22,10 +22,12 @@ from typing import TYPE_CHECKING, Any
 # Import parser_registration to auto-register all parsers
 import lintro.utils.output.parser_registration  # noqa: F401
 from lintro.enums.action import Action
+from lintro.enums.group_by import GroupBy, normalize_group_by
 from lintro.enums.output_format import OutputFormat, normalize_output_format
 from lintro.enums.tool_name import ToolName
 from lintro.formatters.formatter import (
     format_issues,
+    format_issues_by_category,
     format_issues_with_sections,
     merge_detected_and_remaining,
 )
@@ -464,6 +466,7 @@ def format_tool_output(
     *,
     success: bool | None = None,
     issues_count: int | None = None,
+    group_by: str | GroupBy | None = None,
 ) -> str:
     """Format tool output using the specified format.
 
@@ -478,11 +481,14 @@ def format_tool_output(
             noise for clean passes (#1534).
         issues_count: int | None: The tool-reported issue count, used together
             with ``success`` to detect a clean zero-issue pass.
+        group_by: Optional grouping strategy. When ``category``, issues are
+            sectioned by concern taxonomy instead of fixable status.
 
     Returns:
         str: Formatted output string.
     """
     output_format = normalize_output_format(output_format)
+    group_by_enum = normalize_group_by(group_by) if group_by is not None else None
 
     # Pytest output is already formatted by build_output_with_failures
     # in pytest_output_processor.py, so return it directly
@@ -491,6 +497,13 @@ def format_tool_output(
 
     # If parsed issues are provided, use the unified formatter
     if issues:
+        if group_by_enum == GroupBy.CATEGORY:
+            return format_issues_by_category(
+                issues=issues,
+                output_format=output_format,
+                tool_name=tool_name,
+            )
+
         # Get fixability predicate from registry (O(1) lookup)
         is_fixable = ParserRegistry.get_fixability_predicate(tool_name)
 

--- a/lintro/utils/post_checks.py
+++ b/lintro/utils/post_checks.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from lintro.enums.action import Action
-from lintro.enums.group_by import normalize_group_by
+from lintro.enums.group_by import GroupBy, normalize_group_by
 from lintro.enums.output_format import OutputFormat, normalize_output_format
 from lintro.plugins.registry import ToolRegistry
 from lintro.tools import tool_manager
@@ -125,7 +125,7 @@ def execute_post_checks(
 
     # Normalize enums while maintaining backward compatibility
     output_fmt_enum: OutputFormat = normalize_output_format(output_format)
-    _ = normalize_group_by(group_by)  # Normalize for validation, return value unused
+    group_by_enum: GroupBy = normalize_group_by(group_by)
     json_output_mode = output_fmt_enum == OutputFormat.JSON
 
     # Load post-checks config
@@ -237,6 +237,7 @@ def execute_post_checks(
                         issues=issues,
                         success=getattr(result, "success", None),
                         issues_count=issues_count,
+                        group_by=group_by_enum,
                     )
 
                 if not json_output_mode:

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -109,6 +109,7 @@ def build_run_context(
         debug: Whether to show DEBUG messages on the console.
         no_art: Whether to suppress the decorative ASCII art.
         dry_run: Whether this is a ``fmt --dry-run`` preview.
+        group_by: How to group issues in formatted and JSON output.
 
     Returns:
         RunContext: The shared context for this run.

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -94,6 +94,7 @@ def build_run_context(
     debug: bool = False,
     no_art: bool = False,
     dry_run: bool = False,
+    group_by: str = "auto",
 ) -> RunContext:
     """Create the run-scoped state shared by the execute and render phases.
 
@@ -165,6 +166,7 @@ def build_run_context(
         lintro_config=lintro_config,
         clean_stdout_output=clean_stdout_output,
         score_only=score_only,
+        group_by=group_by,
     )
 
 
@@ -746,6 +748,7 @@ def run_lint_tools_simple(
         debug=debug,
         no_art=no_art,
         dry_run=dry_run,
+        group_by=group_by,
     )
     from lintro.utils.execution.run_renderer import make_result_display
 
@@ -771,6 +774,7 @@ def run_lint_tools_simple(
             output_format=output_format,
             raw_output=raw_output,
             action=ctx.action,
+            group_by=group_by,
         ),
     )
     render_run(

--- a/tests/unit/cli/test_check_command.py
+++ b/tests/unit/cli/test_check_command.py
@@ -222,8 +222,8 @@ def test_check_command_group_by_option(
 
 @pytest.mark.parametrize(
     "group_by_option",
-    ["file", "code", "none", "auto"],
-    ids=["file", "code", "none", "auto"],
+    ["file", "code", "none", "auto", "category"],
+    ids=["file", "code", "none", "auto", "category"],
 )
 def test_check_command_group_by_valid_choices(
     cli_runner: CliRunner,

--- a/tests/unit/cli/test_check_command.py
+++ b/tests/unit/cli/test_check_command.py
@@ -220,6 +220,25 @@ def test_check_command_group_by_option(
     assert_that(call_kwargs["group_by"]).is_equal_to("code")
 
 
+def test_check_command_group_by_category_is_forwarded(
+    cli_runner: CliRunner,
+    mock_run_lint_tools_check: MagicMock,
+) -> None:
+    """Verify --group-by category is passed through to the executor.
+
+    Args:
+        cli_runner: The Click CLI test runner.
+        mock_run_lint_tools_check: Mock for the run_lint_tools_check function.
+    """
+    with cli_runner.isolated_filesystem():
+        result = cli_runner.invoke(check_command, ["--group-by", "category"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    mock_run_lint_tools_check.assert_called_once()
+    call_kwargs = mock_run_lint_tools_check.call_args.kwargs
+    assert_that(call_kwargs["group_by"]).is_equal_to("category")
+
+
 @pytest.mark.parametrize(
     "group_by_option",
     ["file", "code", "none", "auto", "category"],

--- a/tests/unit/cli/test_format_command.py
+++ b/tests/unit/cli/test_format_command.py
@@ -222,8 +222,8 @@ def test_format_command_group_by_option(
 
 @pytest.mark.parametrize(
     "group_by_option",
-    ["file", "code", "none", "auto"],
-    ids=["file", "code", "none", "auto"],
+    ["file", "code", "none", "auto", "category"],
+    ids=["file", "code", "none", "auto", "category"],
 )
 def test_format_command_group_by_valid_choices(
     cli_runner: CliRunner,

--- a/tests/unit/cli/test_format_command.py
+++ b/tests/unit/cli/test_format_command.py
@@ -220,6 +220,25 @@ def test_format_command_group_by_option(
     assert_that(call_kwargs["group_by"]).is_equal_to("code")
 
 
+def test_format_command_group_by_category_is_forwarded(
+    cli_runner: CliRunner,
+    mock_run_lint_tools_format: MagicMock,
+) -> None:
+    """Verify --group-by category is passed through to the executor.
+
+    Args:
+        cli_runner: The Click CLI test runner.
+        mock_run_lint_tools_format: Mock for the run_lint_tools_format function.
+    """
+    with cli_runner.isolated_filesystem():
+        result = cli_runner.invoke(format_command, ["--group-by", "category"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    mock_run_lint_tools_format.assert_called_once()
+    call_kwargs = mock_run_lint_tools_format.call_args.kwargs
+    assert_that(call_kwargs["group_by"]).is_equal_to("category")
+
+
 @pytest.mark.parametrize(
     "group_by_option",
     ["file", "code", "none", "auto", "category"],

--- a/tests/unit/formatters/test_format_issues_by_category.py
+++ b/tests/unit/formatters/test_format_issues_by_category.py
@@ -1,0 +1,54 @@
+"""Tests for category-based issue section formatting."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.formatters.formatter import format_issues_by_category
+from lintro.parsers.base_issue import BaseIssue
+from lintro.parsers.oxlint.oxlint_issue import OxlintIssue
+from lintro.parsers.ruff.ruff_issue import RuffIssue
+from lintro.utils.output.file_writer import format_tool_output
+
+
+def test_format_issues_by_category_sections() -> None:
+    """Category grouping emits titled sections in taxonomy order."""
+    issues = [
+        RuffIssue(file="a.py", line=1, code="PERF401", message="slow"),
+        OxlintIssue(
+            file="b.tsx",
+            line=2,
+            code="jsx-a11y/alt-text",
+            message="alt",
+        ),
+        BaseIssue(file="c.py", line=3, message="secret"),
+    ]
+    # Force security via existing category for the third issue.
+    issues[2].category = "Security"
+
+    output = format_issues_by_category(issues, output_format="plain", tool_name="ruff")
+
+    assert_that(output).contains("Security (1)")
+    assert_that(output).contains("Performance (1)")
+    assert_that(output).contains("Accessibility (1)")
+    assert_that(output.index("Security")).is_less_than(output.index("Performance"))
+    assert_that(output.index("Performance")).is_less_than(
+        output.index("Accessibility"),
+    )
+
+
+def test_format_tool_output_respects_group_by_category() -> None:
+    """format_tool_output sections by category when group_by=category."""
+    issues = [
+        RuffIssue(file="a.py", line=1, code="PERF401", message="slow"),
+        RuffIssue(file="a.py", line=2, code="F401", message="unused"),
+    ]
+    output = format_tool_output(
+        tool_name="ruff",
+        output="",
+        output_format="plain",
+        issues=issues,
+        group_by="category",
+    )
+    assert_that(output).contains("Performance (1)")
+    assert_that(issues[0].category).is_equal_to("Performance")

--- a/tests/unit/formatters/test_format_issues_by_category.py
+++ b/tests/unit/formatters/test_format_issues_by_category.py
@@ -71,6 +71,21 @@ def test_format_issues_by_category_csv_is_single_table() -> None:
     assert_that(output).contains("S105")
 
 
+def test_format_issues_by_category_sarif_has_no_section_headers() -> None:
+    """SARIF stays a single document so section titles do not break the schema."""
+    issues = [
+        RuffIssue(file="a.py", line=1, code="PERF401", message="slow"),
+        RuffIssue(file="a.py", line=2, code="S105", message="hardcoded"),
+    ]
+    output = format_issues_by_category(
+        issues,
+        output_format="sarif",
+        tool_name="ruff",
+    )
+    assert_that(output).does_not_contain("Performance (")
+    assert_that(output).does_not_contain("Security (")
+
+
 def test_format_tool_output_parses_raw_output_with_category() -> None:
     """Raw parseable output still sections by category when group_by=category."""
     raw_output = """[

--- a/tests/unit/formatters/test_format_issues_by_category.py
+++ b/tests/unit/formatters/test_format_issues_by_category.py
@@ -52,3 +52,50 @@ def test_format_tool_output_respects_group_by_category() -> None:
     )
     assert_that(output).contains("Performance (1)")
     assert_that(issues[0].category).is_equal_to("Performance")
+
+
+def test_format_issues_by_category_csv_is_single_table() -> None:
+    """CSV stays a single table so section titles do not break the schema."""
+    issues = [
+        RuffIssue(file="a.py", line=1, code="PERF401", message="slow"),
+        RuffIssue(file="a.py", line=2, code="S105", message="hardcoded"),
+    ]
+    output = format_issues_by_category(
+        issues,
+        output_format="csv",
+        tool_name="ruff",
+    )
+    assert_that(output).does_not_contain("Performance (")
+    assert_that(output).does_not_contain("Security (")
+    assert_that(output).contains("PERF401")
+    assert_that(output).contains("S105")
+
+
+def test_format_tool_output_parses_raw_output_with_category() -> None:
+    """Raw parseable output still sections by category when group_by=category."""
+    raw_output = """[
+        {
+            "code": "PERF401",
+            "message": "slow",
+            "filename": "a.py",
+            "location": {"row": 1, "column": 1},
+            "end_location": {"row": 1, "column": 10},
+            "fix": null
+        },
+        {
+            "code": "S105",
+            "message": "hardcoded",
+            "filename": "a.py",
+            "location": {"row": 2, "column": 1},
+            "end_location": {"row": 2, "column": 10},
+            "fix": null
+        }
+    ]"""
+    output = format_tool_output(
+        tool_name="ruff",
+        output=raw_output,
+        output_format="plain",
+        group_by="category",
+    )
+    assert_that(output).contains("Performance (1)")
+    assert_that(output).contains("Security (1)")

--- a/tests/unit/pytest/test_pytest_cli_options.py
+++ b/tests/unit/pytest/test_pytest_cli_options.py
@@ -94,6 +94,17 @@ def test_test_command_group_by() -> None:
         assert_that(call_args.kwargs["group_by"]).is_equal_to("code")
 
 
+def test_test_command_rejects_group_by_category() -> None:
+    """``lintro test`` does not advertise category grouping (pytest is raw)."""
+    runner = CliRunner()
+    with patch("lintro.cli_utils.commands.test.run_lint_with_ai") as mock_run:
+        mock_run.return_value = 0
+        result = runner.invoke(pytest_cli_command, ["--group-by", "category"])
+    assert_that(result.exit_code).is_not_equal_to(0)
+    assert_that(result.output).contains("Invalid value")
+    assert_that(mock_run.called).is_false()
+
+
 def test_test_command_verbose() -> None:
     """Test test command with verbose flag."""
     runner = CliRunner()

--- a/tests/unit/tools/executor/test_execute_render_split.py
+++ b/tests/unit/tools/executor/test_execute_render_split.py
@@ -20,6 +20,7 @@ import lintro.utils.tool_executor as te
 from lintro.enums.action import Action
 from lintro.models.core.run_artifact import RunArtifact
 from lintro.models.core.tool_result import ToolResult
+from lintro.parsers.ruff.ruff_issue import RuffIssue
 from lintro.tools import tool_manager
 from lintro.utils.execution.run_context import RunContext
 from lintro.utils.execution.run_renderer import render_run
@@ -113,6 +114,7 @@ def _context(
     fake_logger: Any,
     output_format: str = "grid",
     score_only: bool = False,
+    group_by: str = "auto",
 ) -> RunContext:
     """Build a run context wired to test doubles.
 
@@ -121,6 +123,7 @@ def _context(
         fake_logger: Console logger double.
         output_format: Output format the run was asked for.
         score_only: Whether stdout carries only the numeric score.
+        group_by: How issues should be grouped in formatted output.
 
     Returns:
         RunContext: A context safe to hand to either phase.
@@ -136,6 +139,7 @@ def _context(
         lintro_config=get_config(),
         clean_stdout_output=output_format in ("json", "sarif", "csv", "markdown"),
         score_only=score_only,
+        group_by=group_by,
     )
 
 
@@ -338,6 +342,47 @@ def test_render_run_emits_json(
     payload = json.loads(capsys.readouterr().out)
     assert_that(payload["summary"]["total_issues"]).is_equal_to(2)
     assert_that(payload["results"][0]["tool"]).is_equal_to("ruff")
+
+
+def test_render_run_enriches_categories_before_json_stdout(
+    tmp_path: Path,
+    fake_logger: Any,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--group-by category`` writes canonical labels onto issues before JSON."""
+    issue = RuffIssue(file="a.py", line=1, code="S105", message="hardcoded")
+    results = [
+        ToolResult(
+            name="ruff",
+            success=False,
+            issues_count=1,
+            issues=[issue],
+        ),
+    ]
+    artifact = RunArtifact(
+        tool_results=results,
+        action=Action.CHECK,
+        workspace_root=Path.cwd(),
+        health=health_score_for_results(results),
+        total_issues=1,
+        total_fixed=0,
+        total_remaining=1,
+        exit_code=1,
+    )
+    ctx = _context(
+        tmp_path=tmp_path,
+        fake_logger=fake_logger,
+        output_format="json",
+        group_by="category",
+    )
+
+    render_run(artifact, ctx=ctx, output_format="json")
+
+    payload = json.loads(capsys.readouterr().out)
+    assert_that(issue.category).is_equal_to("Security")
+    assert_that(payload["results"][0]["issues"][0]["category"]).is_equal_to(
+        "Security",
+    )
 
 
 def test_render_run_emits_sarif(

--- a/tests/unit/utils/test_enums_and_normalizers.py
+++ b/tests/unit/utils/test_enums_and_normalizers.py
@@ -29,6 +29,8 @@ def test_group_by_normalization() -> None:
     """Normalize group-by strings and enum instances consistently."""
     assert_that(normalize_group_by("file")).is_equal_to(GroupBy.FILE)
     assert_that(normalize_group_by(GroupBy.AUTO)).is_equal_to(GroupBy.AUTO)
+    assert_that(normalize_group_by("category")).is_equal_to(GroupBy.CATEGORY)
+    assert_that(normalize_group_by(GroupBy.CATEGORY)).is_equal_to(GroupBy.CATEGORY)
     assert_that(normalize_group_by("bad")).is_equal_to(GroupBy.FILE)
 
 

--- a/tests/unit/utils/test_issue_category.py
+++ b/tests/unit/utils/test_issue_category.py
@@ -1,0 +1,104 @@
+"""Tests for issue category taxonomy helpers."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.enums.issue_category import IssueCategory
+from lintro.enums.tool_type import ToolType
+from lintro.parsers.base_issue import BaseIssue
+from lintro.parsers.oxlint.oxlint_issue import OxlintIssue
+from lintro.parsers.ruff.ruff_issue import RuffIssue
+from lintro.utils.issue_category import (
+    category_from_rule_code,
+    category_from_tool_type,
+    enrich_issue_category,
+    resolve_issue_category,
+)
+
+
+def test_category_from_rule_code_accessibility() -> None:
+    """Oxlint jsx-a11y rule codes map to Accessibility."""
+    assert_that(category_from_rule_code("jsx-a11y/alt-text")).is_equal_to(
+        IssueCategory.ACCESSIBILITY,
+    )
+    assert_that(
+        category_from_rule_code("eslint(jsx-a11y/anchor-is-valid)"),
+    ).is_equal_to(
+        IssueCategory.ACCESSIBILITY,
+    )
+
+
+def test_category_from_rule_code_performance() -> None:
+    """Ruff PERF/complexity codes and oxlint perf rules map to Performance."""
+    assert_that(category_from_rule_code("PERF401")).is_equal_to(
+        IssueCategory.PERFORMANCE,
+    )
+    assert_that(category_from_rule_code("C901")).is_equal_to(IssueCategory.PERFORMANCE)
+    assert_that(category_from_rule_code("PLR0915")).is_equal_to(
+        IssueCategory.PERFORMANCE,
+    )
+    assert_that(
+        category_from_rule_code("eslint(perf/no-accumulate-spread)"),
+    ).is_equal_to(
+        IssueCategory.PERFORMANCE,
+    )
+
+
+def test_category_from_tool_type_fallbacks() -> None:
+    """ToolType flags map to the expected concern categories."""
+    assert_that(category_from_tool_type(ToolType.SECURITY)).is_equal_to(
+        IssueCategory.SECURITY,
+    )
+    assert_that(category_from_tool_type(ToolType.TYPE_CHECKER)).is_equal_to(
+        IssueCategory.CORRECTNESS,
+    )
+    assert_that(category_from_tool_type(ToolType.FORMATTER)).is_equal_to(
+        IssueCategory.STYLE,
+    )
+    assert_that(category_from_tool_type(ToolType.DOCUMENTATION)).is_equal_to(
+        IssueCategory.DOCUMENTATION,
+    )
+    assert_that(category_from_tool_type(ToolType.INFRASTRUCTURE)).is_equal_to(
+        IssueCategory.INFRASTRUCTURE,
+    )
+    assert_that(category_from_tool_type(ToolType.LINTER)).is_equal_to(
+        IssueCategory.CORRECTNESS,
+    )
+
+
+def test_resolve_prefers_existing_category() -> None:
+    """Existing issue.category wins over heuristics."""
+    issue = BaseIssue(file="a.py", line=1, message="x", category="security")
+    assert_that(resolve_issue_category(issue, tool_name="ruff")).is_equal_to(
+        IssueCategory.SECURITY,
+    )
+
+
+def test_resolve_uses_tool_name_defaults() -> None:
+    """Known tools fall back to taxonomy defaults when codes are unhelpful."""
+    issue = RuffIssue(file="a.py", line=1, code="E501", message="long")
+    bandit_issue = BaseIssue(file="a.py", line=1, message="hardcoded")
+    assert_that(resolve_issue_category(bandit_issue, tool_name="bandit")).is_equal_to(
+        IssueCategory.SECURITY,
+    )
+    assert_that(
+        resolve_issue_category(BaseIssue(message="x"), tool_name="markdownlint"),
+    ).is_equal_to(IssueCategory.DOCUMENTATION)
+    assert_that(
+        resolve_issue_category(BaseIssue(message="x"), tool_name="shellcheck"),
+    ).is_equal_to(IssueCategory.INFRASTRUCTURE)
+    assert_that(issue.code).is_equal_to("E501")
+
+
+def test_enrich_issue_category_persists_title_case() -> None:
+    """Enrichment writes the title-case category onto the issue."""
+    issue = OxlintIssue(
+        file="a.tsx",
+        line=1,
+        code="jsx-a11y/alt-text",
+        message="missing alt",
+    )
+    category = enrich_issue_category(issue, tool_name="oxlint")
+    assert_that(category).is_equal_to(IssueCategory.ACCESSIBILITY)
+    assert_that(issue.category).is_equal_to("Accessibility")

--- a/tests/unit/utils/test_issue_category.py
+++ b/tests/unit/utils/test_issue_category.py
@@ -65,6 +65,9 @@ def test_category_from_tool_type_fallbacks() -> None:
     assert_that(category_from_tool_type(ToolType.LINTER)).is_equal_to(
         IssueCategory.CORRECTNESS,
     )
+    assert_that(
+        category_from_tool_type(ToolType.LINTER | ToolType.FORMATTER),
+    ).is_equal_to(IssueCategory.CORRECTNESS)
 
 
 def test_resolve_prefers_existing_category() -> None:
@@ -89,6 +92,18 @@ def test_resolve_uses_tool_name_defaults() -> None:
         resolve_issue_category(BaseIssue(message="x"), tool_name="shellcheck"),
     ).is_equal_to(IssueCategory.INFRASTRUCTURE)
     assert_that(issue.code).is_equal_to("E501")
+
+
+def test_ruff_lint_codes_are_correctness() -> None:
+    """Ruff is a linter+formatter; unused-import and line-length are Correctness."""
+    unused = RuffIssue(file="a.py", line=1, code="F401", message="unused")
+    long_line = RuffIssue(file="a.py", line=1, code="E501", message="long")
+    assert_that(resolve_issue_category(unused, tool_name="ruff")).is_equal_to(
+        IssueCategory.CORRECTNESS,
+    )
+    assert_that(resolve_issue_category(long_line, tool_name="ruff")).is_equal_to(
+        IssueCategory.CORRECTNESS,
+    )
 
 
 def test_enrich_issue_category_persists_title_case() -> None:

--- a/tests/unit/utils/test_issue_category.py
+++ b/tests/unit/utils/test_issue_category.py
@@ -6,6 +6,7 @@ from assertpy import assert_that
 
 from lintro.enums.issue_category import IssueCategory
 from lintro.enums.tool_type import ToolType
+from lintro.models.core.tool_result import ToolResult
 from lintro.parsers.base_issue import BaseIssue
 from lintro.parsers.oxlint.oxlint_issue import OxlintIssue
 from lintro.parsers.ruff.ruff_issue import RuffIssue
@@ -13,6 +14,7 @@ from lintro.utils.issue_category import (
     category_from_rule_code,
     category_from_tool_type,
     enrich_issue_category,
+    enrich_tool_results_with_categories,
     resolve_issue_category,
 )
 
@@ -42,6 +44,16 @@ def test_category_from_rule_code_performance() -> None:
         category_from_rule_code("eslint(perf/no-accumulate-spread)"),
     ).is_equal_to(
         IssueCategory.PERFORMANCE,
+    )
+
+
+def test_category_from_rule_code_ruff_security() -> None:
+    """Ruff flake8-bandit S-prefix codes map to Security."""
+    assert_that(category_from_rule_code("S105")).is_equal_to(IssueCategory.SECURITY)
+    assert_that(category_from_rule_code("S101")).is_equal_to(IssueCategory.SECURITY)
+    unused = RuffIssue(file="a.py", line=1, code="S105", message="hardcoded")
+    assert_that(resolve_issue_category(unused, tool_name="ruff")).is_equal_to(
+        IssueCategory.SECURITY,
     )
 
 
@@ -117,3 +129,31 @@ def test_enrich_issue_category_persists_title_case() -> None:
     category = enrich_issue_category(issue, tool_name="oxlint")
     assert_that(category).is_equal_to(IssueCategory.ACCESSIBILITY)
     assert_that(issue.category).is_equal_to("Accessibility")
+
+
+def test_enrich_issue_category_replaces_unrecognized_label() -> None:
+    """Unrecognized parser labels are overwritten with the resolved enum."""
+    issue = BaseIssue(
+        file="a.py",
+        line=1,
+        message="use a safer API",
+        category="best-practice",
+    )
+    category = enrich_issue_category(issue, tool_name="semgrep")
+    assert_that(category).is_equal_to(IssueCategory.SECURITY)
+    assert_that(issue.category).is_equal_to("Security")
+
+
+def test_enrich_tool_results_with_categories_covers_initial_issues() -> None:
+    """Both remaining and pre-fix issues get canonical category labels."""
+    remaining = RuffIssue(file="a.py", line=1, code="S105", message="hardcoded")
+    detected = RuffIssue(file="a.py", line=2, code="PERF401", message="slow")
+    result = ToolResult(
+        name="ruff",
+        success=True,
+        issues=[remaining],
+        initial_issues=[detected],
+    )
+    enrich_tool_results_with_categories([result])
+    assert_that(remaining.category).is_equal_to("Security")
+    assert_that(detected.category).is_equal_to("Performance")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(cli): add --group-by category for issue grouping
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

- `GroupBy.CATEGORY` and CLI choice wiring for check/format/test
- Optional `BaseIssue.category` with taxonomy helper (rule-code heuristics + `ToolType` fallback)
- Thin category sectioning in `format_tool_output` (no display-layer redesign)
- JSON enrichment when grouping by category
- Unit tests for taxonomy and formatting

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #616

## Details

- `uv run lintro fmt` / `uv run lintro chk` — clean for this change
- `uv run pytest --maxfail=0` — 7072+ passed; remaining failures env-only (missing optional tools)

Closes #616


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added category-based grouping for check and format results.
  * Issues are classified into categories such as Security, Correctness, Performance, Style, and Documentation.
  * Category labels are included in supported structured output.
* **Documentation**
  * Updated command and configuration references with the new `category` grouping option.
* **Tests**
  * Added coverage for category classification, formatting, CLI handling, and serialized output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->