### PR TITLE
fix(ci): tolerate baked-tool version lag and bump astro to 7.1.3

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -95,7 +95,7 @@ jobs:
         # code that runs with ANTHROPIC_API_KEY must be trusted; the PR diff is
         # fetched separately via `gh` in the review step. base.sha is the exact
         # commit the PR targets and is already merged into main, so it is safe.
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 1

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: scripts
 
@@ -84,7 +84,7 @@ jobs:
             uploads.github.com:443
 
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -166,7 +166,7 @@ jobs:
             nuitka.net:443
 
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -286,7 +286,7 @@ jobs:
             nuitka.net:443
 
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -465,7 +465,7 @@ jobs:
             pypi.org:443
 
       - name: Checkout scripts
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: scripts
           persist-credentials: false

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -978,13 +978,14 @@ jobs:
         # tagged py-lintro:latest by load-ci-docker-images.sh), so forks gate
         # on the exact image their integration tests run.
         #
-        # New-binary-tool tolerance (#1565): BASE_REF lets the wrapper compute
-        # the tools this PR newly adds to the manifest (diff vs the merge-base)
-        # and pass them as --allow-missing, so their absent binary in the
-        # digest-pinned base image downgrades to a warning instead of failing
-        # this required check structurally. BASE_REF is empty for non-PR events
+        # New-binary-tool tolerance (#1565) and baked-tool version-bump
+        # tolerance (#1582): BASE_REF lets the wrapper compute tools this PR
+        # newly adds (--allow-missing) or whose manifest version it bumps
+        # (--allow-version-lag) vs the merge-base, so digest-lag in the
+        # pinned base image downgrades to a warning instead of failing this
+        # required check structurally. BASE_REF is empty for non-PR events
         # (github.base_ref is only set on pull_request), so main pushes keep
-        # full enforcement; the fail-closed diff also yields an empty allowlist
+        # full enforcement; the fail-closed diff also yields empty allowlists
         # if the merge-base cannot be computed.
         if: needs.changes.outputs.pipeline != 'false'
         env:

--- a/.github/workflows/lintro-report-scheduled.yml
+++ b/.github/workflows/lintro-report-scheduled.yml
@@ -47,7 +47,7 @@ jobs:
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: >-
             ${{
@@ -97,6 +97,6 @@ jobs:
             codeload.github.com:443
             objects.githubusercontent.com:443
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Report status
         run: scripts/ci/ci-log.sh "Lintro report generated successfully"

--- a/.github/workflows/pr-comment-cleanup.yml
+++ b/.github/workflows/pr-comment-cleanup.yml
@@ -40,7 +40,7 @@ jobs:
             objects.githubusercontent.com:443
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Environment setup
         uses: ./.github/actions/setup-env

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -88,7 +88,7 @@ jobs:
             oauth2.sigstore.dev:443
 
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/test-built-package.yml
+++ b/.github/workflows/test-built-package.yml
@@ -71,7 +71,7 @@ jobs:
             files.pythonhosted.org:443
 
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Egress audit (allowlist verification)
         env:

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -4,17 +4,3 @@
 # suppressions. Review periodically and add [[IgnoredVulns]] entries only when
 # necessary. Each entry is time-boxed via ignoreUntil so it cannot silently
 # outlive its rationale.
-
-# astro <= 7.0.9 — GHSA-4g3v-8h47-v7g6 (severity 5.3). Patched in astro 7.1.0.
-# The straightforward bump is blocked by CI: astro backs the `astro_check`
-# tool (tier `tools`), so bumping it forces a manifest version change that the
-# required `Docker Integration Tests` manifest gate hard-fails against the
-# digest-pinned lintro-tools base image (which still ships astro 7.0.9). The
-# patched tools image cannot exist until after merge + republish, so the bump
-# is not achievable in a single mergeable PR. This time-boxed suppression keeps
-# the security audit (and main) green in the interim; the coordinated
-# bump + tools-image republish + Dockerfile digest bump is tracked in #1582.
-[[IgnoredVulns]]
-id = "GHSA-4g3v-8h47-v7g6"
-ignoreUntil = 2026-09-15
-reason = "astro dev/build dependency; patched in 7.1.0 but the bump is blocked by the docker manifest gate digest-lag (see #1582). Time-boxed interim suppression."

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # Built from docker/tools.Dockerfile and published by docker-tools-publish.yml
 # (cosign-signed, SBOM + provenance). Renovate manages the digest bump (#1360).
 # yamllint / hadolint: pin is immutable by digest; tag is informational.
-FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:455dafaae346ce51da02d10a50c5f0aa0ee5bd76ebd34f516fd429a066c5ba36 AS tools
+FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:0b5e3128b6c0b45bef7e138e9386e03060a77d6e159718e5fbb0855aca0bfc82 AS tools
 
 # -----------------------------------------------------------------------------
 # Stage: full — lintro application (default target)

--- a/apps/site/bun.lock
+++ b/apps/site/bun.lock
@@ -8,7 +8,7 @@
         "@astrojs/markdown-remark": "^7.2.1",
         "@astrojs/sitemap": "^3.7.3",
         "@lgtm-hq/turbo-themes": "^0.21.0",
-        "astro": "7.0.9",
+        "astro": "7.1.3",
         "rehype-parse": "^9.0.1",
         "sanitize-html": "^2.17.5",
       },
@@ -449,7 +449,7 @@
 
     "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.2", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ=="],
 
-    "astro": ["astro@7.0.9", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.1", "@astrojs/internal-helpers": "0.10.1", "@astrojs/markdown-satteri": "0.3.4", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.1" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-WB5pA4LLQnmqjBh6EIu0z8aUV4q2/AoThgSZq57Rsp+oqqvPu7OwZ5eF+W4ku20TUTxIhiJW8dccuGvJPiW2UA=="],
+    "astro": ["astro@7.1.3", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.1", "@astrojs/internal-helpers": "0.10.1", "@astrojs/markdown-satteri": "0.3.4", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^2.0.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^1.0.1", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.1" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-4dhPyAAXthf3xLEYnG8SeL7yr/nTPPABfY7e9YF0yuO+vK9Xp+8Q5j4xzsmL3GueukQv4oNwGNTBepLOiDGeJA=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -487,7 +487,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "cookie": ["cookie@2.0.1", "", {}, "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w=="],
 
     "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
@@ -769,7 +769,7 @@
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
-    "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
+    "neotraverse": ["neotraverse@1.0.1", "", {}, "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w=="],
 
     "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
 

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -20,7 +20,7 @@
     "@astrojs/markdown-remark": "^7.2.1",
     "@astrojs/sitemap": "^3.7.3",
     "@lgtm-hq/turbo-themes": "^0.21.0",
-    "astro": "7.0.9",
+    "astro": "7.1.3",
     "rehype-parse": "^9.0.1",
     "sanitize-html": "^2.17.5"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@astrojs/check": "0.9.9",
         "@commitlint/cli": "21.2.1",
         "@commitlint/config-conventional": "21.2.0",
-        "astro": "7.0.9",
+        "astro": "7.1.3",
         "markdownlint-cli2": "0.23.0",
         "oxfmt": "0.58.0",
         "oxlint": "1.73.0",
@@ -522,7 +522,7 @@
 
     "astral-regex": ["astral-regex@2.0.0", "", {}, "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="],
 
-    "astro": ["astro@7.0.9", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.1", "@astrojs/internal-helpers": "0.10.1", "@astrojs/markdown-satteri": "0.3.4", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.1" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-WB5pA4LLQnmqjBh6EIu0z8aUV4q2/AoThgSZq57Rsp+oqqvPu7OwZ5eF+W4ku20TUTxIhiJW8dccuGvJPiW2UA=="],
+    "astro": ["astro@7.1.3", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.1", "@astrojs/internal-helpers": "0.10.1", "@astrojs/markdown-satteri": "0.3.4", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^2.0.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^1.0.1", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.1" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-4dhPyAAXthf3xLEYnG8SeL7yr/nTPPABfY7e9YF0yuO+vK9Xp+8Q5j4xzsmL3GueukQv4oNwGNTBepLOiDGeJA=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -572,7 +572,7 @@
 
     "conventional-commits-parser": ["conventional-commits-parser@7.1.0", "", { "dependencies": { "@simple-libs/stream-utils": "^2.0.0", "argue-cli": "^3.1.0" }, "bin": { "conventional-commits-parser": "./dist/cli/index.js" } }, "sha512-DPp6hkUjvwIivxbkrTiLXeRswNv1A/4GFA2X6scXma0AMa9632V3TwxmrlkUIEtUktiM3Ln+RrSH2xlP3/jUTw=="],
 
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "cookie": ["cookie@2.0.1", "", {}, "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w=="],
 
     "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
@@ -912,7 +912,7 @@
 
     "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
 
-    "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
+    "neotraverse": ["neotraverse@1.0.1", "", {}, "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w=="],
 
     "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
 

--- a/lintro/_generated_versions.py
+++ b/lintro/_generated_versions.py
@@ -12,7 +12,7 @@ NPM_VERSIONS: dict[str, str] = {
     "@astrojs/check": "0.9.9",
     "@commitlint/cli": "21.2.1",
     "@commitlint/config-conventional": "21.2.0",
-    "astro": "7.0.9",
+    "astro": "7.1.3",
     "markdownlint-cli2": "0.23.0",
     "oxfmt": "0.58.0",
     "oxlint": "1.73.0",

--- a/lintro/tools/manifest.json
+++ b/lintro/tools/manifest.json
@@ -73,7 +73,7 @@
     },
     {
       "name": "astro_check",
-      "version": "7.0.9",
+      "version": "7.1.3",
       "install": {
         "type": "npm",
         "package": "astro",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@astrojs/check": "0.9.9",
     "@commitlint/cli": "21.2.1",
     "@commitlint/config-conventional": "21.2.0",
-    "astro": "7.0.9",
+    "astro": "7.1.3",
     "markdownlint-cli2": "0.23.0",
     "oxfmt": "0.58.0",
     "oxlint": "1.73.0",

--- a/scripts/ci/compute-new-manifest-tools.py
+++ b/scripts/ci/compute-new-manifest-tools.py
@@ -121,6 +121,11 @@ def _version_tuple(version: str) -> tuple[int, ...]:
         if not digits:
             break
         parts.append(int(digits))
+        if len(digits) != len(segment):
+            # Segment had trailing non-digit content (e.g. "0-rc"): stop
+            # entirely so a pre-release tag drops everything after it and
+            # "7.1.0-rc.1" compares as (7, 1, 0), per the documented contract.
+            break
     return tuple(parts)
 
 

--- a/scripts/ci/compute-new-manifest-tools.py
+++ b/scripts/ci/compute-new-manifest-tools.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
-"""Print tool names present in a new manifest but absent from an old one.
+"""Diff tool names / versions between an old and a new manifest.
 
-Used by ``compute-new-manifest-tools.sh`` to derive the set of tools a PR
-introduces, so the manifest-vs-image gate can tolerate their (necessarily)
-missing binary in the digest-pinned base image. JSON parsing lives here; git
-resolution (merge-base, ``git show``) lives in the shell wrapper.
+Used by ``compute-new-manifest-tools.sh`` to derive allowlists for the
+manifest-vs-image gate:
+
+* ``--emit added`` (default): tool names present in the new manifest but
+  absent from the old one → fed to ``--allow-missing`` so a PR-introduced
+  tool's absent binary in the digest-pinned base image is tolerated (#1565).
+* ``--emit version-changed``: tool names whose declared version changed
+  between the old and new manifest → fed to ``--allow-version-lag`` so a
+  PR that bumps a baked tool can merge before the tools image republishes
+  (#1582).
+
+JSON parsing lives here; git resolution (merge-base, ``git show``) lives in
+the shell wrapper.
 """
 
 from __future__ import annotations
@@ -51,16 +60,78 @@ def _tool_names(manifest_path: Path) -> set[str]:
     return names
 
 
-def main() -> int:
-    """Print comma-separated tool names added between the old and new manifest.
+def _tool_versions(manifest_path: Path) -> dict[str, str]:
+    """Extract ``name -> version`` mappings declared in a manifest file.
+
+    A path that does not exist yields an empty dict (same "brand-new
+    manifest" semantics as :func:`_tool_names`).
+
+    Args:
+        manifest_path: Path to a manifest JSON file.
 
     Returns:
-        ``0`` on success (the added-name list, possibly empty, is printed to
+        Mapping of non-empty tool names to their declared version strings.
+        Entries missing a non-empty version are omitted.
+
+    Raises:
+        ValueError: When the manifest is not a JSON object or ``tools`` is not
+            a list of objects.
+    """
+    if not manifest_path.exists():
+        return {}
+    data: Any = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"manifest must be a JSON object, got {type(data).__name__}")
+    tools = data.get("tools", [])
+    if not isinstance(tools, list):
+        raise ValueError("manifest tools must be a list")
+    versions: dict[str, str] = {}
+    for entry in tools:
+        if not isinstance(entry, dict):
+            raise ValueError("manifest tools[] entries must be objects")
+        name = str(entry.get("name", "")).strip()
+        version = str(entry.get("version", "")).strip()
+        if name and version:
+            versions[name] = version
+    return versions
+
+
+def _version_changed_names(
+    old_versions: dict[str, str],
+    new_versions: dict[str, str],
+) -> list[str]:
+    """Return sorted names whose version string changed between manifests.
+
+    Only tools present in *both* manifests are considered. Newly-added tools
+    are handled by ``--emit added`` / ``--allow-missing`` instead.
+
+    Args:
+        old_versions: Name → version from the base-branch manifest.
+        new_versions: Name → version from the current manifest.
+
+    Returns:
+        Sorted list of tool names whose version string differs.
+    """
+    changed: list[str] = []
+    for name, new_version in new_versions.items():
+        old_version = old_versions.get(name)
+        if old_version is not None and old_version != new_version:
+            changed.append(name)
+    return sorted(changed)
+
+
+def main() -> int:
+    """Print comma-separated tool names for the requested emit mode.
+
+    Returns:
+        ``0`` on success (the name list, possibly empty, is printed to
         stdout); ``2`` when either manifest cannot be parsed. Callers treat a
         non-zero exit as "fail closed": an empty allowlist, full enforcement.
     """
     parser = argparse.ArgumentParser(
-        description="Print tool names added between two manifests.",
+        description=(
+            "Print tool names added or version-changed between two manifests."
+        ),
     )
     parser.add_argument(
         "--old",
@@ -72,17 +143,31 @@ def main() -> int:
         required=True,
         help="Path to the current manifest",
     )
+    parser.add_argument(
+        "--emit",
+        choices=("added", "version-changed"),
+        default="added",
+        help=(
+            "What to print: tools newly added to the manifest (default), or "
+            "tools whose declared version changed between the two manifests."
+        ),
+    )
     args = parser.parse_args()
 
     try:
-        old_names = _tool_names(Path(args.old))
-        new_names = _tool_names(Path(args.new))
+        if args.emit == "version-changed":
+            old_versions = _tool_versions(Path(args.old))
+            new_versions = _tool_versions(Path(args.new))
+            names = _version_changed_names(old_versions, new_versions)
+        else:
+            old_names = _tool_names(Path(args.old))
+            new_names = _tool_names(Path(args.new))
+            names = sorted(new_names - old_names)
     except (ValueError, OSError, json.JSONDecodeError) as exc:
         print(f"Failed to compute new manifest tools: {exc}", file=sys.stderr)
         return 2
 
-    added = sorted(new_names - old_names)
-    print(",".join(added))
+    print(",".join(names))
     return 0
 
 

--- a/scripts/ci/compute-new-manifest-tools.py
+++ b/scripts/ci/compute-new-manifest-tools.py
@@ -96,26 +96,85 @@ def _tool_versions(manifest_path: Path) -> dict[str, str]:
     return versions
 
 
+def _version_tuple(version: str) -> tuple[int, ...]:
+    """Parse a dotted numeric version into a comparable integer tuple.
+
+    Non-numeric trailing segments (pre-release tags) stop parsing, so
+    ``7.1.0-rc.1`` compares as ``(7, 1, 0)``. Mirrors the helper in
+    ``verify-manifest-tools.py`` so both sides order versions identically.
+
+    Args:
+        version: A dotted version string.
+
+    Returns:
+        Integer segments for lexicographic comparison. Empty when no leading
+        digits are found.
+    """
+    parts: list[int] = []
+    for segment in version.split("."):
+        digits = ""
+        for char in segment:
+            if char.isdigit():
+                digits += char
+            else:
+                break
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts)
+
+
+def _is_upward_bump(old_version: str, new_version: str) -> bool:
+    """Return True only when *new* is strictly newer than *old*.
+
+    ``--allow-version-lag`` exists solely for upward bumps: the digest-pinned
+    image still ships the pre-bump (older) build, so an image-older-than-
+    manifest mismatch is expected until the tools image republishes. A
+    downgrade must NOT enter the allowlist — the pinned image would then be
+    *newer* than the manifest, which is a real drift the gate must hard-fail
+    (fail closed). Unparseable versions on either side also fail closed.
+
+    Args:
+        old_version: Version declared in the base-branch manifest.
+        new_version: Version declared in the current manifest.
+
+    Returns:
+        True when both versions parse and ``new > old``; False otherwise.
+    """
+    old_parts = _version_tuple(old_version)
+    new_parts = _version_tuple(new_version)
+    if not old_parts or not new_parts:
+        return False
+    width = max(len(old_parts), len(new_parts))
+    old_padded = old_parts + (0,) * (width - len(old_parts))
+    new_padded = new_parts + (0,) * (width - len(new_parts))
+    return new_padded > old_padded
+
+
 def _version_changed_names(
     old_versions: dict[str, str],
     new_versions: dict[str, str],
 ) -> list[str]:
-    """Return sorted names whose version string changed between manifests.
+    """Return sorted names whose version was bumped *upward* between manifests.
 
     Only tools present in *both* manifests are considered. Newly-added tools
-    are handled by ``--emit added`` / ``--allow-missing`` instead.
+    are handled by ``--emit added`` / ``--allow-missing`` instead. Downgrades
+    and unparseable version changes are deliberately excluded so they fail
+    closed: ``--allow-version-lag`` is meant for upward bumps only, and a
+    downgrade leaves the pinned image *newer* than the manifest — a real drift
+    the gate must still hard-fail.
 
     Args:
         old_versions: Name → version from the base-branch manifest.
         new_versions: Name → version from the current manifest.
 
     Returns:
-        Sorted list of tool names whose version string differs.
+        Sorted list of tool names whose version was bumped upward.
     """
     changed: list[str] = []
     for name, new_version in new_versions.items():
         old_version = old_versions.get(name)
-        if old_version is not None and old_version != new_version:
+        if old_version is not None and _is_upward_bump(old_version, new_version):
             changed.append(name)
     return sorted(changed)
 

--- a/scripts/ci/compute-new-manifest-tools.sh
+++ b/scripts/ci/compute-new-manifest-tools.sh
@@ -5,14 +5,19 @@ set -euo pipefail
 
 # compute-new-manifest-tools.sh
 #
-# Print the comma-separated set of tool names a PR *introduces* into
-# lintro/tools/manifest.json, computed as the git diff of tool names between
-# the current manifest and the manifest at the merge-base with the PR base
-# branch. The manifest-vs-image gate (verify-image-manifest-tools.sh) feeds
-# this to verify-manifest-tools.py via --allow-missing so a newly-added tool's
-# (necessarily) absent binary in the digest-pinned base image downgrades to a
-# warning instead of structurally failing the required check (#1565). The
-# post-merge tools-image republish + digest bump restores full coverage.
+# Print the comma-separated set of tool names a PR changes in
+# lintro/tools/manifest.json, computed as a git diff against the merge-base
+# with the PR base branch. The manifest-vs-image gate
+# (verify-image-manifest-tools.sh) feeds this to verify-manifest-tools.py:
+#
+#   EMIT=added (default) → --allow-missing: a newly-added tool's absent binary
+#     in the digest-pinned base image downgrades to a warning (#1565).
+#   EMIT=version-changed → --allow-version-lag: a baked tool whose manifest
+#     version the PR bumps may still be older in the digest-pinned base image;
+#     a version mismatch (image older than manifest) downgrades to a warning
+#     (#1582). Missing binaries and image-newer-than-manifest still hard-fail.
+#
+# The post-merge tools-image republish + digest bump restores full coverage.
 #
 # Fail CLOSED: any trouble resolving the base ref, merge-base, the old manifest
 # blob, or the name diff prints an EMPTY set. An empty allowlist means full
@@ -38,12 +43,14 @@ the merge-base with the base branch. Fails closed (empty output) on any error.
 
 Environment:
   BASE_REF   Optional. PR base branch (github.base_ref), e.g. main. When unset
-             or empty (main / nightly runs), the added set is empty.
+             or empty (main / nightly runs), the emitted set is empty.
   MANIFEST   Optional. Manifest path relative to the repo root
              (default: lintro/tools/manifest.json).
+  EMIT       Optional. ``added`` (default) or ``version-changed``. Selects
+             which name set the Python helper prints.
 
 Output:
-  A single line on stdout: comma-separated added tool names (possibly empty).
+  A single line on stdout: comma-separated tool names (possibly empty).
 
 Exit codes:
   0  always (fail-closed: errors print an empty set and still exit 0)
@@ -57,6 +64,7 @@ fi
 
 : "${BASE_REF:=}"
 : "${MANIFEST:=lintro/tools/manifest.json}"
+: "${EMIT:=added}"
 
 log_info() { echo "[INFO] $*" >&2; }
 log_warn() { echo "[WARN] $*" >&2; }
@@ -68,9 +76,17 @@ emit() {
 	exit 0
 }
 
+case "$EMIT" in
+added | version-changed) ;;
+*)
+	log_warn "Invalid EMIT='${EMIT}' (expected added|version-changed); failing closed"
+	emit ""
+	;;
+esac
+
 # No PR context (main push / nightly): full enforcement, empty allowlist.
 if [[ -z "$BASE_REF" ]]; then
-	log_info "No BASE_REF (not a PR context); empty allow-missing set"
+	log_info "No BASE_REF (not a PR context); empty ${EMIT} set"
 	emit ""
 fi
 
@@ -106,16 +122,16 @@ if ! git show "${merge_base}:${MANIFEST}" >"$old_manifest" 2>/dev/null; then
 	rm -f "$old_manifest"
 fi
 
-added=""
-if ! added="$(python3 "${script_dir}/compute-new-manifest-tools.py" \
-	--old "$old_manifest" --new "$MANIFEST")"; then
+names=""
+if ! names="$(python3 "${script_dir}/compute-new-manifest-tools.py" \
+	--old "$old_manifest" --new "$MANIFEST" --emit "$EMIT")"; then
 	log_warn "Name diff failed; failing closed (empty set)"
 	emit ""
 fi
 
-if [[ -n "$added" ]]; then
-	log_info "Tools newly added by this PR: ${added}"
+if [[ -n "$names" ]]; then
+	log_info "Tools ${EMIT} by this PR: ${names}"
 else
-	log_info "No tools newly added by this PR"
+	log_info "No tools ${EMIT} by this PR"
 fi
-emit "$added"
+emit "$names"

--- a/scripts/ci/verify-image-manifest-tools.sh
+++ b/scripts/ci/verify-image-manifest-tools.sh
@@ -49,10 +49,14 @@ Environment:
                  the PR newly adds to the manifest are computed (diff vs the
                  merge-base) and passed as --allow-missing, so their absent
                  binary in the digest-pinned base image downgrades to a
-                 warning instead of failing the gate (#1565). Unset on
-                 main/nightly -> empty allowlist -> full enforcement.
+                 warning instead of failing the gate (#1565). Tools whose
+                 manifest *version* the PR bumps are likewise computed and
+                 passed as --allow-version-lag (#1582). Unset on main/nightly
+                 -> empty allowlists -> full enforcement.
   ALLOW_MISSING  Optional. Explicit comma-separated allow-missing tool names.
                  Overrides the BASE_REF-derived set (used by unit tests).
+  ALLOW_VERSION_LAG  Optional. Explicit comma-separated allow-version-lag
+                 tool names. Overrides the BASE_REF-derived set (unit tests).
   DRY_RUN        Optional. When "1"/"true", print the docker command and exit 0
                  without invoking docker (used by unit tests).
 
@@ -73,6 +77,7 @@ fi
 : "${MANIFEST:=lintro/tools/manifest.json}"
 : "${BASE_REF:=}"
 : "${ALLOW_MISSING:=}"
+: "${ALLOW_VERSION_LAG:=}"
 : "${DRY_RUN:=}"
 
 log_info() { echo "[INFO] $*"; }
@@ -93,12 +98,18 @@ if [[ ! -f "${repo_root}/${MANIFEST}" ]]; then
 	exit 2
 fi
 
-# Compute the newly-added-tool allowlist (#1565). An explicit ALLOW_MISSING
-# wins (tests); otherwise derive it from BASE_REF via the fail-closed helper.
-# On main/nightly (no BASE_REF) the helper returns empty -> full enforcement.
+# Compute allowlists (#1565 / #1582). Explicit ALLOW_* wins (tests); otherwise
+# derive from BASE_REF via the fail-closed helper. On main/nightly (no
+# BASE_REF) the helper returns empty -> full enforcement.
 if [[ -z "$ALLOW_MISSING" ]]; then
-	ALLOW_MISSING="$(BASE_REF="$BASE_REF" MANIFEST="$MANIFEST" \
+	ALLOW_MISSING="$(BASE_REF="$BASE_REF" MANIFEST="$MANIFEST" EMIT=added \
 		"${script_dir}/compute-new-manifest-tools.sh")"
+fi
+if [[ -z "$ALLOW_VERSION_LAG" ]]; then
+	ALLOW_VERSION_LAG="$(
+		BASE_REF="$BASE_REF" MANIFEST="$MANIFEST" EMIT=version-changed \
+			"${script_dir}/compute-new-manifest-tools.sh"
+	)"
 fi
 
 # Bypass the image entrypoint so the container's baked ENV is used verbatim and
@@ -116,6 +127,10 @@ declare -a docker_args=(
 if [[ -n "$ALLOW_MISSING" ]]; then
 	docker_args+=(--allow-missing "$ALLOW_MISSING")
 	log_info "Tolerating newly-added tool(s): ${ALLOW_MISSING}"
+fi
+if [[ -n "$ALLOW_VERSION_LAG" ]]; then
+	docker_args+=(--allow-version-lag "$ALLOW_VERSION_LAG")
+	log_info "Tolerating version-lag tool(s): ${ALLOW_VERSION_LAG}"
 fi
 
 if [[ "$DRY_RUN" == "1" || "$DRY_RUN" == "true" ]]; then

--- a/scripts/ci/verify-manifest-tools.py
+++ b/scripts/ci/verify-manifest-tools.py
@@ -183,6 +183,11 @@ def _version_tuple(version: str) -> tuple[int, ...]:
         if not digits:
             break
         parts.append(int(digits))
+        if len(digits) != len(segment):
+            # Segment had trailing non-digit content (e.g. "0-rc"): stop
+            # entirely so a pre-release tag drops everything after it and
+            # "7.1.0-rc.1" compares as (7, 1, 0), per the documented contract.
+            break
     return tuple(parts)
 
 

--- a/scripts/ci/verify-manifest-tools.py
+++ b/scripts/ci/verify-manifest-tools.py
@@ -155,6 +155,63 @@ def _parse_allow_missing(values: list[str] | None) -> set[str]:
     return names
 
 
+# Alias: --allow-version-lag uses the same comma/repeat parsing as allow-missing.
+_parse_allow_version_lag = _parse_allow_missing
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    """Parse a dotted numeric version into a comparable integer tuple.
+
+    Non-numeric trailing segments (pre-release tags) are dropped so
+    ``7.1.0-rc.1`` compares as ``(7, 1, 0)``.
+
+    Args:
+        version: A dotted version string.
+
+    Returns:
+        Integer segments for lexicographic comparison. Empty when no digits
+        are found.
+    """
+    parts: list[int] = []
+    for segment in version.split("."):
+        digits = ""
+        for char in segment:
+            if char.isdigit():
+                digits += char
+            else:
+                break
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts)
+
+
+def _is_image_older_than_manifest(*, expected: str, actual: str) -> bool:
+    """Return True when the installed version is strictly older than expected.
+
+    Used by ``--allow-version-lag``: an image that still ships the pre-bump
+    version is tolerated; an image that is *newer* than the manifest (or
+    equal) must not use this escape hatch.
+
+    Args:
+        expected: Manifest-declared version.
+        actual: Version parsed from the installed binary.
+
+    Returns:
+        True when ``actual < expected`` under numeric segment comparison.
+        False when equal, newer, or either side cannot be parsed.
+    """
+    expected_parts = _version_tuple(expected)
+    actual_parts = _version_tuple(actual)
+    if not expected_parts or not actual_parts:
+        return False
+    # Pad the shorter tuple with zeros so 7.1 vs 7.1.0 compares fairly.
+    width = max(len(expected_parts), len(actual_parts))
+    expected_padded = expected_parts + (0,) * (width - len(expected_parts))
+    actual_padded = actual_parts + (0,) * (width - len(actual_parts))
+    return actual_padded < expected_padded
+
+
 def main() -> int:
     """Verify tools in manifest.json are installed with correct versions."""
     parser = argparse.ArgumentParser()
@@ -180,10 +237,24 @@ def main() -> int:
             "version-match; every other tool keeps hard-fail behavior."
         ),
     )
+    parser.add_argument(
+        "--allow-version-lag",
+        action="append",
+        default=None,
+        help=(
+            "Tool name(s) whose *older-than-manifest* installed version "
+            "downgrades to a warning instead of failing. Repeatable and/or "
+            "comma-separated. Intended for a PR that bumps a baked tool's "
+            "manifest version before the digest-pinned base image republishes "
+            "(#1582). Missing binaries, parse failures, and image-newer-than-"
+            "manifest mismatches still hard-fail for these tools."
+        ),
+    )
     args = parser.parse_args()
 
     tiers = [t.strip() for t in args.tiers.split(",")]
     allow_missing = _parse_allow_missing(args.allow_missing)
+    allow_version_lag = _parse_allow_version_lag(args.allow_version_lag)
     try:
         all_tools = _load_manifest(args.manifest)
     except (ValueError, OSError, json.JSONDecodeError) as exc:
@@ -238,6 +309,20 @@ def main() -> int:
             continue
 
         if not _versions_match(name, expected, actual):
+            # Digest-lag version bump (#1582): when the PR raised the manifest
+            # version and the digest-pinned base image still ships the older
+            # build, tolerate with a loud warning. Image-newer-than-manifest
+            # (or unparseable ordering) stays a hard failure.
+            if name in allow_version_lag and _is_image_older_than_manifest(
+                expected=expected,
+                actual=actual,
+            ):
+                warnings.append(
+                    f"{name}: version lag (manifest {expected}, image {actual}); "
+                    f"tolerated because this PR bumped the tool version and the "
+                    f"digest-pinned base image has not republished yet",
+                )
+                continue
             failures.append(
                 f"{name}: version mismatch (expected {expected}, got {actual})",
             )
@@ -245,10 +330,10 @@ def main() -> int:
     if warnings:
         # GitHub Actions annotation (::warning::) plus a human-readable block so
         # the tolerated tool is prominent in both the checks UI and raw logs.
-        print("::warning::Tool verification tolerated newly-added tool(s):")
+        print("::warning::Tool verification tolerated digest-lag tool(s):")
         for item in warnings:
             print(f"::warning::{item}")
-        print("Tolerated missing tool(s) (newly added by this PR):")
+        print("Tolerated tool(s) (newly added or version-bumped by this PR):")
         for item in warnings:
             print(f"  - {item}")
 
@@ -261,7 +346,7 @@ def main() -> int:
     tiers_str = ", ".join(tiers)
     summary = f"Verified {len(tools)} tool(s) against manifest tiers: {tiers_str}"
     if warnings:
-        summary = f"{summary} ({len(warnings)} newly-added tool(s) tolerated)"
+        summary = f"{summary} ({len(warnings)} digest-lag tool(s) tolerated)"
     print(summary)
     return 0
 

--- a/tests/scripts/test_compute_new_manifest_tools.py
+++ b/tests/scripts/test_compute_new_manifest_tools.py
@@ -372,6 +372,32 @@ def test_py_version_changed_no_change_is_empty(tmp_path: Path) -> None:
     assert_that(result.stdout.strip()).is_equal_to("")
 
 
+def test_py_version_changed_excludes_downgrades(tmp_path: Path) -> None:
+    """A downgrade must not enter the version-lag allowlist (fail closed).
+
+    ``--allow-version-lag`` is for upward bumps only; a downgrade leaves the
+    pinned image newer than the manifest, which the gate must hard-fail.
+    """
+    old = tmp_path / "old.json"
+    new = tmp_path / "new.json"
+    old.write_text(_manifest_versions([("ruff", "0.9.0"), ("astro_check", "7.1.3")]))
+    new.write_text(_manifest_versions([("ruff", "0.9.0"), ("astro_check", "7.0.9")]))
+    result = _run_py_emit(old, new, emit="version-changed")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("")
+
+
+def test_py_version_changed_excludes_unparseable_change(tmp_path: Path) -> None:
+    """A change to/from an unparseable version fails closed (excluded)."""
+    old = tmp_path / "old.json"
+    new = tmp_path / "new.json"
+    old.write_text(_manifest_versions([("astro_check", "7.0.9")]))
+    new.write_text(_manifest_versions([("astro_check", "latest")]))
+    result = _run_py_emit(old, new, emit="version-changed")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("")
+
+
 def test_py_version_changed_invalid_exits_two(tmp_path: Path) -> None:
     """Malformed manifests fail closed (exit 2) for version-changed too."""
     old = tmp_path / "old.json"

--- a/tests/scripts/test_compute_new_manifest_tools.py
+++ b/tests/scripts/test_compute_new_manifest_tools.py
@@ -372,6 +372,19 @@ def test_py_version_changed_no_change_is_empty(tmp_path: Path) -> None:
     assert_that(result.stdout.strip()).is_equal_to("")
 
 
+def test_version_tuple_stops_at_prerelease_tag() -> None:
+    """A pre-release tag stops parsing so "7.1.0-rc.1" is (7, 1, 0)."""
+    module = _load_module()
+    version_tuple = module._version_tuple  # noqa: SLF001
+    assert_that(version_tuple("7.1.0-rc.1")).is_equal_to((7, 1, 0))
+    assert_that(version_tuple("7.1.3")).is_equal_to((7, 1, 3))
+    # Pre-release tags collapse to their release base, so ordering is decided
+    # by the numeric segments only.
+    is_upward = module._is_upward_bump  # noqa: SLF001
+    assert_that(is_upward("7.1.0-rc.1", "7.2.0")).is_true()
+    assert_that(is_upward("7.2.0", "7.1.0-rc.1")).is_false()
+
+
 def test_py_version_changed_excludes_downgrades(tmp_path: Path) -> None:
     """A downgrade must not enter the version-lag allowlist (fail closed).
 

--- a/tests/scripts/test_compute_new_manifest_tools.py
+++ b/tests/scripts/test_compute_new_manifest_tools.py
@@ -284,3 +284,166 @@ def test_sh_help_exits_zero() -> None:
     assert_that(result.returncode).is_equal_to(0)
     assert_that(result.stdout).contains("Usage:")
     assert_that(result.stdout).contains("BASE_REF")
+
+
+def _manifest_versions(entries: list[tuple[str, str]]) -> str:
+    """Render a manifest JSON string with explicit name/version pairs.
+
+    Args:
+        entries: (name, version) pairs to declare.
+
+    Returns:
+        str: The manifest JSON.
+    """
+    return json.dumps(
+        {
+            "version": 2,
+            "tools": [{"name": n, "version": v} for n, v in entries],
+        },
+    )
+
+
+def _run_py_emit(
+    old: Path,
+    new: Path,
+    *,
+    emit: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run the python diff helper with an explicit --emit mode.
+
+    Args:
+        old: Old manifest path.
+        new: New manifest path.
+        emit: ``added`` or ``version-changed``.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed run.
+    """
+    return subprocess.run(  # nosec B603 B607 - fixed argv, shell=False, controlled test
+        [
+            "python3",
+            str(_PY_SCRIPT),
+            "--old",
+            str(old),
+            "--new",
+            str(new),
+            "--emit",
+            emit,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_py_version_changed_reports_bumped_tools(tmp_path: Path) -> None:
+    """Version-changed emit lists tools whose version string differs."""
+    old = tmp_path / "old.json"
+    new = tmp_path / "new.json"
+    old.write_text(_manifest_versions([("ruff", "0.9.0"), ("astro_check", "7.0.9")]))
+    new.write_text(_manifest_versions([("ruff", "0.9.0"), ("astro_check", "7.1.3")]))
+    result = _run_py_emit(old, new, emit="version-changed")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("astro_check")
+
+
+def test_py_version_changed_ignores_newly_added(tmp_path: Path) -> None:
+    """Newly-added tools are not reported as version-changed."""
+    old = tmp_path / "old.json"
+    new = tmp_path / "new.json"
+    old.write_text(_manifest_versions([("ruff", "0.9.0")]))
+    new.write_text(
+        _manifest_versions([("ruff", "0.9.0"), ("terraform", "1.9.0")]),
+    )
+    result = _run_py_emit(old, new, emit="version-changed")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("")
+
+
+def test_py_version_changed_no_change_is_empty(tmp_path: Path) -> None:
+    """Identical versions print an empty version-changed set."""
+    old = tmp_path / "old.json"
+    new = tmp_path / "new.json"
+    payload = _manifest_versions([("ruff", "0.9.0"), ("black", "25.1.0")])
+    old.write_text(payload)
+    new.write_text(payload)
+    result = _run_py_emit(old, new, emit="version-changed")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("")
+
+
+def test_py_version_changed_invalid_exits_two(tmp_path: Path) -> None:
+    """Malformed manifests fail closed (exit 2) for version-changed too."""
+    old = tmp_path / "old.json"
+    new = tmp_path / "new.json"
+    old.write_text(_manifest_versions([("ruff", "0.9.0")]))
+    new.write_text("not json")
+    result = _run_py_emit(old, new, emit="version-changed")
+    assert_that(result.returncode).is_equal_to(2)
+
+
+def _run_sh_emit(
+    repo: Path,
+    *,
+    base_ref: str,
+    emit: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run the shell wrapper with an explicit EMIT mode.
+
+    Args:
+        repo: Repository to run in (cwd).
+        base_ref: BASE_REF value.
+        emit: ``added`` or ``version-changed``.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed run.
+    """
+    return subprocess.run(  # nosec B603 - fixed argv against a real binary; shell=False
+        [str(_SH_SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=repo,
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": os.environ.get("HOME", "/tmp"),  # nosec B108 - test fallback
+            "BASE_REF": base_ref,
+            "EMIT": emit,
+        },
+    )
+
+
+def _write_manifest_versions(repo: Path, entries: list[tuple[str, str]]) -> None:
+    """Write the repo manifest with explicit name/version pairs.
+
+    Args:
+        repo: Repository root.
+        entries: (name, version) pairs.
+    """
+    manifest = repo / "lintro" / "tools" / "manifest.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(_manifest_versions(entries))
+
+
+def test_sh_version_changed_reports_bump(tmp_path: Path) -> None:
+    """A version bump on the branch is reported under EMIT=version-changed."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    _write_manifest_versions(repo, [("ruff", "0.9.0"), ("astro_check", "7.0.9")])
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "checkout", "-b", "feature")
+    _write_manifest_versions(repo, [("ruff", "0.9.0"), ("astro_check", "7.1.3")])
+    _git(repo, "commit", "-am", "bump astro")
+    result = _run_sh_emit(repo, base_ref="main", emit="version-changed")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("astro_check")
+
+
+def test_sh_version_changed_unresolvable_fails_closed(tmp_path: Path) -> None:
+    """Unresolvable base ref fails closed for version-changed emit too."""
+    repo = _init_repo_with_base(tmp_path)
+    result = _run_sh_emit(repo, base_ref="does-not-exist", emit="version-changed")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("")

--- a/tests/scripts/test_verify_image_manifest_tools.py
+++ b/tests/scripts/test_verify_image_manifest_tools.py
@@ -278,3 +278,23 @@ def test_no_allow_missing_without_base_ref(
     ]
     assert_that(run_lines).is_length(1)
     assert_that(run_lines[0]).does_not_contain("--allow-missing")
+
+
+def test_explicit_allow_version_lag_passes_through(
+    image_repo: Path,
+    docker_stub: tuple[Path, Path],
+) -> None:
+    """An explicit ALLOW_VERSION_LAG flows through as --allow-version-lag (#1582)."""
+    bin_dir, args_log = docker_stub
+    result = _run_script(
+        image_repo,
+        bin_dir,
+        args_log,
+        extra_env={"ALLOW_VERSION_LAG": "astro_check"},
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    run_lines = [
+        line for line in args_log.read_text().splitlines() if line.startswith("run ")
+    ]
+    assert_that(run_lines).is_length(1)
+    assert_that(run_lines[0]).contains("--allow-version-lag astro_check")

--- a/tests/scripts/test_verify_manifest_tools.py
+++ b/tests/scripts/test_verify_manifest_tools.py
@@ -250,3 +250,104 @@ def test_empty_allow_missing_leaves_behavior_unchanged(
     code = _run_main(module, monkeypatch, ["--manifest", str(manifest)])
 
     assert_that(code).is_equal_to(0)
+
+
+def test_parse_allow_version_lag_splits_and_dedupes() -> None:
+    """--allow-version-lag uses the same comma-split parsing as allow-missing."""
+    module = _load_verify_manifest_tools_module()
+
+    parse = module._parse_allow_version_lag  # noqa: SLF001
+    assert_that(parse(None)).is_equal_to(set())
+    assert_that(parse(["astro_check, ruff", "ruff"])).is_equal_to(
+        {"astro_check", "ruff"},
+    )
+
+
+def test_is_image_older_than_manifest_ordering() -> None:
+    """Numeric segment ordering distinguishes older / equal / newer images."""
+    module = _load_verify_manifest_tools_module()
+
+    older = module._is_image_older_than_manifest  # noqa: SLF001
+    assert_that(older(expected="7.1.3", actual="7.0.9")).is_true()
+    assert_that(older(expected="7.1.3", actual="7.1.3")).is_false()
+    assert_that(older(expected="7.1.0", actual="7.1.3")).is_false()
+    assert_that(older(expected="7.1", actual="7.0.9")).is_true()
+
+
+def test_allow_version_lag_older_image_passes_with_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An allow-version-lag tool with an older installed version warns, not fails."""
+    module = _load_verify_manifest_tools_module()
+    _, output = module._run(["git", "--version"])  # noqa: SLF001
+    actual = module._parse_version(output, "git")  # noqa: SLF001
+    assert_that(actual).is_not_none()
+    # Declare a version strictly newer than whatever git reports on this runner.
+    parts = [int(p) for p in str(actual).split(".")]
+    parts[0] += 1
+    expected = ".".join(str(p) for p in parts)
+    manifest = _write_manifest(
+        tmp_path,
+        name="git",
+        version=expected,
+        version_command=["git", "--version"],
+    )
+
+    code = _run_main(
+        module,
+        monkeypatch,
+        ["--manifest", str(manifest), "--allow-version-lag", "git"],
+    )
+
+    assert_that(code).is_equal_to(0)
+    out = capsys.readouterr().out
+    assert_that(out).contains("::warning::")
+    assert_that(out).contains("version lag")
+    assert_that(out).contains("git")
+
+
+def test_allow_version_lag_newer_image_still_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Image-newer-than-manifest stays a hard failure even with version-lag."""
+    module = _load_verify_manifest_tools_module()
+    # Manifest declares an impossibly old version so the real git binary is newer.
+    manifest = _write_manifest(
+        tmp_path,
+        name="git",
+        version="0.0.1",
+        version_command=["git", "--version"],
+    )
+
+    code = _run_main(
+        module,
+        monkeypatch,
+        ["--manifest", str(manifest), "--allow-version-lag", "git"],
+    )
+
+    assert_that(code).is_equal_to(1)
+
+
+def test_allow_version_lag_missing_binary_still_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Version-lag does not tolerate a missing binary (unlike allow-missing)."""
+    module = _load_verify_manifest_tools_module()
+    manifest = _write_manifest(
+        tmp_path,
+        name="brandnew",
+        version="1.0.0",
+        version_command=["definitely-not-a-real-binary-xyz", "--version"],
+    )
+
+    code = _run_main(
+        module,
+        monkeypatch,
+        ["--manifest", str(manifest), "--allow-version-lag", "brandnew"],
+    )
+
+    assert_that(code).is_equal_to(1)

--- a/tests/scripts/test_verify_manifest_tools.py
+++ b/tests/scripts/test_verify_manifest_tools.py
@@ -274,6 +274,18 @@ def test_is_image_older_than_manifest_ordering() -> None:
     assert_that(older(expected="7.1", actual="7.0.9")).is_true()
 
 
+def test_version_tuple_stops_at_prerelease_tag() -> None:
+    """A pre-release tag stops parsing so "7.1.0-rc.1" is (7, 1, 0)."""
+    module = _load_verify_manifest_tools_module()
+
+    version_tuple = module._version_tuple  # noqa: SLF001
+    assert_that(version_tuple("7.1.0-rc.1")).is_equal_to((7, 1, 0))
+    assert_that(version_tuple("7.1.3")).is_equal_to((7, 1, 3))
+    # A pre-release build must not read as newer than its release.
+    older = module._is_image_older_than_manifest  # noqa: SLF001
+    assert_that(older(expected="7.1.0", actual="7.1.0-rc.1")).is_false()
+
+
 def test_allow_version_lag_older_image_passes_with_warning(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): tolerate baked-tool version lag and bump astro to 7.1.3
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

### Part 1 — manifest gate version-lag tolerance
- `compute-new-manifest-tools.py` / `.sh`: `--emit version-changed` (fail-closed) lists tools whose manifest version changed vs merge-base
- `verify-manifest-tools.py`: `--allow-version-lag` — image **older** than manifest → loud `::warning::`; missing binary, parse failures, and image-**newer**-than-manifest still hard-fail
- Wired through `verify-image-manifest-tools.sh` + docker-ci comment
- Tests in `tests/scripts/` for bump tolerated, newer/missing still fail, fail-closed allowlist

### Part 2 — astro bump + suppression removal
- `astro` `7.0.9` → `7.1.3` in root + `apps/site` `package.json`, lockfiles, `_generated_versions.py`, manifest
- Removed `GHSA-4g3v-8h47-v7g6` from `.osv-scanner.toml`

### Also
- Aligned `actions/checkout` Renovate comments (`# v7` → `# v7.0.0`) so the action-pinning gate matches the pinned SHA (required because this PR touches workflows)

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1582

## Details

- `uv run lintro fmt` / `uv run lintro chk` — 0 issues (100/100)
- `uv run pytest --maxfail=0` — **7274 passed**, 118 skipped
- `bun run build` in `apps/site` — succeeded
- `osv-scanner scan source --lockfile apps/site/bun.lock` — **No issues found**

Closes #1582
