### PR TITLE
fix(cli): resolve symlinks in --diff changed-file matching

### DIFF
--- a/lintro/utils/git_diff.py
+++ b/lintro/utils/git_diff.py
@@ -288,8 +288,12 @@ def _path_in_repo(path: str, repo_root: str) -> bool:
     Returns:
         True when ``path`` is the root itself or a path beneath it.
     """
-    abs_path = Path(path).absolute()
-    abs_root = Path(repo_root).absolute()
+    # Resolve symlinks on both sides: ``repo_root`` comes from ``git rev-parse
+    # --show-toplevel`` (realpath'd) while ``path`` comes from discovery
+    # (``os.path.abspath``, symlink-preserved). Comparing them unresolved makes
+    # files reached through a symlink fall outside their own repository.
+    abs_path = Path(path).resolve()
+    abs_root = Path(repo_root).resolve()
     if abs_path == abs_root:
         return True
     return abs_root in abs_path.parents
@@ -490,4 +494,12 @@ def filter_files_by_diff(
     changed = get_changed_files(base, cwd)
     if not changed:
         return []
-    return [f for f in files if absolute_path_without_resolving(Path(f)) in changed]
+    # Resolve symlinks on both sides of the membership test. ``git rev-parse
+    # --show-toplevel`` reports a realpath'd root (so ``changed`` paths are
+    # symlink-resolved), while discovery yields ``os.path.abspath`` paths that
+    # preserve symlinks. Without resolving both, a scan target reached through
+    # a symlink (e.g. macOS ``/var`` -> ``/private/var``) never matches and the
+    # changed files are silently dropped. Keys only; the original ``f`` is
+    # returned so callers keep the discovered path form.
+    changed_keys = {str(Path(c).resolve()) for c in changed}
+    return [f for f in files if str(Path(f).resolve()) in changed_keys]

--- a/lintro/utils/git_diff.py
+++ b/lintro/utils/git_diff.py
@@ -278,6 +278,32 @@ def _probe_path_for_repo(path: str) -> str:
     return str(parent) if str(parent) != str(abs_path) else "."
 
 
+def _diff_key(path: str) -> str:
+    """Return a canonical membership key for diff comparisons.
+
+    Resolves symlinks in the **directory** portion of ``path`` but keeps the
+    final component unfollowed. This mirrors git, which reports a realpath'd
+    worktree root (``git rev-parse --show-toplevel``) yet leaves tracked
+    in-tree symlinks as their own paths. Directory-symlinked scan targets (e.g.
+    macOS ``/var`` -> ``/private/var``) therefore compare equal to git's
+    changed set, while a tracked terminal symlink is neither followed out of its
+    repository nor collapsed onto the file it aliases.
+
+    Args:
+        path: File or directory path to canonicalize.
+
+    Returns:
+        Absolute path with directory symlinks resolved and the final component
+        preserved.
+    """
+    candidate = Path(path)
+    try:
+        parent = candidate.parent.resolve()
+    except OSError:
+        parent = candidate.parent.absolute()
+    return str(parent / candidate.name)
+
+
 def _path_in_repo(path: str, repo_root: str) -> bool:
     """Return whether ``path`` lies inside ``repo_root``.
 
@@ -288,11 +314,12 @@ def _path_in_repo(path: str, repo_root: str) -> bool:
     Returns:
         True when ``path`` is the root itself or a path beneath it.
     """
-    # Resolve symlinks on both sides: ``repo_root`` comes from ``git rev-parse
-    # --show-toplevel`` (realpath'd) while ``path`` comes from discovery
-    # (``os.path.abspath``, symlink-preserved). Comparing them unresolved makes
-    # files reached through a symlink fall outside their own repository.
-    abs_path = Path(path).resolve()
+    # ``repo_root`` comes from ``git rev-parse --show-toplevel`` (realpath'd)
+    # while ``path`` comes from discovery (``os.path.abspath``, symlink
+    # preserved). Canonicalize both so a file reached through a symlinked
+    # directory is still recognized as belonging to its repository, without
+    # following a tracked terminal symlink out of the tree.
+    abs_path = Path(_diff_key(path))
     abs_root = Path(repo_root).resolve()
     if abs_path == abs_root:
         return True
@@ -494,12 +521,14 @@ def filter_files_by_diff(
     changed = get_changed_files(base, cwd)
     if not changed:
         return []
-    # Resolve symlinks on both sides of the membership test. ``git rev-parse
+    # Canonicalize both sides of the membership test. ``git rev-parse
     # --show-toplevel`` reports a realpath'd root (so ``changed`` paths are
-    # symlink-resolved), while discovery yields ``os.path.abspath`` paths that
-    # preserve symlinks. Without resolving both, a scan target reached through
-    # a symlink (e.g. macOS ``/var`` -> ``/private/var``) never matches and the
-    # changed files are silently dropped. Keys only; the original ``f`` is
-    # returned so callers keep the discovered path form.
-    changed_keys = {str(Path(c).resolve()) for c in changed}
-    return [f for f in files if str(Path(f).resolve()) in changed_keys]
+    # directory-resolved), while discovery yields ``os.path.abspath`` paths that
+    # preserve symlinks. Without canonicalizing, a scan target reached through a
+    # symlinked directory (e.g. macOS ``/var`` -> ``/private/var``) never
+    # matches and the changed files are silently dropped. ``_diff_key`` keeps
+    # the final component unfollowed so tracked symlink aliases stay distinct.
+    # Keys only; the original ``f`` is returned so callers keep the discovered
+    # path form.
+    changed_keys = {_diff_key(c) for c in changed}
+    return [f for f in files if _diff_key(f) in changed_keys]

--- a/tests/unit/utils/test_git_diff.py
+++ b/tests/unit/utils/test_git_diff.py
@@ -208,6 +208,56 @@ def test_filter_files_by_diff_restricts_to_changed(git_repo: Path) -> None:
     assert_that(_names(filtered)).is_equal_to(["a.py"])
 
 
+def test_filter_files_by_diff_matches_through_symlinked_path(
+    git_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """A repo reached through a symlink still matches changed files.
+
+    ``git rev-parse --show-toplevel`` realpath's the root while discovery
+    preserves symlinks (``os.path.abspath``). Without resolving both sides of
+    the membership test, a changed file under a symlinked path is silently
+    dropped. Regression test for the ``--diff`` symlink drop.
+
+    Args:
+        git_repo: Initialized git repository fixture.
+        tmp_path: Pytest temporary directory (the repo itself).
+    """
+    (git_repo / "a.py").write_text("x = 9\n")  # changed vs main
+    link = tmp_path.parent / f"{tmp_path.name}-link"
+    link.symlink_to(git_repo, target_is_directory=True)
+    # Candidate discovered via the symlink path (symlink preserved).
+    candidate = str(link / "a.py")
+
+    filtered = filter_files_by_diff([candidate], "main", str(link))
+
+    assert_that(_names(filtered)).is_equal_to(["a.py"])
+
+
+def test_filter_files_by_diff_for_paths_matches_through_symlinked_path(
+    git_repo: Path,
+    tmp_path: Path,
+) -> None:
+    """Per-repo filtering matches changed files under a symlinked target.
+
+    Exercises both the symlink-aware repo bucketing (``_path_in_repo``) and the
+    resolved membership test, since the multi-repo path groups discovered files
+    by realpath'd repo root before filtering.
+
+    Args:
+        git_repo: Initialized git repository fixture.
+        tmp_path: Pytest temporary directory (the repo itself).
+    """
+    (git_repo / "a.py").write_text("x = 9\n")  # changed vs main
+    link = tmp_path.parent / f"{tmp_path.name}-mrlink"
+    link.symlink_to(git_repo, target_is_directory=True)
+    candidate = str(link / "a.py")
+
+    filtered = filter_files_by_diff_for_paths([candidate], "main", [str(link)])
+
+    assert_that(_names(filtered)).is_equal_to(["a.py"])
+
+
 def test_filter_files_by_diff_empty_changed_set(git_repo: Path) -> None:
     """With no changes, filtering returns an empty list."""
     candidates = [str(git_repo / "a.py"), str(git_repo / "b.py")]

--- a/tests/unit/utils/test_git_diff.py
+++ b/tests/unit/utils/test_git_diff.py
@@ -231,7 +231,8 @@ def test_filter_files_by_diff_matches_through_symlinked_path(
 
     filtered = filter_files_by_diff([candidate], "main", str(link))
 
-    assert_that(_names(filtered)).is_equal_to(["a.py"])
+    # Matched, and the discovered (symlink-preserved) path form is returned.
+    assert_that(filtered).is_equal_to([candidate])
 
 
 def test_filter_files_by_diff_for_paths_matches_through_symlinked_path(
@@ -254,6 +255,30 @@ def test_filter_files_by_diff_for_paths_matches_through_symlinked_path(
     candidate = str(link / "a.py")
 
     filtered = filter_files_by_diff_for_paths([candidate], "main", [str(link)])
+
+    assert_that(filtered).is_equal_to([candidate])
+
+
+def test_filter_files_by_diff_keeps_tracked_symlink_alias_distinct(
+    git_repo: Path,
+) -> None:
+    """A tracked symlink aliasing a changed file is not itself treated as changed.
+
+    Canonicalization must resolve directory symlinks without following a tracked
+    terminal symlink; otherwise a symlink pointing at a changed regular file
+    collapses onto the same membership key and is linted as changed too.
+
+    Args:
+        git_repo: Initialized git repository fixture.
+    """
+    (git_repo / "alias.py").symlink_to("a.py")  # tracked symlink -> a.py
+    _git(git_repo, "add", ".")
+    _git(git_repo, "commit", "-qm", "add alias")
+    _git(git_repo, "branch", "aliasbase")  # base already contains alias.py
+    (git_repo / "a.py").write_text("x = 9\n")  # only a.py's content changes
+    candidates = [str(git_repo / "a.py"), str(git_repo / "alias.py")]
+
+    filtered = filter_files_by_diff(candidates, "aliasbase", str(git_repo))
 
     assert_that(_names(filtered)).is_equal_to(["a.py"])
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(cli): resolve symlinks in --diff changed-file matching
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`--diff` silently dropped changed files when the scan path (or cwd) traversed a symlink.
`git rev-parse --show-toplevel` reports a **realpath'd** root (so the changed set is
symlink-resolved), while file discovery uses `os.path.abspath` and **preserves** symlinks.
Comparing the two unresolved, they never matched — so on macOS (`/tmp`, `/var`), symlinked
project dirs, or CI temp dirs, `lintro chk --diff <ref> <path>` reported a false-clean
result while skipping files that actually changed.

Fix: resolve symlinks on **both sides of the membership test** (comparison keys only —
returned paths keep their discovered form):
- `filter_files_by_diff` — resolve changed-set keys and candidates before comparing.
- `_path_in_repo` — resolve both sides so the multi-repo bucketing groups files under
  their realpath'd repo root (otherwise `repo_files` came back empty before filtering).

`filter_files_by_diff_for_paths` inherits the fix via its internal `filter_files_by_diff`
call plus the `_path_in_repo` bucketing fix.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1620

## Details

_See What’s Changing._
