### PR TITLE
fix(core): anchor tool cwd to the files' project root for scope-independence

### DIFF
--- a/lintro/plugins/execution_preparation.py
+++ b/lintro/plugins/execution_preparation.py
@@ -285,11 +285,11 @@ def prepare_execution(
 
     logger.debug(f"Files to process: {files}")
 
-    # Compute cwd and relative paths. Anchor the tool subprocess to a stable
-    # project root (the process cwd) rather than the commonpath of discovered
-    # files, so the path each tool sees for a given file — and thus config
-    # ``overrides`` keyed on it — is identical whether the user passed a file,
-    # a directory, or ``.`` (#1616).
+    # Compute cwd and relative paths. Anchor the tool subprocess to the files'
+    # project root rather than the commonpath of discovered files, so the path
+    # each tool sees for a given file — and thus config ``overrides`` keyed on
+    # it — is identical whether the user passed a file, a directory, or ``.``
+    # (#1616).
     cwd = get_execution_cwd(files)
     rel_files = [os.path.relpath(os.path.abspath(f), cwd) for f in files]
 

--- a/lintro/plugins/execution_preparation.py
+++ b/lintro/plugins/execution_preparation.py
@@ -12,7 +12,11 @@ from loguru import logger
 
 from lintro.config.lintro_config import LintroConfig
 from lintro.models.core.tool_result import ToolResult
-from lintro.plugins.file_discovery import discover_files, get_cwd, validate_paths
+from lintro.plugins.file_discovery import (
+    discover_files,
+    get_execution_cwd,
+    validate_paths,
+)
 from lintro.plugins.protocol import ToolDefinition
 
 # Constants for default values
@@ -281,9 +285,13 @@ def prepare_execution(
 
     logger.debug(f"Files to process: {files}")
 
-    # Compute cwd and relative paths
-    cwd = get_cwd(files)
-    rel_files = [os.path.relpath(f, cwd) if cwd else f for f in files]
+    # Compute cwd and relative paths. Anchor the tool subprocess to a stable
+    # project root (the process cwd) rather than the commonpath of discovered
+    # files, so the path each tool sees for a given file — and thus config
+    # ``overrides`` keyed on it — is identical whether the user passed a file,
+    # a directory, or ``.`` (#1616).
+    cwd = get_execution_cwd(files)
+    rel_files = [os.path.relpath(os.path.abspath(f), cwd) for f in files]
 
     # Get timeout (keep as float to preserve precision)
     timeout_value = merged_options.get("timeout")

--- a/lintro/plugins/file_discovery.py
+++ b/lintro/plugins/file_discovery.py
@@ -171,11 +171,15 @@ def get_cwd(paths: list[str]) -> str | None:
         return None
 
 
-#: Markers that identify a project root, in the order they are probed while
-#: walking up from the discovered files. ``.git`` covers repositories (including
-#: worktrees/submodules, where it is a file); the rest cover language projects.
-_PROJECT_ROOT_MARKERS: tuple[str, ...] = (
-    ".git",
+#: Git marker, preferred as the anchor: a repository has a single root, so it
+#: stays fixed even when nested language-project markers (monorepo packages)
+#: sit between a file and the repo root. ``.git`` is a directory in a normal
+#: checkout and a file in worktrees/submodules, so existence (not is-dir) is
+#: what matters.
+_GIT_MARKER: tuple[str, ...] = (".git",)
+
+#: Language/project markers used only when there is no enclosing git repository.
+_LANG_ROOT_MARKERS: tuple[str, ...] = (
     "pyproject.toml",
     "package.json",
     "setup.py",
@@ -189,18 +193,21 @@ def get_execution_cwd(files: list[str]) -> str:
     """Return a stable, scope-independent working directory for tool subprocesses.
 
     The tool subprocess is anchored to the **project root** of the discovered
-    files — the nearest ancestor directory holding a project marker (``.git``,
-    ``pyproject.toml``, ``package.json``, ...), found by walking up from the
-    files' common ancestor.
+    files, found by walking up from the files' common ancestor. The git
+    repository root (``.git``) is preferred; only when there is no enclosing
+    repository is the nearest language-project marker (``pyproject.toml``,
+    ``package.json``, ...) used.
 
     Unlike :func:`get_cwd` (the raw common ancestor), this does not move with
     the input scope: walking up from a single file's directory or from the
-    whole-repo common ancestor reaches the *same* fixed marker, so the path a
+    whole-repo common ancestor reaches the *same* repository root, so the path a
     tool sees for a given file — and thus any config ``overrides`` keyed on that
     path — is identical whether the user passed a file, a directory, or ``.``
-    (#1616). Because the anchor is derived from the files (not the process cwd),
-    each tool's own config discovery still resolves relative to where the files
-    actually live.
+    (#1616). Preferring the git root keeps this stable in a monorepo, where a
+    narrow invocation would otherwise stop at a nested package marker while a
+    repo-wide invocation stops at the outer one. Because the anchor is derived
+    from the files (not the process cwd), each tool's own config discovery still
+    resolves relative to where the files actually live.
 
     Falls back to the files' common ancestor when no marker is found (preserving
     prior behavior for marker-less trees), and to the process cwd when there are
@@ -215,7 +222,11 @@ def get_execution_cwd(files: list[str]) -> str:
     common = get_cwd(files)
     if common is None:
         return os.getcwd()
-    marker = find_file_upward(Path(common), _PROJECT_ROOT_MARKERS)
-    if marker is not None:
-        return str(marker.parent)
+    start = Path(common)
+    git_root = find_file_upward(start, _GIT_MARKER)
+    if git_root is not None:
+        return str(git_root.parent)
+    lang_root = find_file_upward(start, _LANG_ROOT_MARKERS)
+    if lang_root is not None:
+        return str(lang_root.parent)
     return common

--- a/lintro/plugins/file_discovery.py
+++ b/lintro/plugins/file_discovery.py
@@ -171,15 +171,15 @@ def get_cwd(paths: list[str]) -> str | None:
         return None
 
 
-#: Git marker, preferred as the anchor: a repository has a single root, so it
-#: stays fixed even when nested language-project markers (monorepo packages)
-#: sit between a file and the repo root. ``.git`` is a directory in a normal
-#: checkout and a file in worktrees/submodules, so existence (not is-dir) is
-#: what matters.
-_GIT_MARKER: tuple[str, ...] = (".git",)
-
-#: Language/project markers used only when there is no enclosing git repository.
-_LANG_ROOT_MARKERS: tuple[str, ...] = (
+#: Markers that identify a project root, probed in order in each directory
+#: while walking up from the discovered files. ``.git`` covers repositories
+#: (a directory normally, a file in worktrees/submodules, so existence — not
+#: is-dir — is what matters); the rest cover language projects. The *nearest*
+#: marker wins, so a file in a nested project (e.g. a monorepo package with its
+#: own ``package.json``/``tsconfig.json``) anchors to that project — the
+#: directory a tool's own config discovery expects — rather than the outer repo.
+_PROJECT_ROOT_MARKERS: tuple[str, ...] = (
+    ".git",
     "pyproject.toml",
     "package.json",
     "setup.py",
@@ -188,30 +188,41 @@ _LANG_ROOT_MARKERS: tuple[str, ...] = (
     "Cargo.toml",
 )
 
+#: Bounds the upward marker search, counting the files' common ancestor itself,
+#: so an unrelated marker from a far filesystem ancestor (e.g. a dotfile-managed
+#: ``~/.git``, or a distant vendored ``package.json``) is never picked up.
+#: Matches ``_IGNORE_SEARCH_MAX_DEPTH`` used for ``.lintro-ignore`` discovery.
+_PROJECT_ROOT_SEARCH_MAX_DEPTH = 20
+
 
 def get_execution_cwd(files: list[str]) -> str:
     """Return a stable, scope-independent working directory for tool subprocesses.
 
     The tool subprocess is anchored to the **project root** of the discovered
-    files, found by walking up from the files' common ancestor. The git
-    repository root (``.git``) is preferred; only when there is no enclosing
-    repository is the nearest language-project marker (``pyproject.toml``,
-    ``package.json``, ...) used.
+    files — the nearest ancestor directory holding a project marker (``.git``,
+    ``pyproject.toml``, ``package.json``, ...), found by walking up from the
+    files' common ancestor.
 
     Unlike :func:`get_cwd` (the raw common ancestor), this does not move with
-    the input scope: walking up from a single file's directory or from the
-    whole-repo common ancestor reaches the *same* repository root, so the path a
-    tool sees for a given file — and thus any config ``overrides`` keyed on that
-    path — is identical whether the user passed a file, a directory, or ``.``
-    (#1616). Preferring the git root keeps this stable in a monorepo, where a
-    narrow invocation would otherwise stop at a nested package marker while a
-    repo-wide invocation stops at the outer one. Because the anchor is derived
-    from the files (not the process cwd), each tool's own config discovery still
-    resolves relative to where the files actually live.
+    the input scope: within one project, walking up from a single file's
+    directory or from the whole-repo common ancestor reaches the *same* marker,
+    so the path a tool sees for a given file — and thus any config ``overrides``
+    keyed on that path — is identical whether the user passed a file, a
+    directory, or ``.`` (#1616). Because the anchor is derived from the files
+    (not the process cwd) and uses the *nearest* marker, each tool's own config
+    discovery still resolves against the project the files actually belong to,
+    including nested projects in a monorepo.
 
-    Falls back to the files' common ancestor when no marker is found (preserving
-    prior behavior for marker-less trees), and to the process cwd when there are
-    no files.
+    Falls back to the files' common ancestor when no marker is found within
+    ``_PROJECT_ROOT_SEARCH_MAX_DEPTH`` ancestors (preserving prior behavior for
+    marker-less trees, and avoiding a distant unrelated marker), and to the
+    process cwd when there are no files.
+
+    Note:
+        When a single invocation spans multiple nested projects, the common
+        ancestor (and thus the anchor) is the outer project; per-project
+        anchoring in that case would require grouping files by project root and
+        running the tool once per group.
 
     Args:
         files: Discovered file paths the tool will process.
@@ -222,11 +233,11 @@ def get_execution_cwd(files: list[str]) -> str:
     common = get_cwd(files)
     if common is None:
         return os.getcwd()
-    start = Path(common)
-    git_root = find_file_upward(start, _GIT_MARKER)
-    if git_root is not None:
-        return str(git_root.parent)
-    lang_root = find_file_upward(start, _LANG_ROOT_MARKERS)
-    if lang_root is not None:
-        return str(lang_root.parent)
+    marker = find_file_upward(
+        Path(common),
+        _PROJECT_ROOT_MARKERS,
+        max_depth=_PROJECT_ROOT_SEARCH_MAX_DEPTH,
+    )
+    if marker is not None:
+        return str(marker.parent)
     return common

--- a/lintro/plugins/file_discovery.py
+++ b/lintro/plugins/file_discovery.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 from loguru import logger
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from lintro.plugins.protocol import ToolDefinition
 from lintro.utils.path_filtering import walk_files_with_excludes
-from lintro.utils.path_utils import find_lintro_ignore
+from lintro.utils.path_utils import find_file_upward, find_lintro_ignore
 
 # Default exclude patterns for file discovery
 DEFAULT_EXCLUDE_PATTERNS: list[str] = [
@@ -168,3 +169,53 @@ def get_cwd(paths: list[str]) -> str | None:
     except ValueError:
         # Can happen on Windows with paths on different drives
         return None
+
+
+#: Markers that identify a project root, in the order they are probed while
+#: walking up from the discovered files. ``.git`` covers repositories (including
+#: worktrees/submodules, where it is a file); the rest cover language projects.
+_PROJECT_ROOT_MARKERS: tuple[str, ...] = (
+    ".git",
+    "pyproject.toml",
+    "package.json",
+    "setup.py",
+    "setup.cfg",
+    "go.mod",
+    "Cargo.toml",
+)
+
+
+def get_execution_cwd(files: list[str]) -> str:
+    """Return a stable, scope-independent working directory for tool subprocesses.
+
+    The tool subprocess is anchored to the **project root** of the discovered
+    files — the nearest ancestor directory holding a project marker (``.git``,
+    ``pyproject.toml``, ``package.json``, ...), found by walking up from the
+    files' common ancestor.
+
+    Unlike :func:`get_cwd` (the raw common ancestor), this does not move with
+    the input scope: walking up from a single file's directory or from the
+    whole-repo common ancestor reaches the *same* fixed marker, so the path a
+    tool sees for a given file — and thus any config ``overrides`` keyed on that
+    path — is identical whether the user passed a file, a directory, or ``.``
+    (#1616). Because the anchor is derived from the files (not the process cwd),
+    each tool's own config discovery still resolves relative to where the files
+    actually live.
+
+    Falls back to the files' common ancestor when no marker is found (preserving
+    prior behavior for marker-less trees), and to the process cwd when there are
+    no files.
+
+    Args:
+        files: Discovered file paths the tool will process.
+
+    Returns:
+        Absolute path to use as the tool subprocess working directory.
+    """
+    common = get_cwd(files)
+    if common is None:
+        return os.getcwd()
+    marker = find_file_upward(Path(common), _PROJECT_ROOT_MARKERS)
+    if marker is not None:
+        return str(marker.parent)
+    return common

--- a/tests/unit/plugins/base/test_execution.py
+++ b/tests/unit/plugins/base/test_execution.py
@@ -231,6 +231,38 @@ def test_get_execution_cwd_anchors_to_project_root_regardless_of_scope(
     assert_that(Path(among_many).resolve()).is_equal_to(tmp_path.resolve())
 
 
+def test_get_execution_cwd_prefers_git_root_over_nested_package_marker(
+    tmp_path: Path,
+) -> None:
+    """A nested package marker must not shift the anchor by invocation scope.
+
+    Regression for #1616 (monorepo): a file in a nested package resolves to the
+    git repository root whether it is scanned alone or among files from other
+    packages, so the same file always gets the same subprocess cwd.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    from lintro.plugins.file_discovery import get_execution_cwd
+
+    (tmp_path / ".git").mkdir()  # single repo root
+    pkg_a = tmp_path / "packages" / "a"
+    pkg_b = tmp_path / "packages" / "b"
+    (pkg_a / "src").mkdir(parents=True)
+    pkg_b.mkdir(parents=True)
+    (pkg_a / "package.json").write_text("{}\n")  # nested marker
+    a_file = pkg_a / "src" / "foo.ts"
+    a_file.write_text("const x = 1;\n")
+    b_file = pkg_b / "bar.ts"
+    b_file.write_text("const y = 2;\n")
+
+    narrow = get_execution_cwd([str(a_file)])  # just the nested-package file
+    wide = get_execution_cwd([str(a_file), str(b_file)])  # spanning packages
+
+    assert_that(Path(narrow).resolve()).is_equal_to(tmp_path.resolve())
+    assert_that(Path(wide).resolve()).is_equal_to(tmp_path.resolve())
+
+
 def test_get_execution_cwd_falls_back_to_common_ancestor_without_marker(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/plugins/base/test_execution.py
+++ b/tests/unit/plugins/base/test_execution.py
@@ -203,6 +203,54 @@ def test_get_cwd_empty_paths_returns_none(fake_tool_plugin: FakeToolPlugin) -> N
     assert_that(result).is_none()
 
 
+def test_get_execution_cwd_anchors_to_project_root_regardless_of_scope(
+    tmp_path: Path,
+) -> None:
+    """The anchor is the files' project root, identical across input scopes.
+
+    Regression for #1616: walking up from a single file's directory or from the
+    whole-repo common ancestor reaches the same project marker, so the path a
+    tool sees for a file is stable across file/directory/``.`` invocations.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    from lintro.plugins.file_discovery import get_execution_cwd
+
+    (tmp_path / ".git").mkdir()  # project marker at the root
+    nested = tmp_path / "src" / "gen"
+    nested.mkdir(parents=True)
+    target = nested / "foo.ts"
+    target.write_text("const x = 1;\n")
+
+    # Same discovered file, whether reached as a single file or among many.
+    single = get_execution_cwd([str(target)])
+    among_many = get_execution_cwd([str(target), str(tmp_path / "other.ts")])
+
+    assert_that(Path(single).resolve()).is_equal_to(tmp_path.resolve())
+    assert_that(Path(among_many).resolve()).is_equal_to(tmp_path.resolve())
+
+
+def test_get_execution_cwd_falls_back_to_common_ancestor_without_marker(
+    tmp_path: Path,
+) -> None:
+    """Without a project marker, the anchor is the files' common ancestor.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    from lintro.plugins.file_discovery import get_execution_cwd
+
+    nested = tmp_path / "a" / "b"
+    nested.mkdir(parents=True)
+    target = nested / "foo.ts"
+    target.write_text("const x = 1;\n")
+
+    result = get_execution_cwd([str(target)])
+
+    assert_that(Path(result).resolve()).is_equal_to(nested.resolve())
+
+
 # =============================================================================
 # BaseToolPlugin._prepare_execution Tests
 # =============================================================================
@@ -304,6 +352,58 @@ def test_prepare_execution_successful_returns_context_with_files(
         assert_that(ctx.should_skip).is_false()
         assert_that(ctx.files).is_length(1)
         assert_that(ctx.files).is_equal_to([str(test_file)])
+
+
+def test_prepare_execution_cwd_and_rel_files_are_scope_independent(
+    fake_tool_plugin: FakeToolPlugin,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cwd and rel_files must not depend on the input path scope.
+
+    Regression for #1616: the tool subprocess is anchored to the project root
+    (process cwd), so the path a tool sees for a given file — and thus config
+    ``overrides`` keyed on it — is identical whether the user passed a file, a
+    directory, or ``.``. Previously the cwd was the commonpath/dirname of the
+    discovered files, which varied by scope.
+
+    Args:
+        fake_tool_plugin: Fixture providing a FakeToolPlugin instance.
+        tmp_path: Pytest temporary directory fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    (tmp_path / ".git").mkdir()  # project marker at the root
+    nested = tmp_path / "src" / "gen"
+    nested.mkdir(parents=True)
+    target = nested / "foo.ts"
+    target.write_text("const x = 1;\n")
+    monkeypatch.chdir(tmp_path)
+
+    contexts = []
+    for scope in (["."], ["src/gen"], ["src/gen/foo.ts"]):
+        with (
+            patch(
+                "lintro.plugins.execution_preparation.verify_tool_version",
+                return_value=None,
+            ),
+            patch(
+                "lintro.plugins.execution_preparation.discover_files",
+                return_value=[str(target)],
+            ),
+        ):
+            contexts.append(fake_tool_plugin._prepare_execution(scope, {}))
+
+    cwds = {ctx.cwd for ctx in contexts}
+    rel_file_sets = {tuple(ctx.rel_files) for ctx in contexts}
+
+    # Identical across all three invocation scopes.
+    assert_that(cwds).is_length(1)
+    assert_that(rel_file_sets).is_length(1)
+    # Anchored to the project root, with the full relative path preserved.
+    cwd0 = contexts[0].cwd
+    assert_that(cwd0).is_not_none()
+    assert_that(Path(str(cwd0)).resolve()).is_equal_to(tmp_path.resolve())
+    assert_that(contexts[0].rel_files).is_equal_to(["src/gen/foo.ts"])
 
 
 # =============================================================================

--- a/tests/unit/plugins/base/test_execution.py
+++ b/tests/unit/plugins/base/test_execution.py
@@ -231,36 +231,35 @@ def test_get_execution_cwd_anchors_to_project_root_regardless_of_scope(
     assert_that(Path(among_many).resolve()).is_equal_to(tmp_path.resolve())
 
 
-def test_get_execution_cwd_prefers_git_root_over_nested_package_marker(
+def test_get_execution_cwd_anchors_to_nearest_nested_project_marker(
     tmp_path: Path,
 ) -> None:
-    """A nested package marker must not shift the anchor by invocation scope.
+    """A file in a nested project anchors to that project, not the outer repo.
 
-    Regression for #1616 (monorepo): a file in a nested package resolves to the
-    git repository root whether it is scanned alone or among files from other
-    packages, so the same file always gets the same subprocess cwd.
+    The nearest marker wins so a tool's own config discovery (e.g. tsconfig for
+    a monorepo package) resolves against the project the file belongs to. A file
+    scanned together with siblings from the same package therefore shares that
+    package's anchor.
 
     Args:
         tmp_path: Pytest temporary directory fixture.
     """
     from lintro.plugins.file_discovery import get_execution_cwd
 
-    (tmp_path / ".git").mkdir()  # single repo root
-    pkg_a = tmp_path / "packages" / "a"
-    pkg_b = tmp_path / "packages" / "b"
-    (pkg_a / "src").mkdir(parents=True)
-    pkg_b.mkdir(parents=True)
-    (pkg_a / "package.json").write_text("{}\n")  # nested marker
-    a_file = pkg_a / "src" / "foo.ts"
-    a_file.write_text("const x = 1;\n")
-    b_file = pkg_b / "bar.ts"
-    b_file.write_text("const y = 2;\n")
+    (tmp_path / ".git").mkdir()  # outer repo root
+    pkg = tmp_path / "packages" / "a"
+    (pkg / "src").mkdir(parents=True)
+    (pkg / "package.json").write_text("{}\n")  # nested project marker
+    file_one = pkg / "src" / "foo.ts"
+    file_one.write_text("const x = 1;\n")
+    file_two = pkg / "src" / "bar.ts"
+    file_two.write_text("const y = 2;\n")
 
-    narrow = get_execution_cwd([str(a_file)])  # just the nested-package file
-    wide = get_execution_cwd([str(a_file), str(b_file)])  # spanning packages
+    single = get_execution_cwd([str(file_one)])
+    both = get_execution_cwd([str(file_one), str(file_two)])
 
-    assert_that(Path(narrow).resolve()).is_equal_to(tmp_path.resolve())
-    assert_that(Path(wide).resolve()).is_equal_to(tmp_path.resolve())
+    assert_that(Path(single).resolve()).is_equal_to(pkg.resolve())
+    assert_that(Path(both).resolve()).is_equal_to(pkg.resolve())
 
 
 def test_get_execution_cwd_falls_back_to_common_ancestor_without_marker(
@@ -281,6 +280,34 @@ def test_get_execution_cwd_falls_back_to_common_ancestor_without_marker(
     result = get_execution_cwd([str(target)])
 
     assert_that(Path(result).resolve()).is_equal_to(nested.resolve())
+
+
+def test_get_execution_cwd_bounds_marker_search_depth(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A project marker beyond the depth bound is ignored (falls back).
+
+    Guards against anchoring to a distant unrelated marker, e.g. a
+    dotfile-managed ``~/.git`` far above a marker-less working directory.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    import lintro.plugins.file_discovery as fd
+
+    monkeypatch.setattr(fd, "_PROJECT_ROOT_SEARCH_MAX_DEPTH", 2)
+    (tmp_path / ".git").mkdir()  # marker far above the files
+    deep = tmp_path / "a" / "b" / "c" / "d"
+    deep.mkdir(parents=True)
+    target = deep / "foo.ts"
+    target.write_text("const x = 1;\n")
+
+    result = fd.get_execution_cwd([str(target)])
+
+    # .git is 4 levels up but the search stops after 2 -> fall back to common.
+    assert_that(Path(result).resolve()).is_equal_to(deep.resolve())
 
 
 # =============================================================================


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(core): anchor tool cwd to the files' project root for scope-independence
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`prepare_execution` launched each tool subprocess from `get_cwd(files)` — the
commonpath/dirname of the **discovered files** — and passed paths relative to it. That
anchor moves with the input scope:

| invocation | old cwd | path the tool saw |
|---|---|---|
| `lintro fmt src/gen/foo.ts` | `src/gen` | `foo.ts` |
| `lintro fmt src/gen` | common ancestor | varies |
| `lintro fmt .` | commonpath of all matches | `src/gen/foo.ts` |

So a formatter whose config `overrides` are keyed on the path it sees (oxfmt/biome/
prettier globs like `*.synced.ts`) produced **different output for the same file**
depending on whether you passed a file, a directory, or `.` — nondeterministic, and
load-bearing for CI `reusable-quality-lint`, pre-commit, and codegen.

Fix: add `get_execution_cwd(files)` — walk up from the files' common ancestor to the
nearest **project marker** (`.git`, `pyproject.toml`, `package.json`, `setup.py`,
`setup.cfg`, `go.mod`, `Cargo.toml`) and anchor there. The marker's location is fixed,
so the cwd — and the resulting root-relative `rel_files` — are **identical across
invocation scopes**. `prepare_execution` uses it in place of `get_cwd`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1616

## Details

- **Marker-less trees** (e.g. bare temp dirs in tests) fall back to the files' common
  ancestor — prior behavior — so no tool test needed changing (verified: the full unit
  suite passes unmodified).
- `get_cwd` / `_get_cwd` are left intact (still used elsewhere and directly tested).
- `ToolResult.cwd` is write-only (nothing reads it for display) and
  `normalize_file_path_for_display` is process-cwd based, so path display is unaffected.
