### PR TITLE
fix(ai): only pass --json-schema-name when the claude CLI supports it

### DIFF
--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -91,8 +91,12 @@ class _AnthropicCliTransport(CliTransport):
             try:
                 result = self.run([self._binary_path, "--help"], timeout=10.0)
                 help_text = f"{result.stdout or ''}{result.stderr or ''}"
-                supported = "--json-schema-name" in help_text
-            except (AIProviderError, AINotAvailableError) as exc:
+                # Only trust a clean exit: a non-zero --help may echo the flag
+                # in an error message without actually supporting it.
+                supported = result.returncode == 0 and "--json-schema-name" in help_text
+            except (AIProviderError, AINotAvailableError, OSError) as exc:
+                # OSError covers PermissionError and other subprocess spawn
+                # failures that CliTransport.run() does not remap.
                 logger.debug(f"Claude CLI capability probe failed: {exc}")
             self._supports_schema_name = supported
             return supported

--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -67,6 +67,35 @@ class _AnthropicCliTransport(CliTransport):
             api_key_env=DEFAULT_API_KEY_ENV,
         )
         self._model = model
+        self._supports_schema_name: bool | None = None
+        self._capability_lock = threading.Lock()
+
+    def supports_json_schema_name(self) -> bool:
+        """Return whether the installed ``claude`` CLI accepts ``--json-schema-name``.
+
+        The current ``@anthropic-ai/claude-code`` (2.1.218) removed the
+        ``--json-schema-name`` option, so passing it fails the whole call with
+        ``unknown option '--json-schema-name'``. Probe ``claude --help`` once and
+        cache whether the flag is advertised, so it is only sent to binaries that
+        accept it (#1611). ``--json-schema`` itself is unaffected — only the name
+        refinement is gated. A failed probe returns ``False`` (send neither):
+        the flag is optional, so omitting it keeps structured output working.
+
+        Returns:
+            True when the installed binary advertises ``--json-schema-name``.
+        """
+        with self._capability_lock:
+            if self._supports_schema_name is not None:
+                return self._supports_schema_name
+            supported = False
+            try:
+                result = self.run([self._binary_path, "--help"], timeout=10.0)
+                help_text = f"{result.stdout or ''}{result.stderr or ''}"
+                supported = "--json-schema-name" in help_text
+            except (AIProviderError, AINotAvailableError) as exc:
+                logger.debug(f"Claude CLI capability probe failed: {exc}")
+            self._supports_schema_name = supported
+            return supported
 
     def parse_stdout(self, stdout: str) -> tuple[AIResponse, str | None]:
         """Parse JSON envelope from ``claude --output-format json``."""
@@ -270,7 +299,7 @@ class AnthropicProvider(BaseAIProvider):
             cmd.extend(["--append-system-prompt", system])
         if cli_schema is not None:
             cmd.extend(["--json-schema", json.dumps(cli_schema.schema)])
-            if cli_schema.schema_name:
+            if cli_schema.schema_name and self._cli.supports_json_schema_name():
                 cmd.extend(["--json-schema-name", cli_schema.schema_name])
         with self._session_lock:
             resume_session_id = None if use_one_shot else self._session_id

--- a/tests/unit/ai/test_claude_cli_provider.py
+++ b/tests/unit/ai/test_claude_cli_provider.py
@@ -116,6 +116,132 @@ class TestClaudeCliComplete:
         schema_arg = cmd[cmd.index("--json-schema") + 1]
         assert_that(schema_arg).contains('"type"')
 
+    def test_json_schema_name_sent_when_cli_advertises_it(
+        self,
+        _mock_claude_on_path: None,
+    ) -> None:
+        """Send --json-schema-name only when the CLI --help advertises it."""
+        from lintro.ai.json_response import CliSchemaRequest
+
+        provider = AnthropicProvider(transport=AITransport.CLI)
+        schema = CliSchemaRequest(
+            schema={"type": "object"},
+            schema_name="lintro_review",
+        )
+        completion = _cli_json(result='{"summary": "ok"}')
+
+        def fake_run(
+            cmd: list[str],
+            *args: object,
+            **kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            if "--help" in cmd:
+                return subprocess.CompletedProcess(
+                    args=cmd,
+                    returncode=0,
+                    stdout="  --json-schema-name <name>  Name the schema\n",
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout=completion,
+                stderr="",
+            )
+
+        with patch("subprocess.run", side_effect=fake_run) as mock_run:
+            provider.complete("Review this diff", cli_schema=schema)
+
+        completion_calls = [
+            call for call in mock_run.call_args_list if "--help" not in call.args[0]
+        ]
+        cmd = completion_calls[-1].args[0]
+        assert_that(cmd).contains("--json-schema-name", "lintro_review")
+
+    def test_json_schema_name_omitted_when_cli_lacks_it(
+        self,
+        _mock_claude_on_path: None,
+    ) -> None:
+        """Omit --json-schema-name (keep --json-schema) when the CLI dropped it.
+
+        Regression for #1611: the current claude CLI errors with
+        ``unknown option '--json-schema-name'``.
+        """
+        from lintro.ai.json_response import CliSchemaRequest
+
+        provider = AnthropicProvider(transport=AITransport.CLI)
+        schema = CliSchemaRequest(
+            schema={"type": "object"},
+            schema_name="lintro_review",
+        )
+        completion = _cli_json(result='{"summary": "ok"}')
+
+        def fake_run(
+            cmd: list[str],
+            *args: object,
+            **kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            if "--help" in cmd:
+                return subprocess.CompletedProcess(
+                    args=cmd,
+                    returncode=0,
+                    stdout="  --json-schema <schema>  Provide a JSON schema\n",
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout=completion,
+                stderr="",
+            )
+
+        with patch("subprocess.run", side_effect=fake_run) as mock_run:
+            provider.complete("Review this diff", cli_schema=schema)
+
+        completion_calls = [
+            call for call in mock_run.call_args_list if "--help" not in call.args[0]
+        ]
+        cmd = completion_calls[-1].args[0]
+        assert_that(cmd).does_not_contain("--json-schema-name")
+        assert_that(cmd).contains("--json-schema")
+
+    def test_supports_json_schema_name_probe_is_cached(
+        self,
+        _mock_claude_on_path: None,
+    ) -> None:
+        """The --help capability probe runs once and caches its result."""
+        from lintro.ai.providers.anthropic import _AnthropicCliTransport
+
+        transport = _AnthropicCliTransport(
+            binary_path="/usr/local/bin/claude",
+            model="claude-sonnet-4-6",
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="  --json-schema-name <name>\n",
+                stderr="",
+            )
+            assert_that(transport.supports_json_schema_name()).is_true()
+            assert_that(transport.supports_json_schema_name()).is_true()
+
+        assert_that(mock_run.call_count).is_equal_to(1)
+
+    def test_supports_json_schema_name_false_on_probe_error(
+        self,
+        _mock_claude_on_path: None,
+    ) -> None:
+        """A failed --help probe reports the flag unsupported (send neither)."""
+        from lintro.ai.providers.anthropic import _AnthropicCliTransport
+
+        transport = _AnthropicCliTransport(
+            binary_path="/usr/local/bin/claude",
+            model="claude-sonnet-4-6",
+        )
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            assert_that(transport.supports_json_schema_name()).is_false()
+
     def test_auth_error(self, _mock_claude_on_path: None) -> None:
         """Surface authentication failures from claude stderr."""
         provider = AnthropicProvider(transport=AITransport.CLI)

--- a/tests/unit/ai/test_claude_cli_provider.py
+++ b/tests/unit/ai/test_claude_cli_provider.py
@@ -242,6 +242,40 @@ class TestClaudeCliComplete:
         with patch("subprocess.run", side_effect=FileNotFoundError()):
             assert_that(transport.supports_json_schema_name()).is_false()
 
+    def test_supports_json_schema_name_false_on_nonzero_help(
+        self,
+        _mock_claude_on_path: None,
+    ) -> None:
+        """A non-zero --help exit is unsupported even if it echoes the flag."""
+        from lintro.ai.providers.anthropic import _AnthropicCliTransport
+
+        transport = _AnthropicCliTransport(
+            binary_path="/usr/local/bin/claude",
+            model="claude-sonnet-4-6",
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr="error near --json-schema-name\n",
+            )
+            assert_that(transport.supports_json_schema_name()).is_false()
+
+    def test_supports_json_schema_name_false_on_permission_error(
+        self,
+        _mock_claude_on_path: None,
+    ) -> None:
+        """A PermissionError spawning the probe reports the flag unsupported."""
+        from lintro.ai.providers.anthropic import _AnthropicCliTransport
+
+        transport = _AnthropicCliTransport(
+            binary_path="/usr/local/bin/claude",
+            model="claude-sonnet-4-6",
+        )
+        with patch("subprocess.run", side_effect=PermissionError()):
+            assert_that(transport.supports_json_schema_name()).is_false()
+
     def test_auth_error(self, _mock_claude_on_path: None) -> None:
         """Surface authentication failures from claude stderr."""
         provider = AnthropicProvider(transport=AITransport.CLI)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ai): only pass --json-schema-name when the claude CLI supports it
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`lintro review --transport cli` failed on the current `@anthropic-ai/claude-code`
(2.1.218): `anthropic.py` unconditionally appended `--json-schema-name`, which that CLI
**removed**, so every call errored `unknown option '--json-schema-name'`. Repro:
lgtm-hq/sandbox-lintro-ai PR #1.

Fix: probe `claude --help` once per transport (cached, thread-safe) and only pass
`--json-schema-name` when the installed binary advertises it. `--json-schema` itself is
unaffected — only the optional name refinement is gated. A failed probe reports the flag
unsupported (send neither), so structured output keeps working without it.

This is the standalone hotfix from epic **#1609**; full capability detection lands in the
guard sub-issue.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1611

## Details

_See What’s Changing._
