### PR TITLE
fix(cli): warn when --diff targets mix repo and non-repo paths

### DIFF
--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -728,6 +728,21 @@ def run_lint_tools_simple(
             except DiffResolutionError as exc:
                 logger.console_output(text=f"Error: {exc}", color="red")
                 return 1
+            # Non-repo scan targets are scanned in full (they have no diff to
+            # filter against), but the changed-file count only covers the
+            # repository targets. Warn so the count below isn't read as the
+            # whole scan scope when targets are mixed (#1618).
+            non_repo_targets = repo_groups.get(None)
+            if non_repo_targets and has_repo_paths:
+                logger.console_output(
+                    text=(
+                        f"--diff: {len(non_repo_targets)} scan target(s) are "
+                        "outside a git repository and are scanned in full (not "
+                        "diff-filtered); the changed-file count below counts only "
+                        "the repository target(s)."
+                    ),
+                    color="yellow",
+                )
             display_base = (
                 "default base"
                 if resolved_diff_base == DIFF_DEFAULT_SENTINEL

--- a/tests/unit/tools/executor/test_tool_executor.py
+++ b/tests/unit/tools/executor/test_tool_executor.py
@@ -823,3 +823,103 @@ def test_executor_dry_run_treats_formatter_issues_without_flag_as_fixable(
     assert_that(code).is_equal_to(1)
     texts = _console_texts(fake_logger)
     assert_that(texts).contains("Would fix 1 issue in")
+
+
+def test_executor_diff_mixed_targets_warns_non_repo_full_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_logger: Any,
+) -> None:
+    """Mixed repo/non-repo ``--diff`` targets warn that non-repo paths full-scan.
+
+    Regression for #1618: the changed-file count only covers repository targets,
+    so a warning must flag that non-repo targets are scanned in full and the
+    count is not the whole scan scope.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        fake_logger: FakeLogger fixture.
+    """
+    _stub_logger(monkeypatch, fake_logger)
+    result = ToolResult(name="ruff", success=True, output="x", issues_count=0)
+    tool = CallTrackingTool("ruff", can_fix=True, result=result)
+    _setup_tool_manager(monkeypatch, {"ruff": tool})
+
+    import lintro.utils.git_diff as git_diff
+
+    monkeypatch.setattr(
+        git_diff,
+        "resolve_git_cwd_from_paths",
+        lambda paths: {"/repo": ["/repo/src"], None: ["/outside"]},
+    )
+    monkeypatch.setattr(
+        git_diff,
+        "get_changed_files_for_paths",
+        lambda base, paths: frozenset({"/repo/src/a.py"}),
+    )
+
+    run_lint_tools_simple(
+        action="check",
+        paths=["/repo/src", "/outside"],
+        tools="all",
+        tool_options=None,
+        exclude=None,
+        include_venv=False,
+        group_by="auto",
+        output_format="grid",
+        verbose=False,
+        raw_output=False,
+        dry_run=False,
+        diff_base="main",
+    )
+
+    texts = _console_texts(fake_logger)
+    assert_that(texts).contains("scanned in full (not")
+    assert_that(texts).contains("Diff mode: scanning 1 file(s)")
+
+
+def test_executor_diff_repo_only_targets_no_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_logger: Any,
+) -> None:
+    """Repository-only ``--diff`` targets do not emit the mixed-scope warning.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        fake_logger: FakeLogger fixture.
+    """
+    _stub_logger(monkeypatch, fake_logger)
+    result = ToolResult(name="ruff", success=True, output="x", issues_count=0)
+    tool = CallTrackingTool("ruff", can_fix=True, result=result)
+    _setup_tool_manager(monkeypatch, {"ruff": tool})
+
+    import lintro.utils.git_diff as git_diff
+
+    monkeypatch.setattr(
+        git_diff,
+        "resolve_git_cwd_from_paths",
+        lambda paths: {"/repo": ["/repo/src"]},
+    )
+    monkeypatch.setattr(
+        git_diff,
+        "get_changed_files_for_paths",
+        lambda base, paths: frozenset({"/repo/src/a.py"}),
+    )
+
+    run_lint_tools_simple(
+        action="check",
+        paths=["/repo/src"],
+        tools="all",
+        tool_options=None,
+        exclude=None,
+        include_venv=False,
+        group_by="auto",
+        output_format="grid",
+        verbose=False,
+        raw_output=False,
+        dry_run=False,
+        diff_base="main",
+    )
+
+    texts = _console_texts(fake_logger)
+    assert_that(texts).does_not_contain("scanned in full")
+    assert_that(texts).contains("Diff mode: scanning")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(cli): warn when --diff targets mix repo and non-repo paths
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

In `--diff` mode with **mixed** repository and non-repository scan targets
(`lintro chk --diff repo/ generated/`), the `Diff mode: scanning N file(s) changed` count
comes from `get_changed_files_for_paths`, which skips the non-repo (`None`) group — while
`filter_files_by_diff_for_paths` full-scans those non-repo paths (they have no diff to
filter against). So the count silently under-reported the real scan scope.

Fix: when targets are mixed, emit a yellow warning naming how many are outside a git
repository and are scanned in full, so the count below isn't read as the whole scope. The
scan itself is unchanged — non-repo full-scan is by design (#1383); this only removes the
silence.

Scoped to the warning (issue option 1). Making the printed count itself include the
non-repo full-scan set is a larger change (`tool_executor` doesn't have the discovered
file set at count time) and is left out.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1618

## Details

_See What’s Changing._
