### PR TITLE
fix(trufflehog): ignore benign missing-path scan errors

### DIFF
--- a/docs/tool-analysis/trufflehog-analysis.md
+++ b/docs/tool-analysis/trufflehog-analysis.md
@@ -60,9 +60,15 @@ never report a clean pass from a scan that did not run. The wrapper therefore:
 - Resolves every requested path to an **absolute path** before scanning, because a
   relative path that does not resolve against TruffleHog's working directory yields a
   silent empty result.
+- Skips optional `--config` / `--exclude-paths` flags when the configured file is
+  absent on disk, so CI-only artifact paths do not generate scan-time `lstat` noise.
 - Treats non-empty-but-unparseable stdout as a **parse failure** (see #1044).
-- Treats `encountered errors during scan` as a **failure**, even when partial findings
-  were emitted for other targets.
+- Treats `encountered errors during scan` as a **failure** when the per-error reasons
+  are missing, unparseable, or genuine (permission denied, a missing target that was
+  part of the resolved scan set, crashes). Benign `lstat`/`stat` `no such file or
+  directory` errors for paths **outside** the resolved scan set (for example CI-only
+  `coverage/` dirs) are logged and ignored so the gate stays green when no secrets
+  were found (see #1631). Partial findings are always preserved.
 
 ### Options
 

--- a/docs/tool-analysis/trufflehog-analysis.md
+++ b/docs/tool-analysis/trufflehog-analysis.md
@@ -60,15 +60,17 @@ never report a clean pass from a scan that did not run. The wrapper therefore:
 - Resolves every requested path to an **absolute path** before scanning, because a
   relative path that does not resolve against TruffleHog's working directory yields a
   silent empty result.
-- Skips optional `--config` / `--exclude-paths` flags when the configured file is
-  absent on disk, so CI-only artifact paths do not generate scan-time `lstat` noise.
+- Fails when an explicitly configured `--config` file is absent, so custom detectors
+  cannot be silently disabled.
+- Skips optional `--exclude-paths` files when they are absent on disk, so CI-only
+  artifact paths do not generate scan-time `lstat` noise.
 - Treats non-empty-but-unparseable stdout as a **parse failure** (see #1044).
 - Treats `encountered errors during scan` as a **failure** when the per-error reasons
   are missing, unparseable, or genuine (permission denied, a missing target that was
-  part of the resolved scan set, crashes). Benign `lstat`/`stat` `no such file or
-  directory` errors for paths **outside** the resolved scan set (for example CI-only
-  `coverage/` dirs) are logged and ignored so the gate stays green when no secrets
-  were found (see #1631). Partial findings are always preserved.
+  part of the resolved scan set, crashes). Benign `lstat`/`stat`
+  `no such file or directory` errors for paths **outside** the resolved scan set (for
+  example CI-only `coverage/` dirs) are logged and ignored so the gate stays green when
+  no secrets were found (see #1631). Partial findings are always preserved.
 
 ### Options
 

--- a/lintro/parsers/trufflehog/__init__.py
+++ b/lintro/parsers/trufflehog/__init__.py
@@ -1,6 +1,17 @@
 """TruffleHog parser module."""
 
+from lintro.parsers.trufflehog.trufflehog_errors import (
+    extract_trufflehog_scan_errors,
+    is_benign_missing_path_error,
+    scan_errors_are_all_benign,
+)
 from lintro.parsers.trufflehog.trufflehog_issue import TrufflehogIssue
 from lintro.parsers.trufflehog.trufflehog_parser import parse_trufflehog_output
 
-__all__ = ["TrufflehogIssue", "parse_trufflehog_output"]
+__all__ = [
+    "TrufflehogIssue",
+    "extract_trufflehog_scan_errors",
+    "is_benign_missing_path_error",
+    "parse_trufflehog_output",
+    "scan_errors_are_all_benign",
+]

--- a/lintro/parsers/trufflehog/trufflehog_errors.py
+++ b/lintro/parsers/trufflehog/trufflehog_errors.py
@@ -1,0 +1,161 @@
+"""Classification helpers for TruffleHog scan-diagnostic stderr.
+
+TruffleHog exits 0 even when it cannot read a scan target, logging
+``encountered errors during scan`` with per-path reasons. A security scanner
+must fail closed on genuine incomplete scans (#1044), but CI-only artifact
+paths that are absent locally (``coverage/``, ``lighthouse-reports/``, …) are
+benign when they were never part of the resolved scan set (#1631).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+# Go's os.Lstat/Stat error form: ``lstat /path: no such file or directory``.
+_MISSING_PATH_RE: re.Pattern[str] = re.compile(
+    r"^(?:lstat|stat)\s+(?P<path>.+):\s+no such file or directory\s*$",
+    re.IGNORECASE,
+)
+
+
+def extract_trufflehog_scan_errors(stderr: str) -> list[str]:
+    """Extract per-path scan error strings from TruffleHog stderr.
+
+    Prefers structured JSON log lines that carry an ``errors`` array. Falls
+    back to bare ``lstat``/``stat`` lines when no JSON payload is present.
+
+    Args:
+        stderr: Raw stderr captured from a TruffleHog run.
+
+    Returns:
+        Ordered list of individual error reason strings. Empty when none can
+        be extracted (caller should fail closed — the scan may be incomplete).
+    """
+    if not stderr or not stderr.strip():
+        return []
+
+    extracted: list[str] = []
+    seen: set[str] = set()
+
+    for line in stderr.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        from_json = _errors_from_json_line(stripped)
+        if from_json:
+            for err in from_json:
+                if err not in seen:
+                    seen.add(err)
+                    extracted.append(err)
+            continue
+
+        # Plain-text / logfmt lines that already look like a path error.
+        is_path_error = (
+            _MISSING_PATH_RE.match(stripped) is not None
+            or "permission denied" in stripped.lower()
+        )
+        if is_path_error and stripped not in seen:
+            seen.add(stripped)
+            extracted.append(stripped)
+
+    return extracted
+
+
+def is_benign_missing_path_error(
+    error: str,
+    *,
+    scan_paths: set[str] | frozenset[str],
+) -> bool:
+    """Return whether a scan error is a benign missing path outside the scan set.
+
+    Args:
+        error: A single TruffleHog error reason string.
+        scan_paths: Absolute paths that were actually passed to TruffleHog for
+            this batch (the resolved, existing scan set).
+
+    Returns:
+        True when the error is ``lstat``/``stat`` ``no such file or directory``
+        for a path that is not among (and not a parent of) the resolved scan
+        paths. Permission errors and missing scan-set targets are not benign.
+    """
+    match = _MISSING_PATH_RE.match(error.strip())
+    if match is None:
+        return False
+
+    missing_raw = match.group("path").strip()
+    if not missing_raw:
+        return False
+
+    try:
+        missing = str(Path(missing_raw).resolve())
+    except (OSError, RuntimeError, ValueError):
+        missing = missing_raw
+
+    if missing in scan_paths:
+        return False
+
+    # A missing directory that contains scanned files would be a genuine
+    # incomplete scan of those targets — treat as non-benign.
+    missing_prefix = missing.rstrip("/") + "/"
+    for scan_path in scan_paths:
+        if scan_path == missing or scan_path.startswith(missing_prefix):
+            return False
+
+    return True
+
+
+def scan_errors_are_all_benign(
+    errors: list[str],
+    *,
+    scan_paths: set[str] | frozenset[str],
+) -> bool:
+    """Return whether every extracted scan error is a benign missing path.
+
+    Args:
+        errors: Per-path error strings from :func:`extract_trufflehog_scan_errors`.
+        scan_paths: Absolute paths passed to TruffleHog for this batch.
+
+    Returns:
+        True only when ``errors`` is non-empty and every entry is benign.
+        An empty list means reasons could not be parsed — fail closed.
+    """
+    if not errors:
+        return False
+    return all(
+        is_benign_missing_path_error(err, scan_paths=scan_paths) for err in errors
+    )
+
+
+def _errors_from_json_line(line: str) -> list[str]:
+    """Pull the ``errors`` array from a TruffleHog JSON log line, if present.
+
+    Args:
+        line: A single stderr line that may be JSON.
+
+    Returns:
+        The string entries from ``errors``, or an empty list when the line is
+        not a scan-error JSON object.
+    """
+    if not line.startswith("{"):
+        return []
+
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError:
+        return []
+
+    if not isinstance(payload, dict):
+        return []
+
+    msg = payload.get("msg")
+    if not isinstance(msg, str) or "encountered errors during scan" not in msg:
+        return []
+
+    raw_errors = payload.get("errors")
+    if not isinstance(raw_errors, list):
+        return []
+
+    return [err for err in raw_errors if isinstance(err, str) and err.strip()]

--- a/lintro/parsers/trufflehog/trufflehog_errors.py
+++ b/lintro/parsers/trufflehog/trufflehog_errors.py
@@ -92,7 +92,8 @@ def is_benign_missing_path_error(
     try:
         missing = str(Path(missing_raw).resolve())
     except (OSError, RuntimeError, ValueError):
-        missing = missing_raw
+        # Unresolvable paths cannot be proven outside the scan set — fail closed.
+        return False
 
     if missing in scan_paths:
         return False

--- a/lintro/tools/definitions/trufflehog.py
+++ b/lintro/tools/definitions/trufflehog.py
@@ -28,6 +28,10 @@ from lintro._tool_versions import get_min_version
 from lintro.enums.tool_name import ToolName
 from lintro.enums.tool_type import ToolType
 from lintro.models.core.tool_result import ToolResult
+from lintro.parsers.trufflehog.trufflehog_errors import (
+    extract_trufflehog_scan_errors,
+    scan_errors_are_all_benign,
+)
 from lintro.parsers.trufflehog.trufflehog_parser import parse_trufflehog_output
 from lintro.plugins.base import BaseToolPlugin
 from lintro.plugins.protocol import ToolDefinition
@@ -76,6 +80,27 @@ def _argv_byte_budget() -> int:
     budget = arg_max - env_bytes - _ARGV_SAFETY_HEADROOM_BYTES
     # Always leave room for at least a moderately long single path per batch.
     return max(budget, _ARGV_SAFETY_HEADROOM_BYTES)
+
+
+def _existing_option_path(raw_path: str) -> str | None:
+    """Return ``raw_path`` when it exists on disk, else ``None``.
+
+    Used for optional TruffleHog file flags (``--config``, ``--exclude-paths``)
+    so CI-only paths that are absent locally are skipped rather than handed to
+    the binary (which would emit ``lstat …: no such file or directory``).
+
+    Args:
+        raw_path: Configured filesystem path string.
+
+    Returns:
+        The path string when the file or directory exists, otherwise ``None``.
+    """
+    try:
+        if Path(raw_path).exists():
+            return raw_path
+    except OSError:
+        return None
+    return None
 
 
 def _chunk_source_paths(
@@ -230,15 +255,29 @@ class TrufflehogPlugin(BaseToolPlugin):
         if results_opt is not None:
             cmd.extend(["--results", str(results_opt)])
 
-        # Custom detector config
+        # Custom detector config — only when the file exists on disk so a
+        # CI-only config path does not generate a scan-time lstat failure.
         config_opt = self.options.get("config")
-        if config_opt is not None:
-            cmd.extend(["--config", str(config_opt)])
+        if isinstance(config_opt, str) and config_opt:
+            config_path = _existing_option_path(config_opt)
+            if config_path is not None:
+                cmd.extend(["--config", config_path])
+            else:
+                logger.debug(
+                    f"[trufflehog] Skipping absent --config path: {config_opt}",
+                )
 
-        # Exclude-paths file
+        # Exclude-paths file — same existence gate for CI-only exclude lists.
         exclude_opt = self.options.get("exclude_paths")
-        if exclude_opt is not None:
-            cmd.extend(["--exclude-paths", str(exclude_opt)])
+        if isinstance(exclude_opt, str) and exclude_opt:
+            exclude_path = _existing_option_path(exclude_opt)
+            if exclude_path is not None:
+                cmd.extend(["--exclude-paths", exclude_path])
+            else:
+                logger.debug(
+                    f"[trufflehog] Skipping absent --exclude-paths file: "
+                    f"{exclude_opt}",
+                )
 
         # Concurrency
         concurrency_opt = self.options.get("concurrency")
@@ -275,7 +314,19 @@ class TrufflehogPlugin(BaseToolPlugin):
         # exit 0 with no output, which a secrets scanner must never treat as a
         # clean pass. A stable sort keeps batch boundaries and aggregated output
         # deterministic.
-        source_paths = sorted(str(Path(f).resolve()) for f in ctx.files)
+        # Re-check existence immediately before invoke so CI-only roots or
+        # paths that disappeared between discovery and exec never reach
+        # TruffleHog (and never trigger benign-but-noisy lstat errors).
+        source_paths = sorted(
+            str(Path(f).resolve()) for f in ctx.files if Path(f).exists()
+        )
+        if not source_paths:
+            return ToolResult(
+                name=self.definition.name,
+                success=True,
+                output="No files to check.",
+                issues_count=0,
+            )
 
         # Expanding every file into one invocation can exceed ARG_MAX on large
         # repositories, so batch the paths under a byte budget and merge the
@@ -395,24 +446,32 @@ class TrufflehogPlugin(BaseToolPlugin):
             )
 
         # TruffleHog exits 0 even when it fails to read a scan target (it logs
-        # "encountered errors during scan" to stderr). A security scanner must
-        # never report a clean or complete pass from a scan that did not fully
-        # run — even if other targets produced findings — so surface this as a
-        # failure while keeping any findings that were emitted (see #1044).
+        # "encountered errors during scan" to stderr). Fail closed on genuine
+        # incomplete scans (#1044), but ignore benign ``lstat``/``stat``
+        # missing-path errors for targets that were never part of the resolved
+        # scan set — typically CI-only artifact dirs (#1631).
         if "encountered errors during scan" in stderr:
-            logger.error(f"TruffleHog reported scan errors: {stderr[:500]}")
-            partial = parse_trufflehog_output(output=stdout) if stdout else []
-            return ToolResult(
-                name=self.definition.name,
-                success=False,
-                output=(
-                    "TruffleHog encountered errors during the scan; "
-                    "treating as a failure rather than a clean pass."
-                ),
-                issues=partial,
-                issues_count=len(partial),
-                parse_failures_count=1,
-            )
+            scan_errors = extract_trufflehog_scan_errors(stderr)
+            scan_path_set = frozenset(source_paths)
+            if scan_errors_are_all_benign(scan_errors, scan_paths=scan_path_set):
+                logger.warning(
+                    "[trufflehog] Ignoring benign missing-path scan errors "
+                    f"outside the resolved scan set: {scan_errors}",
+                )
+            else:
+                logger.error(f"TruffleHog reported scan errors: {stderr[:500]}")
+                partial = parse_trufflehog_output(output=stdout) if stdout else []
+                return ToolResult(
+                    name=self.definition.name,
+                    success=False,
+                    output=(
+                        "TruffleHog encountered errors during the scan; "
+                        "treating as a failure rather than a clean pass."
+                    ),
+                    issues=partial,
+                    issues_count=len(partial),
+                    parse_failures_count=1,
+                )
 
         issues = parse_trufflehog_output(output=stdout)
         issues_count = len(issues)

--- a/lintro/tools/definitions/trufflehog.py
+++ b/lintro/tools/definitions/trufflehog.py
@@ -85,9 +85,9 @@ def _argv_byte_budget() -> int:
 def _existing_option_path(raw_path: str) -> str | None:
     """Return ``raw_path`` when it exists on disk, else ``None``.
 
-    Used for optional TruffleHog file flags (``--config``, ``--exclude-paths``)
-    so CI-only paths that are absent locally are skipped rather than handed to
-    the binary (which would emit ``lstat …: no such file or directory``).
+    Used for optional TruffleHog file flags (currently ``--exclude-paths``) so
+    CI-only paths that are absent locally are skipped rather than handed to the
+    binary (which would emit ``lstat …: no such file or directory``).
 
     Args:
         raw_path: Configured filesystem path string.
@@ -234,6 +234,10 @@ class TrufflehogPlugin(BaseToolPlugin):
 
         Returns:
             List of command arguments.
+
+        Raises:
+            ValueError: If an explicitly configured TruffleHog config file is
+                missing.
         """
         cmd: list[str] = ["trufflehog", "filesystem", *source_paths]
 
@@ -256,15 +260,18 @@ class TrufflehogPlugin(BaseToolPlugin):
             cmd.extend(["--results", str(results_opt)])
 
         # Custom detector config — only when the file exists on disk so a
-        # CI-only config path does not generate a scan-time lstat failure.
+        # missing explicit config never downgrades the scan to default
+        # detectors.
         config_opt = self.options.get("config")
         if isinstance(config_opt, str) and config_opt:
             config_path = _existing_option_path(config_opt)
             if config_path is not None:
                 cmd.extend(["--config", config_path])
             else:
-                logger.debug(
-                    f"[trufflehog] Skipping absent --config path: {config_opt}",
+                raise ValueError(
+                    "TruffleHog config file does not exist: "
+                    f"{config_opt}. Refusing to run without the configured "
+                    "custom detectors.",
                 )
 
         # Exclude-paths file — same existence gate for CI-only exclude lists.
@@ -274,7 +281,7 @@ class TrufflehogPlugin(BaseToolPlugin):
             if exclude_path is not None:
                 cmd.extend(["--exclude-paths", exclude_path])
             else:
-                logger.debug(
+                logger.warning(
                     f"[trufflehog] Skipping absent --exclude-paths file: "
                     f"{exclude_opt}",
                 )
@@ -314,12 +321,7 @@ class TrufflehogPlugin(BaseToolPlugin):
         # exit 0 with no output, which a secrets scanner must never treat as a
         # clean pass. A stable sort keeps batch boundaries and aggregated output
         # deterministic.
-        # Re-check existence immediately before invoke so CI-only roots or
-        # paths that disappeared between discovery and exec never reach
-        # TruffleHog (and never trigger benign-but-noisy lstat errors).
-        source_paths = sorted(
-            str(Path(f).resolve()) for f in ctx.files if Path(f).exists()
-        )
+        source_paths = sorted(str(Path(f).resolve()) for f in ctx.files)
         if not source_paths:
             return ToolResult(
                 name=self.definition.name,
@@ -327,11 +329,38 @@ class TrufflehogPlugin(BaseToolPlugin):
                 output="No files to check.",
                 issues_count=0,
             )
+        missing_scan_paths = [
+            source_path
+            for source_path in source_paths
+            if not Path(source_path).exists()
+        ]
+        if missing_scan_paths:
+            missing_list = "\n".join(f"  - {path}" for path in missing_scan_paths)
+            return ToolResult(
+                name=self.definition.name,
+                success=False,
+                output=(
+                    "TruffleHog scan incomplete: resolved scan target(s) "
+                    "disappeared before execution.\n"
+                    f"{missing_list}"
+                ),
+                issues_count=0,
+                parse_failures_count=1,
+            )
 
         # Expanding every file into one invocation can exceed ARG_MAX on large
         # repositories, so batch the paths under a byte budget and merge the
         # per-batch results into a single ToolResult.
-        fixed_args = self._build_check_command(source_paths=[])
+        try:
+            fixed_args = self._build_check_command(source_paths=[])
+        except (OSError, ValueError, RuntimeError) as e:
+            logger.error(f"Failed to prepare TruffleHog command: {e}")
+            return ToolResult(
+                name=self.definition.name,
+                success=False,
+                output=f"TruffleHog failed: {e}",
+                issues_count=0,
+            )
         fixed_arg_bytes = sum(
             len(a.encode("utf-8", "surrogatepass")) + 1 for a in fixed_args
         )
@@ -388,14 +417,13 @@ class TrufflehogPlugin(BaseToolPlugin):
             A ToolResult for the batch: ``success`` False on any execution,
             scan, or parse failure, with any emitted findings preserved.
         """
-        cmd = self._build_check_command(source_paths=source_paths)
-        logger.debug(
-            f"[trufflehog] Running: {' '.join(cmd[:10])}... (cwd={ctx.cwd})",
-        )
-
         # TruffleHog writes JSONL findings to stdout and diagnostic logs to
         # stderr, so parse stdout independently (see #1043).
         try:
+            cmd = self._build_check_command(source_paths=source_paths)
+            logger.debug(
+                f"[trufflehog] Running: {' '.join(cmd[:10])}... (cwd={ctx.cwd})",
+            )
             result = self._run_subprocess_result(
                 cmd=cmd,
                 timeout=ctx.timeout,

--- a/tests/unit/parsers/trufflehog_parser/test_scan_errors.py
+++ b/tests/unit/parsers/trufflehog_parser/test_scan_errors.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
 from assertpy import assert_that
 
 from lintro.parsers.trufflehog.trufflehog_errors import (
@@ -72,6 +75,24 @@ def test_permission_denied_is_not_benign() -> None:
     assert_that(
         is_benign_missing_path_error(
             "open /secret: permission denied",
+            scan_paths={"/repo/src/a.py"},
+        ),
+    ).is_false()
+
+
+def test_unresolvable_missing_path_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Path.resolve failures must not classify the error as benign."""
+
+    def _boom(self: Path) -> Path:
+        raise OSError("cannot resolve")
+
+    monkeypatch.setattr(Path, "resolve", _boom)
+
+    assert_that(
+        is_benign_missing_path_error(
+            "lstat /ci/coverage: no such file or directory",
             scan_paths={"/repo/src/a.py"},
         ),
     ).is_false()

--- a/tests/unit/parsers/trufflehog_parser/test_scan_errors.py
+++ b/tests/unit/parsers/trufflehog_parser/test_scan_errors.py
@@ -1,0 +1,96 @@
+"""Unit tests for TruffleHog scan-error classification helpers."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.parsers.trufflehog.trufflehog_errors import (
+    extract_trufflehog_scan_errors,
+    is_benign_missing_path_error,
+    scan_errors_are_all_benign,
+)
+
+
+def test_extract_errors_from_json_scan_log() -> None:
+    """JSON scan-error logs should yield the per-path error strings."""
+    stderr = (
+        '{"level":"error","msg":"encountered errors during scan",'
+        '"errors":["lstat /ci/coverage: no such file or directory",'
+        '"open /secret: permission denied"]}'
+    )
+
+    errors = extract_trufflehog_scan_errors(stderr)
+
+    assert_that(errors).is_equal_to(
+        [
+            "lstat /ci/coverage: no such file or directory",
+            "open /secret: permission denied",
+        ],
+    )
+
+
+def test_extract_errors_from_plain_lstat_lines() -> None:
+    """Plain lstat lines should be collected when JSON is absent."""
+    stderr = "lstat /ci/coverage: no such file or directory\n"
+
+    errors = extract_trufflehog_scan_errors(stderr)
+
+    assert_that(errors).is_equal_to(
+        ["lstat /ci/coverage: no such file or directory"],
+    )
+
+
+def test_extract_errors_empty_when_banner_has_no_details() -> None:
+    """A bare scan-error banner without reasons yields an empty list."""
+    stderr = "level=error msg=encountered errors during scan"
+
+    assert_that(extract_trufflehog_scan_errors(stderr)).is_empty()
+
+
+def test_benign_missing_path_outside_scan_set() -> None:
+    """Missing CI-only dirs outside the scan set are benign."""
+    assert_that(
+        is_benign_missing_path_error(
+            "lstat /ci/coverage: no such file or directory",
+            scan_paths={"/repo/src/a.py"},
+        ),
+    ).is_true()
+
+
+def test_missing_path_in_scan_set_is_not_benign() -> None:
+    """A missing path that was requested for scanning is not benign."""
+    assert_that(
+        is_benign_missing_path_error(
+            "lstat /repo/src/a.py: no such file or directory",
+            scan_paths={"/repo/src/a.py"},
+        ),
+    ).is_false()
+
+
+def test_permission_denied_is_not_benign() -> None:
+    """Permission errors are never classified as benign missing paths."""
+    assert_that(
+        is_benign_missing_path_error(
+            "open /secret: permission denied",
+            scan_paths={"/repo/src/a.py"},
+        ),
+    ).is_false()
+
+
+def test_scan_errors_all_benign_requires_non_empty() -> None:
+    """Empty extracted errors must fail closed (not all-benign)."""
+    assert_that(
+        scan_errors_are_all_benign([], scan_paths={"/repo/a.py"}),
+    ).is_false()
+
+
+def test_scan_errors_all_benign_mixed_fails() -> None:
+    """A mix of benign and genuine errors is not all-benign."""
+    errors = [
+        "lstat /ci/coverage: no such file or directory",
+        "open /secret: permission denied",
+    ]
+
+    assert_that(
+        scan_errors_are_all_benign(errors, scan_paths={"/repo/a.py"}),
+    ).is_false()

--- a/tests/unit/tools/trufflehog/test_execution.py
+++ b/tests/unit/tools/trufflehog/test_execution.py
@@ -128,11 +128,11 @@ def test_check_unparseable_output_is_not_clean(
     assert_that(result.parse_failures_count).is_equal_to(1)
 
 
-def test_check_scan_error_is_not_clean(
+def test_check_benign_missing_path_scan_error_passes(
     trufflehog_plugin: TrufflehogPlugin,
     tmp_path: Path,
 ) -> None:
-    """A scan-error log with empty stdout must fail, not pass clean.
+    """Lstat missing-path errors outside the scan set must not hard-fail.
 
     Args:
         trufflehog_plugin: The plugin under test.
@@ -143,12 +143,133 @@ def test_check_scan_error_is_not_clean(
 
     stderr = (
         '{"level":"error","msg":"encountered errors during scan",'
-        '"errors":["lstat /nope: no such file or directory"]}'
+        '"errors":["lstat /nope/coverage: no such file or directory",'
+        '"lstat /nope/lighthouse-reports: no such file or directory"]}'
     )
     with patch.object(
         trufflehog_plugin,
         "_run_subprocess_result",
         return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
+    ):
+        result = trufflehog_plugin.check([str(test_file)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    # Benign scan noise must not surface as a version-incompat parse warning.
+    assert_that(result.parse_failures_count in (0, None)).is_true()
+
+
+def test_check_permission_denied_scan_error_fails(
+    trufflehog_plugin: TrufflehogPlugin,
+    tmp_path: Path,
+) -> None:
+    """A permission-denied scan error is a genuine incomplete scan.
+
+    Args:
+        trufflehog_plugin: The plugin under test.
+        tmp_path: Temporary directory path.
+    """
+    test_file = tmp_path / "module.py"
+    test_file.write_text('"""Module."""\n')
+
+    stderr = (
+        '{"level":"error","msg":"encountered errors during scan",'
+        '"errors":["open /secret: permission denied"]}'
+    )
+    with patch.object(
+        trufflehog_plugin,
+        "_run_subprocess_result",
+        return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
+    ):
+        result = trufflehog_plugin.check([str(test_file)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.parse_failures_count).is_equal_to(1)
+
+
+def test_check_missing_scan_set_path_fails(
+    trufflehog_plugin: TrufflehogPlugin,
+    tmp_path: Path,
+) -> None:
+    """A missing path that was part of the resolved scan set must fail closed.
+
+    Args:
+        trufflehog_plugin: The plugin under test.
+        tmp_path: Temporary directory path.
+    """
+    test_file = tmp_path / "module.py"
+    test_file.write_text('"""Module."""\n')
+    resolved = str(test_file.resolve())
+
+    stderr = (
+        '{"level":"error","msg":"encountered errors during scan",'
+        '"errors":["lstat ' + resolved + ': no such file or directory"]}'
+    )
+    with patch.object(
+        trufflehog_plugin,
+        "_run_subprocess_result",
+        return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
+    ):
+        result = trufflehog_plugin.check([str(test_file)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.parse_failures_count).is_equal_to(1)
+
+
+def test_check_benign_scan_error_with_findings_still_reports_secrets(
+    trufflehog_plugin: TrufflehogPlugin,
+    tmp_path: Path,
+) -> None:
+    """Benign missing-path noise must not hide or fail real secret findings.
+
+    Args:
+        trufflehog_plugin: The plugin under test.
+        tmp_path: Temporary directory path.
+    """
+    test_file = tmp_path / "config.py"
+    test_file.write_text("TOKEN = 'ghp_fake'\n")
+
+    stderr = (
+        '{"level":"error","msg":"encountered errors during scan",'
+        '"errors":["lstat /ci-only/coverage: no such file or directory"]}'
+    )
+    with patch.object(
+        trufflehog_plugin,
+        "_run_subprocess_result",
+        return_value=make_subprocess_result(
+            stdout=sample_finding_line(file=str(test_file), line=1),
+            stderr=stderr,
+            returncode=0,
+        ),
+    ):
+        result = trufflehog_plugin.check([str(test_file)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(1)
+    assert_that(result.parse_failures_count in (0, None)).is_true()
+
+
+def test_check_unparseable_scan_error_details_fail_closed(
+    trufflehog_plugin: TrufflehogPlugin,
+    tmp_path: Path,
+) -> None:
+    """Scan-error banner without extractable reasons must fail closed.
+
+    Args:
+        trufflehog_plugin: The plugin under test.
+        tmp_path: Temporary directory path.
+    """
+    test_file = tmp_path / "module.py"
+    test_file.write_text('"""Module."""\n')
+
+    with patch.object(
+        trufflehog_plugin,
+        "_run_subprocess_result",
+        return_value=make_subprocess_result(
+            stdout="",
+            stderr="level=error msg=encountered errors during scan",
+            returncode=0,
+        ),
     ):
         result = trufflehog_plugin.check([str(test_file)], {})
 
@@ -212,11 +333,11 @@ def test_check_nonzero_exit_with_partial_findings_fails(
     assert_that(result.issues_count).is_equal_to(1)
 
 
-def test_check_scan_error_with_findings_still_fails(
+def test_check_genuine_scan_error_with_findings_still_fails(
     trufflehog_plugin: TrufflehogPlugin,
     tmp_path: Path,
 ) -> None:
-    """Scan errors on one target fail the run even when another had findings.
+    """Genuine scan errors fail the run even when another target had findings.
 
     Args:
         trufflehog_plugin: The plugin under test.
@@ -225,12 +346,16 @@ def test_check_scan_error_with_findings_still_fails(
     test_file = tmp_path / "module.py"
     test_file.write_text("AWS_KEY = 'AKIA...'\n")
 
+    stderr = (
+        '{"level":"error","msg":"encountered errors during scan",'
+        '"errors":["open /etc/shadow: permission denied"]}'
+    )
     with patch.object(
         trufflehog_plugin,
         "_run_subprocess_result",
         return_value=make_subprocess_result(
             stdout=sample_finding_line(file=str(test_file)),
-            stderr="level=error msg=encountered errors during scan",
+            stderr=stderr,
             returncode=0,
         ),
     ):

--- a/tests/unit/tools/trufflehog/test_execution.py
+++ b/tests/unit/tools/trufflehog/test_execution.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from assertpy import assert_that
 
 from lintro.parsers.trufflehog.trufflehog_issue import TrufflehogIssue
+from lintro.plugins.base import ExecutionContext
 from lintro.tools.definitions.trufflehog import TrufflehogPlugin
 from tests.unit.tools.trufflehog.conftest import (
     make_subprocess_result,
@@ -101,6 +102,62 @@ def test_check_passes_absolute_paths_to_command(
 
     # The resolved absolute path should appear in the command.
     assert_that(captured["cmd"]).contains(str(test_file.resolve()))
+
+
+def test_check_fails_when_resolved_scan_target_disappears(
+    trufflehog_plugin: TrufflehogPlugin,
+    tmp_path: Path,
+) -> None:
+    """A resolved scan-set file disappearing before invoke must fail closed.
+
+    Args:
+        trufflehog_plugin: The plugin under test.
+        tmp_path: Temporary directory path.
+    """
+    test_file = tmp_path / "module.py"
+    test_file.write_text('"""Module."""\n')
+    prepared = ExecutionContext(
+        files=[str(test_file)],
+        cwd=str(tmp_path),
+        timeout=60,
+    )
+    test_file.unlink()
+
+    with (
+        patch.object(trufflehog_plugin, "_prepare_execution", return_value=prepared),
+        patch.object(trufflehog_plugin, "_run_subprocess_result") as run_mock,
+    ):
+        result = trufflehog_plugin.check([str(test_file)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.output).contains("disappeared before execution")
+    assert_that(result.output).contains(str(test_file.resolve()))
+    assert_that(result.parse_failures_count).is_equal_to(1)
+    run_mock.assert_not_called()
+
+
+def test_check_fails_when_config_is_absent(
+    trufflehog_plugin: TrufflehogPlugin,
+    tmp_path: Path,
+) -> None:
+    """A missing explicit config must not fall back to default detectors.
+
+    Args:
+        trufflehog_plugin: The plugin under test.
+        tmp_path: Temporary directory path.
+    """
+    test_file = tmp_path / "module.py"
+    test_file.write_text('"""Module."""\n')
+    missing_config = tmp_path / "missing-trufflehog.yaml"
+    trufflehog_plugin.set_options(config=str(missing_config))
+
+    with patch.object(trufflehog_plugin, "_run_subprocess_result") as run_mock:
+        result = trufflehog_plugin.check([str(test_file)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.output).contains("config file does not exist")
+    assert_that(result.output).contains(str(missing_config))
+    run_mock.assert_not_called()
 
 
 def test_check_unparseable_output_is_not_clean(

--- a/tests/unit/tools/trufflehog/test_options.py
+++ b/tests/unit/tools/trufflehog/test_options.py
@@ -185,26 +185,38 @@ def test_build_check_command_optional_flags(
     assert_that(cmd).contains("8")
 
 
-def test_build_check_command_skips_absent_config_and_exclude_paths(
+def test_build_check_command_fails_when_config_is_absent(
     trufflehog_plugin: TrufflehogPlugin,
     tmp_path: Path,
 ) -> None:
-    """Absent CI-only config/exclude files must not be passed to TruffleHog.
+    """A missing explicit config must fail instead of disabling detectors.
 
     Args:
         trufflehog_plugin: The plugin under test.
         tmp_path: Temporary directory path.
     """
     missing_config = tmp_path / "missing-config.yaml"
+    trufflehog_plugin.set_options(config=str(missing_config))
+
+    with pytest.raises(ValueError, match="config file does not exist"):
+        trufflehog_plugin._build_check_command(source_paths=["/abs/path"])
+
+
+def test_build_check_command_skips_absent_exclude_paths(
+    trufflehog_plugin: TrufflehogPlugin,
+    tmp_path: Path,
+) -> None:
+    """Absent CI-only exclude files must not be passed to TruffleHog.
+
+    Args:
+        trufflehog_plugin: The plugin under test.
+        tmp_path: Temporary directory path.
+    """
     missing_exclude = tmp_path / "missing-exclude.txt"
-    trufflehog_plugin.set_options(
-        config=str(missing_config),
-        exclude_paths=str(missing_exclude),
-    )
+    trufflehog_plugin.set_options(exclude_paths=str(missing_exclude))
     cmd = trufflehog_plugin._build_check_command(source_paths=["/abs/path"])
 
     assert_that(cmd).does_not_contain("--config")
-    assert_that(cmd).does_not_contain(str(missing_config))
     assert_that(cmd).does_not_contain("--exclude-paths")
     assert_that(cmd).does_not_contain(str(missing_exclude))
 

--- a/tests/unit/tools/trufflehog/test_options.py
+++ b/tests/unit/tools/trufflehog/test_options.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from assertpy import assert_that
 
@@ -152,16 +154,23 @@ def test_build_check_command_verification_enabled(
 
 def test_build_check_command_optional_flags(
     trufflehog_plugin: TrufflehogPlugin,
+    tmp_path: Path,
 ) -> None:
-    """Optional flags should be appended when set.
+    """Optional flags should be appended when set and paths exist.
 
     Args:
         trufflehog_plugin: The plugin under test.
+        tmp_path: Temporary directory for on-disk option files.
     """
+    config_file = tmp_path / "cfg.yaml"
+    config_file.write_text("detectors: []\n")
+    exclude_file = tmp_path / "exclude.txt"
+    exclude_file.write_text("vendor/.*\n")
+
     trufflehog_plugin.set_options(
         results="verified,unverified",
-        config="/cfg.yaml",
-        exclude_paths="/exclude.txt",
+        config=str(config_file),
+        exclude_paths=str(exclude_file),
         concurrency=8,
     )
     cmd = trufflehog_plugin._build_check_command(source_paths=["/abs/path"])
@@ -169,11 +178,35 @@ def test_build_check_command_optional_flags(
     assert_that(cmd).contains("--results")
     assert_that(cmd).contains("verified,unverified")
     assert_that(cmd).contains("--config")
-    assert_that(cmd).contains("/cfg.yaml")
+    assert_that(cmd).contains(str(config_file))
     assert_that(cmd).contains("--exclude-paths")
-    assert_that(cmd).contains("/exclude.txt")
+    assert_that(cmd).contains(str(exclude_file))
     assert_that(cmd).contains("--concurrency")
     assert_that(cmd).contains("8")
+
+
+def test_build_check_command_skips_absent_config_and_exclude_paths(
+    trufflehog_plugin: TrufflehogPlugin,
+    tmp_path: Path,
+) -> None:
+    """Absent CI-only config/exclude files must not be passed to TruffleHog.
+
+    Args:
+        trufflehog_plugin: The plugin under test.
+        tmp_path: Temporary directory path.
+    """
+    missing_config = tmp_path / "missing-config.yaml"
+    missing_exclude = tmp_path / "missing-exclude.txt"
+    trufflehog_plugin.set_options(
+        config=str(missing_config),
+        exclude_paths=str(missing_exclude),
+    )
+    cmd = trufflehog_plugin._build_check_command(source_paths=["/abs/path"])
+
+    assert_that(cmd).does_not_contain("--config")
+    assert_that(cmd).does_not_contain(str(missing_config))
+    assert_that(cmd).does_not_contain("--exclude-paths")
+    assert_that(cmd).does_not_contain(str(missing_exclude))
 
 
 def test_build_check_command_multiple_paths(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(trufflehog): ignore benign missing-path scan errors
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

TruffleHog was hard-failing the quality gate on benign `encountered errors during
scan` stderr when CI-only paths (`coverage/`, `lighthouse-reports/`, etc.) were
absent locally — even with zero secrets found. The classifier now inspects
per-error reasons: `lstat`/`stat` `no such file or directory` for paths outside
the resolved existing scan set are logged and ignored; permission denied,
unparseable error banners, missing scan-set targets, non-zero exits, and
genuinely unparseable findings still fail closed (#1044). Absent
`--config` / `--exclude-paths` files are skipped before invoke so they never
generate scan-time `lstat` noise. Benign noise no longer sets
`parse_failures_count`, so it no longer surfaces as a false
“tool version may be incompatible” warning.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1631

## Details

**Implementation**
- New helpers in `lintro/parsers/trufflehog/trufflehog_errors.py`:
  extract JSON/`lstat` error strings and classify benign missing paths.
- `TrufflehogPlugin._scan_batch` uses that classification before failing closed.
- Optional file flags and pre-invoke scan paths are existence-filtered.

**Testing strategy**
- Unit tests cover benign missing-path → success; permission denied → failure;
  missing scan-set path → failure; unparseable banner → fail closed; benign
  noise + real findings → findings preserved with success; absent
  config/exclude paths omitted from argv.
