### PR TITLE
fix(ci): upload build-binary artifacts on workflow_dispatch

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -120,7 +120,8 @@ jobs:
           retention-days: 7
 
       - name: Upload to release
-        if: inputs.release_tag != ''
+        # Resolved tag is set for both workflow_call and workflow_dispatch.
+        if: needs.get-release-info.outputs.release_tag != ''
         # yamllint disable-line rule:line-length
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
@@ -242,7 +243,8 @@ jobs:
           retention-days: 7
 
       - name: Upload to release
-        if: inputs.release_tag != ''
+        # Resolved tag is set for both workflow_call and workflow_dispatch.
+        if: needs.get-release-info.outputs.release_tag != ''
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ needs.get-release-info.outputs.release_tag }}
@@ -363,7 +365,8 @@ jobs:
           retention-days: 7
 
       - name: Upload to release
-        if: inputs.release_tag != ''
+        # Resolved tag is set for both workflow_call and workflow_dispatch.
+        if: needs.get-release-info.outputs.release_tag != ''
         # yamllint disable-line rule:line-length
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
@@ -424,7 +427,8 @@ jobs:
           retention-days: 7
 
       - name: Upload to release
-        if: inputs.release_tag != ''
+        # Resolved tag is set for both workflow_call and workflow_dispatch.
+        if: needs.get-release-info.outputs.release_tag != ''
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ needs.get-release-info.outputs.release_tag }}
@@ -444,8 +448,8 @@ jobs:
     # to recover) instead of shipping a partial bump. The universal guard
     # keeps single-arch workflow_call runs from failing on a missing
     # checksum artifact.
+    # Use resolved tag: workflow_dispatch has no release_tag input.
     if: >-
-      inputs.release_tag != '' &&
       inputs.arch == 'universal' &&
       needs.get-release-info.outputs.release_tag != '' &&
       needs.get-release-info.outputs.is_prerelease == 'false'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): upload build-binary artifacts on workflow_dispatch
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`build-binary.yml` gated every Upload-to-release step (and Homebrew notify) on
`inputs.release_tag != ''`, but that input exists only on `workflow_call`. Manual
`workflow_dispatch` backfills therefore built binaries as run artifacts and never
uploaded them to the resolved release.

Gate uploads and Homebrew notify on
`needs.get-release-info.outputs.release_tag != ''`, which is populated for both
trigger paths. Tag-triggered `workflow_call` behavior is unchanged.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1573

## Details

- Repro context: workflow run 29765995289 (backfill of v0.88.1) built green but
  never uploaded `lintro-linux-x64` because upload steps no-oped on empty
  `inputs.release_tag`.
- Acceptance: a `workflow_dispatch` run with `arch=universal` uploads man page +
  binaries to the resolved latest release and reaches Notify Homebrew Tap;
  `workflow_call` with `release_tag` continues to upload as before.
