### PR TITLE
fix(cli): accept hyphenated names in --tools selection

### DIFF
--- a/lintro/config/lintro_config.py
+++ b/lintro/config/lintro_config.py
@@ -24,6 +24,24 @@ __all__ = [
 ]
 
 
+def _tool_name_aliases(tool_name: str) -> tuple[str, ...]:
+    """Return case-normalized lookup aliases for hyphen/underscore tool names."""
+    tool_lower = tool_name.lower()
+    candidates = [
+        tool_lower,
+        tool_lower.replace("-", "_"),
+        tool_lower.replace("_", "-"),
+    ]
+    return tuple(dict.fromkeys(candidates))
+
+
+def _contains_tool_name_alias(tool_name: str, configured_names: list[str]) -> bool:
+    """Check whether a configured tool-name list contains any spelling alias."""
+    aliases = set(_tool_name_aliases(tool_name))
+    configured = {name.lower() for name in configured_names}
+    return not aliases.isdisjoint(configured)
+
+
 class LintroConfig(BaseModel):
     """Main Lintro configuration container.
 
@@ -71,7 +89,25 @@ class LintroConfig(BaseModel):
             LintroToolConfig: Tool configuration. Returns default config if not
                 explicitly configured.
         """
-        return self.tools.get(tool_name.lower(), LintroToolConfig())
+        tool_configs = {name.lower(): config for name, config in self.tools.items()}
+        for candidate in _tool_name_aliases(tool_name):
+            if candidate in tool_configs:
+                return tool_configs[candidate]
+        return LintroToolConfig()
+
+    def is_tool_in_enabled_tools(self, tool_name: str) -> bool:
+        """Check if a tool is allowed by ``execution.enabled_tools``.
+
+        Args:
+            tool_name: Name of the tool.
+
+        Returns:
+            bool: True when ``enabled_tools`` is empty or contains the tool name
+                using either hyphen or underscore spelling.
+        """
+        if not self.execution.enabled_tools:
+            return True
+        return _contains_tool_name_alias(tool_name, self.execution.enabled_tools)
 
     def is_tool_enabled(self, tool_name: str) -> bool:
         """Check if a tool is enabled.
@@ -87,16 +123,12 @@ class LintroConfig(BaseModel):
         Returns:
             bool: True if tool should run.
         """
-        tool_lower = tool_name.lower()
-
         # Check execution.enabled_tools filter
-        if self.execution.enabled_tools:
-            enabled_lower = [t.lower() for t in self.execution.enabled_tools]
-            if tool_lower not in enabled_lower:
-                return False
+        if not self.is_tool_in_enabled_tools(tool_name):
+            return False
 
         # Check tool-specific enabled flag
-        tool_config = self.get_tool_config(tool_lower)
+        tool_config = self.get_tool_config(tool_name)
         return bool(tool_config.enabled)
 
     def get_tool_defaults(self, tool_name: str) -> dict[str, Any]:

--- a/lintro/utils/execution/tool_configuration.py
+++ b/lintro/utils/execution/tool_configuration.py
@@ -6,6 +6,7 @@ and determining which tools to run.
 
 from __future__ import annotations
 
+import difflib
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -19,6 +20,77 @@ from lintro.utils.unified_config import UnifiedConfigManager
 if TYPE_CHECKING:
     from lintro.config.lintro_config import LintroConfig
     from lintro.plugins.base import BaseToolPlugin
+
+
+def _tool_name_lookup_candidates(name: str) -> list[str]:
+    """Build hyphen/underscore lookup candidates for a user-supplied tool name.
+
+    Registry keys are inconsistently hyphenated or underscored (e.g.
+    ``html_validate`` vs ``astro-check``). Accept either spelling by trying
+    both forms, matching :func:`lintro.enums.tool_name.normalize_tool_name`'s
+    hyphen→underscore tolerance without breaking hyphen-registered tools.
+
+    Args:
+        name: Raw tool name from ``--tools`` (already stripped/lowercased).
+
+    Returns:
+        Deduplicated candidate registry keys to try, in preference order.
+    """
+    candidates: list[str] = [name]
+    underscored = name.replace("-", "_")
+    if underscored != name:
+        candidates.append(underscored)
+    hyphenated = name.replace("_", "-")
+    if hyphenated != name:
+        candidates.append(hyphenated)
+    return candidates
+
+
+def _resolve_registered_tool_name(name: str) -> str | None:
+    """Resolve a user-supplied tool name to the registered registry key.
+
+    Args:
+        name: Raw tool name from ``--tools`` (already stripped/lowercased).
+
+    Returns:
+        The registered tool name if found, otherwise ``None``.
+    """
+    for candidate in _tool_name_lookup_candidates(name=name):
+        if tool_manager.is_tool_registered(candidate):
+            return candidate
+    return None
+
+
+def _unknown_tool_error_message(*, name: str, available_names: list[str]) -> str:
+    """Build an Unknown-tool error with an optional nearest-match hint.
+
+    Args:
+        name: The unresolved user-supplied name.
+        available_names: Registered tool names (excluding pytest).
+
+    Returns:
+        Error message string for ``ValueError``.
+    """
+    message = f"Unknown tool '{name}'. Available tools: {available_names}"
+    # Prefer matching against both registered names and underscore/hyphen
+    # aliases so typos near either spelling still suggest well.
+    suggestion_pool: list[str] = list(available_names)
+    for registered in available_names:
+        underscored = registered.replace("-", "_")
+        hyphenated = registered.replace("_", "-")
+        if underscored not in suggestion_pool:
+            suggestion_pool.append(underscored)
+        if hyphenated not in suggestion_pool:
+            suggestion_pool.append(hyphenated)
+    matches = difflib.get_close_matches(
+        name,
+        suggestion_pool,
+        n=1,
+        cutoff=0.6,
+    )
+    if matches:
+        message = f"{message} Did you mean '{matches[0]}'?"
+    return message
 
 
 @dataclass(frozen=True)
@@ -307,39 +379,43 @@ def get_tools_to_run(
 
         return ToolsToRunResult(to_run=to_run, skipped=skipped)
 
-    # Parse specific tools
+    # Parse specific tools (accept hyphen or underscore spellings)
     tool_names: list[str] = [name.strip().lower() for name in tools.split(",")]
     to_run = []
     skipped = []
 
-    for name in tool_names:
-        # Reject pytest for check/fmt actions
-        if name == ToolName.PYTEST.value.lower():
+    for raw_name in tool_names:
+        # Reject pytest for check/fmt actions (either spelling)
+        if raw_name.replace("-", "_") == ToolName.PYTEST.value.lower():
             raise ValueError(
                 "pytest tool is not available for check/fmt actions. "
                 "Use 'lintro test' instead.",
             )
-        # Use tool_manager to trigger discovery before checking registration
-        if not tool_manager.is_tool_registered(name):
+        # Resolve hyphen↔underscore aliases to the registered registry key
+        resolved_name = _resolve_registered_tool_name(name=raw_name)
+        if resolved_name is None:
             available_names = [
                 n for n in tool_manager.get_tool_names() if n.lower() != "pytest"
             ]
             raise ValueError(
-                f"Unknown tool '{name}'. Available tools: {available_names}",
+                _unknown_tool_error_message(
+                    name=raw_name,
+                    available_names=available_names,
+                ),
             )
         # Track disabled tools with reason
-        if not config.is_tool_enabled(name):
-            reason = _get_disabled_reason(config, name)
-            skipped.append(SkippedTool(name=name, reason=reason))
+        if not config.is_tool_enabled(resolved_name):
+            reason = _get_disabled_reason(config, resolved_name)
+            skipped.append(SkippedTool(name=resolved_name, reason=reason))
             continue
         # Verify the tool supports the requested action
         if action == Action.FIX:
-            tool_instance = tool_manager.get_tool(name)
+            tool_instance = tool_manager.get_tool(resolved_name)
             if not tool_instance.definition.can_fix:
                 raise ValueError(
-                    f"Tool '{name}' does not support formatting",
+                    f"Tool '{resolved_name}' does not support formatting",
                 )
-        to_run.append(name)
+        to_run.append(resolved_name)
 
     to_run = _apply_conflict_resolution(
         to_run,

--- a/lintro/utils/execution/tool_configuration.py
+++ b/lintro/utils/execution/tool_configuration.py
@@ -152,16 +152,12 @@ def _get_disabled_reason(config: LintroConfig, tool_name: str) -> str:
     Returns:
         Human-readable reason string.
     """
-    tool_lower = tool_name.lower()
-
     # Check if excluded by enabled_tools allowlist
-    if config.execution.enabled_tools:
-        enabled_lower = [t.lower() for t in config.execution.enabled_tools]
-        if tool_lower not in enabled_lower:
-            return "not in enabled_tools"
+    if not config.is_tool_in_enabled_tools(tool_name):
+        return "not in enabled_tools"
 
     # Check tool-level enabled flag
-    tool_config = config.get_tool_config(tool_lower)
+    tool_config = config.get_tool_config(tool_name)
     if not tool_config.enabled:
         return "disabled in config"
 

--- a/tests/unit/config/test_lintro_config.py
+++ b/tests/unit/config/test_lintro_config.py
@@ -70,6 +70,22 @@ def test_get_tool_config_case_insensitive() -> None:
     assert_that(result.enabled).is_false()
 
 
+def test_get_tool_config_matches_hyphen_config_for_underscore_tool() -> None:
+    """get_tool_config accepts hyphenated config for underscored tools."""
+    tool_config = LintroToolConfig(enabled=False)
+    config = LintroConfig(tools={"html-validate": tool_config})
+    result = config.get_tool_config("html_validate")
+    assert_that(result.enabled).is_false()
+
+
+def test_get_tool_config_matches_underscore_config_for_hyphen_tool() -> None:
+    """get_tool_config accepts underscored config for hyphenated tools."""
+    tool_config = LintroToolConfig(enabled=False)
+    config = LintroConfig(tools={"astro_check": tool_config})
+    result = config.get_tool_config("astro-check")
+    assert_that(result.enabled).is_false()
+
+
 def test_is_tool_enabled_default_true() -> None:
     """is_tool_enabled returns True for unconfigured tool."""
     config = LintroConfig()
@@ -105,6 +121,22 @@ def test_is_tool_enabled_case_insensitive() -> None:
     config = LintroConfig(execution=execution)
     assert_that(config.is_tool_enabled("ruff")).is_true()
     assert_that(config.is_tool_enabled("Ruff")).is_true()
+
+
+def test_is_tool_enabled_matches_enabled_tools_aliases() -> None:
+    """execution.enabled_tools accepts hyphen/underscore spelling aliases."""
+    execution = ExecutionConfig(enabled_tools=["html-validate"])
+    config = LintroConfig(execution=execution)
+    assert_that(config.is_tool_enabled("html_validate")).is_true()
+    assert_that(config.is_tool_enabled("ruff")).is_false()
+
+
+def test_is_tool_enabled_matches_tool_config_aliases() -> None:
+    """tools.<name>.enabled applies across hyphen/underscore aliases."""
+    config = LintroConfig(
+        tools={"html-validate": LintroToolConfig(enabled=False)},
+    )
+    assert_that(config.is_tool_enabled("html_validate")).is_false()
 
 
 def test_get_tool_defaults_returns_configured_defaults() -> None:

--- a/tests/unit/tools/executor/test_tool_configuration_enabled.py
+++ b/tests/unit/tools/executor/test_tool_configuration_enabled.py
@@ -403,3 +403,139 @@ def test_disabled_tool_case_insensitive(
     assert_that(result.to_run).is_equal_to(["ruff"])
     assert_that(result.to_run).does_not_contain("MyPy")
     assert_that(result.to_run).does_not_contain("mypy")
+
+
+# =============================================================================
+# Hyphenated --tools names (#1630)
+# =============================================================================
+
+
+def test_hyphenated_tools_resolve_to_underscore_registry_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hyphenated canonical names resolve to underscored registry keys."""
+    from lintro.tools import tool_manager
+
+    registered = {"html_validate", "pip_audit", "golangci_lint", "ruff"}
+
+    monkeypatch.setattr(
+        tool_manager,
+        "is_tool_registered",
+        lambda name: name in registered,
+    )
+    monkeypatch.setattr(
+        tool_manager,
+        "get_tool_names",
+        lambda: sorted(registered),
+    )
+
+    config = LintroConfig()
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(
+            tools="html-validate,pip-audit,golangci-lint",
+            action="check",
+        )
+
+    assert_that(result.to_run).contains_only(
+        "html_validate",
+        "pip_audit",
+        "golangci_lint",
+    )
+
+
+def test_mixed_hyphen_and_plain_tools_resolve(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mixed hyphenated and plain names both resolve in one --tools list."""
+    from lintro.tools import tool_manager
+
+    registered = {"html_validate", "ruff"}
+
+    monkeypatch.setattr(
+        tool_manager,
+        "is_tool_registered",
+        lambda name: name in registered,
+    )
+    monkeypatch.setattr(
+        tool_manager,
+        "get_tool_names",
+        lambda: sorted(registered),
+    )
+
+    config = LintroConfig()
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(tools="html-validate,ruff", action="check")
+
+    assert_that(result.to_run).contains_only("html_validate", "ruff")
+
+
+def test_underscore_alias_resolves_hyphen_registered_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Underscore spelling resolves tools registered with hyphens."""
+    from lintro.tools import tool_manager
+
+    registered = {"astro-check", "vue-tsc"}
+
+    monkeypatch.setattr(
+        tool_manager,
+        "is_tool_registered",
+        lambda name: name in registered,
+    )
+    monkeypatch.setattr(
+        tool_manager,
+        "get_tool_names",
+        lambda: sorted(registered),
+    )
+
+    config = LintroConfig()
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(tools="astro_check,vue_tsc", action="check")
+
+    assert_that(result.to_run).contains_only("astro-check", "vue-tsc")
+
+
+def test_unknown_tool_includes_did_you_mean_suggestion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Genuine unknown names still raise, with a nearest-match hint."""
+    from lintro.tools import tool_manager
+
+    registered = {"html_validate", "ruff", "mypy"}
+
+    monkeypatch.setattr(
+        tool_manager,
+        "is_tool_registered",
+        lambda name: name in registered,
+    )
+    monkeypatch.setattr(
+        tool_manager,
+        "get_tool_names",
+        lambda: sorted(registered),
+    )
+
+    config = LintroConfig()
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        with pytest.raises(ValueError) as exc_info:
+            get_tools_to_run(tools="html-valdate", action="check")
+
+    message = str(exc_info.value)
+    assert_that(message).contains("Unknown tool 'html-valdate'")
+    assert_that(message).contains("Did you mean")
+    assert_that(message).contains("html")

--- a/tests/unit/tools/executor/test_tool_configuration_enabled.py
+++ b/tests/unit/tools/executor/test_tool_configuration_enabled.py
@@ -686,6 +686,75 @@ def test_underscore_alias_resolves_hyphen_registered_tool(
     assert_that(result.to_run).contains_only("astro-check", "vue-tsc")
 
 
+def test_hyphenated_config_disables_underscore_registry_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hyphenated tool config disables an underscored registered tool."""
+    from lintro.tools import tool_manager
+
+    registered = {"html_validate", "ruff"}
+
+    monkeypatch.setattr(
+        tool_manager,
+        "get_check_tools",
+        lambda: sorted(registered),
+    )
+
+    config = LintroConfig(
+        tools={"html-validate": LintroToolConfig(enabled=False)},
+    )
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(tools=None, action="check")
+
+    assert_that(result.to_run).contains_only("ruff")
+    skipped_by_name = {s.name: s for s in result.skipped}
+    assert_that(skipped_by_name).contains_key("html_validate")
+    assert_that(skipped_by_name["html_validate"].reason).is_equal_to(
+        "disabled in config",
+    )
+
+
+def test_underscore_config_disables_hyphen_registry_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Underscored tool config disables a hyphenated registered tool."""
+    from lintro.tools import tool_manager
+
+    registered = {"astro-check", "ruff"}
+
+    monkeypatch.setattr(
+        tool_manager,
+        "is_tool_registered",
+        lambda name: name in registered,
+    )
+    monkeypatch.setattr(
+        tool_manager,
+        "get_tool_names",
+        lambda: sorted(registered),
+    )
+
+    config = LintroConfig(
+        tools={"astro_check": LintroToolConfig(enabled=False)},
+    )
+
+    with patch(
+        "lintro.utils.execution.tool_configuration.get_config",
+        return_value=config,
+    ):
+        result = get_tools_to_run(tools="astro_check,ruff", action="check")
+
+    assert_that(result.to_run).contains_only("ruff")
+    skipped_by_name = {s.name: s for s in result.skipped}
+    assert_that(skipped_by_name).contains_key("astro-check")
+    assert_that(skipped_by_name["astro-check"].reason).is_equal_to(
+        "disabled in config",
+    )
+
+
 def test_unknown_tool_includes_did_you_mean_suggestion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(cli): accept hyphenated names in --tools selection
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`--tools html-validate` (and other hyphenated canonical names) was rejected as
unknown even though `normalize_tool_name` already accepts hyphens. The
`--tools` selection path now resolves hyphen↔underscore aliases to the
registered registry key (so both `html-validate`/`html_validate` and
`astro_check`/`astro-check` work), and unknown-tool errors include a
nearest-match “Did you mean …?” hint.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1630

## Details

- Helpers in `tool_configuration.py`: `_tool_name_lookup_candidates`,
  `_resolve_registered_tool_name`, `_unknown_tool_error_message`.
- Registry keys remain inconsistently hyphenated/underscored; resolution tries
  both forms rather than blindly forcing underscores (which would break
  hyphen-registered tools like `astro-check`).
- Unit tests cover hyphen→underscore, mixed lists, underscore→hyphen, and
  did-you-mean suggestions.
