### PR TITLE
fix(tools): add missing @commitlint/cli install hint

### DIFF
--- a/lintro/tools/core/version_checking.py
+++ b/lintro/tools/core/version_checking.py
@@ -56,6 +56,7 @@ from loguru import logger
 from lintro._tool_versions import (
     _NPM_PACKAGE_TO_TOOL,
     get_all_minimum_versions,
+    get_tool_version,
 )
 from lintro.enums.tool_name import ToolName
 
@@ -63,6 +64,8 @@ from lintro.enums.tool_name import ToolName
 # during parallel execution
 _logged_warnings: set[str] = set()
 _logged_warnings_lock: threading.Lock = threading.Lock()
+_COMMITLINT_CONFIG_CONVENTIONAL_PACKAGE = "@commitlint/config-conventional"
+_COMMITLINT_HINT_KEYS = {"commitlint", "@commitlint/cli"}
 
 
 def _get_version_timeout() -> int:
@@ -136,7 +139,7 @@ def get_install_hints() -> dict[str, str]:
     Returns:
         dict[str, str]: Dictionary mapping tool names to installation hint strings.
     """
-    # Static templates mapping tool -> install hint template with {version} placeholder
+    # Static templates mapping tool -> install hint template with placeholders.
     templates: dict[str, str] = {
         "bandit": (
             "Install via: pip install bandit>={version} or uv add bandit>={version}"
@@ -166,11 +169,11 @@ def get_install_hints() -> dict[str, str]:
         ),
         "commitlint": (
             "Install via: bun add -g @commitlint/cli@{version} "
-            "@commitlint/config-conventional@{version}"
+            "@commitlint/config-conventional@{commitlint_config_conventional_version}"
         ),
         "@commitlint/cli": (
             "Install via: bun add -g @commitlint/cli@{version} "
-            "@commitlint/config-conventional@{version}"
+            "@commitlint/config-conventional@{commitlint_config_conventional_version}"
         ),
         "html_validate": "Install via: bun add -d html-validate@>={version}",
         "html-validate": "Install via: bun add -d html-validate@>={version}",
@@ -273,7 +276,17 @@ def get_install_hints() -> dict[str, str]:
     for tool, template in templates.items():
         version = versions.get(tool)
         if version is not None:
-            hints[tool] = template.format(version=version)
+            template_values = {"version": version}
+            if tool in _COMMITLINT_HINT_KEYS:
+                companion_version = get_tool_version(
+                    _COMMITLINT_CONFIG_CONVENTIONAL_PACKAGE,
+                )
+                if companion_version is None:
+                    continue
+                template_values["commitlint_config_conventional_version"] = (
+                    companion_version
+                )
+            hints[tool] = template.format(**template_values)
 
     # Log tools in versions that don't have templates (only once).
     # Debug-level: the completeness gate in test_tool_completeness.py fails

--- a/lintro/tools/core/version_checking.py
+++ b/lintro/tools/core/version_checking.py
@@ -168,6 +168,10 @@ def get_install_hints() -> dict[str, str]:
             "Install via: bun add -g @commitlint/cli@{version} "
             "@commitlint/config-conventional@{version}"
         ),
+        "@commitlint/cli": (
+            "Install via: bun add -g @commitlint/cli@{version} "
+            "@commitlint/config-conventional@{version}"
+        ),
         "html_validate": "Install via: bun add -d html-validate@>={version}",
         "html-validate": "Install via: bun add -d html-validate@>={version}",
         "markdownlint": "Install via: bun add -d markdownlint-cli2@>={version}",
@@ -271,14 +275,17 @@ def get_install_hints() -> dict[str, str]:
         if version is not None:
             hints[tool] = template.format(version=version)
 
-    # Warn about tools in versions that don't have templates (only once)
+    # Log tools in versions that don't have templates (only once).
+    # Debug-level: the completeness gate in test_tool_completeness.py fails
+    # CI when a registered tool or version key lacks a hint; a warning here
+    # would only noise user runs for the same gap.
     missing = set(versions) - set(templates)
     if missing:
         warning_key = f"missing_hints:{','.join(sorted(missing))}"
         with _logged_warnings_lock:
             if warning_key not in _logged_warnings:
                 _logged_warnings.add(warning_key)
-                logger.warning(
+                logger.debug(
                     f"Missing install hints for tools: {', '.join(sorted(missing))}",
                 )
 

--- a/lintro/tools/core/version_checking.py
+++ b/lintro/tools/core/version_checking.py
@@ -271,6 +271,7 @@ def get_install_hints() -> dict[str, str]:
 
     versions = get_minimum_versions()
     hints: dict[str, str] = {}
+    skipped_hints: set[str] = set()
 
     # Build hints only for tools that exist in versions
     for tool, template in templates.items():
@@ -282,6 +283,7 @@ def get_install_hints() -> dict[str, str]:
                     _COMMITLINT_CONFIG_CONVENTIONAL_PACKAGE,
                 )
                 if companion_version is None:
+                    skipped_hints.add(tool)
                     continue
                 template_values["commitlint_config_conventional_version"] = (
                     companion_version
@@ -292,7 +294,7 @@ def get_install_hints() -> dict[str, str]:
     # Debug-level: the completeness gate in test_tool_completeness.py fails
     # CI when a registered tool or version key lacks a hint; a warning here
     # would only noise user runs for the same gap.
-    missing = set(versions) - set(templates)
+    missing = (set(versions) - set(templates)) | skipped_hints
     if missing:
         warning_key = f"missing_hints:{','.join(sorted(missing))}"
         with _logged_warnings_lock:

--- a/tests/unit/test_tool_completeness.py
+++ b/tests/unit/test_tool_completeness.py
@@ -39,7 +39,10 @@ from assertpy import assert_that
 
 from lintro.enums.tool_type import ToolType
 from lintro.tools.core.tool_manager import ToolManager
-from lintro.tools.core.version_checking import get_install_hints
+from lintro.tools.core.version_checking import (
+    get_install_hints,
+    get_minimum_versions,
+)
 from lintro.utils.unified_config import get_tool_priority
 
 # ── Repository layout ──────────────────────────────────────────────────────
@@ -435,6 +438,22 @@ def test_install_hint_exists(tool: str) -> None:
     assert_that(has_hint).described_as(
         f"{tool}: no install hint in version_checking.py",
     ).is_true()
+
+
+def test_install_hints_cover_all_version_keys() -> None:
+    """Every ``get_minimum_versions()`` key has an install-hint template.
+
+    Guards npm package aliases (e.g. ``@commitlint/cli``) that appear in
+    version maps alongside the registry tool name (``commitlint``). A gap
+    here is what made ``get_install_hints()`` emit
+    ``Missing install hints for tools: ...`` (#1593).
+    """
+    versions = get_minimum_versions()
+    hints = get_install_hints()
+    missing = sorted(set(versions) - set(hints))
+    assert_that(missing).described_as(
+        f"version keys without install hints: {missing}",
+    ).is_empty()
 
 
 @pytest.mark.parametrize("tool", TOOL_NAMES)

--- a/tests/unit/tools/core/test_version_checking.py
+++ b/tests/unit/tools/core/test_version_checking.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from assertpy import assert_that
 
+from lintro.tools.core import version_checking
 from lintro.tools.core.version_checking import (
     _get_version_timeout,
     get_install_hints,
@@ -114,6 +117,39 @@ def test_get_install_hints_bun_for_node_tools() -> None:
     """Node.js tools have bun install hints."""
     result = get_install_hints()
     assert_that("bun add" in result.get("markdownlint", "")).is_true()
+
+
+def test_get_install_hints_includes_commitlint_cli_alias() -> None:
+    """``@commitlint/cli`` npm alias has the same bun install hint as commitlint."""
+    result = get_install_hints()
+    assert_that(result).contains_key("@commitlint/cli")
+    assert_that(result["@commitlint/cli"]).contains("bun add")
+    assert_that(result["@commitlint/cli"]).contains("@commitlint/cli@")
+    assert_that(result["@commitlint/cli"]).is_equal_to(result["commitlint"])
+
+
+def test_get_install_hints_missing_template_logs_debug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing hint templates log at debug, not warning (#1593 / #1425).
+
+    Args:
+        monkeypatch: Pytest fixture for patching modules and attributes.
+    """
+    monkeypatch.setattr(
+        version_checking,
+        "get_minimum_versions",
+        lambda: {"hadolint": "2.12.0", "totally_missing_tool": "1.0.0"},
+    )
+    version_checking._logged_warnings.clear()
+    mock_logger = MagicMock()
+    with patch.object(version_checking, "logger", mock_logger):
+        get_install_hints()
+    mock_logger.warning.assert_not_called()
+    mock_logger.debug.assert_called()
+    debug_msg = mock_logger.debug.call_args[0][0]
+    assert_that(debug_msg).contains("Missing install hints")
+    assert_that(debug_msg).contains("totally_missing_tool")
 
 
 def test_get_install_hints_external_tools() -> None:

--- a/tests/unit/tools/core/test_version_checking.py
+++ b/tests/unit/tools/core/test_version_checking.py
@@ -154,6 +154,31 @@ def test_get_install_hints_uses_commitlint_companion_version(
     assert_that(result["@commitlint/cli"]).is_equal_to(result["commitlint"])
 
 
+def test_get_install_hints_logs_commitlint_when_companion_version_unresolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dropped commitlint hints are included in the missing-hint diagnostic."""
+    monkeypatch.setattr(
+        version_checking,
+        "get_minimum_versions",
+        lambda: {"commitlint": "21.2.1", "@commitlint/cli": "21.2.1"},
+    )
+    monkeypatch.setattr(version_checking, "get_tool_version", lambda _package: None)
+    version_checking._logged_warnings.clear()
+    mock_logger = MagicMock()
+
+    with patch.object(version_checking, "logger", mock_logger):
+        result = get_install_hints()
+
+    assert_that(result).does_not_contain_key("commitlint")
+    assert_that(result).does_not_contain_key("@commitlint/cli")
+    mock_logger.debug.assert_called()
+    debug_msg = mock_logger.debug.call_args[0][0]
+    assert_that(debug_msg).contains("Missing install hints")
+    assert_that(debug_msg).contains("commitlint")
+    assert_that(debug_msg).contains("@commitlint/cli")
+
+
 def test_get_install_hints_missing_template_logs_debug(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/tools/core/test_version_checking.py
+++ b/tests/unit/tools/core/test_version_checking.py
@@ -128,6 +128,32 @@ def test_get_install_hints_includes_commitlint_cli_alias() -> None:
     assert_that(result["@commitlint/cli"]).is_equal_to(result["commitlint"])
 
 
+def test_get_install_hints_uses_commitlint_companion_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Commitlint hint uses each npm package's resolved version."""
+    monkeypatch.setattr(
+        version_checking,
+        "get_minimum_versions",
+        lambda: {"commitlint": "21.2.1", "@commitlint/cli": "21.2.1"},
+    )
+    monkeypatch.setattr(
+        version_checking,
+        "get_tool_version",
+        lambda package: (
+            "21.2.0" if package == "@commitlint/config-conventional" else None
+        ),
+    )
+
+    result = get_install_hints()
+
+    assert_that(result["commitlint"]).contains("@commitlint/cli@21.2.1")
+    assert_that(result["commitlint"]).contains(
+        "@commitlint/config-conventional@21.2.0",
+    )
+    assert_that(result["@commitlint/cli"]).is_equal_to(result["commitlint"])
+
+
 def test_get_install_hints_missing_template_logs_debug(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(tools): add missing @commitlint/cli install hint
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`get_minimum_versions()` exposes the npm package alias `@commitlint/cli`, but
`get_install_hints()` only had a template for the registry name `commitlint`.
That gap caused `Missing install hints for tools: @commitlint/cli` on every run.

This PR:
- Adds the `@commitlint/cli` install-hint entry (bun-based, matching other npm tools)
- Re-applies the missing-hints log downgrade (`warning` → `debug`)
- Adds a completeness gate so every `get_minimum_versions()` key must have a hint template

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1593

## Details

Root cause: commitlint is versioned under both `commitlint` and `@commitlint/cli`,
but only `commitlint` had a hint template. Completeness previously checked
registry tool names only, so the npm alias gap slipped through.
