### PR TITLE
fix(security): override mcp>=1.28.1 and bump click>=8.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-  "click>=8.1.8",
+  # click 8.1.8 is vulnerable to PYSEC-2026-2132 / CVE-2026-7246
+  # (GHSA-47fr-3ffg-hgmw, High); fixed in 8.3.3.
+  "click>=8.3.3",
   "loguru>=0.7.3",
   "packaging>=25.0",
   "pathspec>=0.12.1",
@@ -382,11 +384,24 @@ override-dependencies = [
   # Safe: lintro invokes semgrep as a subprocess; rich version doesn't affect its behavior.
   # TODO: Remove once semgrep drops the rich<14 pin (not tracked by Renovate).
   "rich>=14.2.0",
-  # semgrep==mcp==1.23.3 but mcp 1.23.3 has high GHSAs blocking release SBOM
-  # fail-on-severity (#1659). Override like rich: lintro runs semgrep as a
-  # subprocess; mcp is not a lintro runtime import.
+  # semgrep 1.168.0 pins mcp==1.23.3 exactly, but mcp 1.23.3 carries high GHSAs
+  # that fail the release SBOM `fail-on-severity: high` gate (#1659). An exact
+  # pin cannot be lifted by constraint-dependencies, so an override is required.
+  # NOTE: unlike a pure subprocess dependency, semgrep *does* import mcp eagerly
+  # (semgrep/mcp/server.py imports mcp.server.fastmcp at `import semgrep.cli`
+  # time), so this override really does change semgrep's runtime dependency.
+  # Validated by CI: the Dockerized dogfooding-lint job builds from this lock and
+  # runs `semgrep (check)` to completion, exercising that import path.
+  # TODO: Remove once semgrep pins an mcp release without these advisories.
   # (GHSA-hvrp-rf83-w775, GHSA-jpw9-pfvf-9f58, GHSA-vj7q-gjh5-988w)
   "mcp>=1.28.1",
+  # click 8.1.8 has PYSEC-2026-2132 / CVE-2026-7246 (High). No semgrep release
+  # accepts click 8.3.x (<=1.170.1 pins <8.2, >=1.171.0 pins ~=8.4.2) and
+  # sqlfluff caps click<8.4.0, so an override is the only way to ship a patched
+  # click alongside both tools. Upper bound keeps sqlfluff natively satisfied;
+  # only semgrep's pin is overridden. Validated: semgrep 1.168.0 and sqlfluff
+  # 4.2.2 both run to completion under click 8.3.3 (dogfooding-lint in CI).
+  "click>=8.3.3,<8.4.0",
 ]
 
 [tool.pydoclint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -382,6 +382,11 @@ override-dependencies = [
   # Safe: lintro invokes semgrep as a subprocess; rich version doesn't affect its behavior.
   # TODO: Remove once semgrep drops the rich<14 pin (not tracked by Renovate).
   "rich>=14.2.0",
+  # semgrep==mcp==1.23.3 but mcp 1.23.3 has high GHSAs blocking release SBOM
+  # fail-on-severity (#1659). Override like rich: lintro runs semgrep as a
+  # subprocess; mcp is not a lintro runtime import.
+  # (GHSA-hvrp-rf83-w775, GHSA-jpw9-pfvf-9f58, GHSA-vj7q-gjh5-988w)
+  "mcp>=1.28.1",
 ]
 
 [tool.pydoclint]

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -22,7 +22,9 @@ def isolated_cli_runner() -> CliRunner:
     Returns:
         A CliRunner instance with isolated filesystem.
     """
-    return CliRunner(mix_stderr=False)
+    # click >= 8.2 removed the ``mix_stderr`` argument; stdout and stderr are
+    # always captured separately, which is the behaviour this fixture wants.
+    return CliRunner()
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,7 @@ constraints = [
     { name = "virtualenv", specifier = ">=20.36.1" },
 ]
 overrides = [
+    { name = "click", specifier = ">=8.3.3,<8.4.0" },
     { name = "mcp", specifier = ">=1.28.1" },
     { name = "rich", specifier = ">=14.2.0" },
 ]
@@ -495,14 +496,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -1315,7 +1316,7 @@ requires-dist = [
     { name = "assertpy", marker = "extra == 'test'", specifier = ">=1.1" },
     { name = "bandit", marker = "extra == 'full'", specifier = ">=1.9.4" },
     { name = "black", marker = "extra == 'full'", specifier = ">=26.3.1" },
-    { name = "click", specifier = ">=8.1.8" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "coverage-badge", marker = "extra == 'dev'", specifier = ">=1.1.2" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,10 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
 [manifest]
@@ -15,7 +18,10 @@ constraints = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "virtualenv", specifier = ">=20.36.1" },
 ]
-overrides = [{ name = "rich", specifier = ">=14.2.0" }]
+overrides = [
+    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "rich", specifier = ">=14.2.0" },
+]
 
 [[package]]
 name = "allure-pytest"
@@ -1475,7 +1481,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.23.3"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1493,9 +1499,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a4/d06a303f45997e266f2c228081abe299bbcba216cb806128e2e49095d25f/mcp-1.23.3.tar.gz", hash = "sha256:b3b0da2cc949950ce1259c7bfc1b081905a51916fcd7c8182125b85e70825201", size = 600697, upload-time = "2025-12-09T16:04:37.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/c6/13c1a26b47b3f3a3b480783001ada4268917c9f42d78a079c336da2e75e5/mcp-1.23.3-py3-none-any.whl", hash = "sha256:32768af4b46a1b4f7df34e2bfdf5c6011e7b63d7f1b0e321d0fdef4cd6082031", size = 231570, upload-time = "2025-12-09T16:04:35.56Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(security): override mcp>=1.28.1 and bump click>=8.3.3
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Two security dependency fixes, no gate weakened:

1. **`mcp` >= 1.28.1** — tagged release publishes for v0.91.26 / v0.91.27 fail at
   `Generate and verify SBOM` -> `grype --fail-on high`, because grype reports three
   high advisories in `mcp@1.23.3`
   (GHSA-hvrp-rf83-w775, GHSA-jpw9-pfvf-9f58, GHSA-vj7q-gjh5-988w).
2. **`click` >= 8.3.3** — `pip-audit` reports `click 8.1.8` affected by
   PYSEC-2026-2132 (aliases CVE-2026-7246, GHSA-47fr-3ffg-hgmw), CVSS 3.1
   `AV:L/AC:H/PR:H/UI:R/S:C/C:H/I:H/A:H` = 7.2 High, fixed in 8.3.3.

`fail-on-severity: high` in `publish-pypi-on-tag.yml` is unchanged.

Files touched:

- `pyproject.toml` — `[project.dependencies]` `click>=8.1.8` -> `click>=8.3.3`;
  `[tool.uv] override-dependencies` gains `mcp>=1.28.1` and `click>=8.3.3,<8.4.0`.
- `uv.lock` — `mcp` 1.23.3 -> 1.28.1, `click` 8.1.8 -> 8.3.3 (regenerated with
  `uv lock`; it is the only other file in the diff).
- `tests/unit/cli/conftest.py` — drop `CliRunner(mix_stderr=False)`; click 8.2 removed
  that argument and now always captures stdout/stderr separately, which is exactly the
  behaviour this fixture wanted.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1659

## Details

### Why overrides rather than constraints

`semgrep` (resolved here at **1.168.0**) pins `mcp==1.23.3` *exactly*, so
`constraint-dependencies` cannot raise it — an exact pin already satisfies any
constraint range. `override-dependencies` is the only mechanism that replaces an exact
pin, which is the same pattern already used for `rich`.

For `click`, no semgrep release accepts 8.3.x at all: `semgrep <= 1.170.1` pins
`click>=8.1.8,<8.2` and `semgrep >= 1.171.0` pins `click~=8.4.2`, while `sqlfluff`
(4.2.2) caps `click<8.4.0`. The `<8.4.0` upper bound on the override is deliberate: it
keeps sqlfluff *natively* satisfied so only semgrep's pin is actually overridden.

### Correction to the original rationale

The first version of this description (and the inline comment in `pyproject.toml`)
claimed the override was safe because "lintro runs semgrep as a subprocess; mcp is not
a lintro runtime import". That is true of lintro but **irrelevant**, and both have been
rewritten: **semgrep itself imports `mcp` eagerly.** `semgrep/mcp/server.py`
(lines 13-20) does `from mcp.server.fastmcp import FastMCP` et al., and that module is
reached at `import semgrep.cli` time. Overriding an exact `mcp==1.23.3` pin by five
minor versions therefore genuinely changes semgrep's runtime dependency, and the same
applies to moving semgrep from click 8.1 to 8.3. The safety argument has to rest on
evidence instead.

### Testing strategy / evidence

- **Docker dogfooding (the load-bearing evidence).** The
  `dogfooding-lint / 🛠️ Dogfooding Lint` job builds the image from *this* PR's
  `uv.lock` and runs the full lintro toolset over the repo. On commit `d973ecb`
  (this PR's head) `semgrep (check)` reported `✅ PASS` — run
  [30071006181](https://github.com/lgtm-hq/py-lintro/actions/runs/30071006181),
  job `89412259394`, log line
  `| 🔧 semgrep | ✅ PASS | 0 |`. An earlier mcp-only revision of this branch passed
  the same way (run 30063518379, job 89390350323). semgrep started, loaded its `mcp`
  import chain, and completed a scan on the overridden mcp *and* click versions.
- **Local verification** with the `tools` extra synced from this lock:
  `import semgrep.cli` loads `mcp`, `mcp.client.*` and `mcp.server.fastmcp.FastMCP`
  successfully on mcp 1.28.1; `semgrep --version` -> 1.168.0,
  `sqlfluff --version` -> 4.2.2, and `lintro chk --tools semgrep` -> `✅ PASS`, all
  under click 8.3.3.
- **Click 8.1 -> 8.3 regression surface.** Full unit suite green (7180 passed,
  92 skipped) after the single `mix_stderr` fixture fix; `lintro --help` and
  subcommand `--help` rendering (including the `\f` truncation introduced in #1457)
  verified unchanged.
- **`pip-audit`** on the updated lock: `No known vulnerabilities found`.
- **grype** on the exported lock dependencies: 0 high/critical.

### Related publish backlog (not fixed here)

v0.91.17–v0.91.25 tag publishes sit **waiting** on the `pypi` environment approval —
that is the maintainer's intentional manual gate, not this SBOM failure. PyPI latest is
still 0.91.11.
