### PR TITLE
fix(tools): keep commitlint install hint when companion version is unresolvable

### DIFF
--- a/lintro/tools/core/version_checking.py
+++ b/lintro/tools/core/version_checking.py
@@ -271,7 +271,6 @@ def get_install_hints() -> dict[str, str]:
 
     versions = get_minimum_versions()
     hints: dict[str, str] = {}
-    skipped_hints: set[str] = set()
 
     # Build hints only for tools that exist in versions
     for tool, template in templates.items():
@@ -279,12 +278,12 @@ def get_install_hints() -> dict[str, str]:
         if version is not None:
             template_values = {"version": version}
             if tool in _COMMITLINT_HINT_KEYS:
-                companion_version = get_tool_version(
-                    _COMMITLINT_CONFIG_CONVENTIONAL_PACKAGE,
+                # Fall back to the CLI version when the companion package
+                # version cannot be resolved: a slightly-stale companion
+                # version in an install hint beats no hint at all (#1663).
+                companion_version = (
+                    get_tool_version(_COMMITLINT_CONFIG_CONVENTIONAL_PACKAGE) or version
                 )
-                if companion_version is None:
-                    skipped_hints.add(tool)
-                    continue
                 template_values["commitlint_config_conventional_version"] = (
                     companion_version
                 )
@@ -294,7 +293,7 @@ def get_install_hints() -> dict[str, str]:
     # Debug-level: the completeness gate in test_tool_completeness.py fails
     # CI when a registered tool or version key lacks a hint; a warning here
     # would only noise user runs for the same gap.
-    missing = (set(versions) - set(templates)) | skipped_hints
+    missing = set(versions) - set(templates)
     if missing:
         warning_key = f"missing_hints:{','.join(sorted(missing))}"
         with _logged_warnings_lock:

--- a/tests/unit/tools/core/test_version_checking.py
+++ b/tests/unit/tools/core/test_version_checking.py
@@ -154,29 +154,29 @@ def test_get_install_hints_uses_commitlint_companion_version(
     assert_that(result["@commitlint/cli"]).is_equal_to(result["commitlint"])
 
 
-def test_get_install_hints_logs_commitlint_when_companion_version_unresolved(
+def test_get_install_hints_falls_back_when_companion_version_unresolved(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Dropped commitlint hints are included in the missing-hint diagnostic."""
+    """Commitlint hints survive an unresolvable companion version (#1663).
+
+    Args:
+        monkeypatch: Pytest fixture for patching modules and attributes.
+    """
     monkeypatch.setattr(
         version_checking,
         "get_minimum_versions",
         lambda: {"commitlint": "21.2.1", "@commitlint/cli": "21.2.1"},
     )
     monkeypatch.setattr(version_checking, "get_tool_version", lambda _package: None)
-    version_checking._logged_warnings.clear()
-    mock_logger = MagicMock()
 
-    with patch.object(version_checking, "logger", mock_logger):
-        result = get_install_hints()
+    result = get_install_hints()
 
-    assert_that(result).does_not_contain_key("commitlint")
-    assert_that(result).does_not_contain_key("@commitlint/cli")
-    mock_logger.debug.assert_called()
-    debug_msg = mock_logger.debug.call_args[0][0]
-    assert_that(debug_msg).contains("Missing install hints")
-    assert_that(debug_msg).contains("commitlint")
-    assert_that(debug_msg).contains("@commitlint/cli")
+    assert_that(result).contains_key("commitlint")
+    assert_that(result).contains_key("@commitlint/cli")
+    for key in ("commitlint", "@commitlint/cli"):
+        assert_that(result[key]).does_not_contain("{")
+        assert_that(result[key]).contains("@commitlint/cli@21.2.1")
+        assert_that(result[key]).contains("@commitlint/config-conventional@21.2.1")
 
 
 def test_get_install_hints_missing_template_logs_debug(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(tools): keep commitlint install hint when companion version is unresolvable
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`get_install_hints()` in `lintro/tools/core/version_checking.py` dropped the
`commitlint` / `@commitlint/cli` install hints entirely when
`get_tool_version("@commitlint/config-conventional")` returned `None`, and the
diagnostic for that gap was logged at DEBUG. Net effect: a user without
commitlint installed got a "tool not found" message with no install hint and no
warning.

This PR falls back to the CLI version for the companion placeholder instead of
skipping the hint:

```python
companion_version = (
    get_tool_version(_COMMITLINT_CONFIG_CONVENTIONAL_PACKAGE) or version
)
```

A slightly-stale companion version in an install hint is strictly better than no
hint. With nothing `continue`ing any more, the `skipped_hints` set is
unreachable and has been removed, along with its union into `missing`.

`logger.debug` for genuinely template-less tools is left untouched — that
demotion is justified by the `test_tool_completeness` gate.

#1636's actual fix is preserved: when the companion version *does* resolve, the
hint still renders the companion version via the separate
`{commitlint_config_conventional_version}` placeholder, not the CLI version.
`test_get_install_hints_uses_commitlint_companion_version` continues to assert
exactly that.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1663

## Details

Test changes in `tests/unit/tools/core/test_version_checking.py`: the old
`test_get_install_hints_logs_commitlint_when_companion_version_unresolved`
asserted the buggy behaviour (hints absent, diagnostic logged) and is replaced by
`test_get_install_hints_falls_back_when_companion_version_unresolved`, which
asserts both keys are present, that neither rendered hint contains an
unsubstituted `{` placeholder, and that the fallback version is used for both
packages.

Verification:

- `uv run lintro fmt` — clean
- `uv run lintro chk` — 0 issues, health 100/100
- `uv run pytest tests --ignore=tests/integration` — 7179 passed, 92 skipped.
  One pre-existing unrelated failure,
  `tests/unit/plugins/base/test_execution.py::test_prepare_execution_version_check_fails_returns_early_result`,
  reproduces identically on unmodified `origin/main` in this worktree (known
  local-worktree path quirk, not touched by this change).
