### PR TITLE
chore(ai): remove dead AUDIT_FILE constant and unused _rotate_audit_log wrapper

### DIFF
--- a/lintro/ai/audit.py
+++ b/lintro/ai/audit.py
@@ -15,9 +15,6 @@ if TYPE_CHECKING:
     from lintro.ai.models import AIFixSuggestion
 
 AUDIT_DIR = ".lintro-cache/ai"
-AUDIT_FILE = "audit.json"
-"""Legacy single-run audit filename (no longer written; kept for reference)."""
-
 AUDIT_JSONL_FILE = "audit.jsonl"
 """JSON Lines audit log — one run record appended per line."""
 
@@ -179,20 +176,3 @@ def _rotate_audit_log_atomic(
         with suppress(OSError):
             os.unlink(tmp_name)
         raise
-
-
-def _rotate_audit_log(audit_path: Path, max_entries: int | None) -> None:
-    """Trim the JSONL audit log to its most recent ``max_entries`` records.
-
-    Args:
-        audit_path: Path to the ``audit.jsonl`` file.
-        max_entries: Maximum records to retain; ``None`` or non-positive
-            leaves the file untouched.
-    """
-    lock_path = audit_path.parent / AUDIT_LOCK_FILE
-    with lock_path.open("a+", encoding="utf-8") as lock_fh:
-        _lock_file(lock_fh)
-        try:
-            _rotate_audit_log_atomic(audit_path, max_entries)
-        finally:
-            _unlock_file(lock_fh)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(ai): remove dead AUDIT_FILE constant and unused _rotate_audit_log wrapper
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Removes two symbols from `lintro/ai/audit.py` that are defined but never referenced
anywhere in the codebase:

- **`AUDIT_FILE = "audit.json"`** — the legacy single-run audit filename. Its own
  docstring said "no longer written; kept for reference". `write_audit_log()` writes
  `AUDIT_JSONL_FILE`; nothing reads or writes `AUDIT_FILE`.
- **`_rotate_audit_log(audit_path, max_entries)`** — a lock-acquiring wrapper around
  `_rotate_audit_log_atomic()`. `write_audit_log()` calls the atomic helper directly
  while already holding the lock, so the wrapper had no caller, no export, and no test.

`_rotate_audit_log_atomic`, `_lock_file` and `_unlock_file` are unchanged.

Verified zero remaining references before and after:

```console
$ git grep -n '_rotate_audit_log\b\|AUDIT_FILE' -- . | grep -v cargo_audit | grep -v pip_audit
(no output)
```

The `*_AUDIT_FILE_PATTERNS` hits in `cargo_audit.py` / `pip_audit.py` are unrelated
constants and were left alone.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1664

## Details

Pure deletion, 20 lines, no behaviour change.

Local verification:

- `uv run lintro fmt` — clean
- `uv run lintro chk` — 0 issues, health score 100/100
- `uv run pytest tests --ignore=tests/integration` — 7179 passed, 92 skipped, 1 failed.
  The single failure is
  `tests/unit/plugins/base/test_execution.py::test_prepare_execution_version_check_fails_returns_early_result`,
  which reproduces identically on a clean `origin/main` checkout in this worktree
  (git-worktree path quirk in local file discovery) and is unrelated to this diff.
