### PR TITLE
fix(trufflehog): fail closed when scan errors cannot be classified

### DIFF
--- a/lintro/parsers/trufflehog/__init__.py
+++ b/lintro/parsers/trufflehog/__init__.py
@@ -4,6 +4,7 @@ from lintro.parsers.trufflehog.trufflehog_errors import (
     extract_trufflehog_scan_errors,
     is_benign_missing_path_error,
     scan_errors_are_all_benign,
+    stderr_reports_scan_errors,
 )
 from lintro.parsers.trufflehog.trufflehog_issue import TrufflehogIssue
 from lintro.parsers.trufflehog.trufflehog_parser import parse_trufflehog_output
@@ -14,4 +15,5 @@ __all__ = [
     "is_benign_missing_path_error",
     "parse_trufflehog_output",
     "scan_errors_are_all_benign",
+    "stderr_reports_scan_errors",
 ]

--- a/lintro/parsers/trufflehog/trufflehog_errors.py
+++ b/lintro/parsers/trufflehog/trufflehog_errors.py
@@ -5,6 +5,10 @@ TruffleHog exits 0 even when it cannot read a scan target, logging
 must fail closed on genuine incomplete scans (#1044), but CI-only artifact
 paths that are absent locally (``coverage/``, ``lighthouse-reports/``, …) are
 benign when they were never part of the resolved scan set (#1631).
+
+Classification is deliberately conservative: only recognised shapes are ever
+called benign, and anything that cannot be classified is kept so the caller
+fails closed rather than reporting a clean pass (#1662).
 """
 
 from __future__ import annotations
@@ -23,8 +27,18 @@ _MISSING_PATH_RE: re.Pattern[str] = re.compile(
 def extract_trufflehog_scan_errors(stderr: str) -> list[str]:
     """Extract per-path scan error strings from TruffleHog stderr.
 
-    Prefers structured JSON log lines that carry an ``errors`` array. Falls
-    back to bare ``lstat``/``stat`` lines when no JSON payload is present.
+    Structured JSON log lines are authoritative: the ``errors`` array of a
+    scan-error payload carries every reason, and other JSON log records
+    (``running source``, ``finished scanning``, …) are routine progress noise
+    that is deliberately ignored.
+
+    Every remaining non-empty line is retained verbatim, even when it matches
+    no known error shape. This is deliberate: unknown means unsafe. An
+    unclassified line is never a benign missing path
+    (:func:`is_benign_missing_path_error` returns False for anything that is
+    not an ``lstat``/``stat`` "no such file or directory" reason), so keeping
+    it makes :func:`scan_errors_are_all_benign` return False and the caller
+    fail closed on a possibly incomplete scan (#1044, #1662).
 
     Args:
         stderr: Raw stderr captured from a TruffleHog run.
@@ -44,20 +58,17 @@ def extract_trufflehog_scan_errors(stderr: str) -> list[str]:
         if not stripped:
             continue
 
-        from_json = _errors_from_json_line(stripped)
-        if from_json:
-            for err in from_json:
+        payload = _json_log_payload(stripped)
+        if payload is not None:
+            for err in _errors_from_payload(payload):
                 if err not in seen:
                     seen.add(err)
                     extracted.append(err)
             continue
 
-        # Plain-text / logfmt lines that already look like a path error.
-        is_path_error = (
-            _MISSING_PATH_RE.match(stripped) is not None
-            or "permission denied" in stripped.lower()
-        )
-        if is_path_error and stripped not in seen:
+        # Plain-text / logfmt line. Retain it whatever it says — an
+        # unclassifiable diagnostic must not be silently dropped.
+        if stripped not in seen:
             seen.add(stripped)
             extracted.append(stripped)
 
@@ -130,27 +141,37 @@ def scan_errors_are_all_benign(
     )
 
 
-def _errors_from_json_line(line: str) -> list[str]:
-    """Pull the ``errors`` array from a TruffleHog JSON log line, if present.
+def _json_log_payload(line: str) -> dict[str, object] | None:
+    """Decode a stderr line as a structured JSON log record.
 
     Args:
-        line: A single stderr line that may be JSON.
+        line: A single stripped stderr line.
 
     Returns:
-        The string entries from ``errors``, or an empty list when the line is
-        not a scan-error JSON object.
+        The decoded mapping when the line is a JSON object, otherwise None
+        (the caller then treats the line as unstructured text).
     """
     if not line.startswith("{"):
-        return []
+        return None
 
     try:
         payload = json.loads(line)
     except json.JSONDecodeError:
-        return []
+        return None
 
-    if not isinstance(payload, dict):
-        return []
+    return payload if isinstance(payload, dict) else None
 
+
+def _errors_from_payload(payload: dict[str, object]) -> list[str]:
+    """Pull the ``errors`` array from a TruffleHog JSON log record.
+
+    Args:
+        payload: A decoded JSON log record from TruffleHog stderr.
+
+    Returns:
+        The string entries from ``errors``, or an empty list when the record
+        is not a scan-error payload.
+    """
     msg = payload.get("msg")
     if not isinstance(msg, str) or "encountered errors during scan" not in msg:
         return []

--- a/lintro/parsers/trufflehog/trufflehog_errors.py
+++ b/lintro/parsers/trufflehog/trufflehog_errors.py
@@ -242,10 +242,24 @@ def _is_error_record(payload: dict[str, object]) -> bool:
         if stem in _ERROR_LEVELS:
             return True
 
-    return any(
-        isinstance(payload.get(key), str) and payload[key].strip()  # type: ignore[union-attr]
-        for key in ("error", "err")
-    )
+    return _error_field_text(payload) is not None
+
+
+def _error_field_text(payload: dict[str, object]) -> str | None:
+    """Return the record's error-reason text, if it carries one.
+
+    Args:
+        payload: A decoded JSON log record from TruffleHog stderr.
+
+    Returns:
+        The stripped ``error``/``err`` text, or None when neither field holds
+        a non-empty string.
+    """
+    for key in ("error", "err"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
 
 
 def _reason_from_error_record(payload: dict[str, object], *, raw: str) -> str:
@@ -260,11 +274,7 @@ def _reason_from_error_record(payload: dict[str, object], *, raw: str) -> str:
         The record's ``error``/``err`` text when present, otherwise the raw
         line so no diagnostic detail is lost.
     """
-    for key in ("error", "err"):
-        value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    return raw
+    return _error_field_text(payload) or raw
 
 
 def _errors_from_payload(payload: dict[str, object]) -> list[str]:

--- a/lintro/parsers/trufflehog/trufflehog_errors.py
+++ b/lintro/parsers/trufflehog/trufflehog_errors.py
@@ -23,14 +23,26 @@ _MISSING_PATH_RE: re.Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 
+# zap log levels that signal a failure. TruffleHog logs progress as
+# ``info-0``/``debug-N`` and failures as ``error``; ``dpanic``/``panic``/
+# ``fatal`` are zap's escalating fatal levels.
+_ERROR_LEVELS: frozenset[str] = frozenset(
+    {"error", "dpanic", "panic", "fatal"},
+)
+
 
 def extract_trufflehog_scan_errors(stderr: str) -> list[str]:
     """Extract per-path scan error strings from TruffleHog stderr.
 
-    Structured JSON log lines are authoritative: the ``errors`` array of a
-    scan-error payload carries every reason, and other JSON log records
-    (``running source``, ``finished scanning``, …) are routine progress noise
-    that is deliberately ignored.
+    JSON log records are classified by severity, not by message:
+
+    * The aggregate ``encountered errors during scan`` payload takes
+      precedence — its ``errors`` array is expanded so each reason stays
+      individually classifiable against the resolved scan set.
+    * Any other error-severity record (``level`` of ``error``/``fatal``/
+      ``panic``, or a non-empty ``error``/``err`` field) is retained.
+    * Routine progress records (``running source``, ``finished scanning``, …)
+      carry an informational level and no error field, so they are ignored.
 
     Every remaining non-empty line is retained verbatim, even when it matches
     no known error shape. This is deliberate: unknown means unsafe. An
@@ -53,6 +65,16 @@ def extract_trufflehog_scan_errors(stderr: str) -> list[str]:
     extracted: list[str] = []
     seen: set[str] = set()
 
+    def _record(reason: str) -> None:
+        """Append a reason once, preserving first-seen order.
+
+        Args:
+            reason: The error reason string to retain.
+        """
+        if reason and reason not in seen:
+            seen.add(reason)
+            extracted.append(reason)
+
     for line in stderr.splitlines():
         stripped = line.strip()
         if not stripped:
@@ -60,19 +82,55 @@ def extract_trufflehog_scan_errors(stderr: str) -> list[str]:
 
         payload = _json_log_payload(stripped)
         if payload is not None:
-            for err in _errors_from_payload(payload):
-                if err not in seen:
-                    seen.add(err)
-                    extracted.append(err)
+            aggregate = _errors_from_payload(payload)
+            if aggregate:
+                for err in aggregate:
+                    _record(err)
+            elif _is_error_record(payload):
+                # An error-severity record that is not the aggregate payload
+                # (or an aggregate with no usable reasons). Keep it so the
+                # caller cannot mistake the batch for a clean scan.
+                _record(_reason_from_error_record(payload, raw=stripped))
             continue
 
         # Plain-text / logfmt line. Retain it whatever it says — an
         # unclassifiable diagnostic must not be silently dropped.
-        if stripped not in seen:
-            seen.add(stripped)
-            extracted.append(stripped)
+        _record(stripped)
 
     return extracted
+
+
+def stderr_reports_scan_errors(stderr: str) -> bool:
+    """Return whether TruffleHog stderr reports any scan error.
+
+    TruffleHog exits 0 either way, so this is the gate that decides whether a
+    batch needs error classification at all. It fires on the aggregate
+    ``encountered errors during scan`` banner *and* on any standalone
+    error-severity JSON record: when an unreadable file is reached through a
+    scanned directory, TruffleHog logs only the standalone record and no
+    aggregate, which would otherwise read as a clean scan (#1662).
+
+    Plain-text stderr is matched on the banner alone, so ordinary non-JSON
+    log noise does not trip the gate.
+
+    Args:
+        stderr: Raw stderr captured from a TruffleHog run.
+
+    Returns:
+        True when the stderr carries at least one scan-error signal.
+    """
+    if not stderr or not stderr.strip():
+        return False
+
+    if "encountered errors during scan" in stderr:
+        return True
+
+    return any(
+        (payload := _json_log_payload(line.strip())) is not None
+        and _is_error_record(payload)
+        for line in stderr.splitlines()
+        if line.strip()
+    )
 
 
 def is_benign_missing_path_error(
@@ -160,6 +218,53 @@ def _json_log_payload(line: str) -> dict[str, object] | None:
         return None
 
     return payload if isinstance(payload, dict) else None
+
+
+def _is_error_record(payload: dict[str, object]) -> bool:
+    """Return whether a JSON log record reports an error.
+
+    Classification is by severity rather than by message text, so a scan
+    failure logged under any ``msg`` is caught. TruffleHog's zap logger emits
+    ``level`` values such as ``info-0`` for progress and ``error`` for
+    failures, and attaches the underlying reason as an ``error`` field.
+
+    Args:
+        payload: A decoded JSON log record from TruffleHog stderr.
+
+    Returns:
+        True when the record's level is error-like or it carries a non-empty
+        ``error``/``err`` field.
+    """
+    level = payload.get("level")
+    if isinstance(level, str):
+        # ``info-0``/``debug-3`` carry a verbosity suffix; compare the stem.
+        stem = level.strip().lower().split("-", 1)[0]
+        if stem in _ERROR_LEVELS:
+            return True
+
+    return any(
+        isinstance(payload.get(key), str) and payload[key].strip()  # type: ignore[union-attr]
+        for key in ("error", "err")
+    )
+
+
+def _reason_from_error_record(payload: dict[str, object], *, raw: str) -> str:
+    """Build a retained reason string for a non-aggregate error record.
+
+    Args:
+        payload: A decoded JSON error record from TruffleHog stderr.
+        raw: The original stripped stderr line, used when the record carries
+            no usable reason text.
+
+    Returns:
+        The record's ``error``/``err`` text when present, otherwise the raw
+        line so no diagnostic detail is lost.
+    """
+    for key in ("error", "err"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return raw
 
 
 def _errors_from_payload(payload: dict[str, object]) -> list[str]:

--- a/lintro/parsers/trufflehog/trufflehog_errors.py
+++ b/lintro/parsers/trufflehog/trufflehog_errors.py
@@ -39,8 +39,9 @@ def extract_trufflehog_scan_errors(stderr: str) -> list[str]:
     * The aggregate ``encountered errors during scan`` payload takes
       precedence — its ``errors`` array is expanded so each reason stays
       individually classifiable against the resolved scan set.
-    * Any other error-severity record (``level`` of ``error``/``fatal``/
-      ``panic``, or a non-empty ``error``/``err`` field) is retained.
+    * Any other error-severity record (``level`` of ``error``/``dpanic``/
+      ``panic``/``fatal``, or a non-empty ``error``/``err`` field) is
+      retained.
     * Routine progress records (``running source``, ``finished scanning``, …)
       carry an informational level and no error field, so they are ignored.
 

--- a/lintro/parsers/trufflehog/trufflehog_errors.py
+++ b/lintro/parsers/trufflehog/trufflehog_errors.py
@@ -23,42 +23,48 @@ _MISSING_PATH_RE: re.Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 
-# zap log levels that signal a failure. TruffleHog logs progress as
-# ``info-0``/``debug-N`` and failures as ``error``; ``dpanic``/``panic``/
-# ``fatal`` are zap's escalating fatal levels.
-_ERROR_LEVELS: frozenset[str] = frozenset(
-    {"error", "dpanic", "panic", "fatal"},
+# zap log levels that are routine advisories, never scan incompleteness. A
+# JSON record at one of these levels *with no error field* is progress noise
+# and is dropped; anything else — an error level, an ``error``/``err`` field,
+# or an unrecognised/absent level — is retained so the caller fails closed
+# (unknown means unsafe). ``warn`` is treated as advisory pending evidence
+# that TruffleHog uses it for incompleteness (#1685).
+_BENIGN_LEVELS: frozenset[str] = frozenset(
+    {"info", "debug", "warn"},
 )
 
 
 def extract_trufflehog_scan_errors(stderr: str) -> list[str]:
     """Extract per-path scan error strings from TruffleHog stderr.
 
-    JSON log records are classified by severity, not by message:
+    The classification is deliberately asymmetric toward retention — unknown
+    means unsafe:
 
     * The aggregate ``encountered errors during scan`` payload takes
       precedence — its ``errors`` array is expanded so each reason stays
       individually classifiable against the resolved scan set.
-    * Any other error-severity record (``level`` of ``error``/``dpanic``/
-      ``panic``/``fatal``, or a non-empty ``error``/``err`` field) is
-      retained.
-    * Routine progress records (``running source``, ``finished scanning``, …)
-      carry an informational level and no error field, so they are ignored.
+    * A JSON record positively identified as a routine advisory (an
+      ``info``/``debug``/``warn`` level with no ``error``/``err`` field —
+      ``running source``, ``finished scanning``, …) is dropped as progress
+      noise.
+    * Every other JSON record is retained: error/fatal/panic levels, records
+      carrying an ``error``/``err`` field, and records whose structure we do
+      not recognise at all (no known level). A structurally unknown record is
+      never proven benign, so it is kept.
+    * Every non-JSON line is retained verbatim.
 
-    Every remaining non-empty line is retained verbatim, even when it matches
-    no known error shape. This is deliberate: unknown means unsafe. An
-    unclassified line is never a benign missing path
-    (:func:`is_benign_missing_path_error` returns False for anything that is
-    not an ``lstat``/``stat`` "no such file or directory" reason), so keeping
-    it makes :func:`scan_errors_are_all_benign` return False and the caller
-    fail closed on a possibly incomplete scan (#1044, #1662).
+    A retained line is never a benign missing path unless it is exactly an
+    ``lstat``/``stat`` "no such file or directory" reason
+    (:func:`is_benign_missing_path_error` returns False for everything else),
+    so keeping it makes :func:`scan_errors_are_all_benign` return False and the
+    caller fail closed on a possibly incomplete scan (#1044, #1662).
 
     Args:
         stderr: Raw stderr captured from a TruffleHog run.
 
     Returns:
-        Ordered list of individual error reason strings. Empty when none can
-        be extracted (caller should fail closed — the scan may be incomplete).
+        Ordered list of individual error reason strings. Empty when only
+        routine progress records were present (a clean scan).
     """
     if not stderr or not stderr.strip():
         return []
@@ -87,10 +93,11 @@ def extract_trufflehog_scan_errors(stderr: str) -> list[str]:
             if aggregate:
                 for err in aggregate:
                     _record(err)
-            elif _is_error_record(payload):
-                # An error-severity record that is not the aggregate payload
-                # (or an aggregate with no usable reasons). Keep it so the
-                # caller cannot mistake the batch for a clean scan.
+            elif not _is_benign_progress_record(payload):
+                # Not the aggregate and not a positively-benign advisory: an
+                # error record, a record with an error field, or a structure
+                # we do not recognise. Keep it so the caller cannot mistake
+                # the batch for a clean scan.
                 _record(_reason_from_error_record(payload, raw=stripped))
             continue
 
@@ -105,33 +112,22 @@ def stderr_reports_scan_errors(stderr: str) -> bool:
     """Return whether TruffleHog stderr reports any scan error.
 
     TruffleHog exits 0 either way, so this is the gate that decides whether a
-    batch needs error classification at all. It fires on the aggregate
-    ``encountered errors during scan`` banner *and* on any standalone
-    error-severity JSON record: when an unreadable file is reached through a
-    scanned directory, TruffleHog logs only the standalone record and no
-    aggregate, which would otherwise read as a clean scan (#1662).
-
-    Plain-text stderr is matched on the banner alone, so ordinary non-JSON
-    log noise does not trip the gate.
+    batch needs error classification at all. It is defined as exactly "did
+    extraction retain anything", so the gate and
+    :func:`extract_trufflehog_scan_errors` can never diverge: any line the
+    extractor keeps trips the gate, and a stderr of only routine progress
+    records does not. This covers the aggregate ``encountered errors during
+    scan`` banner, standalone error records emitted without an aggregate (an
+    unreadable file reached through a scanned directory — #1662), and any
+    unclassifiable JSON or plain-text diagnostic.
 
     Args:
         stderr: Raw stderr captured from a TruffleHog run.
 
     Returns:
-        True when the stderr carries at least one scan-error signal.
+        True when the stderr carries at least one line the extractor retains.
     """
-    if not stderr or not stderr.strip():
-        return False
-
-    if "encountered errors during scan" in stderr:
-        return True
-
-    return any(
-        (payload := _json_log_payload(line.strip())) is not None
-        and _is_error_record(payload)
-        for line in stderr.splitlines()
-        if line.strip()
-    )
+    return bool(extract_trufflehog_scan_errors(stderr))
 
 
 def is_benign_missing_path_error(
@@ -221,29 +217,38 @@ def _json_log_payload(line: str) -> dict[str, object] | None:
     return payload if isinstance(payload, dict) else None
 
 
-def _is_error_record(payload: dict[str, object]) -> bool:
-    """Return whether a JSON log record reports an error.
+def _is_benign_progress_record(payload: dict[str, object]) -> bool:
+    """Return whether a JSON log record is a routine advisory, not an error.
 
-    Classification is by severity rather than by message text, so a scan
-    failure logged under any ``msg`` is caught. TruffleHog's zap logger emits
-    ``level`` values such as ``info-0`` for progress and ``error`` for
-    failures, and attaches the underlying reason as an ``error`` field.
+    Classification is by severity, not message text, so a scan failure logged
+    under any ``msg`` is still caught by retaining everything this rejects.
+    TruffleHog's zap logger emits ``level`` values such as ``info-0`` for
+    progress and ``error`` for failures, and attaches the underlying reason as
+    an ``error`` field.
+
+    A record is benign progress only when it is positively recognised as such:
+    an ``info``/``debug``/``warn`` level *and* no ``error``/``err`` field. A
+    record with an error field, an error/fatal/panic level, or an
+    unrecognised/absent level is not benign — the caller retains it so an
+    unknown record fails the scan closed.
 
     Args:
         payload: A decoded JSON log record from TruffleHog stderr.
 
     Returns:
-        True when the record's level is error-like or it carries a non-empty
-        ``error``/``err`` field.
+        True only when the record is a recognised advisory carrying no error.
     """
-    level = payload.get("level")
-    if isinstance(level, str):
-        # ``info-0``/``debug-3`` carry a verbosity suffix; compare the stem.
-        stem = level.strip().lower().split("-", 1)[0]
-        if stem in _ERROR_LEVELS:
-            return True
+    if _error_field_text(payload) is not None:
+        return False
 
-    return _error_field_text(payload) is not None
+    level = payload.get("level")
+    if not isinstance(level, str):
+        # No recognisable level — cannot prove it benign, so it is not.
+        return False
+
+    # ``info-0``/``debug-3`` carry a verbosity suffix; compare the stem.
+    stem = level.strip().lower().split("-", 1)[0]
+    return stem in _BENIGN_LEVELS
 
 
 def _error_field_text(payload: dict[str, object]) -> str | None:

--- a/lintro/tools/definitions/trufflehog.py
+++ b/lintro/tools/definitions/trufflehog.py
@@ -31,6 +31,7 @@ from lintro.models.core.tool_result import ToolResult
 from lintro.parsers.trufflehog.trufflehog_errors import (
     extract_trufflehog_scan_errors,
     scan_errors_are_all_benign,
+    stderr_reports_scan_errors,
 )
 from lintro.parsers.trufflehog.trufflehog_parser import parse_trufflehog_output
 from lintro.plugins.base import BaseToolPlugin
@@ -474,11 +475,12 @@ class TrufflehogPlugin(BaseToolPlugin):
             )
 
         # TruffleHog exits 0 even when it fails to read a scan target (it logs
-        # "encountered errors during scan" to stderr). Fail closed on genuine
-        # incomplete scans (#1044), but ignore benign ``lstat``/``stat``
-        # missing-path errors for targets that were never part of the resolved
-        # scan set — typically CI-only artifact dirs (#1631).
-        if "encountered errors during scan" in stderr:
+        # "encountered errors during scan" to stderr, and/or a standalone
+        # error-severity JSON record). Fail closed on genuine incomplete scans
+        # (#1044), but ignore benign ``lstat``/``stat`` missing-path errors for
+        # targets that were never part of the resolved scan set — typically
+        # CI-only artifact dirs (#1631).
+        if stderr_reports_scan_errors(stderr):
             scan_errors = extract_trufflehog_scan_errors(stderr)
             scan_path_set = frozenset(source_paths)
             if scan_errors_are_all_benign(scan_errors, scan_paths=scan_path_set):

--- a/tests/unit/parsers/trufflehog_parser/test_scan_errors.py
+++ b/tests/unit/parsers/trufflehog_parser/test_scan_errors.py
@@ -43,11 +43,88 @@ def test_extract_errors_from_plain_lstat_lines() -> None:
     )
 
 
-def test_extract_errors_empty_when_banner_has_no_details() -> None:
-    """A bare scan-error banner without reasons yields an empty list."""
+def test_extract_retains_unclassifiable_banner_line() -> None:
+    """A plain-text banner without reasons is retained so callers fail closed."""
     stderr = "level=error msg=encountered errors during scan"
 
-    assert_that(extract_trufflehog_scan_errors(stderr)).is_empty()
+    errors = extract_trufflehog_scan_errors(stderr)
+
+    assert_that(errors).is_equal_to([stderr])
+    assert_that(
+        scan_errors_are_all_benign(errors, scan_paths={"/repo/src/a.py"}),
+    ).is_false()
+
+
+def test_extract_returns_empty_for_blank_stderr() -> None:
+    """Whitespace-only stderr yields nothing, which the caller treats as unsafe."""
+    errors = extract_trufflehog_scan_errors("   \n\t\n")
+
+    assert_that(errors).is_empty()
+    assert_that(
+        scan_errors_are_all_benign(errors, scan_paths={"/repo/src/a.py"}),
+    ).is_false()
+
+
+def test_extract_retains_unclassified_line_alongside_benign_one() -> None:
+    """An unrecognised error must survive next to a benign missing-path error."""
+    stderr = (
+        "lstat /ci/coverage: no such file or directory\n"
+        "failed to open archive /repo/src/big.zip: unexpected EOF\n"
+    )
+
+    errors = extract_trufflehog_scan_errors(stderr)
+
+    assert_that(errors).is_equal_to(
+        [
+            "lstat /ci/coverage: no such file or directory",
+            "failed to open archive /repo/src/big.zip: unexpected EOF",
+        ],
+    )
+    assert_that(
+        scan_errors_are_all_benign(errors, scan_paths={"/repo/src/a.py"}),
+    ).is_false()
+
+
+def test_extract_deduplicates_repeated_unclassified_lines() -> None:
+    """Repeated unclassified lines are recorded once."""
+    stderr = "weird failure\nweird failure\n"
+
+    assert_that(extract_trufflehog_scan_errors(stderr)).is_equal_to(
+        ["weird failure"],
+    )
+
+
+def test_extract_ignores_routine_json_log_records() -> None:
+    """Non-error JSON log records are progress noise, not scan errors."""
+    stderr = (
+        '{"level":"info-0","msg":"running source","source_manager_worker_id":"x"}\n'
+        '{"level":"error","msg":"encountered errors during scan",'
+        '"errors":["lstat /ci/coverage: no such file or directory"]}\n'
+        '{"level":"info-0","msg":"finished scanning","chunks":1}\n'
+    )
+
+    errors = extract_trufflehog_scan_errors(stderr)
+
+    assert_that(errors).is_equal_to(
+        ["lstat /ci/coverage: no such file or directory"],
+    )
+    assert_that(
+        scan_errors_are_all_benign(errors, scan_paths={"/repo/src/a.py"}),
+    ).is_true()
+
+
+def test_plain_text_benign_missing_paths_remain_benign() -> None:
+    """Plain-text stderr of only benign missing paths still passes."""
+    stderr = (
+        "lstat /ci/coverage: no such file or directory\n"
+        "lstat /ci/lighthouse-reports: no such file or directory\n"
+    )
+
+    errors = extract_trufflehog_scan_errors(stderr)
+
+    assert_that(
+        scan_errors_are_all_benign(errors, scan_paths={"/repo/src/a.py"}),
+    ).is_true()
 
 
 def test_benign_missing_path_outside_scan_set() -> None:

--- a/tests/unit/parsers/trufflehog_parser/test_scan_errors.py
+++ b/tests/unit/parsers/trufflehog_parser/test_scan_errors.py
@@ -170,6 +170,47 @@ def test_json_error_record_without_reason_keeps_raw_line() -> None:
     assert_that(extract_trufflehog_scan_errors(record)).is_equal_to([record])
 
 
+@pytest.mark.parametrize(
+    "record",
+    [
+        '{"level":"warn","msg":"detector deprecated"}',
+        '{"level":"debug-2","msg":"chunk emitted","chunks":3}',
+        '{"level":"info-0","msg":"running source"}',
+    ],
+    ids=["warn-advisory", "debug-progress", "info-progress"],
+)
+def test_json_advisory_records_are_dropped(record: str) -> None:
+    """Info/debug/warn records with no error field are routine noise.
+
+    Args:
+        record: A single benign-advisory JSON log record.
+    """
+    assert_that(extract_trufflehog_scan_errors(record)).is_empty()
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        '{"error":"read: broken pipe"}',
+        '{"unexpected":"structure","no":"level"}',
+        '{"level":"trace","msg":"unknown level stem"}',
+    ],
+    ids=["error-field-no-level", "no-level-at-all", "unrecognised-level"],
+)
+def test_unclassifiable_json_records_are_retained(record: str) -> None:
+    """A JSON record we cannot prove benign is kept so the caller fails closed.
+
+    Args:
+        record: A single JSON record with no recognised benign level.
+    """
+    errors = extract_trufflehog_scan_errors(record)
+
+    assert_that(errors).is_length(1)
+    assert_that(
+        scan_errors_are_all_benign(errors, scan_paths={"/repo/src/a.py"}),
+    ).is_false()
+
+
 def test_aggregate_payload_takes_precedence_over_raw_retention() -> None:
     """The aggregate payload expands to reasons rather than the raw line."""
     stderr = (
@@ -204,6 +245,11 @@ def test_aggregate_payload_with_empty_errors_fails_closed() -> None:
             '{"level":"info-0","msg":"finished scanning","chunks":1}',
             False,
         ),
+        (
+            '{"level":"debug-2","msg":"chunk emitted"}\n'
+            '{"level":"warn","msg":"detector deprecated"}',
+            False,
+        ),
         ("level=error msg=encountered errors during scan", True),
         (
             '{"level":"error","msg":"encountered errors during scan","errors":[]}',
@@ -216,20 +262,25 @@ def test_aggregate_payload_with_empty_errors_fails_closed() -> None:
             '{"level":"info-0","msg":"finished scanning"}',
             True,
         ),
-        ("scanning 12 files", False),
+        ('{"error":"read: broken pipe"}', True),
+        ('{"unexpected":"structure","no":"level"}', True),
+        ("scanning 12 files", True),
     ],
     ids=[
         "empty",
         "whitespace",
-        "progress-only",
+        "info-progress-only",
+        "debug-and-warn-advisories-only",
         "plain-text-banner",
         "aggregate-json",
         "standalone-error-record-without-aggregate",
-        "plain-text-noise-does-not-trip-gate",
+        "error-field-without-level",
+        "unrecognised-json-structure",
+        "unclassifiable-plain-text-trips-gate",
     ],
 )
 def test_stderr_reports_scan_errors(stderr: str, expected: bool) -> None:
-    """The plugin gate fires on aggregate banners and standalone error records.
+    """The gate mirrors extraction exactly: retained lines trip it, noise does not.
 
     Args:
         stderr: Raw stderr captured from a TruffleHog run.

--- a/tests/unit/parsers/trufflehog_parser/test_scan_errors.py
+++ b/tests/unit/parsers/trufflehog_parser/test_scan_errors.py
@@ -11,6 +11,7 @@ from lintro.parsers.trufflehog.trufflehog_errors import (
     extract_trufflehog_scan_errors,
     is_benign_missing_path_error,
     scan_errors_are_all_benign,
+    stderr_reports_scan_errors,
 )
 
 
@@ -111,6 +112,130 @@ def test_extract_ignores_routine_json_log_records() -> None:
     assert_that(
         scan_errors_are_all_benign(errors, scan_paths={"/repo/src/a.py"}),
     ).is_true()
+
+
+def test_json_error_record_beside_benign_aggregate_is_retained() -> None:
+    """A separate JSON error record must not be lost behind a benign aggregate.
+
+    This is the exact shape TruffleHog emits when one target is unreadable and
+    another is a missing CI-only path: an ``error``-level record carrying an
+    ``error`` field, plus the aggregate payload.
+    """
+    stderr = (
+        '{"level":"info-0","msg":"running source"}\n'
+        '{"level":"error","msg":"error scanning file","path":"/repo/secret.txt",'
+        '"error":"unable to open file: open /repo/secret.txt: permission denied"}\n'
+        '{"level":"error","msg":"encountered errors during scan",'
+        '"errors":["lstat /ci/coverage: no such file or directory"]}\n'
+    )
+
+    errors = extract_trufflehog_scan_errors(stderr)
+
+    assert_that(errors).contains(
+        "unable to open file: open /repo/secret.txt: permission denied",
+    )
+    assert_that(
+        scan_errors_are_all_benign(errors, scan_paths={"/repo/src/a.py"}),
+    ).is_false()
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        '{"level":"error","msg":"failed to open archive","path":"/repo/x.zip"}',
+        '{"level":"fatal","msg":"scanner aborted"}',
+        '{"level":"panic","msg":"boom"}',
+        '{"level":"info-0","msg":"chunk skipped","error":"read: broken pipe"}',
+    ],
+    ids=["error-level", "fatal-level", "panic-level", "info-with-error-field"],
+)
+def test_json_error_records_are_retained(record: str) -> None:
+    """Error-severity JSON records are retained regardless of their message.
+
+    Args:
+        record: A single JSON log record that signals a failure.
+    """
+    errors = extract_trufflehog_scan_errors(record)
+
+    assert_that(errors).is_length(1)
+    assert_that(
+        scan_errors_are_all_benign(errors, scan_paths={"/repo/src/a.py"}),
+    ).is_false()
+
+
+def test_json_error_record_without_reason_keeps_raw_line() -> None:
+    """An error record with no reason text retains the raw line verbatim."""
+    record = '{"level":"error","msg":"failed to open archive","path":"/repo/x.zip"}'
+
+    assert_that(extract_trufflehog_scan_errors(record)).is_equal_to([record])
+
+
+def test_aggregate_payload_takes_precedence_over_raw_retention() -> None:
+    """The aggregate payload expands to reasons rather than the raw line."""
+    stderr = (
+        '{"level":"error","msg":"encountered errors during scan",'
+        '"errors":["lstat /ci/coverage: no such file or directory"]}'
+    )
+
+    assert_that(extract_trufflehog_scan_errors(stderr)).is_equal_to(
+        ["lstat /ci/coverage: no such file or directory"],
+    )
+
+
+def test_aggregate_payload_with_empty_errors_fails_closed() -> None:
+    """An aggregate payload with no usable reasons is still retained."""
+    stderr = '{"level":"error","msg":"encountered errors during scan","errors":[]}'
+
+    errors = extract_trufflehog_scan_errors(stderr)
+
+    assert_that(errors).is_equal_to([stderr])
+    assert_that(
+        scan_errors_are_all_benign(errors, scan_paths={"/repo/src/a.py"}),
+    ).is_false()
+
+
+@pytest.mark.parametrize(
+    ("stderr", "expected"),
+    [
+        ("", False),
+        ("   \n\t", False),
+        (
+            '{"level":"info-0","msg":"running source"}\n'
+            '{"level":"info-0","msg":"finished scanning","chunks":1}',
+            False,
+        ),
+        ("level=error msg=encountered errors during scan", True),
+        (
+            '{"level":"error","msg":"encountered errors during scan","errors":[]}',
+            True,
+        ),
+        (
+            '{"level":"info-0","msg":"running source"}\n'
+            '{"level":"error","msg":"error scanning file",'
+            '"error":"unable to open file: open /repo/x: permission denied"}\n'
+            '{"level":"info-0","msg":"finished scanning"}',
+            True,
+        ),
+        ("scanning 12 files", False),
+    ],
+    ids=[
+        "empty",
+        "whitespace",
+        "progress-only",
+        "plain-text-banner",
+        "aggregate-json",
+        "standalone-error-record-without-aggregate",
+        "plain-text-noise-does-not-trip-gate",
+    ],
+)
+def test_stderr_reports_scan_errors(stderr: str, expected: bool) -> None:
+    """The plugin gate fires on aggregate banners and standalone error records.
+
+    Args:
+        stderr: Raw stderr captured from a TruffleHog run.
+        expected: Whether the gate should engage error classification.
+    """
+    assert_that(stderr_reports_scan_errors(stderr)).is_equal_to(expected)
 
 
 def test_plain_text_benign_missing_paths_remain_benign() -> None:

--- a/tests/unit/tools/trufflehog/conftest.py
+++ b/tests/unit/tools/trufflehog/conftest.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 from collections.abc import Generator
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from lintro.models.core.tool_result import ToolResult
 from lintro.plugins.subprocess_executor import SubprocessResult
 from lintro.tools.definitions.trufflehog import TrufflehogPlugin
 
@@ -48,6 +50,41 @@ def make_subprocess_result(
         stderr=stderr,
         output=(stdout + stderr),
     )
+
+
+def run_check_with_stderr(
+    *,
+    plugin: TrufflehogPlugin,
+    tmp_path: Path,
+    stderr: str,
+    stdout: str = "",
+    returncode: int = 0,
+) -> ToolResult:
+    """Run a check over one throwaway module with a canned subprocess result.
+
+    Args:
+        plugin: The plugin under test.
+        tmp_path: Temporary directory to hold the scanned module.
+        stderr: Captured standard error to feed the plugin.
+        stdout: Captured standard output to feed the plugin.
+        returncode: Process exit code to feed the plugin.
+
+    Returns:
+        The ToolResult produced by the check.
+    """
+    test_file = tmp_path / "module.py"
+    test_file.write_text('"""Module."""\n')
+
+    with patch.object(
+        plugin,
+        "_run_subprocess_result",
+        return_value=make_subprocess_result(
+            stdout=stdout,
+            stderr=stderr,
+            returncode=returncode,
+        ),
+    ):
+        return plugin.check([str(test_file)], {})
 
 
 def sample_finding_line(*, file: str, line: int = 8, verified: bool = False) -> str:

--- a/tests/unit/tools/trufflehog/conftest.py
+++ b/tests/unit/tools/trufflehog/conftest.py
@@ -59,6 +59,7 @@ def run_check_with_stderr(
     stderr: str,
     stdout: str = "",
     returncode: int = 0,
+    scan_path: Path | None = None,
 ) -> ToolResult:
     """Run a check over one throwaway module with a canned subprocess result.
 
@@ -68,12 +69,16 @@ def run_check_with_stderr(
         stderr: Captured standard error to feed the plugin.
         stdout: Captured standard output to feed the plugin.
         returncode: Process exit code to feed the plugin.
+        scan_path: File to scan. When omitted, a throwaway ``module.py`` is
+            created under ``tmp_path``. Pass this when the stderr payload
+            references the scanned path so the two stay coupled.
 
     Returns:
         The ToolResult produced by the check.
     """
-    test_file = tmp_path / "module.py"
-    test_file.write_text('"""Module."""\n')
+    if scan_path is None:
+        scan_path = tmp_path / "module.py"
+        scan_path.write_text('"""Module."""\n')
 
     with patch.object(
         plugin,
@@ -84,7 +89,7 @@ def run_check_with_stderr(
             returncode=returncode,
         ),
     ):
-        return plugin.check([str(test_file)], {})
+        return plugin.check([str(scan_path)], {})
 
 
 def sample_finding_line(*, file: str, line: int = 8, verified: bool = False) -> str:

--- a/tests/unit/tools/trufflehog/test_execution.py
+++ b/tests/unit/tools/trufflehog/test_execution.py
@@ -216,6 +216,65 @@ def test_check_benign_missing_path_scan_error_passes(
     assert_that(result.parse_failures_count in (0, None)).is_true()
 
 
+def test_check_realistic_json_log_stream_with_benign_error_passes(
+    trufflehog_plugin: TrufflehogPlugin,
+    tmp_path: Path,
+) -> None:
+    """Routine JSON progress logs must not turn a benign scan into a failure.
+
+    Args:
+        trufflehog_plugin: The plugin under test.
+        tmp_path: Temporary directory path.
+    """
+    test_file = tmp_path / "module.py"
+    test_file.write_text('"""Module."""\n')
+
+    stderr = (
+        '{"level":"info-0","msg":"running source","source_manager_worker_id":"x"}\n'
+        '{"level":"error","msg":"encountered errors during scan","job":1,'
+        '"errors":["lstat /nope/coverage: no such file or directory"]}\n'
+        '{"level":"info-0","msg":"finished scanning","chunks":1,"bytes":3}\n'
+    )
+    with patch.object(
+        trufflehog_plugin,
+        "_run_subprocess_result",
+        return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
+    ):
+        result = trufflehog_plugin.check([str(test_file)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+
+
+def test_check_unclassified_error_beside_benign_one_fails(
+    trufflehog_plugin: TrufflehogPlugin,
+    tmp_path: Path,
+) -> None:
+    """An unrecognised diagnostic must fail closed even next to benign noise.
+
+    Args:
+        trufflehog_plugin: The plugin under test.
+        tmp_path: Temporary directory path.
+    """
+    test_file = tmp_path / "module.py"
+    test_file.write_text('"""Module."""\n')
+
+    stderr = (
+        '{"level":"error","msg":"encountered errors during scan",'
+        '"errors":["lstat /nope/coverage: no such file or directory"]}\n'
+        "failed to open archive /repo/src/big.zip: unexpected EOF\n"
+    )
+    with patch.object(
+        trufflehog_plugin,
+        "_run_subprocess_result",
+        return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
+    ):
+        result = trufflehog_plugin.check([str(test_file)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.parse_failures_count).is_equal_to(1)
+
+
 def test_check_permission_denied_scan_error_fails(
     trufflehog_plugin: TrufflehogPlugin,
     tmp_path: Path,

--- a/tests/unit/tools/trufflehog/test_execution.py
+++ b/tests/unit/tools/trufflehog/test_execution.py
@@ -246,6 +246,73 @@ def test_check_realistic_json_log_stream_with_benign_error_passes(
     assert_that(result.issues_count).is_equal_to(0)
 
 
+def test_check_standalone_error_record_without_aggregate_fails(
+    trufflehog_plugin: TrufflehogPlugin,
+    tmp_path: Path,
+) -> None:
+    """An unreadable target logged without an aggregate must still fail closed.
+
+    This is the stderr TruffleHog emits when the unreadable file is reached
+    through a scanned directory: a standalone error record and no
+    ``encountered errors during scan`` banner at all.
+
+    Args:
+        trufflehog_plugin: The plugin under test.
+        tmp_path: Temporary directory path.
+    """
+    test_file = tmp_path / "module.py"
+    test_file.write_text('"""Module."""\n')
+
+    stderr = (
+        '{"level":"info-0","msg":"running source","with_units":true}\n'
+        '{"level":"error","msg":"error scanning file","unit_kind":"unit",'
+        '"path":"/nope/locked.py",'
+        '"error":"unable to open file: open /nope/locked.py: permission denied"}\n'
+        '{"level":"info-0","msg":"finished scanning","chunks":1}\n'
+    )
+    with patch.object(
+        trufflehog_plugin,
+        "_run_subprocess_result",
+        return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
+    ):
+        result = trufflehog_plugin.check([str(test_file)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.parse_failures_count).is_equal_to(1)
+
+
+def test_check_json_error_record_beside_benign_aggregate_fails(
+    trufflehog_plugin: TrufflehogPlugin,
+    tmp_path: Path,
+) -> None:
+    """A JSON error record must fail the batch despite a benign aggregate.
+
+    Args:
+        trufflehog_plugin: The plugin under test.
+        tmp_path: Temporary directory path.
+    """
+    test_file = tmp_path / "module.py"
+    test_file.write_text('"""Module."""\n')
+
+    stderr = (
+        '{"level":"info-0","msg":"running source"}\n'
+        '{"level":"error","msg":"error scanning file","path":"/nope/secret.txt",'
+        '"error":"unable to open file: open /nope/secret.txt: permission denied"}\n'
+        '{"level":"error","msg":"encountered errors during scan",'
+        '"errors":["lstat /nope/coverage: no such file or directory"]}\n'
+        '{"level":"info-0","msg":"finished scanning","chunks":1}\n'
+    )
+    with patch.object(
+        trufflehog_plugin,
+        "_run_subprocess_result",
+        return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
+    ):
+        result = trufflehog_plugin.check([str(test_file)], {})
+
+    assert_that(result.success).is_false()
+    assert_that(result.parse_failures_count).is_equal_to(1)
+
+
 def test_check_unclassified_error_beside_benign_one_fails(
     trufflehog_plugin: TrufflehogPlugin,
     tmp_path: Path,

--- a/tests/unit/tools/trufflehog/test_execution.py
+++ b/tests/unit/tools/trufflehog/test_execution.py
@@ -12,6 +12,7 @@ from lintro.plugins.base import ExecutionContext
 from lintro.tools.definitions.trufflehog import TrufflehogPlugin
 from tests.unit.tools.trufflehog.conftest import (
     make_subprocess_result,
+    run_check_with_stderr,
     sample_finding_line,
 )
 
@@ -195,20 +196,16 @@ def test_check_benign_missing_path_scan_error_passes(
         trufflehog_plugin: The plugin under test.
         tmp_path: Temporary directory path.
     """
-    test_file = tmp_path / "module.py"
-    test_file.write_text('"""Module."""\n')
-
     stderr = (
         '{"level":"error","msg":"encountered errors during scan",'
         '"errors":["lstat /nope/coverage: no such file or directory",'
         '"lstat /nope/lighthouse-reports: no such file or directory"]}'
     )
-    with patch.object(
-        trufflehog_plugin,
-        "_run_subprocess_result",
-        return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
-    ):
-        result = trufflehog_plugin.check([str(test_file)], {})
+    result = run_check_with_stderr(
+        plugin=trufflehog_plugin,
+        tmp_path=tmp_path,
+        stderr=stderr,
+    )
 
     assert_that(result.success).is_true()
     assert_that(result.issues_count).is_equal_to(0)
@@ -226,21 +223,17 @@ def test_check_realistic_json_log_stream_with_benign_error_passes(
         trufflehog_plugin: The plugin under test.
         tmp_path: Temporary directory path.
     """
-    test_file = tmp_path / "module.py"
-    test_file.write_text('"""Module."""\n')
-
     stderr = (
         '{"level":"info-0","msg":"running source","source_manager_worker_id":"x"}\n'
         '{"level":"error","msg":"encountered errors during scan","job":1,'
         '"errors":["lstat /nope/coverage: no such file or directory"]}\n'
         '{"level":"info-0","msg":"finished scanning","chunks":1,"bytes":3}\n'
     )
-    with patch.object(
-        trufflehog_plugin,
-        "_run_subprocess_result",
-        return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
-    ):
-        result = trufflehog_plugin.check([str(test_file)], {})
+    result = run_check_with_stderr(
+        plugin=trufflehog_plugin,
+        tmp_path=tmp_path,
+        stderr=stderr,
+    )
 
     assert_that(result.success).is_true()
     assert_that(result.issues_count).is_equal_to(0)
@@ -260,9 +253,6 @@ def test_check_standalone_error_record_without_aggregate_fails(
         trufflehog_plugin: The plugin under test.
         tmp_path: Temporary directory path.
     """
-    test_file = tmp_path / "module.py"
-    test_file.write_text('"""Module."""\n')
-
     stderr = (
         '{"level":"info-0","msg":"running source","with_units":true}\n'
         '{"level":"error","msg":"error scanning file","unit_kind":"unit",'
@@ -270,12 +260,11 @@ def test_check_standalone_error_record_without_aggregate_fails(
         '"error":"unable to open file: open /nope/locked.py: permission denied"}\n'
         '{"level":"info-0","msg":"finished scanning","chunks":1}\n'
     )
-    with patch.object(
-        trufflehog_plugin,
-        "_run_subprocess_result",
-        return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
-    ):
-        result = trufflehog_plugin.check([str(test_file)], {})
+    result = run_check_with_stderr(
+        plugin=trufflehog_plugin,
+        tmp_path=tmp_path,
+        stderr=stderr,
+    )
 
     assert_that(result.success).is_false()
     assert_that(result.parse_failures_count).is_equal_to(1)
@@ -291,9 +280,6 @@ def test_check_json_error_record_beside_benign_aggregate_fails(
         trufflehog_plugin: The plugin under test.
         tmp_path: Temporary directory path.
     """
-    test_file = tmp_path / "module.py"
-    test_file.write_text('"""Module."""\n')
-
     stderr = (
         '{"level":"info-0","msg":"running source"}\n'
         '{"level":"error","msg":"error scanning file","path":"/nope/secret.txt",'
@@ -302,12 +288,11 @@ def test_check_json_error_record_beside_benign_aggregate_fails(
         '"errors":["lstat /nope/coverage: no such file or directory"]}\n'
         '{"level":"info-0","msg":"finished scanning","chunks":1}\n'
     )
-    with patch.object(
-        trufflehog_plugin,
-        "_run_subprocess_result",
-        return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
-    ):
-        result = trufflehog_plugin.check([str(test_file)], {})
+    result = run_check_with_stderr(
+        plugin=trufflehog_plugin,
+        tmp_path=tmp_path,
+        stderr=stderr,
+    )
 
     assert_that(result.success).is_false()
     assert_that(result.parse_failures_count).is_equal_to(1)
@@ -323,20 +308,16 @@ def test_check_unclassified_error_beside_benign_one_fails(
         trufflehog_plugin: The plugin under test.
         tmp_path: Temporary directory path.
     """
-    test_file = tmp_path / "module.py"
-    test_file.write_text('"""Module."""\n')
-
     stderr = (
         '{"level":"error","msg":"encountered errors during scan",'
         '"errors":["lstat /nope/coverage: no such file or directory"]}\n'
         "failed to open archive /repo/src/big.zip: unexpected EOF\n"
     )
-    with patch.object(
-        trufflehog_plugin,
-        "_run_subprocess_result",
-        return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
-    ):
-        result = trufflehog_plugin.check([str(test_file)], {})
+    result = run_check_with_stderr(
+        plugin=trufflehog_plugin,
+        tmp_path=tmp_path,
+        stderr=stderr,
+    )
 
     assert_that(result.success).is_false()
     assert_that(result.parse_failures_count).is_equal_to(1)
@@ -352,19 +333,15 @@ def test_check_permission_denied_scan_error_fails(
         trufflehog_plugin: The plugin under test.
         tmp_path: Temporary directory path.
     """
-    test_file = tmp_path / "module.py"
-    test_file.write_text('"""Module."""\n')
-
     stderr = (
         '{"level":"error","msg":"encountered errors during scan",'
         '"errors":["open /secret: permission denied"]}'
     )
-    with patch.object(
-        trufflehog_plugin,
-        "_run_subprocess_result",
-        return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
-    ):
-        result = trufflehog_plugin.check([str(test_file)], {})
+    result = run_check_with_stderr(
+        plugin=trufflehog_plugin,
+        tmp_path=tmp_path,
+        stderr=stderr,
+    )
 
     assert_that(result.success).is_false()
     assert_that(result.parse_failures_count).is_equal_to(1)
@@ -388,12 +365,11 @@ def test_check_missing_scan_set_path_fails(
         '{"level":"error","msg":"encountered errors during scan",'
         '"errors":["lstat ' + resolved + ': no such file or directory"]}'
     )
-    with patch.object(
-        trufflehog_plugin,
-        "_run_subprocess_result",
-        return_value=make_subprocess_result(stdout="", stderr=stderr, returncode=0),
-    ):
-        result = trufflehog_plugin.check([str(test_file)], {})
+    result = run_check_with_stderr(
+        plugin=trufflehog_plugin,
+        tmp_path=tmp_path,
+        stderr=stderr,
+    )
 
     assert_that(result.success).is_false()
     assert_that(result.parse_failures_count).is_equal_to(1)

--- a/tests/unit/tools/trufflehog/test_execution.py
+++ b/tests/unit/tools/trufflehog/test_execution.py
@@ -369,6 +369,7 @@ def test_check_missing_scan_set_path_fails(
         plugin=trufflehog_plugin,
         tmp_path=tmp_path,
         stderr=stderr,
+        scan_path=test_file,
     )
 
     assert_that(result.success).is_false()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(trufflehog): fail closed when scan errors cannot be classified
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`extract_trufflehog_scan_errors()` silently discarded every stderr line it could not
classify. A genuine scan error emitted alongside a benign missing-path error therefore
vanished, `scan_errors_are_all_benign()` saw only the benign subset and returned `True`,
and `TrufflehogPlugin._run_batch` reported a clean pass on an incomplete scan — a
fail-open in a secret scanner.

Now every unclassifiable plain-text stderr line is retained verbatim (still deduped).
No new classification logic and no widening of `_MISSING_PATH_RE`: the correctness
property is **unknown means unsafe**. `is_benign_missing_path_error()` already returns
`False` for anything that is not an `lstat`/`stat` "no such file or directory" reason,
so retaining an unrecognized line is sufficient to make the caller fail closed.

Structured JSON log records keep their existing treatment. The `errors` array of a
scan-error payload stays authoritative, and routine JSON progress records
(`running source`, `finished scanning`) stay ignored. This matters in practice: lintro
runs `trufflehog --json`, whose stderr is *entirely* JSON lines, so retaining
non-scan-error JSON records would have failed every benign run and regressed #1631.
The extra retention applies only to genuinely unstructured (plain-text / logfmt) lines,
which is exactly the branch the issue identified.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1662

## Details

Reproduction from the issue now behaves correctly:

```
['time=... msg="encountered errors during scan" errors=[]',
 'lstat /repo/coverage: no such file or directory',
 'failed to open archive /repo/src/big.zip: unexpected EOF']
False
```

### Tests

`tests/unit/parsers/trufflehog_parser/test_scan_errors.py`

- unclassified line retained alongside a benign missing-path line -> not all benign
- plain-text banner without reasons is retained and fails closed (replaces the old
  "yields an empty list" expectation; caller-visible behaviour is unchanged — it failed
  closed before via the empty-list rule and fails closed now via retention)
- blank/whitespace-only stderr -> `[]`, and `scan_errors_are_all_benign([])` is `False`
- repeated unclassified lines are deduped
- routine JSON progress records ignored; JSON benign payload still all-benign (#1631)
- plain-text stderr of only benign missing paths still all-benign

`tests/unit/tools/trufflehog/test_execution.py`

- realistic full `--json` stderr stream (info + benign scan error + info) still passes
- benign JSON payload plus an unrecognized plain-text diagnostic now fails closed

### Regression checks

- #1631 (benign CI-only artifact dirs tolerated): existing plugin tests pass, plus a new
  realistic JSON-stream test.
- #1044 (genuine incomplete scans fail closed): existing permission-denied /
  missing-scan-set-path / unparseable-banner tests pass.
- Dogfooded: `uv run lintro chk` is green (trufflehog PASS, health 100/100).
