### PR TITLE
fix(output): --output-format csv emits doubled CR on Windows stdout

### DIFF
--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -51,11 +51,11 @@ __all__ = [
 
 
 def _write_stdout_verbatim(payload: str) -> None:
-    """Write ``payload`` to stdout without newline translation.
+    r"""Write ``payload`` to stdout without newline translation.
 
-    The CSV renderer emits RFC 4180 ``\\r\\n`` line terminators. Writing that
-    through the text-mode ``sys.stdout`` wrapper would translate every ``\\n``
-    a second time on Windows, producing ``\\r\\r\\n`` and breaking the
+    The CSV renderer emits RFC 4180 ``\r\n`` line terminators. Writing that
+    through the text-mode ``sys.stdout`` wrapper would translate every ``\n``
+    a second time on Windows, producing ``\r\r\n`` and breaking the
     byte-for-byte equality between the stdout payload and the
     ``--output <file>.csv`` artifact (#1665).
 

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -11,6 +11,7 @@ Supports parallel execution when enabled via configuration.
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, Any
 
 from lintro.enums.action import Action, normalize_action
@@ -47,6 +48,35 @@ __all__ = [
     "DEFAULT_REMAINING_COUNT",
     "run_lint_tools_simple",
 ]
+
+
+def _write_stdout_verbatim(payload: str) -> None:
+    """Write ``payload`` to stdout without newline translation.
+
+    The CSV renderer emits RFC 4180 ``\\r\\n`` line terminators. Writing that
+    through the text-mode ``sys.stdout`` wrapper would translate every ``\\n``
+    a second time on Windows, producing ``\\r\\r\\n`` and breaking the
+    byte-for-byte equality between the stdout payload and the
+    ``--output <file>.csv`` artifact (#1665).
+
+    Writing UTF-8 bytes straight to ``sys.stdout.buffer`` bypasses translation
+    on every platform. Streams without a binary ``buffer`` (for example a
+    ``StringIO`` substituted by a caller) fall back to a plain text write,
+    which is already correct because such streams perform no translation.
+
+    Args:
+        payload: The exact document to emit on stdout.
+    """
+    stream = sys.stdout
+    buffer = getattr(stream, "buffer", None)
+    if buffer is None:
+        stream.write(payload)
+        stream.flush()
+        return
+    # Flush any pending text writes first so byte output stays ordered.
+    stream.flush()
+    buffer.write(payload.encode("utf-8"))
+    buffer.flush()
 
 
 def _get_remaining_count(result: ToolResult) -> int:
@@ -1148,7 +1178,10 @@ def run_lint_tools_simple(
             # routed to stderr so stdout parses with csv.reader.
             from lintro.utils.output.file_writer import render_csv_report
 
-            print(render_csv_report(all_results), end="")
+            # Emitted verbatim as UTF-8 bytes so the csv module's \r\n line
+            # terminators are not translated a second time on Windows and the
+            # payload stays byte-identical to the --output file artifact.
+            _write_stdout_verbatim(render_csv_report(all_results))
         elif output_format.lower() == "markdown":
             # Emit a single clean Markdown report on stdout.
             from lintro.utils.output.file_writer import render_markdown_report

--- a/tests/unit/tools/executor/test_tool_executor.py
+++ b/tests/unit/tools/executor/test_tool_executor.py
@@ -430,11 +430,11 @@ def test_executor_csv_stdout_bytes_match_file_artifact(
     capsysbinary: pytest.CaptureFixture[bytes],
     tmp_path: Path,
 ) -> None:
-    """--output-format csv stdout is byte-identical to the --output artifact.
+    r"""--output-format csv stdout is byte-identical to the --output artifact.
 
-    Regression test for #1665: the csv module emits ``\\r\\n`` terminators and
-    a text-mode stdout would translate every ``\\n`` a second time on Windows,
-    yielding ``\\r\\r\\n``. Assertions are on raw bytes because a decoded-text
+    Regression test for #1665: the csv module emits ``\r\n`` terminators and
+    a text-mode stdout would translate every ``\n`` a second time on Windows,
+    yielding ``\r\r\n``. Assertions are on raw bytes because a decoded-text
     comparison cannot observe the doubled carriage return.
 
     Args:
@@ -512,12 +512,12 @@ def test_executor_csv_stdout_survives_windows_newline_translation(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """--output-format csv does not double carriage returns on Windows stdout.
+    r"""--output-format csv does not double carriage returns on Windows stdout.
 
     Regression test for #1665. POSIX text streams perform no newline
     translation, so a byte comparison on Linux/macOS alone cannot observe the
-    bug. This test substitutes a stdout that translates ``\\n`` to ``\\r\\n``
-    exactly like a Windows console does, which makes the doubled ``\\r\\r\\n``
+    bug. This test substitutes a stdout that translates ``\n`` to ``\r\n``
+    exactly like a Windows console does, which makes the doubled ``\r\r\n``
     reproducible on every platform.
 
     Args:

--- a/tests/unit/tools/executor/test_tool_executor.py
+++ b/tests/unit/tools/executor/test_tool_executor.py
@@ -450,7 +450,18 @@ def test_executor_csv_stdout_bytes_match_file_artifact(
     from lintro.parsers.ruff.ruff_issue import RuffIssue
     from lintro.utils.output.file_writer import write_output_file
 
-    issue = RuffIssue(file="a.py", line=1, column=1, message="unused", code="F401")
+    # A non-ASCII message exercises the explicit UTF-8 encode that the fix
+    # relies on; an ASCII-only payload would pass even if the encoding were
+    # swapped or left to the platform default.
+    non_ascii_message = "unused import café"
+
+    issue = RuffIssue(
+        file="a.py",
+        line=1,
+        column=1,
+        message=non_ascii_message,
+        code="F401",
+    )
 
     def _make_result() -> ToolResult:
         return ToolResult(
@@ -498,6 +509,10 @@ def test_executor_csv_stdout_bytes_match_file_artifact(
     assert_that(artifact_bytes).does_not_contain(b"\r\r")
     # RFC 4180 terminators survive intact.
     assert_that(stdout_bytes).contains(b"\r\n")
+    # The non-ASCII field must go out as UTF-8 on both sides, pinning the
+    # explicit encode rather than any platform-default codec.
+    assert_that(stdout_bytes).contains(non_ascii_message.encode("utf-8"))
+    assert_that(artifact_bytes).contains(non_ascii_message.encode("utf-8"))
     # The payload still round-trips through csv.reader.
     rows = list(_csv.reader(_io.StringIO(stdout_bytes.decode("utf-8"))))
     assert_that(rows[0]).is_equal_to(
@@ -506,6 +521,7 @@ def test_executor_csv_stdout_bytes_match_file_artifact(
     assert_that(rows).is_length(2)
     assert_that(rows[1][0]).is_equal_to("ruff")
     assert_that(rows[1][4]).is_equal_to("F401")
+    assert_that(rows[1][5]).is_equal_to(non_ascii_message)
 
 
 def test_executor_csv_stdout_survives_windows_newline_translation(

--- a/tests/unit/tools/executor/test_tool_executor.py
+++ b/tests/unit/tools/executor/test_tool_executor.py
@@ -425,6 +425,165 @@ def test_executor_csv_stdout_is_clean_and_banners_go_to_stderr(
     assert_that(captured.err).contains("[LINTRO]")
 
 
+def test_executor_csv_stdout_bytes_match_file_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    capsysbinary: pytest.CaptureFixture[bytes],
+    tmp_path: Path,
+) -> None:
+    """--output-format csv stdout is byte-identical to the --output artifact.
+
+    Regression test for #1665: the csv module emits ``\\r\\n`` terminators and
+    a text-mode stdout would translate every ``\\n`` a second time on Windows,
+    yielding ``\\r\\r\\n``. Assertions are on raw bytes because a decoded-text
+    comparison cannot observe the doubled carriage return.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        capsysbinary: Pytest capture fixture yielding raw stdout/stderr bytes.
+        tmp_path: Temporary directory for the CSV artifact.
+    """
+    import csv as _csv
+    import io as _io
+
+    from lintro.enums.action import Action
+    from lintro.enums.output_format import OutputFormat
+    from lintro.parsers.ruff.ruff_issue import RuffIssue
+    from lintro.utils.output.file_writer import write_output_file
+
+    issue = RuffIssue(file="a.py", line=1, column=1, message="unused", code="F401")
+
+    def _make_result() -> ToolResult:
+        return ToolResult(
+            name="ruff",
+            success=False,
+            output="raw",
+            issues_count=1,
+            issues=[issue],
+        )
+
+    _setup_tool_manager(
+        monkeypatch,
+        {"ruff": FakeTool("ruff", can_fix=True, result=_make_result())},
+    )
+    code = run_lint_tools_simple(
+        action="check",
+        paths=["."],
+        tools="all",
+        tool_options=None,
+        exclude=None,
+        include_venv=False,
+        group_by="auto",
+        output_format="csv",
+        verbose=False,
+        raw_output=False,
+    )
+    assert_that(code).is_equal_to(1)
+    stdout_bytes = capsysbinary.readouterr().out
+
+    artifact = tmp_path / "report.csv"
+    write_output_file(
+        output_path=str(artifact),
+        output_format=OutputFormat.CSV,
+        all_results=[_make_result()],
+        action=Action.CHECK,
+        total_issues=1,
+        total_fixed=0,
+    )
+    artifact_bytes = artifact.read_bytes()
+
+    # The stdout payload and the file artifact must not drift apart.
+    assert_that(stdout_bytes).is_equal_to(artifact_bytes)
+    # Neither side may carry a doubled carriage return.
+    assert_that(stdout_bytes).does_not_contain(b"\r\r")
+    assert_that(artifact_bytes).does_not_contain(b"\r\r")
+    # RFC 4180 terminators survive intact.
+    assert_that(stdout_bytes).contains(b"\r\n")
+    # The payload still round-trips through csv.reader.
+    rows = list(_csv.reader(_io.StringIO(stdout_bytes.decode("utf-8"))))
+    assert_that(rows[0]).is_equal_to(
+        ["tool", "issues_count", "file", "line", "code", "message", "doc_url"],
+    )
+    assert_that(rows).is_length(2)
+    assert_that(rows[1][0]).is_equal_to("ruff")
+    assert_that(rows[1][4]).is_equal_to("F401")
+
+
+def test_executor_csv_stdout_survives_windows_newline_translation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """--output-format csv does not double carriage returns on Windows stdout.
+
+    Regression test for #1665. POSIX text streams perform no newline
+    translation, so a byte comparison on Linux/macOS alone cannot observe the
+    bug. This test substitutes a stdout that translates ``\\n`` to ``\\r\\n``
+    exactly like a Windows console does, which makes the doubled ``\\r\\r\\n``
+    reproducible on every platform.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary directory for the CSV artifact.
+    """
+    import io as _io
+    import sys as _sys
+
+    from lintro.enums.action import Action
+    from lintro.enums.output_format import OutputFormat
+    from lintro.parsers.ruff.ruff_issue import RuffIssue
+    from lintro.utils.output.file_writer import write_output_file
+
+    issue = RuffIssue(file="a.py", line=1, column=1, message="unused", code="F401")
+
+    def _make_result() -> ToolResult:
+        return ToolResult(
+            name="ruff",
+            success=False,
+            output="raw",
+            issues_count=1,
+            issues=[issue],
+        )
+
+    _setup_tool_manager(
+        monkeypatch,
+        {"ruff": FakeTool("ruff", can_fix=True, result=_make_result())},
+    )
+    raw_stdout = _io.BytesIO()
+    # newline="\r\n" reproduces the Windows console's text-mode translation.
+    windows_stdout = _io.TextIOWrapper(
+        raw_stdout,
+        encoding="utf-8",
+        newline="\r\n",
+    )
+    monkeypatch.setattr(_sys, "stdout", windows_stdout)
+    run_lint_tools_simple(
+        action="check",
+        paths=["."],
+        tools="all",
+        tool_options=None,
+        exclude=None,
+        include_venv=False,
+        group_by="auto",
+        output_format="csv",
+        verbose=False,
+        raw_output=False,
+    )
+    windows_stdout.flush()
+    stdout_bytes = raw_stdout.getvalue()
+
+    artifact = tmp_path / "report.csv"
+    write_output_file(
+        output_path=str(artifact),
+        output_format=OutputFormat.CSV,
+        all_results=[_make_result()],
+        action=Action.CHECK,
+        total_issues=1,
+        total_fixed=0,
+    )
+
+    assert_that(stdout_bytes).does_not_contain(b"\r\r")
+    assert_that(stdout_bytes).is_equal_to(artifact.read_bytes())
+
+
 def test_executor_markdown_stdout_is_clean_and_banners_go_to_stderr(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(output): --output-format csv emits doubled CR on Windows stdout
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`--output-format csv` printed the rendered CSV document through text-mode
`sys.stdout`:

```python
print(render_csv_report(all_results), end="")
```

`csv.writer` already emits RFC 4180 `\r\n` terminators. On Windows the text
layer translates every `\n` a second time, so each line went out as
`\r\r\n`. It also broke the invariant #1464 introduced: the stdout payload
and the `--output <file>.csv` artifact are supposed to be byte-for-byte
identical, and the file path (`write_text(..., newline="")`) was already
correct.

### Approach chosen: option (a) — write raw bytes to `sys.stdout.buffer`

New `_write_stdout_verbatim()` helper in `lintro/utils/tool_executor.py`
encodes the payload to UTF-8 and writes it straight to `sys.stdout.buffer`,
bypassing newline translation on **every** platform. `lintro/utils/output/file_writer.py`
is untouched, as the issue requires.

Why (a) rather than (b) (`lineterminator="\n"` + dropping `newline=""`):

- (a) makes the two sides emit *the same bytes on every platform*. Under (b)
  the equality would only hold because `write_text(newline=None)` and text
  stdout happen to apply the same `os.linesep` translation — a coincidence of
  two independent translation layers, and one that a POSIX CI run can never
  actually verify.
- (a) keeps the emitted document RFC 4180-conformant (`\r\n` terminators)
  rather than downgrading it to LF-only.
- (a) touches one call site instead of changing the shared renderer's output
  for every consumer.

The helper falls back to a plain text write when the substituted stream has no
binary `buffer` (e.g. a caller-supplied `StringIO`), which is correct because
such streams perform no translation.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1665

## Details

Two regression tests in `tests/unit/tools/executor/test_tool_executor.py`,
both asserting on **raw bytes**:

1. `test_executor_csv_stdout_bytes_match_file_artifact` — `capsysbinary` +
   `tmp_path`. Asserts stdout bytes == artifact bytes, neither contains
   `b"\r\r"`, `b"\r\n"` is present, and the payload still round-trips through
   `csv.reader` with the expected 7-column header and exactly one data row
   (`ruff` / `F401`).
2. `test_executor_csv_stdout_survives_windows_newline_translation` —
   substitutes stdout with `io.TextIOWrapper(BytesIO(), newline="\r\n")`,
   which reproduces the Windows console's translation on any platform. This
   is the test that actually catches the bug: a byte comparison alone passes
   on POSIX because POSIX does no translation at all.

Red/green verified by stashing the fix:

```
E   AssertionError: Expected <b'tool,issues_count,file,line,code,message,doc_url\r\r\n
    ruff,1,a.py,1,F401,unused,\r\r\n'> to not contain item <b'\r\r'>, but did.
====== 1 failed, 2 passed, 17 deselected ======
```

With the fix restored, all 20 tests in the file pass.

Full suite: 7181 passed, 92 skipped. The single local failure
(`test_prepare_execution_version_check_fails_returns_early_result`) is the
known file-discovery quirk for worktrees nested under `.claude/` and is
unrelated to this change — it fails identically on an unmodified tree.
