### PR TITLE
fix(ci): validate MIN_AGE_DAYS floor and TAG_PREFIX in GHCR CI-tag sweep

### DIFF
--- a/scripts/ci/maintenance/sweep-ci-ghcr-tags.sh
+++ b/scripts/ci/maintenance/sweep-ci-ghcr-tags.sh
@@ -53,6 +53,9 @@ Environment:
                  retention window. Only for testing: a shorter window
                  sweeps ci-<run_id> tags of still-running workflows and
                  re-creates the "manifest unknown" failure of #1138.
+                 Taking the bypass logs a ::warning:: so an inherited
+                 value can never waive the guard silently.
+                 ghcr-cleanup.yml never sets it.
   DRY_RUN        When "true", log candidates without deleting (default: false)
 EOF
 	exit 0
@@ -81,12 +84,19 @@ if ! [[ "$min_age_days" =~ ^[0-9]+$ ]]; then
 	exit 2
 fi
 
-if [[ "$min_age_days" -lt "$SAFE_MIN_AGE_DAYS" &&
-	"${ALLOW_SHORT_RETENTION:-false}" != "true" ]]; then
-	echo "MIN_AGE_DAYS=${min_age_days} is below the ${SAFE_MIN_AGE_DAYS}d" \
-		"rerun-retention window (#1138)." >&2
-	echo "Set ALLOW_SHORT_RETENTION=true to override." >&2
-	exit 2
+if [[ "$min_age_days" -lt "$SAFE_MIN_AGE_DAYS" ]]; then
+	if [[ "${ALLOW_SHORT_RETENTION:-false}" != "true" ]]; then
+		echo "MIN_AGE_DAYS=${min_age_days} is below the ${SAFE_MIN_AGE_DAYS}d" \
+			"rerun-retention window (#1138)." >&2
+		echo "Set ALLOW_SHORT_RETENTION=true to override." >&2
+		exit 2
+	fi
+	# Never let an inherited ALLOW_SHORT_RETENTION bypass go unnoticed: an
+	# operator reading the log must see that the #1138 guard was waived.
+	echo "::warning::ALLOW_SHORT_RETENTION=true waives the" \
+		"${SAFE_MIN_AGE_DAYS}d guard; sweeping with" \
+		"MIN_AGE_DAYS=${min_age_days} can delete ci-<run_id> tags of" \
+		"workflows that are still re-runnable (#1138)." >&2
 fi
 
 # TAG_PREFIX is interpolated into the gh api --jq program below (gh has no

--- a/scripts/ci/maintenance/sweep-ci-ghcr-tags.sh
+++ b/scripts/ci/maintenance/sweep-ci-ghcr-tags.sh
@@ -42,8 +42,17 @@ Environment:
   ORG            GHCR org owner (default: lgtm-hq)
   PACKAGES       Space-separated package names
                  (default: "py-lintro py-lintro-base")
-  TAG_PREFIX     Only sweep tags starting with this (default: ci-)
-  MIN_AGE_DAYS   Only delete versions older than N days (default: 91)
+  TAG_PREFIX     Only sweep tags starting with this (default: ci-).
+                 Must match ^[A-Za-z0-9._-]+$ because it is interpolated
+                 into the gh api --jq filter program.
+  MIN_AGE_DAYS   Only delete versions older than N days (default: 91).
+                 Values below 91 are rejected unless ALLOW_SHORT_RETENTION
+                 is "true" (see below).
+  ALLOW_SHORT_RETENTION
+                 When "true", allow MIN_AGE_DAYS below the 91-day rerun-
+                 retention window. Only for testing: a shorter window
+                 sweeps ci-<run_id> tags of still-running workflows and
+                 re-creates the "manifest unknown" failure of #1138.
   DRY_RUN        When "true", log candidates without deleting (default: false)
 EOF
 	exit 0
@@ -57,6 +66,11 @@ min_age_days="${MIN_AGE_DAYS:-91}"
 dry_run="${DRY_RUN:-false}"
 sweep_errors=0
 
+# Actions keeps runs for 90 days from completion; GHCR updated_at reflects the
+# push, so +1 day covers the skew. Sweeping below this window deletes
+# ci-<run_id> tags of runs that can still be partially re-run (#1138).
+readonly SAFE_MIN_AGE_DAYS=91
+
 if [[ -z "$gh_token" ]]; then
 	echo "GH_TOKEN is required" >&2
 	exit 2
@@ -67,8 +81,20 @@ if ! [[ "$min_age_days" =~ ^[0-9]+$ ]]; then
 	exit 2
 fi
 
-if [[ -z "$tag_prefix" ]]; then
-	echo "TAG_PREFIX must be non-empty" >&2
+if [[ "$min_age_days" -lt "$SAFE_MIN_AGE_DAYS" &&
+	"${ALLOW_SHORT_RETENTION:-false}" != "true" ]]; then
+	echo "MIN_AGE_DAYS=${min_age_days} is below the ${SAFE_MIN_AGE_DAYS}d" \
+		"rerun-retention window (#1138)." >&2
+	echo "Set ALLOW_SHORT_RETENTION=true to override." >&2
+	exit 2
+fi
+
+# TAG_PREFIX is interpolated into the gh api --jq program below (gh has no
+# --arg equivalent), so constrain it to characters that cannot terminate the
+# jq string literal or alter the filter's semantics. This also subsumes the
+# previous non-empty check.
+if ! [[ "$tag_prefix" =~ ^[A-Za-z0-9._-]+$ ]]; then
+	echo "TAG_PREFIX must match ^[A-Za-z0-9._-]+\$, got: ${tag_prefix}" >&2
 	exit 2
 fi
 

--- a/tests/scripts/test_docker_ci_scripts.py
+++ b/tests/scripts/test_docker_ci_scripts.py
@@ -460,9 +460,16 @@ def _run_sweep_validation(
     )
 
 
-def test_sweep_ci_ghcr_tags_rejects_short_retention(tmp_path: Path) -> None:
-    """MIN_AGE_DAYS below the 91d rerun window must be rejected (#1138)."""
-    result = _run_sweep_validation(tmp_path, {"MIN_AGE_DAYS": "0"})
+@pytest.mark.parametrize("min_age_days", ["0", "1", "90"])
+def test_sweep_ci_ghcr_tags_rejects_short_retention(
+    tmp_path: Path,
+    min_age_days: str,
+) -> None:
+    """MIN_AGE_DAYS below the 91d rerun window must be rejected (#1138).
+
+    90 pins the boundary so a regressed floor cannot pass unnoticed.
+    """
+    result = _run_sweep_validation(tmp_path, {"MIN_AGE_DAYS": min_age_days})
 
     assert_that(result.returncode).is_equal_to(2)
     assert_that(result.stderr).contains("below the 91d")
@@ -482,9 +489,17 @@ def test_sweep_ci_ghcr_tags_short_retention_override(tmp_path: Path) -> None:
     assert_that(result.stdout).contains("Sweeping ci-* tags older than 0d")
 
 
-def test_sweep_ci_ghcr_tags_accepts_default_floor(tmp_path: Path) -> None:
+def test_sweep_ci_ghcr_tags_accepts_floor_value(tmp_path: Path) -> None:
     """MIN_AGE_DAYS equal to the 91d floor must pass validation."""
     result = _run_sweep_validation(tmp_path, {"MIN_AGE_DAYS": "91"})
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("Sweeping ci-* tags older than 91d")
+
+
+def test_sweep_ci_ghcr_tags_default_min_age_is_the_floor(tmp_path: Path) -> None:
+    """With MIN_AGE_DAYS unset the script must default to the 91d floor."""
+    result = _run_sweep_validation(tmp_path, {})
 
     assert_that(result.returncode).is_equal_to(0)
     assert_that(result.stdout).contains("Sweeping ci-* tags older than 91d")

--- a/tests/scripts/test_docker_ci_scripts.py
+++ b/tests/scripts/test_docker_ci_scripts.py
@@ -429,6 +429,99 @@ def test_sweep_ci_ghcr_tags_validates_min_age_days() -> None:
     assert_that(result.stderr).contains("MIN_AGE_DAYS must be")
 
 
+def _run_sweep_validation(
+    tmp_path: Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Run the GHCR sweep with a no-op ``gh`` stub so no network call happens.
+
+    The stub prints nothing, so any invocation that reaches the sweep body
+    finds no candidate versions and exits 0. Only input validation is
+    exercised.
+
+    Args:
+        tmp_path: Pytest temporary directory for the PATH shim.
+        env: Extra environment variables for the script.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed process.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_stub(bin_dir, "gh", "exit 0")
+    return _run_with_stubs(
+        "scripts/ci/maintenance/sweep-ci-ghcr-tags.sh",
+        bin_dir,
+        {
+            "GH_TOKEN": "dummy",  # nosec B105 - fake token, gh is stubbed
+            "PACKAGES": "py-lintro",
+            **env,
+        },
+    )
+
+
+def test_sweep_ci_ghcr_tags_rejects_short_retention(tmp_path: Path) -> None:
+    """MIN_AGE_DAYS below the 91d rerun window must be rejected (#1138)."""
+    result = _run_sweep_validation(tmp_path, {"MIN_AGE_DAYS": "0"})
+
+    assert_that(result.returncode).is_equal_to(2)
+    assert_that(result.stderr).contains("below the 91d")
+    assert_that(result.stderr).contains("rerun-retention window")
+    assert_that(result.stderr).contains("ALLOW_SHORT_RETENTION=true")
+
+
+def test_sweep_ci_ghcr_tags_short_retention_override(tmp_path: Path) -> None:
+    """ALLOW_SHORT_RETENTION=true must permit a MIN_AGE_DAYS below the floor."""
+    result = _run_sweep_validation(
+        tmp_path,
+        {"MIN_AGE_DAYS": "0", "ALLOW_SHORT_RETENTION": "true"},
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stderr).does_not_contain("rerun-retention window")
+    assert_that(result.stdout).contains("Sweeping ci-* tags older than 0d")
+
+
+def test_sweep_ci_ghcr_tags_accepts_default_floor(tmp_path: Path) -> None:
+    """MIN_AGE_DAYS equal to the 91d floor must pass validation."""
+    result = _run_sweep_validation(tmp_path, {"MIN_AGE_DAYS": "91"})
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("Sweeping ci-* tags older than 91d")
+
+
+@pytest.mark.parametrize(
+    "tag_prefix",
+    [
+        'ci-" or true or "',
+        "ci-$(id)",
+        "ci-*",
+        "ci with space",
+    ],
+)
+def test_sweep_ci_ghcr_tags_rejects_unsafe_tag_prefix(
+    tmp_path: Path,
+    tag_prefix: str,
+) -> None:
+    """TAG_PREFIX is interpolated into jq, so unsafe characters must fail."""
+    result = _run_sweep_validation(tmp_path, {"TAG_PREFIX": tag_prefix})
+
+    assert_that(result.returncode).is_equal_to(2)
+    assert_that(result.stderr).contains("TAG_PREFIX must match")
+
+
+@pytest.mark.parametrize("tag_prefix", ["ci-", "ci", "ci.1_0-x"])
+def test_sweep_ci_ghcr_tags_accepts_safe_tag_prefix(
+    tmp_path: Path,
+    tag_prefix: str,
+) -> None:
+    """A TAG_PREFIX within the allowed character class must pass validation."""
+    result = _run_sweep_validation(tmp_path, {"TAG_PREFIX": tag_prefix})
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains(f"Sweeping {tag_prefix}* tags")
+
+
 def test_sweep_ci_ghcr_tags_deletes_ci_only_versions(
     tmp_path: Path,
 ) -> None:
@@ -465,6 +558,7 @@ def test_sweep_ci_ghcr_tags_deletes_ci_only_versions(
             "GH_TOKEN": "dummy",  # nosec B105 - fake token for stubbed gh
             "PACKAGES": "py-lintro",
             "MIN_AGE_DAYS": "0",
+            "ALLOW_SHORT_RETENTION": "true",
             "GH_LOG": str(gh_log),
             # id\\tupdated_at\\ttags (jq filtering is stubbed).
             "GH_VERSIONS_TSV": (
@@ -517,6 +611,7 @@ def test_sweep_ci_ghcr_tags_recheck_aborts_on_persistent_tag(
             "GH_TOKEN": "dummy",  # nosec B105 - fake token for stubbed gh
             "PACKAGES": "py-lintro",
             "MIN_AGE_DAYS": "0",
+            "ALLOW_SHORT_RETENTION": "true",
             "GH_LOG": str(gh_log),
             "GH_VERSIONS_TSV": "202\t2026-01-02T00:00:00Z\tci-old",
             # Promotion attached main between snapshot and delete.
@@ -559,6 +654,7 @@ def test_sweep_ci_ghcr_tags_recheck_aborts_on_updated_at_change(
             "GH_TOKEN": "dummy",  # nosec B105 - fake token for stubbed gh
             "PACKAGES": "py-lintro",
             "MIN_AGE_DAYS": "0",
+            "ALLOW_SHORT_RETENTION": "true",
             "GH_LOG": str(gh_log),
             "GH_VERSIONS_TSV": "202\t2026-01-02T00:00:00Z\tci-old",
             "GH_VERSION_STATE": "2026-01-03T00:00:00Z\tci-old",
@@ -589,6 +685,7 @@ def test_sweep_ci_ghcr_tags_fails_on_query_error(
             "GH_TOKEN": "dummy",  # nosec B105 - fake token for stubbed gh
             "PACKAGES": "py-lintro",
             "MIN_AGE_DAYS": "0",
+            "ALLOW_SHORT_RETENTION": "true",
         },
     )
 
@@ -626,6 +723,7 @@ def test_sweep_ci_ghcr_tags_recheck_404_is_benign(
             "GH_TOKEN": "dummy",  # nosec B105 - fake token for stubbed gh
             "PACKAGES": "py-lintro",
             "MIN_AGE_DAYS": "0",
+            "ALLOW_SHORT_RETENTION": "true",
             "GH_LOG": str(gh_log),
             "GH_VERSIONS_TSV": "202\t2026-01-02T00:00:00Z\tci-old",
         },
@@ -662,6 +760,7 @@ def test_sweep_ci_ghcr_tags_recheck_hard_error_fails(
             "GH_TOKEN": "dummy",  # nosec B105 - fake token for stubbed gh
             "PACKAGES": "py-lintro",
             "MIN_AGE_DAYS": "0",
+            "ALLOW_SHORT_RETENTION": "true",
             "GH_VERSIONS_TSV": "202\t2026-01-02T00:00:00Z\tci-old",
         },
     )
@@ -700,6 +799,7 @@ def test_sweep_ci_ghcr_tags_recheck_aborts_on_second_ci_tag(
             "GH_TOKEN": "dummy",  # nosec B105 - fake token for stubbed gh
             "PACKAGES": "py-lintro",
             "MIN_AGE_DAYS": "0",
+            "ALLOW_SHORT_RETENTION": "true",
             "GH_LOG": str(gh_log),
             "GH_VERSIONS_TSV": "202\t2026-01-02T00:00:00Z\tci-old",
             # Concurrent build attached another ci-* tag.
@@ -732,6 +832,7 @@ def test_sweep_ci_ghcr_tags_dry_run_skips_delete(
             "GH_TOKEN": "dummy",  # nosec B105 - fake token for stubbed gh
             "PACKAGES": "py-lintro",
             "MIN_AGE_DAYS": "0",
+            "ALLOW_SHORT_RETENTION": "true",
             "DRY_RUN": "true",
             "GH_LOG": str(gh_log),
             "GH_VERSIONS_TSV": "202\t2026-01-02T00:00:00Z\tci-old",

--- a/tests/scripts/test_docker_ci_scripts.py
+++ b/tests/scripts/test_docker_ci_scripts.py
@@ -439,6 +439,10 @@ def _run_sweep_validation(
     finds no candidate versions and exits 0. Only input validation is
     exercised.
 
+    Sweep-specific variables the caller does not set are blanked rather than
+    inherited, so an ambient ``MIN_AGE_DAYS``/``TAG_PREFIX`` in the developer
+    or CI environment cannot mask the script's own defaults.
+
     Args:
         tmp_path: Pytest temporary directory for the PATH shim.
         env: Extra environment variables for the script.
@@ -449,12 +453,18 @@ def _run_sweep_validation(
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     _write_stub(bin_dir, "gh", "exit 0")
+    scrubbed = {
+        name: ""
+        for name in ("MIN_AGE_DAYS", "TAG_PREFIX", "ALLOW_SHORT_RETENTION", "DRY_RUN")
+        if name not in env
+    }
     return _run_with_stubs(
         "scripts/ci/maintenance/sweep-ci-ghcr-tags.sh",
         bin_dir,
         {
             "GH_TOKEN": "dummy",  # nosec B105 - fake token, gh is stubbed
             "PACKAGES": "py-lintro",
+            **scrubbed,
             **env,
         },
     )
@@ -478,15 +488,17 @@ def test_sweep_ci_ghcr_tags_rejects_short_retention(
 
 
 def test_sweep_ci_ghcr_tags_short_retention_override(tmp_path: Path) -> None:
-    """ALLOW_SHORT_RETENTION=true must permit a MIN_AGE_DAYS below the floor."""
+    """ALLOW_SHORT_RETENTION=true permits a sub-floor MIN_AGE_DAYS, loudly."""
     result = _run_sweep_validation(
         tmp_path,
         {"MIN_AGE_DAYS": "0", "ALLOW_SHORT_RETENTION": "true"},
     )
 
     assert_that(result.returncode).is_equal_to(0)
-    assert_that(result.stderr).does_not_contain("rerun-retention window")
     assert_that(result.stdout).contains("Sweeping ci-* tags older than 0d")
+    # The bypass must never be silent: an inherited value has to be visible.
+    assert_that(result.stderr).contains("::warning::ALLOW_SHORT_RETENTION=true")
+    assert_that(result.stderr).contains("waives the 91d guard")
 
 
 def test_sweep_ci_ghcr_tags_accepts_floor_value(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): validate MIN_AGE_DAYS floor and TAG_PREFIX in GHCR CI-tag sweep
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Two input-validation guards in `scripts/ci/maintenance/sweep-ci-ghcr-tags.sh`.

### 1. `MIN_AGE_DAYS` floor

The script validated the *type* of `MIN_AGE_DAYS` but not its *range*, so `0` passed.
`ghcr-cleanup.yml` wires the `sweep_min_age_days` dispatch input straight through, so a
`workflow_dispatch` with `0` computed `cutoff_epoch = now` and swept `ci-<run_id>` tags
belonging to **currently running** workflows — re-creating the `manifest unknown`
downstream-pull failure this script exists to prevent (#1138). `dry_run` only mitigated
that if the operator remembered to set it.

Added a `SAFE_MIN_AGE_DAYS=91` floor (Actions' 90-day run retention plus one day of
push-vs-completion skew) with an `ALLOW_SHORT_RETENTION=true` escape hatch for tests and
deliberate manual overrides.

### 2. `TAG_PREFIX` character class

`TAG_PREFIX` is interpolated into a jq program (`all(startswith(\"${tag_prefix}\"))`).
`gh api --jq` genuinely has no `--arg` equivalent, so interpolation is the only option
and the input is validated instead: `^[A-Za-z0-9._-]+$`. A value containing a double
quote could otherwise terminate the jq string literal and alter the filter's semantics.
This is hardening, not a live vulnerability — `TAG_PREFIX` is not a `workflow_dispatch`
input and is only settable by a maintainer running the script directly.

The regex subsumes the previous non-empty check, which is removed.

Both guards live in the **script**, not the workflow, so direct and local invocations are
protected too. `ghcr-cleanup.yml` is unchanged.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1666

## Details

**Tests** (`tests/scripts/test_docker_ci_scripts.py`, matching the conventions already in
that file — pytest functions, no classes, assertpy):

- `MIN_AGE_DAYS=0` without the override → exit 2, stderr names the window and the override
- `MIN_AGE_DAYS=0` with `ALLOW_SHORT_RETENTION=true` → passes validation
- `MIN_AGE_DAYS=91` → passes validation
- `TAG_PREFIX` containing a double quote, `$(...)`, `*`, or a space → exit 2
  (parameterized)
- `TAG_PREFIX` in `ci-` / `ci` / `ci.1_0-x` → passes validation (parameterized)

All new cases run against a no-op `gh` PATH stub with a dummy `GH_TOKEN`, so validation is
reached with **no network call** and nothing can be deleted. The eight pre-existing sweep
tests that used `MIN_AGE_DAYS=0` now also set `ALLOW_SHORT_RETENTION=true`.

**Testing strategy notes:** an empty `TAG_PREFIX=""` is not reachable — `${TAG_PREFIX:-ci-}`
substitutes the default for both unset and empty — so the removed non-empty check was
already dead code and there is no test case for it.

**Coordination:** #1652 (residual TOCTOU in the pre-delete recheck) touches the same
script and is deliberately **not** folded in here.
