### PR TITLE
test(ci): throwaway probe for #1667 skip path — DO NOT MERGE

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -66,6 +66,12 @@ on `main` failures — hence the `actions: read` + `issues: write` job permissio
   (`sweep-ci-ghcr-tags.sh`, #1138)
 - **vuln-suppression-check.yml** — Weekly OSV suppression staleness via
   `reusable-vuln-suppression-check.yml`
+- **dependency-vuln-gate.yml** — Pre-merge mirror of the release SBOM vulnerability
+  gate (#1667): same lgtm-ci syft/grype actions, same pin, same `fail-on: high` as
+  `publish-pypi-on-tag.yml`'s `sbom` job, so a lockfile that would break the tagged
+  publish fails on the PR instead. Unfiltered trigger with the scan steps gated
+  *inside* the job (`uv.lock`, `pyproject.toml`, the publish workflow), so the
+  `🔐 Dependency Vulnerability Gate` context always reports and is safe to require
 - **renovate.yml** — Daily dependency updates (lgtm-ci `harden-runner` +
   `secure-checkout`)
 - **lintro-report-scheduled.yml**, **pr-comment-cleanup.yml**,

--- a/.github/workflows/dependency-vuln-gate.yml
+++ b/.github/workflows/dependency-vuln-gate.yml
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Security - Dependency Vulnerability Gate
+
+# Pre-merge mirror of the release SBOM vulnerability gate (#1667).
+#
+# publish-pypi-on-tag.yml runs grype at `fail-on-severity: high` in its `sbom`
+# job, and every publish job depends on it — but that job only ever runs on a
+# version-tag push, i.e. after merge, at a ref whose lockfile can no longer be
+# fixed. #1648 enabled that gate, merged with all required checks green, and
+# then broke the v0.91.26 and v0.91.27 publishes permanently; both versions had
+# to be abandoned. This workflow runs the same scan, at the same threshold,
+# from the same lgtm-ci pin, on the PR that introduces the change.
+#
+# Required-check safety (#1196; see also the header of test-ci.yml). There is
+# deliberately NO `paths:` filter here, and no job-level `if:` on the scan job:
+# a path-filtered workflow never reports its contexts, and a skipped reusable
+# *caller* collapses its nested contexts into a single check named after the
+# caller job — either way a required context is never created and the merge
+# queue waits on it forever. Instead this is a plain (non-reusable) job that
+# always runs and therefore always reports `🔐 Dependency Vulnerability Gate`,
+# with the expensive steps skipped INSIDE the job when the PR touches none of
+# the dependency-resolving paths. That is the same shape docker-ci.yml uses for
+# its required `🔐 Security Audit`, so the context is safe to add to the
+# `checks-py-lintro` ruleset later without re-plumbing anything.
+#
+# Drift safety: `fail-on: high` and the lgtm-ci pin below must stay equal to
+# the ones in publish-pypi-on-tag.yml's `sbom` job — a pre-merge gate that is
+# looser than the release gate manufactures false confidence.
+# tests/unit/test_workflow_wiring.py asserts that equality, so changing one
+# side without the other fails the test suite.
+
+'on':
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: dependency-vuln-gate-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  dependency-vuln-scan:
+    name: 🔐 Dependency Vulnerability Gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      # read: checkout only. Unlike the release gate this job uploads no SARIF
+      # (security-events) and creates no attestation (id-token/attestations) —
+      # it only has to fail the way the release gate fails.
+      contents: read
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          # lgtm-ci egress preset `sbom` (scripts/ci/lib/egress/presets.sh),
+          # minus the sigstore/uploads hosts that only release-asset signing
+          # needs. The anchore hosts serve the syft/grype binaries and the
+          # grype vulnerability database.
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pipelines.actions.githubusercontent.com:443
+            anchore.io:443
+            get.anchore.io:443
+            toolbox-data.anchore.io:443
+            grype.anchore.io:443
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history so dorny can resolve the merge_group base by git;
+          # an unresolvable base fails open (all filters true) and scans.
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect dependency-resolving changes
+        id: changes
+        # Required-check-safe replacement for `on.pull_request.paths` (see the
+        # header): the job always runs, this step decides whether the scan
+        # steps below do. Fails open — an unresolvable diff base reports every
+        # filter true, so infrastructure trouble scans rather than silently
+        # skipping the gate.
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/detect-changes@ee8484ca71db3a2c2c33da6128bbf2330fcd7c88 # v0.59.2
+        with:
+          filters: |
+            # Anything that can change the resolved dependency set the
+            # release gate scans, plus the two workflow files that define
+            # the gate itself (so changes to the gate exercise the gate).
+            deps:
+              - 'uv.lock'
+              - 'pyproject.toml'
+              - '.github/workflows/publish-pypi-on-tag.yml'
+              - '.github/workflows/dependency-vuln-gate.yml'
+      - name: Generate SBOM
+        id: sbom
+        # Same syft action, target and format as the release gate; the
+        # artifact upload is release-only, the PR path just needs the file.
+        if: >-
+          steps.changes.outputs.changes == '' ||
+          fromJSON(steps.changes.outputs.changes).deps
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/generate-sbom@ee8484ca71db3a2c2c33da6128bbf2330fcd7c88 # v0.59.2
+        with:
+          target: .
+          target-type: dir
+          format: cyclonedx-json
+          upload-artifact: 'false'
+          upload-release-assets: 'false'
+      - name: Scan SBOM for vulnerabilities
+        # The gate itself: identical grype action, pin and threshold as the
+        # `sbom` job of publish-pypi-on-tag.yml. Keep `fail-on` in lockstep
+        # with that job (test_workflow_wiring.py enforces it).
+        if: >-
+          steps.changes.outputs.changes == '' ||
+          fromJSON(steps.changes.outputs.changes).deps
+        # yamllint disable-line rule:line-length
+        uses: lgtm-hq/lgtm-ci/.github/actions/scan-vulnerabilities@ee8484ca71db3a2c2c33da6128bbf2330fcd7c88 # v0.59.2
+        with:
+          target: ${{ steps.sbom.outputs.sbom-file }}
+          target-type: sbom
+          fail-on: high
+      - name: Report skipped scan
+        if: >-
+          steps.changes.outputs.changes != '' &&
+          !fromJSON(steps.changes.outputs.changes).deps
+        env:
+          SUMMARY: >-
+            No changes to uv.lock, pyproject.toml or the release publish
+            workflow — the release SBOM vulnerability gate cannot change
+            result for this PR, so the scan was skipped.
+        run: |
+          {
+            echo "### 🔐 Dependency Vulnerability Gate"
+            echo
+            echo "$SUMMARY"
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dependency-vuln-gate.yml
+++ b/.github/workflows/dependency-vuln-gate.yml
@@ -102,7 +102,6 @@ jobs:
               - 'uv.lock'
               - 'pyproject.toml'
               - '.github/workflows/publish-pypi-on-tag.yml'
-              - '.github/workflows/dependency-vuln-gate.yml'
       - name: Generate SBOM
         id: sbom
         # Same syft action, target and format as the release gate; the

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -1227,3 +1227,129 @@ def test_publish_pypi_sbom_fails_on_high_severity() -> None:
     sbom = publish["jobs"]["sbom"]
     assert_that(sbom["with"]).contains_entry({"fail-on-severity": "high"})
     assert_that(sbom["with"].get("scan-vulnerabilities")).is_true()
+
+
+# --- Pre-merge dependency vulnerability gate (#1667) ------------------------
+#
+# The release gate (publish-pypi-on-tag.yml `sbom`) only runs on a version-tag
+# push, so a lockfile that trips grype merges green and breaks the publish at a
+# ref that can no longer be fixed (v0.91.26 / v0.91.27).
+# dependency-vuln-gate.yml runs the same scan pre-merge; these tests pin it to
+# the release gate so the two cannot drift, and pin its required-check-safe
+# shape (#1196).
+
+_VULN_GATE_WORKFLOW = "dependency-vuln-gate.yml"
+_VULN_GATE_JOB = "dependency-vuln-scan"
+_VULN_SCAN_ACTION = "lgtm-hq/lgtm-ci/.github/actions/scan-vulnerabilities"
+_VULN_SBOM_ACTION = "lgtm-hq/lgtm-ci/.github/actions/generate-sbom"
+_VULN_DETECT_ACTION = "lgtm-hq/lgtm-ci/.github/actions/detect-changes"
+
+
+def _vuln_gate_job() -> dict[str, Any]:
+    """Return the pre-merge dependency vulnerability gate job definition.
+
+    Returns:
+        The ``dependency-vuln-scan`` job mapping.
+    """
+    workflow = _load_workflow(name=_VULN_GATE_WORKFLOW)
+    return cast(dict[str, Any], workflow["jobs"][_VULN_GATE_JOB])
+
+
+def _vuln_gate_step(*, uses_prefix: str) -> dict[str, Any]:
+    """Return the first gate step whose ``uses`` starts with ``uses_prefix``.
+
+    Args:
+        uses_prefix: Action reference prefix to match.
+
+    Returns:
+        The matching step mapping.
+    """
+    steps = _vuln_gate_job()["steps"]
+    step = next(step for step in steps if step.get("uses", "").startswith(uses_prefix))
+    return cast(dict[str, Any], step)
+
+
+def test_dependency_vuln_gate_job_exists() -> None:
+    """The pre-merge gate job exists and scans the repo dependency set."""
+    job = _vuln_gate_job()
+    assert_that(job["name"]).contains("Dependency Vulnerability Gate")
+
+    sbom_step = _vuln_gate_step(uses_prefix=_VULN_SBOM_ACTION)
+    assert_that(sbom_step["with"]).contains_entry({"target": "."})
+    assert_that(sbom_step["with"]).contains_entry({"target-type": "dir"})
+
+    scan_step = _vuln_gate_step(uses_prefix=_VULN_SCAN_ACTION)
+    assert_that(scan_step["with"]).contains_entry({"target-type": "sbom"})
+    assert_that(str(scan_step["with"]["target"])).contains("steps.sbom.outputs")
+
+
+def test_dependency_vuln_gate_matches_release_fail_on_threshold() -> None:
+    """Pre-merge threshold must equal the release gate's (#1667).
+
+    A pre-merge scan looser than publish-pypi-on-tag.yml's ``sbom`` job
+    manufactures false confidence, so the threshold is asserted equal to the
+    release gate rather than merely asserted to be ``high``.
+    """
+    publish = _load_workflow(name="publish-pypi-on-tag.yml")
+    release_threshold = publish["jobs"]["sbom"]["with"]["fail-on-severity"]
+
+    scan_step = _vuln_gate_step(uses_prefix=_VULN_SCAN_ACTION)
+
+    assert_that(scan_step["with"]["fail-on"]).is_equal_to(release_threshold)
+
+
+def test_dependency_vuln_gate_shares_release_tooling_ref() -> None:
+    """Gate actions are pinned at the release gate's lgtm-ci tooling-ref."""
+    publish = _load_workflow(name="publish-pypi-on-tag.yml")
+    release_ref = str(publish["jobs"]["sbom"]["with"]["tooling-ref"])
+
+    pinned = [
+        step["uses"]
+        for step in _vuln_gate_job()["steps"]
+        if step.get("uses", "").startswith("lgtm-hq/lgtm-ci/")
+    ]
+
+    assert_that(pinned).is_not_empty()
+    for uses in pinned:
+        assert_that(uses).contains(f"@{release_ref}")
+
+
+def test_dependency_vuln_gate_is_required_check_safe() -> None:
+    """The gate must always report its context (#1196).
+
+    A ``paths:`` filter, or a job-level ``if:``, would stop the context from
+    ever being created — which deadlocks the merge queue the moment the
+    context is added to the ``checks-py-lintro`` ruleset. Path scoping
+    therefore lives on the steps inside the job, not on the trigger or the job.
+    """
+    workflow = _load_workflow(name=_VULN_GATE_WORKFLOW)
+    triggers = workflow["on"]
+
+    assert_that(triggers).contains_key(_GITHUB_PULL_REQUEST_EVENT)
+    assert_that(triggers).contains_key("merge_group")
+    for event in (_GITHUB_PULL_REQUEST_EVENT, "merge_group"):
+        assert_that(triggers[event] or {}).does_not_contain_key("paths")
+        assert_that(triggers[event] or {}).does_not_contain_key("paths-ignore")
+
+    job = _vuln_gate_job()
+    assert_that(job).does_not_contain_key("if")
+    # A skipped reusable *caller* collapses its nested contexts, so the gate
+    # must stay a plain job that always reports its own check run.
+    assert_that(job).does_not_contain_key("uses")
+    assert_that(job).contains_key("runs-on")
+
+    # The expensive steps are the ones that skip.
+    for prefix in (_VULN_SBOM_ACTION, _VULN_SCAN_ACTION):
+        step_if = _normalize_github_expr(_vuln_gate_step(uses_prefix=prefix)["if"])
+        assert_that(step_if).contains("steps.changes.outputs.changes")
+
+
+def test_dependency_vuln_gate_scopes_to_dependency_paths() -> None:
+    """The scan is scoped to files that can change the resolved dep set."""
+    detect_step = _vuln_gate_step(uses_prefix=_VULN_DETECT_ACTION)
+    filters = yaml.safe_load(detect_step["with"]["filters"])
+
+    assert_that(filters).contains_key("deps")
+    assert_that(filters["deps"]).contains("uv.lock")
+    assert_that(filters["deps"]).contains("pyproject.toml")
+    assert_that(filters["deps"]).contains(".github/workflows/publish-pypi-on-tag.yml")


### PR DESCRIPTION
Throwaway draft used only to verify that `🔐 Dependency Vulnerability Gate` reports green (with the scan steps skipped) on a PR that touches none of the dependency paths. Will be closed immediately. Do not merge. Related #1667 / #1675.