### PR TITLE
fix(core): prettier reports PASS when node_modules is absent instead of skipping loudly

### DIFF
--- a/.lintro-config.yaml
+++ b/.lintro-config.yaml
@@ -15,7 +15,10 @@ execution:
   fail_fast: false
   parallel: true
   max_workers: 10 # 1-32, defaults to CPU count if omitted
-  auto_install_deps: true # Auto-install Node.js deps if node_modules missing
+  # Auto-install Node.js deps if node_modules is missing. Applies only to tools
+  # that need a project dependency tree (tsc, vue-tsc, svelte-check, astro-check);
+  # standalone binaries like prettier and oxlint run without node_modules.
+  auto_install_deps: true
   # artifacts: ['sarif', 'json']  # Side-channel outputs alongside primary display
   # Supported: json, csv, markdown, html, sarif, plain
   # SARIF auto-emits in GitHub Actions even without this

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,9 +47,10 @@ The configuration system works in a specific order:
    - `fail_fast`: Whether to stop on first tool failure
    - `parallel`: Whether to run tools in parallel (default: `true`)
    - `max_workers`: Maximum parallel workers, 1-32 (default: CPU count)
-   - `auto_install_deps`: Auto-install Node.js dependencies if missing. Unset by
-     default, in which case Lintro falls back to container auto-detection (enabled
-     inside containers, disabled otherwise)
+   - `auto_install_deps`: Auto-install Node.js dependencies if missing, for the tools
+     that need a project dependency tree (`tsc`, `vue-tsc`, `svelte-check`,
+     `astro-check`). Unset by default, in which case Lintro falls back to container
+     auto-detection (enabled inside containers, disabled otherwise)
 
 2. **Enforce Tier** - Cross-cutting settings injected as CLI flags
    - These settings override native configs via CLI arguments
@@ -308,9 +309,15 @@ lintro check src/ --tools tsc,oxlint --auto-install
 ```
 
 The `--auto-install` flag is available for both `check` and `format` commands. When
-enabled, Lintro will automatically run `bun install` (or `npm install` if bun is
-unavailable) before running Node.js-based tools like tsc, oxlint, oxfmt, prettier, or
-markdownlint-cli2.
+enabled, Lintro runs `bun install` (or `npm install` if bun is unavailable) before
+running the tools that need a project's dependency tree to work: `tsc`, `vue-tsc`,
+`svelte-check` and `astro-check`.
+
+It does **not** apply to standalone Node.js binaries such as `prettier`, `oxlint`,
+`oxfmt`, `stylelint` or `markdownlint-cli2`. Those are invoked from `PATH` (or via
+`bunx`/`npx`) and run fine without a local `node_modules`. When one of them cannot be
+resolved at all, Lintro reports a `⏭️ SKIP` row with the reason instead of a pass —
+installing project dependencies would not have helped.
 
 You can also enable this globally via configuration:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -139,6 +139,28 @@ lintro check --tools ruff,prettier
 
 ---
 
+### Every tool passes with 0 issues
+
+**Cause**: Nothing was actually scanned. The summary table marks such rows with a
+`no files matched` note — a run where every tool carries that note inspected no files at
+all.
+
+**Solution**: Check your exclusions. Exclude patterns from `.lintro-ignore` and the
+built-in defaults are gitignore-style and are interpreted **relative to the project
+root** (the nearest directory containing `.lintro-ignore`, `.lintro-config.yaml`,
+`pyproject.toml`, `package.json` or `.git`). Directories _above_ that root never exclude
+your files, so a checkout living under a path such as `~/build/my-project` is scanned
+normally. Inside the project, verify the paths you passed are not matched by a pattern:
+
+```bash
+lintro check --verbose
+```
+
+A tool that could not run at all is reported separately as a `⏭️ SKIP` row with the
+reason, never as a pass.
+
+---
+
 ### Configuration not being applied
 
 **Cause**: Lintro may not be finding your configuration file.

--- a/lintro/utils/path_filtering.py
+++ b/lintro/utils/path_filtering.py
@@ -86,12 +86,13 @@ def resolve_exclude_anchors(paths: "Sequence[str] | None" = None) -> tuple[str, 
     scan that never happened (#1678).
 
     Args:
-        paths: Input paths for the current scan. Directory inputs — and the
-            project root of any file input — act as fallback anchors for trees
-            outside the current project (temporary directories, sibling
-            checkouts). They are only consulted when the current project root
-            does not contain the file, so exclusions inside the project are
-            unaffected.
+        paths: Input paths for the current scan. Each input contributes its
+            enclosing project root (falling back to a directory input's own
+            path, or a file input's own directory, when no marker exists) as a
+            fallback anchor for trees outside the current project — temporary
+            directories, sibling checkouts. Fallbacks are only consulted when
+            the current project root does not contain the file, so exclusions
+            inside the project are unaffected.
 
     Returns:
         Anchor directories in preference order, project root first.
@@ -110,8 +111,13 @@ def resolve_exclude_anchors(paths: "Sequence[str] | None" = None) -> tuple[str, 
         except (ValueError, OSError):  # pragma: no cover - defensive
             continue
         if os.path.isdir(abs_path):
-            if abs_path not in anchors:
-                anchors.append(abs_path)
+            # Resolve the enclosing project root first, for symmetry with the
+            # file-input branch: a passed subdirectory that contains no marker
+            # (e.g. ``src/pkg``) must still anchor slash-patterns like
+            # ``src/build`` at the true project root, not at the subdirectory.
+            dir_root = find_project_root(abs_path) or abs_path
+            if dir_root not in anchors:
+                anchors.append(dir_root)
             continue
         # A file named outside the current project still belongs to *some*
         # project; anchor on its own root rather than the filesystem root.

--- a/lintro/utils/path_filtering.py
+++ b/lintro/utils/path_filtering.py
@@ -115,12 +115,16 @@ def resolve_exclude_anchors(paths: "Sequence[str] | None" = None) -> tuple[str, 
             continue
         # A file named outside the current project still belongs to *some*
         # project; anchor on its own root rather than the filesystem root.
+        # When no marker exists anywhere above it, anchor on its own directory
+        # so only filename-level patterns (e.g. ``*.pyc``) can match — an
+        # explicitly requested file must never be dropped because an ancestor
+        # is named ``build``, ``dist`` or ``cache`` (#1678, greptile P1).
         parent = os.path.dirname(abs_path)
         if not parent or parent in seen_parents:
             continue
         seen_parents.add(parent)
-        file_root = find_project_root(parent)
-        if file_root is not None and file_root not in file_roots:
+        file_root = find_project_root(parent) or parent
+        if file_root not in file_roots:
             file_roots.append(file_root)
 
     anchors.extend(root for root in file_roots if root not in anchors)

--- a/lintro/utils/path_filtering.py
+++ b/lintro/utils/path_filtering.py
@@ -103,6 +103,7 @@ def resolve_exclude_anchors(paths: "Sequence[str] | None" = None) -> tuple[str, 
         anchors.append(project_root)
 
     file_roots: list[str] = []
+    seen_parents: set[str] = set()
     for path in paths or ():
         try:
             abs_path = os.path.abspath(path)
@@ -115,10 +116,11 @@ def resolve_exclude_anchors(paths: "Sequence[str] | None" = None) -> tuple[str, 
         # A file named outside the current project still belongs to *some*
         # project; anchor on its own root rather than the filesystem root.
         parent = os.path.dirname(abs_path)
-        if not parent:
+        if not parent or parent in seen_parents:
             continue
+        seen_parents.add(parent)
         file_root = find_project_root(parent)
-        if file_root is not None and file_root not in anchors:
+        if file_root is not None and file_root not in file_roots:
             file_roots.append(file_root)
 
     anchors.extend(root for root in file_roots if root not in anchors)

--- a/lintro/utils/path_filtering.py
+++ b/lintro/utils/path_filtering.py
@@ -7,12 +7,29 @@ patterns. Uses pathspec library for gitignore-style pattern matching.
 import fnmatch
 import os
 from functools import lru_cache
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pathspec
 
 if TYPE_CHECKING:
-    pass
+    from collections.abc import Sequence
+
+# Files/directories that mark the root of a project. Exclude patterns are
+# gitignore-style and therefore anchored at the project root, not at the
+# filesystem root — see ``resolve_exclude_anchors`` (#1678).
+PROJECT_ROOT_MARKERS: tuple[str, ...] = (
+    ".lintro-ignore",
+    ".lintro-config.yaml",
+    ".lintro-config.yml",
+    "pyproject.toml",
+    "package.json",
+    ".git",
+)
+
+# Bound the upward search for a project root so a far filesystem ancestor is
+# never treated as the anchor. Mirrors the ``.lintro-ignore`` search bound.
+_ROOT_SEARCH_MAX_DEPTH: int = 20
 
 
 @lru_cache(maxsize=32)
@@ -28,18 +45,152 @@ def _compile_pathspec(patterns_tuple: tuple[str, ...]) -> pathspec.GitIgnoreSpec
     return pathspec.GitIgnoreSpec.from_lines(patterns_tuple)
 
 
+def find_project_root(start: str | Path | None = None) -> str | None:
+    """Locate the project root by walking up for a project marker.
+
+    Args:
+        start: Directory to begin searching from. Defaults to the current
+            working directory.
+
+    Returns:
+        Absolute path of the directory containing the first marker found, or
+        None when no marker exists within the bounded search.
+    """
+    from lintro.utils.path_utils import find_file_upward
+
+    begin = Path(start) if start is not None else Path.cwd()
+    try:
+        begin = begin.absolute()
+    except OSError:  # pragma: no cover - defensive
+        return None
+
+    found = find_file_upward(
+        begin,
+        PROJECT_ROOT_MARKERS,
+        max_depth=_ROOT_SEARCH_MAX_DEPTH,
+    )
+    if found is None:
+        return None
+    return str(found.parent)
+
+
+def resolve_exclude_anchors(paths: "Sequence[str] | None" = None) -> tuple[str, ...]:
+    """Return the directories exclude patterns are interpreted relative to.
+
+    Exclude patterns (``.lintro-ignore`` entries and the built-in defaults)
+    use gitignore semantics, which are relative to the project root. Matching
+    them against the *absolute* path instead means any ancestor directory
+    **above** the project — for example a checkout living under
+    ``<repo>/.claude/worktrees/<id>`` or under ``~/build`` — silently excludes
+    every file in the project and every tool then reports a clean pass on a
+    scan that never happened (#1678).
+
+    Args:
+        paths: Input paths for the current scan. Directory inputs — and the
+            project root of any file input — act as fallback anchors for trees
+            outside the current project (temporary directories, sibling
+            checkouts). They are only consulted when the current project root
+            does not contain the file, so exclusions inside the project are
+            unaffected.
+
+    Returns:
+        Anchor directories in preference order, project root first.
+    """
+    anchors: list[str] = []
+
+    project_root = find_project_root()
+    if project_root is not None:
+        anchors.append(project_root)
+
+    file_roots: list[str] = []
+    for path in paths or ():
+        try:
+            abs_path = os.path.abspath(path)
+        except (ValueError, OSError):  # pragma: no cover - defensive
+            continue
+        if os.path.isdir(abs_path):
+            if abs_path not in anchors:
+                anchors.append(abs_path)
+            continue
+        # A file named outside the current project still belongs to *some*
+        # project; anchor on its own root rather than the filesystem root.
+        parent = os.path.dirname(abs_path)
+        if not parent:
+            continue
+        file_root = find_project_root(parent)
+        if file_root is not None and file_root not in anchors:
+            file_roots.append(file_root)
+
+    anchors.extend(root for root in file_roots if root not in anchors)
+
+    if not anchors:
+        anchors.append(str(Path.cwd()))
+
+    return tuple(anchors)
+
+
+def _match_candidates(path: str, anchors: tuple[str, ...]) -> list[str]:
+    """Build the path forms an exclude spec should be matched against.
+
+    For a file inside one of the anchors, the candidates are the
+    anchor-relative path and its sub-path suffixes. Suffixes keep patterns
+    such as ``test_samples/*`` matching at any depth inside the project, while
+    anchoring keeps directories *above* the project — ``<repo>/.claude/…``,
+    ``~/build/…`` — from excluding the entire scan (#1678).
+
+    A file outside every anchor falls back to legacy whole-path matching.
+
+    Args:
+        path: Absolute file path to check.
+        anchors: Anchor directories in preference order.
+
+    Returns:
+        Candidate path strings to test against the compiled spec.
+    """
+    normalized = path.replace("\\", "/")
+
+    for anchor in anchors:
+        try:
+            relative = os.path.relpath(path, anchor)
+        except (ValueError, OSError):  # pragma: no cover - cross-drive paths
+            continue
+        if relative == os.pardir or relative.startswith(os.pardir + os.sep):
+            continue
+        return _path_suffixes(relative.replace("\\", "/"))
+
+    return _path_suffixes(normalized)
+
+
+def _path_suffixes(path: str) -> list[str]:
+    """Return a path plus every sub-path suffix of it.
+
+    Args:
+        path: Slash-separated path.
+
+    Returns:
+        The path itself followed by each suffix starting at a later component.
+    """
+    parts = [part for part in path.split("/") if part]
+    return ["/".join(parts[i:]) for i in range(len(parts))]
+
+
 def should_exclude_path(
     path: str,
     exclude_patterns: list[str],
+    anchors: tuple[str, ...] | None = None,
 ) -> bool:
     """Check if a path should be excluded based on patterns.
 
     Uses pathspec library for gitignore-style pattern matching, which provides
     better support for complex patterns like ** globs and directory matching.
+    Matching is anchored at the project root so directories above it cannot
+    exclude the whole project (#1678).
 
     Args:
         path: str: File path to check for exclusion (can be absolute or relative).
         exclude_patterns: list[str]: List of gitignore-style patterns to match against.
+        anchors: Anchor directories to interpret patterns relative to. Defaults
+            to the resolved project root (falling back to the cwd).
 
     Returns:
         bool: True if the path should be excluded, False otherwise.
@@ -53,9 +204,6 @@ def should_exclude_path(
     except (ValueError, OSError):
         abs_path = path
 
-    # Normalize path separators for cross-platform compatibility
-    normalized_path: str = abs_path.replace("\\", "/")
-
     # Convert patterns list to tuple for caching
     patterns_tuple = tuple(p.strip() for p in exclude_patterns if p.strip())
 
@@ -65,19 +213,11 @@ def should_exclude_path(
     # Compile patterns using pathspec (with caching)
     spec = _compile_pathspec(patterns_tuple)
 
-    # Check if the full path matches
-    if spec.match_file(normalized_path):
-        return True
-
-    # Also check relative parts of the path for directory patterns
-    # This handles patterns like "build" matching "/path/to/build/file.py"
-    path_parts = normalized_path.split("/")
-    for i in range(len(path_parts)):
-        relative_part = "/".join(path_parts[i:])
-        if relative_part and spec.match_file(relative_part):
-            return True
-
-    return False
+    return _should_exclude_with_spec(
+        abs_path,
+        spec,
+        anchors if anchors is not None else resolve_exclude_anchors([path]),
+    )
 
 
 def walk_files_with_excludes(
@@ -112,6 +252,9 @@ def walk_files_with_excludes(
     # Pre-compile exclude patterns for efficiency
     exclude_tuple = tuple(p.strip() for p in exclude_patterns if p.strip())
     exclude_spec = _compile_pathspec(exclude_tuple) if exclude_tuple else None
+    # Anchor gitignore-style patterns at the project root so ancestors above
+    # it cannot silently exclude the entire scan (#1678).
+    anchors = resolve_exclude_anchors(paths)
 
     for path in paths:
         if os.path.isfile(path):
@@ -120,7 +263,11 @@ def walk_files_with_excludes(
             for pattern in file_patterns:
                 if fnmatch.fnmatch(filename, pattern):
                     abs_path = os.path.abspath(path)
-                    if not _should_exclude_with_spec(abs_path, exclude_spec):
+                    if not _should_exclude_with_spec(
+                        abs_path,
+                        exclude_spec,
+                        anchors,
+                    ):
                         all_files.append(abs_path)
                     break
         elif os.path.isdir(path):
@@ -145,6 +292,7 @@ def walk_files_with_excludes(
                     if matches_pattern and not _should_exclude_with_spec(
                         abs_file_path,
                         exclude_spec,
+                        anchors,
                     ):
                         all_files.append(abs_file_path)
 
@@ -178,12 +326,14 @@ def walk_files_with_excludes(
 def _should_exclude_with_spec(
     path: str,
     spec: pathspec.GitIgnoreSpec | None,
+    anchors: tuple[str, ...],
 ) -> bool:
     """Check if a path should be excluded using a pre-compiled PathSpec.
 
     Args:
         path: Absolute file path to check.
         spec: Pre-compiled PathSpec, or None if no exclusions.
+        anchors: Anchor directories the patterns are relative to.
 
     Returns:
         bool: True if the path should be excluded.
@@ -191,19 +341,10 @@ def _should_exclude_with_spec(
     if spec is None:
         return False
 
-    normalized = path.replace("\\", "/")
-
-    if spec.match_file(normalized):
-        return True
-
-    # Check relative parts for directory pattern matching
-    path_parts = normalized.split("/")
-    for i in range(len(path_parts)):
-        relative = "/".join(path_parts[i:])
-        if relative and spec.match_file(relative):
-            return True
-
-    return False
+    return any(
+        candidate and spec.match_file(candidate)
+        for candidate in _match_candidates(path, anchors)
+    )
 
 
 def _is_venv_directory(dirname: str) -> bool:

--- a/lintro/utils/summary_tables.py
+++ b/lintro/utils/summary_tables.py
@@ -21,6 +21,16 @@ from lintro.utils.console import (
 # Constants
 DEFAULT_REMAINING_COUNT: str = "?"
 
+# Note shown when a tool passed without inspecting a single file. A zero-file
+# run and a genuinely clean run are both ``PASS 0``; without this note they are
+# indistinguishable, which is how a fully excluded scan reads as green (#1678).
+NO_FILES_NOTE: str = "no files matched"
+_NO_FILES_SUFFIXES: tuple[str, ...] = (
+    " found to check.",
+    " files to check.",
+    " files to format.",
+)
+
 # ANSI color codes — only emit when stdout is a terminal
 _USE_COLOR = sys.stdout.isatty()
 _GREEN = "\033[92m" if _USE_COLOR else ""
@@ -111,6 +121,21 @@ def _get_ai_verified_count(result: object) -> int:
 def _get_ai_unverified_count(result: object) -> int:
     """Get count of AI-applied fixes that remain unresolved."""
     return get_ai_count(result, "unverified_count")
+
+
+def _is_no_files_result(output: object) -> bool:
+    """Report whether a tool result means "no files were inspected".
+
+    Args:
+        output: The tool result ``output`` value.
+
+    Returns:
+        True when the output is one of the framework's no-files messages.
+    """
+    if not isinstance(output, str):
+        return False
+    text = output.strip()
+    return text.startswith("No ") and text.endswith(_NO_FILES_SUFFIXES)
 
 
 def _is_result_skipped(result: object) -> tuple[bool, str]:
@@ -401,11 +426,12 @@ def print_summary_table(
                 ai_verified_value = _get_ai_verified_count(result)
                 ai_verified_display: str = f"{_GREEN}{ai_verified_value}{_RESET}"
                 ai_unverified_value = _get_ai_unverified_count(result)
-                notes_display = (
-                    f"{_YELLOW}{ai_unverified_value} unresolved{_RESET}"
-                    if ai_unverified_value > 0
-                    else ""
-                )
+                if ai_unverified_value > 0:
+                    notes_display = f"{_YELLOW}{ai_unverified_value} unresolved{_RESET}"
+                elif _is_no_files_result(result_output):
+                    notes_display = f"{_YELLOW}{NO_FILES_NOTE}{_RESET}"
+                else:
+                    notes_display = ""
 
                 # Remaining issues display
                 if isinstance(remaining_count, str):
@@ -449,7 +475,11 @@ def print_summary_table(
                     or "tool execution failed" in result_output.lower()
                 )
 
-                notes_display = ""
+                notes_display = (
+                    f"{_YELLOW}{NO_FILES_NOTE}{_RESET}"
+                    if _is_no_files_result(result_output)
+                    else ""
+                )
 
                 # Check for framework deferral pattern in output
                 if (

--- a/lintro/utils/summary_tables.py
+++ b/lintro/utils/summary_tables.py
@@ -25,10 +25,18 @@ DEFAULT_REMAINING_COUNT: str = "?"
 # run and a genuinely clean run are both ``PASS 0``; without this note they are
 # indistinguishable, which is how a fully excluded scan reads as green (#1678).
 NO_FILES_NOTE: str = "no files matched"
+# Fragments (any terminal period stripped before matching) that a framework
+# "nothing to do" message ends with. Covers every discovery outcome —
+# ``No <ext> found to check``, ``No files to format``, ``No .py/.pyi files
+# found`` — across check and fix. Deliberately excludes ``No issues found``
+# and ``No configuration found``, which mean the tool *did* run.
 _NO_FILES_SUFFIXES: tuple[str, ...] = (
-    " found to check.",
-    " files to check.",
-    " files to format.",
+    " found to check",
+    " found to fix",
+    " files to check",
+    " files to fix",
+    " files to format",
+    " files found",
 )
 
 # ANSI color codes — only emit when stdout is a terminal
@@ -134,7 +142,7 @@ def _is_no_files_result(output: object) -> bool:
     """
     if not isinstance(output, str):
         return False
-    text = output.strip()
+    text = output.strip().rstrip(".")
     return text.startswith("No ") and text.endswith(_NO_FILES_SUFFIXES)
 
 

--- a/tests/unit/tools/prettier/test_cannot_run_vs_no_files.py
+++ b/tests/unit/tools/prettier/test_cannot_run_vs_no_files.py
@@ -1,0 +1,108 @@
+"""Regression tests for the silent-pass hole reported in issue #1678.
+
+Two outcomes must stay distinguishable:
+
+* **cannot run** — the tool's binary could not be resolved. The result must be
+  a loud skip carrying a reason, never a plain ``PASS``.
+* **nothing to check** — the tool ran its discovery and no file matched its
+  patterns. That is a legitimate pass and must not regress into a skip.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from assertpy import assert_that
+
+from lintro.plugins import execution_preparation
+from lintro.tools.definitions.oxlint import OxlintPlugin
+from lintro.tools.definitions.prettier import PrettierPlugin
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_MISSING_BINARY: str = "lintro-nonexistent-binary-1678"
+
+_BADLY_FORMATTED_MARKDOWN: str = (
+    "# probe\n\n- a deliberately badly wrapped markdown line far longer than "
+    "eighty eight characters so prettier proseWrap always must reflow it\n"
+)
+
+
+@pytest.fixture
+def unresolvable_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every tool binary unresolvable for the duration of a test.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        execution_preparation,
+        "get_executable_command",
+        lambda tool_name: [_MISSING_BINARY],
+    )
+
+
+def test_prettier_cannot_run_is_a_loud_skip_not_a_pass(
+    tmp_path: Path,
+    unresolvable_binary: None,
+) -> None:
+    """Prettier that cannot resolve its binary reports a skip with a reason.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        unresolvable_binary: Fixture making the binary unresolvable.
+    """
+    target = tmp_path / "probe.md"
+    target.write_text(_BADLY_FORMATTED_MARKDOWN, encoding="utf-8")
+
+    plugin = PrettierPlugin()
+    plugin.exclude_patterns = []
+    result = plugin.check([str(target)], {})
+
+    assert_that(result.skipped).is_true()
+    assert_that(result.skip_reason).is_not_none()
+    assert_that(result.skip_reason).is_not_equal_to("")
+    assert_that(result.output).contains("Skipping prettier")
+
+
+def test_oxlint_cannot_run_is_a_loud_skip_not_a_pass(
+    tmp_path: Path,
+    unresolvable_binary: None,
+) -> None:
+    """A sibling Node-backed tool shares the same cannot-run contract.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+        unresolvable_binary: Fixture making the binary unresolvable.
+    """
+    target = tmp_path / "probe.js"
+    target.write_text("const x = 1\n", encoding="utf-8")
+
+    plugin = OxlintPlugin()
+    plugin.exclude_patterns = []
+    result = plugin.check([str(target)], {})
+
+    assert_that(result.skipped).is_true()
+    assert_that(result.skip_reason).is_not_none()
+    assert_that(result.skip_reason).is_not_equal_to("")
+
+
+def test_prettier_with_no_matching_files_is_a_plain_pass(tmp_path: Path) -> None:
+    """No file matching prettier's patterns stays a legitimate pass.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+    target = tmp_path / "module.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    plugin = PrettierPlugin()
+    plugin.exclude_patterns = []
+    result = plugin.check([str(target)], {})
+
+    assert_that(result.success).is_true()
+    assert_that(result.skipped).is_false()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.output).contains("found to check")

--- a/tests/unit/utils/summary/test_display.py
+++ b/tests/unit/utils/summary/test_display.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 from assertpy import assert_that
 
 from lintro.enums.action import Action
 from lintro.utils.summary_tables import (
     DEFAULT_REMAINING_COUNT,
     NO_FILES_NOTE,
+    _is_no_files_result,
     print_summary_table,
 )
 
@@ -207,6 +209,8 @@ def test_fix_no_files_shows_zero(
     assert_that(combined).contains("PASS")
     # Should show 0 for both Fixed and Remaining, not SKIPPED
     assert_that(combined).does_not_contain("SKIPPED")
+    # A zero-file fix run is annotated too, mirroring the CHECK note (#1678).
+    assert_that(combined).contains(NO_FILES_NOTE)
 
 
 def test_fix_parsing_remaining_from_output(
@@ -540,3 +544,69 @@ def test_check_pass_over_real_files_has_no_note(
     combined = "".join(output)
     assert_that(combined).contains("PASS")
     assert_that(combined).does_not_contain(NO_FILES_NOTE)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "No .md files found to check.",
+        "No .md files found to check",
+        "No files to check.",
+        "No files to fix.",
+        "No files to format",
+        "No Astro files to check.",
+        "No TOML files to format.",
+        "No Go files found to fix.",
+        "No .py/.pyi files found",
+        "No {file_type} found to check.",
+    ],
+    ids=[
+        "found_to_check_period",
+        "found_to_check_no_period",
+        "files_to_check",
+        "files_to_fix",
+        "files_to_format_no_period",
+        "typed_files_to_check",
+        "typed_files_to_format",
+        "found_to_fix",
+        "files_found_no_period",
+        "templated",
+    ],
+)
+def test_is_no_files_result_recognizes_discovery_messages(message: str) -> None:
+    """Every framework no-files message is recognized, with or without a period.
+
+    Args:
+        message: A framework "nothing to do" message.
+    """
+    assert_that(_is_no_files_result(message)).is_true()
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "No issues found.",
+        "No issues found",
+        "No configuration found",
+        "No fixes needed.",
+        "Found 3 issues",
+        "",
+        None,
+    ],
+    ids=[
+        "ran_clean_period",
+        "ran_clean",
+        "no_config",
+        "no_fixes_needed",
+        "has_issues",
+        "empty",
+        "none",
+    ],
+)
+def test_is_no_files_result_ignores_ran_messages(message: object) -> None:
+    """A tool that actually ran is never mistaken for a zero-file run.
+
+    Args:
+        message: A message that must not be treated as a no-files result.
+    """
+    assert_that(_is_no_files_result(message)).is_false()

--- a/tests/unit/utils/summary/test_display.py
+++ b/tests/unit/utils/summary/test_display.py
@@ -16,6 +16,7 @@ from assertpy import assert_that
 from lintro.enums.action import Action
 from lintro.utils.summary_tables import (
     DEFAULT_REMAINING_COUNT,
+    NO_FILES_NOTE,
     print_summary_table,
 )
 
@@ -484,3 +485,58 @@ def test_default_remaining_count_used_in_fix_output(
     combined = "".join(output)
     # The "?" should appear in the remaining column when count is unknown
     assert_that(combined).contains(DEFAULT_REMAINING_COUNT)
+
+
+# =============================================================================
+# Tests for the no-files note (issue #1678)
+# =============================================================================
+
+
+def test_check_pass_with_no_files_is_annotated(
+    console_capture: tuple[Callable[[str], None], list[str]],
+    fake_tool_result_factory: Callable[..., FakeToolResult],
+) -> None:
+    """A pass over zero files is annotated so it is not read as a clean scan.
+
+    Args:
+        console_capture: Mock console output capture.
+        fake_tool_result_factory: Factory for creating fake tool results.
+    """
+    capture, output = console_capture
+    result = fake_tool_result_factory(
+        name="prettier",
+        success=True,
+        issues_count=0,
+        output="No .md files found to check.",
+    )
+
+    print_summary_table(capture, Action.CHECK, [result])
+
+    combined = "".join(output)
+    assert_that(combined).contains("PASS")
+    assert_that(combined).contains(NO_FILES_NOTE)
+
+
+def test_check_pass_over_real_files_has_no_note(
+    console_capture: tuple[Callable[[str], None], list[str]],
+    fake_tool_result_factory: Callable[..., FakeToolResult],
+) -> None:
+    """A genuine clean scan is not annotated with the no-files note.
+
+    Args:
+        console_capture: Mock console output capture.
+        fake_tool_result_factory: Factory for creating fake tool results.
+    """
+    capture, output = console_capture
+    result = fake_tool_result_factory(
+        name="prettier",
+        success=True,
+        issues_count=0,
+        output=None,
+    )
+
+    print_summary_table(capture, Action.CHECK, [result])
+
+    combined = "".join(output)
+    assert_that(combined).contains("PASS")
+    assert_that(combined).does_not_contain(NO_FILES_NOTE)

--- a/tests/unit/utils/test_path_filtering.py
+++ b/tests/unit/utils/test_path_filtering.py
@@ -482,3 +482,36 @@ def test_markerless_named_file_still_matched_by_filename_pattern(
     )
 
     assert_that(files).is_empty()
+
+
+def test_directory_input_anchors_at_project_root_not_subdir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A marker-less subdirectory input anchors slash-patterns at the root.
+
+    Args:
+        tmp_path: Temporary directory path.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    project = tmp_path / "proj"
+    (project / "src" / "pkg").mkdir(parents=True)
+    (project / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    # A slash-anchored pattern that should only match at the project root.
+    keep = project / "src" / "pkg" / "build.md"
+    keep.write_text("# keep\n", encoding="utf-8")
+
+    # Run from an unrelated cwd so the project root is not cwd-derived.
+    workdir = tmp_path / "elsewhere"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    files = walk_files_with_excludes(
+        paths=[str(project / "src" / "pkg")],
+        file_patterns=["*.md"],
+        exclude_patterns=["src/build"],
+    )
+
+    # ``src/build`` is anchored at the project root and does not match
+    # ``src/pkg/build.md``, so the file is kept.
+    assert_that([Path(f).name for f in files]).is_equal_to(["build.md"])

--- a/tests/unit/utils/test_path_filtering.py
+++ b/tests/unit/utils/test_path_filtering.py
@@ -423,3 +423,62 @@ def test_resolve_exclude_anchors_prefers_project_root(
     anchors = resolve_exclude_anchors([str(project_under_excluded_ancestor)])
 
     assert_that(anchors[0]).is_equal_to(str(project_under_excluded_ancestor))
+
+
+def test_markerless_file_outside_project_ignores_ancestor_dir_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A named file with no project marker is not excluded by ancestor names.
+
+    Args:
+        tmp_path: Temporary directory path.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    # A tree with no project marker anywhere, under a ``build`` ancestor.
+    loose = tmp_path / "build" / "scratch"
+    loose.mkdir(parents=True)
+    target = loose / "note.md"
+    target.write_text("# note\n", encoding="utf-8")
+
+    # Run from a directory that is itself markerless so no project root is
+    # resolved for the current working directory either.
+    workdir = tmp_path / "elsewhere"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    files = walk_files_with_excludes(
+        paths=[str(target)],
+        file_patterns=["*.md"],
+        exclude_patterns=["build", "dist", "cache"],
+    )
+
+    assert_that(files).is_length(1)
+
+
+def test_markerless_named_file_still_matched_by_filename_pattern(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Filename-level excludes still apply to a markerless named file.
+
+    Args:
+        tmp_path: Temporary directory path.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    loose = tmp_path / "build"
+    loose.mkdir()
+    target = loose / "note.md"
+    target.write_text("# note\n", encoding="utf-8")
+
+    workdir = tmp_path / "elsewhere"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    files = walk_files_with_excludes(
+        paths=[str(target)],
+        file_patterns=["*.md"],
+        exclude_patterns=["*.md"],
+    )
+
+    assert_that(files).is_empty()

--- a/tests/unit/utils/test_path_filtering.py
+++ b/tests/unit/utils/test_path_filtering.py
@@ -10,6 +10,7 @@ from assertpy import assert_that
 
 from lintro.utils.path_filtering import (
     _is_venv_directory,
+    resolve_exclude_anchors,
     should_exclude_path,
     walk_files_with_excludes,
 )
@@ -295,3 +296,130 @@ def test_is_venv_directory(dirname: str, expected: bool) -> None:
     """
     result = _is_venv_directory(dirname)
     assert_that(result).is_equal_to(expected)
+
+
+# =============================================================================
+# Tests for exclude-pattern anchoring (issue #1678)
+# =============================================================================
+
+
+@pytest.fixture
+def project_under_excluded_ancestor(tmp_path: Path) -> Path:
+    """Create a project whose parent directory name is an exclude pattern.
+
+    Mirrors a checkout living at ``<repo>/.claude/worktrees/<id>`` or under
+    ``~/build``: the project itself is fine, but an ancestor matches a
+    gitignore-style exclude pattern.
+
+    Args:
+        tmp_path: Temporary directory path.
+
+    Returns:
+        Path to the project root created beneath the excluded ancestor.
+    """
+    project = tmp_path / ".claude" / "worktrees" / "agent-1" / "checkout"
+    project.mkdir(parents=True)
+    (project / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    (project / "README.md").write_text("# readme\n", encoding="utf-8")
+    nested = project / "docs"
+    nested.mkdir()
+    (nested / "guide.md").write_text("# guide\n", encoding="utf-8")
+    return project
+
+
+def test_ancestor_above_project_root_does_not_exclude_project(
+    project_under_excluded_ancestor: Path,
+) -> None:
+    """A ``.claude`` ancestor above the project must not exclude every file.
+
+    Args:
+        project_under_excluded_ancestor: Project root beneath ``.claude``.
+    """
+    files = walk_files_with_excludes(
+        paths=[str(project_under_excluded_ancestor)],
+        file_patterns=["*.md"],
+        exclude_patterns=[".claude", "node_modules", "build"],
+    )
+
+    names = sorted(Path(f).name for f in files)
+    assert_that(names).is_equal_to(["README.md", "guide.md"])
+
+
+def test_single_file_under_excluded_ancestor_is_still_discovered(
+    project_under_excluded_ancestor: Path,
+) -> None:
+    """An explicitly named file under an excluded ancestor is still scanned.
+
+    Args:
+        project_under_excluded_ancestor: Project root beneath ``.claude``.
+    """
+    target = project_under_excluded_ancestor / "README.md"
+
+    files = walk_files_with_excludes(
+        paths=[str(target)],
+        file_patterns=["*.md"],
+        exclude_patterns=[".claude"],
+    )
+
+    assert_that(files).is_length(1)
+
+
+def test_excluded_directory_inside_project_is_still_excluded(
+    project_under_excluded_ancestor: Path,
+) -> None:
+    """Exclusions below the project root keep working.
+
+    Args:
+        project_under_excluded_ancestor: Project root beneath ``.claude``.
+    """
+    vendored = project_under_excluded_ancestor / "node_modules" / "pkg"
+    vendored.mkdir(parents=True)
+    (vendored / "readme.md").write_text("# vendored\n", encoding="utf-8")
+
+    files = walk_files_with_excludes(
+        paths=[str(project_under_excluded_ancestor)],
+        file_patterns=["*.md"],
+        exclude_patterns=[".claude", "node_modules"],
+    )
+
+    names = sorted(Path(f).name for f in files)
+    assert_that(names).is_equal_to(["README.md", "guide.md"])
+
+
+def test_nested_exclude_pattern_still_matches_inside_project(
+    project_under_excluded_ancestor: Path,
+) -> None:
+    """Sub-path exclude patterns keep matching at any depth in the project.
+
+    Args:
+        project_under_excluded_ancestor: Project root beneath ``.claude``.
+    """
+    generated = project_under_excluded_ancestor / "pkg" / "test_samples"
+    generated.mkdir(parents=True)
+    (generated / "sample.md").write_text("# sample\n", encoding="utf-8")
+
+    files = walk_files_with_excludes(
+        paths=[str(project_under_excluded_ancestor)],
+        file_patterns=["*.md"],
+        exclude_patterns=["test_samples/*"],
+    )
+
+    names = sorted(Path(f).name for f in files)
+    assert_that(names).is_equal_to(["README.md", "guide.md"])
+
+
+def test_resolve_exclude_anchors_prefers_project_root(
+    monkeypatch: pytest.MonkeyPatch,
+    project_under_excluded_ancestor: Path,
+) -> None:
+    """The project root is the first anchor when one can be resolved.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        project_under_excluded_ancestor: Project root beneath ``.claude``.
+    """
+    monkeypatch.chdir(project_under_excluded_ancestor)
+
+    anchors = resolve_exclude_anchors([str(project_under_excluded_ancestor)])
+
+    assert_that(anchors[0]).is_equal_to(str(project_under_excluded_ancestor))


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(core): prettier reports PASS when node_modules is absent instead of skipping loudly
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Fixes the silent `✅ PASS | 0` reported in #1678. The root cause is **not**
`node_modules` — it is exclude-pattern matching.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1678

## Details

_See What’s Changing._
