### PR TITLE
fix(ci): backtick-wrap snake_case identifiers in generated CHANGELOG (MD037)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- **ai**: remove dead AUDIT_FILE constant and unused _rotate_audit_log wrapper (#1669)
-  (d6367ff)
+- **ai**: remove dead `AUDIT_FILE` constant and unused `_rotate_audit_log` wrapper
+  (#1669) (d6367ff)
 
 ### Fixed
 
-- **ci**: validate MIN_AGE_DAYS floor and TAG_PREFIX in GHCR CI-tag sweep (#1674)
+- **ci**: validate `MIN_AGE_DAYS` floor and `TAG_PREFIX` in GHCR CI-tag sweep (#1674)
   (aaa4124)
 
 ## [0.91.31] - 2026-07-24
@@ -147,13 +147,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- **ci**: upload build-binary artifacts on workflow_dispatch (#1634) (60572af)
+- **ci**: upload build-binary artifacts on `workflow_dispatch` (#1634) (60572af)
 
 ## [0.91.13] - 2026-07-23
 
 ### Fixed
 
-- **cli**: let explicit --tools bypass enabled_tools allowlist (#1451) (9def246)
+- **cli**: let explicit --tools bypass `enabled_tools` allowlist (#1451) (9def246)
 
 ## [0.91.12] - 2026-07-23
 
@@ -313,7 +313,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - **oxlint**: add type-aware linting support with doctor checks (#1526) (1f6a979)
-- **pip_audit**: close parity gaps with osv_scanner (#1525) (1171941)
+- **pip_audit**: close parity gaps with `osv_scanner` (#1525) (1171941)
 - **ci**: run verify-manifest-tools inside built and pinned images to catch
   manifest-vs-image drift (#1528) (1ee3b3b)
 
@@ -417,7 +417,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- **idiom-review**: remove dead DEFAULT_ENABLED ClassVar (#1520) (fd4ad29)
+- **idiom-review**: remove dead `DEFAULT_ENABLED` ClassVar (#1520) (fd4ad29)
 
 ## [0.81.3] - 2026-07-18
 
@@ -430,7 +430,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- **deps**: exclude test_samples fixtures from Renovate tracking (#1504) (a8e051e)
+- **deps**: exclude `test_samples` fixtures from Renovate tracking (#1504) (a8e051e)
 
 ## [0.81.1] - 2026-07-18
 
@@ -471,8 +471,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **repo**: add root CONTRIBUTING.md pointer and remove stray findings.md (#1455)
   (504e31d)
-- replace bare assert with assertpy assert_that across test suite (#1389) (4fc76f4)
-- move inline tool sample inputs to test_samples fixtures (#1382) (9f75984)
+- replace bare assert with assertpy `assert_that` across test suite (#1389) (4fc76f4)
+- move inline tool sample inputs to `test_samples` fixtures (#1382) (9f75984)
 
 ### Fixed
 
@@ -488,7 +488,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- **tools**: preserve explicit timeout=0 and route ruff through _prepare_execution
+- **tools**: preserve explicit timeout=0 and route ruff through `_prepare_execution`
   (#1266) (ca1b013)
 
 ## [0.80.7] - 2026-07-17
@@ -550,7 +550,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- **ai/review**: preserve Findings in section-aware _cap_body truncation (#1334)
+- **ai/review**: preserve Findings in section-aware `_cap_body` truncation (#1334)
   (f3d98f2)
 
 ## [0.80.3] - 2026-07-16
@@ -646,8 +646,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- **security**: verify ANTHROPIC_API_KEY exposure ordering for dogfood AI review (#1325)
-  (c5caf17)
+- **security**: verify `ANTHROPIC_API_KEY` exposure ordering for dogfood AI review
+  (#1325) (c5caf17)
 
 ### Fixed
 
@@ -932,7 +932,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- **ai/review**: classify ValueError as INVALID_RESPONSE before shared severity
+- **ai/review**: classify ValueError as `INVALID_RESPONSE` before shared severity
   signatures (#1122) (14b618f)
 
 ## [0.69.0] - 2026-07-06
@@ -978,7 +978,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - **changelog**: wrap release-note lines to satisfy lint gate (#1088) (1180000)
-- **tools**: deduplicate tsc and vue_tsc definitions (76% identical) (#1092) (e13bb69)
+- **tools**: deduplicate tsc and `vue_tsc` definitions (76% identical) (#1092) (e13bb69)
 - **tools**: replace repetitive tool-option type validation with schema-based checks
   (#1076) (caa0540)
 
@@ -1022,9 +1022,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **config**: enforce module size limit via lint gate (#1078) (276929e)
 - **output**: SARIF output should emit standard lint results, not only AI metadata
   (#1079) (4a423f1)
-- **utils**: extract shared find_file_upward helper for duplicated config-walk logic
+- **utils**: extract shared `find_file_upward` helper for duplicated config-walk logic
   (#1077) (8d983ca)
-- pin merge_group activity type to checks_requested (#1059) (5f8edcd)
+- pin `merge_group` activity type to `checks_requested` (#1059) (5f8edcd)
 - **plugins**: separate stdout/stderr from subprocess and harden parsers (#1061)
   (23f6f09)
 - **deps**: update actions/attest-build-provenance to v4.1.1 (#874) (d839d3d)

--- a/scripts/ci/format-changelog.py
+++ b/scripts/ci/format-changelog.py
@@ -43,84 +43,203 @@ _HTML_COMMENT_RE = re.compile(r"^\s*<!--")
 _LINK_REF_RE = re.compile(r"^\s*\[[^\]]+\]:\s")
 _FENCE_RE = re.compile(r"^(?P<indent>\s*)(?P<marker>`{3,}|~{3,})")
 
-# Word-boundary run of identifier characters that contains at least one
-# underscore. The lookarounds refuse to start or end the match adjacent to a
-# word character (so we grab whole tokens), a backtick (already a code span), an
-# asterisk (an existing ``**bold**`` / ``*em*`` marker — e.g. the ``**scope**``
-# prefix of a conventional-commit changelog entry must stay intact), or a slash
-# (a path/URL segment that must not be broken). This targets snake_case and
-# SCREAMING_SNAKE_CASE code identifiers copied verbatim from commit subjects.
-_IDENT_RE = re.compile(r"(?<![\w`*/])([A-Za-z0-9_]*_[A-Za-z0-9_]*)(?![\w`*/])")
+# A "clean" code identifier: only identifier characters, at least one letter
+# (so numeric group separators like ``1_000`` are ignored) and at least one
+# underscore. Anchored to a whole token — callers strip surrounding punctuation
+# and skip links/URLs/filenames first, so a match here is unambiguously a bare
+# snake_case / SCREAMING_SNAKE_CASE identifier lifted from a commit subject.
+_PURE_IDENT_RE = re.compile(r"^(?=[A-Za-z0-9_]*[A-Za-z])[A-Za-z0-9]*_[A-Za-z0-9_]*$")
+
+# Spans that must be passed through untouched inside otherwise-plain prose: a
+# Markdown inline link/image ``[text](dest)``, an autolink ``<url>``, a bare
+# URL, or a dotted token such as a filename or domain (``format_changelog.py``,
+# ``example.com``). Wrapping any of these would break the rendered link or path.
+_SKIP_SPAN_RE = re.compile(
+    r"""
+    !?\[[^\]]*\]\([^)]*\)        # [text](dest) or ![alt](src)
+    | <[^>\s]+>                  # <autolink>
+    | (?:https?://|www\.)\S+     # bare URL
+    | \S*[A-Za-z0-9]\.[A-Za-z0-9]\S*  # dotted token: foo_bar.py, a.b.c
+    """,
+    re.VERBOSE,
+)
+
+# Leading and trailing punctuation stripped from a whitespace-delimited word
+# before testing it as an identifier, then re-attached around the code span.
+_LEADING_PUNCT = "([{"
+_TRAILING_PUNCT = ")]}.,;:!?"
 
 
-def _wrap_identifiers(segment: str) -> str:
-    """Wrap bare underscore identifiers in a code-span-free text segment.
+def _wrap_words(prose: str) -> str:
+    """Wrap bare underscore identifiers in a link-free, code-free prose span.
 
-    ``markdownlint`` (and CommonMark) treat a leading or trailing underscore on
-    a word as a potential emphasis delimiter, so a snake_case identifier lifted
-    from a commit subject (e.g. ``_rotate_audit_log``) can pair with another
-    stray underscore on the line to open a spurious emphasis span and trip
-    ``MD037`` ("spaces inside emphasis markers"). Rendering the identifier as an
-    inline code span is both the correct presentation for code and immune to
-    emphasis parsing, so the generated changelog stays fully lintable without
-    excluding the file or disabling the rule.
+    Each whitespace-delimited word is stripped of surrounding punctuation and, if
+    the remaining core is a clean identifier, wrapped in an inline code span.
+    ``**bold**`` markers, ``*emphasis*``, and anything that is not purely an
+    identifier are left untouched.
+
+    Args:
+        prose: Plain inline text with no code spans, links, URLs, or filenames.
+
+    Returns:
+        str: The prose with identifier words wrapped in backticks.
+    """
+
+    def _wrap_word(match: re.Match[str]) -> str:
+        word = match.group(0)
+        lead = ""
+        trail = ""
+        core = word
+        while core and core[0] in _LEADING_PUNCT:
+            lead += core[0]
+            core = core[1:]
+        while core and core[-1] in _TRAILING_PUNCT:
+            trail = core[-1] + trail
+            core = core[:-1]
+        if _PURE_IDENT_RE.match(core):
+            return f"{lead}`{core}`{trail}"
+        return word
+
+    return re.sub(r"\S+", _wrap_word, prose)
+
+
+def _wrap_prose(segment: str) -> str:
+    """Wrap identifiers in prose, leaving links, URLs, and filenames intact.
 
     Args:
         segment: Inline text known to contain no backtick code spans.
 
     Returns:
-        str: The segment with underscore identifiers wrapped in backticks.
+        str: The segment with bare identifiers wrapped in inline code spans.
     """
+    parts: list[str] = []
+    pos = 0
+    for match in _SKIP_SPAN_RE.finditer(segment):
+        parts.append(_wrap_words(segment[pos : match.start()]))
+        parts.append(match.group(0))
+        pos = match.end()
+    parts.append(_wrap_words(segment[pos:]))
+    return "".join(parts)
 
-    def _replace(match: re.Match[str]) -> str:
-        core = match.group(1)
-        # Skip purely numeric runs like ``1_000`` — they are not identifiers and
-        # never open emphasis, so wrapping them would only add noise.
-        if not any(char.isalpha() for char in core):
-            return core
-        return f"`{core}`"
 
-    return _IDENT_RE.sub(_replace, segment)
+def _protect_line(
+    line: str,
+    in_code: bool,
+    delim_len: int,
+) -> tuple[str, bool, int]:
+    """Wrap identifiers on one physical line, tracking inline-code-span state.
+
+    Backtick code spans are preserved verbatim. Delimiter runs are matched by
+    length (a span opened with N backticks closes only on a run of exactly N), so
+    multi-backtick spans such as ``code`` are handled correctly. The open/closed
+    state and the opening delimiter length are threaded through the return value
+    so a span that continues onto the next physical line stays protected.
+
+    Args:
+        line: The physical line to transform.
+        in_code: Whether an inline code span is already open from a prior line.
+        delim_len: Backtick-run length that opened the currently-open span.
+
+    Returns:
+        tuple[str, bool, int]: The transformed line, the updated in-code flag,
+        and the updated open-delimiter length.
+    """
+    parts: list[str] = []
+    seg_start = 0
+    index = 0
+    length = len(line)
+    while index < length:
+        if line[index] != "`":
+            index += 1
+            continue
+        run_end = index
+        while run_end < length and line[run_end] == "`":
+            run_end += 1
+        run = run_end - index
+        if not in_code:
+            parts.append(_wrap_prose(line[seg_start:index]))
+            parts.append(line[index:run_end])
+            in_code = True
+            delim_len = run
+            seg_start = run_end
+        elif run == delim_len:
+            parts.append(line[seg_start:run_end])
+            in_code = False
+            delim_len = 0
+            seg_start = run_end
+        index = run_end
+    if in_code:
+        # Span continues onto the next line: emit the remainder verbatim.
+        parts.append(line[seg_start:])
+    else:
+        parts.append(_wrap_prose(line[seg_start:]))
+    return "".join(parts), in_code, delim_len
 
 
 def _protect_code_identifiers(text: str) -> str:
-    """Wrap underscore identifiers in backticks outside existing code spans.
+    """Wrap bare underscore identifiers across a whole markdown document.
 
-    Inline code spans are preserved verbatim (their contents are already immune
-    to emphasis parsing and must not be re-wrapped), and only the text between
-    them is transformed. Backtick tracking mirrors :func:`_tokenize` so the two
-    agree on what counts as a code span. The transform is idempotent: an
-    identifier already inside backticks is left untouched.
+    ``markdownlint`` (and CommonMark) treat a leading or trailing underscore on
+    a word as a potential emphasis delimiter, so a snake_case identifier lifted
+    from a commit subject (e.g. ``_rotate_audit_log``) can pair with another
+    stray underscore to open a spurious emphasis span and trip ``MD037`` ("spaces
+    inside emphasis markers"). Rendering the identifier as an inline code span is
+    both the correct presentation for code and immune to emphasis parsing, so the
+    generated changelog stays fully lintable without excluding the file or
+    disabling the rule.
+
+    Fenced code blocks, headings, HTML comments, link reference definitions, and
+    blank lines are passed through untouched, matching the reflow pass. Every
+    other line — including list-item continuations and hard-break lines — is
+    protected, with inline-code-span state carried across consecutive content
+    lines so a span that wraps onto a following line is never rewritten. The
+    transform is idempotent: identifiers already inside code spans are left
+    alone.
 
     Args:
-        text: The raw inline text of a paragraph or list item.
+        text: The full markdown document.
 
     Returns:
-        str: The text with bare underscore identifiers wrapped in code spans.
+        str: The document with bare identifiers wrapped in inline code spans.
     """
-    parts: list[str] = []
-    buffer: list[str] = []
+    out: list[str] = []
+    fence_marker: str | None = None
+    fence_length = 0
     in_code = False
-    for char in text:
-        if char == "`":
-            if in_code:
-                buffer.append(char)
-                parts.append("".join(buffer))
-                buffer = []
-                in_code = False
-            else:
-                parts.append(_wrap_identifiers("".join(buffer)))
-                buffer = [char]
-                in_code = True
-        else:
-            buffer.append(char)
-    if in_code:
-        # An unterminated code span: emit the remainder verbatim rather than
-        # transforming inside what markdown will still treat as code-ish text.
-        parts.append("".join(buffer))
-    else:
-        parts.append(_wrap_identifiers("".join(buffer)))
-    return "".join(parts)
+    delim_len = 0
+    for line in text.split("\n"):
+        fence_match = _FENCE_RE.match(line)
+        if fence_match is not None:
+            marker = fence_match.group("marker")
+            marker_char = marker[0]
+            marker_length = len(marker)
+            if fence_marker is None:
+                fence_marker = marker_char
+                fence_length = marker_length
+            elif marker_char == fence_marker and marker_length >= fence_length:
+                fence_marker = None
+                fence_length = 0
+            out.append(line)
+            in_code = False
+            delim_len = 0
+            continue
+        if fence_marker is not None:
+            out.append(line)
+            continue
+        if (
+            line.strip() == ""
+            or _HEADING_RE.match(line)
+            or _HTML_COMMENT_RE.match(line)
+            or _LINK_REF_RE.match(line)
+        ):
+            out.append(line)
+            # A block boundary ends any inline code span.
+            in_code = False
+            delim_len = 0
+            continue
+        protected, in_code, delim_len = _protect_line(line, in_code, delim_len)
+        out.append(protected)
+    return "\n".join(out)
 
 
 def _tokenize(text: str) -> list[str]:
@@ -190,7 +309,10 @@ def format_changelog(text: str) -> str:
     Headings, blank lines, HTML comments, link reference definitions, and fenced
     code blocks are passed through unchanged. Consecutive blank lines are
     collapsed to a single blank line and the result ends with exactly one
-    newline, matching ``prettier``.
+    newline, matching ``prettier``. Before reflowing, bare underscore identifiers
+    in commit-subject prose are wrapped in inline code spans so the generated
+    changelog does not trip ``markdownlint`` ``MD037`` (see
+    :func:`_protect_code_identifiers`).
 
     Args:
         text: The full markdown document.
@@ -198,7 +320,7 @@ def format_changelog(text: str) -> str:
     Returns:
         str: The formatted document.
     """
-    lines = text.split("\n")
+    lines = _protect_code_identifiers(text).split("\n")
     out: list[str] = []
     index = 0
     total = len(lines)
@@ -243,7 +365,7 @@ def format_changelog(text: str) -> str:
             marker = list_match.group("marker")
             first_prefix = f"{indent}{marker} "
             cont_prefix = " " * len(first_prefix)
-            tokens = _tokenize(_protect_code_identifiers(list_match.group("text")))
+            tokens = _tokenize(list_match.group("text"))
             index += 1
             while index < total:
                 nxt = lines[index]
@@ -256,7 +378,7 @@ def format_changelog(text: str) -> str:
                     # markers are not stripped by flatten-and-rewrap.
                     if nxt.rstrip().endswith("\\") or nxt.rstrip("\n").endswith("  "):
                         break
-                    tokens.extend(_tokenize(_protect_code_identifiers(nxt.strip())))
+                    tokens.extend(_tokenize(nxt.strip()))
                     index += 1
                 else:
                     break
@@ -284,7 +406,7 @@ def format_changelog(text: str) -> str:
                 out.append(candidate.rstrip("\n"))
                 index += 1
                 break
-            paragraph.extend(_tokenize(_protect_code_identifiers(candidate.strip())))
+            paragraph.extend(_tokenize(candidate.strip()))
             index += 1
         if paragraph:
             out.extend(_wrap(paragraph, "", ""))

--- a/scripts/ci/format-changelog.py
+++ b/scripts/ci/format-changelog.py
@@ -43,6 +43,85 @@ _HTML_COMMENT_RE = re.compile(r"^\s*<!--")
 _LINK_REF_RE = re.compile(r"^\s*\[[^\]]+\]:\s")
 _FENCE_RE = re.compile(r"^(?P<indent>\s*)(?P<marker>`{3,}|~{3,})")
 
+# Word-boundary run of identifier characters that contains at least one
+# underscore. The lookarounds refuse to start or end the match adjacent to a
+# word character (so we grab whole tokens), a backtick (already a code span), an
+# asterisk (an existing ``**bold**`` / ``*em*`` marker — e.g. the ``**scope**``
+# prefix of a conventional-commit changelog entry must stay intact), or a slash
+# (a path/URL segment that must not be broken). This targets snake_case and
+# SCREAMING_SNAKE_CASE code identifiers copied verbatim from commit subjects.
+_IDENT_RE = re.compile(r"(?<![\w`*/])([A-Za-z0-9_]*_[A-Za-z0-9_]*)(?![\w`*/])")
+
+
+def _wrap_identifiers(segment: str) -> str:
+    """Wrap bare underscore identifiers in a code-span-free text segment.
+
+    ``markdownlint`` (and CommonMark) treat a leading or trailing underscore on
+    a word as a potential emphasis delimiter, so a snake_case identifier lifted
+    from a commit subject (e.g. ``_rotate_audit_log``) can pair with another
+    stray underscore on the line to open a spurious emphasis span and trip
+    ``MD037`` ("spaces inside emphasis markers"). Rendering the identifier as an
+    inline code span is both the correct presentation for code and immune to
+    emphasis parsing, so the generated changelog stays fully lintable without
+    excluding the file or disabling the rule.
+
+    Args:
+        segment: Inline text known to contain no backtick code spans.
+
+    Returns:
+        str: The segment with underscore identifiers wrapped in backticks.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        core = match.group(1)
+        # Skip purely numeric runs like ``1_000`` — they are not identifiers and
+        # never open emphasis, so wrapping them would only add noise.
+        if not any(char.isalpha() for char in core):
+            return core
+        return f"`{core}`"
+
+    return _IDENT_RE.sub(_replace, segment)
+
+
+def _protect_code_identifiers(text: str) -> str:
+    """Wrap underscore identifiers in backticks outside existing code spans.
+
+    Inline code spans are preserved verbatim (their contents are already immune
+    to emphasis parsing and must not be re-wrapped), and only the text between
+    them is transformed. Backtick tracking mirrors :func:`_tokenize` so the two
+    agree on what counts as a code span. The transform is idempotent: an
+    identifier already inside backticks is left untouched.
+
+    Args:
+        text: The raw inline text of a paragraph or list item.
+
+    Returns:
+        str: The text with bare underscore identifiers wrapped in code spans.
+    """
+    parts: list[str] = []
+    buffer: list[str] = []
+    in_code = False
+    for char in text:
+        if char == "`":
+            if in_code:
+                buffer.append(char)
+                parts.append("".join(buffer))
+                buffer = []
+                in_code = False
+            else:
+                parts.append(_wrap_identifiers("".join(buffer)))
+                buffer = [char]
+                in_code = True
+        else:
+            buffer.append(char)
+    if in_code:
+        # An unterminated code span: emit the remainder verbatim rather than
+        # transforming inside what markdown will still treat as code-ish text.
+        parts.append("".join(buffer))
+    else:
+        parts.append(_wrap_identifiers("".join(buffer)))
+    return "".join(parts)
+
 
 def _tokenize(text: str) -> list[str]:
     """Split text into wrap tokens, treating inline code spans as atomic.
@@ -164,7 +243,7 @@ def format_changelog(text: str) -> str:
             marker = list_match.group("marker")
             first_prefix = f"{indent}{marker} "
             cont_prefix = " " * len(first_prefix)
-            tokens = _tokenize(list_match.group("text"))
+            tokens = _tokenize(_protect_code_identifiers(list_match.group("text")))
             index += 1
             while index < total:
                 nxt = lines[index]
@@ -177,7 +256,7 @@ def format_changelog(text: str) -> str:
                     # markers are not stripped by flatten-and-rewrap.
                     if nxt.rstrip().endswith("\\") or nxt.rstrip("\n").endswith("  "):
                         break
-                    tokens.extend(_tokenize(nxt.strip()))
+                    tokens.extend(_tokenize(_protect_code_identifiers(nxt.strip())))
                     index += 1
                 else:
                     break
@@ -205,7 +284,7 @@ def format_changelog(text: str) -> str:
                 out.append(candidate.rstrip("\n"))
                 index += 1
                 break
-            paragraph.extend(_tokenize(candidate.strip()))
+            paragraph.extend(_tokenize(_protect_code_identifiers(candidate.strip())))
             index += 1
         if paragraph:
             out.extend(_wrap(paragraph, "", ""))

--- a/tests/scripts/test_format_changelog.py
+++ b/tests/scripts/test_format_changelog.py
@@ -219,6 +219,85 @@ def test_identifier_wrapping_is_idempotent(module: ModuleType) -> None:
     assert_that(twice).is_equal_to(once)
 
 
+def test_dotted_filename_underscore_is_not_wrapped(module: ModuleType) -> None:
+    """An underscore inside a dotted filename/domain is left intact."""
+    src = "- **ci**: fix format_changelog.py wrapping and update a_b.example.com (#1)\n"
+    result = module.format_changelog(src)
+
+    assert_that(result).contains("format_changelog.py")
+    assert_that(result).does_not_contain("`format_changelog`")
+    assert_that(result).contains("a_b.example.com")
+
+
+def test_inline_link_destination_underscore_is_not_wrapped(
+    module: ModuleType,
+) -> None:
+    """An underscore inside a Markdown inline link is left intact."""
+    src = "- **docs**: see [the guide](https://x.test/get_started.md) now (#1)\n"
+    result = module.format_changelog(src)
+
+    assert_that(result).contains("[the guide](https://x.test/get_started.md)")
+    assert_that(result).does_not_contain("`get_started`")
+
+
+def test_url_query_parameter_underscore_is_not_wrapped(module: ModuleType) -> None:
+    """An underscore inside a URL query string is left intact."""
+    src = "- **api**: call https://x.test/search?sort_by=name&page_size=20 (#1)\n"
+    result = module.format_changelog(src)
+
+    assert_that(result).contains("https://x.test/search?sort_by=name&page_size=20")
+    assert_that(result).does_not_contain("`sort_by`")
+    assert_that(result).does_not_contain("`page_size`")
+
+
+def test_multi_backtick_code_span_is_preserved(module: ModuleType) -> None:
+    """A double-backtick code span containing an underscore is not rewrapped."""
+    src = "- **x**: keep ``inner_code`` intact and wrap outer_ident here (#1)\n"
+    result = module.format_changelog(src)
+
+    assert_that(result).contains("``inner_code``")
+    assert_that(result).does_not_contain("`inner_code`_")
+    assert_that(result).contains("`outer_ident`")
+
+
+def test_code_span_spanning_physical_lines_is_preserved(
+    module: ModuleType,
+) -> None:
+    """Inline-code-span state carries across physical lines within a paragraph."""
+    src = (
+        "A paragraph with `code that keeps going\n"
+        "onto under_score line` then real_ident after it.\n"
+    )
+    result = module._protect_code_identifiers(src)
+
+    # The underscore inside the wrapped code span is untouched...
+    assert_that(result).contains("onto under_score line`")
+    assert_that(result).does_not_contain("`under_score`")
+    # ...while the identifier after the span closes is wrapped.
+    assert_that(result).contains("`real_ident`")
+
+
+def test_hard_break_line_identifier_is_wrapped(module: ModuleType) -> None:
+    """A snake_case identifier on a hard-break line is protected in place."""
+    src = "first line has real_ident here  \nsecond line has other_ident too\n"
+    result = module._protect_code_identifiers(src)
+
+    assert_that(result).contains("`real_ident`")
+    assert_that(result).contains("`other_ident`")
+    # The trailing hard-break marker (two spaces) is preserved.
+    assert_that(result).contains("`real_ident` here  ")
+
+
+def test_fenced_code_block_is_not_transformed(module: ModuleType) -> None:
+    """Identifiers inside a fenced code block are never wrapped."""
+    src = "```python\nx = some_func_call()\n```\n\nprose with plain_ident here\n"
+    result = module.format_changelog(src)
+
+    assert_that(result).contains("x = some_func_call()")
+    assert_that(result).does_not_contain("`some_func_call`")
+    assert_that(result).contains("`plain_ident`")
+
+
 def test_missing_file_is_a_non_fatal_skip(
     module: ModuleType,
     tmp_path: Path,

--- a/tests/scripts/test_format_changelog.py
+++ b/tests/scripts/test_format_changelog.py
@@ -146,6 +146,79 @@ def test_hard_break_lines_are_not_flattened(module: ModuleType) -> None:
     assert_that(result).contains("second line continues here")
 
 
+def test_boundary_underscore_identifier_is_wrapped(module: ModuleType) -> None:
+    """A snake_case identifier from a commit subject becomes an inline code span.
+
+    Regression for #1686: ``_rotate_audit_log`` paired with the earlier
+    ``AUDIT_FILE`` underscore to open a spurious emphasis span and trip MD037.
+    Wrapping both identifiers in backticks renders them as code and removes the
+    emphasis ambiguity.
+    """
+    src = (
+        "### Changed\n\n"
+        "- **ai**: remove dead AUDIT_FILE constant and unused _rotate_audit_log "
+        "wrapper (#1669) (d6367ff)\n"
+    )
+    result = module.format_changelog(src)
+
+    assert_that(result).contains("`AUDIT_FILE`")
+    assert_that(result).contains("`_rotate_audit_log`")
+    # The bare, emphasis-capable underscore token must no longer be present.
+    assert_that(result).does_not_contain(" _rotate_audit_log ")
+
+
+def test_bold_scope_prefix_is_not_wrapped(module: ModuleType) -> None:
+    """A ``**scope**`` prefix containing an underscore stays a bold marker."""
+    src = "- **pip_audit**: close parity gaps with osv_scanner (#1525) (1171941)\n"
+    result = module.format_changelog(src)
+
+    # The conventional-commit bold scope must be preserved verbatim.
+    assert_that(result).contains("**pip_audit**:")
+    assert_that(result).does_not_contain("`pip_audit`")
+    # The subject-body identifier is still wrapped.
+    assert_that(result).contains("`osv_scanner`")
+
+
+def test_existing_code_span_is_not_double_wrapped(module: ModuleType) -> None:
+    """An identifier already in a code span is not re-wrapped."""
+    src = "- **x**: keep `_already_code` intact and wrap _new_ident_ here (#1)\n"
+    result = module.format_changelog(src)
+
+    assert_that(result).contains("`_already_code`")
+    assert_that(result).does_not_contain("``_already_code``")
+    assert_that(result).contains("`_new_ident_`")
+
+
+def test_purely_numeric_underscore_run_is_left_alone(module: ModuleType) -> None:
+    """A numeric group separator like ``1_000`` is not treated as an identifier."""
+    src = "- **perf**: cut allocations from 1_000 to 10 per call (#1) (abc1234)\n"
+    result = module.format_changelog(src)
+
+    assert_that(result).contains("1_000")
+    assert_that(result).does_not_contain("`1_000`")
+
+
+def test_slash_delimited_path_underscore_is_not_wrapped(module: ModuleType) -> None:
+    """An underscore inside a slash-delimited path/URL segment is left intact."""
+    src = "- **docs**: link https://example.com/a_b/c_d guide (#1) (abc1234)\n"
+    result = module.format_changelog(src)
+
+    assert_that(result).contains("https://example.com/a_b/c_d")
+    assert_that(result).does_not_contain("`a_b`")
+    assert_that(result).does_not_contain("`c_d`")
+
+
+def test_identifier_wrapping_is_idempotent(module: ModuleType) -> None:
+    """Wrapping identifiers twice yields the same output."""
+    src = "- **ci**: validate MIN_AGE_DAYS floor and TAG_PREFIX sweep (#1674)\n"
+    once = module.format_changelog(src)
+    twice = module.format_changelog(once)
+
+    assert_that(once).contains("`MIN_AGE_DAYS`")
+    assert_that(once).contains("`TAG_PREFIX`")
+    assert_that(twice).is_equal_to(once)
+
+
 def test_missing_file_is_a_non_fatal_skip(
     module: ModuleType,
     tmp_path: Path,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): backtick-wrap snake_case identifiers in generated CHANGELOG (MD037)
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

The auto-generated `CHANGELOG.md` trips markdownlint `MD037` (spaces inside emphasis markers) when a conventional-commit subject contains a `snake_case` identifier. A word-boundary underscore (e.g. the leading `_` in `_rotate_audit_log`) is a valid CommonMark emphasis opener; paired with another stray underscore on the same line (e.g. `AUDIT_FILE`) it opens a spurious emphasis span, and the generated changelog can even render with unintended italics. markdownlint is correct to flag it.

This is **latent on `main`** (changed-files-scoped dogfooding never lints the unchanged CHANGELOG) but fails **full-scope** dogfooding, which `lintro-code-quality` (a required check) derives from — currently blocking PR #1683.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1686

## Details

- **Root cause pinned empirically**: MD037 fires only when a word-boundary-underscore token pairs with another underscore token; wrapping the identifier(s) in backticks removes it (confirmed against markdownlint-cli2 directly).
- **All three markdown tools pass** on the regenerated `CHANGELOG.md`: `uv run lintro chk CHANGELOG.md --tools markdownlint,prettier,vale` -> 0 issues. prettier's `proseWrap` reflow agrees with the finalizer's output (backtick spans are atomic to both).
- **Survives real regeneration**: feeding raw, unreflowed generator-style output (one long line with `_rotate_audit_log`, `_prepare_execution`, `AUDIT_FILE`) through the finalizer produces reflowed, backtick-wrapped, fully lint-clean markdown.
- **No coverage lost**: the markdownlint config is byte-identical to `main`.
- **Tests**: 6 new unit tests in `tests/scripts/test_format_changelog.py` cover boundary-underscore wrapping, bold-scope preservation, existing-code-span protection, numeric-run skipping, URL-path skipping, and idempotency. Full suite green (the one local failure is the documented `.claude`-worktree discovery quirk, which passes in CI).
