### PR TITLE
fix(ci): retry and idempotency for npm publish to survive Sigstore tlog 409

### DIFF
--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -6,6 +6,13 @@
 # is via npm trusted publishing (OIDC), so no NODE_AUTH_TOKEN is required.
 # Caller must provide npm ≥ 11.5.1 (Node 24 bundled npm in CI). Do not
 # self-upgrade npm in-place before invoking this script.
+#
+# Resilience (see issue #1682): each publish is wrapped in bounded exponential
+# backoff that retries ONLY transient Sigstore/registry failures (notably the
+# `TLOG_CREATE_ENTRY_ERROR` Rekor 409 that half-published v0.91.15). Auth and
+# validation failures are never retried — retrying them only hides the real
+# problem. Combined with the idempotency skip below, a re-run repairs a partial
+# publish instead of compounding it.
 
 set -euo pipefail
 
@@ -20,12 +27,19 @@ Publish lintro npm packages.
 Usage: publish_packages.sh
 
 Environment:
-  LIVE=1              Perform a real publish. Default (unset) is --dry-run.
-  NPM_PROVENANCE=0    Disable --provenance (default: enabled).
-  NPM_DIST_TAG        Dist-tag for npm publish (default: latest). Use a
-                      non-latest tag (e.g. backfill) when publishing a version
-                      lower than the current latest — npm refuses to move
-                      latest backwards without an explicit --tag.
+  LIVE=1                     Perform a real publish. Default (unset) is
+                             --dry-run.
+  NPM_PROVENANCE=0           Disable --provenance (default: enabled). The retry
+                             re-attempts the same signed publish; it never
+                             falls back to an unsigned one.
+  NPM_DIST_TAG               Dist-tag for npm publish (default: latest). Use a
+                             non-latest tag (e.g. backfill) when publishing a
+                             version lower than the current latest — npm refuses
+                             to move latest backwards without an explicit --tag.
+  NPM_PUBLISH_MAX_ATTEMPTS   Max publish attempts per package on a transient
+                             error (default: 3).
+  NPM_PUBLISH_RETRY_DELAY    Base backoff in seconds; doubles each retry
+                             (default: 5).
 
 Publishes @lgtm-hq/lintro-<platform> packages first, then the root meta-package,
 so consumers never resolve a meta-package whose optional deps are missing.
@@ -63,6 +77,61 @@ else
 	echo "LIVE mode: packages WILL be published to the registry (dist-tag=$dist_tag)."
 fi
 
+max_attempts="${NPM_PUBLISH_MAX_ATTEMPTS:-3}"
+retry_base_delay="${NPM_PUBLISH_RETRY_DELAY:-5}"
+
+# Transient failures that are safe to retry: the Rekor transparency-log 409
+# (TLOG_CREATE_ENTRY_ERROR), other Sigstore/tlog hiccups, registry 5xx, and
+# transient network errors. Auth (E401/E403/ENEEDAUTH/EOTP) and validation
+# errors do NOT match and therefore fall through to a hard failure.
+TRANSIENT_ERROR_RE='TLOG_CREATE_ENTRY_ERROR|creating tlog entry|transparency log|rekor|fulcio|sigstore|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|socket hang up|(50[0-9]|5[0-9][0-9]) (internal server error|bad gateway|service unavailable|gateway time-?out)|internal server error|bad gateway|service unavailable|gateway time-?out|EAGAIN'
+# A publish conflict means the exact name@version is already on the registry —
+# the desired end state. Treat it as an idempotent success (a prior attempt in
+# this loop or an earlier run landed the tarball) rather than a failure.
+ALREADY_PUBLISHED_RE='EPUBLISHCONFLICT|cannot publish over|previously published version|already published|forbidden.*over'
+
+# Publish one package directory with bounded, exponential-backoff retry on
+# transient Sigstore/registry errors only.
+#
+# Args:
+#   $1: package subdirectory under $NPM_DIR (e.g. "linux-arm64").
+# Returns:
+#   0 on a successful (or idempotently already-present) publish; 1 otherwise.
+publish_one() {
+	local pkg="$1"
+	local pkg_dir="$NPM_DIR/$pkg"
+	local attempt=1
+	local delay="$retry_base_delay"
+	local output rc
+	while :; do
+		echo "==> Publishing $pkg (attempt $attempt/$max_attempts) (${publish_flags[*]})"
+		# Re-run the identical signed publish each attempt (provenance intact).
+		# Capture combined output so we can both echo it and classify the error.
+		output="$( (cd "$pkg_dir" && npm publish "${publish_flags[@]}") 2>&1 )" && rc=0 || rc=$?
+		printf '%s\n' "$output"
+		if [[ "$rc" -eq 0 ]]; then
+			return 0
+		fi
+		if grep -qiE "$ALREADY_PUBLISHED_RE" <<<"$output"; then
+			echo "==> $pkg already present on the registry (publish conflict); treating as an idempotent success." >&2
+			return 0
+		fi
+		if grep -qiE "$TRANSIENT_ERROR_RE" <<<"$output"; then
+			if [[ "$attempt" -ge "$max_attempts" ]]; then
+				echo "ERROR: $pkg publish failed after $max_attempts attempts on a transient error." >&2
+				return 1
+			fi
+			echo "WARNING: transient publish error for $pkg (attempt $attempt/$max_attempts); retrying in ${delay}s." >&2
+			sleep "$delay"
+			attempt=$((attempt + 1))
+			delay=$((delay * 2))
+			continue
+		fi
+		echo "ERROR: $pkg publish failed with a non-transient error (exit $rc); not retrying." >&2
+		return 1
+	done
+}
+
 for pkg in "${PACKAGES[@]}"; do
 	pkg_dir="$NPM_DIR/$pkg"
 	# Idempotency: if this exact name@version is already on the registry
@@ -74,22 +143,24 @@ for pkg in "${PACKAGES[@]}"; do
 		pkg_name="$(node -p "require('$pkg_dir/package.json').name")"
 		pkg_version="$(node -p "require('$pkg_dir/package.json').version")"
 		# Distinguish "version not published" (npm E404) from a lookup that
-		# failed for another reason (network, rate-limit, auth). Only a real
-		# 404 means "safe to publish". Any other failure must abort rather
-		# than fall through to a publish that would error on a duplicate and
-		# leave the release partially published.
+		# failed for another reason (network, rate-limit, 5xx).
 		view_err="$(npm view "$pkg_name@$pkg_version" version 2>&1 >/dev/null)" && view_ok=1 || view_ok=0
 		if [[ "$view_ok" == "1" ]]; then
 			echo "==> Skipping $pkg_name@$pkg_version (already published)"
 			continue
-		elif ! grep -qi 'E404\|404 Not Found\|is not in this registry' <<<"$view_err"; then
-			echo "ERROR: could not verify $pkg_name@$pkg_version on the registry" >&2
+		elif ! grep -qiE 'E404|404 Not Found|is not in this registry' <<<"$view_err"; then
+			# The existence check itself failed, so we cannot prove the version
+			# is absent. Fail safe by neither skipping nor aborting the whole
+			# release: proceed to publish. publish_one() is conflict-safe — if
+			# the version is in fact already present, npm's publish conflict is
+			# treated as an idempotent success, and a genuine transient error is
+			# retried. Aborting here would instead risk leaving a multi-package
+			# release partially published on a mere lookup hiccup.
+			echo "WARNING: could not verify $pkg_name@$pkg_version on the registry; proceeding to publish (publish is conflict-safe)." >&2
 			echo "$view_err" >&2
-			exit 1
 		fi
 	fi
-	echo "==> Publishing $pkg (${publish_flags[*]})"
-	(cd "$pkg_dir" && npm publish "${publish_flags[@]}")
+	publish_one "$pkg"
 done
 
 echo "npm publish step complete."

--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -81,10 +81,11 @@ max_attempts="${NPM_PUBLISH_MAX_ATTEMPTS:-3}"
 retry_base_delay="${NPM_PUBLISH_RETRY_DELAY:-5}"
 
 # Transient failures that are safe to retry: the Rekor transparency-log 409
-# (TLOG_CREATE_ENTRY_ERROR), other Sigstore/tlog hiccups, registry 5xx, and
-# transient network errors. Auth (E401/E403/ENEEDAUTH/EOTP) and validation
-# errors do NOT match and therefore fall through to a hard failure.
-TRANSIENT_ERROR_RE='TLOG_CREATE_ENTRY_ERROR|creating tlog entry|transparency log|rekor|fulcio|sigstore|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|socket hang up|5[0-9][0-9] (internal server error|bad gateway|service unavailable|gateway time-?out)|internal server error|bad gateway|service unavailable|gateway time-?out|EAGAIN'
+# (TLOG_CREATE_ENTRY_ERROR), other Sigstore/tlog hiccups, registry 5xx,
+# rate-limit 429s, and transient network errors. Auth (E401/E403/ENEEDAUTH/EOTP)
+# and validation errors do NOT match and therefore fall through to a hard
+# failure.
+TRANSIENT_ERROR_RE='TLOG_CREATE_ENTRY_ERROR|creating tlog entry|transparency log|rekor|fulcio|sigstore|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|socket hang up|5[0-9][0-9] (internal server error|bad gateway|service unavailable|gateway time-?out)|internal server error|bad gateway|service unavailable|gateway time-?out|EAGAIN|E429|429 too many requests'
 # A publish conflict means the exact name@version is already on the registry —
 # the desired end state. Treat it as an idempotent success (a prior attempt in
 # this loop or an earlier run landed the tarball) rather than a failure.

--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -79,12 +79,25 @@ fi
 
 max_attempts="${NPM_PUBLISH_MAX_ATTEMPTS:-3}"
 retry_base_delay="${NPM_PUBLISH_RETRY_DELAY:-5}"
+# Reject non-integer / negative / octal-looking values up front: bad values
+# would otherwise break arithmetic in the retry loop or loop unexpectedly.
+if [[ ! "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+	echo "ERROR: NPM_PUBLISH_MAX_ATTEMPTS must be a positive integer (got '$max_attempts')" >&2
+	exit 1
+fi
+if [[ ! "$retry_base_delay" =~ ^(0|[1-9][0-9]*)$ ]]; then
+	echo "ERROR: NPM_PUBLISH_RETRY_DELAY must be a non-negative integer (got '$retry_base_delay')" >&2
+	exit 1
+fi
 
+# Non-retryable failures: authentication, permission, and validation errors.
+# These are checked BEFORE the transient patterns because an auth message can
+# also mention a Sigstore component (e.g. "sigstore authentication failed
+# (E401)"), and retrying it would only hide the real problem.
+NON_RETRYABLE_ERROR_RE='E401|E403|E402|ENEEDAUTH|EOTP|EPERM|unauthorized|forbidden|authentication failed|permission denied'
 # Transient failures that are safe to retry: the Rekor transparency-log 409
 # (TLOG_CREATE_ENTRY_ERROR), other Sigstore/tlog hiccups, registry 5xx,
-# rate-limit 429s, and transient network errors. Auth (E401/E403/ENEEDAUTH/EOTP)
-# and validation errors do NOT match and therefore fall through to a hard
-# failure.
+# rate-limit 429s, and transient network errors.
 TRANSIENT_ERROR_RE='TLOG_CREATE_ENTRY_ERROR|creating tlog entry|transparency log|rekor|fulcio|sigstore|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|socket hang up|5[0-9][0-9] (internal server error|bad gateway|service unavailable|gateway time-?out)|internal server error|bad gateway|service unavailable|gateway time-?out|EAGAIN|E429|429 too many requests'
 # A publish conflict means the exact name@version is already on the registry —
 # the desired end state. Treat it as an idempotent success (a prior attempt in
@@ -116,6 +129,10 @@ publish_one() {
 		if grep -qiE "$ALREADY_PUBLISHED_RE" <<<"$output"; then
 			echo "==> $pkg already present on the registry (publish conflict); treating as an idempotent success." >&2
 			return 0
+		fi
+		if grep -qiE "$NON_RETRYABLE_ERROR_RE" <<<"$output"; then
+			echo "ERROR: $pkg publish failed with a non-retryable auth/validation error; not retrying." >&2
+			return 1
 		fi
 		if grep -qiE "$TRANSIENT_ERROR_RE" <<<"$output"; then
 			if [[ "$attempt" -ge "$max_attempts" ]]; then

--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -79,6 +79,9 @@ fi
 
 max_attempts="${NPM_PUBLISH_MAX_ATTEMPTS:-3}"
 retry_base_delay="${NPM_PUBLISH_RETRY_DELAY:-5}"
+# Ceiling for the exponential backoff. Without it, a high attempt count would
+# double the delay unboundedly and stall the release job for hours.
+retry_max_delay="${NPM_PUBLISH_MAX_DELAY:-60}"
 # Reject non-integer / negative / octal-looking values up front: bad values
 # would otherwise break arithmetic in the retry loop or loop unexpectedly.
 if [[ ! "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
@@ -87,6 +90,10 @@ if [[ ! "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
 fi
 if [[ ! "$retry_base_delay" =~ ^(0|[1-9][0-9]*)$ ]]; then
 	echo "ERROR: NPM_PUBLISH_RETRY_DELAY must be a non-negative integer (got '$retry_base_delay')" >&2
+	exit 1
+fi
+if [[ ! "$retry_max_delay" =~ ^(0|[1-9][0-9]*)$ ]]; then
+	echo "ERROR: NPM_PUBLISH_MAX_DELAY must be a non-negative integer (got '$retry_max_delay')" >&2
 	exit 1
 fi
 
@@ -143,6 +150,9 @@ publish_one() {
 			sleep "$delay"
 			attempt=$((attempt + 1))
 			delay=$((delay * 2))
+			if [[ "$delay" -gt "$retry_max_delay" ]]; then
+				delay="$retry_max_delay"
+			fi
 			continue
 		fi
 		echo "ERROR: $pkg publish failed with a non-transient error (exit $rc); not retrying." >&2
@@ -162,6 +172,11 @@ for pkg in "${PACKAGES[@]}"; do
 		pkg_version="$(node -p "require('$pkg_dir/package.json').version")"
 		# Distinguish "version not published" (npm E404) from a lookup that
 		# failed for another reason (network, rate-limit, 5xx).
+		# Redirect order is intentional: inside $() stdout is the capture pipe,
+		# so `2>&1` routes stderr into it and `>/dev/null` then discards stdout
+		# only. view_err therefore holds just the error text. Do NOT "simplify"
+		# this to `>/dev/null 2>&1` — that discards both streams and would
+		# break the E404 classification below.
 		view_err="$(npm view "$pkg_name@$pkg_version" version 2>&1 >/dev/null)" && view_ok=1 || view_ok=0
 		if [[ "$view_ok" == "1" ]]; then
 			echo "==> Skipping $pkg_name@$pkg_version (already published)"

--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -107,7 +107,7 @@ publish_one() {
 		echo "==> Publishing $pkg (attempt $attempt/$max_attempts) (${publish_flags[*]})"
 		# Re-run the identical signed publish each attempt (provenance intact).
 		# Capture combined output so we can both echo it and classify the error.
-		output="$( (cd "$pkg_dir" && npm publish "${publish_flags[@]}") 2>&1 )" && rc=0 || rc=$?
+		output="$( (cd "$pkg_dir" && npm publish "${publish_flags[@]}") 2>&1)" && rc=0 || rc=$?
 		printf '%s\n' "$output"
 		if [[ "$rc" -eq 0 ]]; then
 			return 0

--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -84,11 +84,11 @@ retry_base_delay="${NPM_PUBLISH_RETRY_DELAY:-5}"
 # (TLOG_CREATE_ENTRY_ERROR), other Sigstore/tlog hiccups, registry 5xx, and
 # transient network errors. Auth (E401/E403/ENEEDAUTH/EOTP) and validation
 # errors do NOT match and therefore fall through to a hard failure.
-TRANSIENT_ERROR_RE='TLOG_CREATE_ENTRY_ERROR|creating tlog entry|transparency log|rekor|fulcio|sigstore|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|socket hang up|(50[0-9]|5[0-9][0-9]) (internal server error|bad gateway|service unavailable|gateway time-?out)|internal server error|bad gateway|service unavailable|gateway time-?out|EAGAIN'
+TRANSIENT_ERROR_RE='TLOG_CREATE_ENTRY_ERROR|creating tlog entry|transparency log|rekor|fulcio|sigstore|ETIMEDOUT|ECONNRESET|EAI_AGAIN|ENOTFOUND|socket hang up|5[0-9][0-9] (internal server error|bad gateway|service unavailable|gateway time-?out)|internal server error|bad gateway|service unavailable|gateway time-?out|EAGAIN'
 # A publish conflict means the exact name@version is already on the registry —
 # the desired end state. Treat it as an idempotent success (a prior attempt in
 # this loop or an earlier run landed the tarball) rather than a failure.
-ALREADY_PUBLISHED_RE='EPUBLISHCONFLICT|cannot publish over|previously published version|already published|forbidden.*over'
+ALREADY_PUBLISHED_RE='EPUBLISHCONFLICT|cannot publish over|previously published version|already published'
 
 # Publish one package directory with bounded, exponential-backoff retry on
 # transient Sigstore/registry errors only.

--- a/tests/scripts/test_npm_publish_packages.py
+++ b/tests/scripts/test_npm_publish_packages.py
@@ -25,6 +25,30 @@ _SCRIPT = _REPO_ROOT / "scripts/ci/npm/publish_packages.sh"
 _PACKAGES = ("darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "lintro")
 
 
+def _publish_log(result: subprocess.CompletedProcess[str]) -> str:
+    """Return the publish-log section the npm stub recorded.
+
+    Args:
+        result: The completed run produced by ``_run``.
+
+    Returns:
+        str: The text between the ``---LOG---`` and ``---SLEEP---`` markers.
+    """
+    return result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
+
+
+def _sleep_log(result: subprocess.CompletedProcess[str]) -> str:
+    """Return the recorded backoff-sleep durations, one per line.
+
+    Args:
+        result: The completed run produced by ``_run``.
+
+    Returns:
+        str: The text after the ``---SLEEP---`` marker.
+    """
+    return result.stdout.split("---SLEEP---", 1)[1]
+
+
 def _write_stub(bin_dir: Path, name: str, body: str) -> None:
     """Write an executable stub binary into a PATH shim directory.
 
@@ -178,7 +202,7 @@ def test_all_packages_publish_when_absent(tmp_path: Path) -> None:
     for pkg in _PACKAGES:
         assert_that(result.stdout).contains(f"Publishing {pkg}")
     # Meta package is published last.
-    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
+    log = _publish_log(result)
     assert_that(log.strip().splitlines()).is_length(len(_PACKAGES))
     assert_that(log.strip().splitlines()[-1]).contains("lintro")
 
@@ -186,7 +210,7 @@ def test_all_packages_publish_when_absent(tmp_path: Path) -> None:
 def test_provenance_flag_is_passed(tmp_path: Path) -> None:
     """Each publish carries --provenance so signing is never dropped."""
     result = _run(tmp_path, npm_body="exit 0")
-    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
+    log = _publish_log(result)
     for line in log.strip().splitlines():
         assert_that(line).contains("--provenance")
 
@@ -205,7 +229,11 @@ def test_transient_tlog_409_is_retried_then_succeeds(tmp_path: Path) -> None:
         "exit 0"
     )
     state = tmp_path / "state"
-    result = _run(tmp_path, npm_body=npm_body, extra_env={"STATE": str(state)})
+    result = _run(
+        tmp_path,
+        npm_body=npm_body,
+        extra_env={"STATE": str(state), "NPM_PUBLISH_MAX_ATTEMPTS": "3"},
+    )
     assert_that(result.returncode).is_equal_to(0)
     assert_that(result.stdout).contains("transient publish error for linux-arm64")
     assert_that(result.stdout).contains("attempt 1/3")
@@ -232,10 +260,14 @@ def test_backoff_delay_doubles_between_retries(tmp_path: Path) -> None:
         tmp_path,
         npm_body=npm_body,
         # Base delay 5s; the stubbed sleep records without waiting.
-        extra_env={"STATE": str(state), "NPM_PUBLISH_RETRY_DELAY": "5"},
+        extra_env={
+            "STATE": str(state),
+            "NPM_PUBLISH_RETRY_DELAY": "5",
+            "NPM_PUBLISH_MAX_ATTEMPTS": "3",
+        },
     )
     assert_that(result.returncode).is_equal_to(0)
-    sleeps = result.stdout.split("---SLEEP---", 1)[1].strip().splitlines()
+    sleeps = _sleep_log(result).strip().splitlines()
     # 5 then 10 — exponential doubling of the base delay.
     assert_that(sleeps).is_equal_to(["5", "10"])
 
@@ -274,7 +306,7 @@ def test_transient_error_exhausts_attempts_and_fails(tmp_path: Path) -> None:
     assert_that(result.returncode).is_not_equal_to(0)
     assert_that(result.stdout).contains("failed after 3 attempts")
     # linux-x64 and the meta package must NOT publish after the hard failure.
-    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
+    log = _publish_log(result)
     assert_that(log).does_not_contain("linux-x64")
     assert_that(log).does_not_contain("lintro")
 
@@ -291,13 +323,48 @@ def test_auth_failure_is_not_retried(tmp_path: Path) -> None:
     )
     result = _run(tmp_path, npm_body=npm_body)
     assert_that(result.returncode).is_not_equal_to(0)
-    assert_that(result.stdout).contains("non-transient error")
+    assert_that(result.stdout).contains("non-retryable auth/validation error")
     # Only one publish attempt for darwin-arm64 (no retry).
-    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
+    log = _publish_log(result)
     darwin_attempts = [
         line for line in log.strip().splitlines() if "darwin-arm64" in line
     ]
     assert_that(darwin_attempts).is_length(1)
+
+
+def test_auth_error_mentioning_sigstore_is_not_retried(tmp_path: Path) -> None:
+    """An auth failure is a hard fail even if it names a Sigstore component.
+
+    The transient regex matches ``sigstore``; the non-retryable auth check must
+    win so ``sigstore authentication failed (E401)`` is never retried.
+    """
+    npm_body = (
+        'if [[ "$(basename "$PWD")" == "darwin-arm64" ]]; then\n'
+        '  echo "npm error sigstore authentication failed (E401)" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0"
+    )
+    result = _run(tmp_path, npm_body=npm_body)
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stdout).contains("non-retryable auth/validation error")
+    log = _publish_log(result)
+    darwin_attempts = [
+        line for line in log.strip().splitlines() if "darwin-arm64" in line
+    ]
+    assert_that(darwin_attempts).is_length(1)
+
+
+def test_invalid_max_attempts_is_rejected(tmp_path: Path) -> None:
+    """A non-integer NPM_PUBLISH_MAX_ATTEMPTS aborts before any publish."""
+    result = _run(
+        tmp_path,
+        npm_body="exit 0",
+        extra_env={"NPM_PUBLISH_MAX_ATTEMPTS": "0"},
+    )
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stdout).contains("NPM_PUBLISH_MAX_ATTEMPTS must be")
+    assert_that(_publish_log(result).strip()).is_equal_to("")
 
 
 def test_already_published_versions_are_skipped(tmp_path: Path) -> None:
@@ -317,7 +384,7 @@ def test_already_published_versions_are_skipped(tmp_path: Path) -> None:
     assert_that(result.stdout).contains("Skipping @lgtm-hq/lintro-darwin-arm64")
     assert_that(result.stdout).contains("Skipping @lgtm-hq/lintro-darwin-x64")
     # Only the three remaining packages actually publish.
-    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
+    log = _publish_log(result)
     published = log.strip().splitlines()
     assert_that(published).is_length(3)
     assert_that(log).does_not_contain("darwin")
@@ -360,7 +427,7 @@ def test_ambiguous_view_failure_falls_through_to_publish(tmp_path: Path) -> None
     assert_that(result.stdout).contains("could not verify @lgtm-hq/lintro-linux-arm64")
     assert_that(result.stdout).contains("proceeding to publish")
     # linux-arm64 is still published despite the ambiguous check.
-    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
+    log = _publish_log(result)
     assert_that(log).contains("linux-arm64")
 
 
@@ -376,5 +443,5 @@ def test_dry_run_publishes_without_existence_check(tmp_path: Path) -> None:
     )
     assert_that(result.returncode).is_equal_to(0)
     assert_that(result.stdout).does_not_contain("VIEW SHOULD NOT RUN")
-    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
+    log = _publish_log(result)
     assert_that(log.strip().splitlines()).is_length(len(_PACKAGES))

--- a/tests/scripts/test_npm_publish_packages.py
+++ b/tests/scripts/test_npm_publish_packages.py
@@ -1,0 +1,324 @@
+"""Tests for scripts/ci/npm/publish_packages.sh.
+
+These exercise the retry + idempotency behaviour of the npm publish helper
+using stub ``npm`` and ``node`` binaries on PATH. Nothing is published and no
+network call is made: the stubs record every invocation and emit canned output
+so we can assert on retries, skips, and hard failures.
+
+The live publish path itself only runs on tag-push, so it is never exercised by
+PR CI; these script-level tests are the correctness signal for the retry and
+existence-check logic.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess  # nosec B404 - drives the script under test with shell=False
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts/ci/npm/publish_packages.sh"
+
+# The five package subdirectories the script publishes, in order.
+_PACKAGES = ("darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "lintro")
+
+
+def _write_stub(bin_dir: Path, name: str, body: str) -> None:
+    """Write an executable stub binary into a PATH shim directory.
+
+    Args:
+        bin_dir: Directory prepended to PATH for the script under test.
+        name: Binary name to shadow (e.g. ``npm``).
+        body: Bash script body executed when the stub is invoked.
+    """
+    stub = bin_dir / name
+    stub.write_text(f"#!/usr/bin/env bash\n{body}\n")
+    stub.chmod(0o755)
+
+
+def _fake_npm_dir(root: Path) -> Path:
+    """Create a fake ``npm`` package tree the script can read manifests from.
+
+    Args:
+        root: Directory that will act as the repository root override.
+
+    Returns:
+        Path: The created ``npm`` directory containing per-package manifests.
+    """
+    npm_dir = root / "npm"
+    for pkg in _PACKAGES:
+        pkg_dir = npm_dir / pkg
+        pkg_dir.mkdir(parents=True)
+        name = "@lgtm-hq/lintro" if pkg == "lintro" else f"@lgtm-hq/lintro-{pkg}"
+        (pkg_dir / "package.json").write_text(
+            f'{{"name": "{name}", "version": "9.9.9"}}\n',
+        )
+    return npm_dir
+
+
+def _node_stub_body() -> str:
+    """Return a bash body that emulates ``node -p "require(...).<field>"``.
+
+    The real script calls ``node -p`` to read the package name and version from
+    each manifest; the stub parses the manifest path and requested field out of
+    the expression and echoes the matching value.
+
+    Returns:
+        str: Bash source for the ``node`` stub.
+    """
+    return r"""
+expr="${2:-}"
+path="$(sed -n "s/.*require('\([^']*\)').*/\1/p" <<<"$expr")"
+field="$(sed -n "s/.*)\.\([a-z]*\).*/\1/p" <<<"$expr")"
+grep -o "\"$field\": *\"[^\"]*\"" "$path" | sed "s/.*: *\"\([^\"]*\)\"/\1/"
+"""
+
+
+def _run(
+    tmp_path: Path,
+    npm_body: str,
+    *,
+    extra_env: dict[str, str] | None = None,
+    view_body: str | None = None,
+    log_name: str = "npm.log",
+) -> subprocess.CompletedProcess[str]:
+    """Run publish_packages.sh with stub ``npm``/``node`` on PATH.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+        npm_body: Bash body for ``npm publish`` handling (receives ``$@``).
+        extra_env: Extra environment variables for the script.
+        view_body: Optional bash body for ``npm view`` handling. When omitted
+            ``npm view`` reports E404 (version not yet published).
+        log_name: File the npm stub appends its argv to for assertions.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed process.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    root = tmp_path / "repo"
+    root.mkdir()
+    _fake_npm_dir(root)
+    log = tmp_path / log_name
+
+    view = view_body or (
+        'echo "npm error code E404" >&2\n'
+        'echo "npm error 404 Not Found - GET registry" >&2\n'
+        "exit 1"
+    )
+    npm = (
+        f'if [[ "$1" == "view" ]]; then\n{view}\nfi\n'
+        f'if [[ "$1" == "publish" ]]; then\n'
+        f'echo "publish $(basename "$PWD") $*" >> "{log}"\n{npm_body}\nfi\n'
+    )
+    _write_stub(bin_dir, "npm", npm)
+    _write_stub(bin_dir, "node", _node_stub_body())
+
+    env = {
+        **os.environ.copy(),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "LIVE": "1",
+        "NPM_PROVENANCE": "1",
+        "NPM_PUBLISH_RETRY_DELAY": "0",
+        # Point the script's REPO_ROOT-derived npm dir at our fake tree by
+        # copying the script into the fake root so its ../../.. resolves there.
+        **(extra_env or {}),
+    }
+    # Copy the script into the fake repo so REPO_ROOT resolves to our tree.
+    script_dst = root / "scripts" / "ci" / "npm" / "publish_packages.sh"
+    script_dst.parent.mkdir(parents=True)
+    script_dst.write_text(_SCRIPT.read_text())
+    script_dst.chmod(0o755)
+
+    result = subprocess.run(  # nosec B603 - fixed argv, stubbed PATH, no network
+        [str(script_dst)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    result_log = log.read_text() if log.exists() else ""
+    # Fold stderr (warnings/errors) into stdout, then append the publish log so
+    # a single ``result.stdout`` carries everything the assertions inspect.
+    result.stdout = f"{result.stdout}\n{result.stderr}\n---LOG---\n{result_log}"
+    return result
+
+
+def test_help_exits_zero() -> None:
+    """The --help flag prints usage and exits 0."""
+    result = subprocess.run(  # nosec B603 - fixed argv against the real script
+        [str(_SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("Usage:")
+    assert_that(result.stdout).contains("NPM_PUBLISH_MAX_ATTEMPTS")
+
+
+def test_all_packages_publish_when_absent(tmp_path: Path) -> None:
+    """When no version exists, all five packages publish once, in order."""
+    result = _run(tmp_path, npm_body="exit 0")
+    assert_that(result.returncode).is_equal_to(0)
+    for pkg in _PACKAGES:
+        assert_that(result.stdout).contains(f"Publishing {pkg}")
+    # Meta package is published last.
+    log = result.stdout.split("---LOG---", 1)[1]
+    assert_that(log.strip().splitlines()).is_length(len(_PACKAGES))
+    assert_that(log.strip().splitlines()[-1]).contains("lintro")
+
+
+def test_provenance_flag_is_passed(tmp_path: Path) -> None:
+    """Each publish carries --provenance so signing is never dropped."""
+    result = _run(tmp_path, npm_body="exit 0")
+    log = result.stdout.split("---LOG---", 1)[1]
+    for line in log.strip().splitlines():
+        assert_that(line).contains("--provenance")
+
+
+def test_transient_tlog_409_is_retried_then_succeeds(tmp_path: Path) -> None:
+    """A TLOG_CREATE_ENTRY_ERROR on the first attempt is retried and succeeds."""
+    # Fail the first publish of linux-arm64 with the tlog 409, then succeed.
+    npm_body = (
+        'if [[ "$(basename "$PWD")" == "linux-arm64" && ! -f "$STATE" ]]; then\n'
+        '  touch "$STATE"\n'
+        '  echo "npm error code TLOG_CREATE_ENTRY_ERROR" >&2\n'
+        '  echo "npm error error creating tlog entry - (409) an equivalent '
+        'entry already exists" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0"
+    )
+    state = tmp_path / "state"
+    result = _run(tmp_path, npm_body=npm_body, extra_env={"STATE": str(state)})
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("transient publish error for linux-arm64")
+    assert_that(result.stdout).contains("attempt 1/3")
+    assert_that(result.stdout).contains("attempt 2/3")
+
+
+def test_transient_error_exhausts_attempts_and_fails(tmp_path: Path) -> None:
+    """A persistently transient error fails after the bounded attempt budget."""
+    npm_body = (
+        'if [[ "$(basename "$PWD")" == "linux-arm64" ]]; then\n'
+        '  echo "npm error code TLOG_CREATE_ENTRY_ERROR" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0"
+    )
+    result = _run(
+        tmp_path,
+        npm_body=npm_body,
+        extra_env={"NPM_PUBLISH_MAX_ATTEMPTS": "3"},
+    )
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stdout).contains("failed after 3 attempts")
+    # linux-x64 and meta must NOT publish after the hard failure.
+    log = result.stdout.split("---LOG---", 1)[1]
+    assert_that(log).does_not_contain("linux-x64")
+
+
+def test_auth_failure_is_not_retried(tmp_path: Path) -> None:
+    """A non-transient auth failure fails immediately without retrying."""
+    npm_body = (
+        'if [[ "$(basename "$PWD")" == "darwin-arm64" ]]; then\n'
+        '  echo "npm error code E401" >&2\n'
+        '  echo "npm error 401 Unauthorized - PUT registry" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0"
+    )
+    result = _run(tmp_path, npm_body=npm_body)
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stdout).contains("non-transient error")
+    # Only one publish attempt for darwin-arm64 (no retry).
+    log = result.stdout.split("---LOG---", 1)[1]
+    darwin_attempts = [
+        line for line in log.strip().splitlines() if "darwin-arm64" in line
+    ]
+    assert_that(darwin_attempts).is_length(1)
+
+
+def test_already_published_versions_are_skipped(tmp_path: Path) -> None:
+    """Versions already on the registry are skipped loudly, not re-published."""
+    # npm view reports the two darwin packages as present, others E404.
+    view_body = (
+        'if grep -qE "darwin-(arm64|x64)" <<<"$*"; then\n'
+        '  echo "9.9.9"\n'
+        "  exit 0\n"
+        "fi\n"
+        'echo "npm error code E404" >&2\n'
+        'echo "npm error 404 Not Found" >&2\n'
+        "exit 1"
+    )
+    result = _run(tmp_path, npm_body="exit 0", view_body=view_body)
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("Skipping @lgtm-hq/lintro-darwin-arm64")
+    assert_that(result.stdout).contains("Skipping @lgtm-hq/lintro-darwin-x64")
+    # Only the three remaining packages actually publish.
+    log = result.stdout.split("---LOG---", 1)[1]
+    published = log.strip().splitlines()
+    assert_that(published).is_length(3)
+    assert_that(log).does_not_contain("darwin")
+
+
+def test_publish_conflict_is_treated_as_idempotent_success(tmp_path: Path) -> None:
+    """A publish conflict (version already present) counts as success."""
+    # view reports absent, but publish returns EPUBLISHCONFLICT — the version
+    # landed via a prior attempt/run. The loop must continue, not abort.
+    npm_body = (
+        'if [[ "$(basename "$PWD")" == "linux-arm64" ]]; then\n'
+        '  echo "npm error code EPUBLISHCONFLICT" >&2\n'
+        '  echo "npm error You cannot publish over the previously published '
+        'versions: 9.9.9." >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0"
+    )
+    result = _run(tmp_path, npm_body=npm_body)
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("idempotent success")
+    # All five packages are attempted; the meta package still publishes.
+    assert_that(result.stdout).contains("Publishing lintro")
+
+
+def test_ambiguous_view_failure_falls_through_to_publish(tmp_path: Path) -> None:
+    """A non-404 view failure does not abort; it proceeds to a conflict-safe publish."""
+    # npm view fails with a 5xx for linux-arm64 (cannot prove absence).
+    view_body = (
+        'if grep -q "linux-arm64" <<<"$*"; then\n'
+        '  echo "npm error code E500" >&2\n'
+        '  echo "npm error 500 Internal Server Error" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        'echo "npm error code E404" >&2\n'
+        "exit 1"
+    )
+    result = _run(tmp_path, npm_body="exit 0", view_body=view_body)
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("could not verify @lgtm-hq/lintro-linux-arm64")
+    assert_that(result.stdout).contains("proceeding to publish")
+    # linux-arm64 is still published despite the ambiguous check.
+    log = result.stdout.split("---LOG---", 1)[1]
+    assert_that(log).contains("linux-arm64")
+
+
+def test_dry_run_publishes_without_existence_check(tmp_path: Path) -> None:
+    """In dry-run mode every package runs and the registry is never queried."""
+    # If npm view were called it would fail loudly; assert it is not.
+    view_body = 'echo "VIEW SHOULD NOT RUN" >&2\nexit 1'
+    result = _run(
+        tmp_path,
+        npm_body="exit 0",
+        view_body=view_body,
+        extra_env={"LIVE": "0", "NPM_PROVENANCE": "0"},
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).does_not_contain("VIEW SHOULD NOT RUN")
+    log = result.stdout.split("---LOG---", 1)[1]
+    assert_that(log.strip().splitlines()).is_length(len(_PACKAGES))

--- a/tests/scripts/test_npm_publish_packages.py
+++ b/tests/scripts/test_npm_publish_packages.py
@@ -16,7 +16,6 @@ import os
 import subprocess  # nosec B404 - drives the script under test with shell=False
 from pathlib import Path
 
-import pytest
 from assertpy import assert_that
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent

--- a/tests/scripts/test_npm_publish_packages.py
+++ b/tests/scripts/test_npm_publish_packages.py
@@ -139,6 +139,7 @@ def _run(
         text=True,
         check=False,
         env=env,
+        timeout=60,
     )
     result_log = log.read_text() if log.exists() else ""
     # Fold stderr (warnings/errors) into stdout, then append the publish log so
@@ -154,6 +155,7 @@ def test_help_exits_zero() -> None:
         capture_output=True,
         text=True,
         check=False,
+        timeout=60,
     )
     assert_that(result.returncode).is_equal_to(0)
     assert_that(result.stdout).contains("Usage:")
@@ -217,9 +219,10 @@ def test_transient_error_exhausts_attempts_and_fails(tmp_path: Path) -> None:
     )
     assert_that(result.returncode).is_not_equal_to(0)
     assert_that(result.stdout).contains("failed after 3 attempts")
-    # linux-x64 and meta must NOT publish after the hard failure.
+    # linux-x64 and the meta package must NOT publish after the hard failure.
     log = result.stdout.split("---LOG---", 1)[1]
     assert_that(log).does_not_contain("linux-x64")
+    assert_that(log).does_not_contain("lintro")
 
 
 def test_auth_failure_is_not_retried(tmp_path: Path) -> None:

--- a/tests/scripts/test_npm_publish_packages.py
+++ b/tests/scripts/test_npm_publish_packages.py
@@ -116,6 +116,10 @@ def _run(
     )
     _write_stub(bin_dir, "npm", npm)
     _write_stub(bin_dir, "node", _node_stub_body())
+    # Record backoff durations without actually sleeping so retry tests stay
+    # fast even with a non-zero NPM_PUBLISH_RETRY_DELAY.
+    sleep_log = tmp_path / "sleep.log"
+    _write_stub(bin_dir, "sleep", f'echo "$1" >> "{sleep_log}"')
 
     env = {
         **os.environ.copy(),
@@ -142,9 +146,14 @@ def _run(
         timeout=60,
     )
     result_log = log.read_text() if log.exists() else ""
-    # Fold stderr (warnings/errors) into stdout, then append the publish log so
-    # a single ``result.stdout`` carries everything the assertions inspect.
-    result.stdout = f"{result.stdout}\n{result.stderr}\n---LOG---\n{result_log}"
+    sleep_record = sleep_log.read_text() if sleep_log.exists() else ""
+    # Fold stderr (warnings/errors) into stdout, then append the publish and
+    # sleep logs so a single ``result.stdout`` carries everything the
+    # assertions inspect.
+    result.stdout = (
+        f"{result.stdout}\n{result.stderr}\n"
+        f"---LOG---\n{result_log}\n---SLEEP---\n{sleep_record}"
+    )
     return result
 
 
@@ -169,7 +178,7 @@ def test_all_packages_publish_when_absent(tmp_path: Path) -> None:
     for pkg in _PACKAGES:
         assert_that(result.stdout).contains(f"Publishing {pkg}")
     # Meta package is published last.
-    log = result.stdout.split("---LOG---", 1)[1]
+    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
     assert_that(log.strip().splitlines()).is_length(len(_PACKAGES))
     assert_that(log.strip().splitlines()[-1]).contains("lintro")
 
@@ -177,7 +186,7 @@ def test_all_packages_publish_when_absent(tmp_path: Path) -> None:
 def test_provenance_flag_is_passed(tmp_path: Path) -> None:
     """Each publish carries --provenance so signing is never dropped."""
     result = _run(tmp_path, npm_body="exit 0")
-    log = result.stdout.split("---LOG---", 1)[1]
+    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
     for line in log.strip().splitlines():
         assert_that(line).contains("--provenance")
 
@@ -203,6 +212,51 @@ def test_transient_tlog_409_is_retried_then_succeeds(tmp_path: Path) -> None:
     assert_that(result.stdout).contains("attempt 2/3")
 
 
+def test_backoff_delay_doubles_between_retries(tmp_path: Path) -> None:
+    """Retry backoff is exponential: the recorded sleeps double each attempt."""
+    # linux-arm64 fails transiently on the first two attempts, then succeeds,
+    # so publish_one sleeps twice before the third attempt lands.
+    npm_body = (
+        'if [[ "$(basename "$PWD")" == "linux-arm64" ]]; then\n'
+        '  n="$(cat "$STATE" 2>/dev/null || echo 0)"\n'
+        '  if [[ "$n" -lt 2 ]]; then\n'
+        '    echo "$((n + 1))" > "$STATE"\n'
+        '    echo "npm error code TLOG_CREATE_ENTRY_ERROR" >&2\n'
+        "    exit 1\n"
+        "  fi\n"
+        "fi\n"
+        "exit 0"
+    )
+    state = tmp_path / "state"
+    result = _run(
+        tmp_path,
+        npm_body=npm_body,
+        # Base delay 5s; the stubbed sleep records without waiting.
+        extra_env={"STATE": str(state), "NPM_PUBLISH_RETRY_DELAY": "5"},
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    sleeps = result.stdout.split("---SLEEP---", 1)[1].strip().splitlines()
+    # 5 then 10 — exponential doubling of the base delay.
+    assert_that(sleeps).is_equal_to(["5", "10"])
+
+
+def test_rate_limit_429_is_retried_then_succeeds(tmp_path: Path) -> None:
+    """A registry 429 (rate limit) is transient and retried, not a hard fail."""
+    npm_body = (
+        'if [[ "$(basename "$PWD")" == "linux-arm64" && ! -f "$STATE" ]]; then\n'
+        '  touch "$STATE"\n'
+        '  echo "npm error code E429" >&2\n'
+        '  echo "npm error 429 Too Many Requests - PUT registry" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0"
+    )
+    state = tmp_path / "state"
+    result = _run(tmp_path, npm_body=npm_body, extra_env={"STATE": str(state)})
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("transient publish error for linux-arm64")
+
+
 def test_transient_error_exhausts_attempts_and_fails(tmp_path: Path) -> None:
     """A persistently transient error fails after the bounded attempt budget."""
     npm_body = (
@@ -220,7 +274,7 @@ def test_transient_error_exhausts_attempts_and_fails(tmp_path: Path) -> None:
     assert_that(result.returncode).is_not_equal_to(0)
     assert_that(result.stdout).contains("failed after 3 attempts")
     # linux-x64 and the meta package must NOT publish after the hard failure.
-    log = result.stdout.split("---LOG---", 1)[1]
+    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
     assert_that(log).does_not_contain("linux-x64")
     assert_that(log).does_not_contain("lintro")
 
@@ -239,7 +293,7 @@ def test_auth_failure_is_not_retried(tmp_path: Path) -> None:
     assert_that(result.returncode).is_not_equal_to(0)
     assert_that(result.stdout).contains("non-transient error")
     # Only one publish attempt for darwin-arm64 (no retry).
-    log = result.stdout.split("---LOG---", 1)[1]
+    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
     darwin_attempts = [
         line for line in log.strip().splitlines() if "darwin-arm64" in line
     ]
@@ -263,7 +317,7 @@ def test_already_published_versions_are_skipped(tmp_path: Path) -> None:
     assert_that(result.stdout).contains("Skipping @lgtm-hq/lintro-darwin-arm64")
     assert_that(result.stdout).contains("Skipping @lgtm-hq/lintro-darwin-x64")
     # Only the three remaining packages actually publish.
-    log = result.stdout.split("---LOG---", 1)[1]
+    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
     published = log.strip().splitlines()
     assert_that(published).is_length(3)
     assert_that(log).does_not_contain("darwin")
@@ -306,7 +360,7 @@ def test_ambiguous_view_failure_falls_through_to_publish(tmp_path: Path) -> None
     assert_that(result.stdout).contains("could not verify @lgtm-hq/lintro-linux-arm64")
     assert_that(result.stdout).contains("proceeding to publish")
     # linux-arm64 is still published despite the ambiguous check.
-    log = result.stdout.split("---LOG---", 1)[1]
+    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
     assert_that(log).contains("linux-arm64")
 
 
@@ -322,5 +376,5 @@ def test_dry_run_publishes_without_existence_check(tmp_path: Path) -> None:
     )
     assert_that(result.returncode).is_equal_to(0)
     assert_that(result.stdout).does_not_contain("VIEW SHOULD NOT RUN")
-    log = result.stdout.split("---LOG---", 1)[1]
+    log = result.stdout.split("---LOG---", 1)[1].split("---SLEEP---", 1)[0]
     assert_that(log.strip().splitlines()).is_length(len(_PACKAGES))

--- a/tests/scripts/test_npm_publish_packages.py
+++ b/tests/scripts/test_npm_publish_packages.py
@@ -16,6 +16,7 @@ import os
 import subprocess  # nosec B404 - drives the script under test with shell=False
 from pathlib import Path
 
+import pytest
 from assertpy import assert_that
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -272,6 +273,41 @@ def test_backoff_delay_doubles_between_retries(tmp_path: Path) -> None:
     assert_that(sleeps).is_equal_to(["5", "10"])
 
 
+def test_backoff_delay_is_capped(tmp_path: Path) -> None:
+    """Exponential backoff stops doubling once it reaches the ceiling.
+
+    Without a cap a high attempt count would grow the delay unboundedly and
+    stall the release job long past any useful retry window.
+    """
+    npm_body = (
+        'if [[ "$(basename "$PWD")" == "linux-arm64" ]]; then\n'
+        '  n="$(cat "$STATE" 2>/dev/null || echo 0)"\n'
+        '  if [[ "$n" -lt 4 ]]; then\n'
+        '    echo "$((n + 1))" > "$STATE"\n'
+        '    echo "npm error code TLOG_CREATE_ENTRY_ERROR" >&2\n'
+        "    exit 1\n"
+        "  fi\n"
+        "fi\n"
+        "exit 0"
+    )
+    state = tmp_path / "state"
+    result = _run(
+        tmp_path,
+        npm_body=npm_body,
+        extra_env={
+            "STATE": str(state),
+            "NPM_PUBLISH_RETRY_DELAY": "10",
+            "NPM_PUBLISH_MAX_ATTEMPTS": "5",
+            "NPM_PUBLISH_MAX_DELAY": "25",
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    sleeps = _sleep_log(result).strip().splitlines()
+    # 10, 20, then clamped to 25 instead of 40 and 80.
+    assert_that(sleeps).is_equal_to(["10", "20", "25", "25"])
+
+
 def test_rate_limit_429_is_retried_then_succeeds(tmp_path: Path) -> None:
     """A registry 429 (rate limit) is transient and retried, not a hard fail."""
     npm_body = (
@@ -330,6 +366,9 @@ def test_auth_failure_is_not_retried(tmp_path: Path) -> None:
         line for line in log.strip().splitlines() if "darwin-arm64" in line
     ]
     assert_that(darwin_attempts).is_length(1)
+    # The run aborts at the first hard failure: later packages never publish.
+    assert_that(log).does_not_contain("linux-x64")
+    assert_that(log).does_not_contain("lintro")
 
 
 def test_auth_error_mentioning_sigstore_is_not_retried(tmp_path: Path) -> None:
@@ -353,18 +392,93 @@ def test_auth_error_mentioning_sigstore_is_not_retried(tmp_path: Path) -> None:
         line for line in log.strip().splitlines() if "darwin-arm64" in line
     ]
     assert_that(darwin_attempts).is_length(1)
+    # The run aborts at the first hard failure: later packages never publish.
+    assert_that(log).does_not_contain("linux-x64")
+    assert_that(log).does_not_contain("lintro")
 
 
-def test_invalid_max_attempts_is_rejected(tmp_path: Path) -> None:
-    """A non-integer NPM_PUBLISH_MAX_ATTEMPTS aborts before any publish."""
+@pytest.mark.parametrize("bad_value", ["0", "abc", "-1"])
+def test_invalid_max_attempts_is_rejected(tmp_path: Path, bad_value: str) -> None:
+    """An out-of-range NPM_PUBLISH_MAX_ATTEMPTS aborts before any publish.
+
+    The guard requires a *positive* integer, so zero and negative values are
+    rejected alongside genuinely non-numeric ones.
+    """
     result = _run(
         tmp_path,
         npm_body="exit 0",
-        extra_env={"NPM_PUBLISH_MAX_ATTEMPTS": "0"},
+        extra_env={"NPM_PUBLISH_MAX_ATTEMPTS": bad_value},
     )
     assert_that(result.returncode).is_not_equal_to(0)
     assert_that(result.stdout).contains("NPM_PUBLISH_MAX_ATTEMPTS must be")
     assert_that(_publish_log(result).strip()).is_equal_to("")
+
+
+def test_unknown_error_is_not_retried(tmp_path: Path) -> None:
+    """An unclassifiable failure falls through to a hard fail without retry.
+
+    Guards the fall-through branch of ``publish_one``: if a future regex edit
+    accidentally widened or narrowed one of the three classifiers, an unknown
+    error could silently start retrying (or stop failing) unnoticed.
+    """
+    npm_body = (
+        'if [[ "$(basename "$PWD")" == "darwin-arm64" ]]; then\n'
+        '  echo "npm error code EUNKNOWN" >&2\n'
+        '  echo "npm error something entirely unclassifiable" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0"
+    )
+    result = _run(tmp_path, npm_body=npm_body)
+
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stdout).contains("non-transient error")
+    log = _publish_log(result)
+    darwin_attempts = [
+        line for line in log.strip().splitlines() if "darwin-arm64" in line
+    ]
+    assert_that(darwin_attempts).is_length(1)
+    assert_that(log).does_not_contain("linux-x64")
+
+
+@pytest.mark.parametrize(
+    ("stderr_line", "expected_marker"),
+    [
+        ("npm error code E401", "non-retryable auth/validation error"),
+        ("npm error 403 Forbidden - PUT registry", "non-retryable"),
+        ("npm error code ENEEDAUTH", "non-retryable"),
+        ("npm error permission denied", "non-retryable"),
+        ("npm error TLOG_CREATE_ENTRY_ERROR creating tlog entry", "transient"),
+        ("npm error 503 Service Unavailable", "transient"),
+        ("npm error 429 Too Many Requests", "transient"),
+        ("npm error ECONNRESET socket hang up", "transient"),
+    ],
+)
+def test_stderr_patterns_select_expected_path(
+    tmp_path: Path,
+    stderr_line: str,
+    expected_marker: str,
+) -> None:
+    """Representative npm failure strings route to their intended classifier.
+
+    Locks the wording of each supported error family so a registry message
+    change cannot silently fall through to the wrong retry path.
+    """
+    npm_body = (
+        'if [[ "$(basename "$PWD")" == "darwin-arm64" ]]; then\n'
+        f'  echo "{stderr_line}" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0"
+    )
+    result = _run(
+        tmp_path,
+        npm_body=npm_body,
+        extra_env={"NPM_PUBLISH_MAX_ATTEMPTS": "2", "NPM_PUBLISH_RETRY_DELAY": "0"},
+    )
+
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stdout).contains(expected_marker)
 
 
 def test_already_published_versions_are_skipped(tmp_path: Path) -> None:

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -1045,6 +1045,55 @@ def test_publish_npm_exposes_dist_tag_for_backfills() -> None:
     assert_that(publish_step["env"]["NPM_DIST_TAG"]).contains("inputs.dist_tag")
 
 
+def test_publish_npm_delegates_publish_to_hardened_script() -> None:
+    """The publish step runs publish_packages.sh (retry/idempotency live there).
+
+    The retry + existence-check logic (issue #1682) must live in a testable
+    script under scripts/ci/npm/, not inline in the workflow, so the publish
+    step's ``run`` invokes that script rather than a raw ``npm publish`` loop.
+    """
+    workflow = _load_workflow(name="publish-npm.yml")
+    publish_step = next(
+        (
+            step
+            for step in workflow["jobs"]["publish"]["steps"]
+            if step.get("name") == "Publish to npm"
+        ),
+        None,
+    )
+    assert_that(publish_step).is_not_none()
+    assert publish_step is not None  # narrow type for mypy
+    assert_that(publish_step["run"]).contains(
+        "scripts/ci/npm/publish_packages.sh",
+    )
+    # Provenance must not be dropped on a live publish.
+    assert_that(publish_step["env"]["NPM_PROVENANCE"]).contains("'0'")
+    assert_that(publish_step["env"]["NPM_PROVENANCE"]).contains("'1'")
+
+
+def test_publish_npm_script_retries_only_transient_errors() -> None:
+    """publish_packages.sh retries transient tlog/registry errors, not auth.
+
+    Guards the core of issue #1682: the Rekor 409 (TLOG_CREATE_ENTRY_ERROR)
+    class is retried with bounded backoff while auth/validation failures are
+    not, and the registry existence check makes a re-run idempotent.
+    """
+    script = (
+        _REPO_ROOT / "scripts" / "ci" / "npm" / "publish_packages.sh"
+    ).read_text()
+    assert_that(script).contains("TLOG_CREATE_ENTRY_ERROR")
+    assert_that(script).contains("NPM_PUBLISH_MAX_ATTEMPTS")
+    # Exponential backoff and a bounded attempt budget.
+    assert_that(script).contains("delay * 2")
+    assert_that(script).contains("-ge")
+    assert_that(script).contains("max_attempts")
+    # Non-transient failures are hard errors, never retried.
+    assert_that(script).contains("non-transient error")
+    # Idempotency: skip an already-published name@version.
+    assert_that(script).contains("npm view")
+    assert_that(script).contains("already published")
+
+
 # Canonical lgtm-ci pin used by all py-lintro workflows (v0.52.4).
 # Pages deploy must not regress to v0.32.3 (missing GH_TOKEN in bundler).
 # The 40-hex git SHA trips trufflehog's Github legacy-token detector under

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -1078,9 +1078,8 @@ def test_publish_npm_script_retries_only_transient_errors() -> None:
     class is retried with bounded backoff while auth/validation failures are
     not, and the registry existence check makes a re-run idempotent.
     """
-    script = (
-        _REPO_ROOT / "scripts" / "ci" / "npm" / "publish_packages.sh"
-    ).read_text()
+    script_path = _REPO_ROOT / "scripts" / "ci" / "npm" / "publish_packages.sh"
+    script = script_path.read_text()
     assert_that(script).contains("TLOG_CREATE_ENTRY_ERROR")
     assert_that(script).contains("NPM_PUBLISH_MAX_ATTEMPTS")
     # Exponential backoff and a bounded attempt budget.

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -1063,7 +1063,10 @@ def test_publish_npm_delegates_publish_to_hardened_script() -> None:
     )
     assert_that(publish_step).is_not_none()
     assert publish_step is not None  # narrow type for mypy
-    assert_that(publish_step["run"]).contains(
+    # The step must delegate to the script as its command, not merely mention
+    # it — an inline ``npm publish`` loop that referenced the path in a comment
+    # would slip past a substring check.
+    assert_that(publish_step["run"].strip()).is_equal_to(
         "scripts/ci/npm/publish_packages.sh",
     )
     # Provenance must not be dropped on a live publish.
@@ -1071,26 +1074,11 @@ def test_publish_npm_delegates_publish_to_hardened_script() -> None:
     assert_that(publish_step["env"]["NPM_PROVENANCE"]).contains("'1'")
 
 
-def test_publish_npm_script_retries_only_transient_errors() -> None:
-    """publish_packages.sh retries transient tlog/registry errors, not auth.
-
-    Guards the core of issue #1682: the Rekor 409 (TLOG_CREATE_ENTRY_ERROR)
-    class is retried with bounded backoff while auth/validation failures are
-    not, and the registry existence check makes a re-run idempotent.
-    """
-    script_path = _REPO_ROOT / "scripts" / "ci" / "npm" / "publish_packages.sh"
-    script = script_path.read_text()
-    assert_that(script).contains("TLOG_CREATE_ENTRY_ERROR")
-    assert_that(script).contains("NPM_PUBLISH_MAX_ATTEMPTS")
-    # Exponential backoff and a bounded attempt budget.
-    assert_that(script).contains("delay * 2")
-    assert_that(script).contains("-ge")
-    assert_that(script).contains("max_attempts")
-    # Non-transient failures are hard errors, never retried.
-    assert_that(script).contains("non-transient error")
-    # Idempotency: skip an already-published name@version.
-    assert_that(script).contains("npm view")
-    assert_that(script).contains("already published")
+# The retry/idempotency behaviour of publish_packages.sh itself is covered by
+# executable stub-based tests in tests/scripts/test_npm_publish_packages.py
+# (transient-retry-success, attempt-exhaustion, auth-not-retried, skip and
+# conflict idempotency). That is a stronger guard than asserting on script
+# substrings here, so this module only asserts the workflow-to-script wiring.
 
 
 # Canonical lgtm-ci pin used by all py-lintro workflows (v0.52.4).


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): retry and idempotency for npm publish to survive Sigstore tlog 409
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`Publish to npm / Package and publish` publishes five packages in sequence. A transient Sigstore transparency-log 409 (`TLOG_CREATE_ENTRY_ERROR`) on the third package left **v0.91.15 half-published** and a re-run could not repair it. This adds the two fixes from #1682.

**1. Bounded retry on transient errors only.** Each `npm publish` now runs inside an exponential-backoff loop (`NPM_PUBLISH_MAX_ATTEMPTS`, default 3; `NPM_PUBLISH_RETRY_DELAY`, default 5s, doubling; both validated as integers up front). It retries **only** transient Sigstore/registry failures — `TLOG_CREATE_ENTRY_ERROR`, other tlog/Rekor/Fulcio/Sigstore hiccups, registry 5xx, rate-limit 429s, and transient network errors. Auth (`E401/E403/ENEEDAUTH/EOTP`) and validation failures are matched **first** by a dedicated non-retryable check and fail immediately — even when the message also names a Sigstore component (e.g. `sigstore authentication failed (E401)`) — so retrying never hides a real auth problem. The retry re-runs the identical `--provenance` publish, so signing is never dropped.

**2. Idempotency (already partly present; hardened).** Before each package the script queries `npm view <name>@<version>` and skips an already-published version with a loud log line, so a re-run repairs a partial publish instead of compounding it. A publish **conflict** returned mid-loop (`EPUBLISHCONFLICT` / "cannot publish over…") is now treated as an idempotent success — the version is already at its desired end state. The meta package is published last (unchanged).

**Fail-safe for an ambiguous existence check:** if `npm view` itself fails with anything other than a clean E404 (network/5xx/rate-limit), the script can no longer prove the version is absent. It previously **aborted the whole release** on this. It now logs loudly and **proceeds to publish**, because the publish path is conflict-safe: a genuinely-already-present version yields a publish conflict that is treated as success, and a genuine transient error is retried. Aborting on a mere lookup hiccup was itself a way to leave a multi-package release partially published, so proceeding is the safer choice.

Fixes #1682

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1682

## Details

_See What’s Changing._
