### PR TITLE
fix(ci): retry cosign OIDC token fetch flakes in docker publish

### DIFF
--- a/scripts/ci/cosign-sign-images.sh
+++ b/scripts/ci/cosign-sign-images.sh
@@ -7,6 +7,15 @@ set -euo pipefail
 # Refs must be pinned by digest (image@sha256:...) so the signature is
 # bound to the exact manifest CI validated and promoted (#1358) — never
 # to a floating tag that could move between promotion and signing.
+#
+# Keyless signing fetches an ambient OIDC token from GitHub's token
+# endpoint, which intermittently returns a non-JSON body and fails the
+# whole signing job (#1567: v0.87.1 py-lintro-base was left unsigned by
+# `invalid character 'u' looking for beginning of value`). That flake is
+# transient and the tag-publish job cannot be re-run in isolation, so we
+# retry ONLY that token-fetch failure class here with bounded exponential
+# backoff (#1646). A genuine signing rejection or any non-token-fetch
+# error stays fatal — it must never be retried away.
 
 show_help() {
 	cat <<'EOF'
@@ -16,8 +25,16 @@ Usage:
   IMAGES=<refs> scripts/ci/cosign-sign-images.sh
 
 Environment:
-  IMAGES  Whitespace/newline-separated image refs pinned by digest,
-          e.g. ghcr.io/lgtm-hq/py-lintro@sha256:... (required)
+  IMAGES                    Whitespace/newline-separated image refs pinned by
+                            digest, e.g. ghcr.io/lgtm-hq/py-lintro@sha256:...
+                            (required)
+  COSIGN_SIGN_MAX_ATTEMPTS  Max attempts per ref when the failure is a
+                            transient OIDC token-fetch flake (default: 4)
+  COSIGN_SIGN_BASE_DELAY    Base backoff in seconds; delay doubles each retry
+                            (default: 2). Set 0 for no wait.
+
+Only the ambient-OIDC / ID-token-fetch failure class is retried. A genuine
+signing rejection, a policy failure, or a non-digest ref fails immediately.
 EOF
 }
 
@@ -27,11 +44,93 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 fi
 
 images="${IMAGES:-}"
+max_attempts="${COSIGN_SIGN_MAX_ATTEMPTS:-4}"
+base_delay="${COSIGN_SIGN_BASE_DELAY:-2}"
 
 if [[ -z "$images" ]]; then
 	echo "IMAGES is required" >&2
 	exit 2
 fi
+
+if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+	echo "COSIGN_SIGN_MAX_ATTEMPTS must be a positive integer, got: ${max_attempts}" >&2
+	exit 2
+fi
+
+if ! [[ "$base_delay" =~ ^[0-9]+$ ]]; then
+	echo "COSIGN_SIGN_BASE_DELAY must be a non-negative integer, got: ${base_delay}" >&2
+	exit 2
+fi
+
+# Fixed-string markers for the transient ambient-OIDC token-fetch failure
+# class only. These identify a token-endpoint flake — never a rejected or
+# invalid signature, so matching them is safe to retry. Matched with
+# grep -qiF (fixed strings, case-insensitive), no regex.
+oidc_flake_markers=(
+	"fetching ambient OIDC credentials"
+	"retrieving ID token"
+	"reading ID token"
+)
+
+# is_transient_oidc_error <output>
+# Return 0 iff the cosign output is the retryable ambient-OIDC token-fetch
+# flake. Any other failure (genuine signing rejection, policy failure,
+# registry error) returns 1 and must stay fatal.
+is_transient_oidc_error() {
+	local output="$1"
+	local marker
+	for marker in "${oidc_flake_markers[@]}"; do
+		if printf '%s' "$output" | grep -qiF -- "$marker"; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+# sign_ref_with_retry <ref>
+# Sign a single digest ref, retrying only the transient OIDC token-fetch
+# flake with exponential backoff. Exits non-zero (fatal) on any other
+# failure or once attempts are exhausted.
+sign_ref_with_retry() {
+	local ref="$1"
+	local attempt=1
+	local output
+	local status
+	local delay
+
+	while true; do
+		echo "Signing ${ref} (attempt ${attempt}/${max_attempts})"
+		set +e
+		output="$(cosign sign --yes "$ref" 2>&1)"
+		status=$?
+		set -e
+
+		if [[ -n "$output" ]]; then
+			printf '%s\n' "$output"
+		fi
+
+		if [[ "$status" -eq 0 ]]; then
+			return 0
+		fi
+
+		if ! is_transient_oidc_error "$output"; then
+			echo "cosign sign failed for ${ref} (not a transient OIDC token-fetch flake); failing." >&2
+			return "$status"
+		fi
+
+		if [[ "$attempt" -ge "$max_attempts" ]]; then
+			echo "cosign sign kept hitting the OIDC token-fetch flake for ${ref} after ${max_attempts} attempt(s); failing." >&2
+			return "$status"
+		fi
+
+		delay=$((base_delay * (1 << (attempt - 1))))
+		echo "Transient OIDC token-fetch flake signing ${ref}; retrying in ${delay}s." >&2
+		if [[ "$delay" -gt 0 ]]; then
+			sleep "$delay"
+		fi
+		attempt=$((attempt + 1))
+	done
+}
 
 refs=()
 while IFS= read -r ref; do
@@ -50,8 +149,7 @@ if [[ ${#refs[@]} -eq 0 ]]; then
 fi
 
 for ref in "${refs[@]}"; do
-	echo "Signing ${ref}"
-	cosign sign --yes "$ref"
+	sign_ref_with_retry "$ref"
 done
 
 echo "Signed ${#refs[@]} image(s)"

--- a/scripts/ci/cosign-sign-images.sh
+++ b/scripts/ci/cosign-sign-images.sh
@@ -32,6 +32,8 @@ Environment:
                             transient OIDC token-fetch flake (default: 4)
   COSIGN_SIGN_BASE_DELAY    Base backoff in seconds; delay doubles each retry
                             (default: 2). Set 0 for no wait.
+  COSIGN_SIGN_MAX_DELAY     Upper bound in seconds for any single backoff wait,
+                            regardless of attempt number (default: 30).
 
 Only the ambient-OIDC / ID-token-fetch failure class is retried. A genuine
 signing rejection, a policy failure, or a non-digest ref fails immediately.
@@ -46,6 +48,7 @@ fi
 images="${IMAGES:-}"
 max_attempts="${COSIGN_SIGN_MAX_ATTEMPTS:-4}"
 base_delay="${COSIGN_SIGN_BASE_DELAY:-2}"
+max_delay="${COSIGN_SIGN_MAX_DELAY:-30}"
 
 if [[ -z "$images" ]]; then
 	echo "IMAGES is required" >&2
@@ -59,6 +62,11 @@ fi
 
 if ! [[ "$base_delay" =~ ^[0-9]+$ ]]; then
 	echo "COSIGN_SIGN_BASE_DELAY must be a non-negative integer, got: ${base_delay}" >&2
+	exit 2
+fi
+
+if ! [[ "$max_delay" =~ ^[0-9]+$ ]]; then
+	echo "COSIGN_SIGN_MAX_DELAY must be a non-negative integer, got: ${max_delay}" >&2
 	exit 2
 fi
 
@@ -124,6 +132,11 @@ sign_ref_with_retry() {
 		fi
 
 		delay=$((base_delay * (1 << (attempt - 1))))
+		# Cap the exponential growth so a large max-attempts value can never
+		# schedule an unbounded wait.
+		if [[ "$delay" -gt "$max_delay" ]]; then
+			delay="$max_delay"
+		fi
 		echo "Transient OIDC token-fetch flake signing ${ref}; retrying in ${delay}s." >&2
 		if [[ "$delay" -gt 0 ]]; then
 			sleep "$delay"

--- a/tests/scripts/test_cosign_sign_images.py
+++ b/tests/scripts/test_cosign_sign_images.py
@@ -45,6 +45,7 @@ def _write_fake_cosign(bin_dir: Path, mode: str, *, fail_until: int = 0) -> Path
         Path: Path to the counter file the stub increments on each call.
     """
     counter = bin_dir / "cosign.calls"
+    args_log = bin_dir / "cosign.args"
     oidc = _OIDC_MESSAGE % "REF"
     reject = _REJECT_MESSAGE % "REF"
     script = textwrap.dedent(
@@ -52,10 +53,14 @@ def _write_fake_cosign(bin_dir: Path, mode: str, *, fail_until: int = 0) -> Path
         #!/usr/bin/env bash
         set -euo pipefail
         counter="{counter}"
+        args_log="{args_log}"
         n=0
         if [[ -f "$counter" ]]; then n=$(cat "$counter"); fi
         n=$((n + 1))
         echo "$n" >"$counter"
+        # Record every ref cosign was asked to sign so tests can assert
+        # coverage, not just invocation count.
+        echo "$*" >>"$args_log"
         case "{mode}" in
           success) exit 0 ;;
           reject) echo "{reject}" >&2; exit 1 ;;
@@ -81,6 +86,7 @@ def _run(
     *,
     images: str,
     max_attempts: str = "4",
+    max_delay: str = "30",
 ) -> subprocess.CompletedProcess[str]:
     """Run the signing script with the stub PATH and no backoff wait.
 
@@ -88,6 +94,7 @@ def _run(
         bin_dir: Directory holding the stub ``cosign`` to prepend to PATH.
         images: Value for the IMAGES environment variable.
         max_attempts: Value for COSIGN_SIGN_MAX_ATTEMPTS.
+        max_delay: Value for COSIGN_SIGN_MAX_DELAY.
 
     Returns:
         subprocess.CompletedProcess: The completed run.
@@ -98,6 +105,7 @@ def _run(
         "IMAGES": images,
         "COSIGN_SIGN_MAX_ATTEMPTS": max_attempts,
         "COSIGN_SIGN_BASE_DELAY": "0",
+        "COSIGN_SIGN_MAX_DELAY": max_delay,
     }
     return subprocess.run(  # nosec B603 - fixed argv, controlled env, shell=False
         [str(_SCRIPT)],
@@ -120,6 +128,21 @@ def _calls(counter: Path) -> int:
     if not counter.exists():
         return 0
     return int(counter.read_text().strip())
+
+
+def _signed_refs(bin_dir: Path) -> list[str]:
+    """Return the refs the stub cosign was asked to sign, in order.
+
+    Args:
+        bin_dir: Directory holding the stub's ``cosign.args`` log.
+
+    Returns:
+        list[str]: One entry per cosign invocation (the ``--yes <ref>`` argv).
+    """
+    args_log = bin_dir / "cosign.args"
+    if not args_log.exists():
+        return []
+    return [line for line in args_log.read_text().splitlines() if line]
 
 
 def test_help_flag_exits_zero() -> None:
@@ -167,6 +190,11 @@ def test_multiple_digests_each_signed(tmp_path: Path) -> None:
     assert_that(result.returncode).is_equal_to(0)
     assert_that(_calls(counter)).is_equal_to(2)
     assert_that(result.stdout).contains("Signed 2 image(s)")
+    # Both digests must actually be handed to cosign, not just counted.
+    signed = _signed_refs(tmp_path)
+    assert_that(signed).is_length(2)
+    assert_that(any(_DIGEST in ref for ref in signed)).is_true()
+    assert_that(any(_DIGEST_TWO in ref for ref in signed)).is_true()
 
 
 def test_transient_oidc_flake_is_retried_then_succeeds(tmp_path: Path) -> None:
@@ -208,5 +236,17 @@ def test_invalid_max_attempts_is_fatal(tmp_path: Path, bad_value: str) -> None:
     """A non-positive or non-integer max-attempts value exits 2."""
     counter = _write_fake_cosign(tmp_path, "success")
     result = _run(tmp_path, images=_DIGEST, max_attempts=bad_value)
+    assert_that(result.returncode).is_equal_to(2)
+    assert_that(_calls(counter)).is_equal_to(0)
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    ["-1", "abc", "1.5"],
+)
+def test_invalid_max_delay_is_fatal(tmp_path: Path, bad_value: str) -> None:
+    """A negative or non-integer max-delay value exits 2 before signing."""
+    counter = _write_fake_cosign(tmp_path, "success")
+    result = _run(tmp_path, images=_DIGEST, max_delay=bad_value)
     assert_that(result.returncode).is_equal_to(2)
     assert_that(_calls(counter)).is_equal_to(0)

--- a/tests/scripts/test_cosign_sign_images.py
+++ b/tests/scripts/test_cosign_sign_images.py
@@ -1,0 +1,212 @@
+"""Tests for scripts/ci/cosign-sign-images.sh retry + error classification.
+
+These exercise the signing wrapper against a stubbed ``cosign`` on PATH so no
+real Sigstore signing happens. They pin the two behaviours #1646 depends on:
+
+* the transient ambient-OIDC token-fetch flake is retried with bounded backoff;
+* a genuine signing rejection (or any non-token-fetch error) stays fatal and is
+  never retried away.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess  # nosec B404 - drives the script under test; shell=False
+import textwrap
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = (_REPO_ROOT / "scripts/ci/cosign-sign-images.sh").resolve()
+_DIGEST = "ghcr.io/lgtm-hq/py-lintro@sha256:" + "a" * 64
+_DIGEST_TWO = "ghcr.io/lgtm-hq/py-lintro-base@sha256:" + "b" * 64
+
+_OIDC_MESSAGE = (
+    "Error: signing [%s]: signing digest: getting keypair and token: "
+    "retrieving ID token: reading ID token: fetching ambient OIDC "
+    "credentials: invalid character 'u' looking for beginning of value"
+)
+_REJECT_MESSAGE = "Error: signing [%s]: signing digest: signature invalid"
+
+
+def _write_fake_cosign(bin_dir: Path, mode: str, *, fail_until: int = 0) -> Path:
+    """Write a stub ``cosign`` that records call count and simulates a mode.
+
+    Args:
+        bin_dir: Directory placed at the front of PATH.
+        mode: One of ``success``, ``reject``, ``oidc_always``,
+            ``oidc_then_success``.
+        fail_until: For ``oidc_then_success``, the number of leading calls that
+            fail with the OIDC flake before one succeeds.
+
+    Returns:
+        Path: Path to the counter file the stub increments on each call.
+    """
+    counter = bin_dir / "cosign.calls"
+    oidc = _OIDC_MESSAGE % "REF"
+    reject = _REJECT_MESSAGE % "REF"
+    script = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        counter="{counter}"
+        n=0
+        if [[ -f "$counter" ]]; then n=$(cat "$counter"); fi
+        n=$((n + 1))
+        echo "$n" >"$counter"
+        case "{mode}" in
+          success) exit 0 ;;
+          reject) echo "{reject}" >&2; exit 1 ;;
+          oidc_always) echo "{oidc}" >&2; exit 1 ;;
+          oidc_then_success)
+            if (( n <= {fail_until} )); then
+              echo "{oidc}" >&2
+              exit 1
+            fi
+            exit 0
+            ;;
+        esac
+        """,
+    )
+    cosign = bin_dir / "cosign"
+    cosign.write_text(script)
+    cosign.chmod(0o755)
+    return counter
+
+
+def _run(
+    bin_dir: Path,
+    *,
+    images: str,
+    max_attempts: str = "4",
+) -> subprocess.CompletedProcess[str]:
+    """Run the signing script with the stub PATH and no backoff wait.
+
+    Args:
+        bin_dir: Directory holding the stub ``cosign`` to prepend to PATH.
+        images: Value for the IMAGES environment variable.
+        max_attempts: Value for COSIGN_SIGN_MAX_ATTEMPTS.
+
+    Returns:
+        subprocess.CompletedProcess: The completed run.
+    """
+    env = {
+        **os.environ.copy(),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+        "IMAGES": images,
+        "COSIGN_SIGN_MAX_ATTEMPTS": max_attempts,
+        "COSIGN_SIGN_BASE_DELAY": "0",
+    }
+    return subprocess.run(  # nosec B603 - fixed argv, controlled env, shell=False
+        [str(_SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def _calls(counter: Path) -> int:
+    """Return how many times the stub cosign was invoked.
+
+    Args:
+        counter: Counter file written by the stub.
+
+    Returns:
+        int: The recorded invocation count (0 if never called).
+    """
+    if not counter.exists():
+        return 0
+    return int(counter.read_text().strip())
+
+
+def test_help_flag_exits_zero() -> None:
+    """--help prints usage and exits 0."""
+    result = subprocess.run(  # nosec B603 - fixed argv, shell=False
+        [str(_SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("Usage:")
+
+
+def test_missing_images_is_fatal(tmp_path: Path) -> None:
+    """A missing IMAGES value exits 2 before any cosign call."""
+    counter = _write_fake_cosign(tmp_path, "success")
+    result = _run(tmp_path, images="")
+    assert_that(result.returncode).is_equal_to(2)
+    assert_that(_calls(counter)).is_equal_to(0)
+
+
+def test_non_digest_ref_is_fatal_and_not_retried(tmp_path: Path) -> None:
+    """A floating-tag ref is rejected outright and cosign is never called."""
+    counter = _write_fake_cosign(tmp_path, "success")
+    result = _run(tmp_path, images="ghcr.io/lgtm-hq/py-lintro:latest")
+    assert_that(result.returncode).is_equal_to(2)
+    assert_that(result.stderr).contains("Refusing to sign non-digest ref")
+    assert_that(_calls(counter)).is_equal_to(0)
+
+
+def test_success_signs_once(tmp_path: Path) -> None:
+    """A clean sign calls cosign exactly once and succeeds."""
+    counter = _write_fake_cosign(tmp_path, "success")
+    result = _run(tmp_path, images=_DIGEST)
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(_calls(counter)).is_equal_to(1)
+    assert_that(result.stdout).contains("Signed 1 image(s)")
+
+
+def test_multiple_digests_each_signed(tmp_path: Path) -> None:
+    """Every digest ref is signed."""
+    counter = _write_fake_cosign(tmp_path, "success")
+    result = _run(tmp_path, images=f"{_DIGEST}\n{_DIGEST_TWO}")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(_calls(counter)).is_equal_to(2)
+    assert_that(result.stdout).contains("Signed 2 image(s)")
+
+
+def test_transient_oidc_flake_is_retried_then_succeeds(tmp_path: Path) -> None:
+    """An OIDC token-fetch flake is retried and the eventual success passes."""
+    counter = _write_fake_cosign(tmp_path, "oidc_then_success", fail_until=2)
+    result = _run(tmp_path, images=_DIGEST)
+    assert_that(result.returncode).is_equal_to(0)
+    # 2 flaked attempts + 1 successful = 3 calls.
+    assert_that(_calls(counter)).is_equal_to(3)
+    assert_that(result.stderr).contains("retrying")
+
+
+def test_persistent_oidc_flake_exhausts_attempts_and_fails(tmp_path: Path) -> None:
+    """A persistent OIDC flake fails after exactly max_attempts tries."""
+    counter = _write_fake_cosign(tmp_path, "oidc_always")
+    result = _run(tmp_path, images=_DIGEST, max_attempts="3")
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(_calls(counter)).is_equal_to(3)
+    assert_that(result.stderr).contains("after 3 attempt(s)")
+
+
+def test_genuine_signing_rejection_stays_fatal_and_is_not_retried(
+    tmp_path: Path,
+) -> None:
+    """A real signing rejection fails immediately and is never retried."""
+    counter = _write_fake_cosign(tmp_path, "reject")
+    result = _run(tmp_path, images=_DIGEST, max_attempts="4")
+    assert_that(result.returncode).is_not_equal_to(0)
+    # Fatal on the first failure — no retry despite attempts remaining.
+    assert_that(_calls(counter)).is_equal_to(1)
+    assert_that(result.stderr).contains("not a transient OIDC token-fetch flake")
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    ["0", "-1", "abc", "1.5"],
+)
+def test_invalid_max_attempts_is_fatal(tmp_path: Path, bad_value: str) -> None:
+    """A non-positive or non-integer max-attempts value exits 2."""
+    counter = _write_fake_cosign(tmp_path, "success")
+    result = _run(tmp_path, images=_DIGEST, max_attempts=bad_value)
+    assert_that(result.returncode).is_equal_to(2)
+    assert_that(_calls(counter)).is_equal_to(0)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): retry cosign OIDC token fetch flakes in docker publish
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

- **`scripts/ci/cosign-sign-images.sh`** — bounded exponential-backoff retry
  around `cosign sign`, scoped strictly to the transient ambient-OIDC /
  ID-token-fetch failure class. Classification is a fixed-string (`grep -qiF`,
  no regex) match on `fetching ambient OIDC credentials`, `retrieving ID token`,
  `reading ID token`. Attempts (`COSIGN_SIGN_MAX_ATTEMPTS`, default 4) and base
  delay (`COSIGN_SIGN_BASE_DELAY`, default 2s) are env-tunable.
- **A genuine signing rejection, a policy failure, or a non-digest ref stays
  fatal and is never retried** — the existing digest-only guard is intact.
- **`tests/scripts/test_cosign_sign_images.py`** — 12 tests driving the script
  against a stubbed `cosign` on PATH (no real signing).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1646

## Details

This edits the **live docker publish / signing pipeline**, which only runs on
tag-push and is **not** exercised by this PR's CI. Validation was therefore done
against a stubbed `cosign` on PATH — no real Sigstore signing:

- `uv run pytest tests/scripts/test_cosign_sign_images.py` — 12 passed.
  Covered: transient OIDC flake retried then succeeds (3 cosign calls);
  persistent OIDC flake fails after exactly `max_attempts`; **genuine signing
  rejection is fatal on the first failure and never retried** (asserted 1
  cosign call despite attempts remaining); non-digest ref and missing IMAGES
  stay fatal with no cosign call; invalid `max_attempts` rejected.
- `uv run lintro chk` — clean (shellcheck/shfmt/ruff etc., 0 issues).
- `uv run pytest tests --ignore=tests/integration` — 7209 passed, 92 skipped.
  The single local failure
  (`test_prepare_execution_version_check_fails_returns_early_result`) is the
  known `.claude/`-worktree file-discovery quirk, reproduces on unmodified
  `origin/main`, and is unrelated to this change.

The retry path itself (a real GitHub OIDC endpoint flake) cannot be reproduced
in CI; the classifier and retry loop are covered by the stubbed tests above.
