### PR TITLE
fix(ci): retry transient registry blips in CI image promote (#1696)

### DIFF
--- a/scripts/ci/promote-ci-docker-images.sh
+++ b/scripts/ci/promote-ci-docker-images.sh
@@ -38,6 +38,51 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 	exit 0
 fi
 
+# Bounded exponential-backoff retry for the registry read/retag calls. A
+# single transient CDN blip ("connection reset by peer", "httpReadSeeker
+# failed") from GitHub's registry otherwise fails the whole main-push
+# promote (#1696). Overridable so tests can drive them fast.
+PROMOTE_MAX_ATTEMPTS="${PROMOTE_MAX_ATTEMPTS:-4}"
+PROMOTE_BACKOFF_SECONDS="${PROMOTE_BACKOFF_SECONDS:-2}"
+
+# Transient network/registry errors worth retrying. A genuine auth/denied/
+# manifest-unknown failure is deliberately NOT here: those are permanent and
+# must fail on the first attempt rather than be retried away (#1696).
+_promote_transient_re='connection reset by peer|httpReadSeeker|broken pipe|i/o timeout|TLS handshake|unexpected EOF|temporarily unavailable|toomanyrequests|50[0234] (Internal Server Error|Bad Gateway|Service Unavailable|Gateway Time-out)'
+
+# retry_registry <cmd...>
+#
+# Run a registry command, retrying only on a transient signature. Command
+# stdout is captured and re-emitted verbatim on success so callers can still
+# `digest="$(retry_registry docker ... inspect ...)"`. stderr is streamed
+# through on every attempt so progress/errors stay visible in the job log.
+retry_registry() {
+	local attempt=1 delay="$PROMOTE_BACKOFF_SECONDS" out rc err
+	err="$(mktemp)"
+	# shellcheck disable=SC2064 # expand err now so the trap removes this file
+	trap "rm -f '$err'" RETURN
+	while true; do
+		if out="$("$@" 2>"$err")"; then
+			cat "$err" >&2
+			[[ -n "$out" ]] && printf '%s\n' "$out"
+			return 0
+		else
+			# Capture the failed command's status here: a bodyless `if`
+			# that falls through would leave $? as the `if`'s own 0.
+			rc=$?
+		fi
+		cat "$err" >&2
+		if ((attempt >= PROMOTE_MAX_ATTEMPTS)) ||
+			! grep -qiE "$_promote_transient_re" "$err"; then
+			return "$rc"
+		fi
+		echo "Transient registry error on '$1' (attempt ${attempt}/${PROMOTE_MAX_ATTEMPTS}); retrying in ${delay}s..." >&2
+		sleep "$delay"
+		delay=$((delay * 2))
+		attempt=$((attempt + 1))
+	done
+}
+
 source_image="${SOURCE_IMAGE:-}"
 ci_tag="${CI_TAG:-}"
 tags="${TAGS:-}"
@@ -59,7 +104,7 @@ fi
 
 source_ref="${source_image}:${ci_tag}"
 
-digest="$(docker buildx imagetools inspect \
+digest="$(retry_registry docker buildx imagetools inspect \
 	--format '{{.Manifest.Digest}}' "$source_ref")"
 
 if [[ "$digest" != sha256:* ]]; then
@@ -86,13 +131,13 @@ fi
 # built with provenance disabled), the default prefer-index=true would
 # wrap the manifest in a new one-entry index — a different digest. A
 # carbon copy keeps the promoted tags on the exact CI-validated digest.
-docker buildx imagetools create --prefer-index=false \
+retry_registry docker buildx imagetools create --prefer-index=false \
 	"${source_image}@${digest}" "${tag_args[@]}"
 
 # Verify the retag preserved the manifest: every promoted tag must resolve
 # to the exact digest CI validated.
 for tag in "${tag_list[@]}"; do
-	promoted="$(docker buildx imagetools inspect \
+	promoted="$(retry_registry docker buildx imagetools inspect \
 		--format '{{.Manifest.Digest}}' "$tag")"
 	if [[ "$promoted" != "$digest" ]]; then
 		echo "Digest mismatch after promotion: ${tag} resolved to" \

--- a/scripts/ci/promote-ci-docker-images.sh
+++ b/scripts/ci/promote-ci-docker-images.sh
@@ -45,6 +45,15 @@ fi
 PROMOTE_MAX_ATTEMPTS="${PROMOTE_MAX_ATTEMPTS:-4}"
 PROMOTE_BACKOFF_SECONDS="${PROMOTE_BACKOFF_SECONDS:-2}"
 
+if ! [[ "$PROMOTE_MAX_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+	echo "PROMOTE_MAX_ATTEMPTS must be a positive integer (got: ${PROMOTE_MAX_ATTEMPTS})" >&2
+	exit 2
+fi
+if ! [[ "$PROMOTE_BACKOFF_SECONDS" =~ ^[0-9]+$ ]]; then
+	echo "PROMOTE_BACKOFF_SECONDS must be a non-negative integer (got: ${PROMOTE_BACKOFF_SECONDS})" >&2
+	exit 2
+fi
+
 # Transient network/registry errors worth retrying. A genuine auth/denied/
 # manifest-unknown failure is deliberately NOT here: those are permanent and
 # must fail on the first attempt rather than be retried away (#1696).
@@ -59,11 +68,12 @@ _promote_transient_re='connection reset by peer|httpReadSeeker|broken pipe|i/o t
 retry_registry() {
 	local attempt=1 delay="$PROMOTE_BACKOFF_SECONDS" out rc err
 	err="$(mktemp)"
-	# shellcheck disable=SC2064 # expand err now so the trap removes this file
-	trap "rm -f '$err'" RETURN
+	# Clean up explicitly at each return rather than via a RETURN trap, which
+	# would overwrite/leak into the caller's shell trap context.
 	while true; do
 		if out="$("$@" 2>"$err")"; then
 			cat "$err" >&2
+			rm -f "$err"
 			[[ -n "$out" ]] && printf '%s\n' "$out"
 			return 0
 		else
@@ -74,6 +84,7 @@ retry_registry() {
 		cat "$err" >&2
 		if ((attempt >= PROMOTE_MAX_ATTEMPTS)) ||
 			! grep -qiE "$_promote_transient_re" "$err"; then
+			rm -f "$err"
 			return "$rc"
 		fi
 		echo "Transient registry error on '$1' (attempt ${attempt}/${PROMOTE_MAX_ATTEMPTS}); retrying in ${delay}s..." >&2

--- a/tests/scripts/test_docker_ci_scripts.py
+++ b/tests/scripts/test_docker_ci_scripts.py
@@ -299,6 +299,78 @@ def test_promote_ci_docker_images_retries_transient_promote_error(
     assert_that(create_calls).is_equal_to(3)
 
 
+def test_promote_ci_docker_images_retries_transient_inspect_error(
+    tmp_path: Path,
+) -> None:
+    """A transient error during the source digest resolve is retried too.
+
+    The retry wraps every registry call, not just the retag — the source
+    digest `inspect` must recover from a transient blip as well.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker_log = tmp_path / "docker.log"
+    # The first inspect (source digest resolve) flakes once, then every
+    # inspect resolves the digest and create succeeds.
+    _write_stub(
+        bin_dir,
+        "docker",
+        (
+            'echo "$*" >> "$DOCKER_LOG"\n'
+            'if [[ "$*" == *" inspect "* ]]; then\n'
+            '  n="$(grep -c " inspect " "$DOCKER_LOG")"\n'
+            "  if (( n == 1 )); then\n"
+            '    echo "ERROR: httpReadSeeker: failed open: read: connection'
+            ' reset by peer" >&2\n'
+            "    exit 1\n"
+            "  fi\n"
+            '  echo "sha256:aaa111"\n'
+            "  exit 0\n"
+            "fi\n"
+            "exit 0"
+        ),
+    )
+
+    result = _run_with_stubs(
+        "scripts/ci/promote-ci-docker-images.sh",
+        bin_dir,
+        {
+            "SOURCE_IMAGE": "ghcr.io/example/app",
+            "CI_TAG": "ci-1",
+            "TAGS": "ghcr.io/example/app:main",
+            "DOCKER_LOG": str(docker_log),
+            "PROMOTE_BACKOFF_SECONDS": "0",
+            "PROMOTE_MAX_ATTEMPTS": "4",
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stderr).contains("Transient registry error")
+
+
+def test_promote_ci_docker_images_rejects_non_numeric_attempts(
+    tmp_path: Path,
+) -> None:
+    """A non-numeric PROMOTE_MAX_ATTEMPTS fails fast before any registry call."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_stub(bin_dir, "docker", "exit 0")
+
+    result = _run_with_stubs(
+        "scripts/ci/promote-ci-docker-images.sh",
+        bin_dir,
+        {
+            "SOURCE_IMAGE": "ghcr.io/example/app",
+            "CI_TAG": "ci-1",
+            "TAGS": "ghcr.io/example/app:main",
+            "PROMOTE_MAX_ATTEMPTS": "not-a-number",
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(2)
+    assert_that(result.stderr).contains("PROMOTE_MAX_ATTEMPTS must be")
+
+
 def test_promote_ci_docker_images_does_not_retry_fatal_error(
     tmp_path: Path,
 ) -> None:

--- a/tests/scripts/test_docker_ci_scripts.py
+++ b/tests/scripts/test_docker_ci_scripts.py
@@ -354,7 +354,8 @@ def test_promote_ci_docker_images_rejects_non_numeric_attempts(
     """A non-numeric PROMOTE_MAX_ATTEMPTS fails fast before any registry call."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    _write_stub(bin_dir, "docker", "exit 0")
+    docker_log = tmp_path / "docker.log"
+    _write_stub(bin_dir, "docker", 'echo "$*" >> "$DOCKER_LOG"\nexit 0')
 
     result = _run_with_stubs(
         "scripts/ci/promote-ci-docker-images.sh",
@@ -364,11 +365,13 @@ def test_promote_ci_docker_images_rejects_non_numeric_attempts(
             "CI_TAG": "ci-1",
             "TAGS": "ghcr.io/example/app:main",
             "PROMOTE_MAX_ATTEMPTS": "not-a-number",
+            "DOCKER_LOG": str(docker_log),
         },
     )
 
     assert_that(result.returncode).is_equal_to(2)
     assert_that(result.stderr).contains("PROMOTE_MAX_ATTEMPTS must be")
+    assert_that(docker_log.exists()).is_false()
 
 
 def test_promote_ci_docker_images_does_not_retry_fatal_error(

--- a/tests/scripts/test_docker_ci_scripts.py
+++ b/tests/scripts/test_docker_ci_scripts.py
@@ -246,6 +246,103 @@ def test_promote_ci_docker_images_fails_on_digest_mismatch(
     assert_that(result.stderr).contains("Digest mismatch after promotion")
 
 
+def test_promote_ci_docker_images_retries_transient_promote_error(
+    tmp_path: Path,
+) -> None:
+    """A transient CDN error during the retag is retried and then succeeds."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker_log = tmp_path / "docker.log"
+    # inspect always resolves the digest; the first two `create` calls flake
+    # with the exact registry-CDN signature from run 30097353380, the third
+    # succeeds. The verify inspects then confirm the promoted digest matches.
+    _write_stub(
+        bin_dir,
+        "docker",
+        (
+            'echo "$*" >> "$DOCKER_LOG"\n'
+            'if [[ "$*" == *" inspect "* ]]; then\n'
+            '  echo "sha256:aaa111"\n'
+            "  exit 0\n"
+            "fi\n"
+            'if [[ "$*" == *" create "* ]]; then\n'
+            '  n="$(grep -c " create " "$DOCKER_LOG")"\n'
+            "  if (( n < 3 )); then\n"
+            '    echo "ERROR: httpReadSeeker: failed open: read tcp'
+            " 10.1.1.153->185.199.108.154:443: read: connection reset by"
+            ' peer" >&2\n'
+            "    exit 1\n"
+            "  fi\n"
+            "  exit 0\n"
+            "fi\n"
+            "exit 0"
+        ),
+    )
+
+    result = _run_with_stubs(
+        "scripts/ci/promote-ci-docker-images.sh",
+        bin_dir,
+        {
+            "SOURCE_IMAGE": "ghcr.io/example/app",
+            "CI_TAG": "ci-1",
+            "TAGS": "ghcr.io/example/app:main",
+            "DOCKER_LOG": str(docker_log),
+            "PROMOTE_BACKOFF_SECONDS": "0",
+            "PROMOTE_MAX_ATTEMPTS": "4",
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stderr).contains("Transient registry error")
+    # Two flakes + one success == three create attempts.
+    create_calls = docker_log.read_text().count("imagetools create")
+    assert_that(create_calls).is_equal_to(3)
+
+
+def test_promote_ci_docker_images_does_not_retry_fatal_error(
+    tmp_path: Path,
+) -> None:
+    """A genuine denied/auth error fails on the first attempt (no retry)."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker_log = tmp_path / "docker.log"
+    _write_stub(
+        bin_dir,
+        "docker",
+        (
+            'echo "$*" >> "$DOCKER_LOG"\n'
+            'if [[ "$*" == *" inspect "* ]]; then\n'
+            '  echo "sha256:aaa111"\n'
+            "  exit 0\n"
+            "fi\n"
+            'if [[ "$*" == *" create "* ]]; then\n'
+            '  echo "denied: requested access to the resource is denied"'
+            " >&2\n"
+            "  exit 1\n"
+            "fi\n"
+            "exit 0"
+        ),
+    )
+
+    result = _run_with_stubs(
+        "scripts/ci/promote-ci-docker-images.sh",
+        bin_dir,
+        {
+            "SOURCE_IMAGE": "ghcr.io/example/app",
+            "CI_TAG": "ci-1",
+            "TAGS": "ghcr.io/example/app:main",
+            "DOCKER_LOG": str(docker_log),
+            "PROMOTE_BACKOFF_SECONDS": "0",
+            "PROMOTE_MAX_ATTEMPTS": "4",
+        },
+    )
+
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stderr).does_not_contain("Transient registry error")
+    create_calls = docker_log.read_text().count("imagetools create")
+    assert_that(create_calls).is_equal_to(1)
+
+
 def test_cosign_sign_images_requires_images() -> None:
     """cosign-sign-images.sh should fail when IMAGES is missing."""
     script_path = (_REPO_ROOT / "scripts/ci/cosign-sign-images.sh").resolve()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): retry transient registry blips in CI image promote (#1696)
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

- **`scripts/ci/promote-ci-docker-images.sh`** — wrap the three registry read/retag calls
  (source digest resolve, `imagetools create` retag, per-tag verify) in a `retry_registry`
  helper: bounded exponential-backoff retry scoped to a **transient** signature (connection
  reset, `httpReadSeeker`, `broken pipe`, i/o timeout, TLS handshake, 5xx, `toomanyrequests`).
  A genuine **auth/denied/manifest-unknown** error is deliberately excluded and still fails on
  the **first attempt** — those are permanent and must not be retried away.
  - `retry_registry` captures command stdout and re-emits it verbatim, so callers keep
    `digest="$(retry_registry docker … inspect …)"`; stderr streams through on every attempt
    so progress/errors stay visible in the job log.
  - Attempts/backoff are env-overridable (`PROMOTE_MAX_ATTEMPTS`, `PROMOTE_BACKOFF_SECONDS`)
    so the tests run instantly.
- **`tests/scripts/test_docker_ci_scripts.py`** — two stubbed tests: a transient create error
  is retried and then succeeds (3 attempts); a `denied` error fails on the first attempt with
  no retry. Existing promote/verify/mismatch tests unchanged and green.

Mirrors the retry+classification discipline of #1690 (cosign) and #1688 (npm).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1696

## Details

_See What’s Changing._
