### PR TITLE
fix(ci): bound dogfood no-silent-skip gate timeout at 20 min (#1704)

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -616,7 +616,8 @@ jobs:
     permissions:
       contents: read
       packages: read # pull the CI lint image from GHCR
-    timeout-minutes: 30
+    # ~14 min median (10–17 observed); 20 fails a stalled run fast (#1704).
+    timeout-minutes: 20
     steps:
       - name: Harden Runner
         # Same allowlist as dogfooding-lint-changed: the container sets

--- a/.github/workflows/dogfood-nightly.yml
+++ b/.github/workflows/dogfood-nightly.yml
@@ -105,7 +105,8 @@ jobs:
     permissions:
       contents: read
       packages: read # pull the pinned release image from GHCR
-    timeout-minutes: 30
+    # ~14 min median (10–17 observed); 20 fails a stalled run fast (#1704).
+    timeout-minutes: 20
     steps:
       - name: Harden Runner
         # yamllint disable-line rule:line-length

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -772,6 +772,30 @@ def test_docker_ci_retries_dogfooding_lint_on_failure() -> None:
     assert_that(retry_condition).contains("needs.docker-build.result == 'success'")
 
 
+def test_dogfood_skip_gate_has_bounded_timeout() -> None:
+    """The no-silent-skip gate must fail predictably on a stall (#1704).
+
+    The gate's healthy range is 10–17 min (median ~14), but its hosted
+    runner can be terminated mid-run with no diagnostic signal. A bounded
+    ``timeout-minutes`` — above the observed healthy max so healthy runs
+    never trip it, at most ~2x the median so a stall fails fast instead of
+    lingering until the runner dies — keeps the failure mode predictable.
+    Applies to both copies of the gate (docker-ci.yml and
+    dogfood-nightly.yml); the owner-approved value is 20.
+    """
+    for workflow_name in ("docker-ci.yml", "dogfood-nightly.yml"):
+        workflow = _load_workflow(name=workflow_name)
+        gate = workflow["jobs"]["dogfood-skip-gate"]
+        assert_that(gate["name"]).is_equal_to("🚦 Dogfood No-Silent-Skip Gate")
+        timeout = gate.get("timeout-minutes")
+        assert_that(
+            timeout,
+            f"{workflow_name} dogfood-skip-gate must set timeout-minutes",
+        ).is_not_none()
+        # Above the 17 min observed healthy max; at most ~2x the ~14 median.
+        assert_that(timeout).is_between(18, 30)
+
+
 # --- Deny-by-default pipeline skip-list drift guard (#1369) ------------------
 #
 # docker-ci pipeline relevance is decided by

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -793,7 +793,9 @@ def test_dogfood_skip_gate_has_bounded_timeout() -> None:
             f"{workflow_name} dogfood-skip-gate must set timeout-minutes",
         ).is_not_none()
         # Above the 17 min observed healthy max; at most ~2x the ~14 median.
-        assert_that(timeout).is_between(18, 30)
+        # Upper bound 28 so the previous 30-minute configuration this PR
+        # removes would fail the contract.
+        assert_that(timeout).is_between(18, 28)
 
 
 # --- Deny-by-default pipeline skip-list drift guard (#1369) ------------------


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): bound dogfood no-silent-skip gate timeout at 20 min (#1704)
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The 🚦 Dogfood No-Silent-Skip Gate died mid-run on release 0.91.35 ([job 89508168015](https://github.com/lgtm-hq/py-lintro/actions/runs/30099694401/job/89508168015)) when its hosted runner received a shutdown signal, leaving a red check with no diagnostic signal. The gate's healthy range is 10–17 min (median ~14). This PR tightens `timeout-minutes` from 30 to the owner-approved **20** on both copies of the gate (`docker-ci.yml`, `dogfood-nightly.yml`), so a stalled run fails predictably at 20 minutes instead of lingering until the runner dies. A new wiring test locks the bound on both workflows.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1704

## Details

### Requirement 1 — timeout-minutes

Both gate jobs already carried `timeout-minutes: 30` since the job's creation in #1536; tightened to **20** per owner review of the observed healthy range (10–17 min, median ~14). The new `test_dogfood_skip_gate_has_bounded_timeout` contract test asserts both copies of the gate keep a timeout above the 17 min observed healthy max and at most ~2x the ~14 min median, so the bound cannot silently regress.

### Requirement 2 — auto-rerun matcher (intentionally not included)

Scoped check per the issue's implementation prompt; **deferred to #1689** (details in [this comment on #1704](https://github.com/lgtm-hq/py-lintro/issues/1704#issuecomment-5077025403)):

- The matcher script does not live in this repo — `auto-rerun-on-infra-failure.yml` delegates log matching to lgtm-ci's `scripts/ci/actions/rerun-on-infra-failure.sh`, which **already lists both runner-loss signatures** (`The runner has received a shutdown signal`, `lost communication with the server`) as built-in defaults.
- The auto-rerun workflow **did fire** for the failing run (run 30102480399, 21s after completion) but found no signature: the dead runner's log tail had not yet been ingested into the run log archive when `--log-failed` was fetched (the same query matches today). The gap is a **log-ingestion race in the lgtm-ci fetch path**, not a missing signature.
- Any caller-side change to `auto-rerun-on-infra-failure.yml` would collide with draft PR #1571, which restructures that exact file; #1689 already owns the `SIGNATURES`-input wiring + contract test for after #1571 merges.

### Requirement 3 — gate runtime (report only; gate not restructured)

From the failing run's log: ~3 min image pull, then ~11 min re-running all 35 tools via in-container `lintro chk .` to derive skip state. The gate re-lints the whole repo because the dogfooding jobs use an external reusable workflow with no place to add a post-lint step. Reducible in principle — e.g. the dogfooding-lint job could upload its JSON report as an artifact for the gate to check skips against instead of re-linting — but that needs support in lgtm-ci's reusable-quality-lint and is out of scope here.

### Testing

- `uv run lintro fmt` + `uv run lintro chk` — zero issues (health 100/100)
- `uv run pytest --maxfail=0` — 7750 passed, 95 skipped; 12 failures in external-tool integration tests (`pip_audit`, `commitlint`, `oxfmt`, `oxlint`) reproduced identically on pristine `origin/main` (local tool-install issues: `pip-audit` at `~/.local/bin` crashes; local commitlint 21.2.0 is below the 21.2.1 floor) — pre-existing and unrelated to this change
- Pre-push AI review: CodeRabbit 0 findings on the 3 changed files; Greptile "safe to merge" (4/5) — its two P2 comments target `scripts/ci/promote-ci-docker-images.sh`, which is not in this diff (merged #1696 work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the maximum runtime for dogfood workflow checks to 20 minutes, allowing stalled runs to fail faster.

* **Tests**
  * Added coverage to verify that dogfood skip gates have a bounded timeout and the expected gate name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Tightens the dogfood no-silent-skip gate timeout and adds regression coverage.
- Reduces `dogfood-skip-gate` timeouts from 30 to 20 minutes in the PR and nightly workflows.
- Adds a wiring test requiring both gate jobs to retain a bounded timeout and stable display name.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/docker-ci.yml | Reduces the PR dogfood skip gate timeout to 20 minutes without changing its dependencies, conditions, permissions, or steps. |
| .github/workflows/dogfood-nightly.yml | Applies the same 20-minute timeout to the nightly copy of the dogfood skip gate. |
| tests/unit/test_workflow_wiring.py | Adds contract coverage ensuring both workflow copies retain the expected gate name and a timeout between 18 and 28 minutes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ci): reject the removed 30-minute d..."](https://github.com/lgtm-hq/py-lintro/commit/5cac2f61c0722be6b9ac42b9c4a4666ebc159366) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47190394)</sub>

**Context used:**

- Knowledge Base — [CI/CD Workflows](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/py-lintro/-/docs/ci-workflows.md)
- Knowledge Base — [Testing and Benchmarks](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/py-lintro/-/docs/testing-and-benchmarks.md)

<!-- /greptile_comment -->