### PR TITLE
fix(ci): strip rustup HTML doc trees from lintro-tools image (#1703)

### DIFF
--- a/docker/tools.Dockerfile
+++ b/docker/tools.Dockerfile
@@ -120,13 +120,22 @@ COPY package.json /app/package.json
 RUN groupadd -r tools && \
     mkdir -p /opt/bun /opt/cargo /opt/rustup
 
+# Keep rustup's bundled HTML doc trees (rust-docs component) out of the
+# image: generated Rust API docs have no runtime use here, they add tens of
+# thousands of small files per toolchain, and Trivy's secret scanner walked
+# them until it hit its timeout (#1703). Install the stable toolchain with
+# --profile minimal (no rust-docs download; clippy/rustfmt added explicitly)
+# and rm any remaining share/doc trees — e.g. from the pinned toolchain
+# install-tools.sh installs with the default profile — in the same layer so
+# they never reach the committed image.
 RUN --mount=type=cache,target=/opt/cargo/registry,sharing=locked \
     --mount=type=cache,target=/opt/cargo/git,sharing=locked \
     --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     find /app/scripts -type f -name "*.sh" -exec chmod +x {} \; && \
     /app/scripts/utils/install-tools.sh --docker && \
+    rustup toolchain install stable --profile minimal --component clippy,rustfmt && \
     rustup default stable && \
-    rustup component add clippy
+    rm -rf /opt/rustup/toolchains/*/share/doc
 
 RUN chgrp -R tools /opt/cargo /opt/rustup /opt/bun && \
     chmod -R g+rwX /opt/cargo /opt/rustup /opt/bun && \


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): strip rustup HTML doc trees from lintro-tools image
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

The `🐳 Lintro Tools Image` Trivy scan intermittently exceeds its timeout because
Trivy's secret scanner walks the `rust-docs` HTML trees bundled in both rustup
toolchains (tens of thousands of small files per toolchain plus a 14MB
`COPYRIGHT.html`). Generated Rust API docs have no runtime use in the image, so
this PR keeps them out of it entirely:

- Install the `stable` toolchain with `rustup toolchain install stable
  --profile minimal --component clippy,rustfmt` — no `rust-docs` download, with
  clippy/rustfmt requested explicitly so the verify block is unaffected.
- `rm -rf /opt/rustup/toolchains/*/share/doc` in the same RUN layer, catching
  the pinned toolchain that `install-tools.sh` installs with the default
  profile. Deleted in-layer, the docs never reach the committed image, which
  also shrinks it.

No scan-side config change: the scan runs inside `lgtm-hq/lgtm-ci`
`reusable-docker.yml` (pinned v0.59.2), which exposes only `scan` and
`scan-exit-code` — no skip-dirs/`.trivyignore` input (lgtm-ci#626), and the
reusable workflow must not be forked. Secret scanning stays enabled for all
application layers; `--timeout` is untouched.

Verified nothing relies on the removed paths: repo-wide grep for `share/doc`
finds zero references, and the root `Dockerfile` consumes this image only via a
digest-pinned `FROM`.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1703

## Details

**Testing strategy:** Dockerfile-only change (one RUN layer + comment); there is
no unit-testable Python surface, and image build/scan validation happens in CI
via the `docker/tools.Dockerfile` path trigger on this PR (local Docker builds
are intentionally not run).

- `uv run lintro fmt` / `uv run lintro chk` — zero issues, health 100/100.
- `uv run pytest --maxfail=0` (full suite) — **7749 passed, 95 skipped, 12
  failed**. All 12 failures are pre-existing environment issues on pristine
  `origin/main` (verified byte-identical failure lists with the change stashed
  vs. applied): `pip_audit` x2 (live vuln-DB dependent), `commitlint` x1,
  `oxfmt` x5, `oxlint` x4 (external-binary integration tests). None are related
  to this change.
- Pre-push AI review: CodeRabbit — no findings; Greptile — 4/5 confidence, one
  P2 suggestion (adopt `--profile minimal` for the stable toolchain), which is
  incorporated in the final diff.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reduces the lintro-tools image’s Rust documentation footprint.
- Installs a minimal stable Rust toolchain with clippy and rustfmt.
- Removes remaining rustup share/doc trees from all installed toolchains.
</details>

<h3>Confidence Score: 3/5</h3>

This PR should not merge until it preserves the pinned default Rust toolchain while removing its documentation.

Selecting the floating stable channel after install-tools.sh overrides the repository’s pinned Rust default, causing rustc and clippy version checks to fail whenever stable differs from the manifest.

**Files Needing Attention:** docker/tools.Dockerfile

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docker/tools.Dockerfile | Strips Rust documentation successfully, but switches the active toolchain from the repository-pinned version to a floating stable release that can fail manifest verification. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocker%2Ftools.Dockerfile%3A137%0A**Floating%20default%20breaks%20version%20pinning**%0A%0AWhen%20the%20current%20stable%20Rust%20release%20differs%20from%20the%20repository-pinned%20version%2C%20%60rustup%20default%20stable%60%20replaces%20the%20pinned%20default%20selected%20by%20%60install-tools.sh%60%2C%20so%20%60rustc%60%20and%20%60clippy%60%20report%20versions%20that%20differ%20from%20the%20manifest%20and%20the%20tools-image%20verification%20fails.%0A%0A&pr=1709&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocker%2Ftools.Dockerfile%3A137%0A**Floating%20default%20breaks%20version%20pinning**%0A%0AWhen%20the%20current%20stable%20Rust%20release%20differs%20from%20the%20repository-pinned%20version%2C%20%60rustup%20default%20stable%60%20replaces%20the%20pinned%20default%20selected%20by%20%60install-tools.sh%60%2C%20so%20%60rustc%60%20and%20%60clippy%60%20report%20versions%20that%20differ%20from%20the%20manifest%20and%20the%20tools-image%20verification%20fails.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1709&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Fpy-lintro%22%20on%20the%20existing%20branch%20%22fix%2F1703-trivy-rustup-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F1703-trivy-rustup-docs%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocker%2Ftools.Dockerfile%3A137%0A**Floating%20default%20breaks%20version%20pinning**%0A%0AWhen%20the%20current%20stable%20Rust%20release%20differs%20from%20the%20repository-pinned%20version%2C%20%60rustup%20default%20stable%60%20replaces%20the%20pinned%20default%20selected%20by%20%60install-tools.sh%60%2C%20so%20%60rustc%60%20and%20%60clippy%60%20report%20versions%20that%20differ%20from%20the%20manifest%20and%20the%20tools-image%20verification%20fails.%0A%0A&repo=lgtm-hq%2Fpy-lintro&pr=1709&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): strip rustup HTML doc trees fro..."](https://github.com/lgtm-hq/py-lintro/commit/6c9e4785e9163acee4445ed0bbfcfe5c0cb67043) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47190587)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Build and Packaging](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/py-lintro/-/docs/build-and-packaging.md)

<!-- /greptile_comment -->