### PR TITLE
fix(ci): reconcile npm dist-tag on idempotent publish skip/conflict paths

### DIFF
--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -13,6 +13,17 @@
 # validation failures are never retried — retrying them only hides the real
 # problem. Combined with the idempotency skip below, a re-run repairs a partial
 # publish instead of compounding it.
+#
+# Dist-tag reconciliation (see issue #1691): on both idempotent paths — the
+# `npm view` pre-check skip and the EPUBLISHCONFLICT conflict-as-success
+# branch — the requested dist-tag is reconciled with `npm dist-tag add` (a
+# no-op when the tag already matches). A fresh publish never calls dist-tag
+# because publish applies --tag atomically. Reconciliation failures are FATAL,
+# never swallowed: publish-npm.yml authenticates via npm trusted publishing
+# (OIDC), whose exchanged token is scoped to `npm publish` only — the registry
+# rejects dist-tag operations under it (npm/cli#8547 is still open). Failing
+# loudly surfaces a skipped-but-mistagged version for manual repair instead of
+# silently claiming a reconcile that never happened.
 
 set -euo pipefail
 
@@ -111,6 +122,39 @@ TRANSIENT_ERROR_RE='TLOG_CREATE_ENTRY_ERROR|creating tlog entry|transparency log
 # this loop or an earlier run landed the tarball) rather than a failure.
 ALREADY_PUBLISHED_RE='EPUBLISHCONFLICT|cannot publish over|previously published version|already published'
 
+# Reconcile the requested dist-tag for an already-published name@version.
+#
+# `npm dist-tag add` is idempotent: a no-op when the tag already points at
+# that version, and (unlike publish) allowed to move latest. A failure is
+# returned non-zero — never swallowed — because the OIDC trusted-publishing
+# token used by publish-npm.yml is publish-scoped and cannot run dist-tag
+# (npm/cli#8547); silently "succeeding" would leave the registry mistagged.
+#
+# Args:
+#   $1: package name (e.g. "@lgtm-hq/lintro-linux-x64").
+#   $2: package version.
+# Returns:
+#   0 when the tag was reconciled; 1 when npm rejected the operation.
+reconcile_dist_tag() {
+	local dt_name="$1"
+	local dt_version="$2"
+	local dt_output dt_rc
+	echo "==> Reconciling dist-tag '$dist_tag' for $dt_name@$dt_version"
+	dt_output="$(npm dist-tag add "$dt_name@$dt_version" "$dist_tag" 2>&1)" && dt_rc=0 || dt_rc=$?
+	printf '%s\n' "$dt_output"
+	if [[ "$dt_rc" -ne 0 ]]; then
+		echo "ERROR: could not reconcile dist-tag '$dist_tag' for $dt_name@$dt_version (exit $dt_rc)." >&2
+		# The OIDC remediation only applies to auth-scope rejections; other
+		# failures (network, registry 5xx) get just the generic error above.
+		if grep -qiE "$NON_RETRYABLE_ERROR_RE" <<<"$dt_output"; then
+			echo "ERROR: npm trusted publishing (OIDC) tokens are publish-scoped and cannot run 'npm dist-tag' (npm/cli#8547)." >&2
+			echo "ERROR: re-apply the tag with classic auth: npm dist-tag add $dt_name@$dt_version $dist_tag" >&2
+		fi
+		return 1
+	fi
+	return 0
+}
+
 # Publish one package directory with bounded, exponential-backoff retry on
 # transient Sigstore/registry errors only.
 #
@@ -135,6 +179,15 @@ publish_one() {
 		fi
 		if grep -qiE "$ALREADY_PUBLISHED_RE" <<<"$output"; then
 			echo "==> $pkg already present on the registry (publish conflict); treating as an idempotent success." >&2
+			# A fresh publish applies --tag atomically, but this version was
+			# published earlier (possibly under a different tag): reconcile the
+			# requested tag. Fatal on failure (see reconcile_dist_tag). Dry-runs
+			# never mutate the registry, so they skip reconciliation.
+			if [[ "${LIVE:-0}" == "1" ]]; then
+				reconcile_dist_tag \
+					"$(node -p "require('$pkg_dir/package.json').name")" \
+					"$(node -p "require('$pkg_dir/package.json').version")" || return 1
+			fi
 			return 0
 		fi
 		if grep -qiE "$NON_RETRYABLE_ERROR_RE" <<<"$output"; then
@@ -180,6 +233,10 @@ for pkg in "${PACKAGES[@]}"; do
 		view_err="$(npm view "$pkg_name@$pkg_version" version 2>&1 >/dev/null)" && view_ok=1 || view_ok=0
 		if [[ "$view_ok" == "1" ]]; then
 			echo "==> Skipping $pkg_name@$pkg_version (already published)"
+			# The version exists but may carry a different tag than this run
+			# requested; reconcile it. Fatal on failure (see reconcile_dist_tag);
+			# set -e aborts the release rather than leaving a stale tag.
+			reconcile_dist_tag "$pkg_name" "$pkg_version"
 			continue
 		elif ! grep -qiE 'E404|404 Not Found|is not in this registry' <<<"$view_err"; then
 			# The existence check itself failed, so we cannot prove the version

--- a/scripts/ci/npm/publish_packages.sh
+++ b/scripts/ci/npm/publish_packages.sh
@@ -23,7 +23,9 @@
 # (OIDC), whose exchanged token is scoped to `npm publish` only — the registry
 # rejects dist-tag operations under it (npm/cli#8547 is still open). Failing
 # loudly surfaces a skipped-but-mistagged version for manual repair instead of
-# silently claiming a reconcile that never happened.
+# silently claiming a reconcile that never happened. Transient registry/network
+# blips on the reconcile itself get the same bounded backoff as publish, so a
+# single 5xx does not abort the ordered rerun after only a prefix of tags.
 
 set -euo pipefail
 
@@ -47,8 +49,8 @@ Environment:
                              non-latest tag (e.g. backfill) when publishing a
                              version lower than the current latest — npm refuses
                              to move latest backwards without an explicit --tag.
-  NPM_PUBLISH_MAX_ATTEMPTS   Max publish attempts per package on a transient
-                             error (default: 3).
+  NPM_PUBLISH_MAX_ATTEMPTS   Max attempts per package publish or dist-tag
+                             reconcile on a transient error (default: 3).
   NPM_PUBLISH_RETRY_DELAY    Base backoff in seconds; doubles each retry
                              (default: 5).
 
@@ -130,6 +132,12 @@ ALREADY_PUBLISHED_RE='EPUBLISHCONFLICT|cannot publish over|previously published 
 # token used by publish-npm.yml is publish-scoped and cannot run dist-tag
 # (npm/cli#8547); silently "succeeding" would leave the registry mistagged.
 #
+# Transient failures (network, registry 5xx, 429) get the same bounded
+# exponential-backoff retry as publish_one: a single-attempt mutation would
+# abort the ordered reconcile after only a prefix of package tags on a mere
+# blip. Auth and validation rejections are never retried — they surface the
+# OIDC remediation immediately.
+#
 # Args:
 #   $1: package name (e.g. "@lgtm-hq/lintro-linux-x64").
 #   $2: package version.
@@ -138,21 +146,41 @@ ALREADY_PUBLISHED_RE='EPUBLISHCONFLICT|cannot publish over|previously published 
 reconcile_dist_tag() {
 	local dt_name="$1"
 	local dt_version="$2"
+	local attempt=1
+	local delay="$retry_base_delay"
 	local dt_output dt_rc
-	echo "==> Reconciling dist-tag '$dist_tag' for $dt_name@$dt_version"
-	dt_output="$(npm dist-tag add "$dt_name@$dt_version" "$dist_tag" 2>&1)" && dt_rc=0 || dt_rc=$?
-	printf '%s\n' "$dt_output"
-	if [[ "$dt_rc" -ne 0 ]]; then
-		echo "ERROR: could not reconcile dist-tag '$dist_tag' for $dt_name@$dt_version (exit $dt_rc)." >&2
-		# The OIDC remediation only applies to auth-scope rejections; other
-		# failures (network, registry 5xx) get just the generic error above.
+	while :; do
+		echo "==> Reconciling dist-tag '$dist_tag' for $dt_name@$dt_version (attempt $attempt/$max_attempts)"
+		dt_output="$(npm dist-tag add "$dt_name@$dt_version" "$dist_tag" 2>&1)" && dt_rc=0 || dt_rc=$?
+		printf '%s\n' "$dt_output"
+		if [[ "$dt_rc" -eq 0 ]]; then
+			return 0
+		fi
+		# The OIDC remediation only applies to auth-scope rejections; retrying
+		# those would only hide the real problem.
 		if grep -qiE "$NON_RETRYABLE_ERROR_RE" <<<"$dt_output"; then
+			echo "ERROR: could not reconcile dist-tag '$dist_tag' for $dt_name@$dt_version (exit $dt_rc)." >&2
 			echo "ERROR: npm trusted publishing (OIDC) tokens are publish-scoped and cannot run 'npm dist-tag' (npm/cli#8547)." >&2
 			echo "ERROR: re-apply the tag with classic auth: npm dist-tag add $dt_name@$dt_version $dist_tag" >&2
+			return 1
 		fi
+		if grep -qiE "$TRANSIENT_ERROR_RE" <<<"$dt_output"; then
+			if [[ "$attempt" -ge "$max_attempts" ]]; then
+				echo "ERROR: could not reconcile dist-tag '$dist_tag' for $dt_name@$dt_version after $max_attempts attempts on a transient error." >&2
+				return 1
+			fi
+			echo "WARNING: transient dist-tag error for $dt_name@$dt_version (attempt $attempt/$max_attempts); retrying in ${delay}s." >&2
+			sleep "$delay"
+			attempt=$((attempt + 1))
+			delay=$((delay * 2))
+			if [[ "$delay" -gt "$retry_max_delay" ]]; then
+				delay="$retry_max_delay"
+			fi
+			continue
+		fi
+		echo "ERROR: could not reconcile dist-tag '$dist_tag' for $dt_name@$dt_version (exit $dt_rc)." >&2
 		return 1
-	fi
-	return 0
+	done
 }
 
 # Publish one package directory with bounded, exponential-backoff retry on

--- a/tests/scripts/test_npm_publish_packages.py
+++ b/tests/scripts/test_npm_publish_packages.py
@@ -663,6 +663,62 @@ def test_dist_tag_failure_on_skip_path_is_fatal(tmp_path: Path) -> None:
     assert_that(result.returncode).is_not_equal_to(0)
     assert_that(result.stdout).contains("could not reconcile dist-tag")
     assert_that(result.stdout).contains("npm/cli#8547")
+    # Auth rejections are never retried: exactly one dist-tag attempt.
+    assert_that(_dist_tag_log(result).strip().splitlines()).is_length(1)
+    # The run aborts at the first unreconciled tag: nothing is published.
+    assert_that(_publish_log(result).strip()).is_equal_to("")
+
+
+def test_dist_tag_transient_error_is_retried_then_succeeds(tmp_path: Path) -> None:
+    """A transient dist-tag failure is retried with backoff, then reconciled.
+
+    A single registry 5xx must not abort the ordered reconcile after only a
+    prefix of tags; the bounded retry (same error classification as publish)
+    rides out the blip.
+    """
+    # npm view reports every version as present, so each package hits the skip
+    # path; the first dist-tag attempt fails with a transient 503.
+    view_body = 'echo "9.9.9"\nexit 0'
+    count_file = tmp_path / "dt-attempts"
+    dist_tag_body = (
+        f'attempts=$(cat "{count_file}" 2>/dev/null || echo 0)\n'
+        f"attempts=$((attempts + 1))\n"
+        f'echo "$attempts" > "{count_file}"\n'
+        'if [[ "$attempts" -eq 1 ]]; then\n'
+        '  echo "npm error 503 Service Unavailable" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0"
+    )
+    result = _run(
+        tmp_path,
+        npm_body="exit 0",
+        view_body=view_body,
+        dist_tag_body=dist_tag_body,
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("transient dist-tag error")
+    tags = _dist_tag_log(result).strip().splitlines()
+    # Five packages reconciled; the first needed one retry.
+    assert_that(tags).is_length(len(_PACKAGES) + 1)
+    assert_that(tags[0]).is_equal_to(tags[1])
+    assert_that(_sleep_log(result).strip().splitlines()).is_length(1)
+
+
+def test_dist_tag_transient_error_exhausts_attempts(tmp_path: Path) -> None:
+    """A persistent transient dist-tag failure is fatal after bounded retries."""
+    view_body = 'echo "9.9.9"\nexit 0'
+    dist_tag_body = 'echo "npm error 502 Bad Gateway" >&2\nexit 1'
+    result = _run(
+        tmp_path,
+        npm_body="exit 0",
+        view_body=view_body,
+        dist_tag_body=dist_tag_body,
+        extra_env={"NPM_PUBLISH_MAX_ATTEMPTS": "2"},
+    )
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stdout).contains("after 2 attempts on a transient error")
+    assert_that(_dist_tag_log(result).strip().splitlines()).is_length(2)
     # The run aborts at the first unreconciled tag: nothing is published.
     assert_that(_publish_log(result).strip()).is_equal_to("")
 

--- a/tests/scripts/test_npm_publish_packages.py
+++ b/tests/scripts/test_npm_publish_packages.py
@@ -47,7 +47,19 @@ def _sleep_log(result: subprocess.CompletedProcess[str]) -> str:
     Returns:
         str: The text after the ``---SLEEP---`` marker.
     """
-    return result.stdout.split("---SLEEP---", 1)[1]
+    return result.stdout.split("---SLEEP---", 1)[1].split("---DISTTAG---", 1)[0]
+
+
+def _dist_tag_log(result: subprocess.CompletedProcess[str]) -> str:
+    """Return the recorded ``npm dist-tag`` invocations, one per line.
+
+    Args:
+        result: The completed run produced by ``_run``.
+
+    Returns:
+        str: The text after the ``---DISTTAG---`` marker.
+    """
+    return result.stdout.split("---DISTTAG---", 1)[1]
 
 
 def _write_stub(bin_dir: Path, name: str, body: str) -> None:
@@ -107,6 +119,7 @@ def _run(
     *,
     extra_env: dict[str, str] | None = None,
     view_body: str | None = None,
+    dist_tag_body: str = "exit 0",
     log_name: str = "npm.log",
 ) -> subprocess.CompletedProcess[str]:
     """Run publish_packages.sh with stub ``npm``/``node`` on PATH.
@@ -117,6 +130,8 @@ def _run(
         extra_env: Extra environment variables for the script.
         view_body: Optional bash body for ``npm view`` handling. When omitted
             ``npm view`` reports E404 (version not yet published).
+        dist_tag_body: Bash body for ``npm dist-tag`` handling. Defaults to
+            success; every invocation is recorded for assertions.
         log_name: File the npm stub appends its argv to for assertions.
 
     Returns:
@@ -128,6 +143,7 @@ def _run(
     root.mkdir()
     _fake_npm_dir(root)
     log = tmp_path / log_name
+    dist_tag_log = tmp_path / "dist-tag.log"
 
     view = view_body or (
         'echo "npm error code E404" >&2\n'
@@ -136,6 +152,8 @@ def _run(
     )
     npm = (
         f'if [[ "$1" == "view" ]]; then\n{view}\nfi\n'
+        f'if [[ "$1" == "dist-tag" ]]; then\n'
+        f'echo "dist-tag $*" >> "{dist_tag_log}"\n{dist_tag_body}\nfi\n'
         f'if [[ "$1" == "publish" ]]; then\n'
         f'echo "publish $(basename "$PWD") $*" >> "{log}"\n{npm_body}\nfi\n'
     )
@@ -172,12 +190,14 @@ def _run(
     )
     result_log = log.read_text() if log.exists() else ""
     sleep_record = sleep_log.read_text() if sleep_log.exists() else ""
-    # Fold stderr (warnings/errors) into stdout, then append the publish and
-    # sleep logs so a single ``result.stdout`` carries everything the
+    dist_tag_record = dist_tag_log.read_text() if dist_tag_log.exists() else ""
+    # Fold stderr (warnings/errors) into stdout, then append the publish, sleep,
+    # and dist-tag logs so a single ``result.stdout`` carries everything the
     # assertions inspect.
     result.stdout = (
         f"{result.stdout}\n{result.stderr}\n"
-        f"---LOG---\n{result_log}\n---SLEEP---\n{sleep_record}"
+        f"---LOG---\n{result_log}\n---SLEEP---\n{sleep_record}\n"
+        f"---DISTTAG---\n{dist_tag_record}"
     )
     return result
 
@@ -559,3 +579,151 @@ def test_dry_run_publishes_without_existence_check(tmp_path: Path) -> None:
     assert_that(result.stdout).does_not_contain("VIEW SHOULD NOT RUN")
     log = _publish_log(result)
     assert_that(log.strip().splitlines()).is_length(len(_PACKAGES))
+
+
+def test_skip_path_reconciles_dist_tag(tmp_path: Path) -> None:
+    """The npm view skip path still reconciles the requested dist-tag.
+
+    A version already on the registry is not re-published, so the tag a fresh
+    publish would have applied atomically must be re-applied explicitly.
+    """
+    # npm view reports the two darwin packages as present, others E404.
+    view_body = (
+        'if grep -qE "darwin-(arm64|x64)" <<<"$*"; then\n'
+        '  echo "9.9.9"\n'
+        "  exit 0\n"
+        "fi\n"
+        'echo "npm error code E404" >&2\n'
+        'echo "npm error 404 Not Found" >&2\n'
+        "exit 1"
+    )
+    result = _run(tmp_path, npm_body="exit 0", view_body=view_body)
+    assert_that(result.returncode).is_equal_to(0)
+    tags = _dist_tag_log(result).strip().splitlines()
+    assert_that(tags).is_length(2)
+    assert_that(tags[0]).contains("add @lgtm-hq/lintro-darwin-arm64@9.9.9 latest")
+    assert_that(tags[1]).contains("add @lgtm-hq/lintro-darwin-x64@9.9.9 latest")
+    # Skipped packages are never re-published.
+    assert_that(_publish_log(result)).does_not_contain("darwin")
+
+
+def test_conflict_path_reconciles_dist_tag(tmp_path: Path) -> None:
+    """An EPUBLISHCONFLICT idempotent success also reconciles the dist-tag."""
+    npm_body = (
+        'if [[ "$(basename "$PWD")" == "linux-arm64" ]]; then\n'
+        '  echo "npm error code EPUBLISHCONFLICT" >&2\n'
+        '  echo "npm error You cannot publish over the previously published '
+        'versions: 9.9.9." >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0"
+    )
+    result = _run(tmp_path, npm_body=npm_body)
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("idempotent success")
+    tags = _dist_tag_log(result).strip().splitlines()
+    assert_that(tags).is_length(1)
+    assert_that(tags[0]).contains("add @lgtm-hq/lintro-linux-arm64@9.9.9 latest")
+
+
+def test_fresh_publish_does_not_call_dist_tag(tmp_path: Path) -> None:
+    """A fresh publish applies the tag atomically and never calls dist-tag.
+
+    Calling dist-tag after a successful publish would be redundant — and would
+    hard-fail under trusted publishing (OIDC), whose token is publish-scoped
+    (npm/cli#8547).
+    """
+    result = _run(tmp_path, npm_body="exit 0")
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(_publish_log(result).strip().splitlines()).is_length(len(_PACKAGES))
+    assert_that(_dist_tag_log(result).strip()).is_equal_to("")
+
+
+def test_dist_tag_failure_on_skip_path_is_fatal(tmp_path: Path) -> None:
+    """A rejected dist-tag reconciliation fails loudly instead of passing silently.
+
+    Trusted-publishing (OIDC) tokens are publish-scoped, so the registry can
+    reject ``npm dist-tag`` with an auth error; the script must surface that
+    as a non-zero exit rather than claim a reconcile it could not perform.
+    """
+    # npm view reports every version as present, so each package hits the skip
+    # path; the dist-tag stub then rejects the reconcile with an auth error.
+    view_body = 'echo "9.9.9"\nexit 0'
+    dist_tag_body = (
+        'echo "npm error code E403" >&2\n'
+        'echo "npm error 403 Forbidden - PUT registry/-/package/dist-tags" >&2\n'
+        "exit 1"
+    )
+    result = _run(
+        tmp_path,
+        npm_body="exit 0",
+        view_body=view_body,
+        dist_tag_body=dist_tag_body,
+    )
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stdout).contains("could not reconcile dist-tag")
+    assert_that(result.stdout).contains("npm/cli#8547")
+    # The run aborts at the first unreconciled tag: nothing is published.
+    assert_that(_publish_log(result).strip()).is_equal_to("")
+
+
+def test_dist_tag_failure_on_conflict_path_is_fatal(tmp_path: Path) -> None:
+    """A dist-tag failure turns a conflict idempotent success into a loud failure."""
+    npm_body = (
+        'if [[ "$(basename "$PWD")" == "darwin-arm64" ]]; then\n'
+        '  echo "npm error code EPUBLISHCONFLICT" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0"
+    )
+    dist_tag_body = 'echo "npm error code ENEEDAUTH" >&2\nexit 1'
+    result = _run(tmp_path, npm_body=npm_body, dist_tag_body=dist_tag_body)
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stdout).contains("could not reconcile dist-tag")
+    # The run aborts at the first hard failure: later packages never publish.
+    log = _publish_log(result)
+    assert_that(log).does_not_contain("linux-x64")
+    assert_that(log).does_not_contain("lintro")
+
+
+def test_dry_run_conflict_does_not_call_dist_tag(tmp_path: Path) -> None:
+    """Dry-runs never mutate the registry, so a conflict hit skips dist-tag."""
+    npm_body = (
+        'if [[ "$(basename "$PWD")" == "linux-arm64" ]]; then\n'
+        '  echo "npm error code EPUBLISHCONFLICT" >&2\n'
+        "  exit 1\n"
+        "fi\n"
+        "exit 0"
+    )
+    result = _run(
+        tmp_path,
+        npm_body=npm_body,
+        extra_env={"LIVE": "0", "NPM_PROVENANCE": "0"},
+    )
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(_dist_tag_log(result).strip()).is_equal_to("")
+
+
+def test_dist_tag_non_auth_failure_omits_oidc_remediation(tmp_path: Path) -> None:
+    """A non-auth dist-tag failure stays fatal but skips the OIDC guidance.
+
+    The npm/cli#8547 remediation is only accurate for auth-scope rejections;
+    other failures (e.g. a registry 5xx) must not point at classic auth.
+    """
+    # npm view reports every version as present so the skip path reconciles;
+    # the dist-tag stub then fails with a non-auth server error.
+    view_body = 'echo "9.9.9"\nexit 0'
+    dist_tag_body = (
+        'echo "npm error code E500" >&2\n'
+        'echo "npm error 500 Internal Server Error" >&2\n'
+        "exit 1"
+    )
+    result = _run(
+        tmp_path,
+        npm_body="exit 0",
+        view_body=view_body,
+        dist_tag_body=dist_tag_body,
+    )
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stdout).contains("could not reconcile dist-tag")
+    assert_that(result.stdout).does_not_contain("npm/cli#8547")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): reconcile npm dist-tag on idempotent publish skip/conflict paths
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What's Changing

`scripts/ci/npm/publish_packages.sh` treated an already-published `name@version` as
an idempotent success on two paths — the `npm view` pre-check skip and (since #1688)
a mid-loop `EPUBLISHCONFLICT` — without reconciling the requested `--tag` dist-tag. A
re-run over a version published earlier under a different tag (e.g. a `backfill` run
followed by a `latest` run) reported success while leaving the tag pointing at the
wrong version.

On both idempotent paths, after confirming `name@version` exists, the script now
reconciles the requested dist-tag with `npm dist-tag add "$pkg_name@$pkg_version"
"$dist_tag"` — a no-op when the tag already matches. A fresh publish never calls
`dist-tag` (publish applies `--tag` atomically), and dry-runs never call it (they
must not mutate the registry).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1691
- Relates to #1688

## Details

### OIDC trusted-publishing scope (validated before shipping, per the issue)

`publish-npm.yml` authenticates with **npm trusted publishing (OIDC)**
(`id-token: write`, no `NODE_AUTH_TOKEN`). Validation of whether that token can run
`npm dist-tag`:

- npm docs state OIDC authentication supports only `npm publish` and
  `npm stage publish`; "Other npm commands such as `install`, `view`, or `access`
  still require traditional authentication methods", and "trusted publishing only
  applies to the `npm publish` command".
- [npm/cli#8547](https://github.com/npm/cli/issues/8547) — "Allow Trusted Publishers
  to run `npm dist-tag add`" — is **open**; reporters confirm the OIDC-exchanged
  token is publish-scoped and `dist-tag add` fails with 401/403 under it.

**Conclusion: the trusted-publishing token cannot run `npm dist-tag` today.**
Per the issue, the reconciliation therefore **fails loudly** rather than silently
claiming success: any `npm dist-tag` rejection aborts the release with a non-zero
exit. Auth-scope rejections (E401/E403/ENEEDAUTH/…) additionally print the
remediation (re-apply the tag with classic auth; cites npm/cli#8547); non-auth
failures get the generic error only.

Impact is narrow by construction: a fresh tag-push never hits the idempotent paths,
so normal releases are unaffected. Only a re-run that skips/conflicts an
already-published version reconciles tags — exactly the case that previously could
leave the registry mistagged while reporting success. If npm later grants dist-tag
scope to trusted publishers (npm/cli#8547), or a classic/granular token is supplied
(npm auto-uses `NODE_AUTH_TOKEN`; **no script change needed** — deliberately not
added here since minting an npm token is an org-admin decision), the same code path
just succeeds.

### Testing strategy

The live publish path runs only on tag-push and is **not exercised by PR CI**;
correctness is validated via the stubbed script tests (stub `npm`/`node` on `PATH`,
no network), which are the signal for this logic.

`tests/scripts/test_npm_publish_packages.py` — 33 tests, 7 new:

- skip path reconciles the requested tag (and does not re-publish)
- conflict path reconciles the requested tag
- fresh publish never calls `dist-tag`
- `dist-tag` rejection is fatal on the skip path (prints the OIDC remediation)
- `dist-tag` rejection is fatal on the conflict path (aborts the release loop)
- dry-run conflict never calls `dist-tag`
- non-auth `dist-tag` failure stays fatal but omits the OIDC remediation

### Verification

- `uv run lintro fmt` / `uv run lintro chk`: 0 issues (shellcheck/shfmt included),
  health score 100/100.
- `uv run pytest` (full suite, `--maxfail=0`): **7755 passed, 95 skipped**; the 12
  failures are pre-existing integration tests requiring external tools absent from
  this environment (`oxlint`, `oxfmt`, `commitlint`, `pip_audit`) — verified to fail
  identically on the base commit with these changes stashed.
- Pre-push AI review: CodeRabbit — 1 minor finding applied (OIDC remediation now
  printed only for auth-scope failures), 1 trivial finding skipped with rationale
  (adding npm credentials is an org-admin decision, out of scope). Greptile — 4/5
  confidence, safe to merge; its 2 P2 comments cover pre-existing code outside this
  diff (CHANGELOG 0.91.38 entry, `TRANSIENT_ERROR_RE` breadth from #1688).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR completes the transient dist-tag retry fix requested in the previous review thread.
- Adds bounded exponential backoff for transient `npm dist-tag add` failures.
- Preserves immediate failure for authentication, permission, and non-transient errors.
- Adds tests for successful retries, exhausted retries, authentication failures, conflict and skip paths, and dry-run behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain in the fix for the previous review thread.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/npm/publish_packages.sh | Adds bounded transient-error retries to dist-tag reconciliation while retaining immediate terminal handling for non-retryable failures. |
| tests/scripts/test_npm_publish_packages.py | Extends the stubbed publishing tests to cover successful and exhausted dist-tag retries alongside terminal and dry-run paths. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): retry transient dist-tag reconc..."](https://github.com/lgtm-hq/py-lintro/commit/d4728a6f5910554b7e67d37b4375cb591ee16cd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47191276)</sub>

**Context used:**

- Knowledge Base — [Build and Packaging](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/py-lintro/-/docs/build-and-packaging.md)
- Knowledge Base — [Testing and Benchmarks](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/py-lintro/-/docs/testing-and-benchmarks.md)

<!-- /greptile_comment -->