### PR TITLE
fix(ci): drop dead free-text failure-reason heuristic from code-quality gate

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -114,7 +114,7 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `evaluate-code-quality-gate.sh`      | Select effective dogfooding lint attempt for code-quality gate        | `./scripts/ci/evaluate-code-quality-gate.sh --help`                                         |
 | `run-code-quality-gate.sh`           | Evaluate + assert docker-ci code-quality gate for required rollup     | `./scripts/ci/run-code-quality-gate.sh --help`                                              |
 | `assert-required-check.sh`           | Fail required check unless upstream passed or infra flake             | `./scripts/ci/assert-required-check.sh --help`                                              |
-| `is-infra-flake-failure.sh`          | Classify runner infra flakes (exit 143, ETIMEDOUT, cancelled)         | `./scripts/ci/is-infra-flake-failure.sh --help`                                             |
+| `is-infra-flake-failure.sh`          | Classify runner infra flakes (exit 143, cancelled, passed lint)       | `./scripts/ci/is-infra-flake-failure.sh --help`                                             |
 | `fail-on-security-audit.sh`          | Fail CI when security audit finds vulnerabilities                     | `./scripts/ci/fail-on-security-audit.sh`                                                    |
 | `free-disk-space.sh`                 | Free disk space on CI runner for Docker builds                        | `./scripts/ci/free-disk-space.sh`                                                           |
 | `validate-docker-backfill-inputs.sh` | Validate workflow-dispatch backfill version/ref inputs                | `BACKFILL_VERSION=<ver> BACKFILL_REF=<ref> ./scripts/ci/validate-docker-backfill-inputs.sh` |

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -55,7 +55,7 @@ reclaimed by `sweep-ci-ghcr-tags.sh` (age-based, default 91 days; #1138).
 - `run-code-quality-gate.sh` — orchestrate evaluation plus `assert-required-check.sh`
   for the required gate job.
 - `is-infra-flake-failure.sh` — classify runner infra flakes (cancelled jobs, exit 143,
-  artifact timeouts).
+  lint passed on a failed job).
 - `assert-required-check.sh` — enforce the required check contract for
   lintro-code-quality.
 

--- a/scripts/ci/assert-required-check.sh
+++ b/scripts/ci/assert-required-check.sh
@@ -23,7 +23,6 @@ Environment variables:
   STATUS_OUTPUT         When non-empty, must equal STATUS_EXPECTED unless infra flake
   STATUS_EXPECTED       Expected STATUS_OUTPUT value (default: passed)
   EXIT_CODE_OUTPUT      Upstream lint exit code for infra flake detection
-  FAILURE_REASON        Free-text step log snippet for infra flake detection
 
 Writes exit-code, status, and infra-flake to GITHUB_OUTPUT when set. An
 infra-flake of true means the required check passed without a lint verdict,
@@ -58,7 +57,6 @@ if [[ "${UPSTREAM_RESULT}" != "success" ]]; then
 		UPSTREAM_CONCLUSION="${UPSTREAM_CONCLUSION:-}" \
 		STATUS_OUTPUT="${STATUS_OUTPUT:-}" \
 		EXIT_CODE_OUTPUT="${EXIT_CODE_OUTPUT:-}" \
-		FAILURE_REASON="${FAILURE_REASON:-}" \
 		bash "${SCRIPT_DIR}/is-infra-flake-failure.sh"; then
 		echo "::warning::Treating upstream ${UPSTREAM_RESULT} as infra flake (non-blocking)"
 		write_gate_outputs 0 passed true
@@ -81,7 +79,6 @@ if [[ -n "${STATUS_OUTPUT:-}" && "${STATUS_OUTPUT}" != "${STATUS_EXPECTED}" ]]; 
 		UPSTREAM_CONCLUSION="${UPSTREAM_CONCLUSION:-}" \
 		STATUS_OUTPUT="${STATUS_OUTPUT}" \
 		EXIT_CODE_OUTPUT="${EXIT_CODE_OUTPUT:-}" \
-		FAILURE_REASON="${FAILURE_REASON:-}" \
 		bash "${SCRIPT_DIR}/is-infra-flake-failure.sh"; then
 		echo "::warning::Treating upstream status ${STATUS_OUTPUT} as infra flake (non-blocking)"
 		write_gate_outputs 0 passed true

--- a/scripts/ci/evaluate-code-quality-gate.sh
+++ b/scripts/ci/evaluate-code-quality-gate.sh
@@ -14,7 +14,6 @@
 #   RETRY_LINT_RESULT
 #   PRIMARY_LINT_STATUS, PRIMARY_LINT_EXIT_CODE, PRIMARY_LINT_CONCLUSION
 #   RETRY_LINT_STATUS, RETRY_LINT_EXIT_CODE, RETRY_LINT_CONCLUSION
-#   PRIMARY_FAILURE_REASON, RETRY_FAILURE_REASON
 
 set -euo pipefail
 
@@ -26,8 +25,8 @@ Usage:
   DOCKER_BUILD_RESULT=success MANIFEST_SYNC_RESULT=success \
     PRIMARY_LINT_RESULT=success scripts/ci/evaluate-code-quality-gate.sh
 
-Writes upstream-result, status-output, exit-code-output, upstream-conclusion,
-and failure-reason to GITHUB_OUTPUT when set.
+Writes upstream-result, status-output, exit-code-output, and
+upstream-conclusion to GITHUB_OUTPUT when set.
 EOF
 	exit 0
 fi
@@ -37,11 +36,10 @@ fi
 : "${PRIMARY_LINT_RESULT:?}"
 
 # GITHUB_OUTPUT is a line-oriented key=value file, so a newline inside a value
-# would be parsed as a new record. FAILURE_REASON is free text (a step log
-# snippet once #1655 wires it), and a value such as
-# $'boom\nstatus-output=passed' would otherwise forge a passing verdict. Refuse
-# to write instead of emitting a malformed record — the caller runs under
-# `set -e`, so the gate fails closed (red) rather than green.
+# would be parsed as a new record. These values are env-derived, and a value
+# such as $'boom\nstatus-output=passed' would otherwise forge a passing
+# verdict. Refuse to write instead of emitting a malformed record — the caller
+# runs under `set -e`, so the gate fails closed (red) rather than green.
 write_output() {
 	local key="$1"
 	local value="$2"
@@ -59,7 +57,6 @@ if [[ "${DOCKER_BUILD_RESULT}" != "success" ]]; then
 	write_output status-output "failed"
 	write_output exit-code-output "1"
 	write_output upstream-conclusion "${DOCKER_BUILD_RESULT}"
-	write_output failure-reason "docker-build ${DOCKER_BUILD_RESULT}"
 	exit 0
 fi
 
@@ -68,7 +65,6 @@ if [[ "${MANIFEST_SYNC_RESULT}" != "success" && "${MANIFEST_SYNC_RESULT}" != "sk
 	write_output status-output "failed"
 	write_output exit-code-output "1"
 	write_output upstream-conclusion "${MANIFEST_SYNC_RESULT}"
-	write_output failure-reason "manifest-sync ${MANIFEST_SYNC_RESULT}"
 	exit 0
 fi
 
@@ -83,7 +79,6 @@ effective_result="${PRIMARY_LINT_RESULT}"
 effective_status="${PRIMARY_LINT_STATUS:-}"
 effective_exit_code="${PRIMARY_LINT_EXIT_CODE:-}"
 effective_conclusion="${PRIMARY_LINT_CONCLUSION:-}"
-effective_failure_reason="${PRIMARY_FAILURE_REASON:-}"
 
 # The retry (full-run only) exists to give a genuinely flaked primary a second
 # chance, so it becomes authoritative only when it is itself authoritative:
@@ -103,7 +98,6 @@ if [[ "${RETRY_LINT_RESULT:-}" == "success" || "${RETRY_LINT_RESULT:-}" == "fail
 		effective_status="${RETRY_LINT_STATUS:-}"
 		effective_exit_code="${RETRY_LINT_EXIT_CODE:-}"
 		effective_conclusion="${RETRY_LINT_CONCLUSION:-}"
-		effective_failure_reason="${RETRY_FAILURE_REASON:-}"
 	fi
 fi
 
@@ -112,7 +106,6 @@ if [[ "${effective_result}" == "success" ]]; then
 	write_output status-output "${effective_status:-passed}"
 	write_output exit-code-output "${effective_exit_code:-0}"
 	write_output upstream-conclusion success
-	write_output failure-reason ""
 	exit 0
 fi
 
@@ -120,4 +113,3 @@ write_output upstream-result "${effective_result}"
 write_output status-output "${effective_status}"
 write_output exit-code-output "${effective_exit_code}"
 write_output upstream-conclusion "${effective_conclusion}"
-write_output failure-reason "${effective_failure_reason}"

--- a/scripts/ci/is-infra-flake-failure.sh
+++ b/scripts/ci/is-infra-flake-failure.sh
@@ -13,7 +13,6 @@
 #   UPSTREAM_CONCLUSION - Job conclusion when distinct from result
 #   STATUS_OUTPUT       - Upstream lint status output (passed, failed, or empty)
 #   EXIT_CODE_OUTPUT    - Upstream lint exit code (0, 1, 143, or empty)
-#   FAILURE_REASON      - Free-text step log snippet for flake signatures
 
 set -euo pipefail
 
@@ -30,7 +29,6 @@ Environment variables:
   UPSTREAM_CONCLUSION   Job conclusion when distinct from result
   STATUS_OUTPUT         Upstream lint status output
   EXIT_CODE_OUTPUT      Upstream lint exit code
-  FAILURE_REASON        Free-text step log snippet
 EOF
 	exit 0
 fi
@@ -58,7 +56,6 @@ is_infra_flake_failure() {
 	local conclusion="${2:-}"
 	local status_output="${3:-}"
 	local exit_code_output="${4:-}"
-	local failure_reason="${5:-}"
 
 	# Nothing to classify when the upstream job succeeded.
 	if [[ "${result}" == "success" ]]; then
@@ -90,21 +87,18 @@ is_infra_flake_failure() {
 		return 0
 	fi
 
-	# Lint completed and passed, yet the job still failed — e.g. the
-	# `Upload linting report` step hitting `CreateArtifact: ETIMEDOUT`. The
-	# lint verdict is authoritative, so this is non-lint (infra) noise.
+	# Lint completed and passed, yet the job still failed — e.g. a post-lint
+	# step such as the report artifact upload flaking (non-fatal upstream
+	# since lgtm-ci#696). The lint verdict is authoritative, so this is
+	# non-lint (infra) noise.
 	if [[ "${status_output}" == "passed" && "${exit_code_output}" == "0" ]]; then
 		return 0
 	fi
 
-	if [[ "${failure_reason}" == *"shutdown signal"* ]]; then
-		return 0
-	fi
-
-	if [[ "${failure_reason}" == *"ETIMEDOUT"* || "${failure_reason}" == *"CreateArtifact"* ]]; then
-		return 0
-	fi
-
+	# No free-text log matching here on purpose: a substring like ETIMEDOUT
+	# appearing anywhere in a job log (including inside a lint report) must
+	# never green the required check — the Greptile concern on #1650/#1655.
+	# Infra classes are recognized only from structural signals above.
 	return 1
 }
 
@@ -112,8 +106,7 @@ if is_infra_flake_failure \
 	"${UPSTREAM_RESULT}" \
 	"${UPSTREAM_CONCLUSION:-}" \
 	"${STATUS_OUTPUT:-}" \
-	"${EXIT_CODE_OUTPUT:-}" \
-	"${FAILURE_REASON:-}"; then
+	"${EXIT_CODE_OUTPUT:-}"; then
 	exit 0
 fi
 

--- a/scripts/ci/run-code-quality-gate.sh
+++ b/scripts/ci/run-code-quality-gate.sh
@@ -9,7 +9,6 @@
 #   RETRY_LINT_RESULT
 #   PRIMARY_LINT_STATUS, PRIMARY_LINT_EXIT_CODE, PRIMARY_LINT_CONCLUSION
 #   RETRY_LINT_STATUS, RETRY_LINT_EXIT_CODE, RETRY_LINT_CONCLUSION
-#   PRIMARY_FAILURE_REASON, RETRY_FAILURE_REASON
 
 set -euo pipefail
 
@@ -74,14 +73,12 @@ upstream_result="$(grep -E '^upstream-result=' "${EVALUATE_OUTPUT}" | tail -1 | 
 status_output="$(grep -E '^status-output=' "${EVALUATE_OUTPUT}" | tail -1 | cut -d= -f2-)"
 exit_code_output="$(grep -E '^exit-code-output=' "${EVALUATE_OUTPUT}" | tail -1 | cut -d= -f2-)"
 upstream_conclusion="$(grep -E '^upstream-conclusion=' "${EVALUATE_OUTPUT}" | tail -1 | cut -d= -f2-)"
-failure_reason="$(grep -E '^failure-reason=' "${EVALUATE_OUTPUT}" | tail -1 | cut -d= -f2-)"
 
 if UPSTREAM_RESULT="${upstream_result}" \
 	STATUS_OUTPUT="${status_output}" \
 	STATUS_EXPECTED=passed \
 	EXIT_CODE_OUTPUT="${exit_code_output}" \
 	UPSTREAM_CONCLUSION="${upstream_conclusion}" \
-	FAILURE_REASON="${failure_reason}" \
 	GITHUB_OUTPUT="${ASSERT_OUTPUT}" \
 	bash "${SCRIPT_DIR}/assert-required-check.sh"; then
 	# infra-flake=true means the required check is green without a lint

--- a/tests/scripts/test_code_quality_gate_scripts.py
+++ b/tests/scripts/test_code_quality_gate_scripts.py
@@ -54,34 +54,30 @@ def test_code_quality_gate_scripts_expose_help(script: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("result", "status", "exit_code", "conclusion", "reason", "expected_infra"),
+    ("result", "status", "exit_code", "conclusion", "expected_infra"),
     [
-        ("cancelled", "", "", "", "", True),
-        ("failure", "", "", "cancelled", "", True),
-        ("failure", "", "", "timed_out", "", True),
+        ("cancelled", "", "", "", True),
+        ("failure", "", "", "cancelled", True),
+        ("failure", "", "", "timed_out", True),
         # Runner shutdown propagates SIGTERM; lintro never exits 143 for lint.
-        ("failure", "", "143", "", "", True),
-        ("failure", "", "", "", "runner shutdown signal", True),
-        ("failure", "", "", "", "Failed to CreateArtifact: ETIMEDOUT", True),
-        # Lint reported success; only the surrounding job failed (artifact
-        # upload), so the lint verdict is authoritative.
-        ("failure", "passed", "0", "", "Failed to CreateArtifact: ETIMEDOUT", True),
-        ("failure", "passed", "0", "", "", True),
-        # Genuine lint failures must never be absorbed, whatever the reason.
-        ("failure", "failed", "1", "", "Failed to CreateArtifact: ETIMEDOUT", False),
-        ("failure", "failed", "1", "", "runner shutdown signal", False),
+        ("failure", "", "143", "", True),
+        # Lint reported success; only the surrounding job failed (e.g. the
+        # report artifact upload before lgtm-ci#696 made it non-fatal), so
+        # the lint verdict is authoritative.
+        ("failure", "passed", "0", "", True),
+        # Genuine lint failures must never be absorbed.
+        ("failure", "failed", "1", "", False),
+        ("failure", "failed", "", "", False),
+        ("failure", "", "1", "", False),
         # A cancellation on top of a reported lint verdict must not absorb it.
-        ("cancelled", "failed", "1", "", "", False),
-        ("failure", "failed", "1", "cancelled", "", False),
+        ("cancelled", "failed", "1", "", False),
+        ("failure", "failed", "1", "cancelled", False),
         # SIGTERM still wins: lintro exits 143 only when the runner kills it.
-        ("cancelled", "failed", "143", "", "", True),
-        ("failure", "failed", "", "", "Failed to CreateArtifact: ETIMEDOUT", False),
-        ("failure", "", "1", "", "Failed to CreateArtifact: ETIMEDOUT", False),
-        ("failure", "failed", "1", "", "", False),
+        ("cancelled", "failed", "143", "", True),
         # Absence of evidence is not infra evidence: a job that never reported
         # a lint verdict must not be claimed to have passed one (#1313).
-        ("failure", "", "", "", "", False),
-        ("success", "passed", "0", "", "", False),
+        ("failure", "", "", "", False),
+        ("success", "passed", "0", "", False),
     ],
 )
 def test_is_infra_flake_failure_classification(
@@ -90,7 +86,6 @@ def test_is_infra_flake_failure_classification(
     status: str,
     exit_code: str,
     conclusion: str,
-    reason: str,
     expected_infra: bool,
 ) -> None:
     """Infra flake classifier should match shutdown and lint-failure cases."""
@@ -101,13 +96,41 @@ def test_is_infra_flake_failure_classification(
             "STATUS_OUTPUT": status,
             "EXIT_CODE_OUTPUT": exit_code,
             "UPSTREAM_CONCLUSION": conclusion,
-            "FAILURE_REASON": reason,
         },
     )
     if expected_infra:
         assert_that(proc.returncode).is_equal_to(0)
     else:
         assert_that(proc.returncode).is_equal_to(1)
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "Failed to CreateArtifact: ETIMEDOUT",
+        "runner shutdown signal received",
+        "ETIMEDOUT",
+    ],
+)
+def test_is_infra_flake_failure_ignores_free_text_reason(reason: str) -> None:
+    """Free-text log snippets must never green the required check (#1655).
+
+    The substring branches Greptile flagged on #1650 are removed: a log (or a
+    lint report) that merely contains ETIMEDOUT/CreateArtifact/shutdown text
+    must not absorb a job that never reported a lint verdict. FAILURE_REASON
+    is no longer consumed, so these stay red.
+    """
+    proc = _run_script(
+        "scripts/ci/is-infra-flake-failure.sh",
+        env={
+            "UPSTREAM_RESULT": "failure",
+            "STATUS_OUTPUT": "",
+            "EXIT_CODE_OUTPUT": "",
+            "UPSTREAM_CONCLUSION": "",
+            "FAILURE_REASON": reason,
+        },
+    )
+    assert_that(proc.returncode).is_equal_to(1)
 
 
 def test_assert_required_check_passes_on_success() -> None:
@@ -153,7 +176,11 @@ def test_assert_required_check_fails_on_genuine_lint_failure() -> None:
 def test_assert_required_check_does_not_absorb_lint_failure_with_artifact_reason() -> (
     None
 ):
-    """Genuine lint failures stay red even if FAILURE_REASON mentions CreateArtifact."""
+    """Genuine lint failures stay red even if FAILURE_REASON mentions CreateArtifact.
+
+    FAILURE_REASON is no longer consumed (#1655); this pins the invariant that
+    surrounding free text can never flip a genuine lint failure.
+    """
     result = _run_script(
         "scripts/ci/assert-required-check.sh",
         env={
@@ -244,10 +271,10 @@ def test_evaluate_code_quality_gate_prefers_retry_success() -> None:
 
 
 @pytest.mark.parametrize("injection", ["\n", "\r"])
-def test_evaluate_code_quality_gate_rejects_newline_in_failure_reason(
+def test_evaluate_code_quality_gate_rejects_newline_in_lint_status(
     injection: str,
 ) -> None:
-    """A newline in free-text input must not forge a second GITHUB_OUTPUT record."""
+    """A newline in env-derived input must not forge a second GITHUB_OUTPUT record."""
     with tempfile.NamedTemporaryFile(mode="w+", delete=False) as output_file:
         output_path = output_file.name
 
@@ -259,9 +286,8 @@ def test_evaluate_code_quality_gate_rejects_newline_in_failure_reason(
                 "DOCKER_BUILD_RESULT": "success",
                 "MANIFEST_SYNC_RESULT": "success",
                 "PRIMARY_LINT_RESULT": "failure",
-                "PRIMARY_LINT_STATUS": "failed",
+                "PRIMARY_LINT_STATUS": f"boom{injection}status-output=passed",
                 "PRIMARY_LINT_EXIT_CODE": "1",
-                "PRIMARY_FAILURE_REASON": f"boom{injection}status-output=passed",
             },
         )
         assert_that(result.returncode).is_equal_to(1)
@@ -275,7 +301,7 @@ def test_evaluate_code_quality_gate_rejects_newline_in_failure_reason(
         Path(output_path).unlink(missing_ok=True)
 
 
-def test_run_code_quality_gate_fails_closed_on_injected_failure_reason() -> None:
+def test_run_code_quality_gate_fails_closed_on_injected_lint_status() -> None:
     """The gate must go red, not green, when evaluation refuses to write."""
     with tempfile.NamedTemporaryFile(mode="w+", delete=False) as output_file:
         output_path = output_file.name
@@ -288,9 +314,8 @@ def test_run_code_quality_gate_fails_closed_on_injected_failure_reason() -> None
                 "DOCKER_BUILD_RESULT": "success",
                 "MANIFEST_SYNC_RESULT": "success",
                 "PRIMARY_LINT_RESULT": "failure",
-                "PRIMARY_LINT_STATUS": "failed",
+                "PRIMARY_LINT_STATUS": "boom\nstatus-output=passed",
                 "PRIMARY_LINT_EXIT_CODE": "1",
-                "PRIMARY_FAILURE_REASON": "boom\nstatus-output=passed",
             },
         )
         assert_that(result.returncode).is_not_equal_to(0)
@@ -458,6 +483,38 @@ def test_run_code_quality_gate_passes_after_runner_shutdown() -> None:
         assert_that(output).contains("result=success")
         assert_that(output).contains("passed=true")
         # Absorbed noise proves nothing about lint, so publish must be blocked.
+        assert_that(output).contains("infra-flake=true")
+    finally:
+        Path(output_path).unlink(missing_ok=True)
+
+
+def test_run_code_quality_gate_absorbs_post_lint_failure_after_passed_lint() -> None:
+    """End-to-end artifact-upload shape: lint passed, then the job failed (#1655).
+
+    Regression asked for by CodeRabbit on the gate env block in docker-ci.yml:
+    with an authoritative passed/0 lint verdict, a surrounding job failure
+    (e.g. the report upload, fatal before lgtm-ci#696) is absorbed and the
+    gate marks infra-flake=true so publish refuses to promote.
+    """
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as output_file:
+        output_path = output_file.name
+
+    try:
+        result = _run_script(
+            "scripts/ci/run-code-quality-gate.sh",
+            env={
+                "GITHUB_OUTPUT": output_path,
+                "DOCKER_BUILD_RESULT": "success",
+                "MANIFEST_SYNC_RESULT": "success",
+                "PRIMARY_LINT_RESULT": "failure",
+                "PRIMARY_LINT_STATUS": "passed",
+                "PRIMARY_LINT_EXIT_CODE": "0",
+            },
+        )
+        assert_that(result.returncode).is_equal_to(0)
+        output = Path(output_path).read_text()
+        assert_that(output).contains("result=success")
+        assert_that(output).contains("passed=true")
         assert_that(output).contains("infra-flake=true")
     finally:
         Path(output_path).unlink(missing_ok=True)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): drop dead free-text failure-reason heuristic from code-quality gate
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What's Changing

Issue #1655 asked for real artifact-upload failure reasons to be plumbed into the
code-quality gate. The upstream supplier for that signal never shipped:
[lgtm-ci#686](https://github.com/lgtm-hq/lgtm-ci/issues/686) was retargeted and
[lgtm-ci#696](https://github.com/lgtm-hq/lgtm-ci/pull/696) made the lint-report
upload non-fatal instead of emitting a classifiable `failure-reason`. Re-scoped
against current `main` (assessment posted on #1655), what remains is removing the
fabricated-reason heuristic Greptile flagged on #1650 — which lgtm-ci#696's
"Not in scope" section explicitly deferred to here.

The `ETIMEDOUT` / `CreateArtifact` / `shutdown signal` substring branches in
`is-infra-flake-failure.sh` were:

- **Unreachable in production** — nothing in `docker-ci.yml` ever populated
  `FAILURE_REASON`; the only intended producer was the dropped upstream output.
- **Unsafe if ever wired** — a substring match on free-form log text means a lint
  report that itself contains `ETIMEDOUT` (e.g. a linter flagging a
  network-timeout constant) could green the required check.
- **Fully redundant** — every legitimate class is already covered structurally:
  runner shutdown via `exit 143` and `cancelled`/`timed_out` results, and the
  lint-passed-then-job-failed shape (incl. an upload flake) via
  `status=passed` + `exit-code=0` under the `reports_genuine_lint_failure` guard.

## Closes

- Closes #1655

## Details

Changes:

- `scripts/ci/is-infra-flake-failure.sh` — drop the two substring branches and the
  `FAILURE_REASON` parameter; infra classes are now recognized only from
  structural signals (documented inline).
- `scripts/ci/assert-required-check.sh`, `run-code-quality-gate.sh`,
  `evaluate-code-quality-gate.sh` — remove the `FAILURE_REASON` /
  `failure-reason` pass-through end to end. The fail-closed `GITHUB_OUTPUT`
  newline guard stays (stale `#1655` comment rewritten).
- `scripts/README.md`, `scripts/ci/README.md` — classifier description updated
  (no more `ETIMEDOUT` signature).

Tests (`tests/scripts/test_code_quality_gate_scripts.py`):

- New: free-text `FAILURE_REASON` is ignored — a job that failed with no lint
  verdict stays red even when the log text says `ETIMEDOUT`/`CreateArtifact`/
  `shutdown signal` (the Greptile regression, fail-closed).
- New: end-to-end artifact-upload regression CodeRabbit asked for on the gate
  env block — primary `failure` with `status=passed`/`exit-code=0` goes green
  with `infra-flake=true`, so `publish` still refuses to promote.
- Newline-injection guard tests retargeted to a live input vector
  (`PRIMARY_LINT_STATUS`); the guard itself is unchanged.

Follow-up (not in this PR): consuming the lgtm-ci v0.59.8 non-fatal upload
requires the repo-wide lgtm-ci pin bump (single canonical pin invariant from
#1280 — `test_all_lgtm_ci_refs_use_the_canonical_pin`). The gate is already
safe without it: a fatal upload at v0.59.2 is absorbed by the `passed/0` branch
and recovered by `dogfooding_lint_retry`; v0.59.8 only avoids the wasted retry.

Pre-push reviews: CodeRabbit CLI 1 minor finding (env isolation in the new
regression test — fixed); Greptile CLI 5/5, no comments.

Local verification: `uv run lintro fmt`/`chk` zero issues (100/100);
`uv run pytest --maxfail=0` 7748 passed — the only 12 failures are pre-existing
environmental ones on unmodified `main` (oxlint/oxfmt below repo minimum
version, pip_audit network, commitlint env), verified identical with this
change stashed.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt && uv run lintro chk && uv run pytest`; see Details for pre-existing environmental failures)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes the unused free-text failure-reason path from the code-quality gate.
- Restricts infrastructure-flake classification to structural job and lint signals.
- Updates gate orchestration, documentation, and regression tests for fail-closed behavior.
- Preserves handling for cancellation, timeout, exit 143, and failed jobs with an authoritative passed lint verdict.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the removed signal was not supplied by production workflow wiring and the remaining structural classifications preserve the required gate behavior.

The gate continues to classify cancellation, timeout, runner termination, and authoritative passed-lint failures while unclassified failures remain red; no active consumer depends on the removed failure-reason output.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/is-infra-flake-failure.sh | Removes unreachable free-text matching while retaining structural infrastructure-flake classifications and fail-closed fallback behavior. |
| scripts/ci/evaluate-code-quality-gate.sh | Removes the unused failure-reason input and output without changing selection of primary or retry lint results. |
| scripts/ci/run-code-quality-gate.sh | Stops parsing and forwarding the removed output while preserving the evaluator-to-assertion gate flow. |
| scripts/ci/assert-required-check.sh | Stops forwarding the unused free-text value to the classifier; required-check behavior remains based on structural signals. |
| tests/scripts/test_code_quality_gate_scripts.py | Adds regression coverage proving free text cannot green the gate and passed lint followed by a job failure remains classified as infrastructure noise. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Docker CI results] --> B[evaluate-code-quality-gate.sh]
  B --> C[Structural outputs: result, status, exit code, conclusion]
  C --> D[assert-required-check.sh]
  D --> E[is-infra-flake-failure.sh]
  E -->|Cancellation, timeout, exit 143, or passed/0 lint| F[Pass as infrastructure flake]
  E -->|No structural infrastructure signal| G[Fail closed]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): drop dead free-text failure-rea..."](https://github.com/lgtm-hq/py-lintro/commit/62febda1f45242b699d277929b35c96e554322a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47191848)</sub>

**Context used:**

- Knowledge Base — [CI/CD Workflows](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/py-lintro/-/docs/ci-workflows.md)

<!-- /greptile_comment -->