### PR TITLE
fix(ci): bump dogfooding mypy timeout to 120s

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -467,7 +467,7 @@ jobs:
       tooling-ref: 'ee8484ca71db3a2c2c33da6128bbf2330fcd7c88' # v0.59.2
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
-        pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,osv_scanner:check_suppressions=false
+        pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
       egress-policy: block
       # Same-repo PRs: lint with the image built in this workflow run.
       # Fork PRs: CI images are not pushed to GHCR (artifact tarball only), so
@@ -572,7 +572,7 @@ jobs:
           # Must stay in sync with the dogfooding-lint lintro-tool-options
           # above: identical tool coverage is the contract of changed mode.
           TOOL_OPTIONS: >-
-            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,osv_scanner:check_suppressions=false
+            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
           # Same image selection as dogfooding-lint: CI-built image for
           # same-repo PRs, pinned release digest for forks (no CI push).
           # Pinned digest — keep in sync with pyproject.toml lintro pin
@@ -674,7 +674,7 @@ jobs:
         env:
           # Same tool coverage as the dogfooding run so skip behaviour matches.
           TOOL_OPTIONS: >-
-            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,osv_scanner:check_suppressions=false
+            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
           # Same image selection as dogfooding-lint: CI-built image for
           # same-repo PRs, pinned release digest for forks (no CI push).
           # Pinned digest — keep in sync with pyproject.toml lintro pin
@@ -712,7 +712,7 @@ jobs:
       tooling-ref: 'ee8484ca71db3a2c2c33da6128bbf2330fcd7c88' # v0.59.2
       job-name: '🛠️ Dogfooding Lint (retry)'
       lintro-tool-options: >-
-        pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,osv_scanner:check_suppressions=false
+        pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
       egress-policy: block
       # Same image selection as dogfooding-lint: CI-built image for
       # same-repo PRs, pinned release digest for forks (no CI push).

--- a/.github/workflows/dogfood-nightly.yml
+++ b/.github/workflows/dogfood-nightly.yml
@@ -37,7 +37,7 @@ jobs:
       tooling-ref: 'ee8484ca71db3a2c2c33da6128bbf2330fcd7c88' # v0.59.2
       job-name: '🌙 Nightly Dogfooding Lint'
       lintro-tool-options: >-
-        pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,osv_scanner:check_suppressions=false
+        pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
       egress-policy: block
       # No CI build in this workflow: lint main with the pinned release
       # image (same digest the fork-PR fallback in docker-ci.yml uses).
@@ -160,7 +160,7 @@ jobs:
         env:
           # Same tool coverage as dogfood-full so skip behaviour matches.
           TOOL_OPTIONS: >-
-            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,osv_scanner:check_suppressions=false
+            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
           # Same pinned release image dogfood-full lints with.
           # Pinned digest — keep in sync with pyproject.toml lintro pin
           LINTRO_IMAGE: >-


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): bump dogfooding mypy timeout to 120s
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

The full-repo dogfooding lint intermittently fails with `mypy execution timed out
(60.0s limit exceeded)` on throttled hosted runners with cold mypy caches, redding
the required `lintro-code-quality` aggregate even though the code is clean (roughly
half of today's full-repo dogfooding attempts timed out; see #1718 for evidence).

The dogfooding `lintro-tool-options` already grants `pydoclint:timeout=120`,
`bandit:timeout=120`, and `prettier:timeout=120` for exactly this cold-cache reason.
This PR adds `mypy:timeout=120` the same way, in all six synced copies of the
options list:

- `.github/workflows/docker-ci.yml` — `dogfooding-lint`, `dogfooding-lint-changed`
  (`TOOL_OPTIONS`), `dogfood-skip-gate` (`TOOL_OPTIONS`), `dogfooding_lint_retry`
- `.github/workflows/dogfood-nightly.yml` — `dogfood-full`, `dogfood-skip-gate`
  (`TOOL_OPTIONS`)

Not a coverage reduction: mypy still runs to completion and reports issues; the
bound only stops killing slow-but-healthy runs.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (N/A — `tests/unit/test_workflow_wiring.py` does not assert
      the `lintro-tool-options` content, so there is nothing to extend; YAML-only change)
- [ ] Docs updated if user-facing (N/A — CI-internal)
- [x] Local CI passed (`uv run lintro fmt` / `uv run lintro chk` zero issues;
      `uv run pytest --maxfail=0` green except 3 pre-existing pip_audit/commitlint
      integration env failures that fail identically on the base tree)

## Closes

- Closes #1718

## Details

Pre-push AI review: CodeRabbit — no findings; Greptile — 5/5 confidence, no comments.

Verified `timeout` is a universal per-tool option in the plugin execution layer
(`lintro/plugins/execution_preparation.py::get_effective_timeout`), so
`mypy:timeout=120` follows the same mechanism as the existing entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 120-second timeout for mypy checks across pull request and nightly validation workflows.
  * Helps prevent linting jobs from hanging indefinitely and improves consistency across automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Extends the mypy timeout for all synchronized dogfooding CI paths.

- Adds `mypy:timeout=120` to full, changed-file, skip-gate, and retry jobs in Docker CI.
- Applies the same timeout to nightly full-lint and skip-gate jobs.
- Keeps the existing tool-option lists consistent across all six locations.
</details>

<h3>Confidence Score: 5/5</h3>

The PR is safe to merge with no actionable issues identified.

The new option uses the supported per-tool timeout syntax and is applied consistently across every changed dogfooding configuration.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/docker-ci.yml | Adds the valid 120-second mypy timeout option consistently to the four Docker dogfooding paths. |
| .github/workflows/dogfood-nightly.yml | Adds the same mypy timeout to the nightly full-lint and skip-gate paths. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): bump dogfooding mypy timeout to..."](https://github.com/lgtm-hq/py-lintro/commit/014431b1c6cef38f9bb7a654d43e78faaffd2dc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47216780)</sub>

<!-- /greptile_comment -->