### PR TITLE
fix(ci): wire transient-infra signatures into the auto-rerun matcher

### DIFF
--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -47,3 +47,13 @@ jobs:
       run-attempt: ${{ format('{0}', github.event.workflow_run.run_attempt) }}
       egress-policy: block
       egress-preset: github-minimal
+      # Cosign ambient-OIDC token-fetch flake (#1567, #1689): appended to
+      # lgtm-ci's built-in infra signatures and matched with grep -qF, so
+      # keep these fixed strings (no regex). Kept in parity with
+      # oidc_flake_markers in scripts/ci/cosign-sign-images.sh so a signing
+      # job that exhausts the in-step retry (#1646) is auto-rerun instead
+      # of needing a manual backfill.
+      signatures: |-
+        fetching ambient OIDC credentials
+        retrieving ID token
+        reading ID token

--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -47,13 +47,27 @@ jobs:
       run-attempt: ${{ format('{0}', github.event.workflow_run.run_attempt) }}
       egress-policy: block
       egress-preset: github-minimal
-      # Cosign ambient-OIDC token-fetch flake (#1567, #1689): appended to
-      # lgtm-ci's built-in infra signatures and matched with grep -qF, so
-      # keep these fixed strings (no regex). Kept in parity with
-      # oidc_flake_markers in scripts/ci/cosign-sign-images.sh so a signing
-      # job that exhausts the in-step retry (#1646) is auto-rerun instead
-      # of needing a manual backfill.
+      # Extra transient-infra signatures, appended to lgtm-ci's built-in
+      # defaults and matched with grep -qF. Keep every line a FIXED string
+      # (no regex, no anchors) and narrow enough that it cannot absorb a
+      # real failure that deserves a human. The embedded double quotes in
+      # the Docker Hub line are part of the log text and this literal block
+      # scalar must preserve them verbatim.
+      #
+      # 1-3. Cosign ambient-OIDC token-fetch flake (#1567, #1689), kept in
+      #      parity with oidc_flake_markers in
+      #      scripts/ci/cosign-sign-images.sh so a signing job that exhausts
+      #      the in-step retry (#1646) is auto-rerun instead of needing a
+      #      manual backfill.
+      # 4.   Docker Hub timeout while Setup Docker Buildx pulls the buildkit
+      #      image. registry-1.docker.io:443 is already allowed, so this is
+      #      Docker Hub slowness, not a harden-runner block. Seen in the
+      #      v0.91.42 release run (30148763859, Merge Manifests job
+      #      89692290242), which no default signature matched. Scoped to the
+      #      registry URL on purpose: a bare "context deadline exceeded"
+      #      would swallow genuine timeouts elsewhere.
       signatures: |-
         fetching ambient OIDC credentials
         retrieving ID token
         reading ID token
+        Get "https://registry-1.docker.io/v2/": context deadline exceeded

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -2025,7 +2025,16 @@ def _cosign_oidc_flake_markers() -> list[str]:
         ``scripts/ci/cosign-sign-images.sh``.
     """
     script = _COSIGN_SIGN_SCRIPT.read_text(encoding="utf-8")
-    array_match = re.search(r"oidc_flake_markers=\(([^)]*)\)", script)
+    # Terminate on the array's own closing line (``)`` alone) rather than the
+    # first ``)`` character: markers are fixed strings under ``grep -F`` and may
+    # legitimately contain parentheses, e.g. ``getting cert (403)``. A
+    # character-class scan would truncate there and silently drop the rest,
+    # letting the parity test pass while a marker is missing from the workflow.
+    array_match = re.search(
+        r"^oidc_flake_markers=\((.*?)^\)",
+        script,
+        re.DOTALL | re.MULTILINE,
+    )
     assert_that(
         array_match,
         description="oidc_flake_markers array not found",

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -2077,3 +2077,25 @@ def test_auto_rerun_signatures_are_fixed_strings() -> None:
     assert_that(signatures).is_not_empty()
     for signature in signatures:
         assert_that(signature).does_not_match(r"[\\^$*+?\[\]()|]")
+
+
+def test_auto_rerun_matches_docker_hub_buildx_pull_timeout() -> None:
+    """The matcher must know the Docker Hub buildkit-pull timeout.
+
+    `Setup Docker Buildx` boots buildkit by pulling moby/buildkit from
+    Docker Hub. When Docker Hub is slow the daemon times out and the job
+    dies before doing any real work -- purely transient, and not a
+    harden-runner block (registry-1.docker.io:443 is already allowed).
+    None of lgtm-ci's default signatures match it, so the v0.91.42 release
+    run (30148763859, Merge Manifests job 89692290242) was never
+    auto-rerun. The signature is scoped to the registry URL rather than a
+    bare "context deadline exceeded", which would absorb genuine timeouts
+    elsewhere that deserve a human.
+    """
+    signatures = _auto_rerun_signatures()
+
+    assert_that(signatures).contains(
+        'Get "https://registry-1.docker.io/v2/": context deadline exceeded',
+    )
+    # A bare timeout string is too broad to auto-rerun on.
+    assert_that(signatures).does_not_contain("context deadline exceeded")

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -2066,17 +2066,38 @@ def test_auto_rerun_signatures_cover_in_step_retry_markers() -> None:
     assert_that(markers).is_subset_of(signatures)
 
 
+# Constructs that only make sense if the author believed the signature was a
+# regex. Bare metacharacters are deliberately NOT listed: ``grep -qF`` compares
+# literally, so parentheses, brackets and plus signs are ordinary text and
+# occur naturally in tool output (``getting cert (403)``). Rejecting those
+# would force future markers to diverge from the log lines they must match.
+_REGEX_INTENT_TELLS = (
+    r"^\^",  # leading anchor
+    r"\$$",  # trailing anchor
+    r"\.\*",  # .*
+    r"\.\+",  # .+
+    r"\\[dwsb]",  # \d \w \s \b
+    r"\(\?",  # (?: (?= (?<
+    r"\[[^\]]*-[^\]]*\]",  # character class with a range, e.g. [0-9]
+)
+
+
 def test_auto_rerun_signatures_are_fixed_strings() -> None:
     """Extra signatures must be plain fixed strings, not regexes.
 
     ``rerun-on-infra-failure.sh`` matches with ``grep -qF``, so a regex or
-    an anchor would be compared literally and silently never match.
+    an anchor would be compared literally and silently never match. The check
+    targets constructs that betray regex *intent* rather than any
+    metacharacter, since literal punctuation is legitimate under ``-F``.
     """
     signatures = _auto_rerun_signatures()
 
     assert_that(signatures).is_not_empty()
     for signature in signatures:
-        assert_that(signature).does_not_match(r"[\\^$*+?\[\]()|]")
+        for tell in _REGEX_INTENT_TELLS:
+            assert_that(re.search(tell, signature)).described_as(
+                f"{signature!r} looks like a regex ({tell})",
+            ).is_none()
 
 
 def test_auto_rerun_matches_docker_hub_buildx_pull_timeout() -> None:

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -2000,3 +2000,80 @@ def test_pinned_release_image_manager_covers_both_workflows() -> None:
         path = f".github/workflows/{filename}"
         covered = any(pattern.search(path) for pattern in file_patterns)
         assert_that(covered).described_as(path).is_true()
+
+
+_COSIGN_SIGN_SCRIPT = _REPO_ROOT / "scripts" / "ci" / "cosign-sign-images.sh"
+
+
+def _auto_rerun_signatures() -> list[str]:
+    """Return the extra signatures wired into the auto-rerun matcher.
+
+    Returns:
+        The non-blank lines of the ``signatures`` input passed to the
+        reusable auto-rerun workflow, one fixed-string signature per line.
+    """
+    workflow = _load_workflow(name="auto-rerun-on-infra-failure.yml")
+    signatures = str(workflow["jobs"]["rerun"]["with"]["signatures"])
+    return [line.strip() for line in signatures.splitlines() if line.strip()]
+
+
+def _cosign_oidc_flake_markers() -> list[str]:
+    """Return the fixed-string markers the in-step cosign retry keys off.
+
+    Returns:
+        The entries of the ``oidc_flake_markers`` bash array declared in
+        ``scripts/ci/cosign-sign-images.sh``.
+    """
+    script = _COSIGN_SIGN_SCRIPT.read_text(encoding="utf-8")
+    array_match = re.search(r"oidc_flake_markers=\(([^)]*)\)", script)
+    assert_that(
+        array_match,
+        description="oidc_flake_markers array not found",
+    ).is_not_none()
+    assert array_match is not None  # narrow for mypy
+    return re.findall(r'"([^"]+)"', array_match.group(1))
+
+
+def test_auto_rerun_passes_cosign_oidc_flake_signatures() -> None:
+    """The auto-rerun matcher must know the cosign ambient-OIDC signatures.
+
+    #1646 retries the transient OIDC token-fetch flake in-step; when that
+    bounded retry is exhausted the signing job still fails and the publish
+    run needs a run-level re-run. The auto-rerun safety net only fires when
+    the failed-job logs match a known signature, so the reusable matcher
+    receives the cosign flake markers via its ``signatures`` input (#1689).
+    Upstream matches with ``grep -qF``, so these must stay fixed strings.
+    """
+    signatures = _auto_rerun_signatures()
+
+    assert_that(signatures).contains("fetching ambient OIDC credentials")
+    assert_that(signatures).contains("retrieving ID token")
+    assert_that(signatures).contains("reading ID token")
+
+
+def test_auto_rerun_signatures_cover_in_step_retry_markers() -> None:
+    """Every in-step cosign retry marker must also reach the auto-rerun net.
+
+    The safety net inspects the final failed attempt's logs, which contain
+    whichever marker the retry loop in scripts/ci/cosign-sign-images.sh
+    matched. A marker missing from the workflow ``signatures`` input would
+    leave that exhausted-retry failure mode needing a manual backfill.
+    """
+    signatures = _auto_rerun_signatures()
+    markers = _cosign_oidc_flake_markers()
+
+    assert_that(markers).is_not_empty()
+    assert_that(markers).is_subset_of(signatures)
+
+
+def test_auto_rerun_signatures_are_fixed_strings() -> None:
+    """Extra signatures must be plain fixed strings, not regexes.
+
+    ``rerun-on-infra-failure.sh`` matches with ``grep -qF``, so a regex or
+    an anchor would be compared literally and silently never match.
+    """
+    signatures = _auto_rerun_signatures()
+
+    assert_that(signatures).is_not_empty()
+    for signature in signatures:
+        assert_that(signature).does_not_match(r"[\\^$*+?\[\]()|]")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): wire transient-infra signatures into the auto-rerun matcher
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Teaches the auto-rerun safety net two transient-infra failure classes that
lgtm-ci's built-in `DEFAULT_SIGNATURES` do not cover, so runs that died on
infrastructure are re-run automatically instead of needing a manual backfill.

Upstream (`lgtm-ci scripts/ci/actions/rerun-on-infra-failure.sh`) appends the
`SIGNATURES` input to its defaults and matches with `grep -qF -- "$signature"`,
so every line is a **fixed string** — no regex, no anchors — and deliberately
narrow enough that it cannot absorb a real failure that deserves a human.

Verified the reusable workflow at the pinned ref (`ee8484ca` / v0.59.2) exposes
an optional `signatures: string` input wired to `SIGNATURES`, so no tooling bump
is needed.

### 1. Cosign ambient-OIDC token-fetch flake (#1689, #1567)

Completes the auto-rerun half of the guard. #1646 shipped the in-step retry in
`scripts/ci/cosign-sign-images.sh`; this covers the case where that bounded
retry is *exhausted* and the signing job still fails (#1567 left
`py-lintro-base` v0.87.1 unsigned).

```
fetching ambient OIDC credentials
retrieving ID token
reading ID token
```

These are exactly the entries of `oidc_flake_markers` in
`scripts/ci/cosign-sign-images.sh`, so the log line that tripped the in-step
retry is the same line the matcher looks for on the final failed attempt.

### 2. Docker Hub buildkit-pull timeout

Evidenced by a real failure, not a hypothetical: the **v0.91.42** release run
[30148763859](https://github.com/lgtm-hq/py-lintro/actions/runs/30148763859),
`Merge Manifests` job `89692290242`, died at step 7 `Setup Docker Buildx` while
booting buildkit:

```
#1 pulling image moby/buildkit:buildx-stable-1  15.0s done
#1 ERROR: Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

`registry-1.docker.io:443` **is** in the egress allowlist, so this was not a
harden-runner block — genuine Docker Hub slowness (harden-runner's own
`agent.api.stepsecurity.io` calls also timed out in the same window). The job
died before doing any real work. None of the four upstream defaults
(`Failed to resolve action download info`, `The runner has received a shutdown
signal`, `Error resolving allowed domain`, `lost communication with the server`)
match it, so the matcher never fired.

```
Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

- Confirmed **verbatim** against the real job log (`gh api .../jobs/89692290242/logs`
  → 3 occurrences of this exact substring).
- Scoped to the registry URL **on purpose**. A bare `context deadline exceeded`
  is broad enough to swallow genuine timeouts elsewhere that deserve a human;
  a test asserts that bare form is *not* present.
- The embedded double quotes are part of the log text; the `|-` literal block
  scalar preserves them exactly, which the contract test round-trips through
  the YAML parser.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1689

## Details

- **Depends on #1571 to be effective.** That PR drops `branches: [main]` and adds
  the publish workflows to the `workflow_run` watch list. Until it merges, a
  tag-triggered publish failure never reaches this matcher and these signatures
  are inert — correct but dormant. Deliberately not touched here to avoid
  conflicting with #1571 on the same file. Note this applies to the Docker Hub
  signature too: its evidencing failure was in a *release* run.
- **Task 3 of the issue** (retry for the nested lgtm-ci `Merge Manifests` signing
  path, the actual #1567 failure site): belongs upstream in lgtm-ci, not
  duplicated here. Not raised in this PR.
- **#1704's log-ingestion race** (auto-rerun fired 21s after completion and
  `gh run view --log-failed` had no tail yet) is an upstream fetch-path problem
  in `rerun-on-infra-failure.sh`, not a missing signature. It affects these
  signatures too — a delay/refetch before giving up needs an lgtm-ci change.
- Both signatures are candidates for promotion into lgtm-ci's
  `DEFAULT_SIGNATURES` if other repos hit them.

Fixes #1689
