### PR TITLE
fix(html-validate): pin executable resolution and pass literal paths

### DIFF
--- a/docs/tool-analysis/html-validate-analysis.md
+++ b/docs/tool-analysis/html-validate-analysis.md
@@ -37,15 +37,25 @@ A clean document emits `[]` and exits `0`; any error exits `1`.
 
 ## Installation
 
-html-validate is a Node.js tool. Lintro installs and invokes it via `bun` (falling back
-to `npx`, then a direct binary):
+html-validate is a Node.js tool. Lintro resolves the executable in this order:
+
+1. A consumer-local `node_modules/.bin/html-validate` (searched upwards from the working
+   directory), so the version is whatever the consumer's lockfile pins.
+2. An `html-validate` binary on `PATH` (how the lintro container runs it).
+3. `bunx html-validate@<version>`, falling back to `npx html-validate@<version>`.
 
 ```bash
 bun add -g html-validate        # or: npm install -g html-validate
 ```
 
 The pinned version lives in `package.json` and is mirrored into
-`lintro/tools/manifest.json` by the tool-version generator.
+`lintro/tools/manifest.json` by the tool-version generator; Renovate bumps it there. The
+registry fallback is always version-pinned — `@latest` is never resolved at runtime, so
+a broken upstream release cannot take every consumer down at once.
+
+Files are passed as literal paths, never globs or directories. html-validate expands
+those through `fs.globSync`, which is missing on some Bun builds and aborts the run
+before any file is validated.
 
 ## Output format
 

--- a/lintro/plugins/base.py
+++ b/lintro/plugins/base.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import copy
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
 
 import click
@@ -667,7 +668,11 @@ class BaseToolPlugin(ABC):
 
         return aggregated
 
-    def _get_executable_command(self, tool_name: str) -> list[str]:
+    def _get_executable_command(
+        self,
+        tool_name: str,
+        cwd: str | Path | None = None,
+    ) -> list[str]:
         """Get the command prefix to execute a tool.
 
         Delegates to CommandBuilderRegistry for language-specific logic.
@@ -675,11 +680,13 @@ class BaseToolPlugin(ABC):
 
         Args:
             tool_name: Name of the tool executable.
+            cwd: Directory the tool will execute in, when known. Project-local
+                ecosystems resolve their binary relative to it (#1727).
 
         Returns:
             Command prefix list.
         """
-        return get_executable_command(tool_name)
+        return get_executable_command(tool_name, cwd=cwd)
 
     def _verify_tool_version(self) -> ToolResult | None:
         """Verify that the tool meets minimum version requirements.

--- a/lintro/plugins/execution_preparation.py
+++ b/lintro/plugins/execution_preparation.py
@@ -6,6 +6,7 @@ This module provides execution preparation, version checking, and config injecti
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Any
 
 from loguru import logger
@@ -98,13 +99,18 @@ def get_effective_timeout(
     return float(default_timeout)
 
 
-def get_executable_command(tool_name: str) -> list[str]:
+def get_executable_command(
+    tool_name: str,
+    cwd: str | Path | None = None,
+) -> list[str]:
     """Get the command prefix to execute a tool.
 
     Delegates to CommandBuilderRegistry for language-specific logic.
 
     Args:
         tool_name: Name of the tool executable.
+        cwd: Directory the tool will execute in, when known. Used by builders
+            whose resolution is project-local (#1727).
 
     Returns:
         Command prefix list.
@@ -117,11 +123,18 @@ def get_executable_command(tool_name: str) -> list[str]:
     except ValueError:
         tool_name_enum = None
 
-    result: list[str] = CommandBuilderRegistry.get_command(tool_name, tool_name_enum)
+    result: list[str] = CommandBuilderRegistry.get_command(
+        tool_name,
+        tool_name_enum,
+        Path(cwd) if cwd is not None else None,
+    )
     return result
 
 
-def verify_tool_version(definition: ToolDefinition) -> ToolResult | None:
+def verify_tool_version(
+    definition: ToolDefinition,
+    cwd: str | Path | None = None,
+) -> ToolResult | None:
     """Verify that the tool meets minimum version requirements.
 
     When ``LINTRO_ALLOW_VERSION_LAG`` lists the tool (or is ``*``) and the
@@ -130,15 +143,20 @@ def verify_tool_version(definition: ToolDefinition) -> ToolResult | None:
     still skip. This matches the CI image gate's ``--allow-version-lag``
     policy for Renovate tool bumps against a digest-pinned base image.
 
+    The check must resolve the same binary the run will use. Verifying a
+    different installation can skip the run even though the target project has
+    a valid pinned binary, or pass on a binary that never executes (#1727).
+
     Args:
         definition: Tool definition with name.
+        cwd: Directory the tool will execute in, when known.
 
     Returns:
         None if version check passes, or a skip result if it fails.
     """
     from lintro.tools.core.version_requirements import check_tool_version
 
-    command = get_executable_command(definition.name)
+    command = get_executable_command(definition.name, cwd=cwd)
     version_info = check_tool_version(definition.name, command)
 
     if version_info.version_check_passed:
@@ -278,11 +296,6 @@ def prepare_execution(
             ),
         }
 
-    # Check version requirements (only when files exist to check)
-    version_result = verify_tool_version(definition)
-    if version_result is not None:
-        return {"early_result": version_result}
-
     logger.debug(f"Files to process: {files}")
 
     # Compute cwd and relative paths. Anchor the tool subprocess to the files'
@@ -290,7 +303,17 @@ def prepare_execution(
     # each tool sees for a given file — and thus config ``overrides`` keyed on
     # it — is identical whether the user passed a file, a directory, or ``.``
     # (#1616).
+    #
+    # Derived before the version check on purpose: the check must resolve the
+    # same binary the run will use, which for project-local tools depends on
+    # this directory (#1727).
     cwd = get_execution_cwd(files)
+
+    # Check version requirements (only when files exist to check)
+    version_result = verify_tool_version(definition, cwd=cwd)
+    if version_result is not None:
+        return {"early_result": version_result}
+
     rel_files = [os.path.relpath(os.path.abspath(f), cwd) for f in files]
 
     # Get timeout (keep as float to preserve precision)

--- a/lintro/tools/core/command_builders.py
+++ b/lintro/tools/core/command_builders.py
@@ -76,6 +76,28 @@ class CommandBuilder(ABC):
         """
         ...
 
+    def get_command_in(
+        self,
+        tool_name: str,
+        tool_name_enum: ToolName | None,
+        cwd: Path | None = None,
+    ) -> list[str]:
+        """Get the command, resolved relative to the execution directory.
+
+        Builders whose resolution depends on where the tool runs override this.
+        The default ignores ``cwd`` and matches :meth:`get_command`, so
+        ecosystems with directory-independent resolution need no change.
+
+        Args:
+            tool_name: String name of the tool.
+            tool_name_enum: Tool name enum, or None if unknown.
+            cwd: Directory the tool will execute in, when known.
+
+        Returns:
+            Command list to execute the tool.
+        """
+        return self.get_command(tool_name, tool_name_enum)
+
 
 class CommandBuilderRegistry:
     """Registry for command builders.
@@ -103,6 +125,7 @@ class CommandBuilderRegistry:
         cls,
         tool_name: str,
         tool_name_enum: ToolName | None,
+        cwd: Path | None = None,
     ) -> list[str]:
         """Get command for a tool using registered builders.
 
@@ -112,13 +135,16 @@ class CommandBuilderRegistry:
         Args:
             tool_name: String name of the tool.
             tool_name_enum: Tool name enum, or None if unknown.
+            cwd: Directory the tool will execute in, when known. Builders that
+                resolve project-local installs use it so the binary comes from
+                the project being checked rather than lintro's own tree.
 
         Returns:
             Command list, or [tool_name] as fallback.
         """
         for builder in cls._builders:
             if builder.can_handle(tool_name_enum):
-                return builder.get_command(tool_name, tool_name_enum)
+                return builder.get_command_in(tool_name, tool_name_enum, cwd)
 
         # Fallback: just use the tool name directly
         return [tool_name]
@@ -531,17 +557,24 @@ class NodeJSBuilder(CommandBuilder):
         """
         return tool_name_enum in self.package_names
 
-    def _get_pinned_command(self, binary_name: str, package_name: str) -> list[str]:
+    def _get_pinned_command(
+        self,
+        binary_name: str,
+        package_name: str,
+        start: Path | None = None,
+    ) -> list[str]:
         """Resolve a Node.js tool without ever resolving ``@latest``.
 
         Args:
             binary_name: Executable name (``node_modules/.bin`` entry).
             package_name: npm package name used for the registry fallback.
+            start: Directory to resolve ``node_modules/.bin`` from. Defaults to
+                the process working directory.
 
         Returns:
             Command list executing the tool at a known, pinned version.
         """
-        local = find_local_node_binary(binary_name)
+        local = find_local_node_binary(binary_name, start=start)
         if local is not None:
             logger.debug(f"Using project-local {binary_name}: {local}")
             return [local]
@@ -593,6 +626,41 @@ class NodeJSBuilder(CommandBuilder):
         if shutil.which("npx"):
             return ["npx", binary_name]
         return [binary_name]
+
+    def get_command_in(
+        self,
+        tool_name: str,
+        tool_name_enum: ToolName | None,
+        cwd: Path | None = None,
+    ) -> list[str]:
+        """Resolve a Node.js tool relative to the execution directory.
+
+        ``node_modules/.bin`` is project-local, so resolution must start from
+        the directory the tool will run in. Searching lintro's own working
+        directory instead can miss the target project's lockfile-pinned binary
+        and — worse — select an unrelated install ahead of PATH, making the
+        result depend on where lintro happened to be invoked from (#1727).
+
+        Args:
+            tool_name: String name of the tool.
+            tool_name_enum: Tool name enum, or None if unknown.
+            cwd: Directory the tool will execute in, when known.
+
+        Returns:
+            Command list to execute the tool.
+        """
+        if tool_name_enum is None or tool_name_enum not in self.pinned_tools:
+            return self.get_command(tool_name, tool_name_enum)
+
+        binary_name = self.binary_names.get(
+            tool_name_enum,
+            self.package_names.get(tool_name_enum, tool_name),
+        )
+        return self._get_pinned_command(
+            binary_name=binary_name,
+            package_name=self.package_names.get(tool_name_enum, tool_name),
+            start=cwd,
+        )
 
 
 @register_command_builder

--- a/lintro/tools/core/command_builders.py
+++ b/lintro/tools/core/command_builders.py
@@ -29,6 +29,7 @@ import shutil
 import sys
 import sysconfig
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
 from loguru import logger
@@ -395,6 +396,57 @@ class PytestBuilder(CommandBuilder):
         return ["pytest"]
 
 
+def find_local_node_binary(
+    binary_name: str,
+    *,
+    start: Path | None = None,
+) -> str | None:
+    """Find a consumer-local ``node_modules/.bin`` executable.
+
+    Walks up from *start* so a tool invoked from a subdirectory still resolves
+    the project's own install. A local install is lockfile-tracked, so it is
+    preferred over any registry fetch.
+
+    On Windows the package manager writes a ``.cmd`` shim; the extension-less
+    shim there is a shell script that cannot be executed with ``shell=False``.
+
+    Args:
+        binary_name: Executable name inside ``node_modules/.bin``.
+        start: Directory to start searching from. Defaults to the process
+            working directory.
+
+    Returns:
+        POSIX path to the local executable, or None when none is present.
+    """
+    origin = (start or Path.cwd()).resolve()
+    name = f"{binary_name}.cmd" if sys.platform == "win32" else binary_name
+    for directory in (origin, *origin.parents):
+        candidate = directory / "node_modules" / ".bin" / name
+        if candidate.is_file():
+            return candidate.as_posix()
+    return None
+
+
+def pinned_npm_spec(package_name: str) -> str:
+    """Build a version-pinned ``package@version`` npm spec.
+
+    The version is read from the repo's canonical pins (``package.json`` via
+    ``lintro._tool_versions``), so Renovate bumps it like any other npm
+    dependency instead of the runtime silently resolving ``@latest``.
+
+    Args:
+        package_name: npm package name (e.g. ``html-validate``).
+
+    Returns:
+        ``package@version`` when a pin is known, otherwise the bare package
+        name.
+    """
+    from lintro._tool_versions import get_tool_version
+
+    version = get_tool_version(package_name)
+    return f"{package_name}@{version}" if version else package_name
+
+
 @register_command_builder
 class NodeJSBuilder(CommandBuilder):
     """Builder for Node.js tools (Astro, Markdownlint, TypeScript, Vue-tsc).
@@ -405,6 +457,7 @@ class NodeJSBuilder(CommandBuilder):
 
     _package_names: dict[ToolName, str] | None = None
     _binary_names: dict[ToolName, str] | None = None
+    _pinned_tools: frozenset[ToolName] | None = None
 
     @property
     def package_names(self) -> dict[ToolName, str]:
@@ -448,6 +501,25 @@ class NodeJSBuilder(CommandBuilder):
             }
         return self._binary_names
 
+    @property
+    def pinned_tools(self) -> frozenset[ToolName]:
+        """Get tools whose registry fallback must be version-pinned.
+
+        For these tools a consumer-local install is preferred, then a binary
+        on PATH, and only then a ``bunx``/``npx`` invocation carrying an
+        explicit version. Without the pin the package manager resolves
+        ``@latest`` on every run, so a broken upstream release takes down
+        every consumer at once with nothing to roll back to.
+
+        Returns:
+            Frozen set of ToolName members that require a pinned spec.
+        """
+        if self._pinned_tools is None:
+            from lintro.enums.tool_name import ToolName
+
+            self._pinned_tools = frozenset({ToolName.HTML_VALIDATE})
+        return self._pinned_tools
+
     def can_handle(self, tool_name_enum: ToolName | None) -> bool:
         """Check if this builder handles the tool.
 
@@ -458,6 +530,32 @@ class NodeJSBuilder(CommandBuilder):
             True if tool is a Node.js tool.
         """
         return tool_name_enum in self.package_names
+
+    def _get_pinned_command(self, binary_name: str, package_name: str) -> list[str]:
+        """Resolve a Node.js tool without ever resolving ``@latest``.
+
+        Args:
+            binary_name: Executable name (``node_modules/.bin`` entry).
+            package_name: npm package name used for the registry fallback.
+
+        Returns:
+            Command list executing the tool at a known, pinned version.
+        """
+        local = find_local_node_binary(binary_name)
+        if local is not None:
+            logger.debug(f"Using project-local {binary_name}: {local}")
+            return [local]
+
+        if shutil.which(binary_name):
+            logger.debug(f"Using {binary_name} from PATH")
+            return [binary_name]
+
+        spec = pinned_npm_spec(package_name)
+        if shutil.which("bunx"):
+            return ["bunx", spec]
+        if shutil.which("npx"):
+            return ["npx", spec]
+        return [binary_name]
 
     def get_command(
         self,
@@ -481,6 +579,13 @@ class NodeJSBuilder(CommandBuilder):
             tool_name_enum,
             self.package_names.get(tool_name_enum, tool_name),
         )
+
+        # Pinned tools never resolve @latest: local install -> PATH -> pinned spec
+        if tool_name_enum in self.pinned_tools:
+            return self._get_pinned_command(
+                binary_name=binary_name,
+                package_name=self.package_names.get(tool_name_enum, tool_name),
+            )
 
         # Prefer bunx (bun), fall back to npx (npm), then direct tool invocation
         if shutil.which("bunx"):

--- a/lintro/tools/definitions/html_validate.py
+++ b/lintro/tools/definitions/html_validate.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import subprocess  # nosec B404 - used safely with shell disabled
 from dataclasses import dataclass
-from pathlib import Path
 
 from loguru import logger
 
@@ -34,7 +33,6 @@ from lintro.parsers.html_validate.html_validate_parser import (
 from lintro.plugins.base import BaseToolPlugin
 from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.registry import register_tool
-from lintro.tools.core.command_builders import find_local_node_binary
 from lintro.tools.core.timeout_utils import create_timeout_result
 from lintro.utils.unified_config import DEFAULT_TOOL_PRIORITIES
 
@@ -150,24 +148,18 @@ class HtmlValidatePlugin(BaseToolPlugin):
         # formatter. ``_get_executable_command`` never yields an unpinned
         # ``@latest`` spec for html-validate (see NodeJSBuilder.pinned_tools).
         #
-        # Resolve node_modules/.bin from the directory the tool will actually
-        # run in. ``_get_executable_command`` searches upward from the *process*
-        # working directory, so when lintro checks a project elsewhere (--diff
-        # against another checkout, a monorepo package) it misses that
-        # project's lockfile-pinned html-validate and silently falls back to
-        # PATH or a registry fetch — diagnostics would then come from a
-        # different installation than the one the project pins. Tracked
-        # generally for every Node tool in #1758.
-        # ctx.cwd is str | None; None means "run in the process cwd", which is
-        # also find_local_node_binary's default, so the fallback is identical.
-        local_binary = find_local_node_binary(
-            "html-validate",
-            start=Path(ctx.cwd) if ctx.cwd else None,
-        )
-        cmd: list[str] = (
-            [local_binary]
-            if local_binary is not None
-            else self._get_executable_command(tool_name="html_validate")
+        # Pass ctx.cwd so node_modules/.bin resolves from the directory the
+        # tool actually runs in. Without it the search starts at lintro's own
+        # working directory, which misses the target project's lockfile-pinned
+        # html-validate and can select an unrelated install ahead of PATH,
+        # making the result depend on where lintro was invoked from (#1727).
+        # Precedence is target-local, then PATH, then the pinned bunx/npx spec.
+        #
+        # ctx.cwd is str | None; None means the process cwd, which is the
+        # default resolution, so that path is unchanged.
+        cmd: list[str] = self._get_executable_command(
+            tool_name="html_validate",
+            cwd=ctx.cwd,
         )
         cmd.extend(["--formatter", "json"])
 

--- a/lintro/tools/definitions/html_validate.py
+++ b/lintro/tools/definitions/html_validate.py
@@ -5,6 +5,11 @@ best practices, standards, and accessibility (WCAG) rules. It is a Node.js tool
 invoked via bun/bunx, mirroring lintro's other Node tools (markdownlint,
 prettier).
 
+Executable resolution prefers a consumer-local ``node_modules/.bin`` install,
+then a binary on PATH, and only then a ``bunx``/``npx`` invocation pinned to the
+version in ``package.json``; ``@latest`` is never resolved at runtime. Files are
+always passed as literal paths so html-validate's glob expansion never runs.
+
 No configuration is required: when no ``.htmlvalidate.*`` config is found,
 html-validate applies its built-in ``html-validate:recommended`` preset, so the
 tool produces sensible results out of the box.
@@ -41,6 +46,24 @@ HTML_VALIDATE_CONFIG_FILENAMES: list[str] = [
     ".htmlvalidate.cjs",
     ".htmlvalidate.mjs",
 ]
+
+# Characters html-validate's CLI treats as glob syntax. Passing any of them
+# would push its ``expandFiles`` helper down the directory-walking branch of
+# ``fs.globSync``, which is not implemented on every Bun release and aborts the
+# run before any file is validated (see issue #1727).
+_GLOB_METACHARACTERS: frozenset[str] = frozenset("*?[]{}")
+
+
+def contains_glob_syntax(argument: str) -> bool:
+    """Report whether an argument would be interpreted as a glob pattern.
+
+    Args:
+        argument: Command-line argument destined for html-validate.
+
+    Returns:
+        True when the argument contains glob metacharacters.
+    """
+    return any(char in _GLOB_METACHARACTERS for char in argument)
 
 
 @register_tool
@@ -121,10 +144,24 @@ class HtmlValidatePlugin(BaseToolPlugin):
             )
         logger.debug(f"[HtmlValidatePlugin] Working directory: {ctx.cwd}")
 
-        # Build command: resolve executable (bunx/npx/direct) + JSON formatter.
+        # Build command: resolve executable (local/PATH/pinned bunx) + JSON
+        # formatter. ``_get_executable_command`` never yields an unpinned
+        # ``@latest`` spec for html-validate (see NodeJSBuilder.pinned_tools).
         cmd: list[str] = self._get_executable_command(tool_name="html_validate")
         cmd.extend(["--formatter", "json"])
-        cmd.extend(ctx.rel_files)
+
+        # Always pass the literal files lintro discovered, never a glob or a
+        # directory: html-validate expands those through ``fs.globSync``, which
+        # aborts the whole run on Bun builds that lack it (issue #1727).
+        file_args: list[str] = ctx.rel_files or ctx.files
+        globbed = [path for path in file_args if contains_glob_syntax(path)]
+        if globbed:
+            logger.warning(
+                f"[HtmlValidatePlugin] {len(globbed)} path(s) contain glob "
+                f"metacharacters and may be re-expanded by html-validate: "
+                f"{globbed[:5]}",
+            )
+        cmd.extend(file_args)
 
         logger.debug(
             f"[HtmlValidatePlugin] Running: {' '.join(cmd)} (cwd={ctx.cwd})",

--- a/lintro/tools/definitions/html_validate.py
+++ b/lintro/tools/definitions/html_validate.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import subprocess  # nosec B404 - used safely with shell disabled
 from dataclasses import dataclass
+from pathlib import Path
 
 from loguru import logger
 
@@ -33,6 +34,7 @@ from lintro.parsers.html_validate.html_validate_parser import (
 from lintro.plugins.base import BaseToolPlugin
 from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.registry import register_tool
+from lintro.tools.core.command_builders import find_local_node_binary
 from lintro.tools.core.timeout_utils import create_timeout_result
 from lintro.utils.unified_config import DEFAULT_TOOL_PRIORITIES
 
@@ -147,7 +149,26 @@ class HtmlValidatePlugin(BaseToolPlugin):
         # Build command: resolve executable (local/PATH/pinned bunx) + JSON
         # formatter. ``_get_executable_command`` never yields an unpinned
         # ``@latest`` spec for html-validate (see NodeJSBuilder.pinned_tools).
-        cmd: list[str] = self._get_executable_command(tool_name="html_validate")
+        #
+        # Resolve node_modules/.bin from the directory the tool will actually
+        # run in. ``_get_executable_command`` searches upward from the *process*
+        # working directory, so when lintro checks a project elsewhere (--diff
+        # against another checkout, a monorepo package) it misses that
+        # project's lockfile-pinned html-validate and silently falls back to
+        # PATH or a registry fetch — diagnostics would then come from a
+        # different installation than the one the project pins. Tracked
+        # generally for every Node tool in #1758.
+        # ctx.cwd is str | None; None means "run in the process cwd", which is
+        # also find_local_node_binary's default, so the fallback is identical.
+        local_binary = find_local_node_binary(
+            "html-validate",
+            start=Path(ctx.cwd) if ctx.cwd else None,
+        )
+        cmd: list[str] = (
+            [local_binary]
+            if local_binary is not None
+            else self._get_executable_command(tool_name="html_validate")
+        )
         cmd.extend(["--formatter", "json"])
 
         # Always pass the literal files lintro discovered, never a glob or a

--- a/tests/unit/plugins/test_execution_preparation.py
+++ b/tests/unit/plugins/test_execution_preparation.py
@@ -72,3 +72,50 @@ def test_version_lag_disallowed_when_unset(monkeypatch: pytest.MonkeyPatch) -> N
     """
     monkeypatch.delenv("LINTRO_ALLOW_VERSION_LAG", raising=False)
     assert_that(_version_lag_allowed("trufflehog")).is_false()
+
+
+def test_verify_tool_version_resolves_from_the_execution_cwd() -> None:
+    """The version check must resolve the binary the run will actually use.
+
+    Verification previously resolved from the process working directory while
+    execution resolved from the target project. A missing or outdated
+    process-visible binary could then skip the run even though the target had
+    a valid lockfile-pinned install — and the reverse, passing on a binary
+    that never executes (#1727).
+
+    """
+    from unittest.mock import patch
+
+    from lintro.plugins.execution_preparation import verify_tool_version
+
+    seen: dict[str, object] = {}
+
+    def _capture(tool_name: str, cwd: object = None) -> list[str]:
+        seen["cwd"] = cwd
+        return ["html-validate"]
+
+    definition = type("Def", (), {"name": "html_validate"})()
+
+    with (
+        patch(
+            "lintro.plugins.execution_preparation.get_executable_command",
+            side_effect=_capture,
+        ),
+        patch(
+            "lintro.tools.core.version_requirements.check_tool_version",
+        ) as mock_check,
+    ):
+        mock_check.return_value = type(
+            "Info",
+            (),
+            {
+                "version_check_passed": True,
+                "below_recommended": False,
+                "current_version": "1.0.0",
+                "recommended_version": "1.0.0",
+                "min_version": "1.0.0",
+            },
+        )()
+        verify_tool_version(definition, cwd="/tmp/target-project")
+
+    assert_that(seen.get("cwd")).is_equal_to("/tmp/target-project")

--- a/tests/unit/tools/core/test_command_builders.py
+++ b/tests/unit/tools/core/test_command_builders.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Generator
+from collections.abc import Callable, Generator
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from assertpy import assert_that
 
+from lintro._tool_versions import get_tool_version
 from lintro.enums.tool_name import ToolName
 from lintro.tools.core.command_builders import (
     CargoBuilder,
@@ -18,6 +20,8 @@ from lintro.tools.core.command_builders import (
     PytestBuilder,
     PythonBundledBuilder,
     StandaloneBuilder,
+    find_local_node_binary,
+    pinned_npm_spec,
 )
 
 
@@ -494,6 +498,153 @@ def test_nodejs_builder_vue_tsc_uses_vue_tsc_binary() -> None:
     with patch("shutil.which", return_value="/usr/local/bin/bunx"):
         cmd = builder.get_command("vue-tsc", ToolName.VUE_TSC)
         assert_that(cmd).is_equal_to(["bunx", "vue-tsc"])
+
+
+# =============================================================================
+# Pinned Node.js tool resolution (issue #1727)
+# =============================================================================
+
+
+def _which_only(*available: str) -> Callable[..., str | None]:
+    """Build a ``shutil.which`` stub that only finds the named executables.
+
+    Args:
+        *available: Executable names that should resolve.
+
+    Returns:
+        Callable usable as a ``shutil.which`` replacement.
+    """
+
+    def _which(name: str, *_args: object, **_kwargs: object) -> str | None:
+        return f"/usr/local/bin/{name}" if name in available else None
+
+    return _which
+
+
+def test_html_validate_is_pinned() -> None:
+    """html-validate is registered as a version-pinned Node.js tool."""
+    builder = NodeJSBuilder()
+    assert_that(builder.pinned_tools).contains(ToolName.HTML_VALIDATE)
+
+
+def test_html_validate_prefers_local_node_modules_binary(tmp_path: Path) -> None:
+    """A consumer-local install wins over any registry fetch."""
+    local_bin = tmp_path / "node_modules" / ".bin"
+    local_bin.mkdir(parents=True)
+    binary = local_bin / (
+        "html-validate.cmd" if sys.platform == "win32" else "html-validate"
+    )
+    binary.write_text("#!/bin/sh\n")
+
+    builder = NodeJSBuilder()
+    with (
+        patch("shutil.which", _which_only("bunx")),
+        patch("pathlib.Path.cwd", return_value=tmp_path),
+    ):
+        cmd = builder.get_command("html_validate", ToolName.HTML_VALIDATE)
+
+    assert_that(cmd).is_equal_to([binary.resolve().as_posix()])
+
+
+def test_html_validate_prefers_path_binary_over_bunx() -> None:
+    """A binary on PATH is used before falling back to bunx."""
+    builder = NodeJSBuilder()
+    with (
+        patch("shutil.which", _which_only("bunx", "html-validate")),
+        patch(
+            "lintro.tools.core.command_builders.find_local_node_binary",
+            return_value=None,
+        ),
+    ):
+        cmd = builder.get_command("html_validate", ToolName.HTML_VALIDATE)
+
+    assert_that(cmd).is_equal_to(["html-validate"])
+
+
+def test_html_validate_bunx_fallback_is_version_pinned() -> None:
+    """The bunx fallback carries an explicit version, never ``@latest``."""
+    builder = NodeJSBuilder()
+    with (
+        patch("shutil.which", _which_only("bunx")),
+        patch(
+            "lintro.tools.core.command_builders.find_local_node_binary",
+            return_value=None,
+        ),
+    ):
+        cmd = builder.get_command("html_validate", ToolName.HTML_VALIDATE)
+
+    expected_version = get_tool_version("html-validate")
+    assert_that(expected_version).is_not_none()
+    assert_that(cmd).is_equal_to(["bunx", f"html-validate@{expected_version}"])
+    assert_that(cmd[1]).does_not_contain("@latest")
+
+
+def test_html_validate_npx_fallback_is_version_pinned() -> None:
+    """The npx fallback is pinned the same way as the bunx fallback."""
+    builder = NodeJSBuilder()
+    with (
+        patch("shutil.which", _which_only("npx")),
+        patch(
+            "lintro.tools.core.command_builders.find_local_node_binary",
+            return_value=None,
+        ),
+    ):
+        cmd = builder.get_command("html_validate", ToolName.HTML_VALIDATE)
+
+    assert_that(cmd).is_equal_to(
+        ["npx", f"html-validate@{get_tool_version('html-validate')}"],
+    )
+
+
+def test_html_validate_falls_back_to_bare_binary() -> None:
+    """Without any package runner the bare binary name is used."""
+    builder = NodeJSBuilder()
+    with (
+        patch("shutil.which", _which_only()),
+        patch(
+            "lintro.tools.core.command_builders.find_local_node_binary",
+            return_value=None,
+        ),
+    ):
+        cmd = builder.get_command("html_validate", ToolName.HTML_VALIDATE)
+
+    assert_that(cmd).is_equal_to(["html-validate"])
+
+
+def test_pinned_npm_spec_falls_back_to_bare_name() -> None:
+    """An unknown package yields a bare name rather than an ``@latest`` spec."""
+    spec = pinned_npm_spec("definitely-not-a-lintro-tool")
+    assert_that(spec).is_equal_to("definitely-not-a-lintro-tool")
+
+
+def test_find_local_node_binary_walks_up_to_project_root(tmp_path: Path) -> None:
+    """Resolution walks up so subdirectories still find the project install."""
+    local_bin = tmp_path / "node_modules" / ".bin"
+    local_bin.mkdir(parents=True)
+    binary = local_bin / (
+        "html-validate.cmd" if sys.platform == "win32" else "html-validate"
+    )
+    binary.write_text("#!/bin/sh\n")
+    nested = tmp_path / "src" / "pages"
+    nested.mkdir(parents=True)
+
+    found = find_local_node_binary("html-validate", start=nested)
+
+    assert_that(found).is_equal_to(binary.resolve().as_posix())
+
+
+def test_find_local_node_binary_returns_none_when_absent(tmp_path: Path) -> None:
+    """No local install resolves to None."""
+    found = find_local_node_binary("html-validate", start=tmp_path)
+    assert_that(found).is_none()
+
+
+def test_unpinned_node_tools_keep_bunx_behaviour() -> None:
+    """Tools outside the pinned set are unaffected by the pinning branch."""
+    builder = NodeJSBuilder()
+    with patch("shutil.which", _which_only("bunx", "markdownlint-cli2")):
+        cmd = builder.get_command("markdownlint", ToolName.MARKDOWNLINT)
+    assert_that(cmd).is_equal_to(["bunx", "markdownlint-cli2"])
 
 
 # =============================================================================

--- a/tests/unit/tools/core/test_command_builders.py
+++ b/tests/unit/tools/core/test_command_builders.py
@@ -786,3 +786,78 @@ def test_registry_clear() -> None:
 
     CommandBuilderRegistry.clear()
     assert_that(CommandBuilderRegistry._builders).is_empty()
+
+
+def test_html_validate_prefers_bunx_when_both_runners_are_present() -> None:
+    """Bunx wins over npx when both resolve on PATH.
+
+    The individual fallback tests each stub a single runner, so neither pins
+    the precedence between them: a regression that flipped the preferred
+    runner, or picked one non-deterministically, would pass both.
+    """
+    builder = NodeJSBuilder()
+    with (
+        # Both runners present, but the tool itself is NOT on PATH — a PATH
+        # hit would correctly win before either runner and mask the ordering.
+        patch(
+            "shutil.which",
+            lambda name: f"/usr/bin/{name}" if name in {"bunx", "npx"} else None,
+        ),
+        patch(
+            "lintro.tools.core.command_builders.find_local_node_binary",
+            return_value=None,
+        ),
+    ):
+        cmd = builder.get_command("html_validate", ToolName.HTML_VALIDATE)
+
+    assert_that(cmd[0]).is_equal_to("bunx")
+
+
+def test_registry_resolves_node_tools_from_the_given_cwd() -> None:
+    """A supplied cwd scopes node_modules/.bin resolution to that directory.
+
+    Without it the search starts at lintro's own working directory, which can
+    select an unrelated install ahead of PATH (#1727).
+    """
+    seen: list[Path | None] = []
+
+    def _record(binary_name: str, *, start: Path | None = None) -> None:
+        seen.append(start)
+        return None
+
+    target = Path("/tmp/some-target-project")
+    with (
+        patch("shutil.which", _which_only("bunx")),
+        patch(
+            "lintro.tools.core.command_builders.find_local_node_binary",
+            side_effect=_record,
+        ),
+    ):
+        CommandBuilderRegistry.get_command(
+            "html_validate",
+            ToolName.HTML_VALIDATE,
+            target,
+        )
+
+    # Exactly one lookup, scoped to the target — no second, process-cwd search.
+    assert_that(seen).is_equal_to([target])
+
+
+def test_registry_without_cwd_preserves_process_relative_resolution() -> None:
+    """Omitting cwd keeps the previous behaviour for every builder."""
+    seen: list[Path | None] = []
+
+    def _record(binary_name: str, *, start: Path | None = None) -> None:
+        seen.append(start)
+        return None
+
+    with (
+        patch("shutil.which", _which_only("bunx")),
+        patch(
+            "lintro.tools.core.command_builders.find_local_node_binary",
+            side_effect=_record,
+        ),
+    ):
+        CommandBuilderRegistry.get_command("html_validate", ToolName.HTML_VALIDATE)
+
+    assert_that(seen).is_equal_to([None])

--- a/tests/unit/tools/html_validate/test_execution.py
+++ b/tests/unit/tools/html_validate/test_execution.py
@@ -11,7 +11,10 @@ from assertpy import assert_that
 
 from lintro.parsers.html_validate.html_validate_issue import HtmlValidateIssue
 from lintro.plugins.subprocess_executor import SubprocessResult
-from lintro.tools.definitions.html_validate import HtmlValidatePlugin
+from lintro.tools.definitions.html_validate import (
+    HtmlValidatePlugin,
+    contains_glob_syntax,
+)
 
 _ISSUE_JSON = (
     '[{"filePath":"index.html","messages":['
@@ -140,6 +143,86 @@ def test_check_returns_early_when_skipped(
         result = html_validate_plugin.check(["x.html"], {})
 
     assert_that(result).is_same_as(early)
+
+
+def test_check_passes_literal_paths_and_pinned_executable(
+    html_validate_plugin: HtmlValidatePlugin,
+    tmp_path: Path,
+) -> None:
+    """Only literal discovered paths are passed, with a pinned executable.
+
+    html-validate expands glob patterns through ``fs.globSync``, which aborts
+    the run on Bun builds lacking it, and an unpinned ``@latest`` spec resolves
+    a fresh release on every run (issue #1727).
+
+    Args:
+        html_validate_plugin: The plugin under test.
+        tmp_path: Temporary directory for the fixture files.
+    """
+    first = tmp_path / "index.html"
+    second = tmp_path / "about.html"
+    for html_file in (first, second):
+        html_file.write_text("<p>ok</p>\n")
+
+    mock_result = SubprocessResult(returncode=0, stdout="[]", stderr="", output="[]")
+    rel_files = ["index.html", "about.html"]
+
+    with (
+        patch.object(html_validate_plugin, "_prepare_execution") as mock_prepare,
+        patch.object(
+            html_validate_plugin,
+            "_run_subprocess_result",
+            return_value=mock_result,
+        ) as mock_run,
+    ):
+        ctx = _mock_ctx(tmp_path, rel_files)
+        mock_prepare.return_value = ctx
+        html_validate_plugin.check([str(tmp_path)], {})
+
+    cmd = cast(list[str], mock_run.call_args.kwargs["cmd"])
+    assert_that(cmd[-2:]).is_equal_to(rel_files)
+    for argument in cmd:
+        assert_that(contains_glob_syntax(argument)).described_as(argument).is_false()
+    assert_that(" ".join(cmd)).does_not_contain("@latest")
+
+
+def test_contains_glob_syntax_detects_metacharacters() -> None:
+    """Glob metacharacters are detected; plain paths are not flagged."""
+    assert_that(contains_glob_syntax("src/**/*.html")).is_true()
+    assert_that(contains_glob_syntax("page[1].html")).is_true()
+    assert_that(contains_glob_syntax("src/index.html")).is_false()
+
+
+def test_check_falls_back_to_absolute_files(
+    html_validate_plugin: HtmlValidatePlugin,
+    tmp_path: Path,
+) -> None:
+    """Absolute discovered files are used when no relative paths are available.
+
+    Args:
+        html_validate_plugin: The plugin under test.
+        tmp_path: Temporary directory for the fixture file.
+    """
+    html_file = tmp_path / "index.html"
+    html_file.write_text("<p>ok</p>\n")
+
+    mock_result = SubprocessResult(returncode=0, stdout="[]", stderr="", output="[]")
+
+    with (
+        patch.object(html_validate_plugin, "_prepare_execution") as mock_prepare,
+        patch.object(
+            html_validate_plugin,
+            "_run_subprocess_result",
+            return_value=mock_result,
+        ) as mock_run,
+    ):
+        ctx = _mock_ctx(tmp_path, [str(html_file)])
+        ctx.rel_files = []
+        mock_prepare.return_value = ctx
+        html_validate_plugin.check([str(html_file)], {})
+
+    cmd = cast(list[str], mock_run.call_args.kwargs["cmd"])
+    assert_that(cmd[-1]).is_equal_to(str(html_file))
 
 
 def test_fix_raises_not_implemented(

--- a/tests/unit/tools/html_validate/test_execution.py
+++ b/tests/unit/tools/html_validate/test_execution.py
@@ -26,6 +26,10 @@ _ISSUE_JSON = (
 )
 
 
+# Deterministic stand-in so tests assert behaviour, not host PATH contents.
+_PINNED_EXECUTABLE = "/pinned/html-validate"
+
+
 def _mock_ctx(tmp_path: Path, files: list[str]) -> MagicMock:
     """Build a mock ExecutionContext.
 
@@ -169,6 +173,15 @@ def test_check_passes_literal_paths_and_pinned_executable(
 
     with (
         patch.object(html_validate_plugin, "_prepare_execution") as mock_prepare,
+        # Pin resolution: ctx.cwd is a real tmp_path, so without this the
+        # command depends on whatever the host has on PATH or in an ancestor
+        # node_modules. These two tests are about argument handling, not about
+        # which executable the host happens to expose.
+        patch.object(
+            html_validate_plugin,
+            "_get_executable_command",
+            return_value=[_PINNED_EXECUTABLE],
+        ),
         patch.object(
             html_validate_plugin,
             "_run_subprocess_result",
@@ -210,6 +223,15 @@ def test_check_falls_back_to_absolute_files(
 
     with (
         patch.object(html_validate_plugin, "_prepare_execution") as mock_prepare,
+        # Pin resolution: ctx.cwd is a real tmp_path, so without this the
+        # command depends on whatever the host has on PATH or in an ancestor
+        # node_modules. These two tests are about argument handling, not about
+        # which executable the host happens to expose.
+        patch.object(
+            html_validate_plugin,
+            "_get_executable_command",
+            return_value=[_PINNED_EXECUTABLE],
+        ),
         patch.object(
             html_validate_plugin,
             "_run_subprocess_result",

--- a/tests/unit/tools/html_validate/test_execution.py
+++ b/tests/unit/tools/html_validate/test_execution.py
@@ -235,3 +235,48 @@ def test_fix_raises_not_implemented(
     """
     with pytest.raises(NotImplementedError):
         html_validate_plugin.fix(["x.html"], {})
+
+
+def test_check_prefers_the_target_projects_local_binary(
+    html_validate_plugin: HtmlValidatePlugin,
+    tmp_path: Path,
+) -> None:
+    """The executable resolves from ctx.cwd, not the process working directory.
+
+    When lintro checks a project outside its own working directory (``--diff``
+    against another checkout, a package inside a monorepo), the run must use
+    that project's lockfile-pinned ``node_modules/.bin/html-validate``.
+    Resolving from the process cwd instead silently falls back to PATH or a
+    registry fetch, so diagnostics come from a different installation than the
+    one the project pins (#1727).
+
+    Args:
+        html_validate_plugin: The plugin under test.
+        tmp_path: Temporary directory standing in for the target project.
+    """
+    project = tmp_path / "target-project"
+    local_bin = project / "node_modules" / ".bin"
+    local_bin.mkdir(parents=True)
+    binary = local_bin / "html-validate"
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+
+    html_file = project / "index.html"
+    html_file.write_text("<p>ok</p>\n")
+
+    mock_result = SubprocessResult(returncode=0, stdout="[]", stderr="", output="[]")
+
+    with (
+        patch.object(html_validate_plugin, "_prepare_execution") as mock_prepare,
+        patch.object(
+            html_validate_plugin,
+            "_run_subprocess_result",
+            return_value=mock_result,
+        ) as mock_run,
+    ):
+        mock_prepare.return_value = _mock_ctx(project, [str(html_file)])
+        html_validate_plugin.check([str(html_file)], {})
+
+    cmd = cast(list[str], mock_run.call_args.kwargs["cmd"])
+    # The project's own binary, not "html-validate" from PATH or a bunx spec.
+    assert_that(cmd[0]).is_equal_to(binary.as_posix())

--- a/tests/unit/tools/html_validate/test_execution.py
+++ b/tests/unit/tools/html_validate/test_execution.py
@@ -280,3 +280,50 @@ def test_check_prefers_the_target_projects_local_binary(
     cmd = cast(list[str], mock_run.call_args.kwargs["cmd"])
     # The project's own binary, not "html-validate" from PATH or a bunx spec.
     assert_that(cmd[0]).is_equal_to(binary.as_posix())
+
+
+def test_check_does_not_fall_back_to_lintros_own_node_modules(
+    html_validate_plugin: HtmlValidatePlugin,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A target without its own install must not use lintro's node_modules.
+
+    Falling back to a process-cwd search would select an unrelated
+    ``node_modules/.bin/html-validate`` ahead of PATH, making resolution depend
+    on where lintro happens to be invoked from (#1727).
+
+    Args:
+        html_validate_plugin: The plugin under test.
+        tmp_path: Temporary directory root.
+        monkeypatch: Fixture used to relocate the process working directory.
+    """
+    # lintro's own tree has an install; the target project does not.
+    lintro_tree = tmp_path / "lintro-cwd"
+    stray_bin = lintro_tree / "node_modules" / ".bin"
+    stray_bin.mkdir(parents=True)
+    stray = stray_bin / "html-validate"
+    stray.write_text("#!/bin/sh\n")
+    stray.chmod(0o755)
+    monkeypatch.chdir(lintro_tree)
+
+    project = tmp_path / "target-project"
+    project.mkdir()
+    html_file = project / "index.html"
+    html_file.write_text("<p>ok</p>\n")
+
+    mock_result = SubprocessResult(returncode=0, stdout="[]", stderr="", output="[]")
+
+    with (
+        patch.object(html_validate_plugin, "_prepare_execution") as mock_prepare,
+        patch.object(
+            html_validate_plugin,
+            "_run_subprocess_result",
+            return_value=mock_result,
+        ) as mock_run,
+    ):
+        mock_prepare.return_value = _mock_ctx(project, [str(html_file)])
+        html_validate_plugin.check([str(html_file)], {})
+
+    cmd = cast(list[str], mock_run.call_args.kwargs["cmd"])
+    assert_that(cmd[0]).is_not_equal_to(stray.as_posix())

--- a/tests/unit/tools/prettier/test_cannot_run_vs_no_files.py
+++ b/tests/unit/tools/prettier/test_cannot_run_vs_no_files.py
@@ -40,7 +40,7 @@ def unresolvable_binary(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         execution_preparation,
         "get_executable_command",
-        lambda tool_name: [_MISSING_BINARY],
+        lambda tool_name, cwd=None: [_MISSING_BINARY],
     )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(html-validate): pin executable resolution and pass literal paths
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

html-validate was invoked as a bare `bunx html-validate`, which resolves `@latest` from
the registry on every run. A transitively-broken upstream release took every consumer
down at once (`TypeError: fs.globSync is not a function` under Bun), with no pinned
version to fall back to and nothing for Renovate to see.

Both halves of the issue are fixed.

**1. `@latest` is never resolved.** `NodeJSBuilder` resolves html-validate as:

1. consumer-local `node_modules/.bin/html-validate`, searched upwards from the working
   directory, so the consuming project's lockfile pin wins;
2. an `html-validate` binary on `PATH` (how the lintro container runs it);
3. `bunx html-validate@<version>`, then `npx html-validate@<version>`.

The version comes from the existing single source of truth — `package.json`
(`html-validate: 11.5.6`) read via `lintro._tool_versions.get_tool_version` — so
**Renovate already bumps it**: html-validate is in the `linting-tools` group in
`renovate.json`, and the pin flows into `_generated_versions.py` / `manifest.json`
through the existing generator. No new pinning mechanism was invented.

This also covers the second unpinned call site: the pre-run version check
(`verify_tool_version`) goes through the same builder.

Only html-validate opts into the pinned path (`NodeJSBuilder.pinned_tools`); every other
Node tool keeps its current behaviour, locked in by a regression test.

**2. Literal file paths only.** `check()` passes exactly the files lintro discovered —
never a glob or a directory — so html-validate's `expandFiles` never takes the
directory-walking `fs.globSync` branch. Added an absolute-path fallback when no relative
paths are available, and a warning when a discovered filename itself contains glob
metacharacters.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1727

## Details

### Tests (assertpy throughout)

`tests/unit/tools/core/test_command_builders.py`

- local `node_modules/.bin` preference; upward walk from a subdirectory
- PATH binary preferred over bunx
- **bunx and npx fallbacks are version-pinned and never contain `@latest`**
- bare-binary last resort; unknown package degrades to a bare name
- unpinned Node tools keep their existing bunx behaviour

`tests/unit/tools/html_validate/test_execution.py`

- the built command contains only literal discovered paths, **zero glob
  metacharacters**, and no `@latest`
- absolute-path fallback when `rel_files` is empty
- glob-detection helper

```console
$ uv run pytest tests/unit/tools/core tests/unit/tools/html_validate \
    tests/integration/tools/html_validate -q
322 passed
```

Full suite run before commit. The only failure is
`tests/integration/tools/pip_audit/test_check.py::test_check_file_with_vulnerabilities`,
which fails identically on a clean unrelated branch (local pip-audit environment issue)
and is untouched here.

### Dogfooding

Resolution, end to end:

```console
['html-validate']                  # PATH binary present
['bunx', 'html-validate@11.5.6']   # only bunx available -> pinned, not @latest
```

Tool still runs and reports findings:

```console
$ uv run lintro chk --tools html_validate <dir containing html_validate_violations.html>
9 issues: element-required-attributes, no-implicit-close (x2), wcag/h37,
          no-implicit-button-type, text-content, close-order (x3)
```

The pinned spec runs cleanly on Bun 1.3.14 with a literal path:

```console
$ bunx html-validate@11.5.6 --formatter json test_samples/.../html_validate_violations.html
[{"filePath":"...","errorCount":9,"warningCount":0, ...}]
```

`uv run lintro chk` is green across the repo (health score 100/100).
