### PR TITLE
fix(osv_scanner): honor .lintro-ignore and --exclude patterns

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1040,7 +1040,17 @@ lintro check --tools osv_scanner --tool-options "osv_scanner:timeout=300"
 
 # Skip suppression staleness check
 lintro check --tools osv_scanner --tool-options "osv_scanner:check_suppressions=false"
+
+# Ignore vendored or nested checkouts (equivalent to a .lintro-ignore entry)
+lintro check --tools osv_scanner --exclude ".claude"
 ```
+
+**Excluding lockfiles:** osv-scanner performs its own recursive lockfile discovery, so
+lintro applies the resolved exclusion set — `.lintro-ignore` entries plus `--exclude`
+patterns — to the lockfile paths it reports. Both mechanisms use the same gitignore
+semantics as file discovery and yield identical results. Directory patterns (`.claude`,
+`vendor/`) drop every finding from that tree — useful when nested checkouts multiply the
+same finding — and file patterns (`bun.lock`, `*.lock`) suppress individual lockfiles.
 
 #### pip-audit Configuration
 

--- a/lintro/tools/definitions/osv_scanner.py
+++ b/lintro/tools/definitions/osv_scanner.py
@@ -239,6 +239,7 @@ class OsvScannerPlugin(BaseToolPlugin):
         self,
         issues: list[OsvScannerIssue],
         paths: list[str],
+        scan_root: Path | None = None,
     ) -> list[OsvScannerIssue]:
         """Drop issues whose lockfile is covered by the exclusion set.
 
@@ -253,6 +254,9 @@ class OsvScannerPlugin(BaseToolPlugin):
         Args:
             issues: Parsed osv-scanner issues.
             paths: Input paths for the run, used to anchor relative patterns.
+            scan_root: Directory osv-scanner ran in. Reported source paths are
+                relative to it, so relative sources are resolved against it
+                rather than lintro's own working directory (#1725).
 
         Returns:
             Issues whose source path is not excluded.
@@ -265,11 +269,19 @@ class OsvScannerPlugin(BaseToolPlugin):
         kept: list[OsvScannerIssue] = []
         for issue in issues:
             source = issue.file or ""
+            # osv-scanner runs with cwd=scan_root and reports sources relative
+            # to it. should_exclude_path resolves a relative path with
+            # os.path.abspath, which uses lintro's own working directory — so
+            # scanning a project elsewhere would anchor the match on the wrong
+            # tree and keep or drop the wrong findings (#1725).
+            resolved = source
+            if source and scan_root is not None and not os.path.isabs(source):
+                resolved = os.path.join(str(scan_root), source)
             if (
                 source
                 and source != _UNKNOWN_SOURCE
                 and should_exclude_path(
-                    path=source,
+                    path=resolved,
                     exclude_patterns=patterns,
                     anchors=anchors,
                 )
@@ -360,7 +372,11 @@ class OsvScannerPlugin(BaseToolPlugin):
         # Apply .lintro-ignore / --exclude patterns to the reported lockfile
         # paths. osv-scanner does its own discovery and has no equivalent
         # ignore mechanism, so exclusions are enforced here (#1725).
-        issues = self.filter_excluded_issues(issues=parsed_issues, paths=paths)
+        issues = self.filter_excluded_issues(
+            issues=parsed_issues,
+            paths=paths,
+            scan_root=scan_root,
+        )
         excluded_count = len(parsed_issues) - len(issues)
         payload = extract_osv_scanner_payload(proc.stdout)
         parse_failures_count = 0 if payload is not None else None
@@ -504,6 +520,7 @@ class OsvScannerPlugin(BaseToolPlugin):
         probe_issues = self.filter_excluded_issues(
             issues=parse_osv_scanner_output(probe.stdout),
             paths=list(paths) if paths else [str(scan_root)],
+            scan_root=scan_root,
         )
 
         # If probe failed and returned no parseable issues, skip classification

--- a/lintro/tools/definitions/osv_scanner.py
+++ b/lintro/tools/definitions/osv_scanner.py
@@ -22,6 +22,7 @@ from lintro.enums.tool_name import ToolName
 from lintro.enums.tool_type import ToolType
 from lintro.models.core.tool_result import ToolResult
 from lintro.parsers.osv_scanner import (
+    OsvScannerIssue,
     classify_suppressions,
     extract_osv_scanner_payload,
     parse_osv_scanner_output,
@@ -35,10 +36,15 @@ from lintro.plugins.execution_preparation import (
 from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.registry import register_tool
 from lintro.tools.core.option_validators import validate_bool, validate_positive_int
+from lintro.utils.path_filtering import resolve_exclude_anchors, should_exclude_path
 
 # Constants
 OSV_SCANNER_DEFAULT_TIMEOUT: int = 120  # Network operations can be slow
 OSV_SCANNER_DEFAULT_PRIORITY: int = 90  # High priority for security tool
+
+# Placeholder source path used by the parser when a result carries no source.
+# It is not a real filesystem path and must never be exclusion-matched.
+_UNKNOWN_SOURCE: str = "lockfile"
 
 
 @register_tool
@@ -51,7 +57,10 @@ class OsvScannerPlugin(BaseToolPlugin):
 
     Unlike other tool plugins, osv-scanner handles its own file discovery
     via --recursive, so file_patterns is empty and check() bypasses the
-    standard file discovery pipeline.
+    standard file discovery pipeline. Because that discovery cannot be
+    steered from the outside, lintro's resolved exclusion set
+    (``.lintro-ignore`` plus ``--exclude``) is applied to the reported
+    lockfile paths instead — see :meth:`filter_excluded_issues` (#1725).
     """
 
     @property
@@ -212,6 +221,66 @@ class OsvScannerPlugin(BaseToolPlugin):
         except ValueError:
             return resolved[0]
 
+    def _active_exclude_patterns(self) -> list[str]:
+        """Return the resolved exclusion patterns for this run.
+
+        ``self.exclude_patterns`` is populated by the base plugin from the
+        built-in defaults plus ``.lintro-ignore`` entries, and extended with
+        ``--exclude`` patterns by ``set_options``. Both mechanisms therefore
+        feed the same list, which is what makes them behave identically here
+        (see #1725).
+
+        Returns:
+            Non-empty, stripped exclusion patterns.
+        """
+        return [p.strip() for p in self.exclude_patterns if p and p.strip()]
+
+    def filter_excluded_issues(
+        self,
+        issues: list[OsvScannerIssue],
+        paths: list[str],
+    ) -> list[OsvScannerIssue]:
+        """Drop issues whose lockfile is covered by the exclusion set.
+
+        osv-scanner performs its own recursive lockfile discovery, so lintro
+        cannot hand it a pre-filtered target list without re-implementing (and
+        eventually falling behind) that discovery for every ecosystem. Instead
+        the resolved exclusion set is applied to the reported source paths,
+        which honours both directory patterns (``.claude``) and file patterns
+        (``bun.lock``, ``*.lock``) with the same gitignore semantics used for
+        file discovery (#1725).
+
+        Args:
+            issues: Parsed osv-scanner issues.
+            paths: Input paths for the run, used to anchor relative patterns.
+
+        Returns:
+            Issues whose source path is not excluded.
+        """
+        patterns = self._active_exclude_patterns()
+        if not patterns or not issues:
+            return list(issues)
+
+        anchors = resolve_exclude_anchors(paths)
+        kept: list[OsvScannerIssue] = []
+        for issue in issues:
+            source = issue.file or ""
+            if (
+                source
+                and source != _UNKNOWN_SOURCE
+                and should_exclude_path(
+                    path=source,
+                    exclude_patterns=patterns,
+                    anchors=anchors,
+                )
+            ):
+                logger.debug(
+                    f"[osv-scanner] Excluding finding from ignored path: {source}",
+                )
+                continue
+            kept.append(issue)
+        return kept
+
     def doc_url(self, code: str) -> str | None:
         """Return OSV vulnerability database URL for the given ID.
 
@@ -287,7 +356,12 @@ class OsvScannerPlugin(BaseToolPlugin):
         # log lines that must not corrupt JSON parsing (see #1043). ``output``
         # (combined) is retained for display and plain-text signal detection.
         output = proc.output
-        issues = parse_osv_scanner_output(proc.stdout)
+        parsed_issues = parse_osv_scanner_output(proc.stdout)
+        # Apply .lintro-ignore / --exclude patterns to the reported lockfile
+        # paths. osv-scanner does its own discovery and has no equivalent
+        # ignore mechanism, so exclusions are enforced here (#1725).
+        issues = self.filter_excluded_issues(issues=parsed_issues, paths=paths)
+        excluded_count = len(parsed_issues) - len(issues)
         payload = extract_osv_scanner_payload(proc.stdout)
         parse_failures_count = 0 if payload is not None else None
         no_op_success = False
@@ -311,6 +385,19 @@ class OsvScannerPlugin(BaseToolPlugin):
             and payload is not None
             and self._payload_has_valid_results(payload)
             and len(payload["results"]) == 0
+        ):
+            success = True
+
+        # Every finding lived under an excluded path. osv-scanner still exits
+        # non-zero because it saw vulnerabilities, but for lintro the scan is
+        # clean. Gated on a valid payload so genuine execution failures still
+        # fail closed (#1725).
+        if (
+            not success
+            and excluded_count
+            and not issues
+            and payload is not None
+            and self._payload_has_valid_results(payload)
         ):
             success = True
 
@@ -348,6 +435,7 @@ class OsvScannerPlugin(BaseToolPlugin):
             scan_root=scan_root,
             timeout=timeout,
             options=merged_options,
+            paths=paths,
         )
 
         if no_op_success and parse_failures_count is None:
@@ -368,6 +456,7 @@ class OsvScannerPlugin(BaseToolPlugin):
         scan_root: Path,
         timeout: float,
         options: dict[str, object],
+        paths: list[str] | None = None,
     ) -> dict[str, Any] | None:
         """Run a probe scan to classify suppression entries.
 
@@ -378,6 +467,9 @@ class OsvScannerPlugin(BaseToolPlugin):
             scan_root: Root directory for the scan.
             timeout: Timeout for subprocess execution.
             options: Merged runtime options.
+            paths: Input paths for the run, used to anchor exclude patterns so
+                probe findings from ignored trees cannot keep a suppression
+                looking active (#1725).
 
         Returns:
             Metadata dict with suppression classifications, or None.
@@ -409,7 +501,10 @@ class OsvScannerPlugin(BaseToolPlugin):
             logger.debug("[osv-scanner] Probe scan timed out, skipping staleness check")
             return None
 
-        probe_issues = parse_osv_scanner_output(probe.stdout)
+        probe_issues = self.filter_excluded_issues(
+            issues=parse_osv_scanner_output(probe.stdout),
+            paths=list(paths) if paths else [str(scan_root)],
+        )
 
         # If probe failed and returned no parseable issues, skip classification
         # to avoid incorrectly marking all suppressions as stale.

--- a/lintro/tools/definitions/osv_scanner.py
+++ b/lintro/tools/definitions/osv_scanner.py
@@ -517,20 +517,27 @@ class OsvScannerPlugin(BaseToolPlugin):
             logger.debug("[osv-scanner] Probe scan timed out, skipping staleness check")
             return None
 
-        probe_issues = self.filter_excluded_issues(
-            issues=parse_osv_scanner_output(probe.stdout),
-            paths=list(paths) if paths else [str(scan_root)],
-            scan_root=scan_root,
-        )
+        parsed_probe_issues = parse_osv_scanner_output(probe.stdout)
 
-        # If probe failed and returned no parseable issues, skip classification
-        # to avoid incorrectly marking all suppressions as stale.
-        if not probe.success and not probe_issues:
+        # Decide "unreadable probe" on the UNFILTERED parse. osv-scanner exits
+        # non-zero whenever vulnerabilities exist, so probe.success is False
+        # both when the probe produced nothing readable and when it found
+        # vulnerabilities that are all under excluded paths. Testing the
+        # filtered list conflates the two, and suppressions covering only
+        # excluded findings would never be classified as stale — the opposite
+        # of the exclusion contract (#1725).
+        if not probe.success and not parsed_probe_issues:
             logger.debug(
                 "[osv-scanner] Probe scan failed with no parseable output, "
                 "skipping staleness check",
             )
             return None
+
+        probe_issues = self.filter_excluded_issues(
+            issues=parsed_probe_issues,
+            paths=list(paths) if paths else [str(scan_root)],
+            scan_root=scan_root,
+        )
 
         probe_vuln_ids = {issue.vuln_id for issue in probe_issues}
 

--- a/tests/unit/tools/osv_scanner/test_exclusions.py
+++ b/tests/unit/tools/osv_scanner/test_exclusions.py
@@ -297,7 +297,39 @@ def test_unrelated_pattern_keeps_all_findings(in_fixture_repo: Path) -> None:
 
 
 def test_filter_keeps_placeholder_source(in_fixture_repo: Path) -> None:
-    """Findings without a real source path are never filtered out."""
+    """The unknown-source sentinel is never exclusion-matched.
+
+    The parser substitutes ``lockfile`` when a result carries no source. That
+    is not a real path, so a pattern that happens to match the sentinel must
+    not drop the finding. The pattern here matches the sentinel exactly — with
+    a non-matching pattern this test would pass even without the guard.
+    """
+    from lintro.parsers.osv_scanner import OsvScannerIssue
+
+    plugin = _plugin()
+    plugin.set_options(exclude_patterns=["lockfile"])
+    issue = OsvScannerIssue(
+        file="lockfile",
+        line=0,
+        column=0,
+        message="",
+        vuln_id="GHSA-placeholder",
+    )
+
+    kept = plugin.filter_excluded_issues(
+        issues=[issue],
+        paths=[str(in_fixture_repo)],
+    )
+
+    assert_that(kept).is_length(1)
+
+
+def test_filter_keeps_empty_source(in_fixture_repo: Path) -> None:
+    """A finding with no source at all is kept.
+
+    Distinct from the sentinel case: an empty source short-circuits before the
+    sentinel comparison, so both paths need their own coverage.
+    """
     from lintro.parsers.osv_scanner import OsvScannerIssue
 
     plugin = _plugin()

--- a/tests/unit/tools/osv_scanner/test_exclusions.py
+++ b/tests/unit/tools/osv_scanner/test_exclusions.py
@@ -403,3 +403,105 @@ def test_execution_failure_still_fails_when_all_findings_excluded(
 
     assert_that(result.success).is_false()
     assert_that(result.parse_failures_count).is_equal_to(1)
+
+
+def test_relative_source_is_resolved_against_the_scan_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A relative source is made absolute against the scan root.
+
+    osv-scanner runs with ``cwd=scan_root`` and reports sources relative to it,
+    while ``should_exclude_path`` resolves relative paths with
+    ``os.path.abspath`` — against lintro's own working directory. Scanning a
+    project elsewhere would anchor the match on the wrong tree (#1725).
+
+    Asserts the path handed to the matcher directly: an end-to-end assertion on
+    kept/dropped can coincide via a different anchor and pass either way.
+
+    Args:
+        tmp_path: Temporary directory root.
+        monkeypatch: Fixture used to move the process working directory.
+    """
+    from unittest.mock import patch
+
+    from lintro.parsers.osv_scanner import OsvScannerIssue
+
+    scan_root = tmp_path / "target-project"
+    scan_root.mkdir()
+    elsewhere = tmp_path / "lintro-cwd"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    plugin = _plugin()
+    plugin.set_options(exclude_patterns=["vendor"])
+    issue = OsvScannerIssue(
+        file="vendor/bun.lock",
+        line=0,
+        column=0,
+        message="",
+        vuln_id="GHSA-vendor",
+    )
+
+    seen: dict[str, object] = {}
+
+    def _capture(*, path: str, exclude_patterns: object, anchors: object) -> bool:
+        seen["path"] = path
+        return False
+
+    with patch(
+        "lintro.tools.definitions.osv_scanner.should_exclude_path",
+        side_effect=_capture,
+    ):
+        plugin.filter_excluded_issues(
+            issues=[issue],
+            paths=[str(scan_root)],
+            scan_root=scan_root,
+        )
+
+    assert_that(seen.get("path")).is_equal_to(
+        str(scan_root / "vendor" / "bun.lock"),
+    )
+
+
+def test_absolute_source_is_left_untouched(tmp_path: Path) -> None:
+    """An absolute source is passed through unchanged.
+
+    Args:
+        tmp_path: Temporary directory root.
+    """
+    from unittest.mock import patch
+
+    from lintro.parsers.osv_scanner import OsvScannerIssue
+
+    scan_root = tmp_path / "target-project"
+    scan_root.mkdir()
+    absolute = str(tmp_path / "elsewhere" / "bun.lock")
+
+    plugin = _plugin()
+    plugin.set_options(exclude_patterns=["vendor"])
+    issue = OsvScannerIssue(
+        file=absolute,
+        line=0,
+        column=0,
+        message="",
+        vuln_id="GHSA-abs",
+    )
+
+    seen: dict[str, object] = {}
+
+    def _capture(*, path: str, exclude_patterns: object, anchors: object) -> bool:
+        seen["path"] = path
+        return False
+
+    with patch(
+        "lintro.tools.definitions.osv_scanner.should_exclude_path",
+        side_effect=_capture,
+    ):
+        plugin.filter_excluded_issues(
+            issues=[issue],
+            paths=[str(scan_root)],
+            scan_root=scan_root,
+        )
+
+    assert_that(seen.get("path")).is_equal_to(absolute)

--- a/tests/unit/tools/osv_scanner/test_exclusions.py
+++ b/tests/unit/tools/osv_scanner/test_exclusions.py
@@ -1,0 +1,373 @@
+"""Tests for osv_scanner exclusion handling (.lintro-ignore and --exclude).
+
+osv-scanner performs its own recursive lockfile discovery, so lintro applies
+its resolved exclusion set to the reported source paths. These tests cover
+both directory-level and lockfile-level patterns, and assert that the two
+entry points (``.lintro-ignore`` and ``--exclude``) behave identically
+(lgtm-hq/py-lintro#1725).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.models.core.tool_result import ToolResult
+from lintro.plugins.subprocess_executor import SubprocessResult
+from lintro.tools.definitions.osv_scanner import OsvScannerPlugin
+
+# Lockfiles laid out by the fixture repo, relative to the project root.
+_MAIN_LOCKFILE: str = "apps/web/bun.lock"
+_NESTED_LOCKFILES: tuple[str, ...] = (
+    ".claude/worktrees/agent-1/apps/web/bun.lock",
+    ".claude/worktrees/agent-2/apps/web/bun.lock",
+)
+
+
+def _result_for(source_path: str, vuln_id: str) -> dict[str, object]:
+    """Build a single osv-scanner JSON result block.
+
+    Args:
+        source_path: Absolute path of the lockfile the finding came from.
+        vuln_id: Vulnerability identifier to report.
+
+    Returns:
+        One entry of the osv-scanner ``results`` list.
+    """
+    return {
+        "source": {"path": source_path, "type": "lockfile"},
+        "packages": [
+            {
+                "package": {
+                    "name": "vite",
+                    "version": "5.0.0",
+                    "ecosystem": "npm",
+                },
+                "groups": [{"ids": [vuln_id], "max_severity": "HIGH"}],
+                "vulnerabilities": [{"id": vuln_id}],
+            },
+        ],
+    }
+
+
+def _payload(lockfiles: list[str]) -> str:
+    """Build an osv-scanner JSON report reporting one finding per lockfile.
+
+    Args:
+        lockfiles: Absolute lockfile paths to report findings for.
+
+    Returns:
+        Serialized osv-scanner JSON report.
+    """
+    return json.dumps(
+        {
+            "results": [
+                _result_for(path, f"GHSA-test-{index}")
+                for index, path in enumerate(lockfiles)
+            ],
+        },
+    )
+
+
+@pytest.fixture
+def fixture_repo(tmp_path: Path) -> Path:
+    """Create a project containing a nested checkout with its own lockfile.
+
+    Reproduces the finding-multiplication case: the same lockfile content is
+    present in the project and again inside each nested worktree.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+
+    Returns:
+        Path to the project root.
+    """
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n")
+    for relative in (_MAIN_LOCKFILE, *_NESTED_LOCKFILES):
+        lockfile = tmp_path / relative
+        lockfile.parent.mkdir(parents=True, exist_ok=True)
+        lockfile.write_text('{"lockfileVersion": 1}\n')
+    return tmp_path
+
+
+@pytest.fixture
+def in_fixture_repo(
+    fixture_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Path]:
+    """Change into the fixture repo so ignore-file discovery anchors there.
+
+    Args:
+        fixture_repo: The generated project root.
+        monkeypatch: Pytest monkeypatch fixture.
+
+    Yields:
+        Path: The project root, with it set as the working directory.
+    """
+    monkeypatch.chdir(fixture_repo)
+    yield fixture_repo
+
+
+def _plugin() -> OsvScannerPlugin:
+    """Build a plugin instance with its version check bypassed.
+
+    Returns:
+        A freshly constructed plugin, which resolves ``.lintro-ignore`` from
+        the current working directory at construction time.
+    """
+    return OsvScannerPlugin()
+
+
+def _run_check(
+    plugin: OsvScannerPlugin,
+    root: Path,
+    lockfiles: list[str],
+) -> ToolResult:
+    """Run ``check`` against a mocked osv-scanner report.
+
+    Args:
+        plugin: Plugin under test.
+        root: Project root passed as the scan path.
+        lockfiles: Project-relative lockfile paths to report findings for.
+
+    Returns:
+        The ToolResult produced by the plugin.
+    """
+    stdout = _payload([str(root / relative) for relative in lockfiles])
+    proc = SubprocessResult(
+        returncode=1,
+        stdout=stdout,
+        stderr="",
+        output=stdout,
+    )
+    with (
+        patch(
+            "lintro.tools.definitions.osv_scanner.verify_tool_version",
+            return_value=None,
+        ),
+        patch.object(
+            OsvScannerPlugin,
+            "_run_subprocess_result",
+            return_value=proc,
+        ),
+    ):
+        return plugin.check(
+            paths=[str(root)],
+            options={"check_suppressions": False},
+        )
+
+
+def _reported_files(result: ToolResult) -> list[str]:
+    """Extract the lockfile paths of the reported issues.
+
+    Args:
+        result: ToolResult from a check run.
+
+    Returns:
+        Sorted source paths of the surviving issues.
+    """
+    return sorted(issue.file for issue in (result.issues or []))
+
+
+def test_baseline_reports_every_lockfile(in_fixture_repo: Path) -> None:
+    """Without exclusions every discovered lockfile finding is reported."""
+    result = _run_check(
+        plugin=_plugin(),
+        root=in_fixture_repo,
+        lockfiles=[_MAIN_LOCKFILE, *_NESTED_LOCKFILES],
+    )
+
+    assert_that(result.issues_count).is_equal_to(3)
+    assert_that(result.success).is_false()
+
+
+def test_lintro_ignore_directory_excludes_nested_lockfiles(
+    in_fixture_repo: Path,
+) -> None:
+    """A directory pattern in .lintro-ignore drops that tree's findings."""
+    (in_fixture_repo / ".lintro-ignore").write_text(".claude\n")
+
+    result = _run_check(
+        plugin=_plugin(),
+        root=in_fixture_repo,
+        lockfiles=[_MAIN_LOCKFILE, *_NESTED_LOCKFILES],
+    )
+
+    assert_that(result.issues_count).is_equal_to(1)
+    assert_that(_reported_files(result)).is_equal_to(
+        [str(in_fixture_repo / _MAIN_LOCKFILE)],
+    )
+
+
+def test_lintro_ignore_comments_and_blanks_are_skipped(
+    in_fixture_repo: Path,
+) -> None:
+    """Comment and blank lines in .lintro-ignore do not affect filtering."""
+    (in_fixture_repo / ".lintro-ignore").write_text(
+        "# nested agent checkouts\n\n.claude\n",
+    )
+
+    result = _run_check(
+        plugin=_plugin(),
+        root=in_fixture_repo,
+        lockfiles=[_MAIN_LOCKFILE, *_NESTED_LOCKFILES],
+    )
+
+    assert_that(result.issues_count).is_equal_to(1)
+
+
+@pytest.mark.parametrize("pattern", ["bun.lock", "*.lock"])
+def test_lintro_ignore_lockfile_pattern_excludes_all_matches(
+    in_fixture_repo: Path,
+    pattern: str,
+) -> None:
+    """A file-level pattern in .lintro-ignore drops matching lockfiles.
+
+    Args:
+        in_fixture_repo: The generated project root, as the working directory.
+        pattern: File-level ignore pattern under test.
+    """
+    (in_fixture_repo / ".lintro-ignore").write_text(f"{pattern}\n")
+
+    result = _run_check(
+        plugin=_plugin(),
+        root=in_fixture_repo,
+        lockfiles=[_MAIN_LOCKFILE, *_NESTED_LOCKFILES],
+    )
+
+    assert_that(result.issues_count).is_equal_to(0)
+    # Nothing left to report, so the non-zero exit must not surface as a
+    # failed scan.
+    assert_that(result.success).is_true()
+
+
+def test_exclude_flag_matches_lintro_ignore(in_fixture_repo: Path) -> None:
+    """--exclude and .lintro-ignore produce an identical surviving set."""
+    flag_plugin = _plugin()
+    flag_plugin.set_options(exclude_patterns=[".claude"])
+    flag_result = _run_check(
+        plugin=flag_plugin,
+        root=in_fixture_repo,
+        lockfiles=[_MAIN_LOCKFILE, *_NESTED_LOCKFILES],
+    )
+
+    (in_fixture_repo / ".lintro-ignore").write_text(".claude\n")
+    ignore_result = _run_check(
+        plugin=_plugin(),
+        root=in_fixture_repo,
+        lockfiles=[_MAIN_LOCKFILE, *_NESTED_LOCKFILES],
+    )
+
+    assert_that(_reported_files(flag_result)).is_equal_to(
+        _reported_files(ignore_result),
+    )
+    assert_that(flag_result.issues_count).is_equal_to(ignore_result.issues_count)
+
+
+def test_exclude_flag_supports_lockfile_patterns(in_fixture_repo: Path) -> None:
+    """--exclude accepts file-level lockfile patterns too."""
+    plugin = _plugin()
+    plugin.set_options(exclude_patterns=["*.lock"])
+
+    result = _run_check(
+        plugin=plugin,
+        root=in_fixture_repo,
+        lockfiles=[_MAIN_LOCKFILE, *_NESTED_LOCKFILES],
+    )
+
+    assert_that(result.issues_count).is_equal_to(0)
+
+
+def test_unrelated_pattern_keeps_all_findings(in_fixture_repo: Path) -> None:
+    """An exclusion that matches nothing leaves every finding intact."""
+    (in_fixture_repo / ".lintro-ignore").write_text("vendor/\n")
+
+    result = _run_check(
+        plugin=_plugin(),
+        root=in_fixture_repo,
+        lockfiles=[_MAIN_LOCKFILE, *_NESTED_LOCKFILES],
+    )
+
+    assert_that(result.issues_count).is_equal_to(3)
+
+
+def test_filter_keeps_placeholder_source(in_fixture_repo: Path) -> None:
+    """Findings without a real source path are never filtered out."""
+    from lintro.parsers.osv_scanner import OsvScannerIssue
+
+    plugin = _plugin()
+    plugin.set_options(exclude_patterns=["*.lock"])
+    issue = OsvScannerIssue(
+        file="",
+        line=0,
+        column=0,
+        message="",
+        vuln_id="GHSA-placeholder",
+    )
+
+    kept = plugin.filter_excluded_issues(
+        issues=[issue],
+        paths=[str(in_fixture_repo)],
+    )
+
+    assert_that(kept).is_length(1)
+
+
+def test_filter_without_patterns_is_identity(in_fixture_repo: Path) -> None:
+    """With no exclusion patterns the issue list is returned unchanged."""
+    from lintro.parsers.osv_scanner import OsvScannerIssue
+
+    plugin = _plugin()
+    plugin.exclude_patterns = []
+    issue = OsvScannerIssue(
+        file=str(in_fixture_repo / _MAIN_LOCKFILE),
+        line=0,
+        column=0,
+        message="",
+        vuln_id="GHSA-none",
+    )
+
+    kept = plugin.filter_excluded_issues(
+        issues=[issue],
+        paths=[str(in_fixture_repo)],
+    )
+
+    assert_that(kept).is_length(1)
+
+
+def test_execution_failure_still_fails_when_all_findings_excluded(
+    in_fixture_repo: Path,
+) -> None:
+    """Unparseable output stays a failure even with exclusions configured."""
+    (in_fixture_repo / ".lintro-ignore").write_text("*.lock\n")
+    plugin = _plugin()
+    proc = SubprocessResult(
+        returncode=1,
+        stdout="connection refused",
+        stderr="",
+        output="connection refused",
+    )
+
+    with (
+        patch(
+            "lintro.tools.definitions.osv_scanner.verify_tool_version",
+            return_value=None,
+        ),
+        patch.object(
+            OsvScannerPlugin,
+            "_run_subprocess_result",
+            return_value=proc,
+        ),
+    ):
+        result = plugin.check(
+            paths=[str(in_fixture_repo)],
+            options={"check_suppressions": False},
+        )
+
+    assert_that(result.success).is_false()
+    assert_that(result.parse_failures_count).is_equal_to(1)

--- a/tests/unit/tools/osv_scanner/test_osv_scanner_plugin.py
+++ b/tests/unit/tools/osv_scanner/test_osv_scanner_plugin.py
@@ -784,3 +784,77 @@ def test_set_options_validates_check_suppressions(
     """set_options rejects non-boolean check_suppressions."""
     with pytest.raises(ValueError, match="check_suppressions must be a boolean"):
         osv_scanner_plugin.set_options(check_suppressions="yes")
+
+
+def test_suppressions_classified_when_probe_findings_are_all_excluded(
+    osv_scanner_plugin: OsvScannerPlugin,
+    tmp_path: Path,
+) -> None:
+    """A probe whose findings are all excluded still classifies suppressions.
+
+    osv-scanner exits non-zero whenever vulnerabilities exist, so a probe that
+    found only excluded findings looks identical to an unreadable probe if the
+    "no parseable output" guard is evaluated after exclusion filtering. That
+    conflation would skip classification entirely, so suppressions covering
+    excluded findings would never be reported stale — the opposite of the
+    exclusion contract (#1725).
+
+    Args:
+        osv_scanner_plugin: The plugin under test.
+        tmp_path: Temporary directory for the fixture project.
+    """
+    lockfile = tmp_path / "requirements.txt"
+    copy_sample(
+        tmp_path,
+        "tools",
+        "security",
+        "osv_scanner",
+        "osv_scanner_fixture_requests_2_32_3.txt",
+        dest_name=lockfile.name,
+    )
+
+    config = tmp_path / ".osv-scanner.toml"
+    config.write_text(
+        "[[IgnoredVulns]]\n"
+        'id = "GHSA-stale-1234"\n'
+        "ignoreUntil = 2027-12-31\n"
+        'reason = "Test suppression"\n',
+    )
+
+    # The probe finds a real vulnerability, but only inside an excluded path,
+    # and exits non-zero because a vulnerability exists.
+    probe_report = json.dumps(
+        {
+            "results": [
+                {
+                    "source": {"path": "vendor/requirements.txt"},
+                    "packages": [
+                        {
+                            "package": {"name": "requests", "version": "2.32.3"},
+                            "vulnerabilities": [{"id": "GHSA-excluded-9999"}],
+                            "groups": [{"ids": ["GHSA-excluded-9999"]}],
+                        },
+                    ],
+                },
+            ],
+        },
+    )
+
+    osv_scanner_plugin.set_options(exclude_patterns=["vendor"])
+
+    with patch.object(
+        osv_scanner_plugin,
+        "_run_subprocess_result",
+        side_effect=[
+            _proc(success=True),  # gating scan
+            _proc(success=False, stdout=probe_report),  # probe: excluded finding
+        ],
+    ):
+        result = osv_scanner_plugin.check([str(lockfile)], {})
+
+    assert_that(result.ai_metadata).is_not_none()
+    assert result.ai_metadata is not None  # narrow type for mypy
+    suppressions = result.ai_metadata["suppressions"]
+    assert_that(suppressions).is_length(1)
+    # The excluded finding must not count as evidence the suppression is live.
+    assert_that(suppressions[0]["status"]).is_equal_to("stale")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(osv_scanner): honor .lintro-ignore and --exclude patterns
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`osv_scanner` never consumed lintro's resolved exclusion set. Because osv-scanner
performs its own recursive lockfile discovery, neither `.lintro-ignore` entries nor
`--exclude` patterns had any effect — nested checkouts (`.claude/worktrees/*`)
multiplied every finding, and lockfile-level patterns like `bun.lock` / `*.lock` were
unexpressible.

The plugin now applies the resolved exclusion set (built-in defaults + `.lintro-ignore`
+ `--exclude`) to the lockfile paths osv-scanner reports, using the same gitignore
semantics (`should_exclude_path` / `resolve_exclude_anchors`) as file discovery. Both
entry points feed the same `self.exclude_patterns` list, so they are identical by
construction.

- Directory patterns (`.claude`, `vendor/`) drop every finding from that tree.
- File patterns (`bun.lock`, `*.lock`) suppress individual lockfiles.
- When all findings are excluded, osv-scanner's non-zero exit no longer surfaces as a
  failed scan — gated on a valid JSON payload so genuine execution errors still fail
  closed.
- The suppression-staleness probe is filtered too, so findings from ignored trees cannot
  keep a suppression looking Active.

### Design note

Findings are filtered by reported source path rather than by enumerating lockfiles and
passing explicit `-L` targets. Enumerating would mean re-implementing osv-scanner's
per-ecosystem lockfile discovery inside lintro; the first time upstream adds a format we
do not know about, that file silently drops out of a **security** scan. Filtering keeps
osv-scanner authoritative over discovery while still giving users a working lever. The
remaining cost is that ignored trees are still scanned (wall-clock only, not
correctness); a follow-up could prune them via `--experimental-exclude` once that flag
leaves experimental status.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1725

## Details

New `tests/unit/tools/osv_scanner/test_exclusions.py` (11 tests, assertpy, no classes),
with a fixture repo containing a nested checkout that reproduces finding multiplication:

- `.lintro-ignore` directory pattern excludes the nested tree's lockfiles
- `.lintro-ignore` `bun.lock` and `*.lock` (parametrized) exclude lockfiles, and the run
  reports success
- `--exclude` parity: identical surviving issue set vs. the same `.lintro-ignore` pattern
- comments/blank lines in `.lintro-ignore`, non-matching patterns, placeholder sources,
  and the empty-pattern identity case
- unparseable output still fails closed with `parse_failures_count == 1`

Full suite: `uv run pytest` → **7807 passed, 95 skipped**. (Two pre-existing local-env
failures deselected and unrelated to this change: `pip_audit` integration —
`ensurepip` SIGABRT in this sandbox — and `commitlint` integration — local commitlint
21.2.0 is below the 21.2.1 minimum.)

### Dogfood evidence

Real `osv-scanner` run against a scratch project with `app/requirements.txt` and a
nested copy at `.claude/worktrees/agent-1/app/requirements.txt`:

| Attempt                             | Findings |
| ----------------------------------- | -------- |
| baseline                            | 28       |
| `.lintro-ignore` = `.claude`        | 14       |
| `--exclude ".claude"`               | 14       |
| `.lintro-ignore` = `requirements.txt` | 0 (clean pass) |

`uv run lintro chk` on this repo: clean (health 100/100 for the touched tools;
`pip-audit` errors locally for the sandbox reason above).
