### PR TITLE
fix(ci): alarm on post-release version skew across PyPI, npm, and Homebrew (#1712)

### DIFF
--- a/.github/workflows/release-version-skew-audit.yml
+++ b/.github/workflows/release-version-skew-audit.yml
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Audit - Release Version Skew
+
+# Post-release version-agreement alarm (#1712, follow-up to #1702).
+#
+# A partially failed release leaves PyPI, npm and the Homebrew tap on different
+# versions while every visible check still reports success: on v0.91.24 the
+# binary build died, the npm publish skipped through its `needs:` chain (a
+# correct fail-safe) and Homebrew kept the old pin — and nothing alarmed. This
+# scheduled audit compares the three published channels and opens/pings the
+# deduplicated main-failure issue when they disagree.
+#
+# It is an alarm, never a gate: it does not block, retry or reorder the release
+# pipeline, and the deliberate `needs:` coupling in build-binary/publish-npm
+# stays untouched. Expected lag is suppressed by the script's settle window and
+# by the in-flight release check (the manual PyPI approval gate surfaces as a
+# `waiting` run, which is intentional and must not alarm).
+
+'on':
+  schedule:
+    # Daily at 05:15 UTC — after the nightly jobs, before EU morning.
+    - cron: '15 5 * * *'
+  workflow_dispatch:
+    inputs:
+      expected_version:
+        description: 'Version every channel must report (default: newest wins)'
+        required: false
+        type: string
+      settle_minutes:
+        description: 'Minutes of propagation lag to tolerate'
+        required: false
+        default: '120'
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: release-version-skew-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: 🔀 Release Version Skew Audit
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # sparse checkout of the audit script
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            pypi.org:443
+            registry.npmjs.org:443
+      - name: Checkout audit script
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: scripts/ci/check-release-version-skew.py
+          sparse-checkout-cone-mode: false
+      - name: Compare published channel versions
+        env:
+          # Read-only token: authenticates the release-run lookup that
+          # suppresses the alarm while a release is still in flight.
+          GITHUB_TOKEN: ${{ github.token }}
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+          SETTLE_MINUTES: ${{ inputs.settle_minutes || '120' }}
+        run: >-
+          python3 scripts/ci/check-release-version-skew.py
+          --settle-minutes "${SETTLE_MINUTES}"
+          --expected "${EXPECTED_VERSION}"
+
+  notify-failure:
+    needs: [audit]
+    # Main-only: a manual dispatch from a feature branch must not open or ping
+    # the main-failure issue for the release-version-skew key.
+    if: failure() && github.ref == 'refs/heads/main'
+    # Deduplicated failure issue (same mechanism as dogfood-nightly.yml): the
+    # first failure opens `fix(ci): main workflow failed: release-version-skew`,
+    # repeat failures comment on it instead of piling up one issue per run.
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-main-failure-notifier.yml@ee8484ca71db3a2c2c33da6128bbf2330fcd7c88 # v0.59.2
+    permissions:
+      actions: read # read workflow/job metadata for the failure context
+      contents: read # repository context for the issue body
+      issues: write # open or ping the deduplicated failure issue
+    with:
+      workflow-key: release-version-skew
+      tooling-ref: 'ee8484ca71db3a2c2c33da6128bbf2330fcd7c88' # v0.59.2

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -127,6 +127,7 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `run-ai-review.sh`                   | Dogfood `lintro review` on a PR using trusted base-branch lintro           | `PR_NUMBER=123 ./scripts/ci/run-ai-review.sh`                                               |
 | `enable_review_config.py`            | Enable AI review + cost cap in `.lintro-config.yaml` for a CI run          | `python3 scripts/ci/enable_review_config.py --help`                                         |
 | `classify-osv-results.py`            | Classify osv_scanner JSON as ok, vulns, or error for CI status             | `python3 scripts/ci/classify-osv-results.py osv-results.json`                               |
+| `check-release-version-skew.py`      | Alarm on post-release PyPI/npm/Homebrew version skew (#1712)               | `python3 scripts/ci/check-release-version-skew.py --help`                                   |
 | `classify-release-tag.py`            | Classify a release tag as stable or prerelease for publish gating          | `python3 scripts/ci/classify-release-tag.py v1.2.3`                                         |
 | `format-security-comment.py`         | Format lintro osv_scanner JSON as security PR comment markdown             | `python3 scripts/ci/format-security-comment.py osv-results.json`                            |
 | `format-changelog.py`                | Reflow generated `CHANGELOG.md` to lintro 88-col markdown                  | `python3 scripts/ci/format-changelog.py CHANGELOG.md`                                       |

--- a/scripts/ci/check-release-version-skew.py
+++ b/scripts/ci/check-release-version-skew.py
@@ -278,20 +278,29 @@ def release_pipeline_pending(
     repo: str,
     workflow: str,
     fetch: TextFetcher,
+    expected: str | None = None,
 ) -> bool:
-    """Return whether a release workflow run is still in flight.
+    """Return whether the release being audited is still in flight.
 
     PyPI publishes sit behind a manual approval gate, which surfaces as a
-    ``waiting`` run. While such a run exists the downstream channels are
-    expected to lag, so skew must not alarm.
+    ``waiting`` run. While such a run exists for *this* release the downstream
+    channels are expected to lag, so skew must not alarm.
+
+    The run must be correlated with ``expected``. A pending run for a different
+    version is not evidence about this one: the approval gate is manual, so a
+    release that is never approved stays ``waiting`` indefinitely and would
+    otherwise suppress the alarm for every later release, permanently. When
+    ``expected`` is None the correlation cannot be made and any pending run
+    suppresses, which is the conservative direction (no false alarm).
 
     Args:
         repo: Repository in ``owner/name`` form.
         workflow: Release workflow file name.
         fetch: Text fetcher used for the GitHub API request.
+        expected: Version under audit. Runs for other versions are ignored.
 
     Returns:
-        ``True`` when at least one recent run has not completed.
+        ``True`` when a recent run for ``expected`` has not completed.
 
     Raises:
         RuntimeError: If the GitHub API could not be queried or parsed.
@@ -309,9 +318,17 @@ def release_pipeline_pending(
     runs = payload.get("workflow_runs", [])
     if not isinstance(runs, list):
         raise RuntimeError("Unexpected GitHub API payload: workflow_runs missing")
-    return any(
-        isinstance(run, dict) and str(run.get("status", "")) in _PENDING_RUN_STATES
+    pending_runs = [
+        run
         for run in runs
+        if isinstance(run, dict) and str(run.get("status", "")) in _PENDING_RUN_STATES
+    ]
+    if expected is None:
+        return bool(pending_runs)
+    wanted = expected.strip().lstrip("vV")
+    return any(
+        str(run.get("head_branch", "")).strip().lstrip("vV") == wanted
+        for run in pending_runs
     )
 
 
@@ -467,6 +484,7 @@ def audit(
             repo=args.repo,
             workflow=args.release_workflow,
             fetch=fetch,
+            expected=expected,
         )
     except RuntimeError as exc:
         return EXIT_DEGRADED, (

--- a/scripts/ci/check-release-version-skew.py
+++ b/scripts/ci/check-release-version-skew.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+"""Alarm on post-release version skew across PyPI, npm and the Homebrew tap.
+
+A partially failed release (see #1702) can leave the published channels on
+different versions while every visible check still reports success: the npm
+publish skips through its ``needs:`` chain (a correct fail-safe), Homebrew keeps
+the previous pin, and PyPI moves on alone. Nothing surfaced that skew, so it
+stayed invisible until somebody compared the registries by hand.
+
+This script is that comparison, automated. It resolves the current version of
+each published channel and fails loudly when they disagree:
+
+    - PyPI: ``https://pypi.org/pypi/<package>/json`` -> ``info.version``
+    - npm: ``https://registry.npmjs.org/<package>`` -> ``dist-tags.latest``
+    - Homebrew: the tap's ``Formula/lintro.rb`` -> ``version "..."``
+
+It is an alarm, never a gate: it does not block, retry, or reorder the release
+pipeline. Two suppression rules keep expected propagation lag quiet:
+
+    1. **Settle window** — a leader version first published less than
+       ``--settle-minutes`` ago is still propagating, so skew is expected.
+    2. **Release in flight** — PyPI publishes pass through a manual approval
+       gate, so a ``waiting``/``queued``/``in_progress`` run of the release
+       workflow means the pipeline has simply not finished yet. Homebrew tap lag
+       during that window is normal and must not alarm.
+
+Usage:
+    python3 scripts/ci/check-release-version-skew.py [options]
+
+Exit codes:
+    0 — All channels agree, or the skew is inside a suppression window.
+    1 — Version skew: the channels disagree past the suppression windows.
+    2 — Check degraded: a channel (or the GitHub API) was unreachable, so no
+        verdict could be reached. Distinct from a real mismatch on purpose.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+DEFAULT_PYPI_PACKAGE = "lintro"
+DEFAULT_NPM_PACKAGE = "@lgtm-hq/lintro"
+DEFAULT_TAP_REPO = "lgtm-hq/homebrew-tap"
+DEFAULT_TAP_FORMULA = "Formula/lintro.rb"
+DEFAULT_TAP_BRANCH = "main"
+DEFAULT_REPO = "lgtm-hq/py-lintro"
+DEFAULT_RELEASE_WORKFLOW = "publish-pypi-on-tag.yml"
+DEFAULT_SETTLE_MINUTES = 120
+DEFAULT_TIMEOUT_SECONDS = 30
+
+EXIT_OK = 0
+EXIT_SKEW = 1
+EXIT_DEGRADED = 2
+
+# GitHub Actions run states that mean "the release pipeline has not finished".
+# ``waiting`` is the manual PyPI approval gate: intentional, never an alarm.
+_PENDING_RUN_STATES = frozenset(
+    {"queued", "in_progress", "waiting", "pending", "requested", "action_required"},
+)
+
+_FORMULA_VERSION = re.compile(r'^\s*version\s+"([^"]+)"', re.MULTILINE)
+_VERSION_CORE = re.compile(r"^(\d+(?:\.\d+)*)(.*)$")
+
+
+class TextFetcher(Protocol):
+    """Callable that returns the decoded body of a URL."""
+
+    def __call__(self, *, url: str) -> str:
+        """Fetch ``url`` and return its body as text.
+
+        Args:
+            url: Absolute URL to fetch.
+
+        Returns:
+            The decoded response body.
+        """
+        ...  # pragma: no cover - protocol definition
+
+
+@dataclass(frozen=True)
+class ChannelStatus:
+    """Resolved state of a single publication channel.
+
+    Attributes:
+        name: Human-readable channel name (``PyPI``, ``npm``, ``Homebrew``).
+        version: The channel's current version, or ``None`` when unreachable.
+        published_at: When that version first appeared, when the channel
+            exposes a timestamp.
+        error: Failure detail when the channel could not be resolved.
+    """
+
+    name: str
+    version: str | None = None
+    published_at: datetime | None = None
+    error: str | None = None
+
+    @property
+    def reachable(self) -> bool:
+        """Return whether the channel produced a usable version."""
+        return self.error is None and self.version is not None
+
+
+def fetch_text(*, url: str, timeout: int = DEFAULT_TIMEOUT_SECONDS) -> str:
+    """Fetch ``url`` over HTTPS and return the decoded body.
+
+    Args:
+        url: Absolute ``https://`` URL to fetch.
+        timeout: Socket timeout in seconds.
+
+    Returns:
+        The decoded response body.
+
+    Raises:
+        ValueError: If ``url`` is not an ``https://`` URL.
+    """
+    if not url.startswith("https://"):
+        raise ValueError(f"Refusing to fetch non-HTTPS URL: {url}")
+    # The https:// scheme is asserted above, so no file:/custom scheme can be
+    # opened; the URLs are built from CLI defaults, not from untrusted input.
+    request = (
+        urllib.request.Request(  # noqa: S310 — HTTPS-only validated above  # nosec B310
+            url,
+            headers={"User-Agent": "py-lintro-version-skew-audit"},
+        )
+    )
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token and urllib.parse.urlsplit(url).hostname == "api.github.com":
+        request.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected  # nosec B310
+        request,
+        timeout=timeout,
+    ) as response:
+        return str(response.read().decode("utf-8"))
+
+
+def _parse_timestamp(*, value: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp, tolerating a trailing ``Z``."""
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def version_sort_key(*, version: str) -> tuple[tuple[int, ...], int, str]:
+    """Return a sort key ordering release versions newest-last.
+
+    Numeric components compare numerically; a bare ``X.Y.Z`` release sorts
+    after any prerelease suffix of the same core (``0.9.1`` > ``0.9.1rc1``).
+
+    Args:
+        version: A version string, with or without a leading ``v``.
+
+    Returns:
+        A tuple usable as a ``sorted``/``max`` key.
+    """
+    core = version.strip().lstrip("vV")
+    match = _VERSION_CORE.match(core)
+    if match is None:
+        return ((), 0, core)
+    numbers = tuple(int(part) for part in match.group(1).split("."))
+    suffix = match.group(2)
+    return (numbers, 0 if suffix else 1, suffix)
+
+
+def resolve_pypi(
+    *,
+    package: str,
+    fetch: TextFetcher,
+) -> ChannelStatus:
+    """Resolve the current PyPI version of ``package``.
+
+    Args:
+        package: PyPI project name.
+        fetch: Text fetcher used for the registry request.
+
+    Returns:
+        The resolved channel status.
+    """
+    url = f"https://pypi.org/pypi/{package}/json"
+    try:
+        payload: dict[str, Any] = json.loads(fetch(url=url))
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return ChannelStatus(name="PyPI", error=f"{type(exc).__name__}: {exc}")
+    version = str(payload.get("info", {}).get("version", "")).strip()
+    if not version:
+        return ChannelStatus(name="PyPI", error="no info.version in PyPI response")
+    uploads = [
+        _parse_timestamp(value=entry.get("upload_time_iso_8601"))
+        for entry in payload.get("urls", [])
+        if isinstance(entry, dict)
+    ]
+    stamps = [stamp for stamp in uploads if stamp is not None]
+    return ChannelStatus(
+        name="PyPI",
+        version=version,
+        published_at=min(stamps) if stamps else None,
+    )
+
+
+def resolve_npm(
+    *,
+    package: str,
+    fetch: TextFetcher,
+) -> ChannelStatus:
+    """Resolve the current ``latest`` dist-tag version of an npm package.
+
+    Args:
+        package: npm package name (may be scoped).
+        fetch: Text fetcher used for the registry request.
+
+    Returns:
+        The resolved channel status.
+    """
+    url = f"https://registry.npmjs.org/{urllib.parse.quote(package, safe='')}"
+    try:
+        payload: dict[str, Any] = json.loads(fetch(url=url))
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return ChannelStatus(name="npm", error=f"{type(exc).__name__}: {exc}")
+    version = str(payload.get("dist-tags", {}).get("latest", "")).strip()
+    if not version:
+        return ChannelStatus(name="npm", error="no dist-tags.latest in npm response")
+    times = payload.get("time", {})
+    published_at = _parse_timestamp(
+        value=times.get(version) if isinstance(times, dict) else None,
+    )
+    return ChannelStatus(name="npm", version=version, published_at=published_at)
+
+
+def resolve_homebrew(
+    *,
+    repo: str,
+    formula: str,
+    branch: str,
+    fetch: TextFetcher,
+) -> ChannelStatus:
+    """Resolve the version pinned by the Homebrew tap formula.
+
+    Args:
+        repo: Tap repository in ``owner/name`` form.
+        formula: Path to the formula inside the tap.
+        branch: Tap branch to read.
+        fetch: Text fetcher used for the raw file request.
+
+    Returns:
+        The resolved channel status.
+    """
+    url = f"https://raw.githubusercontent.com/{repo}/{branch}/{formula}"
+    try:
+        body = fetch(url=url)
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return ChannelStatus(name="Homebrew", error=f"{type(exc).__name__}: {exc}")
+    match = _FORMULA_VERSION.search(body)
+    if match is None:
+        return ChannelStatus(
+            name="Homebrew",
+            error=f"no version stanza found in {formula}",
+        )
+    return ChannelStatus(name="Homebrew", version=match.group(1).strip())
+
+
+def release_pipeline_pending(
+    *,
+    repo: str,
+    workflow: str,
+    fetch: TextFetcher,
+) -> bool:
+    """Return whether a release workflow run is still in flight.
+
+    PyPI publishes sit behind a manual approval gate, which surfaces as a
+    ``waiting`` run. While such a run exists the downstream channels are
+    expected to lag, so skew must not alarm.
+
+    Args:
+        repo: Repository in ``owner/name`` form.
+        workflow: Release workflow file name.
+        fetch: Text fetcher used for the GitHub API request.
+
+    Returns:
+        ``True`` when at least one recent run has not completed.
+
+    Raises:
+        RuntimeError: If the GitHub API could not be queried or parsed.
+    """
+    url = (
+        f"https://api.github.com/repos/{repo}/actions/workflows/"
+        f"{workflow}/runs?per_page=10"
+    )
+    try:
+        payload: dict[str, Any] = json.loads(fetch(url=url))
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        raise RuntimeError(
+            f"GitHub API unreachable: {type(exc).__name__}: {exc}",
+        ) from exc
+    runs = payload.get("workflow_runs", [])
+    if not isinstance(runs, list):
+        raise RuntimeError("Unexpected GitHub API payload: workflow_runs missing")
+    return any(
+        isinstance(run, dict) and str(run.get("status", "")) in _PENDING_RUN_STATES
+        for run in runs
+    )
+
+
+def leader_version(*, channels: list[ChannelStatus]) -> str | None:
+    """Return the newest version reported by any reachable channel."""
+    versions = [c.version for c in channels if c.reachable and c.version]
+    if not versions:
+        return None
+    return max(versions, key=lambda value: version_sort_key(version=value))
+
+
+def leader_published_at(
+    *,
+    channels: list[ChannelStatus],
+    leader: str,
+) -> datetime | None:
+    """Return when ``leader`` first appeared on any channel that reports it."""
+    stamps = [
+        channel.published_at
+        for channel in channels
+        if channel.version == leader and channel.published_at is not None
+    ]
+    return min(stamps) if stamps else None
+
+
+def render_table(*, channels: list[ChannelStatus], expected: str | None) -> str:
+    """Render a per-channel status table as Markdown.
+
+    Args:
+        channels: Resolved channel statuses.
+        expected: The version every channel should report, when known.
+
+    Returns:
+        A Markdown table.
+    """
+    rows = ["| Channel | Version | Status |", "| --- | --- | --- |"]
+    for channel in channels:
+        if channel.error is not None:
+            rows.append(f"| {channel.name} | — | unreachable: {channel.error} |")
+            continue
+        if expected is None or channel.version == expected:
+            status = "ok"
+        else:
+            status = f"SKEW (expected {expected})"
+        rows.append(f"| {channel.name} | {channel.version} | {status} |")
+    return "\n".join(rows)
+
+
+def _write_summary(*, text: str) -> None:
+    """Append ``text`` to the GitHub step summary when running in Actions."""
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary:
+        return
+    with Path(summary).open("a", encoding="utf-8") as handle:
+        handle.write(f"{text}\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Alarm on post-release version skew across PyPI, npm and Homebrew."
+        ),
+        epilog="Exit codes: 0 agree/settling, 1 version skew, 2 check degraded.",
+    )
+    parser.add_argument(
+        "--expected",
+        default=None,
+        help=(
+            "Version every channel must report (default, or when empty: the "
+            "newest version any channel reports wins)."
+        ),
+    )
+    parser.add_argument("--pypi-package", default=DEFAULT_PYPI_PACKAGE)
+    parser.add_argument("--npm-package", default=DEFAULT_NPM_PACKAGE)
+    parser.add_argument("--tap-repo", default=DEFAULT_TAP_REPO)
+    parser.add_argument("--tap-formula", default=DEFAULT_TAP_FORMULA)
+    parser.add_argument("--tap-branch", default=DEFAULT_TAP_BRANCH)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--release-workflow", default=DEFAULT_RELEASE_WORKFLOW)
+    parser.add_argument(
+        "--settle-minutes",
+        type=int,
+        default=DEFAULT_SETTLE_MINUTES,
+        help=(
+            "Suppress skew while the newest version is younger than this "
+            f"(default: {DEFAULT_SETTLE_MINUTES})."
+        ),
+    )
+    return parser
+
+
+def audit(
+    *,
+    args: argparse.Namespace,
+    fetch: TextFetcher,
+    now: datetime | None = None,
+) -> tuple[int, str]:
+    """Run the version-skew audit and return an exit code and report.
+
+    Args:
+        args: Parsed command-line arguments.
+        fetch: Text fetcher used for every network request.
+        now: Current time, injectable for tests.
+
+    Returns:
+        A ``(exit_code, report)`` pair.
+    """
+    moment = now or datetime.now(tz=UTC)
+    # An empty ``--expected`` (workflow dispatch with the input left blank) is
+    # the same as omitting it: fall back to the newest channel version.
+    requested = args.expected or None
+    channels = [
+        resolve_pypi(package=args.pypi_package, fetch=fetch),
+        resolve_npm(package=args.npm_package, fetch=fetch),
+        resolve_homebrew(
+            repo=args.tap_repo,
+            formula=args.tap_formula,
+            branch=args.tap_branch,
+            fetch=fetch,
+        ),
+    ]
+
+    unreachable = [channel for channel in channels if not channel.reachable]
+    if unreachable:
+        names = ", ".join(channel.name for channel in unreachable)
+        table = render_table(channels=channels, expected=requested)
+        return EXIT_DEGRADED, (
+            f"## Version skew audit: degraded\n\n"
+            f"Could not resolve {names}; no skew verdict was reached.\n\n{table}"
+        )
+
+    expected = requested or leader_version(channels=channels)
+    table = render_table(channels=channels, expected=expected)
+    skewed = [channel for channel in channels if channel.version != expected]
+    if not skewed:
+        return EXIT_OK, f"## Version skew audit: all channels agree\n\n{table}"
+
+    if expected is not None:
+        published = leader_published_at(channels=channels, leader=expected)
+        if published is not None:
+            age_minutes = (moment - published).total_seconds() / 60
+            if age_minutes < args.settle_minutes:
+                return EXIT_OK, (
+                    f"## Version skew audit: settling\n\n"
+                    f"`{expected}` is {age_minutes:.0f}m old "
+                    f"(settle window {args.settle_minutes}m); "
+                    f"channel lag is still expected.\n\n{table}"
+                )
+
+    try:
+        pending = release_pipeline_pending(
+            repo=args.repo,
+            workflow=args.release_workflow,
+            fetch=fetch,
+        )
+    except RuntimeError as exc:
+        return EXIT_DEGRADED, (
+            f"## Version skew audit: degraded\n\n"
+            f"Channels disagree but the release-pipeline state could not be "
+            f"confirmed ({exc}), so no alarm was raised.\n\n{table}"
+        )
+    if pending:
+        return EXIT_OK, (
+            f"## Version skew audit: release in flight\n\n"
+            f"A `{args.release_workflow}` run has not completed (the PyPI "
+            f"approval gate is a `waiting` run); channel lag is expected.\n\n"
+            f"{table}"
+        )
+
+    lagging = ", ".join(f"{c.name}={c.version}" for c in skewed)
+    return EXIT_SKEW, (
+        f"## Version skew audit: FAILED\n\n"
+        f"Published channels disagree past the settle window. "
+        f"Expected `{expected}`; lagging: {lagging}.\n\n{table}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the version-skew audit.
+
+    Args:
+        argv: Command-line arguments, defaulting to ``sys.argv[1:]``.
+
+    Returns:
+        The process exit code.
+    """
+    args = build_parser().parse_args(argv)
+    exit_code, report = audit(args=args, fetch=fetch_text)
+    print(report)
+    _write_summary(text=report)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/ci/test_check_release_version_skew.py
+++ b/tests/scripts/ci/test_check_release_version_skew.py
@@ -74,9 +74,27 @@ def _formula_body(*, version: str) -> str:
     )
 
 
-def _runs_body(*, statuses: list[str]) -> str:
-    """Build a stub GitHub workflow-runs payload."""
-    return json.dumps({"workflow_runs": [{"status": status} for status in statuses]})
+def _runs_body(*, statuses: list[str], version: str = "1.2.3") -> str:
+    """Build a stub GitHub workflow-runs payload.
+
+    Runs are tagged with ``version`` because suppression is correlated with the
+    release under audit: a pending run for some *other* version is not evidence
+    about this one (#1712 review).
+
+    Args:
+        statuses: Run statuses, newest first.
+        version: Tag the runs belong to, without the ``v`` prefix.
+
+    Returns:
+        A JSON payload shaped like the GitHub workflow-runs API.
+    """
+    return json.dumps(
+        {
+            "workflow_runs": [
+                {"status": status, "head_branch": f"v{version}"} for status in statuses
+            ],
+        },
+    )
 
 
 def _fetcher(
@@ -310,3 +328,96 @@ def test_main_writes_step_summary(
     )
     assert_that(module.main([])).is_equal_to(0)
     assert_that(summary.read_text(encoding="utf-8")).contains("all channels agree")
+
+
+def test_pending_run_for_another_version_does_not_suppress() -> None:
+    """A pending run for a different release must not suppress this audit.
+
+    The PyPI approval gate is manual, so a release that is never approved sits
+    in ``waiting`` indefinitely. Treating any recent pending run as evidence
+    would let that one stale run suppress the skew alarm for every subsequent
+    release, permanently (#1712 review).
+    """
+    module = _load_module()
+    payload = json.dumps(
+        {
+            "workflow_runs": [
+                {"status": "waiting", "head_branch": "v0.91.48"},
+                {"status": "completed", "head_branch": "v0.91.47"},
+            ],
+        },
+    )
+
+    pending = module.release_pipeline_pending(
+        repo="lgtm-hq/py-lintro",
+        workflow="publish-pypi-on-tag.yml",
+        fetch=lambda url: payload,
+        expected="0.91.47",
+    )
+
+    assert_that(pending).is_false()
+
+
+def test_pending_run_for_the_audited_version_suppresses() -> None:
+    """The release under audit still publishing is expected lag, not skew."""
+    module = _load_module()
+    payload = json.dumps(
+        {
+            "workflow_runs": [
+                {"status": "waiting", "head_branch": "v0.91.48"},
+            ],
+        },
+    )
+
+    pending = module.release_pipeline_pending(
+        repo="lgtm-hq/py-lintro",
+        workflow="publish-pypi-on-tag.yml",
+        fetch=lambda url: payload,
+        expected="0.91.48",
+    )
+
+    assert_that(pending).is_true()
+
+
+def test_pending_correlation_without_expected_is_conservative() -> None:
+    """With no version to correlate against, any pending run suppresses.
+
+    Failing towards suppression avoids a false alarm when the audit has no
+    expected version to reason about.
+    """
+    module = _load_module()
+    payload = json.dumps(
+        {"workflow_runs": [{"status": "waiting", "head_branch": "v0.91.48"}]},
+    )
+
+    pending = module.release_pipeline_pending(
+        repo="lgtm-hq/py-lintro",
+        workflow="publish-pypi-on-tag.yml",
+        fetch=lambda url: payload,
+        expected=None,
+    )
+
+    assert_that(pending).is_true()
+
+
+def test_stale_waiting_run_for_older_release_still_alarms(module: Any) -> None:
+    """A never-approved older release must not mask skew in a later one.
+
+    End-to-end counterpart of the correlation unit tests: the PyPI gate is
+    manual, so an unapproved run stays ``waiting`` forever. Before correlation
+    that single run suppressed every subsequent audit (#1712 review).
+    """
+    code, report = module.audit(
+        args=_args(module),
+        fetch=_fetcher(
+            pypi=_pypi_body(version="1.2.2"),
+            npm=_npm_body(version="1.2.3"),
+            formula=_formula_body(version="1.2.3"),
+            # Waiting run belongs to an unrelated, older tag.
+            runs=_runs_body(statuses=["waiting"], version="0.9.9"),
+        ),
+        now=NOW,
+    )
+
+    assert_that(code).is_equal_to(1)
+    assert_that(report).contains("FAILED")

--- a/tests/scripts/ci/test_check_release_version_skew.py
+++ b/tests/scripts/ci/test_check_release_version_skew.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+"""Tests for the post-release version-skew audit script (#1712)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+from assertpy import assert_that
+
+ROOT = Path(__file__).resolve().parents[3]
+SKEW_SCRIPT = ROOT / "scripts" / "ci" / "check-release-version-skew.py"
+
+NOW = datetime(2026, 7, 25, 12, 0, tzinfo=UTC)
+OLD = (NOW - timedelta(days=2)).isoformat().replace("+00:00", "Z")
+RECENT = (NOW - timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+
+
+def _load_module() -> Any:
+    """Load the hyphenated audit script as an importable module."""
+    spec = importlib.util.spec_from_file_location(
+        "check_release_version_skew",
+        SKEW_SCRIPT,
+    )
+    assert_that(spec).is_not_none()
+    assert spec is not None  # narrow type for mypy
+    assert spec.loader is not None  # narrow type for mypy
+    module = importlib.util.module_from_spec(spec)
+    # Register before executing: the module defines a dataclass, and
+    # ``dataclasses`` resolves string annotations through ``sys.modules``.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def module() -> Any:
+    """Return the loaded audit module."""
+    return _load_module()
+
+
+def _pypi_body(*, version: str, uploaded: str = OLD) -> str:
+    """Build a stub PyPI JSON payload."""
+    return json.dumps(
+        {
+            "info": {"version": version},
+            "urls": [{"upload_time_iso_8601": uploaded}],
+        },
+    )
+
+
+def _npm_body(*, version: str, published: str = OLD) -> str:
+    """Build a stub npm registry JSON payload."""
+    return json.dumps({"dist-tags": {"latest": version}, "time": {version: published}})
+
+
+def _formula_body(*, version: str) -> str:
+    """Build a stub Homebrew formula body."""
+    return "\n".join(
+        [
+            "class Lintro < Formula",
+            '  desc "Unified CLI"',
+            f'  version "{version}"',
+            '  license "MIT"',
+            "end",
+        ],
+    )
+
+
+def _runs_body(*, statuses: list[str]) -> str:
+    """Build a stub GitHub workflow-runs payload."""
+    return json.dumps({"workflow_runs": [{"status": status} for status in statuses]})
+
+
+def _fetcher(
+    *,
+    pypi: str | Exception,
+    npm: str | Exception,
+    formula: str | Exception,
+    runs: str | Exception | None = None,
+) -> Callable[..., str]:
+    """Build a stub fetcher routing by URL host/path."""
+
+    def fetch(*, url: str) -> str:
+        if "pypi.org" in url:
+            response: str | Exception | None = pypi
+        elif "registry.npmjs.org" in url:
+            response = npm
+        elif "raw.githubusercontent.com" in url:
+            response = formula
+        elif "api.github.com" in url:
+            response = runs if runs is not None else _runs_body(statuses=["completed"])
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected URL: {url}")
+        if isinstance(response, Exception):
+            raise response
+        return str(response)
+
+    return fetch
+
+
+def _args(module: Any, *extra: str) -> Any:
+    """Parse default CLI arguments with optional overrides."""
+    return module.build_parser().parse_args(list(extra))
+
+
+def test_all_channels_agree_exits_zero(module: Any) -> None:
+    """Matching versions on every channel produce no alarm."""
+    code, report = module.audit(
+        args=_args(module),
+        fetch=_fetcher(
+            pypi=_pypi_body(version="1.2.3"),
+            npm=_npm_body(version="1.2.3"),
+            formula=_formula_body(version="1.2.3"),
+        ),
+        now=NOW,
+    )
+    assert_that(code).is_equal_to(0)
+    assert_that(report).contains("all channels agree")
+
+
+@pytest.mark.parametrize(
+    ("lagging_channel", "versions"),
+    [
+        ("npm", {"pypi": "1.2.3", "npm": "1.2.2", "formula": "1.2.3"}),
+        ("Homebrew", {"pypi": "1.2.3", "npm": "1.2.3", "formula": "1.2.2"}),
+        ("PyPI", {"pypi": "1.2.2", "npm": "1.2.3", "formula": "1.2.3"}),
+    ],
+)
+def test_single_channel_skew_exits_one(
+    module: Any,
+    lagging_channel: str,
+    versions: dict[str, str],
+) -> None:
+    """A lagging channel past the settle window alarms with its own row."""
+    code, report = module.audit(
+        args=_args(module),
+        fetch=_fetcher(
+            pypi=_pypi_body(version=versions["pypi"]),
+            npm=_npm_body(version=versions["npm"]),
+            formula=_formula_body(version=versions["formula"]),
+        ),
+        now=NOW,
+    )
+    assert_that(code).is_equal_to(1)
+    assert_that(report).contains("FAILED")
+    assert_that(report).contains(f"{lagging_channel}=1.2.2")
+    assert_that(report).contains("SKEW (expected 1.2.3)")
+
+
+@pytest.mark.parametrize("channel", ["pypi", "npm", "formula"])
+def test_unreachable_channel_exits_two(module: Any, channel: str) -> None:
+    """A registry outage is reported distinctly from a version mismatch."""
+    bodies: dict[str, Any] = {
+        "pypi": _pypi_body(version="1.2.3"),
+        "npm": _npm_body(version="1.2.3"),
+        "formula": _formula_body(version="1.2.3"),
+    }
+    bodies[channel] = OSError("connection reset")
+    code, report = module.audit(args=_args(module), fetch=_fetcher(**bodies), now=NOW)
+    assert_that(code).is_equal_to(2)
+    assert_that(report).contains("degraded")
+    assert_that(report).contains("unreachable")
+
+
+def test_malformed_payload_is_unreachable_not_skew(module: Any) -> None:
+    """A formula without a version stanza degrades rather than alarms."""
+    code, report = module.audit(
+        args=_args(module),
+        fetch=_fetcher(
+            pypi=_pypi_body(version="1.2.3"),
+            npm=_npm_body(version="1.2.3"),
+            formula="class Lintro < Formula\nend\n",
+        ),
+        now=NOW,
+    )
+    assert_that(code).is_equal_to(2)
+    assert_that(report).contains("Homebrew")
+
+
+def test_recent_release_is_inside_settle_window(module: Any) -> None:
+    """Skew on a just-published version is suppressed as propagation lag."""
+    code, report = module.audit(
+        args=_args(module),
+        fetch=_fetcher(
+            pypi=_pypi_body(version="1.2.3", uploaded=RECENT),
+            npm=_npm_body(version="1.2.2"),
+            formula=_formula_body(version="1.2.2"),
+        ),
+        now=NOW,
+    )
+    assert_that(code).is_equal_to(0)
+    assert_that(report).contains("settling")
+
+
+def test_settle_window_is_configurable(module: Any) -> None:
+    """A shorter settle window lets recent skew alarm."""
+    code, report = module.audit(
+        args=_args(module, "--settle-minutes", "1"),
+        fetch=_fetcher(
+            pypi=_pypi_body(version="1.2.3", uploaded=RECENT),
+            npm=_npm_body(version="1.2.2"),
+            formula=_formula_body(version="1.2.2"),
+        ),
+        now=NOW,
+    )
+    assert_that(code).is_equal_to(1)
+    assert_that(report).contains("FAILED")
+
+
+@pytest.mark.parametrize("status", ["waiting", "queued", "in_progress"])
+def test_pending_release_run_suppresses_alarm(module: Any, status: str) -> None:
+    """The manual PyPI approval gate (a waiting run) must never alarm."""
+    code, report = module.audit(
+        args=_args(module),
+        fetch=_fetcher(
+            pypi=_pypi_body(version="1.2.2"),
+            npm=_npm_body(version="1.2.3"),
+            formula=_formula_body(version="1.2.3"),
+            runs=_runs_body(statuses=[status, "completed"]),
+        ),
+        now=NOW,
+    )
+    assert_that(code).is_equal_to(0)
+    assert_that(report).contains("release in flight")
+
+
+def test_github_api_outage_degrades_instead_of_alarming(module: Any) -> None:
+    """An unconfirmable pipeline state degrades rather than firing a false alarm."""
+    code, report = module.audit(
+        args=_args(module),
+        fetch=_fetcher(
+            pypi=_pypi_body(version="1.2.3"),
+            npm=_npm_body(version="1.2.2"),
+            formula=_formula_body(version="1.2.3"),
+            runs=OSError("api down"),
+        ),
+        now=NOW,
+    )
+    assert_that(code).is_equal_to(2)
+    assert_that(report).contains("release-pipeline state could not be confirmed")
+
+
+def test_expected_version_overrides_leader(module: Any) -> None:
+    """An explicit expected version alarms even when all channels agree."""
+    code, report = module.audit(
+        args=_args(module, "--expected", "1.3.0"),
+        fetch=_fetcher(
+            pypi=_pypi_body(version="1.2.3"),
+            npm=_npm_body(version="1.2.3"),
+            formula=_formula_body(version="1.2.3"),
+        ),
+        now=NOW,
+    )
+    assert_that(code).is_equal_to(1)
+    assert_that(report).contains("Expected `1.3.0`")
+
+
+@pytest.mark.parametrize(
+    ("lower", "higher"),
+    [
+        ("0.9.9", "0.10.0"),
+        ("1.2.3", "1.2.10"),
+        ("1.2.3rc1", "1.2.3"),
+        ("v1.2.3", "1.2.4"),
+    ],
+)
+def test_version_sort_key_orders_releases(
+    module: Any,
+    lower: str,
+    higher: str,
+) -> None:
+    """Version ordering is numeric and treats prereleases as older."""
+    assert_that(
+        module.version_sort_key(version=lower)
+        < module.version_sort_key(version=higher),
+    ).is_true()
+
+
+def test_fetch_text_rejects_non_https(module: Any) -> None:
+    """Only HTTPS URLs may be fetched."""
+    assert_that(module.fetch_text).raises(ValueError).when_called_with(
+        url="http://pypi.org/pypi/lintro/json",
+    )
+
+
+def test_main_writes_step_summary(
+    module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The report is appended to the GitHub step summary when set."""
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    monkeypatch.setattr(
+        module,
+        "fetch_text",
+        _fetcher(
+            pypi=_pypi_body(version="1.2.3"),
+            npm=_npm_body(version="1.2.3"),
+            formula=_formula_body(version="1.2.3"),
+        ),
+    )
+    assert_that(module.main([])).is_equal_to(0)
+    assert_that(summary.read_text(encoding="utf-8")).contains("all channels agree")

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -2342,3 +2342,69 @@ def test_code_quality_gate_sparse_checkout_covers_gate_scripts() -> None:
         "scripts/ci/is-infra-flake-failure.sh",
     ):
         assert_that(sparse).contains(script)
+
+
+# --- Release version-skew audit wiring (#1712) ------------------------------
+
+_SKEW_WORKFLOW = "release-version-skew-audit.yml"
+_SKEW_SCRIPT = "scripts/ci/check-release-version-skew.py"
+
+
+def test_version_skew_audit_runs_on_schedule_and_dispatch() -> None:
+    """The skew audit is a scheduled backstop, also runnable on demand.
+
+    Propagation lag means the settle window matters more than immediacy, so
+    the alarm runs as a periodic audit rather than inline in the release run.
+    """
+    workflow = _load_workflow(name=_SKEW_WORKFLOW)
+    triggers = workflow["on"]
+    assert_that(triggers).contains_key("schedule")
+    assert_that(triggers).contains_key("workflow_dispatch")
+    assert_that(triggers["schedule"]).is_not_empty()
+    assert_that(workflow["permissions"]).is_equal_to({})
+
+
+def test_version_skew_audit_invokes_the_checked_in_script() -> None:
+    """The audit job calls the dedicated script, not inline shell logic."""
+    workflow = _load_workflow(name=_SKEW_WORKFLOW)
+    steps = workflow["jobs"]["audit"]["steps"]
+    run_steps = [step for step in steps if "run" in step]
+    assert_that(run_steps).is_length(1)
+    assert_that(run_steps[0]["run"]).contains(_SKEW_SCRIPT)
+    assert_that((_REPO_ROOT / _SKEW_SCRIPT).exists()).is_true()
+    # Alarm, not gate: the audit must not be wired into any release job's
+    # ``needs:`` chain, and must not carry write permissions.
+    assert_that(workflow["jobs"]["audit"]["permissions"]).is_equal_to(
+        {"contents": "read"},
+    )
+
+
+def test_version_skew_audit_notifies_via_deduplicated_notifier() -> None:
+    """Skew alarms ping one deduplicated issue instead of one issue per run."""
+    workflow = _load_workflow(name=_SKEW_WORKFLOW)
+    notify = workflow["jobs"]["notify-failure"]
+    assert_that(notify["needs"]).contains("audit")
+    assert_that(notify["uses"]).contains("reusable-main-failure-notifier.yml")
+    assert_that(notify["with"]["workflow-key"]).is_equal_to("release-version-skew")
+    # Main-only: a dispatch from a feature branch must not open the issue.
+    assert_that(_normalize_github_expr(notify["if"])).contains(
+        "github.ref == 'refs/heads/main'",
+    )
+
+
+def test_version_skew_audit_allows_every_channel_endpoint() -> None:
+    """Egress policy allows exactly the hosts the audit must reach."""
+    workflow = _load_workflow(name=_SKEW_WORKFLOW)
+    steps = workflow["jobs"]["audit"]["steps"]
+    harden = next(
+        step for step in steps if str(step.get("uses", "")).startswith("step-security/")
+    )
+    assert_that(harden["with"]["egress-policy"]).is_equal_to("block")
+    allowed = harden["with"]["allowed-endpoints"].split()
+    for endpoint in (
+        "pypi.org:443",
+        "registry.npmjs.org:443",
+        "raw.githubusercontent.com:443",
+        "api.github.com:443",
+    ):
+        assert_that(allowed).contains(endpoint)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): alarm on post-release version skew across PyPI, npm, and Homebrew (#1712)
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

- `scripts/ci/check-release-version-skew.py` — stdlib-only resolver:
  - PyPI `info.version`, npm `dist-tags.latest`, tap `Formula/lintro.rb` `version`
  - exit **0** agree/suppressed, **1** skew, **2** check degraded (registry or
    GitHub API unreachable — deliberately distinct from a real mismatch)
  - suppression 1: **settle window** (`--settle-minutes`, default 120) keyed on
    when the newest version first appeared (PyPI upload time / npm `time`)
  - suppression 2: **release in flight** — the manual PyPI approval gate shows
    up as a `waiting` run of `publish-pypi-on-tag.yml`, so the Homebrew/npm lag
    it implies never alarms
  - Markdown status table to stdout and `$GITHUB_STEP_SUMMARY`
- `.github/workflows/release-version-skew-audit.yml` — daily 05:15 UTC +
  `workflow_dispatch` (optional `expected_version`, `settle_minutes`), blocked
  egress with only the four needed hosts, `contents: read`, SHA-pinned actions.
  On failure it opens/pings the deduplicated main-failure issue under the
  `release-version-skew` key (same mechanism as `dogfood-nightly.yml`) — one
  issue, not one per run.
- `scripts/README.md` entry (README-coverage test enforces it).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1712

## Details

_See What’s Changing._
