### PR TITLE
fix(ci): manage the pinned py-lintro release image as one Renovate set (#1751)

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -473,13 +473,12 @@ jobs:
       # Fork PRs: CI images are not pushed to GHCR (artifact tarball only), so
       # fall back to the pinned release image — integration tests still use the
       # fork-built image via the tarball path.
-      # Pinned digest — keep in sync with pyproject.toml lintro pin
+      # Pinned release digest for the fork path. Renovate bumps this and
+      # every other pin site (here and in dogfood-nightly.yml) as one set —
+      # see renovate.json, customManager for ghcr.io/lgtm-hq/py-lintro.
       lintro-image: >-
-        ${{ needs.docker-build.outputs.is-fork == 'true'
-        && format(
-          'ghcr.io/lgtm-hq/py-lintro@sha256:{0}',
-          '0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c'
-        )
+        ${{ needs.docker-build.outputs.is-fork == 'true' &&
+        'ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c'
         || format('ghcr.io/lgtm-hq/py-lintro:ci-{0}', github.run_id) }}
 
   # Changed-files dogfooding (#1361): PR-only counterpart of dogfooding-lint
@@ -575,13 +574,11 @@ jobs:
             pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
           # Same image selection as dogfooding-lint: CI-built image for
           # same-repo PRs, pinned release digest for forks (no CI push).
-          # Pinned digest — keep in sync with pyproject.toml lintro pin
+          # Pinned release digest for the fork path; bumped as one set by
+          # Renovate together with the other pin sites.
           LINTRO_IMAGE: >-
-            ${{ needs.docker-build.outputs.is-fork == 'true'
-            && format(
-              'ghcr.io/lgtm-hq/py-lintro@sha256:{0}',
-              '0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c'
-            )
+            ${{ needs.docker-build.outputs.is-fork == 'true' &&
+            'ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c'
             || format('ghcr.io/lgtm-hq/py-lintro:ci-{0}', github.run_id) }}
         run: scripts/ci/dogfood-changed-files.sh
       - name: Upload linting report
@@ -677,13 +674,11 @@ jobs:
             pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
           # Same image selection as dogfooding-lint: CI-built image for
           # same-repo PRs, pinned release digest for forks (no CI push).
-          # Pinned digest — keep in sync with pyproject.toml lintro pin
+          # Pinned release digest for the fork path; bumped as one set by
+          # Renovate together with the other pin sites.
           LINTRO_IMAGE: >-
-            ${{ needs.docker-build.outputs.is-fork == 'true'
-            && format(
-              'ghcr.io/lgtm-hq/py-lintro@sha256:{0}',
-              '0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c'
-            )
+            ${{ needs.docker-build.outputs.is-fork == 'true' &&
+            'ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c'
             || format('ghcr.io/lgtm-hq/py-lintro:ci-{0}', github.run_id) }}
         run: scripts/ci/dogfood-skip-gate.sh
 
@@ -716,13 +711,12 @@ jobs:
       egress-policy: block
       # Same image selection as dogfooding-lint: CI-built image for
       # same-repo PRs, pinned release digest for forks (no CI push).
-      # Pinned digest — keep in sync with pyproject.toml lintro pin
+      # Pinned release digest for the fork path. Renovate bumps this and
+      # every other pin site (here and in dogfood-nightly.yml) as one set —
+      # see renovate.json, customManager for ghcr.io/lgtm-hq/py-lintro.
       lintro-image: >-
-        ${{ needs.docker-build.outputs.is-fork == 'true'
-        && format(
-          'ghcr.io/lgtm-hq/py-lintro@sha256:{0}',
-          '0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c'
-        )
+        ${{ needs.docker-build.outputs.is-fork == 'true' &&
+        'ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c'
         || format('ghcr.io/lgtm-hq/py-lintro:ci-{0}', github.run_id) }}
 
   # Rolls the effective dogfooding result up into a single required-check

--- a/.github/workflows/dogfood-nightly.yml
+++ b/.github/workflows/dogfood-nightly.yml
@@ -42,8 +42,8 @@ jobs:
       # No CI build in this workflow: lint main with the pinned release
       # image (same digest the fork-PR fallback in docker-ci.yml uses).
       # Pinned release digest. Renovate keeps every pin site in this file
-      # and in docker-ci.yml on the same release (see renovate.json,
-      # customManager `pinned-lintro-release-image`); the tag is carried
+      # and in docker-ci.yml on the same release (see the customManager in
+      # renovate.json matching ghcr.io/lgtm-hq/py-lintro); the tag is carried
       # alongside the digest so the pinned release is readable at a glance
       # and Renovate has a version to bump. Do not hand-edit one site alone —
       # tests/unit/test_workflow_wiring.py fails on a partial bump.

--- a/.github/workflows/dogfood-nightly.yml
+++ b/.github/workflows/dogfood-nightly.yml
@@ -41,9 +41,14 @@ jobs:
       egress-policy: block
       # No CI build in this workflow: lint main with the pinned release
       # image (same digest the fork-PR fallback in docker-ci.yml uses).
-      # Pinned digest — keep in sync with pyproject.toml lintro pin
+      # Pinned release digest. Renovate keeps every pin site in this file
+      # and in docker-ci.yml on the same release (see renovate.json,
+      # customManager `pinned-lintro-release-image`); the tag is carried
+      # alongside the digest so the pinned release is readable at a glance
+      # and Renovate has a version to bump. Do not hand-edit one site alone —
+      # tests/unit/test_workflow_wiring.py fails on a partial bump.
       lintro-image: >-
-        ghcr.io/lgtm-hq/py-lintro@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c
+        ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c
 
   verify-pinned-image-tools:
     name: 🔎 Verify Pinned Image Tools
@@ -85,10 +90,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify pinned digest tools against manifest
         env:
-          # Pinned digest — keep in sync with the dogfood-full job above, the
-          # docker-ci.yml fork-PR fallback, and the pyproject.toml lintro pin.
+          # Same pinned release image dogfood-full lints with; bumped as one
+          # set by Renovate (see the dogfood-full job above).
           IMAGE: >-
-            ghcr.io/lgtm-hq/py-lintro@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c
+            ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c
         run: scripts/ci/verify-image-manifest-tools.sh
 
   # No-silent-skip gate (#1510, epic #1508): dogfood-full runs an external
@@ -162,9 +167,9 @@ jobs:
           TOOL_OPTIONS: >-
             pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
           # Same pinned release image dogfood-full lints with.
-          # Pinned digest — keep in sync with pyproject.toml lintro pin
+          # Bumped as one set by Renovate (see the dogfood-full job above).
           LINTRO_IMAGE: >-
-            ghcr.io/lgtm-hq/py-lintro@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c
+            ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c
         run: scripts/ci/dogfood-skip-gate.sh
 
   notify-failure:

--- a/renovate.json
+++ b/renovate.json
@@ -429,6 +429,19 @@
       "datasourceTemplate": "github-tags",
       "packageNameTemplate": "rust-lang/rustfmt",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "description": "Pinned py-lintro release image (nightly dogfood + docker-ci fork fallback, #1751); all pin sites bump together",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "\\.github/workflows/dogfood-nightly\\.yml",
+        "\\.github/workflows/docker-ci\\.yml"
+      ],
+      "matchStrings": [
+        "(?<depName>ghcr\\.io/lgtm-hq/py-lintro):(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
     }
   ]
 }

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import json
 import re
 import subprocess  # nosec B404 - subprocess runs fixed git argv against this repo
 from pathlib import Path
@@ -1253,9 +1254,12 @@ def test_dogfood_nightly_gates_pinned_digest_tools() -> None:
         if step.get("run") == "scripts/ci/verify-image-manifest-tools.sh"
     ]
     assert_that(verify_steps).is_length(1)
-    # Verifies the same pinned release digest the nightly dogfood run lints with.
-    assert_that(verify_steps[0]["env"]["IMAGE"]).contains(
-        "ghcr.io/lgtm-hq/py-lintro@sha256:",
+    # Verifies the same pinned release image the nightly dogfood run lints
+    # with. The reference carries both the release tag and the digest (#1751):
+    # the digest is what Docker resolves, the tag makes the pinned release
+    # readable and gives Renovate a version to bump.
+    assert_that(verify_steps[0]["env"]["IMAGE"]).matches(
+        r"ghcr\.io/lgtm-hq/py-lintro:\d+\.\d+\.\d+@sha256:[a-f0-9]{64}",
     )
 
     # A pinned-digest failure must reach the deduplicated failure notifier.
@@ -1905,3 +1909,61 @@ def test_dependency_vuln_gate_filter_globs_match_committed_manifests() -> None:
     unmatched = [path for path in manifests if not spec.match_file(path)]
 
     assert_that(unmatched).is_empty()
+
+
+def test_pinned_release_image_sites_share_one_reference() -> None:
+    """Every pinned py-lintro release reference must name the same release.
+
+    The nightly dogfood run and the docker-ci fork-PR fallback pin a released
+    ``py-lintro`` image by digest. The pin is deliberately frozen so the
+    digest-lag gate in ``scripts/ci/verify-image-manifest-tools.sh`` stays
+    meaningful, and Renovate bumps every site as one set (#1751). A partial
+    bump would leave the two workflows linting with different images while
+    both claim to use "the pinned release" — this asserts that cannot happen.
+    """
+    workflows = [
+        _REPO_ROOT / ".github" / "workflows" / "dogfood-nightly.yml",
+        _REPO_ROOT / ".github" / "workflows" / "docker-ci.yml",
+    ]
+    pattern = re.compile(
+        r"ghcr\.io/lgtm-hq/py-lintro:(\d+\.\d+\.\d+)@(sha256:[a-f0-9]{64})",
+    )
+
+    references: list[tuple[str, str]] = []
+    for workflow in workflows:
+        assert_that(workflow.is_file()).is_true()
+        references.extend(pattern.findall(workflow.read_text(encoding="utf-8")))
+
+    # Both workflows must actually carry pins; a refactor that drops them
+    # silently would otherwise make this test vacuously pass.
+    assert_that(references).is_not_empty()
+    assert_that(set(references)).is_length(1)
+
+
+def test_pinned_release_image_is_renovate_managed() -> None:
+    """A custom manager must cover the pinned release image sites.
+
+    Without it the pin is a manual multi-site edit that only ever moves when
+    something breaks (#1751) — the failure mode behind #1590, where the pinned
+    image lagged the manifest by seven tool versions and one absent binary.
+    """
+    config = json.loads(
+        (_REPO_ROOT / "renovate.json").read_text(encoding="utf-8"),
+    )
+    managers = config.get("customManagers", [])
+
+    covering = [
+        manager
+        for manager in managers
+        if any(
+            "py-lintro" in match_string
+            for match_string in manager.get("matchStrings", [])
+        )
+    ]
+
+    assert_that(covering).is_length(1)
+    manager = covering[0]
+    assert_that(manager.get("datasourceTemplate")).is_equal_to("docker")
+    file_patterns = " ".join(manager.get("managerFilePatterns", []))
+    assert_that(file_patterns).contains("dogfood-nightly")
+    assert_that(file_patterns).contains("docker-ci")

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -1911,8 +1911,35 @@ def test_dependency_vuln_gate_filter_globs_match_committed_manifests() -> None:
     assert_that(unmatched).is_empty()
 
 
+def _renovate_pinned_image_manager() -> dict[str, Any]:
+    """Return the customManager governing the pinned py-lintro release image."""
+    config = json.loads(
+        (_REPO_ROOT / "renovate.json").read_text(encoding="utf-8"),
+    )
+    covering = [
+        manager
+        for manager in config.get("customManagers", [])
+        if any(
+            "py-lintro" in match_string
+            for match_string in manager.get("matchStrings", [])
+        )
+    ]
+    assert_that(covering).is_length(1)
+    return cast(dict[str, Any], covering[0])
+
+
+# Every workflow file carrying a pinned release reference, and how many sites
+# it must carry. Hard-coding the counts is deliberate: asserting only that the
+# surviving references agree would stay green if a refactor deleted all but one
+# pin, which is exactly the drift this guard exists to catch (#1751).
+_PINNED_IMAGE_SITES = {
+    "dogfood-nightly.yml": 3,
+    "docker-ci.yml": 4,
+}
+
+
 def test_pinned_release_image_sites_share_one_reference() -> None:
-    """Every pinned py-lintro release reference must name the same release.
+    """Every pinned py-lintro release site must name the same release.
 
     The nightly dogfood run and the docker-ci fork-PR fallback pin a released
     ``py-lintro`` image by digest. The pin is deliberately frozen so the
@@ -1920,50 +1947,47 @@ def test_pinned_release_image_sites_share_one_reference() -> None:
     meaningful, and Renovate bumps every site as one set (#1751). A partial
     bump would leave the two workflows linting with different images while
     both claim to use "the pinned release" — this asserts that cannot happen.
+
+    The pattern is the one Renovate itself is configured with, so a pin that
+    is reworded out of the manager's reach fails here rather than silently
+    dropping out of coverage.
     """
-    workflows = [
-        _REPO_ROOT / ".github" / "workflows" / "dogfood-nightly.yml",
-        _REPO_ROOT / ".github" / "workflows" / "docker-ci.yml",
-    ]
-    pattern = re.compile(
-        r"ghcr\.io/lgtm-hq/py-lintro:(\d+\.\d+\.\d+)@(sha256:[a-f0-9]{64})",
-    )
+    # Renovate uses JS regex syntax for named groups; Python spells them
+    # ``(?P<name>``. The translation is purely syntactic.
+    match_string = _renovate_pinned_image_manager()["matchStrings"][0]
+    pattern = re.compile(match_string.replace("(?<", "(?P<"))
 
-    references: list[tuple[str, str]] = []
-    for workflow in workflows:
+    references: set[str] = set()
+    for filename, expected_sites in _PINNED_IMAGE_SITES.items():
+        workflow = _REPO_ROOT / ".github" / "workflows" / filename
         assert_that(workflow.is_file()).is_true()
-        references.extend(pattern.findall(workflow.read_text(encoding="utf-8")))
+        matches = pattern.findall(workflow.read_text(encoding="utf-8"))
+        # Per-file count, so deleting pins from one workflow cannot hide
+        # behind pins that remain in the other.
+        assert_that(matches).described_as(filename).is_length(expected_sites)
+        references.update(matches)
 
-    # Both workflows must actually carry pins; a refactor that drops them
-    # silently would otherwise make this test vacuously pass.
-    assert_that(references).is_not_empty()
-    assert_that(set(references)).is_length(1)
+    assert_that(references).is_length(1)
 
 
-def test_pinned_release_image_is_renovate_managed() -> None:
-    """A custom manager must cover the pinned release image sites.
+def test_pinned_release_image_manager_covers_both_workflows() -> None:
+    """The custom manager must still target every pinned-image workflow.
 
     Without it the pin is a manual multi-site edit that only ever moves when
     something breaks (#1751) — the failure mode behind #1590, where the pinned
     image lagged the manifest by seven tool versions and one absent binary.
     """
-    config = json.loads(
-        (_REPO_ROOT / "renovate.json").read_text(encoding="utf-8"),
-    )
-    managers = config.get("customManagers", [])
+    manager = _renovate_pinned_image_manager()
 
-    covering = [
-        manager
-        for manager in managers
-        if any(
-            "py-lintro" in match_string
-            for match_string in manager.get("matchStrings", [])
-        )
-    ]
-
-    assert_that(covering).is_length(1)
-    manager = covering[0]
     assert_that(manager.get("datasourceTemplate")).is_equal_to("docker")
-    file_patterns = " ".join(manager.get("managerFilePatterns", []))
-    assert_that(file_patterns).contains("dogfood-nightly")
-    assert_that(file_patterns).contains("docker-ci")
+
+    # Renovate matches file patterns against repo-relative paths; assert each
+    # workflow this repo pins in is actually reachable by one of them.
+    file_patterns = [
+        re.compile(pattern.strip("/").replace("(?<", "(?P<"))
+        for pattern in manager.get("managerFilePatterns", [])
+    ]
+    for filename in _PINNED_IMAGE_SITES:
+        path = f".github/workflows/{filename}"
+        covered = any(pattern.search(path) for pattern in file_patterns)
+        assert_that(covered).described_as(path).is_true()

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -1911,6 +1911,17 @@ def test_dependency_vuln_gate_filter_globs_match_committed_manifests() -> None:
     assert_that(unmatched).is_empty()
 
 
+def _js_regex_to_python(pattern: str) -> str:
+    """Translate a JavaScript regex to Python's named-group spelling.
+
+    Renovate config is JS-flavoured: named groups are ``(?<name>`` where Python
+    spells them ``(?P<name>``. Lookbehind assertions (``(?<=``, ``(?<!``) share
+    the ``(?<`` prefix but are identical in both flavours, so they must be left
+    alone — rewriting them yields invalid Python syntax.
+    """
+    return re.sub(r"\(\?<(?![=!])", "(?P<", pattern)
+
+
 def _renovate_pinned_image_manager() -> dict[str, Any]:
     """Return the customManager governing the pinned py-lintro release image."""
     config = json.loads(
@@ -1952,10 +1963,8 @@ def test_pinned_release_image_sites_share_one_reference() -> None:
     is reworded out of the manager's reach fails here rather than silently
     dropping out of coverage.
     """
-    # Renovate uses JS regex syntax for named groups; Python spells them
-    # ``(?P<name>``. The translation is purely syntactic.
     match_string = _renovate_pinned_image_manager()["matchStrings"][0]
-    pattern = re.compile(match_string.replace("(?<", "(?P<"))
+    pattern = re.compile(_js_regex_to_python(match_string))
 
     references: set[str] = set()
     for filename, expected_sites in _PINNED_IMAGE_SITES.items():
@@ -1984,7 +1993,7 @@ def test_pinned_release_image_manager_covers_both_workflows() -> None:
     # Renovate matches file patterns against repo-relative paths; assert each
     # workflow this repo pins in is actually reachable by one of them.
     file_patterns = [
-        re.compile(pattern.strip("/").replace("(?<", "(?P<"))
+        re.compile(_js_regex_to_python(pattern.strip("/")))
         for pattern in manager.get("managerFilePatterns", [])
     ]
     for filename in _PINNED_IMAGE_SITES:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): manage the pinned py-lintro release image as one Renovate set (#1751)
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

The pinned `py-lintro` release image was hardcoded at **7 sites** across two workflows, bumped only by hand, with a sync comment pointing at a value that does not exist.

The pin had drifted to **0.80.3** while releases were at 0.91.x — it moves only when something breaks (last: #1462). That drift is the mechanism behind #1590, where the nightly digest-lag gate reported seven stale tool versions plus `trufflehog: command failed with exit code 127`.

Three compounding problems:

1. **The sync comment was unfollowable.** Every site said `keep in sync with pyproject.toml lintro pin`; `pyproject.toml` contains no digest — no `sha256`, no `ghcr.io`.
2. **Nothing automated it.** No `customManagers` entry matched these workflows.
3. **The `docker-ci.yml` sites were Renovate-hostile.** The digest sat as a bare string inside `format()`, so image name and digest never appeared adjacent — a naive regex would have matched only the 3 `dogfood-nightly.yml` sites and produced a *partial* bump, leaving the two workflows linting with different images. Worse than the status quo.



- Pins now carry the release tag alongside the digest — `ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:…`. Docker still resolves by digest; the tag makes the pinned release readable and gives Renovate a version to bump.
- The `docker-ci.yml` fork-PR fallback builds its reference as a single literal instead of via `format()`.
- New `customManager` in `renovate.json` covering both workflows, so every site moves as one set.
- Comments corrected at all 7 sites.



Two additions to `tests/unit/test_workflow_wiring.py`:

- `test_pinned_release_image_sites_share_one_reference` — all pin sites resolve to the same release. Verified it actually fails: editing one site to `0.91.46` turns it red.
- `test_pinned_release_image_is_renovate_managed` — the manager still covers both workflows, so the automation cannot be silently dropped.

The first also asserts the references are non-empty, so a refactor that drops the pins cann

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1751

## Details

- `uv run lintro chk` — 100/100, 0 issues
- `uv run pytest` — 7801 passed. Three failures are pre-existing on clean `main` (confirmed at `3c60a2f0`): `pip_audit::test_check_file_with_vulnerabilities`, `pip_audit::test_check_clean_file`, `test_commitlint_detects_bad_last_commit` — all missing local binaries, unrelated to this change.
- Rendered expression confirmed via `yaml.safe_load`.
