### PR TITLE
fix(ci): bump the pinned release image and keep it synced (#1590)

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -478,7 +478,7 @@ jobs:
       # see renovate.json, customManager for ghcr.io/lgtm-hq/py-lintro.
       lintro-image: >-
         ${{ needs.docker-build.outputs.is-fork == 'true' &&
-        'ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c'
+        'ghcr.io/lgtm-hq/py-lintro:0.91.49@sha256:268e9a5c3c09998c4e42f59309fe47de74bb1dc8e0a7f6d4e88cf07a7cb1d738'
         || format('ghcr.io/lgtm-hq/py-lintro:ci-{0}', github.run_id) }}
 
   # Changed-files dogfooding (#1361): PR-only counterpart of dogfooding-lint
@@ -578,7 +578,7 @@ jobs:
           # Renovate together with the other pin sites.
           LINTRO_IMAGE: >-
             ${{ needs.docker-build.outputs.is-fork == 'true' &&
-            'ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c'
+            'ghcr.io/lgtm-hq/py-lintro:0.91.49@sha256:268e9a5c3c09998c4e42f59309fe47de74bb1dc8e0a7f6d4e88cf07a7cb1d738'
             || format('ghcr.io/lgtm-hq/py-lintro:ci-{0}', github.run_id) }}
         run: scripts/ci/dogfood-changed-files.sh
       - name: Upload linting report
@@ -689,7 +689,7 @@ jobs:
           # Renovate together with the other pin sites.
           LINTRO_IMAGE: >-
             ${{ needs.docker-build.outputs.is-fork == 'true' &&
-            'ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c'
+            'ghcr.io/lgtm-hq/py-lintro:0.91.49@sha256:268e9a5c3c09998c4e42f59309fe47de74bb1dc8e0a7f6d4e88cf07a7cb1d738'
             || format('ghcr.io/lgtm-hq/py-lintro:ci-{0}', github.run_id) }}
         run: scripts/ci/dogfood-skip-gate.sh
 
@@ -727,7 +727,7 @@ jobs:
       # see renovate.json, customManager for ghcr.io/lgtm-hq/py-lintro.
       lintro-image: >-
         ${{ needs.docker-build.outputs.is-fork == 'true' &&
-        'ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c'
+        'ghcr.io/lgtm-hq/py-lintro:0.91.49@sha256:268e9a5c3c09998c4e42f59309fe47de74bb1dc8e0a7f6d4e88cf07a7cb1d738'
         || format('ghcr.io/lgtm-hq/py-lintro:ci-{0}', github.run_id) }}
 
   # Rolls the effective dogfooding result up into a single required-check

--- a/.github/workflows/dogfood-nightly.yml
+++ b/.github/workflows/dogfood-nightly.yml
@@ -48,7 +48,7 @@ jobs:
       # and Renovate has a version to bump. Do not hand-edit one site alone —
       # tests/unit/test_workflow_wiring.py fails on a partial bump.
       lintro-image: >-
-        ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c
+        ghcr.io/lgtm-hq/py-lintro:0.91.49@sha256:268e9a5c3c09998c4e42f59309fe47de74bb1dc8e0a7f6d4e88cf07a7cb1d738
 
   verify-pinned-image-tools:
     name: 🔎 Verify Pinned Image Tools
@@ -93,7 +93,7 @@ jobs:
           # Same pinned release image dogfood-full lints with; bumped as one
           # set by Renovate (see the dogfood-full job above).
           IMAGE: >-
-            ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c
+            ghcr.io/lgtm-hq/py-lintro:0.91.49@sha256:268e9a5c3c09998c4e42f59309fe47de74bb1dc8e0a7f6d4e88cf07a7cb1d738
         run: scripts/ci/verify-image-manifest-tools.sh
 
   # No-silent-skip gate (#1510, epic #1508): dogfood-full runs an external
@@ -169,7 +169,7 @@ jobs:
           # Same pinned release image dogfood-full lints with.
           # Bumped as one set by Renovate (see the dogfood-full job above).
           LINTRO_IMAGE: >-
-            ghcr.io/lgtm-hq/py-lintro:0.80.3@sha256:0e8f3892f31f7bb6ce56a33d037d983591b82c325bf56281f9d9e2fec488aa5c
+            ghcr.io/lgtm-hq/py-lintro:0.91.49@sha256:268e9a5c3c09998c4e42f59309fe47de74bb1dc8e0a7f6d4e88cf07a7cb1d738
         run: scripts/ci/dogfood-skip-gate.sh
 
   notify-failure:

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -115,6 +115,50 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run == true }}
         run: scripts/ci/maintenance/sweep-ci-ghcr-tags.sh
 
+  # Age-based sweep of per-commit tags (sha-<commit>) published alongside
+  # releases. Unbounded growth here is not just storage: the tag list is what
+  # Renovate's docker datasource must enumerate to find newer versions, and
+  # at >1000 tags the first page held neither the pinned release nor any
+  # recent one — over half of it was sha-* (#1590).
+  #
+  # Reuses the ci-* sweeper via TAG_PREFIX. Its safety rule does the heavy
+  # lifting: only versions whose EVERY tag matches the prefix are candidates,
+  # so a release version carrying both sha-<commit> and 0.91.49 is skipped
+  # and can never be deleted by this job.
+  sweep-sha-tags:
+    name: 🧹 Sweep aged commit tags
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # checkout sweep-ci-ghcr-tags.sh
+      packages: write # delete aged-out CI tags from GHCR
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Sweep aged-out commit tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_PREFIX: sha-
+          # Same 91-day window as the ci-* sweep. sha-<commit> tags have no
+          # rerun-retention constraint of their own, but a shared floor keeps
+          # one knob instead of two and stays clear of the #1138 hazard.
+          # yamllint disable-line rule:line-length
+          MIN_AGE_DAYS: ${{ github.event_name != 'workflow_dispatch' && 91 || inputs.sweep_min_age_days }}
+          DRY_RUN: ${{ inputs.dry_run == true }}
+        run: scripts/ci/maintenance/sweep-ci-ghcr-tags.sh
+
   prune-untagged-base:
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@ee8484ca71db3a2c2c33da6128bbf2330fcd7c88 # v0.59.2

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -128,6 +128,7 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `enable_review_config.py`            | Enable AI review + cost cap in `.lintro-config.yaml` for a CI run          | `python3 scripts/ci/enable_review_config.py --help`                                         |
 | `classify-osv-results.py`            | Classify osv_scanner JSON as ok, vulns, or error for CI status             | `python3 scripts/ci/classify-osv-results.py osv-results.json`                               |
 | `check-release-version-skew.py`      | Alarm on post-release PyPI/npm/Homebrew version skew (#1712)               | `python3 scripts/ci/check-release-version-skew.py --help`                                   |
+| `sync-pinned-release-image.py`       | Point the pinned release image at the newest published release (#1590)     | `python3 scripts/ci/sync-pinned-release-image.py --help`                                    |
 | `classify-release-tag.py`            | Classify a release tag as stable or prerelease for publish gating          | `python3 scripts/ci/classify-release-tag.py v1.2.3`                                         |
 | `format-security-comment.py`         | Format lintro osv_scanner JSON as security PR comment markdown             | `python3 scripts/ci/format-security-comment.py osv-results.json`                            |
 | `format-changelog.py`                | Reflow generated `CHANGELOG.md` to lintro 88-col markdown                  | `python3 scripts/ci/format-changelog.py CHANGELOG.md`                                       |

--- a/scripts/ci/finalize-version-pr.py
+++ b/scripts/ci/finalize-version-pr.py
@@ -15,6 +15,10 @@ committed. This orchestrator runs the two repo-side finalizers in order:
    ``major.minor`` line so minor/major bumps do not go stale and break the
    unattended release PR (#1372), via
    :func:`update_security_support.main`.
+3. Point the pinned py-lintro release image at the newest published release so
+   the digest-lag gate cannot drift (#1590), via
+   :func:`sync_pinned_release_image.main`. Deliberately last, and non-fatal:
+   it reports problems as warnings and never blocks a release.
 
 The finalizer scripts have hyphenated filenames, so they are loaded by path
 rather than imported as packages. That job has no Node toolchain and blocks npm
@@ -64,11 +68,17 @@ def main() -> int:
     """
     changelog = _load("format_changelog", "format-changelog.py")
     security = _load("update_security_support", "update-security-support.py")
+    pin_sync = _load("sync_pinned_release_image", "sync-pinned-release-image.py")
 
     result = int(changelog.main([]))
     if result != 0:
         return result
-    return int(security.main([]))
+    result = int(security.main([]))
+    if result != 0:
+        return result
+    # Always 0 by design — the pin sync warns instead of failing, so a
+    # registry hiccup or a missing token cannot block an unattended release.
+    return int(pin_sync.main([]))
 
 
 if __name__ == "__main__":

--- a/scripts/ci/sync-pinned-release-image.py
+++ b/scripts/ci/sync-pinned-release-image.py
@@ -62,6 +62,12 @@ PINNED_SITES: dict[str, int] = {
 ORG = "lgtm-hq"
 PACKAGE = "py-lintro"
 
+# The package carries thousands of ephemeral versions, so the newest release
+# is not guaranteed to sit on page one. Walk pages until a release tag is
+# found, bounded so a pathological listing cannot spin (#1590).
+_PER_PAGE = 100
+_MAX_PAGES = 20
+
 _PIN_PATTERN = re.compile(
     r"ghcr\.io/lgtm-hq/py-lintro:(?P<version>\d+\.\d+\.\d+)"
     r"@(?P<digest>sha256:[a-f0-9]{64})",
@@ -99,9 +105,43 @@ def _fetch_package_versions(token: str) -> list[dict[str, Any]]:
     Returns:
         Parsed version records, or an empty list when unavailable.
     """
+    versions: list[dict[str, Any]] = []
+    for page in range(1, _MAX_PAGES + 1):
+        page_records = _fetch_page(token=token, page=page)
+        if not page_records:
+            break
+        versions.extend(page_records)
+        if len(page_records) < _PER_PAGE:
+            break  # short page means the last one
+        if latest_published_release(versions) is not None:
+            # A release tag is in hand; deeper pages are older by construction
+            # (the API returns newest first), so stop rather than walk them all.
+            break
+    else:
+        _warn(
+            f"stopped after {_MAX_PAGES} pages of package versions; "
+            "pin may be based on an incomplete list",
+        )
+    return versions
+
+
+def _fetch_page(*, token: str, page: int) -> list[dict[str, Any]]:
+    """Fetch one page of container versions.
+
+    The package carries thousands of ``sha-``/``ci-`` versions, so a single
+    page is not enough to guarantee a release tag is visible — the exact
+    enumeration problem that stopped Renovate maintaining this pin (#1590).
+
+    Args:
+        token: GitHub token with ``read:packages``.
+        page: 1-based page number.
+
+    Returns:
+        Version records for the page, or an empty list when unavailable.
+    """
     url = (
         f"https://api.github.com/orgs/{ORG}/packages/container/"
-        f"{PACKAGE}/versions?per_page=100"
+        f"{PACKAGE}/versions?per_page={_PER_PAGE}&page={page}"
     )
     if not url.startswith("https://"):  # pragma: no cover - constant URL
         _warn("refusing to fetch a non-HTTPS URL; pin unchanged")
@@ -183,8 +223,12 @@ def apply_pin(*, version: str, digest: str, dry_run: bool = False) -> bool:
         True when a change was made (or would be), False when already current.
     """
     replacement = f"ghcr.io/lgtm-hq/py-lintro:{version}@{digest}"
-    changed = False
 
+    # Two phases on purpose. Validating and writing in one pass would rewrite
+    # dogfood-nightly.yml and then bail on docker-ci.yml, leaving the workflows
+    # pinned to different images — the exact partial bump the wiring test in
+    # #1752 exists to catch, reached here without any failure being reported.
+    planned: list[tuple[Path, str]] = []
     for relative_path, expected_sites in PINNED_SITES.items():
         path = _REPO_ROOT / relative_path
         if not path.is_file():
@@ -195,18 +239,22 @@ def apply_pin(*, version: str, digest: str, dry_run: bool = False) -> bool:
         matches = _PIN_PATTERN.findall(text)
         if len(matches) != expected_sites:
             # A changed pin shape means this script no longer understands the
-            # file. Rewriting part of it would leave the workflows disagreeing.
+            # file, so no file is touched.
             _warn(
                 f"{relative_path}: expected {expected_sites} pinned sites, "
                 f"found {len(matches)}; pin unchanged",
             )
             return False
 
-        updated = _PIN_PATTERN.sub(replacement, text)
-        if updated != text:
-            changed = True
-            if not dry_run:
-                path.write_text(updated, encoding="utf-8")
+        planned.append((path, _PIN_PATTERN.sub(replacement, text)))
+
+    changed = False
+    for path, updated in planned:
+        if path.read_text(encoding="utf-8") == updated:
+            continue
+        changed = True
+        if not dry_run:
+            path.write_text(updated, encoding="utf-8")
 
     return changed
 

--- a/scripts/ci/sync-pinned-release-image.py
+++ b/scripts/ci/sync-pinned-release-image.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+"""Point the pinned py-lintro release image at the newest published release.
+
+The nightly dogfood run and the docker-ci fork-PR fallback pin a released
+``py-lintro`` image by tag and digest. The pin is what makes the digest-lag
+gate in ``verify-image-manifest-tools.sh`` meaningful, but nothing moved it
+automatically: it drifted from 0.80.3 to eleven minor versions behind before
+anyone noticed (#1590).
+
+Renovate cannot do it. The ``docker`` datasource has to enumerate tags to find
+a newer version, and ``ghcr.io/lgtm-hq/py-lintro`` carries thousands — the
+first 1000-tag page contains neither the current pin nor any recent release,
+because over half of it is ``sha-<commit>`` CI tags. So the pin is synced here
+instead, from the release Version-PR finalizer, where the answer is a direct
+lookup rather than a search.
+
+**The pin deliberately lags by one release.** This runs while the Version-PR
+for release *X* is being prepared, and the image for *X* does not exist yet —
+it is built after the tag. So the pin targets the newest release already
+published, *X-1*. That is a bounded, self-healing lag: a manifest tool bump
+landing in *X* shows as digest lag until *X+1*, instead of drifting
+indefinitely.
+
+**Failures are non-fatal.** This runs in the unattended release path, so an
+unreachable API, a missing permission, or an unparseable payload must never
+break the release PR. Every failure logs a GitHub ``::warning::`` and leaves
+the pin untouched — visible in the run, but never blocking a release.
+
+Digests are resolved through the GitHub Packages API on ``api.github.com``
+rather than the registry: the Version-PR job's egress allowlist permits the
+former and not ``ghcr.io``. Standard library only, for the same reason.
+
+Usage:
+    python3 scripts/ci/sync-pinned-release-image.py
+    python3 scripts/ci/sync-pinned-release-image.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Every workflow carrying a pinned reference, and how many sites it must hold.
+# Counts are asserted so a partial rewrite is a failure rather than a silent
+# half-update — the same contract tests/unit/test_workflow_wiring.py enforces.
+PINNED_SITES: dict[str, int] = {
+    ".github/workflows/dogfood-nightly.yml": 3,
+    ".github/workflows/docker-ci.yml": 4,
+}
+
+ORG = "lgtm-hq"
+PACKAGE = "py-lintro"
+
+_PIN_PATTERN = re.compile(
+    r"ghcr\.io/lgtm-hq/py-lintro:(?P<version>\d+\.\d+\.\d+)"
+    r"@(?P<digest>sha256:[a-f0-9]{64})",
+)
+_RELEASE_TAG = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def _warn(message: str) -> None:
+    """Emit a GitHub Actions warning annotation.
+
+    Args:
+        message: Human-readable explanation of what was skipped and why.
+    """
+    print(f"::warning::sync-pinned-release-image: {message}", file=sys.stderr)
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    """Return a sortable key for a ``major.minor.patch`` string.
+
+    Args:
+        version: Release version without a leading ``v``.
+
+    Returns:
+        Numeric components, comparable across releases.
+    """
+    return tuple(int(part) for part in version.split("."))
+
+
+def _fetch_package_versions(token: str) -> list[dict[str, Any]]:
+    """Fetch container versions for the release package.
+
+    Args:
+        token: GitHub token with ``read:packages``.
+
+    Returns:
+        Parsed version records, or an empty list when unavailable.
+    """
+    url = (
+        f"https://api.github.com/orgs/{ORG}/packages/container/"
+        f"{PACKAGE}/versions?per_page=100"
+    )
+    if not url.startswith("https://"):  # pragma: no cover - constant URL
+        _warn("refusing to fetch a non-HTTPS URL; pin unchanged")
+        return []
+    # The https:// scheme is asserted above, so no file:/custom scheme can be
+    # opened; the URL is built from module constants, not from user input.
+    request = (
+        urllib.request.Request(  # noqa: S310 — HTTPS-only validated above  # nosec B310
+            url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "py-lintro-pin-sync",
+            },
+        )
+    )
+    try:
+        with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected  # nosec B310
+            request,
+            timeout=30,
+        ) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        # 403 is the expected shape when the release token lacks read:packages.
+        _warn(f"packages API returned HTTP {exc.code}; pin left unchanged")
+        return []
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        _warn(f"packages API unreachable ({type(exc).__name__}); pin unchanged")
+        return []
+
+    return payload if isinstance(payload, list) else []
+
+
+def latest_published_release(versions: list[dict[str, Any]]) -> tuple[str, str] | None:
+    """Return the newest published ``(version, digest)`` pair.
+
+    Only versions carrying a bare ``major.minor.patch`` tag are considered, so
+    ``sha-<commit>``, ``ci-<run_id>``, ``latest`` and ``cache`` are ignored.
+
+    Args:
+        versions: Records from the GitHub Packages API.
+
+    Returns:
+        The newest release and its digest, or None when none qualify.
+    """
+    candidates: list[tuple[tuple[int, ...], str, str]] = []
+    for record in versions:
+        if not isinstance(record, dict):
+            continue
+        digest = str(record.get("name", ""))
+        if not digest.startswith("sha256:"):
+            continue
+        metadata = record.get("metadata")
+        container = metadata.get("container") if isinstance(metadata, dict) else None
+        tags = container.get("tags") if isinstance(container, dict) else None
+        if not isinstance(tags, list):
+            continue
+        for tag in tags:
+            tag_text = str(tag)
+            if _RELEASE_TAG.match(tag_text):
+                candidates.append((_version_key(tag_text), tag_text, digest))
+
+    if not candidates:
+        return None
+    _, version, digest = max(candidates)
+    return version, digest
+
+
+def apply_pin(*, version: str, digest: str, dry_run: bool = False) -> bool:
+    """Rewrite every pinned reference to ``version``/``digest``.
+
+    Args:
+        version: Release version to pin.
+        digest: Image digest for that release.
+        dry_run: When True, report what would change without writing.
+
+    Returns:
+        True when a change was made (or would be), False when already current.
+    """
+    replacement = f"ghcr.io/lgtm-hq/py-lintro:{version}@{digest}"
+    changed = False
+
+    for relative_path, expected_sites in PINNED_SITES.items():
+        path = _REPO_ROOT / relative_path
+        if not path.is_file():
+            _warn(f"{relative_path} not found; pin unchanged")
+            return False
+
+        text = path.read_text(encoding="utf-8")
+        matches = _PIN_PATTERN.findall(text)
+        if len(matches) != expected_sites:
+            # A changed pin shape means this script no longer understands the
+            # file. Rewriting part of it would leave the workflows disagreeing.
+            _warn(
+                f"{relative_path}: expected {expected_sites} pinned sites, "
+                f"found {len(matches)}; pin unchanged",
+            )
+            return False
+
+        updated = _PIN_PATTERN.sub(replacement, text)
+        if updated != text:
+            changed = True
+            if not dry_run:
+                path.write_text(updated, encoding="utf-8")
+
+    return changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Sync the pinned release image, never failing the caller.
+
+    Args:
+        argv: Command-line arguments, defaulting to ``sys.argv[1:]``.
+
+    Returns:
+        Always 0 — this runs in the unattended release path, so a problem
+        here must warn rather than block a release.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report the change without writing files",
+    )
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+    if not token:
+        _warn("no GH_TOKEN/GITHUB_TOKEN in environment; pin unchanged")
+        return 0
+
+    resolved = latest_published_release(_fetch_package_versions(token))
+    if resolved is None:
+        _warn("no published release version found in the package; pin unchanged")
+        return 0
+
+    version, digest = resolved
+    if apply_pin(version=version, digest=digest, dry_run=args.dry_run):
+        action = "would pin" if args.dry_run else "pinned"
+        print(f"[INFO] {action} py-lintro release image to {version} ({digest})")
+    else:
+        print(f"[INFO] pinned release image already at {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/ci/test_sync_pinned_release_image.py
+++ b/tests/scripts/ci/test_sync_pinned_release_image.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+"""Tests for the pinned release-image sync (#1590)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from assertpy import assert_that
+
+ROOT = Path(__file__).resolve().parents[3]
+SYNC_SCRIPT = ROOT / "scripts" / "ci" / "sync-pinned-release-image.py"
+
+DIGEST_A = "sha256:" + "a" * 64
+DIGEST_B = "sha256:" + "b" * 64
+
+
+def _load_module() -> Any:
+    """Load the hyphenated sync script as an importable module.
+
+    Returns:
+        The loaded module.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "sync_pinned_release_image",
+        SYNC_SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None  # narrow for mypy
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def module() -> Any:
+    """Provide the loaded sync module.
+
+    Returns:
+        The loaded module.
+    """
+    return _load_module()
+
+
+def _version_record(*, digest: str, tags: list[str]) -> dict[str, Any]:
+    """Build a GitHub Packages API version record.
+
+    Args:
+        digest: Version digest, used as the record ``name``.
+        tags: Container tags attached to the version.
+
+    Returns:
+        A record shaped like the packages API response.
+    """
+    return {"name": digest, "metadata": {"container": {"tags": tags}}}
+
+
+def test_picks_the_newest_release_tag(module: Any) -> None:
+    """The newest ``major.minor.patch`` tag wins.
+
+    Args:
+        module: The loaded sync module.
+    """
+    resolved = module.latest_published_release(
+        [
+            _version_record(digest=DIGEST_A, tags=["0.91.9"]),
+            _version_record(digest=DIGEST_B, tags=["0.91.49"]),
+        ],
+    )
+
+    # 0.91.49 > 0.91.9 numerically; a string comparison would pick the wrong one.
+    assert_that(resolved).is_equal_to(("0.91.49", DIGEST_B))
+
+
+def test_ignores_non_release_tags(module: Any) -> None:
+    """``sha-``, ``ci-``, ``latest`` and ``cache`` tags are never selected.
+
+    These dominate the tag list — they are exactly why Renovate could not
+    enumerate versions in the first place (#1590).
+
+    Args:
+        module: The loaded sync module.
+    """
+    resolved = module.latest_published_release(
+        [
+            _version_record(digest=DIGEST_A, tags=["sha-95e628b"]),
+            _version_record(digest=DIGEST_A, tags=["ci-30192266188"]),
+            _version_record(digest=DIGEST_A, tags=["latest"]),
+            _version_record(digest=DIGEST_A, tags=["cache-linux-amd64"]),
+            _version_record(digest=DIGEST_B, tags=["0.91.48"]),
+        ],
+    )
+
+    assert_that(resolved).is_equal_to(("0.91.48", DIGEST_B))
+
+
+def test_release_version_carrying_a_commit_tag_is_still_selectable(
+    module: Any,
+) -> None:
+    """A release tagged alongside ``sha-<commit>`` is still a candidate.
+
+    Release images carry both, so requiring a sole release tag would make the
+    newest release invisible.
+
+    Args:
+        module: The loaded sync module.
+    """
+    resolved = module.latest_published_release(
+        [_version_record(digest=DIGEST_A, tags=["sha-95e628b", "0.91.48"])],
+    )
+
+    assert_that(resolved).is_equal_to(("0.91.48", DIGEST_A))
+
+
+def test_no_release_versions_yields_none(module: Any) -> None:
+    """With nothing release-tagged, the caller must leave the pin alone.
+
+    Args:
+        module: The loaded sync module.
+    """
+    resolved = module.latest_published_release(
+        [_version_record(digest=DIGEST_A, tags=["sha-95e628b"])],
+    )
+
+    assert_that(resolved).is_none()
+
+
+def test_malformed_records_are_skipped(module: Any) -> None:
+    """Unexpected payload shapes never raise.
+
+    This runs in the unattended release path, so a surprising response must
+    degrade to "no change" rather than break the release PR.
+
+    Args:
+        module: The loaded sync module.
+    """
+    resolved = module.latest_published_release(
+        [
+            "not-a-dict",
+            {"name": "not-a-digest", "metadata": {"container": {"tags": ["0.9.9"]}}},
+            {"name": DIGEST_A, "metadata": None},
+            {"name": DIGEST_A, "metadata": {"container": {"tags": "not-a-list"}}},
+            _version_record(digest=DIGEST_B, tags=["0.91.48"]),
+        ],
+    )
+
+    assert_that(resolved).is_equal_to(("0.91.48", DIGEST_B))
+
+
+def test_missing_token_is_non_fatal(
+    module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing token warns and exits 0 without touching the workflows.
+
+    Args:
+        module: The loaded sync module.
+        monkeypatch: Fixture used to clear the token environment.
+    """
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    assert_that(module.main([])).is_equal_to(0)
+
+
+def test_every_pinned_site_is_declared(module: Any) -> None:
+    """The declared site counts must match the workflows on disk.
+
+    The rewrite refuses to run when the counts disagree, so a drifted
+    declaration would silently disable the sync rather than fail loudly.
+
+    Args:
+        module: The loaded sync module.
+    """
+    for relative_path, expected_sites in module.PINNED_SITES.items():
+        text = (ROOT / relative_path).read_text(encoding="utf-8")
+        found = len(module._PIN_PATTERN.findall(text))  # noqa: SLF001
+        assert_that(found).described_as(relative_path).is_equal_to(expected_sites)

--- a/tests/scripts/ci/test_sync_pinned_release_image.py
+++ b/tests/scripts/ci/test_sync_pinned_release_image.py
@@ -180,3 +180,103 @@ def test_every_pinned_site_is_declared(module: Any) -> None:
         text = (ROOT / relative_path).read_text(encoding="utf-8")
         found = len(module._PIN_PATTERN.findall(text))  # noqa: SLF001
         assert_that(found).described_as(relative_path).is_equal_to(expected_sites)
+
+
+def test_apply_pin_writes_nothing_when_a_later_file_is_invalid(
+    module: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bad second file must leave the first untouched.
+
+    Validating and writing in one pass would rewrite the first workflow and
+    then bail on the second, leaving them pinned to different images — the
+    exact partial bump the wiring test guards against, reached without any
+    failure being reported (#1590 review).
+
+    Args:
+        module: The loaded sync module.
+        tmp_path: Temporary repo root.
+        monkeypatch: Fixture used to repoint the module at the fake repo.
+    """
+    good = tmp_path / "good.yml"
+    bad = tmp_path / "bad.yml"
+    original_good = f"image: ghcr.io/lgtm-hq/py-lintro:0.1.0@{DIGEST_A}\n"
+    good.write_text(original_good)
+    # Declared as holding one site, but holds none.
+    bad.write_text("image: something-else\n")
+
+    monkeypatch.setattr(module, "_REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "PINNED_SITES", {"good.yml": 1, "bad.yml": 1})
+
+    changed = module.apply_pin(version="0.9.9", digest=DIGEST_B)
+
+    assert_that(changed).is_false()
+    # The decisive assertion: the valid file was not written.
+    assert_that(good.read_text()).is_equal_to(original_good)
+
+
+def test_fetch_walks_pages_until_a_release_is_found(
+    module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pagination continues past pages holding only ephemeral versions.
+
+    The package carries thousands of ``sha-``/``ci-`` versions, so the newest
+    release is not guaranteed to be on page one. Reading a single page is the
+    same enumeration failure that stopped Renovate maintaining this pin.
+
+    Args:
+        module: The loaded sync module.
+        monkeypatch: Fixture used to stub the per-page fetch.
+    """
+    pages = {
+        1: [
+            _version_record(digest=DIGEST_A, tags=[f"sha-{i:07x}"]) for i in range(100)
+        ],
+        2: [_version_record(digest=DIGEST_B, tags=["0.91.49"])],
+    }
+    seen: list[int] = []
+
+    def _fake_page(*, token: str, page: int) -> list[dict[str, Any]]:
+        seen.append(page)
+        return pages.get(page, [])
+
+    monkeypatch.setattr(module, "_fetch_page", _fake_page)
+
+    versions = module._fetch_package_versions("token")  # noqa: SLF001
+
+    assert_that(seen).is_equal_to([1, 2])
+    assert_that(module.latest_published_release(versions)).is_equal_to(
+        ("0.91.49", DIGEST_B),
+    )
+
+
+def test_fetch_stops_once_a_release_is_in_hand(
+    module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Paging stops at the first page carrying a release tag.
+
+    The API returns newest first, so deeper pages are older by construction
+    and walking them would only cost requests.
+
+    Args:
+        module: The loaded sync module.
+        monkeypatch: Fixture used to stub the per-page fetch.
+    """
+    seen: list[int] = []
+
+    def _fake_page(*, token: str, page: int) -> list[dict[str, Any]]:
+        seen.append(page)
+        records = [
+            _version_record(digest=DIGEST_A, tags=[f"sha-{i:07x}"]) for i in range(99)
+        ]
+        records.append(_version_record(digest=DIGEST_B, tags=["0.91.49"]))
+        return records
+
+    monkeypatch.setattr(module, "_fetch_page", _fake_page)
+
+    module._fetch_package_versions("token")  # noqa: SLF001
+
+    assert_that(seen).is_equal_to([1])

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -2408,3 +2408,30 @@ def test_version_skew_audit_allows_every_channel_endpoint() -> None:
         "api.github.com:443",
     ):
         assert_that(allowed).contains(endpoint)
+
+
+def test_ghcr_cleanup_sweeps_commit_tags_with_the_shared_safety_rule() -> None:
+    """Per-commit tags must be swept, reusing the ci-* sweeper's guardrails.
+
+    Unbounded ``sha-<commit>`` growth is not only storage: the tag list is what
+    Renovate's docker datasource enumerates to find newer versions, and past
+    1000 tags the first page held no recent release at all (#1590).
+
+    The sweep must go through ``sweep-ci-ghcr-tags.sh`` rather than a bespoke
+    deletion path, because that script only deletes versions whose *every* tag
+    matches the prefix — so a release carrying both ``sha-<commit>`` and a
+    version tag can never be removed by it.
+    """
+    cleanup = _load_workflow(name="ghcr-cleanup.yml")
+    jobs = cleanup["jobs"]
+    assert_that(jobs).contains_key("sweep-sha-tags")
+
+    job = jobs["sweep-sha-tags"]
+    sweep_steps = [
+        step
+        for step in job["steps"]
+        if step.get("run") == "scripts/ci/maintenance/sweep-ci-ghcr-tags.sh"
+    ]
+    assert_that(sweep_steps).is_length(1)
+    assert_that(sweep_steps[0]["env"]["TAG_PREFIX"]).is_equal_to("sha-")
+    assert_that(job["permissions"]["packages"]).is_equal_to("write")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): bump the pinned release image and keep it synced (#1590)
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

**1. Pin bumped to 0.91.49** across all 7 sites. Verified the digest is a healthy multi-arch index with both `amd64`/`arm64` children resolving, given this repo's history of dangling indexes.

**2. `scripts/ci/sync-pinned-release-image.py`** — resolves the newest published release through the GitHub Packages API and rewrites every pin site. Runs from the release Version-PR finalizer, where the answer is a direct lookup instead of a search.

- Uses `api.github.com`, not `ghcr.io`: that job's egress allowlist permits the former only. Stdlib-only for the same reason.
- **Lags by exactly one release, by construction** — the image for the version being prepared does not exist yet, so it targets the newest already published. Bounded and self-healing: a manifest bump landing in *X* shows as lag until *X+1*, rather than drifting indefinitely.
- **Non-fatal by design.** Unreachable API, missing `read:packages`, unexpected payload → `::warning::` and the pin is left untouched. It runs in the unattended release path, so it must never block a release.
- Refuses to rewrite when the site count disagrees with expectation, so a changed pin shape fails visibly rather than half-updating.

**3. `ghcr-cleanup.yml` sweeps aged `sha-<commit>` tags**, reusing `sweep-ci-ghcr-tags.sh` through `TAG_PREFIX`. That script's existing rule carries the risk: only versions whose *every* tag matches the prefix are candidates, so a release carrying both `sha-<commit>` and a version tag can never be deleted by it.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1590

## Details

The bump in this PR **was produced by running the new script** — it resolved 0.91.49 from live package data and rewrote all 7 sites, so the mechanism is exercised rather than asserted. The #1752 wiring test confirms the sites agree.

Tests cover newest-release selection (numeric, so `0.91.49 > 0.91.9`), rejection of `sha-`/`ci-`/`latest`/`cache` tags, a release co-tagged with `sha-<commit>` still being selectable, malformed payloads degrading to no-change, missing token exiting 0, and the declared site counts matching the workflows on disk.

- `uv run lintro chk` — 100/100
- `uv run pytest` — 7903 passed (3 pre-existing local env failures deselected: `pip_audit` ×2, `commitlint`)
