### PR TITLE
test(ci): trace gate memory to diagnose the repeated runner kills (#1761)

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -691,7 +691,14 @@ jobs:
             ${{ needs.docker-build.outputs.is-fork == 'true' &&
             'ghcr.io/lgtm-hq/py-lintro:0.91.49@sha256:268e9a5c3c09998c4e42f59309fe47de74bb1dc8e0a7f6d4e88cf07a7cb1d738'
             || format('ghcr.io/lgtm-hq/py-lintro:ci-{0}', github.run_id) }}
-        run: scripts/ci/dogfood-skip-gate.sh
+          # Memory trace (#1761): this job is repeatedly killed mid-lint with
+          # "runner has received a shutdown signal" + container EOF, and
+          # memory pressure is the leading hypothesis. Samples stream into
+          # this step's log rather than an artifact, because a runner death
+          # skips later steps and would discard the evidence.
+        run: >-
+          scripts/ci/run-with-memory-trace.sh
+          scripts/ci/dogfood-skip-gate.sh
 
   # Bounded retry (1 attempt) when the full-repo dogfooding-lint fails —
   # absorbs runner shutdown (exit 143) and artifact ETIMEDOUT flakes without a

--- a/.github/workflows/dogfood-nightly.yml
+++ b/.github/workflows/dogfood-nightly.yml
@@ -170,7 +170,14 @@ jobs:
           # Bumped as one set by Renovate (see the dogfood-full job above).
           LINTRO_IMAGE: >-
             ghcr.io/lgtm-hq/py-lintro:0.91.49@sha256:268e9a5c3c09998c4e42f59309fe47de74bb1dc8e0a7f6d4e88cf07a7cb1d738
-        run: scripts/ci/dogfood-skip-gate.sh
+        # Memory trace (#1761): this job is repeatedly killed mid-lint with
+        # "runner has received a shutdown signal" + container EOF, and memory
+        # pressure is the leading hypothesis. Samples stream into this step's
+        # log rather than an artifact, because a runner death skips later
+        # steps and would discard the evidence.
+        run: >-
+          scripts/ci/run-with-memory-trace.sh
+          scripts/ci/dogfood-skip-gate.sh
 
   notify-failure:
     needs: [dogfood-full, verify-pinned-image-tools, dogfood-skip-gate]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -119,6 +119,7 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `fail-on-security-audit.sh`          | Fail CI when security audit finds vulnerabilities                          | `./scripts/ci/fail-on-security-audit.sh`                                                    |
 | `free-disk-space.sh`                 | Free disk space on CI runner for Docker builds                             | `./scripts/ci/free-disk-space.sh`                                                           |
 | `memory-sampler.sh`                  | Background vmstat/free memory sampler around binary builds (#1707)         | `./scripts/ci/memory-sampler.sh start <log> <pid-file>`                                     |
+| `run-with-memory-trace.sh`           | Run a command with a live memory trace streamed to the job log (#1761)     | `./scripts/ci/run-with-memory-trace.sh <command> [args...]`                                 |
 | `collect-oom-evidence.sh`            | Best-effort dmesg/journal OOM-killer evidence after a failed build (#1707) | `./scripts/ci/collect-oom-evidence.sh <output-file>`                                        |
 | `validate-docker-backfill-inputs.sh` | Validate workflow-dispatch backfill version/ref inputs                     | `BACKFILL_VERSION=<ver> BACKFILL_REF=<ref> ./scripts/ci/validate-docker-backfill-inputs.sh` |
 | `security-comment.sh`                | Run osv-scanner via lintro in Docker and generate security PR comment      | `./scripts/ci/security-comment.sh --help`                                                   |

--- a/scripts/ci/run-with-memory-trace.sh
+++ b/scripts/ci/run-with-memory-trace.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+#
+# run-with-memory-trace.sh
+#
+# Run a command with a live memory trace streamed to stdout (#1761).
+#
+# The Dogfood No-Silent-Skip Gate is repeatedly killed part-way through its
+# lint with "The runner has received a shutdown signal" and
+# "error waiting for container: unexpected EOF". Memory pressure is the
+# obvious suspect -- 35 tools at 10 workers inside a container -- but that is
+# a hypothesis, and this script exists to replace it with a measurement.
+#
+# Why not the build-binary pattern (#1707): that job samples to a file and
+# uploads it as an artifact `if: failure()`. When the *runner* dies, later
+# steps never run and no artifact is ever uploaded, so the evidence for this
+# exact failure mode would be lost. Actions streams step stdout as it is
+# produced, so the job log survives a runner death -- samples are therefore
+# tee'd into the log of the same step that runs the command, rather than
+# collected afterwards.
+#
+# The command's exit code is preserved, so wrapping a step never changes
+# whether it passes.
+#
+# Usage:
+#   scripts/ci/run-with-memory-trace.sh <command> [args...]
+#
+# Environment:
+#   MEMORY_TRACE_INTERVAL  Seconds between snapshots (default: 30).
+#   MEMORY_TRACE_LOG       Sampler log path (default: memory-trace.log).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../utils/utils.sh disable=SC1091 # Can't follow dynamic path; verified at runtime
+source "$SCRIPT_DIR/../utils/utils.sh"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Run a command with a live memory trace streamed to stdout (#1761).
+
+Usage:
+  scripts/ci/run-with-memory-trace.sh <command> [args...]
+
+Samples are streamed into the current step's log rather than collected as an
+artifact, because a runner shutdown skips later steps and would discard the
+evidence for the failure this is meant to diagnose.
+
+Environment:
+  MEMORY_TRACE_INTERVAL  Seconds between snapshots (default: 30)
+  MEMORY_TRACE_LOG       Sampler log path (default: memory-trace.log)
+
+Exit code:
+  The wrapped command's exit code, unchanged.
+EOF
+	exit 0
+fi
+
+if [[ $# -eq 0 ]]; then
+	log_error "No command given. See --help."
+	exit 2
+fi
+
+TRACE_LOG="${MEMORY_TRACE_LOG:-memory-trace.log}"
+TRACE_PID_FILE="${TRACE_LOG}.pid"
+TRACE_INTERVAL="${MEMORY_TRACE_INTERVAL:-30}"
+
+tail_pid=""
+
+# shellcheck disable=SC2329 # Invoked via `trap cleanup EXIT` below.
+cleanup() {
+	# Stop the streamer first so the sampler's final snapshot is not raced,
+	# then stop the sampler. Both are idempotent and must never fail the run.
+	if [[ -n "${tail_pid}" ]] && kill -0 "${tail_pid}" 2>/dev/null; then
+		kill "${tail_pid}" 2>/dev/null || true
+		wait "${tail_pid}" 2>/dev/null || true
+	fi
+	"${SCRIPT_DIR}/memory-sampler.sh" stop "${TRACE_LOG}" "${TRACE_PID_FILE}" \
+		>/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+log_info "Starting memory trace (interval ${TRACE_INTERVAL}s) -> ${TRACE_LOG}"
+"${SCRIPT_DIR}/memory-sampler.sh" start \
+	"${TRACE_LOG}" "${TRACE_PID_FILE}" "${TRACE_INTERVAL}" || {
+	# Instrumentation must never block the thing it is measuring.
+	log_warning "Memory sampler failed to start; running without a trace"
+	trap - EXIT
+	exec "$@"
+}
+
+# Stream the sampler log into this step's stdout. `tail -F` tolerates the file
+# not existing yet and keeps following if it is rotated.
+#
+# Piping through `sed` would block-buffer: its stdout is a pipe, so up to 4KB
+# of samples sit unflushed. That is fine for a clean exit and useless here --
+# the samples closest to a runner kill are exactly the ones needed, and they
+# would be discarded with the buffer. A read loop with printf issues one write
+# per line, so every sample reaches the log as it is taken.
+tail -F "${TRACE_LOG}" 2>/dev/null | while IFS= read -r trace_line; do
+	printf '[mem] %s\n' "${trace_line}"
+done &
+tail_pid=$!
+
+set +e
+"$@"
+command_status=$?
+set -e
+
+log_info "Command exited ${command_status}; memory trace follows the final snapshot"
+exit "${command_status}"

--- a/scripts/ci/run-with-memory-trace.sh
+++ b/scripts/ci/run-with-memory-trace.sh
@@ -64,6 +64,7 @@ fi
 
 TRACE_LOG="${MEMORY_TRACE_LOG:-memory-trace.log}"
 TRACE_PID_FILE="${TRACE_LOG}.pid"
+TRACE_CURSOR_FILE="${TRACE_LOG}.cursor"
 TRACE_INTERVAL="${MEMORY_TRACE_INTERVAL:-30}"
 
 tail_pid=""
@@ -106,35 +107,46 @@ log_info "Starting memory trace (interval ${TRACE_INTERVAL}s) -> ${TRACE_LOG}"
 # Emitting line-by-line with printf also avoids the block buffering a pipe
 # through `sed` would introduce -- the samples closest to a kill are the ones
 # that matter, and they would sit unflushed.
-streamed_lines=0
+#
+# The cursor lives in a file, not a variable. `stream_trace` runs in a
+# background subshell, so any progress it recorded in a shell variable would be
+# invisible to the parent's cleanup flush -- which would then re-emit the whole
+# trace from line 1 and duplicate every sample already in the job log. Only one
+# of the two reads the cursor at a time: cleanup kills the streamer before
+# flushing, so there is no concurrent writer.
+printf '0\n' >"${TRACE_CURSOR_FILE}"
 
-# shellcheck disable=SC2329 # Invoked from cleanup(), which runs via trap.
-flush_trace() {
-	local total
-	total="$(wc -l <"${TRACE_LOG}" 2>/dev/null || echo 0)"
-	total="${total//[[:space:]]/}"
-	if [[ "${total}" -gt "${streamed_lines}" ]]; then
-		tail -n "+$((streamed_lines + 1))" "${TRACE_LOG}" 2>/dev/null |
-			while IFS= read -r trace_line; do
-				printf '[mem] %s\n' "${trace_line}"
-			done
-		streamed_lines="${total}"
+# shellcheck disable=SC2329 # Invoked from cleanup() and stream_trace().
+emit_new_trace_lines() {
+	local cursor emitted=0
+	cursor="$(cat "${TRACE_CURSOR_FILE}" 2>/dev/null || echo 0)"
+	cursor="${cursor//[[:space:]]/}"
+	[[ "${cursor}" =~ ^[0-9]+$ ]] || cursor=0
+	# Advance the cursor by what was actually printed, never by a separately
+	# measured line count. The sampler appends while we read, so a `wc -l`
+	# taken before `tail` under-reports what `tail` then emits, and the
+	# difference is replayed on the next pass. Counting inside the loop makes
+	# the cursor exact by construction.
+	#
+	# Process substitution, not a pipe: a piped `while` runs in a subshell and
+	# its counter would be lost.
+	while IFS= read -r trace_line; do
+		printf '[mem] %s\n' "${trace_line}"
+		emitted=$((emitted + 1))
+	done < <(tail -n "+$((cursor + 1))" "${TRACE_LOG}" 2>/dev/null)
+	if [[ "${emitted}" -gt 0 ]]; then
+		printf '%s\n' "$((cursor + emitted))" >"${TRACE_CURSOR_FILE}"
 	fi
 }
 
+# shellcheck disable=SC2329 # Invoked from cleanup(), which runs via trap.
+flush_trace() {
+	emit_new_trace_lines
+}
+
 stream_trace() {
-	local last=0
 	while :; do
-		local total
-		total="$(wc -l <"${TRACE_LOG}" 2>/dev/null || echo 0)"
-		total="${total//[[:space:]]/}"
-		if [[ "${total}" -gt "${last}" ]]; then
-			tail -n "+$((last + 1))" "${TRACE_LOG}" 2>/dev/null |
-				while IFS= read -r trace_line; do
-					printf '[mem] %s\n' "${trace_line}"
-				done
-			last="${total}"
-		fi
+		emit_new_trace_lines
 		sleep 2
 	done
 }

--- a/scripts/ci/run-with-memory-trace.sh
+++ b/scripts/ci/run-with-memory-trace.sh
@@ -70,14 +70,20 @@ tail_pid=""
 
 # shellcheck disable=SC2329 # Invoked via `trap cleanup EXIT` below.
 cleanup() {
-	# Stop the streamer first so the sampler's final snapshot is not raced,
-	# then stop the sampler. Both are idempotent and must never fail the run.
+	# Order matters. Stopping the streamer first would discard the sampler's
+	# final snapshot -- the measurement closest to a kill, and the whole point
+	# of the trace -- leaving it only in a local file that a dying runner never
+	# uploads. So stop the sampler first, then the streamer.
+	"${SCRIPT_DIR}/memory-sampler.sh" stop "${TRACE_LOG}" "${TRACE_PID_FILE}" \
+		>/dev/null 2>&1 || true
 	if [[ -n "${tail_pid}" ]] && kill -0 "${tail_pid}" 2>/dev/null; then
 		kill "${tail_pid}" 2>/dev/null || true
 		wait "${tail_pid}" 2>/dev/null || true
 	fi
-	"${SCRIPT_DIR}/memory-sampler.sh" stop "${TRACE_LOG}" "${TRACE_PID_FILE}" \
-		>/dev/null 2>&1 || true
+	# Flush synchronously once the streamer is gone, so the sampler's final
+	# snapshot reaches the job log rather than only the local file that a
+	# dying runner never uploads.
+	flush_trace || true
 }
 trap cleanup EXIT
 
@@ -90,17 +96,50 @@ log_info "Starting memory trace (interval ${TRACE_INTERVAL}s) -> ${TRACE_LOG}"
 	exec "$@"
 }
 
-# Stream the sampler log into this step's stdout. `tail -F` tolerates the file
-# not existing yet and keeps following if it is rotated.
+# Stream new sampler output into this step's stdout.
 #
-# Piping through `sed` would block-buffer: its stdout is a pipe, so up to 4KB
-# of samples sit unflushed. That is fine for a clean exit and useless here --
-# the samples closest to a runner kill are exactly the ones needed, and they
-# would be discarded with the buffer. A read loop with printf issues one write
-# per line, so every sample reaches the log as it is taken.
-tail -F "${TRACE_LOG}" 2>/dev/null | while IFS= read -r trace_line; do
-	printf '[mem] %s\n' "${trace_line}"
-done &
+# Not `tail -F ... | while read`: `$!` after a pipeline is the PID of its LAST
+# element, so killing it leaves `tail -F` alive holding stdout open and the
+# step never finishes. This loop runs as a single background subshell whose PID
+# is exactly what `$!` reports, so cleanup can stop it deterministically.
+#
+# Emitting line-by-line with printf also avoids the block buffering a pipe
+# through `sed` would introduce -- the samples closest to a kill are the ones
+# that matter, and they would sit unflushed.
+streamed_lines=0
+
+# shellcheck disable=SC2329 # Invoked from cleanup(), which runs via trap.
+flush_trace() {
+	local total
+	total="$(wc -l <"${TRACE_LOG}" 2>/dev/null || echo 0)"
+	total="${total//[[:space:]]/}"
+	if [[ "${total}" -gt "${streamed_lines}" ]]; then
+		tail -n "+$((streamed_lines + 1))" "${TRACE_LOG}" 2>/dev/null |
+			while IFS= read -r trace_line; do
+				printf '[mem] %s\n' "${trace_line}"
+			done
+		streamed_lines="${total}"
+	fi
+}
+
+stream_trace() {
+	local last=0
+	while :; do
+		local total
+		total="$(wc -l <"${TRACE_LOG}" 2>/dev/null || echo 0)"
+		total="${total//[[:space:]]/}"
+		if [[ "${total}" -gt "${last}" ]]; then
+			tail -n "+$((last + 1))" "${TRACE_LOG}" 2>/dev/null |
+				while IFS= read -r trace_line; do
+					printf '[mem] %s\n' "${trace_line}"
+				done
+			last="${total}"
+		fi
+		sleep 2
+	done
+}
+
+stream_trace &
 tail_pid=$!
 
 set +e

--- a/tests/scripts/ci/test_run_with_memory_trace.py
+++ b/tests/scripts/ci/test_run_with_memory_trace.py
@@ -159,6 +159,38 @@ def test_final_snapshot_reaches_stdout(tmp_path: Path) -> None:
     assert_that(result.stdout).contains("sampler stopped")
 
 
+def test_each_trace_line_is_streamed_exactly_once(tmp_path: Path) -> None:
+    """Streamed samples must not be replayed by the cleanup flush.
+
+    The streamer runs in a background subshell, so a cursor kept in a shell
+    variable stayed at zero in the parent and the cleanup flush re-emitted the
+    whole trace — duplicating every ``[mem]`` line already in the job log
+    (#1761 review). The cursor is shared through a file instead.
+
+    Args:
+        tmp_path: Temporary directory for the trace log.
+    """
+    trace_log = tmp_path / "trace.log"
+    result = _run(
+        "bash",
+        "-c",
+        "sleep 5",
+        trace_log=trace_log,
+        interval="1",
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    trace_lines = trace_log.read_text().splitlines()
+    assert_that(trace_lines).is_not_empty()
+
+    streamed = [
+        line.removeprefix("[mem] ")
+        for line in result.stdout.splitlines()
+        if line.startswith("[mem] ")
+    ]
+    assert_that(streamed).is_equal_to(trace_lines)
+
+
 def test_wrapper_terminates_when_no_samples_are_written(tmp_path: Path) -> None:
     """A run shorter than the sample interval still exits promptly.
 

--- a/tests/scripts/ci/test_run_with_memory_trace.py
+++ b/tests/scripts/ci/test_run_with_memory_trace.py
@@ -132,3 +132,46 @@ def test_wrapper_exposes_help() -> None:
 
     assert_that(result.returncode).is_equal_to(0)
     assert_that(result.stdout).contains("memory trace")
+
+
+def test_final_snapshot_reaches_stdout(tmp_path: Path) -> None:
+    """The sampler's last snapshot must be streamed, not just written to file.
+
+    Cleanup originally stopped the streamer before the sampler, so the final
+    snapshot — the measurement closest to a kill, and the point of the trace —
+    landed only in a local file that a dying runner never uploads (#1761
+    review).
+
+    Args:
+        tmp_path: Temporary directory for the trace log.
+    """
+    result = _run(
+        "bash",
+        "-c",
+        "sleep 3",
+        trace_log=tmp_path / "trace.log",
+        interval="2",
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    # The stop marker is appended after the final snapshot, so seeing it on
+    # stdout proves the tail of the trace was flushed rather than discarded.
+    assert_that(result.stdout).contains("sampler stopped")
+
+
+def test_wrapper_terminates_when_no_samples_are_written(tmp_path: Path) -> None:
+    """A run shorter than the sample interval still exits promptly.
+
+    An earlier design backgrounded a pipeline and killed the wrong PID, leaving
+    ``tail -F`` alive holding stdout open so the step never finished.
+
+    Args:
+        tmp_path: Temporary directory for the trace log.
+    """
+    result = _run(
+        "true",
+        trace_log=tmp_path / "trace.log",
+        interval="3600",
+    )
+
+    assert_that(result.returncode).is_equal_to(0)

--- a/tests/scripts/ci/test_run_with_memory_trace.py
+++ b/tests/scripts/ci/test_run_with_memory_trace.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+"""Tests for the memory-trace wrapper used to diagnose gate kills (#1761)."""
+
+from __future__ import annotations
+
+import os
+import subprocess  # nosec B404 - drives a repo shell script; shell=False
+from pathlib import Path
+
+from assertpy import assert_that
+
+ROOT = Path(__file__).resolve().parents[3]
+WRAPPER = ROOT / "scripts" / "ci" / "run-with-memory-trace.sh"
+
+
+def _run(
+    *args: str,
+    trace_log: Path,
+    interval: str = "1",
+) -> subprocess.CompletedProcess[str]:
+    """Run the wrapper with a scoped trace log.
+
+    Args:
+        *args: Command and arguments to wrap.
+        trace_log: Sampler log path for this invocation.
+        interval: Seconds between snapshots.
+
+    Returns:
+        The completed process.
+    """
+    env = {
+        **os.environ,
+        "MEMORY_TRACE_LOG": str(trace_log),
+        "MEMORY_TRACE_INTERVAL": interval,
+    }
+    return subprocess.run(  # nosec B603 - fixed argv, shell=False
+        [str(WRAPPER), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+        check=False,
+    )
+
+
+def test_wrapper_preserves_a_successful_exit_code(tmp_path: Path) -> None:
+    """A passing command still passes when wrapped.
+
+    Instrumentation must not change whether the gate passes, or it would be
+    worse than the problem it is diagnosing.
+
+    Args:
+        tmp_path: Temporary directory for the trace log.
+    """
+    result = _run("true", trace_log=tmp_path / "trace.log")
+
+    assert_that(result.returncode).is_equal_to(0)
+
+
+def test_wrapper_preserves_a_failing_exit_code(tmp_path: Path) -> None:
+    """A failing command's exact exit code is propagated.
+
+    The gate distinguishes exit codes (1 is a lint verdict, 143 is SIGTERM),
+    so collapsing them would corrupt the code-quality gate's classification.
+
+    Args:
+        tmp_path: Temporary directory for the trace log.
+    """
+    result = _run("bash", "-c", "exit 7", trace_log=tmp_path / "trace.log")
+
+    assert_that(result.returncode).is_equal_to(7)
+
+
+def test_wrapper_streams_samples_to_stdout(tmp_path: Path) -> None:
+    """Samples appear on stdout, not only in the log file.
+
+    A runner shutdown skips later steps, so an artifact upload would never
+    run. Streaming into the step log is what makes the evidence survive.
+
+    Args:
+        tmp_path: Temporary directory for the trace log.
+    """
+    result = _run(
+        "bash",
+        "-c",
+        "sleep 3",
+        trace_log=tmp_path / "trace.log",
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("[mem]")
+    assert_that(result.stdout).contains("snapshot")
+
+
+def test_wrapper_passes_command_output_through(tmp_path: Path) -> None:
+    """The wrapped command's own output is not swallowed.
+
+    Args:
+        tmp_path: Temporary directory for the trace log.
+    """
+    result = _run(
+        "bash",
+        "-c",
+        "echo GATE_OUTPUT_MARKER",
+        trace_log=tmp_path / "trace.log",
+    )
+
+    assert_that(result.stdout).contains("GATE_OUTPUT_MARKER")
+
+
+def test_wrapper_requires_a_command(tmp_path: Path) -> None:
+    """Invoking with no command is a usage error, not a silent success.
+
+    Args:
+        tmp_path: Temporary directory for the trace log.
+    """
+    result = _run(trace_log=tmp_path / "trace.log")
+
+    assert_that(result.returncode).is_equal_to(2)
+
+
+def test_wrapper_exposes_help() -> None:
+    """``--help`` documents the wrapper without running anything."""
+    result = subprocess.run(  # nosec B603 - fixed argv, shell=False
+        [str(WRAPPER), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("memory trace")

--- a/tests/scripts/ci/test_run_with_memory_trace.py
+++ b/tests/scripts/ci/test_run_with_memory_trace.py
@@ -18,6 +18,7 @@ def _run(
     *args: str,
     trace_log: Path,
     interval: str = "1",
+    timeout: float = 120,
 ) -> subprocess.CompletedProcess[str]:
     """Run the wrapper with a scoped trace log.
 
@@ -25,6 +26,7 @@ def _run(
         *args: Command and arguments to wrap.
         trace_log: Sampler log path for this invocation.
         interval: Seconds between snapshots.
+        timeout: Seconds to wait before giving up on the wrapper.
 
     Returns:
         The completed process.
@@ -39,7 +41,7 @@ def _run(
         capture_output=True,
         text=True,
         env=env,
-        timeout=120,
+        timeout=timeout,
         check=False,
     )
 
@@ -197,6 +199,10 @@ def test_wrapper_terminates_when_no_samples_are_written(tmp_path: Path) -> None:
     An earlier design backgrounded a pipeline and killed the wrong PID, leaving
     ``tail -F`` alive holding stdout open so the step never finished.
 
+    The short timeout is the assertion: the whole point is that the wrapper
+    returns without waiting for a sample, so a regression should surface in
+    seconds rather than sitting on the default two-minute budget.
+
     Args:
         tmp_path: Temporary directory for the trace log.
     """
@@ -204,6 +210,7 @@ def test_wrapper_terminates_when_no_samples_are_written(tmp_path: Path) -> None:
         "true",
         trace_log=tmp_path / "trace.log",
         interval="3600",
+        timeout=15,
     )
 
     assert_that(result.returncode).is_equal_to(0)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  test(ci): trace gate memory to diagnose the repeated runner kills (#1761)
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Instrumentation for #1761. **Diagnostic only — no behaviour change.**



`🚦 Dogfood No-Silent-Skip Gate` is repeatedly killed part-way through its lint:

```
Running 35 tools in parallel (max 10 workers)
##[error]The runner has received a shutdown signal.
time="..." level=error msg="error waiting for container: unexpected EOF"
```

Five occurrences across unrelated commits, including two `main` pushes (0.91.46, 0.91.47) — both of which passed on rerun with no code change, so these are not real skip violations. It has cost reruns on four PRs.

**It is not the timeout.** The job is bounded at 20 minutes (#1704); successful runs take 12–17 and the kills land at 9–15, inside the normal range. Separately, one run has now exhausted the 20-minute bound, so whatever is degrading the job may be getting worse.

Memory pressure is the obvious suspect — 35 tools at 10 workers inside a container — but that is a **hypothesis**. This PR measures rather than assumes, so the fix (likely lowering the gate's worker count) can be chosen on evidence.



`build-binary.yml` samples to a file and uploads it as an artifact `if: failure()`. When the **runner** dies, later steps never run and no artifact is produced — the evidence for this exact failure mode would be lost.

Actions streams step stdout as it is produced, so the job log survives a runner death. Samples are therefore tee'd into the log of the step running the command, not collected afterwards. This reuses the existing `memory-sampler.sh` rather than adding a second sampler.



- **Exit code is preserved exactly.** The gate distinguishes `1` (lint verdict) from `143` (SIGTERM), and `is-infra-flake-failure.sh` classifies on those, so collapsing them would corrupt the required check's verdict.
- **A sampler that fails to start degrades to running the command untraced.** Instrumentation must never block what it measures.
- **Streaming is a read loop, not a pipe through `sed`.** `sed` block-buffers when its stdout is a pipe, so up to

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Relates to #1761

## Details

- `uv run lintro chk` — 100/100
- `uv run pytest` — 7927 passed (3 pre-existing local env failures deselected)
- Tests cover exit-code preservation for success and a non-zero code, samples reaching stdout, wrapped output passing through, missing-command usage error, and `--help`.
