### PR TITLE
fix(tools): pin down builder cwd resolution contract (#1758)

### DIFF
--- a/lintro/tools/core/command_builders.py
+++ b/lintro/tools/core/command_builders.py
@@ -262,6 +262,18 @@ class PythonBundledBuilder(CommandBuilder):
     Prefers PATH-based discovery to support various installation methods
     (Homebrew, system packages, pipx, uv tool). Falls back to Python module
     execution for pip installs where the binary isn't in PATH.
+
+    Resolution is deliberately directory-independent, so the inherited
+    :meth:`CommandBuilder.get_command_in` default is correct and this class does
+    not override it (#1758). Every candidate — the venv scripts directory from
+    :mod:`sysconfig`, ``PATH``, and ``sys.executable -m`` — is a property of the
+    process Lintro runs in, not of the directory being checked. That is the
+    intended source: these tools are Lintro's own declared dependencies, gated
+    on the version manifest's minimums and parsed by version-specific parsers,
+    so a checked project's own virtualenv is **not** consulted. Running an
+    arbitrary project-supplied version would break both the version gate and
+    output parsing. Project-relative work (config discovery, ``per-file-ignores``
+    and friends) is done by the tool itself from the cwd the executor sets.
     """
 
     _tools: frozenset[ToolName] | None = None
@@ -355,6 +367,17 @@ class PytestBuilder(CommandBuilder):
 
     Pytest is handled separately because it uses a different module
     invocation pattern. Prefers PATH-based discovery like PythonBundledBuilder.
+
+    Like :class:`PythonBundledBuilder`, resolution is directory-independent and
+    the inherited :meth:`CommandBuilder.get_command_in` default is kept (#1758):
+    the venv scripts directory, ``PATH`` and ``sys.executable -m pytest`` are all
+    process-scoped. Pytest must run in the environment whose interpreter can
+    import the code under test, and Lintro supports that by being invoked from
+    inside that environment (``uv run lintro ...``), where ``sys.prefix`` already
+    *is* the project's virtualenv. Discovering some other project's ``.venv`` by
+    walking up from the execution directory is intentionally not done — it would
+    silently pick an interpreter whose installed plugins and dependencies Lintro
+    knows nothing about.
     """
 
     def can_handle(self, tool_name_enum: ToolName | None) -> bool:
@@ -590,19 +613,27 @@ class NodeJSBuilder(CommandBuilder):
             return ["npx", spec]
         return [binary_name]
 
-    def get_command(
+    def _resolve(
         self,
         tool_name: str,
         tool_name_enum: ToolName | None,
+        start: Path | None,
     ) -> list[str]:
-        """Get command for Node.js tool.
+        """Resolve a Node.js tool command from a single search origin.
+
+        Both public entry points funnel through here so they cannot drift:
+        ``get_command`` is exactly ``get_command_in`` with no execution
+        directory known, rather than a second, subtly different code path
+        (#1758).
 
         Args:
             tool_name: String name of the tool.
-            tool_name_enum: Tool name enum.
+            tool_name_enum: Tool name enum, or None if unknown.
+            start: Directory to resolve project-local installs from, or None to
+                use the process working directory.
 
         Returns:
-            Command list to execute the tool via bunx or directly.
+            Command list to execute the tool via bunx/npx or directly.
         """
         if tool_name_enum is None:
             return [tool_name]
@@ -618,6 +649,7 @@ class NodeJSBuilder(CommandBuilder):
             return self._get_pinned_command(
                 binary_name=binary_name,
                 package_name=self.package_names.get(tool_name_enum, tool_name),
+                start=start,
             )
 
         # Prefer bunx (bun), fall back to npx (npm), then direct tool invocation
@@ -626,6 +658,27 @@ class NodeJSBuilder(CommandBuilder):
         if shutil.which("npx"):
             return ["npx", binary_name]
         return [binary_name]
+
+    def get_command(
+        self,
+        tool_name: str,
+        tool_name_enum: ToolName | None,
+    ) -> list[str]:
+        """Get command for Node.js tool, resolved from the process directory.
+
+        Prefer :meth:`get_command_in` whenever the execution directory is known;
+        this overload can only search from :func:`pathlib.Path.cwd`, which for a
+        project-local install is the wrong tree unless Lintro happens to have
+        been invoked from it.
+
+        Args:
+            tool_name: String name of the tool.
+            tool_name_enum: Tool name enum.
+
+        Returns:
+            Command list to execute the tool via bunx or directly.
+        """
+        return self._resolve(tool_name, tool_name_enum, None)
 
     def get_command_in(
         self,
@@ -649,18 +702,7 @@ class NodeJSBuilder(CommandBuilder):
         Returns:
             Command list to execute the tool.
         """
-        if tool_name_enum is None or tool_name_enum not in self.pinned_tools:
-            return self.get_command(tool_name, tool_name_enum)
-
-        binary_name = self.binary_names.get(
-            tool_name_enum,
-            self.package_names.get(tool_name_enum, tool_name),
-        )
-        return self._get_pinned_command(
-            binary_name=binary_name,
-            package_name=self.package_names.get(tool_name_enum, tool_name),
-            start=cwd,
-        )
+        return self._resolve(tool_name, tool_name_enum, cwd)
 
 
 @register_command_builder
@@ -668,6 +710,18 @@ class CargoBuilder(CommandBuilder):
     """Builder for Cargo/Rust tools (Clippy, cargo-audit, cargo-deny).
 
     Invokes Rust tools via cargo subcommands.
+
+    Resolution is directory-independent, so the inherited
+    :meth:`CommandBuilder.get_command_in` default is correct and is not
+    overridden (#1758). The command is a bare ``cargo`` looked up on ``PATH``
+    (in practice the rustup shim), and everything project-relative is resolved
+    by cargo itself from *its own* process cwd, which the executor sets to the
+    crate root: the workspace root and ``target/`` come from the enclosing
+    ``Cargo.toml``, and ``rust-toolchain.toml`` is found by rustup walking up
+    from that same directory. Subcommand binaries (``cargo-audit``,
+    ``cargo-deny``) live in ``$CARGO_HOME/bin`` or on ``PATH`` — Cargo has no
+    project-local ``node_modules``-style install location for them, so there is
+    nothing under the checked directory that could or should win.
     """
 
     def can_handle(self, tool_name_enum: ToolName | None) -> bool:
@@ -723,6 +777,15 @@ class StandaloneBuilder(CommandBuilder):
     These tools are invoked directly by name without any wrapper.
     Uses an explicit mapping for tools whose binary name differs
     from their internal tool name.
+
+    Resolution is directory-independent, so the inherited
+    :meth:`CommandBuilder.get_command_in` default is correct and is not
+    overridden (#1758). The builder emits a bare binary name that the OS
+    resolves against ``PATH``; none of these ecosystems define a project-local
+    install directory that a checked project could ship, so there is no
+    per-directory candidate to prefer. Anything project-relative — config
+    discovery, lockfile reading, the dependency set ``pip-audit`` audits — is
+    done by the tool itself from the cwd the executor sets.
     """
 
     _tools: frozenset[ToolName] | None = None

--- a/tests/unit/tools/core/test_command_builders.py
+++ b/tests/unit/tools/core/test_command_builders.py
@@ -861,3 +861,101 @@ def test_registry_without_cwd_preserves_process_relative_resolution() -> None:
         CommandBuilderRegistry.get_command("html_validate", ToolName.HTML_VALIDATE)
 
     assert_that(seen).is_equal_to([None])
+
+
+# =============================================================================
+# Execution-directory (cwd) resolution contract, per builder (#1758)
+# =============================================================================
+
+
+def test_node_get_command_matches_get_command_in_without_cwd() -> None:
+    """``get_command`` is ``get_command_in`` with no execution directory.
+
+    The pinned path used to reach ``_get_pinned_command`` twice, once with a
+    ``start`` and once without, so a direct caller could get a different search
+    origin than the registry. Both now share one resolver (#1758).
+    """
+    builder = NodeJSBuilder()
+    seen: list[Path | None] = []
+
+    def _record(binary_name: str, *, start: Path | None = None) -> str | None:
+        seen.append(start)
+        return None
+
+    with (
+        patch("shutil.which", _which_only("bunx")),
+        patch(
+            "lintro.tools.core.command_builders.find_local_node_binary",
+            side_effect=_record,
+        ),
+    ):
+        direct = builder.get_command("html_validate", ToolName.HTML_VALIDATE)
+        threaded = builder.get_command_in(
+            "html_validate",
+            ToolName.HTML_VALIDATE,
+            None,
+        )
+
+    assert_that(direct).is_equal_to(threaded)
+    assert_that(seen).is_equal_to([None, None])
+
+
+def test_python_bundled_builder_ignores_the_execution_directory(
+    tmp_path: Path,
+) -> None:
+    """Bundled Python tools resolve from Lintro's own environment.
+
+    They are Lintro's declared dependencies, gated on the manifest minimum and
+    parsed by version-specific parsers, so a checked project's virtualenv must
+    not win. Locks the documented decision for #1758.
+    """
+    builder = PythonBundledBuilder()
+    with patch("shutil.which", _which_only("ruff")):
+        external = builder.get_command_in("ruff", ToolName.RUFF, tmp_path)
+        process_relative = builder.get_command("ruff", ToolName.RUFF)
+
+    assert_that(external).is_equal_to(process_relative)
+
+
+def test_pytest_builder_ignores_the_execution_directory(tmp_path: Path) -> None:
+    """Pytest resolves from the running interpreter, not the target tree.
+
+    Walking up from the execution directory for a ``.venv`` would select an
+    interpreter whose plugins and dependencies Lintro knows nothing about.
+    Locks the documented decision for #1758.
+    """
+    builder = PytestBuilder()
+    with patch("shutil.which", _which_only("pytest")):
+        external = builder.get_command_in("pytest", ToolName.PYTEST, tmp_path)
+        process_relative = builder.get_command("pytest", ToolName.PYTEST)
+
+    assert_that(external).is_equal_to(process_relative)
+
+
+def test_cargo_builder_ignores_the_execution_directory(tmp_path: Path) -> None:
+    """Cargo resolves from PATH; cargo itself does the project-relative work.
+
+    Workspace root, ``target/`` and ``rust-toolchain.toml`` are found by cargo
+    and rustup from the cwd the executor sets, so the command never varies.
+    Locks the documented decision for #1758.
+    """
+    builder = CargoBuilder()
+    external = builder.get_command_in("clippy", ToolName.CLIPPY, tmp_path)
+
+    assert_that(external).is_equal_to(["cargo", "clippy"])
+    assert_that(external).is_equal_to(builder.get_command("clippy", ToolName.CLIPPY))
+
+
+def test_standalone_builder_ignores_the_execution_directory(tmp_path: Path) -> None:
+    """Standalone binaries resolve against PATH only.
+
+    None of these ecosystems define a project-local install directory, so there
+    is no per-directory candidate to prefer. Locks the decision for #1758.
+    """
+    builder = StandaloneBuilder()
+    external = builder.get_command_in("hadolint", ToolName.HADOLINT, tmp_path)
+
+    assert_that(external).is_equal_to(["hadolint"])
+    assert_that(external).is_equal_to(
+        builder.get_command("hadolint", ToolName.HADOLINT),
+    )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(tools): pin down builder cwd resolution contract (#1758)
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`CommandBuilder.get_command_in()` defaults to `get_command()`, which ignores `cwd`.
That default is correct only where resolution really is directory-independent, but it
was applied to every non-Node builder without anyone checking. #1731 fixed the Node
path; this PR audits the rest and records the answer **in code** so the next reader does
not have to re-derive it.

**Verdict: no live bug in the remaining builders.** All four are genuinely
directory-independent, so each keeps the inherited default and gains a docstring stating
the mechanism:

| Builder | Verdict | Mechanism |
| --- | --- | --- |
| `PythonBundledBuilder` | independent, by design | venv scripts dir / `PATH` / `sys.executable -m` are all process-scoped. That is the intended source: these are lintro's own declared dependencies, gated on the manifest minimum and parsed by version-specific parsers, so a checked project's virtualenv must **not** win. |
| `PytestBuilder` | independent, by design | Same process-scoped resolution. Pytest must run in the interpreter that can import the code under test, which lintro supports by being invoked from inside it (`uv run lintro ...`). Walking up for someone else's `.venv` would pick an interpreter whose plugins lintro knows nothing about. |
| `CargoBuilder` | independent | Bare `cargo` off `PATH` (the rustup shim). Workspace root, `target/` and `rust-toolchain.toml` are resolved by cargo/rustup from *their* process cwd, which the executor sets to the crate root. Subcommand binaries live in `$CARGO_HOME/bin` — cargo has no project-local install location. Verified against `clippy.py`, which passes `cwd=cargo_root` to the subprocess. |
| `StandaloneBuilder` | independent | Bare binary name resolved against `PATH`; none of these ecosystems define a project-local install dir, so there is no per-directory candidate to prefer. |

The one real (latent) defect was requirement 3: `NodeJSBuilder.get_command` and
`get_command_in` reached `_get_pinned_command` by two separate paths, only one of which
passed `start`. Every production call goes through the registry, so it was never live —
but a direct caller or test got a different search origin than the registry would. Both
entry points now funnel through a single `_resolve()` helper, so `get_command` **is**
`get_command_in` with no execution directory known, structurally rather than by comment.

No behaviour change for any production path.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1758

## Details

**Tests** (`tests/unit/tools/core/test_command_builders.py`, +5):

- `test_node_get_command_matches_get_command_in_without_cwd` — asserts both Node entry
  points agree and each performs exactly one lookup with the same origin.
- One per builder (`python_bundled`, `pytest`, `cargo`, `standalone`) asserting
  `get_command_in(..., tmp_path)` equals `get_command(...)` for a target directory
  distinct from the process cwd. These lock the documented decision, so a future
  "helpful" override has to argue with a red test rather than slip through.

**Gate:** `uv run lintro fmt` clean, `uv run lintro chk` 0 issues, `uv run pytest
--maxfail=0` → 7907 passed, 114 skipped. The only 3 failures are pre-existing on clean
main for local-toolchain reasons (`pip_audit/test_check.py` ×2 — pip-audit's `ensurepip`
aborts in the sandbox; `test_commitlint_detects_bad_last_commit` — local commitlint
21.2.0 < required 21.2.1).
