### PR TITLE
fix(ci): verify persistent GHCR tags survive the CI-tag sweep (#1652)

### DIFF
--- a/scripts/ci/maintenance/sweep-ci-ghcr-tags.sh
+++ b/scripts/ci/maintenance/sweep-ci-ghcr-tags.sh
@@ -143,6 +143,10 @@ for prefix in $volatile_prefixes; do
 			"^[A-Za-z0-9._-]+\$, got: ${prefix}" >&2
 		exit 2
 	fi
+	# The default VOLATILE_TAG_PREFIXES repeats the default TAG_PREFIX, so
+	# skip what the seed already covers. `any` short-circuits either way;
+	# this just keeps the array matching what the comment above promises.
+	[[ "$prefix" == "$tag_prefix" ]] && continue
 	volatile_prefixes_jq+=",\"${prefix}\""
 done
 readonly volatile_prefixes_jq

--- a/scripts/ci/maintenance/sweep-ci-ghcr-tags.sh
+++ b/scripts/ci/maintenance/sweep-ci-ghcr-tags.sh
@@ -29,6 +29,21 @@ set -euo pipefail
 # The persistent ":cache" tag never matches the CI prefix. Architecture-
 # specific child manifests that become untagged are left for the weekly
 # untagged prune (reusable-ghcr-cleanup.yml).
+#
+# Conditional delete: NOT available (checked 2026-07-26, #1652). GitHub's
+# REST API supports conditional requests only through ETag/If-None-Match and
+# Last-Modified/If-Modified-Since on reads; "conditional requests for unsafe
+# methods, such as POST, PUT, PATCH, and DELETE are not supported unless
+# otherwise noted", and the delete-package-version endpoint documents no
+# If-Match. So the recheck -> DELETE window cannot be closed atomically and
+# the guards below (sole-tag rule, dual recheck, post-delete verification)
+# are the mitigation. Re-check the docs before re-investigating this.
+#
+# Post-delete verification (#1652): the sweep only ever deletes versions whose
+# sole tag is a ci-* tag, so no persistent (non-CI) tag may disappear while it
+# runs. The package's persistent tag set is snapshotted before the deletions
+# and re-read after them; a tag that vanished means the residual race actually
+# fired, and that is reported as an ::error:: which fails the job.
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 	cat <<'EOF'
@@ -56,6 +71,13 @@ Environment:
                  Taking the bypass logs a ::warning:: so an inherited
                  value can never waive the guard silently.
                  ghcr-cleanup.yml never sets it.
+  VOLATILE_TAG_PREFIXES
+                 Space-separated tag prefixes excluded from the post-delete
+                 verification baseline (default: "ci- sha-"). ghcr-cleanup.yml
+                 runs the ci-* and sha-* sweeps as parallel jobs, so each one
+                 sees the other's deletions; without this the sha-* sweep
+                 would report swept ci-* tags as lost (#1652). Each entry must
+                 match ^[A-Za-z0-9._-]+$ (interpolated into the jq filter).
   DRY_RUN        When "true", log candidates without deleting (default: false)
 EOF
 	exit 0
@@ -66,6 +88,7 @@ org="${ORG:-lgtm-hq}"
 packages="${PACKAGES:-py-lintro py-lintro-base}"
 tag_prefix="${TAG_PREFIX:-ci-}"
 min_age_days="${MIN_AGE_DAYS:-91}"
+volatile_prefixes="${VOLATILE_TAG_PREFIXES:-ci- sha-}"
 dry_run="${DRY_RUN:-false}"
 sweep_errors=0
 
@@ -108,6 +131,22 @@ if ! [[ "$tag_prefix" =~ ^[A-Za-z0-9._-]+$ ]]; then
 	exit 2
 fi
 
+# The verification baseline must ignore every tag family that some sweep may
+# legitimately delete, otherwise a sibling job's work reads as a lost tag
+# (#1652). TAG_PREFIX is always excluded; the rest come from
+# VOLATILE_TAG_PREFIXES and are interpolated into jq, so apply the same
+# character class.
+volatile_prefixes_jq="\"${tag_prefix}\""
+for prefix in $volatile_prefixes; do
+	if ! [[ "$prefix" =~ ^[A-Za-z0-9._-]+$ ]]; then
+		echo "VOLATILE_TAG_PREFIXES entries must match" \
+			"^[A-Za-z0-9._-]+\$, got: ${prefix}" >&2
+		exit 2
+	fi
+	volatile_prefixes_jq+=",\"${prefix}\""
+done
+readonly volatile_prefixes_jq
+
 cutoff_epoch=$(($(date -u +%s) - min_age_days * 86400))
 
 tags_are_ci_only() {
@@ -130,6 +169,99 @@ fetch_version_state() {
 	gh api \
 		"orgs/${org}/packages/container/${pkg}/versions/${vid}" \
 		--jq '[.updated_at, ((.metadata.container.tags // []) | join(" "))] | @tsv'
+}
+
+# Print the package's persistent tags (those carrying none of the volatile
+# prefixes), one per line, sorted. This is the invariant the post-delete
+# verification checks: the sweep only deletes sole-ci-tagged versions, so this
+# set may never shrink (#1652).
+fetch_persistent_tags() {
+	local pkg="$1"
+	gh api \
+		"orgs/${org}/packages/container/${pkg}/versions" \
+		--paginate \
+		--jq ".[]
+			| (.metadata.container.tags // [])[]
+			| . as \$tag
+			| select([${volatile_prefixes_jq}]
+				| any(. as \$p | \$tag | startswith(\$p))
+				| not)" |
+		LC_ALL=C sort -u
+}
+
+# Print the entries of newline-separated list "$1" absent from list "$2".
+# Container tags cannot contain whitespace, so line-wise matching is exact.
+tags_missing_from() {
+	local expected="$1"
+	local actual="$2"
+	local tag=""
+	while IFS= read -r tag; do
+		[[ -z "$tag" ]] && continue
+		case $'\n'"${actual}"$'\n' in
+		*$'\n'"${tag}"$'\n'*) ;;
+		*) printf '%s\n' "$tag" ;;
+		esac
+	done <<<"$expected"
+}
+
+# Verify no persistent tag was collateral damage of this package's deletions.
+#
+# One check per package rather than one per DELETE: re-listing thousands of
+# versions after every deletion would be prohibitively expensive, and the
+# invariant is identical either way.
+#
+# A false "we deleted a release tag" alarm is worse than no alarm, so a tag is
+# only reported after it is missing from two independent reads — a paginated
+# listing on a busy registry can momentarily under-report. A read that fails
+# outright is reported as "could not verify" and still fails the job, keeping
+# the sweep fail-closed without claiming a loss that was never observed.
+#
+# Known limit: a tag first created after the baseline read and destroyed by a
+# DELETE in the same run is invisible to this check. That is the deliberate
+# trade — detecting it needs a per-delete listing, whose cost and raciness buy
+# false alarms. The realistic race (a byte-identical rebuild letting promotion
+# move latest/main/a release tag onto an aged ci-* digest) moves tags that the
+# baseline already holds, so it is caught.
+verify_persistent_tags_survived() {
+	local pkg="$1"
+	local baseline="$2"
+	local deleted_ids="$3"
+	local after=""
+	local missing=""
+	local err_file=""
+
+	err_file="$(mktemp)"
+	if ! after=$(fetch_persistent_tags "$pkg" 2>"${err_file}"); then
+		echo "::error::Could not verify persistent tags for ${pkg} after" \
+			"deleting [${deleted_ids}]: $(cat "${err_file}") (#1652)" >&2
+		rm -f "${err_file}"
+		sweep_errors=1
+		return
+	fi
+	rm -f "${err_file}"
+
+	missing="$(tags_missing_from "$baseline" "$after")"
+	[[ -z "$missing" ]] && return
+
+	# Second, independent read before alarming.
+	err_file="$(mktemp)"
+	if ! after=$(fetch_persistent_tags "$pkg" 2>"${err_file}"); then
+		echo "::error::Could not confirm persistent tags for ${pkg} after" \
+			"deleting [${deleted_ids}]: $(cat "${err_file}") (#1652)" >&2
+		rm -f "${err_file}"
+		sweep_errors=1
+		return
+	fi
+	rm -f "${err_file}"
+
+	missing="$(tags_missing_from "$missing" "$after")"
+	[[ -z "$missing" ]] && return
+
+	echo "::error::Persistent tags disappeared from ${pkg} during the sweep:" \
+		"[$(printf '%s' "$missing" | tr '\n' ' ')]. Deleted versions:" \
+		"[${deleted_ids}]. A promotion very likely raced the DELETE and its" \
+		"tag was removed with the CI version (#1652)." >&2
+	sweep_errors=1
 }
 
 sweep_package() {
@@ -168,6 +300,27 @@ sweep_package() {
 	if [[ -z "$versions" ]]; then
 		echo "No ${tag_prefix}* tags older than ${min_age_days}d for ${pkg}"
 		return
+	fi
+
+	# Snapshot the persistent tags that must survive the deletions (#1652).
+	# Fail closed: without a baseline the post-delete verification is blind,
+	# so skip the package rather than delete unverifiably. DRY_RUN deletes
+	# nothing, so it needs no baseline.
+	local baseline_tags=""
+	local deleted_ids=""
+	if [[ "$dry_run" != "true" ]]; then
+		local baseline_err_file=""
+		baseline_err_file="$(mktemp)"
+		if ! baseline_tags=$(fetch_persistent_tags "$pkg" \
+			2>"${baseline_err_file}"); then
+			echo "::error::Failed to snapshot persistent tags for ${pkg};" \
+				"skipping its deletions: $(cat "${baseline_err_file}")" \
+				"(#1652)" >&2
+			rm -f "${baseline_err_file}"
+			sweep_errors=1
+			return
+		fi
+		rm -f "${baseline_err_file}"
 	fi
 
 	while IFS=$'\t' read -r vid snap_updated tags; do
@@ -260,6 +413,7 @@ sweep_package() {
 			"orgs/${org}/packages/container/${pkg}/versions/${vid}" \
 			>/dev/null 2>"${delete_err_file}"; then
 			rm -f "${delete_err_file}"
+			deleted_ids+="${vid} "
 			echo "Deleted ${pkg} version ${vid} (tags: ${current_tags})"
 		else
 			echo "::error::Failed to delete ${pkg} version ${vid}: $(cat "${delete_err_file}")" >&2
@@ -267,6 +421,11 @@ sweep_package() {
 			sweep_errors=1
 		fi
 	done <<<"$versions"
+
+	if [[ -n "$deleted_ids" ]]; then
+		verify_persistent_tags_survived "$pkg" "$baseline_tags" \
+			"${deleted_ids% }"
+	fi
 }
 
 echo "Sweeping ${tag_prefix}* tags older than ${min_age_days}d (dry_run=${dry_run})"

--- a/tests/scripts/test_docker_ci_scripts.py
+++ b/tests/scripts/test_docker_ci_scripts.py
@@ -1052,7 +1052,7 @@ def test_sweep_ci_ghcr_tags_dry_run_skips_delete(
     assert_that(result.stdout).contains("[dry-run] Would delete")
     assert_that(gh_log.read_text()).does_not_contain("--method DELETE")
     # A dry run deletes nothing, so it must not pay for a baseline listing.
-    assert_that(gh_log.read_text()).does_not_contain("select(startswith(")
+    assert_that(gh_log.read_text()).does_not_contain(_PERSISTENT_QUERY_MARKER)
 
 
 # The persistent-tag listing is the only gh call whose jq program binds the tag

--- a/tests/scripts/test_docker_ci_scripts.py
+++ b/tests/scripts/test_docker_ci_scripts.py
@@ -631,7 +631,13 @@ def _run_sweep_validation(
     _write_stub(bin_dir, "gh", "exit 0")
     scrubbed = {
         name: ""
-        for name in ("MIN_AGE_DAYS", "TAG_PREFIX", "ALLOW_SHORT_RETENTION", "DRY_RUN")
+        for name in (
+            "MIN_AGE_DAYS",
+            "TAG_PREFIX",
+            "ALLOW_SHORT_RETENTION",
+            "DRY_RUN",
+            "VOLATILE_TAG_PREFIXES",
+        )
         if name not in env
     }
     return _run_with_stubs(
@@ -1045,3 +1051,241 @@ def test_sweep_ci_ghcr_tags_dry_run_skips_delete(
     assert_that(result.returncode).is_equal_to(0)
     assert_that(result.stdout).contains("[dry-run] Would delete")
     assert_that(gh_log.read_text()).does_not_contain("--method DELETE")
+    # A dry run deletes nothing, so it must not pay for a baseline listing.
+    assert_that(gh_log.read_text()).does_not_contain("select(startswith(")
+
+
+# The persistent-tag listing is the only gh call whose jq program binds the tag
+# to ``$tag``; the candidate query filters with ``all(startswith(...))``.
+_PERSISTENT_QUERY_MARKER = ". as $tag"
+
+_SWEEP_VERIFY_GH_STUB = (
+    'echo "$*" >> "$GH_LOG"\n'
+    'if [[ "$*" == *"DELETE"* ]]; then\n'
+    "  exit 0\n"
+    "fi\n"
+    f'if [[ "$*" == *"{_PERSISTENT_QUERY_MARKER}"* ]]; then\n'
+    "  n=0\n"
+    '  if [[ -f "$GH_PERSISTENT_COUNT" ]]; then\n'
+    '    n="$(cat "$GH_PERSISTENT_COUNT")"\n'
+    "  fi\n"
+    "  n=$((n + 1))\n"
+    '  echo "$n" > "$GH_PERSISTENT_COUNT"\n'
+    '  case " ${GH_PERSISTENT_FAIL} " in\n'
+    '  *" ${n} "*)\n'
+    '    echo "API rate limit exceeded" >&2\n'
+    "    exit 1\n"
+    "    ;;\n"
+    "  esac\n"
+    '  var="GH_PERSISTENT_${n}"\n'
+    '  if [[ -n "${!var:-}" ]]; then\n'
+    '    printf "%s\\n" "${!var}"\n'
+    "  else\n"
+    '    printf "%s\\n" "$GH_PERSISTENT_DEFAULT"\n'
+    "  fi\n"
+    "  exit 0\n"
+    "fi\n"
+    'if [[ "$*" =~ /versions/([0-9]+) ]]; then\n'
+    "  printf '%s\\t%s\\n' '2026-01-02T00:00:00Z' 'ci-old'\n"
+    "  exit 0\n"
+    "fi\n"
+    'printf "%s\\n" "$GH_VERSIONS_TSV"'
+)
+
+
+def _run_sweep_with_persistent_tags(
+    tmp_path: Path,
+    gh_log: Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Run the sweep against a ``gh`` stub that scripts the persistent listings.
+
+    The stub answers the persistent-tag listing from ``GH_PERSISTENT_<n>``
+    (1-based call order, falling back to ``GH_PERSISTENT_DEFAULT``) so a test
+    can make a tag vanish, come back, or make a read fail outright.
+
+    Args:
+        tmp_path: Pytest temporary directory for the PATH shim.
+        gh_log: File the stub appends every ``gh`` invocation to.
+        env: Extra environment variables, typically ``GH_PERSISTENT_*``.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed process.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_stub(bin_dir, "gh", _SWEEP_VERIFY_GH_STUB)
+
+    return _run_with_stubs(
+        "scripts/ci/maintenance/sweep-ci-ghcr-tags.sh",
+        bin_dir,
+        {
+            "GH_TOKEN": "dummy",  # nosec B105 - fake token for stubbed gh
+            "PACKAGES": "py-lintro",
+            "MIN_AGE_DAYS": "0",
+            "ALLOW_SHORT_RETENTION": "true",
+            "GH_LOG": str(gh_log),
+            "GH_VERSIONS_TSV": "202\t2026-01-02T00:00:00Z\tci-old",
+            "GH_PERSISTENT_COUNT": str(tmp_path / "persistent.count"),
+            "GH_PERSISTENT_DEFAULT": "latest\n0.9.9",
+            "GH_PERSISTENT_FAIL": "",
+            **env,
+        },
+    )
+
+
+def test_sweep_ci_ghcr_tags_verifies_persistent_tags_after_delete(
+    tmp_path: Path,
+) -> None:
+    """A clean sweep still re-reads the persistent tags and stays green (#1652)."""
+    gh_log = tmp_path / "gh.log"
+
+    result = _run_sweep_with_persistent_tags(tmp_path, gh_log, {})
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("Deleted py-lintro version 202")
+    assert_that(result.stderr).does_not_contain("Persistent tags disappeared")
+    # Baseline before the delete, one confirmation after it.
+    assert_that(gh_log.read_text().count(_PERSISTENT_QUERY_MARKER)).is_equal_to(2)
+
+
+def test_sweep_ci_ghcr_tags_alerts_when_a_persistent_tag_disappears(
+    tmp_path: Path,
+) -> None:
+    """A release tag lost to the recheck/DELETE race must fail the job (#1652).
+
+    This is the residual TOCTOU the sole-tag rule and dual recheck cannot
+    close: GHCR has no conditional delete, so a promotion landing in the
+    window takes its tag down with the CI version.
+    """
+    gh_log = tmp_path / "gh.log"
+
+    result = _run_sweep_with_persistent_tags(
+        tmp_path,
+        gh_log,
+        {
+            # Baseline sees the release tag; both post-delete reads do not.
+            "GH_PERSISTENT_1": "latest\n0.9.9",
+            "GH_PERSISTENT_2": "latest",
+            "GH_PERSISTENT_3": "latest",
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(1)
+    assert_that(result.stdout).contains("Deleted py-lintro version 202")
+    assert_that(result.stderr).contains("Persistent tags disappeared from py-lintro")
+    assert_that(result.stderr).contains("0.9.9")
+    assert_that(result.stderr).contains("202")
+
+
+def test_sweep_ci_ghcr_tags_tolerates_a_transient_listing_gap(
+    tmp_path: Path,
+) -> None:
+    """A tag missing from one read only is not reported (#1652).
+
+    A paginated listing on a busy registry can momentarily under-report, and a
+    false "we deleted a release tag" alarm is worse than no alarm at all.
+    """
+    gh_log = tmp_path / "gh.log"
+
+    result = _run_sweep_with_persistent_tags(
+        tmp_path,
+        gh_log,
+        {
+            "GH_PERSISTENT_1": "latest\n0.9.9",
+            "GH_PERSISTENT_2": "latest",
+            "GH_PERSISTENT_3": "latest\n0.9.9",
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stderr).does_not_contain("Persistent tags disappeared")
+    assert_that(gh_log.read_text().count(_PERSISTENT_QUERY_MARKER)).is_equal_to(3)
+
+
+def test_sweep_ci_ghcr_tags_skips_deletes_when_the_baseline_fails(
+    tmp_path: Path,
+) -> None:
+    """Without a baseline the verification is blind, so nothing is deleted."""
+    gh_log = tmp_path / "gh.log"
+
+    result = _run_sweep_with_persistent_tags(
+        tmp_path,
+        gh_log,
+        {"GH_PERSISTENT_FAIL": "1"},
+    )
+
+    assert_that(result.returncode).is_equal_to(1)
+    assert_that(result.stderr).contains("Failed to snapshot persistent tags")
+    assert_that(gh_log.read_text()).does_not_contain("--method DELETE")
+
+
+def test_sweep_ci_ghcr_tags_fails_when_verification_cannot_read(
+    tmp_path: Path,
+) -> None:
+    """An unreadable post-delete listing fails closed without claiming a loss."""
+    gh_log = tmp_path / "gh.log"
+
+    result = _run_sweep_with_persistent_tags(
+        tmp_path,
+        gh_log,
+        {"GH_PERSISTENT_FAIL": "2"},
+    )
+
+    assert_that(result.returncode).is_equal_to(1)
+    assert_that(result.stderr).contains("Could not verify persistent tags")
+    # Never accuse the sweep of a deletion it did not observe.
+    assert_that(result.stderr).does_not_contain("Persistent tags disappeared")
+
+
+def test_sweep_ci_ghcr_tags_fails_when_the_confirmation_read_cannot_run(
+    tmp_path: Path,
+) -> None:
+    """A failed confirmation read must not be treated as proof of loss."""
+    gh_log = tmp_path / "gh.log"
+
+    result = _run_sweep_with_persistent_tags(
+        tmp_path,
+        gh_log,
+        {
+            "GH_PERSISTENT_1": "latest\n0.9.9",
+            "GH_PERSISTENT_2": "latest",
+            "GH_PERSISTENT_FAIL": "3",
+        },
+    )
+
+    assert_that(result.returncode).is_equal_to(1)
+    assert_that(result.stderr).contains("Could not confirm persistent tags")
+    assert_that(result.stderr).does_not_contain("Persistent tags disappeared")
+
+
+def test_sweep_ci_ghcr_tags_baseline_excludes_volatile_prefixes(
+    tmp_path: Path,
+) -> None:
+    """The baseline must ignore tag families a sibling sweep may delete (#1652).
+
+    ghcr-cleanup.yml runs the ci-* and sha-* sweeps as parallel jobs. Without
+    the exclusion the sha-* sweep would report the ci-* sweep's legitimate
+    deletions as lost release tags — exactly the false alarm to avoid.
+    """
+    gh_log = tmp_path / "gh.log"
+
+    result = _run_sweep_with_persistent_tags(tmp_path, gh_log, {})
+
+    assert_that(result.returncode).is_equal_to(0)
+    listing = gh_log.read_text()
+    assert_that(listing).contains('"ci-"')
+    assert_that(listing).contains('"sha-"')
+
+
+def test_sweep_ci_ghcr_tags_rejects_unsafe_volatile_prefix(
+    tmp_path: Path,
+) -> None:
+    """VOLATILE_TAG_PREFIXES is interpolated into jq, so it must be validated."""
+    result = _run_sweep_validation(
+        tmp_path,
+        {"VOLATILE_TAG_PREFIXES": 'ci-" or true or "'},
+    )
+
+    assert_that(result.returncode).is_equal_to(2)
+    assert_that(result.stderr).contains("VOLATILE_TAG_PREFIXES entries must match")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): verify persistent GHCR tags survive the CI-tag sweep (#1652)
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Closes the residual TOCTOU gap in the GHCR CI-tag sweep. The sole-tag rule and the
dual pre-delete recheck already landed; what was missing was any check that the
digest actually removed was still the one that had been vetted.

- **Conditional delete: investigated, not available.** GitHub's REST API supports
  conditional requests only for reads (`ETag`/`If-None-Match`,
  `Last-Modified`/`If-Modified-Since`) and states that "conditional requests for
  unsafe methods, such as POST, PUT, PATCH, and DELETE are not supported unless
  otherwise noted"; the delete-package-version endpoint documents no `If-Match`.
  The negative result is recorded in the script header with the date checked so
  nobody re-runs this spike.
- **Post-delete verification.** The package's persistent tag set is snapshotted
  before the deletions and re-read afterwards. This sweep only ever deletes
  sole-`ci-*`-tagged versions, so that set may never shrink; a tag that vanished is
  reported with `::error::` and fails the job.
- **False alarms are designed out.** A tag is only reported after it is missing from
  two independent reads (a paginated listing on a busy registry can momentarily
  under-report). A read that fails outright is reported as "could not verify" — it
  still fails the job, but never claims a loss that was not observed.
- **Parallel-sibling false alarm fixed.** `ghcr-cleanup.yml` runs the `ci-*` and
  `sha-*` sweeps as parallel jobs, so each sees the other's deletions. The baseline
  now excludes `VOLATILE_TAG_PREFIXES` (default `ci- sha-`, plus `TAG_PREFIX`),
  which is validated against the same character class as `TAG_PREFIX` because it is
  interpolated into the jq filter.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1652

## Details

_See What’s Changing._
