### PR TITLE
fix(ci): make the lgtm-ci pin self-maintaining across bumps

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,9 +2,10 @@
 
 This repository uses GitHub Actions for quality gates, release automation, and
 publishing. Shared workflows are thin callers to
-[lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at
-`ea2eef45ec331a743dffd362a7397a0863501bd4` (**v0.59.25**). All workflow SHA pins include
-trailing `# vX.Y.Z` comments so Renovate can track digest updates. Policy is enforced by
+[lgtm-ci](https://github.com/lgtm-hq/lgtm-ci) reusable workflows pinned at a single
+canonical commit — read the current value off any `uses:` line rather than from here,
+since a copy in prose only ever drifts (#1771). All SHA pins include trailing `# vX.Y.Z`
+comments so Renovate can track digest updates. Policy is enforced by
 [lgtm-ci validate-action-pinning](https://github.com/lgtm-hq/lgtm-ci/pull/221) (via
 `validate-action-pinning.yml`) and automated by the
 [org Renovate preset](https://github.com/lgtm-hq/.github/pull/12)

--- a/renovate.json
+++ b/renovate.json
@@ -454,6 +454,18 @@
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver"
+    },
+    {
+      "description": "lgtm-ci tooling checkout in site-quality.yml pins through actions/checkout `with.ref:`, a shape the github-actions manager does not see, so every lgtm-ci bump left this one site behind and failed the single-pin invariant (#1771/#1280)",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "\\.github/workflows/site-quality\\.yml"
+      ],
+      "matchStrings": [
+        "ref: (?<currentDigest>[a-f0-9]{40}) # (?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "lgtm-hq/lgtm-ci"
     }
   ]
 }

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -6,6 +6,7 @@ import ast
 import json
 import re
 import subprocess  # nosec B404 - subprocess runs fixed git argv against this repo
+from collections import Counter
 from pathlib import Path
 from typing import Any, cast
 
@@ -1335,11 +1336,44 @@ def test_auto_rerun_covers_every_workflow_that_can_redden_main() -> None:
     ).is_subset_of(reddens_main)
 
 
-# Canonical lgtm-ci pin used by all py-lintro workflows (v0.52.4).
-# Pages deploy must not regress to v0.32.3 (missing GH_TOKEN in bundler).
-# The 40-hex git SHA trips trufflehog's Github legacy-token detector under
-# --no-verification; it is a commit pin, not a credential.
-_LGTM_CI_PIN = "ea2eef45ec331a743dffd362a7397a0863501bd4"  # trufflehog:ignore
+_LGTM_CI_USES = re.compile(r"lgtm-hq/lgtm-ci/[^@\s]+@([0-9a-f]{40})")
+
+
+def _canonical_lgtm_ci_pin() -> str:
+    """Return the lgtm-ci commit the repo's `uses:` refs agree on.
+
+    Derived rather than hardcoded (#1771). A literal here had to be edited by
+    hand on every lgtm-ci bump, and nothing updated it: Renovate's
+    github-actions manager rewrites the ~49 `uses:` refs but cannot see a
+    constant in a test file. The bump then failed *this* test and listed all 49
+    correctly-updated refs as offenders, because the one stale value was the
+    thing they were compared against — 49 right answers reported as wrong.
+
+    The modal `uses:` ref is the source of truth precisely because that is the
+    shape Renovate maintains reliably and en masse. Sites it cannot reach are
+    the ones that drift, so they are what this must catch, not define.
+
+    Returns:
+        The 40-character commit SHA shared by the majority of `uses:` refs.
+    """
+    refs: Counter[str] = Counter()
+    for path in _workflow_paths():
+        refs.update(_LGTM_CI_USES.findall(path.read_text(encoding="utf-8")))
+
+    assert_that(refs).described_as(
+        "no pinned lgtm-ci `uses:` refs found",
+    ).is_not_empty()
+    return refs.most_common(1)[0][0]
+
+
+def _workflow_paths() -> list[Path]:
+    """Return every workflow file, both YAML extensions, in stable order.
+
+    Returns:
+        Sorted list of workflow file paths.
+    """
+    workflows_dir = _REPO_ROOT / ".github" / "workflows"
+    return sorted((*workflows_dir.glob("*.yml"), *workflows_dir.glob("*.yaml")))
 
 
 def test_all_lgtm_ci_refs_use_the_canonical_pin() -> None:
@@ -1351,22 +1385,19 @@ def test_all_lgtm_ci_refs_use_the_canonical_pin() -> None:
     silently drift apart again. Any ref shape (tag, branch, short SHA,
     any quoting) that is not the canonical pin is an offender.
     """
+    canonical = _canonical_lgtm_ci_pin()
     ref_pattern = re.compile(
         r"lgtm-hq/lgtm-ci/[^@\s]+@([^\s#]+)|tooling-ref:\s*[\"']?([^\"'\s#]+)",
     )
-    workflows_dir = _REPO_ROOT / ".github" / "workflows"
     offenders: list[str] = []
-    workflow_paths = sorted(
-        (*workflows_dir.glob("*.yml"), *workflows_dir.glob("*.yaml")),
-    )
-    for path in workflow_paths:
+    for path in _workflow_paths():
         for lineno, line in enumerate(
             path.read_text(encoding="utf-8").splitlines(),
             start=1,
         ):
             for match in ref_pattern.finditer(line):
                 ref = match.group(1) or match.group(2)
-                if ref != _LGTM_CI_PIN:
+                if ref != canonical:
                     offenders.append(f"{path.name}:{lineno}: {ref}")
 
         # Manual lgtm-ci tooling checkouts pin via a separate `ref:` field
@@ -1378,13 +1409,72 @@ def test_all_lgtm_ci_refs_use_the_canonical_pin() -> None:
                 with_block = step.get("with") or {}
                 if with_block.get("repository") != "lgtm-hq/lgtm-ci":
                     continue
-                if with_block.get("ref") != _LGTM_CI_PIN:
+                if with_block.get("ref") != canonical:
                     offenders.append(
                         f"{path.name}:{job_id}: checkout ref "
                         f"{with_block.get('ref')!r}",
                     )
 
     assert_that(offenders).is_empty()
+
+
+def _js_named_groups_to_python(pattern: str) -> str:
+    """Rewrite JavaScript named capture groups into Python's spelling.
+
+    Renovate's regexes are evaluated by RE2/JS, which writes a named group as
+    ``(?<name>...)``; Python's ``re`` requires ``(?P<name>...)`` and raises on
+    the JS form. Lookbehinds (``(?<=`` and ``(?<!``) share the prefix and must
+    survive untouched, so the rewrite requires a name character after ``?<``.
+
+    Args:
+        pattern: A regex written in Renovate's dialect.
+
+    Returns:
+        The same regex, compilable by Python's ``re``.
+    """
+    return re.sub(r"\(\?<(?=[A-Za-z_])", "(?P<", pattern)
+
+
+def test_every_odd_shaped_lgtm_ci_pin_is_renovate_managed() -> None:
+    """Pin sites Renovate cannot see must be taught to it, not left to drift.
+
+    Renovate's github-actions manager rewrites ``uses:`` refs, and the org
+    preset covers ``tooling-ref:`` inputs. Anything else holding the same SHA
+    is invisible to it, so a bump updates the rest of the repo and strands that
+    line — breaking the single-pin invariant (#1280) on every release. The
+    v0.59.2 pin sat 22 releases stale exactly this way, which also left the
+    ``overwrite: true`` retry fix (#1737) unadopted long after it shipped.
+
+    Rather than name the known offender, derive the set: any lgtm-ci SHA in a
+    workflow that is not a ``uses:`` or ``tooling-ref:`` line must be matched
+    by one of this repo's own ``customManagers`` regexes (#1771).
+    """
+    canonical = _canonical_lgtm_ci_pin()
+    renovate = json.loads(
+        (_REPO_ROOT / "renovate.json").read_text(encoding="utf-8"),
+    )
+    custom_patterns = [
+        re.compile(_js_named_groups_to_python(pattern))
+        for manager in renovate.get("customManagers") or []
+        for pattern in manager.get("matchStrings") or []
+    ]
+
+    unmanaged: list[str] = []
+    for path in _workflow_paths():
+        for lineno, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(),
+            start=1,
+        ):
+            if canonical not in line:
+                continue
+            if "uses:" in line or "tooling-ref:" in line:
+                continue
+            if not any(pattern.search(line) for pattern in custom_patterns):
+                unmanaged.append(f"{path.name}:{lineno}: {line.strip()}")
+
+    assert_that(unmanaged).described_as(
+        "lgtm-ci pin sites no Renovate manager updates",
+    ).is_empty()
 
 
 def test_stage_coverage_html_allows_setup_uv_manifest_host() -> None:
@@ -1411,14 +1501,15 @@ def test_deploy_pages_pins_bundler_with_github_token() -> None:
     bundle-workflow-artifacts. v0.32.3 omitted GH_TOKEN; v0.32.4+ (lgtm-ci#300)
     sets ``GH_TOKEN: ${{ github.token }}``. Stay on the repo-standard v0.52.4 pin.
     """
+    canonical = _canonical_lgtm_ci_pin()
     workflow = _load_workflow(name="deploy-pages.yml")
     deploy = workflow["jobs"]["deploy"]
     uses = deploy["uses"]
     tooling_ref = deploy["with"]["tooling-ref"]
 
-    assert_that(uses).contains(_LGTM_CI_PIN)
+    assert_that(uses).contains(canonical)
     assert_that(uses).contains("reusable-deploy-site-with-reports.yml")
-    assert_that(tooling_ref).contains(_LGTM_CI_PIN)
+    assert_that(tooling_ref).contains(canonical)
     # v0.52.4 build job requests actions: write (lgtm-ci#415 rerun
     # self-heal); a lower caller grant is a parse-time startup_failure.
     assert_that(deploy["permissions"]).contains_entry({"actions": "write"})

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -1418,6 +1418,25 @@ def test_all_lgtm_ci_refs_use_the_canonical_pin() -> None:
     assert_that(offenders).is_empty()
 
 
+def _strip_regex_delimiters(pattern: str) -> str:
+    r"""Return a ``managerFilePatterns`` entry as a bare regex.
+
+    Renovate accepts both spellings and this repo uses each: bare
+    (``\\.github/workflows/docker-ci\\.yml``) and slash-delimited
+    (``/^\\.github/workflows/sbom-on-main\\.yml$/``). Only the delimited form
+    needs unwrapping, and a lone ``/`` must not be mistaken for one.
+
+    Args:
+        pattern: A single ``managerFilePatterns`` entry.
+
+    Returns:
+        The entry with any surrounding delimiters removed.
+    """
+    if len(pattern) > 1 and pattern.startswith("/") and pattern.endswith("/"):
+        return pattern[1:-1]
+    return pattern
+
+
 def _js_named_groups_to_python(pattern: str) -> str:
     """Rewrite JavaScript named capture groups into Python's spelling.
 
@@ -1453,14 +1472,34 @@ def test_every_odd_shaped_lgtm_ci_pin_is_renovate_managed() -> None:
     renovate = json.loads(
         (_REPO_ROOT / "renovate.json").read_text(encoding="utf-8"),
     )
-    custom_patterns = [
-        re.compile(_js_named_groups_to_python(pattern))
+    # Keep each manager's regexes bound to the files it is scoped to. Renovate
+    # only applies a customManager where its managerFilePatterns match, so
+    # flattening every matchStrings across all managers would let a regex
+    # scoped to one file vouch for a pin in another -- reporting an unmanaged
+    # site as covered, which is the exact blindness #1771 exists to remove.
+    scoped_managers = [
+        (
+            [
+                re.compile(_strip_regex_delimiters(file_pattern))
+                for file_pattern in manager.get("managerFilePatterns") or []
+            ],
+            [
+                re.compile(_js_named_groups_to_python(pattern))
+                for pattern in manager.get("matchStrings") or []
+            ],
+        )
         for manager in renovate.get("customManagers") or []
-        for pattern in manager.get("matchStrings") or []
     ]
 
     unmanaged: list[str] = []
     for path in _workflow_paths():
+        relative = path.relative_to(_REPO_ROOT).as_posix()
+        applicable = [
+            pattern
+            for file_matchers, patterns in scoped_managers
+            if any(matcher.search(relative) for matcher in file_matchers)
+            for pattern in patterns
+        ]
         for lineno, line in enumerate(
             path.read_text(encoding="utf-8").splitlines(),
             start=1,
@@ -1469,8 +1508,8 @@ def test_every_odd_shaped_lgtm_ci_pin_is_renovate_managed() -> None:
                 continue
             if "uses:" in line or "tooling-ref:" in line:
                 continue
-            if not any(pattern.search(line) for pattern in custom_patterns):
-                unmanaged.append(f"{path.name}:{lineno}: {line.strip()}")
+            if not any(pattern.search(line) for pattern in applicable):
+                unmanaged.append(f"{relative}:{lineno}: {line.strip()}")
 
     assert_that(unmanaged).described_as(
         "lgtm-ci pin sites no Renovate manager updates",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): make the lgtm-ci pin self-maintaining across bumps
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Every lgtm-ci bump opens red and needs a manual follow-up commit, because three sites hold the canonical SHA in shapes Renovate's `github-actions` manager cannot see. This makes all three self-maintaining.

Closes #1771

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1771

## Details

- Realistic-bump simulation, before/after, as in the table above.
- Both new assertions mutation-checked in each direction (removing the customManager fails naming `site-quality.yml:92`; restoring it passes).
- Named-group translator checked against 4 shapes including both lookbehind forms.
- `lintro fmt` / `chk` clean, 100/100. 97 workflow-wiring tests pass.
