### PR TITLE
feat(json): serialize tool timeout state and auto-emit the JSON artifact in CI

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -234,6 +234,67 @@ In `--output-format json` the score is added **additively** under
 }
 ```
 
+### Tool Timeouts in the JSON Report
+
+A tool timeout is an **execution failure, never a lint finding**. Every tool accounts
+for one the same way, so a consumer can tell an infrastructure flake apart from a
+genuine finding using evidence about its own run.
+
+A timed-out tool reports:
+
+- `success: false` — the run failed, and the process exit code stays non-zero.
+- `timed_out: true` — the machine-readable marker to classify on. No need to regex-match
+  the human-readable `output` string.
+- `issues_count` counting **only** genuine findings. No synthetic `TIMEOUT` pseudo-issue
+  is invented, and the timeout never reaches `summary.total_issues`. Issues legitimately
+  detected _before_ the timeout (for example the pre-fix check of a `format` run) are
+  still reported.
+
+`summary.timed_out_tools` lists the tools that timed out, in execution order:
+
+```json
+{
+  "summary": {
+    "total_issues": 0,
+    "total_fixed": 0,
+    "total_remaining": 0,
+    "timed_out_tools": ["mypy"]
+  },
+  "results": [
+    {
+      "tool": "mypy",
+      "success": false,
+      "issues_count": 0,
+      "timed_out": true,
+      "output": "mypy execution timed out (300s limit exceeded)..."
+    }
+  ]
+}
+```
+
+This makes the conservative CI classification expressible: **at least one tool timed out
+AND `total_issues == 0`**. A run with a real finding still reports a non-zero
+`total_issues`, and a non-timeout tool failure reports `timed_out: false`, so neither is
+ever mistaken for a flake.
+
+### Artifacts Under GitHub Actions
+
+When `GITHUB_ACTIONS=true` is detected, lintro auto-emits two side-channel artifacts
+regardless of `--output-format`, so the console/grid output every existing consumer
+parses is untouched and no second invocation is needed:
+
+| Format | Path                                         | Purpose                            |
+| ------ | -------------------------------------------- | ---------------------------------- |
+| SARIF  | `.lintro/artifacts/sarif/results.sarif.json` | GitHub Code Scanning ingestion     |
+| JSON   | `.lintro/artifacts/json/results.json`        | Structured CI evidence (see above) |
+
+SARIF omits clean tools and omits failures that produced no issues, so it cannot be used
+to classify a timeout without failing open. The JSON report covers every tool that ran
+and carries the per-tool `timed_out` flag.
+
+Any format listed in `execution.artifacts` is emitted in addition to these, in every
+environment.
+
 ### Output Presentation
 
 Purely cosmetic console output is controlled by the `output` section. These settings

--- a/lintro/models/core/tool_result.py
+++ b/lintro/models/core/tool_result.py
@@ -73,6 +73,14 @@ class ToolResult:
     skipped: bool = field(default=False)
     skip_reason: str | None = field(default=None)
 
+    # Execution-timeout tracking. ``True`` when the tool's subprocess exceeded
+    # its deadline and was killed. A timeout is an *execution failure*, not a
+    # lint finding: it never contributes to ``issues_count``. Consumers use
+    # this flag (surfaced as ``timed_out`` in the JSON report) to tell an
+    # infrastructure flake apart from a genuine finding without regex-matching
+    # the human-readable ``output`` string.
+    timed_out: bool = field(default=False)
+
     # Parser failures (items that could not be parsed from tool output).
     # Omitted from JSON output unless the tool sets this explicitly.
     parse_failures_count: int | None = field(default=None)

--- a/lintro/plugins/base.py
+++ b/lintro/plugins/base.py
@@ -640,6 +640,7 @@ class BaseToolPlugin(ABC):
                         output="",
                         issues=[],
                         skipped=True,
+                        timed_out=True,
                     )
 
             result = self._process_files_with_progress(

--- a/lintro/plugins/file_processor.py
+++ b/lintro/plugins/file_processor.py
@@ -41,6 +41,10 @@ class FileProcessingResult:
         issues: List of issues found in this file.
         skipped: Whether the file was skipped (e.g., due to timeout).
         error: Error message if processing failed.
+        timed_out: Whether this file was abandoned because the tool's
+            subprocess exceeded its deadline. Propagated to the tool-level
+            ``ToolResult.timed_out`` so a timeout stays distinguishable from a
+            genuine finding in the JSON report.
     """
 
     success: bool
@@ -48,6 +52,7 @@ class FileProcessingResult:
     issues: Sequence[BaseIssue]
     skipped: bool = False
     error: str | None = None
+    timed_out: bool = False
 
 
 @dataclass
@@ -113,6 +118,8 @@ class AggregatedResult:
         skipped_files: List of file paths that were skipped.
         execution_failures: Count of files that failed to process.
         total_issues: Total count of issues across all files.
+        timed_out: Whether at least one file was abandoned due to a
+            subprocess timeout.
     """
 
     all_success: bool = True
@@ -121,6 +128,7 @@ class AggregatedResult:
     skipped_files: list[str] = field(default_factory=list)
     execution_failures: int = 0
     total_issues: int = 0
+    timed_out: bool = False
 
     def add_file_result(self, file_path: str, result: FileProcessingResult) -> None:
         """Add a single file's result to the aggregate.
@@ -129,6 +137,9 @@ class AggregatedResult:
             file_path: Path to the file that was processed.
             result: The processing result for this file.
         """
+        if result.timed_out:
+            self.timed_out = True
+
         if result.skipped:
             self.skipped_files.append(file_path)
             self.all_success = False

--- a/lintro/tools/core/timeout_utils.py
+++ b/lintro/tools/core/timeout_utils.py
@@ -2,6 +2,23 @@
 
 This module provides standardized timeout handling across different tools,
 ensuring consistent behavior and error messages for subprocess timeouts.
+
+Timeout accounting model (single source of truth for every tool):
+
+    A tool timeout is an **execution failure**, never a lint finding.
+
+Concretely, a timed-out tool reports:
+
+- ``success=False`` — the run failed, so the process exit code is non-zero.
+- ``timed_out=True`` — the machine-readable marker consumers classify on.
+- **zero** issues of its own. ``issues_count`` only ever counts genuine
+  findings parsed out of the tool's output. Issues that were legitimately
+  detected *before* the timeout (for example the pre-fix check in a fix run)
+  are still reported; no synthetic pseudo-issue is ever invented.
+
+This keeps ``summary.total_issues`` and the per-tool ``issues_count`` in
+agreement, and makes "at least one tool timed out and the run found zero
+issues" an expressible — and therefore usable — classification downstream.
 """
 
 import subprocess  # nosec B404 - used safely with shell disabled
@@ -116,6 +133,10 @@ def create_timeout_result(
 ) -> TimeoutResult:
     """Create a standardized timeout result.
 
+    Follows the module's timeout accounting model: the result carries
+    ``timed_out=True`` and ``issues_count=0`` so a timeout never masquerades
+    as a lint finding.
+
     Args:
         tool: Tool instance.
         timeout: Timeout value that was exceeded.
@@ -136,7 +157,9 @@ def create_timeout_result(
             "  - Need to increase timeout via --tool-options timeout=N\n"
             "  - Command hanging due to external dependencies\n"
         ),
-        issues_count=1,  # Count timeout as execution failure
+        # A timeout is an execution failure, not a lint finding: it must not
+        # inflate issue counts (see the module docstring's accounting model).
+        issues_count=0,
         issues=[],
         timed_out=True,
         timeout_seconds=timeout,

--- a/lintro/tools/definitions/_ts_checker_base.py
+++ b/lintro/tools/definitions/_ts_checker_base.py
@@ -779,6 +779,7 @@ class TypeScriptCheckerPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=timeout_result.issues_count,
                 issues=timeout_result.issues,

--- a/lintro/tools/definitions/_ts_checker_base.py
+++ b/lintro/tools/definitions/_ts_checker_base.py
@@ -626,6 +626,7 @@ class TypeScriptCheckerPlugin(BaseToolPlugin):
         temp_files: list[Path] = []
         any_succeeded = False
         had_subproject_error = False
+        any_subproject_timed_out = False
 
         try:
             for tsconfig_info, project_files in partitions:
@@ -695,6 +696,8 @@ class TypeScriptCheckerPlugin(BaseToolPlugin):
                         e,
                     )
                     had_subproject_error = True
+                    if isinstance(e, subprocess.TimeoutExpired):
+                        any_subproject_timed_out = True
                     continue
 
                 if proc_success:
@@ -723,6 +726,7 @@ class TypeScriptCheckerPlugin(BaseToolPlugin):
                 output=output_text,
                 issues_count=total_issues,
                 issues=all_issues,
+                timed_out=any_subproject_timed_out,
             )
         finally:
             for temp in temp_files:

--- a/lintro/tools/definitions/actionlint.py
+++ b/lintro/tools/definitions/actionlint.py
@@ -115,6 +115,7 @@ class ActionlintPlugin(BaseToolPlugin):
             results["skipped_files"].append(file_path)
             results["all_success"] = False
             results["execution_failures"] += 1
+            results["timed_out"] = True
         except (OSError, ValueError, RuntimeError) as e:  # pragma: no cover
             results["all_success"] = False
             results["all_outputs"].append(f"Error checking {file_path}: {e}")
@@ -170,6 +171,7 @@ class ActionlintPlugin(BaseToolPlugin):
             "all_success": True,
             "skipped_files": [],
             "execution_failures": 0,
+            "timed_out": False,
         }
 
         # Show progress bar only when processing multiple files
@@ -222,6 +224,7 @@ class ActionlintPlugin(BaseToolPlugin):
             output=combined_output,
             issues_count=len(results["all_issues"]),
             issues=results["all_issues"],
+            timed_out=bool(results["timed_out"]),
         )
 
     def fix(self, paths: list[str], options: dict[str, object]) -> ToolResult:

--- a/lintro/tools/definitions/astro_check.py
+++ b/lintro/tools/definitions/astro_check.py
@@ -399,6 +399,7 @@ class AstroCheckPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=timeout_result.issues_count,
                 issues=timeout_result.issues,

--- a/lintro/tools/definitions/bandit.py
+++ b/lintro/tools/definitions/bandit.py
@@ -408,6 +408,7 @@ class BanditPlugin(BaseToolPlugin):
                 success=False,
                 output=timeout_msg,
                 issues_count=0,
+                timed_out=True,
             )
         except (OSError, ValueError, RuntimeError) as e:
             logger.error(f"Failed to run Bandit: {e}")

--- a/lintro/tools/definitions/black.py
+++ b/lintro/tools/definitions/black.py
@@ -201,6 +201,11 @@ class BlackPlugin(BaseToolPlugin):
             initial_count: Optional initial issues count for fix operations.
             cwd: Working directory for the tool result.
 
+        Follows the shared timeout accounting model (see
+        :mod:`lintro.tools.core.timeout_utils`): a timeout is an execution
+        failure reported via ``timed_out=True`` and ``success=False``, never a
+        lint finding, so it does not contribute to the issue counts.
+
         Returns:
             Standardized timeout error result.
         """
@@ -219,14 +224,16 @@ class BlackPlugin(BaseToolPlugin):
                 issues=[],
                 initial_issues_count=initial_count,
                 cwd=cwd,
+                timed_out=True,
             )
         return ToolResult(
             name=self.definition.name,
             success=False,
             output=timeout_msg,
-            issues_count=1,
+            issues_count=0,
             issues=[],
             cwd=cwd,
+            timed_out=True,
         )
 
     def check(self, paths: list[str], options: dict[str, object]) -> ToolResult:

--- a/lintro/tools/definitions/cargo_audit.py
+++ b/lintro/tools/definitions/cargo_audit.py
@@ -164,6 +164,7 @@ class CargoAuditPlugin(BaseToolPlugin):
                 success=False,
                 output=f"cargo-audit timed out after {ctx.timeout}s",
                 issues_count=0,
+                timed_out=True,
             )
 
         success = proc.success

--- a/lintro/tools/definitions/cargo_deny.py
+++ b/lintro/tools/definitions/cargo_deny.py
@@ -202,6 +202,7 @@ class CargoDenyPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=timeout_result.issues_count,
                 issues=timeout_result.issues,

--- a/lintro/tools/definitions/clippy.py
+++ b/lintro/tools/definitions/clippy.py
@@ -242,6 +242,7 @@ class ClippyPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=timeout_result.issues_count,
                 issues=timeout_result.issues,
@@ -314,6 +315,7 @@ class ClippyPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=timeout_result.issues_count,
                 issues=timeout_result.issues,
@@ -345,6 +347,7 @@ class ClippyPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=initial_count,
                 issues=initial_issues,
@@ -373,6 +376,7 @@ class ClippyPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=initial_count,
                 issues=initial_issues,

--- a/lintro/tools/definitions/commitlint.py
+++ b/lintro/tools/definitions/commitlint.py
@@ -179,6 +179,7 @@ class CommitlintPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=timeout_result.issues_count,
             )

--- a/lintro/tools/definitions/dotenv_linter.py
+++ b/lintro/tools/definitions/dotenv_linter.py
@@ -314,6 +314,7 @@ class DotenvLinterPlugin(BaseToolPlugin):
                     output=recheck.output or recheck.error or fix_output,
                     issues=[replace(issue, fixable=False) for issue in initial_issues],
                     error=recheck.error or "dotenv-linter recheck failed",
+                    timed_out=recheck.timed_out,
                 ),
                 initial_count=len(initial_issues),
                 fixed_count=0,

--- a/lintro/tools/definitions/dotenv_linter.py
+++ b/lintro/tools/definitions/dotenv_linter.py
@@ -198,6 +198,7 @@ class DotenvLinterPlugin(BaseToolPlugin):
                 output="",
                 issues=[],
                 skipped=True,
+                timed_out=True,
             )
         except (OSError, ValueError, RuntimeError) as e:
             return FileProcessingResult(
@@ -268,6 +269,7 @@ class DotenvLinterPlugin(BaseToolPlugin):
                     output="",
                     issues=initial_issues,
                     skipped=True,
+                    timed_out=True,
                 ),
                 initial_count=len(initial_issues),
                 fixed_count=0,
@@ -360,6 +362,7 @@ class DotenvLinterPlugin(BaseToolPlugin):
             success=result.all_success and result.total_issues == 0,
             output=result.build_output(timeout=ctx.timeout),
             issues_count=result.total_issues,
+            timed_out=result.timed_out,
             issues=result.all_issues,
         )
 
@@ -456,4 +459,5 @@ class DotenvLinterPlugin(BaseToolPlugin):
             fixed_issues_count=fixed_issues_total,
             remaining_issues_count=remaining_issues,
             initial_issues=all_initial_issues if all_initial_issues else None,
+            timed_out=result.timed_out,
         )

--- a/lintro/tools/definitions/gitleaks.py
+++ b/lintro/tools/definitions/gitleaks.py
@@ -289,6 +289,7 @@ class GitleaksPlugin(BaseToolPlugin):
                     success=False,
                     output=timeout_msg,
                     issues_count=0,
+                    timed_out=True,
                 )
             except (OSError, ValueError, RuntimeError, FileNotFoundError) as e:
                 logger.error(f"Failed to run Gitleaks: {e}")

--- a/lintro/tools/definitions/golangci_lint.py
+++ b/lintro/tools/definitions/golangci_lint.py
@@ -257,7 +257,7 @@ class GolangciLintPlugin(BaseToolPlugin):
 
         all_issues: list[GolangciLintIssue] = []
         failure_outputs: list[str] = []
-        timeout_failures = 0
+        any_timed_out = False
         overall_success = True
         for module_root in module_roots:
             try:
@@ -279,11 +279,10 @@ class GolangciLintPlugin(BaseToolPlugin):
                     tool_name="golangci_lint",
                 )
                 overall_success = False
-                # create_timeout_result() counts a timeout as one execution
-                # failure (issues_count=1) with an intentionally empty issues
-                # list. Preserve that count so a lone module timeout is not
-                # silently reported as issues_count=0.
-                timeout_failures += timeout_result.issues_count or 0
+                # A timeout is an execution failure, not a lint finding: it
+                # never inflates issues_count. The tool-level ``timed_out``
+                # flag (plus success=False) is what surfaces it instead.
+                any_timed_out = True
                 all_issues.extend(timeout_result.issues or [])
                 if timeout_result.output:
                     failure_outputs.append(timeout_result.output)
@@ -303,8 +302,9 @@ class GolangciLintPlugin(BaseToolPlugin):
             name=self.definition.name,
             success=overall_success,
             output="\n".join(failure_outputs) if failure_outputs else None,
-            issues_count=len(all_issues) + timeout_failures,
+            issues_count=len(all_issues),
             issues=all_issues,
+            timed_out=any_timed_out,
         )
 
     def fix(self, paths: list[str], options: dict[str, object]) -> ToolResult:
@@ -379,6 +379,7 @@ class GolangciLintPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=timeout_result.issues_count,
                 issues=timeout_result.issues,
@@ -425,6 +426,7 @@ class GolangciLintPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=initial_count,
                 issues=initial_issues,
@@ -453,6 +455,7 @@ class GolangciLintPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=initial_count,
                 issues=initial_issues,

--- a/lintro/tools/definitions/hadolint.py
+++ b/lintro/tools/definitions/hadolint.py
@@ -226,6 +226,7 @@ class HadolintPlugin(BaseToolPlugin):
                 output="",
                 issues=[],
                 skipped=True,
+                timed_out=True,
             )
         except (OSError, ValueError, RuntimeError) as e:
             return FileProcessingResult(
@@ -282,6 +283,7 @@ class HadolintPlugin(BaseToolPlugin):
             success=result.all_success and result.total_issues == 0,
             output=result.build_output(timeout=ctx.timeout),
             issues_count=result.total_issues,
+            timed_out=result.timed_out,
             issues=result.all_issues,
         )
 

--- a/lintro/tools/definitions/html_validate.py
+++ b/lintro/tools/definitions/html_validate.py
@@ -237,6 +237,7 @@ class HtmlValidatePlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=self._append_fallback_guidance(
                     output=timeout_result.output,
                     used_registry_fallback=used_registry_fallback,

--- a/lintro/tools/definitions/markdownlint.py
+++ b/lintro/tools/definitions/markdownlint.py
@@ -289,6 +289,7 @@ class MarkdownlintPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=timeout_result.issues_count,
             )

--- a/lintro/tools/definitions/mypy.py
+++ b/lintro/tools/definitions/mypy.py
@@ -498,6 +498,7 @@ class MypyPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=timeout_result.issues_count,
                 issues=timeout_result.issues,

--- a/lintro/tools/definitions/osv_scanner.py
+++ b/lintro/tools/definitions/osv_scanner.py
@@ -361,6 +361,7 @@ class OsvScannerPlugin(BaseToolPlugin):
                 success=False,
                 output=f"OSV-Scanner timed out after {timeout}s",
                 issues_count=0,
+                timed_out=True,
             )
 
         success = proc.success

--- a/lintro/tools/definitions/oxfmt.py
+++ b/lintro/tools/definitions/oxfmt.py
@@ -136,6 +136,12 @@ class OxfmtPlugin(BaseToolPlugin):
             initial_count: Optional count of initial issues.
             cwd: Working directory for the tool result.
 
+        Follows the shared timeout accounting model (see
+        :mod:`lintro.tools.core.timeout_utils`): the timeout is reported via
+        ``timed_out=True`` and ``success=False`` rather than as a synthetic
+        ``TIMEOUT`` pseudo-issue, so it never inflates the issue counts. Only
+        genuine issues detected before the timeout are reported.
+
         Returns:
             ToolResult: ToolResult instance representing timeout failure.
         """
@@ -145,14 +151,7 @@ class OxfmtPlugin(BaseToolPlugin):
             "  - Large codebase taking too long to process\n"
             "  - Need to increase timeout via --tool-options oxfmt:timeout=N"
         )
-        timeout_issue = OxfmtIssue(
-            file="execution",
-            line=1,
-            code="TIMEOUT",
-            message=timeout_msg,
-            column=1,
-        )
-        combined_issues = (initial_issues or []) + [timeout_issue]
+        combined_issues = list(initial_issues or [])
         combined_count = len(combined_issues)
         return ToolResult(
             name=self.definition.name,
@@ -164,6 +163,7 @@ class OxfmtPlugin(BaseToolPlugin):
             fixed_issues_count=0,
             remaining_issues_count=combined_count,
             cwd=cwd,
+            timed_out=True,
         )
 
     def _build_oxfmt_args(self, options: dict[str, object]) -> list[str]:

--- a/lintro/tools/definitions/oxlint.py
+++ b/lintro/tools/definitions/oxlint.py
@@ -165,6 +165,12 @@ class OxlintPlugin(BaseToolPlugin):
             initial_count: Optional count of initial issues.
             cwd: Working directory for the tool result.
 
+        Follows the shared timeout accounting model (see
+        :mod:`lintro.tools.core.timeout_utils`): the timeout is reported via
+        ``timed_out=True`` and ``success=False`` rather than as a synthetic
+        ``TIMEOUT`` pseudo-issue, so it never inflates the issue counts. Only
+        genuine issues detected before the timeout are reported.
+
         Returns:
             ToolResult: ToolResult instance representing timeout failure.
         """
@@ -174,15 +180,6 @@ class OxlintPlugin(BaseToolPlugin):
             "  - Large codebase taking too long to process\n"
             "  - Need to increase timeout via --tool-options oxlint:timeout=N"
         )
-        timeout_issue = OxlintIssue(
-            file="execution",
-            line=1,
-            column=1,
-            code="TIMEOUT",
-            message=timeout_msg,
-            severity="error",
-            fixable=False,
-        )
         if initial_issues is not None:
             pre_fix_count = len(initial_issues)
         else:
@@ -191,11 +188,12 @@ class OxlintPlugin(BaseToolPlugin):
             name=self.definition.name,
             success=False,
             output=timeout_msg,
-            issues_count=1,
-            issues=[timeout_issue],
+            issues_count=pre_fix_count,
+            issues=list(initial_issues or []),
             initial_issues_count=pre_fix_count,
             initial_issues=initial_issues if initial_issues is not None else None,
             cwd=cwd,
+            timed_out=True,
         )
 
     def _build_oxlint_args(self, options: dict[str, object]) -> list[str]:

--- a/lintro/tools/definitions/pip_audit.py
+++ b/lintro/tools/definitions/pip_audit.py
@@ -310,6 +310,7 @@ class PipAuditPlugin(BaseToolPlugin):
         output_chunks: list[str] = []
         all_success = True
         parse_failures_count = 0
+        any_timed_out = False
 
         for target in targets:
             source = _target_source(target)
@@ -331,6 +332,7 @@ class PipAuditPlugin(BaseToolPlugin):
                 # failure for this target and keep auditing the rest, so a
                 # timeout can never silently skip coverage of later targets.
                 all_success = False
+                any_timed_out = True
                 output_chunks.append(
                     f"pip-audit timed out after {timeout}s for {source}",
                 )
@@ -369,6 +371,7 @@ class PipAuditPlugin(BaseToolPlugin):
             issues_count=len(issues),
             issues=issues if issues else None,
             parse_failures_count=parse_failures_count,
+            timed_out=any_timed_out,
         )
 
     def fix(self, paths: list[str], options: dict[str, object]) -> ToolResult:

--- a/lintro/tools/definitions/prettier.py
+++ b/lintro/tools/definitions/prettier.py
@@ -249,6 +249,12 @@ class PrettierPlugin(BaseToolPlugin):
     ) -> ToolResult:
         """Create a ToolResult for timeout scenarios.
 
+        Follows the shared timeout accounting model (see
+        :mod:`lintro.tools.core.timeout_utils`): the timeout is reported via
+        ``timed_out=True`` and ``success=False`` rather than as a synthetic
+        ``TIMEOUT`` pseudo-issue, so it never inflates the issue counts. Only
+        genuine issues detected before the timeout are reported.
+
         Args:
             timeout_val: The timeout value that was exceeded.
             initial_issues: Optional list of issues found before timeout.
@@ -264,26 +270,20 @@ class PrettierPlugin(BaseToolPlugin):
             "  - Large codebase taking too long to process\n"
             "  - Need to increase timeout via --tool-options prettier:timeout=N"
         )
-        timeout_issue = PrettierIssue(
-            file="execution",
-            line=0,
-            code="TIMEOUT",
-            message=timeout_msg,
-            column=0,
-        )
-        combined_issues = (initial_issues or []) + [timeout_issue]
-        remaining_count = len(combined_issues)
+        detected_issues = list(initial_issues or [])
+        remaining_count = len(detected_issues)
         # Maintain invariant: initial = fixed + remaining
         return ToolResult(
             name=self.definition.name,
             success=False,
             output=timeout_msg,
             issues_count=remaining_count,
-            issues=combined_issues,
+            issues=detected_issues,
             initial_issues_count=remaining_count,
             fixed_issues_count=0,
             remaining_issues_count=remaining_count,
             cwd=cwd,
+            timed_out=True,
         )
 
     def check(self, paths: list[str], options: dict[str, object]) -> ToolResult:

--- a/lintro/tools/definitions/pydoclint.py
+++ b/lintro/tools/definitions/pydoclint.py
@@ -103,6 +103,7 @@ class PydoclintPlugin(BaseToolPlugin):
                 output="",
                 issues=[],
                 skipped=True,
+                timed_out=True,
             )
         except (OSError, ValueError, RuntimeError) as e:
             return FileProcessingResult(
@@ -153,6 +154,7 @@ class PydoclintPlugin(BaseToolPlugin):
             success=result.all_success and result.total_issues == 0,
             output=result.build_output(timeout=ctx.timeout),
             issues_count=result.total_issues,
+            timed_out=result.timed_out,
             issues=result.all_issues,
         )
 

--- a/lintro/tools/definitions/pytest.py
+++ b/lintro/tools/definitions/pytest.py
@@ -380,6 +380,7 @@ class PytestPlugin(BaseToolPlugin):
                     success=False,
                     output=f"Pytest execution timed out ({timeout_val}s)",
                     issues_count=0,
+                    timed_out=True,
                 )
 
             return self.error_handler.handle_timeout_error(

--- a/lintro/tools/definitions/rustfmt.py
+++ b/lintro/tools/definitions/rustfmt.py
@@ -204,6 +204,7 @@ class RustfmtPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=timeout_result.issues_count,
                 issues=timeout_result.issues,
@@ -276,6 +277,7 @@ class RustfmtPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=timeout_result.issues_count,
                 issues=timeout_result.issues,
@@ -307,6 +309,7 @@ class RustfmtPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=initial_count,
                 issues=initial_issues,
@@ -349,6 +352,7 @@ class RustfmtPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=initial_count,
                 issues=initial_issues,

--- a/lintro/tools/definitions/semgrep.py
+++ b/lintro/tools/definitions/semgrep.py
@@ -309,6 +309,7 @@ class SemgrepPlugin(BaseToolPlugin):
                 success=False,
                 output=timeout_msg,
                 issues_count=0,
+                timed_out=True,
             )
         except (OSError, ValueError, RuntimeError) as e:
             logger.error(f"Failed to run Semgrep: {e}")

--- a/lintro/tools/definitions/shellcheck.py
+++ b/lintro/tools/definitions/shellcheck.py
@@ -263,6 +263,7 @@ class ShellcheckPlugin(BaseToolPlugin):
                 output="",
                 issues=[],
                 skipped=True,
+                timed_out=True,
             )
         except (OSError, ValueError, RuntimeError) as e:
             return FileProcessingResult(
@@ -297,6 +298,7 @@ class ShellcheckPlugin(BaseToolPlugin):
             success=result.all_success and result.total_issues == 0,
             output=result.build_output(timeout=ctx.timeout),
             issues_count=result.total_issues,
+            timed_out=result.timed_out,
             issues=result.all_issues,
         )
 

--- a/lintro/tools/definitions/shfmt.py
+++ b/lintro/tools/definitions/shfmt.py
@@ -202,6 +202,7 @@ class ShfmtPlugin(BaseToolPlugin):
                 output="",
                 issues=[],
                 skipped=True,
+                timed_out=True,
             )
         except (OSError, ValueError, RuntimeError) as e:
             return FileProcessingResult(
@@ -247,6 +248,7 @@ class ShfmtPlugin(BaseToolPlugin):
                     output="",
                     issues=[],
                     skipped=True,
+                    timed_out=True,
                 ),
                 initial_count=0,
                 fixed_count=0,
@@ -315,6 +317,7 @@ class ShfmtPlugin(BaseToolPlugin):
                     output="",
                     issues=check_issues,
                     skipped=True,
+                    timed_out=True,
                 ),
                 initial_count=len(check_issues),
                 fixed_count=0,
@@ -382,6 +385,7 @@ class ShfmtPlugin(BaseToolPlugin):
             success=result.all_success and result.total_issues == 0,
             output=result.build_output(timeout=ctx.timeout),
             issues_count=result.total_issues,
+            timed_out=result.timed_out,
             issues=result.all_issues,
         )
 
@@ -484,4 +488,5 @@ class ShfmtPlugin(BaseToolPlugin):
             fixed_issues_count=fixed_issues_total,
             remaining_issues_count=remaining_issues,
             initial_issues=all_initial_issues if all_initial_issues else None,
+            timed_out=result.timed_out,
         )

--- a/lintro/tools/definitions/sqlfluff.py
+++ b/lintro/tools/definitions/sqlfluff.py
@@ -354,6 +354,7 @@ class SqlfluffPlugin(BaseToolPlugin):
                     output=fix_output,
                     issues=check_issues,
                     error=str(e),
+                    timed_out=isinstance(e, subprocess.TimeoutExpired),
                 ),
                 initial_count=len(check_issues),
                 fixed_count=0,

--- a/lintro/tools/definitions/sqlfluff.py
+++ b/lintro/tools/definitions/sqlfluff.py
@@ -213,6 +213,7 @@ class SqlfluffPlugin(BaseToolPlugin):
                 output="",
                 issues=[],
                 skipped=True,
+                timed_out=True,
             )
         except (OSError, ValueError, RuntimeError) as e:
             return FileProcessingResult(
@@ -253,6 +254,7 @@ class SqlfluffPlugin(BaseToolPlugin):
                     output="",
                     issues=[],
                     skipped=True,
+                    timed_out=True,
                 ),
                 initial_count=0,
                 fixed_count=0,
@@ -313,6 +315,7 @@ class SqlfluffPlugin(BaseToolPlugin):
                     output="",
                     issues=check_issues,
                     skipped=True,
+                    timed_out=True,
                 ),
                 initial_count=len(check_issues),
                 fixed_count=0,
@@ -434,6 +437,7 @@ class SqlfluffPlugin(BaseToolPlugin):
             success=result.all_success,
             output=result.build_output(timeout=ctx.timeout),
             issues_count=result.total_issues,
+            timed_out=result.timed_out,
             issues=result.all_issues,
         )
 
@@ -488,4 +492,5 @@ class SqlfluffPlugin(BaseToolPlugin):
             fixed_issues_count=fixed_count,
             remaining_issues_count=remaining_count,
             initial_issues=all_initial_issues if all_initial_issues else None,
+            timed_out=result.timed_out,
         )

--- a/lintro/tools/definitions/stylelint.py
+++ b/lintro/tools/definitions/stylelint.py
@@ -18,7 +18,6 @@ from lintro.enums.doc_url_template import DocUrlTemplate
 from lintro.enums.tool_name import ToolName
 from lintro.enums.tool_type import ToolType
 from lintro.models.core.tool_result import ToolResult
-from lintro.parsers.stylelint.stylelint_issue import StylelintIssue
 from lintro.parsers.stylelint.stylelint_parser import parse_stylelint_output
 from lintro.plugins.base import BaseToolPlugin
 from lintro.plugins.protocol import ToolDefinition
@@ -173,6 +172,12 @@ class StylelintPlugin(BaseToolPlugin):
             timeout_val: The timeout value that was exceeded.
             cwd: Working directory for the tool result.
 
+        Follows the shared timeout accounting model (see
+        :mod:`lintro.tools.core.timeout_utils`): the timeout is reported via
+        ``timed_out=True`` and ``success=False`` rather than as a synthetic
+        ``TIMEOUT`` pseudo-issue, so it never inflates the issue counts. Only
+        genuine issues detected before the timeout are reported.
+
         Returns:
             ToolResult: ToolResult instance representing timeout failure.
         """
@@ -182,22 +187,14 @@ class StylelintPlugin(BaseToolPlugin):
             "  - Large codebase taking too long to process\n"
             "  - Need to increase timeout via --tool-options stylelint:timeout=N"
         )
-        timeout_issue = StylelintIssue(
-            file="execution",
-            line=1,
-            column=1,
-            code="TIMEOUT",
-            message=timeout_msg,
-            severity="error",
-            fixable=False,
-        )
         return ToolResult(
             name=self.definition.name,
             success=False,
             output=timeout_msg,
-            issues_count=1,
-            issues=[timeout_issue],
+            issues_count=0,
+            issues=[],
             cwd=cwd,
+            timed_out=True,
         )
 
     def doc_url(self, code: str) -> str | None:

--- a/lintro/tools/definitions/svelte_check.py
+++ b/lintro/tools/definitions/svelte_check.py
@@ -297,6 +297,7 @@ class SvelteCheckPlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=timeout_result.issues_count,
                 issues=timeout_result.issues,

--- a/lintro/tools/definitions/taplo.py
+++ b/lintro/tools/definitions/taplo.py
@@ -348,6 +348,7 @@ class TaploPlugin(BaseToolPlugin):
             return self._handle_timeout_error(
                 timeout_val=ctx.timeout,
                 initial_count=initial_count,
+                initial_issues=initial_issues,
             )
 
         lint_issues = parse_taplo_output(output=lint_output)
@@ -370,6 +371,7 @@ class TaploPlugin(BaseToolPlugin):
             return self._handle_timeout_error(
                 timeout_val=ctx.timeout,
                 initial_count=initial_count,
+                initial_issues=initial_issues,
             )
 
         # Check for remaining formatting issues
@@ -383,6 +385,7 @@ class TaploPlugin(BaseToolPlugin):
             return self._handle_timeout_error(
                 timeout_val=ctx.timeout,
                 initial_count=initial_count,
+                initial_issues=initial_issues,
             )
 
         remaining_format_issues = parse_taplo_output(output=final_output)
@@ -398,6 +401,7 @@ class TaploPlugin(BaseToolPlugin):
             return self._handle_timeout_error(
                 timeout_val=ctx.timeout,
                 initial_count=initial_count,
+                initial_issues=initial_issues,
             )
 
         remaining_lint_issues = parse_taplo_output(output=final_lint_output)

--- a/lintro/tools/definitions/taplo.py
+++ b/lintro/tools/definitions/taplo.py
@@ -158,6 +158,11 @@ class TaploPlugin(BaseToolPlugin):
             initial_count: Optional initial issues count for fix operations.
             initial_issues: Optional list of initial issues found before timeout.
 
+        Follows the shared timeout accounting model (see
+        :mod:`lintro.tools.core.timeout_utils`): a timeout is an execution
+        failure reported via ``timed_out=True`` and ``success=False``, never a
+        lint finding, so it does not contribute to the issue counts.
+
         Returns:
             Standardized timeout error result.
         """
@@ -167,32 +172,26 @@ class TaploPlugin(BaseToolPlugin):
             "  - Large codebase taking too long to process\n"
             "  - Need to increase timeout via --tool-options taplo:timeout=N"
         )
-        timeout_issue = TaploIssue(
-            file="execution",
-            line=0,
-            column=0,
-            level="error",
-            code="TIMEOUT",
-            message=f"Taplo execution timed out ({timeout_val}s limit exceeded)",
-        )
         if initial_count is not None and initial_count > 0:
-            combined_issues = (initial_issues or []) + [timeout_issue]
+            combined_issues = list(initial_issues or [])
             return ToolResult(
                 name=self.definition.name,
                 success=False,
                 output=timeout_msg,
-                issues_count=len(combined_issues),
+                issues_count=initial_count,
                 issues=combined_issues,
                 initial_issues_count=initial_count,
                 fixed_issues_count=0,
                 remaining_issues_count=initial_count,
+                timed_out=True,
             )
         return ToolResult(
             name=self.definition.name,
             success=False,
             output=timeout_msg,
-            issues_count=1,
-            issues=[timeout_issue],
+            issues_count=0,
+            issues=[],
+            timed_out=True,
         )
 
     def doc_url(self, code: str) -> str | None:

--- a/lintro/tools/definitions/trufflehog.py
+++ b/lintro/tools/definitions/trufflehog.py
@@ -459,6 +459,7 @@ class TrufflehogPlugin(BaseToolPlugin):
                 success=False,
                 output=timeout_msg,
                 issues_count=0,
+                timed_out=True,
             )
         except (OSError, ValueError, RuntimeError) as e:
             logger.error(f"Failed to run TruffleHog: {e}")

--- a/lintro/tools/definitions/vale.py
+++ b/lintro/tools/definitions/vale.py
@@ -199,6 +199,7 @@ class ValePlugin(BaseToolPlugin):
             return ToolResult(
                 name=self.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=timeout_result.issues_count,
             )

--- a/lintro/tools/definitions/yamllint.py
+++ b/lintro/tools/definitions/yamllint.py
@@ -488,6 +488,7 @@ class YamllintPlugin(BaseToolPlugin):
             output=combined_output,
             issues_count=results["total_issues"],
             issues=results["all_issues"],
+            timed_out=results["timeout_count"] > 0,
         )
 
     def fix(self, paths: list[str], options: dict[str, object]) -> ToolResult:

--- a/lintro/tools/implementations/pytest/pytest_error_handler.py
+++ b/lintro/tools/implementations/pytest/pytest_error_handler.py
@@ -67,7 +67,10 @@ class PytestErrorHandler:
             success=False,
             issues=[],
             output=error_msg,
-            issues_count=max(initial_count, 1),  # Count timeout as execution failure
+            # A timeout is an execution failure, not a finding: only genuine
+            # pre-timeout issues are counted (see timeout_utils' model).
+            issues_count=initial_count,
+            timed_out=True,
         )
 
     def handle_execution_error(
@@ -124,5 +127,6 @@ class PytestErrorHandler:
             success=False,
             issues=[],
             output=error_msg,
-            issues_count=1 if isinstance(error, subprocess.TimeoutExpired) else 0,
+            issues_count=0,
+            timed_out=isinstance(error, subprocess.TimeoutExpired),
         )

--- a/lintro/tools/implementations/ruff/check.py
+++ b/lintro/tools/implementations/ruff/check.py
@@ -87,6 +87,7 @@ def execute_ruff_check(
         return ToolResult(
             name=tool.definition.name,
             success=timeout_result.success,
+            timed_out=timeout_result.timed_out,
             output=timeout_result.output,
             issues_count=timeout_result.issues_count,
             issues=timeout_result.issues,
@@ -131,6 +132,7 @@ def execute_ruff_check(
             return ToolResult(
                 name=tool.definition.name,
                 success=timeout_result.success,
+                timed_out=timeout_result.timed_out,
                 output=timeout_result.output,
                 issues_count=lint_issues_count + timeout_result.issues_count,
                 issues=lint_issues + timeout_result.issues,

--- a/lintro/tools/implementations/ruff/fix.py
+++ b/lintro/tools/implementations/ruff/fix.py
@@ -129,6 +129,7 @@ def execute_ruff_fix(
         return ToolResult(
             name=tool.definition.name,
             success=timeout_result.success,
+            timed_out=timeout_result.timed_out,
             output=timeout_result.output,
             issues_count=timeout_result.issues_count,
             issues=timeout_result.issues,
@@ -166,12 +167,15 @@ def execute_ruff_fix(
                 name=tool.definition.name,
                 success=False,
                 output=timeout_msg,
-                issues_count=1,  # Count timeout as execution failure
+                # A timeout is an execution failure, not a finding: only
+                # genuine pre-timeout issues are counted.
+                issues_count=initial_count,
                 # Include any lint issues found before timeout
                 issues=initial_issues,
                 initial_issues_count=initial_count,
                 fixed_issues_count=0,
-                remaining_issues_count=1,
+                remaining_issues_count=initial_count,
+                timed_out=True,
             )
         format_files = parse_ruff_format_check_output(output=output_format_check)
         initial_format_count = len(format_files)
@@ -203,11 +207,14 @@ def execute_ruff_fix(
                 name=tool.definition.name,
                 success=False,
                 output=timeout_msg,
-                issues_count=1,  # Count timeout as execution failure
+                # A timeout is an execution failure, not a finding: only
+                # genuine pre-timeout issues are counted.
+                issues_count=total_initial_count,
                 issues=initial_issues,  # Include initial issues found
                 initial_issues_count=total_initial_count,
                 fixed_issues_count=0,
-                remaining_issues_count=1,
+                remaining_issues_count=total_initial_count,
+                timed_out=True,
             )
         remaining_issues = parse_ruff_output(output=output)
         remaining_count = len(remaining_issues)
@@ -289,11 +296,14 @@ def execute_ruff_fix(
                 name=tool.definition.name,
                 success=False,
                 output=timeout_msg,
-                issues_count=1,  # Count timeout as execution failure
+                # A timeout is an execution failure, not a finding: only
+                # genuine pre-timeout issues are counted.
+                issues_count=total_initial_count - fixed_lint_count,
                 issues=remaining_issues,  # Include any issues found before timeout
                 initial_issues_count=total_initial_count,
                 fixed_issues_count=fixed_lint_count,
-                remaining_issues_count=1,
+                remaining_issues_count=total_initial_count - fixed_lint_count,
+                timed_out=True,
             )
         # Formatting fixes are counted separately from lint fixes
         if initial_format_count > 0:

--- a/lintro/utils/json_output.py
+++ b/lintro/utils/json_output.py
@@ -13,6 +13,7 @@ Both build each per-tool object via :func:`serialize_tool_result` so their
 schemas cannot silently drift.
 """
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from lintro.ai.metadata import normalize_ai_metadata
@@ -46,6 +47,30 @@ def serialize_issue(issue: "BaseIssue") -> dict[str, Any]:
     return data
 
 
+def timed_out_tool_names(results: Sequence[ToolResult]) -> list[str]:
+    """Collect the names of tools whose execution timed out.
+
+    Used to populate ``summary.timed_out_tools`` in every JSON payload so a
+    consumer can classify "the only failure was a timeout" without walking
+    ``results`` or regex-matching the human-readable ``output`` string.
+
+    Args:
+        results: Tool results from the run, in execution order.
+
+    Returns:
+        Tool names that timed out, in execution order and de-duplicated.
+        Empty when nothing timed out.
+    """
+    names: list[str] = []
+    for result in results:
+        if not getattr(result, "timed_out", False):
+            continue
+        name = result.name
+        if name not in names:
+            names.append(name)
+    return names
+
+
 def serialize_tool_result(
     result: ToolResult,
     *,
@@ -63,15 +88,23 @@ def serialize_tool_result(
     ``issues`` array in fix mode, where ``merge_detected_and_remaining``
     collapses duplicate detected/remaining entries.
 
+    ``timed_out`` reports whether the tool's subprocess exceeded its deadline.
+    Per the timeout accounting model in
+    :mod:`lintro.tools.core.timeout_utils`, a timeout is an execution failure
+    rather than a lint finding, so a timed-out tool serializes
+    ``timed_out: true``, ``success: false`` and contributes nothing to
+    ``issues_count``.
+
     Args:
         result: The tool result to serialize.
         action: The action being performed (check, fmt, test).
 
     Returns:
         The per-tool JSON object: always ``tool``, ``success``,
-        ``issues_count``, ``skipped``, ``skip_reason`` and ``output``; plus
-        ``parse_failures_count`` when set, ``fixed``/``remaining`` in FIX mode,
-        normalized ``ai_metadata`` when present, and ``issues`` when any exist.
+        ``issues_count``, ``skipped``, ``skip_reason``, ``timed_out`` and
+        ``output``; plus ``parse_failures_count`` when set,
+        ``fixed``/``remaining`` in FIX mode, normalized ``ai_metadata`` when
+        present, and ``issues`` when any exist.
     """
     merged_issues = merge_detected_and_remaining(
         getattr(result, "initial_issues", None),
@@ -83,6 +116,7 @@ def serialize_tool_result(
         "issues_count": len(merged_issues),
         "skipped": getattr(result, "skipped", False),
         "skip_reason": getattr(result, "skip_reason", None),
+        "timed_out": bool(getattr(result, "timed_out", False)),
         "output": getattr(result, "output", ""),
     }
     if result.parse_failures_count is not None:
@@ -142,6 +176,10 @@ def create_json_output(
             "total_remaining": (
                 total_remaining if action_enum == Action.FIX else total_issues
             ),
+            # Names of tools whose execution timed out. Timeouts are execution
+            # failures, not findings, so they never appear in ``total_issues``;
+            # this list is where a consumer reads them instead.
+            "timed_out_tools": timed_out_tool_names(results),
         },
     }
     # Additive: include the health score under summary when supplied so the

--- a/lintro/utils/output/file_writer.py
+++ b/lintro/utils/output/file_writer.py
@@ -30,7 +30,7 @@ from lintro.formatters.formatter import (
     merge_detected_and_remaining,
 )
 from lintro.parsers.base_issue import BaseIssue
-from lintro.utils.json_output import serialize_tool_result
+from lintro.utils.json_output import serialize_tool_result, timed_out_tool_names
 from lintro.utils.output.helpers import sanitize_csv_value
 from lintro.utils.output.parser_registration import ParserError
 from lintro.utils.output.parser_registry import ParserRegistry
@@ -322,6 +322,9 @@ def write_output_file(
                 "total_issues": total_issues,
                 "total_fixed": total_fixed,
                 "tools_run": len(all_results),
+                # Timeouts are execution failures, not findings, so they never
+                # appear in ``total_issues``; a consumer reads them here.
+                "timed_out_tools": timed_out_tool_names(all_results),
             },
             "results": [],
         }

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -326,8 +326,11 @@ def _write_artifacts(
     """Write side-channel artifact files alongside primary output.
 
     Emits artifact files into ``.lintro/artifacts/<format>/`` for each
-    format listed in ``execution.artifacts``.  SARIF is also auto-emitted
-    when ``GITHUB_ACTIONS=true`` is detected (for Code Scanning).
+    format listed in ``execution.artifacts``.  SARIF (for Code Scanning) and
+    JSON (for structured CI evidence, including per-tool ``timed_out`` state)
+    are also auto-emitted when ``GITHUB_ACTIONS=true`` is detected, landing at
+    ``.lintro/artifacts/sarif/results.sarif.json`` and
+    ``.lintro/artifacts/json/results.json`` respectively.
 
     Supported formats match ``OutputFormat``: json, csv, markdown,
     html, sarif, plain.
@@ -354,6 +357,15 @@ def _write_artifacts(
     # Auto-emit SARIF in GitHub Actions for Code Scanning integration.
     if is_gha and "sarif" not in artifacts:
         artifacts.append("sarif")
+
+    # Auto-emit the JSON report in GitHub Actions too. SARIF omits clean tools
+    # and omits failures that produced no issues, so a CI consumer cannot use
+    # it to tell a tool timeout from a genuine finding without failing open.
+    # The JSON report covers every tool and carries the ``timed_out`` flag,
+    # and emitting it here keeps ``--output-format`` (and therefore the
+    # console/grid output every existing consumer parses) untouched.
+    if is_gha and "json" not in artifacts:
+        artifacts.append("json")
 
     if not artifacts:
         return

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -144,7 +144,9 @@ def _run_fix_with_retry(
         remaining = _get_remaining_count(result)
 
     # Merge: keep initial_issues_count and initial_issues from first pass,
-    # rest from last pass
+    # rest from last pass. ``timed_out`` must be carried over from the final
+    # pass: rebuilding the result field-by-field would otherwise erase it, and
+    # a tool that really did time out would serialize ``timed_out: false``.
     if initial_issues_count is not None:
         fixed = max(0, initial_issues_count - remaining)
         result = ToolResult(
@@ -159,6 +161,7 @@ def _run_fix_with_retry(
             formatted_output=result.formatted_output,
             initial_issues=first_pass_initial_issues,
             cwd=result.cwd,
+            timed_out=result.timed_out,
         )
     elif first_pass_initial_issues is not None:
         # Preserve initial_issues even when initial_issues_count is absent
@@ -175,6 +178,7 @@ def _run_fix_with_retry(
             formatted_output=result.formatted_output,
             initial_issues=first_pass_initial_issues,
             cwd=result.cwd,
+            timed_out=result.timed_out,
         )
 
     return result

--- a/tests/unit/ai/test_sarif_artifact.py
+++ b/tests/unit/ai/test_sarif_artifact.py
@@ -146,6 +146,10 @@ def test_sarif_auto_emits_in_github_actions(
 
     sarif_path = tmp_path / ".lintro" / "artifacts" / "sarif" / "results.sarif.json"
     assert_that(sarif_path.exists()).is_true()
+    # JSON is auto-emitted alongside it so CI has a structured report that
+    # covers clean tools and issue-free failures (see #1768).
+    json_path = tmp_path / ".lintro" / "artifacts" / "json" / "results.json"
+    assert_that(json_path.exists()).is_true()
 
 
 def test_unknown_artifact_format_warns(
@@ -181,6 +185,9 @@ def test_artifact_logs_warning_on_write_failure(
     results = [ToolResult(name="ruff", success=True, issues_count=0)]
     _call_write(results, _make_config(), logger)
 
-    logger.console_output.assert_called_once()
-    call_arg = logger.console_output.call_args[0][0]
-    assert_that(call_arg).contains("sarif artifact")
+    # Both GHA auto-emitted artifacts (SARIF and JSON) fail to write, and each
+    # reports its own warning rather than aborting the run.
+    warnings = [call.args[0] for call in logger.console_output.call_args_list]
+    assert_that(warnings).is_length(2)
+    assert_that(any("sarif artifact" in warning for warning in warnings)).is_true()
+    assert_that(any("json artifact" in warning for warning in warnings)).is_true()

--- a/tests/unit/tools/golangci_lint/test_execution.py
+++ b/tests/unit/tools/golangci_lint/test_execution.py
@@ -377,9 +377,10 @@ def test_check_timeout_in_one_module_preserves_others(
 ) -> None:
     """A timeout in one module does not discard earlier modules' findings.
 
-    The timed-out module is aggregated as one execution failure (matching
-    ``create_timeout_result``'s standardized timeout contract), so the total
-    count is the earlier module's two findings plus one for the timeout.
+    The timed-out module is aggregated as an execution failure, not as a lint
+    finding (matching ``create_timeout_result``'s standardized timeout
+    contract, #1768), so the total count stays at the earlier module's two
+    genuine findings while ``timed_out`` records the timeout.
 
     Args:
         golangci_lint_plugin: Plugin under test.
@@ -409,7 +410,8 @@ def test_check_timeout_in_one_module_preserves_others(
         )
 
     assert_that(result.success).is_false()
-    assert_that(result.issues_count).is_equal_to(3)
+    assert_that(result.issues_count).is_equal_to(2)
+    assert_that(result.timed_out).is_true()
     assert_that(result.output).contains("timed out")
 
 

--- a/tests/unit/tools/oxlint/test_check_method.py
+++ b/tests/unit/tools/oxlint/test_check_method.py
@@ -134,9 +134,12 @@ def test_check_timeout_handling(oxlint_plugin: OxlintPlugin, tmp_path: Path) -> 
         assert_that(result.success).is_false()
         assert_that(result.output).contains("timed out")
         assert_that(result.output).contains("30s")
-        assert_that(result.issues_count).is_equal_to(1)
-        issue = cast(OxlintIssue, result.issues[0])  # type: ignore[index]  # validated via is_not_none
-        assert_that(issue.code).is_equal_to("TIMEOUT")
+        # A timeout is an execution failure, not a lint finding: it is reported
+        # via ``timed_out`` rather than a synthetic TIMEOUT pseudo-issue, so it
+        # never inflates the issue counts (#1768).
+        assert_that(result.timed_out).is_true()
+        assert_that(result.issues_count).is_equal_to(0)
+        assert_that(list(result.issues or [])).is_empty()
 
 
 def test_check_early_skip(oxlint_plugin: OxlintPlugin, tmp_path: Path) -> None:

--- a/tests/unit/tools/ruff/check/test_error_handling.py
+++ b/tests/unit/tools/ruff/check/test_error_handling.py
@@ -29,7 +29,10 @@ def test_execute_ruff_check_handles_timeout(
 
         assert_that(result.success).is_false()
         assert_that(result.output).contains("timed out")
-        assert_that(result.issues_count).is_equal_to(1)
+        # A timeout is an execution failure, not a lint finding: it never
+        # inflates the issue counts; ``timed_out`` carries the signal (#1768).
+        assert_that(result.issues_count).is_equal_to(0)
+        assert_that(result.timed_out).is_true()
 
 
 def test_execute_ruff_check_handles_format_timeout(

--- a/tests/unit/tools/ruff/check/test_error_handling.py
+++ b/tests/unit/tools/ruff/check/test_error_handling.py
@@ -67,8 +67,11 @@ def test_execute_ruff_check_handles_format_timeout(
 
         assert_that(result.success).is_false()
         assert_that(result.output).contains("timed out")
-        # Should include lint issues count plus timeout issue
-        assert_that(result.issues_count).is_greater_than_or_equal_to(1)
+        # The timeout contributes nothing; only the genuine lint finding
+        # detected before it is counted, and ``timed_out`` carries the
+        # execution-failure signal (#1768).
+        assert_that(result.issues_count).is_equal_to(1)
+        assert_that(result.timed_out).is_true()
 
 
 def test_execute_ruff_check_subprocess_failure_respected(

--- a/tests/unit/tools/ruff/fix/test_timeout.py
+++ b/tests/unit/tools/ruff/fix/test_timeout.py
@@ -27,7 +27,10 @@ def test_execute_ruff_fix_timeout_on_initial_check(
 
     assert_that(result.success).is_false()
     assert_that(result.output).contains("timed out")
-    assert_that(result.issues_count).is_equal_to(1)
+    # A timeout is an execution failure, not a lint finding: it never inflates
+    # the issue counts; ``timed_out`` carries the signal (#1768).
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(result.timed_out).is_true()
 
 
 def test_execute_ruff_fix_timeout_on_fix_command(

--- a/tests/unit/tools/rustfmt/test_error_handling.py
+++ b/tests/unit/tools/rustfmt/test_error_handling.py
@@ -46,7 +46,9 @@ def test_check_with_timeout(
 
     assert_that(result.success).is_false()
     assert_that(result.output).contains("timed out")
-    assert_that(result.issues_count).is_equal_to(1)
+    # A timeout is an execution failure, not a lint finding (#1768).
+    assert_that(result.timed_out).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
 
 
 def test_fix_with_timeout_on_initial_check(
@@ -79,8 +81,10 @@ def test_fix_with_timeout_on_initial_check(
 
     assert_that(result.success).is_false()
     assert_that(result.output).contains("timed out")
-    # Timeout is counted as an execution failure (consistent with clippy)
-    assert_that(result.issues_count).is_equal_to(1)
+    # A timeout is an execution failure, not a lint finding, so it never
+    # inflates the issue counts (consistent with every other tool, #1768).
+    assert_that(result.timed_out).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
 
 
 def test_fix_with_timeout_on_fix_command(

--- a/tests/unit/tools/taplo/test_error_handling.py
+++ b/tests/unit/tools/taplo/test_error_handling.py
@@ -41,7 +41,9 @@ def test_check_with_timeout(
         result = taplo_plugin.check([str(test_file)], {})
 
     assert_that(result.success).is_false()
-    assert_that(result.issues_count).is_greater_than(0)
+    # A timeout is an execution failure, not a lint finding (#1768).
+    assert_that(result.timed_out).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
     assert_that(result.output).contains("timed out")
 
 

--- a/tests/unit/tools/tsc/test_execution.py
+++ b/tests/unit/tools/tsc/test_execution.py
@@ -120,7 +120,9 @@ def test_check_with_timeout(
             result = tsc_plugin.check([str(test_file)], {})
 
     assert_that(result.success).is_false()
-    assert_that(result.issues_count).is_greater_than(0)
+    # A timeout is an execution failure, not a lint finding (#1768).
+    assert_that(result.timed_out).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
 
 
 def test_check_with_no_typescript_files(

--- a/tests/unit/utils/test_timeout_json_state.py
+++ b/tests/unit/utils/test_timeout_json_state.py
@@ -41,7 +41,7 @@ from lintro.utils.json_output import (
     serialize_tool_result,
     timed_out_tool_names,
 )
-from lintro.utils.tool_executor import _write_artifacts
+from lintro.utils.tool_executor import _run_fix_with_retry, _write_artifacts
 
 
 @dataclass
@@ -71,6 +71,25 @@ def _raise_timeout(*args: object, **kwargs: object) -> tuple[bool, str]:
     raise subprocess.TimeoutExpired(cmd=["stub"], timeout=1)
 
 
+def _assume_tool_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize the pre-run version gate so the timeout path is reached.
+
+    ``prepare_execution`` verifies the tool binary before running it and
+    returns a ``skipped=True`` early result when it is missing. Test runners
+    without the npm-managed binaries (prettier, oxlint, ...) would therefore
+    never reach the subprocess stub, and the run would be reported as skipped
+    and successful rather than timed out. Stubbing the gate keeps these tests
+    hermetic and asserting the timeout contract on every runner.
+
+    Args:
+        monkeypatch: Fixture used to stub the version gate.
+    """
+    monkeypatch.setattr(
+        "lintro.plugins.execution_preparation.verify_tool_version",
+        lambda definition, cwd=None: None,
+    )
+
+
 def _timed_out_mypy_result(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -86,6 +105,7 @@ def _timed_out_mypy_result(
     """
     target = tmp_path / "sample.py"
     target.write_text("x: int = 1\n", encoding="utf-8")
+    _assume_tool_installed(monkeypatch)
     plugin = MypyPlugin()
     monkeypatch.setattr(plugin, "_run_subprocess", _raise_timeout)
     return plugin.check(paths=[str(target)], options={})
@@ -106,6 +126,7 @@ def _timed_out_prettier_result(
     """
     target = tmp_path / "sample.json"
     target.write_text('{"a":1}\n', encoding="utf-8")
+    _assume_tool_installed(monkeypatch)
     plugin = PrettierPlugin()
     monkeypatch.setattr(plugin, "_run_subprocess", _raise_timeout)
     return plugin.check(paths=[str(target)], options={})
@@ -475,3 +496,79 @@ def test_json_artifact_not_duplicated_when_already_configured(
         (tmp_path / ".lintro" / "artifacts" / "json" / "results.json").exists(),
     ).is_true()
     logger.console_output.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# The flag must survive result post-processing
+# ---------------------------------------------------------------------------
+
+
+def _timing_out_fix_tool(initial_issues_count: int) -> Any:
+    """Build a fix-capable tool whose every pass times out.
+
+    Args:
+        initial_issues_count: Genuine issues detected before the timeout.
+
+    Returns:
+        A stub exposing the ``fix`` shape the real implementations return on
+        timeout, with pre-timeout counts populated.
+    """
+    tool = MagicMock()
+    tool.definition.name = "ruff"
+    tool.fix.return_value = ToolResult(
+        name="ruff",
+        success=False,
+        output="ruff execution timed out (1s limit exceeded)",
+        issues_count=initial_issues_count,
+        issues=[],
+        initial_issues_count=initial_issues_count,
+        fixed_issues_count=0,
+        remaining_issues_count=initial_issues_count,
+        timed_out=True,
+    )
+    return tool
+
+
+@pytest.mark.parametrize("initial_issues_count", [0, 3])
+def test_fix_retry_merge_preserves_timed_out(initial_issues_count: int) -> None:
+    """The retry merge must not erase ``timed_out``.
+
+    ``_run_fix_with_retry`` rebuilds the ``ToolResult`` field-by-field after
+    the final pass. Omitting ``timed_out`` there would make every ``lintro
+    fmt`` run report ``timed_out: false`` for a tool that really did time out
+    — a false negative worse than the original bug, because a consumer would
+    read an infrastructure flake as a genuine lint failure.
+
+    Args:
+        initial_issues_count: Pre-timeout issue count, exercising both the
+            zero and non-zero merge branches.
+    """
+    tool = _timing_out_fix_tool(initial_issues_count=initial_issues_count)
+
+    merged = _run_fix_with_retry(tool=tool, paths=[], options={}, max_retries=3)
+
+    assert_that(merged.timed_out).is_true()
+    assert_that(merged.success).is_false()
+    assert_that(serialize_tool_result(merged, action=Action.FIX)["timed_out"]).is_true()
+    assert_that(timed_out_tool_names([merged])).is_equal_to(["ruff"])
+
+
+def test_fix_retry_merge_leaves_clean_result_not_timed_out() -> None:
+    """A successful fix run must not be mislabelled as timed out."""
+    tool = MagicMock()
+    tool.definition.name = "ruff"
+    tool.fix.return_value = ToolResult(
+        name="ruff",
+        success=True,
+        output="",
+        issues_count=0,
+        issues=[],
+        initial_issues_count=2,
+        fixed_issues_count=2,
+        remaining_issues_count=0,
+    )
+
+    merged = _run_fix_with_retry(tool=tool, paths=[], options={}, max_retries=3)
+
+    assert_that(merged.timed_out).is_false()
+    assert_that(timed_out_tool_names([merged])).is_empty()

--- a/tests/unit/utils/test_timeout_json_state.py
+++ b/tests/unit/utils/test_timeout_json_state.py
@@ -1,0 +1,477 @@
+"""Tests for tool-timeout state in the JSON report (#1768).
+
+A CI consumer must be able to tell a tool *timeout* from a genuine lint
+finding using evidence about its own run. These tests pin the three pieces
+that make that possible:
+
+- ``timed_out`` is serialized per tool,
+- timeout accounting is identical for every tool (a timeout is an execution
+  failure, never a finding, so it never reaches ``summary.total_issues``),
+- the ``json`` artifact is auto-emitted under GitHub Actions alongside SARIF.
+
+Coverage spans all four run shapes the classifier must separate: timeout with
+no other findings, timeout alongside a real finding, a non-timeout tool
+failure, and a clean run — exercised through the real ``mypy`` and
+``prettier`` plugins, which historically disagreed about timeout accounting.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess  # nosec B404 - only TimeoutExpired is referenced, nothing spawns
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from assertpy import assert_that
+
+from lintro.enums.action import Action
+from lintro.models.core.tool_result import ToolResult
+from lintro.parsers.base_issue import BaseIssue
+from lintro.tools.definitions.mypy import MypyPlugin
+from lintro.tools.definitions.prettier import PrettierPlugin
+from lintro.utils.execution.exit_codes import (
+    aggregate_tool_results,
+    determine_exit_code,
+)
+from lintro.utils.json_output import (
+    create_json_output,
+    serialize_tool_result,
+    timed_out_tool_names,
+)
+from lintro.utils.tool_executor import _write_artifacts
+
+
+@dataclass
+class _StubIssue(BaseIssue):
+    """Minimal issue standing in for a genuine lint finding."""
+
+    file: str = "src/main.py"
+    line: int = 7
+    code: str = "E001"
+    message: str = "genuine finding"
+
+
+def _raise_timeout(*args: object, **kwargs: object) -> tuple[bool, str]:
+    """Raise the timeout the tools catch, standing in for a slow subprocess.
+
+    Args:
+        *args: Ignored positional arguments.
+        **kwargs: Ignored keyword arguments.
+
+    Returns:
+        Never returns; the signature matches ``_run_subprocess`` so it can
+        stand in for it.
+
+    Raises:
+        subprocess.TimeoutExpired: Always.
+    """
+    raise subprocess.TimeoutExpired(cmd=["stub"], timeout=1)
+
+
+def _timed_out_mypy_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> ToolResult:
+    """Run the real mypy plugin against a subprocess that always times out.
+
+    Args:
+        monkeypatch: Fixture used to stub the plugin's subprocess runner.
+        tmp_path: Directory holding the Python file handed to the plugin.
+
+    Returns:
+        The plugin's ``ToolResult`` for the timed-out run.
+    """
+    target = tmp_path / "sample.py"
+    target.write_text("x: int = 1\n", encoding="utf-8")
+    plugin = MypyPlugin()
+    monkeypatch.setattr(plugin, "_run_subprocess", _raise_timeout)
+    return plugin.check(paths=[str(target)], options={})
+
+
+def _timed_out_prettier_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> ToolResult:
+    """Run the real prettier plugin against a subprocess that always times out.
+
+    Args:
+        monkeypatch: Fixture used to stub the plugin's subprocess runner.
+        tmp_path: Directory holding the JSON file handed to the plugin.
+
+    Returns:
+        The plugin's ``ToolResult`` for the timed-out run.
+    """
+    target = tmp_path / "sample.json"
+    target.write_text('{"a":1}\n', encoding="utf-8")
+    plugin = PrettierPlugin()
+    monkeypatch.setattr(plugin, "_run_subprocess", _raise_timeout)
+    return plugin.check(paths=[str(target)], options={})
+
+
+def _make_config(*, artifacts: list[str] | None = None) -> MagicMock:
+    """Build a minimal ``LintroConfig``-like stub.
+
+    Args:
+        artifacts: Formats to place in ``execution.artifacts``.
+
+    Returns:
+        A mock exposing only the attribute ``_write_artifacts`` reads.
+    """
+    cfg = MagicMock()
+    cfg.execution.artifacts = artifacts or []
+    return cfg
+
+
+def _json_for(results: list[ToolResult]) -> dict[str, Any]:
+    """Render the stdout JSON payload for a set of results.
+
+    Args:
+        results: Tool results making up the run.
+
+    Returns:
+        The JSON-serializable payload, with ``summary`` totals aggregated the
+        same way the real executor aggregates them.
+    """
+    total_issues, total_fixed, total_remaining = aggregate_tool_results(
+        results,
+        Action.CHECK,
+    )
+    return create_json_output(
+        action=Action.CHECK,
+        results=results,
+        total_issues=total_issues,
+        total_fixed=total_fixed,
+        total_remaining=total_remaining,
+        exit_code=determine_exit_code(
+            action=Action.CHECK,
+            all_results=results,
+            total_issues=total_issues,
+            total_remaining=total_remaining,
+            main_phase_empty_due_to_filter=False,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-tool serialization
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_tool_result_reports_timed_out_false_by_default() -> None:
+    """A result that did not time out serializes ``timed_out: false``."""
+    result = ToolResult(name="ruff", success=True, issues_count=0)
+
+    data = serialize_tool_result(result, action=Action.CHECK)
+
+    assert_that(data).contains_key("timed_out")
+    assert_that(data["timed_out"]).is_false()
+
+
+def test_serialize_tool_result_reports_timed_out_true() -> None:
+    """A timed-out result serializes ``timed_out: true``."""
+    result = ToolResult(
+        name="mypy",
+        success=False,
+        issues_count=0,
+        timed_out=True,
+    )
+
+    data = serialize_tool_result(result, action=Action.CHECK)
+
+    assert_that(data["timed_out"]).is_true()
+
+
+# ---------------------------------------------------------------------------
+# Consistent accounting across tools that historically disagreed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "factory"),
+    [
+        ("mypy", _timed_out_mypy_result),
+        ("prettier", _timed_out_prettier_result),
+    ],
+)
+def test_timeout_is_not_counted_as_an_issue(
+    tool_name: str,
+    factory: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Every tool accounts for a timeout identically: failure, zero issues.
+
+    Args:
+        tool_name: Name the plugin reports itself under.
+        factory: Helper producing a timed-out result for that plugin.
+        monkeypatch: Fixture used to stub the plugin's subprocess runner.
+        tmp_path: Directory holding the file handed to the plugin.
+    """
+    result = factory(monkeypatch, tmp_path)
+
+    assert_that(result.name).is_equal_to(tool_name)
+    assert_that(result.success).is_false()
+    assert_that(result.timed_out).is_true()
+    assert_that(result.issues_count).is_equal_to(0)
+    assert_that(list(result.issues or [])).is_empty()
+
+    data = serialize_tool_result(result, action=Action.CHECK)
+    assert_that(data["timed_out"]).is_true()
+    assert_that(data["issues_count"]).is_equal_to(0)
+    assert_that(data).does_not_contain_key("issues")
+
+
+# ---------------------------------------------------------------------------
+# The four run shapes a downstream classifier must separate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_timed_out_mypy_result, _timed_out_prettier_result],
+)
+def test_timeout_with_no_other_findings_reports_zero_issues(
+    factory: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A run whose only failure is a timeout reports zero genuine issues.
+
+    Args:
+        factory: Helper producing a timed-out result for a plugin.
+        monkeypatch: Fixture used to stub the plugin's subprocess runner.
+        tmp_path: Directory holding the file handed to the plugin.
+    """
+    timed_out = factory(monkeypatch, tmp_path)
+    clean = ToolResult(name="ruff", success=True, issues_count=0)
+    results = [timed_out, clean]
+
+    payload = _json_for(results)
+
+    assert_that(payload["summary"]["total_issues"]).is_equal_to(0)
+    assert_that(payload["summary"]["total_remaining"]).is_equal_to(0)
+    assert_that(payload["summary"]["timed_out_tools"]).is_equal_to([timed_out.name])
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_timed_out_mypy_result, _timed_out_prettier_result],
+)
+def test_timeout_alongside_a_real_finding_keeps_the_finding(
+    factory: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A genuine finding survives a concurrent timeout and stays counted.
+
+    Args:
+        factory: Helper producing a timed-out result for a plugin.
+        monkeypatch: Fixture used to stub the plugin's subprocess runner.
+        tmp_path: Directory holding the file handed to the plugin.
+    """
+    timed_out = factory(monkeypatch, tmp_path)
+    finding = ToolResult(
+        name="ruff",
+        success=False,
+        issues_count=1,
+        issues=[_StubIssue()],
+    )
+    results = [timed_out, finding]
+
+    payload = _json_for(results)
+
+    assert_that(payload["summary"]["total_issues"]).is_equal_to(1)
+    assert_that(payload["summary"]["timed_out_tools"]).is_equal_to([timed_out.name])
+    by_tool = {entry["tool"]: entry for entry in payload["results"]}
+    assert_that(by_tool[timed_out.name]["issues_count"]).is_equal_to(0)
+    assert_that(by_tool["ruff"]["issues_count"]).is_equal_to(1)
+    assert_that(by_tool["ruff"]["timed_out"]).is_false()
+
+
+def test_non_timeout_tool_failure_is_not_reported_as_a_timeout() -> None:
+    """A tool that failed without timing out reports no timeout at all."""
+    crashed = ToolResult(
+        name="mypy",
+        success=False,
+        issues_count=0,
+        output="mypy execution failed: config error",
+    )
+    results = [crashed, ToolResult(name="ruff", success=True, issues_count=0)]
+
+    payload = _json_for(results)
+
+    assert_that(payload["summary"]["total_issues"]).is_equal_to(0)
+    assert_that(payload["summary"]["timed_out_tools"]).is_empty()
+    by_tool = {entry["tool"]: entry for entry in payload["results"]}
+    assert_that(by_tool["mypy"]["timed_out"]).is_false()
+    assert_that(by_tool["mypy"]["success"]).is_false()
+
+
+def test_clean_run_reports_no_timeouts_and_no_issues() -> None:
+    """A clean run reports zero issues and an empty timeout list."""
+    results = [
+        ToolResult(name="mypy", success=True, issues_count=0),
+        ToolResult(name="prettier", success=True, issues_count=0),
+    ]
+
+    payload = _json_for(results)
+
+    assert_that(payload["summary"]["total_issues"]).is_equal_to(0)
+    assert_that(payload["summary"]["timed_out_tools"]).is_empty()
+    assert_that([entry["timed_out"] for entry in payload["results"]]).does_not_contain(
+        True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The timeout must still fail the run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [_timed_out_mypy_result, _timed_out_prettier_result],
+)
+def test_timeout_still_fails_the_run_despite_zero_issues(
+    factory: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Dropping the pseudo-issue must not turn a timed-out run green.
+
+    Args:
+        factory: Helper producing a timed-out result for a plugin.
+        monkeypatch: Fixture used to stub the plugin's subprocess runner.
+        tmp_path: Directory holding the file handed to the plugin.
+    """
+    results = [factory(monkeypatch, tmp_path)]
+    total_issues, _, total_remaining = aggregate_tool_results(results, Action.CHECK)
+
+    exit_code = determine_exit_code(
+        action=Action.CHECK,
+        all_results=results,
+        total_issues=total_issues,
+        total_remaining=total_remaining,
+        main_phase_empty_due_to_filter=False,
+    )
+
+    assert_that(total_issues).is_equal_to(0)
+    assert_that(exit_code).is_equal_to(1)
+
+
+# ---------------------------------------------------------------------------
+# summary.timed_out_tools helper
+# ---------------------------------------------------------------------------
+
+
+def test_timed_out_tool_names_preserves_order_and_deduplicates() -> None:
+    """Timed-out tool names are listed once each, in execution order."""
+    results = [
+        ToolResult(name="mypy", success=False, issues_count=0, timed_out=True),
+        ToolResult(name="ruff", success=True, issues_count=0),
+        ToolResult(name="mypy", success=False, issues_count=0, timed_out=True),
+        ToolResult(name="prettier", success=False, issues_count=0, timed_out=True),
+    ]
+
+    assert_that(timed_out_tool_names(results)).is_equal_to(["mypy", "prettier"])
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions auto-emission of the json artifact
+# ---------------------------------------------------------------------------
+
+
+def test_json_artifact_auto_emits_in_github_actions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Under GHA the json artifact lands beside SARIF without extra config.
+
+    Args:
+        tmp_path: Directory the artifacts are written beneath.
+        monkeypatch: Fixture used to set ``GITHUB_ACTIONS`` and the cwd.
+    """
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.chdir(tmp_path)
+
+    results = [
+        ToolResult(name="mypy", success=False, issues_count=0, timed_out=True),
+        ToolResult(name="ruff", success=True, issues_count=0),
+    ]
+    _write_artifacts(
+        results,
+        _make_config(),
+        MagicMock(),
+        action=Action.CHECK,
+        total_issues=0,
+        total_fixed=0,
+    )
+
+    json_path = tmp_path / ".lintro" / "artifacts" / "json" / "results.json"
+    sarif_path = tmp_path / ".lintro" / "artifacts" / "sarif" / "results.sarif.json"
+    assert_that(json_path.exists()).is_true()
+    assert_that(sarif_path.exists()).is_true()
+
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert_that(data["summary"]["total_issues"]).is_equal_to(0)
+    assert_that(data["summary"]["timed_out_tools"]).is_equal_to(["mypy"])
+    by_tool = {entry["tool"]: entry for entry in data["results"]}
+    assert_that(by_tool["mypy"]["timed_out"]).is_true()
+    assert_that(by_tool["ruff"]["timed_out"]).is_false()
+
+
+def test_json_artifact_not_emitted_outside_github_actions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Outside GHA nothing is emitted unless the config asks for it.
+
+    Args:
+        tmp_path: Directory the artifacts would be written beneath.
+        monkeypatch: Fixture used to clear ``GITHUB_ACTIONS`` and set the cwd.
+    """
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    _write_artifacts(
+        [ToolResult(name="ruff", success=True, issues_count=0)],
+        _make_config(),
+        MagicMock(),
+        action=Action.CHECK,
+        total_issues=0,
+        total_fixed=0,
+    )
+
+    assert_that((tmp_path / ".lintro" / "artifacts").exists()).is_false()
+
+
+def test_json_artifact_not_duplicated_when_already_configured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``json`` artifact is not requested twice under GHA.
+
+    Args:
+        tmp_path: Directory the artifacts are written beneath.
+        monkeypatch: Fixture used to set ``GITHUB_ACTIONS`` and the cwd.
+    """
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.chdir(tmp_path)
+
+    logger = MagicMock()
+    _write_artifacts(
+        [ToolResult(name="ruff", success=True, issues_count=0)],
+        _make_config(artifacts=["json"]),
+        logger,
+        action=Action.CHECK,
+        total_issues=0,
+        total_fixed=0,
+    )
+
+    assert_that(
+        (tmp_path / ".lintro" / "artifacts" / "json" / "results.json").exists(),
+    ).is_true()
+    logger.console_output.assert_not_called()

--- a/tests/unit/utils/test_timeout_utils.py
+++ b/tests/unit/utils/test_timeout_utils.py
@@ -91,7 +91,9 @@ def test_create_timeout_result() -> None:
     assert_that(result.output).contains(
         "pytest execution timed out (30s limit exceeded)",
     )
-    assert_that(result.issues_count).is_equal_to(1)
+    # A timeout is an execution failure, not a lint finding, so it contributes
+    # nothing to the issue counts; ``timed_out`` carries the signal (#1768).
+    assert_that(result.issues_count).is_equal_to(0)
     assert_that(result.issues).is_empty()
     assert_that(result.timed_out).is_true()
     assert_that(result.timeout_seconds).is_equal_to(30)


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(json): serialize tool timeout state and auto-emit the JSON artifact in CI
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

A consumer could not tell, from lintro's JSON report, that a tool **timed out**
rather than **found issues**. This makes that distinction expressible from a
single run, unblocking lgtm-hq/lgtm-ci#746.

Three changes:

1. **`timed_out` is serialized per tool.** New `ToolResult.timed_out`, emitted
   by `serialize_tool_result` into both JSON payloads (stdout and file
   artifact). Consumers stop regex-matching the prose in `output`.
2. **One timeout accounting model for every tool.** A timeout is an *execution
   failure*, never a lint finding.
3. **The `json` artifact auto-emits under GitHub Actions**, exactly as SARIF
   already does, at `.lintro/artifacts/json/results.json`. `--output-format`
   semantics and the console/grid output are untouched.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (full `uv run lintro fmt && uv run lintro chk` + full
      `uv run pytest --maxfail=0`)

## Closes

- Closes #1768
- Relates to lgtm-hq/lgtm-ci#746

## Details

### Re-verification against current `main`

The issue's claims were verified against 0.91.52. I re-verified empirically
against **0.91.59** before designing. Everything still reproduced exactly as
described:

- mypy timeout: `summary.total_issues: 1` while its own `issues_count: 0`.
- prettier timeout: `issues_count: 1` with a synthetic `code: "TIMEOUT"` issue.
- `timed_out` absent from every serialized result.

**One correction to the issue.** It states the `timed_out` flag "already exists
on the result object". It exists on `TimeoutResult`
(`lintro/tools/core/timeout_utils.py`), which is an *intermediate* that tools
discard when they build their `ToolResult`. `ToolResult` itself had no such
field, so requirement 1 needed a new model field plus plumbing through every
timeout path, not just a serializer change. That is why this diff is wide.

### The `summary.total_issues` decision

Proposal 2 offered two options: keep timeout pseudo-issues out of
`summary.total_issues`, *or* expose them separately. **I did both, and I want to
be explicit that changing `total_issues` is a deliberate behavioural change to a
public field.**

Reasoning:

- **The existing value is already incoherent, not merely inconvenient.** For a
  mypy timeout, `summary.total_issues` reports `1` while the same document's
  per-tool `issues_count` reports `0`. A consumer reading the document cannot
  reconcile the two. And prettier reports `1` in *both* fields for the same
  event. There is no single existing behaviour to preserve — there are two
  contradictory ones. Anything I ship changes what *some* tool reports.
- **A purely additive fix would not satisfy the acceptance criteria.** The issue
  requires that "a run whose only failure is a timeout reports zero genuine
  issues in whichever field the classifier is meant to read", and lgtm-ci#746's
  classifier is specified as `>=1 tool timed out AND total_issues == 0`. Adding
  `timed_out_tools` while leaving `total_issues` at `1` would leave that
  classifier permanently `false` — exactly the dead-code failure the issue
  exists to prevent. The consumer would have to be rewritten around a different
  field, and every *other* consumer would still be reading a self-contradictory
  number.
- **The blast radius is narrow and the failure mode is safe.** `total_issues`
  only changes for runs where a tool timed out — an infrastructure fault, not
  a routine outcome. In that case it moves from an arbitrary `+1` (or `+N` for
  prettier/oxlint/oxfmt/stylelint/taplo/golangci, which each counted timeouts
  differently) to the count of genuine findings. A consumer that gated on
  `total_issues > 0` to detect failure does **not** silently go green: see
  below.
- **`timed_out_tools` is still worth adding on top**, because it saves every
  consumer from walking `results` to find the timeouts, and because it makes
  the summary self-describing — the timeouts are visibly *somewhere*, rather
  than merely absent from `total_issues`.

I considered and rejected leaving `total_issues` alone and adding only
`summary.timed_out_tools` + `summary.genuine_issues`. It preserves the public
field's current value, but it enshrines the mypy/prettier contradiction
permanently and forces the downstream classifier onto a third field. The issue
asks for one model applied to every tool; two coexisting models is the thing
being fixed.

### A timeout still fails the run

This is the load-bearing safety property of dropping the pseudo-issue.
`determine_exit_code` fails on `any(not r.success)` **before** it looks at
`total_issues`, and a timed-out result is `success=False`. So a timeout-only run
is `total_issues: 0`, `timed_out_tools: ["mypy"]`, **exit code 1**. Verified
empirically and pinned by
`test_timeout_still_fails_the_run_despite_zero_issues`.

### Scope of the accounting change

Applied to every path that produces a timeout result, not just mypy/prettier:

- `create_timeout_result` → `issues_count=0` (covers mypy, ruff-check,
  markdownlint, commitlint, clippy, astro-check, golangci-lint, rustfmt,
  svelte-check, vale, html-validate, cargo-deny, tsc/vue-tsc, cargo-audit).
- Synthetic `TIMEOUT` pseudo-issues removed from prettier, oxlint, oxfmt,
  stylelint and taplo. Genuine pre-timeout issues are still reported.
- Hand-rolled timeout returns in ruff-fix, golangci-lint (per-module),
  pytest, bandit, semgrep, gitleaks, trufflehog, osv-scanner, pip-audit,
  actionlint, yamllint, black now set `timed_out=True`.
- `FileProcessingResult.timed_out` → `AggregatedResult.timed_out` →
  `ToolResult.timed_out` for the per-file tools (shellcheck, hadolint,
  pydoclint, shfmt, sqlfluff, dotenv-linter, and the generic
  `BaseToolPlugin` path).

### Console output is unaffected

No formatter or renderer changed. The grid/plain output for a timed-out tool
still carries the full "… execution timed out (Ns limit exceeded)" message via
`ToolResult.output`; the tool row simply no longer lists a synthetic
`execution / TIMEOUT` finding, consistent with how mypy already behaved.

### Testing

New `tests/unit/utils/test_timeout_json_state.py` (16 tests) covering all four
run shapes the classifier must separate — timeout-only, timeout alongside a real
finding, non-timeout tool failure, clean run — driven through the **real** mypy
and prettier plugins (the two that disagreed), plus per-tool serialization,
exit-code preservation, `timed_out_tools` ordering/dedup, and the GHA artifact
auto-emission (present under GHA, absent outside it, not duplicated when
already configured).

Eight existing tests pinned the old inconsistent contract (`issues_count == 1`
for a timeout, oxlint's `TIMEOUT` pseudo-issue, `_write_artifacts` emitting only
SARIF under GHA). Each was **re-pinned to the new contract with a comment
explaining why**, not deleted or loosened — every one now additionally asserts
`timed_out is True`, which is a stronger assertion than what it replaced.

### Verification

- `uv run lintro fmt` + full `uv run lintro chk` → **0 issues**, health 100/100.
- Full `uv run pytest --maxfail=0` → **7952 passed, 18 failed**, byte-identical
  to the failure list from a clean `origin/main` worktree run on the same host
  (stylelint/oxlint/oxfmt/vale/trufflehog/commitlint below pinned minimum
  versions; pip-audit `ensurepip` SIGABRT). No new failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeout results now include a machine-readable `timed_out` status.
  * JSON output identifies timed-out tools and keeps timeout failures separate from lint issue counts.
  * GitHub Actions now automatically produces both SARIF and JSON artifacts.

* **Bug Fixes**
  * Timeout failures no longer create misleading synthetic lint findings or inflate issue totals.

* **Documentation**
  * Added guidance on timeout representation and GitHub Actions artifact behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Timeout reporting is now machine-readable and consistent across tool integrations.
- Adds `ToolResult.timed_out` and includes timeout state in JSON reports and summary metadata.
- Treats timeouts as execution failures rather than synthetic lint findings.
- Preserves timeout state through fix retries and pre-timeout findings in the updated formatter paths.
- Automatically emits a JSON artifact alongside SARIF under GitHub Actions.
- Updates documentation and timeout-focused tests for the new contract.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previous retry-state issue is fixed by preserving timed_out during result reconstruction, while the stylelint report was invalid as a PR-introduced regression because its genuine-finding discard behavior predates this change.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lintro/models/core/tool_result.py | Adds the canonical timeout-state field used by tool adapters and JSON serialization. |
| lintro/utils/tool_executor.py | Preserves timeout state while reconstructing results across automatic fix retries. |
| lintro/utils/json_output.py | Serializes per-tool timeout state and reports timed-out tools in the summary. |
| lintro/utils/output/file_writer.py | Adds automatic JSON artifact emission under GitHub Actions without duplicating configured artifacts. |
| lintro/tools/core/timeout_utils.py | Standardizes timeouts as zero-issue execution failures with explicit timeout state. |
| lintro/tools/definitions/stylelint.py | Replaces synthetic timeout findings with the shared machine-readable timeout contract. |
| tests/unit/utils/test_timeout_json_state.py | Exercises timeout-only, mixed-finding, retry, serialization, exit-code, and CI artifact behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Tool subprocess] --> B{Timed out?}
  B -- No --> C[Parse genuine findings]
  B -- Yes --> D[ToolResult: success false, timed_out true]
  C --> E[ToolResult]
  D --> F[JSON serializer]
  E --> F
  F --> G[Console-selected output]
  F --> H[GitHub Actions JSON artifact]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(json): stop the retry merge erasing ..."](https://github.com/lgtm-hq/py-lintro/commit/fa1eb32731897f18a85cf02a8bdfab2b4b40ec17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47572702)</sub>

**Context used:**

- Knowledge Base — [Core Domain Types](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/py-lintro/-/docs/core-domain-types.md)
- Knowledge Base — [Plugin Execution](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/py-lintro/-/docs/plugin-execution.md)

<!-- /greptile_comment -->