### PR TITLE
fix(ci): drop unnecessary contents:write from SBOM jobs

### DIFF
--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -79,9 +79,11 @@ jobs:
       egress-policy: block
       egress-preset: sbom
     permissions:
-      # write: reusable-sbom v0.52.3 requests contents: write (attach SBOM to
-      # release assets, lgtm-ci#505); a lower grant is a startup_failure
-      contents: write
+      # read: SBOM generation, vuln scan and attestation only read the repo.
+      # The contents:write release-asset upload moved out to
+      # reusable-sbom-release-upload.yml upstream (lgtm-ci#770), so every job
+      # in reusable-sbom.yml now declares contents: read.
+      contents: read
       # write: upload vulnerability findings to GitHub Security tab
       security-events: write
       # write: OIDC for SBOM attestation signing

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -28,9 +28,11 @@ jobs:
       egress-policy: block
       egress-preset: sbom
     permissions:
-      # write: reusable-sbom v0.52.3 requests contents: write (release SBOM
-      # asset upload); a lower caller grant is a parse-time startup_failure
-      contents: write
+      # read: SBOM generation, vuln scan and attestation only read the repo.
+      # The contents:write release-asset upload moved out to
+      # reusable-sbom-release-upload.yml upstream (lgtm-ci#770), so every job
+      # in reusable-sbom.yml now declares contents: read.
+      contents: read
       security-events: write
       id-token: write
       attestations: write

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -1716,6 +1716,27 @@ def test_publish_pypi_sbom_fails_on_high_severity() -> None:
     assert_that(sbom["with"].get("scan-vulnerabilities")).is_true()
 
 
+@pytest.mark.parametrize(
+    "workflow_name",
+    ["publish-pypi-on-tag.yml", "sbom-on-main.yml"],
+)
+def test_sbom_callers_grant_contents_read_only(workflow_name: str) -> None:
+    """SBOM callers stay read-only on contents (#1807).
+
+    Generation, vulnerability scan and attestation only read the repository.
+    The ``contents: write`` release-asset upload moved into
+    ``reusable-sbom-release-upload.yml`` upstream (lgtm-ci#770), so a
+    ``contents: write`` grant here is silent over-permissioning on the
+    production tag-publish path.
+    """
+    permissions = _load_workflow(name=workflow_name)["jobs"]["sbom"]["permissions"]
+    assert_that(permissions).contains_entry({"contents": "read"})
+    # Attestation signing and code-scanning upload still need these.
+    assert_that(permissions).contains_entry({"security-events": "write"})
+    assert_that(permissions).contains_entry({"id-token": "write"})
+    assert_that(permissions).contains_entry({"attestations": "write"})
+
+
 # --- Binary build job timeouts (#1702) ---------------------------------------
 #
 # No job in build-binary.yml set timeout-minutes, so every binary build


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): drop unnecessary contents:write from SBOM jobs
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Both SBOM callers granted the reusable workflow `contents: write` with a comment
claiming `reusable-sbom` needs it to attach SBOMs to release assets, and warning
that a lower grant is a parse-time `startup_failure`. Both statements are false
now: lgtm-hq/lgtm-ci#770 moved the `contents: write` upload out into
`reusable-sbom-release-upload.yml`.

Verified against the SHA actually pinned in this branch —
`d8fff0c6025ddf39c1ae048c04c5a050c7729a6e` (v0.62.0), the same pin in both
callers — where all three jobs in `reusable-sbom.yml` (`validate`, `sbom`,
`release-assets`) declare `contents: read`. Neither caller passes `mode` or the
deprecated `upload-release-assets` input, so the read-only path is the one we
take.

- `.github/workflows/publish-pypi-on-tag.yml` — `sbom` job: `contents: write` -> `contents: read`
- `.github/workflows/sbom-on-main.yml` — same change
- Justification comments in both replaced with the accurate rationale
- `security-events: write`, `id-token: write` and `attestations: write` are untouched — the `sbom` job still needs all three

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1807

## Details

**Observable before any tag publish.** This touches the production tag-publish
path, but `sbom-on-main.yml` invokes the *same* reusable workflow with the same
permission block, and it runs on every push to `main` (and on
`workflow_dispatch`). So the reduced grant is exercised end-to-end on this
branch's merge to main, well before a version tag depends on it. If the grant
were insufficient the reusable call would fail at parse time with
`startup_failure`, which the main-push run would surface immediately.

**Regression guard.** `tests/unit/test_workflow_wiring.py` had no assertion
pinning these permission values, so a re-escalation would have been silent.
Added `test_sbom_callers_grant_contents_read_only`, parametrized over both
workflows, asserting `contents: read` *and* that the three still-required
`write` scopes remain — so the test fails both on re-escalation and on an
over-eager future trim.

**Verification run locally:** `uv run lintro fmt` + `uv run lintro chk` report
zero issues (health 100/100); `uv run pytest --maxfail=0` gives
`18 failed, 8007 passed, 114 skipped`, with all 18 the documented pre-existing
host-environment failures (stylelint/vale/trufflehog below minimum version,
oxlint/oxfmt, pip-audit, commitlint) — none related to workflow wiring.
