### PR TITLE
docs: correct Node tool install advice to match resolution (#1799)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ system.
 <td><a href="https://commitlint.js.org/"><img src="https://img.shields.io/badge/commitlint-f7b93e?logo=commitlint&logoColor=black" alt="commitlint"></a></td>
 <td>🔀 Git commits</td>
 <td>-</td>
-<td><code>bun add -g @commitlint/cli @commitlint/config-conventional</code><br><code>brew install commitlint</code></td>
+<td><code>bun add -D @commitlint/cli @commitlint/config-conventional</code><br><code>npm install -D @commitlint/cli @commitlint/config-conventional</code></td>
 </tr>
 <tr>
 <td><a href="https://github.com/golangci/golangci-lint"><img src="https://img.shields.io/badge/golangci--lint-00ADD8?logo=go&logoColor=white" alt="golangci-lint"></a></td>
@@ -127,7 +127,7 @@ system.
 <td><a href="https://github.com/DavidAnson/markdownlint-cli2"><img src="https://img.shields.io/badge/Markdownlint--cli2-000000?logo=markdown&logoColor=white" alt="Markdownlint"></a></td>
 <td>📝 Markdown</td>
 <td>-</td>
-<td><code>bun add -g markdownlint-cli2</code><br><code>npm install -g markdownlint-cli2</code></td>
+<td><code>bun add -D markdownlint-cli2</code><br><code>npm install -D markdownlint-cli2</code></td>
 </tr>
 <tr>
 <td><a href="https://vale.sh/"><img src="https://img.shields.io/badge/Vale-2ea44f?logo=markdown&logoColor=white" alt="Vale"></a></td>
@@ -139,7 +139,7 @@ system.
 <td><a href="https://oxc.rs/"><img src="https://img.shields.io/badge/Oxlint-e05d44?logo=javascript&logoColor=white" alt="Oxlint"></a></td>
 <td>🟨 JS/TS</td>
 <td>✅</td>
-<td><code>bun add -g oxlint</code><br><code>npm install -g oxlint</code></td>
+<td><code>bun add -D oxlint</code><br><code>npm install -D oxlint</code></td>
 </tr>
 <tr>
 <td><a href="https://github.com/jsh9/pydoclint"><img src="https://img.shields.io/badge/pydoclint-3776AB?logo=python&logoColor=white" alt="pydoclint"></a></td>
@@ -170,7 +170,7 @@ system.
 <td><a href="https://oxc.rs/"><img src="https://img.shields.io/badge/Oxfmt-e05d44?logo=javascript&logoColor=white" alt="Oxfmt"></a></td>
 <td>🟨 JS/TS</td>
 <td>✅</td>
-<td><code>bun add -g oxfmt</code><br><code>npm install -g oxfmt</code></td>
+<td><code>bun add -D oxfmt</code><br><code>npm install -D oxfmt</code></td>
 </tr>
 <tr>
 <td><a href="https://prettier.io/"><img src="https://img.shields.io/badge/Prettier-1a2b34?logo=prettier&logoColor=white" alt="Prettier"></a></td>
@@ -219,7 +219,7 @@ system.
 <td><a href="https://stylelint.io/"><img src="https://img.shields.io/badge/Stylelint-263238?logo=stylelint&logoColor=white" alt="Stylelint"></a></td>
 <td>🎨 CSS/SCSS/Sass/Less</td>
 <td>✅</td>
-<td><code>bun add -g stylelint</code><br><code>npm install -g stylelint</code></td>
+<td><code>bun add -D stylelint</code><br><code>npm install -D stylelint</code></td>
 </tr>
 <tr><th colspan="4">Type Checkers</th></tr>
 <tr>
@@ -244,7 +244,7 @@ system.
 <td><a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-3178c6?logo=typescript&logoColor=white" alt="TypeScript"></a></td>
 <td>🟨 JS/TS</td>
 <td>-</td>
-<td><code>bun add -g typescript</code><br><code>npm install -g typescript</code><br><code>brew install typescript</code></td>
+<td><code>bun add -D typescript</code><br><code>npm install -D typescript</code></td>
 </tr>
 <tr>
 <td><a href="https://github.com/vuejs/language-tools"><img src="https://img.shields.io/badge/vue--tsc-42b883?logo=vuedotjs&logoColor=white" alt="vue-tsc"></a></td>
@@ -312,7 +312,13 @@ system.
 </table>
 
 > 📦 = bundled with lintro — no separate install needed\
-> ⚡ Node.js tools support `--auto-install` to install dependencies automatically
+> ⚡ Node.js tools support `--auto-install` to install dependencies automatically\
+> 🟨 Node.js tools installed with `-D` above are run via `bunx`/`npx`, which resolve the
+> **project's own** `node_modules` — install them into the project you check. A global
+> (`-g`) install or a Homebrew formula only lands on `PATH`, which that path does not
+> consult. Prettier is the exception: it is invoked by bare name and resolved from
+> `PATH`, so a global install is what it needs. See
+> [Node.js tool resolution](docs/configuration.md#nodejs-tool-resolution).
 
 <!-- markdownlint-enable MD013 MD033 MD060 -->
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ system.
 <td><a href="https://commitlint.js.org/"><img src="https://img.shields.io/badge/commitlint-f7b93e?logo=commitlint&logoColor=black" alt="commitlint"></a></td>
 <td>🔀 Git commits</td>
 <td>-</td>
-<td><code>bun add -D @commitlint/cli @commitlint/config-conventional</code><br><code>npm install -D @commitlint/cli @commitlint/config-conventional</code></td>
+<td><code>bun add -g @commitlint/cli @commitlint/config-conventional</code><br><code>brew install commitlint</code></td>
 </tr>
 <tr>
 <td><a href="https://github.com/golangci/golangci-lint"><img src="https://img.shields.io/badge/golangci--lint-00ADD8?logo=go&logoColor=white" alt="golangci-lint"></a></td>
@@ -127,7 +127,7 @@ system.
 <td><a href="https://github.com/DavidAnson/markdownlint-cli2"><img src="https://img.shields.io/badge/Markdownlint--cli2-000000?logo=markdown&logoColor=white" alt="Markdownlint"></a></td>
 <td>📝 Markdown</td>
 <td>-</td>
-<td><code>bun add -D markdownlint-cli2</code><br><code>npm install -D markdownlint-cli2</code></td>
+<td><code>bun add -g markdownlint-cli2</code><br><code>npm install -g markdownlint-cli2</code></td>
 </tr>
 <tr>
 <td><a href="https://vale.sh/"><img src="https://img.shields.io/badge/Vale-2ea44f?logo=markdown&logoColor=white" alt="Vale"></a></td>
@@ -244,7 +244,7 @@ system.
 <td><a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-3178c6?logo=typescript&logoColor=white" alt="TypeScript"></a></td>
 <td>🟨 JS/TS</td>
 <td>-</td>
-<td><code>bun add -D typescript</code><br><code>npm install -D typescript</code></td>
+<td><code>bun add -g typescript</code><br><code>npm install -g typescript</code><br><code>brew install typescript</code></td>
 </tr>
 <tr>
 <td><a href="https://github.com/vuejs/language-tools"><img src="https://img.shields.io/badge/vue--tsc-42b883?logo=vuedotjs&logoColor=white" alt="vue-tsc"></a></td>
@@ -313,11 +313,11 @@ system.
 
 > 📦 = bundled with lintro — no separate install needed\
 > ⚡ Node.js tools support `--auto-install` to install dependencies automatically\
-> 🟨 Node.js tools installed with `-D` above are run via `bunx`/`npx`, which resolve the
-> **project's own** `node_modules` — install them into the project you check. A global
-> (`-g`) install or a Homebrew formula only lands on `PATH`, which that path does not
-> consult. Prettier is the exception: it is invoked by bare name and resolved from
-> `PATH`, so a global install is what it needs. See
+> 🟨 Node.js tools do not all resolve the same way — the command above is the one that
+> works for that tool. Tools shown with `-D` (oxlint, oxfmt, stylelint, html-validate)
+> are run through `bunx`/`npx`, which look in the checked project's `node_modules` and
+> never at `PATH`, so a global or Homebrew install is not what Lintro picks up. The rest
+> prefer a binary on `PATH`, which is what `-g` and `brew install` provide. See
 > [Node.js tool resolution](docs/configuration.md#nodejs-tool-resolution).
 
 <!-- markdownlint-enable MD013 MD033 MD060 -->

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -375,10 +375,11 @@ running the tools that need a project's dependency tree to work: `tsc`, `vue-tsc
 `svelte-check` and `astro-check`.
 
 It does **not** apply to standalone Node.js binaries such as `prettier`, `oxlint`,
-`oxfmt`, `stylelint` or `markdownlint-cli2`. Those are invoked from `PATH` (or via
-`bunx`/`npx`) and run fine without a local `node_modules`. When one of them cannot be
-resolved at all, Lintro reports a `⏭️ SKIP` row with the reason instead of a pass —
-installing project dependencies would not have helped.
+`oxfmt`, `stylelint` or `markdownlint-cli2`. Those are invoked via `bunx`/`npx` (or, for
+`prettier`, from `PATH` — see [Node.js Tool Resolution](#nodejs-tool-resolution)) and
+run fine without a local `node_modules`, because the runner fetches the package on
+demand. When one of them cannot be resolved at all, Lintro reports a `⏭️ SKIP` row with
+the reason instead of a pass — installing project dependencies would not have helped.
 
 You can also enable this globally via configuration:
 
@@ -804,6 +805,36 @@ Rationale:
   Ruff’s stricter lint rules (e.g., `COM812`, `E501`).
 - Black’s safe wrapping is preferred for long lines; Ruff continues to enforce lint
   limits during checks.
+
+### Node.js Tool Resolution {#nodejs-tool-resolution}
+
+How Lintro locates a Node.js tool decides which install actually works, and the answer
+is not the same for every tool. There are three resolution modes.
+
+**1. Registry-runner tools (most Node.js tools).** `commitlint`, `markdownlint-cli2`,
+`oxlint`, `oxfmt`, `stylelint`, `tsc`, `vue-tsc`, `svelte-check` and `astro check` are
+invoked as:
+
+1. `bunx <binary>` — if `bunx` is available.
+2. `npx <binary>` — if only `npx` is available.
+3. bare `<binary>` — if neither runner exists.
+
+`bunx`/`npx` resolve the **project's own** `node_modules/.bin` first and otherwise fetch
+the package from the npm registry. Branches 1 and 2 never look at `PATH`, so a global
+install (`bun add -g`, `npm install -g`) or a Homebrew formula is not what Lintro picks
+up on a machine that has `bun` or `npm`. Install these tools as a **dependency of the
+project you check** (`bun add -D <pkg>` / `npm install -D <pkg>`); that also pins the
+version through your lockfile instead of resolving `@latest` at check time.
+
+**2. Pinned local-first tools.** `html-validate` uses a stricter chain that prefers a
+project-local install, then `PATH`, then a version-pinned registry fallback. A global
+install does work here, though a devDependency is still the supported configuration. See
+[html-validate Configuration](#html-validate-configuration) for the full order.
+
+**3. `PATH`-resolved tools.** `prettier` has no Node-specific builder: Lintro executes
+the bare `prettier` name and lets the OS resolve it against `PATH`. A global install
+(`npm install -g prettier`, `brew install prettier`) is therefore the correct one; a
+project devDependency alone does not put `prettier` on `PATH`.
 
 ### Python Tools
 
@@ -1284,15 +1315,17 @@ wraps `tsc --noEmit` to check types without generating output files.
 **Installation:**
 
 ```bash
-# Homebrew (macOS/Linux)
-brew install typescript
+# bun (recommended)
+bun add -D typescript
 
 # npm
-npm install -g typescript
-
-# bun
-bun add -g typescript
+npm install -D typescript
 ```
+
+Install TypeScript into the project you check. Lintro runs `tsc` through `bunx`/`npx`,
+which resolve the project's `node_modules` and never consult `PATH`, so a global install
+or `brew install typescript` is not what gets used. See
+[Node.js Tool Resolution](#nodejs-tool-resolution).
 
 **File:** `tsconfig.json`
 
@@ -1355,13 +1388,16 @@ When a native config exists, Lintro uses it automatically and skips generating d
 **Installation:**
 
 ```bash
-# npm/bun
-npm install -g oxlint
-bun add -g oxlint
+# bun (recommended)
+bun add -D oxlint
 
-# Homebrew (macOS)
-brew install oxlint
+# npm
+npm install -D oxlint
 ```
+
+Lintro invokes oxlint via `bunx`/`npx`, which resolve the project's `node_modules` and
+not `PATH` — a global or Homebrew install is not what gets used. See
+[Node.js Tool Resolution](#nodejs-tool-resolution).
 
 **File:** `.oxlintrc.json`
 
@@ -1437,13 +1473,16 @@ Stylelint resolves configuration per file (walking upward). Lintro supports:
 **Installation:**
 
 ```bash
-# npm/bun
-npm install -g stylelint
-bun add -g stylelint
+# bun (recommended, with a shareable config)
+bun add -D stylelint stylelint-config-standard
 
-# Per-project (recommended, with a shareable config)
-bun add -d stylelint stylelint-config-standard
+# npm
+npm install -D stylelint stylelint-config-standard
 ```
+
+Lintro invokes stylelint via `bunx`/`npx`, which resolve the project's `node_modules`
+and not `PATH` — a global install is not what gets used. See
+[Node.js Tool Resolution](#nodejs-tool-resolution).
 
 **File:** `.stylelintrc.json`
 
@@ -1499,13 +1538,16 @@ When a native config exists, Lintro uses it automatically and skips generating d
 **Installation:**
 
 ```bash
-# npm/bun
-npm install -g oxfmt
-bun add -g oxfmt
+# bun (recommended)
+bun add -D oxfmt
 
-# Homebrew (macOS)
-brew install oxfmt
+# npm
+npm install -D oxfmt
 ```
+
+Lintro invokes oxfmt via `bunx`/`npx`, which resolve the project's `node_modules` and
+not `PATH` — a global or Homebrew install is not what gets used. See
+[Node.js Tool Resolution](#nodejs-tool-resolution).
 
 **File:** `.oxfmtrc.json` or `.oxfmtrc.jsonc`
 
@@ -1705,6 +1747,10 @@ A project-local devDependency is the **supported configuration**. It is the firs
 most reliable branch of Lintro's executable resolution, it is lockfile-pinned, and it
 needs no registry access at check time. A global install (`-g`) does _not_ populate
 `node_modules/.bin`, so it lands on a later, weaker branch.
+
+html-validate is the only tool on this pinned chain; see
+[Node.js Tool Resolution](#nodejs-tool-resolution) for how the other Node.js tools
+resolve.
 
 **Executable resolution order:**
 
@@ -2536,9 +2582,11 @@ file-based tools, it inspects git state: Lintro runs `commitlint --last` to vali
 repository's most recent commit message.
 
 - Requires a config; Lintro skips it as a non-error when none is present.
-- Install: `bun add -g @commitlint/cli @commitlint/config-conventional`,
-  `npm install -g @commitlint/cli @commitlint/config-conventional`, or
-  `brew install commitlint`.
+- Install: `bun add -D @commitlint/cli @commitlint/config-conventional` or
+  `npm install -D @commitlint/cli @commitlint/config-conventional`. Lintro runs
+  commitlint through `bunx`/`npx`, which resolve the project's `node_modules` and not
+  `PATH`, so a global or `brew install commitlint` is not what gets used — see
+  [Node.js Tool Resolution](#nodejs-tool-resolution).
 - Cannot auto-fix — amend the commit to satisfy the rules.
 
 **File:** `commitlint.config.js` (or `.commitlintrc.{js,cjs,json,yaml,yml}`, or a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -375,11 +375,12 @@ running the tools that need a project's dependency tree to work: `tsc`, `vue-tsc
 `svelte-check` and `astro-check`.
 
 It does **not** apply to standalone Node.js binaries such as `prettier`, `oxlint`,
-`oxfmt`, `stylelint` or `markdownlint-cli2`. Those are invoked via `bunx`/`npx` (or, for
-`prettier`, from `PATH` — see [Node.js Tool Resolution](#nodejs-tool-resolution)) and
-run fine without a local `node_modules`, because the runner fetches the package on
-demand. When one of them cannot be resolved at all, Lintro reports a `⏭️ SKIP` row with
-the reason instead of a pass — installing project dependencies would not have helped.
+`oxfmt`, `stylelint` or `markdownlint-cli2`. Those run fine without a local
+`node_modules`: `oxlint`, `oxfmt` and `stylelint` are fetched on demand by `bunx`/`npx`,
+while `prettier` and `markdownlint-cli2` are resolved from `PATH` — see
+[Node.js Tool Resolution](#nodejs-tool-resolution). When one of them cannot be resolved
+at all, Lintro reports a `⏭️ SKIP` row with the reason instead of a pass — installing
+project dependencies would not have helped.
 
 You can also enable this globally via configuration:
 
@@ -809,32 +810,49 @@ Rationale:
 ### Node.js Tool Resolution {#nodejs-tool-resolution}
 
 How Lintro locates a Node.js tool decides which install actually works, and the answer
-is not the same for every tool. There are three resolution modes.
+is not the same for every tool. Four resolution modes are in use; the tool's own
+definition, not a single shared code path, decides which one applies.
 
-**1. Registry-runner tools (most Node.js tools).** `commitlint`, `markdownlint-cli2`,
-`oxlint`, `oxfmt`, `stylelint`, `tsc`, `vue-tsc`, `svelte-check` and `astro check` are
-invoked as:
+**1. Runner-only tools — install as a project dependency.** `oxlint`, `oxfmt` and
+`stylelint` go through `NodeJSBuilder` in `lintro/tools/core/command_builders.py`:
 
 1. `bunx <binary>` — if `bunx` is available.
 2. `npx <binary>` — if only `npx` is available.
 3. bare `<binary>` — if neither runner exists.
 
-`bunx`/`npx` resolve the **project's own** `node_modules/.bin` first and otherwise fetch
-the package from the npm registry. Branches 1 and 2 never look at `PATH`, so a global
+`bunx`/`npx` resolve the **checked project's** `node_modules/.bin` first and otherwise
+fetch the package from the npm registry. Neither branch looks at `PATH`, so a global
 install (`bun add -g`, `npm install -g`) or a Homebrew formula is not what Lintro picks
-up on a machine that has `bun` or `npm`. Install these tools as a **dependency of the
-project you check** (`bun add -D <pkg>` / `npm install -D <pkg>`); that also pins the
-version through your lockfile instead of resolving `@latest` at check time.
+up on any machine that has `bun` or `npm`. Install these as a dependency of the project
+you check (`bun add -D <pkg>` / `npm install -D <pkg>`); that also pins the version
+through your lockfile instead of resolving `@latest` at check time.
 
-**2. Pinned local-first tools.** `html-validate` uses a stricter chain that prefers a
-project-local install, then `PATH`, then a version-pinned registry fallback. A global
-install does work here, though a devDependency is still the supported configuration. See
-[html-validate Configuration](#html-validate-configuration) for the full order.
+**2. `PATH`-first tools — a global install is what they prefer.** `commitlint`,
+`markdownlint-cli2`, `tsc`, `vue-tsc` and `svelte-check` resolve in their own tool
+definitions, and each checks the binary **before** any runner:
 
-**3. `PATH`-resolved tools.** `prettier` has no Node-specific builder: Lintro executes
-the bare `prettier` name and lets the OS resolve it against `PATH`. A global install
-(`npm install -g prettier`, `brew install prettier`) is therefore the correct one; a
-project devDependency alone does not put `prettier` on `PATH`.
+1. `<binary>` from `PATH` — a global install (`-g`) or a Homebrew formula.
+2. `bunx <binary>`.
+3. `npx <binary>` — **not available for `commitlint` or `markdownlint-cli2`**, which
+   fall straight through to step 4.
+4. bare `<binary>` — fails if nothing is installed.
+
+The `npx` gap matters: on a machine with npm but no bun, a `commitlint` or
+`markdownlint-cli2` devDependency is never reached and the tool reports a skip. Install
+those two globally, or make sure `bun` is available.
+
+**3. Local-first with a runner fallback.** `astro check` prefers the project's
+`node_modules/.bin/astro` (which also avoids the interactive "install @astrojs/check?"
+prompt that hangs without a TTY), then `PATH`, then `bunx`/`npx`. `html-validate` uses a
+similar chain with a **version-pinned** registry fallback; see
+[html-validate Configuration](#html-validate-configuration) for the full order. A global
+install works for both, though a project-local one is preferred.
+
+**4. `PATH` only.** `prettier` has no Node-specific builder at all — the command builder
+registry falls through to its bare-name default and the OS resolves `prettier` against
+`PATH`. A global install (`npm install -g prettier`, `brew install prettier`) is
+therefore the correct one; a project devDependency alone does not put `prettier` on
+`PATH`.
 
 ### Python Tools
 
@@ -1315,17 +1333,19 @@ wraps `tsc --noEmit` to check types without generating output files.
 **Installation:**
 
 ```bash
-# bun (recommended)
-bun add -D typescript
+# Homebrew (macOS/Linux)
+brew install typescript
 
 # npm
-npm install -D typescript
+npm install -g typescript
+
+# bun
+bun add -g typescript
 ```
 
-Install TypeScript into the project you check. Lintro runs `tsc` through `bunx`/`npx`,
-which resolve the project's `node_modules` and never consult `PATH`, so a global install
-or `brew install typescript` is not what gets used. See
-[Node.js Tool Resolution](#nodejs-tool-resolution).
+Lintro prefers a `tsc` binary on `PATH` and only falls back to `bunx`/`npx`, so any of
+the above works; a project-local devDependency is picked up through the `bunx`/`npx`
+fallback. See [Node.js Tool Resolution](#nodejs-tool-resolution).
 
 **File:** `tsconfig.json`
 
@@ -2582,10 +2602,10 @@ file-based tools, it inspects git state: Lintro runs `commitlint --last` to vali
 repository's most recent commit message.
 
 - Requires a config; Lintro skips it as a non-error when none is present.
-- Install: `bun add -D @commitlint/cli @commitlint/config-conventional` or
-  `npm install -D @commitlint/cli @commitlint/config-conventional`. Lintro runs
-  commitlint through `bunx`/`npx`, which resolve the project's `node_modules` and not
-  `PATH`, so a global or `brew install commitlint` is not what gets used — see
+- Install: `bun add -g @commitlint/cli @commitlint/config-conventional`,
+  `npm install -g @commitlint/cli @commitlint/config-conventional`, or
+  `brew install commitlint`. Lintro checks `PATH` first and falls back only to `bunx` —
+  there is no `npx` branch, so a devDependency is unreachable without `bun`. See
   [Node.js Tool Resolution](#nodejs-tool-resolution).
 - Cannot auto-fix — amend the commit to satisfy the rules.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,12 +82,16 @@ are centrally managed in `manifest.json` and `pyproject.toml`:
 ### Optional External Tools
 
 Some tools require separate installation. Their minimum versions are also managed in
-`pyproject.toml`:
+`pyproject.toml`. Most Node.js tools are run through `bunx`/`npx`, which resolve the
+checked project's `node_modules` rather than `PATH` — install those as project
+dependencies, not globally. See
+[Node.js Tool Resolution](configuration.md#nodejs-tool-resolution) for the exceptions.
 
 - `prettier` - JavaScript/TypeScript formatter (install via npm)
-- `commitlint` - Conventional Commits message linter
-  (`bun add -g @commitlint/cli @commitlint/config-conventional` or
-  `brew install commitlint`); requires a commitlint config, skipped otherwise
+- `commitlint` - Conventional Commits message linter (install into the project with
+  `bun add -D @commitlint/cli @commitlint/config-conventional` or
+  `npm install -D @commitlint/cli @commitlint/config-conventional`); requires a
+  commitlint config, skipped otherwise
 - `hadolint` - Dockerfile linter (download from GitHub releases)
 - `actionlint` - GitHub Actions linter (download from GitHub releases)
 - `semgrep` - Security scanner and code analyzer (`pipx install semgrep`,
@@ -103,9 +107,9 @@ Some tools require separate installation. Their minimum versions are also manage
 - `dotenv-linter` - `.env` file linter and fixer (`brew install dotenv-linter`,
   `cargo install dotenv-linter`, or GitHub releases)
 - `sqlfluff` - SQL linter and formatter (`pip install sqlfluff`)
-- `stylelint` - CSS/SCSS/Sass/Less linter and fixer (`bun add -g stylelint` or
-  `npm install -g stylelint`); skips cleanly when no stylelint config is found — add one
-  (e.g. `.stylelintrc.json`) to enable linting
+- `stylelint` - CSS/SCSS/Sass/Less linter and fixer (install into the project with
+  `bun add -D stylelint` or `npm install -D stylelint`); skips cleanly when no stylelint
+  config is found — add one (e.g. `.stylelintrc.json`) to enable linting
 - `pip-audit` - Python dependency vulnerability scanner (`pip install pip-audit`,
   `uv add pip-audit`, or `brew install pip-audit`)
 - `taplo` - TOML linter and formatter (`brew install taplo` or GitHub releases)
@@ -116,8 +120,8 @@ Some tools require separate installation. Their minimum versions are also manage
 - `osv-scanner` - Multi-ecosystem vulnerability scanner using the OSV database
   (`go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest` or GitHub
   releases)
-- `typescript` - TypeScript compiler for type checking (`brew install typescript`,
-  `bun add -g typescript`, or `npm install -g typescript`)
+- `typescript` - TypeScript compiler for type checking (install into the project with
+  `bun add -D typescript` or `npm install -D typescript`)
 - `astro` - Astro type checker for `.astro` files (install locally with
   `bun add -d astro @astrojs/check` or `npm install --save-dev astro @astrojs/check`,
   then invoke with `bunx astro check` or `npx astro check`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,16 +82,18 @@ are centrally managed in `manifest.json` and `pyproject.toml`:
 ### Optional External Tools
 
 Some tools require separate installation. Their minimum versions are also managed in
-`pyproject.toml`. Most Node.js tools are run through `bunx`/`npx`, which resolve the
-checked project's `node_modules` rather than `PATH` — install those as project
-dependencies, not globally. See
-[Node.js Tool Resolution](configuration.md#nodejs-tool-resolution) for the exceptions.
+`pyproject.toml`. Node.js tools do not all resolve the same way — some prefer a binary
+on `PATH` (a `-g` or Homebrew install), others are only ever run through `bunx`/`npx`
+and so must be a dependency of the project you check. See
+[Node.js Tool Resolution](configuration.md#nodejs-tool-resolution) before choosing an
+install mode.
 
 - `prettier` - JavaScript/TypeScript formatter (install via npm)
-- `commitlint` - Conventional Commits message linter (install into the project with
-  `bun add -D @commitlint/cli @commitlint/config-conventional` or
-  `npm install -D @commitlint/cli @commitlint/config-conventional`); requires a
-  commitlint config, skipped otherwise
+- `commitlint` - Conventional Commits message linter
+  (`bun add -g @commitlint/cli @commitlint/config-conventional` or
+  `brew install commitlint`); resolved from `PATH` first with only a `bunx` fallback, so
+  a devDependency is unreachable without `bun`; requires a commitlint config, skipped
+  otherwise
 - `hadolint` - Dockerfile linter (download from GitHub releases)
 - `actionlint` - GitHub Actions linter (download from GitHub releases)
 - `semgrep` - Security scanner and code analyzer (`pipx install semgrep`,
@@ -107,9 +109,10 @@ dependencies, not globally. See
 - `dotenv-linter` - `.env` file linter and fixer (`brew install dotenv-linter`,
   `cargo install dotenv-linter`, or GitHub releases)
 - `sqlfluff` - SQL linter and formatter (`pip install sqlfluff`)
-- `stylelint` - CSS/SCSS/Sass/Less linter and fixer (install into the project with
-  `bun add -D stylelint` or `npm install -D stylelint`); skips cleanly when no stylelint
-  config is found — add one (e.g. `.stylelintrc.json`) to enable linting
+- `stylelint` - CSS/SCSS/Sass/Less linter and fixer (install into the project you check
+  with `bun add -D stylelint` or `npm install -D stylelint`; it is run through
+  `bunx`/`npx`, which never consult `PATH`); skips cleanly when no stylelint config is
+  found — add one (e.g. `.stylelintrc.json`) to enable linting
 - `pip-audit` - Python dependency vulnerability scanner (`pip install pip-audit`,
   `uv add pip-audit`, or `brew install pip-audit`)
 - `taplo` - TOML linter and formatter (`brew install taplo` or GitHub releases)
@@ -120,8 +123,9 @@ dependencies, not globally. See
 - `osv-scanner` - Multi-ecosystem vulnerability scanner using the OSV database
   (`go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest` or GitHub
   releases)
-- `typescript` - TypeScript compiler for type checking (install into the project with
-  `bun add -D typescript` or `npm install -D typescript`)
+- `typescript` - TypeScript compiler for type checking (`brew install typescript`,
+  `bun add -g typescript`, or `npm install -g typescript`; a project devDependency also
+  works via the `bunx`/`npx` fallback)
 - `astro` - Astro type checker for `.astro` files (install locally with
   `bun add -d astro @astrojs/check` or `npm install --save-dev astro @astrojs/check`,
   then invoke with `bunx astro check` or `npx astro check`)

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -103,6 +103,33 @@ def test_cli_help_works() -> None:
         pytest.fail("lintro --help timed out")
 
 
+def _heading_anchors(markdown: str) -> set[str]:
+    """Collect the anchors a Markdown document exposes.
+
+    Supports both GitHub's implicit heading slugs and the explicit
+    ``{#custom-anchor}`` suffix used in the longer guides.
+
+    Args:
+        markdown: Full text of a Markdown document.
+
+    Returns:
+        Set of anchor names (without the leading ``#``).
+    """
+    anchors: set[str] = set()
+    for line in markdown.splitlines():
+        match = re.match(r"^#{1,6}\s+(.*)$", line)
+        if match is None:
+            continue
+        heading = match.group(1).strip()
+        explicit = re.search(r"\{#([^}]+)\}\s*$", heading)
+        if explicit is not None:
+            anchors.add(explicit.group(1))
+            heading = heading[: explicit.start()].strip()
+        slug = re.sub(r"[^\w\- ]", "", heading.lower())
+        anchors.add(slug.replace(" ", "-"))
+    return anchors
+
+
 def test_internal_doc_links() -> None:
     """Test that internal documentation links are valid."""
     doc_files = [
@@ -127,12 +154,21 @@ def test_internal_doc_links() -> None:
         for link_text, link_url in links:
             if link_url.startswith("docs/") or link_url.startswith("./docs/"):
                 # Internal documentation link
-                link_path = link_url
+                link_path, _, fragment = link_url.partition("#")
                 if link_path.startswith("./"):
                     link_path = link_path[2:]
 
-                if not Path(link_path).exists():
+                target = Path(link_path)
+                if not target.exists():
                     broken_links.append(f"{doc_file}: {link_text} -> {link_url}")
+                    continue
+
+                if fragment and target.is_file():
+                    anchors = _heading_anchors(target.read_text(encoding="utf-8"))
+                    if fragment not in anchors:
+                        broken_links.append(
+                            f"{doc_file}: {link_text} -> {link_url} (missing anchor)",
+                        )
 
     if broken_links:
         pytest.fail("Broken internal links:\n" + "\n".join(broken_links))

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -103,11 +103,38 @@ def test_cli_help_works() -> None:
         pytest.fail("lintro --help timed out")
 
 
+def _slugify_heading(heading: str) -> str:
+    """Slugify heading text the way GitHub does.
+
+    GitHub renders the heading first and then slugs the resulting *text*, so
+    inline markup (emphasis, inline code, links) contributes its content but
+    not its markers. ``github-slugger`` then lowercases, drops punctuation and
+    turns spaces into hyphens. Its character class keeps ``-`` and ``_`` — both
+    survive into the anchor — which is why underscores are retained here.
+
+    Args:
+        heading: Raw heading text, without the leading ``#`` markers.
+
+    Returns:
+        The anchor GitHub would generate for that heading.
+    """
+    # Render-ish pass: keep the text inside inline markup, drop the markers.
+    text = re.sub(r"!?\[([^\]]*)\]\([^)]*\)", r"\1", heading)  # links/images
+    text = re.sub(r"`([^`]*)`", r"\1", text)  # inline code
+    text = re.sub(r"(\*{1,3})(\S.*?\S|\S)\1", r"\2", text)  # *em* / **strong**
+    text = re.sub(r"(?<!\w)(_{1,3})(\S.*?\S|\S)\1(?!\w)", r"\2", text)  # _em_
+    # github-slugger: lowercase, strip punctuation except "-" and "_", " " -> "-"
+    slug = re.sub(r"[^\w\- ]", "", text.lower())
+    return slug.replace(" ", "-")
+
+
 def _heading_anchors(markdown: str) -> set[str]:
     """Collect the anchors a Markdown document exposes.
 
     Supports both GitHub's implicit heading slugs and the explicit
-    ``{#custom-anchor}`` suffix used in the longer guides.
+    ``{#custom-anchor}`` suffix used in the longer guides. Fenced code blocks
+    are skipped so that shell comments such as ``# install foo`` do not
+    register as headings and silently validate a link that does not resolve.
 
     Args:
         markdown: Full text of a Markdown document.
@@ -116,7 +143,19 @@ def _heading_anchors(markdown: str) -> set[str]:
         Set of anchor names (without the leading ``#``).
     """
     anchors: set[str] = set()
+    fence: str | None = None
     for line in markdown.splitlines():
+        fence_match = re.match(r"^\s*(`{3,}|~{3,})", line)
+        if fence_match is not None:
+            marker = fence_match.group(1)
+            if fence is None:
+                fence = marker[0]
+            elif marker[0] == fence:
+                fence = None
+            continue
+        if fence is not None:
+            continue
+
         match = re.match(r"^#{1,6}\s+(.*)$", line)
         if match is None:
             continue
@@ -125,9 +164,40 @@ def _heading_anchors(markdown: str) -> set[str]:
         if explicit is not None:
             anchors.add(explicit.group(1))
             heading = heading[: explicit.start()].strip()
-        slug = re.sub(r"[^\w\- ]", "", heading.lower())
-        anchors.add(slug.replace(" ", "-"))
+        anchors.add(_slugify_heading(heading))
     return anchors
+
+
+def test_slugify_heading_matches_github() -> None:
+    """Heading slugs match anchors GitHub's renderer actually emits.
+
+    Expected values were taken from GitHub's ``POST /markdown`` API, which
+    returns ``id="user-content-<anchor>"`` for each rendered heading. Note that
+    underscores survive (``github-slugger`` keeps ``_`` and ``-``) while
+    emphasis markers do not, because GitHub slugs the rendered text.
+    """
+    assert_that(_slugify_heading("snake_case option names")).is_equal_to(
+        "snake_case-option-names",
+    )
+    assert_that(_slugify_heading("What Lintro does _not_ do yet")).is_equal_to(
+        "what-lintro-does-not-do-yet",
+    )
+    assert_that(_slugify_heading("Ruff vs. Black Policy (Python)")).is_equal_to(
+        "ruff-vs-black-policy-python",
+    )
+    assert_that(_slugify_heading("Node.js Tool Resolution")).is_equal_to(
+        "nodejs-tool-resolution",
+    )
+
+
+def test_heading_anchors_ignore_fenced_code_blocks() -> None:
+    """Shell comments inside fences must not register as headings."""
+    markdown = "# Real\n\n```bash\n# npm install -g typescript\n```\n\n## Second\n"
+
+    anchors = _heading_anchors(markdown)
+
+    assert_that(anchors).contains("real", "second")
+    assert_that(anchors).does_not_contain("npm-install--g-typescript")
 
 
 def test_internal_doc_links() -> None:

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -136,6 +136,9 @@ def _heading_anchors(markdown: str) -> set[str]:
     are skipped so that shell comments such as ``# install foo`` do not
     register as headings and silently validate a link that does not resolve.
 
+    Repeated headings get the ``-1``, ``-2`` … suffixes ``github-slugger``
+    assigns, so a link to the second occurrence is not reported as broken.
+
     Args:
         markdown: Full text of a Markdown document.
 
@@ -143,6 +146,7 @@ def _heading_anchors(markdown: str) -> set[str]:
         Set of anchor names (without the leading ``#``).
     """
     anchors: set[str] = set()
+    seen: dict[str, int] = {}
     fence: str | None = None
     for line in markdown.splitlines():
         fence_match = re.match(r"^\s*(`{3,}|~{3,})", line)
@@ -164,7 +168,11 @@ def _heading_anchors(markdown: str) -> set[str]:
         if explicit is not None:
             anchors.add(explicit.group(1))
             heading = heading[: explicit.start()].strip()
-        anchors.add(_slugify_heading(heading))
+
+        slug = _slugify_heading(heading)
+        occurrence = seen.get(slug, 0)
+        seen[slug] = occurrence + 1
+        anchors.add(slug if occurrence == 0 else f"{slug}-{occurrence}")
     return anchors
 
 
@@ -200,6 +208,15 @@ def test_heading_anchors_ignore_fenced_code_blocks() -> None:
     assert_that(anchors).does_not_contain("npm-install--g-typescript")
 
 
+def test_heading_anchors_number_repeated_headings() -> None:
+    """Repeated headings get GitHub's ``-1``/``-2`` occurrence suffixes."""
+    markdown = "## Installation\n\n## Installation\n\n## Installation\n"
+
+    anchors = _heading_anchors(markdown)
+
+    assert_that(anchors).contains("installation", "installation-1", "installation-2")
+
+
 def test_internal_doc_links() -> None:
     """Test that internal documentation links are valid."""
     doc_files = [
@@ -222,23 +239,27 @@ def test_internal_doc_links() -> None:
         # Find markdown links
         links = re.findall(r"\[([^\]]+)\]\(([^)]+)\)", content)
         for link_text, link_url in links:
-            if link_url.startswith("docs/") or link_url.startswith("./docs/"):
-                # Internal documentation link
-                link_path, _, fragment = link_url.partition("#")
-                if link_path.startswith("./"):
-                    link_path = link_path[2:]
+            # Skip anything that leaves the repository or is not a file link.
+            if re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*:", link_url) or link_url.startswith(
+                "//",
+            ):
+                continue
 
-                target = Path(link_path)
-                if not target.exists():
-                    broken_links.append(f"{doc_file}: {link_text} -> {link_url}")
-                    continue
+            link_path, _, fragment = link_url.partition("#")
+            # A bare "#anchor" points at the current document.
+            source = Path(doc_file)
+            target = source if not link_path else (source.parent / link_path).resolve()
 
-                if fragment and target.is_file():
-                    anchors = _heading_anchors(target.read_text(encoding="utf-8"))
-                    if fragment not in anchors:
-                        broken_links.append(
-                            f"{doc_file}: {link_text} -> {link_url} (missing anchor)",
-                        )
+            if not target.exists():
+                broken_links.append(f"{doc_file}: {link_text} -> {link_url}")
+                continue
+
+            if fragment and target.is_file() and target.suffix == ".md":
+                anchors = _heading_anchors(target.read_text(encoding="utf-8"))
+                if fragment not in anchors:
+                    broken_links.append(
+                        f"{doc_file}: {link_text} -> {link_url} (missing anchor)",
+                    )
 
     if broken_links:
         pytest.fail("Broken internal links:\n" + "\n".join(broken_links))


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  docs: correct Node tool install advice to match resolution (#1799)
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [x] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

README told users to install `oxlint`, `oxfmt` and `stylelint` globally
(`bun add -g` / `npm install -g`). Lintro resolves those three with plain
`bunx <binary>` / `npx <binary>`, which look at the checked project's
`node_modules` and the npm registry — never at `PATH`. A global or Homebrew
install therefore cannot be the binary Lintro runs on any machine that has `bun`
or `npm`. Those three cells now say `-D`.

Every other Node tool in the table was checked and left alone; several of them
prefer a `PATH` binary and would have been *broken* by a blanket `-D` change.
See the table below.

### Verified per-tool findings

**Corrected after Greptile review.** The first pass assumed every Node tool went
through `NodeJSBuilder`. It does not: five tools bypass the command-builder
registry entirely and resolve their binary in their own definition, checking
`PATH` **before** any runner. Verified by reading each definition and by
executing the resolvers with `shutil.which` patched.

| Tool | Real resolver | Order | `PATH` consulted? | Install cell |
| --- | --- | --- | --- | --- |
| commitlint | `commitlint.py:112` | PATH → bunx → bare (**no npx**) | Yes, first | `-g` / brew (unchanged) |
| markdownlint-cli2 | `markdownlint.py:143` | PATH → bunx → bare (**no npx**) | Yes, first | `-g` (unchanged) |
| tsc | `_ts_checker_base.py:125` | PATH → bunx → npx → bare | Yes, first | `-g` / brew (unchanged) |
| vue-tsc | `_ts_checker_base.py:125` | PATH → bunx → npx → bare | Yes, first | `-D` (unchanged, works) |
| svelte-check | `svelte_check.py:113` | PATH → bunx → npx → bare | Yes, first | `-D` (unchanged, works) |
| astro-check | `astro_check.py:131` | local `node_modules/.bin` → PATH → bunx → npx | Yes | local (unchanged) |
| **oxlint** | `NodeJSBuilder` (unpinned) | bunx → npx → bare | **No** | `-g` → **`-D`** |
| **oxfmt** | `NodeJSBuilder` (unpinned) | bunx → npx → bare | **No** | `-g` → **`-D`** |
| **stylelint** | `NodeJSBuilder` (unpinned) | bunx → npx → bare | **No** | `-g` → **`-D`** |
| html-validate | `NodeJSBuilder` (**pinned**) | local → PATH → `bunx <pkg>@<pin>` → npx → bare | Yes | `-D` (unchanged, #1786) |
| prettier | no builder — registry fallback | bare name only | **Yes, only** | `-g` (unchanged) |

Executed with `bunx` absent, `npx` present, nothing on `PATH` — i.e. a
devDependency-only install on an npm-without-bun machine:

```
markdownlint -> ['markdownlint-cli2']   # bare name, not found -> tool skips
commitlint   -> ['commitlint']          # same gap
tsc          -> ['npx', 'tsc']
svelte-check -> ['npx', 'svelte-check']
oxlint       -> ['npx', 'oxlint']
```

**Only three rows actually change**: oxlint, oxfmt and stylelint, the tools that
genuinely go through plain `bunx`/`npx` and never look at `PATH`.

**This contradicts the issue's suspected line list on four of its seven rows:**

- **106 (commitlint)** and **130 (markdownlint-cli2)** — `PATH` is checked first,
  so `-g` and `brew install` are correct. Worse, neither has an `npx` branch, so
  the `-D` advice the issue asked for would have made these tools *unusable* for
  npm-without-bun users. Left as-is on main.
- **247 (typescript)** — `PATH` first via `_resolve_binary_command`; `-g` and
  brew are correct. Left as-is.
- **179 (prettier)** — absent from every builder, resolved from `PATH` by bare
  name; `-g` is the only thing that works. Left as-is.
- 142 (oxlint), 173 (oxfmt), 222 (stylelint) — confirmed, changed to `-D`.

### Homebrew decision: kept, and documented

`brew install commitlint` (row 106) and `brew install typescript` (row 247) are
**kept**. The premise in the issue — that Homebrew lands on `PATH` which
"the plain-bunx path does not consult either" — does not hold for these two
tools, because neither goes through the plain-bunx path. Both check
`shutil.which(<binary>)` first, which is exactly what a Homebrew install
satisfies. Removing them (as the first revision of this PR did) would have been
a regression. No brew entry anywhere in the table belongs to a tool that cannot
use one.

### Shared resolution note

Added `### Node.js Tool Resolution` to `docs/configuration.md` describing the
four modes that actually exist (runner-only, `PATH`-first, local-first with
runner fallback, `PATH`-only), including the missing `npx` branch that makes a
commitlint/markdownlint devDependency unreachable without `bun`. Linked from the
README table legend, `docs/getting-started.md` and the html-validate section
rather than repeated per tool. Also corrected a stale sentence in the
`--auto-install` section which lumped all five "standalone Node.js binaries"
together as "invoked from `PATH` (or via `bunx`/`npx`)".

### Out of scope (behavioural)

Filed as #1811, deliberately not fixed here:

1. Five tools (commitlint, markdownlint-cli2, tsc, vue-tsc, svelte-check) hand-roll
   their own resolution instead of using `CommandBuilderRegistry`, so the
   registry entries for them are dead code and the two-branch resolvers silently
   drop npm-only users.
2. Only `html-validate` is on the pinned local-first chain; oxlint/oxfmt/stylelint
   resolve `@latest` through `bunx`/`npx` and ignore project-local installs.
3. `prettier` has no builder at all, so a project's pinned prettier is never used.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro fmt && uv run lintro chk`, `uv run pytest --maxfail=0`)

## Closes

- Closes #1799

## Details

Files changed:

- `README.md` — install cells for oxlint, oxfmt and stylelint switched to `-D`;
  new legend line explaining that Node tools do not all resolve the same way.
- `docs/configuration.md` — new `Node.js Tool Resolution` section; oxlint,
  oxfmt and stylelint install blocks corrected; typescript and commitlint blocks
  gained a note about their `PATH`-first order and (for commitlint) the missing
  `npx` branch; html-validate section cross-links the shared section;
  `--auto-install` `PATH` claim corrected.
- `docs/getting-started.md` — stylelint entry corrected, commitlint and
  typescript entries annotated with their real resolution order, plus a pointer
  to the shared section.
- `tests/test_documentation.py` — `test_internal_doc_links` did not strip URL
  fragments, so any `docs/foo.md#anchor` link was reported as broken. It now
  splits the fragment off **and** verifies the anchor exists in the target.
  Slug generation matches GitHub's renderer: inline markup (emphasis, code,
  links) is stripped before slugging, underscores are kept, and fenced code
  blocks are skipped so shell comments cannot register as phantom headings. Two
  new tests pin this to output from GitHub's `POST /markdown` API.

Review follow-ups (2 Greptile threads, both handled):

- **P1, markdownlint omits the npx path — correct, and it invalidated part of
  this PR.** `MarkdownlintPlugin` never calls `_get_executable_command`; it
  resolves `PATH → bunx → bare` in its own definition, with no `npx` branch, as
  does `CommitlintPlugin`. Verifying this revealed that five tools bypass the
  command-builder registry altogether, so the original `-D` changes for
  commitlint, markdownlint-cli2 and typescript were wrong and have been reverted
  (commit 7032487f). Table above is the corrected version.
- **P2, slug generation preserves underscores — refuted.** `github-slugger`'s
  strip regex runs `\[-\^` then resumes at `` ` ``, so `_` (0x5F) is never
  removed; `POST /markdown` returns `id="user-content-snake_case-option-names"`
  for `### snake_case option names`. The adjacent real defect — emphasis
  underscores, which GitHub *does* drop because it slugs rendered text — was
  fixed, along with fenced-code-block false positives.

Testing: `uv run lintro fmt` + `uv run lintro chk` report 0 issues (health
100/100). `uv run pytest --maxfail=0` → 8016 passed, 18 failed. All 18 failures
are the pre-existing host-environment set — stylelint/oxlint/oxfmt/vale/
trufflehog binaries below the pinned minimums (the same versions `lintro chk`
reports as SKIP), `pip-audit` ensurepip, and the commitlint git-state test. None
touch any file in this diff, which is docs plus one docs test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance to recommend project-local development dependencies for Node.js tools.
  * Added guidance on Node.js tool resolution, including `bunx`/`npx`, auto-install behavior, fallback modes, and configuration requirements.
  * Clarified setup instructions for TypeScript, Prettier, Stylelint, Commitlint, and related tools.

* **Tests**
  * Improved validation of documentation links and heading anchors.
  * Added coverage for GitHub-compatible heading slugs and headings inside code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR aligns Node.js installation documentation with Lintro’s actual executable-resolution behavior.
- Corrects global versus project-local installation commands across the README and guides.
- Documents runner-only, PATH-first, local-first, and PATH-only resolution modes.
- Extends documentation-link tests to validate fragments against implicit and explicit heading anchors.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Updates the supported-tools installation matrix and links users to the shared Node.js resolution guidance. |
| docs/configuration.md | Documents the executable-resolution modes and corrects tool-specific installation and auto-install guidance. |
| docs/getting-started.md | Aligns introductory Node.js dependency instructions with the documented runtime resolution behavior. |
| tests/test_documentation.py | Adds fragment validation with heading-slug generation, explicit-anchor support, and fenced-code exclusion. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;docs/1799-node-install-mod..."](https://github.com/lgtm-hq/py-lintro/commit/601ec7768f82098b2473d836c3fa280002ca500c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47597378)</sub>

<!-- /greptile_comment -->