### PR TITLE
build(ai): add lintro-ai-tools base image

### DIFF
--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -51,6 +51,7 @@ name: Auto Rerun on Infra Failure
   workflow_run:
     workflows:
       - Build - Docker Image & Registry
+      - Build - Lintro AI Tools Image
       - Build - Lintro Tools Image
       - CI - Docker
       - CI - Tests

--- a/.github/workflows/docker-ai-tools-publish.yml
+++ b/.github/workflows/docker-ai-tools-publish.yml
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Build - Lintro AI Tools Image
+# Builds and publishes ghcr.io/lgtm-hq/lintro-ai-tools — the lintro-tools base
+# plus the agent CLIs lintro's `--transport cli` providers drive (claude,
+# codex, Cursor's agent) — via lgtm-ci reusable-docker. Once the first image is
+# published, the root Dockerfile gains an `ai` stage that consumes it through a
+# digest-pinned FROM; Renovate bumps the digest from then on (issue #1613).
+#
+# Triggers:
+#   - push (main) / pull_request touching the AI tools Dockerfile, its
+#     installer or its smoke test. PR runs validate only (no push). Not a
+#     required check, so on.<event>.paths filtering is safe here (see
+#     docker-ci.yml header for the required-check deadlock caveat).
+#   - weekly schedule with no-cache. The agent CLIs release close to daily;
+#     Renovate batches the version ARGs weekly and this rebuild also refreshes
+#     the OS layer for CVE patches instead of reusing stale cached layers.
+#   - workflow_dispatch with force_publish for maintainer-driven publishes
+#     from a branch (e.g. seeding the first image before the FROM pin lands).
+
+'on':
+  push:
+    branches: [main]
+    paths:
+      - 'docker/ai-tools.Dockerfile'
+      - '.github/workflows/docker-ai-tools-publish.yml'
+      - 'scripts/utils/install-ai-tools.sh'
+      - 'scripts/ci/smoke-test-ai-tools.sh'
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'docker/ai-tools.Dockerfile'
+      - '.github/workflows/docker-ai-tools-publish.yml'
+      - 'scripts/utils/install-ai-tools.sh'
+      - 'scripts/ci/smoke-test-ai-tools.sh'
+  schedule:
+    # Weekly rebuild (Monday 03:47 UTC), staggered after the tools image so the
+    # two multi-arch builds do not contend for runners.
+    - cron: '47 3 * * 1'
+  workflow_dispatch:
+    inputs:
+      force_publish:
+        description: 'Publish from this branch (maintainer seeding/testing)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-ai-tools-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  ai-tools-image:
+    name: 🤖 Lintro AI Tools Image
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d8fff0c6025ddf39c1ae048c04c5a050c7729a6e # v0.62.0
+    permissions:
+      contents: read
+      packages: write # push image, cache, and staging tags to GHCR
+      id-token: write # OIDC token for cosign keyless signing
+      attestations: write # publish SBOM + build provenance attestations
+      security-events: write # upload Trivy SARIF to code scanning
+    with:
+      file: docker/ai-tools.Dockerfile
+      image-name: lgtm-hq/lintro-ai-tools
+      # No app version: the image floats on latest/main/sha-* tags and
+      # consumers pin by digest (Renovate-managed FROM in the root Dockerfile).
+      tags: latest
+      push: >-
+        ${{ github.event_name != 'pull_request'
+        && (github.ref == 'refs/heads/main'
+        || (github.event_name == 'workflow_dispatch'
+        && inputs.force_publish == 'true')) }}
+      platforms: linux/amd64,linux/arm64
+      runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
+      # Build-time RUN steps only exercise the architecture they ran on, so the
+      # smoke test re-runs every CLI per platform: that is what catches a
+      # broken per-platform npm resolution or a corrupt arch-specific Cursor
+      # tarball before the manifest merges. A script rather than the
+      # `smoke-test` shorthand because three commands are needed, not one.
+      smoke-test-script: scripts/ci/smoke-test-ai-tools.sh
+      validate-on-pr: true
+      cache-registry-ref: ghcr.io/lgtm-hq/lintro-ai-tools:cache
+      # Scheduled rebuilds must not reuse cached layers, otherwise the weekly
+      # CLI-freshness rebuild is a no-op cache hit.
+      no-cache: ${{ github.event_name == 'schedule' }}
+      provenance: true
+      sbom: true
+      cosign-sign: true
+      scan: true
+      scan-exit-code: '0'
+      tooling-ref: 'd8fff0c6025ddf39c1ae048c04c5a050c7729a6e' # v0.62.0
+      egress-policy: block
+      egress-preset: docker
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the docker preset baseline. The sigstore
+      # hosts cover cosign keyless signing in the merge job; get.trivy.dev
+      # serves the Trivy binary and mirror.gcr.io is its DB fallback.
+      # nodejs.org serves the bundled Node.js tarball + SHASUMS256.txt, and
+      # downloads.cursor.com the pinned Cursor agent package.
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        ghcr.io:443
+        pkg-containers.githubusercontent.com:443
+        docker.io:443
+        registry-1.docker.io:443
+        auth.docker.io:443
+        production.cloudflare.docker.com:443
+        production.cloudfront.docker.com:443
+        deb.debian.org:80
+        pypi.org:443
+        files.pythonhosted.org:443
+        nodejs.org:443
+        downloads.cursor.com:443
+        registry.npmjs.org:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+        timestamp.sigstore.dev:443
+        oauth2.sigstore.dev:443
+        get.trivy.dev:443
+        mirror.gcr.io:443

--- a/docker/ai-tools.Dockerfile
+++ b/docker/ai-tools.Dockerfile
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89
+# =============================================================================
+# Lintro AI Tools Base Image
+# =============================================================================
+# The agent CLIs lintro's `--transport cli` providers shell out to (`claude`,
+# `codex`, Cursor's `agent`), pre-installed on top of the lintro-tools base so
+# the lint-only image stays lean.
+#
+# Published as ghcr.io/lgtm-hq/lintro-ai-tools by
+# .github/workflows/docker-ai-tools-publish.yml (cosign-signed, SBOM +
+# provenance). Once the first image is published, the root Dockerfile gains an
+# `ai` stage that consumes it via a digest-pinned FROM and copies
+# /opt/ai-tools out wholesale; Renovate manages the digest bump from then on.
+#
+# FROM lintro-tools rather than a bare python base so the copied install tree
+# is built against exactly the libc/OS layer it will be dropped into.
+#
+# Build context is the repository root:
+#   docker build -f docker/ai-tools.Dockerfile .
+#
+# Version policy: the agent CLIs release close to daily, so Renovate batches
+# these ARGs weekly (see renovate.json) and the hybrid capability guard
+# (lintro/ai/providers/cli_transport.py, #1612) tolerates the lag. Bumping a
+# CLI here does not change what lintro sends -- that contract lives in
+# lintro/ai/providers/cli_contracts.py.
+# =============================================================================
+
+# yamllint / hadolint: pin is immutable by digest; tag is informational.
+FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:e7afee4616ca6e9426f97fdbb080417585f11b011e2f57f264657d8b4cc51d36 AS ai-tools
+
+# Renovate: npm datasource for the two published CLIs, node-version for the
+# runtime. CURSOR_AGENT_VERSION has no Renovate datasource -- Cursor ships the
+# agent CLI only as a tarball behind https://cursor.com/install, with no
+# registry or release feed to query -- so it is bumped by hand; the weekly
+# rebuild keeps everything around it fresh regardless.
+ARG NODE_VERSION=24.18.0
+ARG CLAUDE_CODE_VERSION=2.1.220
+ARG CODEX_VERSION=0.145.0
+ARG CURSOR_AGENT_VERSION=2026.07.23-e383d2b
+# Cursor ships no checksum sidecar, so both architectures' hashes are pinned
+# here by hand and bumped together with CURSOR_AGENT_VERSION. Recompute with:
+#   curl -fsSL https://downloads.cursor.com/lab/<version>/linux/<arch>/agent-cli-package.tar.gz | sha256sum
+ARG CURSOR_AGENT_SHA256_X64=702ad595213bee5df0268be9f80a19f29fcceaa2a42fc55e39f2b5199051f0c4
+ARG CURSOR_AGENT_SHA256_ARM64=f40b99647cb24e0da885e97620a2048034f1fe8961910d573d827d77c4d26dcb
+
+LABEL maintainer="lgtm-hq"
+LABEL org.opencontainers.image.source="https://github.com/lgtm-hq/py-lintro"
+LABEL org.opencontainers.image.description="Pre-built AI agent CLIs for lintro --transport cli"
+LABEL org.opencontainers.image.licenses="MIT"
+
+ENV AI_TOOLS_PREFIX="/opt/ai-tools" \
+    PATH="/opt/ai-tools/bin:${PATH}"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY scripts/utils/install-ai-tools.sh /tmp/install-ai-tools.sh
+
+RUN chmod +x /tmp/install-ai-tools.sh && \
+    NODE_VERSION="${NODE_VERSION}" \
+    CLAUDE_CODE_VERSION="${CLAUDE_CODE_VERSION}" \
+    CODEX_VERSION="${CODEX_VERSION}" \
+    CURSOR_AGENT_VERSION="${CURSOR_AGENT_VERSION}" \
+    CURSOR_AGENT_SHA256_X64="${CURSOR_AGENT_SHA256_X64}" \
+    CURSOR_AGENT_SHA256_ARM64="${CURSOR_AGENT_SHA256_ARM64}" \
+    /tmp/install-ai-tools.sh && \
+    rm -f /tmp/install-ai-tools.sh
+
+# The installer already verifies each binary through an explicit prefix. This
+# repeat proves the same thing through the image's own ENV PATH, which is what
+# consumers actually get. The non-root smoke lives in the root Dockerfile's
+# `ai` stage, where the `lintro` user exists.
+RUN echo "=== Verifying AI agent CLIs on PATH ===" && \
+    claude --version && codex --version && agent --version && \
+    echo "=== All AI agent CLIs verified! ==="

--- a/renovate.json
+++ b/renovate.json
@@ -113,6 +113,21 @@
       "automerge": false
     },
     {
+      "description": "Agent CLIs release close to daily; batch them into one weekly PR — the hybrid capability guard (#1612) tolerates the lag",
+      "groupName": "ai agent CLIs",
+      "groupSlug": "ai-agent-clis",
+      "matchFileNames": [
+        "docker/ai-tools.Dockerfile"
+      ],
+      "matchPackageNames": [
+        "@anthropic-ai/claude-code",
+        "@openai/codex",
+        "node"
+      ],
+      "schedule": ["before 5am on monday"],
+      "automerge": false
+    },
+    {
       "description": "Regenerate version artifacts when tool version sources change",
       "matchManagers": [
         "custom.regex",
@@ -211,6 +226,42 @@
       ],
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "astral-sh/uv"
+    },
+    {
+      "description": "Bundled Node.js runtime in the lintro-ai-tools image; the agent CLIs are Node apps and the lint image aliases node to bun (checksum fetched at build time, so only the version pins here)",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "docker/ai-tools.Dockerfile"
+      ],
+      "matchStrings": [
+        "ARG NODE_VERSION=(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "node-version",
+      "depNameTemplate": "node"
+    },
+    {
+      "description": "Claude Code CLI baked into the lintro-ai-tools image (no CURSOR_AGENT_VERSION equivalent: Cursor publishes no registry or release feed for the agent CLI, so that ARG is hand-bumped)",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "docker/ai-tools.Dockerfile"
+      ],
+      "matchStrings": [
+        "ARG CLAUDE_CODE_VERSION=(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "@anthropic-ai/claude-code"
+    },
+    {
+      "description": "Codex CLI baked into the lintro-ai-tools image",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "docker/ai-tools.Dockerfile"
+      ],
+      "matchStrings": [
+        "ARG CODEX_VERSION=(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "@openai/codex"
     },
     {
       "description": "Bundled Go toolchain in the lintro-tools image (checksum fetched at build time, so only the version pins here)",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -99,6 +99,7 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `maintenance/delete-ci-ghcr-tags.sh` | Manually delete a specific ephemeral CI GHCR tag (sole-tag versions)       | `CI_TAG=<tag> ./scripts/ci/maintenance/delete-ci-ghcr-tags.sh`                              |
 | `maintenance/sweep-ci-ghcr-tags.sh`  | Age-based sweep of ephemeral `ci-*` GHCR tags (weekly ghcr-cleanup)        | `./scripts/ci/maintenance/sweep-ci-ghcr-tags.sh`                                            |
 | `promote-ci-docker-images.sh`        | Promote CI-validated image to release tags by digest retag                 | `./scripts/ci/promote-ci-docker-images.sh --help`                                           |
+| `smoke-test-ai-tools.sh`             | Run every baked agent CLI in the ai-tools staging image                    | `IMAGE=<ref> PLATFORM=linux/arm64 ./scripts/ci/smoke-test-ai-tools.sh`                      |
 | `cosign-sign-images.sh`              | Sign promoted image digests with Cosign keyless OIDC                       | `./scripts/ci/cosign-sign-images.sh --help`                                                 |
 | `coverage-badge-update.sh`           | Generate and update coverage badge                                         | `./scripts/ci/coverage-badge-update.sh --help`                                              |
 | `sbom-generate.sh`                   | Generate and export SBOMs via bomctl                                       | `./scripts/ci/sbom-generate.sh --help`                                                      |
@@ -230,6 +231,7 @@ Shared utilities and helper scripts.
 | `extract-version.py`                 | Print `version=X.Y.Z` from TOML                     | `python scripts/utils/extract-version.py`                               |
 | `find_comment_with_marker.py`        | Find GitHub comment ID containing a specific marker | `python scripts/utils/find_comment_with_marker.py <json> <marker>`      |
 | `generate_docs.py`                   | Generate documentation from docstrings              | `python scripts/utils/generate_docs.py`                                 |
+| `install-ai-tools.sh`                | Install the AI agent CLIs (claude, codex, agent)    | `./scripts/utils/install-ai-tools.sh --help`                            |
 | `install-tools.sh`                   | Install external tools (hadolint, prettier, etc.)   | `./scripts/utils/install-tools.sh [--dry-run] [--verbose] --local`      |
 | `install.sh`                         | Install Lintro with dependencies                    | `./scripts/utils/install.sh`                                            |
 | `json_encode_body.py`                | JSON encode comment body for GitHub API requests    | `python scripts/utils/json_encode_body.py <file_or_stdin>`              |
@@ -493,6 +495,32 @@ Installs all external tools required by Lintro.
 
 # Docker installation
 ./scripts/utils/install-tools.sh --docker
+```
+
+#### `install-ai-tools.sh`
+
+Installs the agent CLIs lintro's `--transport cli` providers shell out to. Used by
+`docker/ai-tools.Dockerfile` to build `ghcr.io/lgtm-hq/lintro-ai-tools`; not part of a
+normal local setup, where the CLIs are bring-your-own.
+
+**Features:**
+
+- Installs `claude`, `codex` and Cursor's `agent` under one prefix
+- Bundles the Node.js runtime those CLIs need, so the image's bun-as-node alias keeps
+  serving the lint toolchain unchanged
+- Pins every version and the Cursor tarball hashes through the environment, and verifies
+  each binary runs
+
+**Usage:**
+
+```bash
+NODE_VERSION=24.18.0 \
+CLAUDE_CODE_VERSION=2.1.220 \
+CODEX_VERSION=0.145.0 \
+CURSOR_AGENT_VERSION=2026.07.23-e383d2b \
+CURSOR_AGENT_SHA256_X64=<sha256 of the linux/x64 tarball> \
+CURSOR_AGENT_SHA256_ARM64=<sha256 of the linux/arm64 tarball> \
+  ./scripts/utils/install-ai-tools.sh
 ```
 
 #### `utils.sh`

--- a/scripts/ci/smoke-test-ai-tools.sh
+++ b/scripts/ci/smoke-test-ai-tools.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# smoke-test-ai-tools.sh - post-build validation for the lintro-ai-tools image
+#
+# Runs every agent CLI the image exists to provide, on the platform staging
+# image, before the multi-arch manifest is merged. The build-time RUN steps
+# only ever exercise the architecture they were built on, so this is what
+# catches a broken per-platform npm resolution or a corrupt arch-specific
+# Cursor tarball -- checking a single CLI would leave two of the three
+# transports unvalidated in the published manifest.
+#
+# Called by .github/workflows/docker-ai-tools-publish.yml through the
+# reusable-docker `smoke-test-script` input, which supplies:
+#
+# Environment:
+#   IMAGE      Fully qualified staging image reference (required)
+#   PLATFORM   Platform being validated, e.g. linux/arm64 (required)
+#   REGISTRY   Registry host (unused here; set by the reusable)
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Usage: smoke-test-ai-tools.sh [--help]
+
+AI Tools Image Smoke Test
+Runs every baked agent CLI inside the given platform staging image.
+
+Options:
+  --help, -h     Show this help message
+
+Environment:
+  IMAGE      Fully qualified staging image reference (required)
+  PLATFORM   Platform being validated, e.g. linux/arm64 (required)
+EOF
+	exit 0
+fi
+
+if [ -z "${IMAGE:-}" ]; then
+	echo "ERROR: IMAGE is required" >&2
+	exit 1
+fi
+if [ -z "${PLATFORM:-}" ]; then
+	echo "ERROR: PLATFORM is required" >&2
+	exit 1
+fi
+
+# Keep in step with the binaries declared in
+# lintro/ai/providers/cli_contracts.py; tests/unit/test_ai_tools_image.py
+# fails the build if the two lists drift apart.
+BINARIES=(claude codex agent)
+
+for binary in "${BINARIES[@]}"; do
+	echo "==> ${PLATFORM}: ${binary} --version"
+	docker run --rm --platform "$PLATFORM" "$IMAGE" "$binary" --version
+done
+
+echo "==> ${PLATFORM}: all AI agent CLIs responded"

--- a/scripts/ci/smoke-test-ai-tools.sh
+++ b/scripts/ci/smoke-test-ai-tools.sh
@@ -51,7 +51,9 @@ BINARIES=(claude codex agent)
 
 for binary in "${BINARIES[@]}"; do
 	echo "==> ${PLATFORM}: ${binary} --version"
-	docker run --rm --platform "$PLATFORM" "$IMAGE" "$binary" --version
+	# Bound each invocation: a stalled or unexpectedly interactive CLI must
+	# fail the smoke test instead of hanging the job until the runner timeout.
+	timeout 60 docker run --rm --platform "$PLATFORM" "$IMAGE" "$binary" --version
 done
 
 echo "==> ${PLATFORM}: all AI agent CLIs responded"

--- a/scripts/utils/install-ai-tools.sh
+++ b/scripts/utils/install-ai-tools.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# install-ai-tools.sh - installer for the AI agent CLIs lintro shells out to
+#
+# lintro's `--transport cli` providers drive three external agent binaries:
+# `claude`, `codex` and Cursor's `agent`. Their names, and the flag surface
+# lintro requires of each, are declared in lintro/ai/providers/cli_contracts.py
+# -- that module is the source of truth; this script only has to make those
+# binaries exist on PATH.
+#
+# Everything lands under a single prefix ($AI_TOOLS_PREFIX, default
+# /opt/ai-tools) so the consuming image can pick it up with one COPY --from:
+#
+#   $PREFIX/node/       pinned Node.js runtime + npm, and the npm-global
+#                       `claude` / `codex` install trees
+#   $PREFIX/cursor/     Cursor agent release tree (standalone native binary)
+#   $PREFIX/bin/        launcher shims -- the only directory that needs to be
+#                       on PATH
+#
+# The bundled Node.js is deliberate rather than redundant: the lintro-tools
+# base image symlinks `node` to bun, and the agent CLIs are not bun-compatible.
+# The shims prepend $PREFIX/node/bin to PATH for their own process only, so the
+# lint toolchain keeps resolving `node` to bun exactly as before.
+#
+# Usage:
+#   NODE_VERSION=24.18.0 \
+#   CLAUDE_CODE_VERSION=2.1.220 \
+#   CODEX_VERSION=0.145.0 \
+#   CURSOR_AGENT_VERSION=2026.07.23-e383d2b \
+#   CURSOR_AGENT_SHA256_X64=<x64 hash> CURSOR_AGENT_SHA256_ARM64=<arm64 hash> \
+#     ./scripts/utils/install-ai-tools.sh
+#
+# Environment:
+#   NODE_VERSION           Node.js version, no leading "v"       (required)
+#   CLAUDE_CODE_VERSION    npm @anthropic-ai/claude-code version (required)
+#   CODEX_VERSION          npm @openai/codex version             (required)
+#   CURSOR_AGENT_VERSION   Cursor agent release id               (required)
+#   CURSOR_AGENT_SHA256_X64    sha256 of the linux/x64 Cursor tarball  (required)
+#   CURSOR_AGENT_SHA256_ARM64  sha256 of the linux/arm64 tarball       (required)
+#   AI_TOOLS_PREFIX        Install prefix (default /opt/ai-tools)
+#
+# Cursor publishes no checksum sidecar next to the agent tarball, so unlike the
+# Node.js download there is nothing to fetch and verify against. Both
+# architectures' hashes are therefore pinned by hand alongside the version and
+# required here, rather than left opt-in: the agent runs against user
+# codebases and API keys, so a silently substituted binary is not an
+# acceptable failure mode.
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Usage: install-ai-tools.sh [--help]
+
+AI Agent CLI Installation Script
+Installs the agent CLIs lintro's `--transport cli` providers shell out to
+(claude, codex, Cursor's agent) under a single prefix, together with the
+Node.js runtime they need.
+
+Options:
+  --help, -h     Show this help message
+
+Environment:
+  NODE_VERSION           Node.js version, no leading "v"       (required)
+  CLAUDE_CODE_VERSION    npm @anthropic-ai/claude-code version (required)
+  CODEX_VERSION          npm @openai/codex version             (required)
+  CURSOR_AGENT_VERSION   Cursor agent release id               (required)
+  CURSOR_AGENT_SHA256_X64    sha256 of the linux/x64 tarball   (required)
+  CURSOR_AGENT_SHA256_ARM64  sha256 of the linux/arm64 tarball (required)
+  AI_TOOLS_PREFIX        Install prefix (default /opt/ai-tools)
+EOF
+	exit 0
+fi
+
+PREFIX="${AI_TOOLS_PREFIX:-/opt/ai-tools}"
+
+log_step() {
+	echo "==> $1"
+}
+
+require_env() {
+	local name="$1"
+	if [ -z "${!name:-}" ]; then
+		echo "ERROR: $name is required" >&2
+		exit 1
+	fi
+}
+
+require_env NODE_VERSION
+require_env CLAUDE_CODE_VERSION
+require_env CODEX_VERSION
+require_env CURSOR_AGENT_VERSION
+require_env CURSOR_AGENT_SHA256_X64
+require_env CURSOR_AGENT_SHA256_ARM64
+
+# Both vendors label the same two architectures identically, so one mapping
+# serves the Node.js tarball and the Cursor download alike.
+detect_arch() {
+	local machine
+	machine="$(uname -m)"
+	case "$machine" in
+	x86_64 | amd64) echo "x64" ;;
+	aarch64 | arm64) echo "arm64" ;;
+	*)
+		echo "ERROR: unsupported architecture: $machine" >&2
+		exit 1
+		;;
+	esac
+}
+
+ARCH="$(detect_arch)"
+
+install_node() {
+	log_step "Installing Node.js ${NODE_VERSION} (${ARCH})"
+	local tarball url base tmp
+	# .tar.gz rather than the smaller .tar.xz: xz-utils is not in the base
+	# image and pulling it in just to unpack one tarball is not worth a layer.
+	tarball="node-v${NODE_VERSION}-linux-${ARCH}.tar.gz"
+	base="https://nodejs.org/dist/v${NODE_VERSION}"
+	url="${base}/${tarball}"
+	tmp="$(mktemp -d)"
+
+	curl -fsSL "$url" -o "${tmp}/${tarball}"
+	curl -fsSL "${base}/SHASUMS256.txt" -o "${tmp}/SHASUMS256.txt"
+	(cd "$tmp" && grep " ${tarball}\$" SHASUMS256.txt | sha256sum -c -)
+
+	mkdir -p "${PREFIX}/node"
+	tar -xzf "${tmp}/${tarball}" -C "${PREFIX}/node" --strip-components=1
+	rm -rf "$tmp"
+}
+
+install_npm_clis() {
+	log_step "Installing claude ${CLAUDE_CODE_VERSION} and codex ${CODEX_VERSION}"
+	# Both packages resolve a platform-specific native binary through
+	# optionalDependencies plus a postinstall step, so they must be installed
+	# with the real npm on the target architecture -- never with --ignore-scripts.
+	PATH="${PREFIX}/node/bin:${PATH}" "${PREFIX}/node/bin/npm" install \
+		--global \
+		--prefix "${PREFIX}/node" \
+		--no-fund \
+		--no-audit \
+		"@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+		"@openai/codex@${CODEX_VERSION}"
+}
+
+install_cursor_agent() {
+	log_step "Installing Cursor agent ${CURSOR_AGENT_VERSION} (${ARCH})"
+	local url dir tmp expected
+	# Same artifact layout the official https://cursor.com/install script
+	# downloads, pinned to an explicit release instead of whatever that script
+	# currently embeds.
+	url="https://downloads.cursor.com/lab/${CURSOR_AGENT_VERSION}/linux/${ARCH}/agent-cli-package.tar.gz"
+	dir="${PREFIX}/cursor/${CURSOR_AGENT_VERSION}"
+	tmp="$(mktemp -d)"
+
+	case "$ARCH" in
+	x64) expected="$CURSOR_AGENT_SHA256_X64" ;;
+	*) expected="$CURSOR_AGENT_SHA256_ARM64" ;;
+	esac
+
+	curl -fsSL "$url" -o "${tmp}/agent-cli-package.tar.gz"
+	echo "${expected}  ${tmp}/agent-cli-package.tar.gz" | sha256sum -c -
+
+	mkdir -p "$dir"
+	tar -xzf "${tmp}/agent-cli-package.tar.gz" -C "$dir" --strip-components=1
+	rm -rf "$tmp"
+}
+
+# Write a launcher that runs *target* with the bundled Node.js ahead of the
+# image's bun-as-node symlink on PATH.
+write_shim() {
+	local name="$1" target="$2"
+	cat >"${PREFIX}/bin/${name}" <<EOF
+#!/bin/sh
+# Generated by scripts/utils/install-ai-tools.sh -- do not edit.
+# The lintro-tools base image aliases \`node\` to bun; the agent CLIs need the
+# real runtime, so put it first for this process only.
+PATH="${PREFIX}/node/bin:\$PATH"
+export PATH
+exec "${target}" "\$@"
+EOF
+	chmod +x "${PREFIX}/bin/${name}"
+}
+
+install_shims() {
+	log_step "Writing launcher shims"
+	mkdir -p "${PREFIX}/bin"
+	write_shim "claude" "${PREFIX}/node/bin/claude"
+	write_shim "codex" "${PREFIX}/node/bin/codex"
+	# `agent` is the binary name lintro's Cursor provider looks up;
+	# `cursor-agent` is the vendor's legacy alias, kept for parity with the
+	# official installer.
+	write_shim "agent" "${PREFIX}/cursor/${CURSOR_AGENT_VERSION}/cursor-agent"
+	write_shim "cursor-agent" "${PREFIX}/cursor/${CURSOR_AGENT_VERSION}/cursor-agent"
+}
+
+relax_permissions() {
+	log_step "Relaxing permissions for non-root use"
+	# The consuming image drops privileges to the UID owning the mounted
+	# workspace, so every baked binary has to stay readable and executable for
+	# arbitrary users.
+	chmod -R a+rX "${PREFIX}"
+}
+
+verify() {
+	log_step "Verifying AI agent CLIs"
+	PATH="${PREFIX}/bin:${PATH}" claude --version
+	PATH="${PREFIX}/bin:${PATH}" codex --version
+	PATH="${PREFIX}/bin:${PATH}" agent --version
+	log_step "All AI agent CLIs verified"
+}
+
+install_node
+install_npm_clis
+install_cursor_agent
+install_shims
+relax_permissions
+verify

--- a/tests/unit/test_ai_tools_image.py
+++ b/tests/unit/test_ai_tools_image.py
@@ -1,0 +1,137 @@
+"""Contract tests for the baked AI agent CLI image.
+
+The value these guard is drift between three places that must agree but have
+no runtime link: the binaries lintro's CLI transports look up
+(``lintro/ai/providers/cli_contracts.py``), the binaries the ai-tools image
+actually bakes (``scripts/utils/install-ai-tools.sh``), and the build/publish
+wiring that ships them.
+
+The root Dockerfile's ``ai`` stage and its publish job land in the follow-up
+that pins this image's digest, so nothing here asserts on them yet.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+from assertpy import assert_that
+
+from lintro.ai.providers.cli_contracts import CLI_CONTRACTS
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_AI_TOOLS_DOCKERFILE = _REPO_ROOT / "docker" / "ai-tools.Dockerfile"
+_INSTALLER = _REPO_ROOT / "scripts" / "utils" / "install-ai-tools.sh"
+_RENOVATE = _REPO_ROOT / "renovate.json"
+_WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
+
+# Cursor ships the agent CLI only as a tarball behind https://cursor.com/install
+# — no registry, no release feed, and no checksum sidecar — so there is nothing
+# for Renovate to query and the version and its two hashes move by hand.
+_ARGS_WITHOUT_RENOVATE_DATASOURCE = frozenset(
+    {
+        "CURSOR_AGENT_VERSION",
+        "CURSOR_AGENT_SHA256_X64",
+        "CURSOR_AGENT_SHA256_ARM64",
+    },
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _load_workflow(*, name: str) -> dict[str, Any]:
+    data = yaml.safe_load(_read(_WORKFLOWS / name))
+    assert_that(data).is_instance_of(dict)
+    return cast(dict[str, Any], data)
+
+
+def _dockerfile_args(text: str) -> set[str]:
+    return set(re.findall(r"^ARG (\w+)=", text, flags=re.MULTILINE))
+
+
+def _contract_binaries() -> list[str]:
+    return sorted({contract.binary for contract in CLI_CONTRACTS.values()})
+
+
+@pytest.mark.parametrize("binary", _contract_binaries())
+def test_installer_bakes_every_declared_cli_binary(binary: str) -> None:
+    """Every binary a CLI transport looks up gets a shim in the image.
+
+    Args:
+        binary: Executable name declared by a provider's CLI contract.
+    """
+    installer = _read(_INSTALLER)
+
+    assert_that(installer).contains(f'write_shim "{binary}"')
+
+
+@pytest.mark.parametrize("binary", _contract_binaries())
+def test_installer_verifies_every_declared_cli_binary(binary: str) -> None:
+    """A baked binary that cannot run fails the image build, not a review.
+
+    Args:
+        binary: Executable name declared by a provider's CLI contract.
+    """
+    installer = _read(_INSTALLER)
+
+    assert_that(installer).contains(f"{binary} --version")
+
+
+def test_ai_tools_image_builds_on_the_pinned_tools_base() -> None:
+    """The AI image extends lintro-tools by immutable digest."""
+    from_lines = [
+        line
+        for line in _read(_AI_TOOLS_DOCKERFILE).splitlines()
+        if line.startswith("FROM ")
+    ]
+
+    assert_that(from_lines).is_length(1)
+    assert_that(from_lines[0]).matches(
+        r"^FROM ghcr\.io/lgtm-hq/lintro-tools:latest@sha256:[a-f0-9]{64} AS ",
+    )
+
+
+def test_ai_tools_dockerfile_passes_every_arg_to_the_installer() -> None:
+    """Every declared version ARG reaches the installer that consumes it."""
+    dockerfile = _read(_AI_TOOLS_DOCKERFILE)
+
+    for arg in _dockerfile_args(dockerfile):
+        assert_that(dockerfile).contains(f'{arg}="${{{arg}}}"')
+
+
+def test_renovate_tracks_every_trackable_ai_tools_arg() -> None:
+    """Baked CLI versions are Renovate-managed except the documented opt-out."""
+    renovate = json.loads(_read(_RENOVATE))
+    ai_tools_managers = [
+        manager
+        for manager in renovate["customManagers"]
+        if "docker/ai-tools.Dockerfile" in manager["managerFilePatterns"]
+    ]
+    tracked = {
+        match.group(1)
+        for manager in ai_tools_managers
+        for pattern in manager["matchStrings"]
+        if (match := re.search(r"ARG (\w+)=", pattern))
+    }
+
+    declared = _dockerfile_args(_read(_AI_TOOLS_DOCKERFILE))
+    assert_that(declared - tracked).is_equal_to(set(_ARGS_WITHOUT_RENOVATE_DATASOURCE))
+
+
+def test_ai_tools_publish_workflow_rebuilds_on_installer_changes() -> None:
+    """Editing the installer or its smoke test rebuilds the image."""
+    workflow = _load_workflow(name="docker-ai-tools-publish.yml")
+    triggers = workflow["on"]
+
+    for event in ("push", "pull_request"):
+        assert_that(triggers[event]["paths"]).contains(
+            "docker/ai-tools.Dockerfile",
+            "scripts/utils/install-ai-tools.sh",
+            "scripts/ci/smoke-test-ai-tools.sh",
+        )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  build(ai): add lintro-ai-tools base image
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

lintro's `--transport cli` providers shell out to three external agent binaries
(`claude`, `codex`, Cursor's `agent`). Today every Docker consumer has to install
them by hand. This adds a dedicated base image that bakes them, so the follow-up
`ai` stage can hand consumers working CLI transports with zero install — while the
lint-only image stays exactly as lean as it is now.

New `docker/ai-tools.Dockerfile` builds `FROM` the digest-pinned `lintro-tools` base
and publishes `ghcr.io/lgtm-hq/lintro-ai-tools` (cosign-signed, SBOM, provenance,
Trivy-scanned, weekly no-cache rebuild).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1613

## Details

### Why a bundled Node.js

The `lintro-tools` base symlinks `node` to bun, and the agent CLIs do not run under
bun. The installer therefore ships a pinned Node.js under the same prefix and puts
only the shim directory on `PATH`; each shim prepends the real runtime for its own
process. The lint toolchain keeps resolving `node` to bun, unchanged.

### Layout

Everything lands under one prefix so the consuming stage needs a single
`COPY --from`:

```text
/opt/ai-tools/node/     pinned Node.js + npm, and the npm-global claude/codex trees
/opt/ai-tools/cursor/   Cursor agent release tree (standalone native binary)
/opt/ai-tools/bin/      launcher shims — the only directory on PATH
```

### Version policy

The agent CLIs release close to daily, so Renovate batches `NODE_VERSION`,
`CLAUDE_CODE_VERSION` and `CODEX_VERSION` into one weekly PR; the hybrid capability
guard (#1612) tolerates the lag. `CURSOR_AGENT_VERSION` has no Renovate datasource —
Cursor ships the agent CLI only as a tarball behind `https://cursor.com/install`,
with no registry or release feed — so it is hand-bumped, and because Cursor also
publishes no checksum sidecar, both architectures' SHA-256 hashes are pinned
alongside it and verified at build time. That verification is mandatory rather than
opt-in: `agent` runs against user codebases and API keys.

### Testing

`tests/unit/test_ai_tools_image.py` ties the image back to
`lintro/ai/providers/cli_contracts.py` — every binary a CLI transport looks up must
be shimmed and verified by the installer, and every trackable version ARG must be
Renovate-managed. Adding a fourth provider CLI cannot silently skip the baked image.

The multi-arch smoke test runs all three CLIs per platform via
`scripts/ci/smoke-test-ai-tools.sh`, since the build-time `RUN` checks only ever
exercise the architecture they ran on.

### Why this is split from the root `ai` stage

#1613 also covers the root `Dockerfile`'s `ai` stage and its publish job. Both need a
digest pin for `ghcr.io/lgtm-hq/lintro-ai-tools`, and that image cannot exist yet:
GitHub refuses `workflow_dispatch` for a workflow absent from the default branch, so
it cannot be seeded from this branch. Merging this PR publishes it automatically via
the push-to-main path filter; a second PR then pins the digest, adds the `ai` stage
and the `docker-ai` publish job, and closes #1613. This is the same order #1360 used
for the `lintro-tools` FROM flip.

One deviation to flag for that follow-up: the epic specifies `ai` → `lintro:ai` /
`lintro:ai-<version>` tags on the existing `py-lintro` package. The reusable always
emits floating `sha-<ref>` and branch tags, which on a shared package would clobber
the release image's promotion tags (see `docker-ci.yml`'s promote step). The follow-up
therefore publishes to a separate `py-lintro-ai` package, mirroring `py-lintro-base`.

### Local verification

`uv run lintro fmt && uv run lintro chk` green (0 issues) and the full suite green —
8032 passed. Three tool suites were deselected for local environment reasons
unrelated to this change: `pip-audit` (its sandbox `ensurepip` aborts on this
machine), `vale` and `trufflehog` (installed versions sit below the repo's minimum
floors). No image was built locally.
