### PR TITLE
build(ai): add baked ai image variant

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -258,3 +258,115 @@ jobs:
         tuf-repo-cdn.sigstore.dev:443
         timestamp.sigstore.dev:443
         oauth2.sigstore.dev:443
+
+  docker-ai:
+    name: 🤖 Docker AI Image
+    needs: [validate-backfill-inputs, docker-full]
+    # Published as a separate GHCR package (py-lintro-ai) rather than an `ai`
+    # tag on py-lintro: the reusable always emits floating `sha-<ref>` and
+    # branch tags, which on a shared package would clobber the release image's
+    # promotion tags (see docker-ci.yml's promote step). A dedicated package
+    # keeps the lint-only pull lean and the tag surface unambiguous.
+    #
+    # Runs after docker-full so a failure in the optional AI variant can never
+    # delay or block the release image.
+    if: >-
+      always() && !cancelled() &&
+      (needs.validate-backfill-inputs.result == 'success' ||
+      needs.validate-backfill-inputs.result == 'skipped') &&
+      needs.docker-full.result == 'success'
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d8fff0c6025ddf39c1ae048c04c5a050c7729a6e # v0.62.0
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      security-events: write
+    with:
+      file: Dockerfile
+      target: ai
+      image-name: lgtm-hq/py-lintro-ai
+      version: >-
+        ${{ (github.event_name == 'workflow_dispatch'
+        && needs.validate-backfill-inputs.outputs.backfill_version != '')
+        && needs.validate-backfill-inputs.outputs.backfill_version
+        || (startsWith(github.ref, 'refs/tags/')
+        && github.ref_name
+        || (github.event_name == 'release' && github.event.release.tag_name || '')) }}
+      push: >-
+        ${{ github.event_name != 'pull_request'
+        && (github.ref == 'refs/heads/main'
+        || startsWith(github.ref, 'refs/tags/')
+        || github.event_name == 'release'
+        || (github.event_name == 'workflow_dispatch'
+        && (needs.validate-backfill-inputs.outputs.force_publish == 'true'
+        || needs.validate-backfill-inputs.outputs.backfill_version != ''))) }}
+      source-ref: >-
+        ${{ github.event_name == 'workflow_dispatch'
+        && needs.validate-backfill-inputs.outputs.backfill_ref || '' }}
+      tag-latest: >-
+        ${{ !(github.event_name == 'workflow_dispatch'
+        && needs.validate-backfill-inputs.outputs.backfill_version != '') }}
+      platforms: linux/amd64,linux/arm64
+      runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
+      smoke-test: lintro --version
+      validate-on-pr: false
+      cache-registry-ref: ghcr.io/lgtm-hq/py-lintro-ai:cache
+      # Release (tag) builds reuse the registry cache (#1358): BuildKit
+      # cache is content-addressed, so a tag build reassembles exactly the
+      # layers already built and validated on main instead of a cold
+      # multi-arch rebuild. Backfills stay no-cache so historical
+      # republishes remain fully cold.
+      no-cache: >-
+        ${{ github.event_name == 'workflow_dispatch'
+        && needs.validate-backfill-inputs.outputs.backfill_version != '' }}
+      provenance: false
+      sbom: false
+      cosign-sign: true
+      tooling-ref: 'd8fff0c6025ddf39c1ae048c04c5a050c7729a6e' # v0.62.0
+      egress-policy: block
+      egress-preset: docker
+      # Full list (v0.50.0+ replace semantics): the reusable passes
+      # allowed-endpoints verbatim to step-security/harden-runner, so a
+      # non-empty value must include the docker preset baseline. The
+      # sigstore hosts cover cosign keyless signing in the merge job. The
+      # agent CLIs arrive prebuilt in the digest-pinned lintro-ai-tools
+      # layer, so this build needs no vendor endpoints of its own.
+      allowed-endpoints-mode: replace
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
+        ghcr.io:443
+        pkg-containers.githubusercontent.com:443
+        docker.io:443
+        registry-1.docker.io:443
+        auth.docker.io:443
+        production.cloudflare.docker.com:443
+        production.cloudfront.docker.com:443
+        deb.debian.org:80
+        pypi.org:443
+        files.pythonhosted.org:443
+        static.rust-lang.org:443
+        bun.sh:443
+        astral.sh:443
+        releases.astral.sh:443
+        sh.rustup.rs:443
+        registry.npmjs.org:443
+        crates.io:443
+        static.crates.io:443
+        index.crates.io:443
+        semgrep.dev:443
+        metrics.semgrep.dev:443
+        token.actions.githubusercontent.com:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+        timestamp.sigstore.dev:443
+        oauth2.sigstore.dev:443

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -275,7 +275,9 @@ jobs:
     permissions:
       contents: read # checkout and build context
       packages: write # push CI-tagged images to GHCR
-    timeout-minutes: 30
+    # 40 rather than 30: the `ai` target adds a large base-image pull plus a
+    # second uv sync on top of the full/base builds already in this job.
+    timeout-minutes: 40
     defaults:
       run:
         shell: bash
@@ -417,6 +419,25 @@ jobs:
             type=registry,ref=ghcr.io/lgtm-hq/py-lintro-base:cache
           cache-to: >-
             type=registry,ref=ghcr.io/lgtm-hq/py-lintro-base:cache,${{ env.CACHE_OPTS }}
+          provenance: false
+      # The `ai` variant is published only from docker-build-publish.yml, which
+      # never runs on PRs — so without this step the stage would first build
+      # during a release, and a failure there would surface mid-release. Build
+      # only (no push, no load): the stage's own RUN steps smoke-test all three
+      # agent CLIs as root and under gosu, so a successful build IS the
+      # validation. Needs no registry auth — lintro-ai-tools is public — so it
+      # covers fork PRs too.
+      - name: Build AI Docker image (validation only)
+        if: needs.changes.outputs.pipeline != 'false'
+        # yamllint disable-line rule:line-length
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          target: ai
+          push: false
+          cache-from: |
+            type=gha
+            type=registry,ref=ghcr.io/lgtm-hq/py-lintro:cache
           provenance: false
       - name: Save Docker images to tarball (fork fallback)
         if: >-

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@
 # Stage `full` (default): Python application layer on top of tools
 #
 # Minimal image (no bundled tools): ghcr.io/lgtm-hq/py-lintro-base (--target base)
+# AI variant (bundled agent CLIs):  ghcr.io/lgtm-hq/py-lintro-ai   (--target ai)
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -135,3 +136,46 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 # gosu (installed above). See scripts/docker/entrypoint.sh.
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["--help"]
+
+# -----------------------------------------------------------------------------
+# Stage: aitools — published lintro-ai-tools base image (digest-pinned)
+# -----------------------------------------------------------------------------
+# Built from docker/ai-tools.Dockerfile and published by
+# docker-ai-tools-publish.yml (cosign-signed, SBOM + provenance). Renovate
+# manages the digest bump. Only the `ai` target below depends on this stage, so
+# `--target base` / `--target full` builds never pull it.
+# yamllint / hadolint: pin is immutable by digest; tag is informational.
+FROM ghcr.io/lgtm-hq/lintro-ai-tools:latest@sha256:8daf68214ca1f8e5af4a20f166284c444f5ba36dff0858426731d66185934478 AS aitools
+
+# -----------------------------------------------------------------------------
+# Stage: ai — full image plus the agent CLIs `--transport cli` drives
+# -----------------------------------------------------------------------------
+FROM full AS ai
+
+LABEL org.opencontainers.image.description="Lintro with bundled AI agent CLIs; GHCR package py-lintro-ai"
+
+# One directory holds the bundled Node.js runtime, the npm-global claude/codex
+# trees, the Cursor agent release and the launcher shims — see
+# scripts/utils/install-ai-tools.sh for the layout. Only /opt/ai-tools/bin goes
+# on PATH, so `node` keeps resolving to bun for the lint toolchain.
+COPY --from=aitools /opt/ai-tools /opt/ai-tools
+
+ENV PATH="/opt/ai-tools/bin:${PATH}"
+
+# The `full` stage syncs without the `ai` extra so the lint-only image does not
+# carry the provider SDKs; add them here for the API transports. The chown
+# mirrors `full`'s, which runs before these newly written .venv files exist.
+RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    uv sync --dev --extra full --extra tools --extra ai --no-progress && \
+    (uv cache clean || true) && \
+    chown -R lintro:lintro /app
+
+# Mirrors the non-root smoke in `full`: the entrypoint drops privileges to the
+# UID owning the mounted volume, so a root-only-readable CLI tree would break
+# every real review while passing a root-run check.
+RUN echo "Smoke-testing AI agent CLIs..." && \
+    claude --version && codex --version && agent --version && \
+    gosu lintro claude --version && \
+    echo "AI CLI smoke check passed."
+
+# ENTRYPOINT, CMD and HEALTHCHECK are inherited from `full`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -176,6 +176,8 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
 RUN echo "Smoke-testing AI agent CLIs..." && \
     claude --version && codex --version && agent --version && \
     gosu lintro claude --version && \
+    gosu lintro codex --version && \
+    gosu lintro agent --version && \
     echo "AI CLI smoke check passed."
 
 # ENTRYPOINT, CMD and HEALTHCHECK are inherited from `full`.

--- a/renovate.json
+++ b/renovate.json
@@ -113,6 +113,15 @@
       "automerge": false
     },
     {
+      "description": "lintro-ai-tools base image digest pin (FROM in the Dockerfile 'aitools' stage); full CI validates the bump",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/lgtm-hq/lintro-ai-tools"
+      ],
+      "matchUpdateTypes": ["digest"],
+      "automerge": false
+    },
+    {
       "description": "Agent CLIs release close to daily; batch them into one weekly PR — the hybrid capability guard (#1612) tolerates the lag",
       "groupName": "ai agent CLIs",
       "groupSlug": "ai-agent-clis",

--- a/tests/unit/test_ai_tools_image.py
+++ b/tests/unit/test_ai_tools_image.py
@@ -5,9 +5,6 @@ no runtime link: the binaries lintro's CLI transports look up
 (``lintro/ai/providers/cli_contracts.py``), the binaries the ai-tools image
 actually bakes (``scripts/utils/install-ai-tools.sh``), and the build/publish
 wiring that ships them.
-
-The root Dockerfile's ``ai`` stage and its publish job land in the follow-up
-that pins this image's digest, so nothing here asserts on them yet.
 """
 
 from __future__ import annotations
@@ -25,6 +22,7 @@ from lintro.ai.providers.cli_contracts import CLI_CONTRACTS
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _AI_TOOLS_DOCKERFILE = _REPO_ROOT / "docker" / "ai-tools.Dockerfile"
+_ROOT_DOCKERFILE = _REPO_ROOT / "Dockerfile"
 _INSTALLER = _REPO_ROOT / "scripts" / "utils" / "install-ai-tools.sh"
 _RENOVATE = _REPO_ROOT / "renovate.json"
 _WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
@@ -135,3 +133,51 @@ def test_ai_tools_publish_workflow_rebuilds_on_installer_changes() -> None:
             "scripts/utils/install-ai-tools.sh",
             "scripts/ci/smoke-test-ai-tools.sh",
         )
+
+
+def test_ai_stage_copies_from_the_pinned_ai_tools_image() -> None:
+    """The root ``ai`` stage layers the baked CLIs onto the full image."""
+    dockerfile = _read(_ROOT_DOCKERFILE)
+
+    assert_that(dockerfile).contains("FROM full AS ai\n")
+    assert_that(dockerfile).contains("COPY --from=aitools /opt/ai-tools /opt/ai-tools")
+    assert_that(dockerfile).matches(
+        r"FROM ghcr\.io/lgtm-hq/lintro-ai-tools:latest@sha256:[a-f0-9]{64} AS aitools",
+    )
+
+
+def test_ai_stage_installs_the_ai_extra() -> None:
+    """The AI variant carries the provider SDKs the API transports need."""
+    ai_stage = _read(_ROOT_DOCKERFILE).split("FROM full AS ai\n", maxsplit=1)[1]
+
+    assert_that(ai_stage).contains("--extra ai")
+
+
+def test_ai_stage_smoke_tests_every_declared_cli_as_non_root() -> None:
+    """A root-only-readable CLI tree would break every real review.
+
+    The entrypoint drops privileges to the UID owning the mounted volume, so a
+    root-run check alone would pass while the image is unusable in practice.
+    """
+    ai_stage = _read(_ROOT_DOCKERFILE).split("FROM full AS ai\n", maxsplit=1)[1]
+
+    assert_that(ai_stage).contains("gosu lintro")
+    for binary in _contract_binaries():
+        assert_that(ai_stage).contains(f"{binary} --version")
+
+
+def test_ai_variant_publishes_to_its_own_package() -> None:
+    """The AI image never shares a GHCR package with the release image.
+
+    The reusable always emits floating ``sha-<ref>`` and branch tags, so a
+    shared package would let the AI variant clobber the tags docker-ci
+    promotes for the release image.
+    """
+    workflow = _load_workflow(name="docker-build-publish.yml")
+    ai_job = workflow["jobs"]["docker-ai"]
+    full_job = workflow["jobs"]["docker-full"]
+
+    assert_that(ai_job["with"]["target"]).is_equal_to("ai")
+    assert_that(ai_job["with"]["image-name"]).is_not_equal_to(
+        full_job["with"]["image-name"],
+    )

--- a/tests/unit/test_ai_tools_image.py
+++ b/tests/unit/test_ai_tools_image.py
@@ -205,3 +205,18 @@ def test_ai_variant_publishes_to_its_own_package() -> None:
     assert_that(ai_job["with"]["image-name"]).is_not_equal_to(
         full_job["with"]["image-name"],
     )
+
+
+def test_ai_stage_is_built_on_prs() -> None:
+    """The AI stage is validated before a release depends on it.
+
+    docker-build-publish.yml never runs on PRs, so without a build here the
+    stage would first be exercised during a release.
+    """
+    workflow = _load_workflow(name="docker-ci.yml")
+    steps = workflow["jobs"]["docker-build"]["steps"]
+    ai_builds = [step for step in steps if step.get("with", {}).get("target") == "ai"]
+
+    assert_that(ai_builds).is_not_empty()
+    for step in ai_builds:
+        assert_that(step["with"]["push"]).is_false()

--- a/tests/unit/test_ai_tools_image.py
+++ b/tests/unit/test_ai_tools_image.py
@@ -53,6 +53,33 @@ def _dockerfile_args(text: str) -> set[str]:
     return set(re.findall(r"^ARG (\w+)=", text, flags=re.MULTILINE))
 
 
+def _ai_stage_body() -> str:
+    """Return the root Dockerfile's ``ai`` stage, excluding later stages.
+
+    Returns:
+        The stage body, from its ``FROM`` line up to the next stage.
+    """
+    body = _read(_ROOT_DOCKERFILE).split("FROM full AS ai\n", maxsplit=1)[1]
+    return re.split(r"^FROM ", body, maxsplit=1, flags=re.MULTILINE)[0]
+
+
+def _from_line(*, stage: str) -> str:
+    """Return the ``FROM`` line declaring *stage* in the root Dockerfile.
+
+    Args:
+        stage: Stage name as written after ``AS``.
+
+    Returns:
+        The single matching ``FROM`` line. A missing stage fails the test by
+        raising, which is the intended signal.
+    """
+    return next(
+        line
+        for line in _read(_ROOT_DOCKERFILE).splitlines()
+        if line.startswith("FROM ") and line.endswith(f" AS {stage}")
+    )
+
+
 def _contract_binaries() -> list[str]:
     return sorted({contract.binary for contract in CLI_CONTRACTS.values()})
 
@@ -137,20 +164,18 @@ def test_ai_tools_publish_workflow_rebuilds_on_installer_changes() -> None:
 
 def test_ai_stage_copies_from_the_pinned_ai_tools_image() -> None:
     """The root ``ai`` stage layers the baked CLIs onto the full image."""
-    dockerfile = _read(_ROOT_DOCKERFILE)
-
-    assert_that(dockerfile).contains("FROM full AS ai\n")
-    assert_that(dockerfile).contains("COPY --from=aitools /opt/ai-tools /opt/ai-tools")
-    assert_that(dockerfile).matches(
-        r"FROM ghcr\.io/lgtm-hq/lintro-ai-tools:latest@sha256:[a-f0-9]{64} AS aitools",
+    assert_that(_read(_ROOT_DOCKERFILE)).contains("FROM full AS ai\n")
+    assert_that(_ai_stage_body()).contains(
+        "COPY --from=aitools /opt/ai-tools /opt/ai-tools",
+    )
+    assert_that(_from_line(stage="aitools")).matches(
+        r"^FROM ghcr\.io/lgtm-hq/lintro-ai-tools:latest@sha256:[a-f0-9]{64} AS aitools$",
     )
 
 
 def test_ai_stage_installs_the_ai_extra() -> None:
     """The AI variant carries the provider SDKs the API transports need."""
-    ai_stage = _read(_ROOT_DOCKERFILE).split("FROM full AS ai\n", maxsplit=1)[1]
-
-    assert_that(ai_stage).contains("--extra ai")
+    assert_that(_ai_stage_body()).contains("--extra ai")
 
 
 def test_ai_stage_smoke_tests_every_declared_cli_as_non_root() -> None:
@@ -159,11 +184,10 @@ def test_ai_stage_smoke_tests_every_declared_cli_as_non_root() -> None:
     The entrypoint drops privileges to the UID owning the mounted volume, so a
     root-run check alone would pass while the image is unusable in practice.
     """
-    ai_stage = _read(_ROOT_DOCKERFILE).split("FROM full AS ai\n", maxsplit=1)[1]
+    ai_stage = _ai_stage_body()
 
-    assert_that(ai_stage).contains("gosu lintro")
     for binary in _contract_binaries():
-        assert_that(ai_stage).contains(f"{binary} --version")
+        assert_that(ai_stage).contains(f"gosu lintro {binary} --version")
 
 
 def test_ai_variant_publishes_to_its_own_package() -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  build(ai): add baked ai image variant
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Part 2 of #1613, and the half that actually reaches users. #1812 built and published
`ghcr.io/lgtm-hq/lintro-ai-tools`; this layers it onto the full image so Docker
consumers get working `--transport cli` with zero install, while the lint-only pull
stays exactly as lean as it is today.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1613

## Details

### Dockerfile

A digest-pinned `aitools` stage plus an `ai` stage `FROM full` that copies
`/opt/ai-tools` out wholesale and syncs the `ai` extra. The pin is
`sha256:8daf68214ca1f8e5af4a20f166284c444f5ba36dff0858426731d66185934478` — the image
#1812 published, verified live in GHCR. Renovate manages the bump from here, as it
does for `lintro-tools`.

Only `/opt/ai-tools/bin` joins `PATH`, so `node` keeps resolving to bun for the lint
toolchain; the shims prepend the bundled real runtime per-process. Nothing about the
`full` or `base` targets changes, and neither pulls the `aitools` stage.

The stage smoke-tests all three CLIs twice: as root, and under `gosu lintro`. The
second pass is the one that matters — the entrypoint drops privileges to the UID
owning the mounted volume, so a root-only-readable CLI tree would pass a root check
and then break every real review.

### Publishing

New `docker-ai` job publishing the **`py-lintro-ai`** package, gated behind
`docker-full` so a failure in the optional variant can never delay the release image.

One deviation from the issue text, flagged earlier on #1613 and unopposed: the issue
specifies `lintro:ai` / `lintro:ai-<version>` tags on the existing `py-lintro`
package. The reusable always emits floating `sha-<ref>` and branch tags, which on a
shared package would clobber the tags `docker-ci.yml`'s promote step uses for the
release image. A separate package avoids that entirely and mirrors `py-lintro-base`.
A test now enforces the separation so it cannot regress into a shared package.

### Testing

`tests/unit/test_ai_tools_image.py` gains four tests: the `ai` stage copies from a
digest-pinned `aitools`, installs the `ai` extra, smoke-tests every contract binary
as non-root, and publishes to its own package. Assertions are scoped to the `ai`
stage body rather than the whole file, so a later stage or a comment cannot satisfy
them.

### Local verification

`uv run lintro fmt && uv run lintro chk` green (0 issues); full suite green — 8045
passed. Same three tool suites deselected for pre-existing local environment reasons
as in #1812 (`pip-audit` sandbox `ensurepip` abort; `vale` and `trufflehog` below
minimum version floors). No image built locally.

CodeRabbit ran locally: three test-scoping findings fixed in `2a2d8dfa`, one trivial
finding skipped (per-permission comments in the workflow block — neither `docker-base`
nor `docker-full` carries them, so adding them to `docker-ai` alone would read as
inconsistent). Greptile hit its free-review limit this cycle, so the CI bot is the
first Greptile pass on this branch.

### Pre-release validation of the new stage

`docker-build-publish.yml` never runs on PRs, so the `ai` stage would otherwise be
built for the first time during a release — a bad place to discover a broken
`COPY --from=aitools` or a failing non-root smoke. `docker-ci.yml` already builds
`full` and `base` on PRs for exactly this reason, so `ai` now gets the same
treatment: build only, no push and no load, gated on the same `pipeline` output.

A successful build *is* the validation — the stage's own RUN steps run all three CLIs
as root and under `gosu lintro`. It needs no registry auth (`lintro-ai-tools` is
public), so fork PRs are covered too. The job timeout moves 30 → 40 minutes for the
extra base-image pull and second `uv sync`. A test asserts the step exists and never
pushes.

This replaces the originally-considered `force_publish` dispatch, which the input
validator rejects unless `backfill_version`/`backfill_ref` are also set — and that
path would republish the *released* `base`/`full` images at an existing version tag.
