### PR TITLE
refactor(ai): migrate providers to async/await

### DIFF
--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -68,7 +68,10 @@ log.
   covered by the unit tests.
 - 🔑 **Bring-your-own key** — reads the `ANTHROPIC_API_KEY` repository secret
 - 💸 **Bounded spend** — caps cost via `ai.max_cost_usd` (from the trusted base config,
-  so a PR cannot raise the cap)
+  so a PR cannot raise the cap). Setting a cap also serializes provider calls: the
+  budget is enforced under a lock held across each call, so budgeted requests run one at
+  a time rather than concurrently. Leave `ai.max_cost_usd` unset if you would rather
+  have concurrent chunk reviews than a hard spend ceiling.
 - 🟢 **Non-blocking / informational** — runs with `continue-on-error` and always exits
   0, so it can never fail a pull request. It is intentionally not a required check.
 - ⏭️ **Graceful skip** — when `ANTHROPIC_API_KEY` is absent (secret not configured yet,

--- a/lintro/ai/budget.py
+++ b/lintro/ai/budget.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TypeVar
 
@@ -23,6 +24,12 @@ class CostBudget:
     _spent: float = field(default=0.0, init=False)
     _lock: threading.Lock = field(
         default_factory=threading.Lock,
+        init=False,
+        repr=False,
+    )
+    _async_lock: asyncio.Lock | None = field(default=None, init=False, repr=False)
+    _async_lock_loop: asyncio.AbstractEventLoop | None = field(
+        default=None,
         init=False,
         repr=False,
     )
@@ -59,11 +66,46 @@ class CostBudget:
             f"limit is ${self.max_cost_usd:.2f}",
         )
 
-    def execute(self, fn: Callable[[], _T], *, cost_of: Callable[[_T], float]) -> _T:
-        """Run ``fn`` under the budget lock to prevent parallel overspend."""
-        with self._lock:
-            if self.max_cost_usd is not None and self._spent >= self.max_cost_usd:
-                self._raise_exceeded()
-            result = fn()
-            self._spent += cost_of(result)
+    def _get_async_lock(self) -> asyncio.Lock:
+        """Return the ``asyncio.Lock`` bound to the running event loop.
+
+        An ``asyncio.Lock`` is tied to the loop it is awaited on, so the
+        lock is rebuilt whenever the budget is used from a different loop
+        (e.g. a tool plugin driving its own ``asyncio.run``).
+
+        Returns:
+            The lock guarding budgeted execution on the current loop.
+        """
+        loop = asyncio.get_running_loop()
+        if self._async_lock is None or self._async_lock_loop is not loop:
+            self._async_lock = asyncio.Lock()
+            self._async_lock_loop = loop
+        return self._async_lock
+
+    async def execute(
+        self,
+        fn: Callable[[], Awaitable[_T]],
+        *,
+        cost_of: Callable[[_T], float],
+    ) -> _T:
+        """Await ``fn`` under the budget lock to prevent parallel overspend.
+
+        The gate is an ``asyncio.Lock``, never the threading lock: holding
+        a threading lock across an ``await`` would stall every other task
+        on the loop.
+
+        Args:
+            fn: Coroutine function performing the budgeted call.
+            cost_of: Extracts the incurred cost from ``fn``'s result.
+
+        Returns:
+            Whatever ``fn`` returned.
+        """
+        async with self._get_async_lock():
+            with self._lock:
+                if self.max_cost_usd is not None and self._spent >= self.max_cost_usd:
+                    self._raise_exceeded()
+            result = await fn()
+            with self._lock:
+                self._spent += cost_of(result)
             return result

--- a/lintro/ai/display/streaming.py
+++ b/lintro/ai/display/streaming.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from lintro.ai.providers.base import AIStreamResult
+from lintro.ai.providers.base import AIStreamResult, AsyncAIStreamResult
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -34,4 +34,31 @@ def stream_to_console(
     return "".join(parts)
 
 
-__all__ = ["stream_to_console"]
+async def async_stream_to_console(
+    stream_result: AsyncAIStreamResult,
+    console: Console,
+    *,
+    style: str = "",
+) -> str:
+    """Stream AI tokens from an async provider stream to a Rich console.
+
+    The async counterpart of :func:`stream_to_console`; every provider
+    stream is async, so this is the variant production code uses.
+
+    Args:
+        stream_result: The async streaming result to display.
+        console: Rich Console instance for output.
+        style: Optional Rich style string applied to each chunk.
+
+    Returns:
+        The full concatenated text that was streamed.
+    """
+    parts: list[str] = []
+    async for chunk in stream_result:
+        console.print(chunk, end="", style=style or None, highlight=False, markup=False)
+        parts.append(chunk)
+    console.print()
+    return "".join(parts)
+
+
+__all__ = ["async_stream_to_console", "stream_to_console"]

--- a/lintro/ai/fallback.py
+++ b/lintro/ai/fallback.py
@@ -7,7 +7,7 @@ Authentication errors are never retried.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import TypeVar
 
 from loguru import logger
@@ -18,14 +18,18 @@ from lintro.ai.exceptions import (
     AIRateLimitError,
 )
 from lintro.ai.json_response import CliSchemaRequest
-from lintro.ai.providers.base import AIResponse, AIStreamResult, BaseAIProvider
+from lintro.ai.providers.base import (
+    AIResponse,
+    AsyncAIStreamResult,
+    BaseAIProvider,
+)
 
 _T = TypeVar("_T")
 
 
-def _with_fallback(
+async def _with_fallback(
     provider: BaseAIProvider,
-    attempt_fn: Callable[[str, str | None, int, float, str], _T],
+    attempt_fn: Callable[[str, str | None, int, float, str], Awaitable[_T]],
     prompt: str,
     *,
     fallback_models: list[str] | None = None,
@@ -46,7 +50,7 @@ def _with_fallback(
 
     Args:
         provider: AI provider instance.
-        attempt_fn: Callable with signature
+        attempt_fn: Coroutine function with signature
             ``(prompt, system, max_tokens, timeout, model) -> T``.
         prompt: The user prompt.
         fallback_models: Ordered list of fallback model identifiers.
@@ -83,7 +87,7 @@ def _with_fallback(
                 idx + 1,
                 len(models_to_try),
             )
-            return attempt_fn(
+            return await attempt_fn(
                 prompt,
                 system,
                 max_tokens,
@@ -118,7 +122,7 @@ def _with_fallback(
     raise AIProviderError(f"{label_prefix} exhausted")
 
 
-def complete_with_fallback(
+async def complete_with_fallback(
     provider: BaseAIProvider,
     prompt: str,
     *,
@@ -154,14 +158,26 @@ def complete_with_fallback(
         The first successful ``AIResponse``.
     """
 
-    def _attempt(
+    async def _attempt(
         prompt: str,
         system: str | None,
         max_tokens: int,
         timeout: float,
         model: str,
     ) -> AIResponse:
-        return provider.complete(
+        """Call the provider once with an explicit model override.
+
+        Args:
+            prompt: The user prompt.
+            system: Optional system prompt.
+            max_tokens: Maximum tokens to generate.
+            timeout: Request timeout in seconds.
+            model: The model identifier for this attempt.
+
+        Returns:
+            The provider response.
+        """
+        return await provider.complete(
             prompt,
             system=system,
             max_tokens=max_tokens,
@@ -172,7 +188,7 @@ def complete_with_fallback(
             cli_schema=cli_schema,
         )
 
-    return _with_fallback(
+    return await _with_fallback(
         provider,
         _attempt,
         prompt,
@@ -184,7 +200,7 @@ def complete_with_fallback(
     )
 
 
-def stream_complete_with_fallback(
+async def stream_complete_with_fallback(
     provider: BaseAIProvider,
     prompt: str,
     *,
@@ -192,7 +208,7 @@ def stream_complete_with_fallback(
     system: str | None = None,
     max_tokens: int = 1024,
     timeout: float = 60.0,
-) -> AIStreamResult:
+) -> AsyncAIStreamResult:
     """Call ``provider.stream_complete()`` with automatic model fallback.
 
     Same fallback logic as ``complete_with_fallback`` but returns a
@@ -209,17 +225,29 @@ def stream_complete_with_fallback(
         timeout: Request timeout in seconds.
 
     Returns:
-        The first successful ``AIStreamResult``.
+        The first successful ``AsyncAIStreamResult``.
     """
 
-    def _attempt(
+    async def _attempt(
         prompt: str,
         system: str | None,
         max_tokens: int,
         timeout: float,
         model: str,
-    ) -> AIStreamResult:
-        return provider.stream_complete(
+    ) -> AsyncAIStreamResult:
+        """Open one stream with an explicit model override.
+
+        Args:
+            prompt: The user prompt.
+            system: Optional system prompt.
+            max_tokens: Maximum tokens to generate.
+            timeout: Request timeout in seconds.
+            model: The model identifier for this attempt.
+
+        Returns:
+            The opened stream result.
+        """
+        return await provider.stream_complete(
             prompt,
             system=system,
             max_tokens=max_tokens,
@@ -227,7 +255,7 @@ def stream_complete_with_fallback(
             model=model,
         )
 
-    return _with_fallback(
+    return await _with_fallback(
         provider,
         _attempt,
         prompt,

--- a/lintro/ai/fix.py
+++ b/lintro/ai/fix.py
@@ -2,15 +2,16 @@
 
 Generates fix suggestions for issues that native tools cannot auto-fix.
 Reads file contents, asks the AI for a corrected version, and produces
-unified diffs. Supports parallel API calls for improved performance.
+unified diffs. Runs concurrent API calls as asyncio tasks under a
+semaphore for improved performance.
 """
 
 from __future__ import annotations
 
+import asyncio
 import threading
 from collections import defaultdict
 from collections.abc import Callable, Sequence
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -82,7 +83,7 @@ def _build_ai_config_for_fix(
     )
 
 
-def _call_fix_ai(
+async def _call_fix_ai(
     *,
     provider: BaseAIProvider,
     ai_config: AIConfig,
@@ -91,8 +92,20 @@ def _call_fix_ai(
     workspace_root: Path,
     batch: bool = False,
 ) -> AIResponse:
-    """Invoke the unified AI transport for fix generation."""
-    return call_ai(
+    """Invoke the unified AI transport for fix generation.
+
+    Args:
+        provider: AI provider instance.
+        ai_config: AI configuration for retry, transport, and fallback.
+        prompt: The fully built fix prompt.
+        max_tokens: Maximum tokens to request.
+        workspace_root: Root directory forwarded as the provider repo root.
+        batch: Whether this is a multi-issue batch prompt.
+
+    Returns:
+        The provider response.
+    """
+    return await call_ai(
         provider=provider,
         ai_config=ai_config,
         user_prompt=prompt,
@@ -111,7 +124,7 @@ def _call_fix_ai(
 DEFAULT_MAX_WORKERS = 5
 
 
-def _call_and_cache_fix(
+async def _call_and_cache_fix(
     prompt: str,
     issue_file: str,
     issue: BaseIssue,
@@ -126,7 +139,7 @@ def _call_and_cache_fix(
 ) -> AIFixSuggestion | None:
     """Call the provider, parse the response, and optionally cache the result."""
     try:
-        response = _call_fix_ai(
+        response = await _call_fix_ai(
             provider=provider,
             ai_config=ai_config,
             prompt=prompt,
@@ -171,7 +184,7 @@ def _call_and_cache_fix(
     return None
 
 
-def _generate_single_fix(
+async def _generate_single_fix(
     issue: BaseIssue,
     provider: BaseAIProvider,
     tool_name: str,
@@ -191,14 +204,18 @@ def _generate_single_fix(
 ) -> AIFixSuggestion | None:
     """Generate a fix suggestion for a single issue.
 
-    Thread-safe — uses a lock for the shared file cache.
+    The shared file cache is guarded by a lock. Concurrent fixes now run
+    as tasks on one event loop, where the guarded sections contain no
+    ``await`` and so cannot interleave; the lock is kept because the cache
+    is also reachable from tool plugins that drive their own loop on a
+    worker thread.
 
     Args:
         issue: The issue to fix.
         provider: AI provider instance.
         tool_name: Name of the tool.
         file_cache: Shared file content cache.
-        cache_lock: Lock for thread-safe cache access.
+        cache_lock: Lock guarding shared cache access.
         workspace_root: Root directory AI is allowed to edit/read.
         max_tokens: Maximum tokens to request from provider.
         ai_config: AI configuration for retry, transport, and fallback.
@@ -255,7 +272,7 @@ def _generate_single_fix(
     if prompt is None:
         return None
 
-    return _call_and_cache_fix(
+    return await _call_and_cache_fix(
         prompt,
         issue_file,
         issue,
@@ -270,7 +287,7 @@ def _generate_single_fix(
     )
 
 
-def _generate_batch_fixes(
+async def _generate_batch_fixes(
     file_path: str,
     file_issues: list[BaseIssue],
     provider: BaseAIProvider,
@@ -356,7 +373,7 @@ def _generate_batch_fixes(
         return None
 
     try:
-        response = _call_fix_ai(
+        response = await _call_fix_ai(
             provider=provider,
             ai_config=ai_config,
             prompt=prompt,
@@ -407,7 +424,7 @@ def _generate_batch_fixes(
         return None
 
 
-def generate_fixes(
+async def generate_fixes(
     issues: Sequence[BaseIssue],
     provider: BaseAIProvider,
     *,
@@ -492,7 +509,7 @@ def generate_fixes(
         fallback_models=fallback_models,
     )
 
-    # Shared file cache with thread safety (capped to limit memory usage).
+    # Shared file cache guarded by a lock (capped to limit memory usage).
     file_cache: dict[str, str | None] = {}
     cache_lock = threading.Lock()
 
@@ -533,7 +550,7 @@ def generate_fixes(
                 del file_cache[oldest_key]
             file_cache[resolved_path] = content
 
-        batch_result = _generate_batch_fixes(
+        batch_result = await _generate_batch_fixes(
             resolved_path,
             group,
             provider,
@@ -565,7 +582,7 @@ def generate_fixes(
 
     if workers <= 1:
         for issue in single_issues:
-            result = _generate_single_fix(
+            result = await _generate_single_fix(
                 issue,
                 provider,
                 tool_name,
@@ -588,10 +605,22 @@ def generate_fixes(
             if progress_callback is not None:
                 progress_callback(completed_count, total_count)
     else:
-        with ThreadPoolExecutor(max_workers=workers) as executor:
-            futures = [
-                executor.submit(
-                    _generate_single_fix,
+        # Bounded concurrency on one event loop replaces the former thread
+        # pool: provider calls are I/O-bound, so tasks + a semaphore give the
+        # same ``max_workers`` ceiling without the thread overhead.
+        semaphore = asyncio.Semaphore(workers)
+
+        async def _run_one(issue: BaseIssue) -> AIFixSuggestion | None:
+            """Generate one fix under the concurrency ceiling.
+
+            Args:
+                issue: The issue to fix.
+
+            Returns:
+                The suggestion, or None when generation fails.
+            """
+            async with semaphore:
+                return await _generate_single_fix(
                     issue,
                     provider,
                     tool_name,
@@ -608,11 +637,12 @@ def generate_fixes(
                     sanitize_mode=sanitize_mode,
                     cache_max_entries=cache_max_entries,
                 )
-                for issue in single_issues
-            ]
-            for future in as_completed(futures):
+
+        tasks = [asyncio.ensure_future(_run_one(issue)) for issue in single_issues]
+        try:
+            for completed in asyncio.as_completed(tasks):
                 try:
-                    result = future.result()
+                    result = await completed
                 except (KeyboardInterrupt, SystemExit):
                     raise
                 except Exception as exc:
@@ -629,9 +659,16 @@ def generate_fixes(
                 completed_count += 1
                 if progress_callback is not None:
                     progress_callback(completed_count, total_count)
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            # Drain the cancellations so no provider call (and no CLI child
+            # process) outlives this function.
+            await asyncio.gather(*tasks, return_exceptions=True)
 
-    # Sort by (file, line) for deterministic ordering regardless of
-    # thread completion order from as_completed().
+    # Sort by (file, line) for deterministic ordering regardless of the
+    # completion order tasks arrive in from as_completed().
     suggestions.sort(key=lambda s: (s.file, s.line))
 
     logger.debug(
@@ -641,7 +678,7 @@ def generate_fixes(
     return suggestions
 
 
-def generate_fixes_from_params(
+async def generate_fixes_from_params(
     issues: Sequence[BaseIssue],
     provider: BaseAIProvider,
     params: FixGenParams,
@@ -659,7 +696,7 @@ def generate_fixes_from_params(
     Returns:
         List of fix suggestions.
     """
-    return generate_fixes(
+    return await generate_fixes(
         issues,
         provider,
         tool_name=params.tool_name,

--- a/lintro/ai/invoke.py
+++ b/lintro/ai/invoke.py
@@ -1,4 +1,9 @@
-"""Unified AI invocation with retry, fallback, and budget tracking."""
+"""Unified async AI invocation with retry, fallback, and budget tracking.
+
+``call_ai`` is the single async entry point every AI product uses. Sync
+callers (Click commands, tool plugins) cross the boundary with
+``asyncio.run`` at their own entry point, never here.
+"""
 
 from __future__ import annotations
 
@@ -17,7 +22,7 @@ if TYPE_CHECKING:
 __all__ = ["call_ai"]
 
 
-def call_ai(
+async def call_ai(
     *,
     provider: BaseAIProvider,
     ai_config: AIConfig,
@@ -47,8 +52,13 @@ def call_ai(
     """
     tokens = max_tokens if max_tokens is not None else ai_config.max_tokens
 
-    def _call_once() -> AIResponse:
-        return complete_with_fallback(
+    async def _call_once() -> AIResponse:
+        """Perform one fallback-guarded provider call.
+
+        Returns:
+            The provider response.
+        """
+        return await complete_with_fallback(
             provider,
             user_prompt,
             fallback_models=list(ai_config.fallback_models),
@@ -60,13 +70,18 @@ def call_ai(
             cli_schema=cli_schema,
         )
 
-    def _budgeted_call() -> AIResponse:
+    async def _budgeted_call() -> AIResponse:
+        """Perform one call, recording its cost against the budget.
+
+        Returns:
+            The provider response.
+        """
         if budget is not None and budget.max_cost_usd is not None:
-            return budget.execute(
+            return await budget.execute(
                 _call_once,
                 cost_of=lambda response: response.cost_estimate,
             )
-        response = _call_once()
+        response = await _call_once()
         if budget is not None:
             budget.record(response.cost_estimate)
         return response
@@ -78,4 +93,4 @@ def call_ai(
         backoff_factor=ai_config.retry_backoff_factor,
     )(_budgeted_call)
 
-    return cast(AIResponse, call_with_retry())
+    return cast(AIResponse, await call_with_retry())

--- a/lintro/ai/orchestrator.py
+++ b/lintro/ai/orchestrator.py
@@ -5,6 +5,7 @@ Thin coordinator that delegates to pipeline and rerun services.
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import os
 from pathlib import Path
@@ -40,6 +41,48 @@ if TYPE_CHECKING:
 
 
 def run_ai_enhancement(
+    *,
+    action: Action,
+    all_results: list[ToolResult],
+    lintro_config: LintroConfig,
+    logger: ThreadSafeConsoleLogger,
+    output_format: str,
+    ai_fix: bool = False,
+    transport: str | None = None,
+) -> AIResult:
+    """Run AI enhancement from synchronous code.
+
+    This is the sync/async boundary for the check/fix products: the whole
+    AI layer below it is async, and ``asyncio.run`` is entered exactly
+    once here so a single event loop (and a single provider HTTP client)
+    serves every call in the run.
+
+    Args:
+        action: The action being performed (CHECK or FIX).
+        all_results: Tool results from the linting run.
+        lintro_config: Full lintro configuration.
+        logger: Thread-safe console logger.
+        output_format: Output format (e.g. "terminal", "json").
+        ai_fix: Whether to generate AI fix suggestions.
+        transport: Optional CLI override for ``ai.transport``.
+
+    Returns:
+        AIResult with structured outcome data for exit code decisions.
+    """
+    return asyncio.run(
+        run_ai_enhancement_async(
+            action=action,
+            all_results=all_results,
+            lintro_config=lintro_config,
+            logger=logger,
+            output_format=output_format,
+            ai_fix=ai_fix,
+            transport=transport,
+        ),
+    )
+
+
+async def run_ai_enhancement_async(
     *,
     action: Action,
     all_results: list[ToolResult],
@@ -85,7 +128,7 @@ def run_ai_enhancement(
             )
 
         if action == Action.CHECK:
-            return _run_ai_check(
+            return await _run_ai_check(
                 all_results=all_results,
                 provider=provider,
                 ai_config=ai_config,
@@ -96,7 +139,7 @@ def run_ai_enhancement(
                 output_format=output_format,
             )
         elif action == Action.FIX:
-            return _run_ai_fix(
+            return await _run_ai_fix(
                 all_results=all_results,
                 provider=provider,
                 ai_config=ai_config,
@@ -121,7 +164,7 @@ def run_ai_enhancement(
         return AIResult(error=True)
 
 
-def _run_ai_check(
+async def _run_ai_check(
     *,
     all_results: list[ToolResult],
     provider: BaseAIProvider,
@@ -132,10 +175,24 @@ def _run_ai_check(
     workspace_root: Path,
     output_format: str = "auto",
 ) -> AIResult:
-    """Run AI summary and optional AI fix suggestions for check action."""
+    """Run AI summary and optional AI fix suggestions for check action.
+
+    Args:
+        all_results: Tool results from the linting run.
+        provider: AI provider instance.
+        ai_config: AI configuration.
+        logger: Thread-safe console logger.
+        is_json: Whether output is JSON.
+        ai_fix: Whether to generate AI fix suggestions.
+        workspace_root: Workspace root path.
+        output_format: Output format string.
+
+    Returns:
+        AIResult with structured outcome data.
+    """
     budget = CostBudget(max_cost_usd=ai_config.max_cost_usd)
 
-    summary = generate_summary(
+    summary = await generate_summary(
         all_results,
         provider,
         ai_config=ai_config,
@@ -203,7 +260,7 @@ def _run_ai_check(
                 fix_issue = dataclasses.replace(issue, file=str(resolved))
                 all_fix_issues.append((result, fix_issue))
 
-    return _collect_and_fix(
+    return await _collect_and_fix(
         fix_issues=all_fix_issues,
         provider=provider,
         ai_config=ai_config,
@@ -214,7 +271,7 @@ def _run_ai_check(
     )
 
 
-def _run_ai_fix(
+async def _run_ai_fix(
     *,
     all_results: list[ToolResult],
     provider: BaseAIProvider,
@@ -223,7 +280,19 @@ def _run_ai_fix(
     is_json: bool,
     workspace_root: Path,
 ) -> AIResult:
-    """Run AI fix suggestions for format action."""
+    """Run AI fix suggestions for format action.
+
+    Args:
+        all_results: Tool results from the linting run.
+        provider: AI provider instance.
+        ai_config: AI configuration.
+        logger: Thread-safe console logger.
+        is_json: Whether output is JSON.
+        workspace_root: Workspace root path.
+
+    Returns:
+        AIResult with structured outcome data.
+    """
     budget = CostBudget(max_cost_usd=ai_config.max_cost_usd)
 
     all_fix_issues: list[tuple[ToolResult, BaseIssue]] = []
@@ -252,7 +321,7 @@ def _run_ai_fix(
                 fix_issue = dataclasses.replace(issue, file=str(resolved))
                 all_fix_issues.append((result, fix_issue))
 
-    return _collect_and_fix(
+    return await _collect_and_fix(
         fix_issues=all_fix_issues,
         provider=provider,
         ai_config=ai_config,
@@ -263,7 +332,7 @@ def _run_ai_fix(
     )
 
 
-def _collect_and_fix(
+async def _collect_and_fix(
     *,
     fix_issues: list[tuple[ToolResult, BaseIssue]],
     provider: BaseAIProvider,
@@ -276,12 +345,24 @@ def _collect_and_fix(
     """Run the fix pipeline and build an AIResult.
 
     Shared by ``_run_ai_check`` and ``_run_ai_fix``.
+
+    Args:
+        fix_issues: Issues to attempt fixing, paired with their tool result.
+        provider: AI provider instance.
+        ai_config: AI configuration.
+        logger: Thread-safe console logger.
+        is_json: Whether output is JSON.
+        workspace_root: Workspace root path.
+        budget: Session cost budget tracker.
+
+    Returns:
+        AIResult with structured outcome data.
     """
     fixes_applied = 0
     fixes_failed = 0
     fix_suggestions: list[AIFixSuggestion] = []
     if fix_issues:
-        fixes_applied, fixes_failed, fix_suggestions = run_fix_pipeline(
+        fixes_applied, fixes_failed, fix_suggestions = await run_fix_pipeline(
             fix_issues=fix_issues,
             provider=provider,
             ai_config=ai_config,

--- a/lintro/ai/pipeline.py
+++ b/lintro/ai/pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -47,7 +48,7 @@ def _confidence_numeric(value: ConfidenceLevel | str) -> int:
         return 1
 
 
-def _generate_all_suggestions(
+async def _generate_all_suggestions(
     by_tool: dict[str, tuple[ToolResult, list[BaseIssue]]],
     provider: BaseAIProvider,
     ai_config: AIConfig,
@@ -57,7 +58,21 @@ def _generate_all_suggestions(
     telemetry: AITelemetry,
     budget: CostBudget | None,
 ) -> list[AIFixSuggestion]:
-    """Iterate tools, generate fix suggestions, and collect telemetry."""
+    """Iterate tools, generate fix suggestions, and collect telemetry.
+
+    Args:
+        by_tool: Issues grouped by tool name with their tool result.
+        provider: AI provider instance.
+        ai_config: AI configuration.
+        logger: Console logger for progress output.
+        workspace_root: Workspace root path.
+        is_json: Whether output is JSON (suppresses console progress).
+        telemetry: Telemetry accumulator to update.
+        budget: Optional cost budget tracker.
+
+    Returns:
+        All generated fix suggestions across tools.
+    """
     all_suggestions: list[AIFixSuggestion] = []
     remaining_budget = ai_config.max_fix_attempts
 
@@ -107,7 +122,7 @@ def _generate_all_suggestions(
             sanitize_mode=ai_config.sanitize_mode,
             ai_config=ai_config,
         )
-        suggestions = generate_fixes_from_params(issues, provider, fix_params)
+        suggestions = await generate_fixes_from_params(issues, provider, fix_params)
         for suggestion in suggestions:
             if not suggestion.tool_name:
                 suggestion.tool_name = tool_name
@@ -255,7 +270,7 @@ def _apply_or_review(
     return applied, rejected, applied_suggestions
 
 
-def _verify_and_refine(
+async def _verify_and_refine(
     applied_suggestions: list[AIFixSuggestion],
     by_tool: dict[str, tuple[ToolResult, list[BaseIssue]]],
     provider: BaseAIProvider,
@@ -284,7 +299,7 @@ def _verify_and_refine(
         and validation.unverified > 0
         and ai_config.max_refinement_attempts >= 1
     ):
-        refined, refinement_cost = refine_unverified_fixes(
+        refined, refinement_cost = await refine_unverified_fixes(
             applied_suggestions=applied_suggestions,
             validation=validation,
             provider=provider,
@@ -328,7 +343,7 @@ def _verify_and_refine(
     return validation
 
 
-def run_fix_pipeline(
+async def run_fix_pipeline(
     *,
     fix_issues: list[tuple[ToolResult, BaseIssue]],
     provider: BaseAIProvider,
@@ -371,7 +386,7 @@ def run_fix_pipeline(
     is_json = output_format.lower() == OutputFormat.JSON
 
     # Step 1: Generate suggestions across all tools
-    all_suggestions = _generate_all_suggestions(
+    all_suggestions = await _generate_all_suggestions(
         by_tool,
         provider,
         ai_config,
@@ -390,7 +405,13 @@ def run_fix_pipeline(
     if not all_suggestions:
         telemetry.successful_fixes = 0
         telemetry.failed_fixes = total_generated
-        write_audit_log(workspace_root, [], 0, telemetry.total_cost_usd)
+        await asyncio.to_thread(
+            write_audit_log,
+            workspace_root,
+            [],
+            0,
+            telemetry.total_cost_usd,
+        )
         attach_telemetry_metadata(
             [r for r, _ in by_tool.values()],
             telemetry,
@@ -426,7 +447,7 @@ def run_fix_pipeline(
     # Step 4: Verify and refine applied fixes
     validation = None
     if applied_suggestions:
-        validation = _verify_and_refine(
+        validation = await _verify_and_refine(
             applied_suggestions,
             by_tool,
             provider,
@@ -479,7 +500,7 @@ def run_fix_pipeline(
             unique_results = _unique_results_from_fix_issues(fix_issues)
 
         if unique_results:
-            post_summary = generate_post_fix_summary(
+            post_summary = await generate_post_fix_summary(
                 applied=applied_for_summary,
                 rejected=rejected,
                 remaining_results=unique_results,
@@ -502,7 +523,10 @@ def run_fix_pipeline(
                 if output:
                     logger.console_output(output)
 
-    write_audit_log(
+    # Audit-log writing takes a blocking inter-process file lock (with a
+    # sleep-based retry on Windows), so it runs off the event loop.
+    await asyncio.to_thread(
+        write_audit_log,
         workspace_root,
         applied_suggestions,
         rejected,

--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import os
 import threading
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from contextlib import contextmanager
 from typing import Any
 
@@ -26,7 +26,7 @@ from lintro.ai.exceptions import (
 from lintro.ai.json_response import CliSchemaRequest
 from lintro.ai.providers.base import (
     AIResponse,
-    AIStreamResult,
+    AsyncAIStreamResult,
     BaseAIProvider,
     ProviderCapabilities,
 )
@@ -233,12 +233,12 @@ class AnthropicProvider(BaseAIProvider):
             api_key: The resolved API key.
 
         Returns:
-            anthropic.Anthropic: The API client.
+            anthropic.AsyncAnthropic: The async API client.
         """
         kwargs: dict[str, Any] = {"api_key": api_key}
         if self._base_url:
             kwargs["base_url"] = self._base_url
-        return anthropic.Anthropic(**kwargs)
+        return anthropic.AsyncAnthropic(**kwargs)
 
     def is_available(self) -> bool:
         """Return True when the configured transport is usable."""
@@ -284,7 +284,7 @@ class AnthropicProvider(BaseAIProvider):
         with self._session_lock:
             self._session_id = None
 
-    def _complete_cli(
+    async def _complete_cli(
         self,
         prompt: str,
         *,
@@ -331,7 +331,7 @@ class AnthropicProvider(BaseAIProvider):
                 OptionalArg(flag="--resume", values=(resume_session_id,)),
             )
 
-        optional_args = self._cli.apply_optional_args(cmd, candidates)
+        optional_args = await self._cli.apply_optional_args(cmd, candidates)
 
         logger.debug(
             f"Claude CLI request: model={effective_model}, "
@@ -339,7 +339,7 @@ class AnthropicProvider(BaseAIProvider):
             f"prompt_len={len(prompt)}",
         )
 
-        result = self._cli.run_guarded(
+        result = await self._cli.run_guarded(
             cmd,
             optional_args=optional_args,
             timeout=timeout,
@@ -360,7 +360,7 @@ class AnthropicProvider(BaseAIProvider):
                 self._session_id = session_id
         return response
 
-    def complete(
+    async def complete(
         self,
         prompt: str,
         *,
@@ -389,7 +389,7 @@ class AnthropicProvider(BaseAIProvider):
         """
         if self._transport == AITransport.CLI:
             del max_tokens
-            return self._complete_cli(
+            return await self._complete_cli(
                 prompt,
                 system=system,
                 timeout=timeout,
@@ -416,7 +416,7 @@ class AnthropicProvider(BaseAIProvider):
             if system:
                 kwargs["system"] = system
 
-            response = client.messages.create(**kwargs)
+            response = await client.messages.create(**kwargs)
 
             content = ""
             for block in response.content:
@@ -436,7 +436,7 @@ class AnthropicProvider(BaseAIProvider):
                 provider=AIProvider.ANTHROPIC,
             )
 
-    def stream_complete(
+    async def stream_complete(
         self,
         prompt: str,
         *,
@@ -444,7 +444,7 @@ class AnthropicProvider(BaseAIProvider):
         max_tokens: int = DEFAULT_PER_CALL_MAX_TOKENS,
         timeout: float = DEFAULT_TIMEOUT,
         model: str | None = None,
-    ) -> AIStreamResult:
+    ) -> AsyncAIStreamResult:
         """Stream a completion from the Anthropic API token-by-token.
 
         Args:
@@ -455,10 +455,10 @@ class AnthropicProvider(BaseAIProvider):
             model: Optional per-call model override.
 
         Returns:
-            An AIStreamResult wrapping the token stream.
+            An AsyncAIStreamResult wrapping the token stream.
         """
         if self._transport == AITransport.CLI:
-            return super().stream_complete(
+            return await super().stream_complete(
                 prompt,
                 system=system,
                 max_tokens=max_tokens,
@@ -485,11 +485,17 @@ class AnthropicProvider(BaseAIProvider):
 
         final_response: list[AIResponse] = []
 
-        def _generate() -> Iterator[str]:
+        async def _generate() -> AsyncIterator[str]:
+            """Yield tokens from the Anthropic stream and capture usage.
+
+            Yields:
+                str: Text deltas in arrival order.
+            """
             with self._map_errors():
-                with client.messages.stream(**kwargs) as stream:
-                    yield from stream.text_stream
-                    final_message = stream.get_final_message()
+                async with client.messages.stream(**kwargs) as stream:
+                    async for text in stream.text_stream:
+                        yield text
+                    final_message = await stream.get_final_message()
 
                 input_tokens = final_message.usage.input_tokens
                 output_tokens = final_message.usage.output_tokens
@@ -512,7 +518,7 @@ class AnthropicProvider(BaseAIProvider):
                 )
             return final_response[0]
 
-        return AIStreamResult(
+        return AsyncAIStreamResult(
             _chunks=_generate(),
             _on_done=_on_done,
         )

--- a/lintro/ai/providers/async_stream_result.py
+++ b/lintro/ai/providers/async_stream_result.py
@@ -1,0 +1,76 @@
+"""Async AI provider streaming result wrapper.
+
+Contains the ``AsyncAIStreamResult`` dataclass that wraps an async token
+iterator and provides finalized metadata after the stream is exhausted.
+It is the async counterpart of
+:class:`~lintro.ai.providers.stream_result.AIStreamResult`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass, field
+
+from lintro.ai.providers.response import AIResponse
+
+
+@dataclass
+class AsyncAIStreamResult:
+    """Wraps an async token iterator and exposes finalized metadata.
+
+    ``_chunks`` yields text chunks as they arrive; ``_on_done`` returns the
+    finalized response and is only valid once the iterator is exhausted.
+    """
+
+    _chunks: AsyncIterator[str]
+    _on_done: Callable[[], AIResponse]
+    _consumed: bool = field(default=False, init=False)
+
+    async def __aiter__(self) -> AsyncIterator[str]:
+        """Yield text chunks from the underlying async iterator.
+
+        The stream is marked consumed as soon as iteration starts, so a
+        second consumer (a repeat ``async for``, or ``collect()`` after a
+        partial read) cannot silently receive a truncated stream.
+
+        Yields:
+            str: Text chunks in arrival order.
+        """
+        self._consumed = True
+        async for chunk in self._chunks:
+            yield chunk
+
+    def response(self) -> AIResponse:
+        """Return the finalized AIResponse.
+
+        Only valid after iteration completes.
+
+        Returns:
+            The finalized AIResponse with usage metadata.
+        """
+        return self._on_done()
+
+    async def collect(self) -> AIResponse:
+        """Consume all tokens and return the complete AIResponse.
+
+        May only be called once -- a second call raises ``RuntimeError``
+        because the underlying iterator has already been exhausted.
+
+        Returns:
+            AIResponse with concatenated content and usage metadata.
+
+        Raises:
+            RuntimeError: If the stream has already been consumed.
+        """
+        if self._consumed:
+            raise RuntimeError("AsyncAIStreamResult already consumed")
+        parts: list[str] = [chunk async for chunk in self]
+        resp = self.response()
+        return AIResponse(
+            content="".join(parts),
+            model=resp.model,
+            input_tokens=resp.input_tokens,
+            output_tokens=resp.output_tokens,
+            cost_estimate=resp.cost_estimate,
+            provider=resp.provider,
+        )

--- a/lintro/ai/providers/base.py
+++ b/lintro/ai/providers/base.py
@@ -7,11 +7,14 @@ here so that concrete providers only implement SDK-specific pieces.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
 from lintro.ai.exceptions import AIAuthenticationError, AINotAvailableError
+from lintro.ai.providers.async_stream_result import AsyncAIStreamResult
 from lintro.ai.providers.capabilities import ProviderCapabilities
 from lintro.ai.providers.constants import (
     DEFAULT_MAX_TOKENS,
@@ -28,6 +31,7 @@ if TYPE_CHECKING:
 __all__ = [
     "AIResponse",
     "AIStreamResult",
+    "AsyncAIStreamResult",
     "BaseAIProvider",
     "ProviderCapabilities",
 ]
@@ -94,11 +98,30 @@ class BaseAIProvider(ABC):
         self._base_url = base_url
         self._transport = transport
         self._client: Any = None
+        self._client_loop: asyncio.AbstractEventLoop | None = None
 
     # -- Client management -------------------------------------------------
 
+    @staticmethod
+    def _current_loop() -> asyncio.AbstractEventLoop | None:
+        """Return the running event loop, or ``None`` outside of one.
+
+        Returns:
+            The running loop when called from async code, else ``None``.
+        """
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+
     def _get_client(self) -> Any:
-        """Get or lazily create the SDK client.
+        """Get or lazily create the SDK client for the running event loop.
+
+        Async SDK clients own an HTTP connection pool bound to the event
+        loop that created them, so a client built on a *different* loop is
+        discarded and rebuilt rather than reused. Callers that stay on a
+        single loop (the normal path) always get the cached instance, and a
+        client injected outside any loop is left alone.
 
         Returns:
             The SDK client instance.
@@ -106,7 +129,9 @@ class BaseAIProvider(ABC):
         Raises:
             AIAuthenticationError: If no API key is found.
         """
-        if self._client is not None:
+        loop = self._current_loop()
+        stale = self._client_loop is not None and self._client_loop is not loop
+        if self._client is not None and not stale:
             return self._client
 
         api_key = os.environ.get(self._api_key_env) or ""
@@ -120,6 +145,7 @@ class BaseAIProvider(ABC):
             api_key = "not-needed"
 
         self._client = self._create_client(api_key=api_key)
+        self._client_loop = loop
         return self._client
 
     @abstractmethod
@@ -137,7 +163,7 @@ class BaseAIProvider(ABC):
     # -- Abstract: SDK-specific completion ---------------------------------
 
     @abstractmethod
-    def complete(
+    async def complete(
         self,
         prompt: str,
         *,
@@ -174,7 +200,7 @@ class BaseAIProvider(ABC):
 
     # -- Streaming (default delegates to complete) --------------------------
 
-    def stream_complete(
+    async def stream_complete(
         self,
         prompt: str,
         *,
@@ -182,7 +208,7 @@ class BaseAIProvider(ABC):
         max_tokens: int = DEFAULT_PER_CALL_MAX_TOKENS,
         timeout: float = DEFAULT_TIMEOUT,
         model: str | None = None,
-    ) -> AIStreamResult:
+    ) -> AsyncAIStreamResult:
         """Stream a completion. Default: delegates to complete().
 
         Providers with native streaming support should override this.
@@ -195,17 +221,26 @@ class BaseAIProvider(ABC):
             model: Optional per-call model override.
 
         Returns:
-            An AIStreamResult wrapping the token stream.
+            An AsyncAIStreamResult wrapping the token stream.
         """
-        response = self.complete(
+        response = await self.complete(
             prompt,
             system=system,
             max_tokens=max_tokens,
             timeout=timeout,
             model=model,
         )
-        return AIStreamResult(
-            _chunks=iter([response.content]),
+
+        async def _single_chunk() -> AsyncIterator[str]:
+            """Yield the whole response as one chunk.
+
+            Yields:
+                str: The complete response text.
+            """
+            yield response.content
+
+        return AsyncAIStreamResult(
+            _chunks=_single_chunk(),
             _on_done=lambda: response,
         )
 

--- a/lintro/ai/providers/cli_transport.py
+++ b/lintro/ai/providers/cli_transport.py
@@ -17,6 +17,8 @@ The flag surface itself is declared in :mod:`lintro.ai.providers.cli_contracts`.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import os
 import re
@@ -82,6 +84,33 @@ def _flag_named_in(lowered_stderr: str, flag: str) -> bool:
     """
     pattern = rf"(?<!{_FLAG_CHAR}){re.escape(flag.lower())}(?!{_FLAG_CHAR})"
     return re.search(pattern, lowered_stderr) is not None
+
+
+async def _terminate(process: asyncio.subprocess.Process) -> None:
+    """Kill a child process and reap it so it cannot linger as a zombie.
+
+    Args:
+        process: The child process to stop.
+    """
+    with contextlib.suppress(ProcessLookupError):
+        process.kill()
+    with contextlib.suppress(ProcessLookupError):
+        await process.wait()
+
+
+def _decode(raw: bytes | None) -> str:
+    """Decode subprocess output, tolerating invalid byte sequences.
+
+    Args:
+        raw: Raw bytes captured from the child process, or ``None``.
+
+    Returns:
+        Decoded text; never ``None`` so callers can treat it like
+        ``subprocess.run(text=True)`` output.
+    """
+    if not raw:
+        return ""
+    return raw.decode("utf-8", errors="replace")
 
 
 @dataclass(frozen=True, slots=True)
@@ -173,8 +202,13 @@ class CliTransport(ABC):
             return None
         return tuple(int(part) for part in match.groups())
 
-    def binary_version(self) -> tuple[int, ...] | None:
+    async def binary_version(self) -> tuple[int, ...] | None:
         """Return the installed binary's version, probing at most once.
+
+        The subprocess probe runs outside the memo lock -- holding a
+        thread lock across an ``await`` would stall the event loop. Racing
+        callers may therefore each spawn one probe; the probe is read-only
+        and idempotent, so the only cost is a duplicated ``--version``.
 
         Returns:
             Parsed version components, or ``None`` when the probe fails or the
@@ -183,17 +217,22 @@ class CliTransport(ABC):
         with self._capability_lock:
             if self._version_probed:
                 return self._version
-            self._version_probed = True
-            args = self._contract.version_args if self._contract else ("--version",)
-            output = self._probe([self._binary_path, *args])
-            self._version = self.parse_version(output) if output is not None else None
-            logger.debug(
-                f"{self._binary_name} CLI version probe: "
-                f"{format_version(self._version)}",
-            )
-            return self._version
 
-    def check_version_floor(self) -> None:
+        args = self._contract.version_args if self._contract else ("--version",)
+        output = await self._probe([self._binary_path, *args])
+        version = self.parse_version(output) if output is not None else None
+
+        with self._capability_lock:
+            if not self._version_probed:
+                self._version_probed = True
+                self._version = version
+            resolved = self._version
+        logger.debug(
+            f"{self._binary_name} CLI version probe: {format_version(resolved)}",
+        )
+        return resolved
+
+    async def check_version_floor(self) -> None:
         """Verify the installed binary meets the declared version floor.
 
         The comparison runs on every call rather than latching a
@@ -213,7 +252,7 @@ class CliTransport(ABC):
         if contract is None or contract.version_floor is None:
             return
 
-        version = self.binary_version()
+        version = await self.binary_version()
         if version is None or version >= contract.version_floor:
             return
 
@@ -223,8 +262,12 @@ class CliTransport(ABC):
             f"{contract.upgrade_hint}",
         )
 
-    def help_text(self) -> str | None:
+    async def help_text(self) -> str | None:
         """Return the binary's help output, probing at most once.
+
+        As with :meth:`binary_version`, the probe runs outside the memo
+        lock so the event loop is never blocked; a racing caller may
+        duplicate the (free, read-only) ``--help`` invocation.
 
         Returns:
             Help text, or ``None`` when the probe failed or exited non-zero.
@@ -234,12 +277,16 @@ class CliTransport(ABC):
         with self._capability_lock:
             if self._help_text is not None:
                 return self._help_text or None
-            args = self._contract.help_args if self._contract else ("--help",)
-            output = self._probe([self._binary_path, *args])
-            self._help_text = output or ""
+
+        args = self._contract.help_args if self._contract else ("--help",)
+        output = await self._probe([self._binary_path, *args])
+
+        with self._capability_lock:
+            if self._help_text is None:
+                self._help_text = output or ""
             return self._help_text or None
 
-    def supports_flag(self, flag: str) -> bool:
+    async def supports_flag(self, flag: str) -> bool:
         """Return whether the installed binary advertises *flag*.
 
         A flag the reactive backstop has already seen rejected is remembered as
@@ -259,7 +306,7 @@ class CliTransport(ABC):
         if cached is not None:
             return cached
 
-        help_text = self.help_text()
+        help_text = await self.help_text()
         # Token-boundary match, not substring: a bare ``flag in help_text`` would
         # read ``--json-schema`` as advertised whenever the help lists only
         # ``--json-schema-name``.
@@ -270,7 +317,7 @@ class CliTransport(ABC):
             self._flag_support.setdefault(flag, supported)
             return self._flag_support[flag]
 
-    def filter_optional_args(
+    async def filter_optional_args(
         self,
         optional_args: list[OptionalArg],
     ) -> list[OptionalArg]:
@@ -284,7 +331,7 @@ class CliTransport(ABC):
         """
         kept: list[OptionalArg] = []
         for arg in optional_args:
-            if self.supports_flag(arg.flag):
+            if await self.supports_flag(arg.flag):
                 kept.append(arg)
                 continue
             logger.debug(
@@ -292,7 +339,7 @@ class CliTransport(ABC):
             )
         return kept
 
-    def apply_optional_args(
+    async def apply_optional_args(
         self,
         cmd: list[str],
         candidates: list[OptionalArg],
@@ -311,12 +358,12 @@ class CliTransport(ABC):
         Returns:
             The optional args that passed the proactive gate.
         """
-        accepted = self.filter_optional_args(candidates)
+        accepted = await self.filter_optional_args(candidates)
         for arg in accepted:
             cmd.extend(arg.as_argv())
         return accepted
 
-    def run_guarded(
+    async def run_guarded(
         self,
         cmd: list[str],
         *,
@@ -344,12 +391,12 @@ class CliTransport(ABC):
             ``AINotAvailableError`` from :meth:`check_version_floor` when the
             binary is below its declared floor.
         """
-        self.check_version_floor()
+        await self.check_version_floor()
 
         argv = list(cmd)
         remaining = list(optional_args or [])
         while True:
-            result = self.run(
+            result = await self.run(
                 argv,
                 input_text=input_text,
                 timeout=timeout,
@@ -432,7 +479,7 @@ class CliTransport(ABC):
         del stripped[index : index + 1 + len(arg.values)]
         return stripped
 
-    def _probe(self, cmd: list[str]) -> str | None:
+    async def _probe(self, cmd: list[str]) -> str | None:
         """Run a free capability probe and return its combined output.
 
         Args:
@@ -443,7 +490,7 @@ class CliTransport(ABC):
             failed or exited non-zero.
         """
         try:
-            result = self.run(cmd, timeout=PROBE_TIMEOUT)
+            result = await self.run(cmd, timeout=PROBE_TIMEOUT)
         except (AIProviderError, AINotAvailableError, OSError) as exc:
             # OSError covers PermissionError and other spawn failures that
             # run() does not remap.
@@ -465,7 +512,7 @@ class CliTransport(ABC):
         """
         return shutil.which(name)
 
-    def run(
+    async def run(
         self,
         cmd: list[str],
         *,
@@ -474,6 +521,11 @@ class CliTransport(ABC):
         cwd: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
         """Execute a CLI command with timeout and env forwarding.
+
+        Spawns the child with ``asyncio.create_subprocess_exec`` so provider
+        calls never block the event loop. The return type stays
+        ``subprocess.CompletedProcess`` so stdout parsers and
+        :meth:`check_exit_code` are unchanged.
 
         Args:
             cmd: Full argv including the binary path.
@@ -487,6 +539,7 @@ class CliTransport(ABC):
         Raises:
             AIProviderError: On timeout.
             AINotAvailableError: When the binary disappears from ``PATH``.
+            asyncio.CancelledError: Re-raised after the child is stopped.
         """
         env = os.environ.copy()
 
@@ -496,24 +549,42 @@ class CliTransport(ABC):
         )
 
         try:
-            return subprocess.run(  # nosec B603 - argv is an internally-built list run with shell=False; binary resolved from a known command, no user shell input
-                cmd,
-                input=input_text,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                check=False,
+            process = await asyncio.create_subprocess_exec(  # nosec B603 - argv is an internally-built list; exec form takes no shell
+                *cmd,
+                stdin=asyncio.subprocess.PIPE if input_text is not None else None,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
                 env=env,
                 cwd=cwd,
             )
-        except subprocess.TimeoutExpired as exc:
-            raise AIProviderError(
-                f"{self._binary_name} CLI timed out after {timeout:.0f}s",
-            ) from exc
         except FileNotFoundError as exc:
             raise AINotAvailableError(
                 f"{self._binary_name} CLI not found on PATH. {self._install_hint}",
             ) from exc
+
+        payload = input_text.encode() if input_text is not None else None
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                process.communicate(payload),
+                timeout=timeout,
+            )
+        except TimeoutError as exc:
+            await _terminate(process)
+            raise AIProviderError(
+                f"{self._binary_name} CLI timed out after {timeout:.0f}s",
+            ) from exc
+        except asyncio.CancelledError:
+            # A cancelled review (e.g. a sibling chunk failed) must not leave
+            # an agent CLI running against the repository.
+            await _terminate(process)
+            raise
+
+        return subprocess.CompletedProcess(
+            args=list(cmd),
+            returncode=process.returncode if process.returncode is not None else 0,
+            stdout=_decode(stdout_bytes),
+            stderr=_decode(stderr_bytes),
+        )
 
     def check_exit_code(
         self,

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -234,7 +234,7 @@ class CursorProvider(BaseAIProvider):
         self._session_id = None
         self._durable_repo_root = None
 
-    def complete(
+    async def complete(
         self,
         prompt: str,
         *,
@@ -299,7 +299,7 @@ class CursorProvider(BaseAIProvider):
                 OptionalArg(flag="--resume", values=(self._session_id,)),
             )
 
-        optional_args = self._cli.apply_optional_args(cmd, candidates)
+        optional_args = await self._cli.apply_optional_args(cmd, candidates)
 
         logger.debug(
             f"Cursor CLI request: model={effective_model}, "
@@ -309,7 +309,7 @@ class CursorProvider(BaseAIProvider):
         )
 
         effective_timeout = max(timeout, CURSOR_MIN_TIMEOUT)
-        result = self._cli.run_guarded(
+        result = await self._cli.run_guarded(
             cmd,
             optional_args=optional_args,
             input_text=combined_prompt,

--- a/lintro/ai/providers/openai.py
+++ b/lintro/ai/providers/openai.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -26,7 +26,7 @@ from lintro.ai.exceptions import (
 from lintro.ai.json_response import CliSchemaRequest
 from lintro.ai.providers.base import (
     AIResponse,
-    AIStreamResult,
+    AsyncAIStreamResult,
     BaseAIProvider,
     ProviderCapabilities,
 )
@@ -244,12 +244,12 @@ class OpenAIProvider(BaseAIProvider):
             api_key: The resolved API key.
 
         Returns:
-            openai.OpenAI: The API client.
+            openai.AsyncOpenAI: The async API client.
         """
         kwargs: dict[str, Any] = {"api_key": api_key}
         if self._base_url:
             kwargs["base_url"] = self._base_url
-        return openai.OpenAI(**kwargs)
+        return openai.AsyncOpenAI(**kwargs)
 
     def is_available(self) -> bool:
         """Return True when the configured transport is usable."""
@@ -277,7 +277,7 @@ class OpenAIProvider(BaseAIProvider):
             supports_streaming=True,
         )
 
-    def _complete_cli(
+    async def _complete_cli(
         self,
         prompt: str,
         *,
@@ -308,7 +308,7 @@ class OpenAIProvider(BaseAIProvider):
                 ),
             )
 
-        optional_args = self._cli.apply_optional_args(cmd, candidates)
+        optional_args = await self._cli.apply_optional_args(cmd, candidates)
         # The prompt is a trailing positional, so it must follow every flag.
         cmd.append(prompt)
 
@@ -316,7 +316,7 @@ class OpenAIProvider(BaseAIProvider):
             f"Codex CLI request: model={effective_model}, prompt_len={len(prompt)}",
         )
 
-        result = self._cli.run_guarded(
+        result = await self._cli.run_guarded(
             cmd,
             optional_args=optional_args,
             timeout=timeout,
@@ -329,7 +329,7 @@ class OpenAIProvider(BaseAIProvider):
         )
         return self._cli.parse_stdout(result.stdout)
 
-    def complete(
+    async def complete(
         self,
         prompt: str,
         *,
@@ -361,7 +361,7 @@ class OpenAIProvider(BaseAIProvider):
             combined = prompt
             if system:
                 combined = f"{system}\n\n---\n\n{prompt}"
-            return self._complete_cli(
+            return await self._complete_cli(
                 combined,
                 timeout=timeout,
                 repo_root=repo_root,
@@ -382,7 +382,7 @@ class OpenAIProvider(BaseAIProvider):
                 messages.append({"role": "system", "content": system})
             messages.append({"role": "user", "content": prompt})
 
-            response = client.chat.completions.create(
+            response = await client.chat.completions.create(
                 model=effective_model,
                 messages=messages,
                 max_tokens=effective_max,
@@ -408,7 +408,7 @@ class OpenAIProvider(BaseAIProvider):
                 provider=AIProvider.OPENAI,
             )
 
-    def stream_complete(
+    async def stream_complete(
         self,
         prompt: str,
         *,
@@ -416,7 +416,7 @@ class OpenAIProvider(BaseAIProvider):
         max_tokens: int = DEFAULT_PER_CALL_MAX_TOKENS,
         timeout: float = DEFAULT_TIMEOUT,
         model: str | None = None,
-    ) -> AIStreamResult:
+    ) -> AsyncAIStreamResult:
         """Stream a completion from the OpenAI API token-by-token.
 
         Args:
@@ -427,10 +427,10 @@ class OpenAIProvider(BaseAIProvider):
             model: Optional per-call model override.
 
         Returns:
-            An AIStreamResult wrapping the token stream.
+            An AsyncAIStreamResult wrapping the token stream.
         """
         if self._transport == AITransport.CLI:
-            return super().stream_complete(
+            return await super().stream_complete(
                 prompt,
                 system=system,
                 max_tokens=max_tokens,
@@ -454,9 +454,14 @@ class OpenAIProvider(BaseAIProvider):
         final_response: list[AIResponse] = []
         accumulated_text: list[str] = []
 
-        def _generate() -> Iterator[str]:
+        async def _generate() -> AsyncIterator[str]:
+            """Yield tokens from the OpenAI stream and capture usage.
+
+            Yields:
+                str: Content deltas in arrival order.
+            """
             with self._map_errors():
-                stream = client.chat.completions.create(
+                stream = await client.chat.completions.create(
                     model=effective_model,
                     messages=messages,
                     max_tokens=effective_max,
@@ -468,7 +473,7 @@ class OpenAIProvider(BaseAIProvider):
                 input_tokens = 0
                 output_tokens = 0
 
-                for chunk in stream:
+                async for chunk in stream:
                     if chunk.choices and chunk.choices[0].delta.content:
                         text = chunk.choices[0].delta.content
                         accumulated_text.append(text)
@@ -496,7 +501,7 @@ class OpenAIProvider(BaseAIProvider):
                 )
             return final_response[0]
 
-        return AIStreamResult(
+        return AsyncAIStreamResult(
             _chunks=_generate(),
             _on_done=_on_done,
         )

--- a/lintro/ai/refinement.py
+++ b/lintro/ai/refinement.py
@@ -66,7 +66,7 @@ def _revert_fix(
     return len(applied) > 0
 
 
-def refine_unverified_fixes(
+async def refine_unverified_fixes(
     *,
     applied_suggestions: list[AIFixSuggestion],
     validation: ValidationResult,
@@ -200,7 +200,7 @@ def refine_unverified_fixes(
 
         # Step 3: Generate refined fix
         try:
-            response = _call_fix_ai(
+            response = await _call_fix_ai(
                 provider=provider,
                 ai_config=ai_config,
                 prompt=prompt,

--- a/lintro/ai/retry.py
+++ b/lintro/ai/retry.py
@@ -1,15 +1,19 @@
-"""Retry decorator for AI API calls with exponential backoff.
+"""Async retry decorator for AI API calls with exponential backoff.
 
 Retries transient failures (network errors, rate limits) while
 immediately propagating permanent failures (authentication errors).
+
+The decorator wraps *coroutine functions*: backoff waits use
+``asyncio.sleep`` so a retrying call never blocks the event loop or the
+other AI calls running concurrently on it.
 """
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import random
-import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from loguru import logger
@@ -33,8 +37,13 @@ def with_retry(
     base_delay: float = DEFAULT_BASE_DELAY,
     max_delay: float = DEFAULT_MAX_DELAY,
     backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+) -> Callable[
+    [Callable[..., Awaitable[Any]]],
+    Callable[..., Awaitable[Any]],
+]:
     """Decorator for retrying AI API calls with exponential backoff and jitter.
+
+    Wraps a coroutine function and returns a coroutine function.
 
     Retries on ``AIProviderError`` and ``AIRateLimitError``.
     Does NOT retry on ``AIAuthenticationError`` (permanent failure).
@@ -73,14 +82,24 @@ def with_retry(
         raise ValueError(msg)
 
     def decorator(
-        func: Callable[..., Any],
-    ) -> Callable[..., Any]:
+        func: Callable[..., Awaitable[Any]],
+    ) -> Callable[..., Awaitable[Any]]:
+        """Wrap *func* with the configured retry loop.
+
+        Args:
+            func: The coroutine function to wrap.
+
+        Returns:
+            A coroutine function with retry behavior.
+        """
+
         @functools.wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            """Await the wrapped call, retrying transient failures."""
             last_exception: Exception | None = None
             for attempt in range(max_retries + 1):
                 try:
-                    return func(*args, **kwargs)
+                    return await func(*args, **kwargs)
                 except AIAuthenticationError:
                     raise  # Never retry auth errors
                 except (AIProviderError, AIRateLimitError) as e:
@@ -100,7 +119,7 @@ def with_retry(
                         f"AI retry {attempt + 1}/{max_retries}: {e}, "
                         f"waiting {delay:.1f}s",
                     )
-                    time.sleep(delay)
+                    await asyncio.sleep(delay)
             assert (
                 last_exception is not None
             ), "Retry loop exhausted without capturing an exception"

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import shlex
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import suppress
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
@@ -80,6 +80,7 @@ __all__ = [
     "parse_review_response",
     "resolve_review_chunks",
     "run_review",
+    "run_review_async",
     "strip_json_fences",
 ]
 _PROMPT_OVERHEAD_TOKENS = 12_000
@@ -245,7 +246,7 @@ def resolve_review_chunks(
     return chunking.chunks or [_single_chunk_from_context(context=context)]
 
 
-def _review_all_chunks(
+async def _review_all_chunks(
     *,
     chunks: list[ReviewChunk],
     context: ReviewContext,
@@ -273,9 +274,13 @@ def _review_all_chunks(
     recover the chunks reviewed so far if the run aborts mid-way (e.g. the cost
     cap is reached), enabling a graceful partial review instead of discarding
     all completed work.
+
+    Chunks are reviewed concurrently under a semaphore capped by
+    ``max_parallel_calls``; a ``ReviewExecutionError`` or a cost-cap stop
+    cancels the remaining work and propagates to ``run_review_async``.
     """
     if len(chunks) <= 1:
-        single = _review_chunk_with_progress(
+        single = await _review_chunk_with_progress(
             chunk_index=0,
             chunk=chunks[0],
             context=context,
@@ -309,7 +314,7 @@ def _review_all_chunks(
                 files=list(chunk.files),
             )
             try:
-                partial, next_id = _review_chunk(
+                partial, next_id = await _review_chunk(
                     chunk=chunk,
                     context=context,
                     provider=provider,
@@ -360,64 +365,87 @@ def _review_all_chunks(
     max_workers = min(len(chunks), effective_parallel)
     first_error: ReviewExecutionError | None = None
 
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {
-            executor.submit(
-                _review_chunk_with_progress,
-                chunk_index=chunk_index,
-                chunk=chunk,
-                context=context,
-                provider=provider,
-                ai_config=ai_config,
-                depth=depth,
-                checklist_text=checklist_text,
-                checklist_count=len(checklist_items),
-                classifications=classifications,
-                lint_results=lint_results,
-                budget=budget,
-                progress=StepTrackingProgress(progress),
-                total_chunks=len(chunks),
-                repo_root=repo_root,
-                use_one_shot=use_one_shot,
-                strictness_section=strictness_section,
-                diff_budget=diff_budget,
-            ): chunk_index
-            for chunk_index, chunk in enumerate(chunks)
-        }
+    # Bounded concurrency on the caller's event loop replaces the former thread
+    # pool: chunk reviews are provider I/O, so tasks under a semaphore keep the
+    # same ``max_parallel_calls`` ceiling without threads.
+    semaphore = asyncio.Semaphore(max_workers)
 
-        completed = 0
-        for future in as_completed(futures):
-            chunk_index = futures[future]
+    async def _run_chunk(
+        chunk_index: int,
+        chunk: ReviewChunk,
+    ) -> tuple[int, _ChunkReviewPartial | Exception]:
+        """Review one chunk, returning its index alongside the outcome.
+
+        Failures are returned rather than raised so the caller keeps the
+        chunk-to-outcome mapping that ``as_completed`` would otherwise lose.
+
+        Args:
+            chunk_index: Position of the chunk in the run.
+            chunk: The chunk to review.
+
+        Returns:
+            The chunk index paired with its partial or the exception raised.
+        """
+        async with semaphore:
             try:
-                chunk_partial = future.result()
-                partials[chunk_index] = chunk_partial
-                if completed_sink is not None:
-                    completed_sink.append(chunk_partial)
-                completed += 1
-            except ReviewExecutionError:
-                for pending in futures:
-                    pending.cancel()
-                raise
-            except AICostBudgetExceededError:
-                # Expected graceful stop from a top-of-chunk budget check:
-                # cancel remaining work and re-raise raw so run_review finalizes
-                # a partial rather than treating it as an aborting error.
-                for pending in futures:
-                    pending.cancel()
-                raise
+                return chunk_index, await _review_chunk_with_progress(
+                    chunk_index=chunk_index,
+                    chunk=chunk,
+                    context=context,
+                    provider=provider,
+                    ai_config=ai_config,
+                    depth=depth,
+                    checklist_text=checklist_text,
+                    checklist_count=len(checklist_items),
+                    classifications=classifications,
+                    lint_results=lint_results,
+                    budget=budget,
+                    progress=StepTrackingProgress(progress),
+                    total_chunks=len(chunks),
+                    repo_root=repo_root,
+                    use_one_shot=use_one_shot,
+                    strictness_section=strictness_section,
+                    diff_budget=diff_budget,
+                )
             except Exception as exc:
+                return chunk_index, exc
+
+    tasks = [
+        asyncio.ensure_future(_run_chunk(chunk_index, chunk))
+        for chunk_index, chunk in enumerate(chunks)
+    ]
+
+    completed = 0
+    try:
+        for finished in asyncio.as_completed(tasks):
+            chunk_index, outcome = await finished
+            if isinstance(outcome, (ReviewExecutionError, AICostBudgetExceededError)):
+                # A cost-cap stop is an expected graceful halt; a
+                # ReviewExecutionError is already wrapped for the caller.
+                # Both propagate raw so run_review can finalize a partial.
+                raise outcome
+            if isinstance(outcome, Exception):
                 if first_error is None:
                     first_error = _aborted_before_completion(
-                        cause=exc,
+                        cause=outcome,
                         provider=provider,
                         chunk_index=chunk_index,
                         total_chunks=len(chunks),
                         step="reviewing",
                         completed_chunks=completed,
                     )
-                for pending in futures:
-                    pending.cancel()
                 break
+            partials[chunk_index] = outcome
+            if completed_sink is not None:
+                completed_sink.append(outcome)
+            completed += 1
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        # Drain the cancellations so no chunk review (and no CLI child
+        # process) outlives this function.
+        await asyncio.gather(*tasks, return_exceptions=True)
 
     if first_error is not None:
         raise first_error
@@ -425,7 +453,7 @@ def _review_all_chunks(
     return [partial for partial in partials if partial is not None]
 
 
-def _review_chunk_with_progress(
+async def _review_chunk_with_progress(
     *,
     chunk_index: int,
     chunk: ReviewChunk,
@@ -446,11 +474,15 @@ def _review_chunk_with_progress(
     next_generated_checklist_id: int = 1,
     diff_budget: int = 0,
 ) -> _ChunkReviewPartial:
-    """Review one chunk with progress tracking and error wrapping."""
+    """Review one chunk with progress tracking and error wrapping.
+
+    A cost-cap stop is re-raised raw; any other failure is wrapped as a
+    ``ReviewExecutionError`` after the progress tracker is notified.
+    """
     budget.check()
     progress.on_chunk_start(chunk_index=chunk_index, files=list(chunk.files))
     try:
-        partial, _next_id = _review_chunk(
+        partial, _next_id = await _review_chunk(
             chunk=chunk,
             context=context,
             provider=provider,
@@ -496,6 +528,66 @@ def _review_chunk_with_progress(
 
 
 def run_review(
+    context: ReviewContext,
+    *,
+    provider: BaseAIProvider,
+    ai_config: AIConfig,
+    depth: int = 1,
+    checklist_items: list[ChecklistItem],
+    checklist_text: str,
+    classifications: list[FileClassification],
+    context_window_override: int | None = None,
+    lint_results: str | None = None,
+    progress: ReviewProgressCallback | None = None,
+    sensitivity: ReviewSensitivityPolicy | None = None,
+    force_semantic_chunking: bool = False,
+    timeout: float | None = None,
+) -> ReviewResult:
+    """Execute an AI diff review from synchronous code.
+
+    This is the sync/async boundary for ``lintro review``: the review
+    pipeline below it is async, and ``asyncio.run`` is entered exactly
+    once here so one event loop (and one provider client) serves the
+    whole review.
+
+    Args:
+        context: Collected review diff context.
+        provider: Configured AI provider instance.
+        ai_config: AI configuration for retries, budget, and fallbacks.
+        depth: Review depth level (1-3).
+        checklist_items: Selected checklist items for the review.
+        checklist_text: Pre-formatted checklist prompt text.
+        classifications: Domain classifications for changed files.
+        context_window_override: Optional explicit context window override.
+        lint_results: Optional lint digest for ``--with-lint`` integration.
+        progress: Optional progress callback for live status updates.
+        sensitivity: Sensitivity preset controlling prompts and filters.
+        force_semantic_chunking: When True, skip the single-chunk fast path.
+        timeout: Optional per-call timeout override in seconds.
+
+    Returns:
+        Complete review result with metadata, checklist, and findings.
+    """
+    return asyncio.run(
+        run_review_async(
+            context,
+            provider=provider,
+            ai_config=ai_config,
+            depth=depth,
+            checklist_items=checklist_items,
+            checklist_text=checklist_text,
+            classifications=classifications,
+            context_window_override=context_window_override,
+            lint_results=lint_results,
+            progress=progress,
+            sensitivity=sensitivity,
+            force_semantic_chunking=force_semantic_chunking,
+            timeout=timeout,
+        ),
+    )
+
+
+async def run_review_async(
     context: ReviewContext,
     *,
     provider: BaseAIProvider,
@@ -612,7 +704,7 @@ def run_review(
             provider.begin_durable_session(repo_root=repo_root)
             durable_session_started = True
         tracker.on_start(total_chunks=len(chunks), depth=depth)
-        partials = _review_all_chunks(
+        partials = await _review_all_chunks(
             chunks=chunks,
             context=context,
             provider=provider,
@@ -992,7 +1084,7 @@ def merge_review_results(
     )
 
 
-def _review_chunk(
+async def _review_chunk(
     *,
     chunk: ReviewChunk,
     context: ReviewContext,
@@ -1012,7 +1104,30 @@ def _review_chunk(
     strictness_section: str = "",
     diff_budget: int = 0,
 ) -> tuple[_ChunkReviewPartial, int]:
-    """Run depth-controlled review for a single chunk."""
+    """Run depth-controlled review for a single chunk.
+
+    Args:
+        chunk: The chunk to review.
+        context: Collected review diff context.
+        provider: Configured AI provider instance.
+        ai_config: AI configuration for retries, budget, and fallbacks.
+        depth: Review depth level (1-3).
+        checklist_text: Pre-formatted checklist prompt text.
+        checklist_count: Number of checklist items in the prompt.
+        next_generated_checklist_id: First id available to generated items.
+        classifications: Domain classifications for changed files.
+        lint_results: Optional lint digest for ``--with-lint`` integration.
+        budget: Session cost budget tracker.
+        progress: Optional progress callback for live status updates.
+        chunk_index: Position of the chunk in the run.
+        repo_root: Absolute path to the repository under review.
+        use_one_shot: When True, avoid durable provider sessions.
+        strictness_section: Pre-formatted strictness prompt section.
+        diff_budget: Token budget available for embedded diffs.
+
+    Returns:
+        The chunk partial and the next available generated checklist id.
+    """
     tracker = progress or NullReviewProgress()
     interaction_paths = generate_interaction_paths(
         classifications=classifications,
@@ -1026,7 +1141,7 @@ def _review_chunk(
             extra_checklist,
             next_generated_checklist_id,
             extra_checklist_usage,
-        ) = _generate_extra_checklist(
+        ) = await _generate_extra_checklist(
             chunk=chunk,
             context=context,
             provider=provider,
@@ -1067,7 +1182,7 @@ def _review_chunk(
             extra_checklist=extra_checklist,
             strictness_section=strictness_section,
         )
-    response = call_ai(
+    response = await call_ai(
         provider=provider,
         ai_config=ai_config,
         system_prompt=system_prompt,
@@ -1090,7 +1205,7 @@ def _review_chunk(
 
     if depth >= 3:
         tracker.on_step(chunk_index=chunk_index, step="adversarial sweep")
-        adversarial = _run_adversarial_pass(
+        adversarial = await _run_adversarial_pass(
             chunk=chunk,
             provider=provider,
             ai_config=ai_config,
@@ -1112,7 +1227,7 @@ def _review_chunk(
     return partial, next_generated_checklist_id
 
 
-def _generate_extra_checklist(
+async def _generate_extra_checklist(
     *,
     chunk: ReviewChunk,
     context: ReviewContext,
@@ -1123,7 +1238,21 @@ def _generate_extra_checklist(
     repo_root: str = "",
     use_one_shot: bool = False,
 ) -> tuple[str, int, _ChunkReviewPartial]:
-    """Generate depth-2 domain-specific checklist questions."""
+    """Generate depth-2 domain-specific checklist questions.
+
+    Args:
+        chunk: The chunk being reviewed.
+        context: Collected review diff context.
+        provider: Configured AI provider instance.
+        ai_config: AI configuration for retries, budget, and fallbacks.
+        budget: Session cost budget tracker.
+        next_generated_checklist_id: First id available to generated items.
+        repo_root: Absolute path to the repository under review.
+        use_one_shot: When True, avoid durable provider sessions.
+
+    Returns:
+        The generated checklist text, the next available id, and usage.
+    """
     changed_files = format_changed_files_for_prompt(
         files=[file for file in context.changed_files if file.path in chunk.files],
     )
@@ -1132,7 +1261,7 @@ def _generate_extra_checklist(
         changed_files=changed_files,
     )
     budget.check()
-    response = call_ai(
+    response = await call_ai(
         provider=provider,
         ai_config=ai_config,
         system_prompt="You generate review checklist questions.",
@@ -1176,7 +1305,7 @@ def _generate_extra_checklist(
     return "\n".join(lines), next_id, usage
 
 
-def _run_adversarial_pass(
+async def _run_adversarial_pass(
     *,
     chunk: ReviewChunk,
     provider: BaseAIProvider,
@@ -1186,7 +1315,20 @@ def _run_adversarial_pass(
     repo_root: str = "",
     use_one_shot: bool = False,
 ) -> _ChunkReviewPartial:
-    """Run depth-3 adversarial sweep for missed findings."""
+    """Run depth-3 adversarial sweep for missed findings.
+
+    Args:
+        chunk: The chunk being reviewed.
+        provider: Configured AI provider instance.
+        ai_config: AI configuration for retries, budget, and fallbacks.
+        prior_findings: Findings already reported for this chunk.
+        budget: Session cost budget tracker.
+        repo_root: Absolute path to the repository under review.
+        use_one_shot: When True, avoid durable provider sessions.
+
+    Returns:
+        A partial carrying any additional findings and usage.
+    """
     prior_json = json.dumps(
         [
             {
@@ -1203,7 +1345,7 @@ def _run_adversarial_pass(
         diff=_redact_prompt_text(text=chunk.diff, source="diff"),
     )
     budget.check()
-    response = call_ai(
+    response = await call_ai(
         provider=provider,
         ai_config=ai_config,
         system_prompt=REVIEW_SYSTEM,

--- a/lintro/ai/summary.py
+++ b/lintro/ai/summary.py
@@ -242,7 +242,7 @@ def _parse_summary_response(
     )
 
 
-def _call_summary_provider(
+async def _call_summary_provider(
     prompt: str,
     *,
     provider: BaseAIProvider,
@@ -250,9 +250,20 @@ def _call_summary_provider(
     max_tokens: int,
     workspace_root: Path | None,
 ) -> AISummary | None:
-    """Shared call/parse helper for summary generation."""
+    """Shared call/parse helper for summary generation.
+
+    Args:
+        prompt: The fully built summary prompt.
+        provider: AI provider instance.
+        ai_config: AI configuration for retry, transport, and fallback.
+        max_tokens: Maximum tokens to request.
+        workspace_root: Optional workspace root forwarded as repo root.
+
+    Returns:
+        The parsed summary, or None when the call or parse fails.
+    """
     try:
-        response = call_ai(
+        response = await call_ai(
             provider=provider,
             ai_config=ai_config,
             user_prompt=prompt,
@@ -273,7 +284,7 @@ def _call_summary_provider(
         return None
 
 
-def generate_summary(
+async def generate_summary(
     results: Sequence[ToolResult],
     provider: BaseAIProvider,
     *,
@@ -340,7 +351,7 @@ def generate_summary(
         fallback_models=fallback_models,
     )
 
-    return _call_summary_provider(
+    return await _call_summary_provider(
         prompt,
         provider=provider,
         ai_config=effective_config,
@@ -349,7 +360,7 @@ def generate_summary(
     )
 
 
-def generate_post_fix_summary(
+async def generate_post_fix_summary(
     *,
     applied: int,
     rejected: int,
@@ -427,7 +438,7 @@ def generate_post_fix_summary(
         fallback_models=fallback_models,
     )
 
-    return _call_summary_provider(
+    return await _call_summary_provider(
         prompt,
         provider=provider,
         ai_config=effective_config,

--- a/lintro/tools/definitions/idiom_review.py
+++ b/lintro/tools/definitions/idiom_review.py
@@ -19,6 +19,7 @@ skipped result rather than failing the run.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import cast
 
@@ -234,27 +235,18 @@ class IdiomReviewPlugin(BaseToolPlugin):
             IdiomReviewMode.BOTH.value,
         )
 
-        scoped = files[:max_files]
-        issues: list[IdiomReviewIssue] = []
-        signatures: list[Signature] = []
-
-        for file_path in scoped:
-            source = self._read_source(file_path)
-            if source is None:
-                continue
-            if run_per_file:
-                issues.extend(
-                    engine.review_file(
-                        file_path=file_path,
-                        source=source,
-                        language=language,
-                    ),
-                )
-            if run_dupe:
-                signatures.extend(extract_python_signatures(file_path, source))
-
-        if run_dupe:
-            issues.extend(engine.review_duplication(signatures))
+        # The engine is async end to end; this tool runs inside the
+        # synchronous plugin protocol, so ``asyncio.run`` is entered once
+        # here for the whole review rather than per provider call.
+        issues = asyncio.run(
+            self._collect_issues(
+                engine=engine,
+                scoped=files[:max_files],
+                run_per_file=run_per_file,
+                run_dupe=run_dupe,
+                language=language,
+            ),
+        )
 
         min_rank = _confidence_rank(min_conf)
         filtered = [i for i in issues if _confidence_rank(i.confidence) >= min_rank]
@@ -266,6 +258,50 @@ class IdiomReviewPlugin(BaseToolPlugin):
             issues_count=len(filtered),
             issues=filtered,
         )
+
+    async def _collect_issues(
+        self,
+        *,
+        engine: IdiomReviewEngine,
+        scoped: list[str],
+        run_per_file: bool,
+        run_dupe: bool,
+        language: str,
+    ) -> list[IdiomReviewIssue]:
+        """Drive the async engine over the scoped files.
+
+        Args:
+            engine: Configured idiom-review engine.
+            scoped: Absolute paths of files to review.
+            run_per_file: Whether to run the per-file review mode.
+            run_dupe: Whether to run the cross-file duplication mode.
+            language: Target language for the per-file prompts.
+
+        Returns:
+            All issues reported across the requested modes.
+        """
+        issues: list[IdiomReviewIssue] = []
+        signatures: list[Signature] = []
+
+        for file_path in scoped:
+            source = self._read_source(file_path)
+            if source is None:
+                continue
+            if run_per_file:
+                issues.extend(
+                    await engine.review_file(
+                        file_path=file_path,
+                        source=source,
+                        language=language,
+                    ),
+                )
+            if run_dupe:
+                signatures.extend(extract_python_signatures(file_path, source))
+
+        if run_dupe:
+            issues.extend(await engine.review_duplication(signatures))
+
+        return issues
 
     @staticmethod
     def _read_source(file_path: str) -> str | None:

--- a/lintro/tools/idiom_review/engine.py
+++ b/lintro/tools/idiom_review/engine.py
@@ -118,14 +118,23 @@ class IdiomReviewEngine:
         except OSError as exc:
             logger.debug("[idiom-review] Failed to write cache: {}", exc)
 
-    def _complete(self, *, system: str, user: str, cache_key: str) -> str:
-        """Return the model response for a prompt, using the cache if set."""
+    async def _complete(self, *, system: str, user: str, cache_key: str) -> str:
+        """Return the model response for a prompt, using the cache if set.
+
+        Args:
+            system: System prompt for the call.
+            user: User prompt for the call.
+            cache_key: Key identifying the cached response.
+
+        Returns:
+            The model response text.
+        """
         cached = self._cache_get(cache_key)
         if cached is not None:
             logger.debug("[idiom-review] Cache hit for {}", cache_key)
             return cached
 
-        response = call_ai(
+        response = await call_ai(
             provider=self.provider,
             ai_config=self.ai_config,
             user_prompt=user,
@@ -137,7 +146,7 @@ class IdiomReviewEngine:
 
     # -- Public API --------------------------------------------------------
 
-    def review_file(
+    async def review_file(
         self,
         *,
         file_path: str,
@@ -162,10 +171,10 @@ class IdiomReviewEngine:
             language=language,
         )
         key = _cache_key(f"idiom:{language}", source)
-        content = self._complete(system=system, user=user, cache_key=key)
+        content = await self._complete(system=system, user=user, cache_key=key)
         return self.parser.parse_file_review(content, file_path)
 
-    def review_duplication(
+    async def review_duplication(
         self,
         signatures: list[Signature],
     ) -> list[IdiomReviewIssue]:
@@ -182,5 +191,5 @@ class IdiomReviewEngine:
             return []
         system, user = build_duplication_prompt(signature_map)
         key = _cache_key("idiom:duplication", signature_map)
-        content = self._complete(system=system, user=user, cache_key=key)
+        content = await self._complete(system=system, user=user, cache_key=key)
         return self.parser.parse_duplication_review(content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ dev = [
   "types-defusedxml>=0.7.0.20250822",
   "tomlkit>=0.13.3",
   "click-man>=0.5.1",
+  "pytest-asyncio>=1.3.0",
 ]
 build = ["nuitka>=2.8.9", "ordered-set>=4.1.0", "zstandard>=0.25.0"]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,10 @@ python_files = test_*.py
 python_functions = test_*
 timeout = 120
 timeout_method = thread
+# The AI provider layer is async end to end (issue #722); auto mode runs
+# plain `async def test_*` functions without per-test decorators.
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
 markers =
     docker_only: mark test as requiring Docker or Docker-specific dependencies
     slow: mark test as slow running (use @pytest.mark.timeout(300) if needed)

--- a/tests/unit/ai/conftest.py
+++ b/tests/unit/ai/conftest.py
@@ -134,11 +134,15 @@ def patch_cli_exec(**mock_kwargs: Any) -> Iterator[MagicMock]:
         ``transport_calls`` attribute records the ``CliTransport.run``
         arguments (``cmd``, ``input_text``, ``timeout``, ``cwd``) that the
         argv alone cannot show, since stdin and timeouts are applied after
-        the spawn.
+        the spawn. Its ``processes`` attribute records every spawned
+        :class:`_FakeProcess` so tests can assert on child lifecycle (for
+        example that a cancelled call actually killed the child).
     """
     recorder = MagicMock(**mock_kwargs)
     transport_calls: list[SimpleNamespace] = []
     recorder.transport_calls = transport_calls
+    processes: list[_FakeProcess] = []
+    recorder.processes = processes
     original_run = CliTransport.run
 
     async def _recording_run(
@@ -193,13 +197,17 @@ def patch_cli_exec(**mock_kwargs: Any) -> Iterator[MagicMock]:
         del spawn_kwargs
         result = recorder(list(argv))
         if result is HANG:
-            return _FakeProcess(None, hang=True)
+            hung_process = _FakeProcess(None, hang=True)
+            processes.append(hung_process)
+            return hung_process
         if not isinstance(result, subprocess.CompletedProcess):
             raise TypeError(
                 "patch_cli_exec needs a CompletedProcess result; "
                 f"got {type(result).__name__}",
             )
-        return _FakeProcess(result)
+        process = _FakeProcess(result)
+        processes.append(process)
+        return process
 
     with (
         patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),

--- a/tests/unit/ai/conftest.py
+++ b/tests/unit/ai/conftest.py
@@ -1,10 +1,16 @@
-"""Shared fixtures for AI tests."""
+"""Shared fixtures and doubles for AI tests."""
 
 from __future__ import annotations
 
+import asyncio
+import subprocess  # nosec B404 - only CompletedProcess objects are constructed here
 import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -12,8 +18,194 @@ from lintro.ai.config import AIConfig
 from lintro.ai.enums import AITransport
 from lintro.ai.models import AIFixSuggestion
 from lintro.ai.providers.base import AIResponse, BaseAIProvider
+from lintro.ai.providers.cli_transport import CliTransport
 from lintro.ai.registry import AIProvider
 from lintro.parsers.base_issue import BaseIssue
+
+
+def completed_process(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+    args: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Build a ``CompletedProcess`` stand-in for CLI transport tests.
+
+    Args:
+        returncode: Process exit code.
+        stdout: Process stdout.
+        stderr: Process stderr.
+        args: Argv the process was invoked with.
+
+    Returns:
+        A populated CompletedProcess.
+    """
+    return subprocess.CompletedProcess(
+        args=args or [],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+class _FakeProcess:
+    """Stand-in for ``asyncio.subprocess.Process``.
+
+    Replays a canned :class:`subprocess.CompletedProcess`, or hangs
+    forever when the test is exercising the timeout path.
+    """
+
+    def __init__(
+        self,
+        result: subprocess.CompletedProcess[str] | None,
+        *,
+        hang: bool = False,
+    ) -> None:
+        """Store the canned outcome.
+
+        Args:
+            result: Result to replay; ``None`` behaves like a clean exit.
+            hang: When True, ``communicate`` never returns so the caller's
+                timeout fires.
+        """
+        self._result = result
+        self._hang = hang
+        self.returncode: int | None = None
+        self.killed = False
+
+    async def communicate(
+        self,
+        payload: bytes | None = None,
+    ) -> tuple[bytes, bytes]:
+        """Return the canned stdout/stderr pair.
+
+        Args:
+            payload: Ignored stdin payload.
+
+        Returns:
+            Encoded ``(stdout, stderr)``.
+        """
+        del payload
+        if self._hang:
+            await asyncio.Event().wait()
+        stdout = (self._result.stdout or "") if self._result else ""
+        stderr = (self._result.stderr or "") if self._result else ""
+        self.returncode = self._result.returncode if self._result else 0
+        return stdout.encode(), stderr.encode()
+
+    def kill(self) -> None:
+        """Record that the transport killed the timed-out process."""
+        self.killed = True
+
+    async def wait(self) -> int:
+        """Reap the killed process.
+
+        Returns:
+            The exit code attributed to the kill.
+        """
+        self.returncode = -9
+        return -9
+
+
+#: Sentinel result telling the fake process to never return output, so the
+#: transport's own timeout fires.
+HANG = object()
+
+
+@contextmanager
+def patch_cli_exec(**mock_kwargs: Any) -> Iterator[MagicMock]:
+    """Patch ``asyncio.create_subprocess_exec`` for CLI transport tests.
+
+    The yielded ``MagicMock`` behaves exactly like a patched
+    ``subprocess.run``: configure it with ``return_value`` or
+    ``side_effect``, and read recorded argv back as
+    ``mock.call_args.args[0]``. Only the spawn mechanism differs -- the
+    transport is async, so a fake process replays the configured
+    ``CompletedProcess``.
+
+    Args:
+        **mock_kwargs: Forwarded to the recording ``MagicMock`` (e.g.
+            ``return_value=...`` or ``side_effect=...``). Returning
+            :data:`HANG` makes that spawn hang so a timeout can be tested.
+
+    Yields:
+        MagicMock: The recording mock standing in for each spawn. Its extra
+        ``transport_calls`` attribute records the ``CliTransport.run``
+        arguments (``cmd``, ``input_text``, ``timeout``, ``cwd``) that the
+        argv alone cannot show, since stdin and timeouts are applied after
+        the spawn.
+    """
+    recorder = MagicMock(**mock_kwargs)
+    transport_calls: list[SimpleNamespace] = []
+    recorder.transport_calls = transport_calls
+    original_run = CliTransport.run
+
+    async def _recording_run(
+        transport: CliTransport,
+        cmd: list[str],
+        *,
+        input_text: str | None = None,
+        timeout: float,
+        cwd: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """Record the transport-level call, then run the real implementation.
+
+        Args:
+            transport: The transport instance under test.
+            cmd: Full argv including the binary path.
+            input_text: Optional stdin payload.
+            timeout: Subprocess timeout in seconds.
+            cwd: Optional working directory.
+
+        Returns:
+            Whatever the real ``CliTransport.run`` returns.
+        """
+        transport_calls.append(
+            SimpleNamespace(
+                cmd=list(cmd),
+                input_text=input_text,
+                timeout=timeout,
+                cwd=cwd,
+            ),
+        )
+        return await original_run(
+            transport,
+            cmd,
+            input_text=input_text,
+            timeout=timeout,
+            cwd=cwd,
+        )
+
+    async def _fake_exec(*argv: str, **spawn_kwargs: Any) -> _FakeProcess:
+        """Spawn a fake process, recording the argv.
+
+        Args:
+            *argv: The command argv.
+            **spawn_kwargs: Ignored spawn keyword arguments.
+
+        Returns:
+            A fake process replaying the configured outcome.
+
+        Raises:
+            TypeError: When the configured result is not a CompletedProcess.
+        """
+        del spawn_kwargs
+        result = recorder(list(argv))
+        if result is HANG:
+            return _FakeProcess(None, hang=True)
+        if not isinstance(result, subprocess.CompletedProcess):
+            raise TypeError(
+                "patch_cli_exec needs a CompletedProcess result; "
+                f"got {type(result).__name__}",
+            )
+        return _FakeProcess(result)
+
+    with (
+        patch("asyncio.create_subprocess_exec", side_effect=_fake_exec),
+        patch.object(CliTransport, "run", _recording_run),
+    ):
+        yield recorder
 
 
 class MockAIProvider(BaseAIProvider):
@@ -48,7 +240,7 @@ class MockAIProvider(BaseAIProvider):
         """Return a mock client."""
         return None
 
-    def complete(
+    async def complete(
         self,
         prompt: str,
         *,
@@ -60,7 +252,21 @@ class MockAIProvider(BaseAIProvider):
         model: str | None = None,
         cli_schema: object | None = None,
     ) -> AIResponse:
-        """Return the next queued response or a default."""
+        """Return the next queued response or a default.
+
+        Args:
+            prompt: The user prompt.
+            system: Optional system prompt.
+            max_tokens: Maximum tokens to generate.
+            timeout: Request timeout in seconds.
+            repo_root: Optional repository root.
+            use_one_shot: When True, avoid durable sessions.
+            model: Optional per-call model override.
+            cli_schema: Optional native CLI JSON schema request.
+
+        Returns:
+            The next queued response, or a generic default.
+        """
         with self._lock:
             self.calls.append(
                 {

--- a/tests/unit/ai/providers/test_anthropic.py
+++ b/tests/unit/ai/providers/test_anthropic.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from assertpy import assert_that
@@ -138,7 +138,7 @@ def test_anthropic_provider_get_client_no_key_raises():
             provider._get_client()
 
 
-def test_anthropic_complete_parses_response():
+async def test_anthropic_complete_parses_response():
     """complete() extracts content, tokens, and cost from SDK response."""
     with patch.object(mod, "_has_anthropic", True):
         provider = AnthropicProvider()
@@ -156,11 +156,11 @@ def test_anthropic_complete_parses_response():
         mock_response.usage = mock_usage
 
         mock_client = MagicMock()
-        mock_client.messages.create.return_value = mock_response
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
         provider._client = mock_client
 
         with patch.dict("os.environ", {"TEST_KEY": "sk-test"}):
-            result = provider.complete("test prompt", system="be helpful")
+            result = await provider.complete("test prompt", system="be helpful")
 
         assert_that(result.content).is_equal_to("Hello, world!")
         assert_that(result.input_tokens).is_equal_to(100)
@@ -175,7 +175,7 @@ def test_anthropic_complete_parses_response():
         )
 
 
-def test_anthropic_complete_multiple_text_blocks():
+async def test_anthropic_complete_multiple_text_blocks():
     """complete() concatenates multiple text blocks."""
     with patch.object(mod, "_has_anthropic", True):
         provider = AnthropicProvider()
@@ -194,16 +194,16 @@ def test_anthropic_complete_multiple_text_blocks():
         mock_response.usage = mock_usage
 
         mock_client = MagicMock()
-        mock_client.messages.create.return_value = mock_response
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
         provider._client = mock_client
 
         with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-test"}):
-            result = provider.complete("prompt")
+            result = await provider.complete("prompt")
 
         assert_that(result.content).is_equal_to("Hello, world!")
 
 
-def test_anthropic_complete_respects_max_tokens_cap():
+async def test_anthropic_complete_respects_max_tokens_cap():
     """complete() uses the lower of per-call and provider-level max_tokens."""
     with patch.object(mod, "_has_anthropic", True):
         provider = AnthropicProvider(max_tokens=2048)
@@ -217,11 +217,11 @@ def test_anthropic_complete_respects_max_tokens_cap():
         mock_response.usage = mock_usage
 
         mock_client = MagicMock()
-        mock_client.messages.create.return_value = mock_response
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
         provider._client = mock_client
 
         with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-test"}):
-            provider.complete("prompt", max_tokens=4096)
+            await provider.complete("prompt", max_tokens=4096)
 
         call_kwargs = mock_client.messages.create.call_args[1]
         assert_that(call_kwargs["max_tokens"]).is_equal_to(2048)

--- a/tests/unit/ai/providers/test_base.py
+++ b/tests/unit/ai/providers/test_base.py
@@ -34,7 +34,7 @@ def test_ai_response_with_all_fields():
     assert_that(resp.cost_estimate).is_equal_to(0.005)
 
 
-def test_base_ai_provider_complete_subclass():
+async def test_base_ai_provider_complete_subclass():
     """A complete BaseAIProvider subclass can be instantiated."""
 
     class TestProvider(BaseAIProvider):
@@ -50,7 +50,7 @@ def test_base_ai_provider_complete_subclass():
         def _create_client(self, *, api_key: str) -> object:
             return None
 
-        def complete(
+        async def complete(
             self,
             prompt: str,
             *,
@@ -62,6 +62,21 @@ def test_base_ai_provider_complete_subclass():
             model: str | None = None,
             cli_schema: CliSchemaRequest | None = None,
         ) -> AIResponse:
+            """Return a canned response.
+
+            Args:
+                prompt: Ignored user prompt.
+                system: Ignored system prompt.
+                max_tokens: Ignored token cap.
+                timeout: Ignored timeout.
+                repo_root: Ignored repository root.
+                use_one_shot: Ignored session flag.
+                model: Ignored model override.
+                cli_schema: Ignored schema request.
+
+            Returns:
+                A canned response.
+            """
             del model, cli_schema
             return AIResponse(
                 content="ok",
@@ -72,7 +87,7 @@ def test_base_ai_provider_complete_subclass():
     assert_that(provider.name).is_equal_to("test")
     assert_that(provider.model_name).is_equal_to("test-model")
 
-    result = provider.complete("hello")
+    result = await provider.complete("hello")
     assert_that(result.content).is_equal_to("ok")
 
 

--- a/tests/unit/ai/providers/test_cli_capability_guard.py
+++ b/tests/unit/ai/providers/test_cli_capability_guard.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import subprocess  # nosec B404 - CompletedProcess objects are constructed to drive the transport under test
-from unittest.mock import patch
 
 import pytest
 from assertpy import assert_that
 
-from lintro.ai.exceptions import AINotAvailableError
+from lintro.ai.exceptions import AINotAvailableError, AIProviderError
 from lintro.ai.provider_enum import AIProvider
 from lintro.ai.providers.cli_contracts import (
     CLI_CONTRACTS,
@@ -17,6 +17,13 @@ from lintro.ai.providers.cli_contracts import (
     format_version,
 )
 from lintro.ai.providers.cli_transport import CliTransport, OptionalArg
+from tests.unit.ai.conftest import (
+    HANG,
+    patch_cli_exec,
+)
+from tests.unit.ai.conftest import (
+    completed_process as _completed,
+)
 
 _TEST_CONTRACT = CliContract(
     binary="fake",
@@ -43,32 +50,6 @@ class _FakeTransport(CliTransport):
             The unmodified stdout.
         """
         return stdout
-
-
-def _completed(
-    *,
-    returncode: int = 0,
-    stdout: str = "",
-    stderr: str = "",
-    args: list[str] | None = None,
-) -> subprocess.CompletedProcess[str]:
-    """Build a CompletedProcess stand-in.
-
-    Args:
-        returncode: Process exit code.
-        stdout: Process stdout.
-        stderr: Process stderr.
-        args: Argv the process was invoked with.
-
-    Returns:
-        A populated CompletedProcess.
-    """
-    return subprocess.CompletedProcess(
-        args=args or [],
-        returncode=returncode,
-        stdout=stdout,
-        stderr=stderr,
-    )
 
 
 def _is_probe(cmd: list[str]) -> bool:
@@ -125,40 +106,39 @@ def test_format_version_renders_unknown() -> None:
     assert_that(format_version((2, 1, 218))).is_equal_to("2.1.218")
 
 
-def test_binary_version_probes_once(transport: _FakeTransport) -> None:
+async def test_binary_version_probes_once(transport: _FakeTransport) -> None:
     """Cache the version probe so repeated calls spawn one subprocess."""
-    with patch("subprocess.run", return_value=_completed(stdout="3.1.0")) as mock_run:
-        assert_that(transport.binary_version()).is_equal_to((3, 1, 0))
-        assert_that(transport.binary_version()).is_equal_to((3, 1, 0))
+    with patch_cli_exec(return_value=_completed(stdout="3.1.0")) as mock_run:
+        assert_that(await transport.binary_version()).is_equal_to((3, 1, 0))
+        assert_that(await transport.binary_version()).is_equal_to((3, 1, 0))
 
     assert_that(mock_run.call_count).is_equal_to(1)
 
 
-def test_binary_version_none_when_probe_fails(transport: _FakeTransport) -> None:
+async def test_binary_version_none_when_probe_fails(transport: _FakeTransport) -> None:
     """Report an unknown version when the probe cannot be spawned."""
-    with patch("subprocess.run", side_effect=PermissionError()):
-        assert_that(transport.binary_version()).is_none()
+    with patch_cli_exec(side_effect=PermissionError()):
+        assert_that(await transport.binary_version()).is_none()
 
 
-def test_binary_version_none_on_nonzero_probe(transport: _FakeTransport) -> None:
+async def test_binary_version_none_on_nonzero_probe(transport: _FakeTransport) -> None:
     """Distrust a non-zero --version exit."""
-    with patch(
-        "subprocess.run",
-        return_value=_completed(returncode=1, stdout="9.9.9"),
-    ):
-        assert_that(transport.binary_version()).is_none()
+    with patch_cli_exec(return_value=_completed(returncode=1, stdout="9.9.9")):
+        assert_that(await transport.binary_version()).is_none()
 
 
 # -- Version floor ----------------------------------------------------------
 
 
-def test_check_version_floor_raises_below_floor(transport: _FakeTransport) -> None:
+async def test_check_version_floor_raises_below_floor(
+    transport: _FakeTransport,
+) -> None:
     """Raise an actionable error when the binary predates the floor."""
     with (
-        patch("subprocess.run", return_value=_completed(stdout="1.9.9")),
+        patch_cli_exec(return_value=_completed(stdout="1.9.9")),
         pytest.raises(AINotAvailableError) as excinfo,
     ):
-        transport.check_version_floor()
+        await transport.check_version_floor()
 
     message = str(excinfo.value)
     assert_that(message).contains("1.9.9")
@@ -166,29 +146,31 @@ def test_check_version_floor_raises_below_floor(transport: _FakeTransport) -> No
     assert_that(message).contains("Upgrade the fake CLI.")
 
 
-def test_check_version_floor_accepts_floor_exactly(transport: _FakeTransport) -> None:
+async def test_check_version_floor_accepts_floor_exactly(
+    transport: _FakeTransport,
+) -> None:
     """Accept a binary sitting exactly on the floor."""
-    with patch("subprocess.run", return_value=_completed(stdout="2.0.0")):
-        transport.check_version_floor()
+    with patch_cli_exec(return_value=_completed(stdout="2.0.0")):
+        await transport.check_version_floor()
 
 
-def test_check_version_floor_allows_unknown_version(
+async def test_check_version_floor_allows_unknown_version(
     transport: _FakeTransport,
 ) -> None:
     """Never block on an unreadable version -- the other guards still apply."""
-    with patch("subprocess.run", return_value=_completed(stdout="mystery build")):
-        transport.check_version_floor()
+    with patch_cli_exec(return_value=_completed(stdout="mystery build")):
+        await transport.check_version_floor()
 
 
-def test_check_version_floor_is_inert_without_contract() -> None:
+async def test_check_version_floor_is_inert_without_contract() -> None:
     """Skip the floor check entirely for transports with no contract."""
     unguarded = _FakeTransport(
         binary_path="/usr/local/bin/fake",
         binary_name="Fake",
         install_hint="Install the fake CLI.",
     )
-    with patch("subprocess.run") as mock_run:
-        unguarded.check_version_floor()
+    with patch_cli_exec(return_value=_completed()) as mock_run:
+        await unguarded.check_version_floor()
 
     assert_that(mock_run.call_count).is_equal_to(0)
 
@@ -196,64 +178,72 @@ def test_check_version_floor_is_inert_without_contract() -> None:
 # -- Proactive --help gate --------------------------------------------------
 
 
-def test_supports_flag_true_when_advertised(transport: _FakeTransport) -> None:
+async def test_supports_flag_true_when_advertised(transport: _FakeTransport) -> None:
     """Report a flag supported when the help text advertises it."""
     help_text = "  --resume <id>  Resume a session\n"
-    with patch("subprocess.run", return_value=_completed(stdout=help_text)):
-        assert_that(transport.supports_flag("--resume")).is_true()
+    with patch_cli_exec(return_value=_completed(stdout=help_text)):
+        assert_that(await transport.supports_flag("--resume")).is_true()
 
 
-def test_supports_flag_false_when_absent(transport: _FakeTransport) -> None:
+async def test_supports_flag_false_when_absent(transport: _FakeTransport) -> None:
     """Report a flag unsupported when readable help text omits it."""
     help_text = "  --json-schema <schema>  Provide a JSON schema\n"
-    with patch("subprocess.run", return_value=_completed(stdout=help_text)):
-        assert_that(transport.supports_flag("--json-schema-name")).is_false()
+    with patch_cli_exec(return_value=_completed(stdout=help_text)):
+        assert_that(await transport.supports_flag("--json-schema-name")).is_false()
 
 
-def test_supports_flag_optimistic_on_nonzero_help(transport: _FakeTransport) -> None:
+async def test_supports_flag_optimistic_on_nonzero_help(
+    transport: _FakeTransport,
+) -> None:
     """Fall back to the backstop when --help exits non-zero."""
     result = _completed(returncode=1, stderr="error near --json-schema-name")
-    with patch("subprocess.run", return_value=result):
-        assert_that(transport.supports_flag("--json-schema-name")).is_true()
+    with patch_cli_exec(return_value=result):
+        assert_that(await transport.supports_flag("--json-schema-name")).is_true()
 
 
-def test_supports_flag_optimistic_when_probe_fails(transport: _FakeTransport) -> None:
+async def test_supports_flag_optimistic_when_probe_fails(
+    transport: _FakeTransport,
+) -> None:
     """Send the flag when help cannot be read, leaving it to the backstop."""
-    with patch("subprocess.run", side_effect=PermissionError()):
-        assert_that(transport.supports_flag("--resume")).is_true()
+    with patch_cli_exec(side_effect=PermissionError()):
+        assert_that(await transport.supports_flag("--resume")).is_true()
 
 
-def test_supports_flag_does_not_match_on_prefix(transport: _FakeTransport) -> None:
+async def test_supports_flag_does_not_match_on_prefix(
+    transport: _FakeTransport,
+) -> None:
     """A flag is not deemed supported by appearing inside a longer flag name.
 
     Help advertising only ``--json-schema-name`` must not report the prefix
     ``--json-schema`` as supported.
     """
     help_text = "  --json-schema-name <name>  Name the structured schema\n"
-    with patch("subprocess.run", return_value=_completed(stdout=help_text)):
-        assert_that(transport.supports_flag("--json-schema")).is_false()
-        assert_that(transport.supports_flag("--json-schema-name")).is_true()
+    with patch_cli_exec(return_value=_completed(stdout=help_text)):
+        assert_that(await transport.supports_flag("--json-schema")).is_false()
+        assert_that(await transport.supports_flag("--json-schema-name")).is_true()
 
 
-def test_supports_flag_caches_help_probe(transport: _FakeTransport) -> None:
+async def test_supports_flag_caches_help_probe(transport: _FakeTransport) -> None:
     """Probe --help once no matter how many flags are queried."""
     help_text = "  --resume <id>\n  --json-schema-name <name>\n"
-    with patch("subprocess.run", return_value=_completed(stdout=help_text)) as mock_run:
-        assert_that(transport.supports_flag("--resume")).is_true()
-        assert_that(transport.supports_flag("--json-schema-name")).is_true()
+    with patch_cli_exec(return_value=_completed(stdout=help_text)) as mock_run:
+        assert_that(await transport.supports_flag("--resume")).is_true()
+        assert_that(await transport.supports_flag("--json-schema-name")).is_true()
 
     assert_that(mock_run.call_count).is_equal_to(1)
 
 
-def test_filter_optional_args_drops_unadvertised(transport: _FakeTransport) -> None:
+async def test_filter_optional_args_drops_unadvertised(
+    transport: _FakeTransport,
+) -> None:
     """Keep only optional args the installed binary advertises."""
     help_text = "  --resume <id>  Resume a session\n"
     candidates = [
         OptionalArg(flag="--json-schema-name", values=("lintro_review",)),
         OptionalArg(flag="--resume", values=("abc123",)),
     ]
-    with patch("subprocess.run", return_value=_completed(stdout=help_text)):
-        kept = transport.filter_optional_args(candidates)
+    with patch_cli_exec(return_value=_completed(stdout=help_text)):
+        kept = await transport.filter_optional_args(candidates)
 
     assert_that([arg.flag for arg in kept]).is_equal_to(["--resume"])
 
@@ -267,7 +257,7 @@ def test_optional_arg_as_argv() -> None:
 # -- Reactive backstop ------------------------------------------------------
 
 
-def test_run_guarded_retries_without_rejected_flag(
+async def test_run_guarded_retries_without_rejected_flag(
     transport: _FakeTransport,
 ) -> None:
     """Drop a rejected optional flag and retry rather than failing the call."""
@@ -300,8 +290,8 @@ def test_run_guarded_retries_without_rejected_flag(
         "--model",
         "m",
     ]
-    with patch("subprocess.run", side_effect=fake_run):
-        result = transport.run_guarded(
+    with patch_cli_exec(side_effect=fake_run):
+        result = await transport.run_guarded(
             cmd,
             optional_args=optional_args,
             timeout=30.0,
@@ -316,7 +306,7 @@ def test_run_guarded_retries_without_rejected_flag(
     assert_that(retried).contains("m")
 
 
-def test_run_guarded_remembers_rejected_flag(transport: _FakeTransport) -> None:
+async def test_run_guarded_remembers_rejected_flag(transport: _FakeTransport) -> None:
     """Cache a backstop rejection so the flag is not sent again."""
 
     def fake_run(
@@ -335,16 +325,16 @@ def test_run_guarded_remembers_rejected_flag(transport: _FakeTransport) -> None:
         return _completed(stdout="done", args=cmd)
 
     optional_args = [OptionalArg(flag="--resume", values=("abc123",))]
-    with patch("subprocess.run", side_effect=fake_run):
-        transport.run_guarded(
+    with patch_cli_exec(side_effect=fake_run):
+        await transport.run_guarded(
             ["/usr/local/bin/fake", "--resume", "abc123"],
             optional_args=optional_args,
             timeout=30.0,
         )
-        assert_that(transport.supports_flag("--resume")).is_false()
+        assert_that(await transport.supports_flag("--resume")).is_false()
 
 
-def test_run_guarded_drops_flags_one_at_a_time(transport: _FakeTransport) -> None:
+async def test_run_guarded_drops_flags_one_at_a_time(transport: _FakeTransport) -> None:
     """Peel off each rejected optional flag until the call succeeds."""
     rejected: list[str] = []
 
@@ -376,8 +366,8 @@ def test_run_guarded_drops_flags_one_at_a_time(transport: _FakeTransport) -> Non
         "--resume",
         "abc123",
     ]
-    with patch("subprocess.run", side_effect=fake_run):
-        result = transport.run_guarded(
+    with patch_cli_exec(side_effect=fake_run):
+        result = await transport.run_guarded(
             cmd,
             optional_args=optional_args,
             timeout=30.0,
@@ -387,7 +377,7 @@ def test_run_guarded_drops_flags_one_at_a_time(transport: _FakeTransport) -> Non
     assert_that(rejected).is_equal_to(["--json-schema-name", "--resume"])
 
 
-def test_run_guarded_returns_unrelated_failure(transport: _FakeTransport) -> None:
+async def test_run_guarded_returns_unrelated_failure(transport: _FakeTransport) -> None:
     """Leave non-flag failures alone so callers map them to real errors."""
     calls: list[list[str]] = []
 
@@ -406,8 +396,8 @@ def test_run_guarded_returns_unrelated_failure(transport: _FakeTransport) -> Non
         )
 
     optional_args = [OptionalArg(flag="--resume", values=("abc123",))]
-    with patch("subprocess.run", side_effect=fake_run):
-        result = transport.run_guarded(
+    with patch_cli_exec(side_effect=fake_run):
+        result = await transport.run_guarded(
             ["/usr/local/bin/fake", "--resume", "abc123"],
             optional_args=optional_args,
             timeout=30.0,
@@ -418,7 +408,7 @@ def test_run_guarded_returns_unrelated_failure(transport: _FakeTransport) -> Non
     assert_that(completion_calls).is_length(1)
 
 
-def test_run_guarded_ignores_unknown_option_for_required_flag(
+async def test_run_guarded_ignores_unknown_option_for_required_flag(
     transport: _FakeTransport,
 ) -> None:
     """Do not retry when the rejected flag is not a declared optional one."""
@@ -436,8 +426,8 @@ def test_run_guarded_ignores_unknown_option_for_required_flag(
             args=cmd,
         )
 
-    with patch("subprocess.run", side_effect=fake_run):
-        result = transport.run_guarded(
+    with patch_cli_exec(side_effect=fake_run):
+        result = await transport.run_guarded(
             ["/usr/local/bin/fake", "--always"],
             optional_args=[],
             timeout=30.0,
@@ -446,19 +436,19 @@ def test_run_guarded_ignores_unknown_option_for_required_flag(
     assert_that(result.returncode).is_equal_to(1)
 
 
-def test_run_guarded_enforces_version_floor(transport: _FakeTransport) -> None:
+async def test_run_guarded_enforces_version_floor(transport: _FakeTransport) -> None:
     """Refuse to invoke a binary below the declared floor."""
     with (
-        patch("subprocess.run", return_value=_completed(stdout="1.0.0")),
+        patch_cli_exec(return_value=_completed(stdout="1.0.0")),
         pytest.raises(AINotAvailableError),
     ):
-        transport.run_guarded(
+        await transport.run_guarded(
             ["/usr/local/bin/fake", "--always"],
             timeout=30.0,
         )
 
 
-def test_run_guarded_matches_flag_on_token_boundary(
+async def test_run_guarded_matches_flag_on_token_boundary(
     transport: _FakeTransport,
 ) -> None:
     """Drop only the rejected flag, not a candidate that is its prefix.
@@ -495,8 +485,8 @@ def test_run_guarded_matches_flag_on_token_boundary(
         "--json-schema-name",
         "lintro_review",
     ]
-    with patch("subprocess.run", side_effect=fake_run):
-        result = transport.run_guarded(
+    with patch_cli_exec(side_effect=fake_run):
+        result = await transport.run_guarded(
             cmd,
             optional_args=optional_args,
             timeout=30.0,
@@ -507,6 +497,56 @@ def test_run_guarded_matches_flag_on_token_boundary(
     retried = [call for call in calls if not _is_probe(call)][-1]
     assert_that(retried).does_not_contain("--json-schema-name")
     assert_that(retried).contains("--json-schema", "{}")
+
+
+# -- Subprocess execution ---------------------------------------------------
+
+
+async def test_run_raises_provider_error_on_timeout(transport: _FakeTransport) -> None:
+    """Map a hung child process to an AIProviderError naming the timeout."""
+    with (
+        patch_cli_exec(return_value=HANG),
+        pytest.raises(AIProviderError, match="timed out after 0s"),
+    ):
+        await transport.run(["/usr/local/bin/fake", "--always"], timeout=0.01)
+
+
+async def test_run_raises_not_available_when_binary_missing(
+    transport: _FakeTransport,
+) -> None:
+    """Map a failed spawn to an actionable AINotAvailableError."""
+    with (
+        patch_cli_exec(side_effect=FileNotFoundError()),
+        pytest.raises(AINotAvailableError, match="Install the fake CLI."),
+    ):
+        await transport.run(["/usr/local/bin/fake", "--always"], timeout=5.0)
+
+
+async def test_run_kills_child_when_cancelled(transport: _FakeTransport) -> None:
+    """Cancelling a call stops the child instead of orphaning the CLI."""
+    with patch_cli_exec(return_value=HANG):
+        task = asyncio.ensure_future(
+            transport.run(["/usr/local/bin/fake", "--always"], timeout=60.0),
+        )
+        # Let the spawn happen before cancelling so a child exists to kill.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+async def test_run_decodes_stdout_and_stderr(transport: _FakeTransport) -> None:
+    """Return decoded stdout/stderr and the child exit code."""
+    with patch_cli_exec(
+        return_value=_completed(returncode=3, stdout="out", stderr="err"),
+    ):
+        result = await transport.run(["/usr/local/bin/fake"], timeout=5.0)
+
+    assert_that(result.returncode).is_equal_to(3)
+    assert_that(result.stdout).is_equal_to("out")
+    assert_that(result.stderr).is_equal_to("err")
 
 
 # -- Declared contracts -----------------------------------------------------

--- a/tests/unit/ai/providers/test_cli_capability_guard.py
+++ b/tests/unit/ai/providers/test_cli_capability_guard.py
@@ -524,7 +524,7 @@ async def test_run_raises_not_available_when_binary_missing(
 
 async def test_run_kills_child_when_cancelled(transport: _FakeTransport) -> None:
     """Cancelling a call stops the child instead of orphaning the CLI."""
-    with patch_cli_exec(return_value=HANG):
+    with patch_cli_exec(return_value=HANG) as mock_run:
         task = asyncio.ensure_future(
             transport.run(["/usr/local/bin/fake", "--always"], timeout=60.0),
         )
@@ -535,6 +535,9 @@ async def test_run_kills_child_when_cancelled(transport: _FakeTransport) -> None
 
         with pytest.raises(asyncio.CancelledError):
             await task
+
+    assert_that(mock_run.processes).is_length(1)
+    assert_that(mock_run.processes[0].killed).is_true()
 
 
 async def test_run_decodes_stdout_and_stderr(transport: _FakeTransport) -> None:

--- a/tests/unit/ai/providers/test_cli_flag_gating.py
+++ b/tests/unit/ai/providers/test_cli_flag_gating.py
@@ -20,6 +20,7 @@ from lintro.ai.json_response import CliSchemaRequest
 from lintro.ai.providers.anthropic import AnthropicProvider
 from lintro.ai.providers.cursor import CursorProvider
 from lintro.ai.providers.openai import OpenAIProvider
+from tests.unit.ai.conftest import patch_cli_exec
 
 _CLAUDE_COMPLETION = json.dumps(
     {
@@ -57,7 +58,7 @@ def _runner(
     reject: str | None = None,
     calls: list[list[str]],
 ) -> Callable[..., subprocess.CompletedProcess[str]]:
-    """Build a ``subprocess.run`` stand-in for a guarded CLI provider.
+    """Build a spawn stand-in for a guarded CLI provider.
 
     Args:
         help_text: Text returned for the ``--help`` capability probe.
@@ -67,7 +68,7 @@ def _runner(
         calls: Sink recording every argv the provider invoked.
 
     Returns:
-        A callable suitable for ``patch("subprocess.run", side_effect=...)``.
+        A callable suitable for ``patch_cli_exec(side_effect=...)``.
     """
 
     def _run(
@@ -149,7 +150,7 @@ def _codex_on_path() -> Iterator[None]:
 # -- Anthropic --------------------------------------------------------------
 
 
-def test_claude_sends_schema_name_when_advertised(_claude_on_path: None) -> None:
+async def test_claude_sends_schema_name_when_advertised(_claude_on_path: None) -> None:
     """Send --json-schema-name to a binary whose help advertises it."""
     calls: list[list[str]] = []
     runner = _runner(
@@ -159,14 +160,16 @@ def test_claude_sends_schema_name_when_advertised(_claude_on_path: None) -> None
         calls=calls,
     )
     provider = AnthropicProvider(transport=AITransport.CLI)
-    with patch("subprocess.run", side_effect=runner):
-        provider.complete("Review this diff", cli_schema=_SCHEMA)
+    with patch_cli_exec(side_effect=runner):
+        await provider.complete("Review this diff", cli_schema=_SCHEMA)
 
     cmd = _completion_calls(calls)[-1]
     assert_that(cmd).contains("--json-schema-name", "lintro_review")
 
 
-def test_claude_omits_schema_name_when_not_advertised(_claude_on_path: None) -> None:
+async def test_claude_omits_schema_name_when_not_advertised(
+    _claude_on_path: None,
+) -> None:
     """Keep --json-schema but omit --json-schema-name on a current claude.
 
     Regression for #1611: ``@anthropic-ai/claude-code`` 2.1.218 removed the
@@ -180,15 +183,17 @@ def test_claude_omits_schema_name_when_not_advertised(_claude_on_path: None) -> 
         calls=calls,
     )
     provider = AnthropicProvider(transport=AITransport.CLI)
-    with patch("subprocess.run", side_effect=runner):
-        provider.complete("Review this diff", cli_schema=_SCHEMA)
+    with patch_cli_exec(side_effect=runner):
+        await provider.complete("Review this diff", cli_schema=_SCHEMA)
 
     cmd = _completion_calls(calls)[-1]
     assert_that(cmd).does_not_contain("--json-schema-name")
     assert_that(cmd).contains("--json-schema")
 
 
-def test_claude_backstop_retries_without_schema_name(_claude_on_path: None) -> None:
+async def test_claude_backstop_retries_without_schema_name(
+    _claude_on_path: None,
+) -> None:
     """Retry without --json-schema-name when help lied about supporting it."""
     calls: list[list[str]] = []
     runner = _runner(
@@ -199,8 +204,8 @@ def test_claude_backstop_retries_without_schema_name(_claude_on_path: None) -> N
         calls=calls,
     )
     provider = AnthropicProvider(transport=AITransport.CLI)
-    with patch("subprocess.run", side_effect=runner):
-        response = provider.complete("Review this diff", cli_schema=_SCHEMA)
+    with patch_cli_exec(side_effect=runner):
+        response = await provider.complete("Review this diff", cli_schema=_SCHEMA)
 
     completions = _completion_calls(calls)
     assert_that(completions).is_length(2)
@@ -208,7 +213,7 @@ def test_claude_backstop_retries_without_schema_name(_claude_on_path: None) -> N
     assert_that(response.content).contains("summary")
 
 
-def test_claude_below_version_floor_raises(_claude_on_path: None) -> None:
+async def test_claude_below_version_floor_raises(_claude_on_path: None) -> None:
     """Refuse a claude binary older than the declared floor."""
     from lintro.ai.exceptions import AINotAvailableError
 
@@ -221,13 +226,13 @@ def test_claude_below_version_floor_raises(_claude_on_path: None) -> None:
     )
     provider = AnthropicProvider(transport=AITransport.CLI)
     with (
-        patch("subprocess.run", side_effect=runner),
+        patch_cli_exec(side_effect=runner),
         pytest.raises(AINotAvailableError, match="1.0.88"),
     ):
-        provider.complete("Review this diff")
+        await provider.complete("Review this diff")
 
 
-def test_claude_durable_session_hooks_reset_resume(_claude_on_path: None) -> None:
+async def test_claude_durable_session_hooks_reset_resume(_claude_on_path: None) -> None:
     """Resume within a durable session and drop the id when it ends."""
     calls: list[list[str]] = []
     runner = _runner(
@@ -237,15 +242,15 @@ def test_claude_durable_session_hooks_reset_resume(_claude_on_path: None) -> Non
         calls=calls,
     )
     provider = AnthropicProvider(transport=AITransport.CLI)
-    with patch("subprocess.run", side_effect=runner):
+    with patch_cli_exec(side_effect=runner):
         provider.begin_durable_session(repo_root="/tmp/repo")
-        provider.complete("first")
-        provider.complete("second")
+        await provider.complete("first")
+        await provider.complete("second")
         second = _completion_calls(calls)[1]
         assert_that(second).contains("--resume", "sess-123")
 
         provider.end_durable_session()
-        provider.complete("third")
+        await provider.complete("third")
         third = _completion_calls(calls)[2]
         assert_that(third).does_not_contain("--resume")
 
@@ -253,7 +258,7 @@ def test_claude_durable_session_hooks_reset_resume(_claude_on_path: None) -> Non
 # -- Cursor -----------------------------------------------------------------
 
 
-def test_cursor_omits_trust_when_not_advertised(_agent_on_path: None) -> None:
+async def test_cursor_omits_trust_when_not_advertised(_agent_on_path: None) -> None:
     """Drop --trust when the installed agent CLI does not advertise it."""
     calls: list[list[str]] = []
     runner = _runner(
@@ -263,15 +268,15 @@ def test_cursor_omits_trust_when_not_advertised(_agent_on_path: None) -> None:
         calls=calls,
     )
     provider = CursorProvider(cursor_trust_workspace=True)
-    with patch("subprocess.run", side_effect=runner):
-        provider.complete("Hello", repo_root="/tmp/repo")
+    with patch_cli_exec(side_effect=runner):
+        await provider.complete("Hello", repo_root="/tmp/repo")
 
     cmd = _completion_calls(calls)[-1]
     assert_that(cmd).does_not_contain("--trust")
     assert_that(cmd).contains("--workspace", "/tmp/repo")
 
 
-def test_cursor_backstop_retries_without_resume(_agent_on_path: None) -> None:
+async def test_cursor_backstop_retries_without_resume(_agent_on_path: None) -> None:
     """Retry without --resume when the agent CLI rejects it."""
     calls: list[list[str]] = []
     runner = _runner(
@@ -282,10 +287,10 @@ def test_cursor_backstop_retries_without_resume(_agent_on_path: None) -> None:
         calls=calls,
     )
     provider = CursorProvider()
-    with patch("subprocess.run", side_effect=runner):
+    with patch_cli_exec(side_effect=runner):
         provider.begin_durable_session(repo_root="/tmp/repo")
-        provider.complete("first", repo_root="/tmp/repo")
-        provider.complete("second", repo_root="/tmp/repo")
+        await provider.complete("first", repo_root="/tmp/repo")
+        await provider.complete("second", repo_root="/tmp/repo")
 
     completions = _completion_calls(calls)
     # first (no session yet) + second's --resume attempt + its retry = 3.
@@ -297,7 +302,7 @@ def test_cursor_backstop_retries_without_resume(_agent_on_path: None) -> None:
 # -- Codex ------------------------------------------------------------------
 
 
-def test_codex_sends_output_schema_when_advertised(_codex_on_path: None) -> None:
+async def test_codex_sends_output_schema_when_advertised(_codex_on_path: None) -> None:
     """Send --output-schema to a codex binary that advertises it."""
     calls: list[list[str]] = []
     runner = _runner(
@@ -307,8 +312,8 @@ def test_codex_sends_output_schema_when_advertised(_codex_on_path: None) -> None
         calls=calls,
     )
     provider = OpenAIProvider(transport=AITransport.CLI)
-    with patch("subprocess.run", side_effect=runner):
-        provider.complete("hello", repo_root="/tmp/repo", cli_schema=_SCHEMA)
+    with patch_cli_exec(side_effect=runner):
+        await provider.complete("hello", repo_root="/tmp/repo", cli_schema=_SCHEMA)
 
     cmd = _completion_calls(calls)[-1]
     assert_that(cmd).contains("--output-schema")
@@ -316,7 +321,9 @@ def test_codex_sends_output_schema_when_advertised(_codex_on_path: None) -> None
     assert_that(cmd[-1]).is_equal_to("hello")
 
 
-def test_codex_omits_output_schema_when_not_advertised(_codex_on_path: None) -> None:
+async def test_codex_omits_output_schema_when_not_advertised(
+    _codex_on_path: None,
+) -> None:
     """Fall back to prose parsing when codex has no --output-schema."""
     calls: list[list[str]] = []
     runner = _runner(
@@ -326,15 +333,17 @@ def test_codex_omits_output_schema_when_not_advertised(_codex_on_path: None) -> 
         calls=calls,
     )
     provider = OpenAIProvider(transport=AITransport.CLI)
-    with patch("subprocess.run", side_effect=runner):
-        provider.complete("hello", repo_root="/tmp/repo", cli_schema=_SCHEMA)
+    with patch_cli_exec(side_effect=runner):
+        await provider.complete("hello", repo_root="/tmp/repo", cli_schema=_SCHEMA)
 
     cmd = _completion_calls(calls)[-1]
     assert_that(cmd).does_not_contain("--output-schema")
     assert_that(cmd[-1]).is_equal_to("hello")
 
 
-def test_codex_backstop_retries_without_output_schema(_codex_on_path: None) -> None:
+async def test_codex_backstop_retries_without_output_schema(
+    _codex_on_path: None,
+) -> None:
     """Retry without --output-schema when codex rejects it."""
     calls: list[list[str]] = []
     runner = _runner(
@@ -345,8 +354,8 @@ def test_codex_backstop_retries_without_output_schema(_codex_on_path: None) -> N
         calls=calls,
     )
     provider = OpenAIProvider(transport=AITransport.CLI)
-    with patch("subprocess.run", side_effect=runner):
-        response = provider.complete(
+    with patch_cli_exec(side_effect=runner):
+        response = await provider.complete(
             "hello",
             repo_root="/tmp/repo",
             cli_schema=_SCHEMA,

--- a/tests/unit/ai/providers/test_openai.py
+++ b/tests/unit/ai/providers/test_openai.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from assertpy import assert_that
@@ -137,7 +137,7 @@ def test_openai_provider_get_client_no_key_raises():
             provider._get_client()
 
 
-def test_openai_complete_parses_response():
+async def test_openai_complete_parses_response():
     """complete() extracts content, tokens, and cost from SDK response."""
     with patch.object(mod, "_has_openai", True):
         provider = OpenAIProvider()
@@ -158,11 +158,11 @@ def test_openai_complete_parses_response():
         mock_response.usage = mock_usage
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
         provider._client = mock_client
 
         with patch.dict("os.environ", {"TEST_KEY": "sk-test"}):
-            result = provider.complete(
+            result = await provider.complete(
                 "test prompt",
                 system="be helpful",
             )
@@ -182,7 +182,7 @@ def test_openai_complete_parses_response():
         )
 
 
-def test_openai_complete_without_system_prompt():
+async def test_openai_complete_without_system_prompt():
     """complete() omits system message when system is None."""
     with patch.object(mod, "_has_openai", True):
         provider = OpenAIProvider()
@@ -202,11 +202,11 @@ def test_openai_complete_without_system_prompt():
         mock_response.usage = mock_usage
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
         provider._client = mock_client
 
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
-            provider.complete("prompt")
+            await provider.complete("prompt")
 
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert_that(call_kwargs["messages"]).is_equal_to(
@@ -214,7 +214,7 @@ def test_openai_complete_without_system_prompt():
         )
 
 
-def test_openai_complete_handles_none_usage():
+async def test_openai_complete_handles_none_usage():
     """complete() handles None usage gracefully (tokens default to 0)."""
     with patch.object(mod, "_has_openai", True):
         provider = OpenAIProvider()
@@ -230,17 +230,17 @@ def test_openai_complete_handles_none_usage():
         mock_response.usage = None
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
         provider._client = mock_client
 
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
-            result = provider.complete("prompt")
+            result = await provider.complete("prompt")
 
         assert_that(result.input_tokens).is_equal_to(0)
         assert_that(result.output_tokens).is_equal_to(0)
 
 
-def test_openai_complete_respects_max_tokens_cap():
+async def test_openai_complete_respects_max_tokens_cap():
     """complete() uses the lower of per-call and provider-level max_tokens."""
     with patch.object(mod, "_has_openai", True):
         provider = OpenAIProvider(max_tokens=2048)
@@ -258,11 +258,11 @@ def test_openai_complete_respects_max_tokens_cap():
         mock_response.usage = mock_usage
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
         provider._client = mock_client
 
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
-            provider.complete("prompt", max_tokens=4096)
+            await provider.complete("prompt", max_tokens=4096)
 
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert_that(call_kwargs["max_tokens"]).is_equal_to(2048)

--- a/tests/unit/ai/providers/test_stream.py
+++ b/tests/unit/ai/providers/test_stream.py
@@ -1,12 +1,19 @@
-"""Tests for AIStreamResult and BaseAIProvider.stream_complete()."""
+"""Tests for the sync and async AI stream results and stream_complete()."""
 
 from __future__ import annotations
+
+from collections.abc import AsyncIterator
 
 import pytest
 from assertpy import assert_that
 
 from lintro.ai.json_response import CliSchemaRequest
-from lintro.ai.providers.base import AIResponse, AIStreamResult, BaseAIProvider
+from lintro.ai.providers.base import (
+    AIResponse,
+    AIStreamResult,
+    AsyncAIStreamResult,
+    BaseAIProvider,
+)
 from lintro.ai.providers.constants import DEFAULT_PER_CALL_MAX_TOKENS, DEFAULT_TIMEOUT
 
 
@@ -26,7 +33,7 @@ class _StubProvider(BaseAIProvider):
     def _create_client(self, *, api_key: str) -> object:
         return "fake"
 
-    def complete(
+    async def complete(
         self,
         prompt: str,
         *,
@@ -38,6 +45,21 @@ class _StubProvider(BaseAIProvider):
         model: str | None = None,
         cli_schema: CliSchemaRequest | None = None,
     ) -> AIResponse:
+        """Return the canned response.
+
+        Args:
+            prompt: Ignored user prompt.
+            system: Ignored system prompt.
+            max_tokens: Ignored token cap.
+            timeout: Ignored timeout.
+            repo_root: Ignored repository root.
+            use_one_shot: Ignored session flag.
+            model: Ignored model override.
+            cli_schema: Ignored schema request.
+
+        Returns:
+            The canned response.
+        """
         del model, cli_schema
         return self._response
 
@@ -117,25 +139,25 @@ def test_stream_result_collect_various_chunk_patterns(
     assert_that(result.collect().content).is_equal_to(expected)
 
 
-def test_base_provider_stream_complete_delegates_to_complete() -> None:
+async def test_base_provider_stream_complete_delegates_to_complete() -> None:
     """Default stream_complete wraps complete() in a single-chunk stream."""
     resp = _make_response("delegated content")
     provider = _StubProvider(response=resp)
 
-    stream = provider.stream_complete("test prompt")
-    collected = stream.collect()
+    stream = await provider.stream_complete("test prompt")
+    collected = await stream.collect()
 
     assert_that(collected.content).is_equal_to("delegated content")
     assert_that(collected.model).is_equal_to("test-model")
     assert_that(collected.provider).is_equal_to("test")
 
 
-def test_base_provider_stream_complete_passes_kwargs() -> None:
+async def test_base_provider_stream_complete_passes_kwargs() -> None:
     """Default stream_complete forwards system/max_tokens/timeout to complete."""
     calls: list[dict[str, object]] = []
 
     class _CapturingProvider(_StubProvider):
-        def complete(
+        async def complete(
             self,
             prompt: str,
             *,
@@ -147,6 +169,21 @@ def test_base_provider_stream_complete_passes_kwargs() -> None:
             model: str | None = None,
             cli_schema: CliSchemaRequest | None = None,
         ) -> AIResponse:
+            """Record the call and return a canned response.
+
+            Args:
+                prompt: The user prompt.
+                system: Optional system prompt.
+                max_tokens: Token cap for the call.
+                timeout: Request timeout in seconds.
+                repo_root: Ignored repository root.
+                use_one_shot: Ignored session flag.
+                model: Optional model override.
+                cli_schema: Ignored schema request.
+
+            Returns:
+                A canned response.
+            """
             del cli_schema
             calls.append(
                 {
@@ -160,13 +197,13 @@ def test_base_provider_stream_complete_passes_kwargs() -> None:
             return _make_response()
 
     provider = _CapturingProvider(response=_make_response())
-    stream = provider.stream_complete(
+    stream = await provider.stream_complete(
         "my prompt",
         system="sys",
         max_tokens=512,
         timeout=30,
     )
-    list(stream)  # consume stream to trigger complete()
+    [chunk async for chunk in stream]  # consume the stream
 
     assert_that(calls).is_length(1)
     assert_that(calls[0]["prompt"]).is_equal_to("my prompt")
@@ -175,13 +212,13 @@ def test_base_provider_stream_complete_passes_kwargs() -> None:
     assert_that(calls[0]["timeout"]).is_equal_to(30)
 
 
-def test_base_provider_stream_complete_single_chunk_iteration() -> None:
+async def test_base_provider_stream_complete_single_chunk_iteration() -> None:
     """Default stream_complete yields exactly one chunk with the full content."""
     resp = _make_response("one shot")
     provider = _StubProvider(response=resp)
 
-    stream = provider.stream_complete("p")
-    chunks = list(stream)
+    stream = await provider.stream_complete("p")
+    chunks = [chunk async for chunk in stream]
 
     assert_that(chunks).is_equal_to(["one shot"])
 
@@ -201,3 +238,76 @@ def test_collect_raises_on_double_call() -> None:
     # Second call raises
     with pytest.raises(RuntimeError, match="already consumed"):
         result.collect()
+
+
+async def _achunks(chunks: list[str]) -> AsyncIterator[str]:
+    """Yield chunks from an async generator.
+
+    Args:
+        chunks: Text chunks to yield.
+
+    Yields:
+        str: Each chunk in order.
+    """
+    for chunk in chunks:
+        yield chunk
+
+
+async def test_async_stream_result_aiter_yields_chunks() -> None:
+    """Async iteration yields all provided chunks."""
+    resp = _make_response("foobarbaz")
+    result = AsyncAIStreamResult(
+        _chunks=_achunks(["foo", "bar", "baz"]),
+        _on_done=lambda: resp,
+    )
+
+    assert_that([chunk async for chunk in result]).is_equal_to(["foo", "bar", "baz"])
+
+
+async def test_async_stream_result_collect_concatenates() -> None:
+    """collect() joins chunks and carries usage metadata through."""
+    resp = _make_response("")
+    result = AsyncAIStreamResult(
+        _chunks=_achunks(["alpha", " ", "beta"]),
+        _on_done=lambda: resp,
+    )
+
+    collected = await result.collect()
+
+    assert_that(collected.content).is_equal_to("alpha beta")
+    assert_that(collected.model).is_equal_to("test-model")
+    assert_that(collected.input_tokens).is_equal_to(10)
+    assert_that(collected.output_tokens).is_equal_to(5)
+    assert_that(collected.provider).is_equal_to("test")
+
+
+async def test_async_stream_result_collect_empty_stream() -> None:
+    """collect() with no chunks returns empty content."""
+    resp = _make_response("")
+    result = AsyncAIStreamResult(_chunks=_achunks([]), _on_done=lambda: resp)
+
+    assert_that((await result.collect()).content).is_equal_to("")
+
+
+async def test_async_stream_result_response_returns_metadata() -> None:
+    """response() returns the AIResponse supplied by _on_done."""
+    resp = _make_response()
+    result = AsyncAIStreamResult(_chunks=_achunks([]), _on_done=lambda: resp)
+    [chunk async for chunk in result]
+
+    assert_that(result.response()).is_equal_to(resp)
+
+
+async def test_async_stream_result_collect_raises_on_double_call() -> None:
+    """collect() raises RuntimeError when called a second time."""
+    resp = _make_response("")
+    result = AsyncAIStreamResult(
+        _chunks=_achunks(["alpha", " ", "beta"]),
+        _on_done=lambda: resp,
+    )
+
+    collected = await result.collect()
+    assert_that(collected.content).is_equal_to("alpha beta")
+
+    with pytest.raises(RuntimeError, match="already consumed"):
+        await result.collect()

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
-import threading
-import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -481,7 +480,7 @@ def _single_file_context() -> ReviewContext:
     )
 
 
-def test_review_chunk_checks_budget_before_each_provider_call() -> None:
+async def test_review_chunk_checks_budget_before_each_provider_call() -> None:
     """Depth-3 review checks the budget before every intra-chunk call."""
     events: list[str] = []
     budget = CostBudget(max_cost_usd=None)
@@ -510,7 +509,7 @@ def test_review_chunk_checks_budget_before_each_provider_call() -> None:
             side_effect=_fake_call_ai,
         ),
     ):
-        _review_chunk(
+        await _review_chunk(
             chunk=_single_chunk(),
             context=_single_file_context(),
             provider=MagicMock(),
@@ -532,7 +531,7 @@ def test_review_chunk_checks_budget_before_each_provider_call() -> None:
             assert_that(events[index - 1]).is_equal_to("check")
 
 
-def test_review_chunk_budget_stops_runaway_calls() -> None:
+async def test_review_chunk_budget_stops_runaway_calls() -> None:
     """An exhausted budget halts the chunk before overspending on more calls."""
     calls: list[str] = []
     budget = CostBudget(max_cost_usd=0.01)
@@ -556,7 +555,7 @@ def test_review_chunk_budget_stops_runaway_calls() -> None:
         side_effect=_fake_call_ai,
     ):
         with pytest.raises(AIError):
-            _review_chunk(
+            await _review_chunk(
                 chunk=_single_chunk(),
                 context=_single_file_context(),
                 provider=MagicMock(),
@@ -646,20 +645,33 @@ def test_run_review_parallelizes_multiple_chunks(tmp_path: Path) -> None:
         for index in range(4)
     ]
     provider = _mock_provider(content=_sample_response_json(include_finding=False))
-    lock = threading.Lock()
     active = 0
     max_active = 0
 
-    def _track_concurrency(*, provider, user_prompt, **kwargs):
+    async def _track_concurrency(
+        *,
+        provider: MagicMock,
+        user_prompt: str,
+        **kwargs: object,
+    ) -> AIResponse:
+        """Record how many chunk reviews overlap on the event loop.
+
+        Args:
+            provider: The provider under review.
+            user_prompt: Ignored prompt text.
+            **kwargs: Ignored call arguments.
+
+        Returns:
+            The provider's canned response.
+        """
         del user_prompt, kwargs
         nonlocal active, max_active
-        with lock:
-            active += 1
-            max_active = max(max_active, active)
-        time.sleep(0.05)
-        with lock:
-            active -= 1
-        return provider.complete("prompt")
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.05)
+        active -= 1
+        response: AIResponse = provider.complete("prompt")
+        return response
 
     with (
         patch(

--- a/tests/unit/ai/test_async_retry.py
+++ b/tests/unit/ai/test_async_retry.py
@@ -1,0 +1,151 @@
+"""Async-specific behaviour of the AI retry decorator.
+
+Covers the properties that only exist once the retry loop is async:
+backoff yields to the event loop instead of blocking it, retries of
+concurrent calls interleave, and the "never retry authentication" rule
+still holds when calls run concurrently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.exceptions import (
+    AIAuthenticationError,
+    AIProviderError,
+    AIRateLimitError,
+)
+from lintro.ai.retry import with_retry
+
+
+async def test_retry_backoff_yields_to_event_loop() -> None:
+    """Verify a retrying call does not block other tasks on the loop."""
+    ticks: list[str] = []
+
+    @with_retry(max_retries=1, base_delay=0.05)
+    async def flaky() -> str:
+        """Fail once, then succeed.
+
+        Returns:
+            A fixed marker value.
+
+        Raises:
+            AIProviderError: On the first attempt.
+        """
+        if not ticks or ticks[0] != "other":
+            ticks.append("retrying")
+            raise AIProviderError("transient")
+        return "ok"
+
+    async def other() -> None:
+        """Record that an unrelated task ran during the backoff wait."""
+        await asyncio.sleep(0)
+        ticks.insert(0, "other")
+
+    results = await asyncio.gather(flaky(), other())
+    assert_that(results[0]).is_equal_to("ok")
+    assert_that(ticks).contains("other")
+
+
+async def test_retry_backoff_does_not_block_the_thread() -> None:
+    """Verify concurrent retrying calls wait in parallel, not in series."""
+    attempts: dict[int, int] = {}
+
+    @with_retry(max_retries=1, base_delay=0.2)
+    async def flaky(key: int) -> str:
+        """Fail once per key, then succeed.
+
+        Args:
+            key: Identifier for the concurrent call.
+
+        Returns:
+            A fixed marker value.
+
+        Raises:
+            AIRateLimitError: On the first attempt for each key.
+        """
+        attempts[key] = attempts.get(key, 0) + 1
+        if attempts[key] == 1:
+            raise AIRateLimitError("slow down")
+        return "ok"
+
+    started = time.monotonic()
+    results = await asyncio.gather(*(flaky(key) for key in range(4)))
+    elapsed = time.monotonic() - started
+
+    assert_that(results).is_equal_to(["ok"] * 4)
+    # Serial blocking sleeps would need ~0.8s; concurrent waits need ~0.2s.
+    assert_that(elapsed).is_less_than(0.6)
+
+
+async def test_auth_error_is_never_retried_under_concurrency() -> None:
+    """Verify AIAuthenticationError fails fast even with concurrent callers."""
+    calls: list[int] = []
+
+    @with_retry(max_retries=3, base_delay=0.01)
+    async def unauthorized(key: int) -> str:
+        """Always fail with an authentication error.
+
+        Args:
+            key: Identifier for the concurrent call.
+
+        Returns:
+            Never returns.
+
+        Raises:
+            AIAuthenticationError: Always.
+        """
+        calls.append(key)
+        raise AIAuthenticationError("bad key")
+
+    outcomes = await asyncio.gather(
+        *(unauthorized(key) for key in range(3)),
+        return_exceptions=True,
+    )
+
+    assert_that(calls).is_length(3)
+    for outcome in outcomes:
+        assert_that(outcome).is_instance_of(AIAuthenticationError)
+
+
+async def test_retry_wrapper_is_a_coroutine_function() -> None:
+    """Verify the decorator returns an awaitable wrapper, not a sync callable."""
+
+    @with_retry(max_retries=0)
+    async def fn() -> str:
+        """Succeed immediately.
+
+        Returns:
+            A fixed marker value.
+        """
+        return "ok"
+
+    assert_that(asyncio.iscoroutinefunction(fn)).is_true()
+    assert_that(await fn()).is_equal_to("ok")
+
+
+async def test_retry_propagates_cancellation() -> None:
+    """Verify cancelling a retrying call is not swallowed as a failure."""
+
+    @with_retry(max_retries=5, base_delay=10.0)
+    async def always_failing() -> str:
+        """Always fail so the wrapper enters its backoff wait.
+
+        Returns:
+            Never returns.
+
+        Raises:
+            AIProviderError: Always.
+        """
+        raise AIProviderError("transient")
+
+    task = asyncio.ensure_future(always_failing())
+    await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/unit/ai/test_budget.py
+++ b/tests/unit/ai/test_budget.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
-import time
 
 import pytest
 from assertpy import assert_that
@@ -120,30 +120,27 @@ def test_thread_safety_concurrent_records() -> None:
     assert_that(budget.spent).is_close_to(expected, tolerance=1e-9)
 
 
-def test_execute_serializes_budgeted_calls() -> None:
+async def test_execute_serializes_budgeted_calls() -> None:
     """execute() holds the budget lock for the full call to avoid races."""
     budget = CostBudget(max_cost_usd=10.0)
-    active_lock = threading.Lock()
     active = 0
     max_active = 0
 
-    def tracked_call() -> float:
+    async def tracked_call() -> float:
+        """Track concurrent entries into the budgeted section.
+
+        Returns:
+            The cost attributed to this call.
+        """
         nonlocal active, max_active
-        with active_lock:
-            active += 1
-            max_active = max(max_active, active)
-        time.sleep(0.05)
-        with active_lock:
-            active -= 1
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.05)
+        active -= 1
         return 0.01
 
-    def worker() -> None:
-        budget.execute(tracked_call, cost_of=lambda cost: cost)
-
-    threads = [threading.Thread(target=worker) for _ in range(4)]
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join()
+    await asyncio.gather(
+        *(budget.execute(tracked_call, cost_of=lambda cost: cost) for _ in range(4)),
+    )
 
     assert_that(max_active).is_equal_to(1)

--- a/tests/unit/ai/test_claude_cli_provider.py
+++ b/tests/unit/ai/test_claude_cli_provider.py
@@ -14,6 +14,7 @@ from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import AIAuthenticationError, AINotAvailableError
 from lintro.ai.providers.anthropic import AnthropicProvider, _find_claude
 from lintro.ai.registry import AIProvider
+from tests.unit.ai.conftest import patch_cli_exec
 
 
 @pytest.fixture()
@@ -65,21 +66,21 @@ class TestClaudeCliInit:
 class TestClaudeCliComplete:
     """Tests for claude -p completions."""
 
-    def test_success(self, _mock_claude_on_path: None) -> None:
+    async def test_success(self, _mock_claude_on_path: None) -> None:
         """Parse JSON output from a successful claude -p invocation."""
         provider = AnthropicProvider(
             model="claude-sonnet-4-6",
             transport=AITransport.CLI,
         )
         stdout = _cli_json(result='{"summary": "ok"}')
-        with patch("subprocess.run") as mock_run:
+        with patch_cli_exec() as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=[],
                 returncode=0,
                 stdout=stdout,
                 stderr="",
             )
-            response = provider.complete("Review this diff", system="Be concise")
+            response = await provider.complete("Review this diff", system="Be concise")
 
         assert_that(response.content).contains("summary")
         assert_that(response.provider).is_equal_to(AIProvider.ANTHROPIC)
@@ -88,7 +89,10 @@ class TestClaudeCliComplete:
         assert_that(cmd).contains("--append-system-prompt", "Be concise")
         assert_that(cmd).contains("--model", "claude-sonnet-4-6")
 
-    def test_cli_schema_flag_when_requested(self, _mock_claude_on_path: None) -> None:
+    async def test_cli_schema_flag_when_requested(
+        self,
+        _mock_claude_on_path: None,
+    ) -> None:
         """Pass --json-schema when cli_schema is provided."""
         from lintro.ai.json_response import CliSchemaRequest
 
@@ -98,14 +102,14 @@ class TestClaudeCliComplete:
             schema_name="lintro_review",
         )
         stdout = _cli_json(result='{"summary": "ok"}')
-        with patch("subprocess.run") as mock_run:
+        with patch_cli_exec() as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=[],
                 returncode=0,
                 stdout=stdout,
                 stderr="",
             )
-            provider.complete(
+            await provider.complete(
                 "Review this diff",
                 system="Be concise",
                 cli_schema=schema,
@@ -116,7 +120,7 @@ class TestClaudeCliComplete:
         schema_arg = cmd[cmd.index("--json-schema") + 1]
         assert_that(schema_arg).contains('"type"')
 
-    def test_json_schema_name_sent_when_cli_advertises_it(
+    async def test_json_schema_name_sent_when_cli_advertises_it(
         self,
         _mock_claude_on_path: None,
     ) -> None:
@@ -149,8 +153,8 @@ class TestClaudeCliComplete:
                 stderr="",
             )
 
-        with patch("subprocess.run", side_effect=fake_run) as mock_run:
-            provider.complete("Review this diff", cli_schema=schema)
+        with patch_cli_exec(side_effect=fake_run) as mock_run:
+            await provider.complete("Review this diff", cli_schema=schema)
 
         completion_calls = [
             call for call in mock_run.call_args_list if "--help" not in call.args[0]
@@ -158,7 +162,7 @@ class TestClaudeCliComplete:
         cmd = completion_calls[-1].args[0]
         assert_that(cmd).contains("--json-schema-name", "lintro_review")
 
-    def test_json_schema_name_omitted_when_cli_lacks_it(
+    async def test_json_schema_name_omitted_when_cli_lacks_it(
         self,
         _mock_claude_on_path: None,
     ) -> None:
@@ -195,8 +199,8 @@ class TestClaudeCliComplete:
                 stderr="",
             )
 
-        with patch("subprocess.run", side_effect=fake_run) as mock_run:
-            provider.complete("Review this diff", cli_schema=schema)
+        with patch_cli_exec(side_effect=fake_run) as mock_run:
+            await provider.complete("Review this diff", cli_schema=schema)
 
         completion_calls = [
             call for call in mock_run.call_args_list if "--help" not in call.args[0]
@@ -205,11 +209,11 @@ class TestClaudeCliComplete:
         assert_that(cmd).does_not_contain("--json-schema-name")
         assert_that(cmd).contains("--json-schema")
 
-    def test_auth_error(self, _mock_claude_on_path: None) -> None:
+    async def test_auth_error(self, _mock_claude_on_path: None) -> None:
         """Surface authentication failures from claude stderr."""
         provider = AnthropicProvider(transport=AITransport.CLI)
         with (
-            patch("subprocess.run") as mock_run,
+            patch_cli_exec() as mock_run,
             pytest.raises(AIAuthenticationError, match="login"),
         ):
             mock_run.return_value = subprocess.CompletedProcess(
@@ -218,7 +222,7 @@ class TestClaudeCliComplete:
                 stdout="",
                 stderr="Authentication required. Please login.",
             )
-            provider.complete("hello")
+            await provider.complete("hello")
 
 
 class TestFindClaude:

--- a/tests/unit/ai/test_codex_cli_provider.py
+++ b/tests/unit/ai/test_codex_cli_provider.py
@@ -14,6 +14,7 @@ from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import AIAuthenticationError, AINotAvailableError
 from lintro.ai.providers.openai import OpenAIProvider, _find_codex
 from lintro.ai.registry import AIProvider
+from tests.unit.ai.conftest import patch_cli_exec
 
 
 @pytest.fixture()
@@ -64,18 +65,21 @@ class TestCodexCliInit:
 class TestCodexCliComplete:
     """Tests for codex exec completions."""
 
-    def test_success(self, _mock_codex_on_path: None) -> None:
+    async def test_success(self, _mock_codex_on_path: None) -> None:
         """Parse JSONL output from a successful codex exec invocation."""
         provider = OpenAIProvider(model="gpt-5.2-codex", transport=AITransport.CLI)
         stdout = _jsonl_response()
-        with patch("subprocess.run") as mock_run:
+        with patch_cli_exec() as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=[],
                 returncode=0,
                 stdout=stdout,
                 stderr="",
             )
-            response = provider.complete("Review this diff", repo_root="/tmp/repo")
+            response = await provider.complete(
+                "Review this diff",
+                repo_root="/tmp/repo",
+            )
 
         assert_that(response.content).contains("summary")
         assert_that(response.provider).is_equal_to(AIProvider.OPENAI)
@@ -83,11 +87,11 @@ class TestCodexCliComplete:
         assert_that(cmd).contains("exec", "--json", "--sandbox", "read-only")
         assert_that(cmd).contains("--model", "gpt-5.2-codex")
 
-    def test_auth_error(self, _mock_codex_on_path: None) -> None:
+    async def test_auth_error(self, _mock_codex_on_path: None) -> None:
         """Surface authentication failures from codex stderr."""
         provider = OpenAIProvider(transport=AITransport.CLI)
         with (
-            patch("subprocess.run") as mock_run,
+            patch_cli_exec() as mock_run,
             pytest.raises(AIAuthenticationError, match="login"),
         ):
             mock_run.return_value = subprocess.CompletedProcess(
@@ -96,7 +100,7 @@ class TestCodexCliComplete:
                 stdout="",
                 stderr="Not authenticated. Run codex login.",
             )
-            provider.complete("hello", repo_root="/tmp/repo")
+            await provider.complete("hello", repo_root="/tmp/repo")
 
 
 class TestFindCodex:

--- a/tests/unit/ai/test_config_wiring.py
+++ b/tests/unit/ai/test_config_wiring.py
@@ -59,7 +59,7 @@ def _make_fix_issues() -> tuple[
 @patch(f"{_PIPELINE}.review_fixes_interactive")
 @patch(f"{_PIPELINE}.apply_fixes")
 @patch(f"{_PIPELINE}.generate_fixes_from_params")
-def test_context_lines_flows_to_generate_fixes(
+async def test_context_lines_flows_to_generate_fixes(
     mock_generate_fixes,
     mock_apply_fixes,
     _mock_review,
@@ -74,7 +74,7 @@ def test_context_lines_flows_to_generate_fixes(
 
     ai_config = AIConfig(enabled=True, transport=AITransport.API, context_lines=42)
 
-    run_fix_pipeline(
+    await run_fix_pipeline(
         fix_issues=fix_issues,
         provider=MockAIProvider(),
         ai_config=ai_config,
@@ -97,7 +97,7 @@ def test_context_lines_flows_to_generate_fixes(
 @patch(f"{_PIPELINE}.review_fixes_interactive")
 @patch(f"{_PIPELINE}.apply_fixes")
 @patch(f"{_PIPELINE}.generate_fixes_from_params")
-def test_fix_search_radius_flows_to_apply_fixes(
+async def test_fix_search_radius_flows_to_apply_fixes(
     mock_generate_fixes,
     mock_apply_fixes,
     _mock_review,
@@ -120,7 +120,7 @@ def test_fix_search_radius_flows_to_apply_fixes(
         fix_search_radius=25,
     )
 
-    run_fix_pipeline(
+    await run_fix_pipeline(
         fix_issues=fix_issues,
         provider=MockAIProvider(),
         ai_config=ai_config,
@@ -143,7 +143,7 @@ def test_fix_search_radius_flows_to_apply_fixes(
 @patch(f"{_PIPELINE}.review_fixes_interactive")
 @patch(f"{_PIPELINE}.apply_fixes")
 @patch(f"{_PIPELINE}.generate_fixes_from_params")
-def test_retry_delays_flow_to_generate_fixes(
+async def test_retry_delays_flow_to_generate_fixes(
     mock_generate_fixes,
     mock_apply_fixes,
     _mock_review,
@@ -164,7 +164,7 @@ def test_retry_delays_flow_to_generate_fixes(
         retry_backoff_factor=3.0,
     )
 
-    run_fix_pipeline(
+    await run_fix_pipeline(
         fix_issues=fix_issues,
         provider=MockAIProvider(),
         ai_config=ai_config,
@@ -189,7 +189,7 @@ def test_retry_delays_flow_to_generate_fixes(
 @patch(f"{_PIPELINE}.review_fixes_interactive")
 @patch(f"{_PIPELINE}.apply_fixes")
 @patch(f"{_PIPELINE}.generate_fixes_from_params")
-def test_timeout_and_retries_flow_to_post_fix_summary(
+async def test_timeout_and_retries_flow_to_post_fix_summary(
     mock_generate_fixes,
     mock_apply_fixes,
     _mock_review,
@@ -222,7 +222,7 @@ def test_timeout_and_retries_flow_to_post_fix_summary(
         retry_backoff_factor=4.0,
     )
 
-    run_fix_pipeline(
+    await run_fix_pipeline(
         fix_issues=fix_issues,
         provider=MockAIProvider(),
         ai_config=ai_config,

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -18,6 +18,7 @@ from lintro.ai.exceptions import (
 )
 from lintro.ai.providers.cursor import CURSOR_MIN_TIMEOUT, CursorProvider, _find_agent
 from lintro.ai.registry import AIProvider
+from tests.unit.ai.conftest import HANG, patch_cli_exec
 
 
 @pytest.fixture()
@@ -81,7 +82,7 @@ def _fake_run_with_probes(
         stdout: Stdout to return for the actual completion call.
 
     Returns:
-        A callable suitable for ``patch("subprocess.run", side_effect=...)``.
+        A callable suitable for ``patch_cli_exec(side_effect=...)``.
     """
 
     def _run(
@@ -171,7 +172,7 @@ def test_cursor_provider_custom_model():
     assert_that(p.model_name).is_equal_to("claude-opus-4-8-thinking-high")
 
 
-def test_cursor_provider_is_available(provider):
+async def test_cursor_provider_is_available(provider):
     """Report available when agent binary is present."""
     assert_that(provider.is_available()).is_true()
 
@@ -179,17 +180,17 @@ def test_cursor_provider_is_available(provider):
 # -- CursorProvider.complete() ---------------------------------------------
 
 
-def test_complete_parses_successful_cli_json(provider):
+async def test_complete_parses_successful_cli_json(provider):
     """Parse successful CLI JSON into AIResponse."""
     stdout = _cli_json(result="review output")
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout=stdout,
             stderr="",
         )
-        resp = provider.complete("Hello", repo_root="/tmp/repo")
+        resp = await provider.complete("Hello", repo_root="/tmp/repo")
     assert_that(resp.content).is_equal_to("review output")
     assert_that(resp.provider).is_equal_to(AIProvider.CURSOR)
     assert_that(resp.input_tokens).is_equal_to(100)
@@ -198,24 +199,21 @@ def test_complete_parses_successful_cli_json(provider):
     assert_that(cmd).contains("--workspace", "/tmp/repo")
 
 
-def test_complete_durable_session_uses_resume(provider):
+async def test_complete_durable_session_uses_resume(provider):
     """Second call in a durable session resumes the CLI session id."""
     stdout = _cli_json(result="ok")
-    with patch(
-        "subprocess.run",
-        side_effect=_fake_run_with_probes(stdout),
-    ) as mock_run:
+    with patch_cli_exec(side_effect=_fake_run_with_probes(stdout)) as mock_run:
         provider.begin_durable_session(repo_root="/tmp/repo")
-        provider.complete("first", repo_root="/tmp/repo")
-        provider.complete("second", repo_root="/tmp/repo")
+        await provider.complete("first", repo_root="/tmp/repo")
+        await provider.complete("second", repo_root="/tmp/repo")
         second_cmd = _completion_calls(mock_run)[1]
         assert_that(second_cmd).contains("--resume", "sess-123")
 
 
-def test_complete_one_shot_skips_resume(provider):
+async def test_complete_one_shot_skips_resume(provider):
     """One-shot calls do not resume an existing durable session."""
     stdout = _cli_json(result="ok")
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
@@ -223,7 +221,7 @@ def test_complete_one_shot_skips_resume(provider):
             stderr="",
         )
         provider.begin_durable_session(repo_root="/tmp/repo")
-        provider.complete(
+        await provider.complete(
             "chunk",
             repo_root="/tmp/repo",
             use_one_shot=True,
@@ -232,54 +230,69 @@ def test_complete_one_shot_skips_resume(provider):
         assert_that(cmd).does_not_contain("--resume")
 
 
-def test_timeout_floor_is_six_hundred_seconds(provider):
+async def test_timeout_floor_is_six_hundred_seconds(provider):
     """Enforce Cursor CLI minimum timeout of 600 seconds."""
     stdout = _cli_json(result="ok")
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout=stdout,
             stderr="",
         )
-        provider.complete("Hello", timeout=120.0, repo_root="/tmp/repo")
-    assert_that(mock_run.call_args.kwargs["timeout"]).is_equal_to(
+        await provider.complete("Hello", timeout=120.0, repo_root="/tmp/repo")
+    assert_that(mock_run.transport_calls[-1].timeout).is_equal_to(
         CURSOR_MIN_TIMEOUT,
     )
 
 
-def test_complete_prepends_system_prompt_via_stdin(provider):
+async def test_complete_prepends_system_prompt_via_stdin(provider):
     """Prepend system prompt to user message via stdin."""
     stdout = _cli_json(result="ok")
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout=stdout,
             stderr="",
         )
-        provider.complete("user msg", system="sys prompt")
-        call_kwargs = mock_run.call_args
-        input_text = call_kwargs.kwargs.get("input", "")
+        await provider.complete("user msg", system="sys prompt")
+        input_text = mock_run.transport_calls[-1].input_text or ""
         assert_that(input_text).contains("sys prompt")
         assert_that(input_text).contains("user msg")
 
 
-def test_complete_raises_on_subprocess_timeout(provider):
+async def test_complete_raises_on_subprocess_timeout(provider):
     """Raise AIProviderError when CLI times out."""
+
+    def _hang_completion(cmd: list[str]) -> object:
+        """Answer the capability probes, then hang on the real call.
+
+        Args:
+            cmd: Argv the transport invoked.
+
+        Returns:
+            A probe result, or the HANG sentinel for the completion call.
+        """
+        if "--version" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "2026.07.09-a3815c0\n", "")
+        if "--help" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, _AGENT_HELP, "")
+        return HANG
+
     with (
-        patch(
-            "subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd="agent", timeout=60),
-        ),
+        # The agent CLI enforces a 600s floor (covered separately), so the
+        # floor is lowered here to keep the timeout path fast.
+        patch("lintro.ai.providers.cursor.CURSOR_MIN_TIMEOUT", 0.01),
+        patch_cli_exec(side_effect=_hang_completion),
         pytest.raises(AIProviderError, match="timed out"),
     ):
-        provider.complete("Hello")
+        await provider.complete("Hello", timeout=0.01)
 
 
-def test_complete_raises_auth_error(provider):
+async def test_complete_raises_auth_error(provider):
     """Raise AIAuthenticationError on auth failure stderr."""
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=1,
@@ -287,12 +300,12 @@ def test_complete_raises_auth_error(provider):
             stderr="Authentication required. Run 'agent login' first.",
         )
         with pytest.raises(AIAuthenticationError, match="login"):
-            provider.complete("Hello")
+            await provider.complete("Hello")
 
 
-def test_complete_raises_on_nonzero_exit(provider):
+async def test_complete_raises_on_nonzero_exit(provider):
     """Raise AIProviderError on non-zero CLI exit code."""
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=2,
@@ -300,12 +313,12 @@ def test_complete_raises_on_nonzero_exit(provider):
             stderr="something broke",
         )
         with pytest.raises(AIProviderError, match="exited with code 2"):
-            provider.complete("Hello")
+            await provider.complete("Hello")
 
 
-def test_complete_raises_on_invalid_json_stdout(provider):
+async def test_complete_raises_on_invalid_json_stdout(provider):
     """Raise AIProviderError when stdout is not valid JSON."""
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
@@ -313,17 +326,17 @@ def test_complete_raises_on_invalid_json_stdout(provider):
             stderr="",
         )
         with pytest.raises(AIProviderError, match="invalid JSON"):
-            provider.complete("Hello")
+            await provider.complete("Hello")
 
 
-def test_complete_raises_on_cli_error_in_response(provider):
+async def test_complete_raises_on_cli_error_in_response(provider):
     """Raise AIProviderError when JSON reports is_error."""
     stdout = _cli_json(
         result="something failed",
         is_error=True,
         subtype="error",
     )
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
@@ -331,116 +344,113 @@ def test_complete_raises_on_cli_error_in_response(provider):
             stderr="",
         )
         with pytest.raises(AIProviderError, match="reported error"):
-            provider.complete("Hello")
+            await provider.complete("Hello")
 
 
-def test_complete_appends_max_tokens_to_prompt(provider):
+async def test_complete_appends_max_tokens_to_prompt(provider):
     """Append token budget constraint to the CLI stdin prompt."""
     stdout = _cli_json(result="ok")
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout=stdout,
             stderr="",
         )
-        provider.complete("Hello", max_tokens=512)
-        input_text = mock_run.call_args.kwargs.get("input", "")
+        await provider.complete("Hello", max_tokens=512)
+        input_text = mock_run.transport_calls[-1].input_text or ""
         assert_that(input_text).contains("Respond in at most 512 tokens")
 
 
-def test_complete_uses_minimum_timeout_for_agent(provider):
+async def test_complete_uses_minimum_timeout_for_agent(provider):
     """Agent CLI calls enforce a minimum subprocess timeout."""
     stdout = _cli_json(result="ok")
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout=stdout,
             stderr="",
         )
-        provider.complete("Hello", timeout=45.0)
-        assert_that(mock_run.call_args.kwargs.get("timeout")).is_equal_to(
+        await provider.complete("Hello", timeout=45.0)
+        assert_that(mock_run.transport_calls[-1].timeout).is_equal_to(
             CURSOR_MIN_TIMEOUT,
         )
 
 
-def test_complete_estimates_nonzero_cost_from_cli_usage(provider):
+async def test_complete_estimates_nonzero_cost_from_cli_usage(provider):
     """Cursor prices reported usage with a non-zero floor for the budget."""
     stdout = _cli_json(result="ok", input_tokens=5000, output_tokens=2000)
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout=stdout,
             stderr="",
         )
-        resp = provider.complete("Hello")
+        resp = await provider.complete("Hello")
     assert_that(resp.input_tokens).is_equal_to(5000)
     assert_that(resp.output_tokens).is_equal_to(2000)
     assert_that(resp.cost_estimate).is_greater_than(0.0)
 
 
-def test_complete_estimates_tokens_when_cli_omits_usage(provider):
+async def test_complete_estimates_tokens_when_cli_omits_usage(provider):
     """When the CLI omits usage, tokens are estimated locally from text."""
     stdout = _cli_json(
         result="a fairly long review answer",
         input_tokens=0,
         output_tokens=0,
     )
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout=stdout,
             stderr="",
         )
-        resp = provider.complete("Hello there, please review this code carefully")
+        resp = await provider.complete("Hello there, please review this code carefully")
     assert_that(resp.input_tokens).is_greater_than(0)
     assert_that(resp.output_tokens).is_greater_than(0)
     assert_that(resp.cost_estimate).is_greater_than(0.0)
 
 
-def test_cursor_cost_accrues_into_budget(provider):
+async def test_cursor_cost_accrues_into_budget(provider):
     """A Cursor response's estimated cost is recorded by CostBudget."""
     stdout = _cli_json(result="ok", input_tokens=5000, output_tokens=2000)
     budget = CostBudget(max_cost_usd=1.0)
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout=stdout,
             stderr="",
         )
-        resp = provider.complete("Hello")
+        resp = await provider.complete("Hello")
     budget.record(resp.cost_estimate)
     assert_that(budget.spent).is_greater_than(0.0)
 
 
-def test_complete_omits_trust_flag_by_default(provider):
+async def test_complete_omits_trust_flag_by_default(provider):
     """The '--trust' flag is absent unless workspace trust is opted in."""
     stdout = _cli_json(result="ok")
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout=stdout,
             stderr="",
         )
-        provider.complete("Hello", repo_root="/tmp/repo")
+        await provider.complete("Hello", repo_root="/tmp/repo")
     cmd = mock_run.call_args.args[0]
     assert_that(cmd).does_not_contain("--trust")
 
 
-def test_complete_includes_trust_flag_when_opted_in(_mock_agent_on_path):
+async def test_complete_includes_trust_flag_when_opted_in(_mock_agent_on_path):
     """The '--trust' flag is present only when the opt-in is set."""
     trusting = CursorProvider(cursor_trust_workspace=True)
     stdout = _cli_json(result="ok")
-    with patch(
-        "subprocess.run",
-        side_effect=_fake_run_with_probes(stdout),
-    ) as mock_run:
-        trusting.complete("Hello", repo_root="/tmp/repo")
+    with patch_cli_exec(side_effect=_fake_run_with_probes(stdout)) as mock_run:
+        await trusting.complete("Hello", repo_root="/tmp/repo")
     cmd = _completion_calls(mock_run)[-1]
     assert_that(cmd).contains("--trust")
 
@@ -486,21 +496,21 @@ def test_extract_json_object_returns_original_when_no_json():
     ).is_equal_to(text)
 
 
-def test_extract_json_object_returns_empty_string_unchanged():
+async def test_extract_json_object_returns_empty_string_unchanged():
     """Return empty string unchanged."""
     assert_that(CursorProvider._extract_json_object("")).is_equal_to("")
 
 
-def test_complete_preserves_plain_text_with_braces(provider):
+async def test_complete_preserves_plain_text_with_braces(provider):
     """Do not truncate plain-text answers that contain balanced braces."""
     result_text = "Use destructuring like { userId } in your handler."
     stdout = _cli_json(result=result_text)
-    with patch("subprocess.run") as mock_run:
+    with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout=stdout,
             stderr="",
         )
-        resp = provider.complete("Hello")
+        resp = await provider.complete("Hello")
     assert_that(resp.content).is_equal_to(result_text)

--- a/tests/unit/ai/test_fallback.py
+++ b/tests/unit/ai/test_fallback.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import threading
+import asyncio
 import time
-from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from assertpy import assert_that
@@ -20,14 +19,29 @@ from lintro.ai.providers.base import AIResponse
 
 
 def _make_provider(model: str = "primary-model") -> MagicMock:
-    """Create a mock provider with a configurable model_name attribute."""
+    """Create a mock provider with an async ``complete`` and a model name.
+
+    Args:
+        model: Value reported by ``provider.model_name``.
+
+    Returns:
+        A mock provider suitable for the fallback chain.
+    """
     provider = MagicMock()
     provider.model_name = model
+    provider.complete = AsyncMock()
     return provider
 
 
 def _ok_response(model: str = "primary-model") -> AIResponse:
-    """Create a successful mock AI response."""
+    """Create a successful mock AI response.
+
+    Args:
+        model: Model identifier recorded on the response.
+
+    Returns:
+        A populated ``AIResponse``.
+    """
     return AIResponse(
         content="ok",
         model=model,
@@ -41,34 +55,34 @@ def _ok_response(model: str = "primary-model") -> AIResponse:
 # -- TestCompleteWithFallbackPrimarySuccess: Primary model succeeds on first try.
 
 
-def test_returns_response_without_fallback() -> None:
+async def test_returns_response_without_fallback() -> None:
     """Return response when primary succeeds without fallback."""
     provider = _make_provider()
     provider.complete.return_value = _ok_response()
 
-    result = complete_with_fallback(provider, "hello")
+    result = await complete_with_fallback(provider, "hello")
 
     assert_that(result.content).is_equal_to("ok")
     provider.complete.assert_called_once()
 
 
-def test_returns_response_with_empty_fallback_list() -> None:
+async def test_returns_response_with_empty_fallback_list() -> None:
     """Return response when fallback list is empty."""
     provider = _make_provider()
     provider.complete.return_value = _ok_response()
 
-    result = complete_with_fallback(provider, "hello", fallback_models=[])
+    result = await complete_with_fallback(provider, "hello", fallback_models=[])
 
     assert_that(result.content).is_equal_to("ok")
     provider.complete.assert_called_once()
 
 
-def test_does_not_try_fallbacks_on_success() -> None:
+async def test_does_not_try_fallbacks_on_success() -> None:
     """Skip fallback models when primary succeeds."""
     provider = _make_provider()
     provider.complete.return_value = _ok_response()
 
-    result = complete_with_fallback(
+    result = await complete_with_fallback(
         provider,
         "hello",
         fallback_models=["fb-1", "fb-2"],
@@ -83,7 +97,7 @@ def test_does_not_try_fallbacks_on_success() -> None:
 # -- TestCompleteWithFallbackChain: Primary fails, fallback models are tried in order.
 
 
-def test_falls_back_on_provider_error() -> None:
+async def test_falls_back_on_provider_error() -> None:
     """Fall back to next model on provider error."""
     provider = _make_provider()
     provider.complete.side_effect = [
@@ -91,7 +105,7 @@ def test_falls_back_on_provider_error() -> None:
         _ok_response("fb-1"),
     ]
 
-    result = complete_with_fallback(
+    result = await complete_with_fallback(
         provider,
         "hello",
         fallback_models=["fb-1"],
@@ -102,7 +116,7 @@ def test_falls_back_on_provider_error() -> None:
     assert_that(provider.model_name).is_equal_to("primary-model")  # restored
 
 
-def test_falls_back_on_rate_limit_error() -> None:
+async def test_falls_back_on_rate_limit_error() -> None:
     """Fall back to next model on rate limit error."""
     provider = _make_provider()
     provider.complete.side_effect = [
@@ -110,7 +124,7 @@ def test_falls_back_on_rate_limit_error() -> None:
         _ok_response("fb-1"),
     ]
 
-    result = complete_with_fallback(
+    result = await complete_with_fallback(
         provider,
         "hello",
         fallback_models=["fb-1"],
@@ -120,7 +134,7 @@ def test_falls_back_on_rate_limit_error() -> None:
     assert_that(provider.complete.call_count).is_equal_to(2)
 
 
-def test_tries_multiple_fallbacks_in_order() -> None:
+async def test_tries_multiple_fallbacks_in_order() -> None:
     """Try fallback models sequentially until one succeeds."""
     provider = _make_provider()
     provider.complete.side_effect = [
@@ -129,7 +143,7 @@ def test_tries_multiple_fallbacks_in_order() -> None:
         _ok_response("fb-2"),
     ]
 
-    result = complete_with_fallback(
+    result = await complete_with_fallback(
         provider,
         "hello",
         fallback_models=["fb-1", "fb-2"],
@@ -140,7 +154,7 @@ def test_tries_multiple_fallbacks_in_order() -> None:
     assert_that(provider.model_name).is_equal_to("primary-model")  # restored
 
 
-def test_model_is_swapped_for_each_fallback() -> None:
+async def test_model_is_swapped_for_each_fallback() -> None:
     """Verify each fallback attempt passes the expected model override."""
     provider = _make_provider("primary")
     models_seen: list[str] = []
@@ -155,7 +169,7 @@ def test_model_is_swapped_for_each_fallback() -> None:
 
     provider.complete.side_effect = capture_model
 
-    complete_with_fallback(
+    await complete_with_fallback(
         provider,
         "hello",
         fallback_models=["fb-1", "fb-2"],
@@ -168,7 +182,7 @@ def test_model_is_swapped_for_each_fallback() -> None:
 # -- TestCompleteWithFallbackAllFail: All models fail -- last error is raised.
 
 
-def test_raises_last_error_when_all_fail() -> None:
+async def test_raises_last_error_when_all_fail() -> None:
     """Raise the last error when all models fail."""
     provider = _make_provider()
     provider.complete.side_effect = [
@@ -178,7 +192,7 @@ def test_raises_last_error_when_all_fail() -> None:
     ]
 
     with pytest.raises(AIProviderError, match="fb-2 down"):
-        complete_with_fallback(
+        await complete_with_fallback(
             provider,
             "hello",
             fallback_models=["fb-1", "fb-2"],
@@ -187,25 +201,25 @@ def test_raises_last_error_when_all_fail() -> None:
     assert_that(provider.model_name).is_equal_to("primary-model")  # restored
 
 
-def test_raises_primary_error_when_no_fallbacks() -> None:
+async def test_raises_primary_error_when_no_fallbacks() -> None:
     """Raise the primary error when no fallbacks are configured."""
     provider = _make_provider()
     provider.complete.side_effect = AIProviderError("primary down")
 
     with pytest.raises(AIProviderError, match="primary down"):
-        complete_with_fallback(provider, "hello")
+        await complete_with_fallback(provider, "hello")
 
 
 # -- TestCompleteWithFallbackAuthError: AIAuthenticationError is never retried.
 
 
-def test_auth_error_propagates_immediately() -> None:
+async def test_auth_error_propagates_immediately() -> None:
     """Propagate authentication error without trying fallbacks."""
     provider = _make_provider()
     provider.complete.side_effect = AIAuthenticationError("bad key")
 
     with pytest.raises(AIAuthenticationError, match="bad key"):
-        complete_with_fallback(
+        await complete_with_fallback(
             provider,
             "hello",
             fallback_models=["fb-1", "fb-2"],
@@ -216,7 +230,7 @@ def test_auth_error_propagates_immediately() -> None:
     assert_that(provider.model_name).is_equal_to("primary-model")  # restored
 
 
-def test_auth_error_on_fallback_propagates() -> None:
+async def test_auth_error_on_fallback_propagates() -> None:
     """Propagate authentication error raised by a fallback model."""
     provider = _make_provider()
     provider.complete.side_effect = [
@@ -225,7 +239,7 @@ def test_auth_error_on_fallback_propagates() -> None:
     ]
 
     with pytest.raises(AIAuthenticationError, match="bad key on fallback"):
-        complete_with_fallback(
+        await complete_with_fallback(
             provider,
             "hello",
             fallback_models=["fb-1"],
@@ -238,13 +252,13 @@ def test_auth_error_on_fallback_propagates() -> None:
 # -- TestCompleteWithFallbackModelRestoration: model_name restored.
 
 
-def test_model_restored_on_auth_error() -> None:
+async def test_model_restored_on_auth_error() -> None:
     """Restore original model after authentication error."""
     provider = _make_provider("orig")
     provider.complete.side_effect = AIAuthenticationError("err")
 
     with pytest.raises(AIAuthenticationError):
-        complete_with_fallback(
+        await complete_with_fallback(
             provider,
             "hello",
             fallback_models=["x"],
@@ -253,18 +267,18 @@ def test_model_restored_on_auth_error() -> None:
     assert_that(provider.model_name).is_equal_to("orig")
 
 
-def test_model_restored_on_provider_error() -> None:
+async def test_model_restored_on_provider_error() -> None:
     """Restore original model after provider error."""
     provider = _make_provider("orig")
     provider.complete.side_effect = AIProviderError("err")
 
     with pytest.raises(AIProviderError):
-        complete_with_fallback(provider, "hello")
+        await complete_with_fallback(provider, "hello")
 
     assert_that(provider.model_name).is_equal_to("orig")
 
 
-def test_model_restored_on_success() -> None:
+async def test_model_restored_on_success() -> None:
     """Restore original model after successful fallback."""
     provider = _make_provider("orig")
     provider.complete.side_effect = [
@@ -272,7 +286,7 @@ def test_model_restored_on_success() -> None:
         _ok_response("fb"),
     ]
 
-    complete_with_fallback(provider, "hello", fallback_models=["fb"])
+    await complete_with_fallback(provider, "hello", fallback_models=["fb"])
 
     assert_that(provider.model_name).is_equal_to("orig")
 
@@ -280,12 +294,12 @@ def test_model_restored_on_success() -> None:
 # -- TestCompleteWithFallbackKwargsPassthrough: kwargs forwarded. -
 
 
-def test_forwards_all_kwargs() -> None:
+async def test_forwards_all_kwargs() -> None:
     """Forward all keyword arguments to provider.complete."""
     provider = _make_provider()
     provider.complete.return_value = _ok_response()
 
-    complete_with_fallback(
+    await complete_with_fallback(
         provider,
         "hello",
         system="sys",
@@ -307,44 +321,45 @@ def test_forwards_all_kwargs() -> None:
 
 # -- TestCompleteWithFallbackConcurrency: parallel calls must not serialize.
 
-_BARRIER_TIMEOUT_SECONDS = 5.0
 
-
-def test_with_fallback_parallel_calls_overlap() -> None:
+async def test_with_fallback_parallel_calls_overlap() -> None:
     """Prove _with_fallback does not serialize concurrent provider calls."""
     provider = _make_provider()
     worker_count = 5
     sleep_seconds = 0.10
-    start_barrier = threading.Barrier(worker_count)
-    active_lock = threading.Lock()
     active_calls = 0
     max_concurrent_calls = 0
 
-    def slow_attempt(
+    async def slow_attempt(
         _prompt: str,
         _system: str | None,
         _max_tokens: int,
         _timeout: float,
         model: str,
     ) -> str:
-        """Sleep to simulate provider latency and track concurrent overlap."""
+        """Sleep to simulate provider latency and track concurrent overlap.
+
+        Args:
+            _prompt: Ignored prompt.
+            _system: Ignored system prompt.
+            _max_tokens: Ignored token cap.
+            _timeout: Ignored timeout.
+            model: The model identifier for this attempt.
+
+        Returns:
+            The model identifier that served the attempt.
+        """
         nonlocal active_calls, max_concurrent_calls
-        start_barrier.wait(timeout=_BARRIER_TIMEOUT_SECONDS)
-        with active_lock:
-            active_calls += 1
-            max_concurrent_calls = max(max_concurrent_calls, active_calls)
-        time.sleep(sleep_seconds)
-        with active_lock:
-            active_calls -= 1
+        active_calls += 1
+        max_concurrent_calls = max(max_concurrent_calls, active_calls)
+        await asyncio.sleep(sleep_seconds)
+        active_calls -= 1
         return model
 
-    def run_fallback(_: int) -> str:
-        """Invoke _with_fallback from a worker thread."""
-        return _with_fallback(provider, slow_attempt, "hello")
-
     started_at = time.perf_counter()
-    with ThreadPoolExecutor(max_workers=worker_count) as pool:
-        results = list(pool.map(run_fallback, range(worker_count)))
+    results = await asyncio.gather(
+        *(_with_fallback(provider, slow_attempt, "hello") for _ in range(worker_count)),
+    )
     elapsed = time.perf_counter() - started_at
 
     serialized_minimum = sleep_seconds * worker_count
@@ -354,38 +369,37 @@ def test_with_fallback_parallel_calls_overlap() -> None:
     assert_that(set(results)).is_equal_to({"primary-model"})
 
 
-def test_complete_with_fallback_parallel_calls_overlap() -> None:
+async def test_complete_with_fallback_parallel_calls_overlap() -> None:
     """Prove complete_with_fallback allows concurrent provider.complete calls."""
     provider = _make_provider()
     worker_count = 5
     sleep_seconds = 0.10
-    start_barrier = threading.Barrier(worker_count)
-    active_lock = threading.Lock()
     active_calls = 0
     max_concurrent_calls = 0
 
-    def slow_complete(*_args: object, **_kwargs: object) -> AIResponse:
-        """Sleep to simulate provider HTTP latency."""
+    async def slow_complete(*_args: object, **_kwargs: object) -> AIResponse:
+        """Sleep to simulate provider HTTP latency.
+
+        Args:
+            *_args: Ignored positional arguments.
+            **_kwargs: Ignored keyword arguments.
+
+        Returns:
+            A successful response.
+        """
         nonlocal active_calls, max_concurrent_calls
-        start_barrier.wait(timeout=_BARRIER_TIMEOUT_SECONDS)
-        with active_lock:
-            active_calls += 1
-            max_concurrent_calls = max(max_concurrent_calls, active_calls)
-        time.sleep(sleep_seconds)
-        with active_lock:
-            active_calls -= 1
+        active_calls += 1
+        max_concurrent_calls = max(max_concurrent_calls, active_calls)
+        await asyncio.sleep(sleep_seconds)
+        active_calls -= 1
         return _ok_response()
 
     provider.complete.side_effect = slow_complete
 
     started_at = time.perf_counter()
-    with ThreadPoolExecutor(max_workers=worker_count) as pool:
-        results = list(
-            pool.map(
-                lambda _: complete_with_fallback(provider, "hello"),
-                range(worker_count),
-            ),
-        )
+    results = await asyncio.gather(
+        *(complete_with_fallback(provider, "hello") for _ in range(worker_count)),
+    )
     elapsed = time.perf_counter() - started_at
 
     serialized_minimum = sleep_seconds * worker_count

--- a/tests/unit/ai/test_fix_context.py
+++ b/tests/unit/ai/test_fix_context.py
@@ -19,7 +19,7 @@ from tests.unit.ai.conftest import MockAIProvider, MockIssue
 # ---------------------------------------------------------------------------
 
 
-def test_full_file_context_for_small_file(tmp_path):
+async def test_full_file_context_for_small_file(tmp_path):
     """Small files should send full content as context (lines 1-N)."""
     source = tmp_path / "small.py"
     source.write_text("x = 1\ny = 2\nz = 3\n")
@@ -32,7 +32,7 @@ def test_full_file_context_for_small_file(tmp_path):
     )
 
     provider = MockAIProvider()
-    generate_fixes(
+    await generate_fixes(
         [issue],
         provider,
         tool_name="ruff",
@@ -47,7 +47,7 @@ def test_full_file_context_for_small_file(tmp_path):
     assert_that(prompt).contains("z = 3")
 
 
-def test_full_file_skipped_when_file_exceeds_threshold(tmp_path):
+async def test_full_file_skipped_when_file_exceeds_threshold(tmp_path):
     """Files over full_file_threshold should use windowed context."""
     # Create a file with 50 lines but set threshold to 5
     source = tmp_path / "big.py"
@@ -63,7 +63,7 @@ def test_full_file_skipped_when_file_exceeds_threshold(tmp_path):
     provider = MockAIProvider()
     ai_config = AIConfig(enabled=True, transport=AITransport.API, max_retries=0)
 
-    _generate_single_fix(
+    await _generate_single_fix(
         issue,
         provider,
         "ruff",
@@ -83,7 +83,7 @@ def test_full_file_skipped_when_file_exceeds_threshold(tmp_path):
     assert_that(prompt).contains("line_25")
 
 
-def test_full_file_skipped_when_over_token_budget(tmp_path):
+async def test_full_file_skipped_when_over_token_budget(tmp_path):
     """Full file that exceeds token budget should fall back to windowed context."""
     # Create a file with 20 lines, set a tight token budget so full-file
     # context is rejected and windowed context is used instead.
@@ -101,7 +101,7 @@ def test_full_file_skipped_when_over_token_budget(tmp_path):
     provider = MockAIProvider()
     ai_config = AIConfig(enabled=True, transport=AITransport.API, max_retries=0)
 
-    _generate_single_fix(
+    await _generate_single_fix(
         issue,
         provider,
         "ruff",

--- a/tests/unit/ai/test_fix_generation_basic.py
+++ b/tests/unit/ai/test_fix_generation_basic.py
@@ -48,9 +48,9 @@ def single_issue(source_file):
 # ---------------------------------------------------------------------------
 
 
-def test_generate_fixes_empty_issues(mock_provider):
+async def test_generate_fixes_empty_issues(mock_provider):
     """Verify that an empty issue list returns an empty result."""
-    result = generate_fixes(
+    result = await generate_fixes(
         [],
         mock_provider,
         tool_name="ruff",
@@ -58,7 +58,7 @@ def test_generate_fixes_empty_issues(mock_provider):
     assert_that(result).is_empty()
 
 
-def test_generate_fixes_generates_fixes_for_unfixable(tmp_path):
+async def test_generate_fixes_generates_fixes_for_unfixable(tmp_path):
     """Unfixable issues are sent to the AI and produce suggestions."""
     source = tmp_path / "test.py"
     source.write_text("assert x > 0\nprint('hello')\n")
@@ -88,7 +88,7 @@ def test_generate_fixes_generates_fixes_for_unfixable(tmp_path):
     )
     provider = MockAIProvider(responses=[response])
 
-    result = generate_fixes(
+    result = await generate_fixes(
         [issue],
         provider,
         tool_name="bandit",
@@ -100,7 +100,7 @@ def test_generate_fixes_generates_fixes_for_unfixable(tmp_path):
     assert_that(result[0].diff).is_not_empty()
 
 
-def test_generate_fixes_processes_fixable_issues(tmp_path):
+async def test_generate_fixes_processes_fixable_issues(tmp_path):
     """AI should attempt fixes for ALL issues, including fixable ones."""
     source = tmp_path / "test.py"
     source.write_text("x = 1\n")
@@ -114,7 +114,7 @@ def test_generate_fixes_processes_fixable_issues(tmp_path):
     )
 
     provider = MockAIProvider()
-    generate_fixes(
+    await generate_fixes(
         [issue],
         provider,
         tool_name="ruff",
@@ -124,10 +124,10 @@ def test_generate_fixes_processes_fixable_issues(tmp_path):
     assert_that(provider.calls).is_not_empty()
 
 
-def test_generate_fixes_skips_issues_without_file(mock_provider):
+async def test_generate_fixes_skips_issues_without_file(mock_provider):
     """Verify that issues without a file path are skipped."""
     issue = MockIssue(line=1, code="B101", message="test")
-    result = generate_fixes(
+    result = await generate_fixes(
         [issue],
         mock_provider,
         tool_name="ruff",
@@ -135,7 +135,7 @@ def test_generate_fixes_skips_issues_without_file(mock_provider):
     assert_that(result).is_empty()
 
 
-def test_generate_fixes_respects_max_issues(tmp_path):
+async def test_generate_fixes_respects_max_issues(tmp_path):
     """Verify that the max_issues parameter limits the number of provider calls."""
     # Use separate files so batching does not group them
     sources = []
@@ -155,7 +155,7 @@ def test_generate_fixes_respects_max_issues(tmp_path):
     ]
 
     provider = MockAIProvider()
-    generate_fixes(
+    await generate_fixes(
         issues,
         provider,
         tool_name="ruff",
@@ -166,7 +166,7 @@ def test_generate_fixes_respects_max_issues(tmp_path):
     assert_that(provider.calls).is_length(2)
 
 
-def test_generate_fixes_provider_prompt_uses_workspace_relative_path(tmp_path):
+async def test_generate_fixes_provider_prompt_uses_workspace_relative_path(tmp_path):
     """Provider prompt contains workspace-relative paths, not absolute."""
     source = tmp_path / "src" / "service.py"
     source.parent.mkdir(parents=True)
@@ -196,7 +196,7 @@ def test_generate_fixes_provider_prompt_uses_workspace_relative_path(tmp_path):
     )
     provider = MockAIProvider(responses=[response])
 
-    generate_fixes(
+    await generate_fixes(
         [issue],
         provider,
         tool_name="ruff",
@@ -211,7 +211,7 @@ def test_generate_fixes_provider_prompt_uses_workspace_relative_path(tmp_path):
     assert_that(provider.calls[0]["max_tokens"]).is_equal_to(333)
 
 
-def test_generate_fixes_skips_issue_outside_workspace_root(tmp_path):
+async def test_generate_fixes_skips_issue_outside_workspace_root(tmp_path):
     """Verify that issues with files outside the workspace root are skipped."""
     outside = tmp_path.parent / "outside.py"
     outside.write_text("assert x\n", encoding="utf-8")
@@ -224,7 +224,7 @@ def test_generate_fixes_skips_issue_outside_workspace_root(tmp_path):
     )
 
     provider = MockAIProvider()
-    result = generate_fixes(
+    result = await generate_fixes(
         [issue],
         provider,
         tool_name="ruff",
@@ -240,7 +240,7 @@ def test_generate_fixes_skips_issue_outside_workspace_root(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_timeout_reaches_provider(tmp_path):
+async def test_timeout_reaches_provider(tmp_path):
     """Custom timeout value is passed through to provider.complete()."""
     source = tmp_path / "test.py"
     source.write_text("x = 1\n")
@@ -253,7 +253,7 @@ def test_timeout_reaches_provider(tmp_path):
     )
 
     provider = MockAIProvider()
-    generate_fixes(
+    await generate_fixes(
         [issue],
         provider,
         tool_name="ruff",
@@ -265,7 +265,7 @@ def test_timeout_reaches_provider(tmp_path):
     assert_that(provider.calls[0]["timeout"]).is_equal_to(120.0)
 
 
-def test_default_timeout_is_60(tmp_path):
+async def test_default_timeout_is_60(tmp_path):
     """Default timeout (60s) is used when no custom value is provided."""
     source = tmp_path / "test.py"
     source.write_text("x = 1\n")
@@ -278,7 +278,7 @@ def test_default_timeout_is_60(tmp_path):
     )
 
     provider = MockAIProvider()
-    generate_fixes(
+    await generate_fixes(
         [issue],
         provider,
         tool_name="ruff",
@@ -311,7 +311,7 @@ def test_tool_result_cwd_preserves_value():
 # ---------------------------------------------------------------------------
 
 
-def test_resolves_relative_paths_with_cwd(tmp_path):
+async def test_resolves_relative_paths_with_cwd(tmp_path):
     """Issues with relative paths should be resolved using result.cwd."""
     tool_cwd = tmp_path / "test_samples" / "tools"
     js_dir = tool_cwd / "javascript" / "oxlint"
@@ -331,7 +331,7 @@ def test_resolves_relative_paths_with_cwd(tmp_path):
         issue.file = os.path.join(cwd, issue.file)
 
     provider = MockAIProvider()
-    generate_fixes(
+    await generate_fixes(
         [issue],
         provider,
         tool_name="oxlint",
@@ -373,7 +373,7 @@ def test_no_resolution_when_cwd_is_none():
     assert_that(issue.file).is_equal_to("relative/path/file.js")
 
 
-def test_generate_fixes_skips_issues_with_unreadable_relative_paths(tmp_path):
+async def test_generate_fixes_skips_issues_with_unreadable_relative_paths(tmp_path):
     """Relative paths not resolvable from CWD are silently skipped."""
     subdir = tmp_path / "tools" / "js"
     subdir.mkdir(parents=True)
@@ -388,7 +388,7 @@ def test_generate_fixes_skips_issues_with_unreadable_relative_paths(tmp_path):
     )
 
     provider = MockAIProvider()
-    result = generate_fixes(
+    result = await generate_fixes(
         [issue],
         provider,
         tool_name="oxlint",
@@ -398,7 +398,7 @@ def test_generate_fixes_skips_issues_with_unreadable_relative_paths(tmp_path):
     assert_that(result).is_empty()
 
 
-def test_single_issue_file_not_batched(tmp_path):
+async def test_single_issue_file_not_batched(tmp_path):
     """A file with only 1 issue should use the single-issue path."""
     source = tmp_path / "single.py"
     source.write_text("x = 1\n")
@@ -411,7 +411,7 @@ def test_single_issue_file_not_batched(tmp_path):
     )
 
     provider = MockAIProvider()
-    generate_fixes(
+    await generate_fixes(
         [issue],
         provider,
         tool_name="ruff",

--- a/tests/unit/ai/test_fix_generation_batch.py
+++ b/tests/unit/ai/test_fix_generation_batch.py
@@ -21,7 +21,7 @@ from tests.unit.ai.conftest import MockAIProvider, MockIssue
 # ---------------------------------------------------------------------------
 
 
-def test_batch_prompt_for_multi_issue_file(tmp_path):
+async def test_batch_prompt_for_multi_issue_file(tmp_path):
     """Multiple issues in one file should trigger a batch prompt."""
     source = tmp_path / "multi.py"
     source.write_text("x = 1\ny = 2\nz = 3\n")
@@ -72,7 +72,7 @@ def test_batch_prompt_for_multi_issue_file(tmp_path):
     )
     provider = MockAIProvider(responses=[batch_response])
 
-    result = generate_fixes(
+    result = await generate_fixes(
         issues,
         provider,
         tool_name="ruff",
@@ -92,7 +92,7 @@ def test_batch_prompt_for_multi_issue_file(tmp_path):
     assert_that(result[0].tool_name).is_equal_to("ruff")
 
 
-def test_batch_fallback_to_single_on_parse_failure(tmp_path):
+async def test_batch_fallback_to_single_on_parse_failure(tmp_path):
     """Failed batch parse falls back to single-issue mode."""
     source = tmp_path / "multi.py"
     source.write_text("x = 1\ny = 2\n")
@@ -155,7 +155,7 @@ def test_batch_fallback_to_single_on_parse_failure(tmp_path):
     ]
     provider = MockAIProvider(responses=responses)
 
-    result = generate_fixes(
+    result = await generate_fixes(
         issues,
         provider,
         tool_name="ruff",

--- a/tests/unit/ai/test_fix_generation_edge.py
+++ b/tests/unit/ai/test_fix_generation_edge.py
@@ -48,7 +48,7 @@ def _make_ai_response(
 # ---------------------------------------------------------------------------
 
 
-def test_generate_fixes_handles_provider_error(tmp_path):
+async def test_generate_fixes_handles_provider_error(tmp_path):
     """Verify that a provider exception results in an empty fix list."""
     source = tmp_path / "test.py"
     source.write_text("x = 1\n")
@@ -61,11 +61,11 @@ def test_generate_fixes_handles_provider_error(tmp_path):
     )
 
     class ErrorProvider(MockAIProvider):
-        def complete(self, prompt, **kwargs):
+        async def complete(self, prompt, **kwargs):
             raise RuntimeError("API down")
 
     provider = ErrorProvider()
-    result = generate_fixes(
+    result = await generate_fixes(
         [issue],
         provider,
         tool_name="ruff",
@@ -79,7 +79,7 @@ def test_generate_fixes_handles_provider_error(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_concurrent_generation_with_multiple_workers(tmp_path):
+async def test_concurrent_generation_with_multiple_workers(tmp_path):
     """generate_fixes with max_workers=3 exercises the ThreadPoolExecutor path."""
     # Use separate files so batching does not group them,
     # exercising the ThreadPoolExecutor path for single-issue calls.
@@ -119,7 +119,7 @@ def test_concurrent_generation_with_multiple_workers(tmp_path):
     ]
     provider = MockAIProvider(responses=responses)
 
-    result = generate_fixes(
+    result = await generate_fixes(
         issues,
         provider,
         tool_name="ruff",
@@ -131,7 +131,7 @@ def test_concurrent_generation_with_multiple_workers(tmp_path):
     assert_that(result).is_length(3)
 
 
-def test_concurrent_mixed_success_and_failure(tmp_path):
+async def test_concurrent_mixed_success_and_failure(tmp_path):
     """Concurrent mode: one success, one failure -> 1 suggestion returned."""
     # Use separate files so batching does not group them
     source1 = tmp_path / "test1.py"
@@ -181,7 +181,7 @@ def test_concurrent_mixed_success_and_failure(tmp_path):
     ]
     provider = MockAIProvider(responses=responses)
 
-    result = generate_fixes(
+    result = await generate_fixes(
         issues,
         provider,
         tool_name="ruff",
@@ -198,7 +198,7 @@ def test_concurrent_mixed_success_and_failure(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_retries_on_provider_error(tmp_path):
+async def test_retries_on_provider_error(tmp_path):
     """Transient AIProviderError triggers retries, then succeeds."""
     from lintro.ai.exceptions import AIProviderError
 
@@ -216,14 +216,14 @@ def test_retries_on_provider_error(tmp_path):
     success_response = _make_ai_response()
 
     class RetryProvider(MockAIProvider):
-        def complete(self, prompt, **kwargs):
+        async def complete(self, prompt, **kwargs):
             call_count["n"] += 1
             if call_count["n"] < 3:
                 raise AIProviderError("transient")
             return success_response
 
     provider = RetryProvider()
-    result = generate_fixes(
+    result = await generate_fixes(
         [issue],
         provider,
         tool_name="ruff",
@@ -235,7 +235,7 @@ def test_retries_on_provider_error(tmp_path):
     assert_that(result).is_length(1)
 
 
-def test_no_retry_on_auth_error(tmp_path):
+async def test_no_retry_on_auth_error(tmp_path):
     """AIAuthenticationError is never retried."""
     from lintro.ai.exceptions import AIAuthenticationError
 
@@ -252,12 +252,12 @@ def test_no_retry_on_auth_error(tmp_path):
     call_count = {"n": 0}
 
     class AuthErrorProvider(MockAIProvider):
-        def complete(self, prompt, **kwargs):
+        async def complete(self, prompt, **kwargs):
             call_count["n"] += 1
             raise AIAuthenticationError("bad key")
 
     provider = AuthErrorProvider()
-    result = generate_fixes(
+    result = await generate_fixes(
         [issue],
         provider,
         tool_name="ruff",
@@ -270,7 +270,7 @@ def test_no_retry_on_auth_error(tmp_path):
     assert_that(result).is_empty()
 
 
-def test_max_retries_zero_means_no_retry(tmp_path):
+async def test_max_retries_zero_means_no_retry(tmp_path):
     """max_retries=0 means no retry on transient error — only one call."""
     from lintro.ai.exceptions import AIProviderError
 
@@ -287,12 +287,12 @@ def test_max_retries_zero_means_no_retry(tmp_path):
     call_count = {"n": 0}
 
     class FailOnceProvider(MockAIProvider):
-        def complete(self, prompt, **kwargs):
+        async def complete(self, prompt, **kwargs):
             call_count["n"] += 1
             raise AIProviderError("transient failure")
 
     provider = FailOnceProvider()
-    result = generate_fixes(
+    result = await generate_fixes(
         [issue],
         provider,
         tool_name="ruff",

--- a/tests/unit/ai/test_invoke.py
+++ b/tests/unit/ai/test_invoke.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from assertpy import assert_that
@@ -16,6 +16,14 @@ from lintro.ai.providers.response import AIResponse
 
 
 def _response(*, cost: float = 0.01) -> AIResponse:
+    """Build a stub provider response.
+
+    Args:
+        cost: Cost estimate recorded on the response.
+
+    Returns:
+        A populated ``AIResponse``.
+    """
     return AIResponse(
         content='{"ok": true}',
         model="test-model",
@@ -26,9 +34,10 @@ def _response(*, cost: float = 0.01) -> AIResponse:
     )
 
 
-def test_call_ai_returns_response_and_records_budget() -> None:
+async def test_call_ai_returns_response_and_records_budget() -> None:
     """call_ai records cost against the session budget."""
     provider = MagicMock()
+    provider.complete = AsyncMock()
     provider.complete.return_value = _response(cost=0.02)
     config = AIConfig(
         enabled=True,
@@ -37,7 +46,7 @@ def test_call_ai_returns_response_and_records_budget() -> None:
     )
     budget = CostBudget(max_cost_usd=1.0)
 
-    response = call_ai(
+    response = await call_ai(
         provider=provider,
         ai_config=config,
         user_prompt="hello",
@@ -49,9 +58,10 @@ def test_call_ai_returns_response_and_records_budget() -> None:
     assert_that(budget.spent).is_equal_to(0.02)
 
 
-def test_call_ai_retries_on_provider_error() -> None:
+async def test_call_ai_retries_on_provider_error() -> None:
     """Transient provider errors are retried according to config."""
     provider = MagicMock()
+    provider.complete = AsyncMock()
     provider.complete.side_effect = [
         AIProviderError("temporary"),
         _response(),
@@ -64,8 +74,8 @@ def test_call_ai_retries_on_provider_error() -> None:
         retry_max_delay=1.0,
     )
 
-    with patch("lintro.ai.retry.time.sleep"):
-        response = call_ai(
+    with patch("lintro.ai.retry.asyncio.sleep"):
+        response = await call_ai(
             provider=provider,
             ai_config=config,
             user_prompt="hello",
@@ -77,9 +87,10 @@ def test_call_ai_retries_on_provider_error() -> None:
     assert_that(provider.complete.call_count).is_equal_to(2)
 
 
-def test_call_ai_returns_response_when_single_call_exceeds_budget() -> None:
+async def test_call_ai_returns_response_when_single_call_exceeds_budget() -> None:
     """A completed call is returned even when it pushes spent over the limit."""
     provider = MagicMock()
+    provider.complete = AsyncMock()
     provider.complete.return_value = _response(cost=0.50)
     config = AIConfig(
         enabled=True,
@@ -88,7 +99,7 @@ def test_call_ai_returns_response_when_single_call_exceeds_budget() -> None:
     )
     budget = CostBudget(max_cost_usd=0.10)
 
-    response = call_ai(
+    response = await call_ai(
         provider=provider,
         ai_config=config,
         user_prompt="hello",
@@ -100,9 +111,10 @@ def test_call_ai_returns_response_when_single_call_exceeds_budget() -> None:
     assert_that(budget.spent).is_equal_to(0.50)
 
 
-def test_call_ai_raises_when_budget_already_exceeded() -> None:
+async def test_call_ai_raises_when_budget_already_exceeded() -> None:
     """Subsequent calls fail once the budget ceiling has been reached."""
     provider = MagicMock()
+    provider.complete = AsyncMock()
     provider.complete.return_value = _response(cost=0.50)
     config = AIConfig(
         enabled=True,
@@ -113,7 +125,7 @@ def test_call_ai_raises_when_budget_already_exceeded() -> None:
     budget.record(0.10)
 
     with pytest.raises(AIError, match="budget exceeded"):
-        call_ai(
+        await call_ai(
             provider=provider,
             ai_config=config,
             user_prompt="hello",

--- a/tests/unit/ai/test_pipeline.py
+++ b/tests/unit/ai/test_pipeline.py
@@ -83,7 +83,7 @@ def _make_fix_issues(
 @patch(f"{_PIPELINE}.review_fixes_interactive")
 @patch(f"{_PIPELINE}.apply_fixes")
 @patch(f"{_PIPELINE}.generate_fixes_from_params")
-def test_budget_tracking_across_multiple_tools(
+async def test_budget_tracking_across_multiple_tools(
     mock_generate_fixes_from_params,
     mock_apply_fixes,
     mock_review_fixes_interactive,
@@ -119,7 +119,7 @@ def test_budget_tracking_across_multiple_tools(
 
     ai_config = _default_ai_config(max_fix_attempts=3)
 
-    run_fix_pipeline(
+    await run_fix_pipeline(
         fix_issues=fix_issues,
         provider=MockAIProvider(),
         ai_config=ai_config,
@@ -147,7 +147,7 @@ def test_budget_tracking_across_multiple_tools(
 @patch(f"{_PIPELINE}.review_fixes_interactive")
 @patch(f"{_PIPELINE}.apply_fixes")
 @patch(f"{_PIPELINE}.generate_fixes_from_params")
-def test_safe_vs_risky_suggestion_splitting(
+async def test_safe_vs_risky_suggestion_splitting(
     mock_generate_fixes_from_params,
     mock_apply_fixes,
     mock_review_fixes_interactive,
@@ -173,7 +173,7 @@ def test_safe_vs_risky_suggestion_splitting(
 
     ai_config = _default_ai_config(auto_apply_safe_fixes=True)
 
-    run_fix_pipeline(
+    await run_fix_pipeline(
         fix_issues=fix_issues,
         provider=MockAIProvider(),
         ai_config=ai_config,
@@ -195,7 +195,7 @@ def test_safe_vs_risky_suggestion_splitting(
 @patch(f"{_PIPELINE}.review_fixes_interactive")
 @patch(f"{_PIPELINE}.apply_fixes")
 @patch(f"{_PIPELINE}.generate_fixes_from_params")
-def test_auto_apply_fast_path_json_mode(
+async def test_auto_apply_fast_path_json_mode(
     mock_generate_fixes_from_params,
     mock_apply_fixes,
     mock_review_fixes_interactive,
@@ -217,7 +217,7 @@ def test_auto_apply_fast_path_json_mode(
 
     ai_config = _default_ai_config(auto_apply_safe_fixes=True, auto_apply=False)
 
-    run_fix_pipeline(
+    await run_fix_pipeline(
         fix_issues=fix_issues,
         provider=MockAIProvider(),
         ai_config=ai_config,
@@ -242,7 +242,7 @@ def test_auto_apply_fast_path_json_mode(
 @patch(f"{_PIPELINE}.apply_fixes")
 @patch(f"{_PIPELINE}.generate_fixes_from_params")
 @patch(f"{_PIPELINE}.sys.stdin.isatty", return_value=True)
-def test_interactive_review_path(
+async def test_interactive_review_path(
     _mock_isatty,
     mock_generate_fixes_from_params,
     mock_apply_fixes,
@@ -265,7 +265,7 @@ def test_interactive_review_path(
 
     ai_config = _default_ai_config(auto_apply=False, auto_apply_safe_fixes=False)
 
-    run_fix_pipeline(
+    await run_fix_pipeline(
         fix_issues=fix_issues,
         provider=MockAIProvider(),
         ai_config=ai_config,
@@ -287,7 +287,7 @@ def test_interactive_review_path(
 @patch(f"{_PIPELINE}.review_fixes_interactive")
 @patch(f"{_PIPELINE}.apply_fixes")
 @patch(f"{_PIPELINE}.generate_fixes_from_params")
-def test_no_suggestions_returns_early(
+async def test_no_suggestions_returns_early(
     mock_generate_fixes_from_params,
     mock_apply_fixes,
     mock_review_fixes_interactive,
@@ -305,7 +305,7 @@ def test_no_suggestions_returns_early(
 
     ai_config = _default_ai_config()
 
-    run_fix_pipeline(
+    await run_fix_pipeline(
         fix_issues=fix_issues,
         provider=MockAIProvider(),
         ai_config=ai_config,
@@ -328,7 +328,7 @@ def test_no_suggestions_returns_early(
 @patch(f"{_PIPELINE}.review_fixes_interactive")
 @patch(f"{_PIPELINE}.apply_fixes")
 @patch(f"{_PIPELINE}.generate_fixes_from_params")
-def test_post_fix_summary_generation(
+async def test_post_fix_summary_generation(
     mock_generate_fixes_from_params,
     mock_apply_fixes,
     mock_review_fixes_interactive,
@@ -356,7 +356,7 @@ def test_post_fix_summary_generation(
 
     ai_config = _default_ai_config(auto_apply=True)
 
-    run_fix_pipeline(
+    await run_fix_pipeline(
         fix_issues=fix_issues,
         provider=MockAIProvider(),
         ai_config=ai_config,
@@ -379,7 +379,7 @@ def test_post_fix_summary_generation(
 @patch(f"{_PIPELINE}.review_fixes_interactive")
 @patch(f"{_PIPELINE}.apply_fixes")
 @patch(f"{_PIPELINE}.generate_fixes_from_params")
-def test_verify_fixes_flow(
+async def test_verify_fixes_flow(
     mock_generate_fixes_from_params,
     mock_apply_fixes,
     mock_review_fixes_interactive,
@@ -407,7 +407,7 @@ def test_verify_fixes_flow(
 
     ai_config = _default_ai_config(auto_apply=True)
 
-    run_fix_pipeline(
+    await run_fix_pipeline(
         fix_issues=fix_issues,
         provider=MockAIProvider(),
         ai_config=ai_config,

--- a/tests/unit/ai/test_refinement.py
+++ b/tests/unit/ai/test_refinement.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from assertpy import assert_that
 
@@ -66,7 +66,7 @@ def test_revert_fix_returns_false_when_apply_fails(tmp_path: Path) -> None:
 # -- refine_unverified_fixes -----------------------------------------------
 
 
-def test_refine_returns_empty_when_no_unverified_keys(tmp_path: Path) -> None:
+async def test_refine_returns_empty_when_no_unverified_keys(tmp_path: Path) -> None:
     """refine_unverified_fixes returns empty list when no detail matches."""
     suggestion = _make_suggestion()
     validation = ValidationResult(
@@ -75,6 +75,7 @@ def test_refine_returns_empty_when_no_unverified_keys(tmp_path: Path) -> None:
         details=["[E001] test.py:10 — fix verified"],
     )
     provider = MagicMock()
+    provider.complete = AsyncMock()
     ai_config = MagicMock()
     ai_config.fallback_models = []
     ai_config.max_retries = 0
@@ -82,7 +83,7 @@ def test_refine_returns_empty_when_no_unverified_keys(tmp_path: Path) -> None:
     ai_config.retry_max_delay = 30.0
     ai_config.retry_backoff_factor = 2.0
 
-    refined, cost = refine_unverified_fixes(
+    refined, cost = await refine_unverified_fixes(
         applied_suggestions=[suggestion],
         validation=validation,
         provider=provider,
@@ -94,7 +95,7 @@ def test_refine_returns_empty_when_no_unverified_keys(tmp_path: Path) -> None:
     assert_that(cost).is_equal_to(0.0)
 
 
-def test_refine_parses_detail_strings_correctly(tmp_path: Path) -> None:
+async def test_refine_parses_detail_strings_correctly(tmp_path: Path) -> None:
     """Parses '[code] file:line - issue still present' details."""
     suggestion = _make_suggestion(code="W123", line=42, file="src/main.py")
     validation = ValidationResult(
@@ -104,6 +105,7 @@ def test_refine_parses_detail_strings_correctly(tmp_path: Path) -> None:
     )
 
     provider = MagicMock()
+    provider.complete = AsyncMock()
     ai_config = MagicMock()
     ai_config.fallback_models = []
     ai_config.max_retries = 0
@@ -140,7 +142,7 @@ def test_refine_parses_detail_strings_correctly(tmp_path: Path) -> None:
         mock_parse.return_value = refined_sugg
         mock_apply.return_value = [refined_sugg]
 
-        refined, cost = refine_unverified_fixes(
+        refined, cost = await refine_unverified_fixes(
             applied_suggestions=[suggestion],
             validation=validation,
             provider=provider,
@@ -152,7 +154,7 @@ def test_refine_parses_detail_strings_correctly(tmp_path: Path) -> None:
     assert_that(cost).is_close_to(0.001, 0.0001)
 
 
-def test_refine_skips_when_revert_fails(tmp_path: Path) -> None:
+async def test_refine_skips_when_revert_fails(tmp_path: Path) -> None:
     """refine_unverified_fixes skips a suggestion when revert fails."""
     suggestion = _make_suggestion(code="E001", line=10)
     validation = ValidationResult(
@@ -162,6 +164,7 @@ def test_refine_skips_when_revert_fails(tmp_path: Path) -> None:
     )
 
     provider = MagicMock()
+    provider.complete = AsyncMock()
     ai_config = MagicMock()
     ai_config.fallback_models = []
     ai_config.max_retries = 0
@@ -171,7 +174,7 @@ def test_refine_skips_when_revert_fails(tmp_path: Path) -> None:
 
     with patch("lintro.ai.refinement._revert_fix") as mock_revert:
         mock_revert.return_value = False
-        refined, cost = refine_unverified_fixes(
+        refined, cost = await refine_unverified_fixes(
             applied_suggestions=[suggestion],
             validation=validation,
             provider=provider,
@@ -183,7 +186,7 @@ def test_refine_skips_when_revert_fails(tmp_path: Path) -> None:
     assert_that(cost).is_equal_to(0.0)
 
 
-def test_refine_skips_when_parse_returns_none(tmp_path: Path) -> None:
+async def test_refine_skips_when_parse_returns_none(tmp_path: Path) -> None:
     """refine_unverified_fixes skips when _parse_fix_response returns None."""
     suggestion = _make_suggestion(code="E001", line=10)
     validation = ValidationResult(
@@ -193,6 +196,7 @@ def test_refine_skips_when_parse_returns_none(tmp_path: Path) -> None:
     )
 
     provider = MagicMock()
+    provider.complete = AsyncMock()
     ai_config = MagicMock()
     ai_config.fallback_models = []
     ai_config.max_retries = 0
@@ -223,7 +227,7 @@ def test_refine_skips_when_parse_returns_none(tmp_path: Path) -> None:
 
         mock_parse.return_value = None
 
-        refined, _cost = refine_unverified_fixes(
+        refined, _cost = await refine_unverified_fixes(
             applied_suggestions=[suggestion],
             validation=validation,
             provider=provider,

--- a/tests/unit/ai/test_retry.py
+++ b/tests/unit/ai/test_retry.py
@@ -1,8 +1,8 @@
-"""Tests for AI retry decorator."""
+"""Tests for the async AI retry decorator."""
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from assertpy import assert_that
@@ -15,102 +15,167 @@ from lintro.ai.exceptions import (
 from lintro.ai.retry import with_retry
 
 
-def test_retry_succeeds_on_first_attempt():
+async def test_retry_succeeds_on_first_attempt() -> None:
     """Verify decorated function returns immediately on success without retrying."""
     call_count = 0
 
     @with_retry(max_retries=3)
-    def fn():
+    async def fn() -> str:
+        """Succeed immediately.
+
+        Returns:
+            A fixed marker value.
+        """
         nonlocal call_count
         call_count += 1
         return "ok"
 
-    result = fn()
+    result = await fn()
     assert_that(result).is_equal_to("ok")
     assert_that(call_count).is_equal_to(1)
 
 
-@patch("lintro.ai.retry.time.sleep")
-def test_retry_retries_on_provider_error(mock_sleep):
-    """Verify AIProviderError triggers retries until success."""
+@patch("lintro.ai.retry.asyncio.sleep")
+async def test_retry_retries_on_provider_error(mock_sleep: MagicMock) -> None:
+    """Verify AIProviderError triggers retries until success.
+
+    Args:
+        mock_sleep: Patched ``asyncio.sleep``.
+    """
     call_count = 0
 
     @with_retry(max_retries=3, base_delay=1.0)
-    def fn():
+    async def fn() -> str:
+        """Fail twice, then succeed.
+
+        Returns:
+            A fixed marker value.
+
+        Raises:
+            AIProviderError: On the first two attempts.
+        """
         nonlocal call_count
         call_count += 1
         if call_count < 3:
             raise AIProviderError("server error")
         return "ok"
 
-    result = fn()
+    result = await fn()
     assert_that(result).is_equal_to("ok")
     assert_that(call_count).is_equal_to(3)
     assert_that(mock_sleep.call_count).is_equal_to(2)
 
 
-@patch("lintro.ai.retry.time.sleep")
-def test_retry_retries_on_rate_limit_error(mock_sleep):
-    """Verify AIRateLimitError triggers retries until success."""
+@patch("lintro.ai.retry.asyncio.sleep")
+async def test_retry_retries_on_rate_limit_error(mock_sleep: MagicMock) -> None:
+    """Verify AIRateLimitError triggers retries until success.
+
+    Args:
+        mock_sleep: Patched ``asyncio.sleep``.
+    """
     call_count = 0
 
     @with_retry(max_retries=2, base_delay=1.0)
-    def fn():
+    async def fn() -> str:
+        """Fail once with a rate limit, then succeed.
+
+        Returns:
+            A fixed marker value.
+
+        Raises:
+            AIRateLimitError: On the first attempt.
+        """
         nonlocal call_count
         call_count += 1
         if call_count < 2:
             raise AIRateLimitError("rate limited")
         return "ok"
 
-    result = fn()
+    result = await fn()
     assert_that(result).is_equal_to("ok")
     assert_that(call_count).is_equal_to(2)
     mock_sleep.assert_called_once()
 
 
-def test_retry_does_not_retry_on_authentication_error():
+async def test_retry_does_not_retry_on_authentication_error() -> None:
     """Verify AIAuthenticationError is raised immediately without retrying."""
     call_count = 0
 
     @with_retry(max_retries=3)
-    def fn():
+    async def fn() -> str:
+        """Always fail with an authentication error.
+
+        Returns:
+            Never returns.
+
+        Raises:
+            AIAuthenticationError: Always.
+        """
         nonlocal call_count
         call_count += 1
         raise AIAuthenticationError("bad key")
 
     with pytest.raises(AIAuthenticationError):
-        fn()
+        await fn()
     assert_that(call_count).is_equal_to(1)
 
 
-@patch("lintro.ai.retry.time.sleep")
-def test_retry_raises_after_max_retries_exhausted(mock_sleep):
-    """Verify the original error is raised after all retry attempts are exhausted."""
+@patch("lintro.ai.retry.asyncio.sleep")
+async def test_retry_raises_after_max_retries_exhausted(mock_sleep: MagicMock) -> None:
+    """Verify the original error is raised after all retry attempts are exhausted.
+
+    Args:
+        mock_sleep: Patched ``asyncio.sleep``.
+    """
 
     @with_retry(max_retries=2, base_delay=0.1)
-    def fn():
+    async def fn() -> str:
+        """Always fail with a provider error.
+
+        Returns:
+            Never returns.
+
+        Raises:
+            AIProviderError: Always.
+        """
         raise AIProviderError("always fails")
 
     with pytest.raises(AIProviderError, match="always fails"):
-        fn()
+        await fn()
     assert_that(mock_sleep.call_count).is_equal_to(2)
 
 
 @patch("lintro.ai.retry.random.uniform", return_value=1.0)
-@patch("lintro.ai.retry.time.sleep")
-def test_retry_exponential_backoff_delays(mock_sleep, _mock_uniform):
-    """Verify retry delays follow exponential backoff progression."""
+@patch("lintro.ai.retry.asyncio.sleep")
+async def test_retry_exponential_backoff_delays(
+    mock_sleep: MagicMock,
+    _mock_uniform: MagicMock,
+) -> None:
+    """Verify retry delays follow exponential backoff progression.
+
+    Args:
+        mock_sleep: Patched ``asyncio.sleep``.
+        _mock_uniform: Patched jitter source pinned to 1.0.
+    """
     call_count = 0
 
     @with_retry(max_retries=3, base_delay=1.0, backoff_factor=2.0)
-    def fn():
+    async def fn() -> str:
+        """Fail three times, then succeed.
+
+        Returns:
+            A fixed marker value.
+
+        Raises:
+            AIProviderError: On the first three attempts.
+        """
         nonlocal call_count
         call_count += 1
         if call_count <= 3:
             raise AIProviderError("fail")
         return "ok"
 
-    result = fn()
+    result = await fn()
     assert_that(result).is_equal_to("ok")
 
     delays = [call.args[0] for call in mock_sleep.call_args_list]
@@ -118,9 +183,17 @@ def test_retry_exponential_backoff_delays(mock_sleep, _mock_uniform):
 
 
 @patch("lintro.ai.retry.random.uniform", return_value=1.0)
-@patch("lintro.ai.retry.time.sleep")
-def test_retry_max_delay_cap(mock_sleep, _mock_uniform):
-    """Verify retry delays are capped at the configured max_delay value."""
+@patch("lintro.ai.retry.asyncio.sleep")
+async def test_retry_max_delay_cap(
+    mock_sleep: MagicMock,
+    _mock_uniform: MagicMock,
+) -> None:
+    """Verify retry delays are capped at the configured max_delay value.
+
+    Args:
+        mock_sleep: Patched ``asyncio.sleep``.
+        _mock_uniform: Patched jitter source pinned to 1.0.
+    """
     call_count = 0
 
     @with_retry(
@@ -129,41 +202,61 @@ def test_retry_max_delay_cap(mock_sleep, _mock_uniform):
         backoff_factor=3.0,
         max_delay=25.0,
     )
-    def fn():
+    async def fn() -> str:
+        """Fail five times, then succeed.
+
+        Returns:
+            A fixed marker value.
+
+        Raises:
+            AIProviderError: On the first five attempts.
+        """
         nonlocal call_count
         call_count += 1
         if call_count <= 5:
             raise AIProviderError("fail")
         return "ok"
 
-    fn()
+    await fn()
     delays = [call.args[0] for call in mock_sleep.call_args_list]
     assert_that(delays).is_length(5)
     assert_that(delays).is_equal_to([10.0, 25.0, 25.0, 25.0, 25.0])
 
 
-def test_retry_does_not_retry_non_ai_exceptions():
+async def test_retry_does_not_retry_non_ai_exceptions() -> None:
     """Verify non-AI exceptions propagate immediately without retrying."""
     call_count = 0
 
     @with_retry(max_retries=3)
-    def fn():
+    async def fn() -> str:
+        """Always fail with a non-AI exception.
+
+        Returns:
+            Never returns.
+
+        Raises:
+            ValueError: Always.
+        """
         nonlocal call_count
         call_count += 1
         raise ValueError("not an AI error")
 
     with pytest.raises(ValueError, match="not an AI error"):
-        fn()
+        await fn()
     assert_that(call_count).is_equal_to(1)
 
 
-def test_retry_preserves_function_metadata():
+def test_retry_preserves_function_metadata() -> None:
     """Verify the retry decorator preserves the wrapped function name and docstring."""
 
     @with_retry(max_retries=1)
-    def my_function():
-        """My docstring."""
+    async def my_function() -> int:
+        """My docstring.
+
+        Returns:
+            A fixed value.
+        """
         return 42
 
     assert_that(my_function.__name__).is_equal_to("my_function")
-    assert_that(my_function.__doc__).is_equal_to("My docstring.")
+    assert_that(my_function.__doc__).starts_with("My docstring.")

--- a/tests/unit/ai/test_stream_fallback.py
+++ b/tests/unit/ai/test_stream_fallback.py
@@ -2,17 +2,28 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+
 import pytest
 from assertpy import assert_that
 
 from lintro.ai.exceptions import AIProviderError
 from lintro.ai.fallback import stream_complete_with_fallback
 from lintro.ai.json_response import CliSchemaRequest
-from lintro.ai.providers.base import AIResponse, AIStreamResult, BaseAIProvider
+from lintro.ai.providers.base import AIResponse, AsyncAIStreamResult, BaseAIProvider
 from lintro.ai.providers.constants import DEFAULT_PER_CALL_MAX_TOKENS, DEFAULT_TIMEOUT
 
 
 def _make_response(content: str = "ok", provider: str = "stub") -> AIResponse:
+    """Build a stub provider response.
+
+    Args:
+        content: Response content.
+        provider: Provider identifier recorded on the response.
+
+    Returns:
+        A populated ``AIResponse``.
+    """
     return AIResponse(
         content=content,
         model="m",
@@ -23,10 +34,27 @@ def _make_response(content: str = "ok", provider: str = "stub") -> AIResponse:
     )
 
 
+async def _one_chunk(text: str) -> AsyncIterator[str]:
+    """Yield a single chunk.
+
+    Args:
+        text: The chunk to yield.
+
+    Yields:
+        str: The chunk.
+    """
+    yield text
+
+
 class _SuccessProvider(BaseAIProvider):
     """Provider that always succeeds."""
 
     def __init__(self, name: str = "success") -> None:
+        """Initialise the stub provider.
+
+        Args:
+            name: Provider identifier used in responses and chunks.
+        """
         self._name = name
         self._provider_name = name
         self._has_sdk = True
@@ -35,11 +63,20 @@ class _SuccessProvider(BaseAIProvider):
         self._max_tokens = DEFAULT_PER_CALL_MAX_TOKENS
         self._base_url = None
         self._client = "fake"
+        self._client_loop = None
 
     def _create_client(self, *, api_key: str) -> object:
+        """Return a stub client.
+
+        Args:
+            api_key: Ignored API key.
+
+        Returns:
+            A stub client marker.
+        """
         return "fake"
 
-    def complete(
+    async def complete(
         self,
         prompt: str,
         *,
@@ -51,10 +88,25 @@ class _SuccessProvider(BaseAIProvider):
         model: str | None = None,
         cli_schema: CliSchemaRequest | None = None,
     ) -> AIResponse:
+        """Return a canned response.
+
+        Args:
+            prompt: Ignored user prompt.
+            system: Ignored system prompt.
+            max_tokens: Ignored token cap.
+            timeout: Ignored timeout.
+            repo_root: Ignored repository root.
+            use_one_shot: Ignored session flag.
+            model: Ignored model override.
+            cli_schema: Ignored schema request.
+
+        Returns:
+            A canned response naming this provider.
+        """
         del model, cli_schema
         return _make_response(content=f"from-{self._name}", provider=self._name)
 
-    def stream_complete(
+    async def stream_complete(
         self,
         prompt: str,
         *,
@@ -62,11 +114,23 @@ class _SuccessProvider(BaseAIProvider):
         max_tokens: int = DEFAULT_PER_CALL_MAX_TOKENS,
         timeout: float = DEFAULT_TIMEOUT,
         model: str | None = None,
-    ) -> AIStreamResult:
+    ) -> AsyncAIStreamResult:
+        """Return a one-chunk async stream.
+
+        Args:
+            prompt: Ignored user prompt.
+            system: Ignored system prompt.
+            max_tokens: Ignored token cap.
+            timeout: Ignored timeout.
+            model: Ignored model override.
+
+        Returns:
+            A stream yielding one chunk naming this provider.
+        """
         del model
         resp = _make_response(content="", provider=self._name)
-        return AIStreamResult(
-            _chunks=iter([f"chunk-{self._name}"]),
+        return AsyncAIStreamResult(
+            _chunks=_one_chunk(f"chunk-{self._name}"),
             _on_done=lambda: resp,
         )
 
@@ -75,6 +139,7 @@ class _FailingProvider(BaseAIProvider):
     """Provider that always raises."""
 
     def __init__(self) -> None:
+        """Initialise the failing stub provider."""
         self._provider_name = "failing"
         self._has_sdk = True
         self._model = "fail-model"
@@ -82,11 +147,20 @@ class _FailingProvider(BaseAIProvider):
         self._max_tokens = DEFAULT_PER_CALL_MAX_TOKENS
         self._base_url = None
         self._client = "fake"
+        self._client_loop = None
 
     def _create_client(self, *, api_key: str) -> object:
+        """Return a stub client.
+
+        Args:
+            api_key: Ignored API key.
+
+        Returns:
+            A stub client marker.
+        """
         return "fake"
 
-    def complete(
+    async def complete(
         self,
         prompt: str,
         *,
@@ -98,10 +172,28 @@ class _FailingProvider(BaseAIProvider):
         model: str | None = None,
         cli_schema: CliSchemaRequest | None = None,
     ) -> AIResponse:
+        """Always fail.
+
+        Args:
+            prompt: Ignored user prompt.
+            system: Ignored system prompt.
+            max_tokens: Ignored token cap.
+            timeout: Ignored timeout.
+            repo_root: Ignored repository root.
+            use_one_shot: Ignored session flag.
+            model: Ignored model override.
+            cli_schema: Ignored schema request.
+
+        Returns:
+            Never returns.
+
+        Raises:
+            AIProviderError: Always.
+        """
         del model, cli_schema
         raise AIProviderError("provider down")
 
-    def stream_complete(
+    async def stream_complete(
         self,
         prompt: str,
         *,
@@ -109,26 +201,43 @@ class _FailingProvider(BaseAIProvider):
         max_tokens: int = DEFAULT_PER_CALL_MAX_TOKENS,
         timeout: float = DEFAULT_TIMEOUT,
         model: str | None = None,
-    ) -> AIStreamResult:
+    ) -> AsyncAIStreamResult:
+        """Always fail before a stream is opened.
+
+        Args:
+            prompt: Ignored user prompt.
+            system: Ignored system prompt.
+            max_tokens: Ignored token cap.
+            timeout: Ignored timeout.
+            model: Ignored model override.
+
+        Returns:
+            Never returns.
+
+        Raises:
+            AIProviderError: Always.
+        """
         del model
         raise AIProviderError("stream provider down")
 
 
-def test_stream_fallback_returns_first_success() -> None:
+async def test_stream_fallback_returns_first_success() -> None:
     """Return the stream from the first working provider."""
     provider = _SuccessProvider("primary")
-    result = stream_complete_with_fallback(provider, "prompt")
+    result = await stream_complete_with_fallback(provider, "prompt")
 
-    chunks = list(result)
+    chunks = [chunk async for chunk in result]
     assert_that(chunks).is_equal_to(["chunk-primary"])
 
 
-def test_stream_fallback_tries_fallback_models() -> None:
+async def test_stream_fallback_tries_fallback_models() -> None:
     """Falls back to alternate model when primary fails."""
     calls: list[str] = []
 
     class _ModelTrackingProvider(_SuccessProvider):
-        def stream_complete(
+        """Stub that fails on the primary model and records attempts."""
+
+        async def stream_complete(
             self,
             prompt: str,
             *,
@@ -136,12 +245,27 @@ def test_stream_fallback_tries_fallback_models() -> None:
             max_tokens: int = DEFAULT_PER_CALL_MAX_TOKENS,
             timeout: float = DEFAULT_TIMEOUT,
             model: str | None = None,
-        ) -> AIStreamResult:
+        ) -> AsyncAIStreamResult:
+            """Fail on the primary model, succeed on any fallback.
+
+            Args:
+                prompt: The user prompt.
+                system: Optional system prompt.
+                max_tokens: Token cap for the call.
+                timeout: Request timeout in seconds.
+                model: Model override for this attempt.
+
+            Returns:
+                A one-chunk stream for a fallback model.
+
+            Raises:
+                AIProviderError: When the primary model is used.
+            """
             effective_model = model or self._model
             calls.append(effective_model)
             if effective_model == "test-model":
                 raise AIProviderError("primary failed")
-            return super().stream_complete(
+            return await super().stream_complete(
                 prompt,
                 system=system,
                 max_tokens=max_tokens,
@@ -150,30 +274,32 @@ def test_stream_fallback_tries_fallback_models() -> None:
             )
 
     provider = _ModelTrackingProvider("tracker")
-    result = stream_complete_with_fallback(
+    result = await stream_complete_with_fallback(
         provider,
         "prompt",
         fallback_models=["fallback-model"],
     )
 
-    chunks = list(result)
+    chunks = [chunk async for chunk in result]
     assert_that(chunks).is_equal_to(["chunk-tracker"])
     assert_that(calls).is_equal_to(["test-model", "fallback-model"])
 
 
-def test_stream_fallback_raises_when_all_fail() -> None:
+async def test_stream_fallback_raises_when_all_fail() -> None:
     """Raise AIProviderError when all providers fail."""
     provider = _FailingProvider()
 
     with pytest.raises(AIProviderError, match="stream provider down"):
-        stream_complete_with_fallback(provider, "prompt")
+        await stream_complete_with_fallback(provider, "prompt")
 
 
-def test_stream_fallback_restores_model_name() -> None:
+async def test_stream_fallback_restores_model_name() -> None:
     """Provider model name is restored after fallback completes."""
 
     class _FailThenSuccessProvider(_SuccessProvider):
-        def stream_complete(
+        """Stub that fails on the primary model only."""
+
+        async def stream_complete(
             self,
             prompt: str,
             *,
@@ -181,11 +307,26 @@ def test_stream_fallback_restores_model_name() -> None:
             max_tokens: int = DEFAULT_PER_CALL_MAX_TOKENS,
             timeout: float = DEFAULT_TIMEOUT,
             model: str | None = None,
-        ) -> AIStreamResult:
+        ) -> AsyncAIStreamResult:
+            """Fail on the primary model, succeed on any fallback.
+
+            Args:
+                prompt: The user prompt.
+                system: Optional system prompt.
+                max_tokens: Token cap for the call.
+                timeout: Request timeout in seconds.
+                model: Model override for this attempt.
+
+            Returns:
+                A one-chunk stream for a fallback model.
+
+            Raises:
+                AIProviderError: When the primary model is used.
+            """
             effective_model = model or self._model
             if effective_model == "test-model":
                 raise AIProviderError("primary failed")
-            return super().stream_complete(
+            return await super().stream_complete(
                 prompt,
                 system=system,
                 max_tokens=max_tokens,
@@ -196,11 +337,11 @@ def test_stream_fallback_restores_model_name() -> None:
     provider = _FailThenSuccessProvider("p1")
     original_model = provider.model_name
 
-    result = stream_complete_with_fallback(
+    result = await stream_complete_with_fallback(
         provider,
         "prompt",
         fallback_models=["other-model"],
     )
-    list(result)  # consume stream so fallback logic completes
+    [chunk async for chunk in result]  # consume so fallback logic completes
 
     assert_that(provider.model_name).is_equal_to(original_model)

--- a/tests/unit/ai/test_streaming.py
+++ b/tests/unit/ai/test_streaming.py
@@ -2,17 +2,26 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from unittest.mock import MagicMock
 
 from assertpy import assert_that
 
-from lintro.ai.display.streaming import stream_to_console
+from lintro.ai.display.streaming import async_stream_to_console, stream_to_console
+from lintro.ai.providers.async_stream_result import AsyncAIStreamResult
 from lintro.ai.providers.response import AIResponse
 from lintro.ai.providers.stream_result import AIStreamResult
 
 
 def _stream(chunks: list[str]) -> AIStreamResult:
-    """Build an AIStreamResult over a fixed list of chunks."""
+    """Build an AIStreamResult over a fixed list of chunks.
+
+    Args:
+        chunks: Text chunks the stream yields.
+
+    Returns:
+        A stream result over the chunks.
+    """
 
     def _on_done() -> AIResponse:
         return AIResponse(
@@ -84,3 +93,71 @@ def test_empty_style_becomes_none() -> None:
 
     first_call = console.print.call_args_list[0]
     assert_that(first_call.kwargs["style"]).is_none()
+
+
+def _async_stream(chunks: list[str]) -> AsyncAIStreamResult:
+    """Build an AsyncAIStreamResult over a fixed list of chunks.
+
+    Args:
+        chunks: Text chunks the stream yields.
+
+    Returns:
+        An async stream result over the chunks.
+    """
+
+    async def _chunks() -> AsyncIterator[str]:
+        """Yield each chunk in order.
+
+        Yields:
+            str: One chunk at a time.
+        """
+        for chunk in chunks:
+            yield chunk
+
+    def _on_done() -> AIResponse:
+        """Return the finalized response.
+
+        Returns:
+            A response carrying the joined chunks.
+        """
+        return AIResponse(
+            content="".join(chunks),
+            model="test",
+            input_tokens=0,
+            output_tokens=0,
+            cost_estimate=0.0,
+            provider="test",
+        )
+
+    return AsyncAIStreamResult(_chunks=_chunks(), _on_done=_on_done)
+
+
+async def test_async_returns_empty_string_for_empty_stream() -> None:
+    """An empty async stream renders nothing but a trailing newline."""
+    console = MagicMock()
+
+    result = await async_stream_to_console(_async_stream([]), console)
+
+    assert_that(result).is_equal_to("")
+    console.print.assert_called_once_with()
+
+
+async def test_async_streams_chunks_in_order() -> None:
+    """Chunks reach the console in arrival order and are concatenated."""
+    console = MagicMock()
+
+    result = await async_stream_to_console(_async_stream(["a", "b", "c"]), console)
+
+    assert_that(result).is_equal_to("abc")
+    printed = [call.args[0] for call in console.print.call_args_list if call.args]
+    assert_that(printed).is_equal_to(["a", "b", "c"])
+
+
+async def test_async_applies_style_to_each_chunk() -> None:
+    """The configured Rich style is applied to every streamed chunk."""
+    console = MagicMock()
+
+    await async_stream_to_console(_async_stream(["x"]), console, style="cyan")
+
+    first_call = console.print.call_args_list[0]
+    assert_that(first_call.kwargs["style"]).is_equal_to("cyan")

--- a/tests/unit/ai/test_summary_generation.py
+++ b/tests/unit/ai/test_summary_generation.py
@@ -208,16 +208,16 @@ def test_parse_summary_response_non_dict_json_int():
 # -- generate_summary ---------------------------------------------------------
 
 
-def test_generate_summary_returns_none_for_no_issues():
+async def test_generate_summary_returns_none_for_no_issues():
     """Returns None and skips provider when no issues exist."""
     provider = MockAIProvider()
     result = ToolResult(name="ruff", success=True, issues_count=0)
-    summary = generate_summary([result], provider)
+    summary = await generate_summary([result], provider)
     assert_that(summary).is_none()
     assert_that(provider.calls).is_empty()
 
 
-def test_generate_summary_generates_summary():
+async def test_generate_summary_generates_summary():
     """Verify generate_summary calls the provider and returns a parsed AISummary."""
     issues = [
         MockIssue(file="a.py", line=1, message="bad code", code="E501"),
@@ -245,13 +245,13 @@ def test_generate_summary_generates_summary():
     )
     provider = MockAIProvider(responses=[response])
 
-    summary = generate_summary([result], provider)
+    summary = await generate_summary([result], provider)
     assert_that(summary).is_not_none()
     assert_that(summary.overview).is_equal_to("One issue found")  # type: ignore[union-attr]  # assertpy is_not_none narrows this
     assert_that(provider.calls).is_length(1)
 
 
-def test_generate_summary_handles_provider_error():
+async def test_generate_summary_handles_provider_error():
     """Verify generate_summary returns None when the provider raises an error."""
     issues = [
         MockIssue(file="a.py", line=1, message="bad", code="E501"),
@@ -264,8 +264,8 @@ def test_generate_summary_handles_provider_error():
     )
 
     class ErrorProvider(MockAIProvider):
-        def complete(self, prompt, **kwargs):
+        async def complete(self, prompt, **kwargs):
             raise RuntimeError("API down")
 
-    summary = generate_summary([result], ErrorProvider())
+    summary = await generate_summary([result], ErrorProvider())
     assert_that(summary).is_none()

--- a/tests/unit/tools/idiom_review/test_idiom_review_engine.py
+++ b/tests/unit/tools/idiom_review/test_idiom_review_engine.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from assertpy import assert_that
@@ -31,9 +31,10 @@ def _response(content: str) -> AIResponse:
     )
 
 
-def test_review_file_parses_mocked_response() -> None:
+async def test_review_file_parses_mocked_response() -> None:
     """review_file returns issues parsed from the provider response."""
     provider = MagicMock()
+    provider.complete = AsyncMock()
     provider.complete.return_value = _response(
         json.dumps(
             {
@@ -50,7 +51,7 @@ def test_review_file_parses_mocked_response() -> None:
     )
     engine = IdiomReviewEngine(provider=provider, ai_config=_config())
 
-    issues = engine.review_file(
+    issues = await engine.review_file(
         file_path="m.py",
         source="found = False\nfor x in items:\n    found = True\n",
     )
@@ -60,20 +61,22 @@ def test_review_file_parses_mocked_response() -> None:
     assert_that(provider.complete.call_count).is_equal_to(1)
 
 
-def test_review_file_empty_source_skips_provider() -> None:
+async def test_review_file_empty_source_skips_provider() -> None:
     """Whitespace-only source never calls the provider."""
     provider = MagicMock()
+    provider.complete = AsyncMock()
     engine = IdiomReviewEngine(provider=provider, ai_config=_config())
 
-    issues = engine.review_file(file_path="m.py", source="   \n")
+    issues = await engine.review_file(file_path="m.py", source="   \n")
 
     assert_that(issues).is_empty()
     assert_that(provider.complete.call_count).is_equal_to(0)
 
 
-def test_review_file_caches_by_content(tmp_path: Path) -> None:
+async def test_review_file_caches_by_content(tmp_path: Path) -> None:
     """A repeat review of identical source is served from cache."""
     provider = MagicMock()
+    provider.complete = AsyncMock()
     provider.complete.return_value = _response('{"findings": []}')
     engine = IdiomReviewEngine(
         provider=provider,
@@ -82,25 +85,27 @@ def test_review_file_caches_by_content(tmp_path: Path) -> None:
     )
     source = "x = 1\n"
 
-    engine.review_file(file_path="m.py", source=source)
-    engine.review_file(file_path="m.py", source=source)
+    await engine.review_file(file_path="m.py", source=source)
+    await engine.review_file(file_path="m.py", source=source)
 
     # Second call hit the cache: the provider was only invoked once.
     assert_that(provider.complete.call_count).is_equal_to(1)
 
 
-def test_review_duplication_empty_signatures_skips_provider() -> None:
+async def test_review_duplication_empty_signatures_skips_provider() -> None:
     """No signatures means no duplication call."""
     provider = MagicMock()
+    provider.complete = AsyncMock()
     engine = IdiomReviewEngine(provider=provider, ai_config=_config())
 
-    assert_that(engine.review_duplication([])).is_empty()
+    assert_that(await engine.review_duplication([])).is_empty()
     assert_that(provider.complete.call_count).is_equal_to(0)
 
 
-def test_review_duplication_parses_groups() -> None:
+async def test_review_duplication_parses_groups() -> None:
     """review_duplication parses duplicate groups into issues."""
     provider = MagicMock()
+    provider.complete = AsyncMock()
     provider.complete.return_value = _response(
         json.dumps(
             {
@@ -121,7 +126,7 @@ def test_review_duplication_parses_groups() -> None:
     engine = IdiomReviewEngine(provider=provider, ai_config=_config())
     sigs = extract_python_signatures("a.py", "def add(a, b):\n    return a + b\n")
 
-    issues = engine.review_duplication(sigs)
+    issues = await engine.review_duplication(sigs)
 
     assert_that(issues).is_length(2)
     assert_that(provider.complete.call_count).is_equal_to(1)

--- a/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
+++ b/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
@@ -70,13 +70,23 @@ class _FakeEngine:
     def __init__(self, *_args: object, **_kwargs: object) -> None:
         pass
 
-    def review_file(
+    async def review_file(
         self,
         *,
         file_path: str,
         source: str,  # noqa: ARG002
         language: str = "python",  # noqa: ARG002
     ) -> list[IdiomReviewIssue]:
+        """Return canned per-file findings.
+
+        Args:
+            file_path: Path recorded on each finding.
+            source: Ignored source text.
+            language: Ignored target language.
+
+        Returns:
+            Two canned findings of differing confidence.
+        """
         return [
             IdiomReviewIssue(
                 file=file_path,
@@ -96,10 +106,18 @@ class _FakeEngine:
             ),
         ]
 
-    def review_duplication(
+    async def review_duplication(
         self,
         _signatures: object,
     ) -> list[IdiomReviewIssue]:
+        """Return no duplication findings.
+
+        Args:
+            _signatures: Ignored signature list.
+
+        Returns:
+            An empty list.
+        """
         return []
 
 
@@ -152,7 +170,18 @@ def test_ai_error_degrades_gracefully(
     monkeypatch.setattr(plugin_module, "get_provider", lambda _cfg: object())
 
     class _RaisingEngine(_FakeEngine):
-        def review_file(self, **_kwargs: object) -> list[IdiomReviewIssue]:
+        async def review_file(self, **_kwargs: object) -> list[IdiomReviewIssue]:
+            """Fail as a provider with depleted credits would.
+
+            Args:
+                **_kwargs: Ignored keyword arguments.
+
+            Returns:
+                Never returns.
+
+            Raises:
+                AIAuthenticationError: Always.
+            """
             raise AIAuthenticationError("no credits")
 
     monkeypatch.setattr(plugin_module, "IdiomReviewEngine", _RaisingEngine)

--- a/uv.lock
+++ b/uv.lock
@@ -1295,6 +1295,7 @@ dev = [
     { name = "click-man" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-timeout" },
@@ -1368,6 +1369,7 @@ dev = [
     { name = "click-man", specifier = ">=0.5.1" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
@@ -2206,6 +2208,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(ai): migrate providers to async/await
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

The AI provider layer is now async end to end. Provider calls are I/O-bound, but
every call path was blocking, so concurrency had to be bought with thread pools
(`ThreadPoolExecutor` in fix generation and review chunking) and backoff waits
blocked whole worker threads.

After this change the provider layer, retry, fallback, budgeting, fix generation,
summary, refinement, the fix pipeline and the review pipeline are all coroutines,
running on a single event loop. `asyncio.run()` appears only at the sync entry
points, so nothing above the AI layer changes: Click commands, the AI hook, and
the tool-plugin protocol keep their existing signatures and behaviour.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #722

## Details

### Provider layer

- New `AsyncAIStreamResult` (`__aiter__`, `collect()`, `response()`);
  `BaseAIProvider.complete()` / `stream_complete()` are coroutines.
- Anthropic uses `AsyncAnthropic` with `async with client.messages.stream(...)`;
  OpenAI uses `AsyncOpenAI` with `async for chunk in stream`. Exception mapping
  (`AuthenticationError` → `AIAuthenticationError`, etc.) is unchanged.
- `CliTransport` spawns with `asyncio.create_subprocess_exec` under
  `asyncio.wait_for`, and kills + reaps the child on timeout **and on
  cancellation**, so an aborted review cannot orphan an agent CLI. It still
  returns `subprocess.CompletedProcess`, so stdout parsers and `check_exit_code`
  are untouched.
- The hybrid capability guard (#1612) is async: version/help probes and the flag
  gate await the transport, and their memo locks are no longer held across an
  `await` (a racing caller may duplicate a free, idempotent probe).
- SDK clients are cached per event loop — an async client owns a connection pool
  bound to the loop that created it, so a client from another loop is rebuilt.

### Call path

- `with_retry` wraps coroutine functions and waits with `asyncio.sleep`.
  `AIAuthenticationError` is still never retried (covered by new tests, including
  under concurrency).
- `_with_fallback`, `complete_with_fallback`, `stream_complete_with_fallback` and
  `call_ai` are async. `CostBudget.execute` is async and gates on an
  `asyncio.Lock`; holding the threading lock across an `await` would have
  deadlocked the loop.
- Fix generation and review chunking replace `ThreadPoolExecutor` with tasks under
  an `asyncio.Semaphore`, preserving the existing `max_workers` /
  `max_parallel_calls` ceilings and the completion-order progress callbacks.
- Audit-log writing moves off the loop with `asyncio.to_thread` — it takes a
  blocking inter-process file lock with a sleep-based retry on Windows
  (`lintro/ai/audit.py`), which is exactly the kind of call that must not run on
  the loop.

### Sync boundaries (unchanged public behaviour)

- `run_ai_enhancement()` → `asyncio.run(run_ai_enhancement_async(...))`
- `run_review()` → `asyncio.run(run_review_async(...))`
- `idiom-review` enters `asyncio.run()` once per tool run, inside the sync plugin
  protocol.

### Display

`async_stream_to_console()` consumes an `AsyncAIStreamResult`; the sync
`AIStreamResult` / `stream_to_console()` remain for sync callers, as the issue
specifies.

### Testing strategy

- `pytest-asyncio` added to the dev group with `asyncio_mode = auto`, so tests are
  plain `async def` functions with fixtures — no decorators, no test classes.
- New `tests/unit/ai/test_async_retry.py` covers async-only retry behaviour:
  backoff yields to the loop, concurrent retries overlap instead of serialising,
  auth errors still fail fast under concurrency, and cancellation propagates.
- New shared `patch_cli_exec` double in `tests/unit/ai/conftest.py` patches
  `asyncio.create_subprocess_exec` while keeping the ergonomics of a patched
  `subprocess.run` (`return_value` / `side_effect`, `call_args.args[0]`), plus a
  `transport_calls` record for stdin/timeout assertions the argv cannot show.
- Added coverage for the new transport paths: timeout mapping, kill-on-cancel,
  spawn failure mapping, and stdout/stderr decoding; plus async stream-result and
  async console-streaming tests.

Full suite green locally except pre-existing, environment-only integration
failures (stylelint/oxlint/oxfmt/vale/trufflehog/pip-audit/commitlint below their
minimum local versions) — verified identical on `origin/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded AI workflows (completion, streaming, fallback, retry, review, fix generation, and summaries) to async execution.
  - Added async streaming support, including async-to-console rendering and stream collection.
  - Implemented event-loop-safe budget enforcement that serializes budgeted requests to prevent concurrent overspend.
  - Updated CLI-based providers for non-blocking subprocess execution with improved timeout/cancellation handling.
- **Documentation**
  - Clarified that setting a max cost cap serializes provider calls.
- **Tests**
  - Expanded async test coverage for streaming, retries, concurrency, budgets, fallback, and CLI transports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->