### PR TITLE
refactor(ai): add AI interface facade and move AI out of the executor

### DIFF
--- a/lintro/ai/display/status.py
+++ b/lintro/ai/display/status.py
@@ -1,0 +1,124 @@
+"""Pre-execution AI status rendering.
+
+Renders the ``AI`` rows of the pre-execution configuration summary. This
+lives in the AI package so the core summary renderer
+(:mod:`lintro.utils.console.pre_execution_summary`) does not import
+:mod:`lintro.ai`. See issue #724.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lintro.ai.config import AIConfig
+
+#: Line shown when no AI configuration is available at all.
+AI_STATUS_NO_CONFIG = "[dim]disabled (no config)[/dim]"
+
+
+def render_ai_status(
+    *,
+    ai_config: AIConfig | None,
+    is_ci: bool,
+) -> list[str]:
+    """Render the pre-execution AI status lines.
+
+    Args:
+        ai_config: AI configuration, or None when unavailable.
+        is_ci: Whether the run is in a CI environment (affects the
+            ``auto_apply`` warning wording).
+
+    Returns:
+        Rich-markup lines describing AI availability and settings. Never
+        empty: a disabled or missing configuration still renders one line.
+    """
+    ai_parts: list[str] = []
+    if ai_config is None:
+        ai_parts.append(AI_STATUS_NO_CONFIG)
+        return ai_parts
+    if not ai_config.enabled:
+        ai_parts.append("[dim]disabled[/dim]")
+        return ai_parts
+
+    import os
+
+    from lintro.ai.availability import is_provider_available
+    from lintro.ai.providers import get_default_model
+    from lintro.ai.registry import PROVIDERS, AIProvider
+
+    provider_name = ai_config.provider.lower()
+    supported = set(AIProvider)
+
+    # Check: unknown provider
+    if provider_name not in supported:
+        ai_parts.append("[red]enabled (unknown provider)[/red]")
+        names = ", ".join(sorted(supported))
+        ai_parts.append(
+            f"  [yellow]'{ai_config.provider}' is not supported. "
+            f"Use: {names}[/yellow]",
+        )
+    else:
+        # Check SDK availability
+        sdk_ok = is_provider_available(provider_name)
+
+        # Check API key
+        key_env = ai_config.api_key_env or PROVIDERS.default_api_key_envs.get(
+            AIProvider(provider_name),
+            "",
+        )
+        key_set = bool(os.environ.get(key_env)) if key_env else False
+
+        if sdk_ok and key_set:
+            ai_parts.append("[green]enabled[/green]")
+        elif not sdk_ok:
+            ai_parts.append(
+                "[red]enabled (SDK not installed)[/red]",
+            )
+            ai_parts.append(
+                "  [yellow]run: uv pip install 'lintro\\[ai]'[/yellow]",
+            )
+        elif not key_set:
+            ai_parts.append(
+                "[yellow]enabled (API key missing)[/yellow]",
+            )
+            ai_parts.append(
+                f"  [yellow]set {key_env} env var[/yellow]",
+            )
+
+    ai_parts.append(f"  provider: {ai_config.provider}")
+
+    effective_model = ai_config.model or get_default_model(
+        provider_name,
+    )
+    if effective_model:
+        model_label = effective_model
+        if not ai_config.model:
+            model_label += " [dim](default)[/dim]"
+        ai_parts.append(f"  model: {model_label}")
+
+    # auto_apply warning
+    if ai_config.auto_apply:
+        if is_ci:
+            ai_parts.append("  auto-apply: [green]on[/green]")
+        else:
+            ai_parts.append(
+                "  auto-apply: [bold red]on (files will be "
+                "modified without confirmation)[/bold red]",
+            )
+
+    # Parallel workers
+    ai_parts.append(
+        f"  parallel: {ai_config.max_parallel_calls} workers",
+    )
+    ai_parts.append(
+        "  safe-auto-apply: "
+        + (
+            "[green]on[/green]" if ai_config.auto_apply_safe_fixes else "[dim]off[/dim]"
+        ),
+    )
+    ai_parts.append(
+        "  verify-fixes: "
+        + ("[green]on[/green]" if ai_config.validate_after_group else "[dim]off[/dim]"),
+    )
+    return ai_parts

--- a/lintro/ai/interface.py
+++ b/lintro/ai/interface.py
@@ -1,0 +1,187 @@
+"""The single integration point between the core runner and the AI layer.
+
+Core modules must not import :mod:`lintro.ai` internals. Callers that want
+AI enhancement (the ``chk``/``fmt`` CLI handlers and the public Python API)
+inject the callables from this module into
+:func:`lintro.utils.tool_executor.run_lint_tools_simple`, which consumes the
+core-owned :class:`~lintro.models.core.ai_seam.AIOutcome` they return.
+
+The surface here is deliberately small — the goal of issue #724 is fewer
+import edges, not a plugin system. All heavy AI imports are function-local so
+that importing this module stays cheap on the no-AI path.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from lintro.enums.action import Action
+from lintro.models.core.ai_seam import AIOutcome
+
+if TYPE_CHECKING:
+    from lintro.ai.config import AIConfig
+    from lintro.ai.models import AIResult
+    from lintro.config.lintro_config import LintroConfig
+    from lintro.models.core.tool_result import ToolResult
+    from lintro.utils.console.logger import ThreadSafeConsoleLogger
+
+__all__ = [
+    "ai_exit_code_override",
+    "render_ai_status",
+    "run_ai_layer",
+]
+
+
+def _warn_ai_fix_disabled(
+    *,
+    action: Action,
+    ai_fix: bool,
+    ai_lint_enabled: bool,
+    logger: Any,
+    output_format: str = "",
+) -> None:
+    """Warn when users request AI fixes but AI lint is disabled in config.
+
+    Args:
+        action: The action being performed.
+        ai_fix: Whether AI fixes were requested (CLI flag or config default).
+        ai_lint_enabled: Whether AI lint enhancement is enabled in config.
+        logger: Console logger used to emit the warning.
+        output_format: Output format string; machine-readable formats are
+            left untouched.
+    """
+    if action != Action.CHECK or not ai_fix or ai_lint_enabled:
+        return
+    # Suppress plain-text warnings for machine-readable output formats
+    if output_format.lower() in ("json", "sarif"):
+        return
+    logger.console_output(
+        "AI fixes requested with --fix, but AI lint is disabled in "
+        ".lintro-config.yaml (set ai.enabled and ai.lint: true); "
+        "skipping AI enhancements.",
+    )
+
+
+def ai_exit_code_override(
+    *,
+    ai_result: AIResult | None,
+    lintro_config: LintroConfig,
+) -> bool:
+    """Whether AI outcomes force a non-zero exit.
+
+    Args:
+        ai_result: Result of the AI run, or None when AI did not run.
+        lintro_config: Full Lintro configuration.
+
+    Returns:
+        True when ``ai.fail_on_unfixed`` or ``ai.fail_on_ai_error`` is
+        configured and the corresponding AI outcome occurred.
+    """
+    if ai_result is None:
+        return False
+    ai_config = lintro_config.ai
+    if ai_config.fail_on_unfixed and ai_result.unfixed_issues > 0:
+        return True
+    return bool(ai_config.fail_on_ai_error and ai_result.error)
+
+
+def run_ai_layer(
+    *,
+    action: Action,
+    all_results: list[ToolResult],
+    lintro_config: LintroConfig,
+    console_logger: ThreadSafeConsoleLogger,
+    output_format: str,
+    ai_fix: bool = False,
+    transport: str | None = None,
+) -> AIOutcome:
+    """Run AI enhancement for a completed lint run.
+
+    Absorbs what the core executor used to do inline: resolve the effective
+    ``ai_fix`` flag, warn when AI fixes were requested with AI lint disabled,
+    gate on the action, run the AI post-execution hook, and translate the AI
+    result into an exit-code decision.
+
+    Args:
+        action: The action that was performed (CHECK, FIX, TEST).
+        all_results: Results from all tools. The AI layer may mutate these
+            in place, which is why the returned ``ran`` flag matters.
+        lintro_config: Full Lintro configuration.
+        console_logger: Logger for console output.
+        output_format: Output format string.
+        ai_fix: Whether AI fix suggestions were requested via CLI.
+        transport: Optional CLI override for ``ai.transport``.
+
+    Returns:
+        An :class:`AIOutcome` with ``ran`` set when the AI layer executed and
+        ``force_failure`` set when AI outcomes require exit code 1.
+
+    Raises:
+        Exception: Re-raised when ``ai.fail_on_ai_error`` is enabled.
+    """
+    effective_ai_fix = ai_fix or lintro_config.ai.default_fix
+    _warn_ai_fix_disabled(
+        action=action,
+        ai_fix=effective_ai_fix,
+        ai_lint_enabled=lintro_config.ai.lint_enabled,
+        logger=console_logger,
+        output_format=output_format,
+    )
+
+    from lintro.ai.hook import AIPostExecutionHook
+
+    ai_hook = AIPostExecutionHook(
+        lintro_config,
+        ai_fix=effective_ai_fix,
+        transport=transport,
+    )
+    if not ai_hook.should_run(action):
+        return AIOutcome(ran=False, force_failure=False)
+
+    ai_result: AIResult | None = None
+    try:
+        ai_result = ai_hook.execute(
+            action,
+            all_results,
+            console_logger=console_logger,
+            output_format=output_format,
+        )
+    except Exception as exc:
+        from loguru import logger as loguru_logger
+
+        loguru_logger.opt(exception=True).debug(f"AI hook failed: {exc}")
+        if getattr(lintro_config.ai, "fail_on_ai_error", False):
+            raise
+        if output_format.lower() not in ("json", "sarif"):
+            console_logger.console_output(f"Warning: AI enhancement failed: {exc}")
+        from lintro.ai.models import AIResult as _AIResult
+
+        ai_result = _AIResult(error=True, message=str(exc))
+
+    return AIOutcome(
+        ran=True,
+        force_failure=ai_exit_code_override(
+            ai_result=ai_result,
+            lintro_config=lintro_config,
+        ),
+    )
+
+
+def render_ai_status(
+    *,
+    ai_config: AIConfig | None,
+    is_ci: bool,
+) -> list[str]:
+    """Render the pre-execution AI status lines.
+
+    Args:
+        ai_config: AI configuration, or None when unavailable.
+        is_ci: Whether the run is in a CI environment.
+
+    Returns:
+        Rich-markup lines for the ``AI`` row of the configuration summary.
+        Never empty: a disabled configuration still renders one line.
+    """
+    from lintro.ai.display.status import render_ai_status as _render_ai_status
+
+    return _render_ai_status(ai_config=ai_config, is_ci=is_ci)

--- a/lintro/ai/review/enums/checklist_display.py
+++ b/lintro/ai/review/enums/checklist_display.py
@@ -1,22 +1,12 @@
-"""Checklist visibility modes for review output."""
+"""Checklist visibility modes for review output.
+
+Compatibility re-export: the enum now lives in :mod:`lintro.enums` so that
+``lintro.config.review_config`` can reference it without importing
+``lintro.ai`` (issue #724).
+"""
 
 from __future__ import annotations
 
-from enum import auto
-
-from lintro.enums.hyphenated_str_enum import HyphenatedStrEnum
+from lintro.enums.checklist_display import ChecklistDisplay
 
 __all__ = ["ChecklistDisplay"]
-
-
-class ChecklistDisplay(HyphenatedStrEnum):
-    """How structured checklist results appear in human-facing output.
-
-    * **off** — findings only (default).
-    * **linked** — review questions under findings with checklist_ids.
-    * **all** — linked plus cleared-check and orphan appendices.
-    """
-
-    OFF = auto()
-    LINKED = auto()
-    ALL = auto()

--- a/lintro/ai/review/enums/file_domain.py
+++ b/lintro/ai/review/enums/file_domain.py
@@ -1,22 +1,12 @@
-"""File domain enumeration for review file classification."""
+"""File domain enumeration for review file classification.
+
+Compatibility re-export: the enum now lives in :mod:`lintro.enums` so that
+``lintro.config.review_config`` can reference it without importing
+``lintro.ai`` (issue #724).
+"""
 
 from __future__ import annotations
 
-from enum import auto
+from lintro.enums.file_domain import FileDomain
 
-from lintro.enums.hyphenated_str_enum import HyphenatedStrEnum
-
-
-class FileDomain(HyphenatedStrEnum):
-    """Domain labels assigned to changed files during review."""
-
-    SHELL = auto()
-    CI = auto()
-    SOURCE = auto()
-    TEST = auto()
-    DOCS = auto()
-    API = auto()
-    SECURITY = auto()
-    DEPS = auto()
-    CONFIG = auto()
-    E2E = auto()
+__all__ = ["FileDomain"]

--- a/lintro/ai/review/enums/review_category.py
+++ b/lintro/ai/review/enums/review_category.py
@@ -1,21 +1,12 @@
-"""Review finding category enumeration."""
+"""Review finding category enumeration.
+
+Compatibility re-export: the enum now lives in :mod:`lintro.enums` so that
+``lintro.config.review_config`` can reference it without importing
+``lintro.ai`` (issue #724).
+"""
 
 from __future__ import annotations
 
-from enum import auto
+from lintro.enums.review_category import ReviewCategory
 
-from lintro.enums.hyphenated_str_enum import HyphenatedStrEnum
-
-
-class ReviewCategory(HyphenatedStrEnum):
-    """Categories for checklist items and review findings."""
-
-    LOGIC_BUG = auto()
-    SILENT_FAILURE = auto()
-    INTEGRATION = auto()
-    TEST_GAP = auto()
-    CONTRACT_DRIFT = auto()
-    SECURITY = auto()
-    BREAKING_CHANGE = auto()
-    CODE_SMELL = auto()
-    ARCHITECTURE = auto()
+__all__ = ["ReviewCategory"]

--- a/lintro/ai/review/enums/review_strictness.py
+++ b/lintro/ai/review/enums/review_strictness.py
@@ -1,23 +1,12 @@
-"""Review strictness / sensitivity presets."""
+"""Review strictness / sensitivity presets.
+
+Compatibility re-export: the enum now lives in :mod:`lintro.enums` so that
+``lintro.config.review_config`` can reference it without importing
+``lintro.ai`` (issue #724).
+"""
 
 from __future__ import annotations
 
-from enum import auto
-
-from lintro.enums.hyphenated_str_enum import HyphenatedStrEnum
+from lintro.enums.review_strictness import ReviewStrictness
 
 __all__ = ["ReviewStrictness"]
-
-
-class ReviewStrictness(HyphenatedStrEnum):
-    """How aggressively lintro review surfaces non-blocking findings.
-
-    * **focused** — merge blockers and behavioral issues; skip doc-only P3 nits.
-    * **balanced** — default; report checklist yes answers as findings.
-    * **thorough** — balanced plus explicit hunt for migration notes and doc
-      drift (prompt-only; does not change chunking).
-    """
-
-    FOCUSED = auto()
-    BALANCED = auto()
-    THOROUGH = auto()

--- a/lintro/api/core.py
+++ b/lintro/api/core.py
@@ -125,6 +125,8 @@ def check(
     """
     path_list: list[str] = list(paths) if paths else list(DEFAULT_PATHS)
 
+    from lintro.ai.interface import render_ai_status, run_ai_layer
+
     exit_code: int = run_lint_tools_simple(
         action=Action.CHECK,
         paths=path_list,
@@ -149,6 +151,8 @@ def check(
         transport=transport,
         score=score,
         fail_under=fail_under,
+        ai_runner=run_ai_layer,
+        ai_status_renderer=render_ai_status,
     )
     return LintroResult(action="check", exit_code=exit_code)
 
@@ -199,6 +203,8 @@ def format(
     """
     path_list: list[str] = list(paths) if paths else list(DEFAULT_PATHS)
 
+    from lintro.ai.interface import render_ai_status, run_ai_layer
+
     exit_code: int = run_lint_tools_simple(
         action="fmt",
         paths=path_list,
@@ -218,6 +224,8 @@ def format(
         auto_install=auto_install,
         yes=yes,
         dry_run=dry_run,
+        ai_runner=run_ai_layer,
+        ai_status_renderer=render_ai_status,
     )
     return LintroResult(action="fmt", exit_code=exit_code)
 
@@ -327,6 +335,8 @@ def test(
         ",".join(tool_option_parts) if tool_option_parts else None
     )
 
+    from lintro.ai.interface import render_ai_status
+
     exit_code: int = run_lint_tools_simple(
         action=Action.TEST,
         paths=path_list,
@@ -341,5 +351,6 @@ def test(
         output_file=output,
         debug=debug,
         yes=yes,
+        ai_status_renderer=render_ai_status,
     )
     return LintroResult(action="test", exit_code=exit_code)

--- a/lintro/cli_utils/commands/check.py
+++ b/lintro/cli_utils/commands/check.py
@@ -240,6 +240,8 @@ def check_command(
         ",".join(tool_option_parts) if tool_option_parts else None
     )
 
+    from lintro.ai.interface import render_ai_status, run_ai_layer
+
     # Run with simplified approach
     exit_code: int = run_lint_tools_simple(
         action=DEFAULT_ACTION,
@@ -265,6 +267,8 @@ def check_command(
         transport=transport,
         score=score,
         fail_under=fail_under,
+        ai_runner=run_ai_layer,
+        ai_status_renderer=render_ai_status,
         no_art=no_art,
     )
 

--- a/lintro/cli_utils/commands/format.py
+++ b/lintro/cli_utils/commands/format.py
@@ -180,6 +180,8 @@ def format_command(
     # Default to current directory if no paths provided
     normalized_paths: list[str] = list(paths) if paths else list(DEFAULT_PATHS)
 
+    from lintro.ai.interface import render_ai_status, run_ai_layer
+
     # Run with simplified approach
     exit_code: int = run_lint_tools_simple(
         action=DEFAULT_ACTION,
@@ -199,6 +201,8 @@ def format_command(
         no_log=no_log,
         auto_install=auto_install,
         yes=yes,
+        ai_runner=run_ai_layer,
+        ai_status_renderer=render_ai_status,
         dry_run=dry_run,
         no_art=no_art,
     )

--- a/lintro/cli_utils/commands/test.py
+++ b/lintro/cli_utils/commands/test.py
@@ -253,6 +253,8 @@ def test_command(
         ",".join(tool_option_parts) if tool_option_parts else None
     )
 
+    from lintro.ai.interface import render_ai_status
+
     # Run with pytest tool
     exit_code: int = run_lint_tools_simple(
         action=DEFAULT_ACTION,
@@ -266,6 +268,7 @@ def test_command(
         verbose=verbose,
         raw_output=raw_output,
         output_file=output,
+        ai_status_renderer=render_ai_status,
         debug=debug,
         yes=yes,
     )

--- a/lintro/config/review_config.py
+++ b/lintro/config/review_config.py
@@ -20,14 +20,12 @@ from __future__ import annotations
 from identify.identify import ALL_TAGS
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from lintro.ai.review.constants import CUSTOM_CHECKLIST_ID_START
-from lintro.ai.review.enums.checklist_display import ChecklistDisplay
-from lintro.ai.review.enums.file_domain import FileDomain
-from lintro.ai.review.enums.review_category import ReviewCategory
-from lintro.ai.review.enums.review_strictness import ReviewStrictness
+from lintro.enums.checklist_display import ChecklistDisplay
+from lintro.enums.file_domain import FileDomain
+from lintro.enums.review_category import ReviewCategory
+from lintro.enums.review_strictness import ReviewStrictness
 
 __all__ = [
-    "CUSTOM_CHECKLIST_ID_START",
     "ReviewChecklistConfig",
     "ReviewChecklistItemConfig",
     "ReviewConfig",

--- a/lintro/enums/checklist_display.py
+++ b/lintro/enums/checklist_display.py
@@ -1,0 +1,22 @@
+"""Checklist visibility modes for review output."""
+
+from __future__ import annotations
+
+from enum import auto
+
+from lintro.enums.hyphenated_str_enum import HyphenatedStrEnum
+
+__all__ = ["ChecklistDisplay"]
+
+
+class ChecklistDisplay(HyphenatedStrEnum):
+    """How structured checklist results appear in human-facing output.
+
+    * **off** — findings only (default).
+    * **linked** — review questions under findings with checklist_ids.
+    * **all** — linked plus cleared-check and orphan appendices.
+    """
+
+    OFF = auto()
+    LINKED = auto()
+    ALL = auto()

--- a/lintro/enums/file_domain.py
+++ b/lintro/enums/file_domain.py
@@ -1,0 +1,22 @@
+"""File domain enumeration for review file classification."""
+
+from __future__ import annotations
+
+from enum import auto
+
+from lintro.enums.hyphenated_str_enum import HyphenatedStrEnum
+
+
+class FileDomain(HyphenatedStrEnum):
+    """Domain labels assigned to changed files during review."""
+
+    SHELL = auto()
+    CI = auto()
+    SOURCE = auto()
+    TEST = auto()
+    DOCS = auto()
+    API = auto()
+    SECURITY = auto()
+    DEPS = auto()
+    CONFIG = auto()
+    E2E = auto()

--- a/lintro/enums/review_category.py
+++ b/lintro/enums/review_category.py
@@ -1,0 +1,21 @@
+"""Review finding category enumeration."""
+
+from __future__ import annotations
+
+from enum import auto
+
+from lintro.enums.hyphenated_str_enum import HyphenatedStrEnum
+
+
+class ReviewCategory(HyphenatedStrEnum):
+    """Categories for checklist items and review findings."""
+
+    LOGIC_BUG = auto()
+    SILENT_FAILURE = auto()
+    INTEGRATION = auto()
+    TEST_GAP = auto()
+    CONTRACT_DRIFT = auto()
+    SECURITY = auto()
+    BREAKING_CHANGE = auto()
+    CODE_SMELL = auto()
+    ARCHITECTURE = auto()

--- a/lintro/enums/review_strictness.py
+++ b/lintro/enums/review_strictness.py
@@ -1,0 +1,23 @@
+"""Review strictness / sensitivity presets."""
+
+from __future__ import annotations
+
+from enum import auto
+
+from lintro.enums.hyphenated_str_enum import HyphenatedStrEnum
+
+__all__ = ["ReviewStrictness"]
+
+
+class ReviewStrictness(HyphenatedStrEnum):
+    """How aggressively lintro review surfaces non-blocking findings.
+
+    * **focused** — merge blockers and behavioral issues; skip doc-only P3 nits.
+    * **balanced** — default; report checklist yes answers as findings.
+    * **thorough** — balanced plus explicit hunt for migration notes and doc
+      drift (prompt-only; does not change chunking).
+    """
+
+    FOCUSED = auto()
+    BALANCED = auto()
+    THOROUGH = auto()

--- a/lintro/models/core/ai_seam.py
+++ b/lintro/models/core/ai_seam.py
@@ -1,0 +1,86 @@
+"""Core-side seam types for the optional AI layer.
+
+The core runner (:mod:`lintro.utils.tool_executor`) must not import
+:mod:`lintro.ai`. Instead, callers that want AI enhancement inject the
+callables declared here, and the runner consumes the small core-owned
+:class:`AIOutcome` value they return. See issue #724.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from lintro.config.lintro_config import LintroConfig
+    from lintro.enums.action import Action
+    from lintro.models.core.tool_result import ToolResult
+    from lintro.utils.console.logger import ThreadSafeConsoleLogger
+
+
+@dataclass(frozen=True)
+class AIOutcome:
+    """Result of an AI layer invocation, expressed in core-only terms.
+
+    Attributes:
+        ran: Whether the AI layer actually executed for this action. When
+            True the runner re-aggregates tool results, because the AI
+            layer may have mutated them in place.
+        force_failure: Whether AI outcomes force a non-zero exit code.
+    """
+
+    ran: bool = False
+    force_failure: bool = False
+
+
+class AIRunner(Protocol):
+    """Callable that runs the AI layer after tool execution."""
+
+    def __call__(
+        self,
+        *,
+        action: Action,
+        all_results: list[ToolResult],
+        lintro_config: LintroConfig,
+        console_logger: ThreadSafeConsoleLogger,
+        output_format: str,
+        ai_fix: bool = False,
+        transport: str | None = None,
+    ) -> AIOutcome:
+        """Run the AI layer and report its effect on the run.
+
+        Args:
+            action: The action that was performed.
+            all_results: Results from all tools, possibly mutated in place.
+            lintro_config: Full Lintro configuration.
+            console_logger: Logger for console output.
+            output_format: Output format string.
+            ai_fix: Whether AI fix suggestions were requested via CLI.
+            transport: Optional CLI override for ``ai.transport``.
+
+        Returns:
+            The :class:`AIOutcome` describing whether AI ran and whether it
+            forces a failing exit code.
+        """
+        ...  # pragma: no cover - protocol declaration
+
+
+class AIStatusRenderer(Protocol):
+    """Callable that renders pre-execution AI status lines."""
+
+    def __call__(
+        self,
+        *,
+        ai_config: Any | None,
+        is_ci: bool,
+    ) -> list[str]:
+        """Render the AI rows for the pre-execution configuration summary.
+
+        Args:
+            ai_config: AI configuration object, or None when unavailable.
+            is_ci: Whether the run is in a CI environment.
+
+        Returns:
+            Rich-markup lines to place in the summary table.
+        """
+        ...  # pragma: no cover - protocol declaration

--- a/lintro/tools/definitions/idiom_review.py
+++ b/lintro/tools/definitions/idiom_review.py
@@ -27,10 +27,10 @@ from loguru import logger
 
 from lintro.ai.availability import is_ai_available
 from lintro.ai.budget import CostBudget
-from lintro.ai.enums import ConfidenceLevel
 from lintro.ai.exceptions import AIError
 from lintro.ai.paths import resolve_workspace_root
 from lintro.ai.providers import get_provider
+from lintro.enums.confidence_level import ConfidenceLevel
 from lintro.enums.tool_type import ToolType
 from lintro.models.core.tool_result import ToolResult
 from lintro.parsers.idiom_review.idiom_review_issue import IdiomReviewIssue

--- a/lintro/utils/console/pre_execution_summary.py
+++ b/lintro/utils/console/pre_execution_summary.py
@@ -13,8 +13,12 @@ from rich.console import Console
 from rich.table import Table
 
 if TYPE_CHECKING:
-    from lintro.ai.config import AIConfig
     from lintro.utils.execution.tool_configuration import SkippedTool
+
+#: Fallback ``AI`` row used when no AI status lines were supplied, i.e. when
+#: the caller did not inject an AI status renderer. Matches what the AI layer
+#: renders for a missing configuration.
+AI_STATUS_FALLBACK = "[dim]disabled (no config)[/dim]"
 
 
 def print_pre_execution_summary(
@@ -25,7 +29,7 @@ def print_pre_execution_summary(
     is_container: bool,
     is_ci: bool,
     per_tool_auto_install: dict[str, bool | None] | None = None,
-    ai_config: AIConfig | None = None,
+    ai_status_lines: list[str] | None = None,
 ) -> None:
     """Print a pre-execution configuration summary table.
 
@@ -36,7 +40,9 @@ def print_pre_execution_summary(
         is_container: Whether running in a container environment.
         is_ci: Whether running in a CI environment.
         per_tool_auto_install: Per-tool auto-install overrides.
-        ai_config: AI configuration, if available.
+        ai_status_lines: Pre-rendered AI status lines from the AI layer
+            (``render_ai_status`` on the AI interface facade). When None or
+            empty, the AI row reports a missing configuration.
     """
     console = Console()
 
@@ -100,99 +106,9 @@ def print_pre_execution_summary(
         ]
         table.add_row("Skipped", "\n".join(skip_lines))
 
-    # AI configuration (always render for visibility).
-    ai_parts: list[str] = []
-    if ai_config is None:
-        ai_parts.append("[dim]disabled (no config)[/dim]")
-    elif not ai_config.enabled:
-        ai_parts.append("[dim]disabled[/dim]")
-    else:
-        import os
-
-        from lintro.ai.availability import is_provider_available
-        from lintro.ai.providers import get_default_model
-        from lintro.ai.registry import PROVIDERS, AIProvider
-
-        provider_name = ai_config.provider.lower()
-        supported = set(AIProvider)
-
-        # Check: unknown provider
-        if provider_name not in supported:
-            ai_parts.append("[red]enabled (unknown provider)[/red]")
-            names = ", ".join(sorted(supported))
-            ai_parts.append(
-                f"  [yellow]'{ai_config.provider}' is not supported. "
-                f"Use: {names}[/yellow]",
-            )
-        else:
-            # Check SDK availability
-            sdk_ok = is_provider_available(provider_name)
-
-            # Check API key
-            key_env = ai_config.api_key_env or PROVIDERS.default_api_key_envs.get(
-                AIProvider(provider_name),
-                "",
-            )
-            key_set = bool(os.environ.get(key_env)) if key_env else False
-
-            if sdk_ok and key_set:
-                ai_parts.append("[green]enabled[/green]")
-            elif not sdk_ok:
-                ai_parts.append(
-                    "[red]enabled (SDK not installed)[/red]",
-                )
-                ai_parts.append(
-                    "  [yellow]run: uv pip install 'lintro\\[ai]'[/yellow]",
-                )
-            elif not key_set:
-                ai_parts.append(
-                    "[yellow]enabled (API key missing)[/yellow]",
-                )
-                ai_parts.append(
-                    f"  [yellow]set {key_env} env var[/yellow]",
-                )
-
-        ai_parts.append(f"  provider: {ai_config.provider}")
-
-        effective_model = ai_config.model or get_default_model(
-            provider_name,
-        )
-        if effective_model:
-            model_label = effective_model
-            if not ai_config.model:
-                model_label += " [dim](default)[/dim]"
-            ai_parts.append(f"  model: {model_label}")
-
-        # auto_apply warning
-        if ai_config.auto_apply:
-            if is_ci:
-                ai_parts.append("  auto-apply: [green]on[/green]")
-            else:
-                ai_parts.append(
-                    "  auto-apply: [bold red]on (files will be "
-                    "modified without confirmation)[/bold red]",
-                )
-
-        # Parallel workers
-        ai_parts.append(
-            f"  parallel: {ai_config.max_parallel_calls} workers",
-        )
-        ai_parts.append(
-            "  safe-auto-apply: "
-            + (
-                "[green]on[/green]"
-                if ai_config.auto_apply_safe_fixes
-                else "[dim]off[/dim]"
-            ),
-        )
-        ai_parts.append(
-            "  verify-fixes: "
-            + (
-                "[green]on[/green]"
-                if ai_config.validate_after_group
-                else "[dim]off[/dim]"
-            ),
-        )
+    # AI configuration (always render for visibility). The lines themselves
+    # are rendered by the AI layer so this module stays free of AI imports.
+    ai_parts: list[str] = list(ai_status_lines or [AI_STATUS_FALLBACK])
 
     table.add_row("AI", "\n".join(ai_parts))
 

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -38,6 +38,7 @@ from lintro.utils.unified_config import UnifiedConfigManager
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
+    from lintro.models.core.ai_seam import AIOutcome, AIRunner, AIStatusRenderer
     from lintro.parsers.base_issue import BaseIssue
     from lintro.plugins.base import BaseToolPlugin
 
@@ -182,27 +183,6 @@ def _run_fix_with_retry(
         )
 
     return result
-
-
-def _warn_ai_fix_disabled(
-    *,
-    action: Action,
-    ai_fix: bool,
-    ai_lint_enabled: bool,
-    logger: Any,
-    output_format: str = "",
-) -> None:
-    """Warn when users request AI fixes but AI lint is disabled in config."""
-    if action != Action.CHECK or not ai_fix or ai_lint_enabled:
-        return
-    # Suppress plain-text warnings for machine-readable output formats
-    if output_format.lower() in ("json", "sarif"):
-        return
-    logger.console_output(
-        "AI fixes requested with --fix, but AI lint is disabled in "
-        ".lintro-config.yaml (set ai.enabled and ai.lint: true); "
-        "skipping AI enhancements.",
-    )
 
 
 def _display_fix_result(
@@ -529,6 +509,8 @@ def run_lint_tools_simple(
     fail_under: float | None = None,
     diff_base: str | None = None,
     no_art: bool = False,
+    ai_runner: AIRunner | None = None,
+    ai_status_renderer: AIStatusRenderer | None = None,
 ) -> int:
     """Simplified runner using Loguru-based logging with rich formatting.
 
@@ -575,6 +557,13 @@ def run_lint_tools_simple(
         no_art: When True, suppress decorative ASCII art regardless of the
             ``output.art`` config value. Art is also suppressed automatically
             when ``output.art`` is ``False`` or stdout is not a TTY.
+        ai_runner: Optional AI layer entry point injected by the caller
+            (``run_ai_layer`` from the AI interface facade). When None, no AI
+            enhancement runs and no AI exit-code adjustment is applied.
+        ai_status_renderer: Optional renderer for the AI rows of the
+            pre-execution configuration summary (``render_ai_status`` from the
+            AI interface facade). When None, the AI row reports a missing
+            configuration.
 
     Returns:
         Exit code (0 for success, 1 for failures).
@@ -582,7 +571,6 @@ def run_lint_tools_simple(
     Raises:
         TypeError: If a programming error occurs during tool execution.
         AttributeError: If a programming error occurs during tool execution.
-        Exception: Re-raised from AI hook when ``ai.fail_on_ai_error`` is enabled.
     """
     # Normalize action to enum
     action = normalize_action(action)
@@ -860,7 +848,11 @@ def run_lint_tools_simple(
             is_container=is_container,
             is_ci=is_ci,
             per_tool_auto_install=per_tool_auto if per_tool_auto else None,
-            ai_config=lintro_config.ai,
+            ai_status_lines=(
+                ai_status_renderer(ai_config=lintro_config.ai, is_ci=is_ci)
+                if ai_status_renderer is not None
+                else None
+            ),
         )
 
         # Confirmation prompt — skip when non-interactive
@@ -1075,44 +1067,21 @@ def run_lint_tools_simple(
             action,
         )
 
-    # AI enhancement via hook pattern
-    effective_ai_fix = ai_fix or lintro_config.ai.default_fix
-    _warn_ai_fix_disabled(
-        action=action,
-        ai_fix=effective_ai_fix,
-        ai_lint_enabled=lintro_config.ai.lint_enabled,
-        logger=logger,
-        output_format=output_format,
-    )
-
-    from lintro.ai.hook import AIPostExecutionHook
-
-    ai_hook = AIPostExecutionHook(
-        lintro_config,
-        ai_fix=effective_ai_fix,
-        transport=transport,
-    )
-    ai_result = None
-    if ai_hook.should_run(action):
-        try:
-            ai_result = ai_hook.execute(
-                action,
-                all_results,
-                console_logger=logger,
-                output_format=output_format,
-            )
-        except Exception as exc:
-            from loguru import logger as loguru_logger
-
-            loguru_logger.opt(exception=True).debug(f"AI hook failed: {exc}")
-            if getattr(lintro_config.ai, "fail_on_ai_error", False):
-                raise
-            if output_format.lower() not in ("json", "sarif"):
-                logger.console_output(f"Warning: AI enhancement failed: {exc}")
-            from lintro.ai.models import AIResult
-
-            ai_result = AIResult(error=True, message=str(exc))
-        if ai_result is not None:
+    # AI enhancement through the injected seam. The AI layer itself lives
+    # behind the AI interface facade; core never imports it (issue #724).
+    ai_outcome: AIOutcome | None = None
+    if ai_runner is not None:
+        ai_outcome = ai_runner(
+            action=action,
+            all_results=all_results,
+            lintro_config=lintro_config,
+            console_logger=logger,
+            output_format=output_format,
+            ai_fix=ai_fix,
+            transport=transport,
+        )
+        if ai_outcome.ran:
+            # The AI layer may mutate results in place, so re-aggregate.
             total_issues, total_fixed, total_remaining = aggregate_tool_results(
                 all_results,
                 action,
@@ -1129,13 +1098,11 @@ def run_lint_tools_simple(
         ),
     )
 
-    # AI-driven exit code adjustments
-    if ai_result is not None:
-        ai_config = lintro_config.ai
-        if ai_config.fail_on_unfixed and ai_result.unfixed_issues > 0:
-            final_exit_code = 1
-        if ai_config.fail_on_ai_error and ai_result.error:
-            final_exit_code = 1
+    # AI-driven exit code adjustments. Must stay after determine_exit_code and
+    # before the fail_under score gate, so the score gate can still fail a run
+    # that AI left at 0.
+    if ai_outcome is not None and ai_outcome.force_failure:
+        final_exit_code = 1
 
     # Compute the deterministic 0-100 health score from the aggregated results.
     from lintro.utils.health_score import health_score_for_results

--- a/tests/unit/ai/test_display_status.py
+++ b/tests/unit/ai/test_display_status.py
@@ -1,0 +1,197 @@
+"""Parity tests for the relocated pre-execution AI status renderer.
+
+The rendering moved out of ``lintro.utils.console.pre_execution_summary`` into
+the AI package (issue #724 PR 2). These tests pin the exact lines for every
+branch so the move is provably output-preserving.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.config import AIConfig
+from lintro.ai.display.status import render_ai_status
+from lintro.ai.enums import AITransport
+from lintro.ai.registry import AIProvider
+
+
+def _stub_config(**overrides: object) -> AIConfig:
+    """Build a duck-typed AI config for branch coverage.
+
+    A namespace stands in for :class:`AIConfig` so branches the real model
+    rejects (an unknown provider name) stay reachable.
+
+    Args:
+        **overrides: Attribute overrides applied on top of the defaults.
+
+    Returns:
+        An object exposing the attributes ``render_ai_status`` reads.
+    """
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "provider": "anthropic",
+        "api_key_env": "",
+        "model": "",
+        "auto_apply": False,
+        "max_parallel_calls": 4,
+        "auto_apply_safe_fixes": True,
+        "validate_after_group": False,
+    }
+    defaults.update(overrides)
+    return cast("AIConfig", SimpleNamespace(**defaults))
+
+
+def test_render_ai_status_no_config() -> None:
+    """A missing config renders the single no-config line."""
+    assert_that(render_ai_status(ai_config=None, is_ci=False)).is_equal_to(
+        ["[dim]disabled (no config)[/dim]"],
+    )
+
+
+def test_render_ai_status_disabled() -> None:
+    """A disabled config renders the single disabled line."""
+    ai_config = AIConfig(enabled=False, transport=AITransport.API)
+
+    assert_that(render_ai_status(ai_config=ai_config, is_ci=False)).is_equal_to(
+        ["[dim]disabled[/dim]"],
+    )
+
+
+def test_render_ai_status_unknown_provider() -> None:
+    """An unsupported provider renders the red unknown-provider lines."""
+    lines = render_ai_status(
+        ai_config=_stub_config(provider="not-a-provider"),
+        is_ci=False,
+    )
+
+    assert_that(lines[0]).is_equal_to("[red]enabled (unknown provider)[/red]")
+    assert_that(lines[1]).contains("'not-a-provider' is not supported. Use: ")
+    assert_that(lines[1]).contains(sorted(set(AIProvider))[0])
+    assert_that(lines[2]).is_equal_to("  provider: not-a-provider")
+
+
+def test_render_ai_status_sdk_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing SDK renders the install hint."""
+    monkeypatch.setattr(
+        "lintro.ai.availability.is_provider_available",
+        lambda _provider: False,
+    )
+
+    lines = render_ai_status(ai_config=_stub_config(), is_ci=False)
+
+    assert_that(lines[0]).is_equal_to("[red]enabled (SDK not installed)[/red]")
+    assert_that(lines[1]).is_equal_to(
+        "  [yellow]run: uv pip install 'lintro\\[ai]'[/yellow]",
+    )
+
+
+def test_render_ai_status_key_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An available SDK with no API key renders the key hint."""
+    monkeypatch.setattr(
+        "lintro.ai.availability.is_provider_available",
+        lambda _provider: True,
+    )
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    lines = render_ai_status(ai_config=_stub_config(), is_ci=False)
+
+    assert_that(lines[0]).is_equal_to("[yellow]enabled (API key missing)[/yellow]")
+    expected = "  [yellow]set ANTHROPIC_API_KEY env var[/yellow]"
+    assert_that(lines[1]).is_equal_to(expected)
+
+
+def test_render_ai_status_fully_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A healthy configuration renders status plus the settings block."""
+    monkeypatch.setattr(
+        "lintro.ai.availability.is_provider_available",
+        lambda _provider: True,
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    lines = render_ai_status(
+        ai_config=_stub_config(max_parallel_calls=3),
+        is_ci=False,
+    )
+
+    assert_that(lines[0]).is_equal_to("[green]enabled[/green]")
+    assert_that(lines).contains("  provider: anthropic")
+    assert_that(lines).contains("  parallel: 3 workers")
+    assert_that(lines).contains("  safe-auto-apply: [green]on[/green]")
+    assert_that(lines).contains("  verify-fixes: [dim]off[/dim]")
+
+
+def test_render_ai_status_auto_apply_warning_outside_ci(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Outside CI, ``auto_apply`` renders the loud destructive warning."""
+    monkeypatch.setattr(
+        "lintro.ai.availability.is_provider_available",
+        lambda _provider: True,
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    lines = render_ai_status(ai_config=_stub_config(auto_apply=True), is_ci=False)
+
+    assert_that(lines).contains(
+        "  auto-apply: [bold red]on (files will be "
+        "modified without confirmation)[/bold red]",
+    )
+
+
+def test_render_ai_status_auto_apply_quiet_in_ci(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In CI, ``auto_apply`` renders the quiet green line."""
+    monkeypatch.setattr(
+        "lintro.ai.availability.is_provider_available",
+        lambda _provider: True,
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    lines = render_ai_status(ai_config=_stub_config(auto_apply=True), is_ci=True)
+
+    assert_that(lines).contains("  auto-apply: [green]on[/green]")
+
+
+def test_render_ai_status_model_marks_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unset model is rendered with the ``(default)`` marker."""
+    monkeypatch.setattr(
+        "lintro.ai.availability.is_provider_available",
+        lambda _provider: True,
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    default_lines = render_ai_status(ai_config=_stub_config(), is_ci=False)
+    explicit_lines = render_ai_status(
+        ai_config=_stub_config(model="some-model"),
+        is_ci=False,
+    )
+
+    assert_that([line for line in default_lines if "model:" in line][0]).contains(
+        "[dim](default)[/dim]",
+    )
+    assert_that(explicit_lines).contains("  model: some-model")
+
+
+def test_render_ai_status_respects_custom_api_key_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured ``api_key_env`` is the variable that gets checked."""
+    monkeypatch.setattr(
+        "lintro.ai.availability.is_provider_available",
+        lambda _provider: True,
+    )
+    monkeypatch.delenv("CUSTOM_AI_KEY", raising=False)
+
+    lines = render_ai_status(
+        ai_config=_stub_config(api_key_env="CUSTOM_AI_KEY"),
+        is_ci=False,
+    )
+
+    assert_that(lines[1]).is_equal_to("  [yellow]set CUSTOM_AI_KEY env var[/yellow]")

--- a/tests/unit/ai/test_interface.py
+++ b/tests/unit/ai/test_interface.py
@@ -1,0 +1,392 @@
+"""Tests for the AI interface facade (issue #724 PR 2)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from assertpy import assert_that
+
+import lintro.ai.interface as interface
+from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
+from lintro.ai.interface import (
+    _warn_ai_fix_disabled,
+    ai_exit_code_override,
+    render_ai_status,
+    run_ai_layer,
+)
+from lintro.ai.models import AIResult
+from lintro.config.lintro_config import LintroConfig
+from lintro.enums.action import Action
+from lintro.models.core.tool_result import ToolResult
+
+# ---------------------------------------------------------------------------
+# _warn_ai_fix_disabled
+# ---------------------------------------------------------------------------
+
+
+def test_warn_ai_fix_disabled_warns_only_for_check_when_fix_requested_and_ai_disabled():
+    """Warn when action is CHECK, ai_fix=True, and AI disabled."""
+    logger = MagicMock()
+
+    _warn_ai_fix_disabled(
+        action=Action.CHECK,
+        ai_fix=True,
+        ai_lint_enabled=False,
+        logger=logger,
+    )
+
+    assert_that(logger.console_output.call_count).is_equal_to(1)
+    warning_text = logger.console_output.call_args[0][0]
+    assert_that(warning_text).contains("AI fixes requested")
+    assert_that(warning_text).contains("AI lint is disabled")
+
+
+def test_warn_ai_fix_disabled_no_warning_for_other_states():
+    """Test that no warning is issued for non-qualifying state combinations."""
+    logger = MagicMock()
+
+    _warn_ai_fix_disabled(
+        action=Action.FIX,
+        ai_fix=True,
+        ai_lint_enabled=False,
+        logger=logger,
+    )
+    _warn_ai_fix_disabled(
+        action=Action.CHECK,
+        ai_fix=False,
+        ai_lint_enabled=False,
+        logger=logger,
+    )
+    _warn_ai_fix_disabled(
+        action=Action.CHECK,
+        ai_fix=True,
+        ai_lint_enabled=True,
+        logger=logger,
+    )
+
+    assert_that(logger.console_output.call_count).is_equal_to(0)
+
+
+@pytest.mark.parametrize("output_format", ["json", "sarif", "JSON", "SARIF"])
+def test_warn_ai_fix_disabled_suppressed_for_machine_formats(
+    output_format: str,
+) -> None:
+    """Warning is suppressed for machine-readable output formats."""
+    logger = MagicMock()
+
+    _warn_ai_fix_disabled(
+        action=Action.CHECK,
+        ai_fix=True,
+        ai_lint_enabled=False,
+        logger=logger,
+        output_format=output_format,
+    )
+
+    assert_that(logger.console_output.call_count).is_equal_to(0)
+
+
+# ---------------------------------------------------------------------------
+# ai_exit_code_override
+# ---------------------------------------------------------------------------
+
+
+def _config(**ai_kwargs: Any) -> LintroConfig:
+    """Build a LintroConfig with the given AI settings.
+
+    Args:
+        **ai_kwargs: Keyword arguments for :class:`AIConfig`.
+
+    Returns:
+        A :class:`LintroConfig` carrying the requested AI settings.
+    """
+    return LintroConfig(ai=AIConfig(transport=AITransport.API, **ai_kwargs))
+
+
+def test_ai_exit_code_override_is_false_without_result():
+    """No AI result means no override."""
+    override = ai_exit_code_override(
+        ai_result=None,
+        lintro_config=_config(enabled=True, fail_on_unfixed=True),
+    )
+
+    assert_that(override).is_false()
+
+
+def test_ai_exit_code_override_true_for_unfixed_issues():
+    """``fail_on_unfixed`` with remaining issues forces failure."""
+    override = ai_exit_code_override(
+        ai_result=AIResult(unfixed_issues=2),
+        lintro_config=_config(enabled=True, fail_on_unfixed=True),
+    )
+
+    assert_that(override).is_true()
+
+
+def test_ai_exit_code_override_false_when_unfixed_not_configured():
+    """Unfixed issues alone do not force failure."""
+    override = ai_exit_code_override(
+        ai_result=AIResult(unfixed_issues=2),
+        lintro_config=_config(enabled=True),
+    )
+
+    assert_that(override).is_false()
+
+
+def test_ai_exit_code_override_true_for_ai_error():
+    """``fail_on_ai_error`` with an AI error forces failure."""
+    override = ai_exit_code_override(
+        ai_result=AIResult(error=True),
+        lintro_config=_config(enabled=True, fail_on_ai_error=True),
+    )
+
+    assert_that(override).is_true()
+
+
+def test_ai_exit_code_override_false_for_ai_error_when_not_configured():
+    """An AI error alone does not force failure."""
+    override = ai_exit_code_override(
+        ai_result=AIResult(error=True),
+        lintro_config=_config(enabled=True),
+    )
+
+    assert_that(override).is_false()
+
+
+# ---------------------------------------------------------------------------
+# run_ai_layer
+# ---------------------------------------------------------------------------
+
+
+def _stub_hook(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    result: AIResult | None = None,
+    error: Exception | None = None,
+    should_run: bool = True,
+) -> dict[str, Any]:
+    """Install a fake ``AIPostExecutionHook`` and record its invocation.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture.
+        result: Result returned by ``execute``.
+        error: Exception raised by ``execute`` instead of returning.
+        should_run: Value returned by ``should_run``.
+
+    Returns:
+        A dict recording constructor and ``execute`` arguments.
+    """
+    recorded: dict[str, Any] = {}
+
+    class _FakeHook:
+        def __init__(
+            self,
+            lintro_config: LintroConfig,
+            *,
+            ai_fix: bool = False,
+            transport: str | None = None,
+        ) -> None:
+            recorded["ai_fix"] = ai_fix
+            recorded["transport"] = transport
+
+        def should_run(self, action: Action) -> bool:
+            recorded["should_run_action"] = action
+            return should_run
+
+        def execute(
+            self,
+            action: Action,
+            all_results: list[ToolResult],
+            *,
+            console_logger: Any,
+            output_format: str,
+        ) -> AIResult:
+            recorded["executed"] = True
+            if error is not None:
+                raise error
+            return result or AIResult()
+
+    import lintro.ai.hook as hook_module
+
+    monkeypatch.setattr(hook_module, "AIPostExecutionHook", _FakeHook)
+    return recorded
+
+
+def test_run_ai_layer_returns_not_ran_when_gate_rejects_action(monkeypatch):
+    """A closed ``should_run`` gate yields an outcome with ``ran`` False."""
+    recorded = _stub_hook(monkeypatch, should_run=False)
+
+    outcome = run_ai_layer(
+        action=Action.TEST,
+        all_results=[],
+        lintro_config=_config(enabled=True),
+        console_logger=MagicMock(),
+        output_format="grid",
+    )
+
+    assert_that(outcome.ran).is_false()
+    assert_that(outcome.force_failure).is_false()
+    assert_that(recorded).does_not_contain_key("executed")
+
+
+def test_run_ai_layer_runs_hook_and_reports_ran(monkeypatch):
+    """A successful AI run reports ``ran`` with no forced failure."""
+    _stub_hook(monkeypatch, result=AIResult(fixes_applied=1))
+
+    outcome = run_ai_layer(
+        action=Action.CHECK,
+        all_results=[],
+        lintro_config=_config(enabled=True),
+        console_logger=MagicMock(),
+        output_format="grid",
+    )
+
+    assert_that(outcome.ran).is_true()
+    assert_that(outcome.force_failure).is_false()
+
+
+def test_run_ai_layer_forces_failure_for_unfixed_issues(monkeypatch):
+    """``fail_on_unfixed`` propagates into the returned outcome."""
+    _stub_hook(monkeypatch, result=AIResult(unfixed_issues=3))
+
+    outcome = run_ai_layer(
+        action=Action.CHECK,
+        all_results=[],
+        lintro_config=_config(enabled=True, fail_on_unfixed=True),
+        console_logger=MagicMock(),
+        output_format="grid",
+    )
+
+    assert_that(outcome.ran).is_true()
+    assert_that(outcome.force_failure).is_true()
+
+
+def test_run_ai_layer_reraises_when_fail_on_ai_error(monkeypatch):
+    """A provider failure propagates when ``fail_on_ai_error`` is set."""
+    _stub_hook(monkeypatch, error=RuntimeError("provider down"))
+
+    assert_that(run_ai_layer).raises(RuntimeError).when_called_with(
+        action=Action.CHECK,
+        all_results=[],
+        lintro_config=_config(enabled=True, fail_on_ai_error=True),
+        console_logger=MagicMock(),
+        output_format="grid",
+    )
+
+
+def test_run_ai_layer_swallows_error_and_warns_without_fail_on_ai_error(monkeypatch):
+    """Without ``fail_on_ai_error`` the failure warns and does not force exit."""
+    _stub_hook(monkeypatch, error=RuntimeError("provider down"))
+    console_logger = MagicMock()
+
+    outcome = run_ai_layer(
+        action=Action.CHECK,
+        all_results=[],
+        lintro_config=_config(enabled=True),
+        console_logger=console_logger,
+        output_format="grid",
+    )
+
+    assert_that(outcome.ran).is_true()
+    assert_that(outcome.force_failure).is_false()
+    assert_that(console_logger.console_output.call_count).is_equal_to(1)
+    assert_that(console_logger.console_output.call_args[0][0]).contains(
+        "AI enhancement failed",
+    )
+
+
+def test_run_ai_layer_error_warning_suppressed_for_json(monkeypatch):
+    """The failure warning is suppressed for machine-readable formats."""
+    _stub_hook(monkeypatch, error=RuntimeError("provider down"))
+    console_logger = MagicMock()
+
+    outcome = run_ai_layer(
+        action=Action.CHECK,
+        all_results=[],
+        lintro_config=_config(enabled=True),
+        console_logger=console_logger,
+        output_format="json",
+    )
+
+    assert_that(outcome.ran).is_true()
+    assert_that(console_logger.console_output.call_count).is_equal_to(0)
+
+
+def test_run_ai_layer_error_forces_failure_is_unreachable_when_reraising(monkeypatch):
+    """A swallowed error still honors ``fail_on_unfixed`` accounting."""
+    _stub_hook(monkeypatch, error=RuntimeError("provider down"))
+
+    outcome = run_ai_layer(
+        action=Action.CHECK,
+        all_results=[],
+        lintro_config=_config(enabled=True, fail_on_unfixed=True),
+        console_logger=MagicMock(),
+        output_format="grid",
+    )
+
+    # The synthesized AIResult reports zero unfixed issues, so no override.
+    assert_that(outcome.force_failure).is_false()
+
+
+def test_run_ai_layer_resolves_effective_ai_fix_from_config(monkeypatch):
+    """``ai.default_fix`` turns on AI fixes without the CLI flag."""
+    recorded = _stub_hook(monkeypatch)
+
+    run_ai_layer(
+        action=Action.CHECK,
+        all_results=[],
+        lintro_config=_config(enabled=True, default_fix=True),
+        console_logger=MagicMock(),
+        output_format="grid",
+        ai_fix=False,
+        transport="cli",
+    )
+
+    assert_that(recorded.get("ai_fix")).is_true()
+    assert_that(recorded.get("transport")).is_equal_to("cli")
+
+
+def test_run_ai_layer_warns_when_ai_fix_requested_but_lint_disabled(monkeypatch):
+    """The disabled-AI warning survives the move into the facade."""
+    _stub_hook(monkeypatch, should_run=False)
+    console_logger = MagicMock()
+
+    outcome = run_ai_layer(
+        action=Action.CHECK,
+        all_results=[],
+        lintro_config=_config(enabled=False),
+        console_logger=console_logger,
+        output_format="grid",
+        ai_fix=True,
+    )
+
+    assert_that(outcome.ran).is_false()
+    assert_that(console_logger.console_output.call_count).is_equal_to(1)
+    assert_that(console_logger.console_output.call_args[0][0]).contains(
+        "AI fixes requested",
+    )
+
+
+# ---------------------------------------------------------------------------
+# render_ai_status
+# ---------------------------------------------------------------------------
+
+
+def test_render_ai_status_delegates_to_display_module():
+    """The facade returns exactly what the display module renders."""
+    from lintro.ai.display.status import render_ai_status as display_render
+
+    ai_config = AIConfig(enabled=False, transport=AITransport.API)
+
+    assert_that(render_ai_status(ai_config=ai_config, is_ci=False)).is_equal_to(
+        display_render(ai_config=ai_config, is_ci=False),
+    )
+
+
+def test_interface_public_surface_stays_small():
+    """The facade exposes exactly three public names."""
+    assert_that(sorted(interface.__all__)).is_equal_to(
+        ["ai_exit_code_override", "render_ai_status", "run_ai_layer"],
+    )

--- a/tests/unit/cli/test_cli_lintro_group.py
+++ b/tests/unit/cli/test_cli_lintro_group.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from assertpy import assert_that
 from click.testing import CliRunner
 
+from lintro.ai.interface import render_ai_status, run_ai_layer
 from lintro.cli import cli
 
 
@@ -111,6 +112,8 @@ def test_invoke_with_comma_separated_commands() -> None:
             transport=None,
             score=False,
             fail_under=None,
+            ai_runner=run_ai_layer,
+            ai_status_renderer=render_ai_status,
             no_art=False,
         )
         mock_fmt.assert_any_call(
@@ -132,6 +135,8 @@ def test_invoke_with_comma_separated_commands() -> None:
             auto_install=False,
             yes=False,
             dry_run=False,
+            ai_runner=run_ai_layer,
+            ai_status_renderer=render_ai_status,
             no_art=False,
         )
 

--- a/tests/unit/utils/console/test_pre_execution_summary.py
+++ b/tests/unit/utils/console/test_pre_execution_summary.py
@@ -1,4 +1,9 @@
-"""Unit tests for pre-execution summary AI rendering."""
+"""Unit tests for pre-execution summary AI rendering.
+
+The AI lines themselves are rendered by the AI layer (issue #724 PR 2); the
+summary only places pre-rendered lines in the table. These tests feed it the
+real AI renderer output so the end-to-end text stays pinned.
+"""
 
 from __future__ import annotations
 
@@ -10,13 +15,30 @@ from rich.console import Console
 
 from lintro.ai.config import AIConfig
 from lintro.ai.enums import AITransport
+from lintro.ai.interface import render_ai_status
 from lintro.ai.registry import AIProvider
 from lintro.utils.console.pre_execution_summary import print_pre_execution_summary
 
 
-def _render_summary(ai_config: AIConfig | None) -> str:
-    """Render the pre-execution summary and return plain text output."""
+def _render_summary(
+    ai_config: AIConfig | None,
+    *,
+    use_renderer: bool = True,
+) -> str:
+    """Render the pre-execution summary and return plain text output.
+
+    Args:
+        ai_config: AI configuration passed to the AI status renderer.
+        use_renderer: When False, no AI lines are supplied at all, mimicking a
+            caller that did not inject an AI status renderer.
+
+    Returns:
+        The recorded console text.
+    """
     console = Console(record=True, force_terminal=False, width=160)
+    ai_status_lines = (
+        render_ai_status(ai_config=ai_config, is_ci=False) if use_renderer else None
+    )
     with patch(
         "lintro.utils.console.pre_execution_summary.Console",
         return_value=console,
@@ -28,7 +50,7 @@ def _render_summary(ai_config: AIConfig | None) -> str:
             is_container=False,
             is_ci=False,
             per_tool_auto_install=None,
-            ai_config=ai_config,
+            ai_status_lines=ai_status_lines,
         )
     return console.export_text()
 
@@ -83,3 +105,11 @@ def test_pre_execution_summary_shows_ai_when_config_missing() -> None:
 
     assert_that(output).contains("AI")
     assert_that(output).contains("disabled (no config)")
+
+
+def test_pre_execution_summary_falls_back_without_ai_lines() -> None:
+    """Omitting the AI lines renders the same row as a missing config."""
+    with_renderer = _render_summary(ai_config=None)
+    without_renderer = _render_summary(ai_config=None, use_renderer=False)
+
+    assert_that(without_renderer).is_equal_to(with_renderer)

--- a/tests/unit/utils/test_tool_executor_ai.py
+++ b/tests/unit/utils/test_tool_executor_ai.py
@@ -1,9 +1,14 @@
-"""Tests for AI-specific behavior in tool executor."""
+"""Tests for the executor's AI seam and AI-driven exit-code behavior.
+
+The executor itself no longer imports :mod:`lintro.ai` (issue #724 PR 2). It
+consumes an injected ``ai_runner`` returning a core
+:class:`~lintro.models.core.ai_seam.AIOutcome`, so these tests exercise the
+seam rather than the AI layer.
+"""
 
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock
 
 from assertpy import assert_that
 
@@ -12,131 +17,72 @@ from lintro.ai.config import AIConfig
 from lintro.ai.enums import AITransport
 from lintro.config.execution_config import ExecutionConfig
 from lintro.config.lintro_config import LintroConfig
-from lintro.enums.action import Action
+from lintro.models.core.ai_seam import AIOutcome
 from lintro.models.core.tool_result import ToolResult
 from lintro.utils.execution.tool_configuration import ToolsToRunResult
-from lintro.utils.tool_executor import _warn_ai_fix_disabled, run_lint_tools_simple
-
-# ---------------------------------------------------------------------------
-# _warn_ai_fix_disabled
-# ---------------------------------------------------------------------------
+from lintro.utils.tool_executor import run_lint_tools_simple
 
 
-def test_warn_ai_fix_disabled_warns_only_for_check_when_fix_requested_and_ai_disabled():
-    """Warn when action is CHECK, ai_fix=True, and AI disabled."""
-    logger = MagicMock()
+class _FakeTool:
+    """Minimal tool double reporting a single unfixed issue."""
 
-    _warn_ai_fix_disabled(
-        action=Action.CHECK,
-        ai_fix=True,
-        ai_lint_enabled=False,
-        logger=logger,
-    )
+    def set_options(self, **_kwargs: Any) -> None:
+        """Accept and ignore runtime options."""
+        return None
 
-    assert_that(logger.console_output.call_count).is_equal_to(1)
-    warning_text = logger.console_output.call_args[0][0]
-    assert_that(warning_text).contains("AI fixes requested")
-    assert_that(warning_text).contains("AI lint is disabled")
+    def reset_options(self) -> None:
+        """Accept and ignore option resets."""
+        return None
 
+    def fix(self, _paths: Any, _options: Any) -> ToolResult:
+        """Return a fix result with one remaining issue.
 
-def test_warn_ai_fix_disabled_no_warning_for_other_states():
-    """Test that no warning is issued for non-qualifying state combinations."""
-    logger = MagicMock()
+        Args:
+            _paths: Ignored paths.
+            _options: Ignored options.
 
-    _warn_ai_fix_disabled(
-        action=Action.FIX,
-        ai_fix=True,
-        ai_lint_enabled=False,
-        logger=logger,
-    )
-    _warn_ai_fix_disabled(
-        action=Action.CHECK,
-        ai_fix=False,
-        ai_lint_enabled=False,
-        logger=logger,
-    )
-    _warn_ai_fix_disabled(
-        action=Action.CHECK,
-        ai_fix=True,
-        ai_lint_enabled=True,
-        logger=logger,
-    )
+        Returns:
+            A failing :class:`ToolResult` with one remaining issue.
+        """
+        return ToolResult(
+            name="ruff",
+            success=False,
+            issues_count=1,
+            fixed_issues_count=0,
+            remaining_issues_count=1,
+            issues=[],
+        )
 
-    assert_that(logger.console_output.call_count).is_equal_to(0)
+    def check(self, _paths: Any, _options: Any) -> ToolResult:
+        """Return a check result with one issue.
 
+        Args:
+            _paths: Ignored paths.
+            _options: Ignored options.
 
-def test_warn_ai_fix_disabled_suppressed_for_json_output():
-    """Warning is suppressed when output format is JSON."""
-    logger = MagicMock()
-
-    _warn_ai_fix_disabled(
-        action=Action.CHECK,
-        ai_fix=True,
-        ai_lint_enabled=False,
-        logger=logger,
-        output_format="json",
-    )
-
-    assert_that(logger.console_output.call_count).is_equal_to(0)
+        Returns:
+            A failing :class:`ToolResult` with one issue.
+        """
+        return ToolResult(
+            name="ruff",
+            success=False,
+            issues_count=1,
+            issues=[],
+        )
 
 
-def test_warn_ai_fix_disabled_suppressed_for_sarif_output():
-    """Warning is suppressed when output format is SARIF."""
-    logger = MagicMock()
+def _install_executor_doubles(
+    monkeypatch: Any,
+    fake_logger: Any,
+    lintro_config: LintroConfig,
+) -> None:
+    """Patch out the executor's environment so only the seam is exercised.
 
-    _warn_ai_fix_disabled(
-        action=Action.CHECK,
-        ai_fix=True,
-        ai_lint_enabled=False,
-        logger=logger,
-        output_format="sarif",
-    )
-
-    assert_that(logger.console_output.call_count).is_equal_to(0)
-
-
-# ---------------------------------------------------------------------------
-# Post-AI total recalculation
-# ---------------------------------------------------------------------------
-
-
-def test_fix_recomputes_totals_after_ai_changes(monkeypatch, fake_logger):
-    """Test that fix recomputes totals after AI changes."""
-
-    class _FakeTool:
-        def set_options(self, **_kwargs: Any) -> None:
-            return None
-
-        def reset_options(self) -> None:
-            return None
-
-        def fix(self, _paths: Any, _options: Any) -> ToolResult:
-            return ToolResult(
-                name="ruff",
-                success=False,
-                issues_count=1,
-                fixed_issues_count=0,
-                remaining_issues_count=1,
-                issues=[],
-            )
-
-        def check(self, _paths: Any, _options: Any) -> ToolResult:
-            return ToolResult(
-                name="ruff",
-                success=False,
-                issues_count=1,
-                issues=[],
-            )
-
-    lintro_config = LintroConfig(
-        execution=ExecutionConfig(parallel=False),
-        ai=AIConfig(
-            enabled=True,
-            transport=AITransport.API,
-            auto_apply=True,
-        ),
-    )
-
+    Args:
+        monkeypatch: pytest monkeypatch fixture.
+        fake_logger: Console logger double.
+        lintro_config: Configuration returned by ``get_config``.
+    """
     monkeypatch.setattr(
         te,
         "get_tools_to_run",
@@ -185,35 +131,69 @@ def test_fix_recomputes_totals_after_ai_changes(monkeypatch, fake_logger):
     )
     monkeypatch.setattr(te, "load_post_checks_config", lambda: {"enabled": False})
 
-    def _fake_ai_enhancement(**kwargs):
-        result = kwargs["all_results"][0]
+
+def _ai_enabled_config() -> LintroConfig:
+    """Build a config with AI enabled and serial execution.
+
+    Returns:
+        A :class:`LintroConfig` with AI enabled.
+    """
+    return LintroConfig(
+        execution=ExecutionConfig(parallel=False),
+        ai=AIConfig(
+            enabled=True,
+            transport=AITransport.API,
+            auto_apply=True,
+        ),
+    )
+
+
+def _fix_results_in_place(all_results: list[ToolResult]) -> None:
+    """Mark every result as fully fixed, mimicking AI auto-apply.
+
+    Args:
+        all_results: Results mutated in place.
+    """
+    for result in all_results:
         result.success = True
         result.fixed_issues_count = result.issues_count
         result.remaining_issues_count = 0
         result.issues_count = 0
 
-    import lintro.ai.hook as hook_module
 
-    class _FakeHook:
-        def should_run(self, action: Any) -> bool:
-            return True
+def _run_executor(**kwargs: Any) -> int:
+    """Invoke the executor with the shared fixture arguments.
 
-        def execute(
-            self,
-            action: Any,
-            all_results: Any,
-            *,
-            console_logger: Any,
-            output_format: Any,
-        ) -> object:
-            _fake_ai_enhancement(all_results=all_results)
-            return object()  # non-None sentinel to signal hook ran
+    Args:
+        **kwargs: Extra keyword arguments forwarded to the executor.
 
-    monkeypatch.setattr(
-        hook_module,
-        "AIPostExecutionHook",
-        lambda lintro_config, ai_fix=False, transport=None: _FakeHook(),
-    )
+    Returns:
+        The exit code returned by the executor.
+    """
+    call_kwargs: dict[str, Any] = {
+        "action": "fmt",
+        "paths": ["."],
+        "tools": "ruff",
+        "tool_options": None,
+        "exclude": None,
+        "include_venv": False,
+        "group_by": "auto",
+        "output_format": "json",
+        "verbose": False,
+        "raw_output": False,
+    }
+    call_kwargs.update(kwargs)
+    return run_lint_tools_simple(**call_kwargs)
+
+
+def test_fix_recomputes_totals_after_ai_runner_changes(monkeypatch, fake_logger):
+    """Totals are re-aggregated when the injected AI runner reports it ran."""
+    lintro_config = _ai_enabled_config()
+    _install_executor_doubles(monkeypatch, fake_logger, lintro_config)
+
+    def _ai_runner(*, all_results: list[ToolResult], **_kwargs: Any) -> AIOutcome:
+        _fix_results_in_place(all_results)
+        return AIOutcome(ran=True, force_failure=False)
 
     captured: dict[str, int] = {}
 
@@ -231,19 +211,138 @@ def test_fix_recomputes_totals_after_ai_changes(monkeypatch, fake_logger):
 
     monkeypatch.setattr(te, "determine_exit_code", _capture_exit_code)
 
-    exit_code = run_lint_tools_simple(
-        action="fmt",
-        paths=["."],
-        tools="ruff",
-        tool_options=None,
-        exclude=None,
-        include_venv=False,
-        group_by="auto",
-        output_format="json",
-        verbose=False,
-        raw_output=False,
-    )
+    exit_code = _run_executor(ai_runner=_ai_runner)
 
     assert_that(exit_code).is_equal_to(0)
     assert_that(captured.get("total_issues")).is_equal_to(0)
     assert_that(captured.get("total_remaining")).is_equal_to(0)
+
+
+def test_no_ai_runner_means_no_ai_and_unchanged_exit_code(monkeypatch, fake_logger):
+    """Without an injected runner the executor runs no AI at all."""
+    lintro_config = _ai_enabled_config()
+    _install_executor_doubles(monkeypatch, fake_logger, lintro_config)
+
+    import lintro.ai.hook as hook_module
+
+    def _fail(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("executor must not construct the AI hook")
+
+    monkeypatch.setattr(hook_module, "AIPostExecutionHook", _fail)
+
+    captured: dict[str, int] = {}
+
+    def _capture_exit_code(
+        *,
+        action,
+        all_results,
+        total_issues,
+        total_remaining,
+        main_phase_empty_due_to_filter,
+    ):
+        captured["total_remaining"] = total_remaining
+        return 0 if total_remaining == 0 else 1
+
+    monkeypatch.setattr(te, "determine_exit_code", _capture_exit_code)
+
+    exit_code = _run_executor()
+
+    assert_that(exit_code).is_equal_to(1)
+    assert_that(captured.get("total_remaining")).is_equal_to(1)
+
+
+def test_ai_runner_force_failure_overrides_clean_exit_code(monkeypatch, fake_logger):
+    """A forcing AI outcome turns a clean run into exit code 1."""
+    lintro_config = _ai_enabled_config()
+    _install_executor_doubles(monkeypatch, fake_logger, lintro_config)
+
+    def _ai_runner(*, all_results: list[ToolResult], **_kwargs: Any) -> AIOutcome:
+        _fix_results_in_place(all_results)
+        return AIOutcome(ran=True, force_failure=True)
+
+    monkeypatch.setattr(te, "determine_exit_code", lambda **_kwargs: 0)
+
+    exit_code = _run_executor(ai_runner=_ai_runner)
+
+    assert_that(exit_code).is_equal_to(1)
+
+
+def test_ai_runner_without_force_failure_leaves_exit_code(monkeypatch, fake_logger):
+    """A non-forcing AI outcome does not change the computed exit code."""
+    lintro_config = _ai_enabled_config()
+    _install_executor_doubles(monkeypatch, fake_logger, lintro_config)
+
+    def _ai_runner(*, all_results: list[ToolResult], **_kwargs: Any) -> AIOutcome:
+        _fix_results_in_place(all_results)
+        return AIOutcome(ran=True, force_failure=False)
+
+    monkeypatch.setattr(te, "determine_exit_code", lambda **_kwargs: 0)
+
+    exit_code = _run_executor(ai_runner=_ai_runner)
+
+    assert_that(exit_code).is_equal_to(0)
+
+
+def test_ai_runner_exception_propagates(monkeypatch, fake_logger):
+    """Errors raised by the AI seam propagate, as ``fail_on_ai_error`` needs."""
+    lintro_config = _ai_enabled_config()
+    _install_executor_doubles(monkeypatch, fake_logger, lintro_config)
+
+    def _ai_runner(**_kwargs: Any) -> AIOutcome:
+        raise RuntimeError("provider exploded")
+
+    assert_that(_run_executor).raises(RuntimeError).when_called_with(
+        ai_runner=_ai_runner,
+    )
+
+
+def test_fail_under_still_forces_failure_after_ai_clears_run(
+    monkeypatch,
+    fake_logger,
+):
+    """The score gate can still fail a run that AI left at exit code 0."""
+    lintro_config = _ai_enabled_config()
+    _install_executor_doubles(monkeypatch, fake_logger, lintro_config)
+
+    def _ai_runner(*, all_results: list[ToolResult], **_kwargs: Any) -> AIOutcome:
+        _fix_results_in_place(all_results)
+        return AIOutcome(ran=True, force_failure=False)
+
+    monkeypatch.setattr(te, "determine_exit_code", lambda **_kwargs: 0)
+
+    exit_code = _run_executor(fail_under=101.0, ai_runner=_ai_runner)
+
+    assert_that(exit_code).is_equal_to(1)
+
+
+def test_ai_status_renderer_lines_reach_the_summary(monkeypatch, fake_logger):
+    """The injected status renderer supplies the summary's AI rows."""
+    lintro_config = _ai_enabled_config()
+    _install_executor_doubles(monkeypatch, fake_logger, lintro_config)
+    monkeypatch.setattr(te, "determine_exit_code", lambda **_kwargs: 0)
+
+    captured: dict[str, Any] = {}
+
+    import lintro.utils.console.pre_execution_summary as summary_module
+
+    def _fake_summary(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        summary_module,
+        "print_pre_execution_summary",
+        _fake_summary,
+    )
+
+    def _renderer(*, ai_config: Any, is_ci: bool) -> list[str]:
+        captured["renderer_ai_config"] = ai_config
+        return ["[green]enabled[/green]"]
+
+    exit_code = _run_executor(
+        output_format="grid",
+        ai_status_renderer=_renderer,
+    )
+
+    assert_that(exit_code).is_equal_to(0)
+    assert_that(captured.get("ai_status_lines")).is_equal_to(["[green]enabled[/green]"])
+    assert_that(captured.get("renderer_ai_config")).is_same_as(lintro_config.ai)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(ai): add AI interface facade and move AI out of the executor
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

PR 2 of 4 for #724. Introduces `lintro/ai/interface.py` as the single
integration point between the core runner and the AI layer, and removes every
`lintro.ai` import from `tool_executor.py` and `pre_execution_summary.py`.

- Add `lintro/models/core/ai_seam.py` with core-owned `AIOutcome` and
  `AIRunner` / `AIStatusRenderer` protocols.
- Executor accepts optional `ai_runner` / `ai_status_renderer` (default
  `None`) instead of importing the AI hook; exit-code adjustment stays after
  `determine_exit_code` and before `fail_under`.
- Move pre-execution AI status rendering into `lintro/ai/display/status.py`.
- `check` / `format` / public API check/fmt inject the AI runner; `test`
  paths inject only the status renderer (matches the CHECK/FIX gate).
- Move four review enums to `lintro/enums/`, re-exported from
  `lintro.ai.review.enums.*`, so `config/review_config.py` no longer imports
  `lintro.ai`.

Facade surface (deliberately three names): `run_ai_layer`,
`ai_exit_code_override`, `render_ai_status`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Relates to #724

## Details

`idiom_review` AI-internal imports intentionally not routed through the facade
(would balloon pass-through re-exports). Behavior matrix covered in
`test_interface.py` / `test_display_status.py` / `test_tool_executor_ai.py`.
Follow-ups: PR 3 (#1829) raw `LintroConfig.ai` dict; PR 4 metadata rename /
remaining import edges.