### PR TITLE
refactor(config): decouple AIConfig from LintroConfig

### DIFF
--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -16,7 +16,9 @@ is the primary interface; the grouping is for documentation only.
 from __future__ import annotations
 
 import warnings
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Any
 
 from loguru import logger
@@ -32,6 +34,29 @@ __all__ = [
     "AIOutputConfig",
     "AIProviderConfig",
 ]
+
+_SUPPRESS_DIAGNOSTICS: ContextVar[bool] = ContextVar(
+    "ai_config_suppress_diagnostics",
+    default=False,
+)
+
+
+@contextmanager
+def _suppressed_diagnostics() -> Iterator[None]:
+    """Silence validator-emitted diagnostics for the duration of the block.
+
+    Model validators on :class:`AIConfig` log migration hints as a side
+    effect of construction. Display-only parses re-build a config that the
+    resolver already parsed, so they must not repeat those hints.
+
+    Yields:
+        None: Control, with diagnostics suppressed on the current context.
+    """
+    token = _SUPPRESS_DIAGNOSTICS.set(True)
+    try:
+        yield
+    finally:
+        _SUPPRESS_DIAGNOSTICS.reset(token)
 
 
 class AIConfig(BaseModel):
@@ -233,6 +258,8 @@ class AIConfig(BaseModel):
         if self.enabled and "lint" not in fields_set and "review" not in fields_set:
             self.lint = True
             self.review = True
+            if _SUPPRESS_DIAGNOSTICS.get():
+                return self
             message = (
                 "ai.enabled without ai.lint/ai.review is deprecated; both AI "
                 "lint summarization and AI review were enabled for backward "
@@ -261,7 +288,7 @@ class AIConfig(BaseModel):
         cls,
         data: Mapping[str, Any] | None,
         *,
-        warn_unknown: bool = True,
+        diagnostics: bool = True,
     ) -> AIConfig:
         """Build an :class:`AIConfig` from a raw ``ai:`` config mapping.
 
@@ -276,9 +303,11 @@ class AIConfig(BaseModel):
 
         Args:
             data: Raw ``ai`` section from config, or None when absent.
-            warn_unknown: Whether to log a warning listing dropped keys.
-                Display-only callers pass False so that rendering a summary
-                never emits diagnostics; resolvers leave it True.
+            diagnostics: Whether this parse may emit user-facing diagnostics
+                — the dropped-unknown-key warning and the validators'
+                migration hints. Display-only callers pass False, because
+                they re-parse a mapping the resolver already reported on and
+                must not duplicate its output; resolvers leave it True.
 
         Returns:
             AIConfig: Parsed AI configuration.
@@ -288,13 +317,16 @@ class AIConfig(BaseModel):
 
         known_fields = set(cls.model_fields)
         unknown = set(data) - known_fields
-        if unknown and warn_unknown:
+        if unknown and diagnostics:
             logger.warning(
                 "Unknown AI config keys ignored: {}",
                 ", ".join(sorted(unknown)),
             )
         filtered = {k: v for k, v in data.items() if k in known_fields}
-        return cls(**filtered)
+        if diagnostics:
+            return cls(**filtered)
+        with _suppressed_diagnostics():
+            return cls(**filtered)
 
     # -- Effective feature state -------------------------------------------
 

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -16,6 +16,8 @@ is the primary interface; the grouping is for documentation only.
 from __future__ import annotations
 
 import warnings
+from collections.abc import Mapping
+from typing import Any
 
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -251,6 +253,48 @@ class AIConfig(BaseModel):
             )
             raise ValueError(msg)
         return self
+
+    # -- Construction from raw config data ---------------------------------
+
+    @classmethod
+    def from_mapping(
+        cls,
+        data: Mapping[str, Any] | None,
+        *,
+        warn_unknown: bool = True,
+    ) -> AIConfig:
+        """Build an :class:`AIConfig` from a raw ``ai:`` config mapping.
+
+        Only recognized keys are passed through, so the model's own defaults
+        apply to every omitted field. Unknown keys are dropped rather than
+        rejected, because ``AIConfig`` itself forbids extras and a stale key
+        in ``.lintro-config.yaml`` must not break the whole run.
+
+        This is the boundary that keeps :mod:`lintro.config` free of any
+        knowledge of ``AIConfig``'s field set (see issue #724): the loader
+        stores the ``ai:`` section verbatim and the AI layer parses it.
+
+        Args:
+            data: Raw ``ai`` section from config, or None when absent.
+            warn_unknown: Whether to log a warning listing dropped keys.
+                Display-only callers pass False so that rendering a summary
+                never emits diagnostics; resolvers leave it True.
+
+        Returns:
+            AIConfig: Parsed AI configuration.
+        """
+        if not data:
+            return cls()
+
+        known_fields = set(cls.model_fields)
+        unknown = set(data) - known_fields
+        if unknown and warn_unknown:
+            logger.warning(
+                "Unknown AI config keys ignored: {}",
+                ", ".join(sorted(unknown)),
+            )
+        filtered = {k: v for k, v in data.items() if k in known_fields}
+        return cls(**filtered)
 
     # -- Effective feature state -------------------------------------------
 

--- a/lintro/ai/display/status.py
+++ b/lintro/ai/display/status.py
@@ -28,9 +28,9 @@ def render_ai_status(
     Args:
         ai_config: Raw ``ai:`` mapping as held by the core executor, an
             already-parsed :class:`AIConfig`, or None when unavailable. A
-            mapping is parsed here; unknown-key warnings are suppressed
-            because rendering a summary must not emit diagnostics (the
-            resolver on the AI entry path already reports them).
+            mapping is parsed here with diagnostics off, because rendering a
+            summary must not emit unknown-key warnings or migration hints
+            (the resolver on the AI entry path already reports them).
         is_ci: Whether the run is in a CI environment (affects the
             ``auto_apply`` warning wording).
 
@@ -45,7 +45,7 @@ def render_ai_status(
     if isinstance(ai_config, Mapping):
         from lintro.ai.config import AIConfig as _AIConfig
 
-        ai_config = _AIConfig.from_mapping(ai_config, warn_unknown=False)
+        ai_config = _AIConfig.from_mapping(ai_config, diagnostics=False)
     if not ai_config.enabled:
         ai_parts.append("[dim]disabled[/dim]")
         return ai_parts

--- a/lintro/ai/display/status.py
+++ b/lintro/ai/display/status.py
@@ -8,7 +8,8 @@ lives in the AI package so the core summary renderer
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from lintro.ai.config import AIConfig
@@ -19,13 +20,17 @@ AI_STATUS_NO_CONFIG = "[dim]disabled (no config)[/dim]"
 
 def render_ai_status(
     *,
-    ai_config: AIConfig | None,
+    ai_config: AIConfig | Mapping[str, Any] | None,
     is_ci: bool,
 ) -> list[str]:
     """Render the pre-execution AI status lines.
 
     Args:
-        ai_config: AI configuration, or None when unavailable.
+        ai_config: Raw ``ai:`` mapping as held by the core executor, an
+            already-parsed :class:`AIConfig`, or None when unavailable. A
+            mapping is parsed here; unknown-key warnings are suppressed
+            because rendering a summary must not emit diagnostics (the
+            resolver on the AI entry path already reports them).
         is_ci: Whether the run is in a CI environment (affects the
             ``auto_apply`` warning wording).
 
@@ -37,6 +42,10 @@ def render_ai_status(
     if ai_config is None:
         ai_parts.append(AI_STATUS_NO_CONFIG)
         return ai_parts
+    if isinstance(ai_config, Mapping):
+        from lintro.ai.config import AIConfig as _AIConfig
+
+        ai_config = _AIConfig.from_mapping(ai_config, warn_unknown=False)
     if not ai_config.enabled:
         ai_parts.append("[dim]disabled[/dim]")
         return ai_parts

--- a/lintro/ai/hook.py
+++ b/lintro/ai/hook.py
@@ -15,6 +15,7 @@ from lintro.ai.models import AIResult
 from lintro.enums.action import Action
 
 if TYPE_CHECKING:
+    from lintro.ai.config import AIConfig
     from lintro.config.lintro_config import LintroConfig
     from lintro.models.core.tool_result import ToolResult
     from lintro.utils.console.logger import ThreadSafeConsoleLogger
@@ -27,6 +28,7 @@ class AIPostExecutionHook:
         self,
         lintro_config: LintroConfig,
         *,
+        ai_config: AIConfig | None = None,
         ai_fix: bool = False,
         transport: str | None = None,
     ) -> None:
@@ -34,10 +36,18 @@ class AIPostExecutionHook:
 
         Args:
             lintro_config: Full Lintro configuration.
+            ai_config: Pre-resolved AI configuration. Passed by callers that
+                already resolved it so the raw ``ai:`` mapping is parsed once
+                per run; resolved here when omitted.
             ai_fix: Whether AI fix suggestions were requested.
             transport: Optional CLI override for ``ai.transport``.
         """
+        from lintro.ai.interface import resolve_ai_config
+
         self._lintro_config = lintro_config
+        self._ai_config = (
+            ai_config if ai_config is not None else resolve_ai_config(lintro_config)
+        )
         self._ai_fix = ai_fix
         self._transport = transport
 
@@ -51,7 +61,7 @@ class AIPostExecutionHook:
             True if AI lint summarization is enabled and action is CHECK or
             FIX.
         """
-        return self._lintro_config.ai.lint_enabled and action in {
+        return self._ai_config.lint_enabled and action in {
             Action.CHECK,
             Action.FIX,
         }
@@ -85,6 +95,7 @@ class AIPostExecutionHook:
                 action=action,
                 all_results=all_results,
                 lintro_config=self._lintro_config,
+                ai_config=self._ai_config,
                 logger=console_logger,
                 output_format=output_format,
                 ai_fix=self._ai_fix,
@@ -92,7 +103,7 @@ class AIPostExecutionHook:
             )
         except Exception as e:
             logger.opt(exception=True).debug(f"AI post-execution hook failed: {e}")
-            if getattr(self._lintro_config.ai, "fail_on_ai_error", False):
+            if self._ai_config.fail_on_ai_error:
                 raise
             if output_format.lower() not in ("json", "sarif"):
                 console_logger.warning(f"AI enhancement unavailable: {e}")

--- a/lintro/ai/interface.py
+++ b/lintro/ai/interface.py
@@ -13,6 +13,7 @@ that importing this module stays cheap on the no-AI path.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from lintro.enums.action import Action
@@ -28,8 +29,33 @@ if TYPE_CHECKING:
 __all__ = [
     "ai_exit_code_override",
     "render_ai_status",
+    "resolve_ai_config",
     "run_ai_layer",
 ]
+
+
+def resolve_ai_config(lintro_config: LintroConfig) -> AIConfig:
+    """Parse the raw ``ai:`` mapping on a config into an :class:`AIConfig`.
+
+    :class:`~lintro.config.lintro_config.LintroConfig` stores the ``ai:``
+    section verbatim as a mapping so that :mod:`lintro.config` never imports
+    :mod:`lintro.ai` (issue #724). Every caller that needs typed AI settings
+    goes through this function.
+
+    Unknown keys are dropped with a warning, so resolving is also what makes
+    a typo'd ``ai.*`` key discoverable. Callers should resolve once per run
+    and pass the result down rather than re-resolving, which would repeat
+    that warning.
+
+    Args:
+        lintro_config: Full Lintro configuration.
+
+    Returns:
+        The parsed AI configuration, with model defaults for omitted fields.
+    """
+    from lintro.ai.config import AIConfig
+
+    return AIConfig.from_mapping(lintro_config.ai)
 
 
 def _warn_ai_fix_disabled(
@@ -65,13 +91,13 @@ def _warn_ai_fix_disabled(
 def ai_exit_code_override(
     *,
     ai_result: AIResult | None,
-    lintro_config: LintroConfig,
+    ai_config: AIConfig,
 ) -> bool:
     """Whether AI outcomes force a non-zero exit.
 
     Args:
         ai_result: Result of the AI run, or None when AI did not run.
-        lintro_config: Full Lintro configuration.
+        ai_config: Resolved AI configuration.
 
     Returns:
         True when ``ai.fail_on_unfixed`` or ``ai.fail_on_ai_error`` is
@@ -79,7 +105,6 @@ def ai_exit_code_override(
     """
     if ai_result is None:
         return False
-    ai_config = lintro_config.ai
     if ai_config.fail_on_unfixed and ai_result.unfixed_issues > 0:
         return True
     return bool(ai_config.fail_on_ai_error and ai_result.error)
@@ -119,11 +144,12 @@ def run_ai_layer(
     Raises:
         Exception: Re-raised when ``ai.fail_on_ai_error`` is enabled.
     """
-    effective_ai_fix = ai_fix or lintro_config.ai.default_fix
+    ai_config = resolve_ai_config(lintro_config)
+    effective_ai_fix = ai_fix or ai_config.default_fix
     _warn_ai_fix_disabled(
         action=action,
         ai_fix=effective_ai_fix,
-        ai_lint_enabled=lintro_config.ai.lint_enabled,
+        ai_lint_enabled=ai_config.lint_enabled,
         logger=console_logger,
         output_format=output_format,
     )
@@ -132,6 +158,7 @@ def run_ai_layer(
 
     ai_hook = AIPostExecutionHook(
         lintro_config,
+        ai_config=ai_config,
         ai_fix=effective_ai_fix,
         transport=transport,
     )
@@ -150,7 +177,7 @@ def run_ai_layer(
         from loguru import logger as loguru_logger
 
         loguru_logger.opt(exception=True).debug(f"AI hook failed: {exc}")
-        if getattr(lintro_config.ai, "fail_on_ai_error", False):
+        if ai_config.fail_on_ai_error:
             raise
         if output_format.lower() not in ("json", "sarif"):
             console_logger.console_output(f"Warning: AI enhancement failed: {exc}")
@@ -162,20 +189,22 @@ def run_ai_layer(
         ran=True,
         force_failure=ai_exit_code_override(
             ai_result=ai_result,
-            lintro_config=lintro_config,
+            ai_config=ai_config,
         ),
     )
 
 
 def render_ai_status(
     *,
-    ai_config: AIConfig | None,
+    ai_config: AIConfig | Mapping[str, Any] | None,
     is_ci: bool,
 ) -> list[str]:
     """Render the pre-execution AI status lines.
 
     Args:
-        ai_config: AI configuration, or None when unavailable.
+        ai_config: Raw ``ai:`` mapping from the config (what the core
+            executor holds), an already-parsed :class:`AIConfig`, or None
+            when unavailable.
         is_ci: Whether the run is in a CI environment.
 
     Returns:

--- a/lintro/ai/orchestrator.py
+++ b/lintro/ai/orchestrator.py
@@ -47,6 +47,7 @@ def run_ai_enhancement(
     lintro_config: LintroConfig,
     logger: ThreadSafeConsoleLogger,
     output_format: str,
+    ai_config: AIConfig | None = None,
     ai_fix: bool = False,
     transport: str | None = None,
 ) -> AIResult:
@@ -63,6 +64,9 @@ def run_ai_enhancement(
         lintro_config: Full lintro configuration.
         logger: Thread-safe console logger.
         output_format: Output format (e.g. "terminal", "json").
+        ai_config: Pre-resolved AI configuration. Passed by callers that
+            already resolved it so the raw ``ai:`` mapping is parsed once
+            per run; resolved here when omitted.
         ai_fix: Whether to generate AI fix suggestions.
         transport: Optional CLI override for ``ai.transport``.
 
@@ -76,6 +80,7 @@ def run_ai_enhancement(
             lintro_config=lintro_config,
             logger=logger,
             output_format=output_format,
+            ai_config=ai_config,
             ai_fix=ai_fix,
             transport=transport,
         ),
@@ -89,6 +94,7 @@ async def run_ai_enhancement_async(
     lintro_config: LintroConfig,
     logger: ThreadSafeConsoleLogger,
     output_format: str,
+    ai_config: AIConfig | None = None,
     ai_fix: bool = False,
     transport: str | None = None,
 ) -> AIResult:
@@ -100,6 +106,9 @@ async def run_ai_enhancement_async(
         lintro_config: Full lintro configuration.
         logger: Thread-safe console logger.
         output_format: Output format (e.g. "terminal", "json").
+        ai_config: Pre-resolved AI configuration. Passed by callers that
+            already resolved it so the raw ``ai:`` mapping is parsed once
+            per run; resolved here when omitted.
         ai_fix: Whether to generate AI fix suggestions.
         transport: Optional CLI override for ``ai.transport``.
 
@@ -111,10 +120,15 @@ async def run_ai_enhancement_async(
         SystemExit: Re-raised immediately.
         Exception: Re-raised when ``fail_on_ai_error`` is True.
     """
+    from lintro.ai.interface import resolve_ai_config
+
+    base_ai_config = (
+        ai_config if ai_config is not None else resolve_ai_config(lintro_config)
+    )
     try:
         require_ai()
 
-        ai_config = apply_transport_override(lintro_config.ai, transport)
+        ai_config = apply_transport_override(base_ai_config, transport)
         workspace_root = resolve_workspace_root(lintro_config.config_path)
         provider = get_provider(ai_config)
         is_json = output_format.lower() == OutputFormat.JSON
@@ -151,7 +165,7 @@ async def run_ai_enhancement_async(
     except (KeyboardInterrupt, SystemExit):
         raise
     except Exception as e:
-        if getattr(lintro_config.ai, "fail_on_ai_error", False):
+        if base_ai_config.fail_on_ai_error:
             raise
         loguru_logger.opt(exception=e).debug(
             f"AI enhancement failed ({type(e).__name__}): {e}",

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -17,6 +17,7 @@ from rich.console import Console
 from rich.text import Text
 
 from lintro.ai.doctor_checks import AICheckResult, check_ai_configuration
+from lintro.ai.interface import resolve_ai_config
 from lintro.enums.tool_status import ToolStatus
 from lintro.tools.core.install_context import RuntimeContext
 from lintro.tools.core.install_strategies import get_strategy
@@ -530,7 +531,7 @@ def doctor_command(
     from lintro.config.config_loader import get_config
 
     config = get_config()
-    ai_checks = check_ai_configuration(config.ai)
+    ai_checks = check_ai_configuration(resolve_ai_config(config))
     ai_failure_count = sum(1 for check in ai_checks if _ai_check_is_failure(check))
 
     oxlint_type_aware = bool(config.get_tool_defaults("oxlint").get("type_aware"))

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -11,6 +11,7 @@ from rich.console import Console
 
 from lintro.ai.availability import require_ai
 from lintro.ai.exceptions import AIError
+from lintro.ai.interface import resolve_ai_config
 from lintro.ai.providers import get_provider
 from lintro.ai.review import (
     classify_changed_files,
@@ -160,7 +161,8 @@ def review_command(
     """Run AI-powered diff-based code review."""
     require_ai()
     lintro_config = get_config()
-    if not lintro_config.ai.review_enabled:
+    ai_config = resolve_ai_config(lintro_config)
+    if not ai_config.review_enabled:
         raise click.UsageError(
             "AI review is disabled in configuration. Set ai.review: true "
             "(and ai.enabled: true) in .lintro-config.yaml",
@@ -238,7 +240,7 @@ def review_command(
                 issue_count,
             )
 
-    effective_ai_config = apply_transport_override(lintro_config.ai, transport)
+    effective_ai_config = apply_transport_override(ai_config, transport)
     if timeout is not None:
         effective_ai_config = effective_ai_config.model_copy(
             update={"api_timeout": timeout},

--- a/lintro/config/config_loader.py
+++ b/lintro/config/config_loader.py
@@ -18,7 +18,6 @@ from typing import Any
 
 from loguru import logger
 
-from lintro.ai.config import AIConfig
 from lintro.config.lintro_config import (
     EnforceConfig,
     ExecutionConfig,
@@ -278,32 +277,6 @@ def _parse_defaults(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
             defaults[tool_name.lower()] = tool_defaults
 
     return defaults
-
-
-def _parse_ai_config(data: dict[str, Any]) -> AIConfig:
-    """Parse AI configuration section.
-
-    Passes only recognized keys through to AIConfig so the model's
-    own defaults apply for any omitted fields.
-
-    Args:
-        data: Raw 'ai' section from config.
-
-    Returns:
-        AIConfig: Parsed AI configuration.
-    """
-    if not data:
-        return AIConfig()
-
-    known_fields = set(AIConfig.model_fields)
-    unknown = set(data) - known_fields
-    if unknown:
-        logger.warning(
-            "Unknown AI config keys ignored: {}",
-            ", ".join(sorted(unknown)),
-        )
-    filtered = {k: v for k, v in data.items() if k in known_fields}
-    return AIConfig(**filtered)
 
 
 def _parse_review_checklist_item_config(data: Any) -> dict[str, Any]:
@@ -688,7 +661,8 @@ def load_config(
     execution_config = _parse_execution_config(data.get("execution", {}))
     defaults = _parse_defaults(data.get("defaults", {}))
     tools_config = _parse_tools_config(data.get("tools", {}))
-    ai_config = _parse_ai_config(data.get("ai", {}))
+    # Stored verbatim: parsing belongs to the AI layer (issue #724).
+    ai_config = data.get("ai") or {}
     review_config = _parse_review_config(data.get("review", {}))
     score_config = _parse_score_config(data.get("score", {}))
     output_config = _parse_output_config(data.get("output", {}))

--- a/lintro/config/lintro_config.py
+++ b/lintro/config/lintro_config.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from lintro.ai.config import AIConfig
 from lintro.config.enforce_config import EnforceConfig
 from lintro.config.execution_config import ExecutionConfig
 from lintro.config.output_config import OutputConfig
@@ -13,7 +12,6 @@ from lintro.config.score_config import ScoreConfig
 from lintro.config.tool_config import LintroToolConfig
 
 __all__ = [
-    "AIConfig",
     "EnforceConfig",
     "ExecutionConfig",
     "LintroConfig",
@@ -52,7 +50,7 @@ class LintroConfig(BaseModel):
     2. enforce: Cross-cutting settings that override native configs
     3. defaults: Fallback config when no native config exists
     4. tools: Per-tool enable/disable and config source
-    5. ai: Optional AI-powered issue intelligence
+    5. ai: Optional AI-powered issue intelligence (raw mapping)
 
     Attributes:
         model_config: Pydantic model configuration.
@@ -60,7 +58,9 @@ class LintroConfig(BaseModel):
         enforce: Cross-cutting settings enforced via CLI flags.
         defaults: Fallback configs for tools without native configs.
         tools: Per-tool configuration, keyed by tool name.
-        ai: AI-powered features configuration (optional, disabled by default).
+        ai: Raw ``ai:`` section from config, stored verbatim. The AI layer
+            parses it into ``AIConfig`` via ``resolve_ai_config`` so that
+            core config never imports the AI package (issue #724).
         review: Diff review command configuration (checklist items).
         score: Health score weights and scale (0-100 metric).
         output: Console output presentation settings (e.g. ASCII art toggle).
@@ -73,7 +73,7 @@ class LintroConfig(BaseModel):
     enforce: EnforceConfig = Field(default_factory=EnforceConfig)
     defaults: dict[str, dict[str, Any]] = Field(default_factory=dict)
     tools: dict[str, LintroToolConfig] = Field(default_factory=dict)
-    ai: AIConfig = Field(default_factory=AIConfig)
+    ai: dict[str, Any] = Field(default_factory=dict)
     review: ReviewConfig = Field(default_factory=ReviewConfig)
     score: ScoreConfig = Field(default_factory=ScoreConfig)
     output: OutputConfig = Field(default_factory=OutputConfig)

--- a/lintro/models/core/ai_seam.py
+++ b/lintro/models/core/ai_seam.py
@@ -77,7 +77,11 @@ class AIStatusRenderer(Protocol):
         """Render the AI rows for the pre-execution configuration summary.
 
         Args:
-            ai_config: AI configuration object, or None when unavailable.
+            ai_config: The raw ``ai:`` mapping held by
+                :class:`~lintro.config.lintro_config.LintroConfig`, or None
+                when unavailable. The core runner passes it through
+                untouched; parsing it into a typed AI configuration is the
+                renderer's job, so core stays free of AI imports.
             is_ci: Whether the run is in a CI environment.
 
         Returns:

--- a/lintro/tools/definitions/idiom_review.py
+++ b/lintro/tools/definitions/idiom_review.py
@@ -28,6 +28,7 @@ from loguru import logger
 from lintro.ai.availability import is_ai_available
 from lintro.ai.budget import CostBudget
 from lintro.ai.exceptions import AIError
+from lintro.ai.interface import resolve_ai_config
 from lintro.ai.paths import resolve_workspace_root
 from lintro.ai.providers import get_provider
 from lintro.enums.confidence_level import ConfidenceLevel
@@ -178,7 +179,7 @@ class IdiomReviewPlugin(BaseToolPlugin):
             ToolResult with the aggregated, confidence-filtered findings.
         """
         lintro_config = self._get_lintro_config()
-        ai_config = lintro_config.ai
+        ai_config = resolve_ai_config(lintro_config)
         provider = get_provider(ai_config)
         budget = CostBudget(max_cost_usd=ai_config.max_cost_usd)
         workspace_root = resolve_workspace_root(lintro_config.config_path)

--- a/tests/unit/ai/review/test_review_command_json_error.py
+++ b/tests/unit/ai/review/test_review_command_json_error.py
@@ -25,7 +25,7 @@ def patched_review(monkeypatch: pytest.MonkeyPatch) -> None:
     ``--output json`` error branch.
     """
     config = MagicMock()
-    config.ai.enabled = True
+    config.ai = {"enabled": True}
     config.review.depth = 1
     config.review.strictness = ReviewStrictness.BALANCED
     config.review.sensitivity = {}

--- a/tests/unit/ai/test_config_resolution.py
+++ b/tests/unit/ai/test_config_resolution.py
@@ -1,0 +1,298 @@
+"""Tests for decoupling ``AIConfig`` parsing from the core config loader.
+
+Issue #724 PR 3 removed the last two ``lintro.config`` -> ``lintro.ai`` import
+edges: ``LintroConfig.ai`` now stores the ``ai:`` section verbatim as a raw
+mapping and the AI layer parses it via :meth:`AIConfig.from_mapping`, exposed
+on the facade as :func:`lintro.ai.interface.resolve_ai_config`.
+
+The behavioural risk this creates is warning *timing*: unknown ``ai.*`` keys
+used to be reported at config-load time. These tests pin that a typo is still
+reported exactly once on the paths a user actually runs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from assertpy import assert_that
+from loguru import logger
+
+from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport, ConfidenceLevel
+from lintro.ai.interface import resolve_ai_config, run_ai_layer
+from lintro.ai.registry import AIProvider
+from lintro.config.config_loader import load_config
+from lintro.config.lintro_config import LintroConfig
+from lintro.enums.action import Action
+
+
+@pytest.fixture
+def warnings_captured() -> Iterator[list[str]]:
+    """Capture loguru WARNING records emitted during the test.
+
+    Yields:
+        list[str]: A list that accumulates formatted warning messages.
+    """
+    messages: list[str] = []
+    handler_id = logger.add(
+        lambda message: messages.append(str(message)),
+        level="WARNING",
+    )
+    try:
+        yield messages
+    finally:
+        logger.remove(handler_id)
+
+
+# ---------------------------------------------------------------------------
+# AIConfig.from_mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("data", [None, {}])
+def test_from_mapping_empty_yields_model_defaults(data: dict[str, Any] | None) -> None:
+    """An absent or empty ``ai:`` section produces a default AIConfig.
+
+    Args:
+        data: The raw mapping under test.
+    """
+    assert_that(AIConfig.from_mapping(data)).is_equal_to(AIConfig())
+
+
+def test_from_mapping_applies_known_keys() -> None:
+    """Recognized keys are applied and omitted ones keep model defaults."""
+    config = AIConfig.from_mapping({"enabled": True, "lint": True, "max_tokens": 1234})
+
+    assert_that(config.enabled).is_true()
+    assert_that(config.lint).is_true()
+    assert_that(config.review).is_false()
+    assert_that(config.max_tokens).is_equal_to(1234)
+    assert_that(config.provider).is_equal_to(AIProvider.ANTHROPIC)
+
+
+def test_from_mapping_drops_unknown_keys_and_warns_sorted(
+    warnings_captured: list[str],
+) -> None:
+    """Unknown keys are dropped, not rejected, and listed sorted in a warning.
+
+    Args:
+        warnings_captured: Captured loguru warning messages.
+    """
+    config = AIConfig.from_mapping(
+        {"enabled": True, "zulu_typo": 1, "alpha_typo": 2},
+    )
+
+    assert_that(config.enabled).is_true()
+    assert_that(config.model_dump()).does_not_contain_key("zulu_typo")
+    assert_that("".join(warnings_captured)).contains(
+        "Unknown AI config keys ignored: alpha_typo, zulu_typo",
+    )
+
+
+def test_from_mapping_can_suppress_the_unknown_key_warning(
+    warnings_captured: list[str],
+) -> None:
+    """Display callers opt out of diagnostics without changing parsing.
+
+    Args:
+        warnings_captured: Captured loguru warning messages.
+    """
+    config = AIConfig.from_mapping({"lint": True, "typo": 1}, warn_unknown=False)
+
+    assert_that(config.lint).is_true()
+    assert_that(warnings_captured).is_empty()
+
+
+# ---------------------------------------------------------------------------
+# Loader round trip
+# ---------------------------------------------------------------------------
+
+
+def test_loader_stores_the_ai_section_verbatim(tmp_path: Path) -> None:
+    """The loader keeps the raw mapping and never builds an AIConfig.
+
+    Args:
+        tmp_path: Temporary directory for the config file.
+    """
+    (tmp_path / ".lintro-config.yaml").write_text(
+        "ai:\n  enabled: true\n  lint: true\n  bogus_key: 1\n",
+        encoding="utf-8",
+    )
+
+    config = load_config(
+        config_path=tmp_path / ".lintro-config.yaml",
+        allow_pyproject_fallback=False,
+    )
+
+    assert_that(config.ai).is_instance_of(dict)
+    assert_that(config.ai).is_equal_to(
+        {"enabled": True, "lint": True, "bogus_key": 1},
+    )
+
+
+def test_loader_missing_ai_section_yields_empty_mapping(tmp_path: Path) -> None:
+    """A config without an ``ai:`` section resolves to a default AIConfig.
+
+    Args:
+        tmp_path: Temporary directory for the config file.
+    """
+    (tmp_path / ".lintro-config.yaml").write_text(
+        "execution:\n  fail_fast: true\n",
+        encoding="utf-8",
+    )
+
+    config = load_config(
+        config_path=tmp_path / ".lintro-config.yaml",
+        allow_pyproject_fallback=False,
+    )
+
+    assert_that(config.ai).is_equal_to({})
+    assert_that(resolve_ai_config(config)).is_equal_to(AIConfig())
+
+
+def test_full_ai_section_round_trips_to_the_same_config(tmp_path: Path) -> None:
+    """A realistic ``ai:`` section parses exactly as it did before the split.
+
+    Args:
+        tmp_path: Temporary directory for the config file.
+    """
+    (tmp_path / ".lintro-config.yaml").write_text(
+        "\n".join(
+            [
+                "ai:",
+                "  enabled: true",
+                "  lint: true",
+                "  review: false",
+                "  provider: openai",
+                "  transport: cli",
+                "  model: gpt-4-turbo",
+                "  api_key_env: MY_API_KEY",
+                "  max_tokens: 2048",
+                "  max_parallel_calls: 3",
+                "  fail_on_unfixed: true",
+                "  fail_on_ai_error: true",
+                "  min_confidence: high",
+                "  exclude_paths:",
+                "    - tests/*",
+                "",
+            ],
+        ),
+        encoding="utf-8",
+    )
+
+    ai_config = resolve_ai_config(
+        load_config(
+            config_path=tmp_path / ".lintro-config.yaml",
+            allow_pyproject_fallback=False,
+        ),
+    )
+
+    assert_that(ai_config.enabled).is_true()
+    assert_that(ai_config.lint).is_true()
+    assert_that(ai_config.review).is_false()
+    assert_that(ai_config.lint_enabled).is_true()
+    assert_that(ai_config.review_enabled).is_false()
+    assert_that(ai_config.provider).is_equal_to(AIProvider.OPENAI)
+    assert_that(ai_config.transport).is_equal_to(AITransport.CLI)
+    assert_that(ai_config.model).is_equal_to("gpt-4-turbo")
+    assert_that(ai_config.api_key_env).is_equal_to("MY_API_KEY")
+    assert_that(ai_config.max_tokens).is_equal_to(2048)
+    assert_that(ai_config.max_parallel_calls).is_equal_to(3)
+    assert_that(ai_config.fail_on_unfixed).is_true()
+    assert_that(ai_config.fail_on_ai_error).is_true()
+    assert_that(ai_config.min_confidence).is_equal_to(ConfidenceLevel.HIGH)
+    assert_that(ai_config.exclude_paths).is_equal_to(["tests/*"])
+    # Untouched fields still fall back to the model defaults.
+    assert_that(ai_config.api_timeout).is_equal_to(AIConfig().api_timeout)
+
+
+def test_resolve_ai_config_reads_the_raw_mapping() -> None:
+    """The facade turns the stored mapping into a typed configuration."""
+    lintro_config = LintroConfig(ai={"enabled": True, "max_fix_attempts": 7})
+
+    ai_config = resolve_ai_config(lintro_config)
+
+    assert_that(ai_config).is_instance_of(AIConfig)
+    assert_that(ai_config.enabled).is_true()
+    assert_that(ai_config.max_fix_attempts).is_equal_to(7)
+
+
+# ---------------------------------------------------------------------------
+# Unknown-key discoverability (the behaviour change this PR makes)
+# ---------------------------------------------------------------------------
+
+
+def test_typo_is_reported_once_on_a_check_run_with_ai_disabled(
+    warnings_captured: list[str],
+) -> None:
+    """A typo'd key still reaches the user on ``lintro chk`` with AI off.
+
+    ``run_ai_layer`` is injected unconditionally by the check/format handlers
+    and resolves the AI config before the ``should_run`` gate, so the warning
+    fires whether or not AI is enabled -- and exactly once, because the
+    resolved config is threaded down instead of re-parsed.
+
+    Args:
+        warnings_captured: Captured loguru warning messages.
+    """
+    lintro_config = LintroConfig(ai={"enabled": False, "revieww": True})
+
+    outcome = run_ai_layer(
+        action=Action.CHECK,
+        all_results=[],
+        lintro_config=lintro_config,
+        console_logger=MagicMock(),
+        output_format="grid",
+    )
+
+    assert_that(outcome.ran).is_false()
+    unknown_key_warnings = [
+        message for message in warnings_captured if "Unknown AI config keys" in message
+    ]
+    assert_that(unknown_key_warnings).is_length(1)
+    assert_that(unknown_key_warnings[0]).contains("revieww")
+
+
+def test_typo_is_reported_on_a_json_run_where_the_summary_is_suppressed(
+    warnings_captured: list[str],
+) -> None:
+    """Machine-readable output does not hide the typo warning.
+
+    The pre-execution summary (the other resolver on the run path) is
+    suppressed for json/sarif, so this pins that the AI entry point is what
+    keeps the warning reachable.
+
+    Args:
+        warnings_captured: Captured loguru warning messages.
+    """
+    run_ai_layer(
+        action=Action.CHECK,
+        all_results=[],
+        lintro_config=LintroConfig(ai={"typo_key": True}),
+        console_logger=MagicMock(),
+        output_format="json",
+    )
+
+    assert_that("".join(warnings_captured)).contains("typo_key")
+
+
+def test_typo_is_reported_by_doctor(warnings_captured: list[str]) -> None:
+    """``lintro doctor`` resolves the AI config, so it reports typos too.
+
+    Args:
+        warnings_captured: Captured loguru warning messages.
+    """
+    from lintro.ai.doctor_checks import check_ai_configuration
+
+    lintro_config = LintroConfig(ai={"enabled": True, "provdier": "anthropic"})
+
+    checks = check_ai_configuration(resolve_ai_config(lintro_config))
+
+    assert_that(checks).is_not_empty()
+    assert_that("".join(warnings_captured)).contains(
+        "Unknown AI config keys ignored: provdier",
+    )

--- a/tests/unit/ai/test_config_resolution.py
+++ b/tests/unit/ai/test_config_resolution.py
@@ -12,6 +12,7 @@ reported exactly once on the paths a user actually runs.
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -101,9 +102,46 @@ def test_from_mapping_can_suppress_the_unknown_key_warning(
     Args:
         warnings_captured: Captured loguru warning messages.
     """
-    config = AIConfig.from_mapping({"lint": True, "typo": 1}, warn_unknown=False)
+    config = AIConfig.from_mapping({"lint": True, "typo": 1}, diagnostics=False)
 
     assert_that(config.lint).is_true()
+    assert_that(warnings_captured).is_empty()
+
+
+def test_from_mapping_warns_on_legacy_enabled_only_config(
+    warnings_captured: list[str],
+) -> None:
+    """A legacy ``enabled``-only mapping still gets the migration hint.
+
+    Args:
+        warnings_captured: Captured loguru warning messages.
+    """
+    config = AIConfig.from_mapping({"enabled": True})
+
+    assert_that(config.lint).is_true()
+    assert_that(config.review).is_true()
+    assert_that("".join(warnings_captured)).contains(
+        "ai.enabled without ai.lint/ai.review is deprecated",
+    )
+
+
+def test_from_mapping_suppresses_the_legacy_deprecation_hint(
+    warnings_captured: list[str],
+) -> None:
+    """Display-only parsing does not repeat the legacy migration hint.
+
+    Regression guard: the resolver reports it once per run, so the
+    pre-execution status renderer must not emit a second copy.
+
+    Args:
+        warnings_captured: Captured loguru warning messages.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        config = AIConfig.from_mapping({"enabled": True}, diagnostics=False)
+
+    assert_that(config.lint).is_true()
+    assert_that(config.review).is_true()
     assert_that(warnings_captured).is_empty()
 
 

--- a/tests/unit/ai/test_config_wiring.py
+++ b/tests/unit/ai/test_config_wiring.py
@@ -269,7 +269,7 @@ def test_timeout_and_retries_flow_to_generate_summary(
             retry_base_delay=1.5,
             retry_max_delay=20.0,
             retry_backoff_factor=2.5,
-        ),
+        ).model_dump(),
     )
 
     result = ToolResult(

--- a/tests/unit/ai/test_display_status.py
+++ b/tests/unit/ai/test_display_status.py
@@ -251,6 +251,36 @@ def test_render_ai_status_ignores_unknown_keys_without_warning() -> None:
     assert_that(messages).is_empty()
 
 
+def test_render_ai_status_does_not_repeat_legacy_deprecation_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A legacy ``enabled``-only mapping renders without a migration hint.
+
+    The resolver on the AI entry path already emits it once per run; the
+    pre-execution summary must not duplicate it.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        "lintro.ai.availability.is_provider_available",
+        lambda provider: True,
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "x")
+    messages: list[str] = []
+    handler_id = logger.add(
+        lambda message: messages.append(str(message)),
+        level="WARNING",
+    )
+    try:
+        lines = render_ai_status(ai_config={"enabled": True}, is_ci=False)
+    finally:
+        logger.remove(handler_id)
+
+    assert_that(lines).is_not_empty()
+    assert_that(messages).is_empty()
+
+
 def test_render_ai_status_respects_custom_api_key_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/ai/test_display_status.py
+++ b/tests/unit/ai/test_display_status.py
@@ -12,6 +12,7 @@ from typing import cast
 
 import pytest
 from assertpy import assert_that
+from loguru import logger
 
 from lintro.ai.config import AIConfig
 from lintro.ai.display.status import render_ai_status
@@ -177,6 +178,77 @@ def test_render_ai_status_model_marks_default(
         "[dim](default)[/dim]",
     )
     assert_that(explicit_lines).contains("  model: some-model")
+
+
+def test_render_ai_status_accepts_empty_mapping_as_disabled() -> None:
+    """An empty ``ai:`` mapping renders ``disabled``, not ``no config``.
+
+    The core executor now holds the raw mapping, and a config file without an
+    ``ai:`` section yields ``{}``. That must keep rendering the same line the
+    default ``AIConfig`` used to produce; only a literal None means no config.
+    """
+    assert_that(render_ai_status(ai_config={}, is_ci=False)).is_equal_to(
+        ["[dim]disabled[/dim]"],
+    )
+
+
+@pytest.mark.parametrize(
+    "mapping",
+    [
+        {},
+        {"enabled": False},
+        {"enabled": True, "provider": "anthropic"},
+        {"enabled": True, "provider": "anthropic", "auto_apply": True},
+        {"enabled": True, "provider": "anthropic", "api_key_env": "CUSTOM_AI_KEY"},
+        {"enabled": True, "provider": "anthropic", "model": "some-model"},
+    ],
+)
+@pytest.mark.parametrize("is_ci", [False, True])
+def test_render_ai_status_mapping_matches_parsed_config(
+    monkeypatch: pytest.MonkeyPatch,
+    mapping: dict[str, object],
+    is_ci: bool,
+) -> None:
+    """Feeding the raw mapping renders exactly what the parsed model renders.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture.
+        mapping: Raw ``ai:`` section as stored on ``LintroConfig``.
+        is_ci: Whether the run is treated as CI.
+    """
+    monkeypatch.setattr(
+        "lintro.ai.availability.is_provider_available",
+        lambda _provider: True,
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.delenv("CUSTOM_AI_KEY", raising=False)
+
+    from_mapping = render_ai_status(ai_config=mapping, is_ci=is_ci)
+    from_model = render_ai_status(
+        ai_config=AIConfig.from_mapping(mapping),
+        is_ci=is_ci,
+    )
+
+    assert_that(from_mapping).is_equal_to(from_model)
+
+
+def test_render_ai_status_ignores_unknown_keys_without_warning() -> None:
+    """Rendering drops unknown keys silently; diagnostics belong to resolvers."""
+    messages: list[str] = []
+    handler_id = logger.add(
+        lambda message: messages.append(str(message)),
+        level="WARNING",
+    )
+    try:
+        lines = render_ai_status(
+            ai_config={"enabled": False, "provdier": "anthropic"},
+            is_ci=False,
+        )
+    finally:
+        logger.remove(handler_id)
+
+    assert_that(lines).is_equal_to(["[dim]disabled[/dim]"])
+    assert_that(messages).is_empty()
 
 
 def test_render_ai_status_respects_custom_api_key_env(

--- a/tests/unit/ai/test_hook.py
+++ b/tests/unit/ai/test_hook.py
@@ -21,7 +21,9 @@ from tests.unit.ai.conftest import MockIssue
 
 def test_should_run_returns_true_for_check_when_enabled():
     """Verify should_run returns True for CHECK action when AI is enabled."""
-    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+    )
     hook = AIPostExecutionHook(config)
 
     result = hook.should_run(Action.CHECK)
@@ -31,7 +33,9 @@ def test_should_run_returns_true_for_check_when_enabled():
 
 def test_should_run_returns_true_for_fix_when_enabled():
     """Verify should_run returns True for FIX action when AI is enabled."""
-    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+    )
     hook = AIPostExecutionHook(config)
 
     result = hook.should_run(Action.FIX)
@@ -41,7 +45,9 @@ def test_should_run_returns_true_for_fix_when_enabled():
 
 def test_should_run_returns_false_for_test_action():
     """Verify should_run returns False for TEST action even when AI is enabled."""
-    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+    )
     hook = AIPostExecutionHook(config)
 
     result = hook.should_run(Action.TEST)
@@ -51,7 +57,7 @@ def test_should_run_returns_false_for_test_action():
 
 def test_should_run_returns_false_when_disabled():
     """Verify should_run returns False when AI is disabled."""
-    config = LintroConfig(ai=AIConfig(enabled=False))
+    config = LintroConfig(ai=AIConfig(enabled=False).model_dump())
     hook = AIPostExecutionHook(config)
 
     result = hook.should_run(Action.CHECK)
@@ -62,7 +68,12 @@ def test_should_run_returns_false_when_disabled():
 def test_should_run_true_when_lint_enabled():
     """Lint summarization runs when ai.lint is enabled."""
     config = LintroConfig(
-        ai=AIConfig(enabled=True, lint=True, review=False, transport=AITransport.API),
+        ai=AIConfig(
+            enabled=True,
+            lint=True,
+            review=False,
+            transport=AITransport.API,
+        ).model_dump(),
     )
     hook = AIPostExecutionHook(config)
 
@@ -72,7 +83,12 @@ def test_should_run_true_when_lint_enabled():
 def test_should_run_false_when_only_review_enabled():
     """Review-only config does not trigger the lint-summary hook."""
     config = LintroConfig(
-        ai=AIConfig(enabled=True, lint=False, review=True, transport=AITransport.API),
+        ai=AIConfig(
+            enabled=True,
+            lint=False,
+            review=True,
+            transport=AITransport.API,
+        ).model_dump(),
     )
     hook = AIPostExecutionHook(config)
 
@@ -88,7 +104,9 @@ def test_should_run_false_when_only_review_enabled():
 @patch("lintro.ai.orchestrator.run_ai_enhancement")
 def test_execute_calls_run_ai_enhancement(mock_run_ai_enhancement):
     """Verify execute delegates to run_ai_enhancement with correct arguments."""
-    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+    )
     hook = AIPostExecutionHook(config, ai_fix=True)
     console_logger = MagicMock()
     results = [
@@ -118,6 +136,7 @@ def test_execute_calls_run_ai_enhancement(mock_run_ai_enhancement):
         action=Action.CHECK,
         all_results=results,
         lintro_config=config,
+        ai_config=AIConfig.from_mapping(config.ai),
         logger=console_logger,
         output_format="json",
         ai_fix=True,
@@ -129,7 +148,9 @@ def test_execute_calls_run_ai_enhancement(mock_run_ai_enhancement):
 def test_execute_catches_exceptions_and_logs_warning(mock_run_ai_enhancement):
     """Exceptions don't propagate; warning is logged."""
     mock_run_ai_enhancement.side_effect = RuntimeError("provider exploded")
-    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+    )
     hook = AIPostExecutionHook(config)
     console_logger = MagicMock()
     results = [
@@ -162,7 +183,9 @@ def test_execute_catches_exceptions_and_logs_warning(mock_run_ai_enhancement):
 
 def test_execute_handles_import_failure():
     """Verify graceful handling when the lazy import of run_ai_enhancement fails."""
-    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+    )
     hook = AIPostExecutionHook(config)
     console_logger = MagicMock()
     results = [

--- a/tests/unit/ai/test_interface.py
+++ b/tests/unit/ai/test_interface.py
@@ -102,14 +102,26 @@ def _config(**ai_kwargs: Any) -> LintroConfig:
     Returns:
         A :class:`LintroConfig` carrying the requested AI settings.
     """
-    return LintroConfig(ai=AIConfig(transport=AITransport.API, **ai_kwargs))
+    return LintroConfig(ai=_ai_config(**ai_kwargs).model_dump())
+
+
+def _ai_config(**ai_kwargs: Any) -> AIConfig:
+    """Build an AIConfig with the given AI settings.
+
+    Args:
+        **ai_kwargs: Keyword arguments for :class:`AIConfig`.
+
+    Returns:
+        The requested AI configuration, pinned to the API transport.
+    """
+    return AIConfig(transport=AITransport.API, **ai_kwargs)
 
 
 def test_ai_exit_code_override_is_false_without_result():
     """No AI result means no override."""
     override = ai_exit_code_override(
         ai_result=None,
-        lintro_config=_config(enabled=True, fail_on_unfixed=True),
+        ai_config=_ai_config(enabled=True, fail_on_unfixed=True),
     )
 
     assert_that(override).is_false()
@@ -119,7 +131,7 @@ def test_ai_exit_code_override_true_for_unfixed_issues():
     """``fail_on_unfixed`` with remaining issues forces failure."""
     override = ai_exit_code_override(
         ai_result=AIResult(unfixed_issues=2),
-        lintro_config=_config(enabled=True, fail_on_unfixed=True),
+        ai_config=_ai_config(enabled=True, fail_on_unfixed=True),
     )
 
     assert_that(override).is_true()
@@ -129,7 +141,7 @@ def test_ai_exit_code_override_false_when_unfixed_not_configured():
     """Unfixed issues alone do not force failure."""
     override = ai_exit_code_override(
         ai_result=AIResult(unfixed_issues=2),
-        lintro_config=_config(enabled=True),
+        ai_config=_ai_config(enabled=True),
     )
 
     assert_that(override).is_false()
@@ -139,7 +151,7 @@ def test_ai_exit_code_override_true_for_ai_error():
     """``fail_on_ai_error`` with an AI error forces failure."""
     override = ai_exit_code_override(
         ai_result=AIResult(error=True),
-        lintro_config=_config(enabled=True, fail_on_ai_error=True),
+        ai_config=_ai_config(enabled=True, fail_on_ai_error=True),
     )
 
     assert_that(override).is_true()
@@ -149,7 +161,7 @@ def test_ai_exit_code_override_false_for_ai_error_when_not_configured():
     """An AI error alone does not force failure."""
     override = ai_exit_code_override(
         ai_result=AIResult(error=True),
-        lintro_config=_config(enabled=True),
+        ai_config=_ai_config(enabled=True),
     )
 
     assert_that(override).is_false()
@@ -185,9 +197,11 @@ def _stub_hook(
             self,
             lintro_config: LintroConfig,
             *,
+            ai_config: AIConfig | None = None,
             ai_fix: bool = False,
             transport: str | None = None,
         ) -> None:
+            recorded["ai_config"] = ai_config
             recorded["ai_fix"] = ai_fix
             recorded["transport"] = transport
 
@@ -386,7 +400,12 @@ def test_render_ai_status_delegates_to_display_module():
 
 
 def test_interface_public_surface_stays_small():
-    """The facade exposes exactly three public names."""
+    """The facade exposes exactly four public names."""
     assert_that(sorted(interface.__all__)).is_equal_to(
-        ["ai_exit_code_override", "render_ai_status", "run_ai_layer"],
+        [
+            "ai_exit_code_override",
+            "render_ai_status",
+            "resolve_ai_config",
+            "run_ai_layer",
+        ],
     )

--- a/tests/unit/ai/test_orchestrator_check.py
+++ b/tests/unit/ai/test_orchestrator_check.py
@@ -49,7 +49,11 @@ def single_issue_result():
 def check_config():
     """LintroConfig with AI enabled and max_fix_attempts=5."""
     return LintroConfig(
-        ai=AIConfig(enabled=True, transport=AITransport.API, max_fix_attempts=5),
+        ai=AIConfig(
+            enabled=True,
+            transport=AITransport.API,
+            max_fix_attempts=5,
+        ).model_dump(),
     )
 
 
@@ -159,7 +163,9 @@ def test_summary_attachment_summary_attached_to_all_results_with_issues(
             ),
         ],
     )
-    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+    )
     logger = MagicMock()
 
     mock_get_provider.return_value = MockAIProvider()
@@ -272,7 +278,9 @@ def test_integration_orchestrator_end_to_end_check_with_real_summary_generation(
     )
 
     mock_get_provider.return_value = MockAIProvider(responses=[summary_response])
-    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+    )
     logger = MagicMock()
 
     run_ai_enhancement(

--- a/tests/unit/ai/test_orchestrator_edge.py
+++ b/tests/unit/ai/test_orchestrator_edge.py
@@ -45,7 +45,9 @@ def test_ai_result_default_no_error(
             ),
         ],
     )
-    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+    )
     logger = MagicMock()
 
     mock_get_provider.return_value = MockAIProvider()
@@ -97,7 +99,11 @@ def test_ai_result_unfixed_issues_when_fixes_fail(
         ],
     )
     config = LintroConfig(
-        ai=AIConfig(enabled=True, transport=AITransport.API, fail_on_unfixed=True),
+        ai=AIConfig(
+            enabled=True,
+            transport=AITransport.API,
+            fail_on_unfixed=True,
+        ).model_dump(),
     )
     logger = MagicMock()
 
@@ -121,7 +127,9 @@ def test_ai_result_unfixed_issues_when_fixes_fail(
 
 def test_ai_result_error_on_exception():
     """AIResult.error is True when AI enhancement raises an exception."""
-    config = LintroConfig(ai=AIConfig(enabled=True, transport=AITransport.API))
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+    )
     logger = MagicMock()
 
     with patch(
@@ -143,7 +151,11 @@ def test_ai_result_error_on_exception():
 def test_ai_result_error_propagates_when_fail_on_ai_error():
     """Exceptions propagate when fail_on_ai_error=True."""
     config = LintroConfig(
-        ai=AIConfig(enabled=True, transport=AITransport.API, fail_on_ai_error=True),
+        ai=AIConfig(
+            enabled=True,
+            transport=AITransport.API,
+            fail_on_ai_error=True,
+        ).model_dump(),
     )
     logger = MagicMock()
 
@@ -216,7 +228,11 @@ def test_ai_result_tracks_applied_fixes(
         tool_name="ruff",
     )
     config = LintroConfig(
-        ai=AIConfig(enabled=True, transport=AITransport.API, auto_apply=True),
+        ai=AIConfig(
+            enabled=True,
+            transport=AITransport.API,
+            auto_apply=True,
+        ).model_dump(),
     )
     logger = MagicMock()
 

--- a/tests/unit/ai/test_orchestrator_fix.py
+++ b/tests/unit/ai/test_orchestrator_fix.py
@@ -59,7 +59,7 @@ def test_run_ai_enhancement_fix_action_generates_fix_metadata(
             transport=AITransport.API,
             max_fix_attempts=5,
             auto_apply=True,
-        ),
+        ).model_dump(),
     )
     logger = MagicMock()
 
@@ -136,7 +136,7 @@ def test_run_ai_enhancement_fix_action_passes_validate_mode_to_interactive_revie
             transport=AITransport.API,
             max_fix_attempts=5,
             validate_after_group=True,
-        ),
+        ).model_dump(),
     )
     logger = MagicMock()
 
@@ -198,7 +198,11 @@ def test_run_ai_enhancement_fix_action_uses_only_remaining_issue_tail(
         remaining_issues_count=1,
     )
     config = LintroConfig(
-        ai=AIConfig(enabled=True, transport=AITransport.API, max_fix_attempts=5),
+        ai=AIConfig(
+            enabled=True,
+            transport=AITransport.API,
+            max_fix_attempts=5,
+        ).model_dump(),
     )
     logger = MagicMock()
 
@@ -246,7 +250,11 @@ def test_run_ai_enhancement_fix_action_skips_tools_with_zero_remaining_issues(
         remaining_issues_count=0,
     )
     config = LintroConfig(
-        ai=AIConfig(enabled=True, transport=AITransport.API, max_fix_attempts=5),
+        ai=AIConfig(
+            enabled=True,
+            transport=AITransport.API,
+            max_fix_attempts=5,
+        ).model_dump(),
     )
     logger = MagicMock()
 
@@ -308,7 +316,7 @@ def test_run_ai_enhancement_fix_action_uses_fresh_rerun_results_for_post_summary
             enabled=True,
             transport=AITransport.API,
             auto_apply=True,
-        ),
+        ).model_dump(),
     )
     logger = MagicMock()
 

--- a/tests/unit/ai/test_orchestrator_multi.py
+++ b/tests/unit/ai/test_orchestrator_multi.py
@@ -70,7 +70,7 @@ def test_run_ai_enhancement_fix_action_noninteractive_applies_safe_then_reviews_
             transport=AITransport.API,
             auto_apply=False,
             auto_apply_safe_fixes=True,
-        ),
+        ).model_dump(),
     )
     logger = MagicMock()
 
@@ -159,7 +159,7 @@ def test_run_ai_enhancement_fix_action_json_auto_applies_safe_style_suggestions(
             max_fix_attempts=5,
             auto_apply=False,
             auto_apply_safe_fixes=True,
-        ),
+        ).model_dump(),
     )
     logger = MagicMock()
 
@@ -247,7 +247,7 @@ def test_run_ai_enhancement_fix_action_json_uses_fresh_rerun_results(
             enabled=True,
             transport=AITransport.API,
             auto_apply=True,
-        ),
+        ).model_dump(),
     )
     logger = MagicMock()
 

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -74,7 +74,12 @@ def test_review_refuses_when_only_lint_enabled() -> None:
     """Lint-only config refuses `lintro review` naming the ai.review key."""
     runner = CliRunner()
     mock_config = MagicMock(
-        ai=AIConfig(enabled=True, lint=True, review=False, transport=AITransport.API),
+        ai=AIConfig(
+            enabled=True,
+            lint=True,
+            review=False,
+            transport=AITransport.API,
+        ).model_dump(),
     )
 
     with (
@@ -98,7 +103,12 @@ def test_review_runs_when_review_enabled_without_lint() -> None:
     )
     patches = _mock_review_pipeline(mock_collect=mock_collect)
     review_config = MagicMock(
-        ai=AIConfig(enabled=True, lint=False, review=True, transport=AITransport.API),
+        ai=AIConfig(
+            enabled=True,
+            lint=False,
+            review=True,
+            transport=AITransport.API,
+        ).model_dump(),
     )
     review_config.review.depth = 1
     review_config.review.strictness = ReviewStrictness.BALANCED
@@ -132,7 +142,7 @@ def test_review_json_output_echoes_payload() -> None:
     mock_context = MagicMock()
     mock_context.changed_files = []
     mock_context.unified_diff = ""
-    mock_config = MagicMock(ai=MagicMock(enabled=True))
+    mock_config = MagicMock(ai={"enabled": True})
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
     mock_config.review.sensitivity = MagicMock()
@@ -200,7 +210,7 @@ def test_review_passes_transport_override_to_provider() -> None:
     mock_context.changed_files = []
     mock_context.unified_diff = ""
     mock_config = MagicMock(
-        ai=AIConfig(enabled=True, transport=AITransport.API),
+        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
     )
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
@@ -263,7 +273,7 @@ def test_review_exits_zero_without_p1_findings() -> None:
     mock_context = MagicMock()
     mock_context.changed_files = []
     mock_context.unified_diff = ""
-    mock_config = MagicMock(ai=MagicMock(enabled=True))
+    mock_config = MagicMock(ai={"enabled": True})
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
     mock_config.review.sensitivity = MagicMock()
@@ -327,7 +337,7 @@ def _mock_review_pipeline(
     mock_context = MagicMock()
     mock_context.changed_files = []
     mock_context.unified_diff = ""
-    mock_config = MagicMock(ai=MagicMock(enabled=True))
+    mock_config = MagicMock(ai={"enabled": True})
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
     mock_config.review.sensitivity = MagicMock()
@@ -529,7 +539,7 @@ def test_review_plain_with_github_repository_env() -> None:
 def test_review_repo_without_pr_fails() -> None:
     """Explicit --repo without --pr fails fast instead of reviewing locally."""
     runner = CliRunner()
-    mock_config = MagicMock(ai=MagicMock(enabled=True))
+    mock_config = MagicMock(ai={"enabled": True})
 
     with (
         patch("lintro.cli_utils.commands.review.require_ai"),
@@ -601,7 +611,7 @@ def test_review_failure_renders_friendly_error_without_traceback() -> None:
         completed_chunks=2,
         cause_message="Cursor CLI timed out after 300s",
     )
-    mock_config = MagicMock(ai=MagicMock(enabled=True))
+    mock_config = MagicMock(ai={"enabled": True})
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
     mock_config.review.sensitivity = MagicMock()

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -10,7 +10,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from assertpy import assert_that
 from click.testing import CliRunner
+from loguru import logger
 
+from lintro.ai.config import AIConfig
 from lintro.cli_utils.commands.doctor import (
     ToolCheckResult,
     _check_tool,
@@ -19,6 +21,7 @@ from lintro.cli_utils.commands.doctor import (
     _output_json,
     doctor_command,
 )
+from lintro.config.lintro_config import LintroConfig
 from lintro.enums.install_context import InstallContext, PackageManager
 from lintro.enums.tool_status import ToolStatus
 from lintro.tools.core.install_context import RuntimeContext
@@ -520,3 +523,68 @@ def test_doctor_unknown_tool_name_exit_1() -> None:
 
     assert_that(result.exit_code).is_equal_to(1)
     assert_that(result.output).contains("Unknown tools")
+
+
+def test_doctor_resolves_ai_checks_from_a_raw_ai_mapping() -> None:
+    """Doctor parses the raw ``ai:`` mapping before running AI checks.
+
+    Issue #724 PR 3 made ``LintroConfig.ai`` a plain dict, so ``doctor`` now
+    resolves it through the AI facade. This pins that the checks still receive
+    a typed configuration and that a typo'd key is reported to the user.
+    """
+    runner = CliRunner()
+    p1, p2 = _patch_doctor_deps()
+    lintro_config = LintroConfig(
+        ai={"enabled": True, "lint": True, "provdier": "anthropic"},
+    )
+    received: list[Any] = []
+
+    def _record(config: Any) -> list[Any]:
+        """Record the AI config the doctor command resolved.
+
+        Args:
+            config: The configuration passed to the AI checks.
+
+        Returns:
+            An empty list of AI check results.
+        """
+        received.append(config)
+        return []
+
+    messages: list[str] = []
+    handler_id = logger.add(
+        lambda message: messages.append(str(message)),
+        level="WARNING",
+    )
+
+    try:
+        with (
+            p1,
+            p2,
+            patch(
+                "lintro.config.config_loader.get_config",
+                return_value=lintro_config,
+            ),
+            patch(
+                "lintro.cli_utils.commands.doctor.check_ai_configuration",
+                side_effect=_record,
+            ),
+            patch("subprocess.run") as mock_run,
+            patch("shutil.which", return_value="/usr/bin/ruff"),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="ruff 0.14.4",
+                stderr="",
+            )
+            result = runner.invoke(doctor_command, [])
+    finally:
+        logger.remove(handler_id)
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(received).is_length(1)
+    assert_that(received[0]).is_instance_of(AIConfig)
+    assert_that(received[0].lint_enabled).is_true()
+    assert_that("".join(messages)).contains(
+        "Unknown AI config keys ignored: provdier",
+    )

--- a/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
+++ b/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
@@ -6,12 +6,15 @@ The AI provider is always mocked; no test requires live API access.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 from assertpy import assert_that
 
 import lintro.tools.definitions.idiom_review as plugin_module
+from lintro.ai.config import AIConfig
 from lintro.ai.exceptions import AIAuthenticationError
+from lintro.config.lintro_config import LintroConfig
 from lintro.parsers.idiom_review.idiom_review_issue import IdiomReviewIssue
 from lintro.plugins.registry import ToolRegistry
 from lintro.tools.definitions.idiom_review import IdiomReviewPlugin
@@ -142,6 +145,48 @@ def test_enabled_with_mocked_engine_reports_issues(
     assert_that(result.skipped).is_false()
     assert_that(result.success).is_false()
     assert_that(result.issues_count).is_equal_to(2)
+
+
+def test_engine_is_built_from_the_raw_ai_mapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tool resolves ``LintroConfig.ai`` (a raw mapping) into an AIConfig.
+
+    Issue #724 PR 3 turned ``LintroConfig.ai`` into a plain dict, so the tool
+    must go through the AI facade before reading provider and budget settings.
+
+    Args:
+        tmp_path: Temporary directory holding the sample module.
+        monkeypatch: pytest monkeypatch fixture.
+    """
+    recorded: dict[str, Any] = {}
+
+    class _RecordingEngine(_FakeEngine):
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            recorded.update(kwargs)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(plugin_module, "is_ai_available", lambda: True)
+    monkeypatch.setattr(plugin_module, "get_provider", lambda cfg: cfg)
+    monkeypatch.setattr(plugin_module, "IdiomReviewEngine", _RecordingEngine)
+    monkeypatch.setattr(
+        IdiomReviewPlugin,
+        "_get_lintro_config",
+        lambda _self: LintroConfig(
+            ai={"enabled": True, "lint": True, "max_cost_usd": 2.5, "cache_ttl": 99},
+        ),
+    )
+
+    IdiomReviewPlugin().check(
+        [_write_py(tmp_path)],
+        {"enabled": True, "min_confidence": "low"},
+    )
+
+    assert_that(recorded["ai_config"]).is_instance_of(AIConfig)
+    assert_that(recorded["ai_config"].max_cost_usd).is_equal_to(2.5)
+    assert_that(recorded["budget"].max_cost_usd).is_equal_to(2.5)
+    assert_that(recorded["cache_ttl"]).is_equal_to(99)
 
 
 def test_min_confidence_filters_low_findings(

--- a/tests/unit/utils/test_tool_executor_ai.py
+++ b/tests/unit/utils/test_tool_executor_ai.py
@@ -144,7 +144,7 @@ def _ai_enabled_config() -> LintroConfig:
             enabled=True,
             transport=AITransport.API,
             auto_apply=True,
-        ),
+        ).model_dump(),
     )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(config): decouple AIConfig from LintroConfig
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

PR 3 of 4 for #724 (builds on #1824 / #1827). Removes the last
`lintro.config` → `lintro.ai` import edges so `lintro/config/` is free of
`lintro.ai`.

- `LintroConfig.ai` becomes `dict[str, Any]`; loader stores the `ai:` section
  verbatim (no `_parse_ai_config` in config).
- `AIConfig.from_mapping(...)` in the AI layer carries the former parse logic
  (unknown keys dropped with a sorted warning).
- `resolve_ai_config(lintro_config)` added on the AI facade; doctor, review,
  idiom-review, and `run_ai_layer` go through it.
- Resolved `AIConfig` threaded through the post-execution hook / orchestrator
  so the mapping is parsed once per run; display parsing stays diagnostic-free
  (`diagnostics=False` / `warn_unknown=False` as applicable).
- `ai_exit_code_override` takes `ai_config: AIConfig` instead of the whole
  `LintroConfig`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Relates to #724
- Relates to #1827

## Details

Unknown-key warnings stay eager on chk/fmt/doctor/review paths (resolver sits
above the AI enable gate); not cached (cheap parse; threading avoids duplicate
warns). Display-only parse must not re-emit deprecation/unknown diagnostics.
Out of scope: `ToolResult.ai_metadata` rename (PR 4), splitting
`run_lint_tools_simple` (#1823), routing idiom-review’s remaining AI-internal
imports through the facade.