### PR TITLE
fix(ai): surface CLI stdout causes and classify CLI auth failures

### DIFF
--- a/lintro/ai/providers/cli_transport.py
+++ b/lintro/ai/providers/cli_transport.py
@@ -595,20 +595,30 @@ class CliTransport(ABC):
     ) -> None:
         """Raise mapped AI exceptions when a CLI exits non-zero.
 
+        The failure cause is taken from stderr, falling back to stdout when
+        stderr is empty or whitespace-only. Several agent CLIs report fatal
+        errors on stdout inside their JSON envelope while leaving stderr empty
+        (a logged-out ``claude`` exits 1 with
+        ``{"is_error": true, ..., "result": "Not logged in ..."}``), so a
+        stderr-only cause silently drops the diagnostic and defeats the auth
+        patterns. stderr stays preferred when present so a chatty but
+        successfully parsed stdout cannot pollute a real stderr diagnostic.
+
         Args:
             result: Completed subprocess result.
-            auth_patterns: Substrings in stderr that indicate auth failure.
+            auth_patterns: Substrings in the resolved cause text (stderr, or
+                stdout when stderr is empty) that indicate auth failure.
             auth_hint: Guidance appended to authentication errors.
 
         Raises:
-            AIAuthenticationError: When stderr matches auth patterns.
+            AIAuthenticationError: When the cause text matches auth patterns.
             AIProviderError: For other non-zero exits.
         """
         if result.returncode == 0:
             return
 
-        stderr = result.stderr.strip()
-        lowered = stderr.lower()
+        cause = result.stderr.strip() or result.stdout.strip()
+        lowered = cause.lower()
         for pattern in auth_patterns:
             if pattern in lowered:
                 message = f"{self._binary_name} CLI authentication required."
@@ -617,7 +627,7 @@ class CliTransport(ABC):
                 raise AIAuthenticationError(message)
 
         raise AIProviderError(
-            f"{self._binary_name} CLI exited with code {result.returncode}: {stderr}",
+            f"{self._binary_name} CLI exited with code {result.returncode}: {cause}",
         )
 
     @staticmethod

--- a/lintro/ai/review/errors_taxonomy.py
+++ b/lintro/ai/review/errors_taxonomy.py
@@ -108,8 +108,19 @@ PROVIDER_ERROR_SIGNATURES: dict[str, dict[ReviewErrorKind, ErrorMatcher]] = {
             substrings=("rate_limit_error", "rate limit"),
             statuses=(429,),
         ),
+        # API-transport signatures first, then the claude CLI wording (the CLI
+        # reports a logged-out session on stdout, e.g.
+        # "Not logged in · Please run /login"; "run /login" also subsumes
+        # "Not signed in to Claude. Run /login first.").
         ReviewErrorKind.AUTH_FAILED: ErrorMatcher(
-            substrings=("authentication_error", "invalid x-api-key", "invalid api key"),
+            substrings=(
+                "authentication_error",
+                "invalid x-api-key",
+                "invalid api key",
+                "not logged in",
+                "not signed in",
+                "run /login",
+            ),
             statuses=(401,),
         ),
         ReviewErrorKind.CONTEXT_LENGTH: ErrorMatcher(
@@ -129,8 +140,18 @@ PROVIDER_ERROR_SIGNATURES: dict[str, dict[ReviewErrorKind, ErrorMatcher]] = {
             substrings=("rate_limit_exceeded", "rate limit"),
             statuses=(429,),
         ),
+        # The openai provider also drives the codex CLI, which reports a
+        # logged-out session as "Not logged in" / "Not signed in. Please run
+        # 'codex login' ..." with no HTTP status.
         ReviewErrorKind.AUTH_FAILED: ErrorMatcher(
-            substrings=("invalid_api_key", "invalid api key"),
+            substrings=(
+                "invalid_api_key",
+                "invalid api key",
+                "not logged in",
+                "not signed in",
+                "not authenticated",
+                "codex login",
+            ),
             statuses=(401,),
         ),
         ReviewErrorKind.CONTEXT_LENGTH: ErrorMatcher(
@@ -154,9 +175,13 @@ PROVIDER_ERROR_SIGNATURES: dict[str, dict[ReviewErrorKind, ErrorMatcher]] = {
         ReviewErrorKind.RATE_LIMITED: ErrorMatcher(
             substrings=("rate limit", "too many requests"),
         ),
+        # cursor-agent emits "Error: Authentication required. Run
+        # 'cursor-agent login' ...", "Not logged in" and "Not authenticated";
+        # "agent login" matches the quoted 'cursor-agent login' hint.
         ReviewErrorKind.AUTH_FAILED: ErrorMatcher(
             substrings=(
                 "not logged in",
+                "not authenticated",
                 "authentication",
                 "unauthorized",
                 "invalid api key",

--- a/tests/unit/ai/providers/test_cli_exit_code.py
+++ b/tests/unit/ai/providers/test_cli_exit_code.py
@@ -1,0 +1,161 @@
+"""Tests for ``CliTransport.check_exit_code`` cause resolution (#1836).
+
+Agent CLIs frequently report a fatal error on stdout (inside their JSON
+envelope) while leaving stderr empty, so the failure cause must fall back to
+stdout — otherwise auth detection never fires and the user sees an empty cause.
+"""
+
+from __future__ import annotations
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.exceptions import AIAuthenticationError, AIProviderError
+from lintro.ai.providers.cli_transport import CliTransport
+from tests.unit.ai.conftest import completed_process as _completed
+
+#: The exact envelope a logged-out ``claude`` CLI writes to stdout on exit 1.
+_CLAUDE_LOGGED_OUT_STDOUT = (
+    '{"type":"result","subtype":"error_during_execution","is_error":true,'
+    '"result":"Not logged in · Please run /login"}'
+)
+
+
+class _FakeTransport(CliTransport):
+    """Minimal concrete transport for exercising exit-code mapping."""
+
+    def parse_stdout(self, stdout: str) -> str:
+        """Return stdout unchanged.
+
+        Args:
+            stdout: Raw stdout from the CLI.
+
+        Returns:
+            The unmodified stdout.
+        """
+        return stdout
+
+
+@pytest.fixture()
+def transport() -> _FakeTransport:
+    """Return a transport standing in for a provider CLI.
+
+    Returns:
+        A ``_FakeTransport`` named ``claude``.
+    """
+    return _FakeTransport(
+        binary_path="/usr/local/bin/claude",
+        binary_name="claude",
+        install_hint="Install the claude CLI.",
+    )
+
+
+def test_zero_exit_raises_nothing(transport: _FakeTransport) -> None:
+    """A successful exit is not mapped to any error."""
+    transport.check_exit_code(_completed(returncode=0, stdout="ok"))
+
+
+@pytest.mark.parametrize(
+    ("auth_patterns", "stdout"),
+    [
+        # anthropic (claude)
+        (
+            ("authentication", "login", "not logged in"),
+            _CLAUDE_LOGGED_OUT_STDOUT,
+        ),
+        # openai (codex)
+        (
+            ("authentication", "login", "not authenticated"),
+            "Not signed in. Please run 'codex login' to sign in with ChatGPT.",
+        ),
+        # cursor (cursor-agent)
+        (
+            ("authentication required", "login"),
+            "Error: Authentication required. Run 'cursor-agent login'.",
+        ),
+    ],
+)
+def test_auth_on_stdout_with_empty_stderr_raises_auth_error(
+    transport: _FakeTransport,
+    auth_patterns: tuple[str, ...],
+    stdout: str,
+) -> None:
+    """Auth wording on stdout is detected when stderr is empty."""
+    result = _completed(returncode=1, stdout=stdout, stderr="")
+
+    with pytest.raises(AIAuthenticationError) as excinfo:
+        transport.check_exit_code(
+            result,
+            auth_patterns=auth_patterns,
+            auth_hint="Run login.",
+        )
+
+    assert_that(str(excinfo.value)).contains("authentication required")
+    assert_that(str(excinfo.value)).contains("Run login.")
+
+
+def test_whitespace_only_stderr_falls_back_to_stdout(
+    transport: _FakeTransport,
+) -> None:
+    """Whitespace-only stderr is treated as empty for cause resolution."""
+    result = _completed(
+        returncode=1,
+        stdout=_CLAUDE_LOGGED_OUT_STDOUT,
+        stderr="   \n\t ",
+    )
+
+    with pytest.raises(AIAuthenticationError):
+        transport.check_exit_code(
+            result,
+            auth_patterns=("authentication", "login", "not logged in"),
+        )
+
+
+def test_non_auth_stdout_with_empty_stderr_surfaces_stdout(
+    transport: _FakeTransport,
+) -> None:
+    """A non-auth stdout failure is surfaced instead of an empty cause."""
+    result = _completed(
+        returncode=2,
+        stdout='{"is_error":true,"result":"model overloaded, try again"}',
+        stderr="",
+    )
+
+    with pytest.raises(AIProviderError) as excinfo:
+        transport.check_exit_code(result)
+
+    message = str(excinfo.value)
+    assert_that(message).contains("exited with code 2")
+    assert_that(message).contains("model overloaded, try again")
+
+
+def test_stderr_wins_over_stdout_when_both_present(
+    transport: _FakeTransport,
+) -> None:
+    """Prefer stderr as the cause so stdout cannot pollute the message."""
+    result = _completed(
+        returncode=1,
+        stdout='{"noise":"successful parse output"}',
+        stderr="fatal: repository not found",
+    )
+
+    with pytest.raises(AIProviderError) as excinfo:
+        transport.check_exit_code(result)
+
+    message = str(excinfo.value)
+    assert_that(message).contains("fatal: repository not found")
+    assert_that(message).does_not_contain("successful parse output")
+
+
+def test_stderr_auth_still_matches_with_noisy_stdout(
+    transport: _FakeTransport,
+) -> None:
+    """Auth patterns still fire against stderr when stdout is non-empty."""
+    result = _completed(
+        returncode=1,
+        stdout='{"noise":"partial output"}',
+        stderr="Invalid API key provided; authentication failed",
+    )
+
+    with pytest.raises(AIAuthenticationError):
+        transport.check_exit_code(result)

--- a/tests/unit/ai/review/test_errors_taxonomy.py
+++ b/tests/unit/ai/review/test_errors_taxonomy.py
@@ -112,6 +112,45 @@ def test_cursor_auth_failed_stderr() -> None:
     assert_that(kind).is_equal_to(ReviewErrorKind.AUTH_FAILED)
 
 
+def test_cursor_auth_failed_not_authenticated() -> None:
+    """Cursor CLI 'Not authenticated' wording classifies as AUTH_FAILED."""
+    error = AIProviderError("cursor-agent CLI exited with code 1: Not authenticated")
+    kind = classify_provider_error(provider="cursor", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.AUTH_FAILED)
+
+
+def test_anthropic_cli_logged_out_classifies_as_auth_failed() -> None:
+    """A logged-out claude CLI cause classifies as AUTH_FAILED, not UNKNOWN."""
+    error = AIProviderError(
+        "claude CLI exited with code 1: Not logged in · Please run /login",
+    )
+    kind = classify_provider_error(provider="anthropic", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.AUTH_FAILED)
+
+
+def test_anthropic_cli_not_signed_in_classifies_as_auth_failed() -> None:
+    """The claude CLI 'Not signed in' wording classifies as AUTH_FAILED."""
+    error = AIProviderError(
+        "claude CLI exited with code 1: Not signed in to Claude. Run /login first.",
+    )
+    kind = classify_provider_error(provider="anthropic", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.AUTH_FAILED)
+
+
+def test_codex_cli_logged_out_classifies_as_auth_failed() -> None:
+    """A logged-out codex CLI cause classifies as AUTH_FAILED under openai."""
+    error = AIProviderError(
+        "codex CLI exited with code 1: Not signed in. Please run 'codex login' "
+        "to sign in with ChatGPT, then re-run.",
+    )
+    kind = classify_provider_error(provider="openai", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.AUTH_FAILED)
+
+
 def test_cursor_timeout_stderr() -> None:
     """Cursor CLI timeout stderr classifies as TIMEOUT."""
     error = AIProviderError("cursor-agent: request timed out after 600s")


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ai): surface CLI stdout causes and classify CLI auth failures
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

A logged-out `claude` CLI exits 1 with **empty stderr**, putting its cause on stdout
inside the JSON envelope (`{"is_error":true, ..., "result":"Not logged in · Please run
/login"}`). Two independent defects followed from that, and both are fixed here.

**Half 1 — `CliTransport.check_exit_code` no longer drops a stdout-only cause.**
The cause is now resolved as stderr, falling back to stdout when stderr is empty or
whitespace-only, and that resolved text drives *both* the `auth_patterns` match and the
`AIProviderError` message. stderr stays preferred when present — the two are never
concatenated — so a chatty but successfully parsed stdout cannot pollute a real stderr
diagnostic. This lives in the shared transport, so anthropic / cursor / openai(codex)
all benefit. The docstring's "stderr" wording in `auth_patterns` and `Raises:` was
updated accordingly.

**Half 2 — the review error taxonomy learned the CLI auth wording.**
`PROVIDER_ERROR_SIGNATURES` only carried API-transport auth signatures, so a logged-out
CLI classified as `UNKNOWN`. Added the CLI wording for each provider (see the confirmed
signatures below).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed

## Closes

- Closes #1836

## Details

### Reproduction (verified against the pre-change branch state)

With `stderr=""` and the logged-out claude envelope on stdout:

```text
A) PROVIDER raised: 'claude CLI exited with code 1: '     <- empty cause, no auth match
B) anthropic: unknown
B) cursor:    auth_failed   (cursor already had "not logged in")
B) openai:    unknown
```

After the change, all three classify as `auth_failed` and the transport raises
`AIAuthenticationError`.

### Signatures — confirmed, not guessed

- **claude** (`2.1.220`, strings extracted from the installed binary): `Please run
  /login`, `Not signed in to Claude. Run /login first.`, `Session expired. Please run
  /login to sign in again.` → added `not logged in`, `not signed in`, `run /login`
  (`run /login` subsumes `please run /login`).
- **cursor-agent** (`2026.07.09-a3815c0`, strings from the installed bundle):
  `Error: Authentication required. Run 'cursor-agent login' ...`, `Not logged in`,
  `Not authenticated` → the existing `authentication` / `not logged in` / `agent login`
  needles already covered most of it; added `not authenticated`.
- **codex**: the globally installed `@openai/codex` ships an **empty**
  `vendor/aarch64-apple-darwin/codex/` directory on this machine, so `codex` cannot run
  at all (`spawn ... ENOENT`) and a live logged-out run was not possible. Signatures
  were instead extracted from the cached `@openai/codex@0.97.0` binary: `Not logged in`,
  `Not signed in. Please run 'codex login' to sign in with ChatGPT, then re-run ...`,
  `chatgpt authentication required`. Added `not logged in`, `not signed in`,
  `not authenticated`, `codex login` under the `openai` entry. **Caveat:** confirmed
  from binary strings at 0.97.0, not from an observed logged-out invocation, and not
  re-confirmed on 0.128.x.

### Tests

New `tests/unit/ai/providers/test_cli_exit_code.py` (assertpy throughout):

- auth-shaped stdout with empty stderr raises `AIAuthenticationError`, parametrized over
  the real `auth_patterns` of anthropic / openai / cursor;
- whitespace-only stderr is treated as empty;
- non-auth stdout with empty stderr raises `AIProviderError` whose message contains the
  stdout text (the empty-cause regression);
- stderr present + stdout present → stderr wins and stdout does not leak into the
  message;
- auth patterns still fire against stderr when stdout is non-empty.

Extended `tests/unit/ai/review/test_errors_taxonomy.py` with the anthropic logged-out /
not-signed-in cases, the codex case under `openai`, and the cursor `Not authenticated`
case.

### Note for #1614 / PR #1834

This unblocks the CLI-auth half of #1614. The `xfail(strict=True)` on
`tests/unit/ai/test_liveness.py::test_logged_out_cli_should_classify_as_auth_failed` is
expected to start passing once this lands; removing that marker happens on #1834's
branch, not here.

### Local verification

`uv run lintro chk` → 0 issues, health 100/100. Full `uv run pytest --maxfail=0 -n auto`
→ only the machine's known pre-existing failures (`pip_audit` ensurepip, `vale` and
`trufflehog` below-minimum-version, plus the documented xdist pollution flakes in
`test_review_command_json_error` / `test_entry_point_plugins`), all of which were
verified to fail identically on the pristine pre-change tree. No existing test was
weakened or removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI CLI error reporting by using standard error when available and falling back to output when necessary.
  * Authentication failures are now recognized across more provider-specific sign-in and login messages.
  * Non-authentication failures with no standard error output now display the available diagnostic details.

* **Tests**
  * Added coverage for error-source selection and expanded authentication detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->