### PR TITLE
fix(ai): detect CLI auth mode instead of forcing --bare (#1838)

### DIFF
--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -348,6 +348,15 @@ ai:
   # Max cached entries before eviction. (int >= 1, default: 1000)
   cache_max_entries: 1000
 
+  # ── Anthropic CLI transport ───────────────────────────────────
+  # Whether to pass "--bare" to the "claude" binary. "--bare" drops the CLI's
+  # agentic tool surface but also disables OAuth session login, so it only
+  # authenticates against an API key. "auto" sends it only when a key is
+  # reachable (ANTHROPIC_API_KEY or an apiKeyHelper), so a subscription login
+  # keeps working. Override per run with LINTRO_CLI_BARE.
+  # (auto | always | never, default: auto)
+  cli_bare: auto
+
   # ── Advanced / trust (leave off unless you understand the risk) ──
   # Pass "--trust" to the Cursor agent CLI. Security risk: the Cursor provider
   # can be fed prompt-injectable content (e.g. fork-PR diffs), so keep this
@@ -441,32 +450,33 @@ config for a single invocation.
 **Every transport needs a credential of its own — CLI transport is not
 credential-free.**
 
-| Provider    | Transport | Credential                                                      |
-| ----------- | --------- | --------------------------------------------------------------- |
-| `anthropic` | `api`     | `ANTHROPIC_API_KEY`                                             |
-| `anthropic` | `cli`     | `ANTHROPIC_API_KEY` (or a `claude` `apiKeyHelper`) — see below  |
-| `openai`    | `api`     | `OPENAI_API_KEY`                                                |
-| `openai`    | `cli`     | `codex login` session (`~/.codex/auth.json`) or `CODEX_API_KEY` |
-| `cursor`    | `cli`     | `agent login` session or `CURSOR_API_KEY` (CLI-only provider)   |
+| Provider    | Transport | Credential                                                        |
+| ----------- | --------- | ----------------------------------------------------------------- |
+| `anthropic` | `api`     | `ANTHROPIC_API_KEY`                                               |
+| `anthropic` | `cli`     | `claude` login session, `ANTHROPIC_API_KEY`, or an `apiKeyHelper` |
+| `openai`    | `api`     | `OPENAI_API_KEY`                                                  |
+| `openai`    | `cli`     | `codex login` session (`~/.codex/auth.json`) or `CODEX_API_KEY`   |
+| `cursor`    | `cli`     | `agent login` session or `CURSOR_API_KEY` (CLI-only provider)     |
 
 `ai.api_key_env` overrides the API-transport variable name if you keep the key somewhere
 else.
 
-> **Anthropic `--transport cli` needs an API key — an interactive Claude login is not
-> enough.**
+> **Anthropic `--transport cli` and the `--bare` flag.**
 >
-> Lintro invokes the Claude CLI as `claude --bare -p …`, and `--bare` disables OAuth
-> session login. Consequences:
+> `claude --bare` runs the CLI without its agentic tool surface, but it also disables
+> OAuth session login — in bare mode the binary authenticates only against an API key.
+> Lintro therefore chooses the flag per invocation (`ai.cli_bare`, default `auto`):
 >
-> - `CLAUDE_CODE_OAUTH_TOKEN` and a logged-in interactive `claude` session **do not**
->   authenticate this path; it fails with `Not logged in · Please run /login` even
->   though the same binary works in the same shell.
-> - `--transport cli` bills an `ANTHROPIC_API_KEY` exactly like `--transport api`.
->   **There is no subscription-billed path today.**
+> - An API key is reachable (`ANTHROPIC_API_KEY` is set, or a Claude Code settings file
+>   declares an `apiKeyHelper`) → lintro sends `--bare`, and the call bills that key
+>   exactly like `--transport api`.
+> - No API key is reachable → lintro omits `--bare`, and the call uses your `claude`
+>   login session, billed to that subscription.
 >
-> This is tracked in [#1838](https://github.com/lgtm-hq/py-lintro/issues/1838); the
-> CLI's own error hint ("`--bare` mode does not use OAuth login") describes the same
-> constraint. Codex and Cursor are unaffected — both accept a CLI login session.
+> Force either mode explicitly with `ai.cli_bare: always|never` in config, or with the
+> `LINTRO_CLI_BARE=always|never` environment variable (the environment wins). Codex and
+> Cursor are unaffected — both accept a CLI login session. See
+> [#1838](https://github.com/lgtm-hq/py-lintro/issues/1838).
 
 ### Failures are visible, never a green no-op
 

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -25,7 +25,12 @@ from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from lintro.ai.config_views import AIBudgetConfig, AIOutputConfig, AIProviderConfig
-from lintro.ai.enums import AITransport, ConfidenceLevel, SanitizeMode
+from lintro.ai.enums import (
+    AITransport,
+    CliBareMode,
+    ConfidenceLevel,
+    SanitizeMode,
+)
 from lintro.ai.registry import AIProvider
 
 __all__ = [
@@ -213,6 +218,20 @@ class AIConfig(BaseModel):
             "'off' disables detection."
         ),
     )
+    cli_bare: CliBareMode = Field(
+        default=CliBareMode.AUTO,
+        description=(
+            "Whether the anthropic CLI transport passes '--bare' to the "
+            "'claude' binary. '--bare' drops the CLI's agentic tool surface "
+            "but also disables OAuth session login, so it only authenticates "
+            "against an API key. 'auto' (default) sends it only when an API "
+            "key is reachable (ANTHROPIC_API_KEY or a configured "
+            "apiKeyHelper), so subscription logins keep working; 'always' and "
+            "'never' force the choice. Overridable per run with the "
+            "LINTRO_CLI_BARE environment variable."
+        ),
+    )
+
     cursor_trust_workspace: bool = Field(
         default=False,
         description=(

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -384,6 +384,7 @@ class AIConfig(BaseModel):
         return AIProviderConfig(
             provider=self.provider,
             transport=self.transport,
+            cli_bare=self.cli_bare,
             model=self.model,
             api_key_env=self.api_key_env,
             api_base_url=self.api_base_url,

--- a/lintro/ai/config_views.py
+++ b/lintro/ai/config_views.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from lintro.ai.enums import AITransport, ConfidenceLevel, SanitizeMode
+from lintro.ai.enums import (
+    AITransport,
+    CliBareMode,
+    ConfidenceLevel,
+    SanitizeMode,
+)
 from lintro.ai.registry import AIProvider
 
 
@@ -20,6 +25,7 @@ class AIProviderConfig:
 
     provider: AIProvider
     transport: AITransport | None
+    cli_bare: CliBareMode
     model: str | None
     api_key_env: str | None
     api_base_url: str | None

--- a/lintro/ai/enums/__init__.py
+++ b/lintro/ai/enums/__init__.py
@@ -6,8 +6,15 @@ backwards compatibility with existing ``lintro.ai.enums`` importers.
 """
 
 from lintro.ai.enums.ai_transport import AITransport
+from lintro.ai.enums.cli_bare_mode import CliBareMode
 from lintro.ai.enums.sanitize_mode import SanitizeMode
 from lintro.enums.confidence_level import ConfidenceLevel
 from lintro.enums.risk_level import RiskLevel
 
-__all__ = ["AITransport", "ConfidenceLevel", "RiskLevel", "SanitizeMode"]
+__all__ = [
+    "AITransport",
+    "CliBareMode",
+    "ConfidenceLevel",
+    "RiskLevel",
+    "SanitizeMode",
+]

--- a/lintro/ai/enums/cli_bare_mode.py
+++ b/lintro/ai/enums/cli_bare_mode.py
@@ -1,0 +1,27 @@
+"""Bare-mode policy for the Claude CLI transport."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+__all__ = ["CliBareMode"]
+
+
+class CliBareMode(StrEnum):
+    """Whether lintro passes ``--bare`` to the ``claude`` CLI.
+
+    ``claude --bare`` runs the binary without its agentic tool surface, but it
+    also disables OAuth session login: in bare mode the CLI authenticates only
+    against an API key. Forcing it therefore locks subscription-authenticated
+    users out of ``--transport cli`` entirely (see #1838).
+
+    Attributes:
+        AUTO: Send ``--bare`` only when an API key is reachable by the CLI
+            (default).
+        ALWAYS: Always send ``--bare``, even without a detected API key.
+        NEVER: Never send ``--bare``; always rely on the CLI's own auth.
+    """
+
+    AUTO = auto()
+    ALWAYS = auto()
+    NEVER = auto()

--- a/lintro/ai/providers/__init__.py
+++ b/lintro/ai/providers/__init__.py
@@ -74,6 +74,14 @@ def get_provider(config: AIConfig) -> BaseAIProvider:
         from lintro.ai.providers.anthropic import AnthropicProvider
 
         provider_cls = AnthropicProvider
+        return provider_cls(
+            model=config.model,
+            api_key_env=config.api_key_env,
+            max_tokens=config.max_tokens,
+            base_url=config.api_base_url,
+            transport=config.transport or AITransport.API,
+            cli_bare=config.cli_bare,
+        )
     elif provider_enum is AIProvider.OPENAI:
         from lintro.ai.providers.openai import OpenAIProvider
 

--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -16,7 +16,7 @@ from typing import Any
 from loguru import logger
 
 from lintro.ai.cost import estimate_cost
-from lintro.ai.enums import AITransport
+from lintro.ai.enums import AITransport, CliBareMode
 from lintro.ai.exceptions import (
     AIAuthenticationError,
     AINotAvailableError,
@@ -30,6 +30,7 @@ from lintro.ai.providers.base import (
     BaseAIProvider,
     ProviderCapabilities,
 )
+from lintro.ai.providers.claude_auth import should_send_bare
 from lintro.ai.providers.cli_contracts import cli_contract_for
 from lintro.ai.providers.cli_transport import CliTransport, OptionalArg
 from lintro.ai.providers.constants import (
@@ -55,6 +56,31 @@ _CLAUDE_BIN = "claude"
 def _find_claude() -> str | None:
     """Return the full path to the ``claude`` binary, or None."""
     return CliTransport.find_binary(_CLAUDE_BIN)
+
+
+def _auth_hint(*, bare: bool) -> str:
+    """Return guidance matching the auth mode the failed call actually used.
+
+    A subscription user told to "run /login" after a bare invocation has
+    already done so; the real remedy differs per mode, so the hint must too.
+
+    Args:
+        bare: Whether ``--bare`` was sent on the failing invocation.
+
+    Returns:
+        Actionable guidance for the mode that failed.
+    """
+    if bare:
+        return (
+            "Set ANTHROPIC_API_KEY or configure apiKeyHelper "
+            "(--bare mode does not use OAuth login), or set "
+            "ai.cli_bare: never / LINTRO_CLI_BARE=never to use the CLI's "
+            "own login session."
+        )
+    return (
+        "Log in with 'claude /login', or set ANTHROPIC_API_KEY to "
+        "authenticate the CLI with an API key."
+    )
 
 
 class _AnthropicCliTransport(CliTransport):
@@ -167,6 +193,7 @@ class AnthropicProvider(BaseAIProvider):
         max_tokens: int = DEFAULT_MAX_TOKENS,
         base_url: str | None = None,
         transport: AITransport = AITransport.API,
+        cli_bare: CliBareMode = CliBareMode.AUTO,
     ) -> None:
         """Initialize the Anthropic provider.
 
@@ -178,12 +205,16 @@ class AnthropicProvider(BaseAIProvider):
             base_url: Custom API base URL for Anthropic-compatible
                 endpoints (proxies, self-hosted, etc.).
             transport: ``api`` for SDK or ``cli`` for ``claude -p``.
+            cli_bare: Whether CLI transport passes ``--bare``. Defaults to
+                auto-detection from the CLI's own API-key sources; see
+                :mod:`lintro.ai.providers.claude_auth`.
 
         Raises:
             AINotAvailableError: When CLI transport is selected but the
                 ``claude`` binary is not on PATH.
         """
         self._transport = transport
+        self._cli_bare = cli_bare
         self._cli: _AnthropicCliTransport | None = None
 
         if transport == AITransport.CLI:
@@ -307,9 +338,14 @@ class AnthropicProvider(BaseAIProvider):
             raise AINotAvailableError("Claude CLI transport is not initialized")
 
         effective_model = model or self._model
+        working_dir = repo_root or os.getcwd()
+        # `--bare` disables the CLI's OAuth session login, so it may only be
+        # sent when the binary can reach an API key. Forcing it locked every
+        # subscription-authenticated user out of this transport (#1838).
+        bare = should_send_bare(configured=self._cli_bare, cwd=working_dir)
         cmd = [
             self._cli._binary_path,
-            "--bare",
+            *(("--bare",) if bare else ()),
             "-p",
             prompt,
             "--output-format",
@@ -344,6 +380,7 @@ class AnthropicProvider(BaseAIProvider):
         logger.debug(
             f"Claude CLI request: model={effective_model}, "
             f"resume={resume_session_id is not None}, "
+            f"bare={bare}, "
             f"prompt_len={len(prompt)}",
         )
 
@@ -351,15 +388,12 @@ class AnthropicProvider(BaseAIProvider):
             cmd,
             optional_args=optional_args,
             timeout=timeout,
-            cwd=repo_root or os.getcwd(),
+            cwd=working_dir,
         )
         self._cli.check_exit_code(
             result,
             auth_patterns=("authentication", "login", "not logged in"),
-            auth_hint=(
-                "Set ANTHROPIC_API_KEY or configure apiKeyHelper "
-                "(--bare mode does not use OAuth login)."
-            ),
+            auth_hint=_auth_hint(bare=bare),
         )
 
         response, session_id = self._cli.parse_stdout(result.stdout)

--- a/lintro/ai/providers/claude_auth.py
+++ b/lintro/ai/providers/claude_auth.py
@@ -1,0 +1,187 @@
+"""Auth-mode detection for the Anthropic ``claude`` CLI transport.
+
+``claude --bare`` disables OAuth session login: in bare mode the binary
+authenticates *only* against an API key (``ANTHROPIC_API_KEY`` or an
+``apiKeyHelper`` declared in Claude Code settings). Sending it unconditionally
+therefore made ``lintro review --transport cli`` unusable for every
+subscription-authenticated user, who has a perfectly working ``claude`` login
+and no API key at all (#1838).
+
+This module decides, per call, whether ``--bare`` is safe to send:
+
+* ``CliBareMode.AUTO`` (default) -- send it only when an API key is reachable
+  by the CLI, so a bare invocation can actually authenticate.
+* ``CliBareMode.ALWAYS`` / ``CliBareMode.NEVER`` -- explicit escape hatches, so
+  neither detection false-negative nor false-positive requires a ``PATH`` shim
+  to work around.
+
+The override is readable from config (``ai.cli_bare``) and from the
+``LINTRO_CLI_BARE`` environment variable, which wins so CI can force a mode
+without editing a checked-in config file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from loguru import logger
+
+from lintro.ai.enums import CliBareMode
+
+__all__ = [
+    "BARE_MODE_ENV",
+    "CLAUDE_API_KEY_ENV",
+    "claude_api_key_available",
+    "resolve_bare_mode",
+    "should_send_bare",
+]
+
+#: Environment variable that overrides the configured ``ai.cli_bare`` policy.
+BARE_MODE_ENV = "LINTRO_CLI_BARE"
+
+#: The only API-key variable the ``claude`` binary itself reads. A custom
+#: ``ai.api_key_env`` renames the variable lintro's *API* transport reads and is
+#: deliberately not consulted here: the CLI subprocess would never look at it,
+#: so treating it as proof of an API key would send ``--bare`` into a CLI that
+#: cannot authenticate.
+CLAUDE_API_KEY_ENV = "ANTHROPIC_API_KEY"
+
+#: Truthy/falsey spellings accepted by ``LINTRO_CLI_BARE`` in addition to the
+#: :class:`CliBareMode` values themselves.
+_BOOLEAN_ALIASES: dict[str, CliBareMode] = {
+    "1": CliBareMode.ALWAYS,
+    "true": CliBareMode.ALWAYS,
+    "yes": CliBareMode.ALWAYS,
+    "on": CliBareMode.ALWAYS,
+    "0": CliBareMode.NEVER,
+    "false": CliBareMode.NEVER,
+    "no": CliBareMode.NEVER,
+    "off": CliBareMode.NEVER,
+}
+
+
+def _settings_candidates(*, cwd: str | None) -> tuple[Path, ...]:
+    """Return the Claude Code settings files that may declare ``apiKeyHelper``.
+
+    Mirrors Claude Code's own settings hierarchy closely enough for a
+    presence check: the user-level file (relocatable via
+    ``CLAUDE_CONFIG_DIR``) plus the project-level files under the working
+    directory the CLI is spawned in.
+
+    Args:
+        cwd: Working directory the CLI subprocess runs in, or ``None`` for the
+            current process directory.
+
+    Returns:
+        Candidate settings paths, in no particular precedence order — any one
+        of them declaring a helper is enough.
+    """
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
+    user_dir = Path(config_dir) if config_dir else Path.home() / ".claude"
+    project_dir = Path(cwd) if cwd else Path.cwd()
+    return (
+        user_dir / "settings.json",
+        project_dir / ".claude" / "settings.json",
+        project_dir / ".claude" / "settings.local.json",
+    )
+
+
+def _declares_api_key_helper(path: Path) -> bool:
+    """Return whether *path* is a settings file declaring ``apiKeyHelper``.
+
+    Args:
+        path: Candidate settings file.
+
+    Returns:
+        True when the file parses as a JSON object carrying a non-empty
+        ``apiKeyHelper`` string. Unreadable or malformed files are treated as
+        "no helper" rather than as an error: settings files are outside
+        lintro's control and a broken one must not fail a review.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return False
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.debug(f"Ignoring unparseable Claude settings file: {path}")
+        return False
+    if not isinstance(data, dict):
+        return False
+    helper = data.get("apiKeyHelper")
+    return isinstance(helper, str) and bool(helper.strip())
+
+
+def claude_api_key_available(*, cwd: str | None = None) -> bool:
+    """Return whether the ``claude`` CLI can authenticate from an API key.
+
+    Args:
+        cwd: Working directory the CLI subprocess runs in, used to locate
+            project-level settings. Defaults to the current directory.
+
+    Returns:
+        True when ``ANTHROPIC_API_KEY`` is set to a non-empty value, or when a
+        reachable Claude Code settings file declares an ``apiKeyHelper``.
+    """
+    if os.environ.get(CLAUDE_API_KEY_ENV, "").strip():
+        return True
+    return any(
+        _declares_api_key_helper(candidate)
+        for candidate in _settings_candidates(cwd=cwd)
+    )
+
+
+def resolve_bare_mode(configured: CliBareMode = CliBareMode.AUTO) -> CliBareMode:
+    """Return the effective bare-mode policy, honouring the env override.
+
+    Args:
+        configured: The mode set in ``ai.cli_bare``.
+
+    Returns:
+        The mode named by ``LINTRO_CLI_BARE`` when it is set to a recognised
+        value, otherwise *configured*. An unrecognised value is warned about and
+        ignored, because silently guessing a mode is exactly the failure this
+        issue was about.
+    """
+    raw = os.environ.get(BARE_MODE_ENV)
+    if raw is None:
+        return configured
+    normalized = raw.strip().lower()
+    if not normalized:
+        return configured
+    alias = _BOOLEAN_ALIASES.get(normalized)
+    if alias is not None:
+        return alias
+    try:
+        return CliBareMode(normalized)
+    except ValueError:
+        logger.warning(
+            f"Ignoring {BARE_MODE_ENV}={raw!r}: expected one of "
+            f"{', '.join(mode.value for mode in CliBareMode)}.",
+        )
+        return configured
+
+
+def should_send_bare(
+    *,
+    configured: CliBareMode = CliBareMode.AUTO,
+    cwd: str | None = None,
+) -> bool:
+    """Decide whether this ``claude`` invocation may carry ``--bare``.
+
+    Args:
+        configured: The mode set in ``ai.cli_bare``.
+        cwd: Working directory the CLI subprocess runs in.
+
+    Returns:
+        True when ``--bare`` should be appended to the command line.
+    """
+    mode = resolve_bare_mode(configured)
+    if mode is CliBareMode.ALWAYS:
+        return True
+    if mode is CliBareMode.NEVER:
+        return False
+    return claude_api_key_available(cwd=cwd)

--- a/lintro/ai/providers/claude_auth.py
+++ b/lintro/ai/providers/claude_auth.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 
 from loguru import logger
@@ -62,13 +63,35 @@ _BOOLEAN_ALIASES: dict[str, CliBareMode] = {
 }
 
 
+#: Upper bound on settings-file bytes read. A Claude settings file is a few
+#: hundred bytes; the cap keeps a pathological or hostile file at one of these
+#: well-known paths from being slurped into memory on every provider call.
+_MAX_SETTINGS_BYTES = 256 * 1024
+
+
+def _managed_settings_path() -> Path | None:
+    """Return the platform's enterprise-managed Claude settings file.
+
+    Returns:
+        The managed settings path for this platform, or ``None`` when the
+        platform has no documented location.
+    """
+    if sys.platform == "darwin":
+        return Path("/Library/Application Support/ClaudeCode/managed-settings.json")
+    if sys.platform == "win32":
+        return Path("C:/ProgramData/ClaudeCode/managed-settings.json")
+    if sys.platform.startswith("linux"):
+        return Path("/etc/claude-code/managed-settings.json")
+    return None
+
+
 def _settings_candidates(*, cwd: str | None) -> tuple[Path, ...]:
     """Return the Claude Code settings files that may declare ``apiKeyHelper``.
 
     Mirrors Claude Code's own settings hierarchy closely enough for a
-    presence check: the user-level file (relocatable via
-    ``CLAUDE_CONFIG_DIR``) plus the project-level files under the working
-    directory the CLI is spawned in.
+    presence check: the enterprise-managed file, the user-level file
+    (relocatable via ``CLAUDE_CONFIG_DIR``), and the project-level files under
+    the working directory the CLI is spawned in.
 
     Args:
         cwd: Working directory the CLI subprocess runs in, or ``None`` for the
@@ -81,11 +104,38 @@ def _settings_candidates(*, cwd: str | None) -> tuple[Path, ...]:
     config_dir = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
     user_dir = Path(config_dir) if config_dir else Path.home() / ".claude"
     project_dir = Path(cwd) if cwd else Path.cwd()
+    managed = _managed_settings_path()
     return (
+        *((managed,) if managed is not None else ()),
         user_dir / "settings.json",
         project_dir / ".claude" / "settings.json",
         project_dir / ".claude" / "settings.local.json",
     )
+
+
+def _read_settings(path: Path) -> str | None:
+    """Read a candidate settings file, refusing anything that is not one.
+
+    Args:
+        path: Candidate settings file.
+
+    Returns:
+        The file's text, or ``None`` when *path* is not a regular file, is
+        unreadable, or is larger than a settings file plausibly is. Refusing
+        non-regular files matters: a FIFO left at one of these well-known paths
+        would otherwise block every provider call forever.
+    """
+    try:
+        if not path.is_file():
+            return None
+        with path.open(encoding="utf-8") as handle:
+            raw = handle.read(_MAX_SETTINGS_BYTES + 1)
+    except (OSError, ValueError):
+        return None
+    if len(raw) > _MAX_SETTINGS_BYTES:
+        logger.debug(f"Ignoring oversized Claude settings file: {path}")
+        return None
+    return raw
 
 
 def _declares_api_key_helper(path: Path) -> bool:
@@ -100,13 +150,12 @@ def _declares_api_key_helper(path: Path) -> bool:
         "no helper" rather than as an error: settings files are outside
         lintro's control and a broken one must not fail a review.
     """
-    try:
-        raw = path.read_text(encoding="utf-8")
-    except (OSError, ValueError):
+    raw = _read_settings(path)
+    if raw is None:
         return False
     try:
         data = json.loads(raw)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, RecursionError):
         logger.debug(f"Ignoring unparseable Claude settings file: {path}")
         return False
     if not isinstance(data, dict):

--- a/lintro/ai/providers/claude_auth.py
+++ b/lintro/ai/providers/claude_auth.py
@@ -128,14 +128,14 @@ def _read_settings(path: Path) -> str | None:
     try:
         if not path.is_file():
             return None
-        with path.open(encoding="utf-8") as handle:
+        with path.open("rb") as handle:
             raw = handle.read(_MAX_SETTINGS_BYTES + 1)
+        if len(raw) > _MAX_SETTINGS_BYTES:
+            logger.debug(f"Ignoring oversized Claude settings file: {path}")
+            return None
+        return raw.decode("utf-8")
     except (OSError, ValueError):
         return None
-    if len(raw) > _MAX_SETTINGS_BYTES:
-        logger.debug(f"Ignoring oversized Claude settings file: {path}")
-        return None
-    return raw
 
 
 def _declares_api_key_helper(path: Path) -> bool:

--- a/lintro/ai/providers/claude_auth.py
+++ b/lintro/ai/providers/claude_auth.py
@@ -207,8 +207,10 @@ def resolve_bare_mode(configured: CliBareMode = CliBareMode.AUTO) -> CliBareMode
     try:
         return CliBareMode(normalized)
     except ValueError:
+        # The value itself is deliberately not echoed: environment content is
+        # untrusted input and log sinks are not a place to replay it.
         logger.warning(
-            f"Ignoring {BARE_MODE_ENV}={raw!r}: expected one of "
+            f"Ignoring invalid {BARE_MODE_ENV}: expected one of "
             f"{', '.join(mode.value for mode in CliBareMode)}.",
         )
         return configured

--- a/lintro/ai/providers/claude_auth.py
+++ b/lintro/ai/providers/claude_auth.py
@@ -211,7 +211,8 @@ def resolve_bare_mode(configured: CliBareMode = CliBareMode.AUTO) -> CliBareMode
         # untrusted input and log sinks are not a place to replay it.
         logger.warning(
             f"Ignoring invalid {BARE_MODE_ENV}: expected one of "
-            f"{', '.join(mode.value for mode in CliBareMode)}.",
+            f"{', '.join(mode.value for mode in CliBareMode)} "
+            "(or a recognized boolean alias).",
         )
         return configured
 

--- a/lintro/ai/providers/cli_contracts.py
+++ b/lintro/ai/providers/cli_contracts.py
@@ -144,6 +144,12 @@ _ANTHROPIC_CONTRACT = CliContract(
     # Claude Code 2.x introduced the --bare / --json-schema surface lintro
     # drives; 1.x cannot serve a structured CLI review at all.
     version_floor=(2, 0, 0),
+    # `--bare` is sent conditionally (see lintro.ai.providers.claude_auth): it
+    # disables OAuth session login, so it is only safe when the binary can
+    # reach an API key. It stays *required* rather than optional because the
+    # API-key path cannot degrade without it -- silently dropping it there
+    # would hand the agentic tool surface a review prompt -- so its
+    # disappearance from the flag surface must break CI, not a user's review.
     required_flags=(
         "--bare",
         "--print",

--- a/tests/unit/ai/providers/test_claude_auth.py
+++ b/tests/unit/ai/providers/test_claude_auth.py
@@ -12,6 +12,7 @@ import pytest
 from assertpy import assert_that
 
 from lintro.ai.enums import AITransport, CliBareMode
+from lintro.ai.providers import claude_auth
 from lintro.ai.providers.anthropic import AnthropicProvider
 from lintro.ai.providers.claude_auth import (
     BARE_MODE_ENV,
@@ -43,6 +44,13 @@ def isolated_auth_env(
     config_dir = tmp_path / "claude-config"
     config_dir.mkdir()
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+    # A real machine-level managed settings file would otherwise leak into
+    # every "no credential" assertion.
+    monkeypatch.setattr(
+        claude_auth,
+        "_managed_settings_path",
+        lambda: tmp_path / "managed-settings.json",
+    )
     workdir = tmp_path / "repo"
     workdir.mkdir()
     yield workdir
@@ -136,6 +144,43 @@ class TestClaudeApiKeyAvailable:
     ) -> None:
         """Treat a blank apiKeyHelper as absent."""
         _write_settings(isolated_auth_env, {"apiKeyHelper": "  "})
+        assert_that(
+            claude_api_key_available(cwd=str(isolated_auth_env)),
+        ).is_false()
+
+    def test_true_when_managed_settings_declare_helper(
+        self,
+        isolated_auth_env: Path,
+    ) -> None:
+        """Report an API key from the enterprise-managed settings file."""
+        managed = isolated_auth_env.parent / "managed-settings.json"
+        managed.write_text(
+            json.dumps({"apiKeyHelper": "/bin/echo key"}),
+            encoding="utf-8",
+        )
+        assert_that(
+            claude_api_key_available(cwd=str(isolated_auth_env)),
+        ).is_true()
+
+    def test_oversized_settings_are_ignored(
+        self,
+        isolated_auth_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Refuse to read a settings file far larger than a settings file."""
+        monkeypatch.setattr(claude_auth, "_MAX_SETTINGS_BYTES", 16)
+        _write_settings(isolated_auth_env, {"apiKeyHelper": "/bin/echo key"})
+        assert_that(
+            claude_api_key_available(cwd=str(isolated_auth_env)),
+        ).is_false()
+
+    def test_non_regular_settings_path_is_ignored(
+        self,
+        isolated_auth_env: Path,
+    ) -> None:
+        """Refuse a directory sitting where a settings file should be."""
+        (isolated_auth_env / ".claude").mkdir()
+        (isolated_auth_env / ".claude" / "settings.json").mkdir()
         assert_that(
             claude_api_key_available(cwd=str(isolated_auth_env)),
         ).is_false()

--- a/tests/unit/ai/providers/test_claude_auth.py
+++ b/tests/unit/ai/providers/test_claude_auth.py
@@ -1,0 +1,381 @@
+"""Tests for Claude CLI auth-mode detection and the ``--bare`` decision."""
+
+from __future__ import annotations
+
+import json
+import subprocess  # nosec B404 - only CompletedProcess objects are constructed here
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.enums import AITransport, CliBareMode
+from lintro.ai.providers.anthropic import AnthropicProvider
+from lintro.ai.providers.claude_auth import (
+    BARE_MODE_ENV,
+    CLAUDE_API_KEY_ENV,
+    claude_api_key_available,
+    resolve_bare_mode,
+    should_send_bare,
+)
+from tests.unit.ai.conftest import patch_cli_exec
+
+
+@pytest.fixture()
+def isolated_auth_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[Path]:
+    """Strip every ambient Claude credential so detection is deterministic.
+
+    Args:
+        monkeypatch: Pytest environment patcher.
+        tmp_path: Per-test temporary directory.
+
+    Yields:
+        Path: An empty directory usable as both the Claude config dir's parent
+        and the CLI working directory.
+    """
+    monkeypatch.delenv(CLAUDE_API_KEY_ENV, raising=False)
+    monkeypatch.delenv(BARE_MODE_ENV, raising=False)
+    config_dir = tmp_path / "claude-config"
+    config_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    yield workdir
+
+
+def _write_settings(workdir: Path, payload: object) -> None:
+    """Write a project-level Claude settings file under *workdir*.
+
+    Args:
+        workdir: Directory that will hold ``.claude/settings.json``.
+        payload: Object serialized as the settings body.
+    """
+    settings_dir = workdir / ".claude"
+    settings_dir.mkdir(exist_ok=True)
+    (settings_dir / "settings.json").write_text(
+        json.dumps(payload),
+        encoding="utf-8",
+    )
+
+
+class TestClaudeApiKeyAvailable:
+    """Tests for API-key reachability detection."""
+
+    def test_false_without_key_or_helper(self, isolated_auth_env: Path) -> None:
+        """Report no API key when neither env var nor helper is present."""
+        assert_that(
+            claude_api_key_available(cwd=str(isolated_auth_env)),
+        ).is_false()
+
+    def test_true_when_env_key_set(
+        self,
+        isolated_auth_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Report an API key when ANTHROPIC_API_KEY is set."""
+        monkeypatch.setenv(CLAUDE_API_KEY_ENV, "sk-ant-test")
+        assert_that(
+            claude_api_key_available(cwd=str(isolated_auth_env)),
+        ).is_true()
+
+    def test_blank_env_key_is_not_a_credential(
+        self,
+        isolated_auth_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Treat a whitespace-only ANTHROPIC_API_KEY as unset."""
+        monkeypatch.setenv(CLAUDE_API_KEY_ENV, "   ")
+        assert_that(
+            claude_api_key_available(cwd=str(isolated_auth_env)),
+        ).is_false()
+
+    def test_true_when_project_settings_declare_helper(
+        self,
+        isolated_auth_env: Path,
+    ) -> None:
+        """Report an API key when project settings declare an apiKeyHelper."""
+        _write_settings(isolated_auth_env, {"apiKeyHelper": "/bin/echo key"})
+        assert_that(
+            claude_api_key_available(cwd=str(isolated_auth_env)),
+        ).is_true()
+
+    def test_true_when_user_settings_declare_helper(
+        self,
+        isolated_auth_env: Path,
+    ) -> None:
+        """Report an API key from the CLAUDE_CONFIG_DIR settings file."""
+        config_dir = isolated_auth_env.parent / "claude-config"
+        (config_dir / "settings.json").write_text(
+            json.dumps({"apiKeyHelper": "/bin/echo key"}),
+            encoding="utf-8",
+        )
+        assert_that(
+            claude_api_key_available(cwd=str(isolated_auth_env)),
+        ).is_true()
+
+    def test_malformed_settings_are_ignored(
+        self,
+        isolated_auth_env: Path,
+    ) -> None:
+        """Treat unparseable settings as declaring no helper."""
+        settings_dir = isolated_auth_env / ".claude"
+        settings_dir.mkdir()
+        (settings_dir / "settings.json").write_text("{not json", encoding="utf-8")
+        assert_that(
+            claude_api_key_available(cwd=str(isolated_auth_env)),
+        ).is_false()
+
+    def test_empty_helper_is_not_a_credential(
+        self,
+        isolated_auth_env: Path,
+    ) -> None:
+        """Treat a blank apiKeyHelper as absent."""
+        _write_settings(isolated_auth_env, {"apiKeyHelper": "  "})
+        assert_that(
+            claude_api_key_available(cwd=str(isolated_auth_env)),
+        ).is_false()
+
+    def test_non_object_settings_are_ignored(
+        self,
+        isolated_auth_env: Path,
+    ) -> None:
+        """Treat a JSON array settings file as declaring no helper."""
+        _write_settings(isolated_auth_env, ["apiKeyHelper"])
+        assert_that(
+            claude_api_key_available(cwd=str(isolated_auth_env)),
+        ).is_false()
+
+
+class TestResolveBareMode:
+    """Tests for the environment override."""
+
+    def test_returns_configured_without_env(self, isolated_auth_env: Path) -> None:
+        """Keep the configured mode when the env var is unset."""
+        del isolated_auth_env
+        assert_that(
+            resolve_bare_mode(CliBareMode.NEVER),
+        ).is_equal_to(CliBareMode.NEVER)
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("always", CliBareMode.ALWAYS),
+            ("NEVER", CliBareMode.NEVER),
+            (" auto ", CliBareMode.AUTO),
+            ("1", CliBareMode.ALWAYS),
+            ("false", CliBareMode.NEVER),
+        ],
+    )
+    def test_env_override_wins(
+        self,
+        isolated_auth_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        raw: str,
+        expected: CliBareMode,
+    ) -> None:
+        """Honour LINTRO_CLI_BARE over the configured mode.
+
+        Args:
+            isolated_auth_env: Credential-free environment fixture.
+            monkeypatch: Pytest environment patcher.
+            raw: Raw environment value under test.
+            expected: Mode the value must resolve to.
+        """
+        del isolated_auth_env
+        monkeypatch.setenv(BARE_MODE_ENV, raw)
+        assert_that(resolve_bare_mode(CliBareMode.AUTO)).is_equal_to(expected)
+
+    def test_unrecognised_env_falls_back(
+        self,
+        isolated_auth_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Ignore an unparseable override rather than guessing a mode."""
+        del isolated_auth_env
+        monkeypatch.setenv(BARE_MODE_ENV, "maybe")
+        assert_that(
+            resolve_bare_mode(CliBareMode.ALWAYS),
+        ).is_equal_to(CliBareMode.ALWAYS)
+
+
+class TestShouldSendBare:
+    """Tests for the combined decision."""
+
+    def test_auto_sends_bare_with_api_key(
+        self,
+        isolated_auth_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Send --bare under auto when an API key is reachable."""
+        monkeypatch.setenv(CLAUDE_API_KEY_ENV, "sk-ant-test")
+        assert_that(
+            should_send_bare(
+                configured=CliBareMode.AUTO,
+                cwd=str(isolated_auth_env),
+            ),
+        ).is_true()
+
+    def test_auto_omits_bare_without_api_key(
+        self,
+        isolated_auth_env: Path,
+    ) -> None:
+        """Omit --bare under auto for a subscription-only login."""
+        assert_that(
+            should_send_bare(
+                configured=CliBareMode.AUTO,
+                cwd=str(isolated_auth_env),
+            ),
+        ).is_false()
+
+    def test_always_sends_bare_without_api_key(
+        self,
+        isolated_auth_env: Path,
+    ) -> None:
+        """Send --bare under always even with no detectable API key."""
+        assert_that(
+            should_send_bare(
+                configured=CliBareMode.ALWAYS,
+                cwd=str(isolated_auth_env),
+            ),
+        ).is_true()
+
+    def test_never_omits_bare_with_api_key(
+        self,
+        isolated_auth_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Omit --bare under never even when an API key is present."""
+        monkeypatch.setenv(CLAUDE_API_KEY_ENV, "sk-ant-test")
+        assert_that(
+            should_send_bare(
+                configured=CliBareMode.NEVER,
+                cwd=str(isolated_auth_env),
+            ),
+        ).is_false()
+
+
+@pytest.fixture()
+def _mock_claude_on_path() -> Iterator[None]:
+    """Patch claude binary discovery for CLI transport tests.
+
+    Yields:
+        None: Control, with ``_find_claude`` returning a fake path.
+    """
+    with patch(
+        "lintro.ai.providers.anthropic._find_claude",
+        return_value="/usr/local/bin/claude",
+    ):
+        yield
+
+
+async def _argv_for(
+    *,
+    workdir: Path,
+    cli_bare: CliBareMode,
+) -> list[str]:
+    """Run one CLI completion and return the argv it built.
+
+    Args:
+        workdir: Working directory passed as the review repo root.
+        cli_bare: Bare-mode policy handed to the provider.
+
+    Returns:
+        The argv the transport was invoked with.
+    """
+    provider = AnthropicProvider(
+        transport=AITransport.CLI,
+        cli_bare=cli_bare,
+    )
+    stdout = json.dumps(
+        {
+            "result": '{"summary": "ok"}',
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+            "total_cost_usd": 0.0,
+        },
+    )
+    with patch_cli_exec() as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+        await provider.complete("Review this diff", repo_root=str(workdir))
+    argv: list[str] = mock_run.call_args.args[0]
+    return argv
+
+
+class TestProviderBareFlag:
+    """Tests for the flag the provider actually sends."""
+
+    async def test_bare_sent_when_api_key_present(
+        self,
+        _mock_claude_on_path: None,
+        isolated_auth_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Pass --bare when the CLI can authenticate from an API key."""
+        monkeypatch.setenv(CLAUDE_API_KEY_ENV, "sk-ant-test")
+        argv = await _argv_for(
+            workdir=isolated_auth_env,
+            cli_bare=CliBareMode.AUTO,
+        )
+        assert_that(argv).contains("--bare")
+
+    async def test_bare_omitted_for_subscription_login(
+        self,
+        _mock_claude_on_path: None,
+        isolated_auth_env: Path,
+    ) -> None:
+        """Omit --bare when no API key is reachable, so OAuth login works."""
+        argv = await _argv_for(
+            workdir=isolated_auth_env,
+            cli_bare=CliBareMode.AUTO,
+        )
+        assert_that(argv).does_not_contain("--bare")
+        assert_that(argv).contains("-p", "--output-format", "json")
+
+    async def test_never_override_omits_bare_with_api_key(
+        self,
+        _mock_claude_on_path: None,
+        isolated_auth_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Honour an explicit 'never' even when an API key is present."""
+        monkeypatch.setenv(CLAUDE_API_KEY_ENV, "sk-ant-test")
+        argv = await _argv_for(
+            workdir=isolated_auth_env,
+            cli_bare=CliBareMode.NEVER,
+        )
+        assert_that(argv).does_not_contain("--bare")
+
+    async def test_always_override_sends_bare_without_api_key(
+        self,
+        _mock_claude_on_path: None,
+        isolated_auth_env: Path,
+    ) -> None:
+        """Honour an explicit 'always' even with no detectable API key."""
+        argv = await _argv_for(
+            workdir=isolated_auth_env,
+            cli_bare=CliBareMode.ALWAYS,
+        )
+        assert_that(argv).contains("--bare")
+
+    async def test_env_override_beats_config(
+        self,
+        _mock_claude_on_path: None,
+        isolated_auth_env: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Let LINTRO_CLI_BARE override a config that says otherwise."""
+        monkeypatch.setenv(BARE_MODE_ENV, "never")
+        argv = await _argv_for(
+            workdir=isolated_auth_env,
+            cli_bare=CliBareMode.ALWAYS,
+        )
+        assert_that(argv).does_not_contain("--bare")

--- a/tests/unit/ai/providers/test_factory.py
+++ b/tests/unit/ai/providers/test_factory.py
@@ -102,3 +102,24 @@ def test_get_provider_cursor_trust_threaded_when_enabled():
     assert_that(isinstance(provider, CursorProvider)).is_true()
     cursor = cast(CursorProvider, provider)
     assert_that(cursor._trust_workspace).is_true()
+
+
+def test_get_provider_anthropic_threads_cli_bare() -> None:
+    """get_provider threads ai.cli_bare into the Anthropic provider."""
+    from lintro.ai.enums import AITransport, CliBareMode
+    from lintro.ai.providers.anthropic import AnthropicProvider
+
+    config = AIConfig(
+        provider="anthropic",  # type: ignore[arg-type]  # Pydantic coerces str
+        transport=AITransport.CLI,
+        cli_bare=CliBareMode.NEVER,
+    )
+    with patch.object(
+        anthropic_mod,
+        "_find_claude",
+        return_value="/usr/local/bin/claude",
+    ):
+        provider = get_provider(config)
+    assert_that(isinstance(provider, AnthropicProvider)).is_true()
+    anthropic_provider = cast(AnthropicProvider, provider)
+    assert_that(anthropic_provider._cli_bare).is_equal_to(CliBareMode.NEVER)

--- a/tests/unit/ai/test_claude_cli_provider.py
+++ b/tests/unit/ai/test_claude_cli_provider.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import pytest
 from assertpy import assert_that
 
-from lintro.ai.enums import AITransport
+from lintro.ai.enums import AITransport, CliBareMode
 from lintro.ai.exceptions import AIAuthenticationError, AINotAvailableError
 from lintro.ai.providers.anthropic import AnthropicProvider, _find_claude
 from lintro.ai.registry import AIProvider
@@ -71,6 +71,7 @@ class TestClaudeCliComplete:
         provider = AnthropicProvider(
             model="claude-sonnet-4-6",
             transport=AITransport.CLI,
+            cli_bare=CliBareMode.ALWAYS,
         )
         stdout = _cli_json(result='{"summary": "ok"}')
         with patch_cli_exec() as mock_run:

--- a/tests/unit/ai/test_config.py
+++ b/tests/unit/ai/test_config.py
@@ -7,7 +7,7 @@ from assertpy import assert_that
 from pydantic import ValidationError
 
 from lintro.ai.config import AIConfig
-from lintro.ai.enums import AITransport
+from lintro.ai.enums import AITransport, CliBareMode
 from lintro.ai.registry import AIProvider
 
 # -- Defaults --------------------------------------------------------------
@@ -42,6 +42,24 @@ def test_cursor_trust_workspace_opt_in() -> None:
     """Cursor workspace trust can be explicitly enabled via config."""
     config = AIConfig(cursor_trust_workspace=True)
     assert_that(config.cursor_trust_workspace).is_true()
+
+
+def test_cli_bare_defaults_to_auto() -> None:
+    """The Claude CLI bare-mode policy auto-detects by default."""
+    config = AIConfig()
+    assert_that(config.cli_bare).is_equal_to(CliBareMode.AUTO)
+
+
+def test_cli_bare_accepts_explicit_override() -> None:
+    """The bare-mode policy is settable from a plain config string."""
+    config = AIConfig.from_mapping({"cli_bare": "never"})
+    assert_that(config.cli_bare).is_equal_to(CliBareMode.NEVER)
+
+
+def test_cli_bare_rejects_unknown_value() -> None:
+    """An unrecognised bare-mode value is a config error, not a guess."""
+    with pytest.raises(ValidationError):
+        AIConfig(cli_bare="sometimes")  # type: ignore[arg-type]
 
 
 def test_default_config_numeric_fields() -> None:

--- a/tests/unit/ai/test_config_views.py
+++ b/tests/unit/ai/test_config_views.py
@@ -13,7 +13,12 @@ from lintro.ai.config_views import (
     AIOutputConfig,
     AIProviderConfig,
 )
-from lintro.ai.enums import AITransport, ConfidenceLevel, SanitizeMode
+from lintro.ai.enums import (
+    AITransport,
+    CliBareMode,
+    ConfidenceLevel,
+    SanitizeMode,
+)
 from lintro.ai.registry import AIProvider
 
 
@@ -22,6 +27,7 @@ def test_provider_config_construction_and_fields() -> None:
     view = AIProviderConfig(
         provider=AIProvider.ANTHROPIC,
         transport=AITransport.API,
+        cli_bare=CliBareMode.AUTO,
         model="claude-sonnet-4-6",
         api_key_env="ANTHROPIC_API_KEY",
         api_base_url=None,
@@ -47,6 +53,7 @@ def test_provider_config_is_frozen() -> None:
     view = AIProviderConfig(
         provider=AIProvider.ANTHROPIC,
         transport=None,
+        cli_bare=CliBareMode.AUTO,
         model=None,
         api_key_env=None,
         api_base_url=None,
@@ -127,3 +134,4 @@ def test_views_derived_from_ai_config() -> None:
     assert_that(budget_view).is_instance_of(AIBudgetConfig)
     assert_that(output_view).is_instance_of(AIOutputConfig)
     assert_that(provider_view.provider).is_equal_to(config.provider)
+    assert_that(provider_view.cli_bare).is_equal_to(config.cli_bare)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ai): detect CLI auth mode instead of forcing --bare (#1838)
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`lintro review --transport cli` invoked the Claude CLI with an unconditional `--bare`.
`claude --bare` disables OAuth session login, so it authenticates only against an API
key. Two consequences, one root cause: subscription-authenticated users could not use
the CLI transport at all (`Not logged in · Please run /login`), and the transport
silently billed `ANTHROPIC_API_KEY` exactly like `--transport api` — defeating the whole
point of a CLI transport.

This PR makes `--bare` a decision instead of a constant.

- **Auto-detect the auth mode** (new `lintro/ai/providers/claude_auth.py`). `--bare` is
  sent only when the `claude` binary can actually reach an API key: `ANTHROPIC_API_KEY`
  is set to a non-empty value, or a reachable Claude Code settings file (managed,
  user-level via `CLAUDE_CONFIG_DIR`/`~/.claude`, or project-level) declares an
  `apiKeyHelper`. Otherwise it is omitted and the CLI uses its own login session.
- **Explicit override in both directions** — `ai.cli_bare: auto|always|never` in config
  (new `CliBareMode` enum), overridable per run by `LINTRO_CLI_BARE`, which wins so CI
  can force a mode without editing a checked-in config. An unrecognised env value is
  warned about and ignored rather than guessed at.
- **Auth hint now matches the mode that failed.** Telling a subscription user to
  "run /login" after a bare invocation is exactly the wrong advice; the hint now differs
  per mode and names the escape hatch.
- Settings probing is defensive: non-regular paths (a FIFO at a well-known settings path
  would otherwise block every provider call), oversized files, and malformed JSON are
  all treated as "no helper" rather than as errors.
- `--bare` deliberately stays in the declared CLI contract's `required_flags`, with a
  comment explaining why: the API-key path cannot silently degrade without it, so its
  disappearance from the flag surface should break CI rather than a user's review.
- Docs (`docs/ai-features.md`) updated: the transport-credential table, the `--bare`
  blockquote, and the full config reference.

Deliberately scoped to the flag/auth decision. The agentic-path response handling that
omitting `--bare` exposes is #1853, which lands on top of this.

Fixes #1838

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1838

## Details

_See What’s Changing._
