### PR TITLE
fix(ai): recover prose review responses instead of discarding findings (#1853)

### DIFF
--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -664,6 +664,24 @@ your normal linting results with a one-line notice:
 AI: enhancement unavailable
 ```
 
+### Non-JSON review responses
+
+`lintro review` asks the model for a JSON object. When an answer comes back as prose
+instead, the findings it contains are recovered rather than discarded:
+
+1. The response is parsed, including JSON embedded in surrounding prose.
+2. If that fails, lintro makes **exactly one** retry asking the model to re-emit its
+   answer in the required schema. The retry is charged against the same per-call
+   `ai.api_timeout` budget as the original call (capped at half of it), and is skipped
+   entirely when too little of that budget remains.
+3. If the retry also fails, the prose is reported as a single low-severity "unstructured
+   review output" finding carrying the complete answer, and the chunk completes instead
+   of aborting.
+
+Every response that fails to parse — at the CLI-envelope layer or the review layer — is
+written in full to `.lintro-cache/ai/raw-responses/`, so nothing the model produced is
+lost to truncation.
+
 ## Pre-Execution Summary
 
 When AI is enabled, the pre-execution summary table includes AI configuration:

--- a/lintro/ai/invoke.py
+++ b/lintro/ai/invoke.py
@@ -33,6 +33,7 @@ async def call_ai(
     repo_root: str | None = None,
     use_one_shot: bool = False,
     cli_schema: CliSchemaRequest | None = None,
+    timeout: float | None = None,
 ) -> AIResponse:
     """Retry, fallback, and budget tracking for all AI products.
 
@@ -46,11 +47,16 @@ async def call_ai(
         repo_root: Optional repository root for CLI providers.
         use_one_shot: When True, avoid durable CLI sessions.
         cli_schema: Optional native CLI JSON schema request.
+        timeout: Per-call timeout override in seconds; defaults to
+            ``ai_config.api_timeout``. Callers making a supplementary call
+            inside an existing timeout budget pass what remains of it so the
+            extra call cannot double the budgeted wall time.
 
     Returns:
         The provider response with usage metadata.
     """
     tokens = max_tokens if max_tokens is not None else ai_config.max_tokens
+    effective_timeout = timeout if timeout is not None else ai_config.api_timeout
 
     async def _call_once() -> AIResponse:
         """Perform one fallback-guarded provider call.
@@ -64,7 +70,7 @@ async def call_ai(
             fallback_models=list(ai_config.fallback_models),
             system=system_prompt,
             max_tokens=tokens,
-            timeout=ai_config.api_timeout,
+            timeout=effective_timeout,
             repo_root=repo_root,
             use_one_shot=use_one_shot,
             cli_schema=cli_schema,

--- a/lintro/ai/prompts/review.py
+++ b/lintro/ai/prompts/review.py
@@ -19,6 +19,7 @@ __all__ = [
     "REVIEW_GIT_NATIVE_DIFF_WORKTREE_COMMAND",
     "REVIEW_GIT_NATIVE_USER_PROMPT_TEMPLATE",
     "REVIEW_OUTPUT_SCHEMA",
+    "REVIEW_SCHEMA_REMINDER_TEMPLATE",
     "REVIEW_SYSTEM",
     "REVIEW_USER_PROMPT_TEMPLATE",
     "format_changed_files_for_prompt",
@@ -62,6 +63,11 @@ REVIEW_GENERATE_QUESTIONS_TEMPLATE = load_prompt_template(
 REVIEW_ADVERSARIAL_SWEEP_TEMPLATE = load_prompt_template(
     "review",
     "adversarial_sweep.md",
+)
+
+REVIEW_SCHEMA_REMINDER_TEMPLATE = load_prompt_template(
+    "review",
+    "schema_reminder.md",
 )
 
 

--- a/lintro/ai/prompts/templates/review/schema_reminder.md
+++ b/lintro/ai/prompts/templates/review/schema_reminder.md
@@ -1,0 +1,13 @@
+Your previous answer was not valid JSON, so it could not be recorded.
+
+Do not repeat the review. Convert the findings you already produced into the
+required JSON object and return that object and nothing else — no prose before
+it, no prose after it, no markdown code fence.
+
+Required schema:
+
+{output_schema}
+
+Your previous answer was:
+
+{previous_response}

--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -38,6 +38,11 @@ from lintro.ai.providers.constants import (
     DEFAULT_PER_CALL_MAX_TOKENS,
     DEFAULT_TIMEOUT,
 )
+from lintro.ai.raw_response import (
+    CLI_ENVELOPE_STAGE,
+    describe_raw_response,
+    recover_prose_envelope,
+)
 from lintro.ai.registry import PROVIDERS, AIProvider
 
 _has_anthropic = False
@@ -106,15 +111,36 @@ class _AnthropicCliTransport(CliTransport):
         try:
             data = json.loads(stdout.strip())
         except json.JSONDecodeError as exc:
-            raise AIProviderError(
-                f"Claude CLI returned invalid JSON: {exc}\n"
-                f"Raw output: {stdout[:500]}",
-            ) from exc
+            recovered = recover_prose_envelope(
+                provider="Claude",
+                stdout=stdout,
+                reason=str(exc),
+            )
+            if recovered is None:
+                evidence = describe_raw_response(
+                    provider="Claude",
+                    stage=CLI_ENVELOPE_STAGE,
+                    raw=stdout,
+                )
+                raise AIProviderError(
+                    f"Claude CLI returned invalid JSON: {exc}\n{evidence}",
+                ) from exc
+            return (
+                AIResponse(
+                    content=recovered,
+                    model=self._model,
+                    provider=AIProvider.ANTHROPIC,
+                ),
+                None,
+            )
 
         if data.get("is_error") or data.get("subtype") == "error":
-            raise AIProviderError(
-                f"Claude CLI reported error: {data.get('result', stdout[:500])}",
+            cause = data.get("result") or describe_raw_response(
+                provider="Claude",
+                stage=CLI_ENVELOPE_STAGE,
+                raw=stdout,
             )
+            raise AIProviderError(f"Claude CLI reported error: {cause}")
 
         content = data.get("result", "")
         structured = data.get("structured_output")

--- a/lintro/ai/providers/cursor.py
+++ b/lintro/ai/providers/cursor.py
@@ -35,6 +35,11 @@ from lintro.ai.providers.constants import (
     DEFAULT_PER_CALL_MAX_TOKENS,
     DEFAULT_TIMEOUT,
 )
+from lintro.ai.raw_response import (
+    CLI_ENVELOPE_STAGE,
+    describe_raw_response,
+    recover_prose_envelope,
+)
 from lintro.ai.registry import PROVIDERS, AIProvider
 from lintro.ai.token_budget import estimate_tokens
 
@@ -58,15 +63,36 @@ class _CursorCliTransport(CliTransport):
         try:
             data = json.loads(stdout.strip())
         except json.JSONDecodeError as exc:
-            raise AIProviderError(
-                f"Cursor CLI returned invalid JSON: {exc}\n"
-                f"Raw output: {stdout[:500]}",
-            ) from exc
+            recovered = recover_prose_envelope(
+                provider="Cursor agent",
+                stdout=stdout,
+                reason=str(exc),
+            )
+            if recovered is None:
+                evidence = describe_raw_response(
+                    provider="Cursor agent",
+                    stage=CLI_ENVELOPE_STAGE,
+                    raw=stdout,
+                )
+                raise AIProviderError(
+                    f"Cursor CLI returned invalid JSON: {exc}\n{evidence}",
+                ) from exc
+            return (
+                AIResponse(
+                    content=recovered,
+                    model=self._model,
+                    provider=AIProvider.CURSOR,
+                ),
+                None,
+            )
 
         if data.get("is_error") or data.get("subtype") == "error":
-            raise AIProviderError(
-                f"Cursor CLI reported error: {data.get('result', stdout[:500])}",
+            cause = data.get("result") or describe_raw_response(
+                provider="Cursor agent",
+                stage=CLI_ENVELOPE_STAGE,
+                raw=stdout,
             )
+            raise AIProviderError(f"Cursor CLI reported error: {cause}")
 
         content = data.get("result", "")
         if not content:

--- a/lintro/ai/providers/openai.py
+++ b/lintro/ai/providers/openai.py
@@ -37,6 +37,11 @@ from lintro.ai.providers.constants import (
     DEFAULT_PER_CALL_MAX_TOKENS,
     DEFAULT_TIMEOUT,
 )
+from lintro.ai.raw_response import (
+    CLI_ENVELOPE_STAGE,
+    describe_raw_response,
+    recover_prose_envelope,
+)
 from lintro.ai.registry import PROVIDERS, AIProvider
 
 _has_openai = False
@@ -128,10 +133,21 @@ class _CodexCliTransport(CliTransport):
                 input_tokens = int(usage.get("input_tokens", input_tokens))
                 output_tokens = int(usage.get("output_tokens", output_tokens))
             except json.JSONDecodeError as exc:
-                raise AIProviderError(
-                    f"Codex CLI returned unparsable output: {exc}\n"
-                    f"Raw output: {stdout[:500]}",
-                ) from exc
+                recovered = recover_prose_envelope(
+                    provider="Codex",
+                    stdout=stdout,
+                    reason=str(exc),
+                )
+                if recovered is None:
+                    evidence = describe_raw_response(
+                        provider="Codex",
+                        stage=CLI_ENVELOPE_STAGE,
+                        raw=stdout,
+                    )
+                    raise AIProviderError(
+                        f"Codex CLI returned unparsable output: {exc}\n{evidence}",
+                    ) from exc
+                final_text = recovered
 
         cost = estimate_cost(self._model, input_tokens, output_tokens)
         return AIResponse(

--- a/lintro/ai/providers/openai.py
+++ b/lintro/ai/providers/openai.py
@@ -147,7 +147,22 @@ class _CodexCliTransport(CliTransport):
                     raise AIProviderError(
                         f"Codex CLI returned unparsable output: {exc}\n{evidence}",
                     ) from exc
-                final_text = recovered
+                # Return the prose untouched: substitute_parsed_json would swap
+                # in any balanced JSON span it finds inside the answer, which
+                # on a prose answer means silently dropping the surrounding
+                # findings. The review layer extracts embedded JSON itself.
+                return AIResponse(
+                    content=recovered,
+                    model=self._model,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    cost_estimate=estimate_cost(
+                        self._model,
+                        input_tokens,
+                        output_tokens,
+                    ),
+                    provider=AIProvider.OPENAI,
+                )
 
         cost = estimate_cost(self._model, input_tokens, output_tokens)
         return AIResponse(

--- a/lintro/ai/raw_response.py
+++ b/lintro/ai/raw_response.py
@@ -1,0 +1,175 @@
+"""Durable capture of raw AI responses that failed to parse.
+
+A model response that does not conform to the requested schema is still
+evidence: it routinely contains real, actionable findings. Truncating it into
+an error message (the historical ``stdout[:500]``) discarded that evidence and
+made the failure look like a tooling problem rather than a recoverable parse
+miss (#1853).
+
+Every parse failure therefore writes the *complete* response to a file under
+``.lintro-cache/ai/raw-responses`` and reports the path, so nothing the model
+produced is ever unrecoverable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import time
+from pathlib import Path
+
+from loguru import logger
+
+__all__ = [
+    "CLI_ENVELOPE_STAGE",
+    "RAW_RESPONSE_DIR",
+    "describe_raw_response",
+    "persist_raw_response",
+    "recover_prose_envelope",
+]
+
+#: Workspace-relative directory holding captured raw responses.
+RAW_RESPONSE_DIR = ".lintro-cache/ai/raw-responses"
+
+#: Stage label for a CLI envelope that did not parse as JSON.
+CLI_ENVELOPE_STAGE = "cli-envelope"
+
+
+def _slug(*, label: str) -> str:
+    """Return a filesystem-safe slug for *label*.
+
+    Args:
+        label: Arbitrary caller-supplied label (provider or stage name).
+
+    Returns:
+        A lowercase slug containing only ``[a-z0-9-]``, never empty.
+    """
+    cleaned = "".join(
+        char if char.isalnum() else "-" for char in (label or "").strip().lower()
+    ).strip("-")
+    return cleaned or "unknown"
+
+
+def _candidate_dirs(*, workspace_root: Path | None) -> tuple[Path, ...]:
+    """Return capture directories to try, in order of preference.
+
+    The workspace cache directory is preferred so the capture sits next to the
+    run that produced it; a read-only or missing workspace falls back to the
+    system temporary directory rather than losing the evidence.
+
+    Args:
+        workspace_root: Workspace root, or ``None`` to use the current
+            directory.
+
+    Returns:
+        Ordered candidate directories.
+    """
+    root = workspace_root if workspace_root is not None else Path.cwd()
+    return (
+        root / RAW_RESPONSE_DIR,
+        Path(tempfile.gettempdir()) / "lintro-ai-raw-responses",
+    )
+
+
+def persist_raw_response(
+    *,
+    provider: str,
+    stage: str,
+    raw: str,
+    workspace_root: Path | None = None,
+) -> Path | None:
+    """Write the complete raw response to disk and return its path.
+
+    Args:
+        provider: Provider or binary identifier, e.g. ``"claude"``.
+        stage: Where the parse failed, e.g. ``"cli-envelope"`` or ``"review"``.
+        raw: The complete raw response text. Never truncated.
+        workspace_root: Workspace root for the capture directory. Defaults to
+            the current working directory.
+
+    Returns:
+        The path written, or ``None`` when no candidate directory was writable.
+        Failing to persist is never fatal: the caller still reports the full
+        text inline.
+    """
+    digest = hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()[:12]
+    name = (
+        f"{_slug(label=stage)}-{_slug(label=provider)}-{int(time.time())}-{digest}.txt"
+    )
+    for directory in _candidate_dirs(workspace_root=workspace_root):
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+            target = directory / name
+            target.write_text(raw, encoding="utf-8")
+        except OSError:
+            continue
+        return target
+    return None
+
+
+def describe_raw_response(
+    *,
+    provider: str,
+    stage: str,
+    raw: str,
+    workspace_root: Path | None = None,
+) -> str:
+    """Persist *raw* and return an evidence block carrying it in full.
+
+    The returned block is embedded verbatim in provider error messages, so a
+    failure that reaches the user always carries every character the model
+    produced plus the path it was saved to.
+
+    Args:
+        provider: Provider or binary identifier, e.g. ``"claude"``.
+        stage: Where the parse failed, e.g. ``"cli-envelope"``.
+        raw: The complete raw response text.
+        workspace_root: Workspace root for the capture directory.
+
+    Returns:
+        A multi-line evidence block. Never truncates *raw*.
+    """
+    path = persist_raw_response(
+        provider=provider,
+        stage=stage,
+        raw=raw,
+        workspace_root=workspace_root,
+    )
+    header = f"Full raw output ({len(raw)} chars)"
+    if path is not None:
+        header = f"{header} saved to {path}"
+    return f"{header}:\n----- raw output start -----\n{raw}\n----- raw output end -----"
+
+
+def recover_prose_envelope(*, provider: str, stdout: str, reason: str) -> str | None:
+    """Return a non-JSON CLI envelope as unstructured prose, or ``None``.
+
+    The CLI has already exited zero by the time a caller reaches this: the
+    envelope simply is not JSON, which in practice means the agent answered in
+    prose. Discarding that answer threw away real findings (#1853), so the
+    prose is handed back as unstructured content for the review layer to
+    recover, and the complete text is persisted either way.
+
+    Args:
+        provider: Provider or binary identifier, e.g. ``"Claude"``.
+        stdout: The complete raw stdout that failed to parse as JSON.
+        reason: The parse error, used in the warning line.
+
+    Returns:
+        The stripped prose, or ``None`` when stdout carries no text at all —
+        an empty response is a genuine failure, not a recoverable answer.
+    """
+    content = (stdout or "").strip()
+    if not content:
+        return None
+    path = persist_raw_response(
+        provider=provider,
+        stage=CLI_ENVELOPE_STAGE,
+        raw=stdout,
+    )
+    location = f" Full response saved to {path}." if path is not None else ""
+    logger.warning(
+        f"{provider} CLI returned a non-JSON envelope ({reason}); "
+        f"recovering it as unstructured prose.{location}",
+    )
+    return content

--- a/lintro/ai/raw_response.py
+++ b/lintro/ai/raw_response.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import stat
 import tempfile
 import time
 from pathlib import Path
@@ -105,6 +106,37 @@ def _candidate_dirs(*, workspace_root: Path | None) -> tuple[Path, ...]:
     )
 
 
+def _prepare_directory(*, directory: Path) -> bool:
+    """Create *directory* and verify it is safe to write captures into.
+
+    The fallback lives at a predictable path in the shared system temp
+    directory, so a pre-existing entry there is untrusted: a symlink, another
+    user's directory, or one with loose permissions would leak captures that
+    can embed diff context. ``lstat`` deliberately does not follow symlinks.
+
+    Args:
+        directory: Candidate capture directory.
+
+    Returns:
+        True when the directory exists, is a real directory (not a symlink),
+        is owned by the current user, and is owner-only.
+
+    Raises:
+        OSError: When the directory cannot be created or inspected.
+    """
+    directory.mkdir(parents=True, exist_ok=True, mode=_DIR_MODE)
+    info = directory.lstat()
+    if not stat.S_ISDIR(info.st_mode):
+        return False
+    if hasattr(os, "geteuid") and info.st_uid != os.geteuid():
+        return False
+    if stat.S_IMODE(info.st_mode) != _DIR_MODE:
+        # A pre-existing directory we own but with looser modes is tightened
+        # rather than rejected: losing the capture is the worse outcome.
+        directory.chmod(_DIR_MODE)
+    return True
+
+
 def persist_raw_response(
     *,
     provider: str,
@@ -132,17 +164,23 @@ def persist_raw_response(
     )
     for directory in _candidate_dirs(workspace_root=workspace_root):
         try:
-            directory.mkdir(parents=True, exist_ok=True, mode=_DIR_MODE)
+            if not _prepare_directory(directory=directory):
+                continue
             target = directory / name
             # Captures can embed diff context, so they are created owner-only
-            # rather than at the process umask.
+            # rather than at the process umask. O_EXCL + O_NOFOLLOW refuse
+            # pre-existing entries and symlinks in the shared temp fallback.
             descriptor = os.open(
                 target,
-                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
                 _FILE_MODE,
             )
             with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
                 handle.write(raw)
+        except FileExistsError:
+            # Same second, same content (the name embeds a content digest in a
+            # directory verified owner-only): the capture already exists.
+            return directory / name
         except OSError:
             continue
         return target

--- a/lintro/ai/raw_response.py
+++ b/lintro/ai/raw_response.py
@@ -14,6 +14,8 @@ produced is ever unrecoverable.
 from __future__ import annotations
 
 import hashlib
+import os
+import re
 import tempfile
 import time
 from pathlib import Path
@@ -26,6 +28,7 @@ __all__ = [
     "describe_raw_response",
     "persist_raw_response",
     "recover_prose_envelope",
+    "sanitize_for_display",
 ]
 
 #: Workspace-relative directory holding captured raw responses.
@@ -33,6 +36,36 @@ RAW_RESPONSE_DIR = ".lintro-cache/ai/raw-responses"
 
 #: Stage label for a CLI envelope that did not parse as JSON.
 CLI_ENVELOPE_STAGE = "cli-envelope"
+
+#: Directory mode for capture directories (owner-only: captures can embed diff
+#: context and other repository content).
+_DIR_MODE = 0o700
+
+#: File mode for captured responses.
+_FILE_MODE = 0o600
+
+# ANSI/OSC escape sequences and other C0 control characters (tab and newline
+# excluded). A model answer is untrusted text that lands in an error message
+# printed to a terminal, so escape sequences are neutralised for display. The
+# capture file keeps the bytes exactly as received.
+_ESCAPE_SEQUENCE_RE = re.compile(
+    r"\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b][^\x07\x1b]*(?:\x07|\x1b\\)",
+)
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+
+
+def sanitize_for_display(*, text: str) -> str:
+    """Return *text* with terminal escape sequences neutralised.
+
+    Args:
+        text: Untrusted model output destined for a terminal.
+
+    Returns:
+        The text with ANSI/OSC sequences and stray control characters replaced
+        by visible placeholders. Tabs and newlines are preserved.
+    """
+    stripped = _ESCAPE_SEQUENCE_RE.sub("", text)
+    return _CONTROL_CHAR_RE.sub("?", stripped)
 
 
 def _slug(*, label: str) -> str:
@@ -45,7 +78,8 @@ def _slug(*, label: str) -> str:
         A lowercase slug containing only ``[a-z0-9-]``, never empty.
     """
     cleaned = "".join(
-        char if char.isalnum() else "-" for char in (label or "").strip().lower()
+        char if char.isascii() and char.isalnum() else "-"
+        for char in (label or "").strip().lower()
     ).strip("-")
     return cleaned or "unknown"
 
@@ -98,9 +132,17 @@ def persist_raw_response(
     )
     for directory in _candidate_dirs(workspace_root=workspace_root):
         try:
-            directory.mkdir(parents=True, exist_ok=True)
+            directory.mkdir(parents=True, exist_ok=True, mode=_DIR_MODE)
             target = directory / name
-            target.write_text(raw, encoding="utf-8")
+            # Captures can embed diff context, so they are created owner-only
+            # rather than at the process umask.
+            descriptor = os.open(
+                target,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                _FILE_MODE,
+            )
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write(raw)
         except OSError:
             continue
         return target
@@ -127,7 +169,9 @@ def describe_raw_response(
         workspace_root: Workspace root for the capture directory.
 
     Returns:
-        A multi-line evidence block. Never truncates *raw*.
+        A multi-line evidence block. Never truncates *raw*; terminal escape
+        sequences are neutralised for display only, and the capture file keeps
+        the original bytes.
     """
     path = persist_raw_response(
         provider=provider,
@@ -138,7 +182,10 @@ def describe_raw_response(
     header = f"Full raw output ({len(raw)} chars)"
     if path is not None:
         header = f"{header} saved to {path}"
-    return f"{header}:\n----- raw output start -----\n{raw}\n----- raw output end -----"
+    body = sanitize_for_display(text=raw)
+    return (
+        f"{header}:\n----- raw output start -----\n{body}\n----- raw output end -----"
+    )
 
 
 def recover_prose_envelope(*, provider: str, stdout: str, reason: str) -> str | None:

--- a/lintro/ai/raw_response.py
+++ b/lintro/ai/raw_response.py
@@ -106,6 +106,31 @@ def _candidate_dirs(*, workspace_root: Path | None) -> tuple[Path, ...]:
     )
 
 
+def _mkdir_private(*, directory: Path) -> None:
+    """Create *directory* and any missing ancestors owner-only.
+
+    ``Path.mkdir(parents=True, mode=...)`` applies the mode only to the leaf,
+    leaving newly created ancestors (``.lintro-cache``, ``.lintro-cache/ai``)
+    at the process umask. Missing ancestors are created here at ``0700`` and
+    chmodded to defeat a restrictive umask; pre-existing directories are left
+    untouched.
+
+    Args:
+        directory: Capture directory to create.
+    """
+    missing: list[Path] = []
+    current = directory
+    while not current.exists():
+        missing.append(current)
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    for path in reversed(missing):
+        path.mkdir(mode=_DIR_MODE, exist_ok=True)
+        path.chmod(_DIR_MODE)
+
+
 def _prepare_directory(*, directory: Path) -> bool:
     """Create *directory* and verify it is safe to write captures into.
 
@@ -113,6 +138,8 @@ def _prepare_directory(*, directory: Path) -> bool:
     directory, so a pre-existing entry there is untrusted: a symlink, another
     user's directory, or one with loose permissions would leak captures that
     can embed diff context. ``lstat`` deliberately does not follow symlinks.
+    ``OSError`` from creation or inspection propagates to the caller, which
+    treats it as "try the next candidate".
 
     Args:
         directory: Candidate capture directory.
@@ -120,11 +147,8 @@ def _prepare_directory(*, directory: Path) -> bool:
     Returns:
         True when the directory exists, is a real directory (not a symlink),
         is owned by the current user, and is owner-only.
-
-    Raises:
-        OSError: When the directory cannot be created or inspected.
     """
-    directory.mkdir(parents=True, exist_ok=True, mode=_DIR_MODE)
+    _mkdir_private(directory=directory)
     info = directory.lstat()
     if not stat.S_ISDIR(info.st_mode):
         return False

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -32,6 +32,7 @@ from lintro.ai.prompts.review import (
     REVIEW_GIT_NATIVE_DIFF_WORKTREE_COMMAND,
     REVIEW_GIT_NATIVE_USER_PROMPT_TEMPLATE,
     REVIEW_OUTPUT_SCHEMA,
+    REVIEW_SCHEMA_REMINDER_TEMPLATE,
     REVIEW_SYSTEM,
     REVIEW_USER_PROMPT_TEMPLATE,
     format_changed_files_for_prompt,
@@ -55,6 +56,11 @@ from lintro.ai.review.progress import (
     NullReviewProgress,
     ReviewProgressCallback,
     StepTrackingProgress,
+)
+from lintro.ai.review.response_recovery import (
+    build_schema_reminder_prompt,
+    resolve_schema_retry_timeout,
+    unstructured_review_payload,
 )
 from lintro.ai.review.sensitivity import (
     ReviewSensitivityPolicy,
@@ -1182,6 +1188,7 @@ async def _review_chunk(
             extra_checklist=extra_checklist,
             strictness_section=strictness_section,
         )
+    started = time.monotonic()
     response = await call_ai(
         provider=provider,
         ai_config=ai_config,
@@ -1192,7 +1199,16 @@ async def _review_chunk(
         use_one_shot=use_one_shot,
         cli_schema=cli_schema_for_review(transport=ai_config.transport),
     )
-    payload = parse_review_response(content=response.content)
+    response, payload = await _parse_review_payload_with_recovery(
+        response=response,
+        chunk=chunk,
+        provider=provider,
+        ai_config=ai_config,
+        budget=budget,
+        repo_root=repo_root,
+        use_one_shot=use_one_shot,
+        elapsed=time.monotonic() - started,
+    )
     partial = _payload_to_partial(response=response, payload=payload)
 
     if extra_checklist_usage is not None:
@@ -1225,6 +1241,125 @@ async def _review_chunk(
         )
 
     return partial, next_generated_checklist_id
+
+
+async def _parse_review_payload_with_recovery(
+    *,
+    response: AIResponse,
+    chunk: ReviewChunk,
+    provider: BaseAIProvider,
+    ai_config: AIConfig,
+    budget: CostBudget,
+    repo_root: str,
+    use_one_shot: bool,
+    elapsed: float,
+) -> tuple[AIResponse, dict[str, Any]]:
+    """Parse a chunk response, recovering non-JSON answers instead of failing.
+
+    The ladder is: parse (which already extracts JSON embedded in prose) →
+    exactly one schema-reminder retry, when the per-call timeout budget still
+    allows one → present the prose as unstructured findings with the full text
+    preserved. A prose answer normally carries real findings, so discarding it
+    as ``invalid_response`` lost work that had already been paid for (#1853).
+
+    Args:
+        response: The response from the main chunk call.
+        chunk: The chunk under review, used to locate the fallback finding.
+        provider: Configured AI provider instance.
+        ai_config: AI configuration for retries, budget, and timeouts.
+        budget: Session cost budget tracker.
+        repo_root: Absolute path to the repository under review.
+        use_one_shot: When True, avoid durable provider sessions.
+        elapsed: Wall-clock seconds the main chunk call consumed.
+
+    Returns:
+        The response whose usage should be attributed to the chunk (the retry's
+        usage folded in when a retry ran) and the parsed review payload.
+    """
+    try:
+        return response, parse_review_response(content=response.content)
+    except ValueError as exc:
+        first_error = exc
+
+    retry_timeout = resolve_schema_retry_timeout(
+        api_timeout=ai_config.api_timeout,
+        elapsed=elapsed,
+    )
+    if retry_timeout is None:
+        logger.warning(
+            "Review response was not valid JSON and the timeout budget left no "
+            "room for a schema-reminder retry; recovering it as unstructured "
+            f"output ({first_error}).",
+        )
+        return response, unstructured_review_payload(
+            content=response.content,
+            files=tuple(chunk.files),
+        )
+
+    logger.warning(
+        f"Review response was not valid JSON ({first_error}); retrying once "
+        f"with a schema reminder (timeout {retry_timeout:.0f}s).",
+    )
+    reminder = build_schema_reminder_prompt(
+        template=REVIEW_SCHEMA_REMINDER_TEMPLATE,
+        output_schema=REVIEW_OUTPUT_SCHEMA,
+        previous_response=response.content,
+    )
+    try:
+        retry_response = await call_ai(
+            provider=provider,
+            ai_config=ai_config,
+            system_prompt=REVIEW_SYSTEM,
+            user_prompt=reminder,
+            budget=budget,
+            repo_root=repo_root or None,
+            use_one_shot=use_one_shot,
+            cli_schema=cli_schema_for_review(transport=ai_config.transport),
+            timeout=retry_timeout,
+        )
+    except AIError as retry_exc:
+        # The reminder is best-effort: a failed retry must never be worse than
+        # not retrying, so the original answer is still recovered.
+        logger.warning(f"Schema-reminder retry failed: {retry_exc}")
+        return response, unstructured_review_payload(
+            content=response.content,
+            files=tuple(chunk.files),
+        )
+
+    merged = _merge_response_usage(first=response, second=retry_response)
+    try:
+        return merged, parse_review_response(content=retry_response.content)
+    except ValueError as retry_error:
+        logger.warning(
+            f"Schema-reminder retry was still not valid JSON ({retry_error}); "
+            "recovering the review as unstructured output.",
+        )
+
+    # The retry's answer is the model's latest word; prefer it when it carries
+    # text, and fall back to the original answer when the retry came back empty.
+    recovered = retry_response.content.strip() or response.content
+    return merged, unstructured_review_payload(
+        content=recovered,
+        files=tuple(chunk.files),
+    )
+
+
+def _merge_response_usage(*, first: AIResponse, second: AIResponse) -> AIResponse:
+    """Return *second* with *first*'s token and cost usage folded in.
+
+    Args:
+        first: The earlier response.
+        second: The later response whose content is authoritative.
+
+    Returns:
+        A response carrying the combined usage of both calls.
+    """
+    return replace(
+        second,
+        input_tokens=first.input_tokens + second.input_tokens,
+        output_tokens=first.output_tokens + second.output_tokens,
+        cost_estimate=first.cost_estimate + second.cost_estimate,
+    )
 
 
 async def _generate_extra_checklist(

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -38,6 +38,7 @@ from lintro.ai.prompts.review import (
     format_changed_files_for_prompt,
     format_lint_results_section,
 )
+from lintro.ai.raw_response import persist_raw_response
 from lintro.ai.review.chunker import chunk_review_context
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
 from lintro.ai.review.errors_taxonomy import (
@@ -1285,6 +1286,17 @@ async def _parse_review_payload_with_recovery(
         return response, parse_review_response(content=response.content)
     except ValueError as exc:
         first_error = exc
+
+    # Persisted immediately: a successful retry replaces this answer in the
+    # payload, and a failed one echoes back only the retry's text, so this is
+    # the sole capture of what the model originally produced.
+    first_capture = persist_raw_response(
+        provider="review",
+        stage="parse-failure",
+        raw=response.content,
+    )
+    if first_capture is not None:
+        logger.debug(f"Unparseable review response saved to {first_capture}")
 
     retry_timeout = resolve_schema_retry_timeout(
         api_timeout=ai_config.api_timeout,

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -1275,6 +1275,11 @@ async def _parse_review_payload_with_recovery(
     Returns:
         The response whose usage should be attributed to the chunk (the retry's
         usage folded in when a retry ran) and the parsed review payload.
+
+    Raises:
+        AICostBudgetExceededError: When the schema-reminder retry hits the cost
+            ceiling. That is a graceful stop the caller finalizes a partial
+            review on, so it is never recovered as prose.
     """
     try:
         return response, parse_review_response(content=response.content)
@@ -1317,6 +1322,11 @@ async def _parse_review_payload_with_recovery(
             cli_schema=cli_schema_for_review(transport=ai_config.transport),
             timeout=retry_timeout,
         )
+    except AICostBudgetExceededError:
+        # The cost cap is a graceful stop the caller finalizes a partial review
+        # on, not a provider failure: swallowing it here would let the run keep
+        # spending past the ceiling.
+        raise
     except AIError as retry_exc:
         # The reminder is best-effort: a failed retry must never be worse than
         # not retrying, so the original answer is still recovered.

--- a/lintro/ai/review/response_recovery.py
+++ b/lintro/ai/review/response_recovery.py
@@ -1,0 +1,162 @@
+"""Recovery of review responses the model did not return as JSON.
+
+A prose answer is not a transport failure: it routinely carries the very
+findings the review was asked for. Aborting the chunk with
+``kind=invalid_response`` discarded them and truncated the evidence (#1853).
+
+This module supplies the two recovery stages the orchestrator layers on top of
+the existing extract-embedded-JSON path:
+
+1. :func:`resolve_schema_retry_timeout` decides whether exactly one
+   schema-reminder retry still fits inside the per-call timeout budget.
+2. :func:`unstructured_review_payload` turns a still-unparseable answer into a
+   review payload carrying the prose verbatim, so the chunk completes with
+   unstructured findings instead of failing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lintro.ai.raw_response import persist_raw_response
+from lintro.ai.review.models.review_finding import Severity
+
+__all__ = [
+    "MAX_ECHOED_RESPONSE_CHARS",
+    "SCHEMA_RETRY_MAX_FRACTION",
+    "SCHEMA_RETRY_MIN_TIMEOUT",
+    "UNSTRUCTURED_CATEGORY",
+    "UNSTRUCTURED_TITLE",
+    "build_schema_reminder_prompt",
+    "resolve_schema_retry_timeout",
+    "unstructured_review_payload",
+]
+
+#: A schema-reminder retry is skipped below this many seconds: a call that
+#: cannot plausibly finish is worse than falling straight through to the prose
+#: fallback, which loses nothing.
+SCHEMA_RETRY_MIN_TIMEOUT: float = 30.0
+
+#: Hard ceiling on the retry's share of the per-call timeout. Even when the
+#: first call returned instantly, the single retry can never more than double
+#: the wall-clock cost of a chunk by half again.
+SCHEMA_RETRY_MAX_FRACTION: float = 0.5
+
+#: Cap on how much of the previous answer is echoed back in the reminder
+#: prompt. The complete text is always preserved on disk and in the fallback
+#: payload; this cap only bounds prompt growth.
+MAX_ECHOED_RESPONSE_CHARS: int = 20_000
+
+#: Category and title used for the synthetic finding carrying prose output.
+UNSTRUCTURED_CATEGORY = "unstructured-review-output"
+UNSTRUCTURED_TITLE = "Unstructured review output (model did not return JSON)"
+
+
+def resolve_schema_retry_timeout(
+    *,
+    api_timeout: float,
+    elapsed: float,
+) -> float | None:
+    """Return the timeout for the single schema-reminder retry, or ``None``.
+
+    The retry is charged against the same per-call budget as the call that
+    produced the unparseable answer: it gets whatever is left of
+    ``api_timeout`` after that call, capped at
+    :data:`SCHEMA_RETRY_MAX_FRACTION` of the budget so a fast first call cannot
+    turn into a second full-length call. When too little remains, the retry is
+    skipped entirely and the caller falls through to the prose fallback.
+
+    Args:
+        api_timeout: Configured per-call provider timeout, in seconds.
+        elapsed: Wall-clock seconds the first call consumed.
+
+    Returns:
+        The retry timeout in seconds, or ``None`` when no retry should be made.
+    """
+    if api_timeout <= 0:
+        return None
+    remaining = api_timeout - max(elapsed, 0.0)
+    allowance = min(remaining, api_timeout * SCHEMA_RETRY_MAX_FRACTION)
+    if allowance < SCHEMA_RETRY_MIN_TIMEOUT:
+        return None
+    return allowance
+
+
+def build_schema_reminder_prompt(
+    *,
+    template: str,
+    output_schema: str,
+    previous_response: str,
+) -> str:
+    """Render the schema-reminder prompt for the single retry.
+
+    Args:
+        template: The reminder template with ``output_schema`` and
+            ``previous_response`` placeholders.
+        output_schema: The review output schema text.
+        previous_response: The model's unparseable answer.
+
+    Returns:
+        The rendered prompt, with the echoed answer capped at
+        :data:`MAX_ECHOED_RESPONSE_CHARS`.
+    """
+    echoed = previous_response
+    if len(echoed) > MAX_ECHOED_RESPONSE_CHARS:
+        echoed = (
+            f"{echoed[:MAX_ECHOED_RESPONSE_CHARS]}\n"
+            "[... truncated in this reminder only; the full answer is preserved]"
+        )
+    return template.format(output_schema=output_schema, previous_response=echoed)
+
+
+def unstructured_review_payload(
+    *,
+    content: str,
+    files: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Build a review payload that carries a prose answer verbatim.
+
+    The prose becomes both the chunk summary and a single low-confidence P3
+    finding whose description is the complete, untruncated answer. Nothing the
+    model produced is dropped, and the chunk completes instead of aborting.
+
+    Args:
+        content: The model's complete non-JSON answer.
+        files: Files in the chunk; the first is used as the finding location so
+            the finding renders against the reviewed code rather than nowhere.
+
+    Returns:
+        A payload in the review response shape (``summary``, ``checklist``,
+        ``findings``).
+    """
+    text = content.strip()
+    path = persist_raw_response(provider="review", stage="unstructured", raw=content)
+    location = f"\n\nFull response saved to {path}." if path is not None else ""
+    return {
+        "summary": (
+            "The model answered in prose instead of the requested JSON. Its "
+            "answer is preserved below and reported as an unstructured "
+            f"finding.{location}\n\n{text}"
+        ),
+        "checklist": [],
+        "findings": [
+            {
+                "severity": Severity.P3.value,
+                "category": UNSTRUCTURED_CATEGORY,
+                "file": files[0] if files else "",
+                "line": 0,
+                "title": UNSTRUCTURED_TITLE,
+                "description": text,
+                "cause": (
+                    "The response did not parse as the review JSON schema, and "
+                    "a schema-reminder retry did not produce one either."
+                ),
+                "fix": (
+                    "Read the preserved answer above: it may contain real "
+                    "findings that could not be recorded structurally."
+                ),
+                "confidence": "low",
+                "checklist_ids": [],
+            },
+        ],
+    }

--- a/tests/unit/ai/providers/test_prose_envelope_recovery.py
+++ b/tests/unit/ai/providers/test_prose_envelope_recovery.py
@@ -145,6 +145,22 @@ async def test_blank_envelope_reports_untruncated_evidence(
 
 
 @pytest.mark.parametrize("name", ["anthropic", "cursor", "openai"])
+async def test_prose_with_an_inline_json_span_is_not_reduced_to_it(
+    name: str,
+    _binaries_on_path: None,
+) -> None:
+    """An incidental ``{...}`` inside prose must not replace the whole answer."""
+    provider = _providers()[name]
+    prose = f'Finding 1: the config `{{"retries": 3}}` is wrong.\n{_PROSE}'
+
+    with patch_cli_exec() as mock_run:
+        mock_run.return_value = _completed(prose)
+        response = await provider.complete("Review this")
+
+    assert_that(response.content).is_equal_to(prose.strip())
+
+
+@pytest.mark.parametrize("name", ["anthropic", "cursor", "openai"])
 async def test_error_evidence_is_never_truncated_to_500_chars(
     name: str,
     _binaries_on_path: None,

--- a/tests/unit/ai/providers/test_prose_envelope_recovery.py
+++ b/tests/unit/ai/providers/test_prose_envelope_recovery.py
@@ -1,0 +1,159 @@
+"""CLI transports recover prose envelopes and never truncate evidence (#1853).
+
+A ``claude``/``agent``/``codex`` invocation that exits zero but answers in prose
+used to be rejected wholesale, with the evidence cut to ``stdout[:500]``. These
+tests pin the replacement: the prose comes back as unstructured content, and any
+genuinely unrecoverable output is reported in full and written to disk.
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 - subprocess types drive the CLI doubles under test
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.enums import AITransport, CliBareMode
+from lintro.ai.exceptions import AIProviderError
+from lintro.ai.providers.anthropic import AnthropicProvider
+from lintro.ai.providers.cursor import CursorProvider
+from lintro.ai.providers.openai import OpenAIProvider
+from lintro.ai.raw_response import RAW_RESPONSE_DIR
+from tests.unit.ai.conftest import patch_cli_exec
+
+_PROSE = (
+    "Reviewed the four commits. Two actionable findings:\n\n"
+    "1. The observer re-arms after close (SearchDropdown.astro:258)\n"
+) + ("detail " * 400)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_captures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write raw-response captures into a temporary workspace.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture()
+def _binaries_on_path() -> Iterator[None]:
+    """Patch every CLI binary lookup used by these tests.
+
+    Yields:
+        None: all three provider binary probes are patched for the test body.
+    """
+    with (
+        patch(
+            "lintro.ai.providers.anthropic._find_claude",
+            return_value="/usr/local/bin/claude",
+        ),
+        patch(
+            "lintro.ai.providers.cursor._find_agent",
+            return_value="/usr/local/bin/agent",
+        ),
+        patch(
+            "lintro.ai.providers.openai._find_codex",
+            return_value="/usr/local/bin/codex",
+        ),
+    ):
+        yield
+
+
+def _completed(stdout: str) -> subprocess.CompletedProcess[str]:
+    """Return a clean-exit completed process carrying *stdout*.
+
+    Args:
+        stdout: Standard output text.
+
+    Returns:
+        A zero-exit completed process.
+    """
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _providers() -> dict[str, object]:
+    """Return one CLI-transport provider per implementation.
+
+    Returns:
+        Mapping of provider label to provider instance.
+    """
+    return {
+        "anthropic": AnthropicProvider(
+            transport=AITransport.CLI,
+            cli_bare=CliBareMode.NEVER,
+        ),
+        "cursor": CursorProvider(transport=AITransport.CLI),
+        "openai": OpenAIProvider(transport=AITransport.CLI),
+    }
+
+
+@pytest.mark.parametrize("name", ["anthropic", "cursor", "openai"])
+async def test_prose_envelope_is_recovered_in_full(
+    name: str,
+    _binaries_on_path: None,
+) -> None:
+    """Prose stdout becomes unstructured content instead of an error."""
+    provider = _providers()[name]
+
+    with patch_cli_exec() as mock_run:
+        mock_run.return_value = _completed(_PROSE)
+        response = await provider.complete("Review this")
+
+    assert_that(response.content).is_equal_to(_PROSE.strip())
+
+
+@pytest.mark.parametrize("name", ["anthropic", "cursor", "openai"])
+async def test_prose_envelope_is_persisted(
+    name: str,
+    tmp_path: Path,
+    _binaries_on_path: None,
+) -> None:
+    """The complete prose response is written to the capture directory."""
+    provider = _providers()[name]
+
+    with patch_cli_exec() as mock_run:
+        mock_run.return_value = _completed(_PROSE)
+        await provider.complete("Review this")
+
+    captures = list((tmp_path / RAW_RESPONSE_DIR).glob("*.txt"))
+    assert_that(captures).is_not_empty()
+    assert_that(captures[0].read_text(encoding="utf-8")).is_equal_to(_PROSE)
+
+
+@pytest.mark.parametrize("name", ["anthropic", "cursor"])
+async def test_blank_envelope_reports_untruncated_evidence(
+    name: str,
+    _binaries_on_path: None,
+) -> None:
+    """An unrecoverable envelope still carries every character it produced."""
+    provider = _providers()[name]
+    # Whitespace-only stdout carries no answer to recover, so it stays an error;
+    # the evidence block must still name the full-output capture.
+    with patch_cli_exec() as mock_run:
+        mock_run.return_value = _completed("   \n\t ")
+        with pytest.raises(AIProviderError) as excinfo:
+            await provider.complete("Review this")
+
+    assert_that(str(excinfo.value)).contains("Full raw output")
+    assert_that(str(excinfo.value)).does_not_contain("Raw output:")
+
+
+@pytest.mark.parametrize("name", ["anthropic", "cursor", "openai"])
+async def test_error_evidence_is_never_truncated_to_500_chars(
+    name: str,
+    _binaries_on_path: None,
+) -> None:
+    """The historical ``stdout[:500]`` cap is gone from every provider."""
+    provider = _providers()[name]
+
+    with patch_cli_exec() as mock_run:
+        mock_run.return_value = _completed(_PROSE)
+        response = await provider.complete("Review this")
+
+    assert_that(len(response.content)).is_greater_than(500)

--- a/tests/unit/ai/providers/test_prose_envelope_recovery.py
+++ b/tests/unit/ai/providers/test_prose_envelope_recovery.py
@@ -8,6 +8,7 @@ genuinely unrecoverable output is reported in full and written to disk.
 
 from __future__ import annotations
 
+import json
 import subprocess  # nosec B404 - subprocess types drive the CLI doubles under test
 from collections.abc import Iterator
 from pathlib import Path
@@ -19,6 +20,7 @@ from assertpy import assert_that
 from lintro.ai.enums import AITransport, CliBareMode
 from lintro.ai.exceptions import AIProviderError
 from lintro.ai.providers.anthropic import AnthropicProvider
+from lintro.ai.providers.base import BaseAIProvider
 from lintro.ai.providers.cursor import CursorProvider
 from lintro.ai.providers.openai import OpenAIProvider
 from lintro.ai.raw_response import RAW_RESPONSE_DIR
@@ -77,7 +79,7 @@ def _completed(stdout: str) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
 
 
-def _providers() -> dict[str, object]:
+def _providers() -> dict[str, BaseAIProvider]:
     """Return one CLI-transport provider per implementation.
 
     Returns:
@@ -160,16 +162,22 @@ async def test_prose_with_an_inline_json_span_is_not_reduced_to_it(
     assert_that(response.content).is_equal_to(prose.strip())
 
 
-@pytest.mark.parametrize("name", ["anthropic", "cursor", "openai"])
-async def test_error_evidence_is_never_truncated_to_500_chars(
+@pytest.mark.parametrize("name", ["anthropic", "cursor"])
+async def test_error_envelope_evidence_is_never_truncated_to_500_chars(
     name: str,
     _binaries_on_path: None,
 ) -> None:
-    """The historical ``stdout[:500]`` cap is gone from every provider."""
+    """The historical ``stdout[:500]`` cap is gone from the error path too."""
     provider = _providers()[name]
+    # An ``is_error`` envelope with no ``result`` used to fall back to
+    # ``stdout[:500]``; the whole envelope must now reach the user.
+    envelope = json.dumps({"is_error": True, "result": "", "note": _PROSE})
+    tail = _PROSE[-40:]
 
     with patch_cli_exec() as mock_run:
-        mock_run.return_value = _completed(_PROSE)
-        response = await provider.complete("Review this")
+        mock_run.return_value = _completed(envelope)
+        with pytest.raises(AIProviderError) as excinfo:
+            await provider.complete("Review this")
 
-    assert_that(len(response.content)).is_greater_than(500)
+    assert_that(len(envelope)).is_greater_than(500)
+    assert_that(str(excinfo.value)).contains(tail)

--- a/tests/unit/ai/review/test_prose_recovery.py
+++ b/tests/unit/ai/review/test_prose_recovery.py
@@ -17,11 +17,12 @@ from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
 from lintro.ai.enums import AITransport
-from lintro.ai.exceptions import AIProviderError
+from lintro.ai.exceptions import AICostBudgetExceededError, AIProviderError
 from lintro.ai.providers.capabilities import ProviderCapabilities
 from lintro.ai.providers.response import AIResponse
 from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.orchestrator import run_review
 from lintro.ai.review.response_recovery import (
     SCHEMA_RETRY_MIN_TIMEOUT,
@@ -99,7 +100,11 @@ def _context() -> ReviewContext:
     )
 
 
-def _run(*, responses: list[AIResponse], api_timeout: float = 900.0):  # noqa: ANN202
+def _run(
+    *,
+    responses: list[AIResponse],
+    api_timeout: float = 900.0,
+) -> tuple[ReviewResult, list[dict[str, object]]]:
     """Run a single-chunk review against a scripted sequence of responses.
 
     Args:
@@ -234,7 +239,7 @@ def test_short_timeout_budget_skips_the_retry() -> None:
 
 def test_failed_retry_still_recovers_the_original_answer() -> None:
     """A retry that errors is never worse than not retrying at all."""
-    queue: list[object] = [
+    queue: list[AIResponse | Exception] = [
         _response(_PROSE),
         AIProviderError("provider exploded"),
     ]
@@ -265,6 +270,40 @@ def test_failed_retry_still_recovers_the_original_answer() -> None:
     assert_that(calls).is_length(2)
     assert_that(result.findings[0].category).is_equal_to(UNSTRUCTURED_CATEGORY)
     assert_that(result.findings[0].description).is_equal_to(_PROSE.strip())
+
+
+def test_cost_cap_on_the_retry_is_not_swallowed() -> None:
+    """The budget stop must propagate, not be recovered as prose."""
+    queue: list[AIResponse | Exception] = [
+        _response(_PROSE),
+        AICostBudgetExceededError("cost cap reached"),
+    ]
+
+    async def _call_ai(**_kwargs: object) -> AIResponse:
+        item = queue.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    with patch("lintro.ai.review.orchestrator.call_ai", side_effect=_call_ai):
+        result = run_review(
+            _context(),
+            provider=_provider(),
+            ai_config=AIConfig(
+                enabled=True,
+                transport=AITransport.API,
+                api_timeout=900.0,
+            ),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+        )
+
+    # The orchestrator finalizes a partial review on the cost cap rather than
+    # continuing; the prose fallback must not have masked the stop.
+    assert_that(result.metadata.partial).is_true()
+    assert_that(result.metadata.stopped_reason).is_not_empty()
 
 
 def test_retry_usage_is_charged_to_the_chunk() -> None:

--- a/tests/unit/ai/review/test_prose_recovery.py
+++ b/tests/unit/ai/review/test_prose_recovery.py
@@ -1,0 +1,281 @@
+"""Review-level recovery of prose (non-JSON) model answers (#1853).
+
+A prose answer used to abort the chunk with ``kind=invalid_response`` and throw
+away findings the model had already produced. These tests pin the recovery
+ladder: parse -> one schema-reminder retry -> unstructured findings, with the
+complete answer preserved at every step.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
+from lintro.ai.exceptions import AIProviderError
+from lintro.ai.providers.capabilities import ProviderCapabilities
+from lintro.ai.providers.response import AIResponse
+from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.orchestrator import run_review
+from lintro.ai.review.response_recovery import (
+    SCHEMA_RETRY_MIN_TIMEOUT,
+    UNSTRUCTURED_CATEGORY,
+)
+
+_PROSE = (
+    "Reviewed the four commits. Two actionable findings:\n\n"
+    "1. The pending-announcement drop is incomplete — the observer re-arms "
+    "after close (SearchDropdown.astro:258)\n\n"
+    "2. The Tab wrap skips the close button.\n"
+) + ("tail " * 400)
+
+
+def _valid_payload() -> str:
+    """Return a schema-conforming review response.
+
+    Returns:
+        JSON text with the required review keys.
+    """
+    return json.dumps(
+        {
+            "summary": "Merge with fixes.",
+            "checklist": [{"id": 1, "answer": "yes", "evidence": "src/main.py:1"}],
+            "findings": [
+                {
+                    "severity": "P1",
+                    "category": "logic-bug",
+                    "file": "src/main.py",
+                    "line": 12,
+                    "title": "Observer re-arms after close",
+                    "description": "The MutationObserver is never disconnected",
+                    "cause": "No stored reference",
+                    "fix": "Disconnect in closeSearch()",
+                    "confidence": "high",
+                    "checklist_ids": [1],
+                },
+            ],
+        },
+    )
+
+
+def _provider() -> MagicMock:
+    """Return a mock provider with sessions disabled.
+
+    Returns:
+        A provider double suitable for single-chunk reviews.
+    """
+    provider = MagicMock()
+    provider.model_name = "claude-sonnet-4-20250514"
+    provider.name = "anthropic"
+    provider.capabilities = ProviderCapabilities(supports_sessions=False)
+    return provider
+
+
+def _context() -> ReviewContext:
+    """Return a single-file review context.
+
+    Returns:
+        A review context covering ``src/main.py``.
+    """
+    return ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(
+                path="src/main.py",
+                status="modified",
+                additions=1,
+                deletions=0,
+            ),
+        ],
+        unified_diff="diff --git a/src/main.py b/src/main.py\n+change",
+        pr_metadata=None,
+    )
+
+
+def _run(*, responses: list[AIResponse], api_timeout: float = 900.0):  # noqa: ANN202
+    """Run a single-chunk review against a scripted sequence of responses.
+
+    Args:
+        responses: Responses returned by successive ``call_ai`` calls.
+        api_timeout: Per-call timeout budget for the run.
+
+    Returns:
+        Tuple of the review result and the recorded ``call_ai`` kwargs.
+    """
+    calls: list[dict[str, object]] = []
+    queue = list(responses)
+
+    async def _call_ai(**kwargs: object) -> AIResponse:
+        calls.append(kwargs)
+        return queue.pop(0)
+
+    with patch("lintro.ai.review.orchestrator.call_ai", side_effect=_call_ai):
+        result = run_review(
+            _context(),
+            provider=_provider(),
+            ai_config=AIConfig(
+                enabled=True,
+                transport=AITransport.API,
+                api_timeout=api_timeout,
+            ),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+        )
+    return result, calls
+
+
+def _response(content: str, *, cost: float = 0.01) -> AIResponse:
+    """Return an ``AIResponse`` carrying *content*.
+
+    Args:
+        content: Response text.
+        cost: Estimated cost for the call.
+
+    Returns:
+        The constructed response.
+    """
+    return AIResponse(
+        content=content,
+        model="claude-sonnet-4-20250514",
+        input_tokens=100,
+        output_tokens=50,
+        cost_estimate=cost,
+        provider="anthropic",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_captures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep raw-response captures out of the working tree.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
+def test_json_happy_path_makes_no_retry() -> None:
+    """A schema-conforming answer is parsed with exactly one provider call."""
+    result, calls = _run(responses=[_response(_valid_payload())])
+
+    assert_that(calls).is_length(1)
+    assert_that(result.findings).is_length(1)
+    assert_that(result.findings[0].title).is_equal_to("Observer re-arms after close")
+
+
+def test_prose_triggers_one_schema_reminder_retry() -> None:
+    """A prose answer is retried once, and the retry's JSON is used."""
+    result, calls = _run(
+        responses=[_response(_PROSE), _response(_valid_payload())],
+    )
+
+    assert_that(calls).is_length(2)
+    assert_that(str(calls[1]["user_prompt"])).contains("Do not repeat the review")
+    assert_that(result.findings).is_length(1)
+    assert_that(result.findings[0].category).is_not_equal_to(UNSTRUCTURED_CATEGORY)
+
+
+def test_retry_receives_the_remaining_timeout_budget() -> None:
+    """The reminder call is bounded so it cannot double the timeout budget."""
+    _, calls = _run(
+        responses=[_response(_PROSE), _response(_valid_payload())],
+        api_timeout=900.0,
+    )
+
+    assert_that(calls[1]["timeout"]).is_instance_of(float)
+    assert_that(calls[1]["timeout"]).is_less_than_or_equal_to(450.0)
+    assert_that(calls[1]["timeout"]).is_greater_than_or_equal_to(
+        SCHEMA_RETRY_MIN_TIMEOUT,
+    )
+
+
+def test_prose_twice_falls_back_to_unstructured_findings() -> None:
+    """Exactly one retry, then the prose is surfaced instead of discarded."""
+    result, calls = _run(
+        responses=[_response(_PROSE), _response("Still prose, sorry.")],
+    )
+
+    assert_that(calls).is_length(2)
+    assert_that(result.findings).is_length(1)
+    assert_that(result.findings[0].category).is_equal_to(UNSTRUCTURED_CATEGORY)
+    assert_that(result.findings[0].description).is_equal_to("Still prose, sorry.")
+
+
+def test_unstructured_fallback_preserves_the_full_answer() -> None:
+    """No part of the model's answer is truncated on the fallback path."""
+    result, _ = _run(responses=[_response(_PROSE), _response(_PROSE)])
+
+    assert_that(result.findings[0].description).is_equal_to(_PROSE.strip())
+    assert_that(result.summary).contains(_PROSE.strip())
+
+
+def test_short_timeout_budget_skips_the_retry() -> None:
+    """When no retry fits the budget, the prose is recovered immediately."""
+    result, calls = _run(
+        responses=[_response(_PROSE)],
+        api_timeout=SCHEMA_RETRY_MIN_TIMEOUT,
+    )
+
+    assert_that(calls).is_length(1)
+    assert_that(result.findings).is_length(1)
+    assert_that(result.findings[0].category).is_equal_to(UNSTRUCTURED_CATEGORY)
+    assert_that(result.findings[0].description).is_equal_to(_PROSE.strip())
+
+
+def test_failed_retry_still_recovers_the_original_answer() -> None:
+    """A retry that errors is never worse than not retrying at all."""
+    queue: list[object] = [
+        _response(_PROSE),
+        AIProviderError("provider exploded"),
+    ]
+    calls: list[dict[str, object]] = []
+
+    async def _call_ai(**kwargs: object) -> AIResponse:
+        calls.append(kwargs)
+        item = queue.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    with patch("lintro.ai.review.orchestrator.call_ai", side_effect=_call_ai):
+        result = run_review(
+            _context(),
+            provider=_provider(),
+            ai_config=AIConfig(
+                enabled=True,
+                transport=AITransport.API,
+                api_timeout=900.0,
+            ),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+        )
+
+    assert_that(calls).is_length(2)
+    assert_that(result.findings[0].category).is_equal_to(UNSTRUCTURED_CATEGORY)
+    assert_that(result.findings[0].description).is_equal_to(_PROSE.strip())
+
+
+def test_retry_usage_is_charged_to_the_chunk() -> None:
+    """Both calls' tokens and cost are attributed, not just the last one."""
+    result, _ = _run(
+        responses=[
+            _response(_PROSE, cost=0.01),
+            _response(_valid_payload(), cost=0.02),
+        ],
+    )
+
+    assert_that(result.metadata.token_usage["prompt"]).is_equal_to(200)
+    assert_that(result.metadata.token_usage["completion"]).is_equal_to(100)
+    assert_that(result.metadata.cost_estimate_usd).is_close_to(0.03, 1e-9)

--- a/tests/unit/ai/review/test_prose_recovery.py
+++ b/tests/unit/ai/review/test_prose_recovery.py
@@ -20,6 +20,7 @@ from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import AICostBudgetExceededError, AIProviderError
 from lintro.ai.providers.capabilities import ProviderCapabilities
 from lintro.ai.providers.response import AIResponse
+from lintro.ai.raw_response import RAW_RESPONSE_DIR
 from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.review_context import ReviewContext
 from lintro.ai.review.models.review_result import ReviewResult
@@ -214,6 +215,30 @@ def test_prose_twice_falls_back_to_unstructured_findings() -> None:
     assert_that(result.findings).is_length(1)
     assert_that(result.findings[0].category).is_equal_to(UNSTRUCTURED_CATEGORY)
     assert_that(result.findings[0].description).is_equal_to("Still prose, sorry.")
+
+
+def test_first_failed_answer_is_persisted_even_when_the_retry_succeeds() -> None:
+    """The original unparseable answer survives a successful retry on disk."""
+    _run(responses=[_response(_PROSE), _response(_valid_payload())])
+
+    captures = list((Path.cwd() / RAW_RESPONSE_DIR).glob("parse-failure-*"))
+    assert_that(captures).is_length(1)
+    assert_that(captures[0].read_text(encoding="utf-8")).is_equal_to(_PROSE)
+
+
+def test_both_failed_answers_are_persisted_on_fallback() -> None:
+    """When the retry also fails, the original and retry answers both survive."""
+    _run(responses=[_response(_PROSE), _response("Still prose, sorry.")])
+
+    capture_dir = Path.cwd() / RAW_RESPONSE_DIR
+    originals = list(capture_dir.glob("parse-failure-*"))
+    fallbacks = list(capture_dir.glob("unstructured-*"))
+    assert_that(originals).is_length(1)
+    assert_that(originals[0].read_text(encoding="utf-8")).is_equal_to(_PROSE)
+    assert_that(fallbacks).is_length(1)
+    assert_that(fallbacks[0].read_text(encoding="utf-8")).is_equal_to(
+        "Still prose, sorry.",
+    )
 
 
 def test_unstructured_fallback_preserves_the_full_answer() -> None:

--- a/tests/unit/ai/review/test_response_recovery.py
+++ b/tests/unit/ai/review/test_response_recovery.py
@@ -1,0 +1,125 @@
+"""Tests for prose-response recovery helpers (#1853)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.prompts.review import (
+    REVIEW_OUTPUT_SCHEMA,
+    REVIEW_SCHEMA_REMINDER_TEMPLATE,
+)
+from lintro.ai.review.models.review_finding import Severity
+from lintro.ai.review.response_recovery import (
+    MAX_ECHOED_RESPONSE_CHARS,
+    SCHEMA_RETRY_MIN_TIMEOUT,
+    UNSTRUCTURED_CATEGORY,
+    build_schema_reminder_prompt,
+    resolve_schema_retry_timeout,
+    unstructured_review_payload,
+)
+
+_PROSE = "Two actionable findings:\n\n1. The observer re-arms after close.\n2. ..."
+
+
+def test_retry_gets_the_remaining_budget_capped_at_half() -> None:
+    """A fast first call still cannot buy a second full-length call."""
+    assert_that(
+        resolve_schema_retry_timeout(api_timeout=900.0, elapsed=10.0),
+    ).is_equal_to(450.0)
+
+
+def test_retry_shrinks_as_the_first_call_consumes_the_budget() -> None:
+    """What remains of the per-call budget bounds the retry."""
+    assert_that(
+        resolve_schema_retry_timeout(api_timeout=900.0, elapsed=600.0),
+    ).is_equal_to(300.0)
+
+
+def test_retry_is_skipped_when_the_budget_is_spent() -> None:
+    """A first call that ate the budget goes straight to the prose fallback."""
+    assert_that(
+        resolve_schema_retry_timeout(api_timeout=900.0, elapsed=890.0),
+    ).is_none()
+
+
+def test_retry_is_skipped_below_the_minimum_useful_timeout() -> None:
+    """Half of a short budget is not enough time to be worth spending."""
+    assert_that(
+        resolve_schema_retry_timeout(
+            api_timeout=SCHEMA_RETRY_MIN_TIMEOUT * 2 - 1,
+            elapsed=0.0,
+        ),
+    ).is_none()
+
+
+@pytest.mark.parametrize("api_timeout", [0.0, -5.0])
+def test_retry_is_skipped_for_a_nonpositive_budget(api_timeout: float) -> None:
+    """A missing or nonsensical timeout never authorises an extra call."""
+    assert_that(
+        resolve_schema_retry_timeout(api_timeout=api_timeout, elapsed=0.0),
+    ).is_none()
+
+
+def test_reminder_prompt_carries_schema_and_previous_answer() -> None:
+    """The reminder asks for a conversion, not a fresh review."""
+    prompt = build_schema_reminder_prompt(
+        template=REVIEW_SCHEMA_REMINDER_TEMPLATE,
+        output_schema=REVIEW_OUTPUT_SCHEMA,
+        previous_response=_PROSE,
+    )
+
+    assert_that(prompt).contains(_PROSE)
+    assert_that(prompt).contains("Do not repeat the review")
+
+
+def test_reminder_prompt_caps_the_echoed_answer() -> None:
+    """A huge prose answer cannot blow up the reminder prompt."""
+    huge = "y" * (MAX_ECHOED_RESPONSE_CHARS + 5000)
+
+    prompt = build_schema_reminder_prompt(
+        template=REVIEW_SCHEMA_REMINDER_TEMPLATE,
+        output_schema=REVIEW_OUTPUT_SCHEMA,
+        previous_response=huge,
+    )
+
+    assert_that(len(prompt)).is_less_than(len(huge))
+    assert_that(prompt).contains("truncated in this reminder only")
+
+
+def test_unstructured_payload_preserves_the_full_prose(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The prose survives verbatim as both summary and finding description."""
+    monkeypatch.chdir(tmp_path)
+    long_prose = _PROSE + ("z" * 4000)
+
+    payload = unstructured_review_payload(
+        content=long_prose,
+        files=("src/main.py",),
+    )
+
+    assert_that(payload["summary"]).contains(long_prose)
+    assert_that(payload["findings"]).is_length(1)
+    finding = payload["findings"][0]
+    assert_that(finding["description"]).is_equal_to(long_prose)
+    assert_that(finding["category"]).is_equal_to(UNSTRUCTURED_CATEGORY)
+    assert_that(finding["severity"]).is_equal_to(Severity.P3.value)
+    assert_that(finding["file"]).is_equal_to("src/main.py")
+
+
+def test_unstructured_payload_matches_the_review_payload_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fallback payload carries the keys the review parser requires."""
+    monkeypatch.chdir(tmp_path)
+
+    payload = unstructured_review_payload(content=_PROSE)
+
+    assert_that(payload).contains_key("summary", "checklist", "findings")
+    assert_that(payload["checklist"]).is_empty()
+    assert_that(payload["findings"][0]["file"]).is_equal_to("")

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -316,13 +316,26 @@ async def test_complete_raises_on_nonzero_exit(provider):
             await provider.complete("Hello")
 
 
-async def test_complete_raises_on_invalid_json_stdout(provider):
-    """Raise AIProviderError when stdout is not valid JSON."""
+async def test_complete_recovers_prose_stdout(provider):
+    """Recover a non-JSON envelope as unstructured prose instead of failing."""
     with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout="not json at all",
+            stderr="",
+        )
+        response = await provider.complete("Hello")
+    assert_that(response.content).is_equal_to("not json at all")
+
+
+async def test_complete_raises_on_blank_stdout(provider):
+    """Raise AIProviderError when stdout carries no recoverable text."""
+    with patch_cli_exec() as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="   \n  ",
             stderr="",
         )
         with pytest.raises(AIProviderError, match="invalid JSON"):

--- a/tests/unit/ai/test_raw_response.py
+++ b/tests/unit/ai/test_raw_response.py
@@ -1,0 +1,90 @@
+"""Tests for durable capture of raw AI responses (#1853)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.raw_response import (
+    RAW_RESPONSE_DIR,
+    describe_raw_response,
+    persist_raw_response,
+)
+
+_LONG_PROSE = "Finding one. " + ("x" * 5000) + " Finding two."
+
+
+def test_persist_writes_the_complete_response(tmp_path: Path) -> None:
+    """The persisted file carries every character of the raw response."""
+    path = persist_raw_response(
+        provider="claude",
+        stage="cli-envelope",
+        raw=_LONG_PROSE,
+        workspace_root=tmp_path,
+    )
+
+    assert_that(path).is_not_none()
+    assert_that(path.read_text(encoding="utf-8")).is_equal_to(_LONG_PROSE)
+    assert_that(str(path)).contains(RAW_RESPONSE_DIR.replace("/", "/"))
+
+
+def test_persist_falls_back_to_tempdir_when_workspace_is_unwritable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A read-only workspace never costs the evidence."""
+    blocked = tmp_path / "blocked"
+    blocked.write_text("not a directory", encoding="utf-8")
+
+    path = persist_raw_response(
+        provider="claude",
+        stage="cli-envelope",
+        raw="prose",
+        workspace_root=blocked,
+    )
+
+    assert_that(path).is_not_none()
+    assert_that(path.read_text(encoding="utf-8")).is_equal_to("prose")
+
+
+def test_describe_embeds_the_untruncated_output(tmp_path: Path) -> None:
+    """The evidence block never truncates, unlike the old ``stdout[:500]``."""
+    block = describe_raw_response(
+        provider="claude",
+        stage="cli-envelope",
+        raw=_LONG_PROSE,
+        workspace_root=tmp_path,
+    )
+
+    assert_that(block).contains(_LONG_PROSE)
+    assert_that(block).contains("Finding two.")
+    assert_that(block).contains(str(len(_LONG_PROSE)))
+
+
+def test_describe_reports_the_saved_path(tmp_path: Path) -> None:
+    """The evidence block names the file the response was saved to."""
+    block = describe_raw_response(
+        provider="claude",
+        stage="cli-envelope",
+        raw="prose answer",
+        workspace_root=tmp_path,
+    )
+
+    captured = list((tmp_path / RAW_RESPONSE_DIR).iterdir())
+    assert_that(captured).is_length(1)
+    assert_that(block).contains(str(captured[0]))
+
+
+def test_persisted_names_are_filesystem_safe(tmp_path: Path) -> None:
+    """Provider and stage labels are slugged, never written raw."""
+    path = persist_raw_response(
+        provider="Cursor agent",
+        stage="CLI/envelope",
+        raw="prose",
+        workspace_root=tmp_path,
+    )
+
+    assert_that(path.name).starts_with("cli-envelope-cursor-agent-")
+    assert_that(path.name).ends_with(".txt")

--- a/tests/unit/ai/test_raw_response.py
+++ b/tests/unit/ai/test_raw_response.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 from assertpy import assert_that
@@ -16,16 +17,43 @@ from lintro.ai.raw_response import (
 _LONG_PROSE = "Finding one. " + ("x" * 5000) + " Finding two."
 
 
+def _persist(
+    *,
+    provider: str = "claude",
+    stage: str = "cli-envelope",
+    raw: str,
+    workspace_root: Path,
+) -> Path:
+    """Persist a raw response and assert a path came back.
+
+    Args:
+        provider: Provider label for the capture name.
+        stage: Stage label for the capture name.
+        raw: The raw response text.
+        workspace_root: Workspace root for the capture directory.
+
+    Returns:
+        The path the capture was written to.
+    """
+    path = persist_raw_response(
+        provider=provider,
+        stage=stage,
+        raw=raw,
+        workspace_root=workspace_root,
+    )
+    assert_that(path).is_not_none()
+    return cast(Path, path)
+
+
 def test_persist_writes_the_complete_response(tmp_path: Path) -> None:
     """The persisted file carries every character of the raw response."""
-    path = persist_raw_response(
+    path = _persist(
         provider="claude",
         stage="cli-envelope",
         raw=_LONG_PROSE,
         workspace_root=tmp_path,
     )
 
-    assert_that(path).is_not_none()
     assert_that(path.read_text(encoding="utf-8")).is_equal_to(_LONG_PROSE)
     assert_that(str(path)).contains(RAW_RESPONSE_DIR.replace("/", "/"))
 
@@ -37,16 +65,21 @@ def test_persist_falls_back_to_tempdir_when_workspace_is_unwritable(
     """A read-only workspace never costs the evidence."""
     blocked = tmp_path / "blocked"
     blocked.write_text("not a directory", encoding="utf-8")
+    fallback = tmp_path / "system-temp"
+    monkeypatch.setattr(
+        "lintro.ai.raw_response.tempfile.gettempdir",
+        lambda: str(fallback),
+    )
 
-    path = persist_raw_response(
+    path = _persist(
         provider="claude",
         stage="cli-envelope",
         raw="prose",
         workspace_root=blocked,
     )
 
-    assert_that(path).is_not_none()
     assert_that(path.read_text(encoding="utf-8")).is_equal_to("prose")
+    assert_that(path.is_relative_to(fallback)).is_true()
 
 
 def test_describe_embeds_the_untruncated_output(tmp_path: Path) -> None:
@@ -77,9 +110,63 @@ def test_describe_reports_the_saved_path(tmp_path: Path) -> None:
     assert_that(block).contains(str(captured[0]))
 
 
+def test_evidence_block_neutralises_terminal_escapes(tmp_path: Path) -> None:
+    """Untrusted output cannot drive the terminal it is printed to."""
+    hostile = "Finding 1\x1b[2J\x1b]0;pwned\x07 and \x1b[31mred\x1b[0m text"
+
+    block = describe_raw_response(
+        provider="claude",
+        stage="cli-envelope",
+        raw=hostile,
+        workspace_root=tmp_path,
+    )
+
+    assert_that(block).does_not_contain("\x1b")
+    assert_that(block).does_not_contain("\x07")
+    assert_that(block).contains("Finding 1")
+    assert_that(block).contains("red")
+
+
+def test_capture_file_keeps_the_original_bytes(tmp_path: Path) -> None:
+    """Sanitization is display-only; the capture stays byte-exact."""
+    hostile = "Finding 1\x1b[2J done"
+
+    describe_raw_response(
+        provider="claude",
+        stage="cli-envelope",
+        raw=hostile,
+        workspace_root=tmp_path,
+    )
+
+    captured = list((tmp_path / RAW_RESPONSE_DIR).iterdir())
+    assert_that(captured[0].read_text(encoding="utf-8")).is_equal_to(hostile)
+
+
+def test_captures_are_owner_readable_only(tmp_path: Path) -> None:
+    """Captures can embed diff context, so they are not world-readable."""
+    path = _persist(
+        provider="claude",
+        stage="cli-envelope",
+        raw="prose",
+        workspace_root=tmp_path,
+    )
+
+    assert_that(path.stat().st_mode & 0o077).is_equal_to(0)
+    assert_that(path.parent.stat().st_mode & 0o077).is_equal_to(0)
+
+
+def test_repeated_identical_captures_do_not_fail(tmp_path: Path) -> None:
+    """Two identical responses in the same second still both resolve a path."""
+    first = _persist(raw="same prose", workspace_root=tmp_path)
+    second = _persist(raw="same prose", workspace_root=tmp_path)
+
+    assert_that(first.name).is_equal_to(second.name)
+    assert_that(second.read_text(encoding="utf-8")).is_equal_to("same prose")
+
+
 def test_persisted_names_are_filesystem_safe(tmp_path: Path) -> None:
     """Provider and stage labels are slugged, never written raw."""
-    path = persist_raw_response(
+    path = _persist(
         provider="Cursor agent",
         stage="CLI/envelope",
         raw="prose",

--- a/tests/unit/ai/test_raw_response.py
+++ b/tests/unit/ai/test_raw_response.py
@@ -186,6 +186,16 @@ def test_symlinked_capture_directory_is_refused(
     assert_that(list(elsewhere.iterdir())).is_empty()
 
 
+def test_created_cache_ancestors_are_owner_only(tmp_path: Path) -> None:
+    """Freshly created ``.lintro-cache`` ancestors never get umask modes."""
+    path = _persist(raw="prose", workspace_root=tmp_path)
+
+    ancestor = path.parent
+    while ancestor != tmp_path:
+        assert_that(ancestor.stat().st_mode & 0o077).is_equal_to(0)
+        ancestor = ancestor.parent
+
+
 def test_loose_directory_permissions_are_tightened(tmp_path: Path) -> None:
     """A pre-existing capture directory with loose modes is made owner-only."""
     directory = tmp_path / RAW_RESPONSE_DIR

--- a/tests/unit/ai/test_raw_response.py
+++ b/tests/unit/ai/test_raw_response.py
@@ -164,6 +164,39 @@ def test_repeated_identical_captures_do_not_fail(tmp_path: Path) -> None:
     assert_that(second.read_text(encoding="utf-8")).is_equal_to("same prose")
 
 
+def test_symlinked_capture_directory_is_refused(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A symlink planted at the capture path never receives captures."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir(mode=0o700)
+    workspace = tmp_path / "workspace"
+    (workspace / ".lintro-cache" / "ai").mkdir(parents=True)
+    (workspace / RAW_RESPONSE_DIR).symlink_to(elsewhere)
+    fallback = tmp_path / "system-temp"
+    monkeypatch.setattr(
+        "lintro.ai.raw_response.tempfile.gettempdir",
+        lambda: str(fallback),
+    )
+
+    path = _persist(raw="prose", workspace_root=workspace)
+
+    assert_that(path.is_relative_to(fallback)).is_true()
+    assert_that(list(elsewhere.iterdir())).is_empty()
+
+
+def test_loose_directory_permissions_are_tightened(tmp_path: Path) -> None:
+    """A pre-existing capture directory with loose modes is made owner-only."""
+    directory = tmp_path / RAW_RESPONSE_DIR
+    directory.mkdir(parents=True)
+    directory.chmod(0o755)
+
+    path = _persist(raw="prose", workspace_root=tmp_path)
+
+    assert_that(path.parent.stat().st_mode & 0o077).is_equal_to(0)
+
+
 def test_persisted_names_are_filesystem_safe(tmp_path: Path) -> None:
     """Provider and stage labels are slugged, never written raw."""
     path = _persist(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ai): recover prose review responses instead of discarding findings (#1853)
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`lintro review` treated a prose (non-JSON) model answer as a transport failure: the chunk
aborted with `kind=invalid_response` and the evidence was cut to `stdout[:500]`, so findings
the model had already produced were discarded. Issue #1853 recorded this on 6 of 6 review
invocations across a seven-PR run, losing at least four confirmed findings.

The recovery ladder is now: parse JSON → extract embedded JSON (existing) → **one**
schema-reminder retry → present the prose as unstructured findings with the full text
preserved.

### 1. Full raw output is persisted, never truncated

New `lintro/ai/raw_response.py` writes every unparseable response in full to
`.lintro-cache/ai/raw-responses/<stage>-<provider>-<ts>-<hash>.txt` (falling back to the
system temp dir when the workspace is not writable) and returns an evidence block that
embeds the complete text plus the saved path. All three `stdout[:500]` sites
(`anthropic.py`, `cursor.py`, `openai.py`) now use it.

### 2. Prose fallback at both layers

- **CLI envelope layer** — when a CLI exits zero but its `--output-format json` envelope is
  not JSON, the prose is recovered as unstructured content instead of raising. An empty /
  whitespace-only stdout is still a genuine error. Applied to `claude`, `cursor agent`, and
  `codex`. The recovered text is returned verbatim (no `substitute_parsed_json`), so an
  incidental `{...}` inside prose cannot replace the whole answer.
- **Review layer** — a chunk response that still will not parse becomes a review payload
  whose summary and single low-confidence **P3** finding carry the complete answer. The
  chunk completes instead of aborting. `line = 0` keeps it out of GitHub inline comments
  (it renders in the sticky body) and P3 keeps it clear of the P1 exit gate.

### 3. Exactly one schema-reminder retry, inside the timeout budget

Before falling back, one retry asks the model to re-emit its answer in the required schema
(new `schema_reminder.md` prompt template; the echoed answer is capped at 20k chars —
prompt-size only, the full text is still preserved).

The retry is charged against the **same** per-call budget as the call that failed:
`resolve_schema_retry_timeout(api_timeout, elapsed)` returns
`min(api_timeout - elapsed, api_timeout * 0.5)`, and `None` when that is under 30s — so a
slow first call skips the retry entirely and a fast one still cannot buy a second
full-length call. `call_ai` gained an optional `timeout` override to carry it. A retry that
errors is never worse than not retrying: the original answer is still recovered. Both calls'
tokens and cost are attributed to the chunk.

Out of scope: constraining the agentic path itself (#1838 / #1859, already shipped).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1853

## Details

_See What’s Changing._
