### PR TITLE
feat(core): remove deprecated ai_metadata alias and JSON dual-emit

### DIFF
--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -577,11 +577,10 @@ AI output adapts to the environment:
 
 When using `--output-format json`, AI data is included in the output.
 
-> **Deprecation:** the per-tool key is now `metadata`. The old `ai_metadata` key is
-> still emitted with identical content for one release cycle and will be removed in a
-> future release — migrate consumers to `metadata`. The key was renamed because it is
-> not AI-specific: osv-scanner writes its suppression classifications there with AI
-> fully disabled.
+> **Note:** the per-tool key is `metadata`. It is deliberately not named `ai_metadata`
+> because it is not AI-specific: osv-scanner writes its suppression classifications
+> there with AI fully disabled. The old `ai_metadata` key was removed after its
+> deprecation cycle — consumers must read `metadata`.
 
 ```json
 {
@@ -597,8 +596,7 @@ When using `--output-format json`, AI data is included in the output.
           "estimated_effort": "20-30 minutes"
         },
         "fix_suggestions": [...]
-      },
-      "ai_metadata": { "...": "deprecated duplicate of metadata" }
+      }
     }
   ],
   "summary": {...},

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1154,8 +1154,7 @@ When `check_suppressions` is enabled, lintro runs a second osv-scanner scan with
 suppressions to classify each `.osv-scanner.toml` entry as **Active** (vulnerability
 still present), **Stale** (vulnerability resolved upstream — safe to remove), or
 **Expired** (past the `ignoreUntil` date). Results appear in the summary table Notes
-column and in JSON output under `metadata.suppressions` (also emitted under the
-deprecated `ai_metadata.suppressions` key for one release cycle).
+column and in JSON output under `metadata.suppressions`.
 
 **Usage Examples:**
 

--- a/lintro/ai/metadata/__init__.py
+++ b/lintro/ai/metadata/__init__.py
@@ -8,7 +8,6 @@ from lintro.ai.metadata.helpers import (
     attach_telemetry_metadata,
     attach_validation_counts_metadata,
     ensure_ai_metadata,
-    normalize_ai_metadata,
     suggestion_to_payload,
     summary_to_payload,
 )
@@ -23,7 +22,6 @@ __all__ = [
     "attach_telemetry_metadata",
     "attach_validation_counts_metadata",
     "ensure_ai_metadata",
-    "normalize_ai_metadata",
     "suggestion_to_payload",
     "summary_to_payload",
 ]

--- a/lintro/ai/metadata/helpers.py
+++ b/lintro/ai/metadata/helpers.py
@@ -1,6 +1,6 @@
 """Helper functions for attaching AI metadata to tool results.
 
-``normalize_ai_metadata`` is re-exported here as a deprecated alias for
+Metadata normalization lives in
 :func:`lintro.utils.tool_metadata.normalize_tool_metadata`, which moved to
 core in issue #724: it is a pure dict whitelist with no AI dependency, and
 leaving it here forced the JSON output path to import :mod:`lintro.ai`.
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any
 
 from lintro.ai.metadata.fix_suggestion_payload import AIFixSuggestionPayload
 from lintro.ai.metadata.summary_payload import AISummaryPayload
-from lintro.utils.tool_metadata import normalize_tool_metadata
 
 if TYPE_CHECKING:
     from lintro.ai.models import AIFixSuggestion, AISummary
@@ -122,8 +121,3 @@ def attach_telemetry_metadata(
         return
     metadata = ensure_ai_metadata(results[0])
     metadata["ai_metrics"] = telemetry.to_dict()
-
-
-#: Deprecated alias retained for backwards compatibility; the implementation
-#: moved to :mod:`lintro.utils.tool_metadata` (issue #724).
-normalize_ai_metadata = normalize_tool_metadata

--- a/lintro/models/core/tool_result.py
+++ b/lintro/models/core/tool_result.py
@@ -7,34 +7,12 @@ fixed vs remaining counts for fix-capable tools.
 
 from __future__ import annotations
 
-import functools
-import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from lintro.parsers.base_issue import BaseIssue
-
-_AI_METADATA_DEPRECATION = (
-    "ToolResult.ai_metadata is deprecated and will be removed in a future "
-    "release; use ToolResult.metadata instead. The field is not AI-specific "
-    "(osv-scanner stores suppression data in it)."
-)
-
-
-def _warn_ai_metadata(*, stacklevel: int) -> None:
-    """Emit the ``ai_metadata`` deprecation warning.
-
-    Args:
-        stacklevel: Stack level to attribute the warning to, so the warning
-            points at the caller rather than at this module.
-    """
-    warnings.warn(
-        _AI_METADATA_DEPRECATION,
-        DeprecationWarning,
-        stacklevel=stacklevel,
-    )
 
 
 @dataclass
@@ -110,31 +88,6 @@ class ToolResult:
     # Omitted from JSON output unless the tool sets this explicitly.
     parse_failures_count: int | None = field(default=None)
 
-    @property
-    def ai_metadata(self) -> dict[str, Any] | None:
-        """Deprecated alias for :attr:`metadata`.
-
-        Defined without a type annotation so :func:`dataclasses.dataclass`
-        does not treat it as a second field: ``dataclasses.fields`` still
-        reports only ``metadata``, and both names are views onto the same
-        dict.
-
-        Returns:
-            The value of :attr:`metadata`.
-        """
-        _warn_ai_metadata(stacklevel=3)
-        return self.metadata
-
-    @ai_metadata.setter
-    def ai_metadata(self, value: dict[str, Any] | None) -> None:
-        """Deprecated alias setter that writes through to :attr:`metadata`.
-
-        Args:
-            value: Metadata dict to store on :attr:`metadata`.
-        """
-        _warn_ai_metadata(stacklevel=3)
-        self.metadata = value
-
     def __post_init__(self) -> None:
         """Validate that the issue counts and skip state are consistent.
 
@@ -168,40 +121,3 @@ class ToolResult:
                 f"remaining={self.remaining_issues_count}. "
                 f"Expected: initial = fixed + remaining",
             )
-
-
-_dataclass_init = ToolResult.__init__
-
-
-@functools.wraps(_dataclass_init)
-def _tool_result_init(self: ToolResult, *args: Any, **kwargs: Any) -> None:
-    """Accept the deprecated ``ai_metadata`` keyword during construction.
-
-    ``ai_metadata`` is an alias property rather than a dataclass field, so the
-    generated ``__init__`` does not know about it. This wrapper folds the
-    deprecated keyword into ``metadata`` before delegating, which keeps
-    ``ToolResult(ai_metadata=...)``, ``dataclasses.replace`` and
-    ``__post_init__`` all working while ``dataclasses.fields`` still reports a
-    single ``metadata`` field.
-
-    Args:
-        self: The instance being initialized.
-        *args: Positional arguments for the generated ``__init__``.
-        **kwargs: Keyword arguments, optionally including ``ai_metadata``.
-
-    Raises:
-        TypeError: If both ``metadata`` and ``ai_metadata`` are supplied.
-    """
-    if "ai_metadata" in kwargs:
-        if "metadata" in kwargs:
-            raise TypeError(
-                "ToolResult() got both 'metadata' and the deprecated "
-                "'ai_metadata'; pass only 'metadata'",
-            )
-        alias_value = kwargs.pop("ai_metadata")
-        _warn_ai_metadata(stacklevel=2)
-        kwargs["metadata"] = alias_value
-    _dataclass_init(self, *args, **kwargs)
-
-
-ToolResult.__init__ = _tool_result_init  # type: ignore[method-assign]

--- a/lintro/utils/json_output.py
+++ b/lintro/utils/json_output.py
@@ -103,9 +103,8 @@ def serialize_tool_result(
         The per-tool JSON object: always ``tool``, ``success``,
         ``issues_count``, ``skipped``, ``skip_reason``, ``timed_out`` and
         ``output``; plus ``parse_failures_count`` when set,
-        ``fixed``/``remaining`` in FIX mode, normalized ``metadata`` (plus its
-        deprecated ``ai_metadata`` duplicate) when present, and ``issues``
-        when any exist.
+        ``fixed``/``remaining`` in FIX mode, normalized ``metadata`` when
+        present, and ``issues`` when any exist.
     """
     merged_issues = merge_detected_and_remaining(
         getattr(result, "initial_issues", None),
@@ -132,10 +131,6 @@ def serialize_tool_result(
         normalized_metadata = normalize_tool_metadata(metadata)
         if normalized_metadata:
             data["metadata"] = normalized_metadata
-            # Deprecated duplicate of ``metadata``, emitted for one release
-            # cycle so existing consumers keep working. Removed in a future
-            # release; see the deprecation note in docs/ai-features.md.
-            data["ai_metadata"] = normalized_metadata
     if merged_issues:
         data["issues"] = [serialize_issue(issue) for issue in merged_issues]
     return data

--- a/scripts/ci/format-security-comment.py
+++ b/scripts/ci/format-security-comment.py
@@ -126,14 +126,14 @@ def format_comment(json_path: str) -> str | None:
         print("osv-scanner did not produce results.", file=sys.stderr)
         return None
 
-    ai_meta = osv_result.get("ai_metadata")
+    tool_meta = osv_result.get("metadata")
     # None means probe didn't run; [] means probe ran but found no suppressions
     probe_suppressions: list[dict[str, object]] | None = None
-    if isinstance(ai_meta, dict) and isinstance(
-        ai_meta.get("suppressions"),
+    if isinstance(tool_meta, dict) and isinstance(
+        tool_meta.get("suppressions"),
         list,
     ):
-        probe_suppressions = ai_meta["suppressions"]
+        probe_suppressions = tool_meta["suppressions"]
 
     sections: list[str] = []
 
@@ -221,7 +221,7 @@ def format_comment(json_path: str) -> str | None:
     else:
         # No probe data: fall back to static TOML entries.
         # Note: TOML uses camelCase keys (e.g. "ignoreUntil") while
-        # probe-derived ai_metadata uses snake_case ("ignore_until").
+        # probe-derived metadata uses snake_case ("ignore_until").
         toml_suppressions = _read_suppressions_from_toml()
         if toml_suppressions:
             sections.append("| ID | Expires | Reason |")

--- a/tests/unit/ai/test_metadata.py
+++ b/tests/unit/ai/test_metadata.py
@@ -11,10 +11,10 @@ from lintro.ai.metadata import (
     attach_fixed_count_metadata,
     attach_summary_metadata,
     attach_validation_counts_metadata,
-    normalize_ai_metadata,
 )
 from lintro.ai.models import AIFixSuggestion, AISummary
 from lintro.models.core.tool_result import ToolResult
+from lintro.utils.tool_metadata import normalize_tool_metadata
 
 
 def test_metadata_summary_and_fixes_coexist():
@@ -46,7 +46,7 @@ def test_metadata_normalize_supports_legacy_suggestions_key():
         "suggestions": [{"file": "a.py", "line": 1, "code": "E501"}],
     }
 
-    normalized = normalize_ai_metadata(raw)
+    normalized = normalize_tool_metadata(raw)
 
     assert_that(normalized).contains_key("summary")
     assert_that(normalized).contains_key("fix_suggestions")
@@ -73,7 +73,7 @@ def test_metadata_fixed_count_is_attached_and_normalized():
     assert_that(result.metadata["verified_count"]).is_equal_to(2)  # type: ignore[index]  # assertpy is_not_none narrows this
     assert_that(result.metadata["unverified_count"]).is_equal_to(1)  # type: ignore[index]  # assertpy is_not_none narrows this
 
-    normalized = normalize_ai_metadata(result.metadata or {})
+    normalized = normalize_tool_metadata(result.metadata or {})
     assert_that(normalized["fixed_count"]).is_equal_to(3)
     assert_that(normalized["applied_count"]).is_equal_to(3)
     assert_that(normalized["verified_count"]).is_equal_to(2)

--- a/tests/unit/core/test_tool_result_metadata.py
+++ b/tests/unit/core/test_tool_result_metadata.py
@@ -1,9 +1,9 @@
-"""Tests for ``ToolResult.metadata`` and its deprecated ``ai_metadata`` alias.
+"""Tests for ``ToolResult.metadata``.
 
-The alias is a property plus an ``__init__`` wrapper rather than a second
-dataclass field, so these tests pin the three things that mechanism could
-plausibly break: keyword construction, :func:`dataclasses.replace`, and
-``__post_init__`` validation.
+``metadata`` is a plain dataclass field again after the deprecated
+``ai_metadata`` alias was removed (issue #1831), so these tests pin the
+things the removed ``__init__`` wrapper used to touch: keyword construction,
+:func:`dataclasses.replace`, and ``__post_init__`` validation.
 """
 
 from __future__ import annotations
@@ -11,14 +11,13 @@ from __future__ import annotations
 import dataclasses
 import warnings
 
-import pytest
 from assertpy import assert_that
 
 from lintro.models.core.tool_result import ToolResult
 
 
 def test_metadata_field_is_the_only_metadata_dataclass_field() -> None:
-    """The alias must not introduce a second dataclass field."""
+    """``metadata`` is the sole metadata field on the dataclass."""
     field_names = [f.name for f in dataclasses.fields(ToolResult)]
 
     assert_that(field_names).contains("metadata")
@@ -26,7 +25,7 @@ def test_metadata_field_is_the_only_metadata_dataclass_field() -> None:
 
 
 def test_construction_with_metadata_keyword() -> None:
-    """The new keyword populates the field without warning."""
+    """The keyword populates the field without warning."""
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         result = ToolResult(name="ruff", metadata={"fixed_count": 2})
@@ -34,54 +33,19 @@ def test_construction_with_metadata_keyword() -> None:
     assert_that(result.metadata).is_equal_to({"fixed_count": 2})
 
 
-def test_construction_with_deprecated_keyword_warns_and_populates() -> None:
-    """The deprecated keyword still constructs and warns."""
-    with pytest.warns(DeprecationWarning, match="ai_metadata is deprecated"):
-        result = ToolResult(name="ruff", ai_metadata={"fixed_count": 2})  # type: ignore[call-arg]
-
-    assert_that(result.metadata).is_equal_to({"fixed_count": 2})
-
-
-def test_both_keywords_together_is_a_type_error() -> None:
-    """Supplying both names is rejected rather than silently picking one."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        assert_that(ToolResult).raises(TypeError).when_called_with(
-            name="ruff",
-            metadata={"a": 1},
-            ai_metadata={"b": 2},
-        )
+def test_removed_alias_keyword_is_a_type_error() -> None:
+    """The removed ``ai_metadata`` keyword is rejected outright."""
+    assert_that(ToolResult).raises(TypeError).when_called_with(
+        name="ruff",
+        ai_metadata={"fixed_count": 2},
+    )
 
 
-def test_explicit_metadata_none_still_rejects_the_alias() -> None:
-    """An explicit ``metadata=None`` counts as supplied, not as absent.
-
-    Presence of the keyword is what matters; otherwise
-    ``ToolResult(metadata=None, ai_metadata=...)`` would silently accept both
-    names and quietly honour the deprecated one.
-    """
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        assert_that(ToolResult).raises(TypeError).when_called_with(
-            name="ruff",
-            metadata=None,
-            ai_metadata={"b": 2},
-        )
-
-
-def test_alias_read_and_write_share_one_dict() -> None:
-    """Both names are views onto the same underlying dict."""
+def test_removed_alias_attribute_does_not_exist() -> None:
+    """Instances expose ``metadata`` only, with no alias attribute."""
     result = ToolResult(name="ruff", metadata={"fixed_count": 1})
 
-    with pytest.warns(DeprecationWarning):
-        via_alias = result.ai_metadata
-
-    assert_that(via_alias).is_same_as(result.metadata)
-
-    with pytest.warns(DeprecationWarning):
-        result.ai_metadata = {"fixed_count": 9}
-
-    assert_that(result.metadata).is_equal_to({"fixed_count": 9})
+    assert_that(hasattr(result, "ai_metadata")).is_false()
 
 
 def test_dataclasses_replace_preserves_metadata() -> None:
@@ -97,7 +61,7 @@ def test_dataclasses_replace_preserves_metadata() -> None:
 
 
 def test_post_init_still_validates_skip_state() -> None:
-    """``__post_init__`` validation is unaffected by the alias wrapper."""
+    """``__post_init__`` validation survives the alias removal."""
     assert_that(ToolResult).raises(ValueError).when_called_with(
         name="ruff",
         skipped=True,
@@ -112,7 +76,7 @@ def test_post_init_still_validates_skip_state() -> None:
 
 
 def test_post_init_still_validates_issue_counts() -> None:
-    """Inconsistent fix counts still raise, alias present or not."""
+    """Inconsistent fix counts still raise."""
     assert_that(ToolResult).raises(ValueError).when_called_with(
         name="ruff",
         initial_issues_count=5,

--- a/tests/unit/utils/test_json_output.py
+++ b/tests/unit/utils/test_json_output.py
@@ -329,11 +329,11 @@ def test_create_json_output_counts_survive_legacy_normalization() -> None:
     assert_that(ai_meta["ai_metrics"]["total_api_calls"]).is_equal_to(2)
 
 
-def test_json_output_dual_emits_metadata_and_deprecated_alias() -> None:
-    """Both ``metadata`` and the deprecated ``ai_metadata`` key are emitted.
+def test_json_output_emits_metadata_only() -> None:
+    """Only ``metadata`` is emitted; the ``ai_metadata`` duplicate is gone.
 
-    The duplicate ships for one release cycle so existing JSON consumers keep
-    working through the rename (issue #724).
+    The deprecated duplicate was removed in issue #1831 after its one-release
+    deprecation cycle.
     """
     result = ToolResult(
         name="ruff",
@@ -353,12 +353,12 @@ def test_json_output_dual_emits_metadata_and_deprecated_alias() -> None:
 
     tool_data = data["results"][0]
     assert_that(tool_data).contains_key("metadata")
-    assert_that(tool_data).contains_key("ai_metadata")
-    assert_that(tool_data["ai_metadata"]).is_equal_to(tool_data["metadata"])
+    assert_that(tool_data["metadata"]["fixed_count"]).is_equal_to(3)
+    assert_that(tool_data).does_not_contain_key("ai_metadata")
 
 
-def test_json_output_omits_both_metadata_keys_when_absent() -> None:
-    """A result without metadata emits neither key."""
+def test_json_output_omits_metadata_key_when_absent() -> None:
+    """A result without metadata emits no metadata key."""
     result = ToolResult(name="ruff", success=True, issues_count=0)
 
     data = create_json_output(

--- a/tests/unit/utils/test_tool_metadata.py
+++ b/tests/unit/utils/test_tool_metadata.py
@@ -9,14 +9,14 @@ from __future__ import annotations
 
 from assertpy import assert_that
 
-from lintro.ai.metadata import normalize_ai_metadata
+import lintro.ai.metadata as ai_metadata_module
 from lintro.models.core.tool_result import ToolResult
 from lintro.utils.tool_metadata import get_ai_count, normalize_tool_metadata
 
 
-def test_deprecated_ai_alias_is_the_core_function() -> None:
-    """``lintro.ai.metadata`` re-exports the relocated core function."""
-    assert_that(normalize_ai_metadata).is_same_as(normalize_tool_metadata)
+def test_ai_package_no_longer_re_exports_the_core_function() -> None:
+    """The ``lintro.ai.metadata`` compatibility shim is gone (issue #1831)."""
+    assert_that(hasattr(ai_metadata_module, "normalize_ai_metadata")).is_false()
 
 
 def test_normalize_drops_unknown_keys() -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(core): remove deprecated ai_metadata alias and JSON dual-emit
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

PR #1830 (issue #724) renamed `ToolResult.ai_metadata` to `metadata` behind a
one-release deprecation. That cycle has elapsed (main is at `0.94.8`), so all
three deprecated surfaces are removed:

1. **`ToolResult`** (`lintro/models/core/tool_result.py`) — dropped the
   `ai_metadata` property alias, its setter, the deprecation-warning helper and
   the `functools.wraps`'d `__init__` wrapper. `metadata` is a plain dataclass
   field again, so `ToolResult(ai_metadata=...)` now raises `TypeError` and
   runtime behaviour finally matches what type checkers already reported.
2. **JSON output** (`lintro/utils/json_output.py`) — emits `metadata` only.
3. **`lintro.ai.metadata`** — dropped the `normalize_ai_metadata` re-export.
   Normalization lives in `lintro.utils.tool_metadata.normalize_tool_metadata`
   only. `ensure_ai_metadata` is untouched — it was never deprecated.

Also updated `scripts/ci/format-security-comment.py`, the one in-repo JSON
consumer, to read `metadata`, plus the deprecation notes and JSON examples in
`docs/ai-features.md` and `docs/configuration.md`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1831

## Details

**Tests.** The tests that asserted the dual-emit contract were deleted rather
than rewritten, per the issue:

- `tests/unit/core/test_tool_result_metadata.py` — the alias-warns,
  both-keywords-`TypeError`, `metadata=None`-still-rejects and
  shared-dict-view tests are gone. Replaced with two that pin the removal:
  `ToolResult(ai_metadata=...)` raises `TypeError`, and instances have no
  `ai_metadata` attribute. The `dataclasses.replace` and `__post_init__`
  coverage is kept — that's what the removed `__init__` wrapper used to touch.
- `tests/unit/utils/test_json_output.py` — the dual-emit test is now
  `test_json_output_emits_metadata_only`, asserting `metadata` is present and
  `ai_metadata` is not. The `ai_summary` promotion test is unchanged and still
  passes.
- `tests/unit/utils/test_tool_metadata.py` — the "alias is the core function"
  test now asserts the shim is *absent* from `lintro.ai.metadata`.
- `tests/unit/ai/test_metadata.py` — imports `normalize_tool_metadata` from
  core instead of the removed re-export.

**Test-suite status.** Full run: 8363 passed, 118 skipped, 16 failed. All 16
failures are pre-existing and environmental — `stylelint`, `pip_audit`,
`commitlint`, `oxfmt` and `oxlint` integration tests that need external tools at
specific versions. Confirmed identical failures on the unmodified base commit
(`6a5e2da9`, `0.94.8`) in the same environment; none of them touch metadata.
