### PR TITLE
chore(ci): dedupe allowed-endpoints across docker image jobs

### DIFF
--- a/.github/allowed-endpoints/docker-build-publish.txt
+++ b/.github/allowed-endpoints/docker-build-publish.txt
@@ -1,0 +1,57 @@
+# Single source of truth for the harden-runner egress allowlist used by the
+# docker-base / docker-full / docker-ai jobs in
+# .github/workflows/docker-build-publish.yml (#1821).
+#
+# The lgtm-ci reusable-docker workflow passes `allowed-endpoints` verbatim to
+# step-security/harden-runner under v0.50.0+ replace semantics, so this list
+# must include the docker preset baseline itself, not just the extras. The
+# sigstore hosts cover cosign keyless signing in the merge job.
+#
+# Format: one `host:port` per line. Blank lines and `#` comments are ignored.
+# Read by scripts/ci/resolve-allowed-endpoints.sh, which flattens it into the
+# single space-separated string harden-runner expects.
+
+# GitHub
+github.com:443
+api.github.com:443
+codeload.github.com:443
+objects.githubusercontent.com:443
+raw.githubusercontent.com:443
+release-assets.githubusercontent.com:443
+github-releases.githubusercontent.com:443
+pipelines.actions.githubusercontent.com:443
+
+# Container registries (docker preset baseline)
+ghcr.io:443
+pkg-containers.githubusercontent.com:443
+docker.io:443
+registry-1.docker.io:443
+auth.docker.io:443
+production.cloudflare.docker.com:443
+production.cloudfront.docker.com:443
+
+# Image build: OS, Python, Rust, JS toolchains
+deb.debian.org:80
+pypi.org:443
+files.pythonhosted.org:443
+static.rust-lang.org:443
+bun.sh:443
+astral.sh:443
+releases.astral.sh:443
+sh.rustup.rs:443
+registry.npmjs.org:443
+crates.io:443
+static.crates.io:443
+index.crates.io:443
+
+# Wrapped tools that self-register during install
+semgrep.dev:443
+metrics.semgrep.dev:443
+
+# Cosign keyless signing (merge job)
+token.actions.githubusercontent.com:443
+fulcio.sigstore.dev:443
+rekor.sigstore.dev:443
+tuf-repo-cdn.sigstore.dev:443
+timestamp.sigstore.dev:443
+oauth2.sigstore.dev:443

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -33,6 +33,37 @@ permissions:
   contents: read
 
 jobs:
+  resolve-endpoints:
+    # Single source of truth for the harden-runner allowlist shared by the
+    # three image jobs (#1821). GitHub Actions rejects YAML anchors and the
+    # `env` context is unavailable in job-level `with:` blocks of
+    # reusable-workflow calls, so the list reaches them as a job output.
+    name: Resolve allowed endpoints
+    runs-on: ubuntu-24.04
+    outputs:
+      endpoints: ${{ steps.resolve.outputs.endpoints }}
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Resolve allowed endpoints
+        id: resolve
+        env:
+          ENDPOINTS_FILE: .github/allowed-endpoints/docker-build-publish.txt
+        run: ./scripts/ci/resolve-allowed-endpoints.sh
+
   validate-backfill-inputs:
     if: github.event_name == 'workflow_dispatch'
     name: Validate backfill inputs
@@ -56,11 +87,12 @@ jobs:
 
   docker-base:
     name: 🐳 Docker Base Image
-    needs: validate-backfill-inputs
+    needs: [validate-backfill-inputs, resolve-endpoints]
     if: >-
       always() && !cancelled() &&
       (needs.validate-backfill-inputs.result == 'success' ||
-      needs.validate-backfill-inputs.result == 'skipped')
+      needs.validate-backfill-inputs.result == 'skipped') &&
+      needs.resolve-endpoints.result == 'success'
     # Base image (tools layer) publishes before full; a full-image failure must
     # not block repairing py-lintro-base tags during backfill dispatch.
     # yamllint disable-line rule:line-length
@@ -115,55 +147,22 @@ jobs:
       tooling-ref: 'd8fff0c6025ddf39c1ae048c04c5a050c7729a6e' # v0.62.0
       egress-policy: block
       egress-preset: docker
-      # Full list (v0.50.0+ replace semantics): the reusable passes
-      # allowed-endpoints verbatim to step-security/harden-runner, so a
-      # non-empty value must include the docker preset baseline. The
-      # sigstore hosts cover cosign keyless signing in the merge job.
+      # Shared allowlist, maintained once in
+      # .github/allowed-endpoints/docker-build-publish.txt: the reusable
+      # passes allowed-endpoints verbatim to step-security/harden-runner
+      # under v0.50.0+ replace semantics, so the file carries the docker
+      # preset baseline as well as the extras this build needs.
       allowed-endpoints-mode: replace
-      allowed-endpoints: >
-        github.com:443
-        api.github.com:443
-        codeload.github.com:443
-        objects.githubusercontent.com:443
-        raw.githubusercontent.com:443
-        release-assets.githubusercontent.com:443
-        github-releases.githubusercontent.com:443
-        pipelines.actions.githubusercontent.com:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        docker.io:443
-        registry-1.docker.io:443
-        auth.docker.io:443
-        production.cloudflare.docker.com:443
-        production.cloudfront.docker.com:443
-        deb.debian.org:80
-        pypi.org:443
-        files.pythonhosted.org:443
-        static.rust-lang.org:443
-        bun.sh:443
-        astral.sh:443
-        releases.astral.sh:443
-        sh.rustup.rs:443
-        registry.npmjs.org:443
-        crates.io:443
-        static.crates.io:443
-        index.crates.io:443
-        semgrep.dev:443
-        metrics.semgrep.dev:443
-        token.actions.githubusercontent.com:443
-        fulcio.sigstore.dev:443
-        rekor.sigstore.dev:443
-        tuf-repo-cdn.sigstore.dev:443
-        timestamp.sigstore.dev:443
-        oauth2.sigstore.dev:443
+      allowed-endpoints: ${{ needs.resolve-endpoints.outputs.endpoints }}
 
   docker-full:
     name: 🐳 Docker Full Image
-    needs: [validate-backfill-inputs, docker-base]
+    needs: [validate-backfill-inputs, resolve-endpoints, docker-base]
     if: >-
       always() && !cancelled() &&
       (needs.validate-backfill-inputs.result == 'success' ||
       needs.validate-backfill-inputs.result == 'skipped') &&
+      needs.resolve-endpoints.result == 'success' &&
       needs.docker-base.result == 'success'
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d8fff0c6025ddf39c1ae048c04c5a050c7729a6e # v0.62.0
@@ -217,51 +216,17 @@ jobs:
       tooling-ref: 'd8fff0c6025ddf39c1ae048c04c5a050c7729a6e' # v0.62.0
       egress-policy: block
       egress-preset: docker
-      # Full list (v0.50.0+ replace semantics): the reusable passes
-      # allowed-endpoints verbatim to step-security/harden-runner, so a
-      # non-empty value must include the docker preset baseline. The
-      # sigstore hosts cover cosign keyless signing in the merge job.
+      # Shared allowlist, maintained once in
+      # .github/allowed-endpoints/docker-build-publish.txt: the reusable
+      # passes allowed-endpoints verbatim to step-security/harden-runner
+      # under v0.50.0+ replace semantics, so the file carries the docker
+      # preset baseline as well as the extras this build needs.
       allowed-endpoints-mode: replace
-      allowed-endpoints: >
-        github.com:443
-        api.github.com:443
-        codeload.github.com:443
-        objects.githubusercontent.com:443
-        raw.githubusercontent.com:443
-        release-assets.githubusercontent.com:443
-        github-releases.githubusercontent.com:443
-        pipelines.actions.githubusercontent.com:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        docker.io:443
-        registry-1.docker.io:443
-        auth.docker.io:443
-        production.cloudflare.docker.com:443
-        production.cloudfront.docker.com:443
-        deb.debian.org:80
-        pypi.org:443
-        files.pythonhosted.org:443
-        static.rust-lang.org:443
-        bun.sh:443
-        astral.sh:443
-        releases.astral.sh:443
-        sh.rustup.rs:443
-        registry.npmjs.org:443
-        crates.io:443
-        static.crates.io:443
-        index.crates.io:443
-        semgrep.dev:443
-        metrics.semgrep.dev:443
-        token.actions.githubusercontent.com:443
-        fulcio.sigstore.dev:443
-        rekor.sigstore.dev:443
-        tuf-repo-cdn.sigstore.dev:443
-        timestamp.sigstore.dev:443
-        oauth2.sigstore.dev:443
+      allowed-endpoints: ${{ needs.resolve-endpoints.outputs.endpoints }}
 
   docker-ai:
     name: 🤖 Docker AI Image
-    needs: [validate-backfill-inputs, docker-full]
+    needs: [validate-backfill-inputs, resolve-endpoints, docker-full]
     # Published as a separate GHCR package (py-lintro-ai) rather than an `ai`
     # tag on py-lintro: the reusable always emits floating `sha-<ref>` and
     # branch tags, which on a shared package would clobber the release image's
@@ -274,6 +239,7 @@ jobs:
       always() && !cancelled() &&
       (needs.validate-backfill-inputs.result == 'success' ||
       needs.validate-backfill-inputs.result == 'skipped') &&
+      needs.resolve-endpoints.result == 'success' &&
       needs.docker-full.result == 'success'
     # yamllint disable-line rule:line-length
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@d8fff0c6025ddf39c1ae048c04c5a050c7729a6e # v0.62.0
@@ -327,46 +293,9 @@ jobs:
       tooling-ref: 'd8fff0c6025ddf39c1ae048c04c5a050c7729a6e' # v0.62.0
       egress-policy: block
       egress-preset: docker
-      # Full list (v0.50.0+ replace semantics): the reusable passes
-      # allowed-endpoints verbatim to step-security/harden-runner, so a
-      # non-empty value must include the docker preset baseline. The
-      # sigstore hosts cover cosign keyless signing in the merge job. The
-      # agent CLIs arrive prebuilt in the digest-pinned lintro-ai-tools
+      # Shared allowlist, maintained once in
+      # .github/allowed-endpoints/docker-build-publish.txt (see docker-base).
+      # The agent CLIs arrive prebuilt in the digest-pinned lintro-ai-tools
       # layer, so this build needs no vendor endpoints of its own.
       allowed-endpoints-mode: replace
-      allowed-endpoints: >
-        github.com:443
-        api.github.com:443
-        codeload.github.com:443
-        objects.githubusercontent.com:443
-        raw.githubusercontent.com:443
-        release-assets.githubusercontent.com:443
-        github-releases.githubusercontent.com:443
-        pipelines.actions.githubusercontent.com:443
-        ghcr.io:443
-        pkg-containers.githubusercontent.com:443
-        docker.io:443
-        registry-1.docker.io:443
-        auth.docker.io:443
-        production.cloudflare.docker.com:443
-        production.cloudfront.docker.com:443
-        deb.debian.org:80
-        pypi.org:443
-        files.pythonhosted.org:443
-        static.rust-lang.org:443
-        bun.sh:443
-        astral.sh:443
-        releases.astral.sh:443
-        sh.rustup.rs:443
-        registry.npmjs.org:443
-        crates.io:443
-        static.crates.io:443
-        index.crates.io:443
-        semgrep.dev:443
-        metrics.semgrep.dev:443
-        token.actions.githubusercontent.com:443
-        fulcio.sigstore.dev:443
-        rekor.sigstore.dev:443
-        tuf-repo-cdn.sigstore.dev:443
-        timestamp.sigstore.dev:443
-        oauth2.sigstore.dev:443
+      allowed-endpoints: ${{ needs.resolve-endpoints.outputs.endpoints }}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -123,6 +123,7 @@ Scripts for GitHub Actions workflows and continuous integration.
 | `run-with-memory-trace.sh`           | Run a command with a live memory trace streamed to the job log (#1761)     | `./scripts/ci/run-with-memory-trace.sh <command> [args...]`                                 |
 | `collect-oom-evidence.sh`            | Best-effort dmesg/journal OOM-killer evidence after a failed build (#1707) | `./scripts/ci/collect-oom-evidence.sh <output-file>`                                        |
 | `validate-docker-backfill-inputs.sh` | Validate workflow-dispatch backfill version/ref inputs                     | `BACKFILL_VERSION=<ver> BACKFILL_REF=<ref> ./scripts/ci/validate-docker-backfill-inputs.sh` |
+| `resolve-allowed-endpoints.sh`       | Flatten the shared harden-runner egress allowlist into a job output        | `./scripts/ci/resolve-allowed-endpoints.sh --help`                                          |
 | `security-comment.sh`                | Run osv-scanner via lintro in Docker and generate security PR comment      | `./scripts/ci/security-comment.sh --help`                                                   |
 | `install-osv-scanner.sh`             | Download and verify osv-scanner with curl exit-23 retries                  | `./scripts/ci/security/install-osv-scanner.sh`                                              |
 | `check-vuln-suppressions.sh`         | Verbose wrapper for lgtm-ci vulnerability suppression check                | `./scripts/ci/security/check-vuln-suppressions.sh`                                          |

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -29,6 +29,7 @@ scripts/ci/
 | `test-ci.yml`                 | lgtm-ci reusable (coverage + PR comments)                                                                                        |
 | `docker-ci.yml`               | Fork detect, image pull/load, lgtm-ci quality, test summary, security audit                                                      |
 | `publish-pypi-on-tag.yml`     | lgtm-ci quality/SBOM; `build-artifacts` + PyPI publish + GitHub release                                                          |
+| `docker-build-publish.yml`    | `validate-docker-backfill-inputs.sh`, `resolve-allowed-endpoints.sh` (shared harden-runner allowlist, #1821)                     |
 | `pr-comment-cleanup.yml`      | `post-pr-delete-previous.sh`                                                                                                     |
 | `lintro-report-scheduled.yml` | `resolve-lintro-image.sh`, `pull-lintro-image.sh`, `lintro-report-generate.sh`                                                   |
 | GHCR cleanup (scheduled)      | lgtm-ci `reusable-ghcr-cleanup.yml` + `maintenance/sweep-ci-ghcr-tags.sh` (`ghcr-cleanup.yml`, #1138)                            |

--- a/scripts/ci/resolve-allowed-endpoints.sh
+++ b/scripts/ci/resolve-allowed-endpoints.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Flatten a harden-runner egress allowlist file into a single workflow output.
+#
+# GitHub Actions rejects YAML anchors, and the `env` context is unavailable in
+# job-level `with:` blocks of reusable-workflow calls, so a shared allowlist
+# has to reach those callers as a job output (#1821).
+#
+# Required environment variables:
+#   ENDPOINTS_FILE - Path to the allowlist file (one host:port per line;
+#                    blank lines and `#` comments are ignored)
+#
+# Optional environment variables:
+#   GITHUB_OUTPUT  - When set, `endpoints=<list>` is appended to it
+
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Flatten a harden-runner egress allowlist file into a single-line list.
+
+Usage:
+  ENDPOINTS_FILE=.github/allowed-endpoints/docker-build-publish.txt \
+    scripts/ci/resolve-allowed-endpoints.sh
+
+Environment:
+  ENDPOINTS_FILE  Allowlist file; one host:port per line, `#` comments ignored.
+  GITHUB_OUTPUT   When set, the flattened list is appended as `endpoints=<list>`.
+
+The flattened list is always written to stdout.
+EOF
+	exit 0
+fi
+
+endpoints_file="${ENDPOINTS_FILE:-}"
+
+if [[ -z "${endpoints_file}" ]]; then
+	echo "ERROR: ENDPOINTS_FILE is required" >&2
+	exit 1
+fi
+
+if [[ ! -f "${endpoints_file}" ]]; then
+	echo "ERROR: allowlist file not found: ${endpoints_file}" >&2
+	exit 1
+fi
+
+# Strip comments and surrounding whitespace, drop blank lines, join with spaces.
+endpoints="$(
+	awk '
+		{ sub(/#.*/, ""); gsub(/^[ \t]+|[ \t]+$/, "") }
+		$0 != "" { printf "%s%s", (seen++ ? " " : ""), $0 }
+		END { print "" }
+	' "${endpoints_file}"
+)"
+
+if [[ -z "${endpoints}" ]]; then
+	echo "ERROR: no endpoints found in ${endpoints_file}" >&2
+	exit 1
+fi
+
+# An empty allowlist under `replace` semantics would block all egress, so the
+# emptiness check above must stay ahead of any output write.
+echo "${endpoints}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	echo "endpoints=${endpoints}" >>"${GITHUB_OUTPUT}"
+fi

--- a/scripts/ci/resolve-allowed-endpoints.sh
+++ b/scripts/ci/resolve-allowed-endpoints.sh
@@ -27,7 +27,9 @@ Environment:
   ENDPOINTS_FILE  Allowlist file; one host:port per line, `#` comments ignored.
   GITHUB_OUTPUT   When set, the flattened list is appended as `endpoints=<list>`.
 
-The flattened list is always written to stdout.
+The flattened list is always written to stdout. Entries are validated as single
+host:port values (wildcard hosts allowed); a malformed or empty allowlist fails
+the script instead of reaching harden-runner.
 EOF
 	exit 0
 fi
@@ -45,11 +47,46 @@ if [[ ! -f "${endpoints_file}" ]]; then
 fi
 
 # Strip comments and surrounding whitespace, drop blank lines, join with spaces.
+# Every remaining line must be exactly one `host:port` value: harden-runner
+# would otherwise accept a typo'd entry silently and block that host at build
+# time, which only surfaces during a release publish.
 endpoints="$(
 	awk '
-		{ sub(/#.*/, ""); gsub(/^[ \t]+|[ \t]+$/, "") }
-		$0 != "" { printf "%s%s", (seen++ ? " " : ""), $0 }
-		END { print "" }
+		{
+			line = $0
+			sub(/#.*/, "", line)
+			gsub(/^[ \t]+|[ \t]+$/, "", line)
+		}
+		line == "" { next }
+		{
+			if (split(line, parts, /[ \t]+/) != 1) {
+				printf "ERROR: %s:%d: expected one host:port value, got %s\n", \
+					FILENAME, FNR, line > "/dev/stderr"
+				invalid = 1
+				next
+			}
+			if (line !~ /^[A-Za-z0-9*][A-Za-z0-9.*_-]*:[0-9]+$/) {
+				printf "ERROR: %s:%d: not a host:port value: %s\n", \
+					FILENAME, FNR, line > "/dev/stderr"
+				invalid = 1
+				next
+			}
+			split(line, host_port, ":")
+			port = host_port[2] + 0
+			if (port < 1 || port > 65535) {
+				printf "ERROR: %s:%d: port out of range: %s\n", \
+					FILENAME, FNR, line > "/dev/stderr"
+				invalid = 1
+				next
+			}
+			resolved = resolved (resolved == "" ? "" : " ") line
+		}
+		END {
+			if (invalid) {
+				exit 1
+			}
+			print resolved
+		}
 	' "${endpoints_file}"
 )"
 

--- a/tests/scripts/test_resolve_allowed_endpoints.py
+++ b/tests/scripts/test_resolve_allowed_endpoints.py
@@ -55,7 +55,12 @@ def test_flattens_the_repository_allowlist_into_one_line() -> None:
     endpoints = result.stdout.strip()
     assert_that(endpoints).does_not_contain("\n")
     assert_that(endpoints).does_not_contain("#")
-    assert_that(endpoints.split()).contains("ghcr.io:443", "fulcio.sigstore.dev:443")
+    expected = [
+        line.split("#", 1)[0].strip()
+        for line in _ALLOWLIST.read_text(encoding="utf-8").splitlines()
+        if line.split("#", 1)[0].strip()
+    ]
+    assert_that(endpoints.split()).is_equal_to(expected)
 
 
 def test_writes_the_endpoints_output_for_the_workflow(tmp_path: Path) -> None:
@@ -108,6 +113,69 @@ def test_fails_instead_of_emitting_an_empty_allowlist(
 
     assert_that(result.returncode).is_not_equal_to(0)
     assert_that(result.stderr).contains("no endpoints found")
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        pytest.param(
+            "github.com:443 ghcr.io:443\n",
+            "expected one host:port value",
+            id="two-values-on-one-line",
+        ),
+        pytest.param("github.com\n", "not a host:port value", id="missing-port"),
+        pytest.param(
+            "https://github.com:443\n",
+            "not a host:port value",
+            id="scheme-prefixed",
+        ),
+        pytest.param("github.com:99999\n", "port out of range", id="port-too-large"),
+        pytest.param("github.com:0\n", "port out of range", id="port-zero"),
+    ],
+)
+def test_rejects_malformed_entries(
+    tmp_path: Path,
+    content: str,
+    message: str,
+) -> None:
+    """A typo'd entry must fail here, not silently block a host at build time.
+
+    harden-runner accepts whatever it is handed, so an unvalidated typo turns
+    into a blocked host that only surfaces during a release publish.
+    """
+    allowlist = tmp_path / "endpoints.txt"
+    allowlist.write_text(content, encoding="utf-8")
+
+    result = _run(endpoints_file=str(allowlist))
+
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stderr).contains(message)
+    assert_that(result.stdout).is_empty()
+
+
+def test_a_malformed_line_discards_the_whole_list(tmp_path: Path) -> None:
+    """One bad line must not yield a partial allowlist for the valid ones."""
+    allowlist = tmp_path / "endpoints.txt"
+    allowlist.write_text("github.com:443\nbroken\nghcr.io:443\n", encoding="utf-8")
+    output_file = tmp_path / "github_output"
+    output_file.touch()
+
+    result = _run(endpoints_file=str(allowlist), github_output=output_file)
+
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stdout).is_empty()
+    assert_that(output_file.read_text(encoding="utf-8")).is_empty()
+
+
+def test_accepts_wildcard_hosts(tmp_path: Path) -> None:
+    """harden-runner supports wildcard hosts, so validation must allow them."""
+    allowlist = tmp_path / "endpoints.txt"
+    allowlist.write_text("*.githubusercontent.com:443\n", encoding="utf-8")
+
+    result = _run(endpoints_file=str(allowlist))
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("*.githubusercontent.com:443")
 
 
 def test_fails_when_the_allowlist_file_is_missing(tmp_path: Path) -> None:

--- a/tests/scripts/test_resolve_allowed_endpoints.py
+++ b/tests/scripts/test_resolve_allowed_endpoints.py
@@ -1,0 +1,142 @@
+"""Tests for ``scripts/ci/resolve-allowed-endpoints.sh``.
+
+The script is the single source of truth feeding the harden-runner allowlist of
+the docker image jobs, and those jobs run only on releases — so every guarantee
+it makes has to be pinned here rather than discovered during a publish (#1821).
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 - subprocess drives the shell script under test
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "ci" / "resolve-allowed-endpoints.sh"
+_ALLOWLIST = _REPO_ROOT / ".github" / "allowed-endpoints" / "docker-build-publish.txt"
+
+
+def _run(
+    *,
+    endpoints_file: str | None,
+    github_output: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the resolver script with a controlled environment.
+
+    Args:
+        endpoints_file: Value for ``ENDPOINTS_FILE``; omitted when None.
+        github_output: Path exported as ``GITHUB_OUTPUT``; omitted when None.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed process.
+    """
+    env = {"PATH": "/usr/bin:/bin:/usr/local/bin"}
+    if endpoints_file is not None:
+        env["ENDPOINTS_FILE"] = endpoints_file
+    if github_output is not None:
+        env["GITHUB_OUTPUT"] = str(github_output)
+    return subprocess.run(  # nosec B603 - fixed argv pointing at a repo script
+        [str(_SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=_REPO_ROOT,
+        env=env,
+    )
+
+
+def test_flattens_the_repository_allowlist_into_one_line() -> None:
+    """The checked-in allowlist resolves to a single whitespace-joined list."""
+    result = _run(endpoints_file=str(_ALLOWLIST))
+
+    assert_that(result.returncode).is_equal_to(0)
+    endpoints = result.stdout.strip()
+    assert_that(endpoints).does_not_contain("\n")
+    assert_that(endpoints).does_not_contain("#")
+    assert_that(endpoints.split()).contains("ghcr.io:443", "fulcio.sigstore.dev:443")
+
+
+def test_writes_the_endpoints_output_for_the_workflow(tmp_path: Path) -> None:
+    """The flattened list is exported as the ``endpoints`` step output."""
+    output_file = tmp_path / "github_output"
+    output_file.touch()
+
+    result = _run(endpoints_file=str(_ALLOWLIST), github_output=output_file)
+
+    assert_that(result.returncode).is_equal_to(0)
+    written = output_file.read_text(encoding="utf-8").strip()
+    assert_that(written).starts_with("endpoints=")
+    assert_that(written.removeprefix("endpoints=")).is_equal_to(result.stdout.strip())
+
+
+def test_strips_comments_and_blank_lines(tmp_path: Path) -> None:
+    """Comments, inline comments and blank lines never reach harden-runner."""
+    allowlist = tmp_path / "endpoints.txt"
+    allowlist.write_text(
+        "# leading comment\n\n  github.com:443  \nghcr.io:443 # inline\n\n",
+        encoding="utf-8",
+    )
+
+    result = _run(endpoints_file=str(allowlist))
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout.strip()).is_equal_to("github.com:443 ghcr.io:443")
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param("", id="empty-file"),
+        pytest.param("# only a comment\n\n", id="comments-only"),
+    ],
+)
+def test_fails_instead_of_emitting_an_empty_allowlist(
+    tmp_path: Path,
+    content: str,
+) -> None:
+    """An empty list under replace semantics would block all egress.
+
+    Failing the resolver job is the safe outcome: the image jobs gate on its
+    success, so nothing builds with a blanked allowlist.
+    """
+    allowlist = tmp_path / "endpoints.txt"
+    allowlist.write_text(content, encoding="utf-8")
+
+    result = _run(endpoints_file=str(allowlist))
+
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stderr).contains("no endpoints found")
+
+
+def test_fails_when_the_allowlist_file_is_missing(tmp_path: Path) -> None:
+    """A renamed or deleted allowlist must fail loudly, not silently empty."""
+    result = _run(endpoints_file=str(tmp_path / "absent.txt"))
+
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stderr).contains("allowlist file not found")
+
+
+def test_fails_when_the_endpoints_file_variable_is_unset() -> None:
+    """Forgetting ``ENDPOINTS_FILE`` in the workflow must not pass silently."""
+    result = _run(endpoints_file=None)
+
+    assert_that(result.returncode).is_not_equal_to(0)
+    assert_that(result.stderr).contains("ENDPOINTS_FILE is required")
+
+
+def test_help_flag_documents_usage() -> None:
+    """``--help`` documents the contract for local reruns."""
+    result = subprocess.run(  # nosec B603 - fixed argv pointing at a repo script
+        [str(_SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=_REPO_ROOT,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin"},
+    )
+
+    assert_that(result.returncode).is_equal_to(0)
+    assert_that(result.stdout).contains("ENDPOINTS_FILE")
+    assert_that(result.stdout).contains("GITHUB_OUTPUT")

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -2669,3 +2669,82 @@ def test_ghcr_cleanup_sweeps_commit_tags_with_the_shared_safety_rule() -> None:
     assert_that(sweep_steps).is_length(1)
     assert_that(sweep_steps[0]["env"]["TAG_PREFIX"]).is_equal_to("sha-")
     assert_that(job["permissions"]["packages"]).is_equal_to("write")
+
+
+def test_docker_image_jobs_share_one_allowed_endpoints_source() -> None:
+    """The three image jobs must not carry their own copies of the allowlist.
+
+    Three verbatim copies drifted apart silently: a host added for one target
+    was easy to forget on the other two, and under ``replace`` semantics a
+    missing baseline host fails the build only during a release (#1821).
+    """
+    workflow = _load_workflow(name="docker-build-publish.yml")
+    jobs = workflow["jobs"]
+    expected = "${{ needs.resolve-endpoints.outputs.endpoints }}"
+
+    for job_name in ("docker-base", "docker-full", "docker-ai"):
+        job = jobs[job_name]
+        assert_that(job["with"]["allowed-endpoints"]).is_equal_to(expected)
+        assert_that(job["with"]["allowed-endpoints-mode"]).is_equal_to("replace")
+        assert_that(job["needs"]).contains("resolve-endpoints")
+        # An empty output would blank the allowlist under replace semantics and
+        # block all egress, so the image jobs must not start without it.
+        assert_that(_normalize_github_expr(job["if"])).contains(
+            "needs.resolve-endpoints.result == 'success'",
+        )
+
+
+def test_resolve_endpoints_job_publishes_the_shared_allowlist() -> None:
+    """The resolver job must read the checked-in allowlist and export it.
+
+    GitHub Actions rejects YAML anchors and forbids the ``env`` context in
+    job-level ``with:`` blocks of reusable-workflow calls, so a job output is
+    the only way the three callers can share one list (#1821).
+    """
+    workflow = _load_workflow(name="docker-build-publish.yml")
+    job = workflow["jobs"]["resolve-endpoints"]
+
+    assert_that(job["outputs"]["endpoints"]).is_equal_to(
+        "${{ steps.resolve.outputs.endpoints }}",
+    )
+    resolve_steps = [
+        step
+        for step in job["steps"]
+        if step.get("run") == "./scripts/ci/resolve-allowed-endpoints.sh"
+    ]
+    assert_that(resolve_steps).is_length(1)
+    assert_that(resolve_steps[0]["id"]).is_equal_to("resolve")
+    assert_that(resolve_steps[0]["env"]["ENDPOINTS_FILE"]).is_equal_to(
+        ".github/allowed-endpoints/docker-build-publish.txt",
+    )
+    assert_that((_REPO_ROOT / resolve_steps[0]["env"]["ENDPOINTS_FILE"]).exists())
+
+
+def test_docker_allowlist_file_keeps_the_baseline_and_signing_hosts() -> None:
+    """The shared allowlist must stay a superset of the docker preset baseline.
+
+    ``allowed-endpoints-mode: replace`` means the list is passed verbatim to
+    harden-runner, so dropping a registry or sigstore host silently breaks
+    pushes or cosign signing on the next release only.
+    """
+    allowlist = (
+        _REPO_ROOT / ".github" / "allowed-endpoints" / "docker-build-publish.txt"
+    ).read_text(encoding="utf-8")
+    endpoints = [
+        line.split("#", 1)[0].strip()
+        for line in allowlist.splitlines()
+        if line.split("#", 1)[0].strip()
+    ]
+
+    assert_that(endpoints).does_not_contain_duplicates()
+    for endpoint in (
+        "ghcr.io:443",
+        "registry-1.docker.io:443",
+        "auth.docker.io:443",
+        "pypi.org:443",
+        "files.pythonhosted.org:443",
+        "fulcio.sigstore.dev:443",
+        "rekor.sigstore.dev:443",
+        "token.actions.githubusercontent.com:443",
+    ):
+        assert_that(endpoints).contains(endpoint)


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title: `chore(ci): dedupe allowed-endpoints across docker image jobs`
- Type:
  - [x] chore / ci / style
- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

`docker-base`, `docker-full` and `docker-ai` in
`.github/workflows/docker-build-publish.yml` each carried a verbatim ~35-line
harden-runner `allowed-endpoints` allowlist (three copies, added by #1819).
A host added for one target was easy to forget on the other two, and under
`allowed-endpoints-mode: replace` a missing baseline host only surfaces during
a release publish.

The list now lives once in `.github/allowed-endpoints/docker-build-publish.txt`
and reaches the three callers as an output of a new `resolve-endpoints` job.

## Closes

- Closes #1821

## Details

### Why a job output rather than an anchor or `env`

Both suggested approaches were checked and neither works here:

- GitHub Actions rejects YAML anchors/aliases in workflow files.
- The `env` context is **not available** in job-level `with:` blocks of
  reusable-workflow calls. Confirmed with actionlint:

  ```text
  context "env" is not allowed here. available contexts are
  "github", "inputs", "matrix", "needs", "strategy", "vars".
  ```

  (Workflow-level `env` works for *step*-level `with:`, which is why the other
  workflows in this repo can inline theirs — these three are reusable-workflow
  calls.)

`vars.*` would move the allowlist out of the repo (invisible to review, breaks
on forks), and wrapping the lgtm-ci reusable in a local reusable workflow would
push the release path to 4 levels of nesting and rename every check. That
leaves `needs.*.outputs.*`, which is valid in job-level `with:`.

### Shape

- `.github/allowed-endpoints/docker-build-publish.txt` — one `host:port` per
  line, `#` comments allowed, grouped and commented by purpose.
- `scripts/ci/resolve-allowed-endpoints.sh` — flattens the file to the single
  space-separated string harden-runner expects and writes it to
  `$GITHUB_OUTPUT`. Fails loudly on a missing file, an unset `ENDPOINTS_FILE`,
  or an empty result. No non-trivial inline shell in the workflow.
- `resolve-endpoints` job — harden-runner (block) + checkout + the script.
  The three image jobs `needs` it and gate on
  `needs.resolve-endpoints.result == 'success'`, because an empty value under
  `replace` semantics would blank the allowlist and block all egress rather
  than fail fast.

### Equivalence

The flattened list is byte-identical to the three blocks it replaces
(verified by parsing the pre-change YAML and diffing against the script's
output — same 35 endpoints, same order).

### Verification

- `uv run lintro fmt && uv run lintro chk` — 0 issues, health 100/100
  (actionlint, yamllint, shellcheck, shfmt included).
- `uv run pytest --maxfail=0` — full suite; the only failures are pre-existing
  local-toolchain mismatches (`oxfmt`, `oxlint`, `stylelint`, `pip_audit`,
  `commitlint`) unrelated to this change.
- New tests: `tests/unit/test_workflow_wiring.py` (three jobs share one source,
  gate on the resolver, allowlist keeps the baseline + signing hosts) and
  `tests/scripts/test_resolve_allowed_endpoints.py` (flattening, comment/blank
  stripping, `$GITHUB_OUTPUT` write, and the empty/missing/unset failure modes).

> [!IMPORTANT]
> **These three jobs never run on `pull_request`** (`validate-on-pr: false`, and
> the job `if:` conditions exclude PRs), so PR CI does not exercise this change.
> First real verification is the next tag/main publish run.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing (`scripts/README.md`, `scripts/ci/README.md`)
- [x] Local CI passed (lint + full pytest, see above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Centralized Docker build and publishing network permissions into a shared, validated allowlist.
  * Hardened CI jobs now use only the approved endpoints, including registry and signing services.

* **Documentation**
  * Added guidance for the shared endpoint configuration and its CI helper.
  * Updated CI script and workflow documentation.

* **Tests**
  * Added coverage for allowlist parsing, validation, workflow output, and Docker workflow wiring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->