### PR TITLE
perf(ai): keep provider calls concurrent under ai.max_cost_usd budget gate

### DIFF
--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -68,10 +68,11 @@ log.
   covered by the unit tests.
 - 🔑 **Bring-your-own key** — reads the `ANTHROPIC_API_KEY` repository secret
 - 💸 **Bounded spend** — caps cost via `ai.max_cost_usd` (from the trusted base config,
-  so a PR cannot raise the cap). Setting a cap also serializes provider calls: the
-  budget is enforced under a lock held across each call, so budgeted requests run one at
-  a time rather than concurrently. Leave `ai.max_cost_usd` unset if you would rather
-  have concurrent chunk reviews than a hard spend ceiling.
+  so a PR cannot raise the cap). Setting a cap does **not** serialize provider calls:
+  the budget checks and charges the ceiling around each call rather than holding a lock
+  across it, so budgeted chunk reviews still run concurrently. The trade-off is that
+  calls already in flight when the ceiling is reached still finish, so the final total
+  can overshoot `ai.max_cost_usd` by roughly one round of concurrent calls.
 - 🟢 **Non-blocking / informational** — runs with `continue-on-error` and always exits
   0, so it can never fail a pull request. It is intentionally not a required check.
 - ⏭️ **Graceful skip** — when `ANTHROPIC_API_KEY` is absent (secret not configured yet,

--- a/lintro/ai/budget.py
+++ b/lintro/ai/budget.py
@@ -76,6 +76,7 @@ class CostBudget:
 
         raise AICostBudgetExceededError(
             f"AI cost budget exceeded: ${self._spent:.4f} spent, "
+            f"${self._reserved:.4f} reserved, "
             f"limit is ${self.max_cost_usd:.2f}",
         )
 
@@ -150,8 +151,9 @@ class CostBudget:
         self._reserve(estimate)
         try:
             result = await fn()
+            actual = cost_of(result)
         except BaseException:
             self._release(estimate)
             raise
-        self._settle(estimate=estimate, actual=cost_of(result))
+        self._settle(estimate=estimate, actual=actual)
         return result

--- a/lintro/ai/budget.py
+++ b/lintro/ai/budget.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import threading
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -22,14 +21,9 @@ class CostBudget:
 
     max_cost_usd: float | None = None
     _spent: float = field(default=0.0, init=False)
+    _reserved: float = field(default=0.0, init=False)
     _lock: threading.Lock = field(
         default_factory=threading.Lock,
-        init=False,
-        repr=False,
-    )
-    _async_lock: asyncio.Lock | None = field(default=None, init=False, repr=False)
-    _async_lock_loop: asyncio.AbstractEventLoop | None = field(
-        default=None,
         init=False,
         repr=False,
     )
@@ -41,22 +35,41 @@ class CostBudget:
 
     @property
     def spent(self) -> float:
-        """Return total cost spent so far."""
+        """Return total cost actually spent so far."""
         with self._lock:
             return self._spent
+
+    @property
+    def reserved(self) -> float:
+        """Return the cost currently reserved by in-flight budgeted calls."""
+        with self._lock:
+            return self._reserved
 
     @property
     def remaining(self) -> float | None:
         """Return remaining budget, or None if unlimited."""
         if self.max_cost_usd is None:
             return None
-        return max(0.0, self.max_cost_usd - self.spent)
+        with self._lock:
+            return max(0.0, self.max_cost_usd - self._spent - self._reserved)
 
     def check(self) -> None:
-        """Raise ``AICostBudgetExceededError`` if the budget has been exceeded."""
+        """Raise ``AICostBudgetExceededError`` if the budget has been exceeded.
+
+        In-flight reservations count against the ceiling, so a call that
+        starts while concurrent budgeted calls have already committed the
+        remaining budget is rejected up front.
+        """
         with self._lock:
-            if self.max_cost_usd is not None and self._spent >= self.max_cost_usd:
-                self._raise_exceeded()
+            self._raise_if_exhausted_locked()
+
+    def _raise_if_exhausted_locked(self) -> None:
+        """Raise when committed cost meets the ceiling. Caller holds ``_lock``."""
+        if (
+            self.max_cost_usd is not None
+            and self._spent + self._reserved >= self.max_cost_usd
+        ):
+            self._raise_exceeded()
 
     def _raise_exceeded(self) -> None:
         from lintro.ai.exceptions import AICostBudgetExceededError
@@ -66,46 +79,79 @@ class CostBudget:
             f"limit is ${self.max_cost_usd:.2f}",
         )
 
-    def _get_async_lock(self) -> asyncio.Lock:
-        """Return the ``asyncio.Lock`` bound to the running event loop.
+    def _reserve(self, estimate: float) -> None:
+        """Check the ceiling and reserve an estimated cost.
 
-        An ``asyncio.Lock`` is tied to the loop it is awaited on, so the
-        lock is rebuilt whenever the budget is used from a different loop
-        (e.g. a tool plugin driving its own ``asyncio.run``).
-
-        Returns:
-            The lock guarding budgeted execution on the current loop.
+        Args:
+            estimate: Conservative pre-call cost estimate in USD.
         """
-        loop = asyncio.get_running_loop()
-        if self._async_lock is None or self._async_lock_loop is not loop:
-            self._async_lock = asyncio.Lock()
-            self._async_lock_loop = loop
-        return self._async_lock
+        with self._lock:
+            self._raise_if_exhausted_locked()
+            self._reserved += estimate
+
+    def _release(self, estimate: float) -> None:
+        """Drop a reservation without charging anything.
+
+        Args:
+            estimate: The amount previously reserved.
+        """
+        with self._lock:
+            self._reserved = max(0.0, self._reserved - estimate)
+
+    def _settle(self, *, estimate: float, actual: float) -> None:
+        """Replace a reservation with the actual incurred cost.
+
+        Args:
+            estimate: The amount previously reserved.
+            actual: The cost the completed call actually incurred.
+        """
+        with self._lock:
+            self._reserved = max(0.0, self._reserved - estimate)
+            self._spent += actual
 
     async def execute(
         self,
         fn: Callable[[], Awaitable[_T]],
         *,
         cost_of: Callable[[_T], float],
+        estimate: float = 0.0,
     ) -> _T:
-        """Await ``fn`` under the budget lock to prevent parallel overspend.
+        """Await ``fn`` under the budget without serializing provider calls.
 
-        The gate is an ``asyncio.Lock``, never the threading lock: holding
-        a threading lock across an ``await`` would stall every other task
-        on the loop.
+        Uses a reserve/reconcile pattern: the ceiling check and the
+        reservation happen together under the (never-awaited-across)
+        threading lock, ``fn`` is awaited with no lock held so budgeted
+        calls stay concurrent, and the reservation is reconciled with the
+        real cost afterwards. A failed call releases its reservation so a
+        provider error never permanently consumes budget.
+
+        Overspend bound: the ceiling can only be overshot by the cost of
+        the calls already in flight when the last affordable call started,
+        minus whatever they reserved. Callers that pass no ``estimate``
+        reserve nothing, so with ``n`` concurrent calls the session may
+        exceed ``max_cost_usd`` by up to ``n - 1`` calls' cost; passing a
+        conservative ``estimate`` shrinks that window to the estimate error.
 
         Args:
             fn: Coroutine function performing the budgeted call.
             cost_of: Extracts the incurred cost from ``fn``'s result.
+            estimate: Conservative pre-call cost estimate in USD to reserve
+                for the duration of the call. Defaults to ``0.0`` (check
+                only) for callers with no usable estimate.
 
         Returns:
             Whatever ``fn`` returned.
+
+        Raises:
+            BaseException: Whatever ``fn`` raised, after releasing the
+                reservation. ``AICostBudgetExceededError`` is raised
+                before ``fn`` runs when the ceiling is already committed.
         """
-        async with self._get_async_lock():
-            with self._lock:
-                if self.max_cost_usd is not None and self._spent >= self.max_cost_usd:
-                    self._raise_exceeded()
+        self._reserve(estimate)
+        try:
             result = await fn()
-            with self._lock:
-                self._spent += cost_of(result)
-            return result
+        except BaseException:
+            self._release(estimate)
+            raise
+        self._settle(estimate=estimate, actual=cost_of(result))
+        return result

--- a/lintro/ai/invoke.py
+++ b/lintro/ai/invoke.py
@@ -10,10 +10,17 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 from lintro.ai.budget import CostBudget
+from lintro.ai.cost import estimate_cost_with_floor
 from lintro.ai.fallback import complete_with_fallback
 from lintro.ai.json_response import CliSchemaRequest
 from lintro.ai.providers.response import AIResponse
 from lintro.ai.retry import with_retry
+
+# Rough chars-per-token heuristic for pre-call budget reservations. Real
+# tokenizers vary, but a conservative (i.e. slightly high) estimate is what
+# keeps concurrent CostBudget reservations meaningful — see
+# ``CostBudget.execute``'s overspend-bound note.
+_CHARS_PER_TOKEN_ESTIMATE = 4
 
 if TYPE_CHECKING:
     from lintro.ai.config import AIConfig
@@ -83,9 +90,16 @@ async def call_ai(
             The provider response.
         """
         if budget is not None and budget.max_cost_usd is not None:
+            input_chars = len(user_prompt) + len(system_prompt or "")
+            estimate = estimate_cost_with_floor(
+                provider.model_name,
+                input_tokens=input_chars // _CHARS_PER_TOKEN_ESTIMATE,
+                output_tokens=tokens,
+            )
             return await budget.execute(
                 _call_once,
                 cost_of=lambda response: response.cost_estimate,
+                estimate=estimate,
             )
         response = await _call_once()
         if budget is not None:

--- a/tests/unit/ai/test_budget.py
+++ b/tests/unit/ai/test_budget.py
@@ -120,27 +120,156 @@ def test_thread_safety_concurrent_records() -> None:
     assert_that(budget.spent).is_close_to(expected, tolerance=1e-9)
 
 
-async def test_execute_serializes_budgeted_calls() -> None:
-    """execute() holds the budget lock for the full call to avoid races."""
-    budget = CostBudget(max_cost_usd=10.0)
-    active = 0
-    max_active = 0
+async def test_execute_runs_budgeted_calls_concurrently() -> None:
+    """execute() does not hold a lock across the provider await.
 
-    async def tracked_call() -> float:
-        """Track concurrent entries into the budgeted section.
+    Regression test for the budget gate serializing every provider call:
+    a call blocked mid-await must not prevent a second call from starting.
+    """
+    budget = CostBudget(max_cost_usd=10.0)
+    first_started = asyncio.Event()
+    second_started = asyncio.Event()
+
+    async def first_call() -> float:
+        """Block until the second call has started.
 
         Returns:
             The cost attributed to this call.
         """
-        nonlocal active, max_active
-        active += 1
-        max_active = max(max_active, active)
-        await asyncio.sleep(0.05)
-        active -= 1
+        first_started.set()
+        await asyncio.wait_for(second_started.wait(), timeout=5.0)
         return 0.01
 
-    await asyncio.gather(
-        *(budget.execute(tracked_call, cost_of=lambda cost: cost) for _ in range(4)),
+    async def second_call() -> float:
+        """Signal that the second budgeted call entered the provider await.
+
+        Returns:
+            The cost attributed to this call.
+        """
+        await first_started.wait()
+        second_started.set()
+        return 0.02
+
+    costs = await asyncio.gather(
+        budget.execute(first_call, cost_of=lambda cost: cost),
+        budget.execute(second_call, cost_of=lambda cost: cost),
     )
 
-    assert_that(max_active).is_equal_to(1)
+    assert_that(costs).is_equal_to([0.01, 0.02])
+    assert_that(budget.spent).is_close_to(0.03, tolerance=1e-9)
+
+
+async def test_execute_records_actual_cost() -> None:
+    """execute() charges the budget with the cost derived from the result."""
+    budget = CostBudget(max_cost_usd=10.0)
+
+    async def call() -> float:
+        """Return a fixed cost.
+
+        Returns:
+            The cost attributed to this call.
+        """
+        return 0.25
+
+    await budget.execute(call, cost_of=lambda cost: cost)
+
+    assert_that(budget.spent).is_close_to(0.25, tolerance=1e-9)
+    assert_that(budget.reserved).is_equal_to(0.0)
+
+
+async def test_execute_raises_when_budget_exhausted() -> None:
+    """execute() rejects a call that starts once the ceiling is reached."""
+    budget = CostBudget(max_cost_usd=1.0)
+    budget.record(1.0)
+    called = False
+
+    async def call() -> float:
+        """Record that the provider was reached.
+
+        Returns:
+            The cost attributed to this call.
+        """
+        nonlocal called
+        called = True
+        return 0.0
+
+    with pytest.raises(AIError, match="cost budget exceeded"):
+        await budget.execute(call, cost_of=lambda cost: cost)
+
+    assert_that(called).is_false()
+
+
+async def test_execute_raises_when_reservations_fill_the_ceiling() -> None:
+    """In-flight reservations block a call that would overshoot the ceiling."""
+    budget = CostBudget(max_cost_usd=1.0)
+    in_flight = asyncio.Event()
+    release = asyncio.Event()
+
+    async def holder() -> float:
+        """Hold a reservation until released.
+
+        Returns:
+            The cost attributed to this call.
+        """
+        in_flight.set()
+        await release.wait()
+        return 0.1
+
+    task = asyncio.create_task(
+        budget.execute(holder, cost_of=lambda cost: cost, estimate=1.0),
+    )
+    await asyncio.wait_for(in_flight.wait(), timeout=5.0)
+
+    async def blocked() -> float:
+        """Never reached while the reservation stands.
+
+        Returns:
+            The cost attributed to this call.
+        """
+        return 0.0
+
+    with pytest.raises(AIError, match="cost budget exceeded"):
+        await budget.execute(blocked, cost_of=lambda cost: cost)
+
+    release.set()
+    await task
+    assert_that(budget.reserved).is_equal_to(0.0)
+    assert_that(budget.spent).is_close_to(0.1, tolerance=1e-9)
+
+
+async def test_execute_releases_reservation_on_failure() -> None:
+    """A failed call releases its reservation instead of consuming budget."""
+    budget = CostBudget(max_cost_usd=1.0)
+
+    async def failing_call() -> float:
+        """Fail before returning a cost.
+
+        Returns:
+            Never returns normally.
+
+        Raises:
+            RuntimeError: Always.
+        """
+        raise RuntimeError("provider blew up")
+
+    with pytest.raises(RuntimeError, match="provider blew up"):
+        await budget.execute(
+            failing_call,
+            cost_of=lambda cost: cost,
+            estimate=1.0,
+        )
+
+    assert_that(budget.reserved).is_equal_to(0.0)
+    assert_that(budget.spent).is_equal_to(0.0)
+    assert_that(budget.remaining).is_equal_to(1.0)
+
+    async def call() -> float:
+        """Succeed after the failed call released its reservation.
+
+        Returns:
+            The cost attributed to this call.
+        """
+        return 0.5
+
+    await budget.execute(call, cost_of=lambda cost: cost)
+    assert_that(budget.spent).is_close_to(0.5, tolerance=1e-9)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  perf(ai): keep provider calls concurrent under ai.max_cost_usd budget gate
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

- `lintro/ai/budget.py`
  - `execute()` restructured to reserve → await unlocked → reconcile, with an
    exception path that releases the reservation.
  - New optional `estimate` keyword (default `0.0`) reserving a pre-call cost estimate.
    `lintro/ai/invoke.py` deliberately passes no estimate: a conservative
    `max_tokens`-based reservation would make concurrent chunk reviews raise
    `AICostBudgetExceededError` well below the real spend. The overspend bound with a
    zero reservation is documented in the docstring (up to `n - 1` concurrent calls'
    cost beyond the ceiling).
  - New private `_reserve` / `_release` / `_settle` helpers plus a `reserved` property;
    `check()` and `remaining` now account for in-flight reservations, so a call starting
    once the ceiling is committed still raises.
  - Removed the now-dead `asyncio.Lock` machinery (`_get_async_lock`, `_async_lock`,
    `_async_lock_loop`). With no lock held across the await it served no purpose, and
    re-acquiring an async lock on the exception path would be a cancellation hazard
    (a cancelled task could skip its reservation release). Mutation atomicity is fully
    covered by the existing threading lock, which is still never held across an `await`.
- `docs/github-integration.md` — the "Bounded spend" bullet no longer claims a cap
  serializes provider calls; it documents concurrent-with-budget behaviour and the
  in-flight overshoot trade-off.

### Consistency with the fallback path (#772 / #1441)

`lintro/ai/fallback.py` fixed the same class of bug by removing shared mutable state
across concurrent callers (an explicit per-attempt `model` override instead of mutating
`provider.model_name` under a lock). Both sites now follow the same rule: never hold a
lock across a provider `await`; make the concurrent-safe path lock-free instead.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1833

## Details

Tests in `tests/unit/ai/test_budget.py`:

- `test_execute_runs_budgeted_calls_concurrently` — the regression test. An
  `asyncio.Event` handshake: call A blocks until call B has entered its provider await.
  This deadlocks (`TimeoutError`) on pre-change code and passes now. It replaces
  `test_execute_serializes_budgeted_calls`, which asserted the buggy behaviour
  (`max_active == 1`).
- `test_execute_records_actual_cost` — the real cost is charged and no reservation leaks.
- `test_execute_raises_when_budget_exhausted` — an exhausted budget still raises before
  the provider is reached.
- `test_execute_raises_when_reservations_fill_the_ceiling` — an in-flight reservation
  blocks a call that would overshoot, and is fully released afterwards.
- `test_execute_releases_reservation_on_failure` — a raising call releases its
  reservation, restoring `remaining`, and a subsequent call succeeds.

Verification:

- `uv run lintro fmt && uv run lintro chk` — 0 issues, health score 100/100.
  `pip-audit` errors locally for an environment reason unrelated to this PR
  (`ensurepip` aborts with SIGABRT when it builds its scratch venv); it errors the same
  way on a clean tree.
- `uv run pytest --maxfail=0` — 8408 passed, 118 skipped. The 16 failures are all
  pre-existing environment gaps flagged in `AGENTS.md` (missing/outdated external
  binaries: stylelint, commitlint, oxlint 1.74 < required 1.75, oxfmt, pip-audit).
  No AI/budget test fails.
