### PR TITLE
fix(ci): tolerate semgrep probe exit-lag in manifest verification

### DIFF
--- a/scripts/ci/verify-image-manifest-tools.sh
+++ b/scripts/ci/verify-image-manifest-tools.sh
@@ -114,9 +114,17 @@ fi
 
 # Bypass the image entrypoint so the container's baked ENV is used verbatim and
 # the checkout is mounted read-only outside /code (the entrypoint's gosu path).
+# Silence semgrep's telemetry POST and update check (#1874). On egress-blocked
+# runners `semgrep --version` prints the version and then stalls on those
+# requests until the probe's 10s timeout fires, failing the gate for a tool
+# that is actually correct. SEMGREP_SEND_METRICS=off disables metrics upload;
+# SEMGREP_ENABLE_VERSION_CHECK=0 disables the new-version check (semgrep
+# >= 1.61.1). Both are inert for every other tool in the manifest.
 declare -a docker_args=(
 	docker run --rm
 	--entrypoint python3
+	-e SEMGREP_SEND_METRICS=off
+	-e SEMGREP_ENABLE_VERSION_CHECK=0
 	-v "${repo_root}:/repo:ro"
 	-w /repo
 	"$IMAGE"

--- a/scripts/ci/verify-manifest-tools.py
+++ b/scripts/ci/verify-manifest-tools.py
@@ -15,16 +15,21 @@ from typing import Any
 _VERSION_RE = re.compile(r"\d+(?:\.\d+){1,3}")
 
 
-def _run(cmd: list[str]) -> tuple[int, str]:
-    """Run a version-probe command and return its exit code and output.
+def _run(cmd: list[str]) -> tuple[int, str, bool]:
+    """Run a version-probe command and return its exit code, output, and timeout state.
 
     Args:
         cmd: Argv of the probe command (run with ``shell=False``).
 
     Returns:
-        tuple[int, str]: The exit code (or a synthetic code: 127 missing
-        binary, 126 permission denied, 125 OS error, 124 timeout) and the
-        combined stdout/stderr text captured before the command ended.
+        tuple[int, str, bool]: The exit code (or a synthetic code: 127
+        missing binary, 126 permission denied, 125 OS error, 124 timeout),
+        the combined stdout/stderr text captured before the command ended,
+        and whether the probe actually hit ``subprocess.TimeoutExpired``.
+        The ``timed_out`` flag is the only reliable signal that the probe
+        was killed for running long — a well-behaved child process that
+        happens to exit with code 124 on its own is NOT a timeout and must
+        not be treated as one.
     """
     try:
         result = subprocess.run(  # nosec B603 - argv is an internally-built list run with shell=False; binary resolved from a known command, no user shell input
@@ -35,11 +40,11 @@ def _run(cmd: list[str]) -> tuple[int, str]:
             timeout=10,
         )
     except FileNotFoundError:
-        return 127, ""
+        return 127, "", False
     except PermissionError as exc:
-        return 126, f"permission denied: {exc}"
+        return 126, f"permission denied: {exc}", False
     except OSError as exc:
-        return 125, f"OS error running command: {exc}"
+        return 125, f"OS error running command: {exc}", False
     except subprocess.TimeoutExpired as exc:
         stdout = (
             exc.stdout.decode() if isinstance(exc.stdout, bytes) else (exc.stdout or "")
@@ -50,9 +55,9 @@ def _run(cmd: list[str]) -> tuple[int, str]:
         output = stdout + stderr
         if not output:
             output = "Command timed out"
-        return 124, output.strip()
+        return _TIMEOUT_EXIT, output.strip(), True
     output = (result.stdout or "") + (result.stderr or "")
-    return result.returncode, output.strip()
+    return result.returncode, output.strip(), False
 
 
 def _parse_version(output: str, tool_name: str) -> str | None:
@@ -304,12 +309,15 @@ def main() -> int:
         except ValueError as exc:
             failures.append(f"{name}: invalid manifest entry ({exc})")
             continue
-        code, output = _run(cmd)
-        if code == _TIMEOUT_EXIT:
+        code, output, timed_out = _run(cmd)
+        if timed_out:
             # Exit-lag tolerance (#1874): the binary printed its version and
             # then hung (blocked telemetry/version-check egress). If that
             # captured output already matches the manifest, the probe proved
             # what the gate needs; otherwise fall through to the hard failure.
+            # `timed_out` comes only from an actual subprocess.TimeoutExpired
+            # (see `_run`) — an ordinary exit code of 124 is NOT a timeout and
+            # must not take this branch.
             timed_out_version = _parse_version(output, name)
             if timed_out_version and _versions_match(
                 name,

--- a/scripts/ci/verify-manifest-tools.py
+++ b/scripts/ci/verify-manifest-tools.py
@@ -16,6 +16,16 @@ _VERSION_RE = re.compile(r"\d+(?:\.\d+){1,3}")
 
 
 def _run(cmd: list[str]) -> tuple[int, str]:
+    """Run a version-probe command and return its exit code and output.
+
+    Args:
+        cmd: Argv of the probe command (run with ``shell=False``).
+
+    Returns:
+        tuple[int, str]: The exit code (or a synthetic code: 127 missing
+        binary, 126 permission denied, 125 OS error, 124 timeout) and the
+        combined stdout/stderr text captured before the command ended.
+    """
     try:
         result = subprocess.run(  # nosec B603 - argv is an internally-built list run with shell=False; binary resolved from a known command, no user shell input
             cmd,
@@ -134,6 +144,14 @@ def _iter_tools(
 # exit means the binary IS present but misbehaving, which stays a hard failure
 # even for an allow-missing tool.
 _MISSING_BINARY_EXIT = 127
+
+# Exit code returned by `_run` when the probe exceeded its timeout. Some tools
+# print their version immediately and then hang on blocked egress before
+# exiting (semgrep's telemetry / version check on network-restricted runners,
+# #1874). When the captured output already carries the expected version, the
+# probe answered the only question the gate asks, so it is treated as a PASS.
+# A timeout with no usable version output stays a hard failure.
+_TIMEOUT_EXIT = 124
 
 
 def _parse_allow_missing(values: list[str] | None) -> set[str]:
@@ -273,6 +291,7 @@ def main() -> int:
 
     failures: list[str] = []
     warnings: list[str] = []
+    notices: list[str] = []
     for tool in tools:
         name = str(tool.get("name", "")).strip()
         expected = str(tool.get("version", "")).strip()
@@ -286,6 +305,22 @@ def main() -> int:
             failures.append(f"{name}: invalid manifest entry ({exc})")
             continue
         code, output = _run(cmd)
+        if code == _TIMEOUT_EXIT:
+            # Exit-lag tolerance (#1874): the binary printed its version and
+            # then hung (blocked telemetry/version-check egress). If that
+            # captured output already matches the manifest, the probe proved
+            # what the gate needs; otherwise fall through to the hard failure.
+            timed_out_version = _parse_version(output, name)
+            if timed_out_version and _versions_match(
+                name,
+                expected,
+                timed_out_version,
+            ):
+                notices.append(
+                    f"{name}: version {timed_out_version} matched before the "
+                    f"probe timed out; treating the hung exit as a pass",
+                )
+                continue
         if code != 0:
             cmd_str = " ".join(cmd)
             # Tolerate ONLY a genuinely-absent binary (127) for a tool the PR
@@ -331,6 +366,12 @@ def main() -> int:
             failures.append(
                 f"{name}: version mismatch (expected {expected}, got {actual})",
             )
+
+    if notices:
+        # Informational only: the tool verified correctly, it just did not
+        # exit before the probe deadline.
+        for item in notices:
+            print(f"::notice::{item}")
 
     if warnings:
         # GitHub Actions annotation (::warning::) plus a human-readable block so

--- a/tests/scripts/test_verify_image_manifest_tools.py
+++ b/tests/scripts/test_verify_image_manifest_tools.py
@@ -192,6 +192,24 @@ def test_runs_verifier_inside_image(
     assert_that(invocation).contains("--tiers tools")
 
 
+def test_semgrep_network_env_is_disabled(
+    image_repo: Path,
+    docker_stub: tuple[Path, Path],
+) -> None:
+    """The container probe runs with semgrep telemetry/version checks off (#1874)."""
+    bin_dir, args_log = docker_stub
+    result = _run_script(image_repo, bin_dir, args_log)
+
+    assert_that(result.returncode).is_equal_to(0)
+    run_lines = [
+        line for line in args_log.read_text().splitlines() if line.startswith("run ")
+    ]
+    assert_that(run_lines).is_length(1)
+    invocation = run_lines[0]
+    assert_that(invocation).contains("-e SEMGREP_SEND_METRICS=off")
+    assert_that(invocation).contains("-e SEMGREP_ENABLE_VERSION_CHECK=0")
+
+
 def test_tiers_override_passed_through(
     image_repo: Path,
     docker_stub: tuple[Path, Path],

--- a/tests/scripts/test_verify_manifest_tools.py
+++ b/tests/scripts/test_verify_manifest_tools.py
@@ -239,7 +239,7 @@ def test_empty_allow_missing_leaves_behavior_unchanged(
     module = _load_verify_manifest_tools_module()
     # `git --version` -> "git version X.Y.Z"; declare that exact version so the
     # match succeeds regardless of the runner's git build.
-    _, output = module._run(["git", "--version"])  # noqa: SLF001
+    _, output, _ = module._run(["git", "--version"])  # noqa: SLF001
     actual = module._parse_version(output, "git")  # noqa: SLF001
     manifest = _write_manifest(
         tmp_path,
@@ -294,7 +294,7 @@ def test_allow_version_lag_older_image_passes_with_warning(
 ) -> None:
     """An allow-version-lag tool with an older installed version warns, not fails."""
     module = _load_verify_manifest_tools_module()
-    _, output = module._run(["git", "--version"])  # noqa: SLF001
+    _, output, _ = module._run(["git", "--version"])  # noqa: SLF001
     actual = module._parse_version(output, "git")  # noqa: SLF001
     assert_that(actual).is_not_none()
     # Declare a version strictly newer than whatever git reports on this runner.
@@ -398,10 +398,11 @@ def test_run_returns_timeout_code_with_captured_output(
     module = _load_verify_manifest_tools_module()
     _fake_timeout_run(module, monkeypatch, stdout=b"1.151.0\n")
 
-    code, output = module._run(["semgrep", "--version"])  # noqa: SLF001
+    code, output, timed_out = module._run(["semgrep", "--version"])  # noqa: SLF001
 
     assert_that(code).is_equal_to(124)
     assert_that(output).is_equal_to("1.151.0")
+    assert_that(timed_out).is_true()
 
 
 def test_timeout_with_matching_version_passes(
@@ -447,6 +448,42 @@ def test_timeout_without_output_still_fails(
     assert_that(code).is_equal_to(1)
     out = capsys.readouterr().out
     assert_that(out).contains("exit code 124")
+
+
+def test_ordinary_exit_code_124_is_not_treated_as_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A child process that legitimately returns 124 is NOT a timeout.
+
+    `_TIMEOUT_EXIT` (124) is only synthetic when `_run` actually caught
+    `subprocess.TimeoutExpired`. A well-behaved probe that happens to exit
+    with the same numeric code -- while printing output that matches the
+    manifest version -- must still hard-fail; only a genuine timeout may use
+    the exit-lag tolerance.
+    """
+    module = _load_verify_manifest_tools_module()
+    manifest = _write_manifest(
+        tmp_path,
+        name="semgrep",
+        version="1.151.0",
+        version_command=["semgrep", "--version"],
+    )
+
+    class _FakeCompleted:
+        returncode = 124
+        stdout = "1.151.0\n"
+        stderr = ""
+
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *args, **kwargs: _FakeCompleted(),
+    )
+
+    code = _run_main(module, monkeypatch, ["--manifest", str(manifest)])
+
+    assert_that(code).is_equal_to(1)
 
 
 def test_timeout_with_wrong_version_still_fails(

--- a/tests/scripts/test_verify_manifest_tools.py
+++ b/tests/scripts/test_verify_manifest_tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess  # nosec B404 - only TimeoutExpired is used, no process is spawned
 from pathlib import Path
 from types import ModuleType
 
@@ -361,5 +362,107 @@ def test_allow_version_lag_missing_binary_still_fails(
         monkeypatch,
         ["--manifest", str(manifest), "--allow-version-lag", "brandnew"],
     )
+
+    assert_that(code).is_equal_to(1)
+
+
+def _fake_timeout_run(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stdout: bytes | str | None,
+) -> None:
+    """Make every probe raise TimeoutExpired with the given captured output.
+
+    Args:
+        module: The loaded verify-manifest-tools module.
+        monkeypatch: Pytest monkeypatch fixture.
+        stdout: Output captured before the timeout fired, as bytes, text, or
+            ``None`` when the command produced nothing.
+    """
+
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(
+            cmd=["semgrep", "--version"],
+            timeout=10,
+            output=stdout,
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", _raise)
+
+
+def test_run_returns_timeout_code_with_captured_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timed-out probe reports code 124 and the output captured so far."""
+    module = _load_verify_manifest_tools_module()
+    _fake_timeout_run(module, monkeypatch, stdout=b"1.151.0\n")
+
+    code, output = module._run(["semgrep", "--version"])  # noqa: SLF001
+
+    assert_that(code).is_equal_to(124)
+    assert_that(output).is_equal_to("1.151.0")
+
+
+def test_timeout_with_matching_version_passes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A hung probe that already printed the expected version passes (#1874)."""
+    module = _load_verify_manifest_tools_module()
+    manifest = _write_manifest(
+        tmp_path,
+        name="semgrep",
+        version="1.151.0",
+        version_command=["semgrep", "--version"],
+    )
+    _fake_timeout_run(module, monkeypatch, stdout=b"1.151.0\n")
+
+    code = _run_main(module, monkeypatch, ["--manifest", str(manifest)])
+
+    assert_that(code).is_equal_to(0)
+    out = capsys.readouterr().out
+    assert_that(out).contains("::notice::")
+    assert_that(out).contains("semgrep")
+
+
+def test_timeout_without_output_still_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A timeout with no usable version output stays a hard failure."""
+    module = _load_verify_manifest_tools_module()
+    manifest = _write_manifest(
+        tmp_path,
+        name="semgrep",
+        version="1.151.0",
+        version_command=["semgrep", "--version"],
+    )
+    _fake_timeout_run(module, monkeypatch, stdout=None)
+
+    code = _run_main(module, monkeypatch, ["--manifest", str(manifest)])
+
+    assert_that(code).is_equal_to(1)
+    out = capsys.readouterr().out
+    assert_that(out).contains("exit code 124")
+
+
+def test_timeout_with_wrong_version_still_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hung probe whose printed version drifts is not tolerated."""
+    module = _load_verify_manifest_tools_module()
+    manifest = _write_manifest(
+        tmp_path,
+        name="semgrep",
+        version="1.151.0",
+        version_command=["semgrep", "--version"],
+    )
+    _fake_timeout_run(module, monkeypatch, stdout=b"1.150.0\n")
+
+    code = _run_main(module, monkeypatch, ["--manifest", str(manifest)])
 
     assert_that(code).is_equal_to(1)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): tolerate semgrep probe exit-lag in manifest verification
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

The nightly "Verify Pinned Image Tools" job fails because `semgrep --version`
prints the correct version and then stalls on telemetry / new-version-check
HTTP requests that the egress-blocked runner never lets complete. The probe in
`scripts/ci/verify-manifest-tools.py::_run` gives up at 10s and returns 124, so
a tool that is actually installed at the manifest version fails the gate.

Two layers of fix:

1. **Kill the network I/O.** The container probe in
   `scripts/ci/verify-image-manifest-tools.sh` now runs with
   `SEMGREP_SEND_METRICS=off` and `SEMGREP_ENABLE_VERSION_CHECK=0`
   (documented by semgrep; the version-check variable requires semgrep
   >= 1.61.1, the manifest pins 1.151.0). Both are inert for every other tool,
   and the plumbing lives in the script, not an inline `run:` block, so
   `dogfood-nightly.yml` and `docker-ci.yml` pick it up unchanged.
2. **Backstop for exit-lag.** When a probe times out but the output captured
   before the timeout already contains a version that matches the manifest,
   the verifier treats it as a pass and emits a `::notice::` annotation.

Deliberately *not* weakened: a timeout with no usable version output still
fails with exit code 124, a timed-out probe reporting the wrong version still
fails, and missing binaries (127) / empty output keep their existing hard-fail
behavior.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1874

## Details

Tests added:

- `tests/scripts/test_verify_manifest_tools.py` — `_run` returns 124 plus the
  captured output on `TimeoutExpired`; main passes (with `::notice::`) on a
  timeout whose output carries the expected version; main still fails on a
  timeout with no output and on a timeout reporting a drifted version.
- `tests/scripts/test_verify_image_manifest_tools.py` — the docker invocation
  carries both semgrep env vars.
