### PR TITLE
test(ai): assert full uv-managed regeneration command in corpus headers

### DIFF
--- a/tests/unit/ai/review/test_checklist_corpus_schema.py
+++ b/tests/unit/ai/review/test_checklist_corpus_schema.py
@@ -292,4 +292,6 @@ def test_corpus_files_document_regeneration(file_name: str) -> None:
         file_name: Corpus YAML file name.
     """
     text = (CORPUS_DIR / file_name).read_text(encoding="utf-8")
-    assert_that(text).contains("scripts/generate-checklist-corpus-schema.py")
+    assert_that(text).contains(
+        "uv run python scripts/generate-checklist-corpus-schema.py",
+    )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  test(ai): assert full uv-managed regeneration command in corpus headers
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [x] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- `test:` titles do not trigger a release bump.

## What’s Changing

Recovers a CodeRabbit-requested test tightening from #1877 that missed the
squash when the merge queue fired: `test_corpus_files_document_regeneration`
now asserts the full `uv run python scripts/generate-checklist-corpus-schema.py`
command in corpus file headers, not just the script name.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Relates to #1309
- Relates to #1877

## Details

Trailing review fix only — no product behavior change. Verification at the
time: `uv run lintro chk` clean; `uv run pytest` 8475 passed / 105 skipped
(known pip_audit integration env failures only).