### PR TITLE
feat(cli): move advisory AI finders out of chk into lintro review

### DIFF
--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -125,7 +125,8 @@ and cost-budget controls.
 > # before
 > lintro chk --tools idiom-review
 >
-> # now
+> # now (both forms still require the tool's own `enabled` opt-in, from
+> # `tools.idiom-review` config or `--tool-options`)
 > lintro review --advisory-only --advisory-tools idiom-review
 > ```
 >

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -107,14 +107,49 @@ issues, the AI generates fix suggestions and presents them interactively (same U
 `--fix` in `check`). After the session, a post-fix summary wraps up what was
 accomplished.
 
-### AI Idiom Review (`idiom-review` tool)
+### Advisory AI finders (`idiom-review`)
 
 Unlike the AI summary and `--fix` flows (where AI _explains_ or _fixes_ issues that
-linters found), the `idiom-review` tool uses AI to _find_ issues that syntax-matching
-linters structurally cannot. It has no external binary — it runs through the existing AI
-provider abstraction, respecting the same retry, fallback, and cost-budget controls.
+linters found), an **AI finder** uses AI to _find_ issues that syntax-matching linters
+structurally cannot. `idiom-review` is the first one. It has no external binary — it
+runs through the existing AI provider abstraction, respecting the same retry, fallback,
+and cost-budget controls.
 
-It offers two modes:
+> **Migration (#1308).** AI finders used to run under `lintro chk`. They now run under
+> `lintro review` only. Every tool declares an execution class — `deterministic` (all
+> classic linters) or `advisory` (AI finders) — and `chk` runs deterministic tools
+> exclusively. Running `lintro chk --tools idiom-review` is now an error that points at
+> the review verb.
+>
+> ```bash
+> # before
+> lintro chk --tools idiom-review
+>
+> # now
+> lintro review --advisory-only --advisory-tools idiom-review
+> ```
+>
+> Why: advisory findings are opinions produced by a nondeterministic model. Letting them
+> share `chk` meant two identical runs could disagree, the `--fail-under` health-score
+> gate could move on model mood rather than on regressions, and every contributor paid
+> API latency and dollars on a command meant to be reflexive and offline. Your
+> `tools.idiom-review` config section is unchanged — only the invoking verb moved.
+
+Advisory tools under `lintro review`:
+
+| Flag                       | Meaning                                                              |
+| -------------------------- | -------------------------------------------------------------------- |
+| _(default)_                | Advisory tools run alongside the diff review, over the changed files |
+| `--advisory-tools <names>` | Comma-separated advisory tools, `all` (default), or `none`           |
+| `--advisory-only`          | Skip the diff review; scan `--path` values (default `.`)             |
+| `--fail-on-findings`       | Exit 1 when advisory tools report findings (default: exit 0)         |
+| `--tool-options`           | `tool:option=value` overrides, as in `chk`                           |
+
+Advisory findings never affect the exit code unless `--fail-on-findings` is passed, and
+they never contribute to the `chk` health score. With `--output json`, they appear under
+an additive `advisory` key so existing consumers of the review JSON keep working.
+
+`idiom-review` offers two modes:
 
 - **per-file** (Mode 1) — flags _idiomatic misses_: code that is correct but verbose,
   e.g. `found = False; for x in items: ...` instead of `any(cond for x in items)`.
@@ -144,7 +179,7 @@ tools:
 Or enable it ad hoc from the CLI:
 
 ```bash
-lintro chk --tools idiom-review --tool-options idiom-review:enabled=true
+lintro review --advisory-only --tool-options idiom-review:enabled=true
 ```
 
 ### Custom Review Agents (`.lintro/review-agents/*.md`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2774,9 +2774,9 @@ ai:
 
 The `idiom-review` tool uses AI to find issues that syntax-matching linters cannot: code
 that is syntactically correct but non-idiomatic or redundantly duplicated across files.
-Unlike the AI summary and `--fix` flows, it is a first-class `ToolDefinition` plugin
-that runs as part of the normal `lintro check` pipeline — distinct from the
-`lintro review` diff-review command.
+Unlike the AI summary and `--fix` flows, it is a first-class `ToolDefinition` plugin. It
+is classified **advisory**, so it runs under `lintro review` — never under
+`lintro check` or `lintro format`, whose findings must stay deterministic (#1308).
 
 **Install:**
 
@@ -2828,7 +2828,7 @@ tools:
 Or enable ad hoc from the CLI without modifying config:
 
 ```bash
-lintro check --tools idiom-review --tool-options idiom-review:enabled=true
+lintro review --advisory-only --tool-options idiom-review:enabled=true
 ```
 
 ## Advanced Configuration

--- a/docs/tool-analysis/idiom-review-analysis.md
+++ b/docs/tool-analysis/idiom-review-analysis.md
@@ -109,7 +109,7 @@ lintro review --advisory-only \
 - Caching is automatic; clear `.lintro-cache/idiom` to force a full re-analysis.
 
 See [AI Configuration](../configuration.md#idiom-review-tool-idiom-review) and
-[AI Features Guide](../ai-features.md#ai-idiom-review-idiom-review-tool) for full
+[AI Features Guide](../ai-features.md#advisory-ai-finders-idiom-review) for full
 configuration reference.
 
 ## Recommendations

--- a/docs/tool-analysis/idiom-review-analysis.md
+++ b/docs/tool-analysis/idiom-review-analysis.md
@@ -3,10 +3,12 @@
 ## Overview
 
 `idiom-review` is a first-class `ToolDefinition` plugin that uses the configured AI
-provider to find issues that syntax-matching linters structurally cannot. It is
-**distinct from the `lintro review` diff-review command** — it participates in the
-normal `lintro check` pipeline like any other tool and produces standard `ToolResult` /
-`Issue` objects.
+provider to find issues that syntax-matching linters structurally cannot. It produces
+standard `ToolResult` / `Issue` objects like any other plugin, but it is classified
+**advisory** rather than deterministic: it runs under `lintro review` (alongside, or
+instead of, the diff review) and never under `lintro check` / `lintro fmt`, so
+nondeterministic findings can never gate deterministic checks or the health score
+(#1308).
 
 It has no external binary; all work is done through the existing AI provider
 abstraction, respecting the same retry, fallback, and cost-budget controls used by other
@@ -77,7 +79,8 @@ orchestration, caching, retry logic, and result parsing.
 
 ```bash
 # Ad-hoc run (opt-in via CLI, no config change needed)
-lintro chk --tools idiom-review --tool-options idiom-review:enabled=true
+# idiom-review is an advisory tool: it runs under `lintro review`, not `chk`.
+lintro review --advisory-only --tool-options idiom-review:enabled=true
 
 # Persistent opt-in via config
 # .lintro-config.yaml:
@@ -88,10 +91,10 @@ lintro chk --tools idiom-review --tool-options idiom-review:enabled=true
 #       mode: per-file
 #       min_confidence: medium
 #       max_files: 25
-lintro chk --tools idiom-review
+lintro review --advisory-only
 
 # Duplication mode across the whole repo
-lintro chk --tools idiom-review \
+lintro review --advisory-only \
   --tool-options idiom-review:enabled=true,idiom-review:mode=duplication
 ```
 
@@ -100,7 +103,7 @@ lintro chk --tools idiom-review \
 - Requires `ai.enabled: true` and a valid API key in the environment before any analysis
   runs.
 - Tool-level `enabled` option (default `false`) acts as a second opt-in gate so that
-  `lintro chk` does not silently incur API costs.
+  `lintro review` does not silently incur API costs.
 - `max_files` (default 25) is the primary cost-control knob for large repos.
 - `min_confidence` (default `medium`) filters noisy low-confidence findings.
 - Caching is automatic; clear `.lintro-cache/idiom` to force a full re-analysis.
@@ -111,8 +114,8 @@ configuration reference.
 
 ## Recommendations
 
-- Enable `idiom-review` selectively in CI on changed files only (combine with `--diff`)
-  to keep API costs bounded.
+- Enable `idiom-review` selectively in CI. A plain `lintro review` already scopes it to
+  the diff's changed files, which keeps API costs bounded.
 - Start with `mode: per-file` and a low `max_files` limit to evaluate finding quality
   before enabling `duplication` mode on large repos.
 - Use `min_confidence: high` in automated pipelines to reduce false positives; reserve

--- a/lintro/cli_utils/commands/list_tools.py
+++ b/lintro/cli_utils/commands/list_tools.py
@@ -41,6 +41,38 @@ def _resolve_conflicts(
     return conflict_names
 
 
+def _tool_capabilities(
+    *,
+    tool_name: str,
+    plugin: BaseToolPlugin,
+    check_tools: dict[str, BaseToolPlugin],
+    fix_tools: dict[str, BaseToolPlugin],
+) -> list[str]:
+    """Resolve the verbs a tool can be invoked with.
+
+    Advisory AI finders report ``review`` rather than ``check``: they are
+    excluded from ``lintro chk`` so their nondeterministic findings never
+    gate deterministic checks or the health score (#1308).
+
+    Args:
+        tool_name: Registered tool name.
+        plugin: The plugin instance.
+        check_tools: Tools that support checking.
+        fix_tools: Tools that support fixing.
+
+    Returns:
+        Capability labels in display order.
+    """
+    if plugin.definition.is_advisory:
+        return ["review"]
+    capabilities: list[str] = []
+    if tool_name in check_tools:
+        capabilities.append("check")
+    if tool_name in fix_tools:
+        capabilities.append("fix")
+    return capabilities
+
+
 @click.command("list-tools")
 @click.option(
     "--output",
@@ -110,15 +142,17 @@ def list_tools(
     if json_output:
         tools_data: dict[str, dict[str, object]] = {}
         for tool_name, plugin in available_tools.items():
-            capabilities: list[str] = []
-            if tool_name in check_tools:
-                capabilities.append("check")
-            if tool_name in fix_tools:
-                capabilities.append("fix")
+            capabilities = _tool_capabilities(
+                tool_name=tool_name,
+                plugin=plugin,
+                check_tools=check_tools,
+                fix_tools=fix_tools,
+            )
 
             tool_info: dict[str, object] = {
                 "description": plugin.definition.description,
                 "capabilities": capabilities,
+                "execution_class": plugin.definition.execution_class.value,
                 "priority": get_tool_priority(tool_name),
                 "syncable": is_tool_injectable(tool_name),
                 "origin": ToolRegistry.get_origin(tool_name),
@@ -171,11 +205,12 @@ def list_tools(
         emoji = get_tool_emoji(tool_name)
 
         # Capabilities
-        tool_capabilities: list[str] = []
-        if tool_name in check_tools:
-            tool_capabilities.append("check")
-        if tool_name in fix_tools:
-            tool_capabilities.append("fix")
+        tool_capabilities = _tool_capabilities(
+            tool_name=tool_name,
+            plugin=plugin,
+            check_tools=check_tools,
+            fix_tools=fix_tools,
+        )
         caps_display = ", ".join(tool_capabilities) if tool_capabilities else "-"
 
         # Priority and type

--- a/lintro/cli_utils/commands/list_tools.py
+++ b/lintro/cli_utils/commands/list_tools.py
@@ -41,6 +41,11 @@ def _resolve_conflicts(
     return conflict_names
 
 
+#: Capability label reported for advisory AI finders, which run under
+#: ``lintro review`` instead of ``chk``/``fmt`` (#1308).
+ADVISORY_CAPABILITY: str = "review"
+
+
 def _tool_capabilities(
     *,
     tool_name: str,
@@ -64,12 +69,12 @@ def _tool_capabilities(
         Capability labels in display order.
     """
     if plugin.definition.is_advisory:
-        return ["review"]
+        return [ADVISORY_CAPABILITY]
     capabilities: list[str] = []
     if tool_name in check_tools:
-        capabilities.append("check")
+        capabilities.append(Action.CHECK.value)
     if tool_name in fix_tools:
-        capabilities.append("fix")
+        capabilities.append(Action.FIX.value)
     return capabilities
 
 
@@ -312,11 +317,12 @@ def _generate_plain_text_output(
         tool_description = plugin.definition.description
         emoji = get_tool_emoji(tool_name)
 
-        capabilities: list[str] = []
-        if tool_name in check_tools:
-            capabilities.append(Action.CHECK.value)
-        if tool_name in fix_tools:
-            capabilities.append(Action.FIX.value)
+        capabilities = _tool_capabilities(
+            tool_name=tool_name,
+            plugin=plugin,
+            check_tools=check_tools,
+            fix_tools=fix_tools,
+        )
 
         capabilities_display = ", ".join(capabilities) if capabilities else "-"
 
@@ -336,9 +342,19 @@ def _generate_plain_text_output(
 
     summary_border = "-" * 70
     output_lines.append(summary_border)
+    # Advisory finders never run under chk/fmt, so they are counted on their
+    # own line rather than inflating the check-tool total (#1308).
+    advisory_names = {
+        name
+        for name, plugin in available_tools.items()
+        if plugin.definition.is_advisory
+    }
     output_lines.append(f"Total tools: {len(available_tools)}")
-    output_lines.append(f"Check tools: {len(check_tools)}")
-    output_lines.append(f"Fix tools: {len(fix_tools)}")
+    output_lines.append(
+        f"Check tools: {len(set(check_tools) - advisory_names)}",
+    )
+    output_lines.append(f"Fix tools: {len(set(fix_tools) - advisory_names)}")
+    output_lines.append(f"Advisory tools: {len(advisory_names)}")
     output_lines.append(summary_border)
 
     return output_lines

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -1,10 +1,26 @@
-"""CLI command for AI diff-based code review."""
+"""CLI command for AI code review.
+
+``lintro review`` owns both AI review surfaces:
+
+* the diff-based checklist review (epic #1609), and
+* **advisory AI-finder tools** — plugins classified
+  :attr:`~lintro.enums.execution_class.ExecutionClass.ADVISORY`, such as
+  ``idiom-review``. Those used to run under ``lintro chk``; because their
+  findings are nondeterministic opinions rather than rule violations they
+  moved here, so ``chk`` stays deterministic and its health score stays
+  stable across identical runs (#1308).
+
+Advisory findings are scoped to the review's changed files (or ``--path``)
+and never change the exit code unless ``--fail-on-findings`` is passed.
+"""
 
 from __future__ import annotations
 
+import json
 import os
 from contextlib import suppress
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from loguru import logger
@@ -41,6 +57,21 @@ from lintro.ai.review.output import render_review_output
 from lintro.ai.review.sensitivity import resolve_sensitivity_policy
 from lintro.ai.transport import apply_transport_override
 from lintro.config.config_loader import get_config
+from lintro.utils.execution.advisory import (
+    ADVISORY_TOOLS_ALL,
+    ADVISORY_TOOLS_NONE,
+    advisory_findings_count,
+    advisory_results_to_payload,
+    render_advisory_results,
+    resolve_advisory_tools,
+    run_advisory_tools,
+)
+
+if TYPE_CHECKING:
+    from lintro.models.core.tool_result import ToolResult
+
+#: Default paths scanned by ``--advisory-only`` when no ``--path`` is given.
+ADVISORY_DEFAULT_PATHS: tuple[str, ...] = (".",)
 
 
 @click.command("review")
@@ -156,6 +187,41 @@ from lintro.config.config_loader import get_config
         ".lintro/review-agents/*.md and exit."
     ),
 )
+@click.option(
+    "--advisory-tools",
+    default=None,
+    metavar="TOOLS",
+    help=(
+        "Advisory AI-finder tools to run (comma-separated), 'all' for every "
+        "enabled advisory tool (default), or 'none' to skip them. Advisory "
+        "tools do not run under 'lintro chk'."
+    ),
+)
+@click.option(
+    "--tool-options",
+    "tool_options",
+    default=None,
+    help=(
+        "Options for advisory tools, as tool:option=value[,tool:option=value] "
+        "(e.g. idiom-review:enabled=true)."
+    ),
+)
+@click.option(
+    "--advisory-only",
+    is_flag=True,
+    help=(
+        "Run only the advisory AI-finder tools and skip the diff-based "
+        "review. Scans --path values, or the current directory."
+    ),
+)
+@click.option(
+    "--fail-on-findings",
+    is_flag=True,
+    help=(
+        "Exit 1 when advisory tools report findings "
+        "(default: advisory findings exit 0)."
+    ),
+)
 def review_command(
     *,
     base: str | None,
@@ -174,8 +240,12 @@ def review_command(
     path_filter: tuple[str, ...],
     transport: str | None,
     list_agents: bool,
+    advisory_tools: str | None,
+    tool_options: str | None,
+    advisory_only: bool,
+    fail_on_findings: bool,
 ) -> None:
-    """Run AI-powered diff-based code review."""
+    """Run AI-powered diff-based code review, plus advisory AI finders."""
     lintro_config = get_config()
     workspace_root = resolve_workspace_root(lintro_config.config_path)
     if list_agents:
@@ -189,7 +259,26 @@ def review_command(
         )
         raise SystemExit(0)
 
+    if advisory_only and (post or pr is not None or uncommitted or base):
+        raise click.UsageError(
+            "--advisory-only runs advisory tools over paths and produces no "
+            "diff review, so it cannot be combined with --base, "
+            "--uncommitted, --pr or --post.",
+        )
+
     require_ai()
+    if advisory_only:
+        # Advisory-only needs no diff context and no review checklist, so it
+        # deliberately bypasses the ai.review gate: the user asked for the
+        # finder tools, not the diff review (#1308).
+        _run_advisory_only(
+            advisory_tools=advisory_tools,
+            tool_options=tool_options,
+            path_filter=path_filter,
+            output_format=output_format,
+            fail_on_findings=fail_on_findings,
+        )
+
     ai_config = resolve_ai_config(lintro_config)
     if not ai_config.review_enabled:
         raise click.UsageError(
@@ -351,14 +440,31 @@ def review_command(
 
     result = enrich_review_result(result=result, question_map=question_map)
 
+    advisory_results = _execute_advisory(
+        advisory_tools=advisory_tools,
+        tool_options=tool_options,
+        paths=[
+            file.path for file in context.changed_files if Path(file.path).is_file()
+        ],
+    )
+
     output = render_review_output(
         result=result,
         output_format=output_format,
         checklist_display=checklist_display,
         question_map=question_map,
     )
+    if output_format == "json":
+        output = _merge_advisory_into_json(
+            review_output=output,
+            advisory_results=advisory_results,
+        )
     if output is not None:
         click.echo(output)
+    if output_format != "json":
+        advisory_text = render_advisory_results(results=advisory_results)
+        if advisory_text:
+            click.echo(f"\n{advisory_text}")
 
     if post:
         from lintro.ai.review.github import post_review_to_github
@@ -374,7 +480,125 @@ def review_command(
             logger.warning("GitHub review posting skipped or failed")
 
     exit_code = 1 if result.has_p1_findings else 0
+    if fail_on_findings and advisory_findings_count(advisory_results):
+        exit_code = 1
     raise SystemExit(exit_code)
+
+
+def _execute_advisory(
+    *,
+    advisory_tools: str | None,
+    tool_options: str | None,
+    paths: list[str],
+) -> list[ToolResult]:
+    """Resolve and run the advisory tools requested for this review.
+
+    Args:
+        advisory_tools: Raw ``--advisory-tools`` value.
+        tool_options: Raw ``--tool-options`` value for advisory tools.
+        paths: Paths to scan (typically the review's changed files).
+
+    Returns:
+        One result per advisory tool that ran; empty when none were selected.
+
+    Raises:
+        click.UsageError: If a requested advisory tool is unknown or is not
+            an advisory tool.
+    """
+    try:
+        selection = resolve_advisory_tools(requested=advisory_tools)
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+    for skipped in selection.skipped:
+        # Only mention explicitly named tools; the default 'all' selection
+        # skipping an opt-in tool is the normal, quiet case.
+        if advisory_tools not in (None, ADVISORY_TOOLS_ALL):
+            logger.info(
+                "Skipping advisory tool {}: {}",
+                skipped.name,
+                skipped.reason,
+            )
+    return run_advisory_tools(
+        paths=paths,
+        tool_names=selection.to_run,
+        tool_options=tool_options,
+    )
+
+
+def _run_advisory_only(
+    *,
+    advisory_tools: str | None,
+    tool_options: str | None,
+    path_filter: tuple[str, ...],
+    output_format: str,
+    fail_on_findings: bool,
+) -> None:
+    """Run only the advisory tools, render their findings, and exit.
+
+    Args:
+        advisory_tools: Raw ``--advisory-tools`` value.
+        tool_options: Raw ``--tool-options`` value for advisory tools.
+        path_filter: ``--path`` values; defaults to the current directory.
+        output_format: ``terminal`` or ``json``.
+        fail_on_findings: Whether findings should produce exit code 1.
+
+    Raises:
+        SystemExit: Always; carries the resolved exit code.
+        click.UsageError: If the selection resolves to no tools at all.
+    """
+    if (advisory_tools or "").strip().lower() == ADVISORY_TOOLS_NONE:
+        raise click.UsageError(
+            "--advisory-only with --advisory-tools none would run nothing.",
+        )
+    paths = list(path_filter) if path_filter else list(ADVISORY_DEFAULT_PATHS)
+    results = _execute_advisory(
+        advisory_tools=advisory_tools,
+        tool_options=tool_options,
+        paths=paths,
+    )
+    if output_format == "json":
+        click.echo(
+            json.dumps(
+                {"advisory": advisory_results_to_payload(results)},
+                indent=2,
+            ),
+        )
+    else:
+        click.echo(
+            render_advisory_results(results=results) or "No advisory tools ran.",
+        )
+    findings = advisory_findings_count(results)
+    raise SystemExit(1 if (fail_on_findings and findings) else 0)
+
+
+def _merge_advisory_into_json(
+    *,
+    review_output: str | None,
+    advisory_results: list[ToolResult],
+) -> str | None:
+    """Add an ``advisory`` key to the review's JSON document.
+
+    The key is purely additive so existing consumers of the review JSON
+    contract keep parsing unchanged documents.
+
+    Args:
+        review_output: Rendered review JSON, or ``None``.
+        advisory_results: Advisory tool results to attach.
+
+    Returns:
+        The JSON document with an ``advisory`` key, or the original output
+        when it is absent or not a JSON object.
+    """
+    if not advisory_results or not isinstance(review_output, str):
+        return review_output
+    try:
+        document = json.loads(review_output)
+    except json.JSONDecodeError:
+        return review_output
+    if not isinstance(document, dict):
+        return review_output
+    document["advisory"] = advisory_results_to_payload(advisory_results)
+    return json.dumps(document, indent=2)
 
 
 def _resolve_custom_agents(
@@ -425,8 +649,6 @@ def _detect_pr_number_from_env() -> int | None:
     if not event_path:
         return None
     try:
-        import json
-
         payload = json.loads(Path(event_path).read_text(encoding="utf-8"))
         number = payload.get("pull_request", {}).get("number")
         return int(number) if isinstance(number, int) else None

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -67,6 +67,8 @@ from lintro.utils.execution.advisory import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from lintro.models.core.tool_result import ToolResult
 
 #: Default paths scanned by ``--advisory-only`` when no ``--path`` is given.
@@ -442,9 +444,10 @@ def review_command(
     advisory_results = _execute_advisory(
         advisory_tools=advisory_tools,
         tool_options=tool_options,
-        paths=[
-            file.path for file in context.changed_files if Path(file.path).is_file()
-        ],
+        paths=_existing_changed_files(
+            changed_files=context.changed_files,
+            workspace_root=workspace_root,
+        ),
     )
 
     output = render_review_output(
@@ -484,6 +487,37 @@ def review_command(
     raise SystemExit(exit_code)
 
 
+def _existing_changed_files(
+    *,
+    changed_files: Sequence[object],
+    workspace_root: Path,
+) -> list[str]:
+    """Resolve a review context's changed files to on-disk absolute paths.
+
+    Paths are resolved against the workspace root rather than the process cwd,
+    and deleted or renamed-away files are dropped: an advisory tool must never
+    be handed a path it cannot open.
+
+    Args:
+        changed_files: Changed-file entries carrying a ``path`` attribute.
+        workspace_root: Absolute workspace root the paths are relative to.
+
+    Returns:
+        Absolute paths of the changed files that still exist.
+    """
+    paths: list[str] = []
+    for changed in changed_files:
+        raw = getattr(changed, "path", None)
+        if not raw:
+            continue
+        candidate = Path(raw)
+        if not candidate.is_absolute():
+            candidate = workspace_root / candidate
+        if candidate.is_file():
+            paths.append(str(candidate))
+    return paths
+
+
 def _execute_advisory(
     *,
     advisory_tools: str | None,
@@ -510,7 +544,11 @@ def _execute_advisory(
         raise click.UsageError(str(exc)) from exc
     # Only report explicitly named tools; the default 'all' selection skipping
     # a config-disabled tool is the normal, quiet case.
-    if advisory_tools not in (None, AdvisoryToolsValue.ALL):
+    explicit_selection = (advisory_tools or "").strip().lower() not in (
+        "",
+        AdvisoryToolsValue.ALL,
+    )
+    if explicit_selection:
         for skipped in selection.skipped:
             logger.info(
                 "Skipping advisory tool {}: {}",

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -57,9 +57,8 @@ from lintro.ai.review.output import render_review_output
 from lintro.ai.review.sensitivity import resolve_sensitivity_policy
 from lintro.ai.transport import apply_transport_override
 from lintro.config.config_loader import get_config
+from lintro.enums.advisory_tools_value import AdvisoryToolsValue
 from lintro.utils.execution.advisory import (
-    ADVISORY_TOOLS_ALL,
-    ADVISORY_TOOLS_NONE,
     advisory_findings_count,
     advisory_results_to_payload,
     render_advisory_results,
@@ -509,10 +508,10 @@ def _execute_advisory(
         selection = resolve_advisory_tools(requested=advisory_tools)
     except ValueError as exc:
         raise click.UsageError(str(exc)) from exc
-    for skipped in selection.skipped:
-        # Only mention explicitly named tools; the default 'all' selection
-        # skipping an opt-in tool is the normal, quiet case.
-        if advisory_tools not in (None, ADVISORY_TOOLS_ALL):
+    # Only report explicitly named tools; the default 'all' selection skipping
+    # a config-disabled tool is the normal, quiet case.
+    if advisory_tools not in (None, AdvisoryToolsValue.ALL):
+        for skipped in selection.skipped:
             logger.info(
                 "Skipping advisory tool {}: {}",
                 skipped.name,
@@ -546,7 +545,7 @@ def _run_advisory_only(
         SystemExit: Always; carries the resolved exit code.
         click.UsageError: If the selection resolves to no tools at all.
     """
-    if (advisory_tools or "").strip().lower() == ADVISORY_TOOLS_NONE:
+    if (advisory_tools or "").strip().lower() == AdvisoryToolsValue.NONE:
         raise click.UsageError(
             "--advisory-only with --advisory-tools none would run nothing.",
         )

--- a/lintro/enums/advisory_tools_value.py
+++ b/lintro/enums/advisory_tools_value.py
@@ -1,0 +1,21 @@
+"""Special values accepted by ``lintro review --advisory-tools``.
+
+Mirrors :class:`lintro.enums.tools_value.ToolsValue` for the advisory tool
+selector, which additionally understands ``none`` (run no advisory tools).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+
+class AdvisoryToolsValue(StrEnum):
+    """Special ``--advisory-tools`` values.
+
+    Attributes:
+        ALL: Run every advisory tool enabled in configuration (the default).
+        NONE: Run no advisory tools at all.
+    """
+
+    ALL = auto()
+    NONE = auto()

--- a/lintro/enums/execution_class.py
+++ b/lintro/enums/execution_class.py
@@ -1,0 +1,54 @@
+"""Execution-class enum separating deterministic tools from advisory finders.
+
+Every classic lintro tool wraps an external binary and is deterministic:
+the same input always produces the same findings, which is what makes
+``lintro chk`` safe to run reflexively in editors, hooks, and CI gates.
+
+AI *finder* tools (``idiom-review`` and any future sibling) break that
+contract: they ask a model for opinions, so identical input can yield
+different findings, at real API cost and latency. Marking them
+:attr:`ExecutionClass.ADVISORY` keeps them out of ``chk`` (and therefore out
+of the health score) and routes them to ``lintro review`` instead (#1308).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+
+class ExecutionClass(StrEnum):
+    """How a tool's findings should be treated by the CLI verbs.
+
+    Attributes:
+        DETERMINISTIC: Same input always yields the same findings. Runs under
+            ``lintro chk`` / ``lintro fmt`` and feeds the health score.
+        ADVISORY: Nondeterministic, opinion-shaped findings (AI finders).
+            Runs under ``lintro review`` only, and never affects the exit
+            code unless ``--fail-on-findings`` is passed.
+    """
+
+    DETERMINISTIC = auto()
+    ADVISORY = auto()
+
+
+def normalize_execution_class(value: str | ExecutionClass) -> ExecutionClass:
+    """Normalize a raw value to an :class:`ExecutionClass`.
+
+    Args:
+        value: str or ExecutionClass to normalize (case-insensitive).
+
+    Returns:
+        ExecutionClass: Normalized enum value.
+
+    Raises:
+        ValueError: If the value is not a valid execution class.
+    """
+    if isinstance(value, ExecutionClass):
+        return value
+    try:
+        return ExecutionClass[value.upper()]
+    except KeyError as err:
+        raise ValueError(
+            f"Unknown execution class: {value!r}. "
+            f"Supported values: {[member.value for member in ExecutionClass]}",
+        ) from err

--- a/lintro/enums/idiom_review_mode.py
+++ b/lintro/enums/idiom_review_mode.py
@@ -1,0 +1,26 @@
+"""Review-mode enum for the AI-powered ``idiom-review`` tool.
+
+Kept in :mod:`lintro.enums` rather than beside the engine so the tool
+definition can name its default mode without importing
+:mod:`lintro.tools.idiom_review.engine` — and therefore without dragging the
+whole :mod:`lintro.ai` stack into plugin discovery on ``chk``-only
+invocations (#1305 / #1308).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class IdiomReviewMode(StrEnum):
+    """Which review modes the tool should run.
+
+    Attributes:
+        PER_FILE: Flag idiomatic misses within a single file.
+        DUPLICATION: Flag the same logic reimplemented across files.
+        BOTH: Run both modes in one pass.
+    """
+
+    PER_FILE = "per-file"
+    DUPLICATION = "duplication"
+    BOTH = "both"

--- a/lintro/plugins/protocol.py
+++ b/lintro/plugins/protocol.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+from lintro.enums.execution_class import ExecutionClass
 from lintro.enums.tool_type import ToolType
 
 if TYPE_CHECKING:
@@ -96,6 +97,9 @@ class ToolDefinition:
         description: Human-readable description of what the tool does.
         can_fix: Whether the tool can auto-fix issues.
         tool_type: Bitmask of ToolType flags describing capabilities.
+        execution_class: Whether the tool is deterministic (runs under ``chk``
+            and ``fmt``) or advisory (an AI finder; runs under
+            ``lintro review`` only).
         file_patterns: Glob patterns for files this tool operates on.
         priority: Execution priority (lower = runs first). Default is 50.
         conflicts_with: Names of tools that conflict with this one.
@@ -115,6 +119,7 @@ class ToolDefinition:
     # Capabilities
     can_fix: bool = False
     tool_type: ToolType = ToolType.LINTER
+    execution_class: ExecutionClass = ExecutionClass.DETERMINISTIC
 
     # File targeting
     file_patterns: list[str] = field(default_factory=list)
@@ -144,6 +149,15 @@ class ToolDefinition:
             raise ValueError("Tool name cannot be empty")
         if self.priority < 0:
             raise ValueError(f"Tool priority must be non-negative, got {self.priority}")
+
+    @property
+    def is_advisory(self) -> bool:
+        """Report whether this tool produces advisory (nondeterministic) findings.
+
+        Returns:
+            True when the tool is an AI finder routed to ``lintro review``.
+        """
+        return self.execution_class is ExecutionClass.ADVISORY
 
 
 @runtime_checkable

--- a/lintro/tools/definitions/idiom_review.py
+++ b/lintro/tools/definitions/idiom_review.py
@@ -9,6 +9,10 @@ detected by a syntax-matching linter. Two modes are offered:
 * **duplication** (Mode 2) — flag the same utility logic reimplemented
   across files, invisible to any per-file linter.
 
+The tool is classified :attr:`~lintro.enums.execution_class.ExecutionClass.ADVISORY`,
+so it never runs under ``lintro chk`` (and never feeds the health score).
+``lintro review`` is its home verb; see :mod:`lintro.utils.execution.advisory`.
+
 The tool ships disabled by default via the ``enabled: False`` option in
 ``default_options``: ``check()`` returns a skipped result immediately unless
 the caller opts in via ``tools.idiom-review`` config or
@@ -21,28 +25,26 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from loguru import logger
 
-from lintro.ai.availability import is_ai_available
-from lintro.ai.budget import CostBudget
-from lintro.ai.exceptions import AIError
-from lintro.ai.interface import resolve_ai_config
-from lintro.ai.paths import resolve_workspace_root
-from lintro.ai.providers import get_provider
 from lintro.enums.confidence_level import ConfidenceLevel
+from lintro.enums.execution_class import ExecutionClass
+from lintro.enums.idiom_review_mode import IdiomReviewMode
 from lintro.enums.tool_type import ToolType
 from lintro.models.core.tool_result import ToolResult
-from lintro.parsers.idiom_review.idiom_review_issue import IdiomReviewIssue
 from lintro.plugins.base import BaseToolPlugin
 from lintro.plugins.protocol import ToolDefinition
 from lintro.plugins.registry import register_tool
-from lintro.tools.idiom_review.engine import IdiomReviewEngine, IdiomReviewMode
 from lintro.tools.idiom_review.signatures import (
     Signature,
     extract_python_signatures,
 )
+
+if TYPE_CHECKING:
+    from lintro.parsers.idiom_review.idiom_review_issue import IdiomReviewIssue
+    from lintro.tools.idiom_review.engine import IdiomReviewEngine
 
 IDIOM_REVIEW_TOOL_NAME = "idiom-review"
 # Late priority so idiom review runs after the fast syntax linters.
@@ -88,6 +90,9 @@ class IdiomReviewPlugin(BaseToolPlugin):
             ),
             can_fix=False,
             tool_type=ToolType.LINTER,
+            # Advisory: nondeterministic AI findings never run under ``chk``
+            # and never feed the health score (#1308).
+            execution_class=ExecutionClass.ADVISORY,
             file_patterns=IDIOM_REVIEW_FILE_PATTERNS,
             priority=IDIOM_REVIEW_PRIORITY,
             conflicts_with=[],
@@ -135,6 +140,12 @@ class IdiomReviewPlugin(BaseToolPlugin):
                 output="idiom-review is disabled (opt-in required).",
             )
 
+        # Imported here, not at module scope: plugin discovery imports every
+        # tool definition, so a top-level ``lintro.ai`` import would drag the
+        # AI stack into every ``chk`` invocation (#1305).
+        from lintro.ai.availability import is_ai_available
+        from lintro.ai.exceptions import AIError
+
         # Graceful no-credentials path — never require live API access.
         if not is_ai_available():
             return ToolResult(
@@ -178,6 +189,12 @@ class IdiomReviewPlugin(BaseToolPlugin):
         Returns:
             ToolResult with the aggregated, confidence-filtered findings.
         """
+        from lintro.ai.budget import CostBudget
+        from lintro.ai.interface import resolve_ai_config
+        from lintro.ai.paths import resolve_workspace_root
+        from lintro.ai.providers import get_provider
+        from lintro.tools.idiom_review.engine import IdiomReviewEngine
+
         lintro_config = self._get_lintro_config()
         ai_config = resolve_ai_config(lintro_config)
         workspace_root = resolve_workspace_root(lintro_config.config_path)
@@ -335,6 +352,5 @@ class IdiomReviewPlugin(BaseToolPlugin):
             NotImplementedError: Always; the tool cannot fix issues.
         """
         raise NotImplementedError(
-            "idiom-review reports findings only. Use 'lintro chk --fix' to "
-            "generate AI fix suggestions for its findings.",
+            "idiom-review reports findings only; it runs under 'lintro review'.",
         )

--- a/lintro/tools/idiom_review/__init__.py
+++ b/lintro/tools/idiom_review/__init__.py
@@ -4,13 +4,39 @@ Groups the prompt templates, signature extraction, and the AI-calling
 engine used by :mod:`lintro.tools.definitions.idiom_review`. These live in
 their own package (rather than under ``lintro/ai/prompts``) so the tool is
 self-contained and its prompt surface can evolve independently.
+
+:class:`~lintro.tools.idiom_review.engine.IdiomReviewEngine` is re-exported
+lazily: importing it eagerly here would pull :mod:`lintro.ai` into plugin
+discovery, and therefore into every ``lintro chk`` invocation (#1305 /
+#1308).
 """
 
 from __future__ import annotations
 
-from lintro.tools.idiom_review.engine import (
-    IdiomReviewEngine,
-    IdiomReviewMode,
-)
+from typing import TYPE_CHECKING, Any
+
+from lintro.enums.idiom_review_mode import IdiomReviewMode
+
+if TYPE_CHECKING:
+    from lintro.tools.idiom_review.engine import IdiomReviewEngine
 
 __all__ = ["IdiomReviewEngine", "IdiomReviewMode"]
+
+
+def __getattr__(name: str) -> Any:  # noqa: ANN401 - module-level lazy re-export
+    """Resolve lazily re-exported names on first access.
+
+    Args:
+        name: Attribute name being looked up on this module.
+
+    Returns:
+        The resolved attribute.
+
+    Raises:
+        AttributeError: If the name is not a lazy re-export of this package.
+    """
+    if name == "IdiomReviewEngine":
+        from lintro.tools.idiom_review.engine import IdiomReviewEngine
+
+        return IdiomReviewEngine
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/lintro/tools/idiom_review/engine.py
+++ b/lintro/tools/idiom_review/engine.py
@@ -13,7 +13,6 @@ import hashlib
 import json
 import time
 from dataclasses import dataclass, field
-from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -37,14 +36,6 @@ if TYPE_CHECKING:
     from lintro.parsers.idiom_review.idiom_review_issue import IdiomReviewIssue
 
 _CACHE_SUBDIR = ".lintro-cache/idiom"
-
-
-class IdiomReviewMode(StrEnum):
-    """Which review modes the tool should run."""
-
-    PER_FILE = "per-file"
-    DUPLICATION = "duplication"
-    BOTH = "both"
 
 
 def _cache_key(namespace: str, payload: str) -> str:

--- a/lintro/utils/execution/advisory.py
+++ b/lintro/utils/execution/advisory.py
@@ -1,0 +1,297 @@
+"""Execution of advisory (AI-finder) tools for ``lintro review``.
+
+Advisory tools are plugins declaring
+:attr:`~lintro.enums.execution_class.ExecutionClass.ADVISORY`. They are
+excluded from ``lintro chk`` / ``lintro fmt`` — and therefore from the health
+score — because their findings are nondeterministic opinions rather than rule
+violations (#1308). This module is the counterpart runner that
+``lintro review`` uses to execute them.
+
+It is deliberately a thin, sequential runner rather than a second copy of the
+full :mod:`lintro.utils.tool_executor` pipeline: advisory tools never fix,
+never participate in post-checks, never feed the health score, and never
+affect the exit code unless the user opts in with ``--fail-on-findings``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from lintro.config.config_loader import get_config
+from lintro.enums.action import Action
+from lintro.models.core.tool_result import ToolResult
+from lintro.tools import tool_manager
+from lintro.utils.execution.tool_configuration import (
+    SkippedTool,
+    configure_tool_for_execution,
+)
+from lintro.utils.unified_config import UnifiedConfigManager
+
+if TYPE_CHECKING:
+    from lintro.config.lintro_config import LintroConfig
+
+__all__ = [
+    "ADVISORY_TOOLS_ALL",
+    "ADVISORY_TOOLS_NONE",
+    "AdvisorySelection",
+    "advisory_findings_count",
+    "advisory_results_to_payload",
+    "get_advisory_tool_names",
+    "render_advisory_results",
+    "resolve_advisory_tools",
+    "run_advisory_tools",
+]
+
+#: ``--advisory-tools`` value selecting every enabled advisory tool.
+ADVISORY_TOOLS_ALL = "all"
+#: ``--advisory-tools`` value disabling advisory execution entirely.
+ADVISORY_TOOLS_NONE = "none"
+
+
+@dataclass(frozen=True)
+class AdvisorySelection:
+    """Outcome of resolving a requested advisory tool selection.
+
+    Attributes:
+        to_run: Registered names of advisory tools that should execute.
+        skipped: Advisory tools excluded by configuration, with reasons.
+    """
+
+    to_run: list[str] = field(default_factory=list)
+    skipped: list[SkippedTool] = field(default_factory=list)
+
+
+def get_advisory_tool_names() -> list[str]:
+    """Return the registered names of every advisory tool.
+
+    Returns:
+        Sorted advisory tool names (empty when none are registered).
+    """
+    return sorted(
+        name
+        for name, plugin in tool_manager.get_all_tools().items()
+        if plugin.definition.is_advisory
+    )
+
+
+def resolve_advisory_tools(
+    *,
+    requested: str | None,
+    lintro_config: LintroConfig | None = None,
+) -> AdvisorySelection:
+    """Resolve the advisory tools to run for a review invocation.
+
+    Propagates the :class:`ValueError` raised by
+    :func:`_resolve_advisory_name` when a requested name is unknown or names a
+    deterministic tool.
+
+    Args:
+        requested: Raw ``--advisory-tools`` value. ``None`` or ``"all"``
+            selects every advisory tool enabled in configuration, ``"none"``
+            selects nothing, and a comma-separated list selects those tools
+            explicitly (bypassing ``execution.enabled_tools`` but still
+            honoring ``tools.<name>.enabled: false``).
+        lintro_config: Optional config override; the global config is loaded
+            when omitted.
+
+    Returns:
+        AdvisorySelection with the tools to run and those skipped.
+    """
+    config = lintro_config or get_config()
+    advisory_names = get_advisory_tool_names()
+
+    normalized = (requested or ADVISORY_TOOLS_ALL).strip().lower()
+    if normalized == ADVISORY_TOOLS_NONE:
+        return AdvisorySelection()
+
+    skipped: list[SkippedTool] = []
+    if normalized == ADVISORY_TOOLS_ALL:
+        to_run: list[str] = []
+        for name in advisory_names:
+            if config.is_tool_enabled(name):
+                to_run.append(name)
+            else:
+                skipped.append(SkippedTool(name=name, reason="disabled in config"))
+        return AdvisorySelection(to_run=to_run, skipped=skipped)
+
+    to_run = []
+    for raw_name in normalized.split(","):
+        name = raw_name.strip()
+        if not name:
+            continue
+        resolved = _resolve_advisory_name(name=name, advisory_names=advisory_names)
+        # Explicit selection bypasses execution.enabled_tools, mirroring how
+        # ``chk --tools`` treats the allowlist, but a per-tool
+        # ``enabled: false`` still wins.
+        if not config.get_tool_config(resolved).enabled:
+            skipped.append(SkippedTool(name=resolved, reason="disabled in config"))
+            continue
+        to_run.append(resolved)
+    return AdvisorySelection(to_run=to_run, skipped=skipped)
+
+
+def _resolve_advisory_name(*, name: str, advisory_names: list[str]) -> str:
+    """Resolve a user-supplied advisory tool name to its registered key.
+
+    Args:
+        name: Lowercased user-supplied tool name.
+        advisory_names: Registered advisory tool names.
+
+    Returns:
+        The matching registered advisory tool name.
+
+    Raises:
+        ValueError: If the name is unknown or names a deterministic tool.
+    """
+    candidates = {name, name.replace("_", "-"), name.replace("-", "_")}
+    for candidate in candidates:
+        if candidate in advisory_names:
+            return candidate
+    if any(tool_manager.is_tool_registered(candidate) for candidate in candidates):
+        raise ValueError(
+            f"Tool '{name}' is not an advisory tool; run it with "
+            f"'lintro chk --tools {name}'.",
+        )
+    raise ValueError(
+        f"Unknown advisory tool '{name}'. Available advisory tools: "
+        f"{advisory_names or ['none']}",
+    )
+
+
+def run_advisory_tools(
+    *,
+    paths: list[str],
+    tool_names: list[str],
+    tool_options: str | None = None,
+    lintro_config: LintroConfig | None = None,
+) -> list[ToolResult]:
+    """Execute the given advisory tools over ``paths``.
+
+    Args:
+        paths: File or directory paths to review.
+        tool_names: Registered advisory tool names to execute.
+        tool_options: Raw ``--tool-options`` string
+            (``tool:option=value,...``) applied on top of configuration.
+        lintro_config: Optional config override; the global config is loaded
+            when omitted.
+
+    Returns:
+        One :class:`~lintro.models.core.tool_result.ToolResult` per tool, in
+        the order given. A tool that raises is reported as a failed result
+        rather than aborting the review.
+    """
+    if not tool_names or not paths:
+        return []
+
+    from lintro.utils.tool_options import parse_tool_options
+
+    config = lintro_config or get_config()
+    config_manager = UnifiedConfigManager()
+    tool_option_dict = parse_tool_options(tool_options)
+    results: list[ToolResult] = []
+    for tool_name in tool_names:
+        tool = configure_tool_for_execution(
+            tool=tool_manager.get_tool(tool_name),
+            tool_name=tool_name,
+            config_manager=config_manager,
+            tool_option_dict=tool_option_dict,
+            exclude=None,
+            include_venv=False,
+            incremental=False,
+            action=Action.CHECK,
+            post_tools=set(),
+            lintro_config=config,
+        )
+        try:
+            results.append(tool.check(paths, {}))
+        except Exception as exc:  # noqa: BLE001 - advisory runs never abort review
+            logger.warning("[{}] advisory tool failed: {}", tool_name, exc)
+            results.append(
+                ToolResult(
+                    name=tool_name,
+                    success=False,
+                    output=f"{tool_name} failed: {exc}",
+                ),
+            )
+    return results
+
+
+def advisory_findings_count(results: list[ToolResult]) -> int:
+    """Return the total number of advisory findings across results.
+
+    Args:
+        results: Advisory tool results.
+
+    Returns:
+        Sum of the per-tool issue counts, ignoring skipped tools.
+    """
+    return sum(
+        result.issues_count or 0
+        for result in results
+        if not getattr(result, "skipped", False)
+    )
+
+
+def render_advisory_results(
+    *,
+    results: list[ToolResult],
+    output_format: str = "grid",
+) -> str:
+    """Render advisory results as a human-readable block.
+
+    Args:
+        results: Advisory tool results to render.
+        output_format: Table format understood by
+            :func:`lintro.utils.output.file_writer.format_tool_output`.
+
+    Returns:
+        Rendered text, or an empty string when there is nothing to show.
+    """
+    from lintro.utils.output.file_writer import format_tool_output
+
+    if not results:
+        return ""
+
+    blocks: list[str] = []
+    for result in results:
+        header = f"Advisory: {result.name}"
+        if getattr(result, "skipped", False):
+            reason = result.skip_reason or "skipped"
+            blocks.append(f"{header}\n  skipped — {reason}")
+            continue
+        body = format_tool_output(
+            tool_name=result.name,
+            output=result.output or "",
+            output_format=output_format,
+            issues=result.issues,
+            success=result.success,
+            issues_count=result.issues_count,
+        )
+        blocks.append(f"{header}\n{body}".rstrip())
+    return "\n\n".join(blocks)
+
+
+def advisory_results_to_payload(results: list[ToolResult]) -> list[dict[str, object]]:
+    """Convert advisory results to JSON-serializable dictionaries.
+
+    Args:
+        results: Advisory tool results.
+
+    Returns:
+        One dictionary per tool with its findings as display rows.
+    """
+    payload: list[dict[str, object]] = []
+    for result in results:
+        payload.append(
+            {
+                "tool": result.name,
+                "skipped": bool(getattr(result, "skipped", False)),
+                "skip_reason": result.skip_reason,
+                "issues_count": result.issues_count or 0,
+                "issues": [issue.to_display_row() for issue in (result.issues or [])],
+            },
+        )
+    return payload

--- a/lintro/utils/execution/advisory.py
+++ b/lintro/utils/execution/advisory.py
@@ -22,6 +22,7 @@ from loguru import logger
 
 from lintro.config.config_loader import get_config
 from lintro.enums.action import Action
+from lintro.enums.advisory_tools_value import AdvisoryToolsValue
 from lintro.models.core.tool_result import ToolResult
 from lintro.tools import tool_manager
 from lintro.utils.execution.tool_configuration import (
@@ -34,8 +35,6 @@ if TYPE_CHECKING:
     from lintro.config.lintro_config import LintroConfig
 
 __all__ = [
-    "ADVISORY_TOOLS_ALL",
-    "ADVISORY_TOOLS_NONE",
     "AdvisorySelection",
     "advisory_findings_count",
     "advisory_results_to_payload",
@@ -44,11 +43,6 @@ __all__ = [
     "resolve_advisory_tools",
     "run_advisory_tools",
 ]
-
-#: ``--advisory-tools`` value selecting every enabled advisory tool.
-ADVISORY_TOOLS_ALL = "all"
-#: ``--advisory-tools`` value disabling advisory execution entirely.
-ADVISORY_TOOLS_NONE = "none"
 
 
 @dataclass(frozen=True)
@@ -103,12 +97,12 @@ def resolve_advisory_tools(
     config = lintro_config or get_config()
     advisory_names = get_advisory_tool_names()
 
-    normalized = (requested or ADVISORY_TOOLS_ALL).strip().lower()
-    if normalized == ADVISORY_TOOLS_NONE:
+    normalized = (requested or AdvisoryToolsValue.ALL).strip().lower()
+    if normalized == AdvisoryToolsValue.NONE:
         return AdvisorySelection()
 
     skipped: list[SkippedTool] = []
-    if normalized == ADVISORY_TOOLS_ALL:
+    if normalized == AdvisoryToolsValue.ALL:
         to_run: list[str] = []
         for name in advisory_names:
             if config.is_tool_enabled(name):

--- a/lintro/utils/execution/advisory.py
+++ b/lintro/utils/execution/advisory.py
@@ -187,19 +187,22 @@ def run_advisory_tools(
     tool_option_dict = parse_tool_options(tool_options)
     results: list[ToolResult] = []
     for tool_name in tool_names:
-        tool = configure_tool_for_execution(
-            tool=tool_manager.get_tool(tool_name),
-            tool_name=tool_name,
-            config_manager=config_manager,
-            tool_option_dict=tool_option_dict,
-            exclude=None,
-            include_venv=False,
-            incremental=False,
-            action=Action.CHECK,
-            post_tools=set(),
-            lintro_config=config,
-        )
+        # Lookup and configuration are inside the guard too: a plugin that
+        # raises while building its option state must not abort the whole
+        # review any more than one that raises inside check().
         try:
+            tool = configure_tool_for_execution(
+                tool=tool_manager.get_tool(tool_name),
+                tool_name=tool_name,
+                config_manager=config_manager,
+                tool_option_dict=tool_option_dict,
+                exclude=None,
+                include_venv=False,
+                incremental=False,
+                action=Action.CHECK,
+                post_tools=set(),
+                lintro_config=config,
+            )
             results.append(tool.check(paths, {}))
         except Exception as exc:  # noqa: BLE001 - advisory runs never abort review
             logger.warning("[{}] advisory tool failed: {}", tool_name, exc)

--- a/lintro/utils/execution/tool_configuration.py
+++ b/lintro/utils/execution/tool_configuration.py
@@ -93,6 +93,40 @@ def _unknown_tool_error_message(*, name: str, available_names: list[str]) -> str
     return message
 
 
+def _is_advisory_tool(*, name: str) -> bool:
+    """Report whether a registered tool is an advisory AI finder.
+
+    Args:
+        name: Registered tool name.
+
+    Returns:
+        True when the tool declares ``ExecutionClass.ADVISORY``. Tools that
+        cannot be resolved are treated as deterministic so selection never
+        fails on a lookup problem.
+    """
+    try:
+        return bool(tool_manager.get_tool(name).definition.is_advisory)
+    except (AttributeError, KeyError, ValueError):
+        return False
+
+
+def _advisory_tool_error_message(*, name: str) -> str:
+    """Build the error shown when an advisory tool is requested from chk/fmt.
+
+    Args:
+        name: The registered advisory tool name the user asked for.
+
+    Returns:
+        Error message string pointing the user at ``lintro review``.
+    """
+    return (
+        f"Tool '{name}' is an advisory AI finder and does not run under "
+        f"'lintro chk' or 'lintro fmt': its findings are nondeterministic, so "
+        f"they must not gate deterministic checks or the health score. "
+        f"Run 'lintro review --advisory-tools {name}' instead."
+    )
+
+
 @dataclass(frozen=True)
 class SkippedTool:
     """A tool that was skipped during tool selection."""
@@ -377,6 +411,11 @@ def get_tools_to_run(
         for name in available_tools:
             if name.lower() == "pytest":
                 continue
+            # Advisory AI finders belong to 'lintro review'. Excluded silently
+            # (not reported as skipped) because they were never part of this
+            # verb's tool set (#1308).
+            if _is_advisory_tool(name=name):
+                continue
             if not config.is_tool_enabled(name):
                 reason = _get_disabled_reason(config, name)
                 skipped.append(SkippedTool(name=name, reason=reason))
@@ -415,6 +454,11 @@ def get_tools_to_run(
                     available_names=available_names,
                 ),
             )
+        # Advisory AI finders are never runnable from chk/fmt, even when named
+        # explicitly: point the user at 'lintro review' instead of silently
+        # dropping the tool they asked for (#1308).
+        if _is_advisory_tool(name=resolved_name):
+            raise ValueError(_advisory_tool_error_message(name=resolved_name))
         # Explicit --tools bypasses execution.enabled_tools (that allowlist
         # scopes default / --tools all runs only). Still honor per-tool
         # tools.<name>.enabled: false.

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -37,7 +37,7 @@ SUBCOMMAND_SUMMARY_PHRASES: dict[str, str] = {
     "install": "Install or upgrade external tools used by lintro.",
     "licenses": "Check dependency licenses for policy compliance.",
     "list-tools": "List all available tools and their configurations.",
-    "review": "Run AI-powered diff-based code review.",
+    "review": "Run AI-powered diff-based code review, plus advisory AI finders.",
     "setup": "Set up lintro for your project.",
     "test": "Run tests using pytest.",
     "versions": "Display version information for all supported tools.",

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -18,6 +19,9 @@ from lintro.ai.review.exceptions import ReviewExecutionError
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.cli import cli
+from lintro.cli_utils.commands.review import _merge_advisory_into_json
+from lintro.models.core.tool_result import ToolResult
+from lintro.parsers.idiom_review.idiom_review_issue import IdiomReviewIssue
 
 
 def _empty_result() -> ReviewResult:
@@ -882,3 +886,197 @@ def test_review_custom_agents_only_with_no_valid_agents_errors(
     assert_that(result.exit_code).is_equal_to(2)
     assert_that(str(result.output)).contains("no valid agents were found")
     assert_that(run_review.called).is_false()
+
+
+# =============================================================================
+# Advisory AI finders (#1308)
+# =============================================================================
+
+
+def _advisory_finding_result() -> ToolResult:
+    """Build an advisory tool result carrying a single finding."""
+    return ToolResult(
+        name="idiom-review",
+        success=False,
+        issues_count=1,
+        issues=[
+            IdiomReviewIssue(
+                file="a.py",
+                line=3,
+                message="prefer any()",
+                code="idiom/python/prefer-any",
+            ),
+        ],
+    )
+
+
+def test_review_help_shows_advisory_flags() -> None:
+    """Review help documents the advisory finder flags."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["review", "--help"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains("--advisory-tools")
+    assert_that(result.output).contains("--advisory-only")
+    assert_that(result.output).contains("--fail-on-findings")
+
+
+def test_advisory_only_exits_zero_with_findings() -> None:
+    """Advisory findings are advisory: exit 0 by default."""
+    runner = CliRunner()
+    with (
+        patch("lintro.cli_utils.commands.review.require_ai"),
+        patch(
+            "lintro.cli_utils.commands.review.run_advisory_tools",
+            return_value=[_advisory_finding_result()],
+        ),
+    ):
+        result = runner.invoke(cli, ["review", "--advisory-only"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains("idiom-review")
+
+
+def test_advisory_only_fail_on_findings_exits_one() -> None:
+    """--fail-on-findings turns advisory findings into a failure."""
+    runner = CliRunner()
+    with (
+        patch("lintro.cli_utils.commands.review.require_ai"),
+        patch(
+            "lintro.cli_utils.commands.review.run_advisory_tools",
+            return_value=[_advisory_finding_result()],
+        ),
+    ):
+        result = runner.invoke(
+            cli,
+            ["review", "--advisory-only", "--fail-on-findings"],
+        )
+
+    assert_that(result.exit_code).is_equal_to(1)
+
+
+def test_advisory_only_json_output() -> None:
+    """--advisory-only --output json emits an advisory document."""
+    runner = CliRunner()
+    with (
+        patch("lintro.cli_utils.commands.review.require_ai"),
+        patch(
+            "lintro.cli_utils.commands.review.run_advisory_tools",
+            return_value=[_advisory_finding_result()],
+        ),
+    ):
+        result = runner.invoke(
+            cli,
+            ["review", "--advisory-only", "--output", "json"],
+        )
+
+    assert_that(result.exit_code).is_equal_to(0)
+    payload = json.loads(result.output)
+    assert_that(payload["advisory"]).is_length(1)
+    assert_that(payload["advisory"][0]["tool"]).is_equal_to("idiom-review")
+
+
+def test_advisory_only_rejects_diff_flags() -> None:
+    """--advisory-only cannot be combined with diff-review flags."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["review", "--advisory-only", "--uncommitted"])
+
+    assert_that(result.exit_code).is_not_equal_to(0)
+    assert_that(result.output).contains("--advisory-only")
+
+
+def test_advisory_only_with_no_tools_errors() -> None:
+    """Asking for advisory-only while disabling every tool is a usage error."""
+    runner = CliRunner()
+    with patch("lintro.cli_utils.commands.review.require_ai"):
+        result = runner.invoke(
+            cli,
+            ["review", "--advisory-only", "--advisory-tools", "none"],
+        )
+
+    assert_that(result.exit_code).is_not_equal_to(0)
+    assert_that(result.output).contains("would run nothing")
+
+
+def test_advisory_tools_none_skips_advisory_in_full_review() -> None:
+    """--advisory-tools none runs the diff review without advisory tools."""
+    runner = CliRunner()
+    patches = _mock_review_pipeline()
+
+    with (
+        patches["require_ai"],
+        patches["get_config"],
+        patches["collect_review_context"],
+        patches["classify_changed_files"],
+        patches["get_all_checklist_items"],
+        patches["select_checklist_items"],
+        patches["format_checklist_for_prompt"],
+        patches["get_provider"],
+        patches["run_review"],
+        patches["render_review_output"],
+        patch(
+            "lintro.cli_utils.commands.review.run_advisory_tools",
+        ) as run_advisory,
+    ):
+        result = runner.invoke(cli, ["review", "--advisory-tools", "none"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(run_advisory.call_args.kwargs["tool_names"]).is_empty()
+
+
+def test_unknown_advisory_tool_is_a_usage_error() -> None:
+    """An unknown advisory tool name fails as a usage error."""
+    runner = CliRunner()
+    with patch("lintro.cli_utils.commands.review.require_ai"):
+        result = runner.invoke(
+            cli,
+            ["review", "--advisory-only", "--advisory-tools", "nope"],
+        )
+
+    assert_that(result.exit_code).is_not_equal_to(0)
+    assert_that(result.output).contains("Unknown advisory tool")
+
+
+def test_deterministic_tool_rejected_by_review() -> None:
+    """Naming a deterministic tool on review points back at chk."""
+    runner = CliRunner()
+    with patch("lintro.cli_utils.commands.review.require_ai"):
+        result = runner.invoke(
+            cli,
+            ["review", "--advisory-only", "--advisory-tools", "ruff"],
+        )
+
+    assert_that(result.exit_code).is_not_equal_to(0)
+    assert_that(result.output).contains("lintro chk --tools ruff")
+
+
+def test_merge_advisory_into_json_adds_key() -> None:
+    """Advisory results are added to the review JSON as an additive key."""
+    merged = _merge_advisory_into_json(
+        review_output=json.dumps({"summary": "ok"}),
+        advisory_results=[_advisory_finding_result()],
+    )
+
+    document = json.loads(str(merged))
+    assert_that(document["summary"]).is_equal_to("ok")
+    assert_that(document["advisory"][0]["issues_count"]).is_equal_to(1)
+
+
+def test_merge_advisory_into_json_leaves_non_json_untouched() -> None:
+    """A non-JSON payload is returned verbatim rather than corrupted."""
+    merged = _merge_advisory_into_json(
+        review_output="not json",
+        advisory_results=[_advisory_finding_result()],
+    )
+
+    assert_that(merged).is_equal_to("not json")
+
+
+def test_merge_advisory_into_json_without_advisory_results() -> None:
+    """No advisory results means the review document is unchanged."""
+    merged = _merge_advisory_into_json(
+        review_output=json.dumps({"summary": "ok"}),
+        advisory_results=[],
+    )
+
+    assert_that(json.loads(str(merged))).does_not_contain_key("advisory")

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -1080,3 +1080,68 @@ def test_merge_advisory_into_json_without_advisory_results() -> None:
     )
 
     assert_that(json.loads(str(merged))).does_not_contain_key("advisory")
+
+
+def test_full_review_renders_advisory_block_after_review_output() -> None:
+    """Terminal output shows advisory findings under the diff review."""
+    runner = CliRunner()
+    patches = _mock_review_pipeline()
+
+    with (
+        patches["require_ai"],
+        patches["get_config"],
+        patches["collect_review_context"],
+        patches["classify_changed_files"],
+        patches["get_all_checklist_items"],
+        patches["select_checklist_items"],
+        patches["format_checklist_for_prompt"],
+        patches["get_provider"],
+        patches["run_review"],
+        patch(
+            "lintro.cli_utils.commands.review.render_review_output",
+            return_value="REVIEW BODY",
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.run_advisory_tools",
+            return_value=[_advisory_finding_result()],
+        ),
+    ):
+        result = runner.invoke(cli, ["review"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains("REVIEW BODY")
+    assert_that(result.output.index("REVIEW BODY")).is_less_than(
+        result.output.index("Advisory: idiom-review"),
+    )
+
+
+def test_full_review_json_merges_advisory_key() -> None:
+    """JSON output carries advisory findings under an additive key."""
+    runner = CliRunner()
+    patches = _mock_review_pipeline()
+
+    with (
+        patches["require_ai"],
+        patches["get_config"],
+        patches["collect_review_context"],
+        patches["classify_changed_files"],
+        patches["get_all_checklist_items"],
+        patches["select_checklist_items"],
+        patches["format_checklist_for_prompt"],
+        patches["get_provider"],
+        patches["run_review"],
+        patch(
+            "lintro.cli_utils.commands.review.render_review_output",
+            return_value=json.dumps({"summary": "ok"}),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.run_advisory_tools",
+            return_value=[_advisory_finding_result()],
+        ),
+    ):
+        result = runner.invoke(cli, ["review", "--output", "json"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    payload = json.loads(result.output)
+    assert_that(payload["summary"]).is_equal_to("ok")
+    assert_that(payload["advisory"][0]["tool"]).is_equal_to("idiom-review")

--- a/tests/unit/tools/executor/test_advisory_tool_selection.py
+++ b/tests/unit/tools/executor/test_advisory_tool_selection.py
@@ -1,0 +1,87 @@
+"""Tool-selection tests for advisory (AI-finder) tools under chk/fmt.
+
+Advisory tools moved out of ``lintro chk`` in #1308: they must never appear
+in a default or ``--tools all`` run, and naming one explicitly must fail with
+a pointer to ``lintro review`` rather than silently doing nothing.
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 - runs a fixed argv against this interpreter
+import sys
+
+import pytest
+from assertpy import assert_that
+
+from lintro.enums.action import Action
+from lintro.utils.execution.tool_configuration import get_tools_to_run
+
+_AI_MODULES_SNIPPET = (
+    "import sys; "
+    "from lintro.plugins.discovery import discover_all_tools; "
+    "discover_all_tools(); "
+    "print(len([m for m in sys.modules if m.startswith('lintro.ai')]))"
+)
+
+
+def test_default_check_run_excludes_advisory_tools() -> None:
+    """A default check run never selects an advisory tool."""
+    result = get_tools_to_run(tools=None, action=Action.CHECK)
+
+    assert_that(result.to_run).does_not_contain("idiom-review")
+    assert_that([tool.name for tool in result.skipped]).does_not_contain(
+        "idiom-review",
+    )
+
+
+def test_tools_all_check_run_excludes_advisory_tools() -> None:
+    """``--tools all`` is still deterministic-only."""
+    result = get_tools_to_run(tools="all", action=Action.CHECK)
+
+    assert_that(result.to_run).does_not_contain("idiom-review")
+
+
+def test_fmt_run_excludes_advisory_tools() -> None:
+    """A default fmt run never selects an advisory tool."""
+    result = get_tools_to_run(tools=None, action=Action.FIX)
+
+    assert_that(result.to_run).does_not_contain("idiom-review")
+
+
+def test_explicit_advisory_tool_errors_with_review_pointer() -> None:
+    """``chk --tools idiom-review`` fails and names the review verb."""
+    with pytest.raises(ValueError) as excinfo:
+        get_tools_to_run(tools="idiom-review", action=Action.CHECK)
+
+    message = str(excinfo.value)
+    assert_that(message).contains("advisory")
+    assert_that(message).contains("lintro review --advisory-tools idiom-review")
+
+
+def test_explicit_advisory_tool_errors_for_underscore_spelling() -> None:
+    """The alias spelling errors the same way as the registered name."""
+    with pytest.raises(ValueError, match="lintro review"):
+        get_tools_to_run(tools="idiom_review", action=Action.CHECK)
+
+
+def test_deterministic_tool_still_selectable() -> None:
+    """Classifying advisory tools does not disturb deterministic ones."""
+    result = get_tools_to_run(tools="ruff", action=Action.CHECK)
+
+    assert_that(result.to_run).is_equal_to(["ruff"])
+
+
+def test_plugin_discovery_loads_no_ai_modules() -> None:
+    """Discovery must not drag the AI stack into chk-only runs (#1305).
+
+    Runs in a fresh interpreter because the in-process ``sys.modules`` is
+    polluted by other tests that legitimately import the AI layer.
+    """
+    completed = subprocess.run(  # nosec B603 - fixed argv, shell=False
+        [sys.executable, "-c", _AI_MODULES_SNIPPET],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert_that(completed.stdout.strip().splitlines()[-1]).is_equal_to("0")

--- a/tests/unit/tools/executor/test_tool_configuration_enabled.py
+++ b/tests/unit/tools/executor/test_tool_configuration_enabled.py
@@ -21,9 +21,15 @@ from lintro.utils.execution.tool_configuration import get_tools_to_run
 class _FakeToolDefinition:
     """Fake ToolDefinition for testing."""
 
-    def __init__(self, name: str, can_fix: bool = True) -> None:
+    def __init__(
+        self,
+        name: str,
+        can_fix: bool = True,
+        is_advisory: bool = False,
+    ) -> None:
         self.name = name
         self.can_fix = can_fix
+        self.is_advisory = is_advisory
         self.description = ""
         self.file_patterns: list[str] = []
         self.native_configs: list[str] = []

--- a/tests/unit/tools/idiom_review/test_idiom_review_engine.py
+++ b/tests/unit/tools/idiom_review/test_idiom_review_engine.py
@@ -12,7 +12,8 @@ from assertpy import assert_that
 from lintro.ai.config import AIConfig
 from lintro.ai.enums import AITransport
 from lintro.ai.providers.response import AIResponse
-from lintro.tools.idiom_review.engine import IdiomReviewEngine, IdiomReviewMode
+from lintro.enums.idiom_review_mode import IdiomReviewMode
+from lintro.tools.idiom_review.engine import IdiomReviewEngine
 from lintro.tools.idiom_review.signatures import extract_python_signatures
 
 

--- a/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
+++ b/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
@@ -11,7 +11,9 @@ from typing import Any
 import pytest
 from assertpy import assert_that
 
-import lintro.tools.definitions.idiom_review as plugin_module
+import lintro.ai.availability as availability_module
+import lintro.ai.providers as providers_module
+import lintro.tools.idiom_review.engine as engine_module
 from lintro.ai.config import AIConfig
 from lintro.ai.exceptions import AIAuthenticationError
 from lintro.config.lintro_config import LintroConfig
@@ -43,6 +45,8 @@ def test_definition_metadata() -> None:
     assert_that(definition.version_command).is_none()
     assert_that(definition.file_patterns).contains("*.py")
     assert_that(definition.default_options["enabled"]).is_false()
+    # Advisory: runs under 'lintro review', never under 'chk' (#1308).
+    assert_that(definition.is_advisory).is_true()
 
 
 def test_disabled_by_default_skips(tmp_path: Path) -> None:
@@ -59,7 +63,7 @@ def test_no_ai_provider_degrades_gracefully(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When no provider is available, the tool skips rather than fails."""
-    monkeypatch.setattr(plugin_module, "is_ai_available", lambda: False)
+    monkeypatch.setattr(availability_module, "is_ai_available", lambda: False)
 
     result = IdiomReviewPlugin().check([_write_py(tmp_path)], {"enabled": True})
 
@@ -125,9 +129,13 @@ class _FakeEngine:
 
 
 def _patch_engine(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(plugin_module, "is_ai_available", lambda: True)
-    monkeypatch.setattr(plugin_module, "get_provider", lambda _cfg, **_kwargs: object())
-    monkeypatch.setattr(plugin_module, "IdiomReviewEngine", _FakeEngine)
+    monkeypatch.setattr(availability_module, "is_ai_available", lambda: True)
+    monkeypatch.setattr(
+        providers_module,
+        "get_provider",
+        lambda _cfg, **_kwargs: object(),
+    )
+    monkeypatch.setattr(engine_module, "IdiomReviewEngine", _FakeEngine)
 
 
 def test_enabled_with_mocked_engine_reports_issues(
@@ -167,9 +175,9 @@ def test_engine_is_built_from_the_raw_ai_mapping(
             recorded.update(kwargs)
             super().__init__(*args, **kwargs)
 
-    monkeypatch.setattr(plugin_module, "is_ai_available", lambda: True)
-    monkeypatch.setattr(plugin_module, "get_provider", lambda cfg, **_kwargs: cfg)
-    monkeypatch.setattr(plugin_module, "IdiomReviewEngine", _RecordingEngine)
+    monkeypatch.setattr(availability_module, "is_ai_available", lambda: True)
+    monkeypatch.setattr(providers_module, "get_provider", lambda cfg, **_kwargs: cfg)
+    monkeypatch.setattr(engine_module, "IdiomReviewEngine", _RecordingEngine)
     monkeypatch.setattr(
         IdiomReviewPlugin,
         "_get_lintro_config",
@@ -211,8 +219,12 @@ def test_ai_error_degrades_gracefully(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Provider errors (e.g. depleted credits) skip instead of crashing."""
-    monkeypatch.setattr(plugin_module, "is_ai_available", lambda: True)
-    monkeypatch.setattr(plugin_module, "get_provider", lambda _cfg, **_kwargs: object())
+    monkeypatch.setattr(availability_module, "is_ai_available", lambda: True)
+    monkeypatch.setattr(
+        providers_module,
+        "get_provider",
+        lambda _cfg, **_kwargs: object(),
+    )
 
     class _RaisingEngine(_FakeEngine):
         async def review_file(self, **_kwargs: object) -> list[IdiomReviewIssue]:
@@ -229,7 +241,7 @@ def test_ai_error_degrades_gracefully(
             """
             raise AIAuthenticationError("no credits")
 
-    monkeypatch.setattr(plugin_module, "IdiomReviewEngine", _RaisingEngine)
+    monkeypatch.setattr(engine_module, "IdiomReviewEngine", _RaisingEngine)
 
     result = IdiomReviewPlugin().check(
         [_write_py(tmp_path)],

--- a/tests/unit/utils/execution/test_advisory.py
+++ b/tests/unit/utils/execution/test_advisory.py
@@ -1,0 +1,194 @@
+"""Tests for the advisory (AI-finder) tool runner used by ``lintro review``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+from assertpy import assert_that
+
+from lintro.enums.execution_class import (
+    ExecutionClass,
+    normalize_execution_class,
+)
+from lintro.models.core.tool_result import ToolResult
+from lintro.plugins.protocol import ToolDefinition
+from lintro.utils.execution import advisory as advisory_module
+from lintro.utils.execution.advisory import (
+    advisory_findings_count,
+    advisory_results_to_payload,
+    get_advisory_tool_names,
+    render_advisory_results,
+    resolve_advisory_tools,
+    run_advisory_tools,
+)
+
+
+def test_execution_class_defaults_to_deterministic() -> None:
+    """A tool definition is deterministic unless it opts into advisory."""
+    definition = ToolDefinition(name="demo", description="demo tool")
+
+    assert_that(definition.execution_class).is_equal_to(ExecutionClass.DETERMINISTIC)
+    assert_that(definition.is_advisory).is_false()
+
+
+def test_execution_class_advisory_flag() -> None:
+    """An advisory definition reports ``is_advisory``."""
+    definition = ToolDefinition(
+        name="demo",
+        description="demo tool",
+        execution_class=ExecutionClass.ADVISORY,
+    )
+
+    assert_that(definition.is_advisory).is_true()
+
+
+def test_normalize_execution_class_accepts_strings() -> None:
+    """String values normalize case-insensitively."""
+    assert_that(normalize_execution_class("ADVISORY")).is_equal_to(
+        ExecutionClass.ADVISORY,
+    )
+    assert_that(
+        normalize_execution_class(ExecutionClass.DETERMINISTIC),
+    ).is_equal_to(ExecutionClass.DETERMINISTIC)
+
+
+def test_normalize_execution_class_rejects_unknown() -> None:
+    """An unknown execution class raises."""
+    with pytest.raises(ValueError, match="Unknown execution class"):
+        normalize_execution_class("opinionated")
+
+
+def test_idiom_review_is_the_registered_advisory_tool() -> None:
+    """idiom-review is classified advisory and discoverable as such."""
+    assert_that(get_advisory_tool_names()).contains("idiom-review")
+
+
+def test_resolve_advisory_tools_defaults_to_all() -> None:
+    """The default selection picks up every enabled advisory tool."""
+    selection = resolve_advisory_tools(requested=None)
+
+    assert_that(selection.to_run).contains("idiom-review")
+
+
+def test_resolve_advisory_tools_none_selects_nothing() -> None:
+    """``none`` disables advisory execution."""
+    selection = resolve_advisory_tools(requested="none")
+
+    assert_that(selection.to_run).is_empty()
+
+
+def test_resolve_advisory_tools_accepts_underscore_spelling() -> None:
+    """Underscore spellings resolve to the registered hyphenated name."""
+    selection = resolve_advisory_tools(requested="idiom_review")
+
+    assert_that(selection.to_run).is_equal_to(["idiom-review"])
+
+
+def test_resolve_advisory_tools_rejects_deterministic_tool() -> None:
+    """Naming a deterministic tool points the user back at chk."""
+    with pytest.raises(ValueError, match="lintro chk --tools ruff"):
+        resolve_advisory_tools(requested="ruff")
+
+
+def test_resolve_advisory_tools_rejects_unknown_tool() -> None:
+    """An unknown advisory tool name raises."""
+    with pytest.raises(ValueError, match="Unknown advisory tool"):
+        resolve_advisory_tools(requested="does-not-exist")
+
+
+def test_run_advisory_tools_without_tools_is_a_noop(tmp_path: Path) -> None:
+    """No selected tools means no results and no work."""
+    assert_that(
+        run_advisory_tools(paths=[str(tmp_path)], tool_names=[]),
+    ).is_empty()
+
+
+def test_run_advisory_tools_reports_tool_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raising advisory tool becomes a failed result, not an abort."""
+
+    class _Boom:
+        def check(self, paths: list[str], options: dict[str, object]) -> ToolResult:
+            raise RuntimeError("provider exploded")
+
+    monkeypatch.setattr(
+        advisory_module,
+        "configure_tool_for_execution",
+        lambda **_kwargs: _Boom(),
+    )
+    results = run_advisory_tools(
+        paths=[str(tmp_path)],
+        tool_names=["idiom-review"],
+    )
+
+    assert_that(results).is_length(1)
+    assert_that(results[0].success).is_false()
+    assert_that(results[0].output).contains("provider exploded")
+
+
+def test_advisory_findings_count_ignores_skipped_results() -> None:
+    """Skipped advisory tools contribute no findings."""
+    results = [
+        ToolResult(
+            name="a",
+            skipped=True,
+            skip_reason="opt-in required",
+            issues_count=5,
+        ),
+        ToolResult(name="b", success=False, issues_count=2),
+    ]
+
+    assert_that(advisory_findings_count(results)).is_equal_to(2)
+
+
+def test_render_advisory_results_reports_skip_reason() -> None:
+    """A skipped advisory tool renders its reason."""
+    rendered = render_advisory_results(
+        results=[
+            ToolResult(
+                name="idiom-review",
+                skipped=True,
+                skip_reason="opt-in required",
+            ),
+        ],
+    )
+
+    assert_that(rendered).contains("Advisory: idiom-review")
+    assert_that(rendered).contains("opt-in required")
+
+
+def test_render_advisory_results_empty_is_blank() -> None:
+    """No results render as an empty string."""
+    assert_that(render_advisory_results(results=[])).is_equal_to("")
+
+
+def test_advisory_results_to_payload_is_json_shaped() -> None:
+    """The payload exposes per-tool counts and display rows."""
+    from lintro.parsers.idiom_review.idiom_review_issue import IdiomReviewIssue
+
+    issue = IdiomReviewIssue(
+        file="a.py",
+        line=3,
+        message="prefer any()",
+        code="idiom/python/prefer-any",
+    )
+    payload = advisory_results_to_payload(
+        [
+            ToolResult(
+                name="idiom-review",
+                success=False,
+                issues_count=1,
+                issues=[issue],
+            ),
+        ],
+    )
+
+    assert_that(payload).is_length(1)
+    assert_that(payload[0]["tool"]).is_equal_to("idiom-review")
+    assert_that(payload[0]["issues_count"]).is_equal_to(1)
+    issues = cast("list[dict[str, str]]", payload[0]["issues"])
+    assert_that(issues[0]["file"]).is_equal_to("a.py")

--- a/tests/unit/utils/execution/test_advisory.py
+++ b/tests/unit/utils/execution/test_advisory.py
@@ -8,6 +8,7 @@ from typing import cast
 import pytest
 from assertpy import assert_that
 
+from lintro.config.lintro_config import LintroConfig, LintroToolConfig
 from lintro.enums.execution_class import (
     ExecutionClass,
     normalize_execution_class,
@@ -192,3 +193,50 @@ def test_advisory_results_to_payload_is_json_shaped() -> None:
     assert_that(payload[0]["issues_count"]).is_equal_to(1)
     issues = cast("list[dict[str, str]]", payload[0]["issues"])
     assert_that(issues[0]["file"]).is_equal_to("a.py")
+
+
+def test_run_advisory_tools_survives_configuration_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool that raises during configuration does not abort the run."""
+
+    def _explode(**_kwargs: object) -> object:
+        raise RuntimeError("config exploded")
+
+    monkeypatch.setattr(
+        advisory_module,
+        "configure_tool_for_execution",
+        _explode,
+    )
+    results = run_advisory_tools(
+        paths=[str(tmp_path)],
+        tool_names=["idiom-review"],
+    )
+
+    assert_that(results).is_length(1)
+    assert_that(results[0].success).is_false()
+    assert_that(results[0].output).contains("config exploded")
+
+
+def test_resolve_advisory_tools_honors_config_disabled_tool() -> None:
+    """A config-disabled advisory tool is skipped in the default selection."""
+    config = LintroConfig(tools={"idiom-review": LintroToolConfig(enabled=False)})
+
+    selection = resolve_advisory_tools(requested=None, lintro_config=config)
+
+    assert_that(selection.to_run).does_not_contain("idiom-review")
+    assert_that([tool.name for tool in selection.skipped]).contains("idiom-review")
+
+
+def test_resolve_advisory_tools_honors_config_disabled_explicit_request() -> None:
+    """An explicitly named but config-disabled tool is skipped, not run."""
+    config = LintroConfig(tools={"idiom-review": LintroToolConfig(enabled=False)})
+
+    selection = resolve_advisory_tools(
+        requested="idiom-review",
+        lintro_config=config,
+    )
+
+    assert_that(selection.to_run).is_empty()
+    assert_that(selection.skipped[0].reason).contains("disabled in config")


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(cli): move advisory AI finders out of chk into lintro review
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

`idiom-review` is lintro's first AI *finder*: it asks a model to find issues linters
structurally cannot. It shipped as an ordinary plugin, so it ran inside `lintro chk`
alongside ruff and hadolint. That broke three contracts `chk` is supposed to keep —
determinism (identical runs can disagree), a stable health score (`--fail-under` could
trip on model mood rather than on a regression), and a cheap offline reflexive path
(one person enabling it made every contributor pay API latency and dollars).

This PR classifies every tool as **deterministic** or **advisory** and routes advisory
finders to `lintro review`.

- `lintro/enums/execution_class.py` — new `ExecutionClass` StrEnum;
  `ToolDefinition.execution_class` defaults to `DETERMINISTIC`, plus an `is_advisory`
  convenience property. `idiom-review` declares `ADVISORY`.
- `chk` / `fmt` select deterministic tools only. Advisory tools are excluded silently
  from default and `--tools all` runs (they were never part of that verb's tool set),
  and naming one explicitly errors with a pointer:

  ```text
  $ lintro chk --tools idiom-review
  Error: Tool 'idiom-review' is an advisory AI finder and does not run under
  'lintro chk' or 'lintro fmt': its findings are nondeterministic, so they must
  not gate deterministic checks or the health score. Run
  'lintro review --advisory-tools idiom-review' instead.
  ```

- `lintro/utils/execution/advisory.py` — a thin sequential runner for advisory tools
  (no fixing, no post-checks, no health score, no exit-code influence). A tool that
  raises becomes a failed result rather than aborting the review.
- `lintro review` gains `--advisory-tools`, `--advisory-only`, `--fail-on-findings`
  and `--tool-options`.
- Health score: advisory findings are excluded by construction — they no longer run
  under `chk` at all.
- `tools.idiom-review` config keeps working unchanged; only the invoking verb moved.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (full `uv run pytest`, `uv run lintro fmt`, `uv run lintro chk`)

## Closes

- Closes #1308
- Relates to #1305
- Relates to #1173

## Details

**Design choice (the issue predates the shipped `review` verb).** #1308 proposed a
brand-new `lintro review` verb, but `lintro review` now exists as the AI diff review
from epic #1609. Rather than inventing a second verb, advisory finders fold into the
existing one, because both surfaces answer the same question — "what would a reviewer
say about this code?" — and both are AI-priced and nondeterministic.

Reconciliation with the existing diff-review UX:

- **Default `lintro review`** runs the diff review and then advisory finders, scoped
  to the same changed files. Since `idiom-review` ships disabled, existing review users
  see no behavior change until they opt in.
- **`--advisory-tools <names>|all|none`** is the review-side filter. `none` skips
  advisory execution entirely.
- **`--advisory-only`** skips the diff review and scans `--path` values (default `.`).
  This is the cheap standalone replacement for the old `chk --tools idiom-review`. It
  deliberately bypasses the `ai.review` config gate, which governs the *diff* review;
  it rejects `--base` / `--uncommitted` / `--pr` / `--post`, which are diff-only flags.
- **Exit codes.** Advisory findings exit 0 by default. `--fail-on-findings` opts into
  exit 1. The diff review's contract is untouched: P1 findings still exit 1, and a
  review that never ran still exits with `REVIEW_ERROR_EXIT_CODE`.
- **JSON.** In a full review, advisory results are attached under an additive
  `advisory` key, so existing consumers of the review JSON keep parsing unchanged
  documents. `--advisory-only --output json` emits `{"advisory": [...]}` — a distinct
  shape, but only ever produced when the caller explicitly asks for advisory-only.
  (Note: `REVIEW_CLI_SCHEMA` is the provider *response* schema, not the CLI stdout
  contract, so it is unaffected.)

**#1305 alignment (lazy imports).** `chk` used to import the whole `lintro.ai` stack:
plugin discovery imports every tool definition, and `idiom_review.py` imported
`lintro.ai.*` at module scope, with `lintro/tools/idiom_review/__init__.py` pulling in
the engine. Both are now lazy, and `IdiomReviewMode` moved to `lintro/enums/`. After
this PR `discover_all_tools()` loads **zero** `lintro.ai` modules — pinned by a test
that measures it in a fresh interpreter.

**`list-tools`** reports `review` instead of `check` for advisory tools, exposes
`execution_class` in JSON, and counts advisory tools on their own line rather than
inflating the check-tool total.

**Testing.** Full suite green (8576 passed). New coverage: chk excludes advisory tools
from default/`all`/fmt selection; explicit `--tools idiom-review` (both spellings)
errors with the review pointer; advisory selection resolution (all/none/aliases,
config-disabled, deterministic-tool and unknown-tool rejection); runner resilience to
failures during lookup, configuration and `check()`; exit-code semantics with and
without `--fail-on-findings`; terminal ordering and JSON merge end to end; and the
AI-import isolation pin above.

**Review.** Local CodeRabbit CLI run applied (10 findings; all valid ones fixed, the
`REVIEW_CLI_SCHEMA` one pushed back on as a false positive — see above). Greptile CLI
was unavailable (`free_reviews_limit_reached`).
