### PR TITLE
feat(mcp): add check and format toolkit with structured findings

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -27,14 +27,109 @@ It is the root that every declared path argument is required to stay within (see
 [Tool contract](#tool-contract)); it is not an OS-level sandbox around the handler
 process.
 
-## Built-in tool
+## Tools
 
-| Tool          | Annotations           | Result                                |
-| ------------- | --------------------- | ------------------------------------- |
-| `lintro_ping` | read-only, idempotent | `{status, lintro_version, workspace}` |
+| Tool            | Annotations                 | Result                                           |
+| --------------- | --------------------------- | ------------------------------------------------ |
+| `lintro_ping`   | read-only, idempotent       | `{status, lintro_version, workspace}`            |
+| `lintro_check`  | read-only, idempotent       | Structured findings plus a per-tool summary      |
+| `lintro_format` | destructive, not idempotent | Unified diffs, changed files, remaining findings |
 
-Additional toolkits (check, format, review, and so on) register through the internal
-`McpToolRegistry` and ship in follow-up issues.
+Further toolkits (review and so on) register through the internal `McpToolRegistry` and
+ship in follow-up issues.
+
+### `lintro_check`
+
+Runs lintro's deterministic linters and returns findings rather than rendered text.
+Advisory AI finders are not reachable here; they run under `lintro review`, and naming
+one is rejected with `tool_unavailable` exactly as the CLI rejects it.
+
+Arguments (all optional):
+
+| Argument | Type       | Default       | Meaning                                    |
+| -------- | ---------- | ------------- | ------------------------------------------ |
+| `paths`  | `string[]` | the workspace | Files or directories to scan               |
+| `tools`  | `string[]` | config-driven | Subset of tools to run, for example `ruff` |
+
+```json
+{
+  "findings": [
+    {
+      "tool": "ruff",
+      "file": "/path/to/repo/bad.py",
+      "line": 1,
+      "column": 8,
+      "rule": "F401",
+      "severity": "WARNING",
+      "message": "`os` imported but unused",
+      "fixable": true,
+      "doc_url": "https://docs.astral.sh/ruff/rules/unused-import/"
+    }
+  ],
+  "tools": [{ "tool": "ruff", "status": "issues", "issue_count": 1, "duration": 0.47 }],
+  "summary": { "total_findings": 1, "tools_run": 1, "success": false }
+}
+```
+
+`status` is one of `passed`, `issues`, `skipped`, `timed_out`, `errored`; a skipped tool
+also carries `skip_reason`. Findings come from the same serializer that feeds SARIF
+(`lintro.utils.findings`), so the two never drift apart.
+
+### `lintro_format`
+
+Runs lintro's formatters. It takes the same `paths` and `tools` arguments plus
+`dry_run`, which **defaults to `true`**.
+
+A dry run reports what the formatters would write, as a real unified diff, and leaves
+the tree byte-identical. It does that by snapshotting the files the selected tools can
+reach, letting them actually run, diffing against the snapshot, and restoring every
+changed file. Running the tools for real is what makes the diff trustworthy — the
+alternatives (a partial temp copy, or a git checkpoint) either format under the wrong
+configuration or only work inside a git work tree. If restoring a file ever fails, the
+call reports `execution_error` with `detail.reason == "restore_failed"` rather than
+quietly leaving the workspace modified.
+
+`dry_run: false` runs the same way but keeps the writes.
+
+```json
+{
+  "findings": [],
+  "tools": [
+    {
+      "tool": "ruff",
+      "status": "passed",
+      "issue_count": 0,
+      "duration": 0.66,
+      "fixed_count": 2
+    }
+  ],
+  "summary": { "total_findings": 0, "tools_run": 1, "success": true },
+  "dry_run": true,
+  "changed_files": ["bad.py"],
+  "diffs": [{ "file": "bad.py", "diff": "--- a/bad.py\n+++ b/bad.py\n@@ ..." }]
+}
+```
+
+`findings` here is the _residue_: what the formatters could not fix. How much they did
+fix is `fixed_count` on each tool summary.
+
+Notes and limits:
+
+- `changed_files` and `diffs` use workspace-relative paths; a finding's `file` is
+  whatever path the underlying tool reported.
+- A dry run holds the candidate files in memory and refuses, with `execution_error` and
+  `detail.reason == "snapshot_too_large"`, rather than running unbounded. Narrow `paths`
+  or `tools`, or call with `dry_run: false`.
+- Anything that would make the snapshot or the diff incomplete is an error rather than a
+  quietly shortened report: `snapshot_read_failed` (a candidate could not be read, so
+  the run never starts), `diff_read_failed`, and `restore_failed`.
+- A tool you asked for by name that the workspace config disabled, or that conflict
+  resolution dropped, comes back as `tool_unavailable` with `detail.skipped` rather than
+  as a run that quietly did less than you asked.
+- Both tools honor the workspace's `.lintro-config.yaml`. There is no MCP-only
+  configuration surface.
+- Runs are serialized: lintro resolves configuration relative to the process working
+  directory, so one lint run happens at a time per server.
 
 ## Tool contract
 

--- a/lintro/enums/tool_run_status.py
+++ b/lintro/enums/tool_run_status.py
@@ -1,0 +1,62 @@
+"""Outcome status for a single tool within a run.
+
+``ToolResult`` records the outcome of a tool as three independent booleans
+(``success``, ``skipped``, ``timed_out``) plus an issue count. Every consumer
+that wants to *name* that outcome has so far re-derived it inline, most
+visibly the human summary tables. This enum is the single collapsed
+vocabulary, so the machine-readable surfaces (MCP tool summaries today) all
+agree on what "the tool passed" means.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lintro.models.core.tool_result import ToolResult
+
+
+class ToolRunStatus(StrEnum):
+    """Collapsed outcome of one tool's participation in a run.
+
+    Attributes:
+        PASSED: The tool ran and reported no issues.
+        ISSUES: The tool ran and reported at least one issue.
+        SKIPPED: The tool did not run (unavailable, disabled, filtered out).
+        TIMED_OUT: The tool's subprocess exceeded its deadline and was killed.
+        ERRORED: The tool failed for a reason that is not a lint finding.
+    """
+
+    PASSED = auto()
+    ISSUES = auto()
+    SKIPPED = auto()
+    TIMED_OUT = auto()
+    ERRORED = auto()
+
+
+def tool_run_status(*, result: ToolResult, issue_count: int) -> ToolRunStatus:
+    """Derive the collapsed status of a completed tool result.
+
+    Precedence is deliberate: a skipped tool never ran, a timeout is an
+    execution failure rather than a finding, and a tool that reports issues is
+    described by those issues even though it also sets ``success=False``.
+
+    Args:
+        result: The completed tool result.
+        issue_count: Issue count as the caller counted it, which may differ
+            from ``result.issues_count`` when detected and remaining issues
+            were merged for a fix run.
+
+    Returns:
+        ToolRunStatus: The collapsed status.
+    """
+    if result.skipped:
+        return ToolRunStatus.SKIPPED
+    if result.timed_out:
+        return ToolRunStatus.TIMED_OUT
+    if issue_count > 0:
+        return ToolRunStatus.ISSUES
+    if not result.success:
+        return ToolRunStatus.ERRORED
+    return ToolRunStatus.PASSED

--- a/lintro/mcp/server.py
+++ b/lintro/mcp/server.py
@@ -65,14 +65,21 @@ def _ping_handler(*, workspace: Path) -> Callable[[dict[str, Any]], dict[str, An
 
 
 def build_default_registry(*, workspace: Path) -> McpToolRegistry:
-    """Create a registry with the built-in smoke tool.
+    """Create a registry with the built-in tools and the lint toolkit.
 
     Args:
-        workspace: Workspace root exposed by ``lintro_ping``.
+        workspace: Workspace root the tools are anchored to.
 
     Returns:
-        Registry containing ``lintro_ping``.
+        Registry containing ``lintro_ping``, ``lintro_check``, and
+        ``lintro_format``.
     """
+    # Deferred deliberately, in the same spirit as this module's other lazy
+    # imports: the lint toolkit pulls the plugin registry, the parsers, and the
+    # formatters, and nothing that merely imports this module (``lintro
+    # doctor``, the CLI's command table) should pay for that.
+    from lintro.mcp.toolkits.lint import build_lint_toolkit
+
     registry = McpToolRegistry()
     registry.register(
         spec=McpToolSpec(
@@ -87,6 +94,7 @@ def build_default_registry(*, workspace: Path) -> McpToolRegistry:
             idempotent=True,
         ),
     )
+    registry.register_toolkit(specs=build_lint_toolkit(workspace=workspace))
     return registry
 
 

--- a/lintro/mcp/toolkits/__init__.py
+++ b/lintro/mcp/toolkits/__init__.py
@@ -1,0 +1,14 @@
+"""MCP toolkits: the tool groups registered on the lintro MCP server.
+
+Each toolkit module exposes a ``build_*_toolkit(*, workspace=...)`` factory
+returning :class:`~lintro.mcp.registry.McpToolSpec` values, which
+:func:`lintro.mcp.server.build_default_registry` feeds to
+``McpToolRegistry.register_toolkit`` so a toolkit lands atomically or not at
+all.
+"""
+
+from __future__ import annotations
+
+from lintro.mcp.toolkits.lint import build_lint_toolkit
+
+__all__ = ["build_lint_toolkit"]

--- a/lintro/mcp/toolkits/lint.py
+++ b/lintro/mcp/toolkits/lint.py
@@ -1,0 +1,265 @@
+"""The ``lintro_check`` and ``lintro_format`` MCP tools.
+
+Both tools drive the real runner (:mod:`lintro.mcp.toolkits.runner`) and shape
+their payload with the canonical serializer in :mod:`lintro.utils.findings`, so
+an agent sees the same finding fields SARIF emits rather than a second,
+MCP-only shape.
+
+Only deterministic tools are reachable here. Advisory AI finders run under
+``lintro review`` (issue #1886), and asking for one by name is rejected with
+``tool_unavailable`` exactly as the CLI rejects it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+from lintro.enums.action import Action
+from lintro.mcp.registry import McpToolSpec
+from lintro.mcp.toolkits.runner import (
+    resolve_tools_to_run,
+    run_lintro,
+    workspace_session,
+)
+from lintro.mcp.toolkits.snapshot import changes_since, restore, snapshot_files
+from lintro.utils.findings import (
+    FindingScope,
+    findings_from_results,
+    tool_summaries_from_results,
+)
+
+if TYPE_CHECKING:
+    from lintro.models.core.run_artifact import RunArtifact
+
+__all__ = ["build_lint_toolkit"]
+
+_PATHS_SCHEMA: Final[dict[str, Any]] = {
+    "type": "array",
+    "items": {"type": "string"},
+    "description": (
+        "Files or directories to scan, relative to the workspace root or "
+        "absolute within it. Defaults to the whole workspace."
+    ),
+}
+
+_TOOLS_SCHEMA: Final[dict[str, Any]] = {
+    "type": "array",
+    "items": {"type": "string"},
+    "description": (
+        "Subset of lintro tools to run (e.g. ['ruff', 'prettier']). Defaults "
+        "to every tool enabled for this action by the workspace config. "
+        "Advisory AI finders are not selectable here."
+    ),
+}
+
+_CHECK_INPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {"paths": _PATHS_SCHEMA, "tools": _TOOLS_SCHEMA},
+    "additionalProperties": False,
+}
+
+_FORMAT_INPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "paths": _PATHS_SCHEMA,
+        "tools": _TOOLS_SCHEMA,
+        "dry_run": {
+            "type": "boolean",
+            "default": True,
+            "description": (
+                "When true (the default) the workspace is left untouched and "
+                "the unified diff of every change is returned. Set false to "
+                "write the changes."
+            ),
+        },
+    },
+    "additionalProperties": False,
+}
+
+_CHECK_DESCRIPTION: Final[str] = (
+    "Run lintro's deterministic linters over the workspace and return "
+    "structured findings (file, line, column, rule, severity, message, "
+    "fixable) plus a per-tool summary. Read-only: no file is modified."
+)
+
+_FORMAT_DESCRIPTION: Final[str] = (
+    "Run lintro's formatters. Defaults to dry_run=true, which reports the "
+    "unified diff of every change without writing anything; call with "
+    "dry_run=false to apply them. Returns the changed files, their diffs, "
+    "the findings that remain, and a per-tool summary."
+)
+
+
+def _resolve_paths(*, arguments: dict[str, Any], workspace: Path) -> list[str]:
+    """Resolve the scan targets for a call.
+
+    The server has already resolved and workspace-checked every entry of
+    ``paths`` (it is declared in ``path_arguments``), so this only supplies the
+    default.
+
+    Args:
+        arguments: Validated tool arguments.
+        workspace: Workspace root.
+
+    Returns:
+        list[str]: Absolute scan targets.
+    """
+    paths = arguments.get("paths") or []
+    return [str(path) for path in paths] or [str(workspace)]
+
+
+def _requested_tools(*, arguments: dict[str, Any]) -> list[str] | None:
+    """Extract the requested tool subset.
+
+    Args:
+        arguments: Validated tool arguments.
+
+    Returns:
+        list[str] | None: The requested tools, or ``None`` for the default set.
+    """
+    tools = arguments.get("tools") or []
+    return [str(tool) for tool in tools] or None
+
+
+def _run_payload(
+    *,
+    artifact: RunArtifact,
+    action: Action,
+    scope: FindingScope,
+) -> dict[str, Any]:
+    """Build the findings/summary block shared by both tools.
+
+    Args:
+        artifact: The completed run.
+        action: The action the run performed.
+        scope: Which population of a fix run's issues to report.
+
+    Returns:
+        dict[str, Any]: Mapping with ``findings``, ``tools``, and ``summary``.
+    """
+    findings = findings_from_results(
+        results=artifact.tool_results,
+        action=action,
+        scope=scope,
+    )
+    summaries = tool_summaries_from_results(
+        results=artifact.tool_results,
+        action=action,
+        scope=scope,
+    )
+    return {
+        "findings": [finding.to_dict() for finding in findings],
+        "tools": [summary.to_dict() for summary in summaries],
+        "summary": {
+            "total_findings": len(findings),
+            "tools_run": len(summaries),
+            "success": artifact.exit_code == 0,
+        },
+    }
+
+
+def _check_handler(
+    *,
+    workspace: Path,
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Build the ``lintro_check`` handler bound to ``workspace``.
+
+    Args:
+        workspace: Workspace root the run is anchored to.
+
+    Returns:
+        Callable: A handler accepting an arguments dict.
+    """
+
+    def handler(arguments: dict[str, Any]) -> dict[str, Any]:
+        paths = _resolve_paths(arguments=arguments, workspace=workspace)
+        tools = _requested_tools(arguments=arguments)
+        with workspace_session(workspace=workspace):
+            # Selection is resolved up front because ``execute_run`` folds a
+            # bad tool name into a console message and an early-exit artifact,
+            # which would reach the agent as "a run with no findings".
+            resolve_tools_to_run(tools=tools, action=Action.CHECK)
+            artifact = run_lintro(action=Action.CHECK, paths=paths, tools=tools)
+        return _run_payload(
+            artifact=artifact,
+            action=Action.CHECK,
+            scope=FindingScope.ALL,
+        )
+
+    return handler
+
+
+def _format_handler(
+    *,
+    workspace: Path,
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Build the ``lintro_format`` handler bound to ``workspace``.
+
+    Args:
+        workspace: Workspace root the run is anchored to.
+
+    Returns:
+        Callable: A handler accepting an arguments dict.
+    """
+
+    def handler(arguments: dict[str, Any]) -> dict[str, Any]:
+        paths = _resolve_paths(arguments=arguments, workspace=workspace)
+        tools = _requested_tools(arguments=arguments)
+        dry_run = bool(arguments.get("dry_run", True))
+
+        with workspace_session(workspace=workspace):
+            to_run = resolve_tools_to_run(tools=tools, action=Action.FIX)
+            snapshot = snapshot_files(paths=paths, tool_names=to_run)
+            try:
+                artifact = run_lintro(action=Action.FIX, paths=paths, tools=tools)
+                changes = changes_since(snapshot=snapshot, workspace=workspace)
+            finally:
+                if dry_run:
+                    restore(snapshot=snapshot)
+
+        payload = _run_payload(
+            artifact=artifact,
+            action=Action.FIX,
+            scope=FindingScope.REMAINING,
+        )
+        payload["dry_run"] = dry_run
+        payload["changed_files"] = [change.path for change in changes]
+        payload["diffs"] = [change.to_dict() for change in changes]
+        return payload
+
+    return handler
+
+
+def build_lint_toolkit(*, workspace: Path) -> tuple[McpToolSpec, ...]:
+    """Build the check/format tool specifications.
+
+    Args:
+        workspace: Workspace root the tools operate on.
+
+    Returns:
+        tuple[McpToolSpec, ...]: ``lintro_check`` and ``lintro_format``.
+    """
+    return (
+        McpToolSpec(
+            name="lintro_check",
+            description=_CHECK_DESCRIPTION,
+            input_schema=_CHECK_INPUT_SCHEMA,
+            handler=_check_handler(workspace=workspace),
+            read_only=True,
+            destructive=False,
+            idempotent=True,
+            path_arguments=("paths",),
+        ),
+        McpToolSpec(
+            name="lintro_format",
+            description=_FORMAT_DESCRIPTION,
+            input_schema=_FORMAT_INPUT_SCHEMA,
+            handler=_format_handler(workspace=workspace),
+            read_only=False,
+            destructive=True,
+            idempotent=False,
+            path_arguments=("paths",),
+        ),
+    )

--- a/lintro/mcp/toolkits/runner.py
+++ b/lintro/mcp/toolkits/runner.py
@@ -1,0 +1,219 @@
+"""Run the real lintro pipeline on behalf of an MCP tool call.
+
+Both MCP lint tools execute the same runner the CLI uses — ``build_run_context``
+plus ``execute_run`` (the execute half of the issue #1823 split) — rather than
+re-deriving tool selection, configuration, or aggregation. The render half is
+deliberately *not* called: an MCP server owns stdout for the JSON-RPC stream,
+so nothing may print a document there.
+
+Three concerns are handled here that a plain CLI invocation gets for free:
+
+* **stdout hygiene** — the context is built with ``output_format="json"``,
+  which routes all decorative console output to stderr.
+* **workspace anchoring** — lintro resolves ``.lintro-config.yaml`` and its
+  tool configs relative to the process cwd, so a run happens with the cwd
+  chdir'd to the server's workspace root and the config cache cleared, which
+  is what "respect the workspace's ``.lintro-config.yaml``" means in practice.
+* **serialization** — cwd is process-global and the config cache is a module
+  singleton, so concurrent tool calls would corrupt each other.
+  :func:`workspace_session` holds one lock for the whole call, which for
+  ``lintro_format`` spans snapshot, run, diff, and restore rather than just
+  the run. MCP tools that do not touch lintro (``lintro_ping``) are
+  unaffected.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from lintro.mcp.enums.mcp_error_code import McpErrorCode
+from lintro.mcp.errors import McpError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from lintro.enums.action import Action
+    from lintro.models.core.run_artifact import RunArtifact
+
+__all__ = ["RUN_LOCK", "resolve_tools_to_run", "run_lintro", "workspace_session"]
+
+# Serializes lintro work across MCP tool calls. See the module docstring.
+RUN_LOCK: threading.Lock = threading.Lock()
+
+# Per-process run-log directory for MCP runs. A CLI run drops its logs in the
+# workspace's ``.lintro/``; doing that here would make ``lintro_check`` write
+# to a tree it advertises as read-only, and would leave a dry-run preview with
+# a visible footprint. One directory is reused for the life of the server
+# rather than one per call, because loguru's file sinks outlive a single run
+# and would be left pointing at a deleted path.
+_LOG_DIR: Path | None = None
+
+
+def _mcp_log_dir() -> str:
+    """Return (creating once) the process-wide run-log directory for MCP runs.
+
+    Returns:
+        str: Path to the directory ``LINTRO_LOG_DIR`` should point at.
+    """
+    global _LOG_DIR
+    if _LOG_DIR is None:
+        _LOG_DIR = Path(tempfile.mkdtemp(prefix="lintro-mcp-"))
+    return str(_LOG_DIR)
+
+
+@contextlib.contextmanager
+def _log_dir_env() -> Iterator[None]:
+    """Point ``LINTRO_LOG_DIR`` at the MCP run-log directory for one session.
+
+    The variable is restored on exit rather than left set: the environment is
+    process-global, and a library that permanently redirected it would follow
+    every other lintro caller in the same process.
+
+    Yields:
+        None: Control, with the variable in place.
+    """
+    previous = os.environ.get("LINTRO_LOG_DIR")
+    if previous is None:
+        # An operator who set LINTRO_LOG_DIR explicitly still wins.
+        os.environ["LINTRO_LOG_DIR"] = _mcp_log_dir()
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("LINTRO_LOG_DIR", None)
+
+
+@contextlib.contextmanager
+def workspace_session(*, workspace: Path) -> Iterator[None]:
+    """Hold the run lock with the process anchored at ``workspace``.
+
+    The lock is not reentrant, so the functions below assume the session is
+    already open rather than acquiring it themselves.
+
+    Args:
+        workspace: Workspace root to make the process cwd for the duration.
+
+    Yields:
+        None: Control, with cwd, log directory, and config cache prepared.
+    """
+    from lintro.config.config_loader import clear_config_cache
+
+    with RUN_LOCK, contextlib.chdir(workspace), _log_dir_env():
+        clear_config_cache()
+        try:
+            yield
+        finally:
+            # The cache is a module singleton keyed by nothing, so leaving the
+            # workspace's configuration in it would follow the next in-process
+            # ``get_config()`` caller back out to whatever cwd they run under.
+            clear_config_cache()
+
+
+def resolve_tools_to_run(*, tools: list[str] | None, action: Action) -> list[str]:
+    """Resolve the tool names a run would execute, validating any subset.
+
+    Must be called inside :func:`workspace_session`, because tool selection
+    reads the workspace configuration.
+
+    Args:
+        tools: Requested tool names, or ``None``/empty for the default set.
+        action: The action the run will perform, which decides whether a tool
+            that cannot fix is acceptable.
+
+    Returns:
+        list[str]: Tool names the run will execute, in execution order.
+
+    Raises:
+        McpError: :attr:`McpErrorCode.TOOL_UNAVAILABLE` when a requested tool
+            is unknown, is an advisory AI finder (which runs under
+            ``lintro review`` rather than ``chk``/``fmt``, per issue #1886),
+            cannot format, or would be skipped (disabled in config, or dropped
+            by conflict resolution). A skip is only an error for an explicitly
+            requested tool: the default set legitimately skips whatever the
+            workspace turned off, and the run reports those skips itself.
+    """
+    from lintro.utils.execution.tool_configuration import get_tools_to_run
+
+    requested = ",".join(tools) if tools else None
+    try:
+        selection = get_tools_to_run(requested, action, ignore_conflicts=False)
+    except ValueError as exc:
+        raise McpError(
+            code=McpErrorCode.TOOL_UNAVAILABLE,
+            message=str(exc),
+            detail={"tools": list(tools or []), "action": str(action)},
+        ) from exc
+
+    if tools and selection.skipped:
+        # ``execute_run`` records a skipped tool as a successful result, so a
+        # partial selection would come back as "success, no findings" for a
+        # tool the caller explicitly asked for.
+        skipped = {tool.name: tool.reason for tool in selection.skipped}
+        raise McpError(
+            code=McpErrorCode.TOOL_UNAVAILABLE,
+            message=(
+                "Requested tools were not run: "
+                + ", ".join(f"{name} ({reason})" for name, reason in skipped.items())
+            ),
+            detail={
+                "tools": list(tools),
+                "action": str(action),
+                "skipped": skipped,
+            },
+        )
+    return list(selection.to_run)
+
+
+def run_lintro(
+    *,
+    action: Action,
+    paths: list[str],
+    tools: list[str] | None,
+) -> RunArtifact:
+    """Execute one lintro run and return its artifact.
+
+    Must be called inside :func:`workspace_session`.
+
+    Args:
+        action: Action to perform.
+        paths: Absolute, already workspace-checked scan targets.
+        tools: Requested tool subset, or ``None`` for the default set.
+
+    Returns:
+        RunArtifact: The completed run's results, totals, and exit code.
+    """
+    from lintro.utils.tool_executor import build_run_context, execute_run
+
+    ctx = build_run_context(
+        action=action,
+        output_format="json",
+        score=False,
+        debug=False,
+        no_art=True,
+        dry_run=False,
+    )
+    return execute_run(
+        ctx=ctx,
+        paths=paths,
+        tools=",".join(tools) if tools else None,
+        tool_options=None,
+        exclude=None,
+        include_venv=False,
+        group_by="auto",
+        output_format="json",
+        verbose=False,
+        raw_output=False,
+        incremental=False,
+        auto_install=False,
+        yes=True,
+        ignore_conflicts=False,
+        fail_under=None,
+        diff_base=None,
+        ai_status_lines=None,
+        on_tool_result=None,
+    )

--- a/lintro/mcp/toolkits/snapshot.py
+++ b/lintro/mcp/toolkits/snapshot.py
@@ -1,0 +1,290 @@
+"""Snapshot-and-diff support for the MCP ``lintro_format`` tool.
+
+``lintro fmt --dry-run`` already exists, but it answers a different question:
+it runs the fix-capable tools in *check* mode and reports which issues a real
+run would address. It produces no diff, because no tool ever wrote anything.
+An agent asking "what would you change?" needs the actual bytes.
+
+Getting real diffs means letting the formatters actually write. Three
+mechanisms were considered:
+
+* **Temp copy of the tree.** Rejected: formatters resolve their configuration
+  (``.prettierrc``, ``pyproject.toml``, ``node_modules``) by walking up from
+  each file, so a partial copy formats under the wrong config and a full copy
+  is unbounded.
+* **Git checkpoint + ``git restore``** (``lintro.ai.checkpoints``). Rejected as
+  the primary path: it only works inside a git work tree, and it cannot
+  represent changes to files git does not track.
+* **In-place with a byte snapshot** — used here. The files the selected tools
+  would touch are read into memory first, the real ``fmt`` runs, diffs are
+  computed from the snapshot against what is now on disk, and for a dry run
+  every changed file is written back from the snapshot in a ``finally``.
+
+The snapshot set comes from the tools' own file discovery, so it is exactly
+the set they can write to, and a total-size ceiling turns a pathological
+workspace into a structured error *before* anything runs rather than an
+out-of-memory kill halfway through.
+"""
+
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+from lintro.mcp.enums.mcp_error_code import McpErrorCode
+from lintro.mcp.errors import McpError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = [
+    "MAX_SNAPSHOT_BYTES",
+    "FileChange",
+    "changes_since",
+    "restore",
+    "snapshot_files",
+]
+
+# Ceiling on the total bytes held in memory for one dry run. Sized to be far
+# above any plausible formattable source tree while still bounding the damage a
+# workspace full of generated files can do to the server process.
+MAX_SNAPSHOT_BYTES: Final[int] = 256 * 1024 * 1024
+
+_BINARY_DIFF_NOTE: Final[str] = "Binary files differ; no textual diff available.\n"
+
+
+@dataclass(frozen=True)
+class FileChange:
+    """A single file's before/after difference.
+
+    Attributes:
+        path: Workspace-relative POSIX path of the changed file, or its
+            absolute path when it resolved outside the workspace.
+        diff: Unified diff from the pre-run bytes to the post-run bytes, or a
+            note when either side is not decodable as UTF-8 text.
+    """
+
+    path: str
+    diff: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the change to a JSON-compatible dict.
+
+        Returns:
+            dict[str, Any]: Mapping with ``file`` and ``diff``.
+        """
+        return {"file": self.path, "diff": self.diff}
+
+
+def snapshot_files(
+    *,
+    paths: list[str],
+    tool_names: Sequence[str],
+) -> dict[Path, bytes]:
+    """Read the current bytes of every file the given tools could rewrite.
+
+    Args:
+        paths: Scan targets for this run.
+        tool_names: Tools the run will execute.
+
+    Returns:
+        dict[Path, bytes]: Resolved file path to its current contents.
+
+    Raises:
+        McpError: :attr:`McpErrorCode.EXECUTION_ERROR` when the snapshot would
+            exceed :data:`MAX_SNAPSHOT_BYTES`, or when a candidate file cannot
+            be read (see below).
+    """
+    from lintro.plugins.file_discovery import discover_files, setup_exclude_patterns
+    from lintro.tools import tool_manager
+
+    exclude_patterns = setup_exclude_patterns([])
+    candidates: set[Path] = set()
+    for tool_name in tool_names:
+        # Names normally arrive already resolved by ``get_tools_to_run``. The
+        # guard is for a caller that passes raw names: an unresolvable one
+        # contributes no files, which is the same outcome the run itself has.
+        try:
+            definition = tool_manager.get_tool(tool_name).definition
+        except (KeyError, ValueError, AttributeError):
+            continue
+        for discovered in discover_files(
+            paths,
+            definition,
+            exclude_patterns,
+            include_venv=False,
+            show_progress=False,
+        ):
+            candidates.add(Path(discovered).resolve())
+
+    snapshot: dict[Path, bytes] = {}
+    total = 0
+    for candidate in sorted(candidates):
+        if not candidate.is_file():
+            continue
+        # Deliberately *not* filtered to the workspace. A file discovery
+        # reaches through a symlink is a file the formatters will write to, and
+        # anything they can write to has to be restorable; dropping it here
+        # would leave a dry run's edits on disk.
+        try:
+            data = candidate.read_bytes()
+        except OSError as exc:
+            # A file discovery reached is a file the formatters may write to,
+            # and ``restore`` can only put back what the snapshot holds. Losing
+            # one here would silently break the dry run's core promise, so the
+            # run does not start at all.
+            raise McpError(
+                code=McpErrorCode.EXECUTION_ERROR,
+                message=(
+                    "Could not read a file the format run may modify; refusing "
+                    "to start without a complete pre-run snapshot"
+                ),
+                detail={
+                    "reason": "snapshot_read_failed",
+                    "file": str(candidate),
+                    "error": str(exc),
+                },
+            ) from exc
+        total += len(data)
+        if total > MAX_SNAPSHOT_BYTES:
+            raise McpError(
+                code=McpErrorCode.EXECUTION_ERROR,
+                message=(
+                    "Refusing to preview a format run over more than "
+                    f"{MAX_SNAPSHOT_BYTES} bytes of source; narrow 'paths' or "
+                    "'tools', or call again with dry_run=false"
+                ),
+                detail={
+                    "reason": "snapshot_too_large",
+                    "max_snapshot_bytes": MAX_SNAPSHOT_BYTES,
+                },
+            )
+        snapshot[candidate] = data
+    return snapshot
+
+
+def _unified_diff(*, before: bytes, after: bytes, relative: str) -> str:
+    """Render a unified diff between two byte blobs.
+
+    Args:
+        before: Pre-run contents.
+        after: Post-run contents.
+        relative: Workspace-relative path used in the diff headers.
+
+    Returns:
+        str: The unified diff, or a note when either side is not UTF-8 text.
+    """
+    try:
+        before_text = before.decode("utf-8")
+        after_text = after.decode("utf-8")
+    except UnicodeDecodeError:
+        return _BINARY_DIFF_NOTE
+    return "".join(
+        difflib.unified_diff(
+            before_text.splitlines(keepends=True),
+            after_text.splitlines(keepends=True),
+            fromfile=f"a/{relative}",
+            tofile=f"b/{relative}",
+        ),
+    )
+
+
+def _display_path(*, path: Path, workspace: Path) -> str:
+    """Render a changed file's path for the caller.
+
+    Args:
+        path: Resolved path of the changed file.
+        workspace: Workspace root.
+
+    Returns:
+        str: The workspace-relative POSIX path, or the absolute path when the
+        file resolved outside the workspace (reached through a symlink).
+    """
+    if path.is_relative_to(workspace):
+        return path.relative_to(workspace).as_posix()
+    return path.as_posix()
+
+
+def changes_since(
+    *,
+    snapshot: dict[Path, bytes],
+    workspace: Path,
+) -> list[FileChange]:
+    """Diff a snapshot against what is now on disk.
+
+    Args:
+        snapshot: Pre-run contents keyed by resolved path.
+        workspace: Workspace root, for rendering relative paths.
+
+    Returns:
+        list[FileChange]: One entry per changed file, ordered by path. A file
+        that was deleted during the run is reported as a diff to empty.
+
+    Raises:
+        McpError: :attr:`McpErrorCode.EXECUTION_ERROR` when a snapshotted file
+            could not be read back, which would silently truncate the report.
+    """
+    changes: list[FileChange] = []
+    unreadable: list[str] = []
+    for path, before in sorted(snapshot.items()):
+        try:
+            after = path.read_bytes() if path.is_file() else b""
+        except OSError as exc:
+            unreadable.append(f"{path}: {exc}")
+            continue
+        if after == before:
+            continue
+        relative = _display_path(path=path, workspace=workspace)
+        changes.append(
+            FileChange(
+                path=relative,
+                diff=_unified_diff(before=before, after=after, relative=relative),
+            ),
+        )
+    if unreadable:
+        # A silently short diff would understate what the run did. Restoring
+        # still happens: this raises inside the caller's ``try``, so a dry
+        # run's ``finally`` puts the tree back before the error surfaces.
+        raise McpError(
+            code=McpErrorCode.EXECUTION_ERROR,
+            message="Could not read every candidate file while computing the diff",
+            detail={"reason": "diff_read_failed", "files": unreadable},
+        )
+    return changes
+
+
+def restore(*, snapshot: dict[Path, bytes]) -> None:
+    """Write the snapshot back over every file whose bytes changed.
+
+    Only differing files are rewritten, so an untouched tree keeps its
+    original mtimes and no downstream build cache is invalidated for nothing.
+    A file the run deleted is recreated.
+
+    Args:
+        snapshot: Pre-run contents keyed by resolved path.
+
+    Raises:
+        McpError: :attr:`McpErrorCode.EXECUTION_ERROR` listing the files that
+            could not be restored. Leaving a dry run's writes on disk silently
+            would break the tool's core promise, so the failure is loud.
+    """
+    failures: list[str] = []
+    for path, before in snapshot.items():
+        try:
+            if path.is_file() and path.read_bytes() == before:
+                continue
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(before)
+        except OSError as exc:  # pragma: no cover - filesystem failure
+            failures.append(f"{path}: {exc}")
+    if failures:
+        raise McpError(
+            code=McpErrorCode.EXECUTION_ERROR,
+            message=(
+                "Dry-run preview could not restore every file it formatted; "
+                "the workspace has been modified"
+            ),
+            detail={"reason": "restore_failed", "files": failures},
+        )

--- a/lintro/models/core/tool_result.py
+++ b/lintro/models/core/tool_result.py
@@ -88,6 +88,11 @@ class ToolResult:
     # Omitted from JSON output unless the tool sets this explicitly.
     parse_failures_count: int | None = field(default=None)
 
+    # Wall-clock seconds the tool took, recorded by the executor around the
+    # check/fix call. ``None`` when the result was not produced by a run (a
+    # synthetic failure result, or a result built directly in a test).
+    duration_seconds: float | None = field(default=None)
+
     def __post_init__(self) -> None:
         """Validate that the issue counts and skip state are consistent.
 

--- a/lintro/utils/async_tool_executor.py
+++ b/lintro/utils/async_tool_executor.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
@@ -102,6 +103,7 @@ class AsyncToolExecutor:
 
         loop = asyncio.get_running_loop()
         opts = options or {}
+        started = time.monotonic()
 
         if action == Action.FIX:
             from lintro.utils.tool_executor import _run_fix_with_retry
@@ -124,6 +126,7 @@ class AsyncToolExecutor:
                 opts,
             )
         logger.debug(f"Completed async execution of {tool.definition.name}")
+        result.duration_seconds = time.monotonic() - started
 
         return result
 

--- a/lintro/utils/findings.py
+++ b/lintro/utils/findings.py
@@ -1,0 +1,328 @@
+"""Canonical structured shape for a lint finding and a per-tool summary.
+
+Before this module every machine-readable surface extracted its own subset of
+:class:`~lintro.parsers.base_issue.BaseIssue`: ``--output-format json`` emitted
+``{file, line, code, message, doc_url}``, the SARIF bridge built its own
+``StandardIssue`` with ``column`` and ``severity``, and CSV had a third shape.
+Adding MCP would have made a fourth. :class:`Finding` is the superset all of
+them can be projected from, so a new consumer normalizes a ``BaseIssue`` in
+exactly one place.
+
+The JSON document's own key set is deliberately *not* changed here — it is a
+published output contract. What changed is where its data comes from: SARIF
+and MCP both build on :func:`findings_from_results`, and JSON's narrower body
+is a projection of the same extraction rules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING, Any
+
+from lintro.enums.action import Action
+from lintro.enums.severity_level import SeverityLevel
+from lintro.enums.tool_run_status import ToolRunStatus, tool_run_status
+from lintro.formatters.formatter import merge_detected_and_remaining
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from lintro.models.core.tool_result import ToolResult
+    from lintro.parsers.base_issue import BaseIssue
+
+__all__ = [
+    "Finding",
+    "FindingScope",
+    "ToolRunSummary",
+    "finding_from_issue",
+    "findings_from_result",
+    "findings_from_results",
+    "issues_for_result",
+    "tool_summaries_from_results",
+    "tool_summary_from_result",
+]
+
+
+class FindingScope(StrEnum):
+    """Which of a fix run's issues a consumer wants to see.
+
+    A fix run knows two populations: everything the tool detected before it
+    started, and what is still unfixed now. Neither is universally right —
+    ``--output-format json`` reports the union so a user can see what was done,
+    while an agent asking a formatter to run wants the residue it must handle
+    itself. A check run has only one population and ignores this entirely.
+
+    Attributes:
+        ALL: Pre-fix detections merged with the post-fix remainder.
+        REMAINING: Only the issues the fix run could not resolve.
+    """
+
+    ALL = auto()
+    REMAINING = auto()
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One normalized lint finding, independent of any output format.
+
+    Attributes:
+        tool: Name of the tool that produced the finding.
+        file: Path to the file the finding refers to, as the tool reported it.
+        line: 1-based line number, or 0 when the tool reported none.
+        column: 1-based column number, or 0 when the tool reported none.
+        rule: Tool-specific rule identifier (ruff's ``F401``, hadolint's
+            ``DL3008``). Empty when the tool emits unclassified diagnostics.
+        severity: Normalized severity.
+        message: Human-readable description of the finding.
+        fixable: Whether the producing tool can fix this finding itself.
+        doc_url: Documentation URL for ``rule``, or an empty string.
+    """
+
+    tool: str
+    file: str
+    line: int
+    column: int
+    rule: str
+    severity: SeverityLevel
+    message: str
+    fixable: bool
+    doc_url: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the finding to a JSON-compatible dict.
+
+        ``doc_url`` is omitted when empty, matching the JSON document's
+        convention of not emitting a key that carries no information.
+
+        Returns:
+            dict[str, Any]: The finding's wire representation.
+        """
+        data: dict[str, Any] = {
+            "tool": self.tool,
+            "file": self.file,
+            "line": self.line,
+            "column": self.column,
+            "rule": self.rule,
+            "severity": str(self.severity),
+            "message": self.message,
+            "fixable": self.fixable,
+        }
+        if self.doc_url:
+            data["doc_url"] = self.doc_url
+        return data
+
+
+@dataclass(frozen=True)
+class ToolRunSummary:
+    """Per-tool outcome of a run.
+
+    Attributes:
+        tool: Name of the tool.
+        status: Collapsed outcome.
+        issue_count: Number of findings attributed to this tool.
+        duration: Wall-clock seconds the tool took, or ``None`` when the run
+            did not record one (a tool that never executed, or a result
+            constructed outside the executor).
+        fixed_count: How many issues the tool fixed, or ``None`` for a check
+            run and for fix-incapable tools.
+        skip_reason: Why the tool was skipped, or ``None``.
+    """
+
+    tool: str
+    status: ToolRunStatus
+    issue_count: int
+    duration: float | None
+    fixed_count: int | None = None
+    skip_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the summary to a JSON-compatible dict.
+
+        Returns:
+            dict[str, Any]: The summary's wire representation.
+        """
+        data: dict[str, Any] = {
+            "tool": self.tool,
+            "status": str(self.status),
+            "issue_count": self.issue_count,
+            "duration": self.duration,
+        }
+        if self.fixed_count is not None:
+            data["fixed_count"] = self.fixed_count
+        if self.skip_reason:
+            data["skip_reason"] = self.skip_reason
+        return data
+
+
+def _severity_of(*, issue: BaseIssue) -> SeverityLevel:
+    """Resolve an issue's severity, falling back to a warning.
+
+    Args:
+        issue: The parsed issue.
+
+    Returns:
+        SeverityLevel: The normalized severity.
+    """
+    try:
+        return issue.get_severity()
+    except (ValueError, AttributeError):
+        return SeverityLevel.WARNING
+
+
+def finding_from_issue(*, issue: BaseIssue, tool_name: str) -> Finding:
+    """Normalize a single parsed issue into a :class:`Finding`.
+
+    ``rule`` and ``message`` come from ``to_display_row`` because subclasses
+    remap those onto their own attribute names (``code`` may live on ``rule``,
+    ``check``, ``id``, …) and the display row is the one place that mapping is
+    already resolved.
+
+    Args:
+        issue: The parsed issue.
+        tool_name: Name of the tool that produced it.
+
+    Returns:
+        Finding: The normalized finding.
+    """
+    row = issue.to_display_row()
+    fixable_attr = issue.DISPLAY_FIELD_MAP.get("fixable", "fixable")
+    return Finding(
+        tool=tool_name,
+        file=str(getattr(issue, "file", "") or ""),
+        line=int(getattr(issue, "line", 0) or 0),
+        column=int(getattr(issue, "column", 0) or 0),
+        rule=str(row.get("code", "") or ""),
+        severity=_severity_of(issue=issue),
+        message=str(row.get("message", "") or ""),
+        fixable=bool(getattr(issue, fixable_attr, False)),
+        doc_url=str(getattr(issue, "doc_url", "") or getattr(issue, "url", "") or ""),
+    )
+
+
+def issues_for_result(
+    *,
+    result: ToolResult,
+    action: Action,
+    scope: FindingScope = FindingScope.ALL,
+) -> list[BaseIssue]:
+    """Return the issues a consumer should report for one tool result.
+
+    A check run has one population and returns ``result.issues`` verbatim. A
+    fix run is filtered by ``scope``; see :class:`FindingScope`. The remaining
+    issues are read off the tail of ``result.issues``, which is the ordering
+    contract :class:`~lintro.models.core.tool_result.ToolResult` documents.
+
+    Args:
+        result: The tool result.
+        action: The action the run performed.
+        scope: Which population of a fix run's issues to return.
+
+    Returns:
+        list[BaseIssue]: Issues attributed to this result.
+    """
+    issues = list(result.issues or [])
+    if action != Action.FIX:
+        return issues
+    if scope == FindingScope.ALL:
+        return merge_detected_and_remaining(result.initial_issues, result.issues)
+    remaining = result.remaining_issues_count
+    if remaining is None:
+        return issues
+    return issues[len(issues) - remaining :] if remaining else []
+
+
+def findings_from_result(
+    *,
+    result: ToolResult,
+    action: Action,
+    scope: FindingScope = FindingScope.ALL,
+) -> list[Finding]:
+    """Normalize one tool result's issues into findings.
+
+    Args:
+        result: The tool result.
+        action: The action the run performed.
+        scope: Which population of a fix run's issues to report.
+
+    Returns:
+        list[Finding]: Normalized findings for this tool.
+    """
+    tool_name = str(result.name or "")
+    return [
+        finding_from_issue(issue=issue, tool_name=tool_name)
+        for issue in issues_for_result(result=result, action=action, scope=scope)
+    ]
+
+
+def findings_from_results(
+    *,
+    results: Sequence[ToolResult],
+    action: Action,
+    scope: FindingScope = FindingScope.ALL,
+) -> list[Finding]:
+    """Normalize every tool result's issues into one flat findings list.
+
+    Args:
+        results: Tool results from a run.
+        action: The action the run performed.
+        scope: Which population of a fix run's issues to report.
+
+    Returns:
+        list[Finding]: Normalized findings across all tools, in tool order.
+    """
+    findings: list[Finding] = []
+    for result in results:
+        findings.extend(
+            findings_from_result(result=result, action=action, scope=scope),
+        )
+    return findings
+
+
+def tool_summary_from_result(
+    *,
+    result: ToolResult,
+    action: Action,
+    scope: FindingScope = FindingScope.ALL,
+) -> ToolRunSummary:
+    """Summarize one tool's outcome.
+
+    Args:
+        result: The tool result.
+        action: The action the run performed.
+        scope: Which population of a fix run's issues ``issue_count`` counts.
+
+    Returns:
+        ToolRunSummary: The per-tool summary.
+    """
+    issue_count = len(issues_for_result(result=result, action=action, scope=scope))
+    return ToolRunSummary(
+        tool=str(result.name or ""),
+        status=tool_run_status(result=result, issue_count=issue_count),
+        issue_count=issue_count,
+        duration=result.duration_seconds,
+        fixed_count=result.fixed_issues_count if action == Action.FIX else None,
+        skip_reason=result.skip_reason,
+    )
+
+
+def tool_summaries_from_results(
+    *,
+    results: Sequence[ToolResult],
+    action: Action,
+    scope: FindingScope = FindingScope.ALL,
+) -> list[ToolRunSummary]:
+    """Summarize every tool's outcome, in run order.
+
+    Args:
+        results: Tool results from a run.
+        action: The action the run performed.
+        scope: Which population of a fix run's issues ``issue_count`` counts.
+
+    Returns:
+        list[ToolRunSummary]: One summary per tool result.
+    """
+    return [
+        tool_summary_from_result(result=result, action=action, scope=scope)
+        for result in results
+    ]

--- a/lintro/utils/output/sarif/bridge.py
+++ b/lintro/utils/output/sarif/bridge.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from lintro.enums.severity_level import SeverityLevel
+from lintro.utils.findings import Finding, finding_from_issue
 from lintro.utils.output.sarif.document import StandardIssue
 
 if TYPE_CHECKING:
@@ -55,6 +55,12 @@ def _to_standard_issue(
 ) -> StandardIssue:
     """Normalize a single ``BaseIssue`` into a ``StandardIssue``.
 
+    Delegates the extraction to :func:`lintro.utils.findings.finding_from_issue`
+    so SARIF and MCP read a ``BaseIssue`` by exactly the same rules;
+    ``StandardIssue`` is the SARIF-shaped projection of that canonical
+    :class:`~lintro.utils.findings.Finding` (it carries no ``fixable``, and
+    names the rule identifier ``code``).
+
     Args:
         issue: Parsed lint issue to normalize.
         tool_name: Name of the tool that produced the issue.
@@ -62,20 +68,27 @@ def _to_standard_issue(
     Returns:
         Normalized standard issue.
     """
-    row = issue.to_display_row()
-    try:
-        severity = issue.get_severity()
-    except (ValueError, AttributeError):
-        severity = SeverityLevel.WARNING
+    return _standard_issue_from_finding(
+        finding=finding_from_issue(issue=issue, tool_name=tool_name),
+    )
+
+
+def _standard_issue_from_finding(*, finding: Finding) -> StandardIssue:
+    """Project a canonical finding onto the SARIF-facing ``StandardIssue``.
+
+    Args:
+        finding: The canonical finding.
+
+    Returns:
+        Normalized standard issue.
+    """
     return StandardIssue(
-        tool_name=tool_name,
-        file=str(getattr(issue, "file", "") or ""),
-        line=int(getattr(issue, "line", 0) or 0),
-        column=int(getattr(issue, "column", 0) or 0),
-        code=str(row.get("code", "") or ""),
-        message=str(row.get("message", "") or ""),
-        severity=severity,
-        doc_url=str(
-            getattr(issue, "doc_url", "") or getattr(issue, "url", "") or "",
-        ),
+        tool_name=finding.tool,
+        file=finding.file,
+        line=finding.line,
+        column=finding.column,
+        code=finding.rule,
+        message=finding.message,
+        severity=finding.severity,
+        doc_url=finding.doc_url,
     )

--- a/lintro/utils/tool_executor.py
+++ b/lintro/utils/tool_executor.py
@@ -17,6 +17,7 @@ enhancement run it between the two phases; see
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Any
 
 from lintro.enums.action import Action, normalize_action
@@ -317,6 +318,7 @@ def _execute_tools_sequential(
             )
 
             # Execute the tool
+            started = time.monotonic()
             if ctx.action == Action.FIX:
                 result = _run_fix_with_retry(
                     tool=tool,
@@ -326,6 +328,7 @@ def _execute_tools_sequential(
                 )
             else:
                 result = tool.check(paths, {})
+            result.duration_seconds = time.monotonic() - started
 
             # Populate doc_url on each issue from the plugin
             _enrich_issues_with_doc_urls(tool, result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ packages = [
   "lintro.cli_utils.commands",
   "lintro.mcp",
   "lintro.mcp.enums",
+  "lintro.mcp.toolkits",
   "lintro.config",
   "lintro.enums",
   "lintro.exceptions",

--- a/tests/unit/mcp/test_toolkit_lint.py
+++ b/tests/unit/mcp/test_toolkit_lint.py
@@ -1,0 +1,383 @@
+"""End-to-end tests for the ``lintro_check`` / ``lintro_format`` MCP tools.
+
+Every test drives a real :class:`mcp.ClientSession` over in-memory streams
+against the same ``Server`` object the stdio transport serves, and every one
+runs the real ``ruff`` binary against a throwaway workspace. Stubbing the
+runner would leave the interesting part — that a dry run really does leave the
+tree byte-identical — untested.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+import pytest
+from assertpy import assert_that
+from mcp import ClientSession, types
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from lintro.mcp.server import create_mcp_server
+
+_T = TypeVar("_T")
+
+_UNFORMATTED = "import os\nx    =  1\n"
+_UNFIXABLE = "undefined_name_here\n"
+
+
+def _run_session(
+    *,
+    workspace: Path,
+    check: Callable[[ClientSession], Awaitable[_T]],
+) -> _T:
+    """Run ``check`` against a connected in-memory MCP client session.
+
+    Args:
+        workspace: Workspace root for the server under test.
+        check: Async callback receiving an initialized client session.
+
+    Returns:
+        Whatever ``check`` returns.
+    """
+    server = create_mcp_server(workspace=workspace)
+
+    async def _main() -> _T:
+        async with create_connected_server_and_client_session(server) as session:
+            return await check(session)
+
+    return asyncio.run(_main())
+
+
+def _payload(result: types.CallToolResult) -> dict[str, Any]:
+    """Extract a tool result payload as a dict.
+
+    Args:
+        result: The ``CallToolResult`` returned by ``session.call_tool``.
+
+    Returns:
+        The payload the server sent.
+    """
+    if result.structuredContent:
+        return dict(result.structuredContent)
+    block = result.content[0]
+    assert isinstance(block, types.TextContent)
+    return dict(json.loads(block.text))
+
+
+def _call(
+    *,
+    workspace: Path,
+    tool: str,
+    arguments: dict[str, Any],
+) -> tuple[types.CallToolResult, dict[str, Any]]:
+    """Call one MCP tool and return its raw result and decoded payload.
+
+    Args:
+        workspace: Workspace root for the server under test.
+        tool: Tool name to call.
+        arguments: Tool arguments.
+
+    Returns:
+        The ``CallToolResult`` and its payload.
+    """
+
+    async def _check(
+        session: ClientSession,
+    ) -> tuple[types.CallToolResult, dict[str, Any]]:
+        result = await session.call_tool(tool, arguments)
+        return result, _payload(result)
+
+    return _run_session(workspace=workspace, check=_check)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """Create a throwaway Python workspace with one unformatted module.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+
+    Returns:
+        Path: The resolved workspace root.
+    """
+    (tmp_path / "bad.py").write_text(_UNFORMATTED, encoding="utf-8")
+    return tmp_path.resolve()
+
+
+def test_lint_tools_are_listed_with_their_annotations(workspace: Path) -> None:
+    """Both tools are advertised with the safety hints their contract implies."""
+
+    async def _check(session: ClientSession) -> dict[str, types.Tool]:
+        listed = await session.list_tools()
+        return {tool.name: tool for tool in listed.tools}
+
+    tools = _run_session(workspace=workspace, check=_check)
+
+    assert_that(tools).contains_key("lintro_check", "lintro_format")
+
+    check_hints = tools["lintro_check"].annotations
+    assert check_hints is not None
+    assert_that(check_hints.readOnlyHint).is_true()
+    assert_that(check_hints.destructiveHint).is_false()
+    assert_that(check_hints.idempotentHint).is_true()
+
+    format_hints = tools["lintro_format"].annotations
+    assert format_hints is not None
+    assert_that(format_hints.readOnlyHint).is_false()
+    assert_that(format_hints.destructiveHint).is_true()
+    assert_that(format_hints.idempotentHint).is_false()
+
+
+def test_check_returns_structured_findings_and_tool_summary(workspace: Path) -> None:
+    """lintro_check reports findings and a per-tool summary, changing nothing."""
+    before = (workspace / "bad.py").read_bytes()
+
+    result, payload = _call(
+        workspace=workspace,
+        tool="lintro_check",
+        arguments={"tools": ["ruff"]},
+    )
+
+    assert_that(result.isError).is_false()
+    assert_that(payload["findings"]).is_not_empty()
+    finding = payload["findings"][0]
+    assert_that(finding).contains_key(
+        "tool",
+        "file",
+        "line",
+        "column",
+        "rule",
+        "severity",
+        "message",
+        "fixable",
+    )
+    assert_that(finding["tool"]).is_equal_to("ruff")
+
+    summary = payload["tools"][0]
+    assert_that(summary["tool"]).is_equal_to("ruff")
+    assert_that(summary["status"]).is_equal_to("issues")
+    assert_that(summary["issue_count"]).is_greater_than(0)
+    assert_that(summary["duration"]).is_greater_than_or_equal_to(0.0)
+    assert_that(payload["summary"]["success"]).is_false()
+    assert_that((workspace / "bad.py").read_bytes()).is_equal_to(before)
+
+
+def test_check_on_a_clean_workspace_returns_no_findings(tmp_path: Path) -> None:
+    """A workspace with nothing to report yields an empty findings array."""
+    (tmp_path / "good.py").write_text("x = 1\n", encoding="utf-8")
+
+    result, payload = _call(
+        workspace=tmp_path.resolve(),
+        tool="lintro_check",
+        arguments={"tools": ["ruff"]},
+    )
+
+    assert_that(result.isError).is_false()
+    assert_that(payload["findings"]).is_empty()
+    assert_that(payload["summary"]["total_findings"]).is_equal_to(0)
+    assert_that(payload["tools"][0]["status"]).is_equal_to("passed")
+    assert_that(payload["summary"]["success"]).is_true()
+
+
+def test_check_respects_the_tools_filter(workspace: Path) -> None:
+    """Only the requested tool appears in the per-tool summary."""
+    _result, payload = _call(
+        workspace=workspace,
+        tool="lintro_check",
+        arguments={"tools": ["ruff"]},
+    )
+
+    assert_that([summary["tool"] for summary in payload["tools"]]).is_equal_to(["ruff"])
+
+
+def test_check_rejects_an_unknown_tool_with_tool_unavailable(workspace: Path) -> None:
+    """An unregistered tool name is refused rather than silently ignored."""
+    result, payload = _call(
+        workspace=workspace,
+        tool="lintro_check",
+        arguments={"tools": ["not-a-real-linter"]},
+    )
+
+    assert_that(result.isError).is_true()
+    envelope = payload["error"]
+    assert_that(envelope["code"]).is_equal_to("tool_unavailable")
+    assert_that(envelope["detail"]["tools"]).is_equal_to(["not-a-real-linter"])
+
+
+def test_check_rejects_an_advisory_tool(workspace: Path) -> None:
+    """Advisory AI finders belong to ``lintro review``, not to chk/fmt."""
+    result, payload = _call(
+        workspace=workspace,
+        tool="lintro_check",
+        arguments={"tools": ["idiom-review"]},
+    )
+
+    assert_that(result.isError).is_true()
+    assert_that(payload["error"]["code"]).is_equal_to("tool_unavailable")
+    assert_that(payload["error"]["message"]).contains("advisory")
+
+
+def test_check_rejects_a_tool_the_workspace_config_disabled(tmp_path: Path) -> None:
+    """A requested tool the config turned off is refused, not silently skipped."""
+    workspace = tmp_path.resolve()
+    (workspace / "bad.py").write_text(_UNFORMATTED, encoding="utf-8")
+    (workspace / ".lintro-config.yaml").write_text(
+        "tools:\n  ruff:\n    enabled: false\n",
+        encoding="utf-8",
+    )
+
+    result, payload = _call(
+        workspace=workspace,
+        tool="lintro_check",
+        arguments={"tools": ["ruff"]},
+    )
+
+    assert_that(result.isError).is_true()
+    envelope = payload["error"]
+    assert_that(envelope["code"]).is_equal_to("tool_unavailable")
+    assert_that(envelope["detail"]["skipped"]).contains_key("ruff")
+
+
+def test_check_rejects_a_path_outside_the_workspace(workspace: Path) -> None:
+    """A path argument escaping the workspace is refused before dispatch."""
+    result, payload = _call(
+        workspace=workspace,
+        tool="lintro_check",
+        arguments={"paths": ["../elsewhere"], "tools": ["ruff"]},
+    )
+
+    assert_that(result.isError).is_true()
+    assert_that(payload["error"]["code"]).is_equal_to("workspace_violation")
+
+
+def test_check_rejects_arguments_that_violate_the_schema(workspace: Path) -> None:
+    """Unknown properties are rejected by the tool's own JSON Schema."""
+    result, payload = _call(
+        workspace=workspace,
+        tool="lintro_check",
+        arguments={"nonsense": True},
+    )
+
+    assert_that(result.isError).is_true()
+    assert_that(payload["error"]["code"]).is_equal_to("invalid_input")
+
+
+def test_format_dry_run_returns_diffs_and_leaves_the_tree_untouched(
+    workspace: Path,
+) -> None:
+    """The default dry run reports a real diff without writing anything."""
+    before = (workspace / "bad.py").read_bytes()
+
+    result, payload = _call(
+        workspace=workspace,
+        tool="lintro_format",
+        arguments={"tools": ["ruff"]},
+    )
+
+    assert_that(result.isError).is_false()
+    assert_that(payload["dry_run"]).is_true()
+    assert_that(payload["changed_files"]).is_equal_to(["bad.py"])
+
+    diff = payload["diffs"][0]
+    assert_that(diff["file"]).is_equal_to("bad.py")
+    assert_that(diff["diff"]).contains("--- a/bad.py", "+++ b/bad.py", "-import os")
+    assert_that((workspace / "bad.py").read_bytes()).is_equal_to(before)
+
+
+def test_format_apply_writes_the_changes_and_reports_them(workspace: Path) -> None:
+    """dry_run=false applies the formatting and still returns the diffs."""
+    before = (workspace / "bad.py").read_bytes()
+
+    result, payload = _call(
+        workspace=workspace,
+        tool="lintro_format",
+        arguments={"tools": ["ruff"], "dry_run": False},
+    )
+
+    assert_that(result.isError).is_false()
+    assert_that(payload["dry_run"]).is_false()
+    assert_that(payload["changed_files"]).is_equal_to(["bad.py"])
+    assert_that(payload["diffs"][0]["diff"]).contains("-import os")
+
+    after = (workspace / "bad.py").read_bytes()
+    assert_that(after).is_not_equal_to(before)
+    assert_that(after.decode("utf-8")).does_not_contain("import os")
+
+
+def test_format_reports_only_the_findings_it_could_not_fix(tmp_path: Path) -> None:
+    """After a fix run the findings array is the residue, not the whole run."""
+    workspace = tmp_path.resolve()
+    (workspace / "bad.py").write_text(_UNFORMATTED + _UNFIXABLE, encoding="utf-8")
+
+    _result, payload = _call(
+        workspace=workspace,
+        tool="lintro_format",
+        arguments={"tools": ["ruff"]},
+    )
+
+    rules = {finding["rule"] for finding in payload["findings"]}
+    assert_that(rules).contains("F821")
+    assert_that(rules).does_not_contain("F401")
+    assert_that(payload["tools"][0]["fixed_count"]).is_greater_than(0)
+
+
+def test_format_on_a_clean_workspace_reports_no_changes(tmp_path: Path) -> None:
+    """Nothing to format means no changed files and no diffs."""
+    workspace = tmp_path.resolve()
+    (workspace / "good.py").write_text("x = 1\n", encoding="utf-8")
+
+    result, payload = _call(
+        workspace=workspace,
+        tool="lintro_format",
+        arguments={"tools": ["ruff"]},
+    )
+
+    assert_that(result.isError).is_false()
+    assert_that(payload["changed_files"]).is_empty()
+    assert_that(payload["diffs"]).is_empty()
+
+
+def test_check_does_not_leave_run_logs_in_the_workspace(workspace: Path) -> None:
+    """A read-only tool keeps its promise: no .lintro directory is created."""
+    result, _payload = _call(
+        workspace=workspace,
+        tool="lintro_check",
+        arguments={"tools": ["ruff"]},
+    )
+
+    assert_that(result.isError).is_false()
+    assert_that((workspace / ".lintro").exists()).is_false()
+
+
+def test_a_call_does_not_leak_the_log_directory_override(workspace: Path) -> None:
+    """LINTRO_LOG_DIR is restored, so the redirect cannot follow other callers."""
+    before = os.environ.get("LINTRO_LOG_DIR")
+
+    _call(workspace=workspace, tool="lintro_check", arguments={"tools": ["ruff"]})
+
+    assert_that(os.environ.get("LINTRO_LOG_DIR")).is_equal_to(before)
+
+
+def test_a_call_restores_the_working_directory(workspace: Path) -> None:
+    """The process cwd is anchored for the run and handed back afterwards."""
+    before = Path.cwd()
+
+    _call(workspace=workspace, tool="lintro_check", arguments={"tools": ["ruff"]})
+
+    assert_that(Path.cwd()).is_equal_to(before)
+
+
+def test_format_rejects_a_tool_that_cannot_format(workspace: Path) -> None:
+    """Asking a check-only tool to format is refused, not silently downgraded."""
+    result, payload = _call(
+        workspace=workspace,
+        tool="lintro_format",
+        arguments={"tools": ["bandit"]},
+    )
+
+    assert_that(result.isError).is_true()
+    assert_that(payload["error"]["code"]).is_equal_to("tool_unavailable")

--- a/tests/unit/mcp/test_toolkit_snapshot.py
+++ b/tests/unit/mcp/test_toolkit_snapshot.py
@@ -1,0 +1,184 @@
+"""Tests for the snapshot/diff/restore primitives behind ``lintro_format``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from assertpy import assert_that
+
+from lintro.mcp.errors import McpError
+from lintro.mcp.toolkits import snapshot as snapshot_module
+from lintro.mcp.toolkits.snapshot import changes_since, restore, snapshot_files
+
+
+def test_snapshot_captures_files_the_tool_can_reach(tmp_path: Path) -> None:
+    """Discovery drives the snapshot, so unrelated file types stay out of it."""
+    (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("hello\n", encoding="utf-8")
+
+    captured = snapshot_files(
+        paths=[str(tmp_path)],
+        tool_names=["ruff"],
+    )
+
+    assert_that(set(captured)).is_equal_to({(tmp_path / "a.py").resolve()})
+
+
+def test_snapshot_ignores_an_unknown_tool_name(tmp_path: Path) -> None:
+    """A tool that cannot be resolved contributes no files rather than raising."""
+    (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
+
+    captured = snapshot_files(
+        paths=[str(tmp_path)],
+        tool_names=["not-a-real-linter"],
+    )
+
+    assert_that(captured).is_empty()
+
+
+def test_snapshot_refuses_to_exceed_its_memory_ceiling(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An oversized tree fails before any tool runs, with a structured error."""
+    (tmp_path / "a.py").write_text("x = 1\n" * 100, encoding="utf-8")
+    monkeypatch.setattr(snapshot_module, "MAX_SNAPSHOT_BYTES", 8)
+
+    with pytest.raises(McpError) as excinfo:
+        snapshot_files(
+            paths=[str(tmp_path)],
+            tool_names=["ruff"],
+        )
+
+    assert_that(str(excinfo.value.code)).is_equal_to("execution_error")
+    assert_that(excinfo.value.envelope.detail).contains_entry(
+        {"reason": "snapshot_too_large"},
+    )
+
+
+def test_snapshot_fails_loudly_when_a_candidate_cannot_be_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreadable candidate aborts the run rather than becoming unrestorable."""
+    (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
+
+    def _boom(self: Path) -> bytes:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_bytes", _boom)
+
+    with pytest.raises(McpError) as excinfo:
+        snapshot_files(paths=[str(tmp_path)], tool_names=["ruff"])
+
+    assert_that(excinfo.value.envelope.detail).contains_entry(
+        {"reason": "snapshot_read_failed"},
+    )
+
+
+def test_changes_since_fails_loudly_when_a_file_cannot_be_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A truncated change report is reported as an error, not returned quietly."""
+    target = tmp_path / "a.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    captured = {target.resolve(): b"x = 0\n"}
+
+    def _boom(self: Path) -> bytes:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_bytes", _boom)
+
+    with pytest.raises(McpError) as excinfo:
+        changes_since(snapshot=captured, workspace=tmp_path)
+
+    assert_that(excinfo.value.envelope.detail).contains_entry(
+        {"reason": "diff_read_failed"},
+    )
+
+
+def test_changes_since_reports_a_unified_diff_for_modified_files(
+    tmp_path: Path,
+) -> None:
+    """A modified file yields a diff with workspace-relative headers."""
+    target = tmp_path / "pkg" / "a.py"
+    target.parent.mkdir()
+    target.write_text("x = 1\n", encoding="utf-8")
+    captured = {target.resolve(): target.read_bytes()}
+    target.write_text("x = 2\n", encoding="utf-8")
+
+    changes = changes_since(snapshot=captured, workspace=tmp_path)
+
+    assert_that(changes).is_length(1)
+    assert_that(changes[0].path).is_equal_to("pkg/a.py")
+    assert_that(changes[0].diff).contains("--- a/pkg/a.py", "-x = 1", "+x = 2")
+
+
+def test_changes_since_ignores_untouched_files(tmp_path: Path) -> None:
+    """A file nothing rewrote produces no change entry."""
+    target = tmp_path / "a.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    captured = {target.resolve(): target.read_bytes()}
+
+    assert_that(changes_since(snapshot=captured, workspace=tmp_path)).is_empty()
+
+
+def test_changes_since_notes_binary_files_instead_of_diffing_them(
+    tmp_path: Path,
+) -> None:
+    """Undecodable content is reported as a note, not a mangled diff."""
+    target = tmp_path / "blob.bin"
+    target.write_bytes(b"\xff\xfe\x00")
+    captured = {target.resolve(): target.read_bytes()}
+    target.write_bytes(b"\xff\xfe\x01")
+
+    changes = changes_since(snapshot=captured, workspace=tmp_path)
+
+    assert_that(changes[0].diff).contains("Binary files differ")
+
+
+def test_changes_since_treats_a_deleted_file_as_a_removal(tmp_path: Path) -> None:
+    """A file the run deleted diffs against empty rather than being skipped."""
+    target = tmp_path / "a.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    captured = {target.resolve(): target.read_bytes()}
+    target.unlink()
+
+    changes = changes_since(snapshot=captured, workspace=tmp_path)
+
+    assert_that(changes[0].diff).contains("-x = 1")
+
+
+def test_restore_rewrites_changed_files_and_recreates_deleted_ones(
+    tmp_path: Path,
+) -> None:
+    """Restoring returns every captured file to its snapshot bytes."""
+    modified = tmp_path / "a.py"
+    deleted = tmp_path / "b.py"
+    modified.write_text("x = 1\n", encoding="utf-8")
+    deleted.write_text("y = 2\n", encoding="utf-8")
+    captured = {
+        modified.resolve(): modified.read_bytes(),
+        deleted.resolve(): deleted.read_bytes(),
+    }
+    modified.write_text("x = 999\n", encoding="utf-8")
+    deleted.unlink()
+
+    restore(snapshot=captured)
+
+    assert_that(modified.read_text(encoding="utf-8")).is_equal_to("x = 1\n")
+    assert_that(deleted.read_text(encoding="utf-8")).is_equal_to("y = 2\n")
+
+
+def test_restore_leaves_untouched_files_alone(tmp_path: Path) -> None:
+    """An unmodified file is not rewritten, so its mtime survives."""
+    target = tmp_path / "a.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    captured = {target.resolve(): target.read_bytes()}
+    before_mtime = target.stat().st_mtime_ns
+
+    restore(snapshot=captured)
+
+    assert_that(target.stat().st_mtime_ns).is_equal_to(before_mtime)

--- a/tests/unit/utils/test_findings.py
+++ b/tests/unit/utils/test_findings.py
@@ -1,0 +1,270 @@
+"""Tests for the canonical finding/summary serializer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from assertpy import assert_that
+
+from lintro.enums.action import Action
+from lintro.enums.severity_level import SeverityLevel
+from lintro.enums.tool_run_status import ToolRunStatus
+from lintro.models.core.tool_result import ToolResult
+from lintro.parsers.base_issue import BaseIssue
+from lintro.utils.findings import (
+    FindingScope,
+    finding_from_issue,
+    findings_from_results,
+    issues_for_result,
+    tool_summaries_from_results,
+    tool_summary_from_result,
+)
+
+
+@dataclass
+class _FixableIssue(BaseIssue):
+    """Issue carrying a code, a severity, and a fixable flag."""
+
+    code: str = ""
+    severity: str = "error"
+    fixable: bool = False
+
+
+@dataclass
+class _RemappedIssue(BaseIssue):
+    """Issue that remaps ``code`` and ``severity`` onto its own attributes."""
+
+    DISPLAY_FIELD_MAP: ClassVar[dict[str, str]] = {
+        "code": "rule_id",
+        "severity": "level",
+        "fixable": "auto_fix",
+        "message": "message",
+    }
+
+    rule_id: str = ""
+    level: str = "note"
+    auto_fix: bool = True
+
+
+def _issue(**overrides: object) -> _FixableIssue:
+    """Build a fixable issue with sensible defaults.
+
+    Args:
+        **overrides: Field values to override.
+
+    Returns:
+        _FixableIssue: The constructed issue.
+    """
+    defaults: dict[str, object] = {
+        "file": "src/app.py",
+        "line": 3,
+        "column": 7,
+        "message": "bad thing",
+        "code": "F401",
+        "severity": "error",
+        "fixable": True,
+    }
+    defaults.update(overrides)
+    return _FixableIssue(**defaults)  # type: ignore[arg-type]
+
+
+def test_finding_from_issue_captures_every_field() -> None:
+    """A finding carries the full superset of issue fields."""
+    finding = finding_from_issue(
+        issue=_issue(doc_url="https://example.test/F401"),
+        tool_name="ruff",
+    )
+
+    assert_that(finding.tool).is_equal_to("ruff")
+    assert_that(finding.file).is_equal_to("src/app.py")
+    assert_that(finding.line).is_equal_to(3)
+    assert_that(finding.column).is_equal_to(7)
+    assert_that(finding.rule).is_equal_to("F401")
+    assert_that(finding.severity).is_equal_to(SeverityLevel.ERROR)
+    assert_that(finding.message).is_equal_to("bad thing")
+    assert_that(finding.fixable).is_true()
+    assert_that(finding.doc_url).is_equal_to("https://example.test/F401")
+
+
+def test_finding_from_issue_follows_display_field_remapping() -> None:
+    """Rule, severity, and fixable resolve through DISPLAY_FIELD_MAP."""
+    issue = _RemappedIssue(
+        file="a.ts",
+        line=1,
+        column=2,
+        message="remapped",
+        rule_id="no-explicit-any",
+        level="note",
+        auto_fix=True,
+    )
+
+    finding = finding_from_issue(issue=issue, tool_name="oxlint")
+
+    assert_that(finding.rule).is_equal_to("no-explicit-any")
+    assert_that(finding.severity).is_equal_to(SeverityLevel.INFO)
+    assert_that(finding.fixable).is_true()
+
+
+def test_finding_to_dict_omits_empty_doc_url() -> None:
+    """The wire payload drops doc_url when the tool supplied none."""
+    payload = finding_from_issue(issue=_issue(), tool_name="ruff").to_dict()
+
+    assert_that(payload).does_not_contain_key("doc_url")
+    assert_that(payload["severity"]).is_equal_to("ERROR")
+    assert_that(payload["fixable"]).is_true()
+
+
+def test_check_run_reports_issues_verbatim() -> None:
+    """A check run reports exactly the issues the tool parsed."""
+    result = ToolResult(name="ruff", success=False, issues=[_issue(), _issue()])
+
+    findings = findings_from_results(results=[result], action=Action.CHECK)
+
+    assert_that(findings).is_length(2)
+    assert_that({finding.tool for finding in findings}).is_equal_to({"ruff"})
+
+
+def test_fix_run_all_scope_merges_detected_and_remaining() -> None:
+    """FindingScope.ALL unions the pre-fix detections with the remainder."""
+    fixed = _issue(code="F401")
+    remaining = _issue(code="E501", fixable=False)
+    result = ToolResult(
+        name="ruff",
+        success=True,
+        issues=[fixed, remaining],
+        initial_issues=[fixed, remaining],
+        initial_issues_count=2,
+        fixed_issues_count=1,
+        remaining_issues_count=1,
+    )
+
+    findings = findings_from_results(
+        results=[result],
+        action=Action.FIX,
+        scope=FindingScope.ALL,
+    )
+
+    assert_that([finding.rule for finding in findings]).is_equal_to(["F401", "E501"])
+
+
+def test_fix_run_remaining_scope_takes_the_tail() -> None:
+    """FindingScope.REMAINING keeps only what the fix run could not resolve."""
+    fixed = _issue(code="F401")
+    remaining = _issue(code="E501", fixable=False)
+    result = ToolResult(
+        name="ruff",
+        success=True,
+        issues=[fixed, remaining],
+        initial_issues=[fixed, remaining],
+        initial_issues_count=2,
+        fixed_issues_count=1,
+        remaining_issues_count=1,
+    )
+
+    findings = findings_from_results(
+        results=[result],
+        action=Action.FIX,
+        scope=FindingScope.REMAINING,
+    )
+
+    assert_that([finding.rule for finding in findings]).is_equal_to(["E501"])
+
+
+def test_fix_run_remaining_scope_is_empty_when_all_fixed() -> None:
+    """Nothing remains when the tool fixed everything it found."""
+    result = ToolResult(
+        name="ruff",
+        success=True,
+        issues=[_issue()],
+        initial_issues_count=1,
+        fixed_issues_count=1,
+        remaining_issues_count=0,
+    )
+
+    issues = issues_for_result(
+        result=result,
+        action=Action.FIX,
+        scope=FindingScope.REMAINING,
+    )
+
+    assert_that(issues).is_empty()
+
+
+def test_fix_run_remaining_scope_falls_back_without_counts() -> None:
+    """A tool that reports no remaining count is treated as all-remaining."""
+    result = ToolResult(name="prettier", success=False, issues=[_issue()])
+
+    issues = issues_for_result(
+        result=result,
+        action=Action.FIX,
+        scope=FindingScope.REMAINING,
+    )
+
+    assert_that(issues).is_length(1)
+
+
+def test_tool_summary_reports_issues_status_and_duration() -> None:
+    """A tool with findings reports the issues status and its duration."""
+    result = ToolResult(
+        name="ruff",
+        success=False,
+        issues=[_issue()],
+        issues_count=1,
+        duration_seconds=1.25,
+    )
+
+    summary = tool_summary_from_result(result=result, action=Action.CHECK)
+
+    assert_that(summary.tool).is_equal_to("ruff")
+    assert_that(summary.status).is_equal_to(ToolRunStatus.ISSUES)
+    assert_that(summary.issue_count).is_equal_to(1)
+    assert_that(summary.duration).is_equal_to(1.25)
+    assert_that(summary.to_dict()).does_not_contain_key("fixed_count")
+
+
+def test_tool_summary_reports_passed_skipped_timed_out_and_errored() -> None:
+    """Each ToolResult failure shape collapses to its own status."""
+    results = [
+        ToolResult(name="clean", success=True),
+        ToolResult(name="absent", skipped=True, skip_reason="binary not installed"),
+        ToolResult(name="slow", success=False, timed_out=True),
+        ToolResult(name="broken", success=False, output="crashed"),
+    ]
+
+    summaries = tool_summaries_from_results(results=results, action=Action.CHECK)
+
+    assert_that([summary.status for summary in summaries]).is_equal_to(
+        [
+            ToolRunStatus.PASSED,
+            ToolRunStatus.SKIPPED,
+            ToolRunStatus.TIMED_OUT,
+            ToolRunStatus.ERRORED,
+        ],
+    )
+    assert_that(summaries[1].to_dict()["skip_reason"]).is_equal_to(
+        "binary not installed",
+    )
+    assert_that(summaries[0].duration).is_none()
+
+
+def test_tool_summary_reports_fixed_count_for_fix_runs() -> None:
+    """A fix run surfaces how many issues the tool resolved."""
+    result = ToolResult(
+        name="ruff",
+        success=True,
+        issues=[_issue()],
+        initial_issues_count=1,
+        fixed_issues_count=1,
+        remaining_issues_count=0,
+    )
+
+    summary = tool_summary_from_result(
+        result=result,
+        action=Action.FIX,
+        scope=FindingScope.REMAINING,
+    )
+
+    assert_that(summary.status).is_equal_to(ToolRunStatus.PASSED)
+    assert_that(summary.issue_count).is_equal_to(0)
+    assert_that(summary.to_dict()["fixed_count"]).is_equal_to(1)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(mcp): add check and format toolkit with structured findings
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Registers the first real MCP toolkit on the server that landed in #1575, so an agent can
lint and format through a typed contract instead of shelling out and parsing text.

- **`lintro_check`** — read-only, idempotent. Inputs `paths` and `tools`. Returns
  `findings[]` (`tool, file, line, column, rule, severity, message, fixable, doc_url`)
  plus a per-tool summary (`tool, status, issue_count, duration`).
- **`lintro_format`** — destructive, not idempotent, `dry_run` defaults to **true**.
  A dry run returns real unified diffs per file and leaves the tree byte-identical;
  `dry_run: false` applies the changes and returns the same diffs plus the changed-file
  list. `findings` is the residue the formatters could not fix, with `fixed_count` on
  each tool summary.

Both handlers drive the same runner the CLI uses (`build_run_context` + `execute_run`)
and never call the render phase, because an MCP server owns stdout for the JSON-RPC
stream.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1238

## Details

### Shared findings serializer

New `lintro/utils/findings.py` holds the canonical `Finding` (the superset of everything
a consumer might want off a `BaseIssue`) and `ToolRunSummary`. The SARIF bridge now
builds its `StandardIssue` by projecting a `Finding`, so SARIF and MCP read a `BaseIssue`
by exactly one set of rules rather than two. The `--output-format json` document keeps
its published key set — it is a narrower projection of the same extraction, and widening
it is a separate, user-visible change.

`FindingScope` distinguishes the two populations a fix run has: `ALL` (pre-fix
detections merged with the remainder, what the JSON document reports) and `REMAINING`
(what the formatters could not resolve, what `lintro_format` reports).

### Format dry-run mechanism

The existing `lintro fmt --dry-run` answers a different question: it runs the fix-capable
tools in *check* mode and lists issues a real run would address. It produces no diff,
because nothing ever wrote. Real diffs need the formatters to actually write. Three
options were weighed:

- **Temp copy of the tree** — rejected. Formatters resolve config (`.prettierrc`,
  `pyproject.toml`, `node_modules`) by walking up from each file, so a partial copy
  formats under the wrong config and a full copy is unbounded.
- **Git checkpoint + `git restore`** (`lintro/ai/checkpoints.py`, #1576) — rejected as
  the primary path: only works inside a git work tree, and cannot represent changes to
  untracked files.
- **In-place with a byte snapshot** — chosen. The files the selected tools can reach
  (via the tools' own `discover_files`) are read into memory, the real `fmt` runs, diffs
  are computed against the snapshot, and for a dry run every changed file is written back
  in a `finally`. A total-size ceiling turns a pathological workspace into a structured
  `execution_error` *before* anything runs, and a failed restore is reported loudly
  (`detail.reason == "restore_failed"`) rather than silently leaving the tree modified.

### Other notes

- `ToolResult.duration_seconds` is new; the sequential and async executors record it
  around each tool's check/fix call. Nothing tracked per-tool timing before, and the
  issue's summary shape requires it.
- `ToolRunStatus` (`passed | issues | skipped | timed_out | errored`) collapses the
  `success`/`skipped`/`timed_out` triple that every consumer previously re-derived inline.
- Runs are serialized behind one lock, and the process cwd is anchored to the workspace
  for the duration of a call, because lintro resolves `.lintro-config.yaml` and tool
  configs relative to the cwd and the config cache is a module singleton.
- `LINTRO_LOG_DIR` is redirected to a per-process temp directory for MCP runs (and
  restored afterwards), so `lintro_check` does not write `.lintro/` into a tree it
  advertises as read-only. An operator's own `LINTRO_LOG_DIR` still wins.
- Advisory AI finders are rejected with `tool_unavailable`, matching how `chk`/`fmt`
  reject them since #1886.
- **`profile` is not implemented.** The issue lists it as an input, but lintro has no
  profile/preset concept in `.lintro-config.yaml` today; adding one here would be exactly
  the MCP-only config surface v1 forbids. Worth a follow-up under #1236 if a config-level
  profile concept is wanted.

### Review follow-ups applied

A local CodeRabbit pass raised eight findings; all were accepted:

- `workspace_session` clears the config cache on exit as well as entry, so the
  workspace's config cannot follow the next in-process `get_config()` caller.
- A tool requested by name that the config disabled (or conflict resolution dropped) is
  rejected with `tool_unavailable` and `detail.skipped`, because `execute_run` records a
  skipped tool as a *successful* result and the call would otherwise report "success, no
  findings" for a tool that never ran.
- An unreadable snapshot candidate now aborts the run (`snapshot_read_failed`) instead of
  being dropped — a file missing from the snapshot could never be restored.
- An unreadable file during diffing raises `diff_read_failed` rather than silently
  shortening the change report.
- `dry_run` carries an explicit `"default": true` in the JSON Schema.
- The deferred `build_lint_toolkit` import in `server.py` is kept (it holds back the
  plugin/parser/formatter stack from anything that merely imports the module) with a
  comment saying so.

### Testing

`tests/unit/mcp/test_toolkit_lint.py` drives a real `mcp.ClientSession` over in-memory
streams against the same `Server` the stdio transport serves, running the real `ruff`
binary against throwaway workspaces: annotations, structured findings, empty findings,
tools filter, unknown/advisory/non-fixable tool rejection, path-boundary rejection,
schema rejection, dry-run leaves the tree byte-identical, apply mode writes, remaining
vs fixed accounting, no `.lintro/` in the workspace, and no cwd/env leakage.
`tests/unit/mcp/test_toolkit_snapshot.py` covers the snapshot primitives (discovery
scope, size ceiling, binary note, deletion, restore). `tests/unit/utils/test_findings.py`
covers the serializer including `DISPLAY_FIELD_MAP` remapping and every status.
