### PR TITLE
feat(mcp): add review toolkit exposing AI diff review

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -34,9 +34,10 @@ process.
 | `lintro_ping`   | read-only, idempotent       | `{status, lintro_version, workspace}`            |
 | `lintro_check`  | read-only, idempotent       | Structured findings plus a per-tool summary      |
 | `lintro_format` | destructive, not idempotent | Unified diffs, changed files, remaining findings |
+| `lintro_review` | read-only, not idempotent   | AI review findings plus run and budget metadata  |
 
-Further toolkits (review and so on) register through the internal `McpToolRegistry` and
-ship in follow-up issues.
+Further toolkits register through the internal `McpToolRegistry` and ship in follow-up
+issues.
 
 ### `lintro_check`
 
@@ -131,6 +132,91 @@ Notes and limits:
 - Runs are serialized: lintro resolves configuration relative to the process working
   directory, so one lint run happens at a time per server.
 
+### `lintro_review`
+
+Runs the same AI diff review as `lintro review` and returns its findings as data. The
+tool is read-only — nothing is written and nothing is posted — but **not idempotent**:
+every call issues provider calls and costs money.
+
+Arguments (all optional):
+
+| Argument       | Type       | Default             | Meaning                                                  |
+| -------------- | ---------- | ------------------- | -------------------------------------------------------- |
+| `base`         | `string`   | `origin/HEAD`       | Base git ref to diff against                             |
+| `uncommitted`  | `boolean`  | `false`             | Review working-tree changes instead of a branch diff     |
+| `depth`        | `1..3`     | `review.depth`      | 1 checklist, 2 + generated questions, 3 + adversarial    |
+| `strictness`   | `string`   | `review.strictness` | `focused`, `balanced`, or `thorough`                     |
+| `with_lint`    | `boolean`  | `false`             | Include a lint digest of the changed files in the prompt |
+| `paths`        | `string[]` | the whole diff      | Limit the review to these path prefixes                  |
+| `max_cost_usd` | `number`   | `ai.max_cost_usd`   | Spend ceiling for this call; can only lower the config   |
+
+```json
+{
+  "summary": "One blocking issue.",
+  "findings": [
+    {
+      "file": "app.py",
+      "line": 3,
+      "severity": "P1",
+      "category": "correctness",
+      "title": "Unbounded loop",
+      "body": "The loop never terminates.\n\nCause: ...\n\nFix: ...",
+      "confidence": "high",
+      "suggested_code": "i += 1",
+      "checklist_ids": [2],
+      "source": ""
+    }
+  ],
+  "run": {
+    "model": "claude-sonnet-4-5",
+    "provider": "anthropic",
+    "depth": 1,
+    "strictness": "balanced",
+    "cost_usd": 0.25,
+    "duration_seconds": 12.5,
+    "chunks": { "total": 2, "reviewed": 2 },
+    "files": { "reviewed": 1, "total": 1 },
+    "token_usage": { "prompt": 10, "completion": 5, "total": 15 },
+    "partial": false,
+    "stopped_reason": ""
+  },
+  "budget": {
+    "requested_usd": null,
+    "configured_usd": 1.0,
+    "effective_usd": 1.0,
+    "clamped": false,
+    "exceeded": false
+  }
+}
+```
+
+Cost control:
+
+- `ai.max_cost_usd` in the workspace config is the ceiling. `max_cost_usd` can only
+  **lower** it; a larger value is clamped to the configured one and reported as
+  `budget.clamped: true`. If the operator sets no ceiling, the argument becomes the
+  ceiling — set `ai.max_cost_usd` if agents must never spend more than a fixed amount.
+- When the ceiling stops a run **after** some chunks were reviewed, the call succeeds
+  with what was found: `run.partial: true`, `run.stopped_reason`,
+  `budget.exceeded: true`.
+- When it stops the run **before any chunk** was reviewed, no review was produced, and
+  the call fails with `budget_exceeded` rather than an empty "clean" result.
+
+Notes and limits:
+
+- `--post` (GitHub commenting) is deliberately not exposed. The calling agent owns
+  outward side effects.
+- An empty diff is a result, not an error: `findings: []` with zero-valued run metadata.
+- Without the `[ai]` extra, without a usable provider, or with `ai.review: false`, the
+  tool is still listed and returns `tool_unavailable` with `detail.reason` so an agent
+  gets a reason rather than a missing capability.
+- A failed review carries the same taxonomy `lintro review --output json` prints, under
+  `detail.review_error` (`kind`, `provider`, `status`, `retryable`).
+- **Latency**: a depth-3 review runs for minutes. Progress notifications are not sent;
+  the call's `timeout_seconds` is 1800s instead of the 300s default, and the review
+  holds the server's run lock for its whole duration, so `lintro_check` calls queue
+  behind it.
+
 ## Tool contract
 
 Each tool is an `McpToolSpec` with a name, description, JSON Schema for its arguments, a
@@ -180,9 +266,9 @@ provider-failure body, so it can never be confused with a tool's own successful 
 }
 ```
 
-Codes: `workspace_violation`, `tool_unavailable`, `invalid_input`, `execution_error`.
-`detail` is optional and may be `null`. A handler that exceeds its time budget
-(`timeout_seconds`, 300s by default) reports `execution_error` with
+Codes: `workspace_violation`, `tool_unavailable`, `invalid_input`, `execution_error`,
+`budget_exceeded`. `detail` is optional and may be `null`. A handler that exceeds its
+time budget (`timeout_seconds`, 300s by default) reports `execution_error` with
 `detail.reason == "timeout"`.
 
 Failures outside a tool call — a missing `lintro[mcp]` extra, a transport or session

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -206,6 +206,10 @@ Notes and limits:
 
 - `--post` (GitHub commenting) is deliberately not exposed. The calling agent owns
   outward side effects.
+- Read-only covers the reviewed tree. The one file a review can create is an AI
+  transcript, and only when the operator enabled `ai.transcript_logging` (or
+  `LINTRO_AI_TRANSCRIPT=1`); it is written under the gitignored `.lintro-cache/`, and no
+  tool argument can turn it on.
 - An empty diff is a result, not an error: `findings: []` with zero-valued run metadata.
 - Without the `[ai]` extra, without a usable provider, or with `ai.review: false`, the
   tool is still listed and returns `tool_unavailable` with `detail.reason` so an agent

--- a/lintro/mcp/enums/mcp_error_code.py
+++ b/lintro/mcp/enums/mcp_error_code.py
@@ -17,9 +17,12 @@ class McpErrorCode(StrEnum):
         TOOL_UNAVAILABLE: The requested tool is not registered on this server.
         INVALID_INPUT: Arguments failed JSON Schema or path validation.
         EXECUTION_ERROR: The tool handler raised an unexpected exception.
+        BUDGET_EXCEEDED: A cost-capped tool stopped on its AI spend ceiling
+            before producing any result.
     """
 
     WORKSPACE_VIOLATION = auto()
     TOOL_UNAVAILABLE = auto()
     INVALID_INPUT = auto()
     EXECUTION_ERROR = auto()
+    BUDGET_EXCEEDED = auto()

--- a/lintro/mcp/server.py
+++ b/lintro/mcp/server.py
@@ -71,14 +71,15 @@ def build_default_registry(*, workspace: Path) -> McpToolRegistry:
         workspace: Workspace root the tools are anchored to.
 
     Returns:
-        Registry containing ``lintro_ping``, ``lintro_check``, and
-        ``lintro_format``.
+        Registry containing ``lintro_ping``, ``lintro_check``,
+        ``lintro_format``, and ``lintro_review``.
     """
     # Deferred deliberately, in the same spirit as this module's other lazy
     # imports: the lint toolkit pulls the plugin registry, the parsers, and the
     # formatters, and nothing that merely imports this module (``lintro
     # doctor``, the CLI's command table) should pay for that.
     from lintro.mcp.toolkits.lint import build_lint_toolkit
+    from lintro.mcp.toolkits.review import build_review_toolkit
 
     registry = McpToolRegistry()
     registry.register(
@@ -95,6 +96,10 @@ def build_default_registry(*, workspace: Path) -> McpToolRegistry:
         ),
     )
     registry.register_toolkit(specs=build_lint_toolkit(workspace=workspace))
+    # Registered unconditionally: the review tool answers ``tool_unavailable``
+    # when the ``[ai]`` extra or the provider is missing, which tells an agent
+    # why it cannot review instead of silently omitting the capability.
+    registry.register_toolkit(specs=build_review_toolkit(workspace=workspace))
     return registry
 
 

--- a/lintro/mcp/toolkits/__init__.py
+++ b/lintro/mcp/toolkits/__init__.py
@@ -10,5 +10,6 @@ all.
 from __future__ import annotations
 
 from lintro.mcp.toolkits.lint import build_lint_toolkit
+from lintro.mcp.toolkits.review import build_review_toolkit
 
-__all__ = ["build_lint_toolkit"]
+__all__ = ["build_lint_toolkit", "build_review_toolkit"]

--- a/lintro/mcp/toolkits/review.py
+++ b/lintro/mcp/toolkits/review.py
@@ -11,6 +11,12 @@ Three things are deliberately different from the CLI:
 * **No side effects.** ``--post`` (GitHub commenting) is not exposed. The
   calling agent owns whatever it does with the findings, which is why the tool
   can be annotated read-only. It is *not* idempotent: every call spends money.
+  The one thing a review can put on disk is an AI transcript, and only when the
+  *operator* opted in with ``ai.transcript_logging`` or
+  ``LINTRO_AI_TRANSCRIPT=1``: it lands in the gitignored ``.lintro-cache/``
+  rather than the reviewed tree, in the same class as the run-log directory
+  :mod:`lintro.mcp.toolkits.runner` redirects. No tool argument can turn it on,
+  so an agent cannot make the server write anything.
 * **Cost is capped from the server side.** ``ai.max_cost_usd`` in the
   workspace's ``.lintro-config.yaml`` is the ceiling. The ``max_cost_usd``
   argument can only *lower* it — a larger value is clamped, never honored — so

--- a/lintro/mcp/toolkits/review.py
+++ b/lintro/mcp/toolkits/review.py
@@ -1,0 +1,742 @@
+"""The ``lintro_review`` MCP tool.
+
+The tool is a protocol surface over the existing AI diff review engine
+(:mod:`lintro.ai.review`): it collects the same git context ``lintro review``
+collects, runs the same orchestrator, and serializes the same
+:class:`~lintro.ai.review.models.review_result.ReviewResult`. Nothing about the
+review itself is reimplemented here, so an agent and the CLI cannot drift apart.
+
+Three things are deliberately different from the CLI:
+
+* **No side effects.** ``--post`` (GitHub commenting) is not exposed. The
+  calling agent owns whatever it does with the findings, which is why the tool
+  can be annotated read-only. It is *not* idempotent: every call spends money.
+* **Cost is capped from the server side.** ``ai.max_cost_usd`` in the
+  workspace's ``.lintro-config.yaml`` is the ceiling. The ``max_cost_usd``
+  argument can only *lower* it — a larger value is clamped, never honored — so
+  a misbehaving agent cannot raise its own spend limit.
+* **Unavailability is data, not a missing tool.** Without the ``[ai]`` extra, a
+  usable provider, or ``ai.review: true``, the tool is still listed and returns
+  a ``tool_unavailable`` envelope. An agent gets a reason it can report instead
+  of silently losing a capability mid-session.
+
+Latency: a depth-3 review issues several provider calls per chunk and routinely
+runs for minutes. The MCP SDK's progress notifications are not used — the
+foundation dispatches synchronous handlers into a worker thread with no access
+to the in-flight request context, so emitting them would mean threading the
+server session through every toolkit. The spec instead carries a much larger
+``timeout_seconds`` than the 300s default (see :data:`REVIEW_TIMEOUT_SECONDS`),
+and callers should expect a single long-running call.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+from lintro.mcp.enums.mcp_error_code import McpErrorCode
+from lintro.mcp.errors import McpError, McpErrorEnvelope
+from lintro.mcp.registry import McpToolSpec
+from lintro.mcp.toolkits.runner import workspace_session
+
+if TYPE_CHECKING:
+    from lintro.ai.config import AIConfig
+    from lintro.ai.review.models.review_context import ReviewContext
+    from lintro.ai.review.models.review_finding import ReviewFinding
+    from lintro.ai.review.models.review_metadata import ReviewMetadata
+    from lintro.ai.review.models.review_result import ReviewResult
+
+__all__ = ["REVIEW_TIMEOUT_SECONDS", "STRICTNESS_VALUES", "build_review_toolkit"]
+
+# A depth-3 review of a large diff runs for minutes, so the foundation's 300s
+# default would abort healthy work. The budget still exists: a wedged provider
+# call must not hold the JSON-RPC stream open forever.
+REVIEW_TIMEOUT_SECONDS: Final[float] = 1800.0
+
+# Mirrors ``ReviewStrictness``. Spelled out rather than imported so this module
+# stays free of AI imports at import time; ``test_toolkit_review`` asserts the
+# two never drift.
+STRICTNESS_VALUES: Final[tuple[str, ...]] = ("focused", "balanced", "thorough")
+
+_INPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "base": {
+            "type": "string",
+            "description": (
+                "Base git ref to diff against. Defaults to the repository "
+                "default branch (origin/HEAD). Cannot be combined with "
+                "uncommitted."
+            ),
+        },
+        "uncommitted": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "Review staged and unstaged working-tree changes instead of a "
+                "branch diff. Untracked files are excluded."
+            ),
+        },
+        "depth": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 3,
+            "description": (
+                "Review depth: 1 = checklist, 2 = plus generated questions, "
+                "3 = plus an adversarial pass. Higher depths cost more and take "
+                "longer. Defaults to review.depth in the workspace config."
+            ),
+        },
+        "strictness": {
+            "type": "string",
+            "enum": list(STRICTNESS_VALUES),
+            "description": (
+                "Sensitivity preset: focused (merge blockers only), balanced, "
+                "or thorough. Defaults to review.strictness in the config."
+            ),
+        },
+        "with_lint": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "Run lintro's deterministic linters on the changed files and "
+                "include a digest of their findings in the review prompt."
+            ),
+        },
+        "paths": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Limit the review to these path prefixes, relative to the "
+                "workspace root or absolute within it. Defaults to the whole diff."
+            ),
+        },
+        "max_cost_usd": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "description": (
+                "Spend ceiling for this review in USD. Clamped to the "
+                "server-side ai.max_cost_usd when that is lower; it can never "
+                "raise the configured ceiling."
+            ),
+        },
+    },
+    "additionalProperties": False,
+}
+
+_DESCRIPTION: Final[str] = (
+    "Run lintro's AI diff review over the workspace's git changes and return "
+    "structured findings (file, line, severity, category, title, body, "
+    "confidence) plus run metadata (model, cost, duration, chunks). Read-only: "
+    "nothing is written and nothing is posted to GitHub. Not idempotent — each "
+    "call issues provider calls and costs money — and a depth-3 review can run "
+    "for several minutes. Requires the [ai] extra, a configured provider, and "
+    "ai.review: true; otherwise it returns a tool_unavailable error."
+)
+
+# Review context failures that describe the caller's request rather than the
+# environment. Everything else is an environment problem or a genuine crash.
+_INVALID_INPUT_CONTEXT_CODES: Final[frozenset[str]] = frozenset(
+    {
+        "default-branch-unknown",
+        "merge-base-failed",
+        "invalid-review-mode",
+        "diff-desync",
+        "no-parseable-diff",
+    },
+)
+
+# Review context failures meaning this workspace cannot serve reviews at all.
+_UNAVAILABLE_CONTEXT_CODES: Final[frozenset[str]] = frozenset(
+    {
+        "git-unavailable",
+        "not-git-repo",
+        "gh-unavailable",
+        "bash-unavailable",
+    },
+)
+
+_NO_CHANGES_CODE: Final[str] = "no-changes"
+
+
+@dataclass(frozen=True)
+class _BudgetPolicy:
+    """The spend ceiling a single review call runs under.
+
+    Attributes:
+        requested_usd: The ``max_cost_usd`` argument, or ``None``.
+        configured_usd: ``ai.max_cost_usd`` from the workspace config, or
+            ``None`` when the operator set no ceiling.
+        effective_usd: The ceiling actually handed to the review engine.
+        clamped: True when the request was larger than the configured ceiling
+            and was lowered to it.
+    """
+
+    requested_usd: float | None
+    configured_usd: float | None
+    effective_usd: float | None
+    clamped: bool
+
+    def to_dict(self, *, exceeded: bool) -> dict[str, Any]:
+        """Serialize the policy for the tool payload.
+
+        Args:
+            exceeded: Whether the run actually stopped on this ceiling.
+
+        Returns:
+            dict[str, Any]: The ``budget`` block of the tool result.
+        """
+        return {
+            "requested_usd": self.requested_usd,
+            "configured_usd": self.configured_usd,
+            "effective_usd": self.effective_usd,
+            "clamped": self.clamped,
+            "exceeded": exceeded,
+        }
+
+
+def resolve_budget_policy(
+    *,
+    requested: float | None,
+    configured: float | None,
+) -> _BudgetPolicy:
+    """Combine the requested and configured spend ceilings.
+
+    The configured ceiling wins whenever it is the smaller of the two, so an
+    argument can only ever tighten the operator's limit. When the operator set
+    no ceiling, the argument becomes the ceiling; when neither is set the review
+    runs uncapped, exactly as the CLI does.
+
+    Args:
+        requested: The call's ``max_cost_usd`` argument, if any.
+        configured: ``ai.max_cost_usd`` from the workspace config, if any.
+
+    Returns:
+        _BudgetPolicy: The resolved ceiling and how it was reached.
+    """
+    if requested is None:
+        effective = configured
+    elif configured is None:
+        effective = requested
+    else:
+        effective = min(requested, configured)
+    return _BudgetPolicy(
+        requested_usd=requested,
+        configured_usd=configured,
+        effective_usd=effective,
+        clamped=(
+            requested is not None and configured is not None and requested > configured
+        ),
+    )
+
+
+def _relative_paths(*, arguments: dict[str, Any], workspace: Path) -> list[str] | None:
+    """Return the ``paths`` argument as workspace-relative prefixes.
+
+    The server has already resolved each entry to an absolute, in-workspace path
+    (``paths`` is declared in ``path_arguments``), but the review context filters
+    on repository-relative prefixes, so the absolute forms are mapped back.
+
+    Args:
+        arguments: Validated tool arguments.
+        workspace: Workspace root.
+
+    Returns:
+        list[str] | None: Relative path prefixes, or ``None`` for the whole diff.
+
+    Raises:
+        McpError: :attr:`McpErrorCode.INVALID_INPUT` when a path cannot be
+            expressed relative to the workspace root.
+    """
+    raw = arguments.get("paths") or []
+    if not raw:
+        return None
+    relative: list[str] = []
+    for entry in raw:
+        candidate = Path(str(entry))
+        try:
+            relative.append(str(candidate.relative_to(workspace)))
+        except ValueError as exc:
+            raise McpError(
+                code=McpErrorCode.INVALID_INPUT,
+                message=f"Path is not relative to the workspace: {entry}",
+                detail={"path": str(entry), "workspace": str(workspace)},
+            ) from exc
+    return relative
+
+
+def _resolve_ai_config(*, workspace: Path) -> tuple[Any, AIConfig]:
+    """Load the workspace config and require AI review to be usable.
+
+    Args:
+        workspace: Workspace root, used only for the error detail.
+
+    Returns:
+        tuple[Any, AIConfig]: The Lintro config and its resolved AI section.
+
+    Raises:
+        McpError: :attr:`McpErrorCode.TOOL_UNAVAILABLE` when no AI provider is
+            installed or ``ai.review`` is disabled for this workspace.
+    """
+    from lintro.ai.availability import is_ai_available
+    from lintro.ai.interface import resolve_ai_config
+    from lintro.config.config_loader import get_config
+
+    if not is_ai_available():
+        raise McpError(
+            code=McpErrorCode.TOOL_UNAVAILABLE,
+            message=(
+                "AI review requires the lintro[ai] extra and a configured "
+                "provider. Install with: uv pip install 'lintro[ai]'"
+            ),
+            detail={"tool": "lintro_review", "reason": "ai_unavailable"},
+        )
+
+    lintro_config = get_config()
+    ai_config = resolve_ai_config(lintro_config)
+    if not ai_config.review_enabled:
+        raise McpError(
+            code=McpErrorCode.TOOL_UNAVAILABLE,
+            message=(
+                "AI review is disabled for this workspace. Set ai.enabled: true "
+                "and ai.review: true in .lintro-config.yaml"
+            ),
+            detail={
+                "tool": "lintro_review",
+                "reason": "review_disabled",
+                "workspace": str(workspace),
+            },
+        )
+    return lintro_config, ai_config
+
+
+def _collect_context(
+    *,
+    arguments: dict[str, Any],
+    workspace: Path,
+) -> ReviewContext | None:
+    """Collect the git diff context for this call.
+
+    Args:
+        arguments: Validated tool arguments.
+        workspace: Workspace root.
+
+    Returns:
+        ReviewContext | None: The collected context, or ``None`` when the diff
+        is empty — "nothing changed" is an answer, not a failure.
+
+    Raises:
+        McpError: With :attr:`McpErrorCode.INVALID_INPUT` for a bad ``base`` or
+            an unusable diff request, :attr:`McpErrorCode.TOOL_UNAVAILABLE` when
+            git itself is missing, and :attr:`McpErrorCode.EXECUTION_ERROR`
+            otherwise.
+    """
+    from lintro.ai.review import collect_review_context
+    from lintro.ai.review.exceptions import ReviewContextError
+
+    try:
+        return collect_review_context(
+            base=arguments.get("base"),
+            uncommitted=bool(arguments.get("uncommitted", False)),
+            paths=_relative_paths(arguments=arguments, workspace=workspace),
+        )
+    except ReviewContextError as exc:
+        code = str(exc.code.value)
+        if code == _NO_CHANGES_CODE:
+            return None
+        if code in _UNAVAILABLE_CONTEXT_CODES:
+            mcp_code = McpErrorCode.TOOL_UNAVAILABLE
+        elif code in _INVALID_INPUT_CONTEXT_CODES:
+            mcp_code = McpErrorCode.INVALID_INPUT
+        else:
+            mcp_code = McpErrorCode.EXECUTION_ERROR
+        raise McpError(
+            code=mcp_code,
+            message=str(exc),
+            detail={"tool": "lintro_review", "context_error": code},
+        ) from exc
+
+
+def _lint_digest(
+    *,
+    context: ReviewContext,
+    lintro_config: Any,
+) -> str | None:
+    """Build the ``with_lint`` digest for the review prompt.
+
+    Args:
+        context: Collected review context.
+        lintro_config: Loaded Lintro configuration.
+
+    Returns:
+        str | None: A compact lint digest, or ``None`` when there is nothing
+        to report.
+    """
+    from lintro.ai.review.lint_bridge import (
+        format_lint_results_for_prompt,
+        run_lint_on_changed_files,
+    )
+
+    results = run_lint_on_changed_files(
+        changed_files=[file.path for file in context.changed_files],
+        lintro_config=lintro_config,
+    )
+    return format_lint_results_for_prompt(results=results) or None
+
+
+def _finding_body(*, finding: ReviewFinding) -> str:
+    """Render a finding's prose into one ``body`` field.
+
+    The review model splits its prose across ``description``, ``cause``, and
+    ``fix``; the MCP contract carries a single labelled body so an agent can
+    quote it verbatim without knowing the review model's shape.
+
+    Args:
+        finding: The review finding.
+
+    Returns:
+        str: The composed body text.
+    """
+    sections = (
+        ("", finding.description),
+        ("Cause: ", finding.cause),
+        ("Fix: ", finding.fix),
+    )
+    return "\n\n".join(
+        f"{label}{text.strip()}" for label, text in sections if text.strip()
+    )
+
+
+def _finding_to_dict(*, finding: ReviewFinding) -> dict[str, Any]:
+    """Serialize one review finding for the tool payload.
+
+    Args:
+        finding: The review finding.
+
+    Returns:
+        dict[str, Any]: The finding as the MCP contract carries it.
+    """
+    return {
+        "file": finding.file,
+        "line": finding.line,
+        "severity": str(finding.severity.value),
+        "category": finding.category,
+        "title": finding.title,
+        "body": _finding_body(finding=finding),
+        "confidence": finding.confidence,
+        "suggested_code": finding.suggested_code,
+        "checklist_ids": list(finding.checklist_ids),
+        "source": finding.source,
+    }
+
+
+def _run_metadata(*, metadata: ReviewMetadata) -> dict[str, Any]:
+    """Serialize review run metadata for the tool payload.
+
+    Args:
+        metadata: Metadata from the completed review.
+
+    Returns:
+        dict[str, Any]: The ``run`` block of the tool result.
+    """
+    return {
+        "model": metadata.model,
+        "provider": metadata.provider,
+        "depth": metadata.depth,
+        "strictness": metadata.strictness,
+        "cost_usd": metadata.cost_estimate_usd,
+        "duration_seconds": metadata.duration_seconds,
+        "chunks": {
+            "total": metadata.chunks_total,
+            "reviewed": metadata.chunks_reviewed,
+        },
+        "files": {
+            "reviewed": metadata.files_reviewed,
+            "total": metadata.files_total,
+        },
+        "token_usage": dict(metadata.token_usage),
+        "token_usage_estimated": metadata.token_usage_estimated,
+        "base_ref": metadata.base_ref,
+        "head_ref": metadata.head_ref,
+        "timestamp": metadata.timestamp,
+        "partial": metadata.partial,
+        "stopped_reason": metadata.stopped_reason,
+    }
+
+
+def _stopped_on_budget(*, metadata: ReviewMetadata) -> bool:
+    """Return whether the run stopped early because of the spend ceiling.
+
+    Args:
+        metadata: Metadata from the completed review.
+
+    Returns:
+        bool: True when the review engine ended the run on its cost cap.
+    """
+    return metadata.partial and "cost cap" in metadata.stopped_reason.lower()
+
+
+def _review_payload(
+    *,
+    result: ReviewResult,
+    budget: _BudgetPolicy,
+) -> dict[str, Any]:
+    """Shape a completed review as the tool result.
+
+    Args:
+        result: The review the orchestrator produced.
+        budget: The ceiling the run was given.
+
+    Returns:
+        dict[str, Any]: Findings, run metadata, and the budget block.
+
+    Raises:
+        McpError: :attr:`McpErrorCode.BUDGET_EXCEEDED` when the ceiling stopped
+            the run before a single chunk was reviewed, so the call produced no
+            review at all rather than a shorter one.
+    """
+    exceeded = _stopped_on_budget(metadata=result.metadata)
+    if exceeded and result.metadata.chunks_reviewed == 0:
+        raise McpError(
+            code=McpErrorCode.BUDGET_EXCEEDED,
+            message=(
+                "AI cost budget exhausted before any chunk was reviewed: "
+                f"{result.metadata.stopped_reason}"
+            ),
+            detail={
+                "tool": "lintro_review",
+                "budget": budget.to_dict(exceeded=True),
+                "chunks_total": result.metadata.chunks_total,
+                "cost_usd": result.metadata.cost_estimate_usd,
+            },
+        )
+    return {
+        "summary": result.summary,
+        "findings": [_finding_to_dict(finding=finding) for finding in result.findings],
+        "run": _run_metadata(metadata=result.metadata),
+        "budget": budget.to_dict(exceeded=exceeded),
+    }
+
+
+def _no_changes_payload(
+    *,
+    ai_config: AIConfig,
+    depth: int,
+    strictness: str,
+    budget: _BudgetPolicy,
+) -> dict[str, Any]:
+    """Build the result for a diff with nothing in it.
+
+    The metadata is assembled from the same :class:`ReviewMetadata` model a real
+    run produces, so the empty answer and a reviewed one carry an identical key
+    set and an agent needs no special case beyond ``findings == []``.
+
+    Args:
+        ai_config: Resolved AI configuration.
+        depth: The depth the call asked for.
+        strictness: The strictness the call asked for.
+        budget: The ceiling the call would have run under.
+
+    Returns:
+        dict[str, Any]: A zero-cost, zero-finding review result.
+    """
+    from lintro.ai.review.models.review_metadata import ReviewMetadata
+    from lintro.ai.review.models.review_result import ReviewResult
+
+    metadata = ReviewMetadata(
+        model=ai_config.model or "",
+        provider=str(ai_config.provider),
+        context_window=0,
+        depth=depth,
+        chunks_total=0,
+        chunks_current=0,
+        files_reviewed=0,
+        files_total=0,
+        checklist_items=0,
+        strictness=strictness,
+    )
+    result = ReviewResult(metadata=metadata, summary="No changes to review.")
+    return {
+        "summary": result.summary,
+        "findings": [],
+        "run": _run_metadata(metadata=result.metadata),
+        "budget": budget.to_dict(exceeded=False),
+    }
+
+
+def _review_failure(*, provider_name: str, error: Exception) -> McpErrorEnvelope:
+    """Translate a failed review into a structured MCP error envelope.
+
+    Args:
+        provider_name: Provider identifier for the error taxonomy.
+        error: The exception that aborted the review.
+
+    Returns:
+        McpErrorEnvelope: The envelope to raise, carrying the review error
+        contract's own ``kind``/``status``/``retryable`` fields as detail so an
+        agent gets the same diagnosis ``lintro review --output json`` prints.
+    """
+    from lintro.ai.review.error_contract import build_error_contract
+
+    contract = build_error_contract(provider=provider_name, error=error)
+    body = dict(contract["error"])
+    code = (
+        McpErrorCode.TOOL_UNAVAILABLE
+        if body.get("provider_unavailable")
+        else McpErrorCode.EXECUTION_ERROR
+    )
+    return McpErrorEnvelope(
+        code=code,
+        message=str(body.get("message") or error) or error.__class__.__name__,
+        detail={"tool": "lintro_review", "review_error": body},
+    )
+
+
+def _execute_review(*, arguments: dict[str, Any], workspace: Path) -> dict[str, Any]:
+    """Run one review end to end inside an open workspace session.
+
+    Args:
+        arguments: Validated tool arguments.
+        workspace: Workspace root the review is anchored to.
+
+    Returns:
+        dict[str, Any]: The tool result payload.
+
+    Raises:
+        McpError: For every failure mode the tool contract defines.
+    """
+    from lintro.ai.exceptions import AIError
+    from lintro.ai.providers import get_provider
+    from lintro.ai.review import (
+        classify_changed_files,
+        format_checklist_for_prompt,
+        get_all_checklist_items,
+        select_checklist_items,
+    )
+    from lintro.ai.review.enums.review_strictness import ReviewStrictness
+    from lintro.ai.review.orchestrator import run_review
+    from lintro.ai.review.sensitivity import resolve_sensitivity_policy
+
+    lintro_config, ai_config = _resolve_ai_config(workspace=workspace)
+    budget = resolve_budget_policy(
+        requested=arguments.get("max_cost_usd"),
+        configured=ai_config.max_cost_usd,
+    )
+    effective_ai_config = ai_config.model_copy(
+        update={"max_cost_usd": budget.effective_usd},
+    )
+    depth = int(arguments.get("depth") or lintro_config.review.depth)
+    strictness = ReviewStrictness(
+        str(
+            arguments.get("strictness") or lintro_config.review.strictness.value,
+        ).lower(),
+    )
+
+    context = _collect_context(arguments=arguments, workspace=workspace)
+    if context is None:
+        return _no_changes_payload(
+            ai_config=ai_config,
+            depth=depth,
+            strictness=strictness.value,
+            budget=budget,
+        )
+
+    classifications = classify_changed_files(context.changed_files)
+    selected_items = select_checklist_items(
+        classifications=classifications,
+        items=get_all_checklist_items(config=lintro_config),
+    )
+    checklist_text, _prompt_mapping = format_checklist_for_prompt(items=selected_items)
+    lint_results = (
+        _lint_digest(context=context, lintro_config=lintro_config)
+        if arguments.get("with_lint", False)
+        else None
+    )
+
+    try:
+        provider = get_provider(effective_ai_config, workspace_root=workspace)
+    except ValueError as exc:
+        raise McpError(
+            code=McpErrorCode.TOOL_UNAVAILABLE,
+            message=str(exc),
+            detail={"tool": "lintro_review", "reason": "provider_unavailable"},
+        ) from exc
+
+    try:
+        result = run_review(
+            context,
+            provider=provider,
+            ai_config=effective_ai_config,
+            depth=depth,
+            checklist_items=selected_items,
+            checklist_text=checklist_text,
+            classifications=classifications,
+            lint_results=lint_results,
+            sensitivity=resolve_sensitivity_policy(
+                strictness=strictness,
+                overrides=lintro_config.review.sensitivity,
+            ),
+            force_semantic_chunking=lintro_config.review.force_semantic_chunking,
+            workspace_root=workspace,
+        )
+    except (AIError, ValueError) as exc:
+        failure = _review_failure(provider_name=str(provider.name), error=exc)
+        raise McpError(
+            code=failure.code,
+            message=failure.message,
+            detail=failure.detail,
+        ) from exc
+    return _review_payload(result=result, budget=budget)
+
+
+def _review_handler(
+    *,
+    workspace: Path,
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Build the ``lintro_review`` handler bound to ``workspace``.
+
+    Args:
+        workspace: Workspace root the review is anchored to.
+
+    Returns:
+        Callable: A handler accepting an arguments dict.
+    """
+
+    def handler(arguments: dict[str, Any]) -> dict[str, Any]:
+        # The session anchors cwd (git, the config file, and the provider's CLI
+        # transport all resolve relative to it) and serializes the call against
+        # the lint tools, which mutate the same process-global state. A review
+        # therefore holds the server's run lock for its whole, possibly
+        # multi-minute duration.
+        with workspace_session(workspace=workspace):
+            return _execute_review(arguments=arguments, workspace=workspace)
+
+    return handler
+
+
+def build_review_toolkit(*, workspace: Path) -> tuple[McpToolSpec, ...]:
+    """Build the review tool specification.
+
+    Args:
+        workspace: Workspace root the tool operates on.
+
+    Returns:
+        tuple[McpToolSpec, ...]: The ``lintro_review`` tool.
+    """
+    return (
+        McpToolSpec(
+            name="lintro_review",
+            description=_DESCRIPTION,
+            input_schema=_INPUT_SCHEMA,
+            handler=_review_handler(workspace=workspace),
+            read_only=True,
+            destructive=False,
+            # Every call issues provider calls and spends money, so repeating
+            # one is never free even though the workspace is untouched.
+            idempotent=False,
+            timeout_seconds=REVIEW_TIMEOUT_SECONDS,
+            path_arguments=("paths",),
+        ),
+    )

--- a/tests/unit/mcp/test_toolkit_review.py
+++ b/tests/unit/mcp/test_toolkit_review.py
@@ -1,0 +1,722 @@
+"""End-to-end tests for the ``lintro_review`` MCP tool.
+
+Every call goes through a real :class:`mcp.ClientSession` over in-memory
+streams, so the schema validation, the workspace path guard, and the error
+envelope under test are the ones the stdio server actually applies.
+
+The AI provider is always mocked. The orchestrator is stubbed at
+``lintro.ai.review.orchestrator.run_review`` (the toolkit imports it lazily,
+inside the handler, so patching the module attribute is what the handler sees),
+which keeps the tests free of network calls, credentials, and cost while still
+exercising context collection, budget resolution, and payload shaping for real.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess  # nosec B404 - subprocess runs fixed git argv in a temp repo
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+import pytest
+from assertpy import assert_that
+from mcp import ClientSession, types
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
+from lintro.ai.review.models.review_metadata import ReviewMetadata
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.mcp.enums.mcp_error_code import McpErrorCode
+from lintro.mcp.server import create_mcp_server
+from lintro.mcp.toolkits.review import (
+    REVIEW_TIMEOUT_SECONDS,
+    STRICTNESS_VALUES,
+    build_review_toolkit,
+    resolve_budget_policy,
+)
+
+_T = TypeVar("_T")
+
+_CONFIG = """ai:
+  enabled: true
+  review: true
+  provider: anthropic
+  model: test-model
+  max_cost_usd: 1.0
+"""
+
+_CONFIG_REVIEW_OFF = """ai:
+  enabled: true
+  review: false
+  provider: anthropic
+"""
+
+
+def _run_session(
+    *,
+    workspace: Path,
+    check: Callable[[ClientSession], Awaitable[_T]],
+) -> _T:
+    """Run ``check`` against a connected in-memory MCP client session.
+
+    Args:
+        workspace: Workspace root for the server under test.
+        check: Async callback receiving an initialized client session.
+
+    Returns:
+        Whatever ``check`` returns.
+    """
+    server = create_mcp_server(workspace=workspace)
+
+    async def _main() -> _T:
+        async with create_connected_server_and_client_session(server) as session:
+            return await check(session)
+
+    return asyncio.run(_main())
+
+
+def _payload(result: types.CallToolResult) -> dict[str, Any]:
+    """Extract a tool result payload as a dict.
+
+    Args:
+        result: The ``CallToolResult`` returned by ``session.call_tool``.
+
+    Returns:
+        The payload the server sent.
+    """
+    if result.structuredContent:
+        return dict(result.structuredContent)
+    block = result.content[0]
+    assert isinstance(block, types.TextContent)
+    return dict(json.loads(block.text))
+
+
+def _call(
+    *,
+    workspace: Path,
+    arguments: dict[str, Any],
+) -> tuple[types.CallToolResult, dict[str, Any]]:
+    """Call ``lintro_review`` and return its raw result and decoded payload.
+
+    Args:
+        workspace: Workspace root for the server under test.
+        arguments: Tool arguments.
+
+    Returns:
+        The ``CallToolResult`` and its payload.
+    """
+
+    async def _check(
+        session: ClientSession,
+    ) -> tuple[types.CallToolResult, dict[str, Any]]:
+        result = await session.call_tool("lintro_review", arguments)
+        return result, _payload(result)
+
+    return _run_session(workspace=workspace, check=_check)
+
+
+def _git(*args: str, cwd: Path) -> None:
+    """Run one git command in ``cwd``, failing loudly.
+
+    Args:
+        *args: Git arguments.
+        cwd: Directory to run in.
+    """
+    subprocess.run(  # nosec B603 B607 - fixed git argv against a temp repo
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+
+
+class _FakeProvider:
+    """Stand-in provider that never issues a call.
+
+    Attributes:
+        name: Provider identifier used by the error taxonomy.
+        model_name: Model identifier reported in run metadata.
+    """
+
+    name = "anthropic"
+    model_name = "test-model"
+
+
+def _metadata(
+    *,
+    partial: bool = False,
+    stopped_reason: str = "",
+    chunks_reviewed: int = 1,
+) -> ReviewMetadata:
+    """Build review metadata for a stubbed run.
+
+    Args:
+        partial: Whether the run stopped before every chunk was reviewed.
+        stopped_reason: Why it stopped.
+        chunks_reviewed: Chunks actually reviewed.
+
+    Returns:
+        ReviewMetadata: Metadata for the stubbed result.
+    """
+    return ReviewMetadata(
+        model="test-model",
+        provider="anthropic",
+        context_window=200000,
+        depth=1,
+        chunks_total=2,
+        chunks_current=chunks_reviewed,
+        files_reviewed=1,
+        files_total=1,
+        checklist_items=3,
+        token_usage={"prompt": 10, "completion": 5, "total": 15},
+        cost_estimate_usd=0.25,
+        base_ref="main",
+        head_ref="HEAD",
+        timestamp="2026-08-01T00:00:00+00:00",
+        partial=partial,
+        chunks_reviewed=chunks_reviewed,
+        stopped_reason=stopped_reason,
+        duration_seconds=12.5,
+    )
+
+
+def _result(
+    *,
+    partial: bool = False,
+    stopped_reason: str = "",
+    chunks_reviewed: int = 1,
+) -> ReviewResult:
+    """Build a stubbed review result carrying one finding.
+
+    Args:
+        partial: Whether the run stopped early.
+        stopped_reason: Why it stopped.
+        chunks_reviewed: Chunks actually reviewed.
+
+    Returns:
+        ReviewResult: The stubbed result.
+    """
+    finding = ReviewFinding(
+        severity=Severity.P1,
+        category="correctness",
+        file="app.py",
+        line=3,
+        title="Unbounded loop",
+        description="The loop never terminates.",
+        cause="The counter is never incremented.",
+        fix="Increment the counter.",
+        confidence="high",
+        checklist_ids=(2,),
+        suggested_code="i += 1",
+    )
+    return ReviewResult(
+        metadata=_metadata(
+            partial=partial,
+            stopped_reason=stopped_reason,
+            chunks_reviewed=chunks_reviewed,
+        ),
+        summary="One blocking issue.",
+        findings=(finding,),
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """Create a git workspace with one committed change to review.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+
+    Returns:
+        Path: The resolved workspace root, on a branch ahead of ``main``.
+    """
+    workspace = tmp_path.resolve()
+    (workspace / ".lintro-config.yaml").write_text(_CONFIG, encoding="utf-8")
+    _git("init", "--initial-branch", "main", cwd=workspace)
+    _git("config", "user.email", "test@example.com", cwd=workspace)
+    _git("config", "user.name", "Test", cwd=workspace)
+    (workspace / "app.py").write_text("x = 1\n", encoding="utf-8")
+    _git("add", "-A", cwd=workspace)
+    _git("commit", "-m", "base", cwd=workspace)
+    _git("checkout", "-b", "feature", cwd=workspace)
+    (workspace / "app.py").write_text("x = 1\ny = 2\n", encoding="utf-8")
+    _git("add", "-A", cwd=workspace)
+    _git("commit", "-m", "change", cwd=workspace)
+    return workspace
+
+
+@pytest.fixture
+def stub_ai(monkeypatch: pytest.MonkeyPatch) -> Callable[..., list[Any]]:
+    """Make AI look available and replace the provider and the orchestrator.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+
+    Returns:
+        Callable: Installs a stubbed ``run_review`` and returns the list the
+        AI configs it was called with are recorded in.
+    """
+    import lintro.ai.availability as availability
+    import lintro.ai.providers as providers
+    import lintro.ai.review.orchestrator as orchestrator
+
+    monkeypatch.setattr(availability, "is_ai_available", lambda: True)
+    monkeypatch.setattr(
+        providers,
+        "get_provider",
+        lambda config, **_kwargs: _FakeProvider(),
+    )
+
+    def install(
+        *,
+        result: ReviewResult | None = None,
+        error: Exception | None = None,
+    ) -> list[Any]:
+        calls: list[Any] = []
+
+        def _run_review(context: Any, **kwargs: Any) -> ReviewResult:
+            calls.append({"context": context, **kwargs})
+            if error is not None:
+                raise error
+            return result if result is not None else _result()
+
+        monkeypatch.setattr(orchestrator, "run_review", _run_review)
+        return calls
+
+    return install
+
+
+def test_review_is_listed_as_read_only_and_not_idempotent(tmp_path: Path) -> None:
+    """The tool advertises the hints its cost and side-effect profile implies."""
+
+    async def _check(session: ClientSession) -> dict[str, types.Tool]:
+        listed = await session.list_tools()
+        return {tool.name: tool for tool in listed.tools}
+
+    tools = _run_session(workspace=tmp_path.resolve(), check=_check)
+
+    assert_that(tools).contains_key("lintro_review")
+    hints = tools["lintro_review"].annotations
+    assert hints is not None
+    assert_that(hints.readOnlyHint).is_true()
+    assert_that(hints.destructiveHint).is_false()
+    assert_that(hints.idempotentHint).is_false()
+
+
+def test_review_spec_allows_more_time_than_the_default_budget(tmp_path: Path) -> None:
+    """A depth-3 review runs for minutes, so the 300s default would abort it."""
+    spec = build_review_toolkit(workspace=tmp_path.resolve())[0]
+
+    assert_that(spec.name).is_equal_to("lintro_review")
+    assert_that(spec.timeout_seconds).is_equal_to(REVIEW_TIMEOUT_SECONDS)
+    assert_that(spec.timeout_seconds).is_greater_than(300.0)
+    assert_that(spec.path_arguments).is_equal_to(("paths",))
+
+
+def test_strictness_choices_match_the_review_enum() -> None:
+    """The hand-written schema enum cannot drift from ReviewStrictness."""
+    from lintro.ai.review.enums.review_strictness import ReviewStrictness
+
+    assert_that(sorted(STRICTNESS_VALUES)).is_equal_to(
+        sorted(level.value for level in ReviewStrictness),
+    )
+
+
+def test_context_error_mapping_uses_real_error_codes() -> None:
+    """Every mapped context code is a real ReviewContextErrorCode value."""
+    from lintro.ai.review.enums.review_context_error_code import (
+        ReviewContextErrorCode,
+    )
+    from lintro.mcp.toolkits import review as review_toolkit
+
+    known = {code.value for code in ReviewContextErrorCode}
+    mapped = (
+        review_toolkit._INVALID_INPUT_CONTEXT_CODES
+        | review_toolkit._UNAVAILABLE_CONTEXT_CODES
+        | {review_toolkit._NO_CHANGES_CODE}
+    )
+
+    assert_that(known).contains(*sorted(mapped))
+
+
+def test_budget_detection_matches_the_engine_stop_reason() -> None:
+    """The engine's cost-cap wording is what the budget detector looks for.
+
+    The orchestrator reports a cost-cap stop only in prose, so this pins the
+    one string both sides depend on; reword it there and this fails rather than
+    the tool silently reporting a capped run as a complete one.
+    """
+    from lintro.ai.review.orchestrator import _cost_cap_reason
+    from lintro.mcp.toolkits.review import _stopped_on_budget
+
+    metadata = _metadata(partial=True, stopped_reason=_cost_cap_reason(cap=1.0))
+
+    assert_that(_stopped_on_budget(metadata=metadata)).is_true()
+
+
+def test_review_rejects_a_base_combined_with_uncommitted(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+) -> None:
+    """Two mutually exclusive diff modes are an input error, not a crash."""
+    stub_ai()
+
+    result, payload = _call(
+        workspace=repo,
+        arguments={"base": "main", "uncommitted": True},
+    )
+
+    assert_that(result.isError).is_true()
+    assert_that(payload["error"]["code"]).is_equal_to(McpErrorCode.INVALID_INPUT.value)
+    assert_that(payload["error"]["detail"]["context_error"]).is_equal_to(
+        "invalid-review-mode",
+    )
+
+
+@pytest.mark.parametrize(
+    ("requested", "configured", "effective", "clamped"),
+    [
+        (None, 1.0, 1.0, False),
+        (0.5, None, 0.5, False),
+        (0.5, 1.0, 0.5, False),
+        (2.0, 1.0, 1.0, True),
+        (None, None, None, False),
+    ],
+)
+def test_budget_policy_never_raises_the_configured_ceiling(
+    requested: float | None,
+    configured: float | None,
+    effective: float | None,
+    clamped: bool,
+) -> None:
+    """An argument can only lower the operator's ai.max_cost_usd ceiling."""
+    policy = resolve_budget_policy(requested=requested, configured=configured)
+
+    assert_that(policy.effective_usd).is_equal_to(effective)
+    assert_that(policy.clamped).is_equal_to(clamped)
+
+
+def test_review_returns_findings_and_run_metadata(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+) -> None:
+    """A completed review is shaped as findings plus run and budget metadata."""
+    stub_ai()
+
+    result, payload = _call(workspace=repo, arguments={"base": "main"})
+
+    assert_that(result.isError).is_false()
+    assert_that(payload["summary"]).is_equal_to("One blocking issue.")
+    finding = payload["findings"][0]
+    assert_that(finding).contains_key(
+        "file",
+        "line",
+        "severity",
+        "category",
+        "title",
+        "body",
+        "confidence",
+    )
+    assert_that(finding["file"]).is_equal_to("app.py")
+    assert_that(finding["severity"]).is_equal_to("P1")
+    assert_that(finding["body"]).contains("The loop never terminates.")
+    assert_that(finding["body"]).contains("Cause:")
+    assert_that(finding["body"]).contains("Fix: Increment the counter.")
+
+    run = payload["run"]
+    assert_that(run["model"]).is_equal_to("test-model")
+    assert_that(run["cost_usd"]).is_equal_to(0.25)
+    assert_that(run["duration_seconds"]).is_equal_to(12.5)
+    assert_that(run["chunks"]).is_equal_to({"total": 2, "reviewed": 1})
+    assert_that(run["partial"]).is_false()
+    assert_that(payload["budget"]["exceeded"]).is_false()
+
+
+def test_review_passes_depth_and_strictness_through(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+) -> None:
+    """Requested depth and strictness reach the orchestrator unchanged."""
+    calls = stub_ai()
+
+    result, _payload_body = _call(
+        workspace=repo,
+        arguments={"base": "main", "depth": 3, "strictness": "focused"},
+    )
+
+    assert_that(result.isError).is_false()
+    assert_that(calls[0]["depth"]).is_equal_to(3)
+    assert_that(calls[0]["sensitivity"].strictness.value).is_equal_to("focused")
+
+
+def test_review_clamps_the_requested_budget_to_the_configured_ceiling(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+) -> None:
+    """An agent asking for more money than the config allows gets the config."""
+    calls = stub_ai()
+
+    result, payload = _call(
+        workspace=repo,
+        arguments={"base": "main", "max_cost_usd": 50.0},
+    )
+
+    assert_that(result.isError).is_false()
+    assert_that(calls[0]["ai_config"].max_cost_usd).is_equal_to(1.0)
+    assert_that(payload["budget"]["requested_usd"]).is_equal_to(50.0)
+    assert_that(payload["budget"]["configured_usd"]).is_equal_to(1.0)
+    assert_that(payload["budget"]["effective_usd"]).is_equal_to(1.0)
+    assert_that(payload["budget"]["clamped"]).is_true()
+
+
+def test_review_honors_a_lower_requested_budget(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+) -> None:
+    """A tighter per-call ceiling is handed to the review engine."""
+    calls = stub_ai()
+
+    result, payload = _call(
+        workspace=repo,
+        arguments={"base": "main", "max_cost_usd": 0.05},
+    )
+
+    assert_that(result.isError).is_false()
+    assert_that(calls[0]["ai_config"].max_cost_usd).is_equal_to(0.05)
+    assert_that(payload["budget"]["clamped"]).is_false()
+
+
+def test_review_reports_a_partial_run_without_discarding_findings(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+) -> None:
+    """A cap reached mid-run still returns what was reviewed, marked partial."""
+    stub_ai(
+        result=_result(
+            partial=True,
+            stopped_reason="cost cap ($1.00) reached",
+            chunks_reviewed=1,
+        ),
+    )
+
+    result, payload = _call(workspace=repo, arguments={"base": "main"})
+
+    assert_that(result.isError).is_false()
+    assert_that(payload["findings"]).is_length(1)
+    assert_that(payload["run"]["partial"]).is_true()
+    assert_that(payload["run"]["stopped_reason"]).contains("cost cap")
+    assert_that(payload["budget"]["exceeded"]).is_true()
+
+
+def test_review_reports_budget_exceeded_when_nothing_was_reviewed(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+) -> None:
+    """A cap that stops the run before any chunk is a structured failure."""
+    stub_ai(
+        result=ReviewResult(
+            metadata=_metadata(
+                partial=True,
+                stopped_reason="cost cap ($0.01) reached",
+                chunks_reviewed=0,
+            ),
+            summary="",
+        ),
+    )
+
+    result, payload = _call(
+        workspace=repo,
+        arguments={"base": "main", "max_cost_usd": 0.01},
+    )
+
+    assert_that(result.isError).is_true()
+    assert_that(payload["error"]["code"]).is_equal_to(
+        McpErrorCode.BUDGET_EXCEEDED.value,
+    )
+    assert_that(payload["error"]["detail"]["budget"]["exceeded"]).is_true()
+    assert_that(payload["error"]["detail"]["budget"]["effective_usd"]).is_equal_to(0.01)
+
+
+def test_review_reports_an_empty_diff_as_a_result_not_a_failure(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+) -> None:
+    """Nothing to review is an answer with the same keys as a real review."""
+    calls = stub_ai()
+
+    result, payload = _call(workspace=repo, arguments={"base": "feature"})
+
+    assert_that(result.isError).is_false()
+    assert_that(payload["findings"]).is_empty()
+    assert_that(payload["run"]).contains_key("model", "cost_usd", "chunks")
+    assert_that(payload["run"]["cost_usd"]).is_equal_to(0.0)
+    assert_that(calls).is_empty()
+
+
+def test_review_surfaces_a_provider_failure_with_its_taxonomy(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+) -> None:
+    """A failed review carries the review error contract as error detail."""
+    from lintro.ai.exceptions import AIError
+
+    stub_ai(error=AIError("401 invalid x-api-key"))
+
+    result, payload = _call(workspace=repo, arguments={"base": "main"})
+
+    assert_that(result.isError).is_true()
+    assert_that(payload["error"]["code"]).is_in(
+        McpErrorCode.EXECUTION_ERROR.value,
+        McpErrorCode.TOOL_UNAVAILABLE.value,
+    )
+    assert_that(payload["error"]["detail"]["review_error"]).contains_key(
+        "kind",
+        "provider",
+        "retryable",
+    )
+
+
+def test_review_is_unavailable_without_the_ai_extra(
+    repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tool stays listed and explains itself instead of vanishing."""
+    import lintro.ai.availability as availability
+
+    monkeypatch.setattr(availability, "is_ai_available", lambda: False)
+
+    result, payload = _call(workspace=repo, arguments={"base": "main"})
+
+    assert_that(result.isError).is_true()
+    assert_that(payload["error"]["code"]).is_equal_to(
+        McpErrorCode.TOOL_UNAVAILABLE.value,
+    )
+    assert_that(payload["error"]["detail"]["reason"]).is_equal_to("ai_unavailable")
+
+
+def test_review_is_unavailable_when_the_workspace_disables_it(
+    repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``ai.review: false`` is reported as unavailability, not a crash."""
+    import lintro.ai.availability as availability
+
+    monkeypatch.setattr(availability, "is_ai_available", lambda: True)
+    (repo / ".lintro-config.yaml").write_text(_CONFIG_REVIEW_OFF, encoding="utf-8")
+
+    result, payload = _call(workspace=repo, arguments={"base": "main"})
+
+    assert_that(result.isError).is_true()
+    assert_that(payload["error"]["code"]).is_equal_to(
+        McpErrorCode.TOOL_UNAVAILABLE.value,
+    )
+    assert_that(payload["error"]["detail"]["reason"]).is_equal_to("review_disabled")
+
+
+def test_review_rejects_a_depth_outside_the_supported_range(repo: Path) -> None:
+    """Schema validation refuses depth 4 before any provider call is made."""
+    result, payload = _call(workspace=repo, arguments={"base": "main", "depth": 4})
+
+    assert_that(result.isError).is_true()
+    assert_that(payload["error"]["code"]).is_equal_to(McpErrorCode.INVALID_INPUT.value)
+
+
+def test_review_rejects_an_unknown_argument(repo: Path) -> None:
+    """``--post`` has no MCP equivalent, and no argument is silently ignored."""
+    result, payload = _call(workspace=repo, arguments={"post": True})
+
+    assert_that(result.isError).is_true()
+    assert_that(payload["error"]["code"]).is_equal_to(McpErrorCode.INVALID_INPUT.value)
+
+
+def test_review_rejects_a_path_outside_the_workspace(repo: Path) -> None:
+    """The server's path guard covers the review tool's paths argument."""
+    result, payload = _call(
+        workspace=repo,
+        arguments={"base": "main", "paths": ["../secrets"]},
+    )
+
+    assert_that(result.isError).is_true()
+    assert_that(payload["error"]["code"]).is_equal_to(
+        McpErrorCode.WORKSPACE_VIOLATION.value,
+    )
+
+
+def test_review_filters_the_diff_to_the_requested_paths(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+) -> None:
+    """Absolute path arguments are mapped back to repo-relative prefixes."""
+    calls = stub_ai()
+
+    result, _payload_body = _call(
+        workspace=repo,
+        arguments={"base": "main", "paths": ["app.py"]},
+    )
+
+    assert_that(result.isError).is_false()
+    assert_that(calls).is_length(1)
+    reviewed = [file.path for file in calls[0]["context"].changed_files]
+    assert_that(reviewed).is_equal_to(["app.py"])
+
+
+def test_review_includes_a_lint_digest_when_asked(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``with_lint`` feeds the deterministic linters' digest into the prompt."""
+    import lintro.ai.review.lint_bridge as lint_bridge
+
+    monkeypatch.setattr(
+        lint_bridge,
+        "run_lint_on_changed_files",
+        lambda **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        lint_bridge,
+        "format_lint_results_for_prompt",
+        lambda **_kwargs: "ruff: 1 issue",
+    )
+    calls = stub_ai()
+
+    result, _payload_body = _call(
+        workspace=repo,
+        arguments={"base": "main", "with_lint": True},
+    )
+
+    assert_that(result.isError).is_false()
+    assert_that(calls[0]["lint_results"]).is_equal_to("ruff: 1 issue")
+
+
+def test_review_omits_the_lint_digest_by_default(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+) -> None:
+    """Without ``with_lint`` no linters run and no digest is sent."""
+    calls = stub_ai()
+
+    result, _payload_body = _call(workspace=repo, arguments={"base": "main"})
+
+    assert_that(result.isError).is_false()
+    assert_that(calls[0]["lint_results"]).is_none()
+
+
+def test_review_reports_no_changes_for_a_path_matching_nothing(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+) -> None:
+    """A path filter that excludes the whole diff yields an empty result."""
+    (repo / "other.py").write_text("z = 3\n", encoding="utf-8")
+    calls = stub_ai()
+
+    result, payload = _call(
+        workspace=repo,
+        arguments={"base": "main", "paths": ["other.py"]},
+    )
+
+    assert_that(result.isError).is_false()
+    assert_that(payload["findings"]).is_empty()
+    assert_that(calls).is_empty()


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(mcp): add review toolkit exposing AI diff review
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Adds `lintro_review`, the third MCP toolkit, exposing lintro's existing AI diff review
engine to agents as structured data instead of terminal output.

The tool is a protocol surface only: it collects the same git context `lintro review`
collects, runs the same orchestrator in `lintro/ai/review/`, and serializes the same
`ReviewResult`. Nothing about the review itself is reimplemented, so the agent surface
and the CLI cannot drift apart.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`, `uv run pytest tests/unit`)

## Closes

- Closes #1239

## Details

**Contract**

- Inputs: `base`, `uncommitted`, `depth` (1-3), `strictness`, `with_lint`, `paths`,
  `max_cost_usd`. `additionalProperties: false`, so nothing is silently ignored.
- Output: `findings[]` (`file`, `line`, `severity`, `category`, `title`, `body`,
  `confidence`, plus `suggested_code` / `checklist_ids` / `source`), a `run` block
  (`model`, `provider`, `cost_usd`, `duration_seconds`, `chunks`, `files`,
  `token_usage`, `partial`, `stopped_reason`), and a `budget` block.
- Annotations: `read_only=True` (nothing is written, nothing is posted),
  `idempotent=False` (every call issues provider calls and costs money).
- `--post` / GitHub commenting is deliberately **not** exposed; the calling agent owns
  outward side effects.

**Cost controls**

- `ai.max_cost_usd` is the server-side ceiling. The `max_cost_usd` argument can only
  *lower* it — a larger value is clamped to the configured one and reported as
  `budget.clamped: true` — so a misbehaving agent cannot raise its own spend limit.
- A cap reached **mid-run** returns what was reviewed: `run.partial: true` with
  `budget.exceeded: true`, rather than discarding completed work.
- A cap that stops the run **before any chunk** produced no review, so it fails with the
  new `budget_exceeded` error code (added to `McpErrorCode`) instead of an empty result
  that reads as "clean" — the same distinction the review exit-code contract draws.

**Availability**

- The tool is registered unconditionally. Without the `[ai]` extra, without a usable
  provider, or with `ai.review: false`, it returns `tool_unavailable` with
  `detail.reason`, so an agent gets a reason rather than a vanished capability.
- A failed review carries the review error taxonomy (`kind`, `provider`, `status`,
  `retryable`) under `detail.review_error`, mapping provider-unavailable kinds to
  `tool_unavailable` and everything else to `execution_error`.
- Review-context failures map by their stable code: `no-changes` is a successful empty
  result (with the same key set a real run returns), git/gh absence is
  `tool_unavailable`, bad `base` / conflicting modes are `invalid_input`.

**Latency and timeout**

- Progress notifications are not emitted: the foundation dispatches synchronous handlers
  into a worker thread with no access to the in-flight request context, so sending them
  would mean threading the server session through every toolkit — a foundation change
  out of scope here. The latency is documented instead.
- The spec carries `timeout_seconds = 1800` rather than the 300s default, since a
  depth-3 review routinely runs for minutes.
- The call holds the shared workspace run lock for its whole duration (cwd, git, and the
  config cache are process-global), so `lintro_check` calls queue behind a review. This
  is documented in `docs/mcp.md`.

**Testing**

- `tests/unit/mcp/test_toolkit_review.py`: 26 tests, all through a real in-memory
  `ClientSession` against the same `Server` object stdio serves. The provider is always
  mocked and the orchestrator stubbed — no network calls, no credentials, no cost.
- Covers: annotations and timeout, budget resolution matrix, clamping (asserted on the
  `AIConfig` actually handed to the engine), `budget_exceeded`, partial-run reporting,
  `tool_unavailable` for both a missing extra and `ai.review: false`, provider-failure
  taxonomy, schema rejection (`depth: 4`, unknown argument), workspace-escape rejection
  for `paths`, path filtering against a real git repo, empty-diff handling, and
  `with_lint`.
- Two drift guards: the hand-written `strictness` enum against `ReviewStrictness`, and
  the cost-cap stop-reason wording the budget detector matches on.