### PR TITLE
feat(mcp): add introspection toolkit for tools, versions, and doctor

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -29,12 +29,15 @@ process.
 
 ## Tools
 
-| Tool            | Annotations                 | Result                                           |
-| --------------- | --------------------------- | ------------------------------------------------ |
-| `lintro_ping`   | read-only, idempotent       | `{status, lintro_version, workspace}`            |
-| `lintro_check`  | read-only, idempotent       | Structured findings plus a per-tool summary      |
-| `lintro_format` | destructive, not idempotent | Unified diffs, changed files, remaining findings |
-| `lintro_review` | read-only, not idempotent   | AI review findings plus run and budget metadata  |
+| Tool                | Annotations                 | Result                                                       |
+| ------------------- | --------------------------- | ------------------------------------------------------------ |
+| `lintro_ping`       | read-only, idempotent       | `{status, lintro_version, workspace}`                        |
+| `lintro_check`      | read-only, idempotent       | Structured findings plus a per-tool summary                  |
+| `lintro_format`     | destructive, not idempotent | Unified diffs, changed files, remaining findings             |
+| `lintro_review`     | read-only, not idempotent   | AI review findings plus run and budget metadata              |
+| `lintro_list_tools` | read-only, idempotent       | Every tool with type, languages, install state               |
+| `lintro_versions`   | read-only, idempotent       | Installed versus expected tool versions                      |
+| `lintro_doctor`     | read-only, idempotent       | Environment health as `{check, status, detail, remediation}` |
 
 Further toolkits register through the internal `McpToolRegistry` and ship in follow-up
 issues.
@@ -220,6 +223,125 @@ Notes and limits:
   the call's `timeout_seconds` is 1800s instead of the 300s default, and the review
   holds the server's run lock for its whole duration, so `lintro_check` calls queue
   behind it.
+
+### `lintro_list_tools`
+
+Takes no arguments. Answers "what can lintro do in this workspace, and what is actually
+installed" in one call, so an agent does not have to discover a missing binary by
+failing a `lintro_check`.
+
+```json
+{
+  "tools": [
+    {
+      "name": "ruff",
+      "description": "Fast Python linter and formatter replacing multiple tools",
+      "types": ["linter", "formatter"],
+      "languages": ["python"],
+      "installed": true,
+      "version": "0.16.0",
+      "expected_version": "0.15.9",
+      "minimum_version": "0.15.9",
+      "status": "ok",
+      "can_fix": true,
+      "capabilities": ["check", "fix"],
+      "execution_class": "deterministic",
+      "origin": "builtin",
+      "profile_membership": ["complete", "full", "minimal", "python"],
+      "install_hint": "uv pip install 'ruff>=0.15.9'"
+    }
+  ],
+  "profiles": [
+    {
+      "name": "minimal",
+      "description": "Core Python linting only (fast CI)",
+      "strategy": "explicit",
+      "resolution": "static"
+    }
+  ],
+  "summary": { "total": 38, "installed": 36, "missing": 2 }
+}
+```
+
+- A tool that is not installed is listed with `installed: false`, `version: null`, its
+  `status` (`missing`, `outdated`, `incompatible`, `unknown`) and an `install_hint` —
+  never omitted. An absent entry would be indistinguishable from a tool lintro does not
+  support.
+- `types` is a list, not a scalar: `ToolType` is a bitmask and tools such as `ruff` and
+  `oxlint` are genuinely both a linter and a formatter.
+- `capabilities` is what you may call the tool with: `check`, `fix`, or `review` for
+  advisory AI finders, which are unreachable from `lintro_check` by design.
+- `profile_membership` lists only the install profiles whose membership is fixed by the
+  manifest. Profiles resolved against the languages detected in a tree (`recommended`,
+  `ci`) are reported in `profiles` with `resolution: "workspace"` instead, because
+  membership in them is a property of the workspace rather than of the tool.
+
+### `lintro_versions`
+
+Takes no arguments. The compatibility view of the same data: what is installed against
+what lintro requires.
+
+```json
+{
+  "tools": [
+    {
+      "name": "ruff",
+      "installed_version": "0.9.0",
+      "minimum_version": "0.15.9",
+      "recommended_version": "0.15.9",
+      "satisfies_minimum": false,
+      "below_recommended": false,
+      "status": "outdated",
+      "error": "Version 0.9.0 is below minimum requirement 0.15.9",
+      "install_hint": "uv pip install 'ruff>=0.15.9'"
+    }
+  ],
+  "summary": { "ok": 28, "outdated": 7, "missing": 2, "total": 37 }
+}
+```
+
+`status` is `ok`, `outdated`, `missing`, or `unknown` (the tool ran but its output could
+not be parsed). A version below the minimum is data, not an error: the call succeeds.
+
+### `lintro_doctor`
+
+Takes no arguments. The same probes `lintro doctor` renders, as records an agent or a
+host UI can act on.
+
+```json
+{
+  "health": "degraded",
+  "checks": [
+    {
+      "check": "config.load",
+      "status": "ok",
+      "detail": "Configuration loaded from /path/to/repo/.lintro-config.yaml",
+      "remediation": "",
+      "category": "config"
+    },
+    {
+      "check": "tools.missing",
+      "status": "error",
+      "detail": "1 enabled tool(s) not installed: hadolint",
+      "remediation": "lintro install hadolint",
+      "category": "tools"
+    }
+  ],
+  "summary": { "ok": 4, "warning": 1, "error": 1, "skipped": 1, "total": 7 }
+}
+```
+
+- `status` is `ok`, `warning`, `error`, or `skipped`. `health` is `healthy` when nothing
+  warned or errored, `degraded` otherwise; `skipped` never counts against it.
+- Categories: `config` (loading and consistency), `tools` (`tools.missing`,
+  `tools.versions`), `ai` (one check per provider/auth probe), `extras` (`extras.mcp` —
+  an uninstalled optional extra is a fact, never a failure).
+- Per-tool installation detail deliberately lives in `lintro_list_tools`; the doctor
+  report answers "is anything wrong, and what fixes it".
+- No provider call is made: AI checks are presence checks only, the same set
+  `lintro doctor` runs without `--ai-liveness`.
+- A malformed config degrades the report (`config.load` with `status: "error"`) instead
+  of failing the call.
 
 ## Tool contract
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -304,10 +304,11 @@ what lintro requires.
 }
 ```
 
-`status` is `ok`, `outdated`, or `missing`. `missing` covers every way a probe fails to
-yield a version — absent binary, non-zero exit, unparseable output — with `error`
-carrying the reason. A version below the minimum is data, not an error: the call
-succeeds.
+`status` uses the same vocabulary as `lintro_list_tools`: `ok`, `outdated` (clears the
+minimum, trails the recommended version), `incompatible` (below the minimum lintro
+requires), or `missing` — which covers every way a probe fails to yield a version
+(absent binary, non-zero exit, unparseable output), with `error` carrying the reason. A
+version below the minimum is data, not an error: the call succeeds.
 
 ### `lintro_doctor`
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -29,15 +29,15 @@ process.
 
 ## Tools
 
-| Tool                | Annotations                 | Result                                                       |
-| ------------------- | --------------------------- | ------------------------------------------------------------ |
-| `lintro_ping`       | read-only, idempotent       | `{status, lintro_version, workspace}`                        |
-| `lintro_check`      | read-only, idempotent       | Structured findings plus a per-tool summary                  |
-| `lintro_format`     | destructive, not idempotent | Unified diffs, changed files, remaining findings             |
-| `lintro_review`     | read-only, not idempotent   | AI review findings plus run and budget metadata              |
-| `lintro_list_tools` | read-only, idempotent       | Every tool with type, languages, install state               |
-| `lintro_versions`   | read-only, idempotent       | Installed versus expected tool versions                      |
-| `lintro_doctor`     | read-only, idempotent       | Environment health as `{check, status, detail, remediation}` |
+| Tool                | Annotations                 | Result                                                                         |
+| ------------------- | --------------------------- | ------------------------------------------------------------------------------ |
+| `lintro_ping`       | read-only, idempotent       | `{status, lintro_version, workspace}`                                          |
+| `lintro_check`      | read-only, idempotent       | Structured findings plus a per-tool summary                                    |
+| `lintro_format`     | destructive, not idempotent | Unified diffs, changed files, remaining findings                               |
+| `lintro_review`     | read-only, not idempotent   | AI review findings plus run and budget metadata                                |
+| `lintro_list_tools` | read-only, idempotent       | Every tool with type, languages, install state                                 |
+| `lintro_versions`   | read-only, idempotent       | Installed versus expected tool versions                                        |
+| `lintro_doctor`     | read-only, idempotent       | `{health, checks, summary}`; each check `{check, status, detail, remediation}` |
 
 Further toolkits register through the internal `McpToolRegistry` and ship in follow-up
 issues.
@@ -300,8 +300,10 @@ what lintro requires.
 }
 ```
 
-`status` is `ok`, `outdated`, `missing`, or `unknown` (the tool ran but its output could
-not be parsed). A version below the minimum is data, not an error: the call succeeds.
+`status` is `ok`, `outdated`, or `missing`. `missing` covers every way a probe fails to
+yield a version — absent binary, non-zero exit, unparseable output — with `error`
+carrying the reason. A version below the minimum is data, not an error: the call
+succeeds.
 
 ### `lintro_doctor`
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -263,10 +263,14 @@ failing a `lintro_check`.
 }
 ```
 
-- A tool that is not installed is listed with `installed: false`, `version: null`, its
-  `status` (`missing`, `outdated`, `incompatible`, `unknown`) and an `install_hint` —
-  never omitted. An absent entry would be indistinguishable from a tool lintro does not
-  support.
+- A tool is listed whether or not it is usable — never omitted, because an absent entry
+  would be indistinguishable from a tool lintro does not support. `status` is `missing`
+  (absent from `PATH`, non-zero exit, or timeout — `installed: false`, `version: null`),
+  `outdated` or `incompatible` (the binary ran and reported a version below the
+  recommended or the minimum — `installed: true`), or `unknown` (it ran but printed
+  nothing a parser recognized — `installed: true`, `version: null`). A missing tool
+  carries an `install_hint`. Tools disabled in the workspace config are still listed and
+  probed here; `lintro doctor` is what reports enablement.
 - `types` is a list, not a scalar: `ToolType` is a bitmask and tools such as `ruff` and
   `oxlint` are genuinely both a linter and a formatter.
 - `capabilities` is what you may call the tool with: `check`, `fix`, or `review` for

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import sys
 from dataclasses import asdict
+from functools import partial
 
 import click
 from rich.console import Console
@@ -462,14 +463,17 @@ def doctor_command(
         1 for check in oxlint_checks if _oxlint_check_is_failure(check)
     )
 
-    # Determine which tools to check (names were validated above)
-    all_results = collect_tool_checks(
+    # Determine which tools to check (names were validated above). Bound once
+    # so the post-fix recheck below cannot drift from the initial selection.
+    probe_tools = partial(
+        collect_tool_checks,
         registry=registry,
         context=context,
         config=config,
         tool_names=tool_names or None,
         check_all=check_all,
     )
+    all_results = probe_tools()
 
     # Split into production and dev
     prod_results = [
@@ -631,13 +635,7 @@ def doctor_command(
 
     if fix and has_fixable:
         _run_fix(display_console, prod_results, context, registry)
-        rechecked = collect_tool_checks(
-            registry=registry,
-            context=context,
-            config=config,
-            tool_names=tool_names or None,
-            check_all=check_all,
-        )
+        rechecked = probe_tools()
         rechecked_prod = [r for r in rechecked if r.tool.tier != "dev"]
         missing_count = sum(1 for r in rechecked_prod if r.status == ToolStatus.MISSING)
         outdated_count = sum(

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -2,15 +2,18 @@
 
 Provides a Flutter doctor-style diagnostic that checks ALL tools, grouped by
 install category, with context-aware install hints.
+
+Only presentation lives here. The probes themselves — and the
+``{check, status, detail, remediation}`` health report the MCP ``lintro_doctor``
+tool serves — live in :mod:`lintro.utils.doctor_report`, so the same data backs
+the terminal output, ``--json``, and an agent (issue #1240).
 """
 
 from __future__ import annotations
 
 import json
-import shutil
-import subprocess  # nosec B404 - subprocess is the core mechanism for invoking external tools; all invocations use shell=False
 import sys
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 
 import click
 from rich.console import Console
@@ -24,185 +27,24 @@ from lintro.ai.doctor_checks import (
 from lintro.ai.interface import resolve_ai_config
 from lintro.enums.tool_status import ToolStatus
 from lintro.tools.core.install_context import RuntimeContext
-from lintro.tools.core.install_strategies import get_strategy
 from lintro.tools.core.tool_registry import (
     CATEGORY_LABELS,
     ManifestRegistry,
-    ManifestTool,
-)
-from lintro.tools.core.version_parsing import (
-    compare_versions,
-    extract_version_from_output,
 )
 from lintro.tools.definitions.oxlint_doctor import (
     OxlintCheckResult,
     check_oxlint_type_aware,
+)
+from lintro.utils.doctor_report import (
+    ToolCheckResult,
+    collect_tool_checks,
+    mcp_extra_status,
 )
 from lintro.utils.environment import (
     EnvironmentReport,
     collect_full_environment,
     render_environment_report,
 )
-
-
-@dataclass
-class ToolCheckResult:
-    """Result of a tool health check.
-
-    Attributes:
-        tool: The manifest tool entry.
-        status: ToolStatus value (OK, MISSING, OUTDATED, UNKNOWN).
-        installed_version: Detected version string, or None.
-        error: Error type if check failed.
-        details: Additional error details.
-        path: Filesystem path where the tool was found.
-        install_hint: Context-aware install command.
-        upgrade_hint: Context-aware upgrade command for outdated tools.
-    """
-
-    tool: ManifestTool
-    status: ToolStatus
-    installed_version: str | None = None
-    error: str | None = None
-    details: str | None = None
-    path: str | None = None
-    install_hint: str = ""
-    upgrade_hint: str = ""
-
-
-def _check_tool(tool: ManifestTool, context: RuntimeContext) -> ToolCheckResult:
-    """Check a single tool's installation status and version.
-
-    Args:
-        tool: Manifest tool entry.
-        context: Runtime context for install hints.
-
-    Returns:
-        ToolCheckResult with status and details.
-    """
-    strategy = get_strategy(tool.install_type)
-    env = context.environment
-    if strategy:
-        _args = (
-            env,
-            tool.name,
-            tool.version,
-            tool.install_package,
-            tool.install_component,
-        )
-        hint = strategy.install_hint(*_args)
-        upgrade_hint = strategy.upgrade_hint(*_args)
-    else:
-        hint = f"Install {tool.name} manually"
-        upgrade_hint = f"Upgrade {tool.name} manually"
-
-    if not tool.version_command:
-        return ToolCheckResult(
-            tool=tool,
-            status=ToolStatus.MISSING,
-            error="no_command",
-            details="No version command defined",
-            install_hint=hint,
-            upgrade_hint=upgrade_hint,
-        )
-
-    # Find the main executable (may be a wrapper like "sh", "cargo", etc.)
-    main_cmd = tool.version_command[0]
-    tool_path = shutil.which(main_cmd)
-
-    if not tool_path:
-        return ToolCheckResult(
-            tool=tool,
-            status=ToolStatus.MISSING,
-            error="not_in_path",
-            details=main_cmd,
-            install_hint=hint,
-            upgrade_hint=upgrade_hint,
-        )
-
-    try:
-        result = subprocess.run(  # nosec B603 - argv is an internally-built list run with shell=False; binary resolved from a known command, no user shell input
-            tool.version_command,
-            capture_output=True,
-            text=True,
-            timeout=10,
-            check=False,
-        )
-        output = result.stdout + result.stderr
-
-        if result.returncode != 0:
-            return ToolCheckResult(
-                tool=tool,
-                status=ToolStatus.MISSING,
-                error="command_failed",
-                details=f"Exit {result.returncode}: {output[:100]}",
-                path=tool_path,
-                install_hint=hint,
-            )
-
-        version = extract_version_from_output(output, tool.name)
-        if not version:
-            return ToolCheckResult(
-                tool=tool,
-                status=ToolStatus.UNKNOWN,
-                error="no_version",
-                details=f"Output: {output[:100]}",
-                path=tool_path,
-                install_hint=hint,
-            )
-
-        status = _compare_versions(version, tool.version, tool.min_version)
-        return ToolCheckResult(
-            tool=tool,
-            status=status,
-            installed_version=version,
-            path=tool_path,
-            install_hint=hint,
-            upgrade_hint=upgrade_hint,
-        )
-    except subprocess.TimeoutExpired:
-        return ToolCheckResult(
-            tool=tool,
-            status=ToolStatus.MISSING,
-            error="timeout",
-            path=tool_path,
-            install_hint=hint,
-            upgrade_hint=upgrade_hint,
-        )
-    except (FileNotFoundError, OSError) as e:
-        return ToolCheckResult(
-            tool=tool,
-            status=ToolStatus.MISSING,
-            error="os_error",
-            details=str(e),
-            install_hint=hint,
-            upgrade_hint=upgrade_hint,
-        )
-
-
-def _compare_versions(
-    installed: str,
-    recommended: str,
-    minimum: str,
-) -> ToolStatus:
-    """Compare installed version against recommended and minimum versions.
-
-    Args:
-        installed: Installed version string.
-        recommended: Recommended/tested version from manifest.
-        minimum: Hard minimum compatible version from manifest.
-
-    Returns:
-        ToolStatus.OK, OUTDATED, INCOMPATIBLE, or UNKNOWN.
-    """
-    try:
-        if compare_versions(installed, minimum) < 0:
-            return ToolStatus.INCOMPATIBLE
-        if compare_versions(installed, recommended) < 0:
-            return ToolStatus.OUTDATED
-        return ToolStatus.OK
-    except ValueError:
-        return ToolStatus.UNKNOWN
 
 
 def _render_category(
@@ -350,34 +192,9 @@ def _render_ai_checks(console: Console, checks: list[AICheckResult]) -> None:
             console.print(f"         [dim]{check.hint}[/dim]")
 
 
-def _mcp_extra_status() -> dict[str, str]:
-    """Return informational status for the optional ``lintro[mcp]`` extra.
-
-    Missing MCP is reported but never treated as a doctor failure.
-
-    Returns:
-        Dict with ``name``, ``status``, ``message``, and ``hint`` keys.
-    """
-    from lintro.mcp import is_mcp_available
-
-    if is_mcp_available():
-        return {
-            "name": "mcp",
-            "status": ToolStatus.OK.value,
-            "message": "Python mcp SDK installed (lintro[mcp])",
-            "hint": "Start with: lintro mcp",
-        }
-    return {
-        "name": "mcp",
-        "status": ToolStatus.DISABLED.value,
-        "message": "optional extra not installed",
-        "hint": "uv pip install 'lintro[mcp]'",
-    }
-
-
 def _render_mcp_extra(console: Console) -> None:
     """Render optional MCP extra availability (informational only)."""
-    info = _mcp_extra_status()
+    info = mcp_extra_status()
     console.print()
     console.print("  [bold]Optional extras[/bold]")
     line = Text("    ")
@@ -646,30 +463,13 @@ def doctor_command(
     )
 
     # Determine which tools to check (names were validated above)
-    if tools:
-        tools_to_check = [registry.get(n) for n in tool_names]
-        disabled_results: list[ToolCheckResult] = []
-    else:
-        all_tools = list(registry.all_tools(include_dev=True))
-        if check_all:
-            tools_to_check = all_tools
-            disabled_results = []
-        else:
-            tools_to_check = [t for t in all_tools if config.is_tool_enabled(t.name)]
-            disabled_results = [
-                ToolCheckResult(
-                    tool=t,
-                    status=ToolStatus.DISABLED,
-                    install_hint="",
-                    upgrade_hint="",
-                )
-                for t in all_tools
-                if not config.is_tool_enabled(t.name)
-            ]
-
-    # Check enabled tools
-    all_results = [_check_tool(tool, context) for tool in tools_to_check]
-    all_results.extend(disabled_results)
+    all_results = collect_tool_checks(
+        registry=registry,
+        context=context,
+        config=config,
+        tool_names=tool_names or None,
+        check_all=check_all,
+    )
 
     # Split into production and dev
     prod_results = [
@@ -831,7 +631,13 @@ def doctor_command(
 
     if fix and has_fixable:
         _run_fix(display_console, prod_results, context, registry)
-        rechecked = [_check_tool(tool, context) for tool in tools_to_check]
+        rechecked = collect_tool_checks(
+            registry=registry,
+            context=context,
+            config=config,
+            tool_names=tool_names or None,
+            check_all=check_all,
+        )
         rechecked_prod = [r for r in rechecked if r.tool.tier != "dev"]
         missing_count = sum(1 for r in rechecked_prod if r.status == ToolStatus.MISSING)
         outdated_count = sum(
@@ -982,7 +788,7 @@ def _output_json(
         "issues": issues,
         "ai": ai_json,
         "oxlint": oxlint_json,
-        "optional_extras": [_mcp_extra_status()],
+        "optional_extras": [mcp_extra_status()],
         "summary": {
             "total": (
                 ok_count

--- a/lintro/mcp/server.py
+++ b/lintro/mcp/server.py
@@ -72,12 +72,14 @@ def build_default_registry(*, workspace: Path) -> McpToolRegistry:
 
     Returns:
         Registry containing ``lintro_ping``, ``lintro_check``,
-        ``lintro_format``, and ``lintro_review``.
+        ``lintro_format``, ``lintro_review``, ``lintro_list_tools``,
+        ``lintro_versions``, and ``lintro_doctor``.
     """
     # Deferred deliberately, in the same spirit as this module's other lazy
     # imports: the lint toolkit pulls the plugin registry, the parsers, and the
     # formatters, and nothing that merely imports this module (``lintro
     # doctor``, the CLI's command table) should pay for that.
+    from lintro.mcp.toolkits.introspection import build_introspection_toolkit
     from lintro.mcp.toolkits.lint import build_lint_toolkit
     from lintro.mcp.toolkits.review import build_review_toolkit
 
@@ -100,6 +102,7 @@ def build_default_registry(*, workspace: Path) -> McpToolRegistry:
     # when the ``[ai]`` extra or the provider is missing, which tells an agent
     # why it cannot review instead of silently omitting the capability.
     registry.register_toolkit(specs=build_review_toolkit(workspace=workspace))
+    registry.register_toolkit(specs=build_introspection_toolkit(workspace=workspace))
     return registry
 
 

--- a/lintro/mcp/toolkits/__init__.py
+++ b/lintro/mcp/toolkits/__init__.py
@@ -9,7 +9,12 @@ all.
 
 from __future__ import annotations
 
+from lintro.mcp.toolkits.introspection import build_introspection_toolkit
 from lintro.mcp.toolkits.lint import build_lint_toolkit
 from lintro.mcp.toolkits.review import build_review_toolkit
 
-__all__ = ["build_lint_toolkit", "build_review_toolkit"]
+__all__ = [
+    "build_introspection_toolkit",
+    "build_lint_toolkit",
+    "build_review_toolkit",
+]

--- a/lintro/mcp/toolkits/introspection.py
+++ b/lintro/mcp/toolkits/introspection.py
@@ -43,13 +43,20 @@ if TYPE_CHECKING:
     from lintro.plugins.protocol import ToolDefinition
     from lintro.tools.core.tool_registry import ManifestRegistry
 
-__all__ = ["build_introspection_toolkit"]
+__all__ = ["INTROSPECTION_TIMEOUT_SECONDS", "build_introspection_toolkit"]
 
 _EMPTY_INPUT_SCHEMA: Final[dict[str, Any]] = {
     "type": "object",
     "properties": {},
     "additionalProperties": False,
 }
+
+# Every one of these tools probes each external binary for its version, and a
+# tool that hangs is allowed up to its own probe timeout, so the worst case
+# scales with the size of the manifest and blows past the foundation's 300s
+# default on a machine with slow or wedged binaries. The budget still exists:
+# a wedged probe must not hold the JSON-RPC stream open forever.
+INTROSPECTION_TIMEOUT_SECONDS: Final[float] = 900.0
 
 #: Capability label reported for advisory AI finders, which run under
 #: ``lintro review`` rather than ``chk``/``fmt``. Mirrors
@@ -158,7 +165,13 @@ def _tool_types(*, tool_type: ToolType) -> list[str]:
     ]
 
 
-def _capabilities(*, name: str, definition: ToolDefinition) -> list[str]:
+def _capabilities(
+    *,
+    name: str,
+    definition: ToolDefinition,
+    check_tools: frozenset[str],
+    fix_tools: frozenset[str],
+) -> list[str]:
     """Resolve the verbs a tool can be invoked with.
 
     Advisory AI finders report ``review``: they are excluded from ``chk`` and
@@ -168,19 +181,21 @@ def _capabilities(*, name: str, definition: ToolDefinition) -> list[str]:
     Args:
         name: Registered tool name.
         definition: The plugin's ``ToolDefinition``.
+        check_tools: Names of tools that support checking, resolved once for
+            the whole listing rather than per tool.
+        fix_tools: Names of tools that support fixing.
 
     Returns:
         list[str]: Capability labels in display order.
     """
     from lintro.enums.action import Action
-    from lintro.tools import tool_manager
 
     if definition.is_advisory:
         return [ADVISORY_CAPABILITY]
     capabilities: list[str] = []
-    if name in tool_manager.get_check_tools():
+    if name in check_tools:
         capabilities.append(Action.CHECK.value)
-    if name in tool_manager.get_fix_tools():
+    if name in fix_tools:
         capabilities.append(Action.FIX.value)
     return capabilities
 
@@ -205,6 +220,8 @@ def _list_tools_payload() -> dict[str, Any]:
     context = RuntimeContext.detect()
     membership = _profile_membership(manifest=manifest)
     plugins = tool_manager.get_all_tools()
+    check_tools = frozenset(tool_manager.get_check_tools())
+    fix_tools = frozenset(tool_manager.get_fix_tools())
 
     entries: list[dict[str, Any]] = []
     for name in sorted(plugins):
@@ -235,7 +252,12 @@ def _list_tools_payload() -> dict[str, Any]:
                 ),
                 "status": str(probe.status) if probe else "unknown",
                 "can_fix": definition.can_fix,
-                "capabilities": _capabilities(name=name, definition=definition),
+                "capabilities": _capabilities(
+                    name=name,
+                    definition=definition,
+                    check_tools=check_tools,
+                    fix_tools=fix_tools,
+                ),
                 "execution_class": definition.execution_class.value,
                 "origin": ToolRegistry.get_origin(name),
                 "profile_membership": list(
@@ -264,16 +286,15 @@ def _version_status(*, info: Any) -> str:
         info: A ``ToolVersionInfo`` from the version-checking machinery.
 
     Returns:
-        str: ``missing`` when nothing answered the probe, ``outdated`` when the
-        installed version is below the minimum lintro requires, ``ok``
-        otherwise. ``unknown`` covers a tool that ran but whose output could
-        not be parsed.
+        str: ``missing`` when nothing usable answered the probe (the binary is
+        absent, exited non-zero, or printed output no parser recognized — in
+        every case the version is unknown and the tool cannot be relied on, and
+        ``error`` carries the reason), ``outdated`` when the installed version
+        is below the minimum lintro requires, ``ok`` otherwise.
     """
     from lintro.enums.tool_status import ToolStatus
 
     if info.current_version is None:
-        if info.error_message and "parse" in info.error_message.lower():
-            return ToolStatus.UNKNOWN.value
         return ToolStatus.MISSING.value
     if not info.version_check_passed:
         return ToolStatus.OUTDATED.value
@@ -373,6 +394,7 @@ def build_introspection_toolkit(*, workspace: Path) -> tuple[McpToolSpec, ...]:
             read_only=True,
             destructive=False,
             idempotent=True,
+            timeout_seconds=INTROSPECTION_TIMEOUT_SECONDS,
         ),
         McpToolSpec(
             name="lintro_versions",
@@ -382,6 +404,7 @@ def build_introspection_toolkit(*, workspace: Path) -> tuple[McpToolSpec, ...]:
             read_only=True,
             destructive=False,
             idempotent=True,
+            timeout_seconds=INTROSPECTION_TIMEOUT_SECONDS,
         ),
         McpToolSpec(
             name="lintro_doctor",
@@ -391,5 +414,6 @@ def build_introspection_toolkit(*, workspace: Path) -> tuple[McpToolSpec, ...]:
             read_only=True,
             destructive=False,
             idempotent=True,
+            timeout_seconds=INTROSPECTION_TIMEOUT_SECONDS,
         ),
     )

--- a/lintro/mcp/toolkits/introspection.py
+++ b/lintro/mcp/toolkits/introspection.py
@@ -1,0 +1,395 @@
+"""The ``lintro_list_tools``, ``lintro_versions``, and ``lintro_doctor`` tools.
+
+An agent deciding whether to call ``lintro_check`` needs to know what lintro
+can actually do *here*: which tools exist, which of them are installed, and
+whether the environment is healthy enough to trust the answer. Without that it
+either parses the human-facing ``lintro ls`` / ``lintro versions`` /
+``lintro doctor`` text or discovers the truth by failing a call (issue #1240).
+
+All three tools are read-only and idempotent: nothing is written, no provider
+is called, and running one twice costs only the subprocess probes.
+
+Two conventions carry over from the toolkits that landed before this one:
+
+* **Degraded but visible.** A tool that is not installed is listed with
+  ``installed: false`` and its install hint rather than omitted. An absent
+  entry is indistinguishable from a tool lintro never supported, which is
+  exactly the confusion that makes an agent give up on a capability it could
+  have asked the operator to install.
+* **No heavy imports at import time.** Only the registry types are imported
+  here; the plugin registry, the manifest, the version probes, and the doctor
+  data layer are all pulled inside the handlers, so registering this toolkit
+  costs nothing.
+
+Both remaining shapes are projections of the same two sources — the live
+plugin registry (what lintro can run) and ``manifest.json`` (what each tool
+is, which version is expected, which install profiles include it) — joined on
+the tool name. Plugin names spell separators with ``-`` and manifest names with
+``_`` (``astro-check`` / ``astro_check``), so the join normalizes before
+matching rather than silently dropping four tools.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+from lintro.mcp.registry import McpToolSpec
+from lintro.mcp.toolkits.runner import workspace_session
+
+if TYPE_CHECKING:
+    from lintro.enums.tool_type import ToolType
+    from lintro.plugins.protocol import ToolDefinition
+    from lintro.tools.core.tool_registry import ManifestRegistry
+
+__all__ = ["build_introspection_toolkit"]
+
+_EMPTY_INPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+#: Capability label reported for advisory AI finders, which run under
+#: ``lintro review`` rather than ``chk``/``fmt``. Mirrors
+#: ``lintro.cli_utils.commands.list_tools.ADVISORY_CAPABILITY``.
+ADVISORY_CAPABILITY: Final[str] = "review"
+
+#: Profile strategies whose membership is fixed by the manifest alone. The
+#: others (``auto-detect``, ``filter``) resolve against whatever languages are
+#: detected in a workspace, so a tool's membership in them is not a property of
+#: the tool and is reported on the profile instead of on every tool.
+_STATIC_PROFILE_STRATEGIES: Final[frozenset[str]] = frozenset({"explicit", "all"})
+
+_LIST_TOOLS_DESCRIPTION: Final[str] = (
+    "List every lintro tool with its type, languages, capabilities, execution "
+    "class, install profiles, and whether its binary is installed in this "
+    "workspace (with the detected and expected versions). Tools that are not "
+    "installed are listed with installed=false and an install hint rather "
+    "than omitted. Read-only: nothing is executed beyond version probes."
+)
+
+_VERSIONS_DESCRIPTION: Final[str] = (
+    "Report the installed version of every external tool against the minimum "
+    "and recommended versions lintro expects, flagging each as ok, outdated, "
+    "missing, or unknown. Read-only."
+)
+
+_DOCTOR_DESCRIPTION: Final[str] = (
+    "Run lintro's environment health checks and return them as structured "
+    "records ({check, status, detail, remediation}) covering configuration "
+    "validity, tool binaries, AI provider availability and authentication, "
+    "and optional extras, plus an overall healthy/degraded verdict. Read-only: "
+    "no provider call is made and nothing is written."
+)
+
+
+def _profile_membership(*, manifest: ManifestRegistry) -> dict[str, tuple[str, ...]]:
+    """Map each manifest tool to the install profiles that always contain it.
+
+    Args:
+        manifest: Loaded manifest registry.
+
+    Returns:
+        dict[str, tuple[str, ...]]: Tool name to sorted profile names. Only
+        statically-resolvable profiles are considered; see
+        :data:`_STATIC_PROFILE_STRATEGIES`.
+    """
+    membership: dict[str, set[str]] = {
+        tool.name: set() for tool in manifest.all_tools(include_dev=True)
+    }
+    for name, profile in manifest.profiles.items():
+        if profile.strategy == "all":
+            for tool_name in membership:
+                membership[tool_name].add(name)
+        elif profile.strategy == "explicit":
+            for tool_name in profile.tools:
+                if tool_name in membership:
+                    membership[tool_name].add(name)
+    return {name: tuple(sorted(names)) for name, names in membership.items()}
+
+
+def _profiles_payload(*, manifest: ManifestRegistry) -> list[dict[str, Any]]:
+    """Describe every install profile the manifest defines.
+
+    Args:
+        manifest: Loaded manifest registry.
+
+    Returns:
+        list[dict[str, Any]]: One entry per profile, marked ``static`` when its
+        membership is fixed and ``workspace`` when it depends on the languages
+        detected in the tree.
+    """
+    return [
+        {
+            "name": name,
+            "description": profile.description,
+            "strategy": profile.strategy,
+            "resolution": (
+                "static"
+                if profile.strategy in _STATIC_PROFILE_STRATEGIES
+                else "workspace"
+            ),
+        }
+        for name, profile in sorted(manifest.profiles.items())
+    ]
+
+
+def _tool_types(*, tool_type: ToolType) -> list[str]:
+    """Decompose a :class:`~lintro.enums.tool_type.ToolType` bitmask.
+
+    Reported as a list rather than the single ``type`` field the issue sketched:
+    ``ToolType`` is a ``Flag`` and several tools are genuinely both a linter and
+    a formatter (ruff, oxlint), so a scalar would have to pick one and lie.
+
+    Args:
+        tool_type: The definition's ``tool_type`` flag value.
+
+    Returns:
+        list[str]: Lowercased flag names, in declaration order.
+    """
+    from lintro.enums.tool_type import ToolType
+
+    return [
+        member.name.lower()
+        for member in ToolType
+        if member.name is not None and member in tool_type
+    ]
+
+
+def _capabilities(*, name: str, definition: ToolDefinition) -> list[str]:
+    """Resolve the verbs a tool can be invoked with.
+
+    Advisory AI finders report ``review``: they are excluded from ``chk`` and
+    ``fmt`` so their nondeterministic findings never gate deterministic checks
+    (issue #1308), which also makes them unreachable from ``lintro_check``.
+
+    Args:
+        name: Registered tool name.
+        definition: The plugin's ``ToolDefinition``.
+
+    Returns:
+        list[str]: Capability labels in display order.
+    """
+    from lintro.enums.action import Action
+    from lintro.tools import tool_manager
+
+    if definition.is_advisory:
+        return [ADVISORY_CAPABILITY]
+    capabilities: list[str] = []
+    if name in tool_manager.get_check_tools():
+        capabilities.append(Action.CHECK.value)
+    if name in tool_manager.get_fix_tools():
+        capabilities.append(Action.FIX.value)
+    return capabilities
+
+
+def _list_tools_payload() -> dict[str, Any]:
+    """Build the ``lintro_list_tools`` result.
+
+    Must be called inside :func:`~lintro.mcp.toolkits.runner.workspace_session`:
+    tool enablement and the plugin registry are resolved against the workspace
+    configuration.
+
+    Returns:
+        dict[str, Any]: Mapping with ``tools``, ``profiles``, and ``summary``.
+    """
+    from lintro.plugins.registry import ToolRegistry
+    from lintro.tools import tool_manager
+    from lintro.tools.core.install_context import RuntimeContext
+    from lintro.tools.core.tool_registry import ManifestRegistry
+    from lintro.utils import doctor_report
+
+    manifest = ManifestRegistry.load()
+    context = RuntimeContext.detect()
+    membership = _profile_membership(manifest=manifest)
+    plugins = tool_manager.get_all_tools()
+
+    entries: list[dict[str, Any]] = []
+    for name in sorted(plugins):
+        definition = plugins[name].definition
+        manifest_tool = manifest.get_or_none(name) or manifest.get_or_none(
+            name.replace("-", "_"),
+        )
+        # An advisory finder (idiom-review) has no binary and no manifest entry,
+        # so there is nothing to probe. It is still listed — with
+        # installed=false — because "lintro knows this tool but cannot run it
+        # as a binary" is what the caller needs to see.
+        probe = (
+            doctor_report.check_tool(tool=manifest_tool, context=context)
+            if manifest_tool is not None
+            else None
+        )
+        entries.append(
+            {
+                "name": name,
+                "description": definition.description,
+                "types": _tool_types(tool_type=definition.tool_type),
+                "languages": (list(manifest_tool.languages) if manifest_tool else []),
+                "installed": probe.installed if probe else False,
+                "version": probe.installed_version if probe else None,
+                "expected_version": manifest_tool.version if manifest_tool else None,
+                "minimum_version": (
+                    manifest_tool.min_version if manifest_tool else None
+                ),
+                "status": str(probe.status) if probe else "unknown",
+                "can_fix": definition.can_fix,
+                "capabilities": _capabilities(name=name, definition=definition),
+                "execution_class": definition.execution_class.value,
+                "origin": ToolRegistry.get_origin(name),
+                "profile_membership": list(
+                    membership.get(manifest_tool.name, ()) if manifest_tool else (),
+                ),
+                "install_hint": probe.install_hint if probe else "",
+            },
+        )
+
+    installed = sum(1 for entry in entries if entry["installed"])
+    return {
+        "tools": entries,
+        "profiles": _profiles_payload(manifest=manifest),
+        "summary": {
+            "total": len(entries),
+            "installed": installed,
+            "missing": len(entries) - installed,
+        },
+    }
+
+
+def _version_status(*, info: Any) -> str:
+    """Classify one tool's version check.
+
+    Args:
+        info: A ``ToolVersionInfo`` from the version-checking machinery.
+
+    Returns:
+        str: ``missing`` when nothing answered the probe, ``outdated`` when the
+        installed version is below the minimum lintro requires, ``ok``
+        otherwise. ``unknown`` covers a tool that ran but whose output could
+        not be parsed.
+    """
+    from lintro.enums.tool_status import ToolStatus
+
+    if info.current_version is None:
+        if info.error_message and "parse" in info.error_message.lower():
+            return ToolStatus.UNKNOWN.value
+        return ToolStatus.MISSING.value
+    if not info.version_check_passed:
+        return ToolStatus.OUTDATED.value
+    return ToolStatus.OK.value
+
+
+def _versions_payload() -> dict[str, Any]:
+    """Build the ``lintro_versions`` result.
+
+    Must be called inside :func:`~lintro.mcp.toolkits.runner.workspace_session`.
+
+    Returns:
+        dict[str, Any]: Mapping with ``tools`` and ``summary``.
+    """
+    from lintro.tools.core.version_requirements import get_all_tool_versions
+
+    entries: list[dict[str, Any]] = []
+    for name, info in sorted(get_all_tool_versions().items()):
+        status = _version_status(info=info)
+        entries.append(
+            {
+                "name": name,
+                "installed_version": info.current_version,
+                "minimum_version": info.min_version,
+                "recommended_version": info.recommended_version or None,
+                "satisfies_minimum": info.version_check_passed,
+                "below_recommended": info.below_recommended,
+                "status": status,
+                "error": info.error_message,
+                "install_hint": info.install_hint,
+            },
+        )
+
+    counts: dict[str, int] = {}
+    for entry in entries:
+        key = str(entry["status"])
+        counts[key] = counts.get(key, 0) + 1
+    counts["total"] = len(entries)
+    return {"tools": entries, "summary": counts}
+
+
+def _handler(
+    *,
+    workspace: Path,
+    build: Callable[[], dict[str, Any]],
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Bind a payload builder to ``workspace`` as an MCP handler.
+
+    The session anchors cwd — the workspace config decides which tools are
+    enabled, and native tool configs are resolved relative to it — and
+    serializes the call against the lint tools, which mutate the same
+    process-global state.
+
+    Args:
+        workspace: Workspace root the introspection is anchored to.
+        build: Zero-argument payload builder to run inside the session.
+
+    Returns:
+        Callable: A handler accepting (and ignoring) an arguments dict.
+    """
+
+    def handler(_arguments: dict[str, Any]) -> dict[str, Any]:
+        with workspace_session(workspace=workspace):
+            return build()
+
+    return handler
+
+
+def _doctor_payload() -> dict[str, Any]:
+    """Build the ``lintro_doctor`` result.
+
+    Returns:
+        dict[str, Any]: The serialized
+        :class:`~lintro.utils.doctor_report.DoctorReport`.
+    """
+    from lintro.utils import doctor_report
+
+    return doctor_report.collect_doctor_report().to_dict()
+
+
+def build_introspection_toolkit(*, workspace: Path) -> tuple[McpToolSpec, ...]:
+    """Build the introspection tool specifications.
+
+    Args:
+        workspace: Workspace root the tools report on.
+
+    Returns:
+        tuple[McpToolSpec, ...]: ``lintro_list_tools``, ``lintro_versions``,
+        and ``lintro_doctor``.
+    """
+    return (
+        McpToolSpec(
+            name="lintro_list_tools",
+            description=_LIST_TOOLS_DESCRIPTION,
+            input_schema=dict(_EMPTY_INPUT_SCHEMA),
+            handler=_handler(workspace=workspace, build=_list_tools_payload),
+            read_only=True,
+            destructive=False,
+            idempotent=True,
+        ),
+        McpToolSpec(
+            name="lintro_versions",
+            description=_VERSIONS_DESCRIPTION,
+            input_schema=dict(_EMPTY_INPUT_SCHEMA),
+            handler=_handler(workspace=workspace, build=_versions_payload),
+            read_only=True,
+            destructive=False,
+            idempotent=True,
+        ),
+        McpToolSpec(
+            name="lintro_doctor",
+            description=_DOCTOR_DESCRIPTION,
+            input_schema=dict(_EMPTY_INPUT_SCHEMA),
+            handler=_handler(workspace=workspace, build=_doctor_payload),
+            read_only=True,
+            destructive=False,
+            idempotent=True,
+        ),
+    )

--- a/lintro/mcp/toolkits/introspection.py
+++ b/lintro/mcp/toolkits/introspection.py
@@ -80,7 +80,7 @@ _LIST_TOOLS_DESCRIPTION: Final[str] = (
 _VERSIONS_DESCRIPTION: Final[str] = (
     "Report the installed version of every external tool against the minimum "
     "and recommended versions lintro expects, flagging each as ok, outdated, "
-    "or missing. Read-only."
+    "incompatible, or missing. Read-only."
 )
 
 _DOCTOR_DESCRIPTION: Final[str] = (
@@ -282,6 +282,10 @@ def _list_tools_payload() -> dict[str, Any]:
 def _version_status(*, info: Any) -> str:
     """Classify one tool's version check.
 
+    The vocabulary is deliberately the same one ``lintro_list_tools`` reports,
+    so an agent that branches on ``status`` cannot get two different labels for
+    one environment from two tools in the same toolkit.
+
     Args:
         info: A ``ToolVersionInfo`` from the version-checking machinery.
 
@@ -289,14 +293,18 @@ def _version_status(*, info: Any) -> str:
         str: ``missing`` when nothing usable answered the probe (the binary is
         absent, exited non-zero, or printed output no parser recognized — in
         every case the version is unknown and the tool cannot be relied on, and
-        ``error`` carries the reason), ``outdated`` when the installed version
-        is below the minimum lintro requires, ``ok`` otherwise.
+        ``error`` carries the reason), ``incompatible`` when the installed
+        version is below the minimum lintro requires, ``outdated`` when it
+        clears the minimum but trails the recommended version, ``ok``
+        otherwise.
     """
     from lintro.enums.tool_status import ToolStatus
 
     if info.current_version is None:
         return ToolStatus.MISSING.value
     if not info.version_check_passed:
+        return ToolStatus.INCOMPATIBLE.value
+    if info.below_recommended:
         return ToolStatus.OUTDATED.value
     return ToolStatus.OK.value
 

--- a/lintro/mcp/toolkits/introspection.py
+++ b/lintro/mcp/toolkits/introspection.py
@@ -80,7 +80,7 @@ _LIST_TOOLS_DESCRIPTION: Final[str] = (
 _VERSIONS_DESCRIPTION: Final[str] = (
     "Report the installed version of every external tool against the minimum "
     "and recommended versions lintro expects, flagging each as ok, outdated, "
-    "missing, or unknown. Read-only."
+    "or missing. Read-only."
 )
 
 _DOCTOR_DESCRIPTION: Final[str] = (

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -237,12 +237,14 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
             install_hint=hint,
             upgrade_hint=upgrade_hint,
         )
-    except (FileNotFoundError, OSError) as e:
+    except OSError as e:
+        # FileNotFoundError is an OSError subclass; naming both said nothing.
         return ToolCheckResult(
             tool=tool,
             status=ToolStatus.MISSING,
             error="os_error",
             details=str(e),
+            path=tool_path,
             install_hint=hint,
             upgrade_hint=upgrade_hint,
         )
@@ -286,22 +288,19 @@ def collect_tool_checks(
     if check_all or config is None:
         return [check_tool(tool=tool, context=context) for tool in all_tools]
 
-    results = [
-        check_tool(tool=tool, context=context)
-        for tool in all_tools
-        if config.is_tool_enabled(tool.name)
-    ]
-    results.extend(
-        ToolCheckResult(
-            tool=tool,
-            status=ToolStatus.DISABLED,
-            install_hint="",
-            upgrade_hint="",
+    return [
+        (
+            check_tool(tool=tool, context=context)
+            if config.is_tool_enabled(tool.name)
+            else ToolCheckResult(
+                tool=tool,
+                status=ToolStatus.DISABLED,
+                install_hint="",
+                upgrade_hint="",
+            )
         )
         for tool in all_tools
-        if not config.is_tool_enabled(tool.name)
-    )
-    return results
+    ]
 
 
 def mcp_extra_status() -> dict[str, str]:
@@ -576,12 +575,12 @@ def _tool_checks(*, config: LintroConfig | None) -> list[DoctorCheck]:
         if result.tool.tier != "dev" and result.status is not ToolStatus.DISABLED
     ]
     missing = [r for r in production if r.status is ToolStatus.MISSING]
-    stale = [
-        r
-        for r in production
-        if r.status in (ToolStatus.OUTDATED, ToolStatus.INCOMPATIBLE)
-    ]
+    incompatible = [r for r in production if r.status is ToolStatus.INCOMPATIBLE]
+    outdated = [r for r in production if r.status is ToolStatus.OUTDATED]
     unreadable = [r for r in production if r.status is ToolStatus.UNKNOWN]
+    # Enablement is only applied when a config was loaded; saying "enabled"
+    # after a failed load would claim a filter that never ran.
+    scope = "enabled tool(s)" if config is not None else "tool(s)"
 
     checks: list[DoctorCheck] = []
     if missing:
@@ -591,8 +590,7 @@ def _tool_checks(*, config: LintroConfig | None) -> list[DoctorCheck]:
                 category=DoctorCheckCategory.TOOLS,
                 check="tools.missing",
                 status=DoctorCheckStatus.ERROR,
-                detail=f"{len(names)} enabled tool(s) not installed: "
-                + ", ".join(names),
+                detail=f"{len(names)} {scope} not installed: " + ", ".join(names),
                 remediation=f"lintro install {' '.join(names)}",
             ),
         )
@@ -602,27 +600,43 @@ def _tool_checks(*, config: LintroConfig | None) -> list[DoctorCheck]:
                 category=DoctorCheckCategory.TOOLS,
                 check="tools.missing",
                 status=DoctorCheckStatus.OK,
-                detail=f"All {len(production)} enabled tool(s) are installed",
+                detail=f"All {len(production)} {scope} are installed",
             ),
         )
 
-    if stale or unreadable:
-        names = sorted(r.tool.name for r in stale)
-        unknown_names = sorted(r.tool.name for r in unreadable)
+    if incompatible or outdated or unreadable:
+        upgradable = sorted(r.tool.name for r in (*incompatible, *outdated))
         parts: list[str] = []
-        if names:
-            parts.append("outdated: " + ", ".join(names))
-        if unknown_names:
-            parts.append("version unreadable: " + ", ".join(unknown_names))
+        if incompatible:
+            parts.append(
+                "below the required minimum: "
+                + ", ".join(sorted(r.tool.name for r in incompatible)),
+            )
+        if outdated:
+            parts.append(
+                "outdated: " + ", ".join(sorted(r.tool.name for r in outdated)),
+            )
+        if unreadable:
+            parts.append(
+                "version unreadable: "
+                + ", ".join(sorted(r.tool.name for r in unreadable)),
+            )
         checks.append(
             DoctorCheck(
                 category=DoctorCheckCategory.TOOLS,
                 check="tools.versions",
-                status=DoctorCheckStatus.WARNING,
+                # A version below the hard minimum is not "a bit old": lintro
+                # skips such a tool outright, so it must not read as a warning
+                # when the same status is an error everywhere else.
+                status=(
+                    DoctorCheckStatus.ERROR
+                    if incompatible
+                    else DoctorCheckStatus.WARNING
+                ),
                 detail="; ".join(parts),
                 remediation=(
-                    f"lintro install --upgrade {' '.join(names)}"
-                    if names
+                    f"lintro install --upgrade {' '.join(upgradable)}"
+                    if upgradable
                     else "Run the tool manually to see what it reports"
                 ),
             ),

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -200,6 +200,7 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
                 details=f"Exit {result.returncode}: {output[:100]}",
                 path=tool_path,
                 install_hint=hint,
+                upgrade_hint=upgrade_hint,
             )
 
         version = extract_version_from_output(output, tool.name)
@@ -211,6 +212,7 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
                 details=f"Output: {output[:100]}",
                 path=tool_path,
                 install_hint=hint,
+                upgrade_hint=upgrade_hint,
             )
 
         status = tool_status_for_versions(
@@ -647,13 +649,6 @@ def _ai_checks(*, config: LintroConfig | None) -> list[DoctorCheck]:
         list[DoctorCheck]: One check per AI probe, or a single skipped record
         when no AI feature is enabled or the ``[ai]`` extra is absent.
     """
-    skipped = DoctorCheck(
-        category=DoctorCheckCategory.AI,
-        check="ai.provider",
-        status=DoctorCheckStatus.SKIPPED,
-        detail="No AI feature is enabled (ai.lint / ai.review)",
-        remediation="Enable ai.review and set ai.transport in the workspace config",
-    )
     if config is None:
         return [
             DoctorCheck(
@@ -679,9 +674,34 @@ def _ai_checks(*, config: LintroConfig | None) -> list[DoctorCheck]:
             ),
         ]
 
-    results = check_ai_configuration(resolve_ai_config(config))
+    try:
+        results = check_ai_configuration(resolve_ai_config(config))
+    except Exception as exc:  # noqa: BLE001 - a probe that blew up is a report line
+        # A malformed ``ai:`` block or a provider whose presence check raises
+        # must not take the whole report down with it: the caller asked what is
+        # wrong with the environment, and this is an answer.
+        return [
+            DoctorCheck(
+                category=DoctorCheckCategory.AI,
+                check="ai.provider",
+                status=DoctorCheckStatus.WARNING,
+                detail=f"AI configuration could not be checked: {exc}",
+                remediation="Review the ai.* settings, then re-run lintro doctor",
+            ),
+        ]
+
     if not results:
-        return [skipped]
+        return [
+            DoctorCheck(
+                category=DoctorCheckCategory.AI,
+                check="ai.provider",
+                status=DoctorCheckStatus.SKIPPED,
+                detail="No AI feature is enabled (ai.lint / ai.review)",
+                remediation=(
+                    "Enable ai.review and set ai.transport in the workspace config"
+                ),
+            ),
+        ]
     return [
         DoctorCheck(
             category=DoctorCheckCategory.AI,

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -1,0 +1,731 @@
+"""Print-free data layer behind ``lintro doctor``.
+
+``lintro doctor`` grew as one 1000-line click command that interleaved probing
+with rendering: the only way to learn whether a binary was present was to let
+the command print a Rich table and read it back. That is fine for a terminal
+and useless for anything else, which is why the MCP ``lintro_doctor`` tool
+(issue #1240) needed the probes extracted rather than reimplemented.
+
+Two layers live here:
+
+* The **raw probes** — :class:`ToolCheckResult`, :func:`check_tool`,
+  :func:`collect_tool_checks`, :func:`mcp_extra_status` — moved verbatim out of
+  :mod:`lintro.cli_utils.commands.doctor`, which now imports them. The CLI's
+  output is unchanged; what changed is that its data collection is importable,
+  testable, and free of ``click``/``rich``.
+* The **health report** — :class:`DoctorReport`, a list of
+  :class:`DoctorCheck` records shaped ``{check, status, detail, remediation}``.
+  This is the agent-facing projection: one record per *condition an operator
+  can act on* rather than one per tool, because per-tool installation detail is
+  already the job of ``lintro_list_tools``.
+
+Nothing here prints, and nothing here raises for an unhealthy environment: a
+broken config, a missing provider, and an absent binary are all *data*. The
+CLI keeps owning exit codes.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess  # nosec B404 - subprocess is the only way to ask a binary its version; every call below is a fixed argv list with shell=False
+from dataclasses import dataclass
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING, Any, Final
+
+from lintro.enums.tool_status import ToolStatus
+from lintro.tools.core.install_strategies import get_strategy
+from lintro.tools.core.tool_registry import ManifestRegistry, ManifestTool
+from lintro.tools.core.version_parsing import (
+    compare_versions,
+    extract_version_from_output,
+)
+
+if TYPE_CHECKING:
+    from lintro.config.lintro_config import LintroConfig
+    from lintro.tools.core.install_context import RuntimeContext
+
+__all__ = [
+    "DoctorCheck",
+    "DoctorCheckCategory",
+    "DoctorCheckStatus",
+    "DoctorHealth",
+    "DoctorReport",
+    "ToolCheckResult",
+    "check_tool",
+    "collect_doctor_report",
+    "collect_tool_checks",
+    "mcp_extra_status",
+    "tool_status_for_versions",
+]
+
+#: Wall-clock budget for a single ``<tool> --version`` probe.
+VERSION_PROBE_TIMEOUT_SECONDS: Final[int] = 10
+
+
+@dataclass
+class ToolCheckResult:
+    """Result of a tool health check.
+
+    Attributes:
+        tool: The manifest tool entry.
+        status: ToolStatus value (OK, MISSING, OUTDATED, UNKNOWN).
+        installed_version: Detected version string, or None.
+        error: Error type if check failed.
+        details: Additional error details.
+        path: Filesystem path where the tool was found.
+        install_hint: Context-aware install command.
+        upgrade_hint: Context-aware upgrade command for outdated tools.
+    """
+
+    tool: ManifestTool
+    status: ToolStatus
+    installed_version: str | None = None
+    error: str | None = None
+    details: str | None = None
+    path: str | None = None
+    install_hint: str = ""
+    upgrade_hint: str = ""
+
+    @property
+    def installed(self) -> bool:
+        """Return whether the tool's binary was found and answered a probe.
+
+        ``UNKNOWN`` counts as installed: the binary ran, lintro just could not
+        parse a version out of what it printed. Everything ``MISSING`` covers
+        — absent from ``PATH``, non-zero exit, timeout — is reported as not
+        installed, because from a caller's point of view the tool cannot run.
+
+        Returns:
+            bool: True when the tool is usable.
+        """
+        return self.status in (
+            ToolStatus.OK,
+            ToolStatus.OUTDATED,
+            ToolStatus.INCOMPATIBLE,
+            ToolStatus.UNKNOWN,
+        )
+
+
+def tool_status_for_versions(
+    *,
+    installed: str,
+    recommended: str,
+    minimum: str,
+) -> ToolStatus:
+    """Compare an installed version against recommended and minimum versions.
+
+    Args:
+        installed: Installed version string.
+        recommended: Recommended/tested version from manifest.
+        minimum: Hard minimum compatible version from manifest.
+
+    Returns:
+        ToolStatus.OK, OUTDATED, INCOMPATIBLE, or UNKNOWN.
+    """
+    try:
+        if compare_versions(installed, minimum) < 0:
+            return ToolStatus.INCOMPATIBLE
+        if compare_versions(installed, recommended) < 0:
+            return ToolStatus.OUTDATED
+        return ToolStatus.OK
+    except ValueError:
+        return ToolStatus.UNKNOWN
+
+
+def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResult:
+    """Check a single tool's installation status and version.
+
+    Args:
+        tool: Manifest tool entry.
+        context: Runtime context for install hints.
+
+    Returns:
+        ToolCheckResult with status and details.
+    """
+    strategy = get_strategy(tool.install_type)
+    env = context.environment
+    if strategy:
+        _args = (
+            env,
+            tool.name,
+            tool.version,
+            tool.install_package,
+            tool.install_component,
+        )
+        hint = strategy.install_hint(*_args)
+        upgrade_hint = strategy.upgrade_hint(*_args)
+    else:
+        hint = f"Install {tool.name} manually"
+        upgrade_hint = f"Upgrade {tool.name} manually"
+
+    if not tool.version_command:
+        return ToolCheckResult(
+            tool=tool,
+            status=ToolStatus.MISSING,
+            error="no_command",
+            details="No version command defined",
+            install_hint=hint,
+            upgrade_hint=upgrade_hint,
+        )
+
+    # Find the main executable (may be a wrapper like "sh", "cargo", etc.)
+    main_cmd = tool.version_command[0]
+    tool_path = shutil.which(main_cmd)
+
+    if not tool_path:
+        return ToolCheckResult(
+            tool=tool,
+            status=ToolStatus.MISSING,
+            error="not_in_path",
+            details=main_cmd,
+            install_hint=hint,
+            upgrade_hint=upgrade_hint,
+        )
+
+    try:
+        result = subprocess.run(  # nosec B603 - argv is an internally-built list run with shell=False; binary resolved from a known command, no user shell input
+            tool.version_command,
+            capture_output=True,
+            text=True,
+            timeout=VERSION_PROBE_TIMEOUT_SECONDS,
+            check=False,
+        )
+        output = result.stdout + result.stderr
+
+        if result.returncode != 0:
+            return ToolCheckResult(
+                tool=tool,
+                status=ToolStatus.MISSING,
+                error="command_failed",
+                details=f"Exit {result.returncode}: {output[:100]}",
+                path=tool_path,
+                install_hint=hint,
+            )
+
+        version = extract_version_from_output(output, tool.name)
+        if not version:
+            return ToolCheckResult(
+                tool=tool,
+                status=ToolStatus.UNKNOWN,
+                error="no_version",
+                details=f"Output: {output[:100]}",
+                path=tool_path,
+                install_hint=hint,
+            )
+
+        status = tool_status_for_versions(
+            installed=version,
+            recommended=tool.version,
+            minimum=tool.min_version,
+        )
+        return ToolCheckResult(
+            tool=tool,
+            status=status,
+            installed_version=version,
+            path=tool_path,
+            install_hint=hint,
+            upgrade_hint=upgrade_hint,
+        )
+    except subprocess.TimeoutExpired:
+        return ToolCheckResult(
+            tool=tool,
+            status=ToolStatus.MISSING,
+            error="timeout",
+            path=tool_path,
+            install_hint=hint,
+            upgrade_hint=upgrade_hint,
+        )
+    except (FileNotFoundError, OSError) as e:
+        return ToolCheckResult(
+            tool=tool,
+            status=ToolStatus.MISSING,
+            error="os_error",
+            details=str(e),
+            install_hint=hint,
+            upgrade_hint=upgrade_hint,
+        )
+
+
+def collect_tool_checks(
+    *,
+    registry: ManifestRegistry,
+    context: RuntimeContext,
+    config: LintroConfig | None = None,
+    tool_names: list[str] | None = None,
+    check_all: bool = False,
+) -> list[ToolCheckResult]:
+    """Probe the selected manifest tools and report each one's status.
+
+    Tools the workspace config disables are reported as
+    :attr:`ToolStatus.DISABLED` rather than dropped, so a caller can tell
+    "turned off here" apart from "not installed" — the distinction the whole
+    report exists to make.
+
+    Args:
+        registry: Loaded manifest registry.
+        context: Runtime context used for install hints.
+        config: Workspace config deciding tool enablement. ``None`` behaves
+            like ``check_all``.
+        tool_names: Explicit tool subset. When given, enablement is ignored:
+            an operator naming a tool wants it probed. Names are looked up with
+            ``registry.get``, which raises ``KeyError`` for an unknown tool;
+            callers validate names before reaching here.
+        check_all: Probe every tool regardless of config enablement.
+
+    Returns:
+        list[ToolCheckResult]: One result per selected tool, in manifest order.
+    """
+    if tool_names:
+        return [
+            check_tool(tool=registry.get(name), context=context) for name in tool_names
+        ]
+
+    all_tools = list(registry.all_tools(include_dev=True))
+    if check_all or config is None:
+        return [check_tool(tool=tool, context=context) for tool in all_tools]
+
+    results = [
+        check_tool(tool=tool, context=context)
+        for tool in all_tools
+        if config.is_tool_enabled(tool.name)
+    ]
+    results.extend(
+        ToolCheckResult(
+            tool=tool,
+            status=ToolStatus.DISABLED,
+            install_hint="",
+            upgrade_hint="",
+        )
+        for tool in all_tools
+        if not config.is_tool_enabled(tool.name)
+    )
+    return results
+
+
+def mcp_extra_status() -> dict[str, str]:
+    """Return informational status for the optional ``lintro[mcp]`` extra.
+
+    Missing MCP is reported but never treated as a doctor failure.
+
+    Returns:
+        Dict with ``name``, ``status``, ``message``, and ``hint`` keys.
+    """
+    from lintro.mcp import is_mcp_available
+
+    if is_mcp_available():
+        return {
+            "name": "mcp",
+            "status": ToolStatus.OK.value,
+            "message": "Python mcp SDK installed (lintro[mcp])",
+            "hint": "Start with: lintro mcp",
+        }
+    return {
+        "name": "mcp",
+        "status": ToolStatus.DISABLED.value,
+        "message": "optional extra not installed",
+        "hint": "uv pip install 'lintro[mcp]'",
+    }
+
+
+class DoctorCheckStatus(StrEnum):
+    """Outcome of a single doctor check.
+
+    Attributes:
+        OK: The condition holds; nothing to do.
+        WARNING: Degraded but usable — an outdated binary, a config
+            inconsistency, a credential that could not be probed.
+        ERROR: Something an operator must fix before the affected feature
+            works at all.
+        SKIPPED: The check does not apply to this environment (an optional
+            extra that is not installed, AI checks with no AI feature
+            enabled). Never counts against health.
+    """
+
+    OK = auto()
+    WARNING = auto()
+    ERROR = auto()
+    SKIPPED = auto()
+
+
+class DoctorCheckCategory(StrEnum):
+    """Which part of the environment a doctor check covers.
+
+    Attributes:
+        CONFIG: Workspace configuration loading and consistency.
+        TOOLS: External tool binaries.
+        AI: AI provider availability and authentication.
+        EXTRAS: Optional lintro extras such as ``lintro[mcp]``.
+    """
+
+    CONFIG = auto()
+    TOOLS = auto()
+    AI = auto()
+    EXTRAS = auto()
+
+
+class DoctorHealth(StrEnum):
+    """Overall verdict for a doctor report.
+
+    Attributes:
+        HEALTHY: Every applicable check passed.
+        DEGRADED: At least one check reported a warning or an error. A single
+            vocabulary covers both, because the actionable question an agent
+            asks is "can I trust this environment as-is", and the per-check
+            statuses already carry the severity.
+    """
+
+    HEALTHY = auto()
+    DEGRADED = auto()
+
+
+#: How a tool/AI :class:`ToolStatus` projects onto a doctor check status.
+_STATUS_PROJECTION: Final[dict[ToolStatus, DoctorCheckStatus]] = {
+    ToolStatus.OK: DoctorCheckStatus.OK,
+    ToolStatus.MISSING: DoctorCheckStatus.ERROR,
+    ToolStatus.INCOMPATIBLE: DoctorCheckStatus.ERROR,
+    ToolStatus.OUTDATED: DoctorCheckStatus.WARNING,
+    # "Ran, but lintro could not read a version out of it" is not proof of a
+    # broken environment, so it must not read as one.
+    ToolStatus.UNKNOWN: DoctorCheckStatus.WARNING,
+    ToolStatus.DISABLED: DoctorCheckStatus.SKIPPED,
+}
+
+
+@dataclass(frozen=True)
+class DoctorCheck:
+    """One actionable statement about the environment's health.
+
+    Attributes:
+        check: Stable machine-readable identifier (``tools.missing``,
+            ``ai.cli.claude``). Agents branch on this, so renaming one is a
+            breaking change.
+        status: The outcome.
+        detail: Human-readable description of what was found.
+        remediation: The command or config change that resolves it. Empty when
+            the check passed or nothing can be done.
+        category: Which part of the environment the check covers.
+    """
+
+    check: str
+    status: DoctorCheckStatus
+    detail: str
+    remediation: str = ""
+    category: DoctorCheckCategory = DoctorCheckCategory.TOOLS
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the check to a JSON-compatible dict.
+
+        Returns:
+            dict[str, Any]: The check's wire representation.
+        """
+        return {
+            "check": self.check,
+            "status": self.status.value,
+            "detail": self.detail,
+            "remediation": self.remediation,
+            "category": self.category.value,
+        }
+
+
+@dataclass(frozen=True)
+class DoctorReport:
+    """A full environment health report.
+
+    Attributes:
+        checks: Every check that was run, in report order.
+    """
+
+    checks: tuple[DoctorCheck, ...]
+
+    @property
+    def health(self) -> DoctorHealth:
+        """Return the overall verdict.
+
+        Returns:
+            DoctorHealth: ``DEGRADED`` when any check warned or errored.
+        """
+        degraded = (DoctorCheckStatus.WARNING, DoctorCheckStatus.ERROR)
+        if any(check.status in degraded for check in self.checks):
+            return DoctorHealth.DEGRADED
+        return DoctorHealth.HEALTHY
+
+    def summary(self) -> dict[str, int]:
+        """Count the checks by status.
+
+        Returns:
+            dict[str, int]: One count per :class:`DoctorCheckStatus` member,
+            plus ``total``.
+        """
+        counts = {
+            status.value: sum(1 for c in self.checks if c.status is status)
+            for status in DoctorCheckStatus
+        }
+        counts["total"] = len(self.checks)
+        return counts
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the report to a JSON-compatible dict.
+
+        Returns:
+            dict[str, Any]: Mapping with ``health``, ``checks``, ``summary``.
+        """
+        return {
+            "health": self.health.value,
+            "checks": [check.to_dict() for check in self.checks],
+            "summary": self.summary(),
+        }
+
+
+def _config_checks() -> tuple[LintroConfig | None, list[DoctorCheck]]:
+    """Load the workspace config and report on it.
+
+    Returns:
+        tuple: The loaded config (``None`` when loading failed) and its checks.
+    """
+    from lintro.config.config_loader import get_config
+    from lintro.utils.config_validation import validate_config_consistency
+
+    try:
+        config = get_config(reload=True)
+    except (
+        Exception
+    ) as exc:  # noqa: BLE001 - any parse failure is a report line, not a crash
+        return None, [
+            DoctorCheck(
+                category=DoctorCheckCategory.CONFIG,
+                check="config.load",
+                status=DoctorCheckStatus.ERROR,
+                detail=f"Configuration could not be loaded: {exc}",
+                remediation=(
+                    "Fix the syntax of .lintro-config.yaml (or [tool.lintro] "
+                    "in pyproject.toml), then re-run lintro doctor"
+                ),
+            ),
+        ]
+
+    source = config.config_path or "built-in defaults (no config file found)"
+    checks = [
+        DoctorCheck(
+            category=DoctorCheckCategory.CONFIG,
+            check="config.load",
+            status=DoctorCheckStatus.OK,
+            detail=f"Configuration loaded from {source}",
+        ),
+    ]
+
+    try:
+        warnings = validate_config_consistency()
+    except (
+        Exception
+    ) as exc:  # noqa: BLE001 - a broken native config must not abort the report
+        warnings = [f"consistency check failed: {exc}"]
+
+    if warnings:
+        checks.append(
+            DoctorCheck(
+                category=DoctorCheckCategory.CONFIG,
+                check="config.consistency",
+                status=DoctorCheckStatus.WARNING,
+                detail="; ".join(warnings),
+                remediation=(
+                    "Align the native tool configs with lintro's line_length, "
+                    "or run lintro config to inspect the effective settings"
+                ),
+            ),
+        )
+    else:
+        checks.append(
+            DoctorCheck(
+                category=DoctorCheckCategory.CONFIG,
+                check="config.consistency",
+                status=DoctorCheckStatus.OK,
+                detail="No conflicting settings between lintro and native configs",
+            ),
+        )
+    return config, checks
+
+
+def _tool_checks(*, config: LintroConfig | None) -> list[DoctorCheck]:
+    """Probe every enabled tool and fold the results into two checks.
+
+    One record per tool would put ~40 near-duplicate entries in front of an
+    agent that already has ``lintro_list_tools`` for the per-tool view. What
+    the report adds is the verdict: is anything missing, is anything too old.
+
+    Args:
+        config: Workspace config, or ``None`` when it failed to load.
+
+    Returns:
+        list[DoctorCheck]: The ``tools.missing`` and ``tools.versions`` checks.
+    """
+    from lintro.tools.core.install_context import RuntimeContext
+
+    registry = ManifestRegistry.load()
+    results = collect_tool_checks(
+        registry=registry,
+        context=RuntimeContext.detect(),
+        config=config,
+    )
+    # Dev-tier tools are optional by construction; the CLI already excludes
+    # them from its failure counts and the report must agree.
+    production = [
+        result
+        for result in results
+        if result.tool.tier != "dev" and result.status is not ToolStatus.DISABLED
+    ]
+    missing = [r for r in production if r.status is ToolStatus.MISSING]
+    stale = [
+        r
+        for r in production
+        if r.status in (ToolStatus.OUTDATED, ToolStatus.INCOMPATIBLE)
+    ]
+    unreadable = [r for r in production if r.status is ToolStatus.UNKNOWN]
+
+    checks: list[DoctorCheck] = []
+    if missing:
+        names = sorted(r.tool.name for r in missing)
+        checks.append(
+            DoctorCheck(
+                category=DoctorCheckCategory.TOOLS,
+                check="tools.missing",
+                status=DoctorCheckStatus.ERROR,
+                detail=f"{len(names)} enabled tool(s) not installed: "
+                + ", ".join(names),
+                remediation=f"lintro install {' '.join(names)}",
+            ),
+        )
+    else:
+        checks.append(
+            DoctorCheck(
+                category=DoctorCheckCategory.TOOLS,
+                check="tools.missing",
+                status=DoctorCheckStatus.OK,
+                detail=f"All {len(production)} enabled tool(s) are installed",
+            ),
+        )
+
+    if stale or unreadable:
+        names = sorted(r.tool.name for r in stale)
+        unknown_names = sorted(r.tool.name for r in unreadable)
+        parts: list[str] = []
+        if names:
+            parts.append("outdated: " + ", ".join(names))
+        if unknown_names:
+            parts.append("version unreadable: " + ", ".join(unknown_names))
+        checks.append(
+            DoctorCheck(
+                category=DoctorCheckCategory.TOOLS,
+                check="tools.versions",
+                status=DoctorCheckStatus.WARNING,
+                detail="; ".join(parts),
+                remediation=(
+                    f"lintro install --upgrade {' '.join(names)}"
+                    if names
+                    else "Run the tool manually to see what it reports"
+                ),
+            ),
+        )
+    else:
+        checks.append(
+            DoctorCheck(
+                category=DoctorCheckCategory.TOOLS,
+                check="tools.versions",
+                status=DoctorCheckStatus.OK,
+                detail="Every installed tool meets its minimum version",
+            ),
+        )
+    return checks
+
+
+def _ai_checks(*, config: LintroConfig | None) -> list[DoctorCheck]:
+    """Report AI provider availability and authentication.
+
+    Args:
+        config: Workspace config, or ``None`` when it failed to load.
+
+    Returns:
+        list[DoctorCheck]: One check per AI probe, or a single skipped record
+        when no AI feature is enabled or the ``[ai]`` extra is absent.
+    """
+    skipped = DoctorCheck(
+        category=DoctorCheckCategory.AI,
+        check="ai.provider",
+        status=DoctorCheckStatus.SKIPPED,
+        detail="No AI feature is enabled (ai.lint / ai.review)",
+        remediation="Enable ai.review and set ai.transport in the workspace config",
+    )
+    if config is None:
+        return [
+            DoctorCheck(
+                category=DoctorCheckCategory.AI,
+                check="ai.provider",
+                status=DoctorCheckStatus.SKIPPED,
+                detail="Configuration could not be loaded, so AI was not checked",
+                remediation="Fix the configuration first",
+            ),
+        ]
+
+    try:
+        from lintro.ai.doctor_checks import check_ai_configuration
+        from lintro.ai.interface import resolve_ai_config
+    except ImportError as exc:
+        return [
+            DoctorCheck(
+                category=DoctorCheckCategory.AI,
+                check="ai.extra",
+                status=DoctorCheckStatus.SKIPPED,
+                detail=f"AI support is not installed: {exc}",
+                remediation="uv pip install 'lintro[ai]'",
+            ),
+        ]
+
+    results = check_ai_configuration(resolve_ai_config(config))
+    if not results:
+        return [skipped]
+    return [
+        DoctorCheck(
+            category=DoctorCheckCategory.AI,
+            check=result.name,
+            status=_STATUS_PROJECTION.get(result.status, DoctorCheckStatus.WARNING),
+            detail=result.message,
+            remediation=result.hint,
+        )
+        for result in results
+    ]
+
+
+def _extras_checks() -> list[DoctorCheck]:
+    """Report availability of lintro's optional extras.
+
+    Returns:
+        list[DoctorCheck]: The ``extras.mcp`` check. Never an error: the MCP
+        SDK being absent is a fact about the install, not a fault.
+    """
+    info = mcp_extra_status()
+    installed = info["status"] == ToolStatus.OK.value
+    return [
+        DoctorCheck(
+            category=DoctorCheckCategory.EXTRAS,
+            check="extras.mcp",
+            status=(DoctorCheckStatus.OK if installed else DoctorCheckStatus.SKIPPED),
+            detail=info["message"],
+            remediation=info["hint"],
+        ),
+    ]
+
+
+def collect_doctor_report() -> DoctorReport:
+    """Run every doctor check against the current working directory.
+
+    The workspace is the process cwd, the same anchor ``lintro doctor`` uses:
+    the config file, native tool configs, and ``PATH`` are all resolved from
+    there. Callers that need a different root (the MCP server) chdir first.
+
+    Returns:
+        DoctorReport: Config, tool, AI, and extras checks.
+    """
+    config, checks = _config_checks()
+    checks.extend(_tool_checks(config=config))
+    checks.extend(_ai_checks(config=config))
+    checks.extend(_extras_checks())
+    return DoctorReport(checks=tuple(checks))

--- a/tests/unit/cli_utils/commands/test_doctor_command.py
+++ b/tests/unit/cli_utils/commands/test_doctor_command.py
@@ -3,22 +3,16 @@
 from __future__ import annotations
 
 import json
-import subprocess  # nosec B404 - subprocess is used to drive the tool/CLI under test; invocations use shell=False
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-import pytest
 from assertpy import assert_that
 from click.testing import CliRunner
 from loguru import logger
 
 from lintro.ai.config import AIConfig
 from lintro.cli_utils.commands.doctor import (
-    ToolCheckResult,
-    _check_tool,
-    _compare_versions,
     _generate_markdown_report,
-    _mcp_extra_status,
     _output_json,
     doctor_command,
 )
@@ -28,6 +22,7 @@ from lintro.enums.tool_status import ToolStatus
 from lintro.tools.core.install_context import RuntimeContext
 from lintro.tools.core.install_strategies.environment import InstallEnvironment
 from lintro.tools.core.tool_registry import ManifestTool
+from lintro.utils.doctor_report import ToolCheckResult
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -80,206 +75,6 @@ def _make_context(*, has_brew: bool = False) -> RuntimeContext:
         ),
         is_ci=False,
     )
-
-
-# ── _compare_versions ────────────────────────────────────────────────
-
-
-@pytest.mark.parametrize(
-    ("installed", "expected", "want"),
-    [
-        ("1.2.3", "1.0.0", ToolStatus.OK),
-        ("1.0.0", "1.0.0", ToolStatus.OK),
-        ("1.0.0", "1.2.0", ToolStatus.OUTDATED),
-        ("0.14.0", "0.15.0", ToolStatus.OUTDATED),
-        ("0.0.1", "2.0.0", ToolStatus.INCOMPATIBLE),
-        ("invalid", "1.0.0", ToolStatus.UNKNOWN),
-    ],
-    ids=["above", "equal", "below", "minor_below", "incompatible", "invalid"],
-)
-def test_compare_versions(installed: str, expected: str, want: ToolStatus) -> None:
-    """Compare two version strings and return the correct ToolStatus."""
-    minimum = expected if want == ToolStatus.INCOMPATIBLE else "0.0.0"
-    assert_that(_compare_versions(installed, expected, minimum)).is_equal_to(want)
-
-
-# ── _check_tool ──────────────────────────────────────────────────────
-
-
-def test_check_tool_ok() -> None:
-    """Tool found in PATH with version meeting minimum."""
-    tool = _make_tool(version="0.14.0")
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch("subprocess.run") as mock_run,
-    ):
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="ruff 0.14.4",
-            stderr="",
-        )
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.OK)
-    assert_that(result.installed_version).is_equal_to("0.14.4")
-    assert_that(result.path).is_equal_to("/usr/bin/ruff")
-
-
-def test_check_tool_outdated() -> None:
-    """Tool found but version below recommended."""
-    tool = _make_tool(version="1.0.0", min_version="0.3.0")
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch("subprocess.run") as mock_run,
-    ):
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="ruff 0.5.0",
-            stderr="",
-        )
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
-    assert_that(result.installed_version).is_equal_to("0.5.0")
-
-
-def test_check_tool_incompatible() -> None:
-    """Tool found but version below hard minimum."""
-    tool = _make_tool(version="1.0.0", min_version="1.0.0")
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch("subprocess.run") as mock_run,
-    ):
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="ruff 0.5.0",
-            stderr="",
-        )
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.INCOMPATIBLE)
-
-
-def test_check_tool_missing_not_in_path() -> None:
-    """Tool executable not found in PATH."""
-    tool = _make_tool()
-    ctx = _make_context()
-
-    with patch("shutil.which", return_value=None):
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
-    assert_that(result.error).is_equal_to("not_in_path")
-
-
-def test_check_tool_missing_command_failed() -> None:
-    """Tool found but version command exits non-zero."""
-    tool = _make_tool()
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch("subprocess.run") as mock_run,
-    ):
-        mock_run.return_value = MagicMock(
-            returncode=1,
-            stdout="",
-            stderr="error",
-        )
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
-    assert_that(result.error).is_equal_to("command_failed")
-
-
-def test_check_tool_missing_timeout() -> None:
-    """Tool version command times out."""
-    tool = _make_tool()
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch(
-            "subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd=["ruff"], timeout=10),
-        ),
-    ):
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
-    assert_that(result.error).is_equal_to("timeout")
-
-
-def test_check_tool_missing_os_error() -> None:
-    """Tool version command raises OSError."""
-    tool = _make_tool()
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch("subprocess.run", side_effect=OSError("exec format error")),
-    ):
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
-    assert_that(result.error).is_equal_to("os_error")
-
-
-def test_check_tool_unknown_no_version() -> None:
-    """Tool runs but output has no parseable version."""
-    tool = _make_tool()
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch("subprocess.run") as mock_run,
-    ):
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="no version here",
-            stderr="",
-        )
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.UNKNOWN)
-    assert_that(result.error).is_equal_to("no_version")
-
-
-def test_check_tool_no_version_command() -> None:
-    """Tool has no version_command defined."""
-    tool = _make_tool(version_command=())
-    ctx = _make_context()
-
-    result = _check_tool(tool, ctx)
-
-    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
-    assert_that(result.error).is_equal_to("no_command")
-
-
-def test_check_tool_upgrade_hint_populated() -> None:
-    """Both install_hint and upgrade_hint are populated."""
-    tool = _make_tool()
-    ctx = _make_context()
-
-    with (
-        patch("shutil.which", return_value="/usr/bin/ruff"),
-        patch("subprocess.run") as mock_run,
-    ):
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="ruff 0.14.4",
-            stderr="",
-        )
-        result = _check_tool(tool, ctx)
-
-    assert_that(result.install_hint).is_not_empty()
-    assert_that(result.upgrade_hint).is_not_empty()
 
 
 # ── _output_json ─────────────────────────────────────────────────────
@@ -589,28 +384,6 @@ def test_doctor_resolves_ai_checks_from_a_raw_ai_mapping() -> None:
     assert_that("".join(messages)).contains(
         "Unknown AI config keys ignored: provdier",
     )
-
-
-# ── optional MCP extra ───────────────────────────────────────────────
-
-
-def test_mcp_extra_status_reports_installed() -> None:
-    """The MCP extra is reported OK when the SDK imports."""
-    with patch("lintro.mcp.is_mcp_available", return_value=True):
-        info = _mcp_extra_status()
-
-    assert_that(info["name"]).is_equal_to("mcp")
-    assert_that(info["status"]).is_equal_to(ToolStatus.OK.value)
-    assert_that(info["hint"]).contains("lintro mcp")
-
-
-def test_mcp_extra_status_reports_missing_without_failing() -> None:
-    """A missing MCP extra is DISABLED (informational), never an error."""
-    with patch("lintro.mcp.is_mcp_available", return_value=False):
-        info = _mcp_extra_status()
-
-    assert_that(info["status"]).is_equal_to(ToolStatus.DISABLED.value)
-    assert_that(info["hint"]).contains("lintro[mcp]")
 
 
 def test_output_json_includes_optional_extras() -> None:

--- a/tests/unit/mcp/test_toolkit_introspection.py
+++ b/tests/unit/mcp/test_toolkit_introspection.py
@@ -1,0 +1,387 @@
+"""End-to-end tests for the introspection MCP tools.
+
+Every test drives a real :class:`mcp.ClientSession` over in-memory streams
+against the same ``Server`` object the stdio transport serves, so the payloads
+asserted here are the bytes an agent receives.
+
+The binary probes are stubbed rather than run: this suite is about what the
+tools *report*, and probing forty external binaries per test would trade
+seconds of runtime for an assertion about the developer's machine. The probes
+themselves are covered in ``tests/unit/utils/test_doctor_report.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+import pytest
+from assertpy import assert_that
+from mcp import ClientSession, types
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from lintro.enums.tool_status import ToolStatus
+from lintro.mcp.server import create_mcp_server
+from lintro.tools.core.tool_registry import ManifestTool
+from lintro.tools.core.version_parsing import ToolVersionInfo
+from lintro.utils import doctor_report
+from lintro.utils.doctor_report import ToolCheckResult
+
+_T = TypeVar("_T")
+
+
+def _run_session(
+    *,
+    workspace: Path,
+    check: Callable[[ClientSession], Awaitable[_T]],
+) -> _T:
+    """Run ``check`` against a connected in-memory MCP client session.
+
+    Args:
+        workspace: Workspace root for the server under test.
+        check: Async callback receiving an initialized client session.
+
+    Returns:
+        Whatever ``check`` returns.
+    """
+    server = create_mcp_server(workspace=workspace)
+
+    async def _main() -> _T:
+        async with create_connected_server_and_client_session(server) as session:
+            return await check(session)
+
+    return asyncio.run(_main())
+
+
+def _payload(result: types.CallToolResult) -> dict[str, Any]:
+    """Extract a tool result payload as a dict.
+
+    Args:
+        result: The ``CallToolResult`` returned by ``session.call_tool``.
+
+    Returns:
+        The payload the server sent.
+    """
+    if result.structuredContent:
+        return dict(result.structuredContent)
+    block = result.content[0]
+    assert isinstance(block, types.TextContent)
+    return dict(json.loads(block.text))
+
+
+def _call(*, workspace: Path, tool: str) -> dict[str, Any]:
+    """Call one argument-less introspection tool and decode its payload.
+
+    Args:
+        workspace: Workspace root for the server under test.
+        tool: Tool name to call.
+
+    Returns:
+        The decoded payload.
+    """
+
+    async def _check(session: ClientSession) -> dict[str, Any]:
+        return _payload(await session.call_tool(tool, {}))
+
+    return _run_session(workspace=workspace, check=_check)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """Create a throwaway workspace root.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+
+    Returns:
+        Path: The resolved workspace root.
+    """
+    return tmp_path.resolve()
+
+
+@pytest.fixture
+def stub_probes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Report every manifest tool as installed and current.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        doctor_report,
+        "check_tool",
+        lambda *, tool, context: ToolCheckResult(
+            tool=tool,
+            status=ToolStatus.OK,
+            installed_version=tool.version,
+            path=f"/usr/local/bin/{tool.name}",
+        ),
+    )
+
+
+def test_introspection_tools_are_advertised_as_read_only_and_idempotent(
+    workspace: Path,
+) -> None:
+    """The annotations tell a host these three calls are always safe to make."""
+
+    async def _check(session: ClientSession) -> dict[str, types.Tool]:
+        listed = await session.list_tools()
+        return {tool.name: tool for tool in listed.tools}
+
+    tools = _run_session(workspace=workspace, check=_check)
+
+    assert_that(tools).contains_key(
+        "lintro_list_tools",
+        "lintro_versions",
+        "lintro_doctor",
+    )
+    for name in ("lintro_list_tools", "lintro_versions", "lintro_doctor"):
+        annotations = tools[name].annotations
+        assert annotations is not None
+        assert_that(annotations.readOnlyHint).is_true()
+        assert_that(annotations.destructiveHint).is_false()
+        assert_that(annotations.idempotentHint).is_true()
+
+
+@pytest.mark.usefixtures("stub_probes")
+def test_list_tools_reports_a_complete_entry_for_every_tool(
+    workspace: Path,
+) -> None:
+    """Each entry carries the fields an agent needs to plan a call."""
+    payload = _call(workspace=workspace, tool="lintro_list_tools")
+
+    assert_that(payload["tools"]).is_not_empty()
+    for entry in payload["tools"]:
+        assert_that(entry).contains_key(
+            "name",
+            "description",
+            "types",
+            "languages",
+            "installed",
+            "version",
+            "expected_version",
+            "can_fix",
+            "capabilities",
+            "execution_class",
+            "profile_membership",
+        )
+    assert_that(payload["summary"]["total"]).is_equal_to(len(payload["tools"]))
+
+
+@pytest.mark.usefixtures("stub_probes")
+def test_list_tools_describes_ruff_as_a_fixing_deterministic_linter(
+    workspace: Path,
+) -> None:
+    """A tool that is both linter and formatter reports both types."""
+    payload = _call(workspace=workspace, tool="lintro_list_tools")
+
+    ruff = next(entry for entry in payload["tools"] if entry["name"] == "ruff")
+    assert_that(ruff["types"]).contains("linter", "formatter")
+    assert_that(ruff["languages"]).contains("python")
+    assert_that(ruff["can_fix"]).is_true()
+    assert_that(ruff["capabilities"]).contains("check", "fix")
+    assert_that(ruff["execution_class"]).is_equal_to("deterministic")
+    assert_that(ruff["installed"]).is_true()
+
+
+@pytest.mark.usefixtures("stub_probes")
+def test_list_tools_marks_advisory_finders_so_they_are_not_called_as_linters(
+    workspace: Path,
+) -> None:
+    """An AI finder runs under ``lintro_review``, never under ``lintro_check``."""
+    payload = _call(workspace=workspace, tool="lintro_list_tools")
+
+    finders = [
+        entry for entry in payload["tools"] if entry["execution_class"] == "advisory"
+    ]
+    assert_that(finders).is_not_empty()
+    for finder in finders:
+        assert_that(finder["capabilities"]).is_equal_to(["review"])
+
+
+@pytest.mark.usefixtures("stub_probes")
+def test_list_tools_reports_static_profile_membership(workspace: Path) -> None:
+    """Profiles whose membership is fixed by the manifest are attributed."""
+    payload = _call(workspace=workspace, tool="lintro_list_tools")
+
+    ruff = next(entry for entry in payload["tools"] if entry["name"] == "ruff")
+    assert_that(ruff["profile_membership"]).contains("minimal", "complete")
+
+    profiles = {profile["name"]: profile for profile in payload["profiles"]}
+    assert_that(profiles["complete"]["resolution"]).is_equal_to("static")
+    # "recommended" resolves against detected languages, so membership in it is
+    # a property of a workspace and is deliberately not claimed per tool.
+    assert_that(profiles["recommended"]["resolution"]).is_equal_to("workspace")
+    for entry in payload["tools"]:
+        assert_that(entry["profile_membership"]).does_not_contain("recommended")
+
+
+def test_list_tools_keeps_missing_binaries_visible(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool that is not installed is listed with installed=false, not dropped."""
+
+    def _probe(*, tool: ManifestTool, context: Any) -> ToolCheckResult:
+        if tool.name == "hadolint":
+            return ToolCheckResult(
+                tool=tool,
+                status=ToolStatus.MISSING,
+                error="not_in_path",
+                install_hint="brew install hadolint",
+            )
+        return ToolCheckResult(
+            tool=tool,
+            status=ToolStatus.OK,
+            installed_version=tool.version,
+        )
+
+    monkeypatch.setattr(doctor_report, "check_tool", _probe)
+
+    payload = _call(workspace=workspace, tool="lintro_list_tools")
+
+    hadolint = next(entry for entry in payload["tools"] if entry["name"] == "hadolint")
+    assert_that(hadolint["installed"]).is_false()
+    assert_that(hadolint["version"]).is_none()
+    assert_that(hadolint["status"]).is_equal_to("missing")
+    assert_that(hadolint["install_hint"]).is_equal_to("brew install hadolint")
+    assert_that(payload["summary"]["missing"]).is_greater_than_or_equal_to(1)
+
+
+def test_versions_reports_installed_against_expected(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A version below the minimum is reported as outdated, not as a failure."""
+    monkeypatch.setattr(
+        "lintro.tools.core.version_requirements.get_all_tool_versions",
+        lambda: {
+            "ruff": ToolVersionInfo(
+                name="ruff",
+                min_version="0.15.9",
+                recommended_version="0.15.9",
+                install_hint="uv pip install ruff",
+                current_version="0.9.0",
+                version_check_passed=False,
+                error_message="Version 0.9.0 is below minimum requirement 0.15.9",
+            ),
+            "hadolint": ToolVersionInfo(
+                name="hadolint",
+                min_version="2.14.0",
+                recommended_version="2.14.0",
+                install_hint="brew install hadolint",
+                error_message="Command failed: hadolint --version",
+            ),
+            "black": ToolVersionInfo(
+                name="black",
+                min_version="26.1.0",
+                recommended_version="26.1.0",
+                install_hint="uv pip install black",
+                current_version="26.1.0",
+                version_check_passed=True,
+            ),
+        },
+    )
+
+    payload = _call(workspace=workspace, tool="lintro_versions")
+
+    entries = {entry["name"]: entry for entry in payload["tools"]}
+    assert_that(entries["ruff"]["status"]).is_equal_to("outdated")
+    assert_that(entries["ruff"]["installed_version"]).is_equal_to("0.9.0")
+    assert_that(entries["ruff"]["minimum_version"]).is_equal_to("0.15.9")
+    assert_that(entries["ruff"]["satisfies_minimum"]).is_false()
+    assert_that(entries["hadolint"]["status"]).is_equal_to("missing")
+    assert_that(entries["hadolint"]["installed_version"]).is_none()
+    assert_that(entries["hadolint"]["install_hint"]).is_equal_to(
+        "brew install hadolint",
+    )
+    assert_that(entries["black"]["status"]).is_equal_to("ok")
+    assert_that(payload["summary"]).is_equal_to(
+        {"outdated": 1, "missing": 1, "ok": 1, "total": 3},
+    )
+
+
+def test_doctor_reports_a_healthy_environment(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With everything in place the report is healthy and still lists its checks."""
+    monkeypatch.setattr(
+        doctor_report,
+        "collect_tool_checks",
+        lambda **_kwargs: [
+            ToolCheckResult(
+                tool=ManifestTool(
+                    name="ruff",
+                    version="1.0.0",
+                    min_version="1.0.0",
+                    install_type="pip",
+                    tier="tools",
+                    category="bundled",
+                    version_command=("ruff", "--version"),
+                ),
+                status=ToolStatus.OK,
+                installed_version="1.0.0",
+            ),
+        ],
+    )
+
+    payload = _call(workspace=workspace, tool="lintro_doctor")
+
+    assert_that(payload["health"]).is_equal_to("healthy")
+    checks = {check["check"]: check for check in payload["checks"]}
+    assert_that(checks).contains_key(
+        "config.load",
+        "config.consistency",
+        "tools.missing",
+        "tools.versions",
+        "extras.mcp",
+    )
+    for check in payload["checks"]:
+        assert_that(check).contains_key(
+            "check",
+            "status",
+            "detail",
+            "remediation",
+        )
+    assert_that(payload["summary"]["error"]).is_equal_to(0)
+
+
+def test_doctor_reports_a_degraded_environment_with_remediation(
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing binary degrades the report and names the command that fixes it."""
+    monkeypatch.setattr(
+        doctor_report,
+        "collect_tool_checks",
+        lambda **_kwargs: [
+            ToolCheckResult(
+                tool=ManifestTool(
+                    name="hadolint",
+                    version="2.14.0",
+                    min_version="2.14.0",
+                    install_type="binary",
+                    tier="tools",
+                    category="external",
+                    version_command=("hadolint", "--version"),
+                ),
+                status=ToolStatus.MISSING,
+                error="not_in_path",
+                install_hint="brew install hadolint",
+            ),
+        ],
+    )
+
+    payload = _call(workspace=workspace, tool="lintro_doctor")
+
+    assert_that(payload["health"]).is_equal_to("degraded")
+    missing = next(
+        check for check in payload["checks"] if check["check"] == "tools.missing"
+    )
+    assert_that(missing["status"]).is_equal_to("error")
+    assert_that(missing["detail"]).contains("hadolint")
+    assert_that(missing["remediation"]).is_equal_to("lintro install hadolint")
+    assert_that(payload["summary"]["error"]).is_greater_than_or_equal_to(1)

--- a/tests/unit/mcp/test_toolkit_introspection.py
+++ b/tests/unit/mcp/test_toolkit_introspection.py
@@ -23,6 +23,7 @@ from assertpy import assert_that
 from mcp import ClientSession, types
 from mcp.shared.memory import create_connected_server_and_client_session
 
+from lintro.config.lintro_config import LintroConfig
 from lintro.enums.tool_status import ToolStatus
 from lintro.mcp.registry import DEFAULT_TOOL_TIMEOUT_SECONDS
 from lintro.mcp.server import create_mcp_server
@@ -123,6 +124,28 @@ def stub_probes(monkeypatch: pytest.MonkeyPatch) -> None:
             installed_version=tool.version,
             path=f"/usr/local/bin/{tool.name}",
         ),
+    )
+
+
+@pytest.fixture
+def stub_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the doctor report's config and AI inputs.
+
+    The workspace session anchors cwd at a throwaway directory, but config
+    discovery searches upward from there, so an inherited ``.lintro-config.yaml``
+    could add consistency warnings or enable AI checks that report missing
+    credentials — and turn a healthy report degraded on someone else's machine.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        "lintro.config.config_loader.get_config",
+        lambda reload=False: LintroConfig(),
+    )
+    monkeypatch.setattr(
+        "lintro.ai.doctor_checks.check_ai_configuration",
+        lambda _config: [],
     )
 
 
@@ -275,7 +298,7 @@ def test_versions_reports_installed_against_expected(
     workspace: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A version below the minimum is reported as outdated, not as a failure."""
+    """A version below the minimum is reported as data, not as a failure."""
     monkeypatch.setattr(
         "lintro.tools.core.version_requirements.get_all_tool_versions",
         lambda: {
@@ -303,13 +326,22 @@ def test_versions_reports_installed_against_expected(
                 current_version="26.1.0",
                 version_check_passed=True,
             ),
+            "yamllint": ToolVersionInfo(
+                name="yamllint",
+                min_version="1.40.0",
+                recommended_version="1.42.0",
+                install_hint="uv pip install yamllint",
+                current_version="1.41.0",
+                version_check_passed=True,
+                below_recommended=True,
+            ),
         },
     )
 
     payload = _call(workspace=workspace, tool="lintro_versions")
 
     entries = {entry["name"]: entry for entry in payload["tools"]}
-    assert_that(entries["ruff"]["status"]).is_equal_to("outdated")
+    assert_that(entries["ruff"]["status"]).is_equal_to("incompatible")
     assert_that(entries["ruff"]["installed_version"]).is_equal_to("0.9.0")
     assert_that(entries["ruff"]["minimum_version"]).is_equal_to("0.15.9")
     assert_that(entries["ruff"]["satisfies_minimum"]).is_false()
@@ -319,11 +351,16 @@ def test_versions_reports_installed_against_expected(
         "brew install hadolint",
     )
     assert_that(entries["black"]["status"]).is_equal_to("ok")
+    # Clears the minimum but trails the recommended version: the milder band,
+    # and the same label lintro_list_tools would report for it.
+    assert_that(entries["yamllint"]["status"]).is_equal_to("outdated")
+    assert_that(entries["yamllint"]["satisfies_minimum"]).is_true()
     assert_that(payload["summary"]).is_equal_to(
-        {"outdated": 1, "missing": 1, "ok": 1, "total": 3},
+        {"incompatible": 1, "missing": 1, "ok": 1, "outdated": 1, "total": 4},
     )
 
 
+@pytest.mark.usefixtures("stub_environment")
 def test_doctor_reports_a_healthy_environment(
     workspace: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/mcp/test_toolkit_introspection.py
+++ b/tests/unit/mcp/test_toolkit_introspection.py
@@ -24,7 +24,12 @@ from mcp import ClientSession, types
 from mcp.shared.memory import create_connected_server_and_client_session
 
 from lintro.enums.tool_status import ToolStatus
+from lintro.mcp.registry import DEFAULT_TOOL_TIMEOUT_SECONDS
 from lintro.mcp.server import create_mcp_server
+from lintro.mcp.toolkits.introspection import (
+    INTROSPECTION_TIMEOUT_SECONDS,
+    build_introspection_toolkit,
+)
 from lintro.tools.core.tool_registry import ManifestTool
 from lintro.tools.core.version_parsing import ToolVersionInfo
 from lintro.utils import doctor_report
@@ -145,6 +150,18 @@ def test_introspection_tools_are_advertised_as_read_only_and_idempotent(
         assert_that(annotations.idempotentHint).is_true()
 
 
+def test_introspection_tools_budget_for_probing_every_binary() -> None:
+    """The default 300s budget is short of a full manifest of slow probes."""
+    specs = build_introspection_toolkit(workspace=Path.cwd())
+
+    assert_that([spec.name for spec in specs]).is_length(3)
+    for spec in specs:
+        assert_that(spec.timeout_seconds).is_equal_to(INTROSPECTION_TIMEOUT_SECONDS)
+        assert_that(spec.timeout_seconds).is_greater_than(
+            DEFAULT_TOOL_TIMEOUT_SECONDS,
+        )
+
+
 @pytest.mark.usefixtures("stub_probes")
 def test_list_tools_reports_a_complete_entry_for_every_tool(
     workspace: Path,
@@ -184,6 +201,10 @@ def test_list_tools_describes_ruff_as_a_fixing_deterministic_linter(
     assert_that(ruff["capabilities"]).contains("check", "fix")
     assert_that(ruff["execution_class"]).is_equal_to("deterministic")
     assert_that(ruff["installed"]).is_true()
+    assert_that(ruff["status"]).is_equal_to("ok")
+    assert_that(ruff["origin"]).is_equal_to("builtin")
+    assert_that(ruff["version"]).is_equal_to(ruff["expected_version"])
+    assert_that(ruff["minimum_version"]).is_not_none()
 
 
 @pytest.mark.usefixtures("stub_probes")
@@ -345,6 +366,7 @@ def test_doctor_reports_a_healthy_environment(
             "status",
             "detail",
             "remediation",
+            "category",
         )
     assert_that(payload["summary"]["error"]).is_equal_to(0)
 

--- a/tests/unit/utils/test_doctor_report.py
+++ b/tests/unit/utils/test_doctor_report.py
@@ -151,24 +151,37 @@ def test_installed_follows_whether_the_binary_can_run(
 
 
 @pytest.mark.parametrize(
-    ("installed", "expected"),
+    ("installed", "recommended", "minimum", "expected"),
     [
-        ("1.2.3", ToolStatus.OK),
-        ("2.0.0", ToolStatus.OK),
-        ("1.1.0", ToolStatus.OUTDATED),
-        ("0.9.0", ToolStatus.INCOMPATIBLE),
-        ("not-a-version", ToolStatus.UNKNOWN),
+        ("1.2.3", "1.2.3", "1.0.0", ToolStatus.OK),
+        ("2.0.0", "1.2.3", "1.0.0", ToolStatus.OK),
+        ("1.1.0", "1.2.3", "1.0.0", ToolStatus.OUTDATED),
+        ("0.14.0", "0.15.0", "0.0.0", ToolStatus.OUTDATED),
+        ("0.9.0", "1.2.3", "1.0.0", ToolStatus.INCOMPATIBLE),
+        ("0.0.1", "2.0.0", "2.0.0", ToolStatus.INCOMPATIBLE),
+        ("not-a-version", "1.2.3", "1.0.0", ToolStatus.UNKNOWN),
+    ],
+    ids=[
+        "equal",
+        "above",
+        "below_recommended",
+        "minor_below_recommended",
+        "below_minimum",
+        "far_below_minimum",
+        "unparseable",
     ],
 )
 def test_version_comparison_classifies_each_band(
     installed: str,
+    recommended: str,
+    minimum: str,
     expected: ToolStatus,
 ) -> None:
     """Installed versions map onto the manifest's minimum/recommended bands."""
     status = tool_status_for_versions(
         installed=installed,
-        recommended="1.2.3",
-        minimum="1.0.0",
+        recommended=recommended,
+        minimum=minimum,
     )
 
     assert_that(status).is_equal_to(expected)
@@ -279,6 +292,27 @@ def test_named_tools_are_probed_even_when_disabled(
     assert_that(results[0].status).is_equal_to(ToolStatus.OK)
 
 
+@pytest.fixture
+def stub_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the report's inputs so a developer's own setup cannot change them.
+
+    ``collect_doctor_report`` reads the workspace config and probes the AI
+    provider; without this the assertions below would depend on whether the
+    machine running them happens to have AI enabled.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        "lintro.config.config_loader.get_config",
+        lambda reload=False: LintroConfig(),
+    )
+    monkeypatch.setattr(
+        "lintro.ai.doctor_checks.check_ai_configuration",
+        lambda _config: [],
+    )
+
+
 def test_unloadable_config_is_reported_as_a_check_not_an_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -305,6 +339,7 @@ def test_unloadable_config_is_reported_as_a_check_not_an_exception(
     assert_that(checks["ai.provider"].status).is_equal_to(DoctorCheckStatus.SKIPPED)
 
 
+@pytest.mark.usefixtures("stub_environment")
 def test_missing_binaries_are_folded_into_one_actionable_check(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -338,6 +373,7 @@ def test_missing_binaries_are_folded_into_one_actionable_check(
     assert_that(checks["tools.versions"].detail).contains("ruff")
 
 
+@pytest.mark.usefixtures("stub_environment")
 def test_healthy_tools_still_emit_their_checks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -355,6 +391,7 @@ def test_healthy_tools_still_emit_their_checks(
     assert_that(checks["tools.versions"]).is_equal_to(DoctorCheckStatus.OK)
 
 
+@pytest.mark.usefixtures("stub_environment")
 def test_mcp_extra_is_never_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     """An uninstalled optional extra is a fact about the install, not a fault."""
     monkeypatch.setattr("lintro.mcp.is_mcp_available", lambda: False)
@@ -372,6 +409,7 @@ def test_mcp_extra_is_never_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     assert_that(extras[0].remediation).contains("lintro[mcp]")
 
 
+@pytest.mark.usefixtures("stub_environment")
 def test_ai_checks_are_projected_onto_the_doctor_vocabulary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -406,33 +444,6 @@ def test_ai_checks_are_projected_onto_the_doctor_vocabulary(
         "Export ANTHROPIC_API_KEY",
     )
     assert_that(report.health).is_equal_to(DoctorHealth.DEGRADED)
-
-
-# ── tool_status_for_versions ─────────────────────────────────────────
-
-
-@pytest.mark.parametrize(
-    ("installed", "expected", "want"),
-    [
-        ("1.2.3", "1.0.0", ToolStatus.OK),
-        ("1.0.0", "1.0.0", ToolStatus.OK),
-        ("1.0.0", "1.2.0", ToolStatus.OUTDATED),
-        ("0.14.0", "0.15.0", ToolStatus.OUTDATED),
-        ("0.0.1", "2.0.0", ToolStatus.INCOMPATIBLE),
-        ("invalid", "1.0.0", ToolStatus.UNKNOWN),
-    ],
-    ids=["above", "equal", "below", "minor_below", "incompatible", "invalid"],
-)
-def test_compare_versions(installed: str, expected: str, want: ToolStatus) -> None:
-    """Compare two version strings and return the correct ToolStatus."""
-    minimum = expected if want == ToolStatus.INCOMPATIBLE else "0.0.0"
-    assert_that(
-        tool_status_for_versions(
-            installed=installed,
-            recommended=expected,
-            minimum=minimum,
-        ),
-    ).is_equal_to(want)
 
 
 # ── check_tool ───────────────────────────────────────────────────────

--- a/tests/unit/utils/test_doctor_report.py
+++ b/tests/unit/utils/test_doctor_report.py
@@ -374,6 +374,39 @@ def test_missing_binaries_are_folded_into_one_actionable_check(
 
 
 @pytest.mark.usefixtures("stub_environment")
+def test_a_version_below_the_minimum_is_an_error_not_a_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lintro skips an incompatible tool outright, so it cannot read as a nit."""
+    monkeypatch.setattr(
+        doctor_report,
+        "collect_tool_checks",
+        lambda **_kwargs: [
+            ToolCheckResult(
+                tool=_make_tool("stylelint"),
+                status=ToolStatus.INCOMPATIBLE,
+                installed_version="0.1.0",
+            ),
+            ToolCheckResult(
+                tool=_make_tool("ruff"),
+                status=ToolStatus.OUTDATED,
+                installed_version="0.13.0",
+            ),
+        ],
+    )
+
+    report = collect_doctor_report()
+
+    versions = next(check for check in report.checks if check.check == "tools.versions")
+    assert_that(versions.status).is_equal_to(DoctorCheckStatus.ERROR)
+    assert_that(versions.detail).contains("below the required minimum: stylelint")
+    assert_that(versions.detail).contains("outdated: ruff")
+    assert_that(versions.remediation).is_equal_to(
+        "lintro install --upgrade ruff stylelint",
+    )
+
+
+@pytest.mark.usefixtures("stub_environment")
 def test_healthy_tools_still_emit_their_checks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/utils/test_doctor_report.py
+++ b/tests/unit/utils/test_doctor_report.py
@@ -1,0 +1,636 @@
+"""Tests for the print-free doctor data layer.
+
+Covers both halves of :mod:`lintro.utils.doctor_report`: the binary probes the
+``lintro doctor`` CLI has always used, and the ``{check, status, detail,
+remediation}`` health report the MCP ``lintro_doctor`` tool serves.
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 - only used to build the TimeoutExpired the probe must survive
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.config.lintro_config import LintroConfig
+from lintro.enums.install_context import InstallContext, PackageManager
+from lintro.enums.tool_status import ToolStatus
+from lintro.tools.core.install_context import RuntimeContext
+from lintro.tools.core.install_strategies.environment import InstallEnvironment
+from lintro.tools.core.tool_registry import ManifestRegistry, ManifestTool
+from lintro.utils import doctor_report
+from lintro.utils.doctor_report import (
+    DoctorCheck,
+    DoctorCheckCategory,
+    DoctorCheckStatus,
+    DoctorHealth,
+    DoctorReport,
+    ToolCheckResult,
+    check_tool,
+    collect_doctor_report,
+    collect_tool_checks,
+    mcp_extra_status,
+    tool_status_for_versions,
+)
+
+
+def _make_tool(
+    name: str = "ruff",
+    version: str = "0.14.0",
+    min_version: str | None = None,
+    *,
+    install_type: str = "pip",
+    tier: str = "tools",
+    category: str = "bundled",
+    version_command: tuple[str, ...] | None = None,
+) -> ManifestTool:
+    """Build a ManifestTool for testing.
+
+    Args:
+        name: Tool name.
+        version: Recommended version from the manifest.
+        min_version: Minimum compatible version; defaults to ``version``.
+        install_type: Manifest install type.
+        tier: Manifest tier ("tools" or "dev").
+        category: Display category.
+        version_command: Probe command; defaults to ``(name, "--version")``.
+
+    Returns:
+        ManifestTool: The constructed entry.
+    """
+    return ManifestTool(
+        name=name,
+        version=version,
+        min_version=min_version or version,
+        install_type=install_type,
+        tier=tier,
+        category=category,
+        version_command=(
+            (name, "--version") if version_command is None else version_command
+        ),
+        languages=("python",),
+        tags=("linter",),
+    )
+
+
+def _make_context(*, has_brew: bool = False) -> RuntimeContext:
+    """Build a RuntimeContext for testing.
+
+    Args:
+        has_brew: Whether Homebrew is among the available package managers.
+
+    Returns:
+        RuntimeContext: The constructed context.
+    """
+    managers = frozenset(
+        {
+            PackageManager.UV,
+            PackageManager.PIP,
+            PackageManager.NPM,
+            PackageManager.CARGO,
+            PackageManager.RUSTUP,
+        },
+    )
+    if has_brew:
+        managers = managers | {PackageManager.BREW}
+    return RuntimeContext(
+        install_context=InstallContext.PIP,
+        platform_label="Linux x86_64",
+        environment=InstallEnvironment(
+            install_context=InstallContext.PIP,
+            available_managers=managers,
+        ),
+        is_ci=False,
+    )
+
+
+def _check(
+    *,
+    name: str = "check",
+    status: DoctorCheckStatus = DoctorCheckStatus.OK,
+) -> DoctorCheck:
+    """Build a doctor check for testing.
+
+    Args:
+        name: Check identifier.
+        status: Check status.
+
+    Returns:
+        DoctorCheck: The constructed record.
+    """
+    return DoctorCheck(
+        check=name,
+        status=status,
+        detail="detail",
+        remediation="do something",
+        category=DoctorCheckCategory.TOOLS,
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (ToolStatus.OK, True),
+        (ToolStatus.OUTDATED, True),
+        (ToolStatus.INCOMPATIBLE, True),
+        (ToolStatus.UNKNOWN, True),
+        (ToolStatus.MISSING, False),
+        (ToolStatus.DISABLED, False),
+    ],
+)
+def test_installed_follows_whether_the_binary_can_run(
+    status: ToolStatus,
+    expected: bool,
+) -> None:
+    """A tool counts as installed exactly when its binary answered a probe."""
+    result = ToolCheckResult(tool=_make_tool(), status=status)
+
+    assert_that(result.installed).is_equal_to(expected)
+
+
+@pytest.mark.parametrize(
+    ("installed", "expected"),
+    [
+        ("1.2.3", ToolStatus.OK),
+        ("2.0.0", ToolStatus.OK),
+        ("1.1.0", ToolStatus.OUTDATED),
+        ("0.9.0", ToolStatus.INCOMPATIBLE),
+        ("not-a-version", ToolStatus.UNKNOWN),
+    ],
+)
+def test_version_comparison_classifies_each_band(
+    installed: str,
+    expected: ToolStatus,
+) -> None:
+    """Installed versions map onto the manifest's minimum/recommended bands."""
+    status = tool_status_for_versions(
+        installed=installed,
+        recommended="1.2.3",
+        minimum="1.0.0",
+    )
+
+    assert_that(status).is_equal_to(expected)
+
+
+def test_report_is_healthy_when_no_check_warns_or_errors() -> None:
+    """Skipped checks describe inapplicable features, not degradation."""
+    report = DoctorReport(
+        checks=(
+            _check(name="a", status=DoctorCheckStatus.OK),
+            _check(name="b", status=DoctorCheckStatus.SKIPPED),
+        ),
+    )
+
+    assert_that(report.health).is_equal_to(DoctorHealth.HEALTHY)
+    assert_that(report.summary()).is_equal_to(
+        {"ok": 1, "warning": 0, "error": 0, "skipped": 1, "total": 2},
+    )
+
+
+@pytest.mark.parametrize(
+    "status",
+    [DoctorCheckStatus.WARNING, DoctorCheckStatus.ERROR],
+)
+def test_report_is_degraded_when_any_check_is_actionable(
+    status: DoctorCheckStatus,
+) -> None:
+    """One warning is enough to stop calling the environment healthy."""
+    report = DoctorReport(
+        checks=(_check(status=DoctorCheckStatus.OK), _check(status=status)),
+    )
+
+    assert_that(report.health).is_equal_to(DoctorHealth.DEGRADED)
+
+
+def test_check_serializes_the_four_contract_fields() -> None:
+    """The wire shape an agent branches on stays ``{check, status, detail, ...}``."""
+    payload = _check(name="tools.missing", status=DoctorCheckStatus.ERROR).to_dict()
+
+    assert_that(payload).contains_key(
+        "check",
+        "status",
+        "detail",
+        "remediation",
+        "category",
+    )
+    assert_that(payload["status"]).is_equal_to("error")
+
+
+def test_disabled_tools_are_reported_rather_than_dropped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool turned off in config must be distinguishable from a missing one."""
+    registry = ManifestRegistry(
+        tools={"ruff": _make_tool("ruff"), "black": _make_tool("black")},
+        language_map={},
+        profiles={},
+    )
+    config = LintroConfig()
+    monkeypatch.setattr(
+        type(config),
+        "is_tool_enabled",
+        lambda _self, name: name == "ruff",
+    )
+    monkeypatch.setattr(
+        doctor_report,
+        "check_tool",
+        lambda *, tool, context: ToolCheckResult(tool=tool, status=ToolStatus.OK),
+    )
+
+    results = collect_tool_checks(
+        registry=registry,
+        context=RuntimeContext.detect(),
+        config=config,
+    )
+
+    by_name = {result.tool.name: result.status for result in results}
+    assert_that(by_name).is_equal_to(
+        {"ruff": ToolStatus.OK, "black": ToolStatus.DISABLED},
+    )
+
+
+def test_named_tools_are_probed_even_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An operator naming a tool wants it probed, config enablement aside."""
+    registry = ManifestRegistry(
+        tools={"ruff": _make_tool("ruff"), "black": _make_tool("black")},
+        language_map={},
+        profiles={},
+    )
+    config = LintroConfig()
+    monkeypatch.setattr(type(config), "is_tool_enabled", lambda _self, name: False)
+    monkeypatch.setattr(
+        doctor_report,
+        "check_tool",
+        lambda *, tool, context: ToolCheckResult(tool=tool, status=ToolStatus.OK),
+    )
+
+    results = collect_tool_checks(
+        registry=registry,
+        context=RuntimeContext.detect(),
+        config=config,
+        tool_names=["black"],
+    )
+
+    assert_that([result.tool.name for result in results]).is_equal_to(["black"])
+    assert_that(results[0].status).is_equal_to(ToolStatus.OK)
+
+
+def test_unloadable_config_is_reported_as_a_check_not_an_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed config file must degrade the report, never crash it."""
+
+    def _explode(reload: bool = False) -> LintroConfig:
+        raise ValueError("mapping values are not allowed here")
+
+    monkeypatch.setattr("lintro.config.config_loader.get_config", _explode)
+    monkeypatch.setattr(
+        doctor_report,
+        "collect_tool_checks",
+        lambda **_kwargs: [ToolCheckResult(tool=_make_tool(), status=ToolStatus.OK)],
+    )
+
+    report = collect_doctor_report()
+
+    checks = {check.check: check for check in report.checks}
+    assert_that(report.health).is_equal_to(DoctorHealth.DEGRADED)
+    assert_that(checks["config.load"].status).is_equal_to(DoctorCheckStatus.ERROR)
+    assert_that(checks["config.load"].detail).contains("mapping values")
+    assert_that(checks["config.load"].remediation).is_not_empty()
+    # Nothing downstream of the config may claim to have checked anything.
+    assert_that(checks["ai.provider"].status).is_equal_to(DoctorCheckStatus.SKIPPED)
+
+
+def test_missing_binaries_are_folded_into_one_actionable_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tools verdict names what is missing and how to install it."""
+    missing = ToolCheckResult(tool=_make_tool("hadolint"), status=ToolStatus.MISSING)
+    outdated = ToolCheckResult(
+        tool=_make_tool("ruff"),
+        status=ToolStatus.OUTDATED,
+        installed_version="1.1.0",
+    )
+    ignored = ToolCheckResult(
+        tool=_make_tool("pytest", tier="dev"),
+        status=ToolStatus.MISSING,
+    )
+    monkeypatch.setattr(
+        doctor_report,
+        "collect_tool_checks",
+        lambda **_kwargs: [missing, outdated, ignored],
+    )
+
+    report = collect_doctor_report()
+
+    checks = {check.check: check for check in report.checks}
+    assert_that(checks["tools.missing"].status).is_equal_to(DoctorCheckStatus.ERROR)
+    assert_that(checks["tools.missing"].detail).contains("hadolint")
+    assert_that(checks["tools.missing"].detail).does_not_contain("pytest")
+    assert_that(checks["tools.missing"].remediation).is_equal_to(
+        "lintro install hadolint",
+    )
+    assert_that(checks["tools.versions"].status).is_equal_to(DoctorCheckStatus.WARNING)
+    assert_that(checks["tools.versions"].detail).contains("ruff")
+
+
+def test_healthy_tools_still_emit_their_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A passing check is reported too, so a caller never guesses from absence."""
+    monkeypatch.setattr(
+        doctor_report,
+        "collect_tool_checks",
+        lambda **_kwargs: [ToolCheckResult(tool=_make_tool(), status=ToolStatus.OK)],
+    )
+
+    report = collect_doctor_report()
+
+    checks = {check.check: check.status for check in report.checks}
+    assert_that(checks["tools.missing"]).is_equal_to(DoctorCheckStatus.OK)
+    assert_that(checks["tools.versions"]).is_equal_to(DoctorCheckStatus.OK)
+
+
+def test_mcp_extra_is_never_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An uninstalled optional extra is a fact about the install, not a fault."""
+    monkeypatch.setattr("lintro.mcp.is_mcp_available", lambda: False)
+    monkeypatch.setattr(
+        doctor_report,
+        "collect_tool_checks",
+        lambda **_kwargs: [ToolCheckResult(tool=_make_tool(), status=ToolStatus.OK)],
+    )
+
+    report = collect_doctor_report()
+
+    extras = [check for check in report.checks if check.check == "extras.mcp"]
+    assert_that(extras).is_length(1)
+    assert_that(extras[0].status).is_equal_to(DoctorCheckStatus.SKIPPED)
+    assert_that(extras[0].remediation).contains("lintro[mcp]")
+
+
+def test_ai_checks_are_projected_onto_the_doctor_vocabulary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing AI credential is an error an operator can act on."""
+    from lintro.ai.doctor_checks import AICheckResult
+
+    monkeypatch.setattr(
+        doctor_report,
+        "collect_tool_checks",
+        lambda **_kwargs: [ToolCheckResult(tool=_make_tool(), status=ToolStatus.OK)],
+    )
+    monkeypatch.setattr(
+        "lintro.ai.doctor_checks.check_ai_configuration",
+        lambda _config: [
+            AICheckResult(
+                name="ai.api.ANTHROPIC_API_KEY",
+                status=ToolStatus.MISSING,
+                message="Environment variable ANTHROPIC_API_KEY is not set",
+                hint="Export ANTHROPIC_API_KEY",
+            ),
+        ],
+    )
+
+    report = collect_doctor_report()
+
+    checks: dict[str, Any] = {check.check: check for check in report.checks}
+    assert_that(checks).contains_key("ai.api.ANTHROPIC_API_KEY")
+    assert_that(checks["ai.api.ANTHROPIC_API_KEY"].status).is_equal_to(
+        DoctorCheckStatus.ERROR,
+    )
+    assert_that(checks["ai.api.ANTHROPIC_API_KEY"].remediation).is_equal_to(
+        "Export ANTHROPIC_API_KEY",
+    )
+    assert_that(report.health).is_equal_to(DoctorHealth.DEGRADED)
+
+
+# ── tool_status_for_versions ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("installed", "expected", "want"),
+    [
+        ("1.2.3", "1.0.0", ToolStatus.OK),
+        ("1.0.0", "1.0.0", ToolStatus.OK),
+        ("1.0.0", "1.2.0", ToolStatus.OUTDATED),
+        ("0.14.0", "0.15.0", ToolStatus.OUTDATED),
+        ("0.0.1", "2.0.0", ToolStatus.INCOMPATIBLE),
+        ("invalid", "1.0.0", ToolStatus.UNKNOWN),
+    ],
+    ids=["above", "equal", "below", "minor_below", "incompatible", "invalid"],
+)
+def test_compare_versions(installed: str, expected: str, want: ToolStatus) -> None:
+    """Compare two version strings and return the correct ToolStatus."""
+    minimum = expected if want == ToolStatus.INCOMPATIBLE else "0.0.0"
+    assert_that(
+        tool_status_for_versions(
+            installed=installed,
+            recommended=expected,
+            minimum=minimum,
+        ),
+    ).is_equal_to(want)
+
+
+# ── check_tool ───────────────────────────────────────────────────────
+
+
+def test_check_tool_ok() -> None:
+    """Tool found in PATH with version meeting minimum."""
+    tool = _make_tool(version="0.14.0")
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ruff 0.14.4",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.OK)
+    assert_that(result.installed_version).is_equal_to("0.14.4")
+    assert_that(result.path).is_equal_to("/usr/bin/ruff")
+
+
+def test_check_tool_outdated() -> None:
+    """Tool found but version below recommended."""
+    tool = _make_tool(version="1.0.0", min_version="0.3.0")
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ruff 0.5.0",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.OUTDATED)
+    assert_that(result.installed_version).is_equal_to("0.5.0")
+
+
+def test_check_tool_incompatible() -> None:
+    """Tool found but version below hard minimum."""
+    tool = _make_tool(version="1.0.0", min_version="1.0.0")
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ruff 0.5.0",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.INCOMPATIBLE)
+
+
+def test_check_tool_missing_not_in_path() -> None:
+    """Tool executable not found in PATH."""
+    tool = _make_tool()
+    ctx = _make_context()
+
+    with patch("shutil.which", return_value=None):
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(result.error).is_equal_to("not_in_path")
+
+
+def test_check_tool_missing_command_failed() -> None:
+    """Tool found but version command exits non-zero."""
+    tool = _make_tool()
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="error",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(result.error).is_equal_to("command_failed")
+
+
+def test_check_tool_missing_timeout() -> None:
+    """Tool version command times out."""
+    tool = _make_tool()
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["ruff"], timeout=10),
+        ),
+    ):
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(result.error).is_equal_to("timeout")
+
+
+def test_check_tool_missing_os_error() -> None:
+    """Tool version command raises OSError."""
+    tool = _make_tool()
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run", side_effect=OSError("exec format error")),
+    ):
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(result.error).is_equal_to("os_error")
+
+
+def test_check_tool_unknown_no_version() -> None:
+    """Tool runs but output has no parseable version."""
+    tool = _make_tool()
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="no version here",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.UNKNOWN)
+    assert_that(result.error).is_equal_to("no_version")
+
+
+def test_check_tool_no_version_command() -> None:
+    """Tool has no version_command defined."""
+    tool = _make_tool(version_command=())
+    ctx = _make_context()
+
+    result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(result.error).is_equal_to("no_command")
+
+
+def test_check_tool_upgrade_hint_populated() -> None:
+    """Both install_hint and upgrade_hint are populated."""
+    tool = _make_tool()
+    ctx = _make_context()
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/ruff"),
+        patch("subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ruff 0.14.4",
+            stderr="",
+        )
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.install_hint).is_not_empty()
+    assert_that(result.upgrade_hint).is_not_empty()
+
+
+# ── optional MCP extra ───────────────────────────────────────────────
+
+
+def test_mcp_extra_status_reports_installed() -> None:
+    """The MCP extra is reported OK when the SDK imports."""
+    with patch("lintro.mcp.is_mcp_available", return_value=True):
+        info = mcp_extra_status()
+
+    assert_that(info["name"]).is_equal_to("mcp")
+    assert_that(info["status"]).is_equal_to(ToolStatus.OK.value)
+    assert_that(info["hint"]).contains("lintro mcp")
+
+
+def test_mcp_extra_status_reports_missing_without_failing() -> None:
+    """A missing MCP extra is DISABLED (informational), never an error."""
+    with patch("lintro.mcp.is_mcp_available", return_value=False):
+        info = mcp_extra_status()
+
+    assert_that(info["status"]).is_equal_to(ToolStatus.DISABLED.value)
+    assert_that(info["hint"]).contains("lintro[mcp]")


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(mcp): add introspection toolkit for tools, versions, and doctor
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Three read-only, idempotent MCP tools so an agent can discover lintro's capabilities
before acting instead of parsing `lintro ls` / `lintro versions` / `lintro doctor` text
— or discovering a missing binary by failing a `lintro_check`:

- **`lintro_list_tools`** — every tool with its types, languages, capabilities,
  execution class, install-profile membership, and whether the binary is installed here.
- **`lintro_versions`** — installed versus minimum/recommended versions.
- **`lintro_doctor`** — environment health as `{check, status, detail, remediation}`
  records plus a `healthy`/`degraded` verdict.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`, full `pytest` suite: 8399 passed)

## Closes

- Closes #1240

## Details

### The doctor refactor (benefits the CLI, does not fork it)

`lintro doctor` was one ~1060-line click command that interleaved probing with Rich
rendering, so the only way to learn whether a binary was present was to print a table
and read it back. The probes moved verbatim into a new print-free
`lintro/utils/doctor_report.py` — `ToolCheckResult`, `check_tool`,
`tool_status_for_versions`, `mcp_extra_status`, plus a new `collect_tool_checks` that
absorbs the command's inline selection/enablement block. `doctor.py` now imports them
and keeps only presentation and exit codes; its output is byte-for-byte unchanged, and
its data collection is finally importable and testable without `click`/`rich`. The same
module gains the agent-facing `DoctorReport`/`DoctorCheck` model that `lintro_doctor`
serves. The probe-level tests moved with the code into
`tests/unit/utils/test_doctor_report.py`.

### `profile_membership` — resolved, not dropped

Lintro does have a profile concept, just not the one the lint toolkit needed: it is an
**install** concept (`minimal`, `python`, `web`, `complete`, `recommended`, `ci`) that
`manifest.json` defines and `lintro setup` / `lintro install` consume. So the field is
implemented rather than omitted — but only where it is a property of the *tool*:

- `explicit` and `all` profiles resolve statically, so membership in them is attributed
  per tool.
- `recommended` (auto-detect) and `ci` (filter over recommended) resolve against the
  languages detected in a tree. Membership there is a property of a *workspace*, so
  claiming it per tool would be a lie. Those are reported in a top-level `profiles`
  block with `resolution: "workspace"` instead.

`execution_class` (#1886) is included per tool for consistency with the `list-tools`
JSON, alongside `capabilities` (`check` / `fix` / `review`), so an agent can see that an
advisory AI finder is unreachable from `lintro_check`.

### Other shape decisions

- `types` is a list, not the scalar `type` the issue sketched: `ToolType` is a `Flag`
  and tools such as `ruff` and `oxlint` are genuinely both linter and formatter, so a
  scalar would have to pick one and lie.
- **Missing tools are listed**, with `installed: false`, their `status`, and an
  `install_hint`. An absent entry is indistinguishable from a tool lintro never
  supported.
- `lintro_doctor` emits one record per *actionable condition* (`config.load`,
  `config.consistency`, `tools.missing`, `tools.versions`, one per AI probe,
  `extras.mcp`) rather than ~40 near-duplicate per-tool rows — that per-tool view is
  `lintro_list_tools`'s job. A version below the hard minimum is an `error`, not a
  warning, matching how lintro actually skips such a tool.
- Nothing in the report can fail the call: a malformed config, an exploding provider
  probe, and an absent `[ai]` extra all come back as checks.
- The tools carry a 900s budget rather than the 300s default: each probes every manifest
  binary, and a machine with slow or wedged binaries can exceed the default.
- Zero heavy imports at module import time, per the established toolkit pattern.

### Testing

- `tests/unit/mcp/test_toolkit_introspection.py` — e2e through a real in-memory
  `ClientSession`: annotations, payload shapes, missing-binary visibility, static
  profile membership, advisory finders, version mismatch, healthy and degraded doctor.
- `tests/unit/utils/test_doctor_report.py` — the data layer: probe statuses, version
  bands, disabled-vs-missing, unloadable config, incompatible-as-error, AI projection.
- Full suite green (`8399 passed, 105 skipped`); `uv run lintro chk` clean.

### Review

CodeRabbit ran twice; all findings applied except one pushed back on: it flagged that a
timed-out handler's abandoned worker still holds `workspace_session`'s `RUN_LOCK`. True,
but that is the foundation's dispatch contract (#1575) and applies equally to
`lintro_check`, `lintro_format`, and `lintro_review` — not something to change under an
introspection PR. Greptile was skipped (free review limit reached).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MCP inspection tools for listing available tools, checking installed and expected versions, and diagnosing environment health.
  - Reports now include tool capabilities, profile membership, configuration status, health results, and remediation guidance.
  - Added structured status information for optional MCP support.

- **Documentation**
  - Expanded MCP documentation with tool responses, status meanings, health checks, metadata, and malformed-configuration behavior.

- **Bug Fixes**
  - Improved consistency between doctor diagnostics and MCP-reported health and tool status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->