### PR TITLE
fix(ci): stop binary-build jobs from syncing the dev group

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -117,6 +117,9 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
 
+      # This job (unlike the binary builds below) does need the dev group:
+      # `click-man` lives there. It runs on Linux, where every dev-group
+      # dependency has a wheel, so the source-build trap in #1897 can't bite.
       - name: Install dependencies
         run: uv sync --group dev
 
@@ -206,9 +209,14 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
 
+      # #1897: binary builds install the runtime deps plus the `build` group and
+      # nothing else. The default `dev` group drags in `mcp` -> `pyjwt[crypto]`
+      # -> `cryptography`, which ships no macOS x86_64 wheel from 49.0.0 on, so
+      # uv would build it from source via maturin/cargo and hit the (correctly)
+      # blocked crates.io egress. A Nuitka binary needs none of that stack.
       - name: Install dependencies
         run: |
-          uv sync --group build --group dev
+          uv sync --group build --no-default-groups
 
       - name: Start memory sampler
         # #1707: background vmstat/free sampler; log uploads on failure only.
@@ -216,8 +224,10 @@ jobs:
 
       - name: Build binary
         timeout-minutes: 25
+        # `--no-default-groups` is required here too: `uv run` re-syncs the
+        # environment with the default groups and would reinstall `dev`.
         run: |
-          uv run python scripts/build/build_macos.py \
+          uv run --no-default-groups python scripts/build/build_macos.py \
             --arch "$BUILD_ARCH" \
             --skip-verify
         env:
@@ -356,9 +366,11 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
 
+      # #1897: kept in lockstep with the macOS job above - binary builds never
+      # install the dev test stack.
       - name: Install dependencies
         run: |
-          uv sync --group build --group dev
+          uv sync --group build --no-default-groups
 
       - name: Start memory sampler
         # #1707: background vmstat/free sampler; log uploads on failure only.
@@ -368,7 +380,7 @@ jobs:
         timeout-minutes: 25
         run: |
           HOST_ARCH="${{ matrix.arch == 'x64' && 'x86_64' || 'arm64' }}"
-          uv run python scripts/build/build_linux.py \
+          uv run --no-default-groups python scripts/build/build_linux.py \
             --arch "$HOST_ARCH" \
             --skip-verify
         env:

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import json
 import re
+import shlex
 import subprocess  # nosec B404 - subprocess runs fixed git argv against this repo
 from collections import Counter
 from pathlib import Path
@@ -1213,6 +1214,71 @@ def test_build_binary_retries_setup_uv_on_failure() -> None:
         assert_that(first.get("continue-on-error")).is_true()
         retry = next(step for step in steps if step.get("name") == "Install uv (retry)")
         assert_that(retry.get("if")).contains("steps.setup-uv.outcome == 'failure'")
+
+
+def _uv_commands(script: str) -> list[list[str]]:
+    """Extract the ``uv`` invocations from a workflow ``run:`` script.
+
+    Backslash continuations are folded first so a multi-line invocation is seen
+    as one command, and each command is tokenised with ``shlex`` so quoted
+    values (``--group "dev"``) parse the same as bare ones. Leading
+    ``NAME=value`` environment prefixes are stripped before matching.
+
+    Args:
+        script: The raw text of a step's ``run:`` block.
+
+    Returns:
+        One token list per ``uv sync`` / ``uv run`` invocation found.
+    """
+    folded = re.sub(r"\\\s*\n", " ", script)
+    commands: list[list[str]] = []
+    for segment in re.split(r"[\n;]|\|\||&&|(?<!\|)\|(?!\|)", folded):
+        try:
+            tokens = shlex.split(segment, comments=True)
+        except ValueError:  # unbalanced quotes in a non-command fragment
+            continue
+        while tokens and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", tokens[0]):
+            tokens = tokens[1:]
+        if tokens[:2] in (["uv", "sync"], ["uv", "run"]):
+            commands.append(tokens)
+    return commands
+
+
+def test_binary_jobs_never_install_the_dev_group() -> None:
+    """Binary builds must opt out of the default dependency groups (#1897).
+
+    The default ``dev`` group pulls ``mcp`` -> ``pyjwt[crypto]`` ->
+    ``cryptography``, which ships no macOS x86_64 wheel from 49.0.0 on. Syncing
+    it makes uv build that package from source via maturin/cargo, which then
+    dies on the (deliberately) blocked crates.io egress. Every ``uv`` command in
+    the binary jobs therefore has to carry ``--no-default-groups`` -- including
+    ``uv run``, which otherwise re-syncs the default groups back in.
+    """
+    workflow = _load_workflow(name="build-binary.yml")
+    binary_jobs = ("build-macos", "build-linux")
+
+    for job_id in binary_jobs:
+        steps = workflow["jobs"][job_id]["steps"]
+        uv_commands = [
+            command
+            for step in steps
+            for command in _uv_commands(script=step.get("run") or "")
+        ]
+        assert_that(uv_commands).described_as(f"{job_id} uv commands").is_not_empty()
+
+        for tokens in uv_commands:
+            rendered = " ".join(tokens)
+            groups = [
+                value
+                for flag, value in zip(tokens, tokens[1:], strict=False)
+                if flag == "--group"
+            ]
+            assert_that(groups).described_as(
+                f"{job_id}: {rendered!r} must not sync the dev group",
+            ).does_not_contain("dev")
+            assert_that(tokens).described_as(
+                f"{job_id}: {rendered!r} must pass --no-default-groups",
+            ).contains("--no-default-groups")
 
 
 def test_auto_rerun_covers_tag_publish_workflows() -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): stop binary-build jobs from syncing the dev group
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

The Homebrew tap `Build macOS Binary (x86_64)` job failed deterministically
because binary jobs synced the full `dev` group. On the Intel macOS runner that
pulls `cryptography` into a crates.io source build, which harden-runner's egress
allowlist blocks. `cryptography` 49.0.0 dropped `macosx_10_9_universal2` wheels
(arm64-only), so only the x86_64 job broke.

- Binary jobs now `uv sync --group build --no-default-groups`, and the same flag
  is repeated on `uv run` so the default groups are not re-synced.
- Egress allowlist stays tight (no source build to serve).
- Regular CI and `Generate Man Page` still use `--group dev` where needed;
  comments document why the three sync sites differ.
- Contract test in `test_workflow_wiring.py` locks the invariant: every `uv`
  command in binary jobs must pass `--no-default-groups` and must not sync `dev`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1897

## Details

Regular CI is untouched and still syncs the dev group (MCP/pytest coverage
unaffected). Widening egress instead would turn a fast failure into a long Rust
compile racing the job timeout; skipping the unnecessary `dev` sync is the fix.