### PR TITLE
fix(ci): pass --timeout 600 to the CLI-transport AI review

### DIFF
--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -126,7 +126,10 @@ output_file="$(mktemp)"
 trap 'rm -f "$output_file"' EXIT
 
 set +e
-uv run lintro review --pr "${pr_number}" "${repo_arg[@]}" --depth 1 --post --output json >"$output_file" 2>&1
+# --timeout 600: the default ai.api_timeout (60s) is sized for streaming API
+# chunks; a CLI-transport turn runs the whole review in one `claude` invocation
+# and needs minutes (#1900; the sandbox reference uses the same value).
+uv run lintro review --pr "${pr_number}" "${repo_arg[@]}" --depth 1 --timeout 600 --post --output json >"$output_file" 2>&1
 review_status=$?
 set -e
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): pass --timeout 600 to the CLI-transport AI review
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

The subscription-auth AI review (#1894/#1895) authenticates since the org-token re-mint, but every run dies at lintro's default `ai.api_timeout` of 60s — sized for streaming API chunks, not a CLI-transport turn where the `claude` binary performs the whole review in one invocation. This passes `--timeout 600` at the invocation site, matching the proven sandbox reference (lgtm-hq/sandbox-lintro-ai PR #1).

Closes #1900

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1900

## Details

- Evidence run: 30734531258 on PR #1858 — auth OK, then `provider unavailable (timeout) — nothing was reviewed: Claude CLI timed out after 60s`.
- **Self-verify trap**: `ai-review.yml` runs this script from the PR's base ref, so this PR's own AI Review check still executes the old script and will time out — expected, non-required, not a blocker. Real verification is the first `lintro/**`-touching PR event after merge.
- Full suite: 8788 passed / 105 skipped locally (pip-audit integration + one xdist-only flake are pre-existing local-env issues, pass serially / on CI).
