### PR TITLE
ci(ai): run the AI review on every PR without a paths filter

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -49,11 +49,12 @@ name: AI Review - Dogfood
 # mechanism from #1074 is the primary control. Re-audit if the checkout ref,
 # job guard, or secret injection site changes.
 
+# No paths filter: every PR gets the dogfood review (#1902). The lintro/**
+# filter dated from API-metered billing; under subscription billing the CI and
+# workflow diffs it skipped are exactly where recent regressions shipped.
 'on':
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'lintro/**'
 
 permissions: {}
 

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -241,6 +241,21 @@ def test_workflow_yaml_parses() -> None:
     assert_that(trigger).contains_key("pull_request")
 
 
+def test_workflow_runs_on_every_pr_without_a_paths_filter() -> None:
+    """The pull_request trigger carries no ``paths`` filter (#1902).
+
+    The old ``lintro/**`` filter meant CI, script, and workflow PRs shipped with
+    no AI review at all — the #1900 timeout bug went out exactly that way. Under
+    subscription billing every PR gets the dogfood review.
+    """
+    loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+    trigger = loaded[True] if True in loaded else loaded["on"]
+    pull_request = trigger["pull_request"]
+    assert_that(pull_request).does_not_contain_key("paths")
+    assert_that(pull_request).does_not_contain_key("paths-ignore")
+
+
 def test_workflow_never_rewrites_its_conclusion_to_success() -> None:
     """No ``continue-on-error`` anywhere, so a failed review shows as failed.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci(ai): run the AI review on every PR without a paths filter
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Removes the `lintro/**` paths filter from `ai-review.yml` so the AI review dogfood runs on every PR. The filter dated from API-metered billing; under subscription billing (#1894/#1895) the CI, script, and workflow diffs it skipped are exactly where recent regressions shipped unreviewed (#1900 among them). A contract test pins the trigger filter-free.

Closes #1902

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1902

## Details

**This PR verifies itself**: the trigger is evaluated against the merge ref (filter already removed), while the scripts run from the base ref — which now includes #1901's `--timeout 600` fix and the re-minted org token. A green AI Review check with a sticky review comment on this PR is the end-to-end proof of the subscription CLI transport.

Full suite: 8789 passed / 105 skipped locally (known local-env pip-audit + xdist-only flake excluded/verified serially). `lintro chk` clean, health 90/100.
