### PR TITLE
feat(review): state schema v2 with per-run stats history and cross-run finding matching

### DIFF
--- a/lintro/ai/review/enums/__init__.py
+++ b/lintro/ai/review/enums/__init__.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
 from lintro.ai.review.enums.file_domain import FileDomain
+from lintro.ai.review.enums.finding_match_outcome import FindingMatchOutcome
+from lintro.ai.review.enums.finding_status import FindingStatus
 from lintro.ai.review.enums.review_category import ReviewCategory
 from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
+from lintro.ai.review.enums.review_verdict import ReviewVerdict
 
 __all__ = [
     "ChangedFileStatus",
     "FileDomain",
+    "FindingMatchOutcome",
+    "FindingStatus",
     "ReviewCategory",
     "ReviewContextErrorCode",
+    "ReviewVerdict",
 ]

--- a/lintro/ai/review/enums/finding_match_outcome.py
+++ b/lintro/ai/review/enums/finding_match_outcome.py
@@ -1,0 +1,22 @@
+"""Per-round transition outcomes produced by the cross-run finding matcher."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+
+class FindingMatchOutcome(StrEnum):
+    """Transition assigned to a finding when a review round is matched.
+
+    Attributes:
+        NEW: First round in which the finding was seen.
+        CARRIED: Still open and previously seen; ``since_round`` is preserved.
+        RESOLVED: Previously open, absent from this round, stamped with the
+            head sha and round that resolved it.
+        REGRESSED: Previously resolved and reported again in this round.
+    """
+
+    NEW = auto()
+    CARRIED = auto()
+    RESOLVED = auto()
+    REGRESSED = auto()

--- a/lintro/ai/review/enums/finding_status.py
+++ b/lintro/ai/review/enums/finding_status.py
@@ -1,0 +1,18 @@
+"""Lifecycle status for a tracked review finding."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+
+class FindingStatus(StrEnum):
+    """Persisted lifecycle status of a finding in the review state blob.
+
+    Attributes:
+        OPEN: The finding was reported by the most recent review round.
+        RESOLVED: The finding disappeared in a later round and is considered
+            addressed as of ``resolved_in``.
+    """
+
+    OPEN = auto()
+    RESOLVED = auto()

--- a/lintro/ai/review/enums/review_verdict.py
+++ b/lintro/ai/review/enums/review_verdict.py
@@ -1,0 +1,24 @@
+"""Readiness verdict derived from the currently open review findings."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+
+class ReviewVerdict(StrEnum):
+    """Merge-readiness verdict for a PR at the end of a review round.
+
+    The verdict is derived in code from open-finding severities (never asked of
+    the model) so the label can never disagree with the findings it summarizes.
+
+    Attributes:
+        BLOCKED: At least one open P1 finding.
+        CHANGES_REQUESTED: No open P1 findings but at least one open P2.
+        NITS_ONLY: Only open P3 findings remain.
+        READY: No open findings remain.
+    """
+
+    BLOCKED = auto()
+    CHANGES_REQUESTED = auto()
+    NITS_ONLY = auto()
+    READY = auto()

--- a/lintro/ai/review/finding_matcher.py
+++ b/lintro/ai/review/finding_matcher.py
@@ -20,6 +20,7 @@ import re
 import unicodedata
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
+from dataclasses import replace
 
 from lintro.ai.review.enums.finding_match_outcome import FindingMatchOutcome
 from lintro.ai.review.enums.finding_status import FindingStatus
@@ -212,6 +213,21 @@ def _pair_group(
     return pairs
 
 
+def _next_free_ordinal(*, taken: set[int]) -> int:
+    """Return the lowest 1-based ordinal not already used in a group.
+
+    Args:
+        taken: Ordinals already claimed by records sharing the fingerprint.
+
+    Returns:
+        The smallest unused ordinal.
+    """
+    ordinal = 1
+    while ordinal in taken:
+        ordinal += 1
+    return ordinal
+
+
 def _merge_pair(
     *,
     prior: FindingRecord,
@@ -229,7 +245,10 @@ def _merge_pair(
     regressed = prior.status is FindingStatus.RESOLVED
     merged = FindingRecord(
         fingerprint=prior.fingerprint,
-        ordinal=current.ordinal,
+        # The ordinal is part of the persistent identity: a matched finding
+        # keeps the one it was first assigned, so its key stays stable and can
+        # never collide with a sibling still tracked under the old ordinal.
+        ordinal=prior.ordinal,
         severity=current.severity,
         category=current.category,
         title=current.title,
@@ -294,22 +313,38 @@ def match_findings(
         prior_indices = prior_by_fingerprint.get(fingerprint, [])
         prior_group = [prior_records[index] for index in prior_indices]
         pairs = _pair_group(prior=prior_group, current=group)
+        # Every prior record of this fingerprint stays in state (matched, or
+        # carried as resolved), so their ordinals remain taken.
+        taken = {record.ordinal for record in prior_group}
+        assigned: dict[int, FindingRecord] = {}
+
         for current_index, record in enumerate(group):
             group_index = pairs.get(current_index)
             if group_index is None:
-                merged.append(record)
-                new.append(record)
-                outcomes[record.key] = FindingMatchOutcome.NEW
                 continue
             prior_record = prior_group[group_index]
             matched_prior.add(prior_indices[group_index])
             updated, outcome = _merge_pair(prior=prior_record, current=record)
-            merged.append(updated)
+            assigned[current_index] = updated
             outcomes[updated.key] = outcome
             if outcome is FindingMatchOutcome.REGRESSED:
                 regressed.append(updated)
             else:
                 carried.append(updated)
+
+        unmatched = sorted(
+            (index for index in range(len(group)) if index not in assigned),
+            key=lambda index: (group[index].line, index),
+        )
+        for current_index in unmatched:
+            ordinal = _next_free_ordinal(taken=taken)
+            taken.add(ordinal)
+            record = replace(group[current_index], ordinal=ordinal)
+            assigned[current_index] = record
+            new.append(record)
+            outcomes[record.key] = FindingMatchOutcome.NEW
+
+        merged.extend(assigned[index] for index in range(len(group)))
 
     for index, record in enumerate(prior_records):
         if index in matched_prior:

--- a/lintro/ai/review/finding_matcher.py
+++ b/lintro/ai/review/finding_matcher.py
@@ -74,7 +74,7 @@ def normalize_file_path(path: str) -> str:
     Returns:
         Path with Windows separators converted and any leading ``./`` removed.
     """
-    return path.replace("\\", "/").removeprefix("./").strip()
+    return path.strip().replace("\\", "/").removeprefix("./")
 
 
 def fingerprint_for(*, file: str, category: str, title: str) -> str:
@@ -352,21 +352,11 @@ def match_findings(
         if record.status is FindingStatus.RESOLVED:
             merged.append(record)
             continue
-        closed = FindingRecord(
-            fingerprint=record.fingerprint,
-            ordinal=record.ordinal,
-            severity=record.severity,
-            category=record.category,
-            title=record.title,
-            file=record.file,
-            line=record.line,
+        closed = replace(
+            record,
             status=FindingStatus.RESOLVED,
-            since_round=record.since_round,
             resolved_sha=head_sha,
             resolved_round=round_number,
-            inline_comment_id=record.inline_comment_id,
-            regressed=record.regressed,
-            checklist_ids=record.checklist_ids,
         )
         merged.append(closed)
         resolved.append(closed)

--- a/lintro/ai/review/finding_matcher.py
+++ b/lintro/ai/review/finding_matcher.py
@@ -1,0 +1,347 @@
+"""Cross-run finding identity and matching for AI review state.
+
+Findings are identified by a stable fingerprint over ``file path``,
+``category``, and a normalized title — deliberately *not* the line number,
+which drifts as the PR evolves. Two findings can legitimately share a
+fingerprint within a single round (two hardcoded credentials in one file), so
+identity is the pair ``(fingerprint, ordinal)`` where the ordinal is assigned
+by first-seen line order.
+
+On later rounds ambiguous candidates are paired by nearest-line distance. When
+the pairing is still ambiguous the matcher biases toward *carrying over* an
+open finding rather than declaring it resolved: a stale open finding is a
+lesser failure than a false "Addressed" banner.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import unicodedata
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
+
+from lintro.ai.review.enums.finding_match_outcome import FindingMatchOutcome
+from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.enums.review_verdict import ReviewVerdict
+from lintro.ai.review.models.finding_match_result import FindingMatchResult
+from lintro.ai.review.models.finding_record import FindingRecord
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
+from lintro.ai.review.models.review_state import ReviewState
+
+__all__ = [
+    "FINGERPRINT_LENGTH",
+    "derive_verdict",
+    "fingerprint_for",
+    "match_findings",
+    "normalize_file_path",
+    "normalize_title",
+]
+
+# Truncated sha256 hex digest length. 16 hex chars (64 bits) keeps the state
+# blob small while making a collision within one PR effectively impossible.
+FINGERPRINT_LENGTH = 16
+
+_PUNCTUATION_RE = re.compile(r"[^\w\s]+", flags=re.UNICODE)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def normalize_title(title: str) -> str:
+    """Normalize a finding title for fingerprinting.
+
+    Lowercases, strips backticks and all other punctuation, and collapses
+    whitespace runs so cosmetic rewordings of the same finding keep a stable
+    identity across rounds.
+
+    Args:
+        title: Raw finding title as reported by the model.
+
+    Returns:
+        The normalized title.
+    """
+    folded = unicodedata.normalize("NFKC", title).casefold()
+    stripped = _PUNCTUATION_RE.sub(" ", folded)
+    return _WHITESPACE_RE.sub(" ", stripped).strip()
+
+
+def normalize_file_path(path: str) -> str:
+    """Normalize a repository-relative file path for fingerprinting.
+
+    Args:
+        path: File path as reported by the model.
+
+    Returns:
+        Path with Windows separators converted and any leading ``./`` removed.
+    """
+    return path.replace("\\", "/").removeprefix("./").strip()
+
+
+def fingerprint_for(*, file: str, category: str, title: str) -> str:
+    """Compute the stable fingerprint for a finding.
+
+    Args:
+        file: Repository-relative file path.
+        category: Finding category label.
+        title: Raw finding title.
+
+    Returns:
+        Truncated sha256 hex digest identifying the finding independently of
+        its line number.
+    """
+    payload = "\x00".join(
+        (
+            normalize_file_path(file),
+            normalize_title(category),
+            normalize_title(title),
+        ),
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return digest[:FINGERPRINT_LENGTH]
+
+
+def derive_verdict(*, findings: Iterable[FindingRecord]) -> ReviewVerdict:
+    """Derive the merge-readiness verdict from open findings.
+
+    Args:
+        findings: Tracked finding records; resolved records are ignored.
+
+    Returns:
+        The readiness verdict implied by the open findings' severities.
+    """
+    severities = {
+        record.severity for record in findings if record.status is FindingStatus.OPEN
+    }
+    if Severity.P1 in severities:
+        return ReviewVerdict.BLOCKED
+    if Severity.P2 in severities:
+        return ReviewVerdict.CHANGES_REQUESTED
+    if Severity.P3 in severities:
+        return ReviewVerdict.NITS_ONLY
+    return ReviewVerdict.READY
+
+
+def _current_records(
+    *,
+    findings: Sequence[ReviewFinding],
+    round_number: int,
+) -> list[FindingRecord]:
+    """Build fresh records for this round's findings with ordinals assigned.
+
+    Ordinals are 1-based and assigned by first-seen line order within each
+    fingerprint group, matching the ambiguity policy.
+
+    Args:
+        findings: Findings reported in the current round.
+        round_number: Round number being recorded.
+
+    Returns:
+        Records in reported order, each carrying its fingerprint and ordinal.
+    """
+    grouped: dict[str, list[int]] = defaultdict(list)
+    fingerprints: list[str] = []
+    for index, finding in enumerate(findings):
+        fingerprint = fingerprint_for(
+            file=finding.file,
+            category=finding.category,
+            title=finding.title,
+        )
+        fingerprints.append(fingerprint)
+        grouped[fingerprint].append(index)
+
+    ordinals: dict[int, int] = {}
+    for indices in grouped.values():
+        ordered = sorted(indices, key=lambda index: (findings[index].line, index))
+        for ordinal, index in enumerate(ordered, start=1):
+            ordinals[index] = ordinal
+
+    return [
+        FindingRecord(
+            fingerprint=fingerprints[index],
+            ordinal=ordinals[index],
+            severity=finding.severity,
+            category=finding.category,
+            title=finding.title,
+            file=normalize_file_path(finding.file),
+            line=finding.line,
+            status=FindingStatus.OPEN,
+            since_round=round_number,
+            checklist_ids=finding.checklist_ids,
+        )
+        for index, finding in enumerate(findings)
+    ]
+
+
+def _pair_group(
+    *,
+    prior: Sequence[FindingRecord],
+    current: Sequence[FindingRecord],
+) -> dict[int, int]:
+    """Pair current records to prior records within one fingerprint group.
+
+    Candidate pairs are ranked by absolute line distance; ties prefer a prior
+    record that is still open, so an ambiguous match carries a finding over
+    rather than declaring it resolved.
+
+    Args:
+        prior: Prior records sharing the fingerprint.
+        current: Current-round records sharing the fingerprint.
+
+    Returns:
+        Mapping of current index to prior index for the chosen pairs.
+    """
+    candidates = [
+        (
+            abs(current_record.line - prior_record.line),
+            0 if prior_record.status is FindingStatus.OPEN else 1,
+            abs(current_record.ordinal - prior_record.ordinal),
+            prior_index,
+            current_index,
+        )
+        for current_index, current_record in enumerate(current)
+        for prior_index, prior_record in enumerate(prior)
+    ]
+    candidates.sort()
+
+    pairs: dict[int, int] = {}
+    used_prior: set[int] = set()
+    for _distance, _open_first, _ordinal_gap, prior_index, current_index in candidates:
+        if current_index in pairs or prior_index in used_prior:
+            continue
+        pairs[current_index] = prior_index
+        used_prior.add(prior_index)
+    return pairs
+
+
+def _merge_pair(
+    *,
+    prior: FindingRecord,
+    current: FindingRecord,
+) -> tuple[FindingRecord, FindingMatchOutcome]:
+    """Merge a matched prior record with its current-round sighting.
+
+    Args:
+        prior: Previously tracked record.
+        current: Freshly built record for this round.
+
+    Returns:
+        Tuple of the merged record and the transition it represents.
+    """
+    regressed = prior.status is FindingStatus.RESOLVED
+    merged = FindingRecord(
+        fingerprint=prior.fingerprint,
+        ordinal=current.ordinal,
+        severity=current.severity,
+        category=current.category,
+        title=current.title,
+        file=current.file,
+        line=current.line,
+        status=FindingStatus.OPEN,
+        since_round=prior.since_round,
+        resolved_sha=prior.resolved_sha,
+        resolved_round=prior.resolved_round,
+        inline_comment_id=prior.inline_comment_id,
+        regressed=regressed or prior.regressed,
+        checklist_ids=current.checklist_ids or prior.checklist_ids,
+    )
+    if regressed:
+        return merged, FindingMatchOutcome.REGRESSED
+    return merged, FindingMatchOutcome.CARRIED
+
+
+def match_findings(
+    *,
+    previous: ReviewState | None,
+    findings: Sequence[ReviewFinding],
+    round_number: int,
+    head_sha: str = "",
+) -> FindingMatchResult:
+    """Match this round's findings against the previously persisted state.
+
+    Every current finding is classified as ``new``, ``carried``, or
+    ``regressed``; every prior open finding absent from this round is marked
+    ``resolved`` and stamped with the head sha and round that resolved it.
+
+    Args:
+        previous: State decoded from the prior sticky comment, or ``None`` for
+            the first round on a PR.
+        findings: Findings reported in the current round.
+        round_number: Round number being recorded (1-based).
+        head_sha: Head commit sha reviewed in this round; stamped onto findings
+            resolved by this round.
+
+    Returns:
+        The per-round transitions plus the merged record set to persist.
+    """
+    prior_records = list(previous.findings) if previous is not None else []
+    current_records = _current_records(findings=findings, round_number=round_number)
+
+    prior_by_fingerprint: dict[str, list[int]] = defaultdict(list)
+    for index, record in enumerate(prior_records):
+        prior_by_fingerprint[record.fingerprint].append(index)
+    current_by_fingerprint: dict[str, list[FindingRecord]] = defaultdict(list)
+    for record in current_records:
+        current_by_fingerprint[record.fingerprint].append(record)
+
+    merged: list[FindingRecord] = []
+    new: list[FindingRecord] = []
+    carried: list[FindingRecord] = []
+    regressed: list[FindingRecord] = []
+    resolved: list[FindingRecord] = []
+    outcomes: dict[str, FindingMatchOutcome] = {}
+    matched_prior: set[int] = set()
+
+    for fingerprint, group in current_by_fingerprint.items():
+        prior_indices = prior_by_fingerprint.get(fingerprint, [])
+        prior_group = [prior_records[index] for index in prior_indices]
+        pairs = _pair_group(prior=prior_group, current=group)
+        for current_index, record in enumerate(group):
+            group_index = pairs.get(current_index)
+            if group_index is None:
+                merged.append(record)
+                new.append(record)
+                outcomes[record.key] = FindingMatchOutcome.NEW
+                continue
+            prior_record = prior_group[group_index]
+            matched_prior.add(prior_indices[group_index])
+            updated, outcome = _merge_pair(prior=prior_record, current=record)
+            merged.append(updated)
+            outcomes[updated.key] = outcome
+            if outcome is FindingMatchOutcome.REGRESSED:
+                regressed.append(updated)
+            else:
+                carried.append(updated)
+
+    for index, record in enumerate(prior_records):
+        if index in matched_prior:
+            continue
+        if record.status is FindingStatus.RESOLVED:
+            merged.append(record)
+            continue
+        closed = FindingRecord(
+            fingerprint=record.fingerprint,
+            ordinal=record.ordinal,
+            severity=record.severity,
+            category=record.category,
+            title=record.title,
+            file=record.file,
+            line=record.line,
+            status=FindingStatus.RESOLVED,
+            since_round=record.since_round,
+            resolved_sha=head_sha,
+            resolved_round=round_number,
+            inline_comment_id=record.inline_comment_id,
+            regressed=record.regressed,
+            checklist_ids=record.checklist_ids,
+        )
+        merged.append(closed)
+        resolved.append(closed)
+        outcomes[closed.key] = FindingMatchOutcome.RESOLVED
+
+    return FindingMatchResult(
+        records=tuple(merged),
+        new=tuple(new),
+        carried=tuple(carried),
+        resolved=tuple(resolved),
+        regressed=tuple(regressed),
+        outcomes=outcomes,
+    )

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -22,6 +22,7 @@ from loguru import logger
 from lintro.ai.integrations.github_pr import GitHubPRReporter
 from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.github_constants import (
+    GITHUB_COMMENT_HARD_LIMIT,
     MAX_COMMENT_CHARS,
     STATE_MARKER_PREFIX,
     STICKY_MARKER,
@@ -43,12 +44,15 @@ from lintro.ai.review.github_sticky import (
 from lintro.ai.review.github_sticky import (
     build_sticky_comment,
     parse_review_state,
+    parse_review_state_v2,
 )
 from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
 
 __all__ = [
+    "GITHUB_COMMENT_HARD_LIMIT",
     "STATE_MARKER_PREFIX",
     "STICKY_MARKER",
     "MAX_COMMENT_CHARS",
@@ -58,6 +62,7 @@ __all__ = [
     "format_review_summary",
     "format_run_mechanics",
     "parse_review_state",
+    "parse_review_state_v2",
     "post_review_error_to_github",
     "post_review_to_github",
     "sanitize_comment_text",
@@ -97,11 +102,12 @@ def post_review_to_github(
         return False
 
     prompt_questions = question_map or {}
-    comment_id, prior_runs = _load_prior_runs(reporter=gh_reporter)
+    comment_id, prior_state = _load_prior_state(reporter=gh_reporter)
     diff_lines = gh_reporter.fetch_pr_diff_lines()
     body = build_sticky_comment(
         result=result,
-        prior_runs=prior_runs,
+        prior_state=prior_state,
+        head_sha=result.metadata.head_ref,
         checklist_display=checklist_display,
         question_map=prompt_questions,
         diff_lines=diff_lines,
@@ -150,34 +156,34 @@ def post_review_error_to_github(
     if not gh_reporter.is_available():
         logger.warning("GitHub PR context not available — skipping error posting")
         return False
-    comment_id, prior_runs = _load_prior_runs(reporter=gh_reporter)
+    comment_id, prior_state = _load_prior_state(reporter=gh_reporter)
     body = format_error_comment(
         error=error,
         provider=provider,
         metadata=metadata,
-        prior_runs=prior_runs,
+        prior_state=prior_state,
     )
     return _upsert_sticky(reporter=gh_reporter, body=body, comment_id=comment_id)
 
 
-def _load_prior_runs(
+def _load_prior_state(
     *,
     reporter: GitHubPRReporter,
-) -> tuple[int | None, list[dict[str, Any]]]:
-    """Locate the sticky comment and parse its prior run records.
+) -> tuple[int | None, ReviewState]:
+    """Locate the sticky comment and decode its persisted review state.
 
     Args:
         reporter: GitHub reporter used to list PR comments.
 
     Returns:
-        Tuple of ``(comment_id, run_records)``; the id is ``None`` when no
-        sticky comment exists yet.
+        Tuple of ``(comment_id, state)``; the id is ``None`` and the state is
+        empty when no sticky comment exists yet.
     """
     found = reporter.find_issue_comment(marker=STICKY_MARKER)
     if found is None:
-        return None, []
+        return None, ReviewState()
     comment_id, prior_body = found
-    return comment_id, parse_review_state(body=prior_body)
+    return comment_id, parse_review_state_v2(body=prior_body)
 
 
 def _upsert_sticky(

--- a/lintro/ai/review/github_constants.py
+++ b/lintro/ai/review/github_constants.py
@@ -9,9 +9,15 @@ from lintro.ai.review.models.review_finding import Severity
 STICKY_MARKER = "<!-- lintro-ai-review -->"
 STATE_MARKER_PREFIX = "<!-- lintro-ai-review-state:"
 STATE_MARKER_SUFFIX = "-->"
-STATE_VERSION = 1
+# Current review-state schema version. v2 adds per-run statistics and
+# per-finding identity records on top of v1's run aggregates (issue #1906).
+STATE_VERSION = 2
+STATE_VERSION_V1 = 1
 
-# GitHub rejects comment bodies over 65,536 characters; stay well under.
+# GitHub rejects comment bodies over 65,536 characters.
+GITHUB_COMMENT_HARD_LIMIT = 65_536
+# Budget for the rendered body; stay well under the hard limit so the hidden
+# state block always has room.
 MAX_COMMENT_CHARS = 60_000
 # Cap how many run records are retained in the sticky state block.
 MAX_STORED_RUNS = 30

--- a/lintro/ai/review/github_errors.py
+++ b/lintro/ai/review/github_errors.py
@@ -15,7 +15,7 @@ from lintro.ai.review.github_render import format_run_mechanics, sanitize_commen
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.run_record import RunRecord
-from lintro.ai.review.review_state_codec import render_state_block
+from lintro.ai.review.review_state_codec import migrate_v1_runs, render_state_block
 
 
 def format_error_comment(
@@ -70,9 +70,14 @@ def format_error_comment(
     body = "\n".join(lines)
     state = prior_state
     if state is None and prior_runs:
-        state = ReviewState(
-            runs=tuple(RunRecord.from_dict(run) for run in prior_runs),
-        )
+        runs = tuple(RunRecord.from_dict(run) for run in prior_runs)
+        if runs and all(run.round == 1 for run in runs):
+            # Legacy v1 mappings carry no round number; number them
+            # positionally, matching the sticky-comment path so the same
+            # legacy runs always renumber the same way regardless of which
+            # surface parsed them.
+            runs = tuple(migrate_v1_runs(runs=list(runs)))
+        state = ReviewState(runs=runs)
     if state is not None and (state.runs or state.findings):
         body += render_state_block(state=state)
     return body

--- a/lintro/ai/review/github_errors.py
+++ b/lintro/ai/review/github_errors.py
@@ -15,7 +15,10 @@ from lintro.ai.review.github_render import format_run_mechanics, sanitize_commen
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.run_record import RunRecord
-from lintro.ai.review.review_state_codec import migrate_v1_runs, render_state_block
+from lintro.ai.review.review_state_codec import (
+    render_state_block,
+    renumber_if_legacy_v1,
+)
 
 
 def format_error_comment(
@@ -71,13 +74,7 @@ def format_error_comment(
     state = prior_state
     if state is None and prior_runs:
         runs = tuple(RunRecord.from_dict(run) for run in prior_runs)
-        if runs and all(run.round == 1 for run in runs):
-            # Legacy v1 mappings carry no round number; number them
-            # positionally, matching the sticky-comment path so the same
-            # legacy runs always renumber the same way regardless of which
-            # surface parsed them.
-            runs = tuple(migrate_v1_runs(runs=list(runs)))
-        state = ReviewState(runs=runs)
+        state = ReviewState(runs=renumber_if_legacy_v1(runs=runs))
     if state is not None and (state.runs or state.findings):
         body += render_state_block(state=state)
     return body

--- a/lintro/ai/review/github_errors.py
+++ b/lintro/ai/review/github_errors.py
@@ -12,8 +12,10 @@ from lintro.ai.review.errors_taxonomy import (
 )
 from lintro.ai.review.github_constants import _FOOTER, STICKY_MARKER
 from lintro.ai.review.github_render import format_run_mechanics, sanitize_comment_text
-from lintro.ai.review.github_sticky import _render_state_block
 from lintro.ai.review.models.review_metadata import ReviewMetadata
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.run_record import RunRecord
+from lintro.ai.review.review_state_codec import render_state_block
 
 
 def format_error_comment(
@@ -22,6 +24,7 @@ def format_error_comment(
     provider: str | None = None,
     metadata: ReviewMetadata | None = None,
     prior_runs: list[dict[str, Any]] | None = None,
+    prior_state: ReviewState | None = None,
 ) -> str:
     """Format a provider/API error as a clear PR comment.
 
@@ -37,8 +40,11 @@ def format_error_comment(
         provider: Provider identifier used for provider-aware classification.
             Falls back to ``metadata.provider`` when omitted.
         metadata: Optional review metadata for a mechanics footer.
-        prior_runs: Run records recovered from the previous sticky comment.
-            Re-emitted so a transient error does not reset cumulative telemetry.
+        prior_runs: Legacy run mappings recovered from the previous sticky
+            comment. Ignored when ``prior_state`` is given.
+        prior_state: Full state decoded from the previous sticky comment.
+            Re-emitted so a transient error does not reset cumulative telemetry
+            or the tracked finding history.
 
     Returns:
         Markdown comment body describing the failure and next steps.
@@ -62,8 +68,13 @@ def format_error_comment(
         lines.extend(["", "<sub>" + format_run_mechanics(metadata=metadata) + "</sub>"])
     lines.extend(["", _FOOTER])
     body = "\n".join(lines)
-    if prior_runs:
-        body += _render_state_block(runs=list(prior_runs))
+    state = prior_state
+    if state is None and prior_runs:
+        state = ReviewState(
+            runs=tuple(RunRecord.from_dict(run) for run in prior_runs),
+        )
+    if state is not None and (state.runs or state.findings):
+        body += render_state_block(state=state)
     return body
 
 

--- a/lintro/ai/review/github_errors.py
+++ b/lintro/ai/review/github_errors.py
@@ -16,6 +16,7 @@ from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.run_record import RunRecord
 from lintro.ai.review.review_state_codec import (
+    prune_state_to_fit,
     render_state_block,
     renumber_if_legacy_v1,
 )
@@ -75,7 +76,8 @@ def format_error_comment(
     if state is None and prior_runs:
         runs = tuple(RunRecord.from_dict(run) for run in prior_runs)
         state = ReviewState(runs=renumber_if_legacy_v1(runs=runs))
-    if state is not None and (state.runs or state.findings):
+    if state is not None and (state.runs or state.findings or state.truncated):
+        state = prune_state_to_fit(state=state, body=body)
         body += render_state_block(state=state)
     return body
 

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -34,6 +34,7 @@ from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.run_record import RunRecord
 from lintro.ai.review.review_state_codec import (
     decode_state,
+    migrate_v1_runs,
     prune_state_to_fit,
     render_state_block,
 )
@@ -99,7 +100,9 @@ def build_sticky_comment(
         auth_mode=auth_mode,
         verdict=derive_verdict(findings=match.records),
     )
-    all_runs = [*prior, current][-MAX_STORED_RUNS:]
+    combined_runs = [*prior, current]
+    all_runs = combined_runs[-MAX_STORED_RUNS:]
+    runs_dropped = len(all_runs) < len(combined_runs)
 
     def assemble(*, findings_char_budget: int | None) -> str:
         sections = [STICKY_MARKER, _format_cumulative_header(runs=all_runs)]
@@ -144,7 +147,7 @@ def build_sticky_comment(
     new_state = ReviewState(
         runs=tuple(all_runs),
         findings=match.records,
-        truncated=state.truncated,
+        truncated=state.truncated or runs_dropped,
     )
     return body + render_state_block(
         state=prune_state_to_fit(state=new_state, body=body),
@@ -164,10 +167,7 @@ def _state_from_runs(prior_runs: list[dict[str, Any]] | None) -> ReviewState:
     runs = tuple(RunRecord.from_dict(run) for run in prior_runs or [])
     if runs and all(run.round == 1 for run in runs):
         # Legacy v1 mappings carry no round number; number them positionally.
-        runs = tuple(
-            RunRecord.from_dict({**run.to_dict(), "round": index})
-            for index, run in enumerate(runs, start=1)
-        )
+        runs = tuple(migrate_v1_runs(runs=list(runs)))
     return ReviewState(runs=runs)
 
 

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from lintro.ai.review.enums.checklist_display import ChecklistDisplay
+from lintro.ai.review.enums.review_verdict import ReviewVerdict
+from lintro.ai.review.finding_matcher import derive_verdict, match_findings
 from lintro.ai.review.github_constants import (
     _CHECKLIST_APPENDIX_RE,
     _FINDING_BLOCK_START_RE,
@@ -16,9 +17,6 @@ from lintro.ai.review.github_constants import (
     _TRUNCATION_MARGIN,
     MAX_COMMENT_CHARS,
     MAX_STORED_RUNS,
-    STATE_MARKER_PREFIX,
-    STATE_MARKER_SUFFIX,
-    STATE_VERSION,
     STICKY_MARKER,
 )
 from lintro.ai.review.github_render import (
@@ -32,15 +30,26 @@ from lintro.ai.review.github_render import (
 )
 from lintro.ai.review.models.review_finding import Severity
 from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.run_record import RunRecord
+from lintro.ai.review.review_state_codec import (
+    decode_state,
+    prune_state_to_fit,
+    render_state_block,
+)
 
 
 def build_sticky_comment(
     *,
     result: ReviewResult,
     prior_runs: list[dict[str, Any]] | None = None,
+    prior_state: ReviewState | None = None,
     checklist_display: ChecklistDisplay = ChecklistDisplay.OFF,
     question_map: dict[int, str] | None = None,
     diff_lines: dict[str, set[int]] | None = None,
+    head_sha: str = "",
+    transport: str = "",
+    auth_mode: str = "",
 ) -> str:
     """Compose the full sticky PR comment body, including cumulative telemetry.
 
@@ -50,21 +59,46 @@ def build_sticky_comment(
     character budget so overflow is dropped explicitly (a visible marker names
     the count) and only ever falls on findings that also post inline.
 
+    This round's findings are matched against the prior state so the persisted
+    v2 blob carries each finding's identity, first-seen round, and resolution
+    provenance for downstream surfaces.
+
     Args:
         result: Current review result.
-        prior_runs: Run records recovered from the previous sticky comment's
-            state block. ``None`` for the first run on a PR.
+        prior_runs: Legacy run records recovered from the previous sticky
+            comment's state block. Ignored when ``prior_state`` is given.
+        prior_state: Full state decoded from the previous sticky comment.
+            ``None`` for the first run on a PR.
         checklist_display: Structured checklist visibility mode.
         question_map: Prompt id to question text for the checklist appendix.
         diff_lines: Diff line map used to order fallback findings first and to
             decide which findings are safe to truncate. ``None`` treats all
             findings as fallback.
+        head_sha: Head commit sha reviewed in this round; stamped onto findings
+            resolved by this round.
+        transport: Provider transport used for this round.
+        auth_mode: Authentication mode used by the transport.
 
     Returns:
         Complete Markdown body carrying the hidden marker and state block.
     """
-    prior = list(prior_runs or [])
-    current = _run_record(result=result)
+    state = prior_state if prior_state is not None else _state_from_runs(prior_runs)
+    round_number = state.next_round
+    match = match_findings(
+        previous=state,
+        findings=result.findings,
+        round_number=round_number,
+        head_sha=head_sha,
+    )
+    prior = list(state.runs)
+    current = _run_record(
+        result=result,
+        round_number=round_number,
+        head_sha=head_sha,
+        transport=transport,
+        auth_mode=auth_mode,
+        verdict=derive_verdict(findings=match.records),
+    )
     all_runs = [*prior, current][-MAX_STORED_RUNS:]
 
     def assemble(*, findings_char_budget: int | None) -> str:
@@ -107,54 +141,101 @@ def build_sticky_comment(
         body = assemble(findings_char_budget=findings_budget)
 
     body = _cap_body(body=body)
-    return body + _render_state_block(runs=all_runs)
-
-
-def _render_state_block(*, runs: list[dict[str, Any]]) -> str:
-    """Render the hidden machine-readable run-state block."""
-    return (
-        f"\n\n{STATE_MARKER_PREFIX} "
-        + json.dumps({"version": STATE_VERSION, "runs": runs})
-        + f" {STATE_MARKER_SUFFIX}"
+    new_state = ReviewState(
+        runs=tuple(all_runs),
+        findings=match.records,
+        truncated=state.truncated,
+    )
+    return body + render_state_block(
+        state=prune_state_to_fit(state=new_state, body=body),
     )
 
 
-def _run_record(*, result: ReviewResult) -> dict[str, Any]:
-    """Build a machine-readable run record from a review result."""
+def _state_from_runs(prior_runs: list[dict[str, Any]] | None) -> ReviewState:
+    """Build a state object from legacy ``prior_runs`` mappings.
+
+    Args:
+        prior_runs: Run mappings recovered from a previous sticky comment, or
+            ``None``.
+
+    Returns:
+        A state carrying those runs and no finding history.
+    """
+    runs = tuple(RunRecord.from_dict(run) for run in prior_runs or [])
+    if runs and all(run.round == 1 for run in runs):
+        # Legacy v1 mappings carry no round number; number them positionally.
+        runs = tuple(
+            RunRecord.from_dict({**run.to_dict(), "round": index})
+            for index, run in enumerate(runs, start=1)
+        )
+    return ReviewState(runs=runs)
+
+
+def _run_record(
+    *,
+    result: ReviewResult,
+    round_number: int,
+    head_sha: str,
+    transport: str,
+    auth_mode: str,
+    verdict: ReviewVerdict,
+) -> RunRecord:
+    """Build a machine-readable run record from a review result.
+
+    Args:
+        result: Current review result.
+        round_number: 1-based round number for this run.
+        head_sha: Head commit sha reviewed in this round.
+        transport: Provider transport used for this round.
+        auth_mode: Authentication mode used by the transport.
+        verdict: Readiness verdict derived from the open findings.
+
+    Returns:
+        The run record persisted in the state blob.
+    """
     metadata = result.metadata
     counts = _severity_counts(findings=result.findings)
     usage = metadata.token_usage
-    return {
-        "timestamp": metadata.timestamp,
-        "model": metadata.model,
-        "provider": metadata.provider,
-        "prompt": int(usage.get("prompt", 0)),
-        "completion": int(usage.get("completion", 0)),
-        "total": int(usage.get("total", 0)),
-        "cost": round(metadata.cost_estimate_usd, 6),
-        "estimated": bool(metadata.token_usage_estimated),
-        "depth": metadata.depth,
-        "duration": round(metadata.duration_seconds, 2),
-        "p1": counts[Severity.P1],
-        "p2": counts[Severity.P2],
-        "p3": counts[Severity.P3],
-        "partial": bool(metadata.partial),
-        "chunks_reviewed": metadata.chunks_reviewed,
-        "chunks_total": metadata.chunks_total,
-    }
+    return RunRecord(
+        round=round_number,
+        timestamp=metadata.timestamp,
+        sha=head_sha,
+        model=metadata.model,
+        provider=metadata.provider,
+        transport=transport,
+        auth_mode=auth_mode,
+        depth=metadata.depth,
+        strictness=metadata.strictness,
+        files_reviewed=metadata.files_reviewed,
+        files_skipped=max(metadata.files_total - metadata.files_reviewed, 0),
+        checks=metadata.checklist_items,
+        duration=metadata.duration_seconds,
+        prompt=int(usage.get("prompt", 0)),
+        completion=int(usage.get("completion", 0)),
+        total=int(usage.get("total", 0)),
+        cost=metadata.cost_estimate_usd,
+        estimated=bool(metadata.token_usage_estimated),
+        verdict=verdict,
+        p1=counts[Severity.P1],
+        p2=counts[Severity.P2],
+        p3=counts[Severity.P3],
+        partial=bool(metadata.partial),
+        chunks_reviewed=metadata.chunks_reviewed,
+        chunks_total=metadata.chunks_total,
+    )
 
 
-def _format_cumulative_header(*, runs: list[dict[str, Any]]) -> str:
+def _format_cumulative_header(*, runs: list[RunRecord]) -> str:
     """Render the always-visible cumulative telemetry header for the PR."""
-    total_tokens = sum(int(run.get("total", 0)) for run in runs)
-    total_cost = sum(float(run.get("cost", 0.0)) for run in runs)
-    any_estimated = any(run.get("estimated") for run in runs)
-    exact = sum(1 for run in runs if not run.get("estimated"))
-    est = sum(1 for run in runs if run.get("estimated"))
+    total_tokens = sum(run.total for run in runs)
+    total_cost = sum(run.cost for run in runs)
+    any_estimated = any(run.estimated for run in runs)
+    exact = sum(1 for run in runs if not run.estimated)
+    est = sum(1 for run in runs if run.estimated)
 
     model_counts: dict[str, int] = {}
     for run in runs:
-        model = str(run.get("model", "")) or "unknown"
+        model = run.model or "unknown"
         model_counts[model] = model_counts.get(model, 0) + 1
     models = ", ".join(
         f"`{sanitize_comment_text(model, limit=60)}` ×{count}"
@@ -170,21 +251,18 @@ def _format_cumulative_header(*, runs: list[dict[str, Any]]) -> str:
     )
 
 
-def _format_previous_runs(*, runs: list[dict[str, Any]]) -> str:
+def _format_previous_runs(*, runs: list[RunRecord]) -> str:
     """Render prior runs in a collapsible with each run's mechanics."""
     lines = [f"<details><summary>🕔 Previous runs ({len(runs)})</summary>", ""]
     for index, run in enumerate(runs, start=1):
-        estimated = bool(run.get("estimated"))
-        tokens = _fmt_tokens(int(run.get("total", 0)), estimated=estimated)
-        cost = _fmt_cost(float(run.get("cost", 0.0)), estimated=estimated)
-        timestamp = sanitize_comment_text(str(run.get("timestamp", "")), limit=40)
-        model = sanitize_comment_text(str(run.get("model", "")), limit=60)
-        findings = (
-            f"🔴 {run.get('p1', 0)} · 🟠 {run.get('p2', 0)} · 🟡 {run.get('p3', 0)}"
-        )
-        partial = " · ⚠️ partial" if run.get("partial") else ""
+        tokens = _fmt_tokens(run.total, estimated=run.estimated)
+        cost = _fmt_cost(run.cost, estimated=run.estimated)
+        timestamp = sanitize_comment_text(run.timestamp, limit=40)
+        model = sanitize_comment_text(run.model, limit=60)
+        findings = f"🔴 {run.p1} · 🟠 {run.p2} · 🟡 {run.p3}"
+        partial = " · ⚠️ partial" if run.partial else ""
         lines.append(
-            f"{index}. `{model}` · depth {run.get('depth', '?')} · {tokens} · "
+            f"{index}. `{model}` · depth {run.depth} · {tokens} · "
             f"{cost} · {findings}{partial} — {timestamp}",
         )
     lines.extend(["", "</details>"])
@@ -300,23 +378,28 @@ def _cap_body(*, body: str) -> str:
 def parse_review_state(*, body: str) -> list[dict[str, Any]]:
     """Extract prior run records from a sticky comment's state block.
 
+    Compatibility wrapper over :func:`parse_review_state_v2` for callers that
+    only need the run history as plain mappings.
+
     Args:
         body: Existing sticky comment body.
 
     Returns:
         List of run records, or an empty list when no valid state is present.
     """
-    start = body.find(STATE_MARKER_PREFIX)
-    if start < 0:
-        return []
-    after = body[start + len(STATE_MARKER_PREFIX) :]
-    end = after.rfind(STATE_MARKER_SUFFIX)
-    raw = after[:end] if end >= 0 else after
-    try:
-        state = json.loads(raw.strip())
-    except (json.JSONDecodeError, ValueError):
-        return []
-    runs = state.get("runs") if isinstance(state, dict) else None
-    if not isinstance(runs, list):
-        return []
-    return [run for run in runs if isinstance(run, dict)]
+    return [run.to_dict() for run in parse_review_state_v2(body=body).runs]
+
+
+def parse_review_state_v2(*, body: str) -> ReviewState:
+    """Decode the full v2 review state from a sticky comment's state block.
+
+    v1 blobs are migrated in place; a missing, malformed, or unknown-version
+    blob yields an empty state rather than raising.
+
+    Args:
+        body: Existing sticky comment body.
+
+    Returns:
+        The decoded review state.
+    """
+    return decode_state(body=body)

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -34,9 +34,9 @@ from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.run_record import RunRecord
 from lintro.ai.review.review_state_codec import (
     decode_state,
-    migrate_v1_runs,
     prune_state_to_fit,
     render_state_block,
+    renumber_if_legacy_v1,
 )
 
 
@@ -165,10 +165,7 @@ def _state_from_runs(prior_runs: list[dict[str, Any]] | None) -> ReviewState:
         A state carrying those runs and no finding history.
     """
     runs = tuple(RunRecord.from_dict(run) for run in prior_runs or [])
-    if runs and all(run.round == 1 for run in runs):
-        # Legacy v1 mappings carry no round number; number them positionally.
-        runs = tuple(migrate_v1_runs(runs=list(runs)))
-    return ReviewState(runs=runs)
+    return ReviewState(runs=renumber_if_legacy_v1(runs=runs))
 
 
 def _run_record(

--- a/lintro/ai/review/models/__init__.py
+++ b/lintro/ai/review/models/__init__.py
@@ -7,12 +7,16 @@ from lintro.ai.review.models.checklist_answer import ChecklistAnswer
 from lintro.ai.review.models.checklist_item import ChecklistItem
 from lintro.ai.review.models.chunking_result import ChunkingResult
 from lintro.ai.review.models.file_classification import FileClassification
+from lintro.ai.review.models.finding_match_result import FindingMatchResult
+from lintro.ai.review.models.finding_record import FindingRecord
 from lintro.ai.review.models.pr_metadata import PRMetadata
 from lintro.ai.review.models.review_chunk import ReviewChunk
 from lintro.ai.review.models.review_context import ReviewContext
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.run_record import RunRecord
 
 __all__ = [
     "ChangedFile",
@@ -20,11 +24,15 @@ __all__ = [
     "ChecklistItem",
     "ChunkingResult",
     "FileClassification",
+    "FindingMatchResult",
+    "FindingRecord",
     "PRMetadata",
     "ReviewChunk",
     "ReviewContext",
     "ReviewFinding",
     "ReviewMetadata",
     "ReviewResult",
+    "ReviewState",
+    "RunRecord",
     "Severity",
 ]

--- a/lintro/ai/review/models/_coerce.py
+++ b/lintro/ai/review/models/_coerce.py
@@ -1,0 +1,44 @@
+"""Shared coercion helpers for parsing untrusted review-state payloads.
+
+The review-state blob lives in a PR comment, so every decoded value is
+untrusted: it may be missing, of the wrong type, or hand-edited. These helpers
+give the record dataclasses one consistent, non-raising coercion path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["coerce_float", "coerce_int"]
+
+
+def coerce_int(value: Any, *, default: int = 0) -> int:
+    """Coerce an untrusted JSON value to an int.
+
+    Args:
+        value: Raw value decoded from the state blob.
+        default: Value used when coercion is impossible.
+
+    Returns:
+        The coerced integer, or ``default``.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def coerce_float(value: Any, *, default: float = 0.0) -> float:
+    """Coerce an untrusted JSON value to a float.
+
+    Args:
+        value: Raw value decoded from the state blob.
+        default: Value used when coercion is impossible.
+
+    Returns:
+        The coerced float, or ``default``.
+    """
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default

--- a/lintro/ai/review/models/_coerce.py
+++ b/lintro/ai/review/models/_coerce.py
@@ -24,7 +24,10 @@ def coerce_int(value: Any, *, default: int = 0) -> int:
     """
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError: json.loads accepts the non-standard Infinity/-Infinity
+        # tokens as float("inf")/float("-inf"), and int() of either raises
+        # rather than returning a usable value.
         return default
 
 

--- a/lintro/ai/review/models/finding_match_result.py
+++ b/lintro/ai/review/models/finding_match_result.py
@@ -15,8 +15,10 @@ class FindingMatchResult:
     """Per-round transitions plus the merged finding set to persist.
 
     Attributes:
-        records: Full tracked finding set after the round, open records first
-            in first-seen order, followed by resolved records.
+        records: Full tracked finding set to persist after the round — every
+            current-round finding plus every prior record that survived. Order
+            is unspecified; consumers that need a particular ordering must sort
+            (for example by ``since_round`` or ``severity``).
         new: Findings seen for the first time in this round.
         carried: Findings that were already open and are still reported.
         resolved: Findings that were open and are absent from this round.

--- a/lintro/ai/review/models/finding_match_result.py
+++ b/lintro/ai/review/models/finding_match_result.py
@@ -1,0 +1,44 @@
+"""Result of matching one review round's findings against prior state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from lintro.ai.review.enums.finding_match_outcome import FindingMatchOutcome
+from lintro.ai.review.models.finding_record import FindingRecord
+
+__all__ = ["FindingMatchResult"]
+
+
+@dataclass(frozen=True, slots=True)
+class FindingMatchResult:
+    """Per-round transitions plus the merged finding set to persist.
+
+    Attributes:
+        records: Full tracked finding set after the round, open records first
+            in first-seen order, followed by resolved records.
+        new: Findings seen for the first time in this round.
+        carried: Findings that were already open and are still reported.
+        resolved: Findings that were open and are absent from this round.
+        regressed: Findings that were resolved and are reported again.
+        outcomes: Map of ``fingerprint#ordinal`` to the transition assigned in
+            this round. Records untouched by this round are absent.
+    """
+
+    records: tuple[FindingRecord, ...] = field(default_factory=tuple)
+    new: tuple[FindingRecord, ...] = field(default_factory=tuple)
+    carried: tuple[FindingRecord, ...] = field(default_factory=tuple)
+    resolved: tuple[FindingRecord, ...] = field(default_factory=tuple)
+    regressed: tuple[FindingRecord, ...] = field(default_factory=tuple)
+    outcomes: dict[str, FindingMatchOutcome] = field(default_factory=dict)
+
+    def outcome_for(self, *, record: FindingRecord) -> FindingMatchOutcome | None:
+        """Return the transition assigned to ``record`` in this round.
+
+        Args:
+            record: Tracked finding record to look up.
+
+        Returns:
+            The outcome, or ``None`` when the round did not touch the record.
+        """
+        return self.outcomes.get(record.key)

--- a/lintro/ai/review/models/finding_record.py
+++ b/lintro/ai/review/models/finding_record.py
@@ -6,25 +6,10 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.models._coerce import coerce_int
 from lintro.ai.review.models.review_finding import Severity
 
 __all__ = ["FindingRecord"]
-
-
-def _coerce_int(value: Any, *, default: int = 0) -> int:
-    """Coerce an untrusted JSON value to an int, falling back to a default.
-
-    Args:
-        value: Raw value decoded from the state blob.
-        default: Value used when coercion is impossible.
-
-    Returns:
-        The coerced integer, or ``default``.
-    """
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return default
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,7 +24,8 @@ class FindingRecord:
     Attributes:
         fingerprint: Stable hash of file path, category, and normalized title.
         ordinal: 1-based position among same-fingerprint findings, assigned by
-            first-seen line order within the round.
+            line order when the finding is first seen and then held for the
+            finding's lifetime so its identity key stays stable.
         severity: Finding severity at the most recent sighting.
         category: Finding category label.
         title: Finding title as reported (unnormalized, for display).
@@ -54,6 +40,7 @@ class FindingRecord:
         inline_comment_id: GitHub inline review comment id anchoring this
             finding, when one was posted.
         regressed: True when the finding reappeared after being resolved.
+        checklist_ids: Prompt checklist ids linked to this finding.
     """
 
     fingerprint: str
@@ -126,26 +113,38 @@ class FindingRecord:
         comment_id = payload.get("inline_comment_id")
         return cls(
             fingerprint=fingerprint,
-            ordinal=_coerce_int(payload.get("ordinal"), default=1) or 1,
+            ordinal=coerce_int(payload.get("ordinal"), default=1) or 1,
             severity=_parse_severity(payload.get("severity")),
             category=str(payload.get("category", "")),
             title=str(payload.get("title", "")),
             file=str(payload.get("file", "")),
-            line=_coerce_int(payload.get("line")),
+            line=coerce_int(payload.get("line")),
             status=_parse_status(payload.get("status")),
-            since_round=_coerce_int(payload.get("since_round"), default=1) or 1,
+            since_round=coerce_int(payload.get("since_round"), default=1) or 1,
             resolved_sha=str(resolved_map.get("sha", "")),
-            resolved_round=_coerce_int(resolved_map.get("round")),
+            resolved_round=coerce_int(resolved_map.get("round")),
             inline_comment_id=(
-                _coerce_int(comment_id) if comment_id is not None else None
+                coerce_int(comment_id) if comment_id is not None else None
             ),
             regressed=bool(payload.get("regressed", False)),
-            checklist_ids=tuple(
-                _coerce_int(item)
-                for item in payload.get("checklist_ids", [])
-                if isinstance(item, int | str)
-            ),
+            checklist_ids=_parse_checklist_ids(payload.get("checklist_ids")),
         )
+
+
+def _parse_checklist_ids(value: Any) -> tuple[int, ...]:
+    """Parse checklist ids from an untrusted state-blob value.
+
+    Args:
+        value: Raw value decoded from the state blob.
+
+    Returns:
+        Tuple of integer ids; empty when the value is not a list of numbers.
+    """
+    if not isinstance(value, list):
+        return ()
+    return tuple(
+        item for item in value if isinstance(item, int) and not isinstance(item, bool)
+    )
 
 
 def _parse_severity(value: Any) -> Severity:

--- a/lintro/ai/review/models/finding_record.py
+++ b/lintro/ai/review/models/finding_record.py
@@ -124,7 +124,7 @@ class FindingRecord:
             resolved_sha=str(resolved_map.get("sha", "")),
             resolved_round=coerce_int(resolved_map.get("round")),
             inline_comment_id=(
-                coerce_int(comment_id) if comment_id is not None else None
+                coerce_int(comment_id) or None if comment_id is not None else None
             ),
             regressed=bool(payload.get("regressed", False)),
             checklist_ids=_parse_checklist_ids(payload.get("checklist_ids")),

--- a/lintro/ai/review/models/finding_record.py
+++ b/lintro/ai/review/models/finding_record.py
@@ -1,0 +1,164 @@
+"""Per-finding identity record persisted in the review state blob."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.models.review_finding import Severity
+
+__all__ = ["FindingRecord"]
+
+
+def _coerce_int(value: Any, *, default: int = 0) -> int:
+    """Coerce an untrusted JSON value to an int, falling back to a default.
+
+    Args:
+        value: Raw value decoded from the state blob.
+        default: Value used when coercion is impossible.
+
+    Returns:
+        The coerced integer, or ``default``.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True, slots=True)
+class FindingRecord:
+    """A single tracked finding, carried across review rounds.
+
+    Identity is ``(fingerprint, ordinal)``. The fingerprint deliberately
+    excludes the line number because lines drift as the PR evolves; the ordinal
+    disambiguates findings that share a fingerprint within one round (for
+    example two hardcoded credentials in the same file).
+
+    Attributes:
+        fingerprint: Stable hash of file path, category, and normalized title.
+        ordinal: 1-based position among same-fingerprint findings, assigned by
+            first-seen line order within the round.
+        severity: Finding severity at the most recent sighting.
+        category: Finding category label.
+        title: Finding title as reported (unnormalized, for display).
+        file: Repository-relative file path.
+        line: Line number at the most recent sighting.
+        status: Whether the finding is currently open or resolved.
+        since_round: Round number in which the finding was first seen.
+        resolved_sha: Head commit sha that resolved the finding. Empty while
+            the finding is open.
+        resolved_round: Round number in which the finding was resolved. Zero
+            while the finding is open.
+        inline_comment_id: GitHub inline review comment id anchoring this
+            finding, when one was posted.
+        regressed: True when the finding reappeared after being resolved.
+    """
+
+    fingerprint: str
+    ordinal: int = 1
+    severity: Severity = Severity.P3
+    category: str = ""
+    title: str = ""
+    file: str = ""
+    line: int = 0
+    status: FindingStatus = FindingStatus.OPEN
+    since_round: int = 1
+    resolved_sha: str = ""
+    resolved_round: int = 0
+    inline_comment_id: int | None = None
+    regressed: bool = False
+    checklist_ids: tuple[int, ...] = field(default_factory=tuple)
+
+    @property
+    def key(self) -> str:
+        """Return the composite identity key ``fingerprint#ordinal``."""
+        return f"{self.fingerprint}#{self.ordinal}"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the record for the hidden state blob.
+
+        Returns:
+            JSON-serializable mapping. Optional members are omitted when unset
+            so the blob stays as small as possible.
+        """
+        payload: dict[str, Any] = {
+            "fingerprint": self.fingerprint,
+            "ordinal": self.ordinal,
+            "severity": str(self.severity),
+            "category": self.category,
+            "title": self.title,
+            "file": self.file,
+            "line": self.line,
+            "status": str(self.status),
+            "since_round": self.since_round,
+        }
+        if self.status is FindingStatus.RESOLVED or self.resolved_sha:
+            payload["resolved_in"] = {
+                "sha": self.resolved_sha,
+                "round": self.resolved_round,
+            }
+        if self.inline_comment_id is not None:
+            payload["inline_comment_id"] = self.inline_comment_id
+        if self.regressed:
+            payload["regressed"] = True
+        if self.checklist_ids:
+            payload["checklist_ids"] = list(self.checklist_ids)
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> FindingRecord | None:
+        """Rebuild a record from an untrusted state-blob mapping.
+
+        Args:
+            payload: Decoded JSON mapping for one finding.
+
+        Returns:
+            The parsed record, or ``None`` when the payload carries no usable
+            fingerprint.
+        """
+        fingerprint = str(payload.get("fingerprint", "")).strip()
+        if not fingerprint:
+            return None
+        resolved = payload.get("resolved_in")
+        resolved_map = resolved if isinstance(resolved, dict) else {}
+        comment_id = payload.get("inline_comment_id")
+        return cls(
+            fingerprint=fingerprint,
+            ordinal=_coerce_int(payload.get("ordinal"), default=1) or 1,
+            severity=_parse_severity(payload.get("severity")),
+            category=str(payload.get("category", "")),
+            title=str(payload.get("title", "")),
+            file=str(payload.get("file", "")),
+            line=_coerce_int(payload.get("line")),
+            status=_parse_status(payload.get("status")),
+            since_round=_coerce_int(payload.get("since_round"), default=1) or 1,
+            resolved_sha=str(resolved_map.get("sha", "")),
+            resolved_round=_coerce_int(resolved_map.get("round")),
+            inline_comment_id=(
+                _coerce_int(comment_id) if comment_id is not None else None
+            ),
+            regressed=bool(payload.get("regressed", False)),
+            checklist_ids=tuple(
+                _coerce_int(item)
+                for item in payload.get("checklist_ids", [])
+                if isinstance(item, int | str)
+            ),
+        )
+
+
+def _parse_severity(value: Any) -> Severity:
+    """Parse a severity label, defaulting to P3 for unknown input."""
+    try:
+        return Severity(str(value).upper())
+    except ValueError:
+        return Severity.P3
+
+
+def _parse_status(value: Any) -> FindingStatus:
+    """Parse a finding status label, defaulting to open for unknown input."""
+    try:
+        return FindingStatus(str(value).lower())
+    except ValueError:
+        return FindingStatus.OPEN

--- a/lintro/ai/review/models/finding_record.py
+++ b/lintro/ai/review/models/finding_record.py
@@ -148,11 +148,17 @@ def _parse_checklist_ids(value: Any) -> tuple[int, ...]:
 
 
 def _parse_severity(value: Any) -> Severity:
-    """Parse a severity label, defaulting to P3 for unknown input."""
+    """Parse a severity label, failing closed to P1 for unknown input.
+
+    An unrecognizable severity must never quietly become the least-blocking
+    label: derive_verdict only escalates to BLOCKED on a P1, so downgrading a
+    corrupted or renamed severity to P3 would fabricate a clean verdict for a
+    finding that may have been a P1.
+    """
     try:
         return Severity(str(value).upper())
     except ValueError:
-        return Severity.P3
+        return Severity.P1
 
 
 def _parse_status(value: Any) -> FindingStatus:

--- a/lintro/ai/review/models/review_state.py
+++ b/lintro/ai/review/models/review_state.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from typing import Any
 
 from lintro.ai.review.enums.finding_status import FindingStatus
@@ -38,7 +38,7 @@ class ReviewState:
 
     @property
     def open_findings(self) -> tuple[FindingRecord, ...]:
-        """Return the currently open findings, oldest round first."""
+        """Return the currently open findings, in tracking order."""
         return tuple(
             record for record in self.findings if record.status is FindingStatus.OPEN
         )
@@ -51,10 +51,6 @@ class ReviewState:
             for record in self.findings
             if record.status is FindingStatus.RESOLVED
         )
-
-    def with_runs(self, *, runs: tuple[RunRecord, ...]) -> ReviewState:
-        """Return a copy of this state carrying a different run history."""
-        return replace(self, runs=runs)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the state for the hidden comment blob.

--- a/lintro/ai/review/models/review_state.py
+++ b/lintro/ai/review/models/review_state.py
@@ -1,0 +1,73 @@
+"""Versioned review state persisted in the sticky comment's hidden blob."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.models.finding_record import FindingRecord
+from lintro.ai.review.models.run_record import RunRecord
+
+__all__ = ["ReviewState"]
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewState:
+    """Machine-readable review history for one pull request.
+
+    Attributes:
+        version: Schema version of the decoded blob.
+        runs: Per-round statistics, oldest first.
+        findings: Tracked findings (open and resolved) across all rounds.
+        truncated: True when older runs or resolved findings were pruned to
+            keep the sticky comment under GitHub's size limit.
+    """
+
+    version: int = 2
+    runs: tuple[RunRecord, ...] = field(default_factory=tuple)
+    findings: tuple[FindingRecord, ...] = field(default_factory=tuple)
+    truncated: bool = False
+
+    @property
+    def next_round(self) -> int:
+        """Return the round number the next review run should record."""
+        if not self.runs:
+            return 1
+        return max(run.round for run in self.runs) + 1
+
+    @property
+    def open_findings(self) -> tuple[FindingRecord, ...]:
+        """Return the currently open findings, oldest round first."""
+        return tuple(
+            record for record in self.findings if record.status is FindingStatus.OPEN
+        )
+
+    @property
+    def resolved_findings(self) -> tuple[FindingRecord, ...]:
+        """Return the findings already marked resolved."""
+        return tuple(
+            record
+            for record in self.findings
+            if record.status is FindingStatus.RESOLVED
+        )
+
+    def with_runs(self, *, runs: tuple[RunRecord, ...]) -> ReviewState:
+        """Return a copy of this state carrying a different run history."""
+        return replace(self, runs=runs)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the state for the hidden comment blob.
+
+        Returns:
+            JSON-serializable mapping with ``version``, ``runs``, and
+            ``findings`` keys (plus ``truncated`` when pruning occurred).
+        """
+        payload: dict[str, Any] = {
+            "version": self.version,
+            "runs": [run.to_dict() for run in self.runs],
+            "findings": [record.to_dict() for record in self.findings],
+        }
+        if self.truncated:
+            payload["truncated"] = True
+        return payload

--- a/lintro/ai/review/models/run_record.py
+++ b/lintro/ai/review/models/run_record.py
@@ -169,8 +169,13 @@ def _parse_verdict(value: Any) -> ReviewVerdict:
         value: Raw verdict value decoded from the state blob.
 
     Returns:
-        The parsed verdict, or ``CHANGES_REQUESTED`` when unrecognized.
+        The parsed verdict, or ``CHANGES_REQUESTED`` when unrecognized or
+        absent. A v1 record carries no verdict key at all, so that absence is
+        treated as the same neutral fallback without logging — it is expected
+        on every migrated legacy run, not an anomaly.
     """
+    if value is None:
+        return ReviewVerdict.CHANGES_REQUESTED
     try:
         return ReviewVerdict(str(value).lower())
     except ValueError:

--- a/lintro/ai/review/models/run_record.py
+++ b/lintro/ai/review/models/run_record.py
@@ -5,25 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from loguru import logger
+
 from lintro.ai.review.enums.review_verdict import ReviewVerdict
+from lintro.ai.review.models._coerce import coerce_float, coerce_int
 
 __all__ = ["RunRecord"]
-
-
-def _coerce_int(value: Any, *, default: int = 0) -> int:
-    """Coerce an untrusted JSON value to an int, falling back to a default."""
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return default
-
-
-def _coerce_float(value: Any, *, default: float = 0.0) -> float:
-    """Coerce an untrusted JSON value to a float, falling back to a default."""
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return default
 
 
 @dataclass(frozen=True, slots=True)
@@ -141,38 +128,54 @@ class RunRecord:
             The parsed run record.
         """
         return cls(
-            round=_coerce_int(payload.get("round"), default=1) or 1,
+            round=coerce_int(payload.get("round"), default=1) or 1,
             timestamp=str(payload.get("timestamp", "")),
             sha=str(payload.get("sha", "")),
             model=str(payload.get("model", "")),
             provider=str(payload.get("provider", "")),
             transport=str(payload.get("transport", "")),
             auth_mode=str(payload.get("auth_mode", "")),
-            depth=_coerce_int(payload.get("depth")),
+            depth=coerce_int(payload.get("depth")),
             strictness=str(payload.get("strictness", "")),
-            files_reviewed=_coerce_int(payload.get("files_reviewed")),
-            files_skipped=_coerce_int(payload.get("files_skipped")),
-            checks=_coerce_int(payload.get("checks")),
-            duration=_coerce_float(payload.get("duration")),
-            prompt=_coerce_int(payload.get("prompt")),
-            completion=_coerce_int(payload.get("completion")),
-            total=_coerce_int(payload.get("total")),
-            cost=_coerce_float(payload.get("cost")),
+            files_reviewed=coerce_int(payload.get("files_reviewed")),
+            files_skipped=coerce_int(payload.get("files_skipped")),
+            checks=coerce_int(payload.get("checks")),
+            duration=coerce_float(payload.get("duration")),
+            prompt=coerce_int(payload.get("prompt")),
+            completion=coerce_int(payload.get("completion")),
+            total=coerce_int(payload.get("total")),
+            cost=coerce_float(payload.get("cost")),
             estimated=bool(payload.get("estimated", False)),
             verdict=_parse_verdict(payload.get("verdict")),
             confidence=str(payload.get("confidence", "")),
-            p1=_coerce_int(payload.get("p1")),
-            p2=_coerce_int(payload.get("p2")),
-            p3=_coerce_int(payload.get("p3")),
+            p1=coerce_int(payload.get("p1")),
+            p2=coerce_int(payload.get("p2")),
+            p3=coerce_int(payload.get("p3")),
             partial=bool(payload.get("partial", False)),
-            chunks_reviewed=_coerce_int(payload.get("chunks_reviewed")),
-            chunks_total=_coerce_int(payload.get("chunks_total")),
+            chunks_reviewed=coerce_int(payload.get("chunks_reviewed")),
+            chunks_total=coerce_int(payload.get("chunks_total")),
         )
 
 
 def _parse_verdict(value: Any) -> ReviewVerdict:
-    """Parse a verdict label, defaulting to ``READY`` for unknown input."""
+    """Parse a stored verdict label from an untrusted state blob.
+
+    An unrecognized label must never fail open: reporting ``READY`` for a
+    corrupted or renamed value would fabricate a clean bill of health for a run
+    that may have been blocked. The neutral middle value is used instead, and
+    the anomaly is logged.
+
+    Args:
+        value: Raw verdict value decoded from the state blob.
+
+    Returns:
+        The parsed verdict, or ``CHANGES_REQUESTED`` when unrecognized.
+    """
     try:
         return ReviewVerdict(str(value).lower())
     except ValueError:
-        return ReviewVerdict.READY
+        logger.debug(
+            f"Unrecognized stored review verdict {value!r}; treating as "
+            f"{ReviewVerdict.CHANGES_REQUESTED}",
+        )
+        return ReviewVerdict.CHANGES_REQUESTED

--- a/lintro/ai/review/models/run_record.py
+++ b/lintro/ai/review/models/run_record.py
@@ -1,0 +1,178 @@
+"""Per-run statistics record persisted in the review state blob."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from lintro.ai.review.enums.review_verdict import ReviewVerdict
+
+__all__ = ["RunRecord"]
+
+
+def _coerce_int(value: Any, *, default: int = 0) -> int:
+    """Coerce an untrusted JSON value to an int, falling back to a default."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value: Any, *, default: float = 0.0) -> float:
+    """Coerce an untrusted JSON value to a float, falling back to a default."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True, slots=True)
+class RunRecord:
+    """Statistics for one AI review round on a pull request.
+
+    The v1 aggregate keys (``timestamp``, ``model``, ``prompt``, ``total``,
+    ``cost``, severity counts, …) are preserved verbatim in the serialized form
+    so existing sticky-comment rendering keeps working across the migration.
+
+    Attributes:
+        round: 1-based review round number on this PR.
+        timestamp: ISO 8601 UTC timestamp of the run.
+        sha: Head commit sha reviewed in this round.
+        model: Model identifier used for the review.
+        provider: Provider name (anthropic, openai, …).
+        transport: Provider transport used (for example ``api`` or ``cli``).
+        auth_mode: Authentication mode used by the transport (for example
+            ``api-key`` or ``subscription``).
+        depth: Review depth level.
+        strictness: Sensitivity preset applied.
+        files_reviewed: Number of changed files included in the review.
+        files_skipped: Number of changed files excluded from the review.
+        checks: Number of checklist items in the prompt.
+        duration: Wall-clock duration in seconds.
+        prompt: Prompt (input) tokens consumed.
+        completion: Completion (output) tokens produced.
+        total: Total tokens consumed.
+        cost: Estimated cost in USD.
+        estimated: True when token counts were estimated locally.
+        verdict: Readiness verdict derived from open findings after this round.
+        confidence: Aggregate confidence label reported for the round.
+        p1: Count of P1 findings reported in this round.
+        p2: Count of P2 findings reported in this round.
+        p3: Count of P3 findings reported in this round.
+        partial: True when the review stopped before every chunk was reviewed.
+        chunks_reviewed: Number of chunks actually reviewed.
+        chunks_total: Total number of chunks in the diff.
+    """
+
+    round: int = 1
+    timestamp: str = ""
+    sha: str = ""
+    model: str = ""
+    provider: str = ""
+    transport: str = ""
+    auth_mode: str = ""
+    depth: int = 0
+    strictness: str = ""
+    files_reviewed: int = 0
+    files_skipped: int = 0
+    checks: int = 0
+    duration: float = 0.0
+    prompt: int = 0
+    completion: int = 0
+    total: int = 0
+    cost: float = 0.0
+    estimated: bool = False
+    verdict: ReviewVerdict = ReviewVerdict.READY
+    confidence: str = ""
+    p1: int = 0
+    p2: int = 0
+    p3: int = 0
+    partial: bool = False
+    chunks_reviewed: int = 0
+    chunks_total: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the run record for the hidden state blob.
+
+        Returns:
+            JSON-serializable mapping carrying both the v1 aggregate keys and
+            the v2 additions.
+        """
+        return {
+            "round": self.round,
+            "timestamp": self.timestamp,
+            "sha": self.sha,
+            "model": self.model,
+            "provider": self.provider,
+            "transport": self.transport,
+            "auth_mode": self.auth_mode,
+            "depth": self.depth,
+            "strictness": self.strictness,
+            "files_reviewed": self.files_reviewed,
+            "files_skipped": self.files_skipped,
+            "checks": self.checks,
+            "duration": round(self.duration, 2),
+            "prompt": self.prompt,
+            "completion": self.completion,
+            "total": self.total,
+            "cost": round(self.cost, 6),
+            "estimated": self.estimated,
+            "verdict": str(self.verdict),
+            "confidence": self.confidence,
+            "p1": self.p1,
+            "p2": self.p2,
+            "p3": self.p3,
+            "partial": self.partial,
+            "chunks_reviewed": self.chunks_reviewed,
+            "chunks_total": self.chunks_total,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> RunRecord:
+        """Rebuild a run record from an untrusted state-blob mapping.
+
+        Missing keys fall back to defaults, so a v1 record parses cleanly and
+        simply carries empty v2 fields.
+
+        Args:
+            payload: Decoded JSON mapping for one run.
+
+        Returns:
+            The parsed run record.
+        """
+        return cls(
+            round=_coerce_int(payload.get("round"), default=1) or 1,
+            timestamp=str(payload.get("timestamp", "")),
+            sha=str(payload.get("sha", "")),
+            model=str(payload.get("model", "")),
+            provider=str(payload.get("provider", "")),
+            transport=str(payload.get("transport", "")),
+            auth_mode=str(payload.get("auth_mode", "")),
+            depth=_coerce_int(payload.get("depth")),
+            strictness=str(payload.get("strictness", "")),
+            files_reviewed=_coerce_int(payload.get("files_reviewed")),
+            files_skipped=_coerce_int(payload.get("files_skipped")),
+            checks=_coerce_int(payload.get("checks")),
+            duration=_coerce_float(payload.get("duration")),
+            prompt=_coerce_int(payload.get("prompt")),
+            completion=_coerce_int(payload.get("completion")),
+            total=_coerce_int(payload.get("total")),
+            cost=_coerce_float(payload.get("cost")),
+            estimated=bool(payload.get("estimated", False)),
+            verdict=_parse_verdict(payload.get("verdict")),
+            confidence=str(payload.get("confidence", "")),
+            p1=_coerce_int(payload.get("p1")),
+            p2=_coerce_int(payload.get("p2")),
+            p3=_coerce_int(payload.get("p3")),
+            partial=bool(payload.get("partial", False)),
+            chunks_reviewed=_coerce_int(payload.get("chunks_reviewed")),
+            chunks_total=_coerce_int(payload.get("chunks_total")),
+        )
+
+
+def _parse_verdict(value: Any) -> ReviewVerdict:
+    """Parse a verdict label, defaulting to ``READY`` for unknown input."""
+    try:
+        return ReviewVerdict(str(value).lower())
+    except ValueError:
+        return ReviewVerdict.READY

--- a/lintro/ai/review/review_state_codec.py
+++ b/lintro/ai/review/review_state_codec.py
@@ -30,6 +30,7 @@ __all__ = [
     "encode_state",
     "migrate_v1_runs",
     "prune_state_to_fit",
+    "renumber_if_legacy_v1",
     "render_state_block",
 ]
 
@@ -124,6 +125,30 @@ def migrate_v1_runs(*, runs: list[RunRecord]) -> list[RunRecord]:
     return [replace(run, round=index) for index, run in enumerate(runs, start=1)]
 
 
+def renumber_if_legacy_v1(*, runs: tuple[RunRecord, ...]) -> tuple[RunRecord, ...]:
+    """Detect and renumber runs that look like an unversioned v1 blob.
+
+    Callers that receive raw ``prior_runs`` mappings (rather than a full,
+    versioned state blob) have no explicit version tag to dispatch on. A v1
+    blob's runs all parse with the round-field default of ``1``, which is the
+    only signal available; a single real round-1 run is indistinguishable
+    from that and is left alone, since renumbering it would be a no-op. This
+    single detection rule is shared by every such entry point (the sticky
+    comment path and the error comment path) so a given set of legacy runs
+    always renumbers the same way regardless of which surface parsed them.
+
+    Args:
+        runs: Runs already parsed via ``RunRecord.from_dict``.
+
+    Returns:
+        The renumbered runs when the v1 heuristic matches, otherwise ``runs``
+        unchanged.
+    """
+    if runs and all(run.round == 1 for run in runs):
+        return tuple(migrate_v1_runs(runs=list(runs)))
+    return runs
+
+
 def decode_state(*, body: str) -> ReviewState:
     """Decode the review state embedded in a sticky comment body.
 
@@ -139,11 +164,11 @@ def decode_state(*, body: str) -> ReviewState:
     if payload is None:
         return ReviewState()
 
-    try:
-        version = int(payload.get("version", STATE_VERSION_V1))
-    except (TypeError, ValueError, OverflowError):
-        # OverflowError: json.loads accepts the non-standard Infinity token as
-        # float("inf"), and int() of that raises rather than failing cleanly.
+    # Require a genuine int: bool is an int subclass (True/False would
+    # otherwise silently decode as v1/v2), and a float like 2.9 would
+    # truncate to a version that was never actually written.
+    version = payload.get("version", STATE_VERSION_V1)
+    if isinstance(version, bool) or not isinstance(version, int):
         return ReviewState()
 
     if version == STATE_VERSION_V1:

--- a/lintro/ai/review/review_state_codec.py
+++ b/lintro/ai/review/review_state_codec.py
@@ -1,0 +1,232 @@
+"""Encode, decode, migrate, and prune the hidden review-state blob.
+
+The blob lives in the sticky PR comment as an HTML comment so GitHub renders
+nothing while later rounds can recover the full history. Schema v2 adds
+per-round statistics and per-finding identity on top of v1's run aggregates;
+v1 blobs are migrated on read and unknown versions start fresh rather than
+crashing a review run.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from typing import Any
+
+from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.github_constants import (
+    GITHUB_COMMENT_HARD_LIMIT,
+    STATE_MARKER_PREFIX,
+    STATE_MARKER_SUFFIX,
+    STATE_VERSION,
+    STATE_VERSION_V1,
+)
+from lintro.ai.review.models.finding_record import FindingRecord
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.run_record import RunRecord
+
+__all__ = [
+    "decode_state",
+    "encode_state",
+    "prune_state_to_fit",
+    "render_state_block",
+]
+
+
+def encode_state(*, state: ReviewState) -> str:
+    """Serialize a state object to its JSON payload.
+
+    Args:
+        state: State to serialize.
+
+    Returns:
+        Compact JSON string. The stored version is always the current schema
+        version, so a migrated v1 blob is written back as v2.
+    """
+    payload = state.to_dict()
+    payload["version"] = STATE_VERSION
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def render_state_block(*, state: ReviewState) -> str:
+    """Render the hidden HTML-comment state block appended to the sticky body.
+
+    Args:
+        state: State to embed.
+
+    Returns:
+        The block, including its leading blank-line separator.
+    """
+    return (
+        f"\n\n{STATE_MARKER_PREFIX} "
+        + encode_state(state=state)
+        + f" {STATE_MARKER_SUFFIX}"
+    )
+
+
+def _extract_payload(*, body: str) -> dict[str, Any] | None:
+    """Pull the JSON mapping out of a sticky comment body.
+
+    Args:
+        body: Existing sticky comment body.
+
+    Returns:
+        The decoded mapping, or ``None`` when absent or unparsable.
+    """
+    start = body.find(STATE_MARKER_PREFIX)
+    if start < 0:
+        return None
+    after = body[start + len(STATE_MARKER_PREFIX) :]
+    end = after.rfind(STATE_MARKER_SUFFIX)
+    raw = after[:end] if end >= 0 else after
+    try:
+        payload = json.loads(raw.strip())
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _parse_runs(*, payload: dict[str, Any]) -> list[RunRecord]:
+    """Parse the run list from a decoded state payload."""
+    runs = payload.get("runs")
+    if not isinstance(runs, list):
+        return []
+    return [RunRecord.from_dict(entry) for entry in runs if isinstance(entry, dict)]
+
+
+def _parse_findings(*, payload: dict[str, Any]) -> list[FindingRecord]:
+    """Parse the finding list from a decoded state payload."""
+    findings = payload.get("findings")
+    if not isinstance(findings, list):
+        return []
+    parsed = (
+        FindingRecord.from_dict(entry) for entry in findings if isinstance(entry, dict)
+    )
+    return [record for record in parsed if record is not None]
+
+
+def _migrate_v1(*, runs: list[RunRecord]) -> list[RunRecord]:
+    """Stamp sequential round numbers onto migrated v1 run records.
+
+    v1 stored no round number, so the position in the (chronological) run list
+    is the only available ordering signal.
+
+    Args:
+        runs: Runs parsed from a v1 blob, oldest first.
+
+    Returns:
+        The same runs with 1-based round numbers applied.
+    """
+    return [replace(run, round=index) for index, run in enumerate(runs, start=1)]
+
+
+def decode_state(*, body: str) -> ReviewState:
+    """Decode the review state embedded in a sticky comment body.
+
+    Args:
+        body: Existing sticky comment body (may contain no state at all).
+
+    Returns:
+        The decoded state. A missing, malformed, or unknown-version blob yields
+        an empty state rather than raising — a review run must never fail
+        because of an unreadable comment.
+    """
+    payload = _extract_payload(body=body)
+    if payload is None:
+        return ReviewState()
+
+    try:
+        version = int(payload.get("version", STATE_VERSION_V1))
+    except (TypeError, ValueError):
+        return ReviewState()
+
+    if version == STATE_VERSION_V1:
+        return ReviewState(
+            version=STATE_VERSION,
+            runs=tuple(_migrate_v1(runs=_parse_runs(payload=payload))),
+        )
+    if version != STATE_VERSION:
+        # Forward-incompatible blob written by a newer lintro: start fresh
+        # instead of guessing at unknown semantics.
+        return ReviewState()
+
+    return ReviewState(
+        version=STATE_VERSION,
+        runs=tuple(_parse_runs(payload=payload)),
+        findings=tuple(_parse_findings(payload=payload)),
+        truncated=bool(payload.get("truncated", False)),
+    )
+
+
+def _block_length(*, state: ReviewState) -> int:
+    """Return the rendered length of the state block for ``state``."""
+    return len(render_state_block(state=state))
+
+
+def prune_state_to_fit(
+    *,
+    state: ReviewState,
+    body: str,
+    limit: int = GITHUB_COMMENT_HARD_LIMIT,
+) -> ReviewState:
+    """Prune state until the body plus its state block fits GitHub's cap.
+
+    Oldest run records are dropped first (the newest run is always kept), then
+    resolved findings oldest-first, then open findings oldest-first. Any
+    pruning sets :attr:`ReviewState.truncated` so downstream surfaces can say
+    the history is incomplete.
+
+    Args:
+        state: State that would be embedded.
+        body: Rendered sticky body *without* the state block.
+        limit: Hard character limit for the whole comment.
+
+    Returns:
+        A state whose block fits the remaining budget, or the smallest state
+        reachable by pruning when even that is impossible.
+    """
+    budget = limit - len(body)
+    if _block_length(state=state) <= budget:
+        return state
+
+    runs = list(state.runs)
+    findings = list(state.findings)
+
+    def candidate_for(*, kept_findings: list[FindingRecord]) -> ReviewState:
+        """Build the pruned candidate state for the current working lists."""
+        return ReviewState(
+            version=state.version,
+            runs=tuple(runs),
+            findings=tuple(kept_findings),
+            truncated=True,
+        )
+
+    while len(runs) > 1:
+        runs.pop(0)
+        candidate = candidate_for(kept_findings=findings)
+        if _block_length(state=candidate) <= budget:
+            return candidate
+
+    # Resolved findings go before open ones; within each group the oldest
+    # (lowest ``since_round``) is dropped first.
+    drop_order = sorted(
+        range(len(findings)),
+        key=lambda index: (
+            findings[index].status is FindingStatus.OPEN,
+            findings[index].since_round,
+            index,
+        ),
+    )
+    dropped: set[int] = set()
+    for index in drop_order:
+        dropped.add(index)
+        kept = [
+            record
+            for position, record in enumerate(findings)
+            if position not in dropped
+        ]
+        candidate = candidate_for(kept_findings=kept)
+        if _block_length(state=candidate) <= budget:
+            return candidate
+
+    return candidate_for(kept_findings=[])

--- a/lintro/ai/review/review_state_codec.py
+++ b/lintro/ai/review/review_state_codec.py
@@ -28,6 +28,7 @@ from lintro.ai.review.models.run_record import RunRecord
 __all__ = [
     "decode_state",
     "encode_state",
+    "migrate_v1_runs",
     "prune_state_to_fit",
     "render_state_block",
 ]
@@ -105,11 +106,14 @@ def _parse_findings(*, payload: dict[str, Any]) -> list[FindingRecord]:
     return [record for record in parsed if record is not None]
 
 
-def _migrate_v1(*, runs: list[RunRecord]) -> list[RunRecord]:
+def migrate_v1_runs(*, runs: list[RunRecord]) -> list[RunRecord]:
     """Stamp sequential round numbers onto migrated v1 run records.
 
     v1 stored no round number, so the position in the (chronological) run list
-    is the only available ordering signal.
+    is the only available ordering signal. Shared by every entry point that
+    can receive legacy v1 run data (the sticky comment path and the error
+    comment path) so a given set of legacy runs always renumbers the same way
+    regardless of which surface parsed them.
 
     Args:
         runs: Runs parsed from a v1 blob, oldest first.
@@ -137,13 +141,15 @@ def decode_state(*, body: str) -> ReviewState:
 
     try:
         version = int(payload.get("version", STATE_VERSION_V1))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError: json.loads accepts the non-standard Infinity token as
+        # float("inf"), and int() of that raises rather than failing cleanly.
         return ReviewState()
 
     if version == STATE_VERSION_V1:
         return ReviewState(
             version=STATE_VERSION,
-            runs=tuple(_migrate_v1(runs=_parse_runs(payload=payload))),
+            runs=tuple(migrate_v1_runs(runs=_parse_runs(payload=payload))),
         )
     if version != STATE_VERSION:
         # Forward-incompatible blob written by a newer lintro: start fresh

--- a/tests/unit/ai/review/test_finding_matcher.py
+++ b/tests/unit/ai/review/test_finding_matcher.py
@@ -75,8 +75,14 @@ def test_normalize_title_strips_noise(raw: str, expected: str) -> None:
         ("./src/app.py", "src/app.py"),
         ("src\\app.py", "src/app.py"),
         (" src/app.py ", "src/app.py"),
+        (" ./src/app.py ", "src/app.py"),
     ],
-    ids=["dot-prefix", "windows-separator", "surrounding-space"],
+    ids=[
+        "dot-prefix",
+        "windows-separator",
+        "surrounding-space",
+        "space-then-dot-prefix",
+    ],
 )
 def test_normalize_file_path(raw: str, expected: str) -> None:
     """File paths normalize to POSIX form without a leading ``./``."""

--- a/tests/unit/ai/review/test_finding_matcher.py
+++ b/tests/unit/ai/review/test_finding_matcher.py
@@ -337,12 +337,71 @@ def test_ambiguous_tie_prefers_carrying_over_an_open_finding() -> None:
     assert_that(result.carried).is_length(1)
     assert_that(result.regressed).is_empty()
     assert_that(result.resolved).is_empty()
+    # The carried record keeps the open sibling's ordinal, so its key cannot
+    # collide with the resolved record still tracked under ordinal 1.
+    assert_that(result.carried[0].ordinal).is_equal_to(2)
+    assert_that({record.key for record in result.records}).is_length(2)
+
+
+def test_record_keys_stay_unique_across_rounds() -> None:
+    """Identity keys never collide, even as duplicate groups grow and shrink."""
+    first = match_findings(
+        previous=None,
+        findings=[
+            _finding(title="Hardcoded credential", line=10),
+            _finding(title="Hardcoded credential", line=100),
+        ],
+        round_number=1,
+    )
+    second = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[_finding(title="Hardcoded credential", line=11)],
+        round_number=2,
+        head_sha="sha2",
+    )
+    third = match_findings(
+        previous=ReviewState(findings=second.records),
+        findings=[
+            _finding(title="Hardcoded credential", line=11),
+            _finding(title="Hardcoded credential", line=300),
+            _finding(title="Hardcoded credential", line=500),
+        ],
+        round_number=3,
+        head_sha="sha3",
+    )
+
+    keys = [record.key for record in third.records]
+    assert_that(keys).is_length(len(set(keys)))
+    assert_that(third.records).is_length(3)
+
+
+def test_carried_finding_keeps_its_original_ordinal() -> None:
+    """A carried finding's ordinal is stable even when siblings disappear."""
+    first = match_findings(
+        previous=None,
+        findings=[
+            _finding(title="Hardcoded credential", line=10),
+            _finding(title="Hardcoded credential", line=100),
+        ],
+        round_number=1,
+    )
+
+    second = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[_finding(title="Hardcoded credential", line=102)],
+        round_number=2,
+        head_sha="sha2",
+    )
+
+    assert_that(second.carried[0].ordinal).is_equal_to(2)
 
 
 def test_resolved_records_are_retained_in_the_merged_set() -> None:
     """Already-resolved findings stay in state so history is not lost."""
     first = match_findings(
-        previous=None, findings=[_finding(title="Leak")], round_number=1
+        previous=None,
+        findings=[_finding(title="Leak")],
+        round_number=1,
     )
     second = match_findings(
         previous=ReviewState(findings=first.records),

--- a/tests/unit/ai/review/test_finding_matcher.py
+++ b/tests/unit/ai/review/test_finding_matcher.py
@@ -1,0 +1,408 @@
+"""Tests for cross-run finding fingerprinting and matching (#1906)."""
+
+from __future__ import annotations
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.review.enums.finding_match_outcome import FindingMatchOutcome
+from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.enums.review_verdict import ReviewVerdict
+from lintro.ai.review.finding_matcher import (
+    FINGERPRINT_LENGTH,
+    derive_verdict,
+    fingerprint_for,
+    match_findings,
+    normalize_file_path,
+    normalize_title,
+)
+from lintro.ai.review.models.finding_record import FindingRecord
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
+from lintro.ai.review.models.review_state import ReviewState
+
+
+def _finding(
+    *,
+    title: str,
+    file: str = "src/app.py",
+    line: int = 10,
+    category: str = "security",
+    severity: Severity = Severity.P1,
+) -> ReviewFinding:
+    """Build a review finding for matcher tests.
+
+    Args:
+        title: Finding title.
+        file: Repository-relative file path.
+        line: Line number.
+        category: Finding category label.
+        severity: Finding severity.
+
+    Returns:
+        The constructed finding.
+    """
+    return ReviewFinding(
+        severity=severity,
+        category=category,
+        file=file,
+        line=line,
+        title=title,
+        description="d",
+        cause="c",
+        fix="f",
+        confidence="high",
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Hardcoded  Credential", "hardcoded credential"),
+        ("`token` leaks!", "token leaks"),
+        ("Missing\tnull-check.", "missing null check"),
+        ("   Spaced   Out   ", "spaced out"),
+    ],
+    ids=["whitespace-run", "backticks", "punctuation", "trim"],
+)
+def test_normalize_title_strips_noise(raw: str, expected: str) -> None:
+    """Titles normalize to lowercase, punctuation-free, single-spaced text."""
+    assert_that(normalize_title(raw)).is_equal_to(expected)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("./src/app.py", "src/app.py"),
+        ("src\\app.py", "src/app.py"),
+        (" src/app.py ", "src/app.py"),
+    ],
+    ids=["dot-prefix", "windows-separator", "surrounding-space"],
+)
+def test_normalize_file_path(raw: str, expected: str) -> None:
+    """File paths normalize to POSIX form without a leading ``./``."""
+    assert_that(normalize_file_path(raw)).is_equal_to(expected)
+
+
+def test_fingerprint_is_stable_across_line_drift() -> None:
+    """The fingerprint ignores line numbers, which drift as the PR evolves."""
+    first = fingerprint_for(file="src/app.py", category="security", title="Leak")
+    second = fingerprint_for(file="./src/app.py", category="security", title="Leak")
+
+    assert_that(first).is_equal_to(second)
+    assert_that(first).is_length(FINGERPRINT_LENGTH)
+
+
+def test_fingerprint_is_stable_across_title_punctuation() -> None:
+    """Cosmetic punctuation and casing changes keep the fingerprint stable."""
+    first = fingerprint_for(
+        file="src/app.py",
+        category="security",
+        title="Hardcoded credential",
+    )
+    second = fingerprint_for(
+        file="src/app.py",
+        category="security",
+        title="`Hardcoded`  Credential!",
+    )
+
+    assert_that(first).is_equal_to(second)
+
+
+def test_fingerprint_differs_by_file_and_category() -> None:
+    """Different files or categories produce different fingerprints."""
+    base = fingerprint_for(file="src/a.py", category="security", title="Leak")
+    other_file = fingerprint_for(file="src/b.py", category="security", title="Leak")
+    other_category = fingerprint_for(file="src/a.py", category="perf", title="Leak")
+
+    assert_that(base).is_not_equal_to(other_file)
+    assert_that(base).is_not_equal_to(other_category)
+
+
+def test_first_round_marks_every_finding_new() -> None:
+    """With no prior state every finding is new and since_round is 1."""
+    result = match_findings(
+        previous=None,
+        findings=[_finding(title="Leak"), _finding(title="Slow loop", line=30)],
+        round_number=1,
+        head_sha="abc123",
+    )
+
+    assert_that(result.new).is_length(2)
+    assert_that(result.carried).is_empty()
+    assert_that(result.resolved).is_empty()
+    assert_that(result.regressed).is_empty()
+    assert_that({record.since_round for record in result.records}).is_equal_to({1})
+
+
+def test_repeat_finding_is_carried_with_original_since_round() -> None:
+    """A finding reported again carries its original first-seen round."""
+    first = match_findings(
+        previous=None,
+        findings=[_finding(title="Leak")],
+        round_number=1,
+    )
+    state = ReviewState(runs=(), findings=first.records)
+
+    second = match_findings(
+        previous=state,
+        findings=[_finding(title="Leak", line=42)],
+        round_number=2,
+        head_sha="sha2",
+    )
+
+    assert_that(second.carried).is_length(1)
+    assert_that(second.new).is_empty()
+    carried = second.carried[0]
+    assert_that(carried.since_round).is_equal_to(1)
+    assert_that(carried.line).is_equal_to(42)
+    assert_that(second.outcome_for(record=carried)).is_equal_to(
+        FindingMatchOutcome.CARRIED,
+    )
+
+
+def test_disappeared_finding_is_resolved_with_provenance() -> None:
+    """A prior open finding absent this round is stamped resolved."""
+    first = match_findings(
+        previous=None,
+        findings=[_finding(title="Leak")],
+        round_number=1,
+    )
+    state = ReviewState(runs=(), findings=first.records)
+
+    second = match_findings(
+        previous=state,
+        findings=[],
+        round_number=2,
+        head_sha="deadbeef",
+    )
+
+    assert_that(second.resolved).is_length(1)
+    resolved = second.resolved[0]
+    assert_that(resolved.status).is_equal_to(FindingStatus.RESOLVED)
+    assert_that(resolved.resolved_sha).is_equal_to("deadbeef")
+    assert_that(resolved.resolved_round).is_equal_to(2)
+    assert_that(second.outcome_for(record=resolved)).is_equal_to(
+        FindingMatchOutcome.RESOLVED,
+    )
+
+
+def test_reappearing_finding_is_marked_regressed() -> None:
+    """A resolved finding reported again re-opens with a regressed marker."""
+    first = match_findings(
+        previous=None,
+        findings=[_finding(title="Leak")],
+        round_number=1,
+    )
+    second = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[],
+        round_number=2,
+        head_sha="sha2",
+    )
+    third = match_findings(
+        previous=ReviewState(findings=second.records),
+        findings=[_finding(title="Leak")],
+        round_number=3,
+        head_sha="sha3",
+    )
+
+    assert_that(third.regressed).is_length(1)
+    regressed = third.regressed[0]
+    assert_that(regressed.regressed).is_true()
+    assert_that(regressed.status).is_equal_to(FindingStatus.OPEN)
+    assert_that(regressed.since_round).is_equal_to(1)
+    # Prior resolution provenance is preserved for the link-back banner.
+    assert_that(regressed.resolved_sha).is_equal_to("sha2")
+    assert_that(third.outcome_for(record=regressed)).is_equal_to(
+        FindingMatchOutcome.REGRESSED,
+    )
+    assert_that(third.new).is_empty()
+
+
+def test_duplicate_fingerprints_get_ordinals_by_line_order() -> None:
+    """Same-fingerprint findings are disambiguated by first-seen line order."""
+    result = match_findings(
+        previous=None,
+        findings=[
+            _finding(title="Hardcoded credential", line=90),
+            _finding(title="Hardcoded credential", line=12),
+        ],
+        round_number=1,
+    )
+
+    by_line = {record.line: record.ordinal for record in result.records}
+    assert_that(by_line).is_equal_to({12: 1, 90: 2})
+    assert_that({record.key for record in result.records}).is_length(2)
+
+
+def test_ambiguous_duplicates_match_by_nearest_line() -> None:
+    """Later rounds pair ambiguous duplicates by nearest line distance."""
+    first = match_findings(
+        previous=None,
+        findings=[
+            _finding(title="Hardcoded credential", line=10),
+            _finding(title="Hardcoded credential", line=100),
+        ],
+        round_number=1,
+    )
+
+    second = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[
+            _finding(title="Hardcoded credential", line=104),
+            _finding(title="Hardcoded credential", line=12),
+        ],
+        round_number=2,
+        head_sha="sha2",
+    )
+
+    assert_that(second.carried).is_length(2)
+    assert_that(second.new).is_empty()
+    assert_that(second.resolved).is_empty()
+
+
+def test_shrinking_duplicate_group_resolves_only_the_extra() -> None:
+    """When duplicates shrink, only the unmatched occurrence resolves."""
+    first = match_findings(
+        previous=None,
+        findings=[
+            _finding(title="Hardcoded credential", line=10),
+            _finding(title="Hardcoded credential", line=100),
+        ],
+        round_number=1,
+    )
+
+    second = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[_finding(title="Hardcoded credential", line=11)],
+        round_number=2,
+        head_sha="sha2",
+    )
+
+    assert_that(second.carried).is_length(1)
+    assert_that(second.resolved).is_length(1)
+    assert_that(second.resolved[0].line).is_equal_to(100)
+
+
+def test_ambiguous_tie_prefers_carrying_over_an_open_finding() -> None:
+    """An equidistant open/resolved tie carries the open finding over.
+
+    A stale open finding is a lesser failure than a false "Addressed" banner,
+    so the open prior record wins the pairing and nothing is resolved.
+    """
+    previous = ReviewState(
+        findings=(
+            FindingRecord(
+                fingerprint=fingerprint_for(
+                    file="src/app.py",
+                    category="security",
+                    title="Hardcoded credential",
+                ),
+                ordinal=1,
+                severity=Severity.P1,
+                category="security",
+                title="Hardcoded credential",
+                file="src/app.py",
+                line=40,
+                status=FindingStatus.RESOLVED,
+                since_round=1,
+                resolved_sha="sha1",
+                resolved_round=1,
+            ),
+            FindingRecord(
+                fingerprint=fingerprint_for(
+                    file="src/app.py",
+                    category="security",
+                    title="Hardcoded credential",
+                ),
+                ordinal=2,
+                severity=Severity.P1,
+                category="security",
+                title="Hardcoded credential",
+                file="src/app.py",
+                line=60,
+                status=FindingStatus.OPEN,
+                since_round=1,
+            ),
+        ),
+    )
+
+    result = match_findings(
+        previous=previous,
+        findings=[_finding(title="Hardcoded credential", line=50)],
+        round_number=2,
+        head_sha="sha2",
+    )
+
+    assert_that(result.carried).is_length(1)
+    assert_that(result.regressed).is_empty()
+    assert_that(result.resolved).is_empty()
+
+
+def test_resolved_records_are_retained_in_the_merged_set() -> None:
+    """Already-resolved findings stay in state so history is not lost."""
+    first = match_findings(
+        previous=None, findings=[_finding(title="Leak")], round_number=1
+    )
+    second = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[],
+        round_number=2,
+        head_sha="sha2",
+    )
+    third = match_findings(
+        previous=ReviewState(findings=second.records),
+        findings=[_finding(title="Other", line=5)],
+        round_number=3,
+        head_sha="sha3",
+    )
+
+    assert_that(third.records).is_length(2)
+    statuses = {record.status for record in third.records}
+    assert_that(statuses).is_equal_to({FindingStatus.OPEN, FindingStatus.RESOLVED})
+
+
+@pytest.mark.parametrize(
+    ("severities", "expected"),
+    [
+        ((Severity.P1, Severity.P3), ReviewVerdict.BLOCKED),
+        ((Severity.P2, Severity.P3), ReviewVerdict.CHANGES_REQUESTED),
+        ((Severity.P3,), ReviewVerdict.NITS_ONLY),
+        ((), ReviewVerdict.READY),
+    ],
+    ids=["blocked", "changes-requested", "nits-only", "ready"],
+)
+def test_derive_verdict_from_open_severities(
+    severities: tuple[Severity, ...],
+    expected: ReviewVerdict,
+) -> None:
+    """The readiness verdict follows the highest open severity."""
+    result = match_findings(
+        previous=None,
+        findings=[
+            _finding(title=f"Issue {index}", line=index, severity=severity)
+            for index, severity in enumerate(severities, start=1)
+        ],
+        round_number=1,
+    )
+
+    assert_that(derive_verdict(findings=result.records)).is_equal_to(expected)
+
+
+def test_derive_verdict_ignores_resolved_findings() -> None:
+    """Resolved findings never hold a PR back."""
+    first = match_findings(
+        previous=None,
+        findings=[_finding(title="Leak", severity=Severity.P1)],
+        round_number=1,
+    )
+    second = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[],
+        round_number=2,
+        head_sha="sha2",
+    )
+
+    assert_that(derive_verdict(findings=second.records)).is_equal_to(
+        ReviewVerdict.READY,
+    )

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -14,6 +14,7 @@ from lintro.ai.exceptions import (
 )
 from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.github import (
+    GITHUB_COMMENT_HARD_LIMIT,
     MAX_COMMENT_CHARS,
     STATE_MARKER_PREFIX,
     STICKY_MARKER,
@@ -576,8 +577,9 @@ def test_sticky_truncation_keeps_fallback_and_marks_dropped(
 
     body = build_sticky_comment(result=result, diff_lines=diff_lines)
 
-    # The final body stays within the cap (plus the appended state block).
-    assert_that(len(body)).is_less_than_or_equal_to(MAX_COMMENT_CHARS + 1000)
+    # The final comment (body plus the appended state block) stays within
+    # GitHub's hard limit.
+    assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
     # The fallback finding — with no inline surface — must survive truncation.
     assert_that(body).contains("FallbackOnlyFinding")
     # Truncation is explicit, not silent.
@@ -746,7 +748,7 @@ def test_build_sticky_cap_body_survives_all_fallback_overflow(
 
     body = build_sticky_comment(result=result, diff_lines=None)
 
-    assert_that(len(body)).is_less_than_or_equal_to(MAX_COMMENT_CHARS + 1000)
+    assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
     assert_that(body).contains("### Findings")
     assert_that(body).contains("StickyFallback0")
     marker_present = "finding(s) omitted" in body or "more finding(s) truncated" in body

--- a/tests/unit/ai/review/test_github_sticky_state.py
+++ b/tests/unit/ai/review/test_github_sticky_state.py
@@ -11,8 +11,10 @@ from lintro.ai.review.enums.finding_status import FindingStatus
 from lintro.ai.review.enums.review_verdict import ReviewVerdict
 from lintro.ai.review.github_constants import (
     GITHUB_COMMENT_HARD_LIMIT,
+    MAX_STORED_RUNS,
     STATE_MARKER_PREFIX,
     STATE_MARKER_SUFFIX,
+    STATE_VERSION,
 )
 from lintro.ai.review.github_errors import format_error_comment
 from lintro.ai.review.github_sticky import (
@@ -22,6 +24,8 @@ from lintro.ai.review.github_sticky import (
 )
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.run_record import RunRecord
 
 
 def _finding(
@@ -62,7 +66,7 @@ def test_sticky_state_block_is_version_two(
 
     state = parse_review_state_v2(body=body)
 
-    assert_that(state.version).is_equal_to(2)
+    assert_that(state.version).is_equal_to(STATE_VERSION)
     assert_that(state.runs).is_length(1)
     assert_that(state.runs[0].round).is_equal_to(1)
     assert_that(state.runs[0].sha).is_equal_to("abc123")
@@ -167,7 +171,7 @@ def test_sticky_migrates_a_v1_state_blob(
     )
 
     state = parse_review_state_v2(body=body)
-    assert_that(state.version).is_equal_to(2)
+    assert_that(state.version).is_equal_to(STATE_VERSION)
     assert_that([run.round for run in state.runs]).is_equal_to([1, 2, 3])
     assert_that(state.findings).is_not_empty()
 
@@ -186,6 +190,30 @@ def test_legacy_prior_runs_argument_still_works(
     state = parse_review_state_v2(body=body)
     assert_that(state.runs).is_length(2)
     assert_that([run.round for run in state.runs]).is_equal_to([1, 2])
+
+
+def test_legacy_prior_runs_with_multiple_raw_v1_dicts_renumbers_positionally(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Raw v1 dicts (no ``round`` key) trigger the positional-renumber branch.
+
+    ``test_legacy_prior_runs_argument_still_works`` passes ``prior_runs``
+    already carrying a ``round`` key (parsed from a v2 comment), so it never
+    exercises the heuristic that fires when every parsed run defaults to
+    round 1 — the actual shape of a genuine v1 blob's runs.
+    """
+    raw_v1_runs = [
+        {"model": "claude", "total": 100, "cost": 0.01},
+        {"model": "claude", "total": 200, "cost": 0.02},
+    ]
+
+    body = build_sticky_comment(
+        result=sample_review_result,
+        prior_runs=raw_v1_runs,
+    )
+
+    state = parse_review_state_v2(body=body)
+    assert_that([run.round for run in state.runs]).is_equal_to([1, 2, 3])
 
 
 def test_error_comment_preserves_finding_history(
@@ -232,3 +260,29 @@ def test_sticky_comment_never_exceeds_github_hard_limit(
 
     assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
     assert_that(body).contains(STATE_MARKER_PREFIX)
+
+
+def test_dropping_runs_past_max_stored_runs_marks_state_truncated(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The state is marked truncated when the run-count cap drops history.
+
+    ``prune_state_to_fit`` sets ``truncated`` when it prunes for size, but the
+    ``[-MAX_STORED_RUNS:]`` slice in ``build_sticky_comment`` is a second,
+    independent place history can be dropped. Both must set the flag.
+    """
+    prior_runs = tuple(
+        RunRecord(round=round_number, sha=f"sha{round_number}")
+        for round_number in range(1, MAX_STORED_RUNS + 1)
+    )
+    prior_state = ReviewState(runs=prior_runs, truncated=False)
+
+    body = build_sticky_comment(
+        result=sample_review_result,
+        prior_state=prior_state,
+        head_sha=f"sha{MAX_STORED_RUNS + 1}",
+    )
+
+    state = parse_review_state_v2(body=body)
+    assert_that(state.runs).is_length(MAX_STORED_RUNS)
+    assert_that(state.truncated).is_true()

--- a/tests/unit/ai/review/test_github_sticky_state.py
+++ b/tests/unit/ai/review/test_github_sticky_state.py
@@ -1,0 +1,234 @@
+"""Sticky-comment integration tests for review state schema v2 (#1906)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+from assertpy import assert_that
+
+from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.enums.review_verdict import ReviewVerdict
+from lintro.ai.review.github_constants import (
+    GITHUB_COMMENT_HARD_LIMIT,
+    STATE_MARKER_PREFIX,
+    STATE_MARKER_SUFFIX,
+)
+from lintro.ai.review.github_errors import format_error_comment
+from lintro.ai.review.github_sticky import (
+    build_sticky_comment,
+    parse_review_state,
+    parse_review_state_v2,
+)
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
+from lintro.ai.review.models.review_result import ReviewResult
+
+
+def _finding(
+    *,
+    title: str,
+    file: str = "src/app.py",
+    line: int = 10,
+    severity: Severity = Severity.P1,
+) -> ReviewFinding:
+    """Build a review finding for sticky-state tests."""
+    return ReviewFinding(
+        severity=severity,
+        category="security",
+        file=file,
+        line=line,
+        title=title,
+        description="d",
+        cause="c",
+        fix="f",
+        confidence="high",
+    )
+
+
+def _with_findings(
+    *,
+    base: ReviewResult,
+    findings: tuple[ReviewFinding, ...],
+) -> ReviewResult:
+    """Return a copy of ``base`` carrying different findings."""
+    return replace(base, findings=findings)
+
+
+def test_sticky_state_block_is_version_two(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A fresh sticky comment writes a v2 blob with runs and findings."""
+    body = build_sticky_comment(result=sample_review_result, head_sha="abc123")
+
+    state = parse_review_state_v2(body=body)
+
+    assert_that(state.version).is_equal_to(2)
+    assert_that(state.runs).is_length(1)
+    assert_that(state.runs[0].round).is_equal_to(1)
+    assert_that(state.runs[0].sha).is_equal_to("abc123")
+    assert_that(state.findings).is_length(len(sample_review_result.findings))
+
+
+def test_sticky_records_transport_and_auth_mode(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Transport and auth mode are persisted with the run record."""
+    body = build_sticky_comment(
+        result=sample_review_result,
+        transport="cli",
+        auth_mode="subscription",
+    )
+
+    run = parse_review_state_v2(body=body).runs[0]
+
+    assert_that(run.transport).is_equal_to("cli")
+    assert_that(run.auth_mode).is_equal_to("subscription")
+    assert_that(run.strictness).is_equal_to(sample_review_result.metadata.strictness)
+    assert_that(run.files_reviewed).is_equal_to(
+        sample_review_result.metadata.files_reviewed,
+    )
+    assert_that(run.checks).is_equal_to(sample_review_result.metadata.checklist_items)
+
+
+def test_sticky_verdict_is_derived_from_open_severities(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The recorded verdict follows the open findings, not the model."""
+    blocked = build_sticky_comment(
+        result=_with_findings(
+            base=sample_review_result,
+            findings=(_finding(title="Leak"),),
+        ),
+    )
+    ready = build_sticky_comment(
+        result=_with_findings(base=sample_review_result, findings=()),
+    )
+
+    assert_that(parse_review_state_v2(body=blocked).runs[0].verdict).is_equal_to(
+        ReviewVerdict.BLOCKED,
+    )
+    assert_that(parse_review_state_v2(body=ready).runs[0].verdict).is_equal_to(
+        ReviewVerdict.READY,
+    )
+
+
+def test_second_round_carries_and_resolves_findings(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A follow-up round carries repeats and resolves disappeared findings."""
+    first = build_sticky_comment(
+        result=_with_findings(
+            base=sample_review_result,
+            findings=(
+                _finding(title="Leak"),
+                _finding(title="Slow loop", line=44, severity=Severity.P2),
+            ),
+        ),
+        head_sha="sha1",
+    )
+
+    second = build_sticky_comment(
+        result=_with_findings(
+            base=sample_review_result,
+            findings=(_finding(title="Leak", line=15),),
+        ),
+        prior_state=parse_review_state_v2(body=first),
+        head_sha="sha2",
+    )
+
+    state = parse_review_state_v2(body=second)
+    assert_that(state.runs).is_length(2)
+    assert_that(state.runs[-1].round).is_equal_to(2)
+    assert_that(state.open_findings).is_length(1)
+    assert_that(state.open_findings[0].since_round).is_equal_to(1)
+    assert_that(state.resolved_findings).is_length(1)
+    assert_that(state.resolved_findings[0].resolved_sha).is_equal_to("sha2")
+    assert_that(state.resolved_findings[0].resolved_round).is_equal_to(2)
+
+
+def test_sticky_migrates_a_v1_state_blob(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A v1 blob from an older lintro is migrated instead of discarded."""
+    legacy = json.dumps(
+        {
+            "version": 1,
+            "runs": [
+                {"model": "claude", "total": 100, "cost": 0.01},
+                {"model": "claude", "total": 200, "cost": 0.02},
+            ],
+        },
+    )
+    prior_body = f"## old\n\n{STATE_MARKER_PREFIX} {legacy} {STATE_MARKER_SUFFIX}"
+
+    body = build_sticky_comment(
+        result=sample_review_result,
+        prior_state=parse_review_state_v2(body=prior_body),
+    )
+
+    state = parse_review_state_v2(body=body)
+    assert_that(state.version).is_equal_to(2)
+    assert_that([run.round for run in state.runs]).is_equal_to([1, 2, 3])
+    assert_that(state.findings).is_not_empty()
+
+
+def test_legacy_prior_runs_argument_still_works(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The ``prior_runs`` compatibility path keeps cumulative telemetry."""
+    first = build_sticky_comment(result=sample_review_result)
+
+    body = build_sticky_comment(
+        result=sample_review_result,
+        prior_runs=parse_review_state(body=first),
+    )
+
+    state = parse_review_state_v2(body=body)
+    assert_that(state.runs).is_length(2)
+    assert_that([run.round for run in state.runs]).is_equal_to([1, 2])
+
+
+def test_error_comment_preserves_finding_history(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A failed round re-emits the prior state instead of resetting it."""
+    first = build_sticky_comment(
+        result=_with_findings(
+            base=sample_review_result,
+            findings=(_finding(title="Leak"),),
+        ),
+        head_sha="sha1",
+    )
+    prior_state = parse_review_state_v2(body=first)
+
+    body = format_error_comment(
+        error=RuntimeError("boom"),
+        provider="anthropic",
+        prior_state=prior_state,
+    )
+
+    recovered = parse_review_state_v2(body=body)
+    assert_that(recovered.runs).is_length(1)
+    assert_that(recovered.open_findings).is_length(1)
+    assert_that(recovered.open_findings[0].status).is_equal_to(FindingStatus.OPEN)
+
+
+def test_sticky_comment_never_exceeds_github_hard_limit(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Even with a large finding history the comment fits GitHub's cap."""
+    findings = tuple(
+        _finding(
+            title=f"Finding number {index} with a reasonably long title",
+            file=f"src/module_{index}.py",
+            line=index,
+            severity=Severity.P2,
+        )
+        for index in range(300)
+    )
+    body = build_sticky_comment(
+        result=_with_findings(base=sample_review_result, findings=findings),
+    )
+
+    assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
+    assert_that(body).contains(STATE_MARKER_PREFIX)

--- a/tests/unit/ai/review/test_github_sticky_state.py
+++ b/tests/unit/ai/review/test_github_sticky_state.py
@@ -22,6 +22,7 @@ from lintro.ai.review.github_sticky import (
     parse_review_state,
     parse_review_state_v2,
 )
+from lintro.ai.review.models.finding_record import FindingRecord
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
@@ -241,6 +242,29 @@ def test_error_comment_preserves_finding_history(
     assert_that(recovered.open_findings[0].status).is_equal_to(FindingStatus.OPEN)
 
 
+def test_error_comment_legacy_prior_runs_path_preserves_history(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The legacy ``prior_runs`` branch (no ``prior_state``) also survives.
+
+    ``test_error_comment_preserves_finding_history`` only exercises the
+    ``prior_state=`` path; a regression in ``RunRecord.from_dict`` or
+    ``renumber_if_legacy_v1`` on the older ``prior_runs=`` branch would
+    otherwise be invisible.
+    """
+    first = build_sticky_comment(result=sample_review_result, head_sha="sha1")
+
+    body = format_error_comment(
+        error=RuntimeError("boom"),
+        provider="anthropic",
+        prior_runs=parse_review_state(body=first),
+    )
+
+    recovered = parse_review_state_v2(body=body)
+    assert_that(recovered.runs).is_length(1)
+    assert_that(recovered.runs[0].round).is_equal_to(1)
+
+
 def test_sticky_comment_never_exceeds_github_hard_limit(
     sample_review_result: ReviewResult,
 ) -> None:
@@ -286,3 +310,35 @@ def test_dropping_runs_past_max_stored_runs_marks_state_truncated(
     state = parse_review_state_v2(body=body)
     assert_that(state.runs).is_length(MAX_STORED_RUNS)
     assert_that(state.truncated).is_true()
+
+
+def test_error_comment_prunes_a_near_limit_prior_state() -> None:
+    """format_error_comment must prune, not just append, an oversized state.
+
+    A valid prior state can nearly fill GitHub's comment cap on its own;
+    appending it to the error body unpruned can push the total over the
+    limit that ``build_sticky_comment`` otherwise always respects.
+    """
+    findings = tuple(
+        FindingRecord(
+            fingerprint=f"{index:016d}",
+            ordinal=1,
+            severity=Severity.P2,
+            category="security",
+            title="x" * 900,
+            file=f"src/module_{index}.py",
+            line=index,
+            status=FindingStatus.OPEN,
+            since_round=1,
+        )
+        for index in range(200)
+    )
+    prior_state = ReviewState(runs=(RunRecord(round=1, sha="sha1"),), findings=findings)
+
+    body = format_error_comment(
+        error=RuntimeError("boom"),
+        provider="anthropic",
+        prior_state=prior_state,
+    )
+
+    assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)

--- a/tests/unit/ai/review/test_review_state_codec.py
+++ b/tests/unit/ai/review/test_review_state_codec.py
@@ -1,0 +1,280 @@
+"""Tests for the versioned review-state blob codec (#1906)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.enums.review_verdict import ReviewVerdict
+from lintro.ai.review.github_constants import (
+    GITHUB_COMMENT_HARD_LIMIT,
+    STATE_MARKER_PREFIX,
+    STATE_MARKER_SUFFIX,
+    STATE_VERSION,
+)
+from lintro.ai.review.models.finding_record import FindingRecord
+from lintro.ai.review.models.review_finding import Severity
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.run_record import RunRecord
+from lintro.ai.review.review_state_codec import (
+    decode_state,
+    encode_state,
+    prune_state_to_fit,
+    render_state_block,
+)
+
+
+def _wrap(payload: dict[str, object]) -> str:
+    """Wrap a state payload in the hidden comment markers.
+
+    Args:
+        payload: State mapping to embed.
+
+    Returns:
+        A sticky comment body carrying the payload.
+    """
+    return (
+        "## Review\n\n"
+        f"{STATE_MARKER_PREFIX} {json.dumps(payload)} {STATE_MARKER_SUFFIX}"
+    )
+
+
+def _record(*, fingerprint: str, since_round: int = 1) -> FindingRecord:
+    """Build a finding record for codec tests."""
+    return FindingRecord(
+        fingerprint=fingerprint,
+        ordinal=1,
+        severity=Severity.P2,
+        category="security",
+        title="Hardcoded credential",
+        file="src/app.py",
+        line=12,
+        status=FindingStatus.OPEN,
+        since_round=since_round,
+    )
+
+
+def test_round_trip_preserves_runs_and_findings() -> None:
+    """Encoding then decoding a v2 state preserves both record kinds."""
+    state = ReviewState(
+        runs=(
+            RunRecord(
+                round=1,
+                sha="abc",
+                model="claude",
+                transport="cli",
+                auth_mode="subscription",
+                verdict=ReviewVerdict.CHANGES_REQUESTED,
+                total=1200,
+                cost=0.05,
+            ),
+        ),
+        findings=(_record(fingerprint="a" * 16),),
+    )
+
+    decoded = decode_state(body=f"body {render_state_block(state=state)}")
+
+    assert_that(decoded.version).is_equal_to(STATE_VERSION)
+    assert_that(decoded.runs).is_length(1)
+    assert_that(decoded.runs[0].transport).is_equal_to("cli")
+    assert_that(decoded.runs[0].auth_mode).is_equal_to("subscription")
+    assert_that(decoded.runs[0].verdict).is_equal_to(ReviewVerdict.CHANGES_REQUESTED)
+    assert_that(decoded.findings).is_length(1)
+    assert_that(decoded.findings[0].fingerprint).is_equal_to("a" * 16)
+
+
+def test_resolved_provenance_round_trips() -> None:
+    """``resolved_in`` survives a serialize/parse cycle."""
+    resolved = FindingRecord(
+        fingerprint="b" * 16,
+        status=FindingStatus.RESOLVED,
+        since_round=1,
+        resolved_sha="deadbeef",
+        resolved_round=3,
+        inline_comment_id=99,
+        regressed=True,
+    )
+
+    decoded = decode_state(
+        body=render_state_block(state=ReviewState(findings=(resolved,))),
+    )
+
+    record = decoded.findings[0]
+    assert_that(record.status).is_equal_to(FindingStatus.RESOLVED)
+    assert_that(record.resolved_sha).is_equal_to("deadbeef")
+    assert_that(record.resolved_round).is_equal_to(3)
+    assert_that(record.inline_comment_id).is_equal_to(99)
+    assert_that(record.regressed).is_true()
+
+
+def test_v1_blob_migrates_with_sequential_rounds() -> None:
+    """A v1 blob decodes as v2 with positional round numbers and no findings."""
+    body = _wrap(
+        {
+            "version": 1,
+            "runs": [
+                {"model": "claude", "total": 100, "cost": 0.01},
+                {"model": "claude", "total": 200, "cost": 0.02},
+            ],
+        },
+    )
+
+    decoded = decode_state(body=body)
+
+    assert_that(decoded.version).is_equal_to(STATE_VERSION)
+    assert_that([run.round for run in decoded.runs]).is_equal_to([1, 2])
+    assert_that(decoded.runs[1].total).is_equal_to(200)
+    assert_that(decoded.findings).is_empty()
+    assert_that(decoded.next_round).is_equal_to(3)
+
+
+def test_migrated_v1_state_is_rewritten_as_v2() -> None:
+    """Re-encoding a migrated state stamps the current schema version."""
+    decoded = decode_state(body=_wrap({"version": 1, "runs": [{"model": "m"}]}))
+
+    payload = json.loads(encode_state(state=decoded))
+
+    assert_that(payload["version"]).is_equal_to(2)
+    assert_that(payload).contains_key("findings")
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "no state block at all",
+        f"{STATE_MARKER_PREFIX} not json at all {STATE_MARKER_SUFFIX}",
+        f"{STATE_MARKER_PREFIX} [1, 2, 3] {STATE_MARKER_SUFFIX}",
+    ],
+    ids=["absent", "malformed-json", "non-mapping"],
+)
+def test_unreadable_state_yields_empty_state(body: str) -> None:
+    """A missing or malformed blob never raises; it starts fresh."""
+    decoded = decode_state(body=body)
+
+    assert_that(decoded.runs).is_empty()
+    assert_that(decoded.findings).is_empty()
+    assert_that(decoded.next_round).is_equal_to(1)
+
+
+@pytest.mark.parametrize(
+    "version",
+    [99, "banana", None],
+    ids=["future", "non-numeric", "null"],
+)
+def test_unknown_version_starts_fresh(version: object) -> None:
+    """An unknown schema version is discarded rather than guessed at."""
+    body = _wrap({"version": version, "runs": [{"model": "claude"}]})
+
+    decoded = decode_state(body=body)
+
+    assert_that(decoded.runs).is_empty()
+
+
+def test_corrupt_finding_entries_are_dropped_not_fatal() -> None:
+    """Findings without a fingerprint are skipped, keeping the rest usable."""
+    body = _wrap(
+        {
+            "version": 2,
+            "runs": [],
+            "findings": [
+                {"severity": "P1"},
+                {"fingerprint": "c" * 16, "severity": "nonsense", "status": "weird"},
+            ],
+        },
+    )
+
+    decoded = decode_state(body=body)
+
+    assert_that(decoded.findings).is_length(1)
+    assert_that(decoded.findings[0].severity).is_equal_to(Severity.P3)
+    assert_that(decoded.findings[0].status).is_equal_to(FindingStatus.OPEN)
+
+
+def test_prune_keeps_state_under_the_hard_limit() -> None:
+    """Oldest runs are pruned until the whole comment fits GitHub's cap."""
+    state = ReviewState(
+        runs=tuple(
+            RunRecord(round=index, model="claude-sonnet-4-20250514", sha="s" * 40)
+            for index in range(1, 200)
+        ),
+        findings=(_record(fingerprint="d" * 16),),
+    )
+    body = "x" * (GITHUB_COMMENT_HARD_LIMIT - 4_000)
+
+    pruned = prune_state_to_fit(state=state, body=body)
+
+    total = len(body) + len(render_state_block(state=pruned))
+    assert_that(total).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
+    assert_that(pruned.truncated).is_true()
+    assert_that(len(pruned.runs)).is_less_than(len(state.runs))
+    # Pruning drops the oldest runs first, so the newest survives.
+    assert_that(pruned.runs[-1].round).is_equal_to(199)
+
+
+def test_prune_is_a_no_op_when_state_already_fits() -> None:
+    """A state that already fits is returned untouched and unflagged."""
+    state = ReviewState(runs=(RunRecord(round=1, model="claude"),))
+
+    pruned = prune_state_to_fit(state=state, body="short body")
+
+    assert_that(pruned).is_equal_to(state)
+    assert_that(pruned.truncated).is_false()
+
+
+def test_prune_drops_resolved_findings_before_open_ones() -> None:
+    """When runs cannot be pruned further, resolved findings go first."""
+    open_record = _record(fingerprint="e" * 16, since_round=5)
+    resolved_records = tuple(
+        FindingRecord(
+            fingerprint=f"{index:016d}",
+            status=FindingStatus.RESOLVED,
+            since_round=1,
+            resolved_sha="f" * 40,
+            resolved_round=2,
+            title="Resolved finding with a fairly long title for bulk",
+            file="src/some/long/path/module.py",
+        )
+        for index in range(200)
+    )
+    state = ReviewState(
+        runs=(RunRecord(round=1, model="claude"),),
+        findings=(*resolved_records, open_record),
+    )
+    body = "x" * (GITHUB_COMMENT_HARD_LIMIT - 2_000)
+
+    pruned = prune_state_to_fit(state=state, body=body)
+
+    total = len(body) + len(render_state_block(state=pruned))
+    assert_that(total).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
+    assert_that(pruned.truncated).is_true()
+    assert_that(pruned.open_findings).is_length(1)
+    assert_that(len(pruned.resolved_findings)).is_less_than(len(resolved_records))
+
+
+def test_prune_gives_up_gracefully_when_body_alone_overflows() -> None:
+    """An oversized body yields an empty state rather than an exception."""
+    state = ReviewState(
+        runs=(RunRecord(round=1, model="claude"),),
+        findings=(_record(fingerprint="a" * 16),),
+    )
+
+    pruned = prune_state_to_fit(state=state, body="x" * GITHUB_COMMENT_HARD_LIMIT)
+
+    assert_that(pruned.findings).is_empty()
+    assert_that(pruned.truncated).is_true()
+
+
+def test_state_helpers_report_open_and_resolved_partitions() -> None:
+    """``open_findings`` and ``resolved_findings`` partition the record set."""
+    state = ReviewState(
+        findings=(
+            _record(fingerprint="1" * 16),
+            FindingRecord(fingerprint="2" * 16, status=FindingStatus.RESOLVED),
+        ),
+    )
+
+    assert_that(state.open_findings).is_length(1)
+    assert_that(state.resolved_findings).is_length(1)

--- a/tests/unit/ai/review/test_review_state_codec.py
+++ b/tests/unit/ai/review/test_review_state_codec.py
@@ -161,8 +161,8 @@ def test_unreadable_state_yields_empty_state(body: str) -> None:
 
 @pytest.mark.parametrize(
     "version",
-    [99, "banana", None],
-    ids=["future", "non-numeric", "null"],
+    [99, "banana", None, 2.9, True],
+    ids=["future", "non-numeric", "null", "fractional", "boolean"],
 )
 def test_unknown_version_starts_fresh(version: object) -> None:
     """An unknown schema version is discarded rather than guessed at."""
@@ -209,7 +209,9 @@ def test_corrupt_finding_entries_are_dropped_not_fatal() -> None:
     decoded = decode_state(body=body)
 
     assert_that(decoded.findings).is_length(1)
-    assert_that(decoded.findings[0].severity).is_equal_to(Severity.P3)
+    # Fails closed to P1 (maximally blocking), not P3 — see
+    # test_unrecognized_severity_fails_closed_to_p1_not_p3 for why.
+    assert_that(decoded.findings[0].severity).is_equal_to(Severity.P1)
     assert_that(decoded.findings[0].status).is_equal_to(FindingStatus.OPEN)
     assert_that(decoded.findings[0].checklist_ids).is_empty()
     assert_that(decoded.findings[0].resolved_sha).is_empty()
@@ -240,6 +242,29 @@ def test_unparsable_inline_comment_id_decodes_as_none_not_zero() -> None:
     decoded = decode_state(body=body)
 
     assert_that(decoded.findings[0].inline_comment_id).is_none()
+
+
+def test_unrecognized_severity_fails_closed_to_p1_not_p3() -> None:
+    """A corrupted severity must stay maximally visible, not vanish into P3.
+
+    derive_verdict only escalates to BLOCKED on an open P1; silently
+    downgrading an unparsable severity to P3 (the least-blocking label) would
+    fabricate a clean verdict for a finding that may have originally been a
+    P1.
+    """
+    body = _wrap(
+        {
+            "version": 2,
+            "runs": [],
+            "findings": [
+                {"fingerprint": "e" * 16, "severity": "totally-bogus"},
+            ],
+        },
+    )
+
+    decoded = decode_state(body=body)
+
+    assert_that(decoded.findings[0].severity).is_equal_to(Severity.P1)
 
 
 def test_unrecognized_stored_verdict_does_not_fail_open() -> None:

--- a/tests/unit/ai/review/test_review_state_codec.py
+++ b/tests/unit/ai/review/test_review_state_codec.py
@@ -173,6 +173,20 @@ def test_unknown_version_starts_fresh(version: object) -> None:
     assert_that(decoded.runs).is_empty()
 
 
+def test_non_finite_version_starts_fresh_instead_of_raising() -> None:
+    """``json.loads`` accepts the non-standard ``Infinity`` token as a float.
+
+    ``int(float("inf"))`` raises ``OverflowError`` rather than failing the way
+    a plain type/value mismatch does; the decoder must catch that too instead
+    of ever raising out of a malformed sticky comment.
+    """
+    body = _wrap({"version": float("inf"), "runs": [{"model": "claude"}]})
+
+    decoded = decode_state(body=body)
+
+    assert_that(decoded.runs).is_empty()
+
+
 def test_corrupt_finding_entries_are_dropped_not_fatal() -> None:
     """Findings without a fingerprint are skipped, keeping the rest usable."""
     body = _wrap(
@@ -201,12 +215,59 @@ def test_corrupt_finding_entries_are_dropped_not_fatal() -> None:
     assert_that(decoded.findings[0].resolved_sha).is_empty()
 
 
+def test_unparsable_inline_comment_id_decodes_as_none_not_zero() -> None:
+    """An unparsable comment id must not become a fake, valid-looking ``0``.
+
+    ``coerce_int``'s ``0`` default is a plausible-looking (but wrong) GitHub
+    comment id; downstream code treats ``inline_comment_id is not None`` as
+    "this finding has a posted inline comment", so a raw ``0`` would silently
+    misreport an unlinked finding as linked.
+    """
+    body = _wrap(
+        {
+            "version": 2,
+            "runs": [],
+            "findings": [
+                {
+                    "fingerprint": "d" * 16,
+                    "severity": "P2",
+                    "inline_comment_id": "not-a-number",
+                },
+            ],
+        },
+    )
+
+    decoded = decode_state(body=body)
+
+    assert_that(decoded.findings[0].inline_comment_id).is_none()
+
+
 def test_unrecognized_stored_verdict_does_not_fail_open() -> None:
     """A corrupted verdict never decodes as READY, which would fabricate a pass."""
     body = _wrap(
         {
             "version": 2,
             "runs": [{"model": "claude", "verdict": "totally-bogus"}],
+            "findings": [],
+        },
+    )
+
+    decoded = decode_state(body=body)
+
+    assert_that(decoded.runs[0].verdict).is_equal_to(ReviewVerdict.CHANGES_REQUESTED)
+
+
+def test_absent_verdict_falls_back_without_logging_as_unrecognized() -> None:
+    """A v1 run (no ``verdict`` key at all) is a normal, expected shape.
+
+    It must resolve to the same neutral fallback as a corrupted value, but
+    without being logged as "unrecognized" — that phrasing is reserved for a
+    value that was actually present and unparsable.
+    """
+    body = _wrap(
+        {
+            "version": 2,
+            "runs": [{"model": "claude"}],
             "findings": [],
         },
     )

--- a/tests/unit/ai/review/test_review_state_codec.py
+++ b/tests/unit/ai/review/test_review_state_codec.py
@@ -181,7 +181,13 @@ def test_corrupt_finding_entries_are_dropped_not_fatal() -> None:
             "runs": [],
             "findings": [
                 {"severity": "P1"},
-                {"fingerprint": "c" * 16, "severity": "nonsense", "status": "weird"},
+                {
+                    "fingerprint": "c" * 16,
+                    "severity": "nonsense",
+                    "status": "weird",
+                    "checklist_ids": "not-a-list",
+                    "resolved_in": "not-a-mapping",
+                },
             ],
         },
     )
@@ -191,6 +197,23 @@ def test_corrupt_finding_entries_are_dropped_not_fatal() -> None:
     assert_that(decoded.findings).is_length(1)
     assert_that(decoded.findings[0].severity).is_equal_to(Severity.P3)
     assert_that(decoded.findings[0].status).is_equal_to(FindingStatus.OPEN)
+    assert_that(decoded.findings[0].checklist_ids).is_empty()
+    assert_that(decoded.findings[0].resolved_sha).is_empty()
+
+
+def test_unrecognized_stored_verdict_does_not_fail_open() -> None:
+    """A corrupted verdict never decodes as READY, which would fabricate a pass."""
+    body = _wrap(
+        {
+            "version": 2,
+            "runs": [{"model": "claude", "verdict": "totally-bogus"}],
+            "findings": [],
+        },
+    )
+
+    decoded = decode_state(body=body)
+
+    assert_that(decoded.runs[0].verdict).is_equal_to(ReviewVerdict.CHANGES_REQUESTED)
 
 
 def test_prune_keeps_state_under_the_hard_limit() -> None:

--- a/tests/unit/ai/review/test_review_state_codec.py
+++ b/tests/unit/ai/review/test_review_state_codec.py
@@ -84,6 +84,9 @@ def test_round_trip_preserves_runs_and_findings() -> None:
     assert_that(decoded.runs[0].verdict).is_equal_to(ReviewVerdict.CHANGES_REQUESTED)
     assert_that(decoded.findings).is_length(1)
     assert_that(decoded.findings[0].fingerprint).is_equal_to("a" * 16)
+    assert_that(decoded.findings[0].severity).is_equal_to(Severity.P2)
+    assert_that(decoded.findings[0].status).is_equal_to(FindingStatus.OPEN)
+    assert_that(decoded.findings[0].since_round).is_equal_to(1)
 
 
 def test_resolved_provenance_round_trips() -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(review): state schema v2 with per-run stats history and cross-run finding matching
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

**Per run** (`RunRecord`): round, commit sha, model, provider, transport +
auth mode, depth, strictness, files reviewed/skipped, checks, duration, tokens
in/out/total, estimated-vs-exact flag, est. cost, derived verdict, severity
counts, partial/chunk telemetry. The v1 aggregate keys are preserved verbatim
so existing sticky rendering keeps working across the migration.

**Per finding** (`FindingRecord`): stable fingerprint, ordinal, severity,
category, title, file, line, `status` (`open`/`resolved`), `since_round`,
`resolved_in {sha, round}`, `inline_comment_id`, `regressed` flag.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1906

## Details

_See What’s Changing._
