### PR TITLE
fix(ci): raise AI review limits so large-diff reviews can complete

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -93,7 +93,7 @@ jobs:
       # `--post` maintains the sticky review comment and posts inline review
       # comments, both of which require write access to pull requests.
       pull-requests: write
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Harden Runner
@@ -182,4 +182,4 @@ jobs:
           DISABLE_AUTOUPDATER: '1'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AI_REVIEW_MAX_COST_USD: '0.50'
+          AI_REVIEW_MAX_COST_USD: '2.00'

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -93,6 +93,12 @@ jobs:
       # `--post` maintains the sticky review comment and posts inline review
       # comments, both of which require write access to pull requests.
       pull-requests: write
+    # COUPLED to run-ai-review.sh's `--timeout` (currently 900 s): the job
+    # budget must cover setup (~7 min) + the full review timeout (15 min) +
+    # posting margin, so lintro's own timeout always fires before the runner
+    # kills the job — a runner kill truncates the JSON envelope the outcome
+    # classifier reads. Invariant enforced by tests/scripts/
+    # test_run_ai_review.py; bump both values together.
     timeout-minutes: 30
 
     steps:

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -126,10 +126,12 @@ output_file="$(mktemp)"
 trap 'rm -f "$output_file"' EXIT
 
 set +e
-# --timeout 600: the default ai.api_timeout (60s) is sized for streaming API
+# --timeout 900: the default ai.api_timeout (60s) is sized for streaming API
 # chunks; a CLI-transport turn runs the whole review in one `claude` invocation
-# and needs minutes (#1900; the sandbox reference uses the same value).
-uv run lintro review --pr "${pr_number}" "${repo_arg[@]}" --depth 1 --timeout 600 --post --output json >"$output_file" 2>&1
+# and needs minutes (#1900). 600s proved too tight for large diffs — PR #1916's
+# review was killed at the boundary while smaller PRs completed — so the cap is
+# sized for the biggest diffs this repo reviews.
+uv run lintro review --pr "${pr_number}" "${repo_arg[@]}" --depth 1 --timeout 900 --post --output json >"$output_file" 2>&1
 review_status=$?
 set -e
 

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -131,6 +131,13 @@ set +e
 # and needs minutes (#1900). 600s proved too tight for large diffs — PR #1916's
 # review was killed at the boundary while smaller PRs completed — so the cap is
 # sized for the biggest diffs this repo reviews.
+#
+# COUPLED to ai-review.yml's `timeout-minutes`: this timeout must fire BEFORE
+# the Actions runner kills the job, or the review dies without a JSON envelope
+# and classify_review_outcome.py reads a truncated file. Invariant (enforced by
+# tests/scripts/test_run_ai_review.py): ceil(--timeout / 60) + setup overhead
+# (~7 min: harden-runner, checkout, Node+claude install, uv sync) + posting
+# margin < timeout-minutes. Bump both together.
 uv run lintro review --pr "${pr_number}" "${repo_arg[@]}" --depth 1 --timeout 900 --post --output json >"$output_file" 2>&1
 review_status=$?
 set -e

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -8,7 +8,9 @@ and that the ``ai-review.yml`` workflow parses as valid YAML.
 from __future__ import annotations
 
 import importlib.util
+import math
 import os
+import re
 import subprocess  # nosec B404 - subprocess is used to drive the tool/CLI under test; invocations use shell=False
 import sys
 from pathlib import Path
@@ -502,3 +504,42 @@ def test_workflow_allows_the_npm_registry_egress() -> None:
 
     endpoints = harden_steps[0]["with"]["allowed-endpoints"].split()
     assert_that(endpoints).contains("registry.npmjs.org:443", "nodejs.org:443")
+
+
+def test_review_timeout_fits_inside_the_job_timeout() -> None:
+    """The lintro ``--timeout`` fires before the runner's ``timeout-minutes``.
+
+    The two values are load-bearing together: when the job budget is exhausted
+    first, the Actions runner kills the review mid-flight, no JSON error
+    envelope is written, and ``classify_review_outcome.py`` reads a truncated
+    output file (how PR #1916's review died under 600 s / 15 min). The
+    invariant is ``ceil(--timeout / 60) + setup overhead + posting margin <=
+    timeout-minutes``, with ~7 minutes observed for harden-runner + checkout +
+    Node/claude install + uv sync, and a 1-minute posting margin. Bump the two
+    values together, in scripts/ci/run-ai-review.sh and ai-review.yml.
+    """
+    setup_overhead_minutes = 7
+    posting_margin_minutes = 1
+
+    shell_text = SHELL_SCRIPT.read_text(encoding="utf-8")
+    timeout_matches = re.findall(
+        r"lintro review .*--timeout (\d+)",
+        shell_text,
+    )
+    assert_that(timeout_matches).described_as(
+        "run-ai-review.sh must pass exactly one --timeout to lintro review",
+    ).is_length(1)
+    review_timeout_minutes = math.ceil(int(timeout_matches[0]) / 60)
+
+    loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    job_timeout_minutes = loaded["jobs"]["ai-review"]["timeout-minutes"]
+
+    budget = review_timeout_minutes + setup_overhead_minutes
+    budget += posting_margin_minutes
+    assert_that(job_timeout_minutes).described_as(
+        f"timeout-minutes ({job_timeout_minutes}) must cover the review "
+        f"--timeout ({review_timeout_minutes} min) plus "
+        f"{setup_overhead_minutes} min setup and "
+        f"{posting_margin_minutes} min posting margin — bump it together "
+        "with --timeout in run-ai-review.sh",
+    ).is_greater_than_or_equal_to(budget)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): raise AI review limits so large-diff reviews can complete
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

The dogfood AI review succeeds on small PRs but is killed on large diffs: PR #1916's review died ~11 minutes in at the `--timeout 600` boundary while #1913/#1915 completed. Per owner direction, reviews must run to completion on every PR.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

_No linked issues._

## Details

_See What’s Changing._
