### PR TITLE
fix(ci): raise semgrep timeout to 600s across dogfood jobs

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -488,7 +488,7 @@ jobs:
       tooling-ref: 'd8fff0c6025ddf39c1ae048c04c5a050c7729a6e' # v0.62.0
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
-        pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
+        pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,semgrep:timeout=600,osv_scanner:check_suppressions=false
       egress-policy: block
       # Same-repo PRs: lint with the image built in this workflow run.
       # Fork PRs: CI images are not pushed to GHCR (artifact tarball only), so
@@ -592,7 +592,7 @@ jobs:
           # Must stay in sync with the dogfooding-lint lintro-tool-options
           # above: identical tool coverage is the contract of changed mode.
           TOOL_OPTIONS: >-
-            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
+            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,semgrep:timeout=600,osv_scanner:check_suppressions=false
           # Same image selection as dogfooding-lint: CI-built image for
           # same-repo PRs, pinned release digest for forks (no CI push).
           # Pinned release digest for the fork path; bumped as one set by
@@ -703,7 +703,7 @@ jobs:
         env:
           # Same tool coverage as the dogfooding run so skip behaviour matches.
           TOOL_OPTIONS: >-
-            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
+            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,semgrep:timeout=600,osv_scanner:check_suppressions=false
           # Same image selection as dogfooding-lint: CI-built image for
           # same-repo PRs, pinned release digest for forks (no CI push).
           # Pinned release digest for the fork path; bumped as one set by
@@ -746,7 +746,7 @@ jobs:
       tooling-ref: 'd8fff0c6025ddf39c1ae048c04c5a050c7729a6e' # v0.62.0
       job-name: '🛠️ Dogfooding Lint (retry)'
       lintro-tool-options: >-
-        pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
+        pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,semgrep:timeout=600,osv_scanner:check_suppressions=false
       egress-policy: block
       # Same image selection as dogfooding-lint: CI-built image for
       # same-repo PRs, pinned release digest for forks (no CI push).

--- a/.github/workflows/dogfood-nightly.yml
+++ b/.github/workflows/dogfood-nightly.yml
@@ -37,7 +37,7 @@ jobs:
       tooling-ref: 'd8fff0c6025ddf39c1ae048c04c5a050c7729a6e' # v0.62.0
       job-name: '🌙 Nightly Dogfooding Lint'
       lintro-tool-options: >-
-        pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
+        pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,semgrep:timeout=600,osv_scanner:check_suppressions=false
       egress-policy: block
       # No CI build in this workflow: lint main with the pinned release
       # image (same digest the fork-PR fallback in docker-ci.yml uses).
@@ -165,7 +165,7 @@ jobs:
         env:
           # Same tool coverage as dogfood-full so skip behaviour matches.
           TOOL_OPTIONS: >-
-            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,osv_scanner:check_suppressions=false
+            pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,semgrep:timeout=600,osv_scanner:check_suppressions=false
           # Same pinned release image dogfood-full lints with.
           # Bumped as one set by Renovate (see the dogfood-full job above).
           LINTRO_IMAGE: >-

--- a/scripts/ci/testing/lintro-report-generate.sh
+++ b/scripts/ci/testing/lintro-report-generate.sh
@@ -45,7 +45,7 @@ LINTRO_OUTPUT=$(mktemp)
 LINTRO_RC=0
 "${DOCKER_RUN[@]}" lintro check . --output-format markdown \
 	--exclude "$EXCLUDE_DIRS" \
-	--tool-options pydoclint:timeout=120 >"$LINTRO_OUTPUT" 2>&1 || LINTRO_RC=$?
+	--tool-options pydoclint:timeout=120,semgrep:timeout=600 >"$LINTRO_OUTPUT" 2>&1 || LINTRO_RC=$?
 
 if [ "$LINTRO_RC" -ne 0 ] && { [ ! -s "$LINTRO_OUTPUT" ] ||
 	[ "$LINTRO_RC" -eq 125 ] || [ "$LINTRO_RC" -eq 126 ] || [ "$LINTRO_RC" -eq 127 ]; }; then


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): raise semgrep timeout to 600s across dogfood jobs
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Fixes #1931 — main's dogfooding-lint and the nightly report fail deterministically with `Semgrep execution timed out (300.0s limit exceeded)` (tool ERROR, zero findings). The repo grew past semgrep's 300s default budget after the review-epic wave landed.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1931

## Details

_See What’s Changing._
