### PR TITLE
feat(review): add corpus-informed finding model to the review pipeline

### DIFF
--- a/lintro/ai/cli_schemas.py
+++ b/lintro/ai/cli_schemas.py
@@ -117,6 +117,30 @@ REVIEW_CLI_SCHEMA: dict[str, object] = {
                     # Requested by the prompt schema; without it here the
                     # strict CLI schema would reject the field outright.
                     "suggested_code": {"type": "string"},
+                    # #1925 finding-model fields. All optional: the parser
+                    # degrades every one of them to a default, so a model that
+                    # ignores them still produces a valid review.
+                    "kind": {
+                        "type": "string",
+                        "enum": ["finding", "question"],
+                    },
+                    "failure_scenario": {"type": "string"},
+                    "evidence_style": {
+                        "type": "string",
+                        "enum": ["diff_local", "cross_file", "speculative"],
+                    },
+                    "occurrences": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["file", "line"],
+                            "additionalProperties": False,
+                            "properties": {
+                                "file": {"type": "string"},
+                                "line": {"type": "integer"},
+                            },
+                        },
+                    },
                     "confidence": {
                         "type": "string",
                         "enum": ["high", "medium", "low"],

--- a/lintro/ai/prompts/templates/review/output_rules.md
+++ b/lintro/ai/prompts/templates/review/output_rules.md
@@ -24,3 +24,26 @@
 - `file_assessments` holds one entry per reviewed file with a single-sentence
   `overview`. Do not include severity counts — lintro derives those from `findings`.
 - Every finding `title` must be a single line with no line breaks.
+- **P1 requires a concrete `failure_scenario`** — the inputs, the path taken, and the
+  observable result. "Could be a problem" is not a failure mechanism. A P1 without one
+  is automatically downgraded to P2 and the downgrade is shown to the reader, so the
+  only thing an uncalibrated P1 buys you is a visible correction.
+- **Calibrate severity.** P1 means merge-blocking defect: expect 0–2 on a typical PR and
+  none at all on most. When you are torn between P1 and P2, choose P2.
+- Set `kind` to `question` when you suspect something but cannot show it — an
+  assumption you want the author to confirm, context you lack. Questions carry no
+  severity, never affect the verdict, and are capped at **3 per review**. Use them
+  instead of inflating severity; if the answer confirms a defect you will report it as
+  a normal finding next round.
+- Set `evidence_style` honestly: `diff_local` when the diff hunk alone shows it,
+  `cross_file` when you traced code outside the hunk, `speculative` when you inferred it
+  without verifying. A speculative finding is not penalized — it is labelled, and its
+  fix prompt tells the agent to reproduce it first.
+- **Style and formatting a linter would catch are out of scope** — lintro runs the
+  native linters in the same check run, so reporting them is pure noise. The one
+  exception is correctness-adjacent style: shadowed names, misleading identifiers, and
+  confusing API misuse stay in scope as P3 `code-smell`.
+- There is no cap on findings, but **do not report the same problem twice**. When one
+  problem repeats across locations, report it once and list every location in
+  `occurrences` as `file`/`line` pairs — including the primary one. It renders as a
+  single collapsed thread, and its fix prompt enumerates every location.

--- a/lintro/ai/prompts/templates/review/output_rules.md
+++ b/lintro/ai/prompts/templates/review/output_rules.md
@@ -26,8 +26,8 @@
 - Every finding `title` must be a single line with no line breaks.
 - **P1 requires a concrete `failure_scenario`** — the inputs, the path taken, and the
   observable result. "Could be a problem" is not a failure mechanism. A P1 without one
-  is automatically downgraded to P2 and the downgrade is shown to the reader, so the
-  only thing an uncalibrated P1 buys you is a visible correction.
+  is automatically downgraded to P2 and the correction is recorded against the run, so
+  an uncalibrated P1 buys you nothing but a logged downgrade.
 - **Calibrate severity.** P1 means merge-blocking defect: expect 0–2 on a typical PR and
   none at all on most. When you are torn between P1 and P2, choose P2.
 - Set `kind` to `question` when you suspect something but cannot show it — an

--- a/lintro/ai/prompts/templates/review/output_schema.json
+++ b/lintro/ai/prompts/templates/review/output_schema.json
@@ -28,15 +28,19 @@
   ],
   "findings": [
     {
+      "kind": "finding|question",
       "severity": "P1|P2|P3",
-      "category": "logic-bug|silent-failure|integration|test-gap|contract-drift|security|breaking-change",
+      "category": "logic-bug|silent-failure|integration|test-gap|contract-drift|security|breaking-change|code-smell",
       "file": "path/to/file",
       "line": 123,
       "title": "Short single-line title (5-8 words, no line breaks)",
       "description": "What is wrong and why it matters in production",
       "cause": "Root cause — trace the code path",
+      "failure_scenario": "REQUIRED for P1 — the concrete mechanism by which this fails (inputs, path taken, observable result); else empty string",
       "fix": "Concise fix suggestion",
       "suggested_code": "Exact replacement for the flagged line(s) when a mechanical fix applies (one-click GitHub suggestion); else empty string",
+      "evidence_style": "diff_local|cross_file|speculative",
+      "occurrences": [{ "file": "path/to/file", "line": 123 }],
       "confidence": "high|medium|low",
       "checklist_ids": [1, 2]
     }

--- a/lintro/ai/prompts/templates/review/system.md
+++ b/lintro/ai/prompts/templates/review/system.md
@@ -70,7 +70,7 @@ script behavior → server routes → middleware → DB → client parsing → U
   verdict worthless.
 - A P1 must come with a concrete `failure_scenario`: the inputs, the code path, and the
   observable failure. If you cannot write that sentence, it is not a P1 — a P1 lacking
-  it is automatically downgraded to P2 and the downgrade is shown to the reader.
+  it is automatically downgraded to P2 and the correction is recorded against the run.
 - Torn between P1 and P2? Choose P2.
 - Suspicion you cannot evidence is not a low-severity finding — report it as a
   `question` (max 3 per review).

--- a/lintro/ai/prompts/templates/review/system.md
+++ b/lintro/ai/prompts/templates/review/system.md
@@ -48,7 +48,9 @@ script behavior → server routes → middleware → DB → client parsing → U
 
 **Do NOT report:**
 
-- Style/formatting issues linters would catch
+- Style/formatting issues linters would catch — lintro runs the native linters in the
+  same check run. The one exception is correctness-adjacent style (shadowed names,
+  misleading identifiers, confusing API misuse), which stays in scope as P3 `code-smell`
 - Missing docstrings unless they hide a behavioral contract
 - Deferred scope explicitly listed in the PR summary (if provided)
 - Suggestions to refactor unrelated code
@@ -60,5 +62,17 @@ script behavior → server routes → middleware → DB → client parsing → U
 - **P2:** Incorrect edge-case behavior, contract drift, or incomplete test coverage
 - **P3:** Breaking default needing migration notes, UX wording, minor inaccuracy, or
   test isolation nit
+
+**Severity calibration (read before assigning a P1):**
+
+- P1 is the merge-blocking bar, not the "I am confident" bar. A typical PR has 0–2; most
+  have none. Every open P1 blocks the PR outright, so an inflated one makes the whole
+  verdict worthless.
+- A P1 must come with a concrete `failure_scenario`: the inputs, the code path, and the
+  observable failure. If you cannot write that sentence, it is not a P1 — a P1 lacking
+  it is automatically downgraded to P2 and the downgrade is shown to the reader.
+- Torn between P1 and P2? Choose P2.
+- Suspicion you cannot evidence is not a low-severity finding — report it as a
+  `question` (max 3 per review).
 
 Respond ONLY with valid JSON. No markdown fences.

--- a/lintro/ai/review/agent_prompts.py
+++ b/lintro/ai/review/agent_prompts.py
@@ -22,12 +22,15 @@ import re
 import textwrap
 
 from lintro.ai.review.enums.agent_prompt_scope_kind import AgentPromptScopeKind
+from lintro.ai.review.enums.evidence_style import EvidenceStyle
 from lintro.ai.review.github_render import sanitize_comment_text
 from lintro.ai.review.models.agent_prompt_scope import AgentPromptScope
 from lintro.ai.review.models.review_finding import ReviewFinding
 
 __all__ = [
+    "SPECULATIVE_NOTICE",
     "VERIFICATION_PREAMBLE",
+    "prompt_findings",
     "render_agent_prompt",
     "render_agent_prompt_panel",
     "render_finding_prompt",
@@ -42,6 +45,13 @@ VERIFICATION_PREAMBLE = (
     "These are open findings from a lintro AI code review. Verify each one "
     "against the current code. Fix only still-valid issues, skip the rest with "
     "a brief reason, keep changes minimal, and validate with tests."
+)
+
+#: Verbatim caution appended to a speculative finding's prompt block. The model
+#: self-reports the evidence basis (#1925); an inferred finding must be
+#: reproduced before an agent starts editing code on its say-so.
+SPECULATIVE_NOTICE = (
+    "This finding is inferred, not verified — confirm it reproduces before fixing."
 )
 
 #: Column at which prompt prose is soft-wrapped inside the fenced code block.
@@ -231,6 +241,67 @@ def _group_by_file(
     return list(grouped.items())
 
 
+def _occurrence_lines(*, finding: ReviewFinding) -> list[str]:
+    """Render every location of a repeated finding pattern.
+
+    Display collapses a repeated pattern to one thread, but the prompt must
+    not: an agent handed "fix this" for a pattern with twenty call sites has
+    to be told about all twenty, or nineteen silently survive the fix.
+
+    Args:
+        finding: Finding whose occurrences are being enumerated.
+
+    Returns:
+        Prompt lines listing every occurrence, or an empty list when the
+        pattern occurs only once.
+    """
+    occurrences = finding.all_occurrences
+    if len(occurrences) < 2:
+        return []
+    lines = [
+        _wrap(
+            text=(
+                f"Occurs at {len(occurrences)} locations — apply the "
+                "equivalent fix at each and verify each one still reproduces "
+                "before changing it:"
+            ),
+            initial_indent=_CONTINUATION_INDENT,
+            subsequent_indent=_CONTINUATION_INDENT,
+        ),
+    ]
+    lines.extend(
+        _wrap(
+            text=(
+                f"- {sanitize_comment_text(occurrence.file, limit=_PATH_LIMIT)}"
+                f":{occurrence.line}"
+            ),
+            initial_indent=_CONTINUATION_INDENT * 2,
+            subsequent_indent=_CONTINUATION_INDENT * 3,
+        )
+        for occurrence in occurrences
+    )
+    return lines
+
+
+def prompt_findings(
+    *,
+    findings: tuple[ReviewFinding, ...],
+) -> tuple[ReviewFinding, ...]:
+    """Select the entries a remediation prompt should cover.
+
+    Questions (#1925) are excluded from every prompt scope: there is nothing
+    to fix until the author answers, and a question promoted to a real finding
+    next round arrives with its own severity and prompt.
+
+    Args:
+        findings: Candidate entries in presentation order.
+
+    Returns:
+        The subset that represents actionable findings.
+    """
+    return tuple(finding for finding in findings if not finding.is_question)
+
+
 def _finding_block(*, finding: ReviewFinding) -> list[str]:
     """Render one finding as a bullet plus indented continuation lines.
 
@@ -275,6 +346,15 @@ def _finding_block(*, finding: ReviewFinding) -> list[str]:
                 subsequent_indent=_CONTINUATION_INDENT,
             ),
         )
+    if finding.evidence_style is EvidenceStyle.SPECULATIVE:
+        lines.append(
+            _wrap(
+                text=SPECULATIVE_NOTICE,
+                initial_indent=_CONTINUATION_INDENT,
+                subsequent_indent=_CONTINUATION_INDENT,
+            ),
+        )
+    lines.extend(_occurrence_lines(finding=finding))
     return lines
 
 
@@ -287,23 +367,27 @@ def render_agent_prompt(
 
     The prompt opens with a scope sentence (so a copied prompt can never be
     confused with the other surface's prompt), then the verbatim verification
-    preamble, then the findings grouped by file.
+    preamble, then the findings grouped by file. Questions are dropped before
+    anything is counted or rendered, so the scope sentence never promises a
+    fix for something that only asked a question.
 
     Args:
         findings: Findings in scope, in the order they should be presented.
         scope: Which finding set the prompt covers.
 
     Returns:
-        Plain-text prompt body, or an empty string when there are no findings.
+        Plain-text prompt body, or an empty string when the scope holds no
+        actionable findings (questions do not count).
     """
-    if not findings:
+    actionable = prompt_findings(findings=findings)
+    if not actionable:
         return ""
 
     sections: list[str] = [
-        _wrap(text=_scope_sentence(scope=scope, count=len(findings))),
+        _wrap(text=_scope_sentence(scope=scope, count=len(actionable))),
         _wrap(text=VERIFICATION_PREAMBLE),
     ]
-    for path, file_findings in _group_by_file(findings=findings):
+    for path, file_findings in _group_by_file(findings=actionable):
         safe_path = sanitize_comment_text(path, limit=_PATH_LIMIT)
         sections.append(f"In `{safe_path}`:")
         sections.extend(
@@ -319,7 +403,8 @@ def render_finding_prompt(*, finding: ReviewFinding) -> str:
         finding: Finding the inline comment is anchored to.
 
     Returns:
-        Plain-text prompt body scoped to exactly this finding.
+        Plain-text prompt body scoped to exactly this finding, or an empty
+        string when the entry is a question — questions get no prompt panel.
     """
     return render_agent_prompt(
         findings=(finding,),
@@ -384,7 +469,7 @@ def render_agent_prompt_panel(
         return ""
     return render_prompt_panel(
         prompt=prompt,
-        title=_panel_title(scope=scope, count=len(findings)),
+        title=_panel_title(scope=scope, count=len(prompt_findings(findings=findings))),
         footer=_FOOTERS[scope.kind] if footer is None else footer,
     )
 
@@ -402,7 +487,8 @@ def render_finding_prompt_panel(
             single-finding footer; pass ``""`` to omit it.
 
     Returns:
-        Markdown for the panel.
+        Markdown for the panel, or an empty string when the entry is a
+        question.
     """
     return render_agent_prompt_panel(
         findings=(finding,),

--- a/lintro/ai/review/enums/__init__.py
+++ b/lintro/ai/review/enums/__init__.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from lintro.ai.review.enums.agent_prompt_scope_kind import AgentPromptScopeKind
 from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
+from lintro.ai.review.enums.evidence_style import EvidenceStyle
 from lintro.ai.review.enums.file_domain import FileDomain
+from lintro.ai.review.enums.finding_kind import FindingKind
 from lintro.ai.review.enums.finding_match_outcome import FindingMatchOutcome
 from lintro.ai.review.enums.finding_status import FindingStatus
 from lintro.ai.review.enums.review_category import ReviewCategory
@@ -14,7 +16,9 @@ from lintro.ai.review.enums.review_verdict import ReviewVerdict
 __all__ = [
     "AgentPromptScopeKind",
     "ChangedFileStatus",
+    "EvidenceStyle",
     "FileDomain",
+    "FindingKind",
     "FindingMatchOutcome",
     "FindingStatus",
     "ReviewCategory",

--- a/lintro/ai/review/enums/evidence_style.py
+++ b/lintro/ai/review/enums/evidence_style.py
@@ -8,9 +8,9 @@ from enum import StrEnum, auto
 class EvidenceStyle(StrEnum):
     """How a finding was arrived at, as reported by the model (#1925).
 
-    Recorded and displayed only: v1 deliberately does no suppression or
-    down-ranking on this field. Its one behavioral effect is the verify-first
-    line added to prompts for speculative findings.
+    Verdict suppression and severity down-ranking are intentionally out of
+    scope for v1; the sole behavioral effect is the verify-first caution line
+    added to prompts for :data:`SPECULATIVE` findings.
 
     Attributes:
         DIFF_LOCAL: Established from the diff hunk alone.

--- a/lintro/ai/review/enums/evidence_style.py
+++ b/lintro/ai/review/enums/evidence_style.py
@@ -1,0 +1,23 @@
+"""Self-reported evidence basis for a review finding."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+
+class EvidenceStyle(StrEnum):
+    """How a finding was arrived at, as reported by the model (#1925).
+
+    Recorded and displayed only: v1 deliberately does no suppression or
+    down-ranking on this field. Its one behavioral effect is the verify-first
+    line added to prompts for speculative findings.
+
+    Attributes:
+        DIFF_LOCAL: Established from the diff hunk alone.
+        CROSS_FILE: Established by tracing code outside the diff hunk.
+        SPECULATIVE: Inferred rather than verified against the code.
+    """
+
+    DIFF_LOCAL = auto()
+    CROSS_FILE = auto()
+    SPECULATIVE = auto()

--- a/lintro/ai/review/enums/finding_kind.py
+++ b/lintro/ai/review/enums/finding_kind.py
@@ -1,0 +1,22 @@
+"""Claim type of an entry in a review's ``findings`` array."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+
+class FindingKind(StrEnum):
+    """What kind of claim a reported entry makes (#1925).
+
+    Questions are the pressure-release valve that makes the P1 evidence gate
+    fair: suspicion the model cannot back with a concrete failure mechanism is
+    asked as a question instead of inflating a severity. Questions therefore
+    never affect the derived verdict and never carry a fix prompt.
+
+    Attributes:
+        FINDING: A defect claim, carrying a severity and a fix.
+        QUESTION: An open question for the author, with no severity semantics.
+    """
+
+    FINDING = auto()
+    QUESTION = auto()

--- a/lintro/ai/review/finding_matcher.py
+++ b/lintro/ai/review/finding_matcher.py
@@ -26,6 +26,7 @@ from lintro.ai.review.enums.finding_match_outcome import FindingMatchOutcome
 from lintro.ai.review.enums.finding_status import FindingStatus
 from lintro.ai.review.enums.review_verdict import ReviewVerdict
 from lintro.ai.review.models.finding_match_result import FindingMatchResult
+from lintro.ai.review.models.finding_occurrence import FindingOccurrence
 from lintro.ai.review.models.finding_record import FindingRecord
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_state import ReviewState
@@ -108,9 +109,13 @@ def derive_verdict(*, findings: Iterable[FindingRecord]) -> ReviewVerdict:
 
     Returns:
         The readiness verdict implied by the open findings' severities.
+        Questions (#1925) are excluded: they carry no severity semantics and
+        must never move the verdict.
     """
     severities = {
-        record.severity for record in findings if record.status is FindingStatus.OPEN
+        record.severity
+        for record in findings
+        if record.status is FindingStatus.OPEN and not record.is_question
     }
     if Severity.P1 in severities:
         return ReviewVerdict.BLOCKED
@@ -119,6 +124,29 @@ def derive_verdict(*, findings: Iterable[FindingRecord]) -> ReviewVerdict:
     if Severity.P3 in severities:
         return ReviewVerdict.NITS_ONLY
     return ReviewVerdict.READY
+
+
+def _normalized_occurrences(
+    *,
+    finding: ReviewFinding,
+) -> tuple[FindingOccurrence, ...]:
+    """Return a finding's occurrences with their paths normalized.
+
+    Args:
+        finding: Finding whose occurrence locations are being tracked.
+
+    Returns:
+        Every occurrence of the pattern — never empty — with file paths
+        normalized the same way the fingerprint normalizes them, so a path
+        that changes only in separator style does not read as a new location.
+    """
+    return tuple(
+        FindingOccurrence(
+            file=normalize_file_path(occurrence.file),
+            line=occurrence.line,
+        )
+        for occurrence in finding.all_occurrences
+    )
 
 
 def _current_records(
@@ -167,6 +195,10 @@ def _current_records(
             status=FindingStatus.OPEN,
             since_round=round_number,
             checklist_ids=finding.checklist_ids,
+            kind=finding.kind,
+            occurrences=_normalized_occurrences(finding=finding),
+            occurrences_total=len(finding.all_occurrences),
+            severity_downgraded=finding.severity_downgraded,
         )
         for index, finding in enumerate(findings)
     ]
@@ -235,6 +267,12 @@ def _merge_pair(
 ) -> tuple[FindingRecord, FindingMatchOutcome]:
     """Merge a matched prior record with its current-round sighting.
 
+    A finding with several occurrences is one pattern, not one finding per
+    location, so the merged record keeps this round's surviving occurrences
+    while holding the high-water total. Fixing 6 of 20 call sites therefore
+    reads as partial progress on an open finding, and only the disappearance
+    of the whole pattern resolves it.
+
     Args:
         prior: Previously tracked record.
         current: Freshly built record for this round.
@@ -261,6 +299,10 @@ def _merge_pair(
         inline_comment_id=prior.inline_comment_id,
         regressed=regressed or prior.regressed,
         checklist_ids=current.checklist_ids or prior.checklist_ids,
+        kind=current.kind,
+        occurrences=current.occurrences,
+        occurrences_total=max(prior.occurrence_total, current.occurrence_total),
+        severity_downgraded=current.severity_downgraded,
     )
     if regressed:
         return merged, FindingMatchOutcome.REGRESSED
@@ -279,6 +321,11 @@ def match_findings(
     Every current finding is classified as ``new``, ``carried``, or
     ``regressed``; every prior open finding absent from this round is marked
     ``resolved`` and stamped with the head sha and round that resolved it.
+
+    Resolution is pattern-level (#1925): a finding reported at several
+    occurrences resolves only when the whole pattern stops being reported.
+    Fixing some of its locations leaves it open with a lower
+    ``occurrence_count`` against an unchanged ``occurrence_total``.
 
     Args:
         previous: State decoded from the prior sticky comment, or ``None`` for

--- a/lintro/ai/review/finding_matcher.py
+++ b/lintro/ai/review/finding_matcher.py
@@ -136,16 +136,19 @@ def _normalized_occurrences(
         finding: Finding whose occurrence locations are being tracked.
 
     Returns:
-        Every occurrence of the pattern — never empty — with file paths
-        normalized the same way the fingerprint normalizes them, so a path
-        that changes only in separator style does not read as a new location.
+        The *explicitly reported* occurrences with file paths normalized the
+        same way the fingerprint normalizes them, so a path that changes only
+        in separator style does not read as a new location. Empty when the
+        model reported none — the distinction matters, because a later round
+        that omits the list must inherit the prior locations rather than
+        appear to have fixed all but one of them.
     """
     return tuple(
         FindingOccurrence(
             file=normalize_file_path(occurrence.file),
             line=occurrence.line,
         )
-        for occurrence in finding.all_occurrences
+        for occurrence in finding.occurrences
     )
 
 
@@ -197,7 +200,7 @@ def _current_records(
             checklist_ids=finding.checklist_ids,
             kind=finding.kind,
             occurrences=_normalized_occurrences(finding=finding),
-            occurrences_total=len(finding.all_occurrences),
+            occurrences_total=len(finding.occurrences),
             severity_downgraded=finding.severity_downgraded,
         )
         for index, finding in enumerate(findings)
@@ -300,7 +303,10 @@ def _merge_pair(
         regressed=regressed or prior.regressed,
         checklist_ids=current.checklist_ids or prior.checklist_ids,
         kind=current.kind,
-        occurrences=current.occurrences,
+        # A round that reports no occurrence list is not a claim that the
+        # pattern shrank to one location — it is silence, so the previously
+        # tracked locations are carried rather than treated as progress.
+        occurrences=current.occurrences or prior.occurrences,
         occurrences_total=max(prior.occurrence_total, current.occurrence_total),
         severity_downgraded=current.severity_downgraded,
     )

--- a/lintro/ai/review/finding_parser.py
+++ b/lintro/ai/review/finding_parser.py
@@ -9,11 +9,17 @@ from __future__ import annotations
 
 from loguru import logger
 
+from lintro.ai.review.enums.evidence_style import EvidenceStyle
+from lintro.ai.review.enums.finding_kind import FindingKind
+from lintro.ai.review.models.finding_occurrence import parse_occurrences
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.narrative_parser import collapse_to_single_line
+from lintro.ai.review.severity_gate import apply_p1_evidence_gate
 
 __all__ = [
     "SEVERITY_SYNONYMS",
+    "normalize_evidence_style",
+    "normalize_finding_kind",
     "normalize_severity",
     "parse_findings",
     "parse_severity_label",
@@ -96,6 +102,42 @@ def normalize_severity(*, raw: object) -> Severity:
     return Severity.P1
 
 
+def normalize_finding_kind(*, raw: object) -> FindingKind:
+    """Normalize a model-reported ``kind`` value to a member.
+
+    Args:
+        raw: Raw ``kind`` value from a parsed model response.
+
+    Returns:
+        The matching member, or :data:`FindingKind.FINDING` when the value is
+        absent or unrecognized. Defaulting to ``FINDING`` is the conservative
+        choice: a mislabelled question still gets reviewed and rendered, while
+        a mislabelled finding would silently vanish from the verdict.
+    """
+    try:
+        return FindingKind(str(raw).strip().lower())
+    except ValueError:
+        return FindingKind.FINDING
+
+
+def normalize_evidence_style(*, raw: object) -> EvidenceStyle:
+    """Normalize a model-reported ``evidence_style`` value to a member.
+
+    Args:
+        raw: Raw ``evidence_style`` value from a parsed model response.
+
+    Returns:
+        The matching member, or :data:`EvidenceStyle.DIFF_LOCAL` when the
+        value is absent or unrecognized. The field drives display only, so an
+        unknown label falls back to the unchipped default rather than
+        asserting an evidence basis the model did not claim.
+    """
+    try:
+        return EvidenceStyle(str(raw).strip().lower())
+    except ValueError:
+        return EvidenceStyle.DIFF_LOCAL
+
+
 def parse_findings(
     *,
     raw_findings: object,
@@ -112,10 +154,15 @@ def parse_findings(
         severity_override: When set, every parsed finding is assigned this
             severity instead of the model-reported one. Custom review agents
             declare a severity policy in front matter, and that declared policy
-            wins over whatever the model labels an individual finding.
+            wins over whatever the model labels an individual finding — it
+            also exempts the pass from the P1 evidence gate.
 
     Returns:
         Parsed findings in payload order. Non-mapping entries are dropped.
+        Every field added by #1925 (``kind``, ``failure_scenario``,
+        ``evidence_style``, ``occurrences``) is optional and degrades to its
+        default, but the P1 evidence gate always runs: a P1 without a concrete
+        failure scenario comes back as a marked P2.
     """
     if not isinstance(raw_findings, list):
         return ()
@@ -156,6 +203,17 @@ def parse_findings(
                 checklist_ids=checklist_ids,
                 suggested_code=str(item.get("suggested_code", "")),
                 source=source,
+                kind=normalize_finding_kind(raw=item.get("kind", "")),
+                failure_scenario=str(item.get("failure_scenario", "")),
+                evidence_style=normalize_evidence_style(
+                    raw=item.get("evidence_style", ""),
+                ),
+                occurrences=parse_occurrences(item.get("occurrences")),
             ),
         )
-    return tuple(findings)
+    if severity_override is not None:
+        # An author-declared severity policy is configuration, not model
+        # output, so the calibration gate has nothing to correct: downgrading
+        # it would silently override the agent's own front matter.
+        return tuple(findings)
+    return apply_p1_evidence_gate(findings=findings)

--- a/lintro/ai/review/finding_parser.py
+++ b/lintro/ai/review/finding_parser.py
@@ -161,8 +161,9 @@ def parse_findings(
         Parsed findings in payload order. Non-mapping entries are dropped.
         Every field added by #1925 (``kind``, ``failure_scenario``,
         ``evidence_style``, ``occurrences``) is optional and degrades to its
-        default, but the P1 evidence gate always runs: a P1 without a concrete
-        failure scenario comes back as a marked P2.
+        default. Unless ``severity_override`` is set, the P1 evidence gate
+        runs: a P1 without a concrete failure scenario comes back as a marked
+        P2.
     """
     if not isinstance(raw_findings, list):
         return ()
@@ -189,6 +190,11 @@ def parse_findings(
             if severity_override is not None
             else normalize_severity(raw=item.get("severity", "P3"))
         )
+        # str() would turn a null failure_scenario into the truthy literal
+        # "None" and walk an unevidenced P1 straight through the gate.
+        failure_scenario = item.get("failure_scenario", "")
+        if not isinstance(failure_scenario, str):
+            failure_scenario = ""
         findings.append(
             ReviewFinding(
                 severity=severity,
@@ -204,7 +210,7 @@ def parse_findings(
                 suggested_code=str(item.get("suggested_code", "")),
                 source=source,
                 kind=normalize_finding_kind(raw=item.get("kind", "")),
-                failure_scenario=str(item.get("failure_scenario", "")),
+                failure_scenario=failure_scenario,
                 evidence_style=normalize_evidence_style(
                     raw=item.get("evidence_style", ""),
                 ),

--- a/lintro/ai/review/github_render.py
+++ b/lintro/ai/review/github_render.py
@@ -96,9 +96,21 @@ def format_run_mechanics(*, metadata: ReviewMetadata) -> str:
 
 
 def _severity_counts(*, findings: tuple[ReviewFinding, ...]) -> dict[Severity, int]:
-    """Count findings by severity."""
+    """Count findings by severity.
+
+    Questions (#1925) carry no severity semantics and are excluded, so the
+    counts always match the finding set the derived verdict was computed from.
+
+    Args:
+        findings: Findings to count over.
+
+    Returns:
+        Count per severity, with every severity present.
+    """
     counts: dict[Severity, int] = {Severity.P1: 0, Severity.P2: 0, Severity.P3: 0}
     for finding in findings:
+        if finding.is_question:
+            continue
         counts[finding.severity] = counts.get(finding.severity, 0) + 1
     return counts
 

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -38,6 +38,7 @@ from lintro.ai.review.review_state_codec import (
     render_state_block,
     renumber_if_legacy_v1,
 )
+from lintro.ai.review.severity_gate import count_downgrades
 
 
 def build_sticky_comment(
@@ -216,6 +217,8 @@ def _run_record(
         p1=counts[Severity.P1],
         p2=counts[Severity.P2],
         p3=counts[Severity.P3],
+        questions=sum(1 for finding in result.findings if finding.is_question),
+        downgraded=count_downgrades(findings=result.findings),
         partial=bool(metadata.partial),
         chunks_reviewed=metadata.chunks_reviewed,
         chunks_total=metadata.chunks_total,

--- a/lintro/ai/review/models/__init__.py
+++ b/lintro/ai/review/models/__init__.py
@@ -10,6 +10,7 @@ from lintro.ai.review.models.chunking_result import ChunkingResult
 from lintro.ai.review.models.file_assessment import FileAssessment
 from lintro.ai.review.models.file_classification import FileClassification
 from lintro.ai.review.models.finding_match_result import FindingMatchResult
+from lintro.ai.review.models.finding_occurrence import FindingOccurrence
 from lintro.ai.review.models.finding_record import FindingRecord
 from lintro.ai.review.models.pr_metadata import PRMetadata
 from lintro.ai.review.models.review_chunk import ReviewChunk
@@ -32,6 +33,7 @@ __all__ = [
     "FileAssessment",
     "FileClassification",
     "FindingMatchResult",
+    "FindingOccurrence",
     "FindingRecord",
     "PRMetadata",
     "ReviewChunk",

--- a/lintro/ai/review/models/finding_occurrence.py
+++ b/lintro/ai/review/models/finding_occurrence.py
@@ -74,4 +74,6 @@ def parse_occurrences(value: Any) -> tuple[FindingOccurrence, ...]:
     parsed = (
         FindingOccurrence.from_dict(item) for item in value if isinstance(item, dict)
     )
-    return tuple(occurrence for occurrence in parsed if occurrence is not None)
+    return tuple(
+        dict.fromkeys(occurrence for occurrence in parsed if occurrence is not None),
+    )

--- a/lintro/ai/review/models/finding_occurrence.py
+++ b/lintro/ai/review/models/finding_occurrence.py
@@ -1,0 +1,74 @@
+"""One location of a repeated finding pattern."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from lintro.ai.review.models._coerce import coerce_int
+
+__all__ = ["FindingOccurrence", "parse_occurrences"]
+
+
+@dataclass(frozen=True, slots=True)
+class FindingOccurrence:
+    """A single ``file:line`` location at which a finding pattern occurs.
+
+    The same defect repeated across twenty call sites is one finding with
+    twenty occurrences, not twenty findings (#1925): display collapses to one
+    thread, prompts enumerate every location, and the matcher resolves the
+    pattern only once every occurrence is gone.
+
+    Attributes:
+        file: Repository-relative file path.
+        line: Line number within that file.
+    """
+
+    file: str
+    line: int = 0
+
+    @property
+    def label(self) -> str:
+        """Return the ``file:line`` label used in prompts and displays."""
+        return f"{self.file}:{self.line}"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the occurrence for the hidden state blob.
+
+        Returns:
+            JSON-serializable mapping with ``file`` and ``line`` keys.
+        """
+        return {"file": self.file, "line": self.line}
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> FindingOccurrence | None:
+        """Rebuild an occurrence from an untrusted mapping.
+
+        Args:
+            payload: Decoded mapping for one occurrence.
+
+        Returns:
+            The parsed occurrence, or ``None`` when it names no file.
+        """
+        file = str(payload.get("file", "")).strip()
+        if not file:
+            return None
+        return cls(file=file, line=coerce_int(payload.get("line")))
+
+
+def parse_occurrences(value: Any) -> tuple[FindingOccurrence, ...]:
+    """Parse an occurrence list from untrusted model or state-blob input.
+
+    Args:
+        value: Raw ``occurrences`` value.
+
+    Returns:
+        The parsed occurrences; empty when the value is not a list of usable
+        mappings. Malformed entries are dropped rather than failing the run.
+    """
+    if not isinstance(value, list):
+        return ()
+    parsed = (
+        FindingOccurrence.from_dict(item) for item in value if isinstance(item, dict)
+    )
+    return tuple(occurrence for occurrence in parsed if occurrence is not None)

--- a/lintro/ai/review/models/finding_occurrence.py
+++ b/lintro/ai/review/models/finding_occurrence.py
@@ -48,12 +48,15 @@ class FindingOccurrence:
             payload: Decoded mapping for one occurrence.
 
         Returns:
-            The parsed occurrence, or ``None`` when it names no file.
+            The parsed occurrence, or ``None`` when it names no usable file.
+            A non-string ``file`` is rejected rather than coerced: ``str()``
+            would turn ``None`` into the path ``"None"`` and quietly invent a
+            location the model never reported.
         """
-        file = str(payload.get("file", "")).strip()
-        if not file:
+        file = payload.get("file")
+        if not isinstance(file, str) or not file.strip():
             return None
-        return cls(file=file, line=coerce_int(payload.get("line")))
+        return cls(file=file.strip(), line=coerce_int(payload.get("line")))
 
 
 def parse_occurrences(value: Any) -> tuple[FindingOccurrence, ...]:

--- a/lintro/ai/review/models/finding_record.py
+++ b/lintro/ai/review/models/finding_record.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from lintro.ai.review.enums.finding_kind import FindingKind
 from lintro.ai.review.enums.finding_status import FindingStatus
 from lintro.ai.review.models._coerce import coerce_int
+from lintro.ai.review.models.finding_occurrence import (
+    FindingOccurrence,
+    parse_occurrences,
+)
 from lintro.ai.review.models.review_finding import Severity
 
 __all__ = ["FindingRecord"]
@@ -41,6 +46,16 @@ class FindingRecord:
             finding, when one was posted.
         regressed: True when the finding reappeared after being resolved.
         checklist_ids: Prompt checklist ids linked to this finding.
+        kind: Whether the tracked entry is a finding or a question (#1925).
+            Questions are tracked like findings but excluded from the derived
+            verdict.
+        occurrences: Locations at which the pattern was still present at the
+            most recent sighting.
+        occurrences_total: High-water number of occurrences ever seen for this
+            pattern. Held across rounds so partial progress reads as
+            ``addressed / total`` even after some locations are fixed.
+        severity_downgraded: True when the P1 evidence gate downgraded the
+            severity at the most recent sighting.
     """
 
     fingerprint: str
@@ -57,11 +72,46 @@ class FindingRecord:
     inline_comment_id: int | None = None
     regressed: bool = False
     checklist_ids: tuple[int, ...] = field(default_factory=tuple)
+    kind: FindingKind = FindingKind.FINDING
+    occurrences: tuple[FindingOccurrence, ...] = field(default_factory=tuple)
+    occurrences_total: int = 0
+    severity_downgraded: bool = False
 
     @property
     def key(self) -> str:
         """Return the composite identity key ``fingerprint#ordinal``."""
         return f"{self.fingerprint}#{self.ordinal}"
+
+    @property
+    def is_question(self) -> bool:
+        """Return True when the tracked entry is a question."""
+        return self.kind is FindingKind.QUESTION
+
+    @property
+    def occurrence_count(self) -> int:
+        """Return how many occurrences were present at the last sighting."""
+        return len(self.occurrences) or 1
+
+    @property
+    def occurrence_total(self) -> int:
+        """Return the high-water occurrence count for this pattern."""
+        return max(self.occurrences_total, self.occurrence_count)
+
+    @property
+    def occurrences_addressed(self) -> int:
+        """Return how many occurrences of the pattern are already gone.
+
+        Resolution is pattern-level: a record only reaches ``RESOLVED`` once
+        every occurrence has disappeared, so while it is open this count is
+        the partial progress surfaces render as ``14/20 addressed``.
+
+        Returns:
+            Number of occurrences addressed since the pattern's high-water
+            mark; the full total once the record is resolved.
+        """
+        if self.status is FindingStatus.RESOLVED:
+            return self.occurrence_total
+        return max(self.occurrence_total - self.occurrence_count, 0)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the record for the hidden state blob.
@@ -92,6 +142,15 @@ class FindingRecord:
             payload["regressed"] = True
         if self.checklist_ids:
             payload["checklist_ids"] = list(self.checklist_ids)
+        if self.kind is not FindingKind.FINDING:
+            payload["kind"] = str(self.kind)
+        if len(self.occurrences) > 1 or self.occurrences_total > 1:
+            payload["occurrences"] = [
+                occurrence.to_dict() for occurrence in self.occurrences
+            ]
+            payload["occurrences_total"] = self.occurrence_total
+        if self.severity_downgraded:
+            payload["severity_downgraded"] = True
         return payload
 
     @classmethod
@@ -128,6 +187,10 @@ class FindingRecord:
             ),
             regressed=bool(payload.get("regressed", False)),
             checklist_ids=_parse_checklist_ids(payload.get("checklist_ids")),
+            kind=_parse_kind(payload.get("kind")),
+            occurrences=parse_occurrences(payload.get("occurrences")),
+            occurrences_total=coerce_int(payload.get("occurrences_total")),
+            severity_downgraded=bool(payload.get("severity_downgraded", False)),
         )
 
 
@@ -159,6 +222,26 @@ def _parse_severity(value: Any) -> Severity:
         return Severity(str(value).upper())
     except ValueError:
         return Severity.P1
+
+
+def _parse_kind(value: Any) -> FindingKind:
+    """Parse a finding kind label from an untrusted state blob.
+
+    An unrecognized or absent label becomes ``FINDING``: a v1/v2 record
+    carries no kind key, and mistaking a question for a finding merely renders
+    it with a severity, whereas the reverse would drop a real defect out of
+    the derived verdict.
+
+    Args:
+        value: Raw kind value decoded from the state blob.
+
+    Returns:
+        The parsed kind, defaulting to :data:`FindingKind.FINDING`.
+    """
+    try:
+        return FindingKind(str(value).lower())
+    except ValueError:
+        return FindingKind.FINDING
 
 
 def _parse_status(value: Any) -> FindingStatus:

--- a/lintro/ai/review/models/finding_record.py
+++ b/lintro/ai/review/models/finding_record.py
@@ -144,10 +144,15 @@ class FindingRecord:
             payload["checklist_ids"] = list(self.checklist_ids)
         if self.kind is not FindingKind.FINDING:
             payload["kind"] = str(self.kind)
-        if len(self.occurrences) > 1 or self.occurrences_total > 1:
+        # A lone occurrence identical to the record's own location adds
+        # nothing to the blob, but one at a *different* location is real
+        # tracked state and must survive the round trip.
+        anchor = (FindingOccurrence(file=self.file, line=self.line),)
+        if self.occurrences and self.occurrences != anchor:
             payload["occurrences"] = [
                 occurrence.to_dict() for occurrence in self.occurrences
             ]
+        if self.occurrence_total > 1:
             payload["occurrences_total"] = self.occurrence_total
         if self.severity_downgraded:
             payload["severity_downgraded"] = True

--- a/lintro/ai/review/models/review_finding.py
+++ b/lintro/ai/review/models/review_finding.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import StrEnum
 
+from lintro.ai.review.enums.evidence_style import EvidenceStyle
+from lintro.ai.review.enums.finding_kind import FindingKind
+from lintro.ai.review.models.finding_occurrence import FindingOccurrence
+
 __all__ = ["ReviewFinding", "Severity"]
 
 
@@ -51,6 +55,22 @@ class ReviewFinding:
         source: Provenance of the finding. Empty for the built-in checklist
             review; the agent name for a user-defined review agent (issue
             #1245) so merged output attributes each finding to its origin.
+        kind: Whether this entry is a defect claim or an open question
+            (#1925). Questions never affect the derived verdict and never get
+            a fix prompt.
+        failure_scenario: Concrete mechanism by which the defect fails in
+            production. Required for P1: a P1 reported without one is
+            downgraded to P2 at parse time and flagged via
+            ``severity_downgraded``.
+        severity_downgraded: True when the P1 evidence gate downgraded this
+            finding's reported severity. Surfaces render the downgrade rather
+            than letting it happen silently.
+        evidence_style: Self-reported basis for the finding. Recorded and
+            displayed only; the sole behavioral effect is the verify-first
+            line prompts add for speculative findings.
+        occurrences: Every ``file:line`` at which this pattern occurs. Empty
+            when the model reported none, in which case
+            :attr:`all_occurrences` falls back to the finding's own location.
     """
 
     severity: Severity
@@ -65,3 +85,27 @@ class ReviewFinding:
     checklist_ids: tuple[int, ...] = field(default_factory=tuple)
     suggested_code: str = ""
     source: str = ""
+    kind: FindingKind = FindingKind.FINDING
+    failure_scenario: str = ""
+    severity_downgraded: bool = False
+    evidence_style: EvidenceStyle = EvidenceStyle.DIFF_LOCAL
+    occurrences: tuple[FindingOccurrence, ...] = field(default_factory=tuple)
+
+    @property
+    def all_occurrences(self) -> tuple[FindingOccurrence, ...]:
+        """Return every location of this pattern, never empty.
+
+        A finding that reports no explicit occurrences still occurs once, at
+        its own ``file:line``, so callers can treat every finding uniformly as
+        a pattern with at least one occurrence.
+
+        Returns:
+            The reported occurrences, or a single occurrence built from the
+            finding's own file and line.
+        """
+        return self.occurrences or (FindingOccurrence(file=self.file, line=self.line),)
+
+    @property
+    def is_question(self) -> bool:
+        """Return True when this entry is a question rather than a finding."""
+        return self.kind is FindingKind.QUESTION

--- a/lintro/ai/review/models/review_finding.py
+++ b/lintro/ai/review/models/review_finding.py
@@ -65,9 +65,9 @@ class ReviewFinding:
         severity_downgraded: True when the P1 evidence gate downgraded this
             finding's reported severity. Surfaces render the downgrade rather
             than letting it happen silently.
-        evidence_style: Self-reported basis for the finding. Recorded and
-            displayed only; the sole behavioral effect is the verify-first
-            line prompts add for speculative findings.
+        evidence_style: Self-reported basis for the finding. Never suppresses
+            or down-ranks anything; the sole behavioral effect is the
+            verify-first line prompts add for speculative findings.
         occurrences: Every ``file:line`` at which this pattern occurs. Empty
             when the model reported none, in which case
             :attr:`all_occurrences` falls back to the finding's own location.

--- a/lintro/ai/review/models/run_record.py
+++ b/lintro/ai/review/models/run_record.py
@@ -46,6 +46,13 @@ class RunRecord:
         p1: Count of P1 findings reported in this round.
         p2: Count of P2 findings reported in this round.
         p3: Count of P3 findings reported in this round.
+        questions: Count of entries reported as questions rather than
+            findings in this round (#1925). Excluded from ``p1``/``p2``/``p3``
+            and from the derived verdict.
+        downgraded: Count of P1 findings the evidence gate downgraded to P2 in
+            this round (#1925). Recorded per run so severity inflation, and
+            how much of it the gate absorbed, stays visible over time rather
+            than being an invisible parse-time edit.
         partial: True when the review stopped before every chunk was reviewed.
         chunks_reviewed: Number of chunks actually reviewed.
         chunks_total: Total number of chunks in the diff.
@@ -74,6 +81,8 @@ class RunRecord:
     p1: int = 0
     p2: int = 0
     p3: int = 0
+    questions: int = 0
+    downgraded: int = 0
     partial: bool = False
     chunks_reviewed: int = 0
     chunks_total: int = 0
@@ -109,6 +118,8 @@ class RunRecord:
             "p1": self.p1,
             "p2": self.p2,
             "p3": self.p3,
+            "questions": self.questions,
+            "downgraded": self.downgraded,
             "partial": self.partial,
             "chunks_reviewed": self.chunks_reviewed,
             "chunks_total": self.chunks_total,
@@ -151,6 +162,8 @@ class RunRecord:
             p1=coerce_int(payload.get("p1")),
             p2=coerce_int(payload.get("p2")),
             p3=coerce_int(payload.get("p3")),
+            questions=coerce_int(payload.get("questions")),
+            downgraded=coerce_int(payload.get("downgraded")),
             partial=bool(payload.get("partial", False)),
             chunks_reviewed=coerce_int(payload.get("chunks_reviewed")),
             chunks_total=coerce_int(payload.get("chunks_total")),

--- a/lintro/ai/review/severity_gate.py
+++ b/lintro/ai/review/severity_gate.py
@@ -1,0 +1,127 @@
+"""P1 evidence gate for review findings (#1925).
+
+Severity inflation is the norm for AI reviewers — in the corpus behind epic
+#1905 one bot marked 92% of its findings P1. Under a verdict derived from open
+severities (any P1 -> Blocked) an uncalibrated P1 makes every PR read blocked,
+and a verdict nobody believes is worse than no verdict at all.
+
+The gate is deliberately mechanical rather than a judgement call: a P1 must
+carry a concrete ``failure_scenario``. One that does not is downgraded to P2 at
+parse time and marked, so the downgrade is visible on the surfaces instead of
+being an invisible edit of the model's output. Nothing is dropped, and no other
+severity is touched.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import replace
+
+from loguru import logger
+
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
+
+__all__ = [
+    "P1_DOWNGRADE_REASON",
+    "apply_p1_evidence_gate",
+    "count_downgrades",
+    "describe_downgrades",
+    "downgraded_findings",
+]
+
+#: Reason shown wherever a gate-driven downgrade is surfaced. Kept as one
+#: constant so the sticky (#1909), the per-review comment (#1910), and the log
+#: line can never drift into describing the rule differently.
+P1_DOWNGRADE_REASON = "no failure mechanism given"
+
+
+def _needs_downgrade(*, finding: ReviewFinding) -> bool:
+    """Return True when a finding is a P1 without a failure scenario.
+
+    Args:
+        finding: Finding to test.
+
+    Returns:
+        True when the P1 evidence gate applies to this finding. Questions are
+        never gated: they carry no severity semantics to begin with.
+    """
+    if finding.is_question:
+        return False
+    return finding.severity is Severity.P1 and not finding.failure_scenario.strip()
+
+
+def apply_p1_evidence_gate(
+    *,
+    findings: Sequence[ReviewFinding],
+) -> tuple[ReviewFinding, ...]:
+    """Downgrade P1 findings that report no concrete failure scenario.
+
+    Args:
+        findings: Findings as reported by the model, in payload order.
+
+    Returns:
+        The same findings in the same order, with ungated P1s rewritten to P2
+        and marked via ``severity_downgraded``.
+    """
+    gated: list[ReviewFinding] = []
+    for finding in findings:
+        if not _needs_downgrade(finding=finding):
+            gated.append(finding)
+            continue
+        logger.info(
+            "Downgrading P1 finding {title!r} to P2: {reason}.",
+            title=finding.title,
+            reason=P1_DOWNGRADE_REASON,
+        )
+        gated.append(
+            replace(
+                finding,
+                severity=Severity.P2,
+                severity_downgraded=True,
+            ),
+        )
+    return tuple(gated)
+
+
+def downgraded_findings(
+    *,
+    findings: Iterable[ReviewFinding],
+) -> tuple[ReviewFinding, ...]:
+    """Select the findings the evidence gate downgraded.
+
+    Args:
+        findings: Findings to filter.
+
+    Returns:
+        The downgraded findings, in the order given.
+    """
+    return tuple(finding for finding in findings if finding.severity_downgraded)
+
+
+def count_downgrades(*, findings: Iterable[ReviewFinding]) -> int:
+    """Count the findings the evidence gate downgraded.
+
+    Args:
+        findings: Findings to count over.
+
+    Returns:
+        Number of downgraded findings.
+    """
+    return len(downgraded_findings(findings=findings))
+
+
+def describe_downgrades(*, findings: Iterable[ReviewFinding]) -> str:
+    """Build the one-line downgrade notice surfaces render.
+
+    Args:
+        findings: Findings to summarize.
+
+    Returns:
+        A line such as ``"1 finding downgraded to P2: no failure mechanism
+        given"``, or an empty string when nothing was downgraded.
+    """
+    count = count_downgrades(findings=findings)
+    if not count:
+        return ""
+    noun = "finding" if count == 1 else "findings"
+    return f"{count} {noun} downgraded to {Severity.P2}: {P1_DOWNGRADE_REASON}"

--- a/lintro/ai/review/verdict.py
+++ b/lintro/ai/review/verdict.py
@@ -66,9 +66,11 @@ def derive_readiness_verdict(
     Returns:
         ``BLOCKED`` when any P1 is open, ``CHANGES_REQUESTED`` when any P2 is
         open, ``NITS_ONLY`` when only P3s are open, and ``READY`` when nothing
-        is open.
+        is open. Questions (#1925) are excluded entirely: a question is
+        suspicion without proof, and letting it move the verdict would
+        reintroduce exactly the severity inflation it exists to absorb.
     """
-    severities = {finding.severity for finding in findings}
+    severities = {finding.severity for finding in findings if not finding.is_question}
     if Severity.P1 in severities:
         return ReviewVerdict.BLOCKED
     if Severity.P2 in severities:
@@ -109,7 +111,8 @@ def resolve_bullet_finding(
 
     Returns:
         The matching finding, or ``None`` when the reference is empty or does
-        not name any reviewed file.
+        not name any reviewed file. Questions are never resolved to: a
+        severity-marked summary bullet must point at a severity'd finding.
     """
     reference = finding_ref.strip()
     if not reference:
@@ -128,7 +131,11 @@ def resolve_bullet_finding(
             # would break the same-file fallback below).
             line = None
 
-    candidates = [finding for finding in findings if finding.file == path]
+    candidates = [
+        finding
+        for finding in findings
+        if finding.file == path and not finding.is_question
+    ]
     if not candidates:
         return None
     if line is None:

--- a/lintro/ai/review/verdict.py
+++ b/lintro/ai/review/verdict.py
@@ -131,16 +131,15 @@ def resolve_bullet_finding(
             # would break the same-file fallback below).
             line = None
 
-    candidates = [
-        finding
-        for finding in findings
-        if finding.file == path and not finding.is_question
-    ]
+    same_file = [finding for finding in findings if finding.file == path]
+    if line is not None:
+        exact = [finding for finding in same_file if finding.line == line]
+        if exact:
+            return next(
+                (finding for finding in exact if not finding.is_question),
+                None,
+            )
+    candidates = [finding for finding in same_file if not finding.is_question]
     if not candidates:
         return None
-    if line is None:
-        return candidates[0]
-    return next(
-        (finding for finding in candidates if finding.line == line),
-        candidates[0],
-    )
+    return candidates[0]

--- a/tests/unit/ai/prompts/test_review_prompts.py
+++ b/tests/unit/ai/prompts/test_review_prompts.py
@@ -137,3 +137,32 @@ def test_review_system_is_nonempty() -> None:
     """System prompt contains review method instructions."""
     assert_that(REVIEW_SYSTEM).contains("Review method")
     assert_that(REVIEW_SYSTEM).contains("P1")
+
+
+def test_review_system_carries_p1_calibration_language() -> None:
+    """The system prompt states the P1 bar and the evidence requirement (#1925)."""
+    assert_that(REVIEW_SYSTEM).contains("Severity calibration")
+    assert_that(REVIEW_SYSTEM).contains("failure_scenario")
+    assert_that(REVIEW_SYSTEM).contains("Torn between P1 and P2? Choose P2.")
+
+
+def test_review_system_keeps_correctness_adjacent_style_in_scope() -> None:
+    """Linter-catchable style is out of scope, code smells are not."""
+    assert_that(REVIEW_SYSTEM).contains("Style/formatting issues linters would catch")
+    assert_that(REVIEW_SYSTEM).contains("code-smell")
+
+
+def test_output_schema_declares_the_corpus_finding_fields() -> None:
+    """The model-facing schema advertises every #1925 field."""
+    for field in ("kind", "failure_scenario", "evidence_style", "occurrences"):
+        assert_that(REVIEW_OUTPUT_SCHEMA).contains(field)
+
+
+def test_output_rules_cap_questions_and_explain_occurrence_collapse() -> None:
+    """Rendered rules carry the question cap and the occurrence instruction."""
+    rules = format_output_rules(checklist_count=4)
+
+    assert_that(rules).contains("3 per review")
+    assert_that(rules).contains("automatically downgraded to P2")
+    assert_that(rules).contains("occurrences")
+    assert_that(rules).contains("do not report the same problem twice")

--- a/tests/unit/ai/review/test_agent_prompts.py
+++ b/tests/unit/ai/review/test_agent_prompts.py
@@ -9,6 +9,7 @@ import pytest
 from assertpy import assert_that
 
 from lintro.ai.review.agent_prompts import (
+    SPECULATIVE_NOTICE,
     VERIFICATION_PREAMBLE,
     render_agent_prompt,
     render_agent_prompt_panel,
@@ -18,7 +19,10 @@ from lintro.ai.review.agent_prompts import (
     render_sticky_prompt_pointer,
 )
 from lintro.ai.review.enums.agent_prompt_scope_kind import AgentPromptScopeKind
+from lintro.ai.review.enums.evidence_style import EvidenceStyle
+from lintro.ai.review.enums.finding_kind import FindingKind
 from lintro.ai.review.models.agent_prompt_scope import AgentPromptScope
+from lintro.ai.review.models.finding_occurrence import FindingOccurrence
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 
 
@@ -516,3 +520,99 @@ def test_sticky_pointer_links_back_instead_of_duplicating_the_prompt() -> None:
         "[sticky comment's fix-all](https://example.test/c/1)",
     )
     assert_that(pointer).does_not_contain("```")
+
+
+def test_questions_are_excluded_from_fix_all_prompts() -> None:
+    """A question contributes nothing to a fix-all prompt (#1925)."""
+    finding = _finding(title="Real defect", file="src/a.py")
+    question = replace(
+        _finding(title="Is this intentional", file="src/b.py"),
+        kind=FindingKind.QUESTION,
+    )
+
+    prompt = render_agent_prompt(
+        findings=(finding, question),
+        scope=AgentPromptScope(kind=AgentPromptScopeKind.ALL_OPEN, round_number=1),
+    )
+
+    assert_that(prompt).contains("Real defect")
+    assert_that(prompt).does_not_contain("Is this intentional")
+    assert_that(prompt).does_not_contain("src/b.py")
+
+
+def test_fix_all_scope_counts_exclude_questions() -> None:
+    """The scope sentence never promises to fix a question."""
+    finding = _finding(title="Real defect")
+    question = replace(_finding(title="A doubt"), kind=FindingKind.QUESTION)
+
+    panel = render_agent_prompt_panel(
+        findings=(finding, question),
+        scope=AgentPromptScope(kind=AgentPromptScopeKind.ALL_OPEN, round_number=1),
+    )
+
+    assert_that(panel).contains("the 1 finding still open")
+    assert_that(panel).contains("1 still-open finding")
+
+
+def test_a_question_gets_no_prompt_at_all() -> None:
+    """Questions render no per-finding prompt or panel."""
+    question = replace(_finding(title="A doubt"), kind=FindingKind.QUESTION)
+
+    assert_that(render_finding_prompt(finding=question)).is_empty()
+    assert_that(render_finding_prompt_panel(finding=question)).is_empty()
+
+
+def test_speculative_findings_carry_the_verify_first_line() -> None:
+    """An inferred finding tells the agent to reproduce it before fixing."""
+    finding = replace(_finding(), evidence_style=EvidenceStyle.SPECULATIVE)
+
+    prompt = render_finding_prompt(finding=finding)
+
+    assert_that(" ".join(prompt.split())).contains(SPECULATIVE_NOTICE)
+
+
+@pytest.mark.parametrize(
+    "evidence_style",
+    [EvidenceStyle.DIFF_LOCAL, EvidenceStyle.CROSS_FILE],
+    ids=["style=diff_local", "style=cross_file"],
+)
+def test_verified_findings_omit_the_verify_first_line(
+    evidence_style: EvidenceStyle,
+) -> None:
+    """Only speculative findings get the extra caution.
+
+    Args:
+        evidence_style: Non-speculative evidence style under test.
+    """
+    finding = replace(_finding(), evidence_style=evidence_style)
+
+    prompt = render_finding_prompt(finding=finding)
+
+    assert_that(" ".join(prompt.split())).does_not_contain(SPECULATIVE_NOTICE)
+
+
+def test_prompts_enumerate_every_occurrence_of_a_pattern() -> None:
+    """Display collapses a repeated pattern; the prompt must not."""
+    finding = replace(
+        _finding(file="src/a.py", line=10),
+        occurrences=(
+            FindingOccurrence(file="src/a.py", line=10),
+            FindingOccurrence(file="src/a.py", line=42),
+            FindingOccurrence(file="src/b.py", line=7),
+        ),
+    )
+
+    prompt = " ".join(render_finding_prompt(finding=finding).split())
+
+    assert_that(prompt).contains("Occurs at 3 locations")
+    assert_that(prompt).contains("apply the equivalent fix at each")
+    assert_that(prompt).contains("src/a.py:10")
+    assert_that(prompt).contains("src/a.py:42")
+    assert_that(prompt).contains("src/b.py:7")
+
+
+def test_single_occurrence_findings_get_no_occurrence_list() -> None:
+    """A pattern that occurs once reads exactly as it did before #1925."""
+    prompt = render_finding_prompt(finding=_finding())
+
+    assert_that(prompt).does_not_contain("Occurs at")

--- a/tests/unit/ai/review/test_finding_matcher.py
+++ b/tests/unit/ai/review/test_finding_matcher.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 from assertpy import assert_that
 
+from lintro.ai.review.enums.finding_kind import FindingKind
 from lintro.ai.review.enums.finding_match_outcome import FindingMatchOutcome
 from lintro.ai.review.enums.finding_status import FindingStatus
 from lintro.ai.review.enums.review_verdict import ReviewVerdict
@@ -16,6 +19,7 @@ from lintro.ai.review.finding_matcher import (
     normalize_file_path,
     normalize_title,
 )
+from lintro.ai.review.models.finding_occurrence import FindingOccurrence
 from lintro.ai.review.models.finding_record import FindingRecord
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_state import ReviewState
@@ -471,3 +475,164 @@ def test_derive_verdict_ignores_resolved_findings() -> None:
     assert_that(derive_verdict(findings=second.records)).is_equal_to(
         ReviewVerdict.READY,
     )
+
+
+def _pattern(
+    *,
+    lines: tuple[int, ...],
+    title: str = "Unchecked return value",
+    file: str = "src/app.py",
+) -> ReviewFinding:
+    """Build a finding that occurs at several locations.
+
+    Args:
+        lines: Line numbers at which the pattern occurs.
+        title: Finding title.
+        file: Repository-relative file path of every occurrence.
+
+    Returns:
+        The constructed finding, anchored at the first occurrence.
+    """
+    return replace(
+        _finding(title=title, file=file, line=lines[0], severity=Severity.P2),
+        occurrences=tuple(FindingOccurrence(file=file, line=line) for line in lines),
+    )
+
+
+def test_a_single_occurrence_finding_tracks_one_location() -> None:
+    """A finding with no explicit occurrences still counts as one (#1925)."""
+    match = match_findings(
+        previous=None,
+        findings=[_finding(title="Solo defect")],
+        round_number=1,
+    )
+
+    record = match.records[0]
+    assert_that(record.occurrence_count).is_equal_to(1)
+    assert_that(record.occurrence_total).is_equal_to(1)
+    assert_that(record.occurrences_addressed).is_equal_to(0)
+
+
+def test_a_repeated_pattern_is_one_tracked_finding() -> None:
+    """Twenty call sites of one defect are one record, not twenty."""
+    match = match_findings(
+        previous=None,
+        findings=[_pattern(lines=(10, 20, 30, 40))],
+        round_number=1,
+    )
+
+    assert_that(match.records).is_length(1)
+    assert_that(match.records[0].occurrence_total).is_equal_to(4)
+
+
+def test_partial_progress_keeps_the_pattern_open_with_counts() -> None:
+    """Fixing some occurrences is progress, not resolution."""
+    first = match_findings(
+        previous=None,
+        findings=[_pattern(lines=(10, 20, 30, 40, 50))],
+        round_number=1,
+    )
+    second = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[_pattern(lines=(30, 50))],
+        round_number=2,
+        head_sha="deadbeef",
+    )
+
+    assert_that(second.resolved).is_empty()
+    assert_that(second.carried).is_length(1)
+    record = second.records[0]
+    assert_that(record.status).is_equal_to(FindingStatus.OPEN)
+    assert_that(record.occurrence_count).is_equal_to(2)
+    assert_that(record.occurrence_total).is_equal_to(5)
+    assert_that(record.occurrences_addressed).is_equal_to(3)
+
+
+def test_a_pattern_resolves_only_when_every_occurrence_is_gone() -> None:
+    """Pattern-level resolution needs the whole pattern to disappear."""
+    first = match_findings(
+        previous=None,
+        findings=[_pattern(lines=(10, 20, 30))],
+        round_number=1,
+    )
+    second = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[],
+        round_number=2,
+        head_sha="cafebabe",
+    )
+
+    record = second.records[0]
+    assert_that(record.status).is_equal_to(FindingStatus.RESOLVED)
+    assert_that(record.occurrences_addressed).is_equal_to(3)
+
+
+def test_one_reappearing_occurrence_regresses_the_whole_pattern() -> None:
+    """A single returning call site reopens the pattern with its full total."""
+    first = match_findings(
+        previous=None,
+        findings=[_pattern(lines=(10, 20, 30))],
+        round_number=1,
+    )
+    resolved = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[],
+        round_number=2,
+        head_sha="cafebabe",
+    )
+    third = match_findings(
+        previous=ReviewState(findings=resolved.records),
+        findings=[_pattern(lines=(20,))],
+        round_number=3,
+        head_sha="f00d",
+    )
+
+    assert_that(third.regressed).is_length(1)
+    record = third.records[0]
+    assert_that(record.status).is_equal_to(FindingStatus.OPEN)
+    assert_that(record.regressed).is_true()
+    assert_that(record.occurrence_count).is_equal_to(1)
+    assert_that(record.occurrence_total).is_equal_to(3)
+    assert_that(record.occurrences_addressed).is_equal_to(2)
+
+
+def test_questions_are_tracked_but_excluded_from_the_verdict() -> None:
+    """A tracked question never blocks the PR (#1925)."""
+    question = replace(
+        _finding(title="Is this intentional", severity=Severity.P1),
+        kind=FindingKind.QUESTION,
+    )
+    match = match_findings(previous=None, findings=[question], round_number=1)
+
+    assert_that(match.records).is_length(1)
+    assert_that(match.records[0].is_question).is_true()
+    assert_that(derive_verdict(findings=match.records)).is_equal_to(
+        ReviewVerdict.READY,
+    )
+
+
+def test_occurrences_survive_a_state_round_trip() -> None:
+    """Occurrence counts persist in the state blob, not just in memory."""
+    match = match_findings(
+        previous=None,
+        findings=[_pattern(lines=(10, 20, 30))],
+        round_number=1,
+    )
+
+    restored = FindingRecord.from_dict(match.records[0].to_dict())
+
+    assert_that(restored).is_not_none()
+    assert_that(restored.occurrence_total).is_equal_to(3)
+    assert_that(restored.occurrences).is_length(3)
+
+
+def test_a_pre_1925_record_degrades_to_a_single_occurrence() -> None:
+    """State written before #1925 parses with sane occurrence defaults."""
+    restored = FindingRecord.from_dict(
+        {"fingerprint": "abc123", "severity": "P2", "file": "a.py", "line": 3},
+    )
+
+    assert_that(restored).is_not_none()
+    assert_that(restored.kind).is_equal_to(FindingKind.FINDING)
+    assert_that(restored.occurrence_count).is_equal_to(1)
+    assert_that(restored.occurrence_total).is_equal_to(1)

--- a/tests/unit/ai/review/test_finding_matcher.py
+++ b/tests/unit/ai/review/test_finding_matcher.py
@@ -622,6 +622,7 @@ def test_occurrences_survive_a_state_round_trip() -> None:
     restored = FindingRecord.from_dict(match.records[0].to_dict())
 
     assert_that(restored).is_not_none()
+    assert restored is not None  # narrow type for mypy
     assert_that(restored.occurrence_total).is_equal_to(3)
     assert_that(restored.occurrences).is_length(3)
 
@@ -633,6 +634,52 @@ def test_a_pre_1925_record_degrades_to_a_single_occurrence() -> None:
     )
 
     assert_that(restored).is_not_none()
+    assert restored is not None  # narrow type for mypy
     assert_that(restored.kind).is_equal_to(FindingKind.FINDING)
     assert_that(restored.occurrence_count).is_equal_to(1)
     assert_that(restored.occurrence_total).is_equal_to(1)
+
+
+def test_an_omitted_occurrence_list_is_silence_not_progress() -> None:
+    """A round that reports no occurrences inherits the tracked locations.
+
+    Regression guard: synthesizing a single anchor occurrence for a finding
+    that simply omitted the field would read as "2 of 3 addressed" on every
+    degraded round, inventing progress that never happened.
+    """
+    first = match_findings(
+        previous=None,
+        findings=[_pattern(lines=(10, 20, 30))],
+        round_number=1,
+    )
+    second = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[
+            _finding(title="Unchecked return value", line=10, severity=Severity.P2),
+        ],
+        round_number=2,
+        head_sha="deadbeef",
+    )
+
+    record = second.records[0]
+    assert_that(record.occurrence_count).is_equal_to(3)
+    assert_that(record.occurrence_total).is_equal_to(3)
+    assert_that(record.occurrences_addressed).is_equal_to(0)
+
+
+def test_a_lone_occurrence_away_from_the_anchor_survives_serialization() -> None:
+    """A single occurrence at another location is real state, not noise."""
+    record = FindingRecord(
+        fingerprint="abc123",
+        file="src/app.py",
+        line=10,
+        occurrences=(FindingOccurrence(file="src/other.py", line=99),),
+    )
+
+    restored = FindingRecord.from_dict(record.to_dict())
+
+    assert_that(restored).is_not_none()
+    assert restored is not None  # narrow type for mypy
+    assert_that(restored.occurrences).is_equal_to(
+        (FindingOccurrence(file="src/other.py", line=99),),
+    )

--- a/tests/unit/ai/review/test_finding_matcher.py
+++ b/tests/unit/ai/review/test_finding_matcher.py
@@ -19,7 +19,10 @@ from lintro.ai.review.finding_matcher import (
     normalize_file_path,
     normalize_title,
 )
-from lintro.ai.review.models.finding_occurrence import FindingOccurrence
+from lintro.ai.review.models.finding_occurrence import (
+    FindingOccurrence,
+    parse_occurrences,
+)
 from lintro.ai.review.models.finding_record import FindingRecord
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_state import ReviewState
@@ -682,4 +685,29 @@ def test_a_lone_occurrence_away_from_the_anchor_survives_serialization() -> None
     assert restored is not None  # narrow type for mypy
     assert_that(restored.occurrences).is_equal_to(
         (FindingOccurrence(file="src/other.py", line=99),),
+    )
+
+
+def test_parse_occurrences_deduplicates_repeated_locations() -> None:
+    """A model that reports the same location twice yields one occurrence.
+
+    The matcher counts occurrences by tuple length to derive
+    ``occurrences_total`` and partial-progress counts. A duplicate raw
+    location must not inflate that count, or a later round that reports the
+    same location once would look like progress was made when the location
+    never changed.
+    """
+    parsed = parse_occurrences(
+        [
+            {"file": "src/app.py", "line": 10},
+            {"file": "src/app.py", "line": 10},
+            {"file": "src/app.py", "line": 20},
+        ],
+    )
+
+    assert_that(parsed).is_equal_to(
+        (
+            FindingOccurrence(file="src/app.py", line=10),
+            FindingOccurrence(file="src/app.py", line=20),
+        ),
     )

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -45,6 +45,7 @@ def _sample_response_json(*, include_finding: bool = True) -> str:
             "description": "Unknown status grants access",
             "cause": "else branch returns Active",
             "fix": "Default to Expired",
+            "failure_scenario": "An unknown status grants access in production",
             "confidence": "high",
             "checklist_ids": [1],
         }

--- a/tests/unit/ai/review/test_orchestrator_hardening.py
+++ b/tests/unit/ai/review/test_orchestrator_hardening.py
@@ -240,7 +240,7 @@ def test_build_review_prompt_logs_secret_warning() -> None:
 def test_severity_normalization_lowercase() -> None:
     """A lowercase 'p1' severity normalizes to Severity.P1."""
     findings = parse_findings(
-        raw_findings=[{"severity": "p1", "title": "Bug"}],
+        raw_findings=[{"severity": "p1", "title": "Bug", "failure_scenario": "boom"}],
     )
 
     assert_that(findings).is_length(1)
@@ -250,7 +250,7 @@ def test_severity_normalization_lowercase() -> None:
 def test_severity_normalization_whitespace() -> None:
     """A trailing-space 'P1 ' severity normalizes to Severity.P1."""
     findings = parse_findings(
-        raw_findings=[{"severity": "P1 ", "title": "Bug"}],
+        raw_findings=[{"severity": "P1 ", "title": "Bug", "failure_scenario": "boom"}],
     )
 
     assert_that(findings).is_length(1)
@@ -260,7 +260,9 @@ def test_severity_normalization_whitespace() -> None:
 def test_severity_synonym_critical_maps_to_p1() -> None:
     """A blocking synonym like 'critical' maps to Severity.P1."""
     findings = parse_findings(
-        raw_findings=[{"severity": "critical", "title": "Bug"}],
+        raw_findings=[
+            {"severity": "critical", "title": "Bug", "failure_scenario": "boom"},
+        ],
     )
 
     assert_that(findings).is_length(1)
@@ -290,7 +292,15 @@ def test_normalize_severity_minor_maps_to_p3() -> None:
 def test_has_p1_findings_after_lowercase_normalization() -> None:
     """The exit gate fires when a lowercase 'p1' finding is normalized."""
     findings = parse_findings(
-        raw_findings=[{"severity": "p1", "title": "Bug", "file": "a.py", "line": 1}],
+        raw_findings=[
+            {
+                "severity": "p1",
+                "title": "Bug",
+                "file": "a.py",
+                "line": 1,
+                "failure_scenario": "boom",
+            },
+        ],
     )
     result = ReviewResult(
         metadata=_placeholder_metadata(),
@@ -306,7 +316,13 @@ def test_has_p1_findings_true_for_blocking_synonym() -> None:
     """A blocking synonym like 'blocker' trips the P1 exit gate."""
     findings = parse_findings(
         raw_findings=[
-            {"severity": "blocker", "title": "Bug", "file": "a.py", "line": 1},
+            {
+                "severity": "blocker",
+                "title": "Bug",
+                "file": "a.py",
+                "line": 1,
+                "failure_scenario": "boom",
+            },
         ],
     )
     result = ReviewResult(
@@ -322,7 +338,9 @@ def test_has_p1_findings_true_for_blocking_synonym() -> None:
 def test_has_p1_findings_true_for_gibberish_severity() -> None:
     """A truly unknown severity fails closed to P1 and trips the exit gate."""
     findings = parse_findings(
-        raw_findings=[{"severity": "banana", "title": "Bug"}],
+        raw_findings=[
+            {"severity": "banana", "title": "Bug", "failure_scenario": "boom"},
+        ],
     )
     result = ReviewResult(
         metadata=_placeholder_metadata(),

--- a/tests/unit/ai/review/test_severity_gate.py
+++ b/tests/unit/ai/review/test_severity_gate.py
@@ -265,3 +265,47 @@ def test_legacy_run_record_defaults_the_new_counts_to_zero() -> None:
 
     assert_that(restored.questions).is_equal_to(0)
     assert_that(restored.downgraded).is_equal_to(0)
+
+
+@pytest.mark.parametrize(
+    "failure_scenario",
+    [None, False, 0, {"why": "because"}, ["reasons"]],
+    ids=["none", "false", "zero", "mapping", "list"],
+)
+def test_a_non_string_failure_scenario_does_not_satisfy_the_gate(
+    failure_scenario: object,
+) -> None:
+    """Malformed evidence is absent evidence.
+
+    Regression guard: coercing the raw value with ``str()`` turns ``None``
+    into the truthy literal ``"None"`` and walks an unevidenced P1 straight
+    through the gate.
+
+    Args:
+        failure_scenario: Malformed ``failure_scenario`` value under test.
+    """
+    findings = parse_findings(
+        raw_findings=[_raw(failure_scenario=failure_scenario)],
+    )
+
+    assert_that(findings[0].failure_scenario).is_empty()
+    assert_that(findings[0].severity).is_equal_to(Severity.P2)
+    assert_that(findings[0].severity_downgraded).is_true()
+
+
+@pytest.mark.parametrize(
+    "file",
+    [None, 7, {"path": "a.py"}, ["a.py"]],
+    ids=["none", "number", "mapping", "list"],
+)
+def test_a_non_string_occurrence_file_is_rejected(file: object) -> None:
+    """A non-string path is dropped rather than coerced into a fake location.
+
+    Args:
+        file: Malformed occurrence ``file`` value under test.
+    """
+    findings = parse_findings(
+        raw_findings=[_raw(severity="P3", occurrences=[{"file": file, "line": 4}])],
+    )
+
+    assert_that(findings[0].occurrences).is_empty()

--- a/tests/unit/ai/review/test_severity_gate.py
+++ b/tests/unit/ai/review/test_severity_gate.py
@@ -1,0 +1,267 @@
+"""Tests for the P1 evidence gate and the #1925 finding-model fields."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.review.enums.evidence_style import EvidenceStyle
+from lintro.ai.review.enums.finding_kind import FindingKind
+from lintro.ai.review.finding_parser import (
+    normalize_evidence_style,
+    normalize_finding_kind,
+    parse_findings,
+)
+from lintro.ai.review.models.finding_occurrence import FindingOccurrence
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
+from lintro.ai.review.models.run_record import RunRecord
+from lintro.ai.review.severity_gate import (
+    P1_DOWNGRADE_REASON,
+    apply_p1_evidence_gate,
+    count_downgrades,
+    describe_downgrades,
+    downgraded_findings,
+)
+
+
+def _raw(**overrides: Any) -> dict[str, Any]:
+    """Build a raw model finding payload.
+
+    Args:
+        **overrides: Keys to set or replace on the base payload.
+
+    Returns:
+        The raw finding mapping.
+    """
+    payload: dict[str, Any] = {
+        "severity": "P1",
+        "category": "security",
+        "file": "src/app.py",
+        "line": 12,
+        "title": "Auth bypass on unknown status",
+        "description": "d",
+        "cause": "c",
+        "fix": "f",
+        "confidence": "high",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _finding(**overrides: Any) -> ReviewFinding:
+    """Build a review finding for gate tests.
+
+    Args:
+        **overrides: Fields to override on the base finding.
+
+    Returns:
+        The constructed finding.
+    """
+    fields: dict[str, Any] = {
+        "severity": Severity.P1,
+        "category": "security",
+        "file": "src/app.py",
+        "line": 12,
+        "title": "Auth bypass on unknown status",
+        "description": "d",
+        "cause": "c",
+        "fix": "f",
+        "confidence": "high",
+    }
+    fields.update(overrides)
+    return ReviewFinding(**fields)
+
+
+def test_p1_with_failure_scenario_keeps_its_severity() -> None:
+    """A P1 backed by a concrete failure mechanism is left alone."""
+    findings = parse_findings(
+        raw_findings=[_raw(failure_scenario="Expired tokens are treated as active")],
+    )
+
+    assert_that(findings).is_length(1)
+    assert_that(findings[0].severity).is_equal_to(Severity.P1)
+    assert_that(findings[0].severity_downgraded).is_false()
+
+
+def test_p1_without_failure_scenario_is_downgraded_to_p2() -> None:
+    """A P1 with no failure mechanism is downgraded rather than trusted."""
+    findings = parse_findings(raw_findings=[_raw()])
+
+    assert_that(findings[0].severity).is_equal_to(Severity.P2)
+    assert_that(findings[0].severity_downgraded).is_true()
+
+
+def test_p1_with_whitespace_only_failure_scenario_is_downgraded() -> None:
+    """Whitespace does not satisfy the evidence gate."""
+    findings = parse_findings(raw_findings=[_raw(failure_scenario="   \n  ")])
+
+    assert_that(findings[0].severity).is_equal_to(Severity.P2)
+    assert_that(findings[0].severity_downgraded).is_true()
+
+
+@pytest.mark.parametrize(
+    "severity",
+    [Severity.P2, Severity.P3],
+    ids=["severity=P2", "severity=P3"],
+)
+def test_gate_leaves_non_p1_severities_untouched(severity: Severity) -> None:
+    """The gate only applies to P1; nothing else is rewritten.
+
+    Args:
+        severity: Non-blocking severity under test.
+    """
+    findings = apply_p1_evidence_gate(findings=(_finding(severity=severity),))
+
+    assert_that(findings[0].severity).is_equal_to(severity)
+    assert_that(findings[0].severity_downgraded).is_false()
+
+
+def test_gate_never_downgrades_a_question() -> None:
+    """Questions carry no severity semantics, so the gate skips them."""
+    findings = apply_p1_evidence_gate(
+        findings=(_finding(kind=FindingKind.QUESTION),),
+    )
+
+    assert_that(findings[0].severity_downgraded).is_false()
+
+
+def test_severity_override_exempts_the_pass_from_the_gate() -> None:
+    """An author-declared severity policy is not model output to calibrate."""
+    findings = parse_findings(
+        raw_findings=[_raw()],
+        severity_override=Severity.P1,
+    )
+
+    assert_that(findings[0].severity).is_equal_to(Severity.P1)
+    assert_that(findings[0].severity_downgraded).is_false()
+
+
+def test_downgrade_is_visible_to_renderers() -> None:
+    """A downgrade is exposed as a countable, describable record."""
+    findings = parse_findings(
+        raw_findings=[
+            _raw(),
+            _raw(title="Second unevidenced blocker", line=40),
+            _raw(severity="P3", title="Nit"),
+        ],
+    )
+
+    assert_that(count_downgrades(findings=findings)).is_equal_to(2)
+    assert_that(downgraded_findings(findings=findings)).is_length(2)
+    notice = describe_downgrades(findings=findings)
+    assert_that(notice).contains("2 findings downgraded to P2")
+    assert_that(notice).contains(P1_DOWNGRADE_REASON)
+
+
+def test_downgrade_notice_is_singular_for_one_finding() -> None:
+    """The rendered notice reads naturally for a single downgrade."""
+    findings = parse_findings(raw_findings=[_raw()])
+
+    assert_that(describe_downgrades(findings=findings)).is_equal_to(
+        f"1 finding downgraded to P2: {P1_DOWNGRADE_REASON}",
+    )
+
+
+def test_downgrade_notice_is_empty_when_nothing_was_downgraded() -> None:
+    """Surfaces render nothing when the gate found nothing to correct."""
+    findings = parse_findings(
+        raw_findings=[_raw(failure_scenario="Requests 500 under load")],
+    )
+
+    assert_that(describe_downgrades(findings=findings)).is_empty()
+
+
+def test_parsed_finding_carries_the_new_model_fields() -> None:
+    """kind, evidence style, and occurrences round-trip through the parser."""
+    findings = parse_findings(
+        raw_findings=[
+            _raw(
+                kind="question",
+                evidence_style="speculative",
+                occurrences=[
+                    {"file": "src/app.py", "line": 12},
+                    {"file": "src/other.py", "line": 30},
+                ],
+            ),
+        ],
+    )
+
+    finding = findings[0]
+    assert_that(finding.kind).is_equal_to(FindingKind.QUESTION)
+    assert_that(finding.is_question).is_true()
+    assert_that(finding.evidence_style).is_equal_to(EvidenceStyle.SPECULATIVE)
+    assert_that(finding.occurrences).is_length(2)
+    assert_that(finding.occurrences[1]).is_equal_to(
+        FindingOccurrence(file="src/other.py", line=30),
+    )
+
+
+def test_missing_new_fields_degrade_to_defaults() -> None:
+    """A model that ignores every #1925 field still produces a valid finding."""
+    findings = parse_findings(raw_findings=[_raw(severity="P3")])
+
+    finding = findings[0]
+    assert_that(finding.kind).is_equal_to(FindingKind.FINDING)
+    assert_that(finding.evidence_style).is_equal_to(EvidenceStyle.DIFF_LOCAL)
+    assert_that(finding.failure_scenario).is_empty()
+    assert_that(finding.occurrences).is_empty()
+    assert_that(finding.all_occurrences).is_equal_to(
+        (FindingOccurrence(file="src/app.py", line=12),),
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["banana", "", None, 7, {"nested": True}],
+    ids=["unknown", "empty", "none", "number", "mapping"],
+)
+def test_malformed_kind_and_style_never_fail_the_run(raw: object) -> None:
+    """Unusable values fall back to defaults instead of raising.
+
+    Args:
+        raw: Malformed value under test.
+    """
+    assert_that(normalize_finding_kind(raw=raw)).is_equal_to(FindingKind.FINDING)
+    assert_that(normalize_evidence_style(raw=raw)).is_equal_to(
+        EvidenceStyle.DIFF_LOCAL,
+    )
+
+
+@pytest.mark.parametrize(
+    "occurrences",
+    ["not-a-list", [], [{"line": 3}], ["nope", {"file": "  "}]],
+    ids=["scalar", "empty", "no_file", "unusable_entries"],
+)
+def test_malformed_occurrences_degrade_to_the_findings_own_location(
+    occurrences: object,
+) -> None:
+    """Unusable occurrence payloads leave the finding as a single location.
+
+    Args:
+        occurrences: Malformed ``occurrences`` value under test.
+    """
+    findings = parse_findings(
+        raw_findings=[_raw(severity="P3", occurrences=occurrences)],
+    )
+
+    assert_that(findings[0].all_occurrences).is_length(1)
+
+
+def test_run_record_round_trips_question_and_downgrade_counts() -> None:
+    """Per-run severity distribution keeps inflation visible over time."""
+    record = RunRecord(round=2, p1=1, p2=3, p3=4, questions=2, downgraded=5)
+
+    restored = RunRecord.from_dict(record.to_dict())
+
+    assert_that(restored.questions).is_equal_to(2)
+    assert_that(restored.downgraded).is_equal_to(5)
+
+
+def test_legacy_run_record_defaults_the_new_counts_to_zero() -> None:
+    """A run recorded before #1925 parses cleanly with empty new counts."""
+    restored = RunRecord.from_dict({"round": 1, "p1": 2})
+
+    assert_that(restored.questions).is_equal_to(0)
+    assert_that(restored.downgraded).is_equal_to(0)

--- a/tests/unit/ai/review/test_verdict.py
+++ b/tests/unit/ai/review/test_verdict.py
@@ -205,3 +205,22 @@ def test_summary_bullets_never_resolve_to_a_question() -> None:
     assert_that(
         resolve_bullet_finding(finding_ref="a.py:7", findings=[question]),
     ).is_none()
+
+
+def test_exact_question_reference_does_not_fall_back_to_another_finding() -> None:
+    """An exact reference to a question line never resolves via same-file fallback.
+
+    ``a.py:7`` is a question and ``a.py:42`` is a real finding. A bullet that
+    references the question's own line must yield ``None`` rather than
+    silently attaching the question's severity to the unrelated finding at
+    ``a.py:42`` through the same-file fallback.
+    """
+    question = replace(
+        _finding(severity=Severity.P1, file="a.py", line=7),
+        kind=FindingKind.QUESTION,
+    )
+    other = _finding(severity=Severity.P2, file="a.py", line=42)
+
+    assert_that(
+        resolve_bullet_finding(finding_ref="a.py:7", findings=[question, other]),
+    ).is_none()

--- a/tests/unit/ai/review/test_verdict.py
+++ b/tests/unit/ai/review/test_verdict.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 from assertpy import assert_that
 
+from lintro.ai.review.enums.finding_kind import FindingKind
 from lintro.ai.review.enums.review_verdict import ReviewVerdict
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_metadata import ReviewMetadata
@@ -165,3 +168,40 @@ def test_resolve_bullet_finding_falls_back_on_malformed_line_suffix() -> None:
     )
 
     assert_that(resolved).is_equal_to(finding)
+
+
+def test_questions_never_move_the_verdict() -> None:
+    """A P1-labelled question leaves the verdict at the findings' level (#1925)."""
+    question = replace(
+        _finding(severity=Severity.P1, file="a.py", line=1),
+        kind=FindingKind.QUESTION,
+    )
+    finding = _finding(severity=Severity.P3, file="b.py", line=2)
+
+    verdict = derive_readiness_verdict(findings=[question, finding])
+
+    assert_that(verdict).is_equal_to(ReviewVerdict.NITS_ONLY)
+
+
+def test_a_review_of_only_questions_is_ready() -> None:
+    """Questions alone leave nothing open to block the merge."""
+    question = replace(
+        _finding(severity=Severity.P1, file="a.py", line=1),
+        kind=FindingKind.QUESTION,
+    )
+
+    assert_that(derive_readiness_verdict(findings=[question])).is_equal_to(
+        ReviewVerdict.READY,
+    )
+
+
+def test_summary_bullets_never_resolve_to_a_question() -> None:
+    """A severity-marked bullet must point at a severity'd finding."""
+    question = replace(
+        _finding(severity=Severity.P1, file="a.py", line=7),
+        kind=FindingKind.QUESTION,
+    )
+
+    assert_that(
+        resolve_bullet_finding(finding_ref="a.py:7", findings=[question]),
+    ).is_none()

--- a/tests/unit/ai/test_cli_schemas.py
+++ b/tests/unit/ai/test_cli_schemas.py
@@ -71,3 +71,37 @@ def test_parse_fix_response_payload_accepts_array() -> None:
     """Fix parser accepts batch arrays."""
     payload = parse_fix_response_payload(content=json.dumps([{"line": 1}]))
     assert_that(payload).is_length(1)
+
+
+def test_review_cli_schema_accepts_the_corpus_finding_fields() -> None:
+    """The strict CLI schema permits every #1925 field (#1925).
+
+    The CLI schema sets ``additionalProperties: false``, so a field the prompt
+    asks for but the schema omits would be rejected outright at the transport
+    boundary.
+    """
+    findings = REVIEW_CLI_SCHEMA["properties"]["findings"]
+    properties = findings["items"]["properties"]
+
+    assert_that(properties).contains_key(
+        "kind",
+        "failure_scenario",
+        "evidence_style",
+        "occurrences",
+    )
+    assert_that(properties["kind"]["enum"]).is_equal_to(["finding", "question"])
+    assert_that(properties["evidence_style"]["enum"]).is_equal_to(
+        ["diff_local", "cross_file", "speculative"],
+    )
+
+
+def test_review_cli_schema_keeps_the_new_fields_optional() -> None:
+    """A model that ignores the #1925 fields still produces a valid review."""
+    findings = REVIEW_CLI_SCHEMA["properties"]["findings"]
+
+    assert_that(findings["items"]["required"]).does_not_contain(
+        "kind",
+        "failure_scenario",
+        "evidence_style",
+        "occurrences",
+    )

--- a/tests/unit/ai/test_cli_schemas.py
+++ b/tests/unit/ai/test_cli_schemas.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any, cast
 
 import pytest
 from assertpy import assert_that
@@ -73,6 +74,17 @@ def test_parse_fix_response_payload_accepts_array() -> None:
     assert_that(payload).is_length(1)
 
 
+def _review_finding_schema() -> dict[str, Any]:
+    """Return the ``findings`` sub-schema of the review CLI schema.
+
+    Returns:
+        The findings array schema, narrowed from the schema's ``object``
+        value type so the structural assertions below stay type-checked.
+    """
+    properties = cast(dict[str, Any], REVIEW_CLI_SCHEMA["properties"])
+    return cast(dict[str, Any], properties["findings"])
+
+
 def test_review_cli_schema_accepts_the_corpus_finding_fields() -> None:
     """The strict CLI schema permits every #1925 field (#1925).
 
@@ -80,8 +92,7 @@ def test_review_cli_schema_accepts_the_corpus_finding_fields() -> None:
     asks for but the schema omits would be rejected outright at the transport
     boundary.
     """
-    findings = REVIEW_CLI_SCHEMA["properties"]["findings"]
-    properties = findings["items"]["properties"]
+    properties = _review_finding_schema()["items"]["properties"]
 
     assert_that(properties).contains_key(
         "kind",
@@ -97,9 +108,7 @@ def test_review_cli_schema_accepts_the_corpus_finding_fields() -> None:
 
 def test_review_cli_schema_keeps_the_new_fields_optional() -> None:
     """A model that ignores the #1925 fields still produces a valid review."""
-    findings = REVIEW_CLI_SCHEMA["properties"]["findings"]
-
-    assert_that(findings["items"]["required"]).does_not_contain(
+    assert_that(_review_finding_schema()["items"]["required"]).does_not_contain(
         "kind",
         "failure_scenario",
         "evidence_style",


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(review): add corpus-informed finding model to the review pipeline
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Wave 1.5 of epic #1905: the four finding-model amendments derived from the
2025-12 → 2026-07 AI-review corpus. This extends the modules wave 1 just merged
(#1916 matcher/state, #1915 rich outputs/verdict, #1913 agent prompts) and
unblocks the rendering wave (#1909 / #1910), which consumes the data surfaces
added here.

**1. P1 evidence gate.** `failure_scenario` is required for P1. A P1 reported
without one is downgraded to P2 at parse time and marked with
`severity_downgraded`, so the correction is a visible record rather than a
silent rewrite of the model's output. `lintro/ai/review/severity_gate.py` is the
renderer-facing surface (`count_downgrades`, `downgraded_findings`,
`describe_downgrades`); the sticky rendering itself is #1909. `RunRecord` gains
a per-run `downgraded` count alongside the existing severity distribution, so
inflation and how much of it the gate absorbed stay visible over time. Custom
review agents that declare a severity policy in front matter are exempt — that
is configuration, not model output to calibrate.

**2. Questions.** New `kind: finding | question` field, default `finding`.
Questions are excluded from the derived verdict (both `verdict.py` and the
matcher's `derive_verdict`), from every fix-prompt scope in `agent_prompts.py`,
and from the per-run severity counts. The prompt caps them at ~3 per review.
This is what makes the P1 gate fair: suspicion without proof has a home that
does not inflate severity.

**3. Evidence style.** Self-reported `diff_local | cross_file | speculative`.
No suppression or down-ranking in v1 — the sole behavioral effect is the
verify-first caution line prompts add for speculative findings.

**4. Occurrence collapse.** Findings gain `occurrences: [{file, line}, ...]`.
Prompts enumerate every location with the instruction to apply the equivalent
fix at each and verify each still reproduces; the matcher treats the pattern as
one finding and resolves it only when every occurrence is gone, exposing partial
progress as `occurrence_count` / `occurrence_total` / `occurrences_addressed`.
A round that omits the list is treated as silence, not as progress. The review
prompt also states that linter-catchable style is out of scope, with the
correctness-adjacent `code-smell` escape hatch.

Degradation rule holds: every new field is optional at parse time except the P1
gate's downgrade path, and no missing or malformed field can fail a run.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run lintro chk`, full `uv run pytest`)

## Closes

- Closes #1925
- Relates to #1905

## Details

New modules: `lintro/ai/review/severity_gate.py`,
`lintro/ai/review/enums/finding_kind.py`,
`lintro/ai/review/enums/evidence_style.py`,
`lintro/ai/review/models/finding_occurrence.py`.

Prompt-side: `output_schema.json`, `output_rules.md`, and `system.md` advertise
the new fields plus the calibration, question-cap, and style-scope language;
`REVIEW_CLI_SCHEMA` permits them (`additionalProperties: false` would otherwise
reject at the transport boundary) while keeping every one of them optional.

**Testing.** 66 tests added or extended across the gate (P1 with and without a
failure scenario, whitespace-only evidence, question exemption, override
exemption, downgrade visibility and notice wording), question exclusion from the
verdict, bullet resolution and prompts, the speculative prompt line, occurrence
enumeration in prompts, pattern-level matcher resolution including partial
counts and single-occurrence regression, state round-trips, and missing-field
degradation for every new field. Full suite: 9014 passed, 105 skipped
(`tests/integration/tools/pip_audit` deselected — pre-existing environment
failure).

**Pre-push review.** CodeRabbit (7 findings; 5 fixed in the follow-up commit,
2 skipped with reason: conditional `if/then` requirements in the strict CLI
schema, and same-file bullet fallback which is pre-existing intended behavior),
lintro `review --transport cli` (4 findings, all addressed). Greptile returned
`free_reviews_limit_reached` — degraded pass, not re-run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review findings now support questions, evidence classification, failure scenarios, and multiple occurrence locations.
  * Repeated findings track progress across all affected locations.
  * P1 findings without concrete failure scenarios are automatically downgraded to P2 with reporting.
  * Review prompts provide clearer severity guidance and verification instructions for speculative findings.

* **Bug Fixes**
  * Questions are excluded from severity totals and readiness verdicts.
  * Style-only issues covered by linters are no longer emphasized in reviews.

* **Tests**
  * Added comprehensive coverage for the new finding, evidence, occurrence, and severity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->