### PR TITLE
feat(review): rebuild the sticky comment as a mission-control status board

### DIFF
--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -15,6 +15,7 @@ Public helpers live in sibling modules and are re-exported here so existing
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from loguru import logger
@@ -142,17 +143,52 @@ def post_review_to_github(
         # unchanged, so this round is not double-counted, and the comment is
         # only ever *updated* — a failed lookup skips rather than posting a
         # second sticky on the PR.
-        sticky_id = _sticky_comment_id(reporter=gh_reporter, known=comment_id)
-        if sticky_id is not None:
-            reporter_body = render(
-                inline_failure=InlinePostFailure(
-                    reason="the review API rejected the inline comments",
-                    findings=tuple(inline_findings),
-                ),
-            )
-            gh_reporter.update_issue_comment(comment_id=sticky_id, body=reporter_body)
+        _fold_inline_failure_into_sticky(
+            reporter=gh_reporter,
+            render=render,
+            findings=inline_findings,
+            comment_id=comment_id,
+        )
 
     return success
+
+
+def _fold_inline_failure_into_sticky(
+    *,
+    reporter: GitHubPRReporter,
+    render: Callable[..., str],
+    findings: list[ReviewFinding],
+    comment_id: int | None,
+) -> None:
+    """Re-render the sticky with the unpostable findings' detail folded in.
+
+    Failing here is not worth failing the run over — the caller has already
+    recorded the inline failure — but it must not be silent either, or a PR
+    quietly ends up with a verdict whose findings appear nowhere.
+
+    Args:
+        reporter: GitHub reporter used to locate and update the sticky comment.
+        render: Callable that renders the sticky body for a given failure.
+        findings: Findings whose inline comments could not be posted.
+        comment_id: Sticky comment id known before the upsert, or ``None``.
+    """
+    sticky_id = _sticky_comment_id(reporter=reporter, known=comment_id)
+    if sticky_id is None:
+        logger.warning(
+            "Sticky comment not found — inline-post failure details could not "
+            "be folded into it",
+        )
+        return
+    body = render(
+        inline_failure=InlinePostFailure(
+            reason="the review API rejected the inline comments",
+            findings=tuple(findings),
+        ),
+    )
+    if not reporter.update_issue_comment(comment_id=sticky_id, body=body):
+        logger.warning(
+            "Failed to fold inline-post failure details into the sticky comment",
+        )
 
 
 def _sticky_comment_id(

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -185,7 +185,10 @@ def _inline_failure(
         return None
     reasons = []
     if rejected:
-        reasons.append("the review API rejected the inline comments")
+        # ``_post_inline_findings`` only reports a boolean, so a 422, a 5xx, a
+        # timeout and a network error all arrive here identically. The wording
+        # must not name a cause the code never observed.
+        reasons.append("the inline review comments could not be posted")
     if unmappable:
         reasons.append("some findings map to no line in this PR's diff")
     return InlinePostFailure(reason="; ".join(reasons), findings=tuple(findings))

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -15,8 +15,7 @@ Public helpers live in sibling modules and are re-exported here so existing
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
+from typing import Any, Protocol
 
 from loguru import logger
 
@@ -153,10 +152,25 @@ def post_review_to_github(
     return success
 
 
+class _StickyRenderer(Protocol):
+    """Callable that renders the sticky body for a given inline-post outcome."""
+
+    def __call__(self, *, inline_failure: InlinePostFailure | None) -> str:
+        """Render the body.
+
+        Args:
+            inline_failure: Findings whose inline comments could not be posted.
+
+        Returns:
+            The complete sticky comment body.
+        """
+        ...  # pragma: no cover - structural type only
+
+
 def _fold_inline_failure_into_sticky(
     *,
     reporter: GitHubPRReporter,
-    render: Callable[..., str],
+    render: _StickyRenderer,
     findings: list[ReviewFinding],
     comment_id: int | None,
 ) -> None:

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -118,18 +118,24 @@ def post_review_to_github(
             inline_failure=inline_failure,
         )
 
-    # The sticky is posted before inline comments so a failure in the inline
-    # path still leaves a status comment on the PR.
-    success = _upsert_sticky(
-        reporter=gh_reporter,
-        body=render(inline_failure=None),
-        comment_id=comment_id,
-    )
-
-    inline_findings, _fallback = _partition_findings(
+    inline_findings, fallback = _partition_findings(
         findings=result.findings,
         diff_lines=diff_lines,
     )
+
+    # A finding that maps to no line in the diff never gets an inline comment,
+    # so the sticky is its only surface from the outset — fold its detail in
+    # rather than leaving it as a title in a table (#1909). The sticky is also
+    # posted before the inline comments so an inline failure still leaves a
+    # status comment on the PR.
+    success = _upsert_sticky(
+        reporter=gh_reporter,
+        body=render(
+            inline_failure=_inline_failure(unmappable=fallback, rejected=[]),
+        ),
+        comment_id=comment_id,
+    )
+
     if inline_findings and not _post_inline_findings(
         reporter=gh_reporter,
         findings=inline_findings,
@@ -137,19 +143,52 @@ def post_review_to_github(
         question_map=prompt_questions,
     ):
         success = False
-        # Degraded path (#1909): those findings now have no surface at all, so
-        # re-render the sticky with their detail folded in. ``prior_state`` is
+        # Degraded path (#1909): the rejected findings now have no surface
+        # either, so re-render with both groups folded in. ``prior_state`` is
         # unchanged, so this round is not double-counted, and the comment is
         # only ever *updated* — a failed lookup skips rather than posting a
         # second sticky on the PR.
         _fold_inline_failure_into_sticky(
             reporter=gh_reporter,
             render=render,
-            findings=inline_findings,
+            failure=_inline_failure(
+                unmappable=fallback,
+                rejected=inline_findings,
+            ),
             comment_id=comment_id,
         )
 
     return success
+
+
+def _inline_failure(
+    *,
+    unmappable: list[ReviewFinding],
+    rejected: list[ReviewFinding],
+) -> InlinePostFailure | None:
+    """Describe the findings that have no inline comment to live on.
+
+    Two different things put a finding here, and the reason says which: it
+    anchors to no line in the PR's diff, or GitHub rejected the review batch
+    that carried it.
+
+    Args:
+        unmappable: Findings that map to no line in the diff.
+        rejected: Findings whose inline review batch the API rejected.
+
+    Returns:
+        The failure descriptor, or ``None`` when every finding has an inline
+        surface.
+    """
+    findings = [*rejected, *unmappable]
+    if not findings:
+        return None
+    reasons = []
+    if rejected:
+        reasons.append("the review API rejected the inline comments")
+    if unmappable:
+        reasons.append("some findings map to no line in this PR's diff")
+    return InlinePostFailure(reason="; ".join(reasons), findings=tuple(findings))
 
 
 class _StickyRenderer(Protocol):
@@ -171,7 +210,7 @@ def _fold_inline_failure_into_sticky(
     *,
     reporter: GitHubPRReporter,
     render: _StickyRenderer,
-    findings: list[ReviewFinding],
+    failure: InlinePostFailure | None,
     comment_id: int | None,
 ) -> None:
     """Re-render the sticky with the unpostable findings' detail folded in.
@@ -183,9 +222,11 @@ def _fold_inline_failure_into_sticky(
     Args:
         reporter: GitHub reporter used to locate and update the sticky comment.
         render: Callable that renders the sticky body for a given failure.
-        findings: Findings whose inline comments could not be posted.
+        failure: Findings whose inline comments could not be posted.
         comment_id: Sticky comment id known before the upsert, or ``None``.
     """
+    if failure is None:
+        return
     sticky_id = _sticky_comment_id(reporter=reporter, known=comment_id)
     if sticky_id is None:
         logger.warning(
@@ -193,13 +234,10 @@ def _fold_inline_failure_into_sticky(
             "be folded into it",
         )
         return
-    body = render(
-        inline_failure=InlinePostFailure(
-            reason="the review API rejected the inline comments",
-            findings=tuple(findings),
-        ),
-    )
-    if not reporter.update_issue_comment(comment_id=sticky_id, body=body):
+    if not reporter.update_issue_comment(
+        comment_id=sticky_id,
+        body=render(inline_failure=failure),
+    ):
         logger.warning(
             "Failed to fold inline-post failure details into the sticky comment",
         )

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -46,6 +46,7 @@ from lintro.ai.review.github_sticky import (
     parse_review_state,
     parse_review_state_v2,
 )
+from lintro.ai.review.models.inline_post_failure import InlinePostFailure
 from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
@@ -104,16 +105,26 @@ def post_review_to_github(
     prompt_questions = question_map or {}
     comment_id, prior_state = _load_prior_state(reporter=gh_reporter)
     diff_lines = gh_reporter.fetch_pr_diff_lines()
-    body = build_sticky_comment(
-        result=result,
-        prior_state=prior_state,
-        head_sha=result.metadata.head_ref,
-        checklist_display=checklist_display,
-        question_map=prompt_questions,
-        diff_lines=diff_lines,
-    )
 
-    success = _upsert_sticky(reporter=gh_reporter, body=body, comment_id=comment_id)
+    def render(*, inline_failure: InlinePostFailure | None) -> str:
+        """Render the sticky body against the unchanged prior state."""
+        return build_sticky_comment(
+            result=result,
+            prior_state=prior_state,
+            head_sha=result.metadata.head_ref,
+            checklist_display=checklist_display,
+            question_map=prompt_questions,
+            diff_lines=diff_lines,
+            inline_failure=inline_failure,
+        )
+
+    # The sticky is posted before inline comments so a failure in the inline
+    # path still leaves a status comment on the PR.
+    success = _upsert_sticky(
+        reporter=gh_reporter,
+        body=render(inline_failure=None),
+        comment_id=comment_id,
+    )
 
     inline_findings, _fallback = _partition_findings(
         findings=result.findings,
@@ -126,8 +137,43 @@ def post_review_to_github(
         question_map=prompt_questions,
     ):
         success = False
+        # Degraded path (#1909): those findings now have no surface at all, so
+        # re-render the sticky with their detail folded in. ``prior_state`` is
+        # unchanged, so this round is not double-counted, and the comment is
+        # only ever *updated* — a failed lookup skips rather than posting a
+        # second sticky on the PR.
+        sticky_id = _sticky_comment_id(reporter=gh_reporter, known=comment_id)
+        if sticky_id is not None:
+            reporter_body = render(
+                inline_failure=InlinePostFailure(
+                    reason="the review API rejected the inline comments",
+                    findings=tuple(inline_findings),
+                ),
+            )
+            gh_reporter.update_issue_comment(comment_id=sticky_id, body=reporter_body)
 
     return success
+
+
+def _sticky_comment_id(
+    *,
+    reporter: GitHubPRReporter,
+    known: int | None,
+) -> int | None:
+    """Return the sticky comment's id, re-locating it when it was just created.
+
+    Args:
+        reporter: GitHub reporter used to list PR comments.
+        known: The id known before the sticky was upserted, or ``None`` when it
+            did not exist yet.
+
+    Returns:
+        The comment id to update, or ``None`` when it still cannot be found.
+    """
+    if known is not None:
+        return known
+    found = reporter.find_issue_comment(marker=STICKY_MARKER)
+    return None if found is None else found[0]
 
 
 def post_review_error_to_github(

--- a/lintro/ai/review/github_constants.py
+++ b/lintro/ai/review/github_constants.py
@@ -21,9 +21,8 @@ GITHUB_COMMENT_HARD_LIMIT = 65_536
 MAX_COMMENT_CHARS = 60_000
 # Cap how many run records are retained in the sticky state block.
 MAX_STORED_RUNS = 30
-# Slack reserved when budgeting the findings section against the comment cap,
-# covering the truncation marker, section joins, and the final _cap_body notice.
-_TRUNCATION_MARGIN = 400
+# Number of leading characters of a commit sha rendered in comment surfaces.
+SHORT_SHA_LENGTH = 7
 
 _SEVERITY_EMOJI: dict[Severity, str] = {
     Severity.P1: "🔴",
@@ -37,19 +36,11 @@ _FOOTER = (
     "usage)</sub>"
 )
 
-_MENTION_RE = re.compile(r"(?<![\w/@.-])@(?=[A-Za-z0-9])")
+#: One-line footer of the v5 sticky comment (#1909). Names where finding detail
+#: actually lives, so the sticky is read as an index rather than a duplicate.
+STICKY_FOOTER = (
+    "<sub>🤖 lintro · finding details on inline comments · updates in place on "
+    "every push · `~` = estimated locally (provider did not report usage)</sub>"
+)
 
-_RUN_MECHANICS_RE = re.compile(
-    r"\n\n<details><summary>⚙️ Run mechanics[\s\S]*?</details>",
-)
-_PREVIOUS_RUNS_RE = re.compile(
-    r"\n\n<details><summary>🕔 Previous runs[\s\S]*?</details>",
-)
-_CHECKLIST_APPENDIX_RE = re.compile(
-    r"\n### Cleared checks \(\d+\)[\s\S]*?(?=\n\n<details><summary>|\Z)",
-)
-_FINDINGS_SECTION_RE = re.compile(
-    r"(\n### Findings(?: \(\d+\))?)([\s\S]*?)"
-    r"(\n\*\*Structured checks:\*\* \d+[\s\S]*?(?=\n\n<details><summary>|\Z)|\Z)",
-)
-_FINDING_BLOCK_START_RE = re.compile(r"(?=\n\n[🔴🟠🟡] \*\*P[123]\*\*)")
+_MENTION_RE = re.compile(r"(?<![\w/@.-])@(?=[A-Za-z0-9])")

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -134,6 +134,13 @@ for _table_name, _table in (
     if _missing:  # pragma: no cover - guards a future verdict
         raise RuntimeError(f"{_table_name} missing entries for: {_missing}")
 
+# _VERDICT_SEVERITY is guarded separately because READY is deliberately absent
+# from it. Without this a new non-READY verdict would pass the loop above and
+# then KeyError inside _readiness_pill on a live PR.
+_missing = set(ReviewVerdict) - {ReviewVerdict.READY} - set(_VERDICT_SEVERITY)
+if _missing:  # pragma: no cover - guards a future verdict
+    raise RuntimeError(f"_VERDICT_SEVERITY missing entries for: {_missing}")
+
 #: Emoji marking a tracked entry that is a question rather than a finding.
 _QUESTION_EMOJI = "❓"
 
@@ -314,9 +321,15 @@ def _fit_body(
 
     # 3. Finally the open findings, keeping as many as fit. A verdict with no
     # substance is worse than an over-long comment the final cap will trim, so
-    # one finding is always rendered even when it alone overflows.
+    # the search floor is one finding, and one is still rendered when even that
+    # overflows.
     limits = replace(limits, resolved=0)
-    fitted = _largest_fitting(assemble=assemble, limits=limits, field="open")
+    fitted = _largest_fitting(
+        assemble=assemble,
+        limits=limits,
+        field="open",
+        minimum=1,
+    )
     if fitted is None:
         fitted = assemble(limits=replace(limits, open=1))
     return _cap_body(body=fitted)
@@ -327,6 +340,7 @@ def _largest_fitting(
     assemble: _Assembler,
     limits: _RenderLimits,
     field: str,
+    minimum: int = 0,
 ) -> str | None:
     """Binary-search the largest value of one limit whose body still fits.
 
@@ -338,13 +352,16 @@ def _largest_fitting(
         assemble: Callable taking ``limits`` and returning the rendered body.
         limits: Limits already applied to the cheaper sections.
         field: Name of the :class:`_RenderLimits` field to search over.
+        minimum: Smallest count the section may be rendered at. Sections whose
+            absence would hollow out the comment pass ``1`` so the search can
+            never settle on showing none of them.
 
     Returns:
         The body rendered at the largest fitting count, or ``None`` when not
-        even zero entries of that section make the body fit.
+        even ``minimum`` entries of that section make the body fit.
     """
     best: str | None = None
-    lower, upper = 0, _PRUNE_SEARCH_CEILING
+    lower, upper = minimum, _PRUNE_SEARCH_CEILING
     while lower <= upper:
         middle = (lower + upper) // 2
         candidate = assemble(limits=replace(limits, **{field: middle}))
@@ -621,10 +638,12 @@ def _tiles_section(*, records: tuple[FindingRecord, ...]) -> str:
     counts = dict.fromkeys((Severity.P1, Severity.P2, Severity.P3), 0)
     fixed = 0
     for record in records:
+        # A question that stopped being asked was never a defect, so it must not
+        # inflate the "fixed" tile, which reads as remediated findings.
+        if record.is_question:
+            continue
         if record.status is FindingStatus.RESOLVED:
             fixed += 1
-            continue
-        if record.is_question:
             continue
         counts[record.severity] = counts.get(record.severity, 0) + 1
     return "\n".join(
@@ -916,7 +935,13 @@ def _history_section(
     prefix = "~" if estimated else ""
     models = _model_counts(runs=runs)
 
-    shown = runs if limit is None else [*runs[:-1][len(runs) - 1 - limit :], runs[-1]]
+    if limit is None:
+        shown = runs
+    else:
+        # Clamp before slicing: a limit above the prior-run count would make the
+        # start index negative and silently show the *newest* few instead of all.
+        keep = min(max(limit, 0), len(runs) - 1)
+        shown = [*runs[:-1][len(runs) - 1 - keep :], runs[-1]]
     dropped = len(runs) - len(shown)
 
     summary = (
@@ -1135,8 +1160,9 @@ def _cell(*, text: str, limit: int) -> str:
 
 def _short_sha(*, sha: str) -> str:
     """Return the display-length prefix of a commit sha, or an empty string."""
-    cleaned = sanitize_comment_text(sha, limit=64).strip()
-    return cleaned[:SHORT_SHA_LENGTH]
+    cleaned = sanitize_comment_text(sha, limit=64).strip()[:SHORT_SHA_LENGTH]
+    # Escape *after* truncating: escaping first could cut an escape pair in half.
+    return cleaned.replace("|", "\\|")
 
 
 def _transport_label(*, transport: str, auth_mode: str) -> str:

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -47,7 +47,11 @@ from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.enums.finding_match_outcome import FindingMatchOutcome
 from lintro.ai.review.enums.finding_status import FindingStatus
 from lintro.ai.review.enums.review_verdict import ReviewVerdict
-from lintro.ai.review.finding_matcher import derive_verdict, match_findings
+from lintro.ai.review.finding_matcher import (
+    derive_verdict,
+    match_findings,
+    normalize_file_path,
+)
 from lintro.ai.review.github_constants import (
     _SEVERITY_EMOJI,
     MAX_COMMENT_CHARS,
@@ -277,7 +281,15 @@ def build_sticky_comment(
             limits=limits,
         )
 
-    body = _fit_body(assemble=assemble, prior_run_count=len(all_runs) - 1)
+    open_count = sum(
+        1 for record in match.records if record.status is FindingStatus.OPEN
+    )
+    body = _fit_body(
+        assemble=assemble,
+        prior_run_count=len(all_runs) - 1,
+        open_count=open_count,
+        resolved_count=len(match.records) - open_count,
+    )
     new_state = ReviewState(
         runs=tuple(all_runs),
         findings=match.records,
@@ -292,6 +304,8 @@ def _fit_body(
     *,
     assemble: _Assembler,
     prior_run_count: int,
+    open_count: int,
+    resolved_count: int,
 ) -> str:
     """Shrink the rendered body until it fits ``MAX_COMMENT_CHARS``.
 
@@ -303,6 +317,8 @@ def _fit_body(
     Args:
         assemble: Callable taking ``limits`` and returning the rendered body.
         prior_run_count: Number of prior runs available to the history table.
+        open_count: Number of open findings, bounding that section's search.
+        resolved_count: Number of resolved findings, likewise.
 
     Returns:
         A body at or under the cap when that is reachable by pruning, else the
@@ -321,7 +337,12 @@ def _fit_body(
             return body
 
     # 2. Then the oldest resolved findings — they are already fixed.
-    fitted = _largest_fitting(assemble=assemble, limits=limits, field="resolved")
+    fitted = _largest_fitting(
+        assemble=assemble,
+        limits=limits,
+        field="resolved",
+        ceiling=resolved_count,
+    )
     if fitted is not None:
         return fitted
 
@@ -334,6 +355,7 @@ def _fit_body(
         assemble=assemble,
         limits=limits,
         field="open",
+        ceiling=open_count,
         minimum=1,
     )
     if fitted is None:
@@ -346,6 +368,7 @@ def _largest_fitting(
     assemble: _Assembler,
     limits: _RenderLimits,
     field: str,
+    ceiling: int,
     minimum: int = 0,
 ) -> str | None:
     """Binary-search the largest value of one limit whose body still fits.
@@ -358,6 +381,9 @@ def _largest_fitting(
         assemble: Callable taking ``limits`` and returning the rendered body.
         limits: Limits already applied to the cheaper sections.
         field: Name of the :class:`_RenderLimits` field to search over.
+        ceiling: Number of entries the section actually has. Bounding the
+            search by this rather than a fixed constant keeps the render count
+            at ~log2(n) instead of ~12 renders for a three-finding round.
         minimum: Smallest count the section may be rendered at. Sections whose
             absence would hollow out the comment pass ``1`` so the search can
             never settle on showing none of them.
@@ -367,7 +393,7 @@ def _largest_fitting(
         even ``minimum`` entries of that section make the body fit.
     """
     best: str | None = None
-    lower, upper = minimum, _PRUNE_SEARCH_CEILING
+    lower, upper = minimum, min(ceiling, _PRUNE_SEARCH_CEILING)
     while lower <= upper:
         middle = (lower + upper) // 2
         candidate = assemble(limits=replace(limits, **{field: middle}))
@@ -536,11 +562,17 @@ def _delta_line(*, match: FindingMatchResult, round_number: int) -> str:
     """
     if round_number <= 1:
         return ""
-    unchanged = len(match.carried) + len(match.regressed)
-    return (
-        f"✔ {len(match.resolved)} resolved · **{len(match.new)} new** · "
-        f"{unchanged} unchanged since round {round_number - 1}"
-    )
+    parts = [
+        f"✔ {len(match.resolved)} resolved",
+        f"**{len(match.new)} new**",
+    ]
+    # A regressed finding was resolved and came back, so it is emphatically not
+    # unchanged — and the open table already labels it "↩ regressed". Folding it
+    # into the unchanged count made the two contradict each other.
+    if match.regressed:
+        parts.append(f"↩ {len(match.regressed)} regressed")
+    parts.append(f"{len(match.carried)} unchanged since round {round_number - 1}")
+    return " · ".join(parts)
 
 
 def _summary_section(*, result: ReviewResult) -> str:
@@ -1103,9 +1135,16 @@ def _sorted_open_findings(
     Returns:
         Findings sorted by severity, then file, then line.
     """
+    # Records store the *normalized* path, so sorting findings by the raw one
+    # would let ``limit`` select a different subset for the prompt than for the
+    # table (for example "./z.py" vs "a.py").
     ordered = sorted(
         findings,
-        key=lambda finding: (finding.severity.value, finding.file, finding.line),
+        key=lambda finding: (
+            finding.severity.value,
+            normalize_file_path(finding.file),
+            finding.line,
+        ),
     )
     return tuple(ordered if limit is None else ordered[:limit])
 
@@ -1231,9 +1270,19 @@ def _model_counts(*, runs: list[RunRecord]) -> list[tuple[str, int]]:
 
 
 def _fmt_compact(*, value: int) -> str:
-    """Format a large count compactly, for example ``24.9k``."""
+    """Format a large count compactly, for example ``24.9k`` or ``1.5M``.
+
+    Args:
+        value: Count to format.
+
+    Returns:
+        The compact representation. Cumulative token totals across many rounds
+        reach seven figures, which must not render as ``1500.0k``.
+    """
     if value < 1000:
         return str(value)
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.1f}M"
     return f"{value / 1000:.1f}k"
 
 

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -422,8 +422,10 @@ def _assemble_body(
         records=match.records,
         limit=limits.resolved,
     )
-    total_open = len(_sorted_open_records(records=match.records, limit=None))
-    total_resolved = len(_sorted_resolved_records(records=match.records, limit=None))
+    total_open = sum(
+        1 for record in match.records if record.status is FindingStatus.OPEN
+    )
+    total_resolved = len(match.records) - total_open
 
     sections: list[str] = [
         STICKY_MARKER,
@@ -683,8 +685,7 @@ def _degraded_row(*, failure: InlinePostFailure | None) -> str:
     surface = "an inline comment" if failure.count == 1 else "inline comments"
     return (
         f"> ⚠️ **{failure.count} {noun} could not be posted as {surface}**"
-        f"{cause}. Full details are folded in below until inline posting "
-        "succeeds."
+        f"{cause}. Full details are folded in below instead."
     )
 
 

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -1,34 +1,72 @@
-"""Sticky-comment assembly, state, and size capping for GitHub reviews."""
+"""Sticky-comment assembly, state, and size capping for GitHub reviews.
+
+The sticky comment is the PR's *mission control* (#1909, epic #1905): a living
+status board edited in place on every run. It leads with the derived readiness
+verdict and the round-over-round delta, then indexes the open findings — it
+deliberately does **not** repeat the finding detail that already lives on the
+inline comments.
+
+Layout, top to bottom:
+
+1. header — ``🔎 Lintro Review · round N · commit <sha>``
+2. readiness pill + delta line
+3. ``Summary`` — headline plus walkthrough bullets, severity-marked when a
+   bullet is tied to an open P1/P2
+4. ``Why it's blocked`` — the model's reasoning, the verdict rubric as
+   fine-print, and the files needing attention
+5. severity tiles (blockers / warnings / nits / fixed)
+6. ``Open findings`` — one line per finding, titles only
+7. the fix-all agent prompt panel, scoped to *all* still-open findings
+8. ``Resolved`` — struck-through titles with their fixing commit
+9. *This run* badges, two lines (model-first ordering)
+10. ``---`` then exactly one ``🕘 Run history`` collapsible
+11. a one-line footer
+
+Two invariants the renderer enforces:
+
+* **No nested ``<details>``.** Every collapsible is top level; the run history
+  carries plain tables and the degraded fold-in flattens finding detail.
+* **The comment always fits GitHub's 65,536-char cap.** Oldest run history is
+  pruned first, then resolved findings, then open findings — each with a
+  visible marker, never a silent drop.
+"""
 
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass, replace
+from typing import Any, Protocol
 
+from lintro.ai.review.agent_prompts import render_agent_prompt_panel
+from lintro.ai.review.checklist_display import (
+    format_review_questions_markdown,
+    questions_for_finding,
+)
+from lintro.ai.review.enums.agent_prompt_scope_kind import AgentPromptScopeKind
 from lintro.ai.review.enums.checklist_display import ChecklistDisplay
+from lintro.ai.review.enums.finding_match_outcome import FindingMatchOutcome
+from lintro.ai.review.enums.finding_status import FindingStatus
 from lintro.ai.review.enums.review_verdict import ReviewVerdict
 from lintro.ai.review.finding_matcher import derive_verdict, match_findings
 from lintro.ai.review.github_constants import (
-    _CHECKLIST_APPENDIX_RE,
-    _FINDING_BLOCK_START_RE,
-    _FINDINGS_SECTION_RE,
-    _FOOTER,
-    _PREVIOUS_RUNS_RE,
-    _RUN_MECHANICS_RE,
-    _TRUNCATION_MARGIN,
+    _SEVERITY_EMOJI,
     MAX_COMMENT_CHARS,
     MAX_STORED_RUNS,
+    SHORT_SHA_LENGTH,
+    STICKY_FOOTER,
     STICKY_MARKER,
 )
 from lintro.ai.review.github_render import (
     _fmt_cost,
-    _fmt_tokens,
-    _format_findings_section,
+    _fmt_int,
+    _format_checklist_appendix_markdown,
     _severity_counts,
-    format_review_summary,
-    format_run_mechanics,
     sanitize_comment_text,
 )
-from lintro.ai.review.models.review_finding import Severity
+from lintro.ai.review.models.agent_prompt_scope import AgentPromptScope
+from lintro.ai.review.models.finding_match_result import FindingMatchResult
+from lintro.ai.review.models.finding_record import FindingRecord
+from lintro.ai.review.models.inline_post_failure import InlinePostFailure
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.run_record import RunRecord
@@ -39,6 +77,108 @@ from lintro.ai.review.review_state_codec import (
     renumber_if_legacy_v1,
 )
 from lintro.ai.review.severity_gate import count_downgrades
+from lintro.ai.review.verdict import (
+    VERDICT_RUBRIC_FINE_PRINT,
+    resolve_bullet_finding,
+    verdict_label,
+)
+
+__all__ = [
+    "build_sticky_comment",
+    "parse_review_state",
+    "parse_review_state_v2",
+]
+
+#: Emoji rendered next to each readiness verdict's label.
+VERDICT_EMOJI: dict[ReviewVerdict, str] = {
+    ReviewVerdict.BLOCKED: "⛔",
+    ReviewVerdict.CHANGES_REQUESTED: "⚠️",
+    ReviewVerdict.NITS_ONLY: "🟡",
+    ReviewVerdict.READY: "✅",
+}
+
+#: Heading used for the reasoning section, per verdict.
+_REASONING_HEADINGS: dict[ReviewVerdict, str] = {
+    ReviewVerdict.BLOCKED: "Why it's blocked",
+    ReviewVerdict.CHANGES_REQUESTED: "Why changes are requested",
+    ReviewVerdict.NITS_ONLY: "Why it's flagged",
+    ReviewVerdict.READY: "Why it's ready",
+}
+
+#: Noun naming the finding class that decides each verdict, for the pill.
+_VERDICT_NOUNS: dict[ReviewVerdict, str] = {
+    ReviewVerdict.BLOCKED: "blocker",
+    ReviewVerdict.CHANGES_REQUESTED: "warning",
+    ReviewVerdict.NITS_ONLY: "nit",
+    ReviewVerdict.READY: "finding",
+}
+
+#: Severity that decides each verdict, used to count the pill's subject.
+#: ``READY`` is deliberately absent — it is decided by the *absence* of open
+#: findings, and :func:`_readiness_pill` returns before consulting this table.
+_VERDICT_SEVERITY: dict[ReviewVerdict, Severity] = {
+    ReviewVerdict.BLOCKED: Severity.P1,
+    ReviewVerdict.CHANGES_REQUESTED: Severity.P2,
+    ReviewVerdict.NITS_ONLY: Severity.P3,
+}
+
+# Import-time exhaustiveness guards, twins of the one in
+# :mod:`lintro.ai.review.verdict`: a verdict added without a rendering entry
+# must fail loudly at import rather than as a KeyError mid-render on a PR.
+for _table_name, _table in (
+    ("VERDICT_EMOJI", VERDICT_EMOJI),
+    ("_REASONING_HEADINGS", _REASONING_HEADINGS),
+    ("_VERDICT_NOUNS", _VERDICT_NOUNS),
+):
+    _missing = set(ReviewVerdict) - set(_table)
+    if _missing:  # pragma: no cover - guards a future verdict
+        raise RuntimeError(f"{_table_name} missing entries for: {_missing}")
+
+#: Emoji marking a tracked entry that is a question rather than a finding.
+_QUESTION_EMOJI = "❓"
+
+#: Maximum characters of a finding title rendered in a table cell.
+_TITLE_LIMIT = 160
+
+#: Upper bound for the finding-count binary searches. No review round
+#: realistically reports more findings than this, and the search costs only
+#: ~log2(n) renders.
+_PRUNE_SEARCH_CEILING = 4096
+
+
+class _Assembler(Protocol):
+    """Callable that renders the whole sticky body at given section limits."""
+
+    def __call__(self, *, limits: _RenderLimits) -> str:
+        """Render the body.
+
+        Args:
+            limits: Per-section render limits to apply.
+
+        Returns:
+            The assembled body, without the hidden state block.
+        """
+        ...  # pragma: no cover - structural type only
+
+
+@dataclass(frozen=True, slots=True)
+class _RenderLimits:
+    """How much of each prunable section the assembler may render.
+
+    ``None`` means unlimited. Sections are pruned in the order the fields are
+    declared, so the cheapest history is dropped before any finding is.
+
+    Attributes:
+        history: Number of *prior* runs shown in the run-history table, newest
+            first. ``None`` shows every stored run.
+        resolved: Number of resolved findings shown, newest first.
+        open: Number of open findings shown (and covered by the fix-all
+            prompt), highest severity first.
+    """
+
+    history: int | None = None
+    resolved: int | None = None
+    open: int | None = None
 
 
 def build_sticky_comment(
@@ -52,18 +192,13 @@ def build_sticky_comment(
     head_sha: str = "",
     transport: str = "",
     auth_mode: str = "",
+    inline_failure: InlinePostFailure | None = None,
 ) -> str:
-    """Compose the full sticky PR comment body, including cumulative telemetry.
+    """Compose the full v5 "mission control" sticky PR comment body.
 
-    Non-diff-mappable ("fallback") findings — whose only surface is this sticky
-    comment — render first in the findings section. When the assembled body
-    exceeds ``MAX_COMMENT_CHARS`` the findings section is re-rendered against a
-    character budget so overflow is dropped explicitly (a visible marker names
-    the count) and only ever falls on findings that also post inline.
-
-    This round's findings are matched against the prior state so the persisted
-    v2 blob carries each finding's identity, first-seen round, and resolution
-    provenance for downstream surfaces.
+    This round's findings are matched against the prior state, so the rendered
+    delta, the ``since`` column, and the persisted v2 blob all agree on each
+    finding's identity, first-seen round, and resolution provenance.
 
     Args:
         result: Current review result.
@@ -72,18 +207,24 @@ def build_sticky_comment(
         prior_state: Full state decoded from the previous sticky comment.
             ``None`` for the first run on a PR.
         checklist_display: Structured checklist visibility mode.
-        question_map: Prompt id to question text for the checklist appendix.
-        diff_lines: Diff line map used to order fallback findings first and to
-            decide which findings are safe to truncate. ``None`` treats all
-            findings as fallback.
+        question_map: Prompt id to question text for the checklist appendix and
+            for linked questions on folded-in finding detail.
+        diff_lines: Diff line map. Retained for interface compatibility with
+            the inline-posting path; the v5 sticky indexes every open finding
+            identically whether or not it also posts inline.
         head_sha: Head commit sha reviewed in this round; stamped onto findings
             resolved by this round.
         transport: Provider transport used for this round.
         auth_mode: Authentication mode used by the transport.
+        inline_failure: Findings whose inline comments could not be posted.
+            When set, the sticky renders a warning row above the open-findings
+            table and folds those findings' full detail back in.
 
     Returns:
-        Complete Markdown body carrying the hidden marker and state block.
+        Complete Markdown body carrying the hidden marker and state block,
+        guaranteed to fit GitHub's comment size limit.
     """
+    del diff_lines  # Interface compatibility; the v5 sticky indexes uniformly.
     state = prior_state if prior_state is not None else _state_from_runs(prior_runs)
     round_number = state.next_round
     match = match_findings(
@@ -92,6 +233,7 @@ def build_sticky_comment(
         round_number=round_number,
         head_sha=head_sha,
     )
+    verdict = derive_verdict(findings=match.records)
     prior = list(state.runs)
     current = _run_record(
         result=result,
@@ -99,52 +241,30 @@ def build_sticky_comment(
         head_sha=head_sha,
         transport=transport,
         auth_mode=auth_mode,
-        verdict=derive_verdict(findings=match.records),
+        verdict=verdict,
     )
     combined_runs = [*prior, current]
     all_runs = combined_runs[-MAX_STORED_RUNS:]
     runs_dropped = len(all_runs) < len(combined_runs)
 
-    def assemble(*, findings_char_budget: int | None) -> str:
-        sections = [STICKY_MARKER, _format_cumulative_header(runs=all_runs)]
-        sections.append(
-            format_review_summary(
-                result=result,
-                checklist_display=checklist_display,
-                question_map=question_map,
-                diff_lines=diff_lines,
-                findings_char_budget=findings_char_budget,
-            ),
+    def assemble(*, limits: _RenderLimits) -> str:
+        """Render the whole body at the given per-section limits."""
+        return _assemble_body(
+            result=result,
+            match=match,
+            verdict=verdict,
+            round_number=round_number,
+            head_sha=head_sha,
+            runs=all_runs,
+            transport=transport,
+            auth_mode=auth_mode,
+            checklist_display=checklist_display,
+            question_map=question_map or {},
+            inline_failure=inline_failure,
+            limits=limits,
         )
-        sections.append(
-            "<details><summary>⚙️ Run mechanics (this run)</summary>\n\n"
-            + format_run_mechanics(metadata=result.metadata)
-            + "\n\n</details>",
-        )
-        if prior:
-            sections.append(_format_previous_runs(runs=prior))
-        sections.append(_FOOTER)
-        return "\n\n".join(sections)
 
-    body = assemble(findings_char_budget=None)
-    if len(body) > MAX_COMMENT_CHARS:
-        # Isolate the findings section's contribution so the remaining budget
-        # can be handed back to it explicitly, keeping fallback findings intact.
-        findings_len = len(
-            "\n".join(
-                _format_findings_section(
-                    findings=result.findings,
-                    checklist_display=checklist_display,
-                    question_map=question_map or {},
-                    diff_lines=diff_lines,
-                ),
-            ),
-        )
-        overhead = len(body) - findings_len
-        findings_budget = max(MAX_COMMENT_CHARS - overhead - _TRUNCATION_MARGIN, 0)
-        body = assemble(findings_char_budget=findings_budget)
-
-    body = _cap_body(body=body)
+    body = _fit_body(assemble=assemble, prior_run_count=len(all_runs) - 1)
     new_state = ReviewState(
         runs=tuple(all_runs),
         findings=match.records,
@@ -153,6 +273,911 @@ def build_sticky_comment(
     return body + render_state_block(
         state=prune_state_to_fit(state=new_state, body=body),
     )
+
+
+def _fit_body(
+    *,
+    assemble: _Assembler,
+    prior_run_count: int,
+) -> str:
+    """Shrink the rendered body until it fits ``MAX_COMMENT_CHARS``.
+
+    Pruning order is deliberate: history is the least valuable content on the
+    comment, resolved findings are already fixed, and open findings are what a
+    reader is actually here for, so they are trimmed last. Each stage leaves a
+    visible marker, so nothing is ever dropped silently.
+
+    Args:
+        assemble: Callable taking ``limits`` and returning the rendered body.
+        prior_run_count: Number of prior runs available to the history table.
+
+    Returns:
+        A body at or under the cap when that is reachable by pruning, else the
+        smallest body pruning can produce, hard-truncated as a last resort.
+    """
+    limits = _RenderLimits()
+    body = assemble(limits=limits)
+    if len(body) <= MAX_COMMENT_CHARS:
+        return body
+
+    # 1. Drop the oldest run history first, one round at a time.
+    for history in range(prior_run_count - 1, -1, -1):
+        limits = replace(limits, history=history)
+        body = assemble(limits=limits)
+        if len(body) <= MAX_COMMENT_CHARS:
+            return body
+
+    # 2. Then the oldest resolved findings — they are already fixed.
+    fitted = _largest_fitting(assemble=assemble, limits=limits, field="resolved")
+    if fitted is not None:
+        return fitted
+
+    # 3. Finally the open findings, keeping as many as fit. A verdict with no
+    # substance is worse than an over-long comment the final cap will trim, so
+    # one finding is always rendered even when it alone overflows.
+    limits = replace(limits, resolved=0)
+    fitted = _largest_fitting(assemble=assemble, limits=limits, field="open")
+    if fitted is None:
+        fitted = assemble(limits=replace(limits, open=1))
+    return _cap_body(body=fitted)
+
+
+def _largest_fitting(
+    *,
+    assemble: _Assembler,
+    limits: _RenderLimits,
+    field: str,
+) -> str | None:
+    """Binary-search the largest value of one limit whose body still fits.
+
+    Both prunable finding sections order newest-first, so capping their count
+    drops the oldest entries — the same oldest-first policy the run history
+    follows.
+
+    Args:
+        assemble: Callable taking ``limits`` and returning the rendered body.
+        limits: Limits already applied to the cheaper sections.
+        field: Name of the :class:`_RenderLimits` field to search over.
+
+    Returns:
+        The body rendered at the largest fitting count, or ``None`` when not
+        even zero entries of that section make the body fit.
+    """
+    best: str | None = None
+    lower, upper = 0, _PRUNE_SEARCH_CEILING
+    while lower <= upper:
+        middle = (lower + upper) // 2
+        candidate = assemble(limits=replace(limits, **{field: middle}))
+        if len(candidate) <= MAX_COMMENT_CHARS:
+            best = candidate
+            lower = middle + 1
+        else:
+            upper = middle - 1
+    return best
+
+
+def _assemble_body(
+    *,
+    result: ReviewResult,
+    match: FindingMatchResult,
+    verdict: ReviewVerdict,
+    round_number: int,
+    head_sha: str,
+    runs: list[RunRecord],
+    transport: str,
+    auth_mode: str,
+    checklist_display: ChecklistDisplay,
+    question_map: dict[int, str],
+    inline_failure: InlinePostFailure | None,
+    limits: _RenderLimits,
+) -> str:
+    """Render every sticky section in order and join the non-empty ones.
+
+    Args:
+        result: Current review result.
+        match: Cross-round matching outcome for this round.
+        verdict: Readiness verdict derived from the open findings.
+        round_number: 1-based round number for this run.
+        head_sha: Head commit sha reviewed in this round.
+        runs: Every retained run record, oldest first, current run last.
+        transport: Provider transport used for this round.
+        auth_mode: Authentication mode used by the transport.
+        checklist_display: Structured checklist visibility mode.
+        question_map: Prompt id to question text.
+        inline_failure: Findings whose inline comments could not be posted.
+        limits: Per-section render limits.
+
+    Returns:
+        The assembled body, without the hidden state block.
+    """
+    open_records = _sorted_open_records(records=match.records, limit=limits.open)
+    open_findings = _sorted_open_findings(
+        findings=result.findings,
+        limit=limits.open,
+    )
+    resolved_records = _sorted_resolved_records(
+        records=match.records,
+        limit=limits.resolved,
+    )
+    total_open = len(_sorted_open_records(records=match.records, limit=None))
+    total_resolved = len(_sorted_resolved_records(records=match.records, limit=None))
+
+    sections: list[str] = [
+        STICKY_MARKER,
+        _header(round_number=round_number, head_sha=head_sha),
+        _readiness_pill(verdict=verdict, records=match.records),
+        _delta_line(match=match, round_number=round_number),
+        _summary_section(result=result),
+        _reasoning_section(result=result, verdict=verdict),
+        _tiles_section(records=match.records),
+        _degraded_row(failure=inline_failure),
+        _open_findings_section(
+            records=open_records,
+            match=match,
+            total=total_open,
+        ),
+        _degraded_details(
+            failure=inline_failure,
+            checklist_display=checklist_display,
+            question_map=question_map,
+        ),
+        render_agent_prompt_panel(
+            findings=open_findings,
+            scope=AgentPromptScope(
+                kind=AgentPromptScopeKind.ALL_OPEN,
+                round_number=round_number,
+            ),
+        ),
+        _resolved_section(records=resolved_records, total=total_resolved),
+        _this_run_section(
+            result=result,
+            transport=transport,
+            auth_mode=auth_mode,
+        ),
+    ]
+    if checklist_display is ChecklistDisplay.ALL:
+        sections.append("\n".join(_format_checklist_appendix_markdown(result=result)))
+    history = _history_section(
+        runs=runs,
+        limit=limits.history,
+        resolved_total=total_resolved,
+    )
+    if history:
+        sections.extend(["---", history])
+    sections.append(STICKY_FOOTER)
+    return "\n\n".join(section for section in sections if section)
+
+
+# --- section renderers -------------------------------------------------------
+
+
+def _header(*, round_number: int, head_sha: str) -> str:
+    """Render the sticky comment's title line.
+
+    Args:
+        round_number: 1-based round number for this run.
+        head_sha: Head commit sha reviewed in this round, possibly empty.
+
+    Returns:
+        The Markdown heading line.
+    """
+    parts = ["## 🔎 Lintro Review", f"round {round_number}"]
+    short = _short_sha(sha=head_sha)
+    if short:
+        parts.append(f"commit `{short}`")
+    return " · ".join(parts)
+
+
+def _readiness_pill(
+    *,
+    verdict: ReviewVerdict,
+    records: tuple[FindingRecord, ...],
+) -> str:
+    """Render the derived readiness verdict and what decided it.
+
+    Args:
+        verdict: Readiness verdict derived from the open findings.
+        records: Every tracked finding record.
+
+    Returns:
+        A single bold line, for example ``**⛔ Blocked** — 1 open blocker``.
+    """
+    label = f"**{VERDICT_EMOJI[verdict]} {verdict_label(verdict=verdict)}**"
+    if verdict is ReviewVerdict.READY:
+        return f"{label} — no open findings"
+    severity = _VERDICT_SEVERITY[verdict]
+    count = sum(
+        1
+        for record in records
+        if record.status is FindingStatus.OPEN
+        and not record.is_question
+        and record.severity is severity
+    )
+    noun = _plural(count=count, noun=_VERDICT_NOUNS[verdict])
+    return f"{label} — {count} open {noun}"
+
+
+def _delta_line(*, match: FindingMatchResult, round_number: int) -> str:
+    """Render the round-over-round finding delta.
+
+    Args:
+        match: Cross-round matching outcome for this round.
+        round_number: 1-based round number for this run.
+
+    Returns:
+        The delta line, or an empty string on round 1 where there is nothing
+        to compare against.
+    """
+    if round_number <= 1:
+        return ""
+    unchanged = len(match.carried) + len(match.regressed)
+    return (
+        f"✔ {len(match.resolved)} resolved · **{len(match.new)} new** · "
+        f"{unchanged} unchanged since round {round_number - 1}"
+    )
+
+
+def _summary_section(*, result: ReviewResult) -> str:
+    """Render the one-line summary plus severity-marked walkthrough bullets.
+
+    A bullet tied to an open P1/P2 finding carries that finding's severity dot
+    and is bolded, so a blocker can never read as neutral prose in the
+    walkthrough.
+
+    Args:
+        result: Current review result.
+
+    Returns:
+        The ``Summary`` section, or an empty string when nothing was returned.
+    """
+    summary = result.pr_summary
+    headline = sanitize_comment_text(
+        (summary.headline if summary else "") or result.summary or "",
+        limit=1000,
+    ).strip()
+    bullets = summary.walkthrough if summary else ()
+    if not headline and not bullets:
+        return ""
+
+    lines = ["### Summary"]
+    if headline:
+        lines.extend(["", headline])
+    if bullets:
+        lines.append("")
+        lines.extend(
+            _summary_bullet(
+                text=bullet.text,
+                finding_ref=bullet.finding_ref,
+                result=result,
+            )
+            for bullet in bullets
+        )
+    return "\n".join(lines)
+
+
+def _summary_bullet(*, text: str, finding_ref: str, result: ReviewResult) -> str:
+    """Render one walkthrough bullet, severity-marked when it names a blocker.
+
+    Args:
+        text: Bullet text as written by the model.
+        finding_ref: The bullet's ``file:line`` finding reference, possibly
+            empty.
+        result: Current review result, used to resolve the reference.
+
+    Returns:
+        The Markdown list item.
+    """
+    safe = sanitize_comment_text(text, limit=500).strip()
+    finding = resolve_bullet_finding(
+        finding_ref=finding_ref,
+        findings=result.findings,
+    )
+    if finding is None or finding.severity not in {Severity.P1, Severity.P2}:
+        return f"- {safe}"
+    return f"- {_SEVERITY_EMOJI[finding.severity]} **{safe}**"
+
+
+def _reasoning_section(*, result: ReviewResult, verdict: ReviewVerdict) -> str:
+    """Render the model's verdict reasoning plus the derivation fine-print.
+
+    Args:
+        result: Current review result.
+        verdict: Readiness verdict derived from the open findings.
+
+    Returns:
+        The reasoning section, or an empty string when there is nothing to
+        explain (no reasoning and nothing open).
+    """
+    reasoning = result.verdict_reasoning
+    has_reasoning = reasoning is not None and not reasoning.is_empty
+    if not has_reasoning and verdict is ReviewVerdict.READY:
+        return ""
+
+    lines = [f"### {_REASONING_HEADINGS[verdict]}"]
+    if reasoning is not None:
+        for paragraph in (reasoning.deciding_factor, reasoning.failure_mechanism):
+            text = sanitize_comment_text(paragraph, limit=2000).strip()
+            if text:
+                lines.extend(["", text])
+    lines.extend(["", f"<sub>{VERDICT_RUBRIC_FINE_PRINT}</sub>"])
+    if reasoning is not None and reasoning.files_needing_attention:
+        files = " · ".join(
+            f"`{sanitize_comment_text(path, limit=200)}`"
+            for path in reasoning.files_needing_attention
+        )
+        lines.extend(["", f"**Files needing attention:** {files}"])
+    return "\n".join(lines)
+
+
+def _tiles_section(*, records: tuple[FindingRecord, ...]) -> str:
+    """Render the compact severity tiles, including the cumulative fixed count.
+
+    Args:
+        records: Every tracked finding record.
+
+    Returns:
+        A three-row Markdown table.
+    """
+    counts = dict.fromkeys((Severity.P1, Severity.P2, Severity.P3), 0)
+    fixed = 0
+    for record in records:
+        if record.status is FindingStatus.RESOLVED:
+            fixed += 1
+            continue
+        if record.is_question:
+            continue
+        counts[record.severity] = counts.get(record.severity, 0) + 1
+    return "\n".join(
+        [
+            "| 🔴 blockers | 🟠 warnings | 🟡 nits | ✔ fixed |",
+            "|:-:|:-:|:-:|:-:|",
+            (
+                f"| **{counts[Severity.P1]}** | **{counts[Severity.P2]}** | "
+                f"**{counts[Severity.P3]}** | **{fixed}** |"
+            ),
+        ],
+    )
+
+
+def _degraded_row(*, failure: InlinePostFailure | None) -> str:
+    """Render the warning row shown when inline posting failed.
+
+    Args:
+        failure: Findings whose inline comments could not be posted.
+
+    Returns:
+        A blockquote warning naming the count and cause, or an empty string
+        when inline posting succeeded.
+    """
+    if failure is None or failure.is_empty:
+        return ""
+    noun = _plural(count=failure.count, noun="finding")
+    reason = sanitize_comment_text(failure.reason, limit=200).strip()
+    cause = f" ({reason})" if reason else ""
+    surface = "an inline comment" if failure.count == 1 else "inline comments"
+    return (
+        f"> ⚠️ **{failure.count} {noun} could not be posted as {surface}**"
+        f"{cause}. Full details are folded in below until inline posting "
+        "succeeds."
+    )
+
+
+def _open_findings_section(
+    *,
+    records: list[FindingRecord],
+    match: FindingMatchResult,
+    total: int,
+) -> str:
+    """Render the open-findings index table.
+
+    Titles only, one line each: the detail lives on the inline comments, and
+    duplicating it here is what made the previous sticky unreadable.
+
+    Args:
+        records: Open records to render, already ordered and limited.
+        match: Cross-round matching outcome, for the ``Δ`` column.
+        total: Total number of open findings before any limit was applied.
+
+    Returns:
+        The ``Open findings`` section, always present so a reader never has to
+        infer that nothing is open.
+    """
+    if total == 0:
+        return "### Open findings (0)\n\n✅ Nothing open."
+
+    lines = [
+        f"### Open findings ({total})",
+        "",
+        "| Δ | Sev | Finding | Where | Since |",
+        "|:-:|:-:|---|---|---|",
+    ]
+    for record in records:
+        lines.append(
+            f"| {_delta_cell(record=record, match=match)} "
+            f"| {_severity_cell(record=record)} "
+            f"| {_cell(text=record.title, limit=_TITLE_LIMIT)} "
+            f"| `{_location(record=record)}` "
+            f"| round {record.since_round} |",
+        )
+    dropped = total - len(records)
+    if dropped > 0:
+        lines.extend(
+            [
+                "",
+                f"> ✂️ **{dropped} more open "
+                f"{_plural(count=dropped, noun='finding')} not listed** to fit "
+                "GitHub's size limit — see the inline comments and the workflow "
+                "run log.",
+            ],
+        )
+    return "\n".join(lines)
+
+
+def _degraded_details(
+    *,
+    failure: InlinePostFailure | None,
+    checklist_display: ChecklistDisplay,
+    question_map: dict[int, str],
+) -> str:
+    """Fold full finding detail into the sticky when inline posting failed.
+
+    Rendered flat inside a single ``<details>``: the sticky's no-nesting rule
+    means this cannot reuse the inline comment renderer, which carries its own
+    collapsible.
+
+    Args:
+        failure: Findings whose inline comments could not be posted.
+        checklist_display: Structured checklist visibility mode.
+        question_map: Prompt id to question text for linked questions.
+
+    Returns:
+        A single-level collapsible carrying each failed finding's detail, or an
+        empty string when inline posting succeeded.
+    """
+    if failure is None or failure.is_empty:
+        return ""
+
+    lines = [
+        f"<details><summary>📋 Details for {failure.count} "
+        f"{_plural(count=failure.count, noun='finding')} not posted inline"
+        "</summary>",
+        "",
+    ]
+    for finding in failure.findings:
+        lines.extend(
+            _folded_finding(
+                finding=finding,
+                checklist_display=checklist_display,
+                question_map=question_map,
+            ),
+        )
+    lines.extend(["", "</details>"])
+    return "\n".join(lines)
+
+
+def _folded_finding(
+    *,
+    finding: ReviewFinding,
+    checklist_display: ChecklistDisplay,
+    question_map: dict[int, str],
+) -> list[str]:
+    """Render one finding's detail flat, with no collapsible of its own.
+
+    Args:
+        finding: Finding to render.
+        checklist_display: Structured checklist visibility mode.
+        question_map: Prompt id to question text for linked questions.
+
+    Returns:
+        Markdown lines for the finding.
+    """
+    emoji = (
+        _QUESTION_EMOJI if finding.is_question else _SEVERITY_EMOJI[finding.severity]
+    )
+    label = "question" if finding.is_question else finding.severity.value
+    location = sanitize_comment_text(finding.file, limit=200)
+    where = f"`{location}:{finding.line}`" if finding.line > 0 else f"`{location}`"
+    lines = [
+        f"**{emoji} {label}** · `{sanitize_comment_text(finding.category, limit=60)}`"
+        f" — **{sanitize_comment_text(finding.title, limit=_TITLE_LIMIT)}** · {where}",
+        "",
+        sanitize_comment_text(finding.description, limit=2000),
+    ]
+    for heading, text in (("Cause", finding.cause), ("Fix", finding.fix)):
+        body = sanitize_comment_text(text, limit=2000).strip()
+        if body:
+            lines.extend(["", f"**{heading}:** {body}"])
+    if checklist_display in {ChecklistDisplay.LINKED, ChecklistDisplay.ALL}:
+        linked = format_review_questions_markdown(
+            questions=questions_for_finding(
+                finding=finding,
+                question_map=question_map,
+            ),
+        )
+        if linked.strip():
+            lines.append(linked)
+    lines.append("")
+    return lines
+
+
+def _resolved_section(*, records: list[FindingRecord], total: int) -> str:
+    """Render the resolved-findings table with fixing-commit provenance.
+
+    Args:
+        records: Resolved records to render, already ordered and limited.
+        total: Total number of resolved findings before any limit was applied.
+
+    Returns:
+        The ``Resolved`` section, or an empty string when nothing is resolved.
+    """
+    if total == 0:
+        return ""
+
+    lines = [
+        f"### ✔ Resolved ({total})",
+        "",
+        "| Sev | Finding | Fixed in |",
+        "|:-:|---|---|",
+    ]
+    for record in records:
+        short = _short_sha(sha=record.resolved_sha)
+        fixed_in = f"`{short}` · round {record.resolved_round}" if short else "—"
+        lines.append(
+            f"| {_severity_cell(record=record)} "
+            f"| ~~{_cell(text=record.title, limit=_TITLE_LIMIT)}~~ "
+            f"| {fixed_in} |",
+        )
+    dropped = total - len(records)
+    if dropped > 0:
+        lines.extend(
+            [
+                "",
+                f"> ✂️ **{dropped} older resolved "
+                f"{_plural(count=dropped, noun='finding')} not listed** "
+                "(history truncated to fit GitHub's size limit).",
+            ],
+        )
+    return "\n".join(lines)
+
+
+def _this_run_section(
+    *,
+    result: ReviewResult,
+    transport: str,
+    auth_mode: str,
+) -> str:
+    """Render the two-line badge block for the current run.
+
+    Ordering is fixed across every surface (epic #1905): model, est. cost,
+    tokens in, tokens out on line 1; transport and mechanics on line 2. No
+    figure is presented as billed — the ``transport`` badge and the ``~``
+    prefix carry that honesty.
+
+    Args:
+        result: Current review result.
+        transport: Provider transport used for this round.
+        auth_mode: Authentication mode used by the transport.
+
+    Returns:
+        The ``This run`` section.
+    """
+    metadata = result.metadata
+    estimated = metadata.token_usage_estimated
+    prefix = "~" if estimated else ""
+    usage = metadata.token_usage
+    first = " · ".join(
+        [
+            f"model `{sanitize_comment_text(metadata.model, limit=60)}`",
+            f"est. cost `{_fmt_cost(metadata.cost_estimate_usd, estimated=estimated)}`",
+            f"tokens in `{prefix}{_fmt_int(int(usage.get('prompt', 0)))}`",
+            f"tokens out `{prefix}{_fmt_int(int(usage.get('completion', 0)))}`",
+        ],
+    )
+    second = " · ".join(
+        [
+            f"transport `{_transport_label(transport=transport, auth_mode=auth_mode)}`",
+            f"depth `{metadata.depth}`",
+            f"files `{metadata.files_reviewed}`",
+            f"checks `{metadata.checklist_items}`",
+            f"duration `{metadata.duration_seconds:.0f}s`",
+        ],
+    )
+    return f"**This run** — {first}\n\n{second}"
+
+
+def _history_section(
+    *,
+    runs: list[RunRecord],
+    limit: int | None,
+    resolved_total: int,
+) -> str:
+    """Render the single run-history collapsible.
+
+    Everything historical lives here and nowhere else: cumulative badges, the
+    per-run table, and one mini-summary line per prior round. It is the only
+    collapsible in the lower half of the comment, and it never nests another.
+
+    Args:
+        runs: Every retained run record, oldest first, current run last.
+        limit: Number of *prior* runs to include, newest first. ``None``
+            includes them all.
+        resolved_total: Number of findings resolved across every round.
+
+    Returns:
+        The collapsible, or an empty string on the first round where there is
+        no history to show.
+    """
+    if len(runs) < 2:
+        return ""
+
+    total_cost = sum(run.cost for run in runs)
+    total_tokens = sum(run.total for run in runs)
+    estimated = any(run.estimated for run in runs)
+    prefix = "~" if estimated else ""
+    models = _model_counts(runs=runs)
+
+    shown = runs if limit is None else [*runs[:-1][len(runs) - 1 - limit :], runs[-1]]
+    dropped = len(runs) - len(shown)
+
+    summary = (
+        f"🕘 Run history — {len(runs)} runs · "
+        f"{_fmt_cost(total_cost, estimated=estimated)} · "
+        f"{prefix}{_fmt_compact(value=total_tokens)} tokens · "
+        f"{len(models)} {_plural(count=len(models), noun='model')}"
+    )
+    badges = " · ".join(
+        [
+            "models "
+            + " ".join(
+                f"`{sanitize_comment_text(model, limit=60)}` ×{count}"
+                for model, count in models
+            ),
+            f"est. cost {_fmt_cost(total_cost, estimated=estimated)}",
+            f"tokens {prefix}{_fmt_int(total_tokens)} "
+            f"(in {prefix}{_fmt_int(sum(run.prompt for run in runs))} / "
+            f"out {prefix}{_fmt_int(sum(run.completion for run in runs))})",
+            f"findings {sum(run.p1 + run.p2 + run.p3 for run in runs)} raised · "
+            f"{resolved_total} resolved",
+        ],
+    )
+
+    lines = [
+        f"<details><summary>{summary}</summary>",
+        "",
+        badges,
+        "",
+        "| Run | Commit | Verdict | Model | Open | Tokens (in/out) | Est. cost "
+        "| Duration |",
+        "|:-:|---|---|---|:-:|---|---|---|",
+    ]
+    for run in reversed(shown):
+        lines.append(_history_row(run=run, latest=run is runs[-1]))
+    if dropped > 0:
+        lines.extend(
+            [
+                "",
+                f"> ✂️ **{dropped} older "
+                f"{_plural(count=dropped, noun='run')} not listed** "
+                "(history truncated to fit GitHub's size limit).",
+            ],
+        )
+    lines.append("")
+    lines.extend(_history_mini_summary(run=run) for run in reversed(shown[:-1]))
+    lines.extend(["", "</details>"])
+    return "\n".join(lines)
+
+
+def _history_row(*, run: RunRecord, latest: bool) -> str:
+    """Render one row of the per-run history table.
+
+    Args:
+        run: Run record to render.
+        latest: True when this is the most recent run.
+
+    Returns:
+        A single Markdown table row.
+    """
+    prefix = "~" if run.estimated else ""
+    short = _short_sha(sha=run.sha)
+    return (
+        f"| {run.round}{' (latest)' if latest else ''} "
+        f"| {f'`{short}`' if short else '—'} "
+        f"| {VERDICT_EMOJI[run.verdict]} {verdict_label(verdict=run.verdict).lower()} "
+        f"| `{_cell(text=run.model or 'unknown', limit=60)}` "
+        f"| {run.p1 + run.p2 + run.p3} "
+        f"| {prefix}{_fmt_int(run.prompt)} / {prefix}{_fmt_int(run.completion)} "
+        f"| {_fmt_cost(run.cost, estimated=run.estimated)} "
+        f"| {run.duration:.0f}s |"
+    )
+
+
+def _history_mini_summary(*, run: RunRecord) -> str:
+    """Render one prior round's one-line recap under the history table.
+
+    Args:
+        run: Prior run record to summarize.
+
+    Returns:
+        A single Markdown line.
+    """
+    short = _short_sha(sha=run.sha)
+    where = f" · `{short}`" if short else ""
+    return (
+        f"**Round {run.round}**{where} · "
+        f"{VERDICT_EMOJI[run.verdict]} {verdict_label(verdict=run.verdict).lower()} — "
+        f"🔴 {run.p1} · 🟠 {run.p2} · 🟡 {run.p3}"
+        + (" · ⚠️ partial" if run.partial else "")
+    )
+
+
+# --- ordering and cell helpers ----------------------------------------------
+
+
+def _record_sort_key(record: FindingRecord) -> tuple[str, str, int]:
+    """Return the presentation sort key for a finding record."""
+    return (record.severity.value, record.file, record.line)
+
+
+def _sorted_open_records(
+    *,
+    records: tuple[FindingRecord, ...],
+    limit: int | None,
+) -> list[FindingRecord]:
+    """Return open records in presentation order, optionally truncated.
+
+    Args:
+        records: Every tracked finding record.
+        limit: Maximum number to return, or ``None`` for all.
+
+    Returns:
+        Open records sorted by severity, then file, then line.
+    """
+    ordered = sorted(
+        (record for record in records if record.status is FindingStatus.OPEN),
+        key=_record_sort_key,
+    )
+    return ordered if limit is None else ordered[:limit]
+
+
+def _sorted_open_findings(
+    *,
+    findings: tuple[ReviewFinding, ...],
+    limit: int | None,
+) -> tuple[ReviewFinding, ...]:
+    """Return this round's findings in the same order as the open table.
+
+    Every open finding is, by construction, reported in the current round: the
+    matcher resolves any prior record this round did not repeat. Sorting both
+    the table and the prompt by the same key keeps them aligned without pairing
+    records to findings one by one.
+
+    Args:
+        findings: This round's findings.
+        limit: Maximum number to return, or ``None`` for all.
+
+    Returns:
+        Findings sorted by severity, then file, then line.
+    """
+    ordered = sorted(
+        findings,
+        key=lambda finding: (finding.severity.value, finding.file, finding.line),
+    )
+    return tuple(ordered if limit is None else ordered[:limit])
+
+
+def _sorted_resolved_records(
+    *,
+    records: tuple[FindingRecord, ...],
+    limit: int | None,
+) -> list[FindingRecord]:
+    """Return resolved records newest-first, optionally truncated.
+
+    Args:
+        records: Every tracked finding record.
+        limit: Maximum number to return, or ``None`` for all.
+
+    Returns:
+        Resolved records, most recently fixed first so pruning drops the
+        oldest history.
+    """
+    ordered = sorted(
+        (record for record in records if record.status is FindingStatus.RESOLVED),
+        key=lambda record: (-record.resolved_round, *_record_sort_key(record)),
+    )
+    return ordered if limit is None else ordered[:limit]
+
+
+def _delta_cell(*, record: FindingRecord, match: FindingMatchResult) -> str:
+    """Render the ``Δ`` cell for one open finding.
+
+    Args:
+        record: Open finding record.
+        match: Cross-round matching outcome for this round.
+
+    Returns:
+        ``**new**``, ``↩ regressed``, or ``—`` for an unchanged finding.
+    """
+    outcome = match.outcome_for(record=record)
+    if outcome is FindingMatchOutcome.NEW:
+        return "**new**"
+    if outcome is FindingMatchOutcome.REGRESSED:
+        return "↩ regressed"
+    return "—"
+
+
+def _severity_cell(*, record: FindingRecord) -> str:
+    """Render the severity cell for a finding record."""
+    if record.is_question:
+        return f"{_QUESTION_EMOJI} question"
+    return f"{_SEVERITY_EMOJI[record.severity]} {record.severity.value}"
+
+
+def _location(*, record: FindingRecord) -> str:
+    """Render a record's ``file:line`` label for a table cell."""
+    path = _cell(text=record.file or "(unknown)", limit=120)
+    return f"{path}:{record.line}" if record.line > 0 else path
+
+
+def _cell(*, text: str, limit: int) -> str:
+    """Sanitize model text for safe rendering inside a Markdown table cell.
+
+    Args:
+        text: Raw model-derived text.
+        limit: Maximum length before truncation.
+
+    Returns:
+        Text with mentions neutralized, pipes escaped, and newlines collapsed
+        so a single cell cannot break the table it sits in.
+    """
+    safe = sanitize_comment_text(text, limit=limit)
+    return safe.replace("|", "\\|").replace("\n", " ").replace("\r", " ").strip()
+
+
+def _short_sha(*, sha: str) -> str:
+    """Return the display-length prefix of a commit sha, or an empty string."""
+    cleaned = sanitize_comment_text(sha, limit=64).strip()
+    return cleaned[:SHORT_SHA_LENGTH]
+
+
+def _transport_label(*, transport: str, auth_mode: str) -> str:
+    """Render the transport badge value, never implying a billed amount."""
+    parts = [
+        sanitize_comment_text(part, limit=40)
+        for part in (transport, auth_mode)
+        if part.strip()
+    ]
+    return " · ".join(parts) if parts else "unknown"
+
+
+def _model_counts(*, runs: list[RunRecord]) -> list[tuple[str, int]]:
+    """Count runs per model, sorted by model name.
+
+    Args:
+        runs: Run records to count over.
+
+    Returns:
+        ``(model, count)`` pairs in stable alphabetical order.
+    """
+    counts: dict[str, int] = {}
+    for run in runs:
+        model = run.model or "unknown"
+        counts[model] = counts.get(model, 0) + 1
+    return sorted(counts.items())
+
+
+def _fmt_compact(*, value: int) -> str:
+    """Format a large count compactly, for example ``24.9k``."""
+    if value < 1000:
+        return str(value)
+    return f"{value / 1000:.1f}k"
+
+
+def _plural(*, count: int, noun: str) -> str:
+    """Return ``noun`` pluralized for ``count``."""
+    return noun if count == 1 else f"{noun}s"
+
+
+# --- state -------------------------------------------------------------------
 
 
 def _state_from_runs(prior_runs: list[dict[str, Any]] | None) -> ReviewState:
@@ -225,154 +1250,24 @@ def _run_record(
     )
 
 
-def _format_cumulative_header(*, runs: list[RunRecord]) -> str:
-    """Render the always-visible cumulative telemetry header for the PR."""
-    total_tokens = sum(run.total for run in runs)
-    total_cost = sum(run.cost for run in runs)
-    any_estimated = any(run.estimated for run in runs)
-    exact = sum(1 for run in runs if not run.estimated)
-    est = sum(1 for run in runs if run.estimated)
-
-    model_counts: dict[str, int] = {}
-    for run in runs:
-        model = run.model or "unknown"
-        model_counts[model] = model_counts.get(model, 0) + 1
-    models = ", ".join(
-        f"`{sanitize_comment_text(model, limit=60)}` ×{count}"
-        for model, count in sorted(model_counts.items())
-    )
-
-    breakdown = f"{len(runs)} runs ({exact} exact, {est} est.)"
-    return (
-        "**Cumulative (this PR):** "
-        f"{_fmt_tokens(total_tokens, estimated=any_estimated)} · "
-        f"{_fmt_cost(total_cost, estimated=any_estimated)} · "
-        f"{breakdown} · models: {models}"
-    )
-
-
-def _format_previous_runs(*, runs: list[RunRecord]) -> str:
-    """Render prior runs in a collapsible with each run's mechanics."""
-    lines = [f"<details><summary>🕔 Previous runs ({len(runs)})</summary>", ""]
-    for index, run in enumerate(runs, start=1):
-        tokens = _fmt_tokens(run.total, estimated=run.estimated)
-        cost = _fmt_cost(run.cost, estimated=run.estimated)
-        timestamp = sanitize_comment_text(run.timestamp, limit=40)
-        model = sanitize_comment_text(run.model, limit=60)
-        findings = f"🔴 {run.p1} · 🟠 {run.p2} · 🟡 {run.p3}"
-        partial = " · ⚠️ partial" if run.partial else ""
-        lines.append(
-            f"{index}. `{model}` · depth {run.depth} · {tokens} · "
-            f"{cost} · {findings}{partial} — {timestamp}",
-        )
-    lines.extend(["", "</details>"])
-    return "\n".join(lines)
-
-
-def _elide_low_value_sections(*, body: str) -> str:
-    """Drop collapsible boilerplate before touching the Findings section.
-
-    Args:
-        body: Sticky comment body without the state block.
-
-    Returns:
-        Body with lower-priority sections removed when over the cap.
-    """
-    trimmed = body
-    for pattern in (_PREVIOUS_RUNS_RE, _RUN_MECHANICS_RE, _CHECKLIST_APPENDIX_RE):
-        if len(trimmed) <= MAX_COMMENT_CHARS:
-            break
-        trimmed = pattern.sub("", trimmed, count=1)
-    footer = f"\n\n{_FOOTER}"
-    if len(trimmed) > MAX_COMMENT_CHARS and trimmed.endswith(footer):
-        trimmed = trimmed[: -len(footer)]
-    return trimmed
-
-
-def _findings_omission_marker(*, dropped: int) -> str:
-    """Render the explicit marker when findings are dropped by ``_cap_body``."""
-    return (
-        f"\n\n> ✂️ **{dropped} finding(s) omitted** to fit "
-        "GitHub's size limit — see the workflow run log for the full list."
-    )
-
-
-def _cap_findings_section(*, body: str) -> str:
-    """Preserve the Findings header and trim finding blocks from the tail.
-
-    Args:
-        body: Sticky comment body that is still over ``MAX_COMMENT_CHARS``.
-
-    Returns:
-        Body with as many finding blocks as fit and an explicit omission marker
-        when any findings were dropped.
-    """
-    match = _FINDINGS_SECTION_RE.search(body)
-    if not match:
-        return body
-
-    prefix = body[: match.start()]
-    findings_header = match.group(1)
-    findings_body = match.group(2)
-    suffix = match.group(3)
-
-    blocks = [
-        block for block in _FINDING_BLOCK_START_RE.split(findings_body) if block.strip()
-    ]
-    if not blocks:
-        return body
-
-    assembled_header = prefix + findings_header
-    kept: list[str] = []
-    for _index, block in enumerate(blocks):
-        trial_kept = kept + [block]
-        dropped = len(blocks) - len(trial_kept)
-        omission = _findings_omission_marker(dropped=dropped) if dropped else ""
-        trial = assembled_header + "".join(trial_kept) + omission + suffix
-        if len(trial) <= MAX_COMMENT_CHARS:
-            kept = trial_kept
-        elif not kept:
-            # Always retain at least one finding block even when oversized.
-            kept = [block]
-            break
-        else:
-            break
-
-    dropped = len(blocks) - len(kept)
-    omission = _findings_omission_marker(dropped=dropped) if dropped else ""
-    return assembled_header + "".join(kept) + omission + suffix
-
-
 def _cap_body(*, body: str) -> str:
-    """Truncate an over-long comment body, preserving Findings preferentially.
+    """Hard-truncate an over-long body as the final size safety net.
 
-    When the assembled sticky comment still exceeds ``MAX_COMMENT_CHARS`` after
-    upstream budgeting, lower-value sections (previous runs, run mechanics,
-    checklist appendix, footer) are elided first. If the body is still over the
-    cap, finding blocks are trimmed from the tail with an explicit omission
-    marker rather than blunt tail truncation that can silently drop Findings.
+    Section-aware pruning in :func:`_fit_body` handles every realistic
+    overflow. This exists so a pathological single section (one enormous
+    finding title, say) can still never produce a comment GitHub rejects.
 
     Args:
         body: Sticky comment body without the state block.
 
     Returns:
-        Body trimmed to ``MAX_COMMENT_CHARS`` with explicit markers when content
-        was dropped.
+        The body unchanged when it fits, else truncated with a visible notice.
     """
     if len(body) <= MAX_COMMENT_CHARS:
         return body
-
-    trimmed = _elide_low_value_sections(body=body)
-    if len(trimmed) <= MAX_COMMENT_CHARS:
-        return trimmed
-
-    capped = _cap_findings_section(body=trimmed)
-    if len(capped) <= MAX_COMMENT_CHARS:
-        return capped
-
     notice = "\n\n> ✂️ Comment truncated to fit GitHub's size limit."
     keep = MAX_COMMENT_CHARS - len(notice)
-    return capped[:keep].rstrip() + notice
+    return body[:keep].rstrip() + notice
 
 
 def parse_review_state(*, body: str) -> list[dict[str, Any]]:

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -33,6 +33,7 @@ Two invariants the renderer enforces:
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, replace
 from typing import Any, Protocol
 
@@ -143,6 +144,11 @@ if _missing:  # pragma: no cover - guards a future verdict
 
 #: Emoji marking a tracked entry that is a question rather than a finding.
 _QUESTION_EMOJI = "❓"
+
+#: Matches a ``<details>``/``</details>`` tag in untrusted model text. The folded
+#: finding detail sits *inside* a collapsible, so a model-written closing tag
+#: would end it early and break the sticky's one-level-only structure.
+_DETAILS_TAG_RE = re.compile(r"<(/?)(details|summary)\b", re.IGNORECASE)
 
 #: Maximum characters of a finding title rendered in a table cell.
 _TITLE_LIMIT = 160
@@ -437,6 +443,7 @@ def _assemble_body(
             failure=inline_failure,
             checklist_display=checklist_display,
             question_map=question_map,
+            limit=limits.open,
         ),
         render_agent_prompt_panel(
             findings=open_findings,
@@ -737,6 +744,7 @@ def _degraded_details(
     failure: InlinePostFailure | None,
     checklist_display: ChecklistDisplay,
     question_map: dict[int, str],
+    limit: int | None = None,
 ) -> str:
     """Fold full finding detail into the sticky when inline posting failed.
 
@@ -748,6 +756,9 @@ def _degraded_details(
         failure: Findings whose inline comments could not be posted.
         checklist_display: Structured checklist visibility mode.
         question_map: Prompt id to question text for linked questions.
+        limit: Maximum number of findings to fold in. Shares the open-finding
+            limit so this section shrinks under the same size pressure instead
+            of being left to blunt tail truncation.
 
     Returns:
         A single-level collapsible carrying each failed finding's detail, or an
@@ -756,19 +767,27 @@ def _degraded_details(
     if failure is None or failure.is_empty:
         return ""
 
+    shown = failure.findings if limit is None else failure.findings[:limit]
     lines = [
         f"<details><summary>📋 Details for {failure.count} "
         f"{_plural(count=failure.count, noun='finding')} not posted inline"
         "</summary>",
         "",
     ]
-    for finding in failure.findings:
+    for finding in shown:
         lines.extend(
             _folded_finding(
                 finding=finding,
                 checklist_display=checklist_display,
                 question_map=question_map,
             ),
+        )
+    dropped = failure.count - len(shown)
+    if dropped > 0:
+        lines.append(
+            f"> ✂️ **{dropped} more failed "
+            f"{_plural(count=dropped, noun='finding')} not detailed** to fit "
+            "GitHub's size limit — see the workflow run log.",
         )
     lines.extend(["", "</details>"])
     return "\n".join(lines)
@@ -794,16 +813,16 @@ def _folded_finding(
         _QUESTION_EMOJI if finding.is_question else _SEVERITY_EMOJI[finding.severity]
     )
     label = "question" if finding.is_question else finding.severity.value
-    location = sanitize_comment_text(finding.file, limit=200)
+    location = _inline_safe(text=finding.file, limit=200)
     where = f"`{location}:{finding.line}`" if finding.line > 0 else f"`{location}`"
     lines = [
-        f"**{emoji} {label}** · `{sanitize_comment_text(finding.category, limit=60)}`"
-        f" — **{sanitize_comment_text(finding.title, limit=_TITLE_LIMIT)}** · {where}",
+        f"**{emoji} {label}** · `{_inline_safe(text=finding.category, limit=60)}`"
+        f" — **{_inline_safe(text=finding.title, limit=_TITLE_LIMIT)}** · {where}",
         "",
-        sanitize_comment_text(finding.description, limit=2000),
+        _inline_safe(text=finding.description, limit=2000),
     ]
     for heading, text in (("Cause", finding.cause), ("Fix", finding.fix)):
-        body = sanitize_comment_text(text, limit=2000).strip()
+        body = _inline_safe(text=text, limit=2000).strip()
         if body:
             lines.extend(["", f"**{heading}:** {body}"])
     if checklist_display in {ChecklistDisplay.LINKED, ChecklistDisplay.ALL}:
@@ -1156,6 +1175,25 @@ def _cell(*, text: str, limit: int) -> str:
     """
     safe = sanitize_comment_text(text, limit=limit)
     return safe.replace("|", "\\|").replace("\n", " ").replace("\r", " ").strip()
+
+
+def _inline_safe(*, text: str, limit: int) -> str:
+    """Sanitize model text for embedding *inside* a collapsible.
+
+    On top of the usual mention neutralization, a model-written ``<details>``
+    or ``</details>`` is defanged: the folded finding detail lives inside a
+    collapsible, so an unescaped closing tag would end it early and let the
+    rest of the comment render at the wrong nesting level.
+
+    Args:
+        text: Raw model-derived text.
+        limit: Maximum length before truncation.
+
+    Returns:
+        Text safe to embed within a ``<details>`` block.
+    """
+    safe = sanitize_comment_text(text, limit=limit)
+    return _DETAILS_TAG_RE.sub(r"&lt;\1\2", safe)
 
 
 def _short_sha(*, sha: str) -> str:

--- a/lintro/ai/review/models/inline_post_failure.py
+++ b/lintro/ai/review/models/inline_post_failure.py
@@ -1,0 +1,38 @@
+"""Descriptor for findings that could not be posted as inline comments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from lintro.ai.review.models.review_finding import ReviewFinding
+
+__all__ = ["InlinePostFailure"]
+
+
+@dataclass(frozen=True, slots=True)
+class InlinePostFailure:
+    """Findings whose inline review comments could not be posted.
+
+    The sticky comment must never be a verdict without substance (#1909): when
+    inline posting fails the affected findings have no other surface, so the
+    sticky folds their full details back in and says why, until a later round
+    posts them successfully.
+
+    Attributes:
+        reason: Short human-readable cause, for example
+            ``"review API returned 422 - line not in diff"``.
+        findings: Findings that failed to post inline, in presentation order.
+    """
+
+    reason: str = ""
+    findings: tuple[ReviewFinding, ...] = field(default_factory=tuple)
+
+    @property
+    def count(self) -> int:
+        """Return how many findings failed to post inline."""
+        return len(self.findings)
+
+    @property
+    def is_empty(self) -> bool:
+        """Return True when nothing failed to post."""
+        return not self.findings

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -233,16 +233,18 @@ def test_suggestion_block_neutralizes_mentions(
 # --- sticky comment + cumulative aggregation --------------------------------
 
 
-def test_build_sticky_comment_has_markers_and_cumulative(
+def test_build_sticky_comment_has_markers_and_verdict_header(
     sample_review_result: ReviewResult,
 ) -> None:
-    """First-run sticky comment carries markers and a cumulative header."""
+    """First-run sticky comment leads with the round and the derived verdict."""
     body = build_sticky_comment(result=sample_review_result)
 
     assert_that(body).contains(STICKY_MARKER)
     assert_that(body).contains(STATE_MARKER_PREFIX)
-    assert_that(body).contains("**Cumulative (this PR):**")
-    assert_that(body).contains("1 runs (1 exact, 0 est.)")
+    assert_that(body).contains("## 🔎 Lintro Review · round 1")
+    assert_that(body).contains("**⛔ Blocked** — 1 open blocker")
+    # Accounting never precedes the verdict (#1905).
+    assert_that(body.index("Lintro Review")).is_less_than(body.index("est. cost"))
 
 
 def test_build_sticky_comment_aggregates_prior_runs(
@@ -265,11 +267,12 @@ def test_build_sticky_comment_aggregates_prior_runs(
     ]
     body = build_sticky_comment(result=sample_review_result, prior_runs=prior)
 
-    assert_that(body).contains("2 runs (1 exact, 1 est.)")
+    assert_that(body).contains("🕘 Run history — 2 runs")
     # Mixed estimate => cumulative flagged approximate.
     assert_that(body).contains("~$")
-    assert_that(body).contains("Previous runs (1)")
     assert_that(body).contains("`cursor:auto` ×1")
+    # History lives in exactly one collapsible.
+    assert_that(body.count("🕘 Run history")).is_equal_to(1)
 
 
 def test_round_trip_state_parsing(sample_review_result: ReviewResult) -> None:
@@ -546,10 +549,16 @@ def test_findings_section_orders_fallback_before_diff_mappable(
     assert_that(fallback_at).is_less_than(mapped_at)
 
 
-def test_sticky_truncation_keeps_fallback_and_marks_dropped(
+def test_sticky_indexes_every_finding_and_stays_under_the_cap(
     sample_review_result: ReviewResult,
 ) -> None:
-    """Over-cap sticky keeps the fallback finding and names the dropped count."""
+    """The v5 sticky indexes findings uniformly, whatever their inline fate.
+
+    The old sticky embedded each finding's full detail, so it had to order
+    non-diff-mappable findings first and truncate the rest. The v5 sticky
+    carries one line per finding, so every finding fits and no ordering
+    workaround is needed — detail lives on the inline comments instead.
+    """
     diff_lines = {"src/mapped.py": set(range(1, 41))}
     mapped = tuple(
         _bulky_finding(
@@ -571,19 +580,16 @@ def test_sticky_truncation_keeps_fallback_and_marks_dropped(
         findings=(*mapped, fallback),
     )
 
-    # Without budgeting the assembled body would blow past the cap.
+    # The old detail-embedding renderer would blow past the cap on this input.
     unbudgeted = format_review_summary(result=result, diff_lines=diff_lines)
     assert_that(len(unbudgeted)).is_greater_than(MAX_COMMENT_CHARS)
 
     body = build_sticky_comment(result=result, diff_lines=diff_lines)
 
-    # The final comment (body plus the appended state block) stays within
-    # GitHub's hard limit.
     assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
-    # The fallback finding — with no inline surface — must survive truncation.
+    assert_that(body).contains("### Open findings (41)")
     assert_that(body).contains("FallbackOnlyFinding")
-    # Truncation is explicit, not silent.
-    assert_that(body).contains("more finding(s) truncated")
+    assert_that(body).contains("MappedFinding1")
 
 
 def test_all_fallback_overflow_truncates_to_logs_not_inline() -> None:
@@ -625,7 +631,7 @@ def test_all_fallback_overflow_truncates_to_logs_not_inline() -> None:
 def test_sticky_state_round_trips_after_truncation(
     sample_review_result: ReviewResult,
 ) -> None:
-    """The state block and cumulative header survive a truncated body."""
+    """The state block and verdict header survive a truncated body."""
     diff_lines = {"src/mapped.py": set(range(1, 41))}
     findings = tuple(
         _bulky_finding(
@@ -643,113 +649,60 @@ def test_sticky_state_round_trips_after_truncation(
 
     body = build_sticky_comment(result=result, diff_lines=diff_lines)
 
-    assert_that(body).contains("**Cumulative (this PR):**")
+    assert_that(body).contains("## 🔎 Lintro Review · round 1")
     assert_that(body).contains(STATE_MARKER_PREFIX)
     runs = parse_review_state(body=body)
     assert_that(runs).is_length(1)
     assert_that(runs[0]["model"]).is_equal_to("claude-sonnet-4-20250514")
 
 
-# --- section-aware _cap_body (#1315) ------------------------------------------
+# --- final size safety net (#1909) -------------------------------------------
 
 
 def test_cap_body_leaves_under_cap_body_unchanged() -> None:
     """Bodies under the cap pass through _cap_body untouched."""
-    body = f"{STICKY_MARKER}\n\n**Cumulative (this PR):** tokens · cost"
+    body = f"{STICKY_MARKER}\n\n## 🔎 Lintro Review · round 1"
 
     capped = _cap_body(body=body)
 
     assert_that(capped).is_equal_to(body)
 
 
-def test_cap_body_elides_boilerplate_before_findings(
-    sample_review_result: ReviewResult,
-) -> None:
-    """_cap_body drops run mechanics and footer before trimming Findings."""
-    findings = tuple(
-        _bulky_finding(
-            severity=Severity.P2,
-            file=f"src/unmapped{index}.py",
-            line=900 + index,
-            title=f"CapBodyFallback{index}",
-            filler_repeats=320,
-        )
-        for index in range(10)
-    )
-    result = _result_with_findings(base=sample_review_result, findings=findings)
-    summary = format_review_summary(result=result, diff_lines=None)
-    mechanics = (
-        "<details><summary>⚙️ Run mechanics (this run)</summary>\n\n"
-        + format_run_mechanics(metadata=result.metadata)
-        + "\n\n</details>"
-    )
-    footer = (
-        "<sub>🤖 Automated review by lintro · not a substitute for human review · "
-        "`~` = approximate (estimated locally; provider did not report token "
-        "usage)</sub>"
-    )
-    body = f"{STICKY_MARKER}\n\n**Cumulative (this PR):** header\n\n{summary}\n\n{mechanics}\n\n{footer}"
+def test_cap_body_truncates_visibly_as_a_last_resort() -> None:
+    """Section-aware pruning handles real overflow; this is the backstop.
 
-    assert_that(len(body)).is_greater_than(MAX_COMMENT_CHARS)
+    ``_fit_body`` sheds history, then resolved findings, then open findings —
+    each with its own marker. ``_cap_body`` only fires when a single
+    unprunable section is itself over the cap, and even then the truncation
+    must be announced rather than leaving a body that stops mid-sentence.
+    """
+    body = f"{STICKY_MARKER}\n\n" + "x" * (MAX_COMMENT_CHARS + 5_000)
 
     capped = _cap_body(body=body)
 
     assert_that(len(capped)).is_less_than_or_equal_to(MAX_COMMENT_CHARS)
-    assert_that(capped).contains("### Findings")
-    assert_that(capped).contains("CapBodyFallback0")
-    assert_that(capped).does_not_contain("Run mechanics (this run)")
-    assert_that(capped).does_not_contain("Automated review by lintro")
+    assert_that(capped).contains("Comment truncated to fit GitHub's size limit")
+    assert_that(capped).starts_with(STICKY_MARKER)
 
 
-def test_cap_body_omits_tail_findings_with_run_log_marker(
+def test_build_sticky_survives_overflowing_finding_sets(
     sample_review_result: ReviewResult,
 ) -> None:
-    """When Findings alone overflow, _cap_body names omitted findings explicitly."""
-    diff_lines: dict[str, set[int]] = {}
-    findings = tuple(
-        _bulky_finding(
-            severity=Severity.P1,
-            file=f"src/unmapped{index}.py",
-            line=100 + index,
-            title=f"OmittedFinding{index}",
-        )
-        for index in range(12)
-    )
-    result = _result_with_findings(base=sample_review_result, findings=findings)
-    summary = format_review_summary(result=result, diff_lines=diff_lines)
-    body = f"{STICKY_MARKER}\n\n**Cumulative (this PR):** header\n\n{summary}"
-
-    assert_that(len(body)).is_greater_than(MAX_COMMENT_CHARS)
-
-    capped = _cap_body(body=body)
-
-    assert_that(len(capped)).is_less_than_or_equal_to(MAX_COMMENT_CHARS)
-    assert_that(capped).contains("### Findings")
-    assert_that(capped).contains("OmittedFinding0")
-    assert_that(capped).contains("finding(s) omitted")
-    assert_that(capped).contains("workflow run log")
-    assert_that(capped).does_not_contain("Comment truncated to fit GitHub's size limit")
-
-
-def test_build_sticky_cap_body_survives_all_fallback_overflow(
-    sample_review_result: ReviewResult,
-) -> None:
-    """Integration: fallback-only overflow keeps the Findings section visible."""
+    """Integration: an over-cap finding set is trimmed explicitly, not silently."""
     findings = tuple(
         _bulky_finding(
             severity=Severity.P2,
             file=f"src/unmapped{index}.py",
             line=800 + index,
-            title=f"StickyFallback{index}",
+            title=f"StickyOverflow{index}",
         )
-        for index in range(14)
+        for index in range(400)
     )
     result = _result_with_findings(base=sample_review_result, findings=findings)
 
     body = build_sticky_comment(result=result, diff_lines=None)
 
     assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
-    assert_that(body).contains("### Findings")
-    assert_that(body).contains("StickyFallback0")
-    marker_present = "finding(s) omitted" in body or "more finding(s) truncated" in body
-    assert_that(marker_present).is_true()
+    assert_that(body).contains("### Open findings (400)")
+    assert_that(body).contains("StickyOverflow0")
+    assert_that(body).contains("more open findings not listed")

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -20,6 +20,7 @@ from lintro.ai.review.github import (
     STICKY_MARKER,
     _cap_body,
     _format_findings_section,
+    _sticky_comment_id,
     build_sticky_comment,
     format_error_comment,
     format_finding_comment,
@@ -359,6 +360,74 @@ def test_post_review_creates_sticky_when_absent(
     reporter.update_issue_comment.assert_not_called()
     body = reporter.post_issue_comment.call_args.args[0]
     assert_that(body).contains(STICKY_MARKER)
+
+
+def test_failed_inline_post_folds_details_into_the_sticky(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A rejected inline batch leaves the sticky as the findings' only surface.
+
+    Without this the PR keeps a verdict whose findings appear nowhere: the
+    inline comments were rejected and the sticky only indexes titles.
+    """
+    reporter = _fresh_reporter()
+    # The inline review batch is the only call routed through api_request.
+    reporter.api_request.return_value = False
+    reporter.find_issue_comment.return_value = (77, "")
+
+    posted = post_review_to_github(
+        result=sample_review_result,
+        reporter=reporter,
+    )
+
+    assert_that(posted).is_false()
+    # Two updates: the healthy render, then the degraded re-render in place.
+    assert_that(reporter.update_issue_comment.call_count).is_equal_to(2)
+    reporter.post_issue_comment.assert_not_called()
+
+    degraded = reporter.update_issue_comment.call_args.kwargs["body"]
+    assert_that(degraded).contains("could not be posted as an inline comment")
+    assert_that(degraded).contains("not posted inline")
+    # The detail that the inline comment would have carried is folded in.
+    assert_that(degraded).contains("Unknown status grants access")
+    # The round is not double-counted by the second render.
+    assert_that(parse_review_state(body=degraded)).is_length(1)
+
+
+def test_failed_inline_post_never_posts_a_second_sticky(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A sticky that cannot be located is skipped, not duplicated on the PR."""
+    reporter = _fresh_reporter()
+    reporter.api_request.return_value = False
+    # No sticky exists beforehand, and the lookup after creation still misses.
+    reporter.find_issue_comment.return_value = None
+
+    posted = post_review_to_github(
+        result=sample_review_result,
+        reporter=reporter,
+    )
+
+    assert_that(posted).is_false()
+    # Exactly one sticky was created, and no degraded duplicate followed it.
+    assert_that(reporter.post_issue_comment.call_count).is_equal_to(1)
+    reporter.update_issue_comment.assert_not_called()
+
+
+def test_sticky_comment_id_short_circuits_on_a_known_id() -> None:
+    """A known id is reused without a second lookup against the API."""
+    reporter = _fresh_reporter()
+
+    assert_that(_sticky_comment_id(reporter=reporter, known=42)).is_equal_to(42)
+    reporter.find_issue_comment.assert_not_called()
+
+
+def test_sticky_comment_id_relocates_a_just_created_comment() -> None:
+    """With no prior id the sticky is re-located by its marker."""
+    reporter = _fresh_reporter()
+    reporter.find_issue_comment.return_value = (99, "body")
+
+    assert_that(_sticky_comment_id(reporter=reporter, known=None)).is_equal_to(99)
 
 
 def test_post_review_updates_existing_sticky(

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -386,12 +386,43 @@ def test_failed_inline_post_folds_details_into_the_sticky(
     reporter.post_issue_comment.assert_not_called()
 
     degraded = reporter.update_issue_comment.call_args.kwargs["body"]
-    assert_that(degraded).contains("could not be posted as an inline comment")
-    assert_that(degraded).contains("not posted inline")
-    # The detail that the inline comment would have carried is folded in.
+    # Both the rejected finding and the one that maps to no diff line.
+    assert_that(degraded).contains("2 findings could not be posted as inline")
+    assert_that(degraded).contains("the review API rejected the inline comments")
+    assert_that(degraded).contains("map to no line in this PR's diff")
+    # The detail the inline comments would have carried is folded in.
     assert_that(degraded).contains("Unknown status grants access")
+    assert_that(degraded).contains("No test for unknown status")
     # The round is not double-counted by the second render.
     assert_that(parse_review_state(body=degraded)).is_length(1)
+
+
+def test_unmappable_findings_are_folded_in_without_any_failure(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A finding that anchors to no diff line still gets its detail shown.
+
+    It never had an inline comment to live on, so a title-only row in the open
+    table would be the whole of it — the sticky would carry a verdict whose
+    substance appears nowhere.
+    """
+    reporter = _fresh_reporter()
+
+    posted = post_review_to_github(
+        result=sample_review_result,
+        reporter=reporter,
+    )
+
+    assert_that(posted).is_true()
+    body = reporter.post_issue_comment.call_args.args[0]
+    assert_that(body).contains("1 finding could not be posted as an inline comment")
+    assert_that(body).contains("map to no line in this PR's diff")
+    # Exactly the unmappable finding is folded in; the diff-mappable one keeps
+    # its inline comment as the place its detail lives.
+    assert_that(body).contains("📋 Details for 1 finding not posted inline")
+    folded = body.split("📋 Details for", 1)[1].split("</details>", 1)[0]
+    assert_that(folded).contains("No test for unknown status")
+    assert_that(folded).does_not_contain("Unknown status grants access")
 
 
 def test_failed_inline_post_never_posts_a_second_sticky(

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -388,7 +388,7 @@ def test_failed_inline_post_folds_details_into_the_sticky(
     degraded = reporter.update_issue_comment.call_args.kwargs["body"]
     # Both the rejected finding and the one that maps to no diff line.
     assert_that(degraded).contains("2 findings could not be posted as inline")
-    assert_that(degraded).contains("the review API rejected the inline comments")
+    assert_that(degraded).contains("could not be posted")
     assert_that(degraded).contains("map to no line in this PR's diff")
     # The detail the inline comments would have carried is folded in.
     assert_that(degraded).contains("Unknown status grants access")

--- a/tests/unit/ai/review/test_github_sticky_mission_control.py
+++ b/tests/unit/ai/review/test_github_sticky_mission_control.py
@@ -511,6 +511,7 @@ def test_degraded_path_warns_and_folds_details_into_the_sticky(
     )
     assert_that(body).contains("review API returned 422 - line not in diff")
     assert_that(body).contains("📋 Details for 1 finding not posted inline")
+    assert_that(body).contains("folded in below instead")
     # The full detail — normally only on the inline comment — is folded in.
     assert_that(body).contains(
         "Stores an application password as a module-level literal.",

--- a/tests/unit/ai/review/test_github_sticky_mission_control.py
+++ b/tests/unit/ai/review/test_github_sticky_mission_control.py
@@ -13,6 +13,7 @@ from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.enums.finding_kind import FindingKind
 from lintro.ai.review.github_constants import (
     GITHUB_COMMENT_HARD_LIMIT,
+    STATE_MARKER_PREFIX,
     STICKY_MARKER,
 )
 from lintro.ai.review.github_sticky import (
@@ -71,7 +72,7 @@ def _with(
 
 def _body_only(*, body: str) -> str:
     """Strip the hidden state blob so assertions only see rendered Markdown."""
-    return body.split("<!-- lintro-ai-review-state", 1)[0]
+    return body.split(STATE_MARKER_PREFIX, 1)[0]
 
 
 def _max_details_depth(*, body: str) -> int:
@@ -241,6 +242,64 @@ def test_open_table_marks_new_and_carries_since_round(
     assert_that(second).contains(
         "| **new** | 🟠 P2 | Unguarded divide | `src/example.py:8` | round 2 |",
     )
+
+
+def test_open_table_marks_a_regressed_finding(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A finding that comes back after being fixed is flagged, not silently new."""
+    first = build_sticky_comment(
+        result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
+        head_sha="sha1",
+    )
+    fixed = build_sticky_comment(
+        result=_with(base=sample_review_result, findings=()),
+        prior_state=parse_review_state_v2(body=first),
+        head_sha="sha2",
+    )
+
+    regressed = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
+            prior_state=parse_review_state_v2(body=fixed),
+            head_sha="sha3",
+        ),
+    )
+
+    assert_that(regressed).contains("| ↩ regressed | 🔴 P1 | Leak |")
+    # Its provenance survives the round trip through resolved and back.
+    assert_that(regressed).contains("round 1 |")
+
+
+def test_resolved_questions_do_not_inflate_the_fixed_tile(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The fixed tile counts remediated findings, not questions that lapsed."""
+    first = build_sticky_comment(
+        result=_with(
+            base=sample_review_result,
+            findings=(
+                _finding(title="Leak"),
+                _finding(
+                    title="Is this intentional?",
+                    line=20,
+                    kind=FindingKind.QUESTION,
+                ),
+            ),
+        ),
+        head_sha="sha1",
+    )
+
+    second = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
+            prior_state=parse_review_state_v2(body=first),
+            head_sha="sha2",
+        ),
+    )
+
+    # One open blocker, and the lapsed question is not counted as fixed.
+    assert_that(second).contains("| **1** | **0** | **0** | **0** |")
 
 
 def test_resolved_table_stamps_the_fixing_commit(
@@ -576,3 +635,28 @@ def test_comment_stays_under_the_hard_limit_with_huge_finding_sets(
     rendered = _body_only(body=body)
     assert_that(rendered).contains("### Open findings (400)")
     assert_that(rendered).contains("more open findings not listed")
+    # Never a verdict with no substance: at least one finding is always listed.
+    assert_that(rendered).contains("| 🟠 P2 |")
+
+
+def test_pruning_never_lists_zero_open_findings(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Even a single finding too large for the cap is still listed.
+
+    The open-finding search floor is one, so it can never settle on the
+    strictly-smaller body that lists none of them.
+    """
+    findings = (
+        _finding(
+            title="Oversized " + "x" * (GITHUB_COMMENT_HARD_LIMIT // 2),
+            severity=Severity.P1,
+        ),
+    )
+
+    body = build_sticky_comment(
+        result=_with(base=sample_review_result, findings=findings),
+    )
+
+    assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
+    assert_that(_body_only(body=body)).contains("### Open findings (1)")

--- a/tests/unit/ai/review/test_github_sticky_mission_control.py
+++ b/tests/unit/ai/review/test_github_sticky_mission_control.py
@@ -17,6 +17,13 @@ from lintro.ai.review.github_constants import (
     STATE_MARKER_PREFIX,
     STICKY_MARKER,
 )
+
+# ``_fit_body``/``_RenderLimits`` are imported deliberately. The floor-of-one
+# invariant they encode cannot be reached through ``build_sticky_comment``:
+# every model-supplied string the renderer embeds is itself length-capped, so
+# no genuine finding set can make a one-finding body overflow. Driving the
+# search with a stub assembler is the only way to prove the floor holds, and a
+# test that cannot fail is worth less than one coupled to a private name.
 from lintro.ai.review.github_sticky import (
     _fit_body,
     _RenderLimits,
@@ -214,6 +221,95 @@ def test_delta_line_counts_resolved_new_and_unchanged(
     assert_that(_body_only(body=second)).contains(
         "✔ 1 resolved · **1 new** · 1 unchanged since round 1",
     )
+
+
+def test_delta_line_reports_regressions_separately(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A regressed finding is not unchanged — it was fixed and came back.
+
+    Counting it as unchanged made the delta line contradict the ``↩ regressed``
+    cell the open table shows immediately below it.
+    """
+    first = build_sticky_comment(
+        result=_with(
+            base=sample_review_result,
+            findings=(
+                _finding(title="Leak"),
+                _finding(title="Slow loop", severity=Severity.P2, line=44),
+            ),
+        ),
+        head_sha="sha1",
+    )
+    fixed = build_sticky_comment(
+        result=_with(
+            base=sample_review_result,
+            findings=(_finding(title="Slow loop", severity=Severity.P2, line=44),),
+        ),
+        prior_state=parse_review_state_v2(body=first),
+        head_sha="sha2",
+    )
+
+    third = _body_only(
+        body=build_sticky_comment(
+            result=_with(
+                base=sample_review_result,
+                findings=(
+                    _finding(title="Leak"),
+                    _finding(title="Slow loop", severity=Severity.P2, line=44),
+                ),
+            ),
+            prior_state=parse_review_state_v2(body=fixed),
+            head_sha="sha3",
+        ),
+    )
+
+    assert_that(third).contains(
+        "✔ 0 resolved · **0 new** · ↩ 1 regressed · 1 unchanged since round 2",
+    )
+    # The line and the table agree on what happened to that finding.
+    assert_that(third).contains("| ↩ regressed | 🔴 P1 | Leak |")
+
+
+def test_delta_line_omits_the_regressed_clause_when_there_are_none(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The common case stays short — no "0 regressed" noise."""
+    first = build_sticky_comment(
+        result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
+        head_sha="sha1",
+    )
+
+    second = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
+            prior_state=parse_review_state_v2(body=first),
+            head_sha="sha2",
+        ),
+    )
+
+    assert_that(second).contains("✔ 0 resolved · **0 new** · 1 unchanged since round 1")
+    assert_that(second).does_not_contain("regressed")
+
+
+def test_history_summary_renders_millions_of_tokens_as_millions(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A long-running PR's cumulative tokens must not read as ``1500.0k``."""
+    prior_state = ReviewState(
+        runs=(RunRecord(round=1, sha="sha1", model="m", total=1_500_000, cost=1.0),),
+    )
+
+    body = _body_only(
+        body=build_sticky_comment(
+            result=sample_review_result,
+            prior_state=prior_state,
+            head_sha="sha2",
+        ),
+    )
+
+    assert_that(body).contains("M tokens")
+    assert_that(body).does_not_contain("1501.2k")
 
 
 def test_open_table_marks_new_and_carries_since_round(
@@ -549,18 +645,9 @@ def test_no_degraded_content_when_inline_posting_succeeded(
 # --- size capping ------------------------------------------------------------
 
 
-def test_oldest_history_is_pruned_before_any_finding(
-    sample_review_result: ReviewResult,
-) -> None:
-    """Under size pressure the oldest rounds go first, and findings go last.
-
-    The exact finding count at which the 65,536-char cap starts biting depends
-    on every string in the layout, so rather than hard-code one the test sweeps
-    a range of finding counts and asserts the invariants at each: the comment
-    always fits, the rounds still shown are always the newest ones, any drop is
-    announced, and no finding is sacrificed while history remains to shed.
-    """
-    prior_state = ReviewState(
+def _history_prior_state() -> ReviewState:
+    """Build a state carrying ``_PRIOR_ROUNDS`` cheap synthetic prior runs."""
+    return ReviewState(
         runs=tuple(
             RunRecord(
                 round=round_number,
@@ -576,22 +663,81 @@ def test_oldest_history_is_pruned_before_any_finding(
             for round_number in range(1, _PRIOR_ROUNDS + 1)
         ),
     )
-    saw_partial_history = False
 
-    for count in range(108, 128):
-        findings = tuple(
-            _finding(
-                title=f"Finding {index} " + "x" * 100,
-                file=f"src/module_{index}.py",
-                line=index,
-                severity=Severity.P2,
-            )
-            for index in range(count)
+
+def _render_with_findings(
+    *,
+    base: ReviewResult,
+    count: int,
+    prior_state: ReviewState,
+) -> str:
+    """Render a sticky carrying ``count`` bulky open findings."""
+    findings = tuple(
+        _finding(
+            title=f"Finding {index} " + "x" * 100,
+            file=f"src/module_{index}.py",
+            line=index,
+            severity=Severity.P2,
         )
-        body = build_sticky_comment(
-            result=_with(base=sample_review_result, findings=findings),
+        for index in range(count)
+    )
+    return build_sticky_comment(
+        result=_with(base=base, findings=findings),
+        prior_state=prior_state,
+        head_sha="deadbee",
+    )
+
+
+def test_oldest_history_is_pruned_before_any_finding(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Under size pressure the oldest rounds go first, and findings go last.
+
+    The finding count at which the 65,536-char cap starts biting depends on
+    every string in the layout, so hard-coding a sweep range would turn any
+    unrelated layout change into a false alarm. The crossing point is located
+    by bisection instead — history shrinks monotonically as findings grow — and
+    the invariants are asserted in a window around wherever it actually falls:
+    the comment always fits, the rounds still shown are always the newest ones,
+    any drop is announced, and no finding is sacrificed while history remains
+    to shed.
+    """
+    prior_state = _history_prior_state()
+
+    def rounds_shown(*, count: int) -> int:
+        """Return how many prior rounds survive at a given finding count."""
+        rendered = _body_only(
+            body=_render_with_findings(
+                base=sample_review_result,
+                count=count,
+                prior_state=prior_state,
+            ),
+        )
+        return len(_ROUND_RE.findall(rendered))
+
+    # Bisect for the smallest finding count at which any history is dropped.
+    low, high = 1, 600
+    assert_that(rounds_shown(count=low)).is_equal_to(_PRIOR_ROUNDS)
+    while low < high:
+        middle = (low + high) // 2
+        if rounds_shown(count=middle) < _PRIOR_ROUNDS:
+            high = middle
+        else:
+            low = middle + 1
+    crossing = low
+
+    # At the crossing some history is gone but the newest rounds remain: a
+    # single extra finding can cost more than one round's worth of characters,
+    # so the drop is not necessarily exactly one.
+    assert_that(rounds_shown(count=crossing)).is_less_than(_PRIOR_ROUNDS)
+    assert_that(rounds_shown(count=crossing)).is_greater_than(0)
+
+    saw_partial_history = False
+    for count in range(max(crossing - 2, 1), crossing + 4):
+        body = _render_with_findings(
+            base=sample_review_result,
+            count=count,
             prior_state=prior_state,
-            head_sha="deadbee",
         )
         rendered = _body_only(body=body)
         shown = [int(number) for number in _ROUND_RE.findall(rendered)]
@@ -660,7 +806,12 @@ def test_pruning_never_settles_on_zero_open_findings() -> None:
         seen.append(limits.open)
         return "x" * (MAX_COMMENT_CHARS + 1_000)
 
-    body = _fit_body(assemble=assemble, prior_run_count=0)
+    body = _fit_body(
+        assemble=assemble,
+        prior_run_count=0,
+        open_count=8,
+        resolved_count=0,
+    )
 
     assert_that(len(body)).is_less_than_or_equal_to(MAX_COMMENT_CHARS)
     assert_that(body).contains("Comment truncated to fit GitHub's size limit")

--- a/tests/unit/ai/review/test_github_sticky_mission_control.py
+++ b/tests/unit/ai/review/test_github_sticky_mission_control.py
@@ -13,10 +13,13 @@ from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.enums.finding_kind import FindingKind
 from lintro.ai.review.github_constants import (
     GITHUB_COMMENT_HARD_LIMIT,
+    MAX_COMMENT_CHARS,
     STATE_MARKER_PREFIX,
     STICKY_MARKER,
 )
 from lintro.ai.review.github_sticky import (
+    _fit_body,
+    _RenderLimits,
     build_sticky_comment,
     parse_review_state_v2,
 )
@@ -639,24 +642,78 @@ def test_comment_stays_under_the_hard_limit_with_huge_finding_sets(
     assert_that(rendered).contains("| 🟠 P2 |")
 
 
-def test_pruning_never_lists_zero_open_findings(
+def test_pruning_never_settles_on_zero_open_findings() -> None:
+    """The open-finding search floors at one, never at none.
+
+    A binary search with a floor of zero would happily pick the body that
+    lists no findings at all when even one overflows — producing exactly the
+    substanceless verdict the whole design exists to prevent. Driven through
+    ``_fit_body`` with a stub assembler because every model-supplied string the
+    real renderer embeds is itself length-capped, so no single genuine finding
+    can push a real body over the limit.
+    """
+    seen: list[int | None] = []
+
+    def assemble(*, limits: _RenderLimits) -> str:
+        """Return an always-oversized body and record the counts tried."""
+        seen.append(limits.open)
+        return "x" * (MAX_COMMENT_CHARS + 1_000)
+
+    body = _fit_body(assemble=assemble, prior_run_count=0)
+
+    assert_that(len(body)).is_less_than_or_equal_to(MAX_COMMENT_CHARS)
+    assert_that(body).contains("Comment truncated to fit GitHub's size limit")
+    # Zero open findings was never even considered.
+    assert_that([count for count in seen if count == 0]).is_empty()
+    assert_that(seen).contains(1)
+
+
+def test_untrusted_text_cannot_close_the_folded_collapsible(
     sample_review_result: ReviewResult,
 ) -> None:
-    """Even a single finding too large for the cap is still listed.
+    """A model-written closing tag must not end the fold-in early.
 
-    The open-finding search floor is one, so it can never settle on the
-    strictly-smaller body that lists none of them.
+    The folded detail is the only place model prose sits inside a
+    ``<details>``; an unescaped ``</details>`` there would break the
+    one-level-only structure the rest of the comment relies on.
     """
-    findings = (
-        _finding(
-            title="Oversized " + "x" * (GITHUB_COMMENT_HARD_LIMIT // 2),
-            severity=Severity.P1,
-        ),
+    hostile = replace(
+        _finding(title="Leak"),
+        description="</details><details><summary>pwned</summary>",
+    )
+
+    body = build_sticky_comment(
+        result=_with(base=sample_review_result, findings=(hostile,)),
+        inline_failure=InlinePostFailure(reason="422", findings=(hostile,)),
+    )
+
+    assert_that(_max_details_depth(body=body)).is_equal_to(1)
+    assert_that(_body_only(body=body)).contains("&lt;/details")
+
+
+def test_folded_details_shrink_under_size_pressure(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The fold-in is pruned with a marker rather than blindly truncated."""
+    findings = tuple(
+        replace(
+            _finding(
+                title=f"Failed finding {index}",
+                file=f"src/module_{index}.py",
+                line=index,
+                severity=Severity.P2,
+            ),
+            description="detail " * 400,
+        )
+        for index in range(120)
     )
 
     body = build_sticky_comment(
         result=_with(base=sample_review_result, findings=findings),
+        inline_failure=InlinePostFailure(reason="422", findings=findings),
     )
 
+    rendered = _body_only(body=body)
     assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
-    assert_that(_body_only(body=body)).contains("### Open findings (1)")
+    assert_that(rendered).contains("not detailed")
+    assert_that(_max_details_depth(body=body)).is_equal_to(1)

--- a/tests/unit/ai/review/test_github_sticky_mission_control.py
+++ b/tests/unit/ai/review/test_github_sticky_mission_control.py
@@ -1,0 +1,578 @@
+"""Layout tests for the v5 "mission control" sticky comment (#1909)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+from typing import Any
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
+from lintro.ai.review.enums.finding_kind import FindingKind
+from lintro.ai.review.github_constants import (
+    GITHUB_COMMENT_HARD_LIMIT,
+    STICKY_MARKER,
+)
+from lintro.ai.review.github_sticky import (
+    build_sticky_comment,
+    parse_review_state_v2,
+)
+from lintro.ai.review.models.inline_post_failure import InlinePostFailure
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.review_summary import ReviewSummary
+from lintro.ai.review.models.run_record import RunRecord
+from lintro.ai.review.models.summary_bullet import SummaryBullet
+from lintro.ai.review.models.verdict_reasoning import VerdictReasoning
+
+_DETAILS_TAG_RE = re.compile(r"</?details\b")
+_ROUND_RE = re.compile(r"\*\*Round (\d+)\*\*")
+
+#: Number of synthetic prior rounds used by the history-pruning sweep.
+_PRIOR_ROUNDS = 8
+
+
+def _finding(
+    *,
+    title: str,
+    severity: Severity = Severity.P1,
+    file: str = "src/example.py",
+    line: int = 10,
+    category: str = "security",
+    kind: FindingKind = FindingKind.FINDING,
+) -> ReviewFinding:
+    """Build a review finding for sticky layout tests."""
+    return ReviewFinding(
+        severity=severity,
+        category=category,
+        file=file,
+        line=line,
+        title=title,
+        description="Stores an application password as a module-level literal.",
+        cause="Assigned at module scope.",
+        fix="Read it from the environment.",
+        confidence="high",
+        kind=kind,
+    )
+
+
+def _with(
+    *,
+    base: ReviewResult,
+    findings: tuple[ReviewFinding, ...],
+    **overrides: Any,
+) -> ReviewResult:
+    """Return a copy of ``base`` carrying different findings and fields."""
+    return replace(base, findings=findings, **overrides)
+
+
+def _body_only(*, body: str) -> str:
+    """Strip the hidden state blob so assertions only see rendered Markdown."""
+    return body.split("<!-- lintro-ai-review-state", 1)[0]
+
+
+def _max_details_depth(*, body: str) -> int:
+    """Return the deepest ``<details>`` nesting level in a rendered body."""
+    depth = 0
+    deepest = 0
+    for tag in _DETAILS_TAG_RE.findall(body):
+        depth += 1 if tag == "<details" else -1
+        deepest = max(deepest, depth)
+    return deepest
+
+
+# --- readiness pill ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("severity", "expected"),
+    [
+        (Severity.P1, "**⛔ Blocked** — 1 open blocker"),
+        (Severity.P2, "**⚠️ Changes requested** — 1 open warning"),
+        (Severity.P3, "**🟡 Nits only** — 1 open nit"),
+    ],
+)
+def test_readiness_pill_is_derived_from_open_severities(
+    sample_review_result: ReviewResult,
+    severity: Severity,
+    expected: str,
+) -> None:
+    """The pill label follows the highest open severity, never the model."""
+    body = build_sticky_comment(
+        result=_with(
+            base=sample_review_result,
+            findings=(_finding(title="Leak", severity=severity),),
+        ),
+    )
+
+    assert_that(_body_only(body=body)).contains(expected)
+
+
+def test_readiness_pill_reads_ready_with_nothing_open(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A round with no findings renders the ready pill and an empty index."""
+    body = _body_only(
+        body=build_sticky_comment(result=_with(base=sample_review_result, findings=())),
+    )
+
+    assert_that(body).contains("**✅ Ready** — no open findings")
+    assert_that(body).contains("### Open findings (0)")
+    assert_that(body).contains("✅ Nothing open.")
+
+
+def test_readiness_pill_ignores_questions(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A question carries no severity, so it cannot block the PR."""
+    body = _body_only(
+        body=build_sticky_comment(
+            result=_with(
+                base=sample_review_result,
+                findings=(
+                    _finding(
+                        title="Is this intentional?",
+                        severity=Severity.P1,
+                        kind=FindingKind.QUESTION,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    assert_that(body).contains("**✅ Ready** — no open findings")
+    assert_that(body).contains("❓ question")
+
+
+def test_pill_counts_only_the_deciding_severity(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Two open blockers alongside a nit read as two blockers, not three."""
+    body = _body_only(
+        body=build_sticky_comment(
+            result=_with(
+                base=sample_review_result,
+                findings=(
+                    _finding(title="Leak one", line=10),
+                    _finding(title="Leak two", line=20),
+                    _finding(title="Stale name", severity=Severity.P3, line=30),
+                ),
+            ),
+        ),
+    )
+
+    assert_that(body).contains("**⛔ Blocked** — 2 open blockers")
+
+
+# --- delta line --------------------------------------------------------------
+
+
+def test_round_one_renders_no_delta_line(
+    sample_review_result: ReviewResult,
+) -> None:
+    """There is nothing to compare against on the first round."""
+    body = _body_only(body=build_sticky_comment(result=sample_review_result))
+
+    assert_that(body).does_not_contain("resolved ·")
+    assert_that(body).contains("round 1")
+
+
+def test_delta_line_counts_resolved_new_and_unchanged(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Round two reports what changed since round one."""
+    first = build_sticky_comment(
+        result=_with(
+            base=sample_review_result,
+            findings=(
+                _finding(title="Leak", line=10),
+                _finding(title="Slow loop", severity=Severity.P2, line=44),
+            ),
+        ),
+        head_sha="sha1",
+    )
+
+    second = build_sticky_comment(
+        result=_with(
+            base=sample_review_result,
+            findings=(
+                _finding(title="Leak", line=12),
+                _finding(title="Unguarded divide", severity=Severity.P2, line=8),
+            ),
+        ),
+        prior_state=parse_review_state_v2(body=first),
+        head_sha="sha2",
+    )
+
+    assert_that(_body_only(body=second)).contains(
+        "✔ 1 resolved · **1 new** · 1 unchanged since round 1",
+    )
+
+
+def test_open_table_marks_new_and_carries_since_round(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The Δ column separates a newly raised finding from a carried one."""
+    first = build_sticky_comment(
+        result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
+        head_sha="sha1",
+    )
+
+    second = _body_only(
+        body=build_sticky_comment(
+            result=_with(
+                base=sample_review_result,
+                findings=(
+                    _finding(title="Leak"),
+                    _finding(title="Unguarded divide", severity=Severity.P2, line=8),
+                ),
+            ),
+            prior_state=parse_review_state_v2(body=first),
+            head_sha="sha2",
+        ),
+    )
+
+    assert_that(second).contains(
+        "| — | 🔴 P1 | Leak | `src/example.py:10` | round 1 |",
+    )
+    assert_that(second).contains(
+        "| **new** | 🟠 P2 | Unguarded divide | `src/example.py:8` | round 2 |",
+    )
+
+
+def test_resolved_table_stamps_the_fixing_commit(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A resolved finding is struck through and names where it was fixed."""
+    first = build_sticky_comment(
+        result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
+        head_sha="0123456789abcdef",
+    )
+
+    second = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=()),
+            prior_state=parse_review_state_v2(body=first),
+            head_sha="fedcba9876543210",
+        ),
+    )
+
+    assert_that(second).contains("### ✔ Resolved (1)")
+    assert_that(second).contains("| 🔴 P1 | ~~Leak~~ | `fedcba9` · round 2 |")
+
+
+# --- summary and reasoning ---------------------------------------------------
+
+
+def test_summary_bullets_tied_to_blockers_are_severity_marked(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A bullet about an open P1 cannot read as neutral prose."""
+    body = _body_only(
+        body=build_sticky_comment(
+            result=_with(
+                base=sample_review_result,
+                findings=(_finding(title="Hardcoded password literal"),),
+                pr_summary=ReviewSummary(
+                    headline="Seeds a sandbox module.",
+                    walkthrough=(
+                        SummaryBullet(text="Adds three utility functions."),
+                        SummaryBullet(
+                            text="Stores an application password.",
+                            finding_ref="src/example.py:10",
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    assert_that(body).contains("### Summary")
+    assert_that(body).contains("- Adds three utility functions.")
+    assert_that(body).contains("- 🔴 **Stores an application password.**")
+
+
+def test_reasoning_section_carries_rubric_and_attention_files(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Model reasoning renders above the derivation fine-print."""
+    body = _body_only(
+        body=build_sticky_comment(
+            result=_with(
+                base=sample_review_result,
+                findings=(_finding(title="Leak"),),
+                verdict_reasoning=VerdictReasoning(
+                    deciding_factor="The credential is evaluated at import time.",
+                    failure_mechanism="Every importer holds the secret.",
+                    files_needing_attention=("src/example.py",),
+                ),
+            ),
+        ),
+    )
+
+    assert_that(body).contains("### Why it's blocked")
+    assert_that(body).contains("The credential is evaluated at import time.")
+    assert_that(body).contains("Every importer holds the secret.")
+    assert_that(body).contains("Verdict is derived from open findings")
+    assert_that(body).contains("**Files needing attention:** `src/example.py`")
+
+
+# --- honesty and structure ---------------------------------------------------
+
+
+def test_this_run_badges_lead_with_the_model_and_name_the_transport(
+    sample_review_result: ReviewResult,
+) -> None:
+    """No figure is presented as billed; the transport badge carries that."""
+    body = _body_only(
+        body=build_sticky_comment(
+            result=sample_review_result,
+            transport="cli",
+            auth_mode="subscription",
+        ),
+    )
+
+    assert_that(body).contains("**This run** — model `claude-sonnet-4-20250514`")
+    assert_that(body).contains("est. cost")
+    assert_that(body).contains("transport `cli · subscription`")
+
+
+def test_body_never_nests_details_more_than_one_level(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Nested collapsibles are what made the previous sticky unreadable."""
+    first = build_sticky_comment(
+        result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
+        head_sha="sha1",
+    )
+    finding = _finding(title="Unguarded divide", severity=Severity.P2, line=8)
+
+    body = build_sticky_comment(
+        result=_with(
+            base=sample_review_result,
+            findings=(_finding(title="Leak"), finding),
+        ),
+        prior_state=parse_review_state_v2(body=first),
+        head_sha="sha2",
+        checklist_display=ChecklistDisplay.ALL,
+        inline_failure=InlinePostFailure(
+            reason="line not in diff",
+            findings=(finding,),
+        ),
+    )
+
+    assert_that(_max_details_depth(body=body)).is_equal_to(1)
+
+
+def test_history_collapsible_appears_once_and_only_after_round_one(
+    sample_review_result: ReviewResult,
+) -> None:
+    """History is a single collapsible, absent while there is no history."""
+    first = build_sticky_comment(result=sample_review_result, head_sha="sha1")
+    assert_that(_body_only(body=first)).does_not_contain("🕘 Run history")
+
+    second = _body_only(
+        body=build_sticky_comment(
+            result=sample_review_result,
+            prior_state=parse_review_state_v2(body=first),
+            head_sha="sha2",
+        ),
+    )
+
+    assert_that(second.count("🕘 Run history")).is_equal_to(1)
+    assert_that(second).contains("🕘 Run history — 2 runs")
+    assert_that(second).contains("| Run | Commit | Verdict | Model | Open |")
+    assert_that(second).contains("**Round 1** · `sha1`")
+
+
+def test_fix_all_panel_is_scoped_to_all_open_findings(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The panel title and the prompt's first line both restate the scope."""
+    first = build_sticky_comment(
+        result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
+        head_sha="sha1",
+    )
+
+    second = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
+            prior_state=parse_review_state_v2(body=first),
+            head_sha="sha2",
+        ),
+    )
+
+    assert_that(second).contains("Fix-all prompt — 1 still-open finding (rounds 1–2)")
+    assert_that(second).contains("still open on this PR after round 2")
+
+
+def test_table_cells_escape_pipes_from_model_titles(
+    sample_review_result: ReviewResult,
+) -> None:
+    """An untrusted title cannot break out of its table cell."""
+    body = _body_only(
+        body=build_sticky_comment(
+            result=_with(
+                base=sample_review_result,
+                findings=(_finding(title="Leaks a | b secret"),),
+            ),
+        ),
+    )
+
+    assert_that(body).contains("Leaks a \\| b secret")
+
+
+# --- degraded path -----------------------------------------------------------
+
+
+def test_degraded_path_warns_and_folds_details_into_the_sticky(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A failed inline post leaves the sticky as the finding's only surface."""
+    finding = _finding(title="Hardcoded password literal")
+
+    body = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=(finding,)),
+            inline_failure=InlinePostFailure(
+                reason="review API returned 422 - line not in diff",
+                findings=(finding,),
+            ),
+        ),
+    )
+
+    assert_that(body).contains(
+        "> ⚠️ **1 finding could not be posted as an inline comment**",
+    )
+    assert_that(body).contains("review API returned 422 - line not in diff")
+    assert_that(body).contains("📋 Details for 1 finding not posted inline")
+    # The full detail — normally only on the inline comment — is folded in.
+    assert_that(body).contains(
+        "Stores an application password as a module-level literal.",
+    )
+    assert_that(body).contains("**Fix:** Read it from the environment.")
+
+
+def test_warning_row_precedes_the_open_findings_table(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The reader must see the caveat before the index it applies to."""
+    finding = _finding(title="Leak")
+    body = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=(finding,)),
+            inline_failure=InlinePostFailure(reason="422", findings=(finding,)),
+        ),
+    )
+
+    assert_that(body.index("could not be posted as an inline")).is_less_than(
+        body.index("### Open findings"),
+    )
+
+
+def test_no_degraded_content_when_inline_posting_succeeded(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The healthy path never duplicates inline-comment detail."""
+    body = _body_only(body=build_sticky_comment(result=sample_review_result))
+
+    assert_that(body).does_not_contain("could not be posted as")
+    assert_that(body).does_not_contain("not posted inline")
+
+
+# --- size capping ------------------------------------------------------------
+
+
+def test_oldest_history_is_pruned_before_any_finding(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Under size pressure the oldest rounds go first, and findings go last.
+
+    The exact finding count at which the 65,536-char cap starts biting depends
+    on every string in the layout, so rather than hard-code one the test sweeps
+    a range of finding counts and asserts the invariants at each: the comment
+    always fits, the rounds still shown are always the newest ones, any drop is
+    announced, and no finding is sacrificed while history remains to shed.
+    """
+    prior_state = ReviewState(
+        runs=tuple(
+            RunRecord(
+                round=round_number,
+                sha=f"{round_number:040d}",
+                model="claude-sonnet-4-6",
+                p1=1,
+                prompt=100,
+                completion=200,
+                total=300,
+                cost=0.01,
+                duration=10.0,
+            )
+            for round_number in range(1, _PRIOR_ROUNDS + 1)
+        ),
+    )
+    saw_partial_history = False
+
+    for count in range(108, 128):
+        findings = tuple(
+            _finding(
+                title=f"Finding {index} " + "x" * 100,
+                file=f"src/module_{index}.py",
+                line=index,
+                severity=Severity.P2,
+            )
+            for index in range(count)
+        )
+        body = build_sticky_comment(
+            result=_with(base=sample_review_result, findings=findings),
+            prior_state=prior_state,
+            head_sha="deadbee",
+        )
+        rendered = _body_only(body=body)
+        shown = [int(number) for number in _ROUND_RE.findall(rendered)]
+
+        assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
+        # Whatever survives is the newest contiguous block of rounds.
+        assert_that(shown).is_equal_to(
+            list(range(_PRIOR_ROUNDS, _PRIOR_ROUNDS - len(shown), -1)),
+        )
+        if len(shown) < _PRIOR_ROUNDS:
+            assert_that(rendered).contains("not listed")
+            assert_that(rendered).contains("history truncated")
+        if shown:
+            # History still had rows to shed, so no finding may be dropped.
+            assert_that(rendered).contains(f"### Open findings ({count})")
+            assert_that(rendered).does_not_contain("more open findings not listed")
+        if 0 < len(shown) < _PRIOR_ROUNDS:
+            saw_partial_history = True
+
+    # The oldest-first branch must actually have been exercised, not merely
+    # skipped over by an all-or-nothing prune.
+    assert_that(saw_partial_history).is_true()
+
+
+def test_comment_stays_under_the_hard_limit_with_huge_finding_sets(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Open findings are trimmed last, explicitly, and never silently."""
+    findings = tuple(
+        _finding(
+            title=f"Finding number {index} with a reasonably long title",
+            file=f"src/module_{index}.py",
+            line=index,
+            severity=Severity.P2,
+        )
+        for index in range(400)
+    )
+
+    body = build_sticky_comment(
+        result=_with(base=sample_review_result, findings=findings),
+    )
+
+    assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
+    assert_that(body).contains(STICKY_MARKER)
+    rendered = _body_only(body=body)
+    assert_that(rendered).contains("### Open findings (400)")
+    assert_that(rendered).contains("more open findings not listed")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(review): rebuild the sticky comment as a mission-control status board
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Rebuilds `lintro/ai/review/github_sticky.py` to the approved v5 "mission
control" layout (epic #1905, mock-4 section 1). The sticky comment becomes an
**index + status board** instead of a telemetry dump that duplicated every
inline comment.

Render order:

1. `## 🔎 Lintro Review · round N · commit <sha>`
2. deterministic readiness pill (`⛔ Blocked` / `⚠️ Changes requested` /
   `🟡 Nits only` / `✅ Ready`) plus the delta line
   `✔ n resolved · n new · n unchanged since round N-1`
3. **Summary** — headline plus walkthrough bullets; a bullet tied to an open
   P1/P2 finding carries that severity dot and is bolded, so a blocker cannot
   read as neutral prose
4. **Why it's blocked/flagged** — the model's reasoning paragraphs, the verdict
   rubric as fine-print, and `Files needing attention:`
5. severity tiles (`blockers / warnings / nits / fixed`)
6. **Open findings** table — `Δ · Sev · Finding · Where · Since`, titles only
7. **⚡ Fix-all prompt** panel scoped to all still-open findings (rounds 1–N)
8. **✔ Resolved** table with the fixing commit and round
9. *This run* badges, two lines, model-first ordering
10. `---` then exactly **one** `🕘 Run history` collapsible: cumulative badges,
    the per-run table, and one mini-summary line per prior round
11. one-line footer

### Honesty and structure rules encoded

- No figure is presented as billed: the `transport: cli · subscription` badge
  and the `~` prefix carry that, and the fictional dollar headline is gone.
- **No nested `<details>`** anywhere — asserted by a test that walks the
  rendered body and checks the collapsible depth never exceeds 1.
- The comment always fits GitHub's 65,536-char cap, pruning **oldest run
  history first**, then resolved findings, then open findings — each stage
  leaving a visible marker rather than dropping content silently.

### Degraded path

New `InlinePostFailure` model. When inline posting fails, those findings have
no surface at all, so the sticky renders a warning row above the open table
(count + cause) and folds their full detail back in — flattened, to keep the
no-nesting rule. `post_review_to_github` re-renders and updates the sticky in
place against the unchanged prior state, so the round is never double-counted
and no second sticky is ever posted.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1909
- Relates to #1906

## Details

- New `tests/unit/ai/review/test_github_sticky_mission_control.py` (22 tests)
  covers the readiness-pill derivation (including that questions never move
  it), the delta line, the Δ/since columns, resolved provenance,
  severity-marked summary bullets, the single-level-details rule, the degraded
  path, table-cell pipe escaping, and the size-cap pruning order.
- The history-pruning test sweeps a range of finding counts rather than
  hard-coding the count at which the cap bites, and asserts the invariants at
  each: the comment always fits, the rounds still shown are always the newest
  contiguous block, any drop is announced, and no finding is sacrificed while
  history remains to shed.
- Six tests in `test_github.py` asserted the old layout (`Cumulative (this
  PR):`, `Previous runs (N)`, the section-aware `_cap_body`) and were rewritten
  against the new contract. `_cap_body` is now only the final hard-truncation
  safety net; section-aware pruning moved into `_fit_body`.
- `github_constants.py`: added `STICKY_FOOTER` and `SHORT_SHA_LENGTH`, removed
  the five regexes that only served the old section-eliding capper.
