### PR TITLE
feat(review): rebuild the per-review comment body

### DIFF
--- a/lintro/ai/integrations/github_pr.py
+++ b/lintro/ai/integrations/github_pr.py
@@ -241,6 +241,57 @@ class GitHubPRReporter:
             result[filename] = _parse_patch_lines(patch)
         return result
 
+    def fetch_pr_commit_shas(self) -> list[str] | None:
+        """Fetch the PR's commit shas, oldest first.
+
+        Used to state how many commits arrived since the previous review round.
+        Failures return ``None`` so callers can omit the count rather than
+        report a fabricated one.
+
+        Returns:
+            Commit shas in chronological order, or ``None`` when the listing
+            could not be fetched.
+        """
+        base_url = f"{self.api_base}/repos/{self.repo}/pulls/{self.pr_number}/commits"
+        parsed = urllib.parse.urlparse(base_url)
+        if parsed.scheme != "https":
+            return None
+
+        shas: list[str] = []
+        page = 1
+        while True:
+            url = f"{base_url}?per_page=100&page={page}"
+            req = urllib.request.Request(
+                url,
+                method="GET",
+                headers={
+                    "Authorization": f"Bearer {self.token}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+            )
+            try:
+                with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected  # nosec B310
+                    req,
+                    timeout=30,
+                ) as resp:
+                    commits_page = json.loads(resp.read().decode())
+            except (urllib.error.URLError, json.JSONDecodeError, OSError):
+                logger.debug("Failed to fetch PR commits; omitting commit count")
+                return None
+
+            if not isinstance(commits_page, list) or not commits_page:
+                break
+            shas.extend(
+                str(commit.get("sha", ""))
+                for commit in commits_page
+                if isinstance(commit, dict) and commit.get("sha")
+            )
+            if len(commits_page) < 100:
+                break
+            page += 1
+        return shas
+
     def find_issue_comment(self, *, marker: str) -> tuple[int, str] | None:
         """Find an existing issue comment containing a hidden marker.
 

--- a/lintro/ai/integrations/github_pr.py
+++ b/lintro/ai/integrations/github_pr.py
@@ -214,7 +214,7 @@ class GitHubPRReporter:
                 },
             )
             try:
-                with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected  # nosec B310
+                with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
                     req,
                     timeout=30,
                 ) as resp:
@@ -271,7 +271,7 @@ class GitHubPRReporter:
                 },
             )
             try:
-                with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected  # nosec B310
+                with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
                     req,
                     timeout=30,
                 ) as resp:
@@ -324,7 +324,7 @@ class GitHubPRReporter:
                 },
             )
             try:
-                with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected  # nosec B310
+                with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
                     req,
                     timeout=30,
                 ) as resp:
@@ -403,7 +403,7 @@ class GitHubPRReporter:
             return False
 
         try:
-            with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected  # nosec B310
+            with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
                 req,
                 timeout=30,
             ) as resp:

--- a/lintro/ai/review/agent_prompts.py
+++ b/lintro/ai/review/agent_prompts.py
@@ -497,7 +497,7 @@ def render_finding_prompt_panel(
     )
 
 
-def render_sticky_prompt_pointer(*, sticky_url: str) -> str:
+def render_sticky_prompt_pointer(*, sticky_url: str = "") -> str:
     """Render the one-line pointer that replaces a duplicate fix-all panel.
 
     When this round's findings are exactly the PR's still-open findings, the
@@ -505,12 +505,16 @@ def render_sticky_prompt_pointer(*, sticky_url: str) -> str:
     to the sticky instead, so there is never a wrong prompt to copy.
 
     Args:
-        sticky_url: URL of the sticky status comment.
+        sticky_url: URL of the sticky status comment. When empty (the sticky's
+            id is not known yet, e.g. the comment is being created in this same
+            run) the pointer renders unlinked rather than as a dead link.
 
     Returns:
         Markdown for the pointer line.
     """
-    return (
-        "⚡ Fix prompt: identical to the "
-        f"[sticky comment's fix-all]({sticky_url}) this round — copy it there."
+    target = (
+        f"[sticky comment's fix-all]({sticky_url})"
+        if sticky_url
+        else "sticky comment's fix-all"
     )
+    return f"⚡ Fix prompt: identical to the {target} this round — copy it there."

--- a/lintro/ai/review/chunker/grouping.py
+++ b/lintro/ai/review/chunker/grouping.py
@@ -14,6 +14,7 @@ from lintro.ai.review.chunker.workflow_scripts import (
 )
 from lintro.ai.review.context import split_unified_diff_by_file
 from lintro.ai.review.enums.file_domain import FileDomain
+from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
 from lintro.ai.review.exceptions import ReviewContextError
 from lintro.ai.review.glob_utils import path_matches_any_glob
@@ -28,6 +29,7 @@ from lintro.ai.review.models.chunking_result import ChunkingResult
 from lintro.ai.review.models.file_classification import FileClassification
 from lintro.ai.review.models.review_chunk import ReviewChunk
 from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.skipped_file import SkippedFile
 from lintro.ai.review.path_utils import is_test_path, matches_test_for_source
 from lintro.ai.token_budget import estimate_tokens, truncate_to_budget
 
@@ -50,7 +52,7 @@ def chunk_review_context(
         max_tokens: Maximum estimated tokens per chunk diff.
         classifications: Domain classifications for changed files.
         allow_omitted_files: When True (default), return omitted repetitive-diff
-            files in ``skipped_files`` instead of raising. Pass False for strict
+            files in ``skipped`` instead of raising. Pass False for strict
             behavior.
 
     Returns:
@@ -117,15 +119,16 @@ def chunk_review_context(
             classification_map=classification_map,
         )
     )
+    skipped_sampling_paths = {entry.path for entry in skipped_from_sampling}
     warnings: list[str] = _unreferenced_workflow_script_warnings(
-        file_paths=[path for path in file_paths if path not in skipped_from_sampling],
+        file_paths=[path for path in file_paths if path not in skipped_sampling_paths],
         per_file_diffs=per_file_diffs,
         post_image_files=context.post_image_files,
     )
     if skipped_from_sampling and not allow_omitted_files:
         raise ReviewContextError(
             "Repetitive identical diffs omitted files from review: "
-            f"{', '.join(sorted(skipped_from_sampling))}. "
+            f"{', '.join(sorted(skipped_sampling_paths))}. "
             "Pass allow_omitted_files=True to proceed with sampling.",
             code=ReviewContextErrorCode.REPETITIVE_SAMPLING_OMITTED,
         )
@@ -139,7 +142,7 @@ def chunk_review_context(
 
     chunks: list[ReviewChunk] = []
     warnings.extend(sampling_warnings)
-    skipped_files: list[str] = list(skipped_from_sampling)
+    skipped_files: list[SkippedFile] = list(skipped_from_sampling)
     truncated = False
     chunk_id = 1
 
@@ -178,7 +181,7 @@ def chunk_review_context(
         chunks=chunks,
         truncated=truncated,
         warnings=warnings,
-        skipped_files=sorted(set(skipped_files)),
+        skipped=sorted(set(skipped_files), key=lambda entry: entry.path),
     )
 
 
@@ -438,8 +441,19 @@ def _sample_repetitive_files(
     file_paths: list[str],
     per_file_diffs: dict[str, str],
     classification_map: dict[str, FileClassification],
-) -> tuple[list[str], dict[str, str], list[str], list[str]]:
-    """Sample repetitive identical diffs, keeping three representative files."""
+) -> tuple[list[str], dict[str, str], list[SkippedFile], list[str]]:
+    """Sample repetitive identical diffs, keeping three representative files.
+
+    Args:
+        file_paths: Candidate paths eligible for sampling.
+        per_file_diffs: Per-file unified diff text.
+        classification_map: Domain classification per path.
+
+    Returns:
+        Tuple of sampled paths, per-path sampling notes, the files omitted by
+        sampling (each carrying the representative file it duplicates), and
+        user-facing sampling warnings.
+    """
     signature_groups: dict[str, list[str]] = defaultdict(list)
     for path in file_paths:
         signature = _hunk_signature(
@@ -451,7 +465,7 @@ def _sample_repetitive_files(
     sampled_paths: list[str] = []
     sampling_notes: dict[str, str] = {}
     sampling_warnings: list[str] = []
-    skipped_paths: list[str] = []
+    skipped_paths: list[SkippedFile] = []
 
     for paths in signature_groups.values():
         if len(paths) <= _REPETITIVE_FILE_THRESHOLD:
@@ -464,7 +478,14 @@ def _sample_repetitive_files(
         )[:_REPETITIVE_SAMPLE_COUNT]
         sampled_paths.extend(selected)
         omitted = sorted(set(paths) - set(selected))
-        skipped_paths.extend(omitted)
+        skipped_paths.extend(
+            SkippedFile(
+                path=path,
+                reason=FileSkipReason.REPETITIVE_DIFF,
+                detail=f"same diff hunks as `{selected[0]}`",
+            )
+            for path in omitted
+        )
         omitted_preview = ", ".join(omitted[:10])
         if len(omitted) > 10:
             omitted_preview = f"{omitted_preview}, and {len(omitted) - 10} more"

--- a/lintro/ai/review/context/collection.py
+++ b/lintro/ai/review/context/collection.py
@@ -22,11 +22,13 @@ from lintro.ai.review.context.pr_metadata import (
     _parse_pr_view_json,
 )
 from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
+from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
 from lintro.ai.review.exceptions import ReviewContextError
 from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.pr_metadata import PRMetadata
 from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.skipped_file import SkippedFile
 
 _WORKFLOW_PATH_PREFIX = ".github/workflows/"
 
@@ -401,6 +403,7 @@ def _populate_post_image_files(*, context: ReviewContext) -> ReviewContext:
         unified_diff=context.unified_diff,
         pr_metadata=context.pr_metadata,
         post_image_files=post_image_files,
+        skipped_files=context.skipped_files,
     )
 
 
@@ -508,6 +511,17 @@ def _filter_context_by_paths(
         for path, content in context.post_image_files.items()
         if path in filtered_paths
     }
+    # Record the exclusions rather than letting them vanish: a `--path` filter
+    # is the difference between "the review saw nothing wrong here" and "the
+    # review never looked", and only the per-file reason distinguishes them.
+    skipped = [
+        *context.skipped_files,
+        *(
+            SkippedFile(path=changed_file.path, reason=FileSkipReason.PATH_FILTER)
+            for changed_file in context.changed_files
+            if changed_file.path not in filtered_paths
+        ),
+    ]
     return ReviewContext(
         base_ref=context.base_ref,
         head_ref=context.head_ref,
@@ -515,6 +529,7 @@ def _filter_context_by_paths(
         unified_diff=unified_diff,
         pr_metadata=context.pr_metadata,
         post_image_files=filtered_post_image,
+        skipped_files=skipped,
     )
 
 

--- a/lintro/ai/review/enums/__init__.py
+++ b/lintro/ai/review/enums/__init__.py
@@ -6,6 +6,7 @@ from lintro.ai.review.enums.agent_prompt_scope_kind import AgentPromptScopeKind
 from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
 from lintro.ai.review.enums.evidence_style import EvidenceStyle
 from lintro.ai.review.enums.file_domain import FileDomain
+from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.enums.finding_kind import FindingKind
 from lintro.ai.review.enums.finding_match_outcome import FindingMatchOutcome
 from lintro.ai.review.enums.finding_status import FindingStatus
@@ -18,6 +19,7 @@ __all__ = [
     "ChangedFileStatus",
     "EvidenceStyle",
     "FileDomain",
+    "FileSkipReason",
     "FindingKind",
     "FindingMatchOutcome",
     "FindingStatus",

--- a/lintro/ai/review/enums/file_skip_reason.py
+++ b/lintro/ai/review/enums/file_skip_reason.py
@@ -1,0 +1,47 @@
+"""Reasons a changed file was excluded from an AI review run."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+__all__ = ["FILE_SKIP_REASON_LABELS", "FileSkipReason", "describe_skip_reason"]
+
+
+class FileSkipReason(StrEnum):
+    """Why the file-selection step dropped a changed file.
+
+    A count of skipped files is not actionable on its own: "2 skipped" reads
+    as either a deliberate filter or a silent gap in coverage. Recording the
+    reason at the point of exclusion is what lets the per-review comment say
+    which of the two it was (#1910).
+    """
+
+    PATH_FILTER = auto()
+    REPETITIVE_DIFF = auto()
+
+
+#: Human-readable phrase rendered after a skipped file's path.
+FILE_SKIP_REASON_LABELS: dict[FileSkipReason, str] = {
+    FileSkipReason.PATH_FILTER: "outside the requested --path filter",
+    FileSkipReason.REPETITIVE_DIFF: (
+        "identical to a sampled file's diff (repetitive-diff sampling)"
+    ),
+}
+
+_MISSING_LABELS = set(FileSkipReason) - set(FILE_SKIP_REASON_LABELS)
+if _MISSING_LABELS:  # pragma: no cover - guards a future skip reason
+    raise RuntimeError(
+        f"FileSkipReason members without a label: {_MISSING_LABELS}",
+    )
+
+
+def describe_skip_reason(*, reason: FileSkipReason) -> str:
+    """Return the human-readable phrase for a skip reason.
+
+    Args:
+        reason: Skip reason recorded by the file-selection step.
+
+    Returns:
+        The phrase rendered after the file path in review surfaces.
+    """
+    return FILE_SKIP_REASON_LABELS[reason]

--- a/lintro/ai/review/enums/file_skip_reason.py
+++ b/lintro/ai/review/enums/file_skip_reason.py
@@ -18,6 +18,7 @@ class FileSkipReason(StrEnum):
 
     PATH_FILTER = auto()
     REPETITIVE_DIFF = auto()
+    AGENT_SCOPE = auto()
 
 
 #: Human-readable phrase rendered after a skipped file's path.
@@ -25,6 +26,9 @@ FILE_SKIP_REASON_LABELS: dict[FileSkipReason, str] = {
     FileSkipReason.PATH_FILTER: "outside the requested --path filter",
     FileSkipReason.REPETITIVE_DIFF: (
         "identical to a sampled file's diff (repetitive-diff sampling)"
+    ),
+    FileSkipReason.AGENT_SCOPE: (
+        "matched no enabled review agent's globs (review.custom_agents: only)"
     ),
 }
 

--- a/lintro/ai/review/file_selection.py
+++ b/lintro/ai/review/file_selection.py
@@ -1,0 +1,64 @@
+"""Reconciliation of which changed files a review round actually looked at.
+
+Two independent stages can drop a changed file: context collection (a
+``--path`` filter) and chunking (repetitive-diff sampling). Each records its
+own :class:`~lintro.ai.review.models.skipped_file.SkippedFile` entries; this
+module merges them into the single reviewed/skipped split that run metadata
+and the per-review comment body report (#1910).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.skipped_file import SkippedFile
+
+__all__ = ["FileSelection", "resolve_file_selection"]
+
+
+@dataclass(frozen=True, slots=True)
+class FileSelection:
+    """The reviewed/skipped split for one review round.
+
+    Attributes:
+        reviewed_paths: Repository-relative paths the review looked at, sorted.
+        skipped: Excluded files with their reasons, sorted by path.
+    """
+
+    reviewed_paths: tuple[str, ...]
+    skipped: tuple[SkippedFile, ...]
+
+
+def resolve_file_selection(
+    *,
+    context: ReviewContext,
+    chunk_skips: Sequence[SkippedFile] = (),
+) -> FileSelection:
+    """Split a round's changed files into reviewed and skipped sets.
+
+    A path skipped by more than one stage keeps the earliest reason recorded
+    for it, so a file dropped by the ``--path`` filter is never re-explained
+    as a sampling omission.
+
+    Args:
+        context: Collected review context, carrying any collection-stage skips.
+        chunk_skips: Per-file skips recorded by the chunker.
+
+    Returns:
+        The reviewed paths and the skipped files with their reasons.
+    """
+    skipped_by_path: dict[str, SkippedFile] = {}
+    for entry in (*context.skipped_files, *chunk_skips):
+        skipped_by_path.setdefault(entry.path, entry)
+
+    reviewed = sorted(
+        {
+            changed_file.path
+            for changed_file in context.changed_files
+            if changed_file.path not in skipped_by_path
+        },
+    )
+    skipped = tuple(skipped_by_path[path] for path in sorted(skipped_by_path))
+    return FileSelection(reviewed_paths=tuple(reviewed), skipped=skipped)

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -21,6 +21,7 @@ from loguru import logger
 
 from lintro.ai.integrations.github_pr import GitHubPRReporter
 from lintro.ai.review.enums.checklist_display import ChecklistDisplay
+from lintro.ai.review.finding_matcher import match_findings
 from lintro.ai.review.github_constants import (
     GITHUB_COMMENT_HARD_LIMIT,
     MAX_COMMENT_CHARS,
@@ -38,6 +39,7 @@ from lintro.ai.review.github_render import (
     format_run_mechanics,
     sanitize_comment_text,
 )
+from lintro.ai.review.github_review_body import build_review_body
 from lintro.ai.review.github_sticky import (
     _cap_body as _cap_body,
 )
@@ -57,6 +59,7 @@ __all__ = [
     "STATE_MARKER_PREFIX",
     "STICKY_MARKER",
     "MAX_COMMENT_CHARS",
+    "build_review_body",
     "build_sticky_comment",
     "format_error_comment",
     "format_finding_comment",
@@ -78,12 +81,16 @@ def post_review_to_github(
     reporter: GitHubPRReporter | None = None,
     checklist_display: ChecklistDisplay = ChecklistDisplay.OFF,
     question_map: dict[int, str] | None = None,
+    transport: str = "",
+    auth_mode: str = "",
+    config_source: str = "",
 ) -> bool:
     """Post (or update) the sticky review comment and inline findings.
 
     Maintains a single sticky comment per PR (identified by ``STICKY_MARKER``),
     updated in place with cumulative telemetry. Diff-mappable findings are also
-    posted as inline review comments carrying suggestion blocks.
+    posted as inline review comments, under a review body describing this round
+    (issue #1910).
 
     Args:
         result: Review result to post.
@@ -92,6 +99,10 @@ def post_review_to_github(
         reporter: Optional preconfigured GitHub reporter.
         checklist_display: Structured checklist visibility mode.
         question_map: Prompt id to question text for linked display.
+        transport: Provider transport used for this round (e.g. ``cli``).
+        auth_mode: Authentication mode used by the transport.
+        config_source: Human-readable description of where this run's settings
+            came from, shown under the review body's run stats.
 
     Returns:
         True when posting succeeded; False on failure or when GitHub context is
@@ -105,16 +116,19 @@ def post_review_to_github(
     prompt_questions = question_map or {}
     comment_id, prior_state = _load_prior_state(reporter=gh_reporter)
     diff_lines = gh_reporter.fetch_pr_diff_lines()
+    head_sha = result.metadata.head_ref
 
     def render(*, inline_failure: InlinePostFailure | None) -> str:
         """Render the sticky body against the unchanged prior state."""
         return build_sticky_comment(
             result=result,
             prior_state=prior_state,
-            head_sha=result.metadata.head_ref,
+            head_sha=head_sha,
             checklist_display=checklist_display,
             question_map=prompt_questions,
             diff_lines=diff_lines,
+            transport=transport,
+            auth_mode=auth_mode,
             inline_failure=inline_failure,
         )
 
@@ -136,27 +150,60 @@ def post_review_to_github(
         comment_id=comment_id,
     )
 
-    if inline_findings and not _post_inline_findings(
-        reporter=gh_reporter,
-        findings=inline_findings,
-        checklist_display=checklist_display,
-        question_map=prompt_questions,
-    ):
-        success = False
-        # Degraded path (#1909): the rejected findings now have no surface
-        # either, so re-render with both groups folded in. ``prior_state`` is
-        # unchanged, so this round is not double-counted, and the comment is
-        # only ever *updated* — a failed lookup skips rather than posting a
-        # second sticky on the PR.
-        _fold_inline_failure_into_sticky(
-            reporter=gh_reporter,
-            render=render,
-            failure=_inline_failure(
-                unmappable=fallback,
-                rejected=inline_findings,
+    if inline_findings:
+        # Built after the sticky upsert so the dedup pointer can resolve the
+        # sticky's real id — including on round 1, where it did not exist a
+        # moment ago and the pointer would otherwise render unlinked (#1910).
+        review_body = build_review_body(
+            result=result,
+            prior_state=prior_state,
+            # Matching is pure and deterministic over (prior_state, findings),
+            # so recomputing it here yields exactly what the sticky persisted —
+            # the two surfaces cannot disagree about what is new or resolved.
+            match=match_findings(
+                previous=prior_state,
+                findings=result.findings,
+                round_number=prior_state.next_round,
+                head_sha=head_sha,
             ),
-            comment_id=comment_id,
+            head_sha=head_sha,
+            sticky_url=_sticky_url(
+                reporter=gh_reporter,
+                comment_id=_sticky_comment_id(
+                    reporter=gh_reporter,
+                    known=comment_id,
+                ),
+            ),
+            transport=transport,
+            auth_mode=auth_mode,
+            config_source=config_source,
+            new_commits=_count_new_commits(
+                reporter=gh_reporter,
+                prior_state=prior_state,
+            ),
         )
+        if not _post_inline_findings(
+            reporter=gh_reporter,
+            findings=inline_findings,
+            checklist_display=checklist_display,
+            question_map=prompt_questions,
+            review_body=review_body,
+        ):
+            success = False
+            # Degraded path (#1909): the rejected findings now have no surface
+            # either, so re-render with both groups folded in. ``prior_state``
+            # is unchanged, so this round is not double-counted, and the
+            # comment is only ever *updated* — a failed lookup skips rather
+            # than posting a second sticky on the PR.
+            _fold_inline_failure_into_sticky(
+                reporter=gh_reporter,
+                render=render,
+                failure=_inline_failure(
+                    unmappable=fallback,
+                    rejected=inline_findings,
+                ),
+                comment_id=comment_id,
+            )
 
     return success
 
@@ -267,6 +314,59 @@ def _sticky_comment_id(
     return None if found is None else found[0]
 
 
+def _sticky_url(
+    *,
+    reporter: GitHubPRReporter,
+    comment_id: int | None,
+) -> str:
+    """Build the browser URL of the sticky comment, when its id is known.
+
+    Args:
+        reporter: GitHub reporter carrying repo and PR context.
+        comment_id: Sticky comment id as resolved after the upsert, or ``None``
+            when it could not be located at all.
+
+    Returns:
+        The comment's anchor URL, or an empty string when the id is unknown —
+        the pointer then renders unlinked rather than as a dead link.
+    """
+    if comment_id is None:
+        return ""
+    return (
+        f"https://github.com/{reporter.repo}/pull/{reporter.pr_number}"
+        f"#issuecomment-{comment_id}"
+    )
+
+
+def _count_new_commits(
+    *,
+    reporter: GitHubPRReporter,
+    prior_state: ReviewState,
+) -> int | None:
+    """Count commits pushed since the previously reviewed head.
+
+    Args:
+        reporter: GitHub reporter used to list the PR's commits.
+        prior_state: State decoded from the sticky comment before this round.
+
+    Returns:
+        Number of commits after the previous round's head sha, or ``None`` when
+        there is no previous round or the sha is not in the fetched listing.
+    """
+    if not prior_state.runs:
+        return None
+    prior_sha = prior_state.runs[-1].sha
+    if not prior_sha:
+        return None
+    shas = reporter.fetch_pr_commit_shas()
+    if not shas:
+        return None
+    for index, sha in enumerate(shas):
+        if sha.startswith(prior_sha) or prior_sha.startswith(sha):
+            return len(shas) - index - 1
+    return None
+
+
 def post_review_error_to_github(
     *,
     error: Exception,
@@ -341,8 +441,21 @@ def _post_inline_findings(
     findings: list[ReviewFinding],
     checklist_display: ChecklistDisplay,
     question_map: dict[int, str],
+    review_body: str = "",
 ) -> bool:
-    """Post inline PR review comments for mappable findings."""
+    """Post inline PR review comments for mappable findings.
+
+    Args:
+        reporter: GitHub reporter used to submit the review.
+        findings: Diff-mappable findings to anchor as inline comments.
+        checklist_display: Structured checklist visibility mode.
+        question_map: Prompt id to question text for linked display.
+        review_body: Markdown body posted with the review. Falls back to a
+            plain label when empty.
+
+    Returns:
+        True when the review was submitted successfully.
+    """
     comments: list[dict[str, Any]] = []
     for finding in findings:
         rel = finding.file.removeprefix("./").replace("\\", "/")
@@ -364,7 +477,7 @@ def _post_inline_findings(
 
     payload = {
         "event": "COMMENT",
-        "body": "Lintro review findings",
+        "body": review_body or "Lintro review findings",
         "comments": comments,
     }
     url = (

--- a/lintro/ai/review/github_review_body.py
+++ b/lintro/ai/review/github_review_body.py
@@ -1,0 +1,429 @@
+"""Per-review comment body for GitHub AI reviews (epic #1905, issue #1910).
+
+The review body is the surface posted *with each round*: it describes this
+round only. The sticky comment owns cumulative status and history; the inline
+comments own per-finding detail. So this body carries exactly four things —
+what this round found (header + resolved delta), what to do about it (the
+scoped fix prompt), what the run cost (visible stats plus the config that
+produced them), and what it looked at (commits and files, with a reason for
+every file it did not look at).
+
+The fix panel is deliberately conditional. When this round's findings are
+*exactly* the PR's still-open findings — round 1, or a round where nothing was
+carried over — the panel would repeat the sticky comment's fix-all byte for
+byte, and two identical prompts on one PR is an invitation to copy the wrong
+one. In that case a one-line pointer to the sticky replaces it.
+"""
+
+from __future__ import annotations
+
+from lintro import __version__ as lintro_version
+from lintro.ai.review.agent_prompts import (
+    prompt_findings,
+    render_agent_prompt_panel,
+    render_sticky_prompt_pointer,
+)
+from lintro.ai.review.enums.agent_prompt_scope_kind import AgentPromptScopeKind
+from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.github_constants import MAX_COMMENT_CHARS
+from lintro.ai.review.github_render import (
+    _fmt_cost,
+    _fmt_int,
+    sanitize_comment_text,
+)
+from lintro.ai.review.models.agent_prompt_scope import AgentPromptScope
+from lintro.ai.review.models.finding_match_result import FindingMatchResult
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.skipped_file import SkippedFile
+
+__all__ = ["REVIEW_BODY_FOOTER", "build_review_body"]
+
+#: Footer cross-linking the two surfaces this body deliberately does not own.
+REVIEW_BODY_FOOTER = (
+    "<sub>🤖 lintro · cumulative status &amp; history → sticky comment · "
+    "finding details → inline comments</sub>"
+)
+
+#: Characters of a commit sha rendered in prose.
+_SHORT_SHA = 7
+
+#: Maximum file entries listed before the files collapsible summarizes the rest.
+_MAX_LISTED_FILES = 60
+
+_TRUNCATION_NOTICE = "\n\n> ✂️ Comment truncated to fit GitHub's size limit."
+
+
+def build_review_body(
+    *,
+    result: ReviewResult,
+    prior_state: ReviewState,
+    match: FindingMatchResult,
+    head_sha: str = "",
+    sticky_url: str = "",
+    transport: str = "",
+    auth_mode: str = "",
+    config_source: str = "",
+    new_commits: int | None = None,
+) -> str:
+    """Compose the body posted alongside this round's inline comments.
+
+    Args:
+        result: This round's review result.
+        prior_state: State decoded from the sticky comment before this round.
+        match: Cross-round matching outcome for this round's findings.
+        head_sha: Head commit sha reviewed in this round. Falls back to the
+            metadata's head ref.
+        sticky_url: URL of the sticky status comment, used by the dedup
+            pointer and the footer. Empty renders unlinked text.
+        transport: Provider transport used for this round (e.g. ``cli``).
+        auth_mode: Authentication mode used by the transport.
+        config_source: Human-readable description of where this run's settings
+            came from. Omitted from the body when empty.
+        new_commits: Number of commits pushed since the previous round. ``None``
+            when it could not be determined; the provenance sentence then omits
+            the count rather than guessing one.
+
+    Returns:
+        Markdown body for the review, capped to GitHub's comment size limit.
+    """
+    round_number = prior_state.next_round
+    sections = [
+        _header(
+            result=result,
+            match=match,
+            prior_state=prior_state,
+            round_number=round_number,
+            head_sha=head_sha,
+        ),
+        _prompt_section(
+            result=result,
+            match=match,
+            round_number=round_number,
+            sticky_url=sticky_url,
+        ),
+        _run_stats_section(
+            result=result,
+            transport=transport,
+            auth_mode=auth_mode,
+            config_source=config_source,
+        ),
+        _commits_section(
+            result=result,
+            prior_state=prior_state,
+            round_number=round_number,
+            head_sha=head_sha,
+            new_commits=new_commits,
+        ),
+        _files_section(result=result),
+        REVIEW_BODY_FOOTER,
+    ]
+    body = "\n\n".join(section for section in sections if section)
+    return _cap(body=body)
+
+
+def _short(sha: str) -> str:
+    """Return a display-length commit sha.
+
+    Args:
+        sha: Full or already-short commit sha.
+
+    Returns:
+        The sha truncated to :data:`_SHORT_SHA` characters, sanitized.
+    """
+    return sanitize_comment_text(sha, limit=64)[:_SHORT_SHA]
+
+
+def _plural(*, count: int, noun: str) -> str:
+    """Format a count with a naively pluralized noun.
+
+    Args:
+        count: Number of items.
+        noun: Singular noun to pluralize with a trailing ``s``.
+
+    Returns:
+        The count and noun, e.g. ``"1 finding"``.
+    """
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
+
+
+def _prior_sha(*, prior_state: ReviewState) -> str:
+    """Return the head sha of the most recent prior round, if any."""
+    return prior_state.runs[-1].sha if prior_state.runs else ""
+
+
+def _header(
+    *,
+    result: ReviewResult,
+    match: FindingMatchResult,
+    prior_state: ReviewState,
+    round_number: int,
+    head_sha: str,
+) -> str:
+    """Render the one-line findings header with the resolved delta.
+
+    The resolved segment is rendered on every round after the first, even at
+    zero: omitting it would make "nothing was fixed since last round" and
+    "there was no last round" look identical.
+
+    Args:
+        result: This round's review result.
+        match: Cross-round matching outcome for this round.
+        prior_state: State before this round.
+        round_number: 1-based round number for this run.
+        head_sha: Head commit sha reviewed in this round.
+
+    Returns:
+        Markdown header line.
+    """
+    head = _short(head_sha or result.metadata.head_ref)
+    base = _short(_prior_sha(prior_state=prior_state) or result.metadata.base_ref)
+    parts = [
+        f"🔎 **Lintro review — {_plural(count=len(result.findings), noun='finding')} "
+        "posted**",
+    ]
+    if round_number > 1:
+        parts.append(
+            f"✔ {len(match.resolved)} resolved since round {round_number - 1}",
+        )
+    parts.append(f"round {round_number}")
+    if base and head:
+        parts.append(f"commits `{base}..{head}`")
+    return " · ".join(parts)
+
+
+def _open_keys(*, match: FindingMatchResult) -> set[str]:
+    """Return the identity keys of every finding still open after this round."""
+    return {
+        record.key for record in match.records if record.status is FindingStatus.OPEN
+    }
+
+
+def _round_keys(*, match: FindingMatchResult) -> set[str]:
+    """Return the identity keys of the findings reported in this round."""
+    return {record.key for record in (*match.new, *match.carried, *match.regressed)}
+
+
+def _prompt_section(
+    *,
+    result: ReviewResult,
+    match: FindingMatchResult,
+    round_number: int,
+    sticky_url: str,
+) -> str:
+    """Render the scoped fix prompt, or the sticky pointer when it would dupe.
+
+    Args:
+        result: This round's review result.
+        match: Cross-round matching outcome for this round.
+        round_number: 1-based round number for this run.
+        sticky_url: URL of the sticky comment for the pointer variant.
+
+    Returns:
+        Markdown for the prompt panel or the one-line pointer; empty when the
+        round produced nothing actionable to fix.
+    """
+    if not prompt_findings(findings=result.findings):
+        return ""
+    if _round_keys(match=match) == _open_keys(match=match):
+        return render_sticky_prompt_pointer(sticky_url=sticky_url)
+    return render_agent_prompt_panel(
+        findings=result.findings,
+        scope=AgentPromptScope(
+            kind=AgentPromptScopeKind.THIS_REVIEW,
+            round_number=round_number,
+        ),
+    )
+
+
+def _badge_table(*, cells: list[tuple[str, str]]) -> list[str]:
+    """Render key/value stats as a two-row Markdown table.
+
+    Args:
+        cells: Ordered ``(key, value)`` pairs.
+
+    Returns:
+        Markdown lines, or an empty list when there is nothing to render.
+    """
+    if not cells:
+        return []
+    keys = " | ".join(key for key, _ in cells)
+    dividers = " | ".join("---" for _ in cells)
+    values = " | ".join(value for _, value in cells)
+    return [f"| {keys} |", f"| {dividers} |", f"| {values} |"]
+
+
+def _run_stats_section(
+    *,
+    result: ReviewResult,
+    transport: str,
+    auth_mode: str,
+    config_source: str,
+) -> str:
+    """Render the visible run-stats block and the config-source note.
+
+    Stats follow the epic's shared ordering rule: model, est. cost, tokens in,
+    tokens out on the first line; mechanics on the second. ``~`` marks values
+    estimated locally, so a subscription run never presents an estimate as a
+    billed figure.
+
+    Args:
+        result: This round's review result.
+        transport: Provider transport used for this round.
+        auth_mode: Authentication mode used by the transport.
+        config_source: Human-readable description of the settings' origin.
+
+    Returns:
+        Markdown for the run-stats section.
+    """
+    metadata = result.metadata
+    estimated = metadata.token_usage_estimated
+    prompt_tokens = int(metadata.token_usage.get("prompt", 0))
+    completion_tokens = int(metadata.token_usage.get("completion", 0))
+    tilde = "~" if estimated else ""
+
+    primary = [
+        ("model", f"`{sanitize_comment_text(metadata.model, limit=60)}`"),
+        ("est. cost", _fmt_cost(metadata.cost_estimate_usd, estimated=estimated)),
+        ("tokens in", f"{tilde}{_fmt_int(prompt_tokens)}"),
+        ("tokens out", f"{tilde}{_fmt_int(completion_tokens)}"),
+    ]
+
+    transport_label = sanitize_comment_text(transport, limit=40)
+    if transport_label and auth_mode:
+        transport_label = (
+            f"{transport_label} · {sanitize_comment_text(auth_mode, limit=40)}"
+        )
+    secondary: list[tuple[str, str]] = []
+    if transport_label:
+        secondary.append(("transport", transport_label))
+    secondary.extend(
+        [
+            ("depth", str(metadata.depth)),
+            ("strictness", sanitize_comment_text(metadata.strictness, limit=40)),
+            ("files", str(metadata.files_reviewed)),
+            ("checks", str(metadata.checklist_items)),
+            ("duration", f"{metadata.duration_seconds:.0f}s"),
+            ("lintro", lintro_version),
+        ],
+    )
+
+    lines = ["**📊 Run stats**", ""]
+    lines.extend(_badge_table(cells=primary))
+    lines.append("")
+    lines.extend(_badge_table(cells=secondary))
+    if config_source:
+        source = sanitize_comment_text(config_source, limit=300)
+        lines.extend(["", f"<sub>Config source: {source}</sub>"])
+    return "\n".join(lines)
+
+
+def _commits_section(
+    *,
+    result: ReviewResult,
+    prior_state: ReviewState,
+    round_number: int,
+    head_sha: str,
+    new_commits: int | None = None,
+) -> str:
+    """Render the commits collapsible describing this round's provenance.
+
+    Args:
+        result: This round's review result.
+        prior_state: State before this round.
+        round_number: 1-based round number for this run.
+        head_sha: Head commit sha reviewed in this round.
+        new_commits: Number of commits pushed since the previous round, or
+            ``None`` when unknown.
+
+    Returns:
+        Markdown for the ``📥 Commits`` collapsible.
+    """
+    metadata = result.metadata
+    head = _short(head_sha or metadata.head_ref)
+    base = _short(metadata.base_ref)
+    prior = _short(_prior_sha(prior_state=prior_state))
+
+    if prior and prior != head:
+        commits = (
+            _plural(count=new_commits, noun="new commit")
+            if new_commits is not None
+            else "new commits"
+        )
+        sentence = (
+            f"This round reviewed the {commits} since round {round_number - 1}, "
+            f"`{prior}` → `{head}`, in the context of the PR's full diff "
+            f"against `{base}`."
+        )
+    else:
+        sentence = (
+            f"This round reviewed the PR's full diff against `{base}` " f"at `{head}`."
+        )
+    return "\n".join(
+        [
+            "<details><summary>📥 Commits</summary>",
+            "",
+            sentence,
+            "",
+            "</details>",
+        ],
+    )
+
+
+def _skipped_line(*, entry: SkippedFile) -> str:
+    """Render one skipped file with the reason it was skipped."""
+    path = sanitize_comment_text(entry.path, limit=300)
+    return f"- `{path}` — skipped ({entry.label})"
+
+
+def _files_section(*, result: ReviewResult) -> str:
+    """Render the files-reviewed collapsible, with per-file skip reasons.
+
+    Args:
+        result: This round's review result.
+
+    Returns:
+        Markdown for the ``📁 Files reviewed`` collapsible; empty when the run
+        recorded neither reviewed nor skipped paths.
+    """
+    metadata = result.metadata
+    reviewed = list(metadata.reviewed_paths)
+    skipped = list(metadata.skipped_files)
+    if not reviewed and not skipped:
+        return ""
+
+    summary = f"📁 Files reviewed ({len(reviewed)})"
+    if skipped:
+        summary += f" · {len(skipped)} skipped"
+
+    entries = [
+        f"- `{sanitize_comment_text(path, limit=300)}`"
+        for path in reviewed[:_MAX_LISTED_FILES]
+    ]
+    hidden_reviewed = max(len(reviewed) - _MAX_LISTED_FILES, 0)
+    if hidden_reviewed:
+        entries.append(f"- …and {hidden_reviewed} more reviewed")
+    remaining = max(_MAX_LISTED_FILES - len(reviewed), 0)
+    entries.extend(_skipped_line(entry=entry) for entry in skipped[:remaining])
+    hidden_skipped = max(len(skipped) - remaining, 0)
+    if hidden_skipped:
+        entries.append(f"- …and {hidden_skipped} more skipped")
+
+    return "\n".join(
+        [f"<details><summary>{summary}</summary>", "", *entries, "", "</details>"],
+    )
+
+
+def _cap(*, body: str) -> str:
+    """Trim an over-long body, leaving an explicit truncation marker.
+
+    Args:
+        body: Assembled review body.
+
+    Returns:
+        The body, truncated with a visible notice when over the size cap.
+    """
+    if len(body) <= MAX_COMMENT_CHARS:
+        return body
+    keep = MAX_COMMENT_CHARS - len(_TRUNCATION_NOTICE)
+    return body[:keep].rstrip() + _TRUNCATION_NOTICE

--- a/lintro/ai/review/github_review_body.py
+++ b/lintro/ai/review/github_review_body.py
@@ -373,7 +373,36 @@ def _commits_section(
 def _skipped_line(*, entry: SkippedFile) -> str:
     """Render one skipped file with the reason it was skipped."""
     path = sanitize_comment_text(entry.path, limit=300)
-    return f"- `{path}` — skipped ({entry.label})"
+    # The reason carries a file path in its detail, so it is sanitized on the
+    # same terms as the path itself rather than trusted because it is
+    # partly-canned text.
+    label = sanitize_comment_text(entry.label, limit=300)
+    return f"- `{path}` — skipped ({label})"
+
+
+def _partial_run_warning(*, result: ReviewResult) -> str:
+    """Warn that a stopped-early run may not have covered the listed files.
+
+    A partial run's chunks are reviewed concurrently, so which files the
+    completed chunks covered is not recoverable per-file. Naming the
+    uncertainty is honest; listing a precise "reviewed" set that may be wrong
+    is not.
+
+    Args:
+        result: This round's review result.
+
+    Returns:
+        A warning line, or an empty string when the run completed.
+    """
+    metadata = result.metadata
+    if not metadata.partial:
+        return ""
+    reason = sanitize_comment_text(metadata.stopped_reason or "incomplete", limit=60)
+    return (
+        f"> ⚠️ Review stopped early ({reason}) after "
+        f"{metadata.chunks_reviewed} of {metadata.chunks_total} chunks — some "
+        "files listed below may not have been reviewed in full."
+    )
 
 
 def _files_section(*, result: ReviewResult) -> str:
@@ -396,16 +425,20 @@ def _files_section(*, result: ReviewResult) -> str:
     if skipped:
         summary += f" · {len(skipped)} skipped"
 
-    entries = [
+    # Reviewed and skipped files get independent budgets. Sharing one would let
+    # a wide PR's reviewed list crowd out the skip lines, and the skips are the
+    # half a reader cannot reconstruct from the diff.
+    warning = _partial_run_warning(result=result)
+    entries = [*([warning, ""] if warning else [])]
+    entries.extend(
         f"- `{sanitize_comment_text(path, limit=300)}`"
         for path in reviewed[:_MAX_LISTED_FILES]
-    ]
+    )
     hidden_reviewed = max(len(reviewed) - _MAX_LISTED_FILES, 0)
     if hidden_reviewed:
         entries.append(f"- …and {hidden_reviewed} more reviewed")
-    remaining = max(_MAX_LISTED_FILES - len(reviewed), 0)
-    entries.extend(_skipped_line(entry=entry) for entry in skipped[:remaining])
-    hidden_skipped = max(len(skipped) - remaining, 0)
+    entries.extend(_skipped_line(entry=entry) for entry in skipped[:_MAX_LISTED_FILES])
+    hidden_skipped = max(len(skipped) - _MAX_LISTED_FILES, 0)
     if hidden_skipped:
         entries.append(f"- …and {hidden_skipped} more skipped")
 

--- a/lintro/ai/review/models/__init__.py
+++ b/lintro/ai/review/models/__init__.py
@@ -21,6 +21,7 @@ from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.review_summary import ReviewSummary
 from lintro.ai.review.models.run_record import RunRecord
+from lintro.ai.review.models.skipped_file import SkippedFile
 from lintro.ai.review.models.summary_bullet import SummaryBullet
 from lintro.ai.review.models.verdict_reasoning import VerdictReasoning
 
@@ -44,6 +45,7 @@ __all__ = [
     "ReviewState",
     "ReviewSummary",
     "RunRecord",
+    "SkippedFile",
     "Severity",
     "SummaryBullet",
     "VerdictReasoning",

--- a/lintro/ai/review/models/chunking_result.py
+++ b/lintro/ai/review/models/chunking_result.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from lintro.ai.review.models.review_chunk import ReviewChunk
+from lintro.ai.review.models.skipped_file import SkippedFile
 
 
 @dataclass
@@ -15,10 +16,15 @@ class ChunkingResult:
         chunks: Ordered review chunks.
         truncated: True when any diff content was trimmed to fit budget.
         warnings: User-facing warnings about trimming or sampling.
-        skipped_files: Paths omitted from chunks due to repetitive-diff sampling.
+        skipped: Files omitted from chunks, each carrying why it was omitted.
     """
 
     chunks: list[ReviewChunk]
     truncated: bool = False
     warnings: list[str] = field(default_factory=list)
-    skipped_files: list[str] = field(default_factory=list)
+    skipped: list[SkippedFile] = field(default_factory=list)
+
+    @property
+    def skipped_files(self) -> list[str]:
+        """Return the paths omitted from chunks, without their reasons."""
+        return [entry.path for entry in self.skipped]

--- a/lintro/ai/review/models/review_context.py
+++ b/lintro/ai/review/models/review_context.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 
 from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.pr_metadata import PRMetadata
+from lintro.ai.review.models.skipped_file import SkippedFile
 
 
 @dataclass
@@ -21,6 +22,9 @@ class ReviewContext:
         post_image_files: Full post-change contents for changed workflow files
             keyed by repository-relative path.
         repo_root: Absolute path to the git repository root.
+        skipped_files: Changed files dropped during context collection, each
+            carrying why it was dropped. Reported on the per-review comment so
+            a narrowed review scope is visible rather than implied (#1910).
     """
 
     base_ref: str
@@ -30,3 +34,4 @@ class ReviewContext:
     pr_metadata: PRMetadata | None = None
     post_image_files: dict[str, str] = field(default_factory=dict)
     repo_root: str = ""
+    skipped_files: list[SkippedFile] = field(default_factory=list)

--- a/lintro/ai/review/models/review_metadata.py
+++ b/lintro/ai/review/models/review_metadata.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from lintro.ai.review.models.skipped_file import SkippedFile
+
 
 @dataclass(frozen=True, slots=True)
 class ReviewMetadata:
@@ -39,6 +41,10 @@ class ReviewMetadata:
             completed a pass in this run (issue #1245).
         custom_agents_skipped (int): Number of discovered agents that did not
             run because they are disabled or matched no changed file.
+        reviewed_paths (tuple[str, ...]): Repository-relative paths the review
+            actually looked at, in sorted order.
+        skipped_files (tuple[SkippedFile, ...]): Changed files excluded from
+            the review, each carrying the reason it was excluded (#1910).
     """
 
     model: str
@@ -63,3 +69,5 @@ class ReviewMetadata:
     duration_seconds: float = 0.0
     custom_agents_run: int = 0
     custom_agents_skipped: int = 0
+    reviewed_paths: tuple[str, ...] = field(default_factory=tuple)
+    skipped_files: tuple[SkippedFile, ...] = field(default_factory=tuple)

--- a/lintro/ai/review/models/skipped_file.py
+++ b/lintro/ai/review/models/skipped_file.py
@@ -1,0 +1,34 @@
+"""A changed file the review deliberately did not look at."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lintro.ai.review.enums.file_skip_reason import (
+    FileSkipReason,
+    describe_skip_reason,
+)
+
+__all__ = ["SkippedFile"]
+
+
+@dataclass(frozen=True, slots=True)
+class SkippedFile:
+    """One changed file excluded from the review, with why it was excluded.
+
+    Attributes:
+        path: Repository-relative path of the excluded file.
+        reason: Which selection rule dropped it.
+        detail: Optional extra context (for example the file whose diff it
+            duplicated). Empty when the reason alone is the whole story.
+    """
+
+    path: str
+    reason: FileSkipReason
+    detail: str = ""
+
+    @property
+    def label(self) -> str:
+        """Return the reason phrase, including ``detail`` when present."""
+        base = describe_skip_reason(reason=self.reason)
+        return f"{base} — {self.detail}" if self.detail else base

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -46,9 +46,11 @@ from lintro.ai.review.custom_agent_runner import (
     run_custom_agent_passes,
 )
 from lintro.ai.review.custom_agents import (
+    CustomAgentSelection,
     CustomAgentSpec,
     select_custom_agents,
 )
+from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
 from lintro.ai.review.errors_taxonomy import (
     classify_provider_error,
@@ -257,9 +259,13 @@ def resolve_review_chunks(
         max_tokens=max(diff_budget, 1),
         classifications=classifications,
     )
+    if not chunking.chunks:
+        # The whole-context fallback reviews every file, so the chunker's
+        # skips no longer describe what happened and must not be reported.
+        return [_single_chunk_from_context(context=context)]
     if skipped_sink is not None:
         skipped_sink.extend(chunking.skipped)
-    return chunking.chunks or [_single_chunk_from_context(context=context)]
+    return chunking.chunks
 
 
 async def _review_all_chunks(
@@ -876,7 +882,17 @@ async def run_review_async(
         or merged.summary
     )
 
-    selection = resolve_file_selection(context=context, chunk_skips=chunk_skips)
+    selection = resolve_file_selection(
+        context=context,
+        chunk_skips=[
+            *chunk_skips,
+            *_agent_scope_skips(
+                context=context,
+                selection=agent_selection,
+                run_builtin_checklist=run_builtin_checklist,
+            ),
+        ],
+    )
 
     metadata = ReviewMetadata(
         model=provider.model_name,
@@ -1925,6 +1941,38 @@ def _pick_preferred_checklist_answer(
     if candidate_strength >= existing_strength:
         return candidate
     return existing
+
+
+def _agent_scope_skips(
+    *,
+    context: ReviewContext,
+    selection: CustomAgentSelection,
+    run_builtin_checklist: bool,
+) -> list[SkippedFile]:
+    """List changed files no custom agent covered in an agents-only run.
+
+    Under ``review.custom_agents: only`` the built-in checklist never runs, so
+    a file outside every enabled agent's globs is not reviewed at all. Without
+    this record the run would report it as reviewed and the gap would read as
+    a clean pass.
+
+    Args:
+        context: Collected review context.
+        selection: Custom agents partitioned into selected and skipped.
+        run_builtin_checklist: Whether the built-in checklist passes ran.
+
+    Returns:
+        Skip records for the uncovered files; empty when the checklist ran
+        (it covers every changed file).
+    """
+    if run_builtin_checklist:
+        return []
+    covered = {path for agent in selection.selected for path in agent.files}
+    return [
+        SkippedFile(path=changed.path, reason=FileSkipReason.AGENT_SCOPE)
+        for changed in context.changed_files
+        if changed.path not in covered
+    ]
 
 
 def _single_chunk_from_context(*, context: ReviewContext) -> ReviewChunk:

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -55,6 +55,7 @@ from lintro.ai.review.errors_taxonomy import (
     resolve_cause_text,
 )
 from lintro.ai.review.exceptions import ReviewExecutionError
+from lintro.ai.review.file_selection import resolve_file_selection
 from lintro.ai.review.finding_parser import parse_findings
 from lintro.ai.review.group_labels import REL_DIRECTORY_PREFIX, REL_SINGLE_FILE
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
@@ -64,6 +65,7 @@ from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_summary import ReviewSummary
+from lintro.ai.review.models.skipped_file import SkippedFile
 from lintro.ai.review.models.summary_bullet import SummaryBullet
 from lintro.ai.review.models.verdict_reasoning import VerdictReasoning
 from lintro.ai.review.narrative_parser import (
@@ -225,6 +227,7 @@ def resolve_review_chunks(
     diff_budget: int,
     classifications: list[FileClassification],
     force_semantic_chunking: bool = False,
+    skipped_sink: list[SkippedFile] | None = None,
 ) -> list[ReviewChunk]:
     """Resolve review chunks using a budget-gated fast path.
 
@@ -236,6 +239,9 @@ def resolve_review_chunks(
         diff_budget: Maximum estimated tokens available for diff content.
         classifications: Domain classifications for changed files.
         force_semantic_chunking: When True, skip the single-chunk fast path.
+        skipped_sink: Optional list the chunker's per-file skips are appended
+            to, so the caller can report *why* a changed file went unreviewed
+            instead of only how many did (#1910).
 
     Returns:
         Ordered list of review chunks to process.
@@ -251,6 +257,8 @@ def resolve_review_chunks(
         max_tokens=max(diff_budget, 1),
         classifications=classifications,
     )
+    if skipped_sink is not None:
+        skipped_sink.extend(chunking.skipped)
     return chunking.chunks or [_single_chunk_from_context(context=context)]
 
 
@@ -694,12 +702,14 @@ async def run_review_async(
         context_window=context_window,
         prompt_overhead=prompt_overhead,
     )
+    chunk_skips: list[SkippedFile] = []
     chunks = (
         resolve_review_chunks(
             context=context,
             diff_budget=diff_budget,
             classifications=classifications,
             force_semantic_chunking=force_semantic_chunking,
+            skipped_sink=chunk_skips,
         )
         if run_builtin_checklist
         else []
@@ -866,6 +876,8 @@ async def run_review_async(
         or merged.summary
     )
 
+    selection = resolve_file_selection(context=context, chunk_skips=chunk_skips)
+
     metadata = ReviewMetadata(
         model=provider.model_name,
         provider=provider.name,
@@ -874,8 +886,10 @@ async def run_review_async(
         strictness=review_sensitivity.strictness.value,
         chunks_total=len(chunks),
         chunks_current=chunks_reviewed,
-        files_reviewed=len(context.changed_files),
-        files_total=len(context.changed_files),
+        files_reviewed=len(selection.reviewed_paths),
+        files_total=len(selection.reviewed_paths) + len(selection.skipped),
+        reviewed_paths=selection.reviewed_paths,
+        skipped_files=selection.skipped,
         checklist_items=len(checklist_items),
         token_usage={
             "prompt": total_input,

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -890,6 +890,9 @@ async def run_review_async(
                 context=context,
                 selection=agent_selection,
                 run_builtin_checklist=run_builtin_checklist,
+                completed_agents=frozenset(
+                    result.agent_name for result in custom_results
+                ),
             ),
         ],
     )
@@ -1948,18 +1951,25 @@ def _agent_scope_skips(
     context: ReviewContext,
     selection: CustomAgentSelection,
     run_builtin_checklist: bool,
+    completed_agents: frozenset[str],
 ) -> list[SkippedFile]:
-    """List changed files no custom agent covered in an agents-only run.
+    """List changed files no custom agent reviewed in an agents-only run.
 
     Under ``review.custom_agents: only`` the built-in checklist never runs, so
-    a file outside every enabled agent's globs is not reviewed at all. Without
-    this record the run would report it as reviewed and the gap would read as
-    a clean pass.
+    a file no agent looked at is not reviewed at all. Without this record the
+    run would report it as reviewed and the gap would read as a clean pass.
+
+    Coverage is credited from the agents that *completed*, never from the ones
+    that were merely selected. A selected agent can fail to produce a pass in
+    two ways — a non-budget ``AIError`` skips it and the run continues, or a
+    cost-cap stop means later agents never start — and in both cases its files
+    were scheduled but never read.
 
     Args:
         context: Collected review context.
         selection: Custom agents partitioned into selected and skipped.
         run_builtin_checklist: Whether the built-in checklist passes ran.
+        completed_agents: Names of the agents that returned a completed pass.
 
     Returns:
         Skip records for the uncovered files; empty when the checklist ran
@@ -1967,7 +1977,12 @@ def _agent_scope_skips(
     """
     if run_builtin_checklist:
         return []
-    covered = {path for agent in selection.selected for path in agent.files}
+    covered = {
+        path
+        for agent in selection.selected
+        if agent.agent.name in completed_agents
+        for path in agent.files
+    }
     return [
         SkippedFile(path=changed.path, reason=FileSkipReason.AGENT_SCOPE)
         for changed in context.changed_files

--- a/lintro/ai/review/pipeline.py
+++ b/lintro/ai/review/pipeline.py
@@ -31,7 +31,7 @@ def prepare_review_chunks(
         context: Collected review diff context.
         max_tokens: Maximum estimated tokens per chunk diff.
         allow_omitted_files: When True (default), return omitted repetitive-diff
-            files in ``skipped_files`` instead of raising. Pass False for strict
+            files in ``skipped`` instead of raising. Pass False for strict
             behavior.
 
     Returns:

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -485,6 +485,7 @@ def review_command(
                     strictness=strictness,
                     transport=transport,
                     timeout=timeout,
+                    context_window=context_window,
                     semantic_chunks=semantic_chunks,
                     paths=paths,
                 ),
@@ -505,6 +506,7 @@ def _cli_overrides(
     strictness: str | None,
     transport: str | None,
     timeout: float | None,
+    context_window: int | None,
     semantic_chunks: bool,
     paths: list[str] | None,
 ) -> list[str]:
@@ -519,6 +521,7 @@ def _cli_overrides(
         strictness: ``--strictness`` value, or None when unset.
         transport: ``--transport`` value, or None when unset.
         timeout: ``--timeout`` value, or None when unset.
+        context_window: ``--context-window`` value, or None when unset.
         semantic_chunks: Whether ``--semantic-chunks`` was passed.
         paths: ``--path`` values, or None when unset.
 
@@ -534,6 +537,8 @@ def _cli_overrides(
         overrides.append(f"--transport {transport}")
     if timeout is not None:
         overrides.append(f"--timeout {timeout:g}")
+    if context_window is not None:
+        overrides.append(f"--context-window {context_window}")
     if semantic_chunks:
         overrides.append("--semantic-chunks")
     overrides.extend(f"--path {path}" for path in paths or [])

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -477,6 +477,18 @@ def review_command(
             repo=effective_repo,
             checklist_display=checklist_display,
             question_map=question_map,
+            transport=str(effective_ai_config.transport),
+            config_source=_describe_config_source(
+                config_path=lintro_config.config_path,
+                overrides=_cli_overrides(
+                    depth=depth,
+                    strictness=strictness,
+                    transport=transport,
+                    timeout=timeout,
+                    semantic_chunks=semantic_chunks,
+                    paths=paths,
+                ),
+            ),
         )
         if not posted:
             logger.warning("GitHub review posting skipped or failed")
@@ -485,6 +497,71 @@ def review_command(
     if fail_on_findings and advisory_findings_count(advisory_results):
         exit_code = 1
     raise SystemExit(exit_code)
+
+
+def _cli_overrides(
+    *,
+    depth: int | None,
+    strictness: str | None,
+    transport: str | None,
+    timeout: float | None,
+    semantic_chunks: bool,
+    paths: list[str] | None,
+) -> list[str]:
+    """List the CLI flags that overrode configured review settings.
+
+    Only explicitly-passed options are listed: the point of the note is to
+    explain why a posted run's stats differ from the checked-in config, so
+    defaults would be noise.
+
+    Args:
+        depth: ``--depth`` value, or None when unset.
+        strictness: ``--strictness`` value, or None when unset.
+        transport: ``--transport`` value, or None when unset.
+        timeout: ``--timeout`` value, or None when unset.
+        semantic_chunks: Whether ``--semantic-chunks`` was passed.
+        paths: ``--path`` values, or None when unset.
+
+    Returns:
+        Rendered flag strings in CLI order.
+    """
+    overrides: list[str] = []
+    if depth is not None:
+        overrides.append(f"--depth {depth}")
+    if strictness is not None:
+        overrides.append(f"--strictness {strictness}")
+    if transport is not None:
+        overrides.append(f"--transport {transport}")
+    if timeout is not None:
+        overrides.append(f"--timeout {timeout:g}")
+    if semantic_chunks:
+        overrides.append("--semantic-chunks")
+    overrides.extend(f"--path {path}" for path in paths or [])
+    return overrides
+
+
+def _describe_config_source(
+    *,
+    config_path: str | None,
+    overrides: list[str],
+) -> str:
+    """Describe where this run's settings came from.
+
+    The config file is named, never pathed: an absolute path on a CI runner
+    leaks the workspace layout into a public PR comment and tells the reader
+    nothing they can act on.
+
+    Args:
+        config_path: Path of the loaded lintro config, if any.
+        overrides: Rendered CLI override flags.
+
+    Returns:
+        Human-readable provenance string for the posted run stats.
+    """
+    base = f"`{Path(config_path).name}`" if config_path else "built-in defaults"
+    if not overrides:
+        return base
+    return f"{base} + CLI overrides ({', '.join(overrides)})"
 
 
 def _existing_changed_files(

--- a/tests/unit/ai/review/test_chunker_sampling.py
+++ b/tests/unit/ai/review/test_chunker_sampling.py
@@ -11,6 +11,7 @@ from lintro.ai.review.chunker import (
     chunk_review_context,
 )
 from lintro.ai.review.classifier import classify_changed_files
+from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
 from lintro.ai.review.exceptions import ReviewContextError
 from lintro.ai.review.group_labels import (
@@ -332,3 +333,39 @@ def test_chunker_raises_when_diff_contains_extra_paths() -> None:
             classifications=classifications,
         )
     assert_that(exc_info.value.code).is_equal_to(ReviewContextErrorCode.DIFF_DESYNC)
+
+
+def test_chunker_records_why_a_sampled_file_was_omitted(
+    repetitive_unified_diff: str,
+) -> None:
+    """Sampling omissions carry a reason and the file whose diff they duplicate."""
+    changed_files = [
+        ChangedFile(
+            path=f"pkg/item{index}.py",
+            status="modified",
+            additions=1,
+            deletions=0,
+        )
+        for index in range(6)
+    ]
+    context = ReviewContext(
+        base_ref="base",
+        head_ref="head",
+        changed_files=changed_files,
+        unified_diff=repetitive_unified_diff,
+        pr_metadata=None,
+    )
+
+    result = chunk_review_context(
+        context=context,
+        max_tokens=10_000,
+        classifications=classify_changed_files(files=changed_files),
+        allow_omitted_files=True,
+    )
+
+    reasons = {entry.reason for entry in result.skipped}
+    assert_that(reasons).is_equal_to({FileSkipReason.REPETITIVE_DIFF})
+    assert_that(result.skipped[0].detail).contains("same diff hunks as")
+    assert_that(result.skipped_files).is_equal_to(
+        sorted(entry.path for entry in result.skipped),
+    )

--- a/tests/unit/ai/review/test_context_collect.py
+++ b/tests/unit/ai/review/test_context_collect.py
@@ -16,6 +16,7 @@ from lintro.ai.review.context import (
     resolve_default_base_branch,
 )
 from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
+from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
 from lintro.ai.review.exceptions import ReviewContextError
 from lintro.ai.review.models.changed_file import ChangedFile
@@ -938,3 +939,42 @@ def test_normalize_path_prefix_preserves_edge_whitespace() -> None:
     assert_that(
         _path_matches_any_prefix(path="foo", prefixes=[spaced_prefix]),
     ).is_false()
+
+
+@patch("lintro.ai.review.context.git_ops.subprocess.run")
+@patch(
+    "lintro.ai.review.context.git_ops.shutil.which",
+    side_effect=_which_for_review_tools,
+)
+def test_collect_review_context_records_path_filter_skips(
+    _mock_which: MagicMock,
+    mock_run: MagicMock,
+) -> None:
+    """Files dropped by --path are recorded with the reason they were dropped."""
+    dispatcher = SubprocessMock()
+    dispatcher.queue(["git", "rev-parse", "--git-dir"], stdout=".git\n")
+    dispatcher.queue(["git", "rev-parse", "--show-toplevel"], stdout="/repo\n")
+    dispatcher.queue(["git", "merge-base", "main", "HEAD"], stdout="base123\n")
+    dispatcher.queue(["git", "rev-parse", "HEAD"], stdout="head456\n")
+    queue_diff_snapshot(
+        dispatcher,
+        diff_ref="base123...head456",
+        unified=(
+            "diff --git a/a.py b/a.py\n"
+            "+++ b/a.py\n"
+            "+a\n"
+            "diff --git a/pkg/b.py b/pkg/b.py\n"
+            "+++ b/pkg/b.py\n"
+            "+b\n"
+        ),
+        name_status="M\0a.py\0M\0pkg/b.py\0",
+        numstat="1\t0\ta.py\01\t0\tpkg/b.py\0",
+    )
+    mock_run.side_effect = dispatcher
+
+    context = collect_review_context(base="main", paths=["pkg/"])
+
+    assert_that([entry.path for entry in context.skipped_files]).is_equal_to(["a.py"])
+    assert_that(context.skipped_files[0].reason).is_equal_to(
+        FileSkipReason.PATH_FILTER,
+    )

--- a/tests/unit/ai/review/test_custom_agent_runner.py
+++ b/tests/unit/ai/review/test_custom_agent_runner.py
@@ -13,7 +13,11 @@ from assertpy import assert_that
 from lintro.ai.budget import CostBudget
 from lintro.ai.config import AIConfig
 from lintro.ai.enums import AITransport
-from lintro.ai.exceptions import AICostBudgetExceededError, AIError
+from lintro.ai.exceptions import (
+    AICostBudgetExceededError,
+    AIError,
+    AIProviderError,
+)
 from lintro.ai.providers.capabilities import ProviderCapabilities
 from lintro.ai.providers.response import AIResponse
 from lintro.ai.review.custom_agent_runner import (
@@ -27,6 +31,7 @@ from lintro.ai.review.custom_agents import (
     parse_custom_agent,
 )
 from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
+from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.review_context import ReviewContext
 from lintro.ai.review.models.review_finding import Severity
@@ -493,3 +498,69 @@ def test_run_review_only_mode_skips_builtin_checklist(tmp_path: Path) -> None:
     assert_that(result.metadata.chunks_total).is_equal_to(0)
     assert_that(result.metadata.custom_agents_run).is_equal_to(1)
     assert_that(result.summary).contains("Custom review agents only")
+
+
+def test_only_mode_marks_a_failed_agent_scope_as_unreviewed(
+    tmp_path: Path,
+) -> None:
+    """A failed agent's files are reported skipped, not silently reviewed.
+
+    The agent is *selected* — its globs match ``src/app.py`` — but a non-budget
+    provider error skips its pass. Crediting coverage from selection rather
+    than completion would report the file as reviewed when nothing read it,
+    which is precisely the clean-pass illusion these records exist to prevent.
+    """
+    agent = _agent(tmp_path=tmp_path)
+    provider = _mock_provider(content="{}")
+
+    with (
+        _patch_builtin_call(content="{}"),
+        patch(
+            "lintro.ai.review.custom_agent_runner.call_ai",
+            side_effect=AIProviderError("agent exploded"),
+        ),
+    ):
+        result = run_review(
+            _context(),
+            provider=provider,
+            ai_config=_ai_config(),
+            checklist_items=[],
+            checklist_text="",
+            classifications=[],
+            custom_agents=(agent,),
+            run_builtin_checklist=False,
+        )
+
+    assert_that(result.metadata.custom_agents_run).is_equal_to(0)
+    assert_that(result.metadata.reviewed_paths).is_empty()
+    skipped = {entry.path: entry.reason for entry in result.metadata.skipped_files}
+    assert_that(skipped).contains_key("src/app.py")
+    assert_that(skipped["src/app.py"]).is_equal_to(FileSkipReason.AGENT_SCOPE)
+
+
+def test_only_mode_credits_coverage_to_a_completed_agent(
+    tmp_path: Path,
+) -> None:
+    """A completed agent's scoped files count as reviewed."""
+    agent = _agent(tmp_path=tmp_path)
+    provider = _mock_provider(content="{}")
+
+    with (
+        _patch_builtin_call(content="{}"),
+        _patch_agent_call(content=_agent_response(findings=[]), cost=0.001),
+    ):
+        result = run_review(
+            _context(),
+            provider=provider,
+            ai_config=_ai_config(),
+            checklist_items=[],
+            checklist_text="",
+            classifications=[],
+            custom_agents=(agent,),
+            run_builtin_checklist=False,
+        )
+
+    assert_that(result.metadata.reviewed_paths).contains("src/app.py")
+    # docs/readme.md matches no agent glob, so it stays an explicit skip.
+    skipped = {entry.path for entry in result.metadata.skipped_files}
+    assert_that(skipped).is_equal_to({"docs/readme.md"})

--- a/tests/unit/ai/review/test_file_selection.py
+++ b/tests/unit/ai/review/test_file_selection.py
@@ -1,0 +1,98 @@
+"""Tests for reviewed/skipped file reconciliation (issue #1910)."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.ai.review.enums.file_skip_reason import (
+    FileSkipReason,
+    describe_skip_reason,
+)
+from lintro.ai.review.file_selection import resolve_file_selection
+from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.skipped_file import SkippedFile
+
+
+def _context(*, paths: list[str], skipped: list[SkippedFile]) -> ReviewContext:
+    """Build a review context over ``paths`` with collection-stage skips.
+
+    Args:
+        paths: Repository-relative paths of the changed files.
+        skipped: Collection-stage skips to attach.
+
+    Returns:
+        The assembled review context.
+    """
+    return ReviewContext(
+        base_ref="main",
+        head_ref="head",
+        changed_files=[
+            ChangedFile(path=path, status="modified", additions=1, deletions=0)
+            for path in paths
+        ],
+        unified_diff="diff",
+        skipped_files=skipped,
+    )
+
+
+def test_selection_splits_reviewed_from_chunk_skips() -> None:
+    """A file the chunker omitted is reported as skipped, not as reviewed."""
+    context = _context(paths=["a.py", "b.py"], skipped=[])
+    chunk_skips = [
+        SkippedFile(path="b.py", reason=FileSkipReason.REPETITIVE_DIFF),
+    ]
+
+    selection = resolve_file_selection(context=context, chunk_skips=chunk_skips)
+
+    assert_that(selection.reviewed_paths).is_equal_to(("a.py",))
+    assert_that([entry.path for entry in selection.skipped]).is_equal_to(["b.py"])
+
+
+def test_selection_keeps_collection_stage_skips() -> None:
+    """Path-filtered files never reach ``changed_files`` but stay reported."""
+    context = _context(
+        paths=["a.py"],
+        skipped=[SkippedFile(path="docs/x.md", reason=FileSkipReason.PATH_FILTER)],
+    )
+
+    selection = resolve_file_selection(context=context)
+
+    assert_that(selection.reviewed_paths).is_equal_to(("a.py",))
+    assert_that(selection.skipped[0].reason).is_equal_to(FileSkipReason.PATH_FILTER)
+
+
+def test_selection_keeps_the_first_reason_for_a_doubly_skipped_file() -> None:
+    """A file dropped twice is explained once, by the stage that dropped it."""
+    context = _context(
+        paths=["a.py", "b.py"],
+        skipped=[SkippedFile(path="b.py", reason=FileSkipReason.PATH_FILTER)],
+    )
+    chunk_skips = [
+        SkippedFile(path="b.py", reason=FileSkipReason.REPETITIVE_DIFF),
+    ]
+
+    selection = resolve_file_selection(context=context, chunk_skips=chunk_skips)
+
+    assert_that(selection.skipped).is_length(1)
+    assert_that(selection.skipped[0].reason).is_equal_to(FileSkipReason.PATH_FILTER)
+
+
+def test_skipped_file_label_appends_detail() -> None:
+    """Detail text is folded into the rendered reason when present."""
+    entry = SkippedFile(
+        path="pkg/item9.py",
+        reason=FileSkipReason.REPETITIVE_DIFF,
+        detail="same diff hunks as `pkg/item1.py`",
+    )
+
+    assert_that(entry.label).starts_with(
+        describe_skip_reason(reason=FileSkipReason.REPETITIVE_DIFF),
+    )
+    assert_that(entry.label).contains("same diff hunks as `pkg/item1.py`")
+
+
+def test_every_skip_reason_has_a_label() -> None:
+    """A new reason cannot ship without prose explaining it to a reader."""
+    for reason in FileSkipReason:
+        assert_that(describe_skip_reason(reason=reason)).is_not_empty()

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -41,6 +41,7 @@ def _fresh_reporter() -> MagicMock:
     reporter.is_available.return_value = True
     reporter.find_issue_comment.return_value = None
     reporter.fetch_pr_diff_lines.return_value = {"src/main.py": {10}}
+    reporter.fetch_pr_commit_shas.return_value = []
     reporter.post_issue_comment.return_value = True
     reporter.update_issue_comment.return_value = True
     reporter.api_request.return_value = True

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -806,3 +806,47 @@ def test_build_sticky_survives_overflowing_finding_sets(
     assert_that(body).contains("### Open findings (400)")
     assert_that(body).contains("StickyOverflow0")
     assert_that(body).contains("more open findings not listed")
+
+
+# --- per-review comment body (#1910) ---------------------------------------
+
+
+def test_post_review_uses_the_rich_review_body(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The review event carries the #1910 body, not the old bare label."""
+    reporter = _fresh_reporter()
+    reporter.fetch_pr_commit_shas.return_value = ["aaa111", "bbb222"]
+
+    posted = post_review_to_github(
+        result=sample_review_result,
+        reporter=reporter,
+        transport="cli",
+        config_source="`.lintro-config.yaml`",
+    )
+
+    assert_that(posted).is_true()
+    payload = reporter.api_request.call_args.args[2]
+    assert_that(payload["body"]).contains("🔎 **Lintro review —")
+    assert_that(payload["body"]).contains("**📊 Run stats**")
+    assert_that(payload["body"]).contains("Config source: `.lintro-config.yaml`")
+    assert_that(payload["body"]).does_not_contain("Lintro review findings")
+
+
+def test_post_review_body_links_the_pointer_to_an_existing_sticky(
+    sample_review_result: ReviewResult,
+) -> None:
+    """When the sticky already exists, the dedup pointer links straight to it."""
+    reporter = _fresh_reporter()
+    reporter.find_issue_comment.return_value = (
+        42,
+        build_sticky_comment(result=sample_review_result),
+    )
+    reporter.fetch_pr_commit_shas.return_value = []
+
+    post_review_to_github(result=sample_review_result, reporter=reporter)
+
+    payload = reporter.api_request.call_args.args[2]
+    assert_that(payload["body"]).contains(
+        "https://github.com/owner/name/pull/7#issuecomment-42",
+    )

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import replace
 from unittest.mock import MagicMock
 
+import pytest
 from assertpy import assert_that
 
 from lintro.ai.exceptions import (
@@ -19,6 +20,7 @@ from lintro.ai.review.github import (
     STATE_MARKER_PREFIX,
     STICKY_MARKER,
     _cap_body,
+    _count_new_commits,
     _format_findings_section,
     _sticky_comment_id,
     build_sticky_comment,
@@ -33,6 +35,8 @@ from lintro.ai.review.github import (
 )
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.run_record import RunRecord
 
 
 def _fresh_reporter() -> MagicMock:
@@ -851,3 +855,53 @@ def test_post_review_body_links_the_pointer_to_an_existing_sticky(
     assert_that(payload["body"]).contains(
         "https://github.com/owner/name/pull/7#issuecomment-42",
     )
+
+
+# --- new-commit counting (#1910) -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("prior_sha", "shas", "expected"),
+    [
+        ("aaa111", ["aaa111", "bbb222", "ccc333"], 2),
+        ("ccc333", ["aaa111", "bbb222", "ccc333"], 0),
+        ("aaa111abcdef", ["aaa111", "bbb222"], 1),
+        ("zzz999", ["aaa111", "bbb222"], None),
+        ("aaa111", [], None),
+        ("", ["aaa111"], None),
+    ],
+)
+def test_count_new_commits_measures_from_the_prior_head(
+    prior_sha: str,
+    shas: list[str],
+    expected: int | None,
+) -> None:
+    """The count is commits after the prior head, or None when unresolvable."""
+    reporter = _fresh_reporter()
+    reporter.fetch_pr_commit_shas.return_value = shas
+    prior_state = ReviewState(runs=(RunRecord(round=1, sha=prior_sha),))
+
+    counted = _count_new_commits(reporter=reporter, prior_state=prior_state)
+
+    assert_that(counted).is_equal_to(expected)
+
+
+def test_count_new_commits_is_none_without_a_prior_round() -> None:
+    """Round 1 has no baseline, so no delta is claimed."""
+    reporter = _fresh_reporter()
+
+    counted = _count_new_commits(reporter=reporter, prior_state=ReviewState())
+
+    assert_that(counted).is_none()
+    reporter.fetch_pr_commit_shas.assert_not_called()
+
+
+def test_count_new_commits_is_none_when_the_listing_fails() -> None:
+    """An unavailable commit listing yields None rather than a wrong count."""
+    reporter = _fresh_reporter()
+    reporter.fetch_pr_commit_shas.return_value = None
+    prior_state = ReviewState(runs=(RunRecord(round=1, sha="aaa111"),))
+
+    assert_that(
+        _count_new_commits(reporter=reporter, prior_state=prior_state),
+    ).is_none()

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -905,3 +905,60 @@ def test_count_new_commits_is_none_when_the_listing_fails() -> None:
     assert_that(
         _count_new_commits(reporter=reporter, prior_state=prior_state),
     ).is_none()
+
+
+def test_review_body_links_a_sticky_created_in_this_same_run(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Round 1's pointer resolves the sticky that was just created (#1909/#1910).
+
+    The sticky is upserted before the inline review is posted, so by the time
+    the body is built the comment exists even on the first round — the pointer
+    must link to it rather than fall back to unlinked text.
+    """
+    reporter = _fresh_reporter()
+    reporter.fetch_pr_commit_shas.return_value = []
+    # First lookup loads prior state (no sticky yet); the second runs after the
+    # sticky has been created and finds it.
+    reporter.find_issue_comment.side_effect = [
+        None,
+        (99, build_sticky_comment(result=sample_review_result)),
+    ]
+
+    post_review_to_github(result=sample_review_result, reporter=reporter)
+
+    payload = reporter.api_request.call_args.args[2]
+    assert_that(payload["body"]).contains(
+        "https://github.com/owner/name/pull/7#issuecomment-99",
+    )
+
+
+def test_review_body_and_degraded_sticky_coexist(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A rejected inline batch still folds detail into the sticky (#1909).
+
+    The per-review body (#1910) is built inside the same branch that owns the
+    degraded path, so a regression there would silently drop either the body or
+    the fold-in.
+    """
+    reporter = _fresh_reporter()
+    reporter.fetch_pr_commit_shas.return_value = []
+    reporter.api_request.return_value = False
+    reporter.find_issue_comment.side_effect = [
+        None,
+        (77, build_sticky_comment(result=sample_review_result)),
+        (77, build_sticky_comment(result=sample_review_result)),
+    ]
+
+    posted = post_review_to_github(result=sample_review_result, reporter=reporter)
+
+    assert_that(posted).is_false()
+    # The review body still reached the (rejected) review call…
+    assert_that(reporter.api_request.call_args.args[2]["body"]).contains(
+        "🔎 **Lintro review —",
+    )
+    # …and the sticky was re-rendered with the unpostable findings folded in.
+    reporter.update_issue_comment.assert_called()
+    folded = reporter.update_issue_comment.call_args.kwargs["body"]
+    assert_that(folded).contains("could not be posted")

--- a/tests/unit/ai/review/test_github_review_body.py
+++ b/tests/unit/ai/review/test_github_review_body.py
@@ -1,0 +1,415 @@
+"""Tests for the per-review GitHub comment body (issue #1910)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from assertpy import assert_that
+
+from lintro import __version__ as lintro_version
+from lintro.ai.review.enums.file_skip_reason import FileSkipReason
+from lintro.ai.review.finding_matcher import match_findings
+from lintro.ai.review.github_review_body import (
+    REVIEW_BODY_FOOTER,
+    build_review_body,
+)
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.run_record import RunRecord
+from lintro.ai.review.models.skipped_file import SkippedFile
+
+
+def _body(
+    *,
+    result: ReviewResult,
+    prior_state: ReviewState,
+    head_sha: str = "fb740b2aaaa",
+    **kwargs: object,
+) -> str:
+    """Build a review body for ``result`` against ``prior_state``.
+
+    Args:
+        result: Review result under test.
+        prior_state: State decoded before this round.
+        head_sha: Head sha reviewed in this round.
+        **kwargs: Extra keyword arguments forwarded to ``build_review_body``.
+
+    Returns:
+        The rendered Markdown body.
+    """
+    match = match_findings(
+        previous=prior_state,
+        findings=result.findings,
+        round_number=prior_state.next_round,
+        head_sha=head_sha,
+    )
+    return build_review_body(
+        result=result,
+        prior_state=prior_state,
+        match=match,
+        head_sha=head_sha,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def _prior_state(*, rounds: int, sha: str = "484f51caaa") -> ReviewState:
+    """Build a prior state carrying ``rounds`` completed runs.
+
+    Args:
+        rounds: Number of completed rounds to record.
+        sha: Head sha of the most recent completed round.
+
+    Returns:
+        A review state whose next round is ``rounds + 1``.
+    """
+    return ReviewState(
+        runs=tuple(
+            RunRecord(round=index, sha=sha if index == rounds else f"old{index}")
+            for index in range(1, rounds + 1)
+        ),
+    )
+
+
+# --- header ----------------------------------------------------------------
+
+
+def test_header_counts_findings_and_omits_delta_on_first_round(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Round 1 has no previous round, so no resolved delta is claimed."""
+    body = _body(result=sample_review_result, prior_state=ReviewState())
+
+    assert_that(body).contains("🔎 **Lintro review — 2 findings posted**")
+    assert_that(body).contains("round 1")
+    assert_that(body).does_not_contain("resolved since round")
+
+
+def test_header_states_resolved_delta_against_previous_round(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A round that clears a prior finding reports it in the header."""
+    first = match_findings(
+        previous=ReviewState(),
+        findings=sample_review_result.findings,
+        round_number=1,
+        head_sha="484f51caaa",
+    )
+    prior_state = ReviewState(
+        runs=(RunRecord(round=1, sha="484f51caaa"),),
+        findings=first.records,
+    )
+    trimmed = replace(
+        sample_review_result,
+        findings=sample_review_result.findings[:1],
+    )
+
+    body = _body(result=trimmed, prior_state=prior_state)
+
+    assert_that(body).contains("🔎 **Lintro review — 1 finding posted**")
+    assert_that(body).contains("✔ 1 resolved since round 1")
+    assert_that(body).contains("round 2")
+
+
+def test_header_reports_zero_resolved_rather_than_hiding_the_delta(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A later round with nothing fixed says so instead of dropping the delta."""
+    first = match_findings(
+        previous=ReviewState(),
+        findings=sample_review_result.findings,
+        round_number=1,
+        head_sha="484f51caaa",
+    )
+    prior_state = ReviewState(
+        runs=(RunRecord(round=1, sha="484f51caaa"),),
+        findings=first.records,
+    )
+
+    body = _body(result=sample_review_result, prior_state=prior_state)
+
+    assert_that(body).contains("✔ 0 resolved since round 1")
+
+
+def test_header_names_the_reviewed_commit_range(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The header pins the round to a short base..head commit range."""
+    body = _body(
+        result=sample_review_result,
+        prior_state=_prior_state(rounds=2),
+    )
+
+    assert_that(body).contains("commits `484f51c..fb740b2`")
+
+
+# --- fix prompt and the dedup rule -----------------------------------------
+
+
+def test_prompt_panel_points_at_sticky_when_scopes_are_identical(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Round 1 findings are all open findings, so the panel is not duplicated."""
+    body = _body(
+        result=sample_review_result,
+        prior_state=ReviewState(),
+        sticky_url="https://github.com/owner/name/pull/7#issuecomment-1",
+    )
+
+    assert_that(body).contains("⚡ Fix prompt: identical to the")
+    assert_that(body).contains("#issuecomment-1")
+    assert_that(body).does_not_contain("Fix prompt — this round's")
+    assert_that(body).does_not_contain("Show prompt")
+
+
+def test_pointer_renders_unlinked_when_the_sticky_id_is_unknown(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A sticky created in this same run has no id yet; no dead link is emitted."""
+    body = _body(result=sample_review_result, prior_state=ReviewState())
+
+    assert_that(body).contains("sticky comment's fix-all this round")
+    assert_that(body).does_not_contain("]()")
+
+
+def test_prompt_panel_renders_when_older_findings_remain_open(
+    sample_review_result: ReviewResult,
+) -> None:
+    """With carried-over findings the two scopes differ, so both panels exist."""
+    first = match_findings(
+        previous=ReviewState(),
+        findings=sample_review_result.findings,
+        round_number=1,
+        head_sha="484f51caaa",
+    )
+    prior_state = ReviewState(
+        runs=(RunRecord(round=1, sha="484f51caaa"),),
+        findings=first.records,
+    )
+    # This round re-reports only the first finding; round 1's second finding
+    # is still open (its file was not part of this round's diff), so the
+    # sticky's all-open scope is strictly larger than this round's scope.
+    reported = replace(
+        sample_review_result,
+        findings=sample_review_result.findings[:1],
+    )
+    match = match_findings(
+        previous=prior_state,
+        findings=reported.findings,
+        round_number=2,
+        head_sha="fb740b2aaa",
+    )
+    still_open = replace(match, records=(*match.records, *first.records[1:]))
+
+    body = build_review_body(
+        result=reported,
+        prior_state=prior_state,
+        match=still_open,
+        head_sha="fb740b2aaa",
+    )
+
+    assert_that(body).contains("⚡ **Fix prompt — this round's 1 finding only**")
+    assert_that(body).contains("<details><summary>Show prompt</summary>")
+    assert_that(body).does_not_contain("identical to the")
+
+
+def test_no_prompt_section_when_the_round_found_nothing(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A clean round has nothing to fix, so neither panel nor pointer appears."""
+    clean = replace(sample_review_result, findings=())
+
+    body = _body(result=clean, prior_state=ReviewState())
+
+    assert_that(body).contains("🔎 **Lintro review — 0 findings posted**")
+    assert_that(body).does_not_contain("Fix prompt")
+
+
+# --- run stats -------------------------------------------------------------
+
+
+def test_run_stats_are_visible_and_ordered(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Stats render outside a collapsible, model first, mechanics second."""
+    body = _body(
+        result=sample_review_result,
+        prior_state=ReviewState(),
+        transport="cli",
+        auth_mode="subscription",
+    )
+
+    assert_that(body).contains("**📊 Run stats**")
+    stats_index = body.index("**📊 Run stats**")
+    details_index = body.index("<details>")
+    assert_that(stats_index).is_less_than(details_index)
+    assert_that(body).contains("| model | est. cost | tokens in | tokens out |")
+    assert_that(body).contains("cli · subscription")
+    assert_that(body).contains(f"| {lintro_version} |")
+
+
+def test_estimated_token_counts_are_marked_approximate(
+    sample_review_result: ReviewResult,
+) -> None:
+    """CLI-transport runs must not present estimates as reported figures."""
+    estimated = replace(
+        sample_review_result,
+        metadata=replace(
+            sample_review_result.metadata,
+            token_usage_estimated=True,
+        ),
+    )
+
+    body = _body(result=estimated, prior_state=ReviewState())
+
+    assert_that(body).contains("~1,000")
+    assert_that(body).contains("~$")
+
+
+def test_config_source_note_renders_when_supplied(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The config provenance note explains why stats differ from the config."""
+    body = _body(
+        result=sample_review_result,
+        prior_state=ReviewState(),
+        config_source="`.lintro-config.yaml` + CLI overrides (--timeout 600)",
+    )
+
+    assert_that(body).contains(
+        "Config source: `.lintro-config.yaml` + CLI overrides (--timeout 600)",
+    )
+
+
+def test_config_source_note_is_omitted_when_unknown(
+    sample_review_result: ReviewResult,
+) -> None:
+    """No config source is better than an empty label."""
+    body = _body(result=sample_review_result, prior_state=ReviewState())
+
+    assert_that(body).does_not_contain("Config source:")
+
+
+# --- commits ---------------------------------------------------------------
+
+
+def test_commits_section_names_the_new_commit_count(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Later rounds state how much new work they looked at, and against what."""
+    body = _body(
+        result=sample_review_result,
+        prior_state=_prior_state(rounds=2),
+        new_commits=2,
+    )
+
+    assert_that(body).contains("<details><summary>📥 Commits</summary>")
+    assert_that(body).contains(
+        "This round reviewed the 2 new commits since round 2, " "`484f51c` → `fb740b2`",
+    )
+    assert_that(body).contains("full diff against `main`")
+
+
+def test_commits_section_omits_an_unknown_count(
+    sample_review_result: ReviewResult,
+) -> None:
+    """An unavailable commit listing must not become a fabricated number."""
+    body = _body(result=sample_review_result, prior_state=_prior_state(rounds=2))
+
+    assert_that(body).contains("This round reviewed the new commits since round 2")
+
+
+def test_commits_section_describes_the_full_diff_on_round_one(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Round 1 has no previous head, so there is no delta to describe."""
+    body = _body(result=sample_review_result, prior_state=ReviewState())
+
+    assert_that(body).contains("This round reviewed the PR's full diff against `main`")
+
+
+# --- files reviewed and skip reasons ---------------------------------------
+
+
+def test_files_section_lists_skipped_files_with_reasons(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A skipped file states why, so a coverage gap cannot read as a clean pass."""
+    metadata = replace(
+        sample_review_result.metadata,
+        reviewed_paths=("src/main.py", "tests/test_main.py"),
+        skipped_files=(
+            SkippedFile(path="docs/README.md", reason=FileSkipReason.PATH_FILTER),
+            SkippedFile(
+                path="pkg/item9.py",
+                reason=FileSkipReason.REPETITIVE_DIFF,
+                detail="same diff hunks as `pkg/item1.py`",
+            ),
+        ),
+    )
+    body = _body(
+        result=replace(sample_review_result, metadata=metadata),
+        prior_state=ReviewState(),
+    )
+
+    assert_that(body).contains("📁 Files reviewed (2) · 2 skipped")
+    assert_that(body).contains("- `src/main.py`")
+    assert_that(body).contains(
+        "- `docs/README.md` — skipped (outside the requested --path filter)",
+    )
+    assert_that(body).contains("same diff hunks as `pkg/item1.py`")
+
+
+def test_files_section_reports_no_skips_when_everything_was_reviewed(
+    sample_review_result: ReviewResult,
+) -> None:
+    """With nothing skipped the summary carries no misleading skip count."""
+    metadata = replace(
+        sample_review_result.metadata,
+        reviewed_paths=("src/main.py",),
+    )
+    body = _body(
+        result=replace(sample_review_result, metadata=metadata),
+        prior_state=ReviewState(),
+    )
+
+    assert_that(body).contains("📁 Files reviewed (1)")
+    assert_that(body).does_not_contain("skipped")
+
+
+def test_files_section_is_omitted_when_no_paths_were_recorded(
+    sample_review_result: ReviewResult,
+) -> None:
+    """An empty file list is dropped rather than rendered as "0 files"."""
+    body = _body(result=sample_review_result, prior_state=ReviewState())
+
+    assert_that(body).does_not_contain("📁 Files reviewed")
+
+
+# --- footer and size -------------------------------------------------------
+
+
+def test_footer_delegates_the_other_two_surfaces(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The body ends by pointing at the surfaces it deliberately does not own."""
+    body = _body(result=sample_review_result, prior_state=ReviewState())
+
+    assert_that(body).ends_with(REVIEW_BODY_FOOTER)
+    assert_that(body).contains("sticky comment")
+    assert_that(body).contains("inline comments")
+
+
+def test_body_stays_within_the_github_comment_limit(
+    sample_review_result: ReviewResult,
+) -> None:
+    """An enormous file list is truncated with a visible marker, not silently."""
+    metadata = replace(
+        sample_review_result.metadata,
+        reviewed_paths=tuple(f"src/module_{index}.py" for index in range(5_000)),
+    )
+    body = _body(
+        result=replace(sample_review_result, metadata=metadata),
+        prior_state=ReviewState(),
+    )
+
+    assert_that(len(body)).is_less_than_or_equal_to(60_000)

--- a/tests/unit/ai/review/test_github_review_body.py
+++ b/tests/unit/ai/review/test_github_review_body.py
@@ -9,6 +9,7 @@ from assertpy import assert_that
 from lintro import __version__ as lintro_version
 from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.finding_matcher import match_findings
+from lintro.ai.review.github_constants import MAX_COMMENT_CHARS
 from lintro.ai.review.github_review_body import (
     REVIEW_BODY_FOOTER,
     build_review_body,
@@ -426,7 +427,7 @@ def test_long_file_lists_are_summarized_not_dumped(
     )
 
     assert_that(body).contains("…and 4940 more reviewed")
-    assert_that(len(body)).is_less_than_or_equal_to(60_000)
+    assert_that(len(body)).is_less_than_or_equal_to(MAX_COMMENT_CHARS)
 
 
 def test_body_truncation_leaves_a_visible_marker(
@@ -455,7 +456,7 @@ def test_body_truncation_leaves_a_visible_marker(
         head_sha="fb740b2aaa",
     )
 
-    assert_that(len(body)).is_less_than_or_equal_to(60_000)
+    assert_that(len(body)).is_less_than_or_equal_to(MAX_COMMENT_CHARS)
     assert_that(body).ends_with("✂️ Comment truncated to fit GitHub's size limit.")
 
 

--- a/tests/unit/ai/review/test_github_review_body.py
+++ b/tests/unit/ai/review/test_github_review_body.py
@@ -13,6 +13,7 @@ from lintro.ai.review.github_review_body import (
     REVIEW_BODY_FOOTER,
     build_review_body,
 )
+from lintro.ai.review.models.finding_record import FindingRecord
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.run_record import RunRecord
@@ -399,10 +400,10 @@ def test_footer_delegates_the_other_two_surfaces(
     assert_that(body).contains("inline comments")
 
 
-def test_body_stays_within_the_github_comment_limit(
+def test_long_file_lists_are_summarized_not_dumped(
     sample_review_result: ReviewResult,
 ) -> None:
-    """An enormous file list is truncated with a visible marker, not silently."""
+    """A wide PR reports a file count rather than thousands of list items."""
     metadata = replace(
         sample_review_result.metadata,
         reviewed_paths=tuple(f"src/module_{index}.py" for index in range(5_000)),
@@ -412,4 +413,35 @@ def test_body_stays_within_the_github_comment_limit(
         prior_state=ReviewState(),
     )
 
+    assert_that(body).contains("…and 4940 more reviewed")
     assert_that(len(body)).is_less_than_or_equal_to(60_000)
+
+
+def test_body_truncation_leaves_a_visible_marker(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Oversized content is cut with a marker, never silently."""
+    finding = sample_review_result.findings[0]
+    bulk = tuple(
+        replace(finding, title=f"Finding {index}", line=index + 1)
+        for index in range(4_000)
+    )
+    result = replace(sample_review_result, findings=bulk)
+    match = match_findings(
+        previous=ReviewState(),
+        findings=bulk,
+        round_number=1,
+        head_sha="fb740b2aaa",
+    )
+    # One extra still-open record makes this round a strict subset of the open
+    # set, so the full prompt panel renders instead of the sticky pointer.
+    carried = FindingRecord(fingerprint="carried", title="Older finding")
+    body = build_review_body(
+        result=result,
+        prior_state=_prior_state(rounds=1),
+        match=replace(match, records=(*match.records, carried)),
+        head_sha="fb740b2aaa",
+    )
+
+    assert_that(len(body)).is_less_than_or_equal_to(60_000)
+    assert_that(body).ends_with("✂️ Comment truncated to fit GitHub's size limit.")

--- a/tests/unit/ai/review/test_github_review_body.py
+++ b/tests/unit/ai/review/test_github_review_body.py
@@ -25,7 +25,11 @@ def _body(
     result: ReviewResult,
     prior_state: ReviewState,
     head_sha: str = "fb740b2aaaa",
-    **kwargs: object,
+    sticky_url: str = "",
+    transport: str = "",
+    auth_mode: str = "",
+    config_source: str = "",
+    new_commits: int | None = None,
 ) -> str:
     """Build a review body for ``result`` against ``prior_state``.
 
@@ -33,7 +37,11 @@ def _body(
         result: Review result under test.
         prior_state: State decoded before this round.
         head_sha: Head sha reviewed in this round.
-        **kwargs: Extra keyword arguments forwarded to ``build_review_body``.
+        sticky_url: URL of the sticky status comment.
+        transport: Provider transport used for the round.
+        auth_mode: Authentication mode used by the transport.
+        config_source: Description of where the run's settings came from.
+        new_commits: Commits pushed since the previous round.
 
     Returns:
         The rendered Markdown body.
@@ -49,7 +57,11 @@ def _body(
         prior_state=prior_state,
         match=match,
         head_sha=head_sha,
-        **kwargs,  # type: ignore[arg-type]
+        sticky_url=sticky_url,
+        transport=transport,
+        auth_mode=auth_mode,
+        config_source=config_source,
+        new_commits=new_commits,
     )
 
 
@@ -445,3 +457,29 @@ def test_body_truncation_leaves_a_visible_marker(
 
     assert_that(len(body)).is_less_than_or_equal_to(60_000)
     assert_that(body).ends_with("✂️ Comment truncated to fit GitHub's size limit.")
+
+
+def test_skip_reasons_survive_a_full_reviewed_list(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A wide reviewed list must not crowd the skip reasons out of the body.
+
+    Reviewed and skipped entries once shared one 60-slot budget, so a PR
+    touching 60+ files rendered a skip *count* with no reason beside it —
+    exactly the ambiguity this section exists to remove.
+    """
+    metadata = replace(
+        sample_review_result.metadata,
+        reviewed_paths=tuple(f"src/module_{index}.py" for index in range(200)),
+        skipped_files=(
+            SkippedFile(path="docs/README.md", reason=FileSkipReason.PATH_FILTER),
+        ),
+    )
+    body = _body(
+        result=replace(sample_review_result, metadata=metadata),
+        prior_state=ReviewState(),
+    )
+
+    assert_that(body).contains(
+        "- `docs/README.md` — skipped (outside the requested --path filter)",
+    )

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -16,6 +16,7 @@ from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import AIError
 from lintro.ai.providers.capabilities import ProviderCapabilities
 from lintro.ai.providers.response import AIResponse
+from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.enums.review_category import ReviewCategory
 from lintro.ai.review.exceptions import ReviewExecutionError
 from lintro.ai.review.group_labels import REL_SINGLE_FILE
@@ -23,6 +24,7 @@ from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.checklist_item import ChecklistItem
 from lintro.ai.review.models.review_chunk import ReviewChunk
 from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.skipped_file import SkippedFile
 from lintro.ai.review.orchestrator import (
     _review_chunk,
     build_git_native_review_prompt,
@@ -998,3 +1000,37 @@ def test_run_review_skips_durable_session_without_capability() -> None:
 
     provider.begin_durable_session.assert_not_called()
     provider.end_durable_session.assert_not_called()
+
+
+def test_run_review_metadata_records_reviewed_and_skipped_files() -> None:
+    """Run metadata carries the reviewed paths and every skip with its reason."""
+    provider = _mock_provider(content=_sample_response_json())
+    context = _one_file_context()
+    context.skipped_files = [
+        SkippedFile(path="docs/README.md", reason=FileSkipReason.PATH_FILTER),
+    ]
+
+    with patch(
+        "lintro.ai.review.orchestrator.call_ai",
+        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: provider.complete(
+            user_prompt,
+            system=system_prompt,
+            max_tokens=kwargs.get("max_tokens", 1024),
+        ),
+    ):
+        result = run_review(
+            context,
+            provider=provider,
+            ai_config=AIConfig(enabled=True),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+        )
+
+    assert_that(result.metadata.reviewed_paths).is_equal_to(("src/main.py",))
+    assert_that(result.metadata.files_reviewed).is_equal_to(1)
+    assert_that(result.metadata.files_total).is_equal_to(2)
+    assert_that(result.metadata.skipped_files[0].reason).is_equal_to(
+        FileSkipReason.PATH_FILTER,
+    )

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -1034,3 +1034,33 @@ def test_run_review_metadata_records_reviewed_and_skipped_files() -> None:
     assert_that(result.metadata.skipped_files[0].reason).is_equal_to(
         FileSkipReason.PATH_FILTER,
     )
+
+
+def test_run_review_records_files_no_custom_agent_covered() -> None:
+    """An agents-only run reports files outside every agent's scope as skipped."""
+    provider = _mock_provider(content=_sample_response_json())
+    context = _one_file_context()
+
+    with patch(
+        "lintro.ai.review.orchestrator.call_ai",
+        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: provider.complete(
+            user_prompt,
+            system=system_prompt,
+            max_tokens=kwargs.get("max_tokens", 1024),
+        ),
+    ):
+        result = run_review(
+            context,
+            provider=provider,
+            ai_config=AIConfig(enabled=True),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+            run_builtin_checklist=False,
+        )
+
+    assert_that(result.metadata.reviewed_paths).is_empty()
+    assert_that(result.metadata.skipped_files[0].reason).is_equal_to(
+        FileSkipReason.AGENT_SCOPE,
+    )

--- a/tests/unit/ai/test_github_pr.py
+++ b/tests/unit/ai/test_github_pr.py
@@ -567,3 +567,98 @@ def test_deprecated_api_request_alias_delegates(test_token: str) -> None:
 
     assert_that(result).is_true()
     mock.assert_called_once_with("POST", "https://api.github.com/x", {"a": 1})
+
+
+# --- PR commit listing (#1910) ---------------------------------------------
+
+
+def _json_response(payload: object) -> MagicMock:
+    """Build a context-manager mock returning ``payload`` as a JSON body.
+
+    Args:
+        payload: Object serialized as the response body.
+
+    Returns:
+        A MagicMock usable as an ``urlopen`` return value.
+    """
+    response = MagicMock()
+    response.read.return_value = json.dumps(payload).encode()
+    response.__enter__ = MagicMock(return_value=response)
+    response.__exit__ = MagicMock(return_value=False)
+    return response
+
+
+def test_fetch_pr_commit_shas_returns_single_page(test_token: str) -> None:
+    """A short-page response ends pagination and yields its shas in order."""
+    reporter = GitHubPRReporter(token=test_token, repo="owner/repo", pr_number=5)
+    page = [{"sha": "aaa"}, {"sha": "bbb"}]
+
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_json_response(page),
+    ) as mock_open:
+        shas = reporter.fetch_pr_commit_shas()
+
+    assert_that(shas).is_equal_to(["aaa", "bbb"])
+    assert_that(mock_open.call_count).is_equal_to(1)
+
+
+def test_fetch_pr_commit_shas_accumulates_pages(test_token: str) -> None:
+    """A full first page triggers a second fetch and both pages are kept."""
+    reporter = GitHubPRReporter(token=test_token, repo="owner/repo", pr_number=5)
+    first = [{"sha": f"sha{index}"} for index in range(100)]
+    second = [{"sha": "tail"}]
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=[_json_response(first), _json_response(second)],
+    ) as mock_open:
+        shas = reporter.fetch_pr_commit_shas()
+
+    assert_that(shas).is_length(101)
+    assert_that((shas or [])[-1]).is_equal_to("tail")
+    assert_that(mock_open.call_count).is_equal_to(2)
+
+
+def test_fetch_pr_commit_shas_skips_malformed_entries(test_token: str) -> None:
+    """Entries without a usable sha are dropped rather than stringified."""
+    reporter = GitHubPRReporter(token=test_token, repo="owner/repo", pr_number=5)
+    page = [{"sha": "aaa"}, {"sha": ""}, "not-a-dict", {"commit": {}}]
+
+    with patch("urllib.request.urlopen", return_value=_json_response(page)):
+        shas = reporter.fetch_pr_commit_shas()
+
+    assert_that(shas).is_equal_to(["aaa"])
+
+
+def test_fetch_pr_commit_shas_rejects_non_https(test_token: str) -> None:
+    """A non-HTTPS API base is refused before any request is made."""
+    reporter = GitHubPRReporter(
+        token=test_token,
+        repo="owner/repo",
+        pr_number=5,
+        api_base="http://internal.example",
+    )
+
+    with patch("urllib.request.urlopen") as mock_open:
+        shas = reporter.fetch_pr_commit_shas()
+
+    assert_that(shas).is_none()
+    mock_open.assert_not_called()
+
+
+def test_fetch_pr_commit_shas_returns_none_on_transport_error(
+    test_token: str,
+) -> None:
+    """A failed listing yields None so callers omit the count, not zero it."""
+    import urllib.error
+
+    reporter = GitHubPRReporter(token=test_token, repo="owner/repo", pr_number=5)
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("boom"),
+    ):
+        shas = reporter.fetch_pr_commit_shas()
+
+    assert_that(shas).is_none()

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -19,7 +19,11 @@ from lintro.ai.review.exceptions import ReviewExecutionError
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.cli import cli
-from lintro.cli_utils.commands.review import _merge_advisory_into_json
+from lintro.cli_utils.commands.review import (
+    _cli_overrides,
+    _describe_config_source,
+    _merge_advisory_into_json,
+)
 from lintro.models.core.tool_result import ToolResult
 from lintro.parsers.idiom_review.idiom_review_issue import IdiomReviewIssue
 
@@ -1145,3 +1149,36 @@ def test_full_review_json_merges_advisory_key() -> None:
     payload = json.loads(result.output)
     assert_that(payload["summary"]).is_equal_to("ok")
     assert_that(payload["advisory"][0]["tool"]).is_equal_to("idiom-review")
+
+
+def test_cli_overrides_lists_only_explicit_flags() -> None:
+    """Only options the caller actually passed appear as overrides."""
+    overrides = _cli_overrides(
+        depth=None,
+        strictness=None,
+        transport="cli",
+        timeout=600.0,
+        semantic_chunks=False,
+        paths=None,
+    )
+
+    assert_that(overrides).is_equal_to(["--transport cli", "--timeout 600"])
+
+
+def test_describe_config_source_names_the_file_without_its_path() -> None:
+    """An absolute CI path must not leak into a public PR comment."""
+    described = _describe_config_source(
+        config_path="/home/runner/work/repo/repo/.lintro-config.yaml",
+        overrides=["--timeout 600"],
+    )
+
+    assert_that(described).is_equal_to(
+        "`.lintro-config.yaml` + CLI overrides (--timeout 600)",
+    )
+
+
+def test_describe_config_source_falls_back_to_defaults() -> None:
+    """With no config file the note says so rather than rendering an empty name."""
+    assert_that(
+        _describe_config_source(config_path=None, overrides=[]),
+    ).is_equal_to("built-in defaults")

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -1183,3 +1183,88 @@ def test_describe_config_source_falls_back_to_defaults() -> None:
     assert_that(
         _describe_config_source(config_path=None, overrides=[]),
     ).is_equal_to("built-in defaults")
+
+
+def test_review_post_reports_config_source_and_transport() -> None:
+    """--post hands the posting layer the config file and the CLI overrides.
+
+    Driven through the CLI rather than the private helpers, so a rename of
+    those helpers cannot pass while the wiring itself has broken.
+    """
+    runner = CliRunner()
+    mock_context = MagicMock()
+    mock_context.changed_files = []
+    mock_context.unified_diff = ""
+    mock_config = MagicMock(
+        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+    )
+    mock_config.config_path = "/home/runner/work/repo/repo/.lintro-config.yaml"
+    mock_config.review.depth = 1
+    mock_config.review.strictness = ReviewStrictness.BALANCED
+    mock_config.review.sensitivity = MagicMock()
+    mock_config.review.force_semantic_chunking = False
+    mock_config.review.checklist_display = ChecklistDisplay.OFF
+
+    with (
+        patch("lintro.cli_utils.commands.review.require_ai"),
+        patch(
+            "lintro.cli_utils.commands.review.get_config",
+            return_value=mock_config,
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.collect_review_context",
+            return_value=mock_context,
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.classify_changed_files",
+            return_value=[],
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.get_all_checklist_items",
+            return_value=[],
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.select_checklist_items",
+            return_value=[],
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.format_checklist_for_prompt",
+            return_value=("", {}),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.get_provider",
+            return_value=MagicMock(model_name="gpt-4o", name="openai"),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.run_review",
+            return_value=_empty_result(),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.render_review_output",
+            return_value="",
+        ),
+        patch(
+            "lintro.ai.review.github.post_review_to_github",
+            return_value=True,
+        ) as mock_post,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "review",
+                "--post",
+                "--pr",
+                "7",
+                "--repo",
+                "owner/name",
+                "--timeout",
+                "600",
+            ],
+        )
+
+    assert_that(result.exit_code).is_equal_to(0)
+    kwargs = mock_post.call_args.kwargs
+    assert_that(kwargs["config_source"]).is_equal_to(
+        "`.lintro-config.yaml` + CLI overrides (--timeout 600)",
+    )
+    assert_that(kwargs["transport"]).is_equal_to(str(AITransport.API))

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -1158,6 +1158,7 @@ def test_cli_overrides_lists_only_explicit_flags() -> None:
         strictness=None,
         transport="cli",
         timeout=600.0,
+        context_window=None,
         semantic_chunks=False,
         paths=None,
     )

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -342,17 +342,29 @@ def test_review_exits_zero_without_p1_findings() -> None:
 def _mock_review_pipeline(
     *,
     mock_collect: MagicMock | None = None,
+    mock_config: MagicMock | None = None,
 ) -> dict[str, Any]:
-    """Return patched review dependencies for CliRunner mode wiring tests."""
+    """Return patched review dependencies for CliRunner mode wiring tests.
+
+    Args:
+        mock_collect: Replacement for the context-collection patch.
+        mock_config: Replacement lintro config. Defaults to a minimal config
+            with AI enabled; pass one to exercise config-dependent wiring
+            without duplicating the whole patch stack.
+
+    Returns:
+        Named patchers to enter around a ``CliRunner`` invocation.
+    """
     mock_context = MagicMock()
     mock_context.changed_files = []
     mock_context.unified_diff = ""
-    mock_config = MagicMock(ai={"enabled": True})
-    mock_config.review.depth = 1
-    mock_config.review.strictness = ReviewStrictness.BALANCED
-    mock_config.review.sensitivity = MagicMock()
-    mock_config.review.force_semantic_chunking = False
-    mock_config.review.checklist_display = ChecklistDisplay.OFF
+    if mock_config is None:
+        mock_config = MagicMock(ai={"enabled": True})
+        mock_config.review.depth = 1
+        mock_config.review.strictness = ReviewStrictness.BALANCED
+        mock_config.review.sensitivity = MagicMock()
+        mock_config.review.force_semantic_chunking = False
+        mock_config.review.checklist_display = ChecklistDisplay.OFF
 
     collect_patch = (
         patch(
@@ -1192,9 +1204,6 @@ def test_review_post_reports_config_source_and_transport() -> None:
     those helpers cannot pass while the wiring itself has broken.
     """
     runner = CliRunner()
-    mock_context = MagicMock()
-    mock_context.changed_files = []
-    mock_context.unified_diff = ""
     mock_config = MagicMock(
         ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
     )
@@ -1204,45 +1213,19 @@ def test_review_post_reports_config_source_and_transport() -> None:
     mock_config.review.sensitivity = MagicMock()
     mock_config.review.force_semantic_chunking = False
     mock_config.review.checklist_display = ChecklistDisplay.OFF
+    patches = _mock_review_pipeline(mock_config=mock_config)
 
     with (
-        patch("lintro.cli_utils.commands.review.require_ai"),
-        patch(
-            "lintro.cli_utils.commands.review.get_config",
-            return_value=mock_config,
-        ),
-        patch(
-            "lintro.cli_utils.commands.review.collect_review_context",
-            return_value=mock_context,
-        ),
-        patch(
-            "lintro.cli_utils.commands.review.classify_changed_files",
-            return_value=[],
-        ),
-        patch(
-            "lintro.cli_utils.commands.review.get_all_checklist_items",
-            return_value=[],
-        ),
-        patch(
-            "lintro.cli_utils.commands.review.select_checklist_items",
-            return_value=[],
-        ),
-        patch(
-            "lintro.cli_utils.commands.review.format_checklist_for_prompt",
-            return_value=("", {}),
-        ),
-        patch(
-            "lintro.cli_utils.commands.review.get_provider",
-            return_value=MagicMock(model_name="gpt-4o", name="openai"),
-        ),
-        patch(
-            "lintro.cli_utils.commands.review.run_review",
-            return_value=_empty_result(),
-        ),
-        patch(
-            "lintro.cli_utils.commands.review.render_review_output",
-            return_value="",
-        ),
+        patches["require_ai"],
+        patches["get_config"],
+        patches["collect_review_context"],
+        patches["classify_changed_files"],
+        patches["get_all_checklist_items"],
+        patches["select_checklist_items"],
+        patches["format_checklist_for_prompt"],
+        patches["get_provider"],
+        patches["run_review"],
+        patches["render_review_output"],
         patch(
             "lintro.ai.review.github.post_review_to_github",
             return_value=True,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(review): rebuild the per-review comment body
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

The review event posted with each `lintro review --post` round carried a bare
`"Lintro review findings"` string. It now carries the approved per-review layout
(mock-4 §2 of the #1905 gist):

1. **Header** — `🔎 **Lintro review — N findings posted** · ✔ n resolved since round N-1 ·
   round N · commits <base>..<head>`. The resolved delta renders on every round after the
   first, *including at zero*: omitting it would make "nothing was fixed" and "there was
   no previous round" look identical.
2. **⚡ Fix prompt panel** scoped to this round's findings (#1908's `THIS_REVIEW` scope),
   with the **dedup rule**: when this round's findings are exactly the PR's still-open
   findings (round 1, or nothing carried over), the panel is replaced by a one-line
   pointer to the sticky's fix-all, so two byte-identical prompts are never posted.
   The pointer renders unlinked when the sticky is being created in the same run and has
   no id yet, rather than emitting a dead link.
3. **📊 Run stats**, visible (not collapsed): model / est. cost / tokens in / tokens out
   on line 1, transport · auth · depth / strictness / files / checks / duration / lintro
   version on line 2, `~` marking locally-estimated values — plus a `Config source:` note.
4. **📥 Commits** collapsible naming the new-commit count, `prior → head`, and the base
   the full diff was read against. An unavailable commit listing omits the count rather
   than fabricating one.
5. **📁 Files reviewed (N) · M skipped** collapsible listing each skipped file **with the
   reason it was skipped**.
6. Footer cross-linking the sticky comment and the inline threads.

**Skip reasons required a new pipeline capability.** Nothing recorded *why* a changed file
went unreviewed — only a count could be derived, and "2 skipped" reads identically whether
it was a deliberate filter or a silent coverage gap. Added `FileSkipReason` +
`SkippedFile`, recorded at both stages that drop files (`--path` filtering during context
collection, repetitive-diff sampling in the chunker), reconciled by a new
`resolve_file_selection`, and surfaced on `ReviewMetadata.reviewed_paths` /
`.skipped_files`. `files_total` is now reviewed + skipped, so the sticky's derived
`files_skipped` becomes real instead of always zero.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1910
- Relates to #1906

## Details

- `lintro/ai/review/github_review_body.py` (new) — body assembly.
- `lintro/ai/review/file_selection.py` (new) — reviewed/skipped reconciliation; a file
  dropped by two stages keeps the earliest reason.
- `lintro/ai/review/enums/file_skip_reason.py`, `models/skipped_file.py` (new).
- `ChunkingResult.skipped` now holds `SkippedFile`s; `skipped_files` stays as a
  path-only property so existing readers are unaffected.
- `post_review_to_github` gained `transport`, `auth_mode`, and `config_source`; the CLI
  wires transport and a config-source note that names the config **file** and the CLI
  overrides, never an absolute path (a CI runner path would leak workspace layout into a
  public comment and tells the reader nothing).
- `GitHubPRReporter.fetch_pr_commit_shas()` (new) backs the commit count; failures are
  swallowed to `None`.
- Not wired here: `auth_mode` detection (subscription vs api-key) is left to the sticky
  work in #1909, which owns the `RunRecord` transport/auth fields — the parameter is
  threaded through so that PR only has to supply a value.

**Testing:** 9,058 passed / 105 skipped. New coverage: dedup rule both ways, unlinked
pointer, header delta wording (round 1 / non-zero / zero), skip-reason recording at both
stages plus reconciliation precedence, orchestrator metadata wiring, and the config-source
path-leak guard. `tests/integration/tools/pip_audit/` fails in this sandbox for lack of
network (reproduces on `main`) and is unrelated.
