### PR TITLE
feat(review): rebuild inline finding comments with a conditional fix slot

### DIFF
--- a/lintro/ai/cli_schemas.py
+++ b/lintro/ai/cli_schemas.py
@@ -117,6 +117,23 @@ REVIEW_CLI_SCHEMA: dict[str, object] = {
                     # Requested by the prompt schema; without it here the
                     # strict CLI schema would reject the field outright.
                     "suggested_code": {"type": "string"},
+                    # #1911 structured hunk. Optional like the rest: a fix that
+                    # is not a clean hunk omits it and renders as a described
+                    # one-liner instead of a committable suggestion.
+                    "suggested_change": {
+                        "type": "object",
+                        "required": ["lines", "replacement"],
+                        "additionalProperties": False,
+                        "properties": {
+                            "lines": {
+                                "type": "array",
+                                "items": {"type": "integer"},
+                                "minItems": 2,
+                                "maxItems": 2,
+                            },
+                            "replacement": {"type": "string"},
+                        },
+                    },
                     # #1925 finding-model fields. All optional: the parser
                     # degrades every one of them to a default, so a model that
                     # ignores them still produces a valid review.

--- a/lintro/ai/integrations/github_pr.py
+++ b/lintro/ai/integrations/github_pr.py
@@ -76,6 +76,43 @@ class GitHubPRReporter:
             gh_ws = os.environ.get("GITHUB_WORKSPACE", "")
             self.workspace_root = Path(gh_ws) if gh_ws else _detect_repo_root()
 
+    def _authorized_request(
+        self,
+        *,
+        url: str,
+        method: str,
+        data: bytes | None = None,
+        content_type: str = "",
+    ) -> urllib.request.Request:
+        """Build an API request whose token cannot leak to a redirect target.
+
+        ``urllib`` copies ordinary headers onto redirected requests without
+        re-checking the scheme or the host, so a ``302`` to ``http://…`` would
+        replay the ``Authorization`` header in cleartext to an arbitrary origin
+        (CWE-319). Adding it as an *unredirected* header is urllib's mechanism
+        for exactly this: the token is sent to the URL validated here and to no
+        other. A redirected GitHub endpoint (a renamed repository, say) then
+        answers 401 and the caller degrades — the token stays put either way.
+
+        Args:
+            url: Fully-built request URL. The caller validates its scheme.
+            method: HTTP method.
+            data: Optional request body.
+            content_type: Optional ``Content-Type`` for a request with a body.
+
+        Returns:
+            The prepared request.
+        """
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if content_type:
+            headers["Content-Type"] = content_type
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        req.add_unredirected_header("Authorization", f"Bearer {self.token}")
+        return req
+
     def is_available(self) -> bool:
         """Check whether all required context is present.
 
@@ -211,15 +248,7 @@ class GitHubPRReporter:
         page = 1
         while True:
             url = f"{base_url}?per_page=100&page={page}"
-            req = urllib.request.Request(
-                url,
-                method="GET",
-                headers={
-                    "Authorization": f"Bearer {self.token}",
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
-            )
+            req = self._authorized_request(url=url, method="GET")
             try:
                 with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
                     req,
@@ -262,52 +291,42 @@ class GitHubPRReporter:
             or ``None`` when the shas are unusable or the comparison cannot be
             fetched. ``None`` is a refusal, not an empty diff: callers must not
             read it as "nothing changed".
+
+            Deliberately a single unpaginated request. Unlike the PR *files*
+            endpoint, the compare endpoint paginates its ``commits`` array, not
+            its ``files`` array, which GitHub caps server-side at 300 entries.
+            Walking ``page`` here would re-request commits and tell us nothing
+            new about files. A comparison wider than that cap simply yields
+            fewer committable suggestions, which is the safe direction: those
+            findings fall back to a described fix.
         """
         if not _SHA_RE.fullmatch(base) or not _SHA_RE.fullmatch(head):
             logger.debug("Refusing to compare non-sha refs: {}...{}", base, head)
             return None
-        base_url = f"{self.api_base}/repos/{self.repo}/compare/{base}...{head}"
-        parsed = urllib.parse.urlparse(base_url)
+        url = f"{self.api_base}/repos/{self.repo}/compare/{base}...{head}"
+        parsed = urllib.parse.urlparse(url)
         if parsed.scheme != "https":
             return None
 
-        all_files: list[dict[str, Any]] = []
-        page = 1
-        while True:
-            url = f"{base_url}?per_page=100&page={page}"
-            req = urllib.request.Request(
-                url,
-                method="GET",
-                headers={
-                    "Authorization": f"Bearer {self.token}",
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
+        req = self._authorized_request(url=url, method="GET")
+        try:
+            with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
+                req,
+                timeout=30,
+            ) as resp:
+                payload = json.loads(resp.read().decode())
+        except (urllib.error.URLError, json.JSONDecodeError, OSError):
+            logger.debug(
+                "Failed to compare {}...{}; treating this round's diff as unknown",
+                base,
+                head,
             )
-            try:
-                with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
-                    req,
-                    timeout=30,
-                ) as resp:
-                    payload = json.loads(resp.read().decode())
-            except (urllib.error.URLError, json.JSONDecodeError, OSError):
-                logger.debug(
-                    "Failed to compare {}...{}; treating this round's diff as "
-                    "unknown",
-                    base,
-                    head,
-                )
-                return None
+            return None
 
-            files_page = payload.get("files") if isinstance(payload, dict) else None
-            if not isinstance(files_page, list) or not files_page:
-                break
-            all_files.extend(files_page)
-            if len(files_page) < 100:
-                break
-            page += 1
-
-        return _files_to_lines(files=all_files)
+        files = payload.get("files") if isinstance(payload, dict) else None
+        if not isinstance(files, list):
+            return None
+        return _files_to_lines(files=files)
 
     def fetch_pr_commit_shas(self) -> list[str] | None:
         """Fetch the PR's commit shas, oldest first.
@@ -329,15 +348,7 @@ class GitHubPRReporter:
         page = 1
         while True:
             url = f"{base_url}?per_page=100&page={page}"
-            req = urllib.request.Request(
-                url,
-                method="GET",
-                headers={
-                    "Authorization": f"Bearer {self.token}",
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
-            )
+            req = self._authorized_request(url=url, method="GET")
             try:
                 with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
                     req,
@@ -382,15 +393,7 @@ class GitHubPRReporter:
         page = 1
         while True:
             url = f"{base_url}?per_page=100&page={page}"
-            req = urllib.request.Request(
-                url,
-                method="GET",
-                headers={
-                    "Authorization": f"Bearer {self.token}",
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
-            )
+            req = self._authorized_request(url=url, method="GET")
             try:
                 with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
                     req,
@@ -454,16 +457,11 @@ class GitHubPRReporter:
             True if the request succeeded (2xx status).
         """
         data = json.dumps(payload).encode()
-        req = urllib.request.Request(
-            url,
-            data=data,
+        req = self._authorized_request(
+            url=url,
             method=method,
-            headers={
-                "Authorization": f"Bearer {self.token}",
-                "Accept": "application/vnd.github+json",
-                "Content-Type": "application/json",
-                "X-GitHub-Api-Version": "2022-11-28",
-            },
+            data=data,
+            content_type="application/json",
         )
         parsed = urllib.parse.urlparse(url)
         if parsed.scheme != "https":

--- a/lintro/ai/integrations/github_pr.py
+++ b/lintro/ai/integrations/github_pr.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -21,6 +22,10 @@ from loguru import logger
 from lintro.ai.enums import ConfidenceLevel
 from lintro.ai.models import AIFixSuggestion, AISummary
 from lintro.ai.paths import OUTSIDE_WORKSPACE_SENTINEL, to_provider_path
+
+#: Commit shas are interpolated into a compare URL, so only hex refs are
+#: accepted — a branch name or user-supplied ref must not reach path building.
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{4,40}$")
 
 
 class GitHubPRReporter:
@@ -232,14 +237,75 @@ class GitHubPRReporter:
                 break
             page += 1
 
-        result: dict[str, set[int]] = {}
-        for f in all_files:
-            filename = f.get("filename", "")
-            patch = f.get("patch", "")
-            if not filename or not patch:
-                continue
-            result[filename] = _parse_patch_lines(patch)
-        return result
+        return _files_to_lines(files=all_files)
+
+    def fetch_compare_lines(
+        self,
+        *,
+        base: str,
+        head: str,
+    ) -> dict[str, set[int]] | None:
+        """Fetch the changed lines between two commits.
+
+        Used to establish *this round's* posted diff (#1911): a committable
+        ``suggestion`` block is only valid on lines the round actually pushed,
+        which is a strictly smaller set than the PR's cumulative diff.
+
+        Args:
+            base: Base commit sha (the previously reviewed head).
+            head: Head commit sha for this round.
+
+        Returns:
+            Mapping of ``{file_path: {line_numbers...}}`` for right-side lines,
+            or ``None`` when the shas are unusable or the comparison cannot be
+            fetched. ``None`` is a refusal, not an empty diff: callers must not
+            read it as "nothing changed".
+        """
+        if not _SHA_RE.match(base) or not _SHA_RE.match(head):
+            logger.debug("Refusing to compare non-sha refs: {}...{}", base, head)
+            return None
+        base_url = f"{self.api_base}/repos/{self.repo}/compare/{base}...{head}"
+        parsed = urllib.parse.urlparse(base_url)
+        if parsed.scheme != "https":
+            return None
+
+        all_files: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            url = f"{base_url}?per_page=100&page={page}"
+            req = urllib.request.Request(
+                url,
+                method="GET",
+                headers={
+                    "Authorization": f"Bearer {self.token}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+            )
+            try:
+                with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
+                    req,
+                    timeout=30,
+                ) as resp:
+                    payload = json.loads(resp.read().decode())
+            except (urllib.error.URLError, json.JSONDecodeError, OSError):
+                logger.debug(
+                    "Failed to compare {}...{}; treating this round's diff as "
+                    "unknown",
+                    base,
+                    head,
+                )
+                return None
+
+            files_page = payload.get("files") if isinstance(payload, dict) else None
+            if not isinstance(files_page, list) or not files_page:
+                break
+            all_files.extend(files_page)
+            if len(files_page) < 100:
+                break
+            page += 1
+
+        return _files_to_lines(files=all_files)
 
     def fetch_pr_commit_shas(self) -> list[str] | None:
         """Fetch the PR's commit shas, oldest first.
@@ -507,6 +573,27 @@ def _detect_repo_root() -> Path | None:
         return None
 
 
+def _files_to_lines(*, files: Sequence[dict[str, Any]]) -> dict[str, set[int]]:
+    """Reduce a GitHub files listing to right-side changed lines per path.
+
+    Args:
+        files: Entries from a ``files`` array (PR files or a comparison).
+
+    Returns:
+        Mapping of file path to the right-side line numbers it changed. Entries
+        without a path or without a patch (binary files, or files too large for
+        GitHub to render) are omitted.
+    """
+    result: dict[str, set[int]] = {}
+    for entry in files:
+        filename = entry.get("filename", "")
+        patch = entry.get("patch", "")
+        if not filename or not patch:
+            continue
+        result[filename] = _parse_patch_lines(patch)
+    return result
+
+
 def _parse_patch_lines(patch: str) -> set[int]:
     """Extract right-side (new) line numbers from a unified diff patch.
 
@@ -516,8 +603,6 @@ def _parse_patch_lines(patch: str) -> set[int]:
     Returns:
         Set of line numbers on the right side of the diff.
     """
-    import re
-
     lines: set[int] = set()
     current_line = 0
     for raw_line in patch.split("\n"):

--- a/lintro/ai/integrations/github_pr.py
+++ b/lintro/ai/integrations/github_pr.py
@@ -25,7 +25,9 @@ from lintro.ai.paths import OUTSIDE_WORKSPACE_SENTINEL, to_provider_path
 
 #: Commit shas are interpolated into a compare URL, so only hex refs are
 #: accepted — a branch name or user-supplied ref must not reach path building.
-_SHA_RE = re.compile(r"^[0-9a-fA-F]{4,40}$")
+#: Matched with ``fullmatch``: ``$`` alone would admit a trailing newline, and
+#: a control character in the URL makes ``Request`` raise outside the handler.
+_SHA_RE = re.compile(r"[0-9a-fA-F]{4,40}")
 
 
 class GitHubPRReporter:
@@ -261,7 +263,7 @@ class GitHubPRReporter:
             fetched. ``None`` is a refusal, not an empty diff: callers must not
             read it as "nothing changed".
         """
-        if not _SHA_RE.match(base) or not _SHA_RE.match(head):
+        if not _SHA_RE.fullmatch(base) or not _SHA_RE.fullmatch(head):
             logger.debug("Refusing to compare non-sha refs: {}...{}", base, head)
             return None
         base_url = f"{self.api_base}/repos/{self.repo}/compare/{base}...{head}"
@@ -581,16 +583,21 @@ def _files_to_lines(*, files: Sequence[dict[str, Any]]) -> dict[str, set[int]]:
 
     Returns:
         Mapping of file path to the right-side line numbers it changed. Entries
-        without a path or without a patch (binary files, or files too large for
-        GitHub to render) are omitted.
+        that are not mappings are skipped rather than raising — the caller's
+        error handling does not wrap this reduction. Entries without a path or
+        without a patch (binary files, or files too large for GitHub to render)
+        are omitted. A filename appearing on more than one page has its line
+        sets merged, not overwritten.
     """
     result: dict[str, set[int]] = {}
     for entry in files:
+        if not isinstance(entry, dict):
+            continue
         filename = entry.get("filename", "")
         patch = entry.get("patch", "")
         if not filename or not patch:
             continue
-        result[filename] = _parse_patch_lines(patch)
+        result.setdefault(filename, set()).update(_parse_patch_lines(patch))
     return result
 
 

--- a/lintro/ai/integrations/github_pr.py
+++ b/lintro/ai/integrations/github_pr.py
@@ -593,6 +593,11 @@ def _files_to_lines(*, files: Sequence[dict[str, Any]]) -> dict[str, set[int]]:
             continue
         filename = entry.get("filename", "")
         patch = entry.get("patch", "")
+        # Type, not merely truthiness: a list ``filename`` is unhashable and a
+        # non-string ``patch`` has no ``split``. Either would raise from outside
+        # the caller's handler instead of degrading to a described fix.
+        if not isinstance(filename, str) or not isinstance(patch, str):
+            continue
         if not filename or not patch:
             continue
         result.setdefault(filename, set()).update(_parse_patch_lines(patch))

--- a/lintro/ai/prompts/templates/review/output_rules.md
+++ b/lintro/ai/prompts/templates/review/output_rules.md
@@ -49,8 +49,8 @@
   included. A partial replacement silently deletes the lines it omits. Omit the object
   entirely when the fix needs edits elsewhere, spans non-contiguous lines, or cannot be
   written out verbatim — a described fix is better than a wrong one-click commit. Keep
-  `replacement` under 4,000 characters and the range under 200 lines; anything larger is
-  dropped and rendered as a described fix anyway.
+  `replacement` to at most 4,000 characters and the range to at most 200 lines; anything
+  larger is dropped and rendered as a described fix anyway.
 - There is no cap on findings, but **do not report the same problem twice**. When one
   problem repeats across locations, report it once and list every location in
   `occurrences` as `file`/`line` pairs — including the primary one. It renders as a

--- a/lintro/ai/prompts/templates/review/output_rules.md
+++ b/lintro/ai/prompts/templates/review/output_rules.md
@@ -43,6 +43,12 @@
   native linters in the same check run, so reporting them is pure noise. The one
   exception is correctness-adjacent style: shadowed names, misleading identifiers, and
   confusing API misuse stay in scope as P3 `code-smell`.
+- Include `suggested_change` **only** when the fix is a clean hunk: `lines` is the
+  inclusive `[start, end]` range it replaces (the finding's own `line` must fall inside
+  it) and `replacement` is the *complete* new text for exactly those lines, indentation
+  included. A partial replacement silently deletes the lines it omits. Omit the object
+  entirely when the fix needs edits elsewhere, spans non-contiguous lines, or cannot be
+  written out verbatim — a described fix is better than a wrong one-click commit.
 - There is no cap on findings, but **do not report the same problem twice**. When one
   problem repeats across locations, report it once and list every location in
   `occurrences` as `file`/`line` pairs — including the primary one. It renders as a

--- a/lintro/ai/prompts/templates/review/output_rules.md
+++ b/lintro/ai/prompts/templates/review/output_rules.md
@@ -48,7 +48,9 @@
   it) and `replacement` is the *complete* new text for exactly those lines, indentation
   included. A partial replacement silently deletes the lines it omits. Omit the object
   entirely when the fix needs edits elsewhere, spans non-contiguous lines, or cannot be
-  written out verbatim — a described fix is better than a wrong one-click commit.
+  written out verbatim — a described fix is better than a wrong one-click commit. Keep
+  `replacement` under 4,000 characters and the range under 200 lines; anything larger is
+  dropped and rendered as a described fix anyway.
 - There is no cap on findings, but **do not report the same problem twice**. When one
   problem repeats across locations, report it once and list every location in
   `occurrences` as `file`/`line` pairs — including the primary one. It renders as a

--- a/lintro/ai/prompts/templates/review/output_schema.json
+++ b/lintro/ai/prompts/templates/review/output_schema.json
@@ -39,6 +39,10 @@
       "failure_scenario": "REQUIRED for P1 — the concrete mechanism by which this fails (inputs, path taken, observable result); else empty string",
       "fix": "Concise fix suggestion",
       "suggested_code": "Exact replacement for the flagged line(s) when a mechanical fix applies (one-click GitHub suggestion); else empty string",
+      "suggested_change": {
+        "lines": [123, 124],
+        "replacement": "Full replacement text for exactly those lines; omit the whole object when the fix is not a clean hunk"
+      },
       "evidence_style": "diff_local|cross_file|speculative",
       "occurrences": [{ "file": "path/to/file", "line": 123 }],
       "confidence": "high|medium|low",

--- a/lintro/ai/review/agent_prompts.py
+++ b/lintro/ai/review/agent_prompts.py
@@ -423,8 +423,11 @@ def _suggested_change_section(*, change: SuggestedChange) -> str:
             f"suggestion block — replace {span} with the following, verbatim:"
         ),
     )
+    # Deliberately uncapped: the suggestion block renders the replacement in
+    # full, and the whole point of this section is that the two are identical.
+    # ``plan_inline_fix`` already bounds the total to MAX_REPLACEMENT_CHARS.
     replacement = "\n".join(
-        f"{_CONTINUATION_INDENT}{sanitize_comment_text(line, limit=_TEXT_LIMIT)}"
+        f"{_CONTINUATION_INDENT}{sanitize_comment_text(line)}"
         for line in change.replacement.splitlines() or [""]
     )
     return f"{header}\n{replacement}"

--- a/lintro/ai/review/agent_prompts.py
+++ b/lintro/ai/review/agent_prompts.py
@@ -410,7 +410,8 @@ def _suggested_change_section(*, change: SuggestedChange) -> str:
         change: The change rendered as the comment's suggestion block.
 
     Returns:
-        Prompt lines naming the range and the exact replacement text.
+        Prompt lines naming the range, then the replacement in its own fenced
+        block, byte-for-byte as the suggestion renders it.
     """
     span = (
         f"line {change.start_line}"
@@ -423,14 +424,18 @@ def _suggested_change_section(*, change: SuggestedChange) -> str:
             f"suggestion block — replace {span} with the following, verbatim:"
         ),
     )
-    # Deliberately uncapped: the suggestion block renders the replacement in
-    # full, and the whole point of this section is that the two are identical.
-    # ``plan_inline_fix`` already bounds the total to MAX_REPLACEMENT_CHARS.
-    replacement = "\n".join(
-        f"{_CONTINUATION_INDENT}{sanitize_comment_text(line)}"
-        for line in change.replacement.splitlines() or [""]
+    # Rendered raw: no continuation indent and no per-line truncation. Both
+    # would silently corrupt an indentation-sensitive replacement, and the
+    # suggestion block applies neither — the two paths have to produce
+    # identical code. Only mention-neutralization is applied, matching
+    # ``_suggestion_block``; ``plan_inline_fix`` already bounds the total size.
+    # The fence is sized against the text so a replacement containing its own
+    # backticks cannot close it early.
+    body = "\n".join(
+        sanitize_comment_text(line) for line in change.replacement.splitlines() or [""]
     )
-    return f"{header}\n{replacement}"
+    fence = _fence_for(text=body)
+    return f"{header}\n{fence}\n{body}\n{fence}"
 
 
 def render_finding_prompt(

--- a/lintro/ai/review/agent_prompts.py
+++ b/lintro/ai/review/agent_prompts.py
@@ -23,9 +23,10 @@ import textwrap
 
 from lintro.ai.review.enums.agent_prompt_scope_kind import AgentPromptScopeKind
 from lintro.ai.review.enums.evidence_style import EvidenceStyle
-from lintro.ai.review.github_render import sanitize_comment_text
 from lintro.ai.review.models.agent_prompt_scope import AgentPromptScope
 from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.suggested_change import SuggestedChange
+from lintro.ai.review.sanitize import sanitize_comment_text
 
 __all__ = [
     "SPECULATIVE_NOTICE",
@@ -396,20 +397,63 @@ def render_agent_prompt(
     return "\n\n".join(sections)
 
 
-def render_finding_prompt(*, finding: ReviewFinding) -> str:
+def _suggested_change_section(*, change: SuggestedChange) -> str:
+    """Render the block tying a prompt to this comment's suggestion block.
+
+    An inline comment in mode A (#1911) carries both a committable suggestion
+    and this prompt. They must specify the *same* edit: a reviewer who commits
+    the suggestion and an agent handed the prompt have to end up with identical
+    code, so the prompt restates the replacement verbatim instead of
+    paraphrasing it.
+
+    Args:
+        change: The change rendered as the comment's suggestion block.
+
+    Returns:
+        Prompt lines naming the range and the exact replacement text.
+    """
+    span = (
+        f"line {change.start_line}"
+        if not change.is_multiline
+        else f"lines {change.start_line}-{change.end_line}"
+    )
+    header = _wrap(
+        text=(
+            "Apply exactly the change already proposed in this comment's "
+            f"suggestion block — replace {span} with the following, verbatim:"
+        ),
+    )
+    replacement = "\n".join(
+        f"{_CONTINUATION_INDENT}{sanitize_comment_text(line, limit=_TEXT_LIMIT)}"
+        for line in change.replacement.splitlines() or [""]
+    )
+    return f"{header}\n{replacement}"
+
+
+def render_finding_prompt(
+    *,
+    finding: ReviewFinding,
+    suggested_change: SuggestedChange | None = None,
+) -> str:
     """Render the single-finding agent prompt used by inline comments.
 
     Args:
         finding: Finding the inline comment is anchored to.
+        suggested_change: The change the same comment renders as a committable
+            suggestion block, when it has one. Restated verbatim so the prompt
+            and the suggestion cannot drift apart.
 
     Returns:
         Plain-text prompt body scoped to exactly this finding, or an empty
         string when the entry is a question — questions get no prompt panel.
     """
-    return render_agent_prompt(
+    prompt = render_agent_prompt(
         findings=(finding,),
         scope=AgentPromptScope(kind=AgentPromptScopeKind.SINGLE_FINDING),
     )
+    if not prompt or suggested_change is None:
+        return prompt
+    return f"{prompt}\n\n{_suggested_change_section(change=suggested_change)}"
 
 
 def render_prompt_panel(*, prompt: str, title: str, footer: str = "") -> str:
@@ -477,12 +521,16 @@ def render_agent_prompt_panel(
 def render_finding_prompt_panel(
     *,
     finding: ReviewFinding,
+    suggested_change: SuggestedChange | None = None,
     footer: str | None = None,
 ) -> str:
     """Render the single-finding prompt panel used by inline comments.
 
     Args:
         finding: Finding the inline comment is anchored to.
+        suggested_change: The change the same comment renders as a committable
+            suggestion block, when it has one (#1911). The prompt then restates
+            that exact replacement so both paths apply the identical fix.
         footer: Small-print line under the collapsed body. Defaults to the
             single-finding footer; pass ``""`` to omit it.
 
@@ -490,10 +538,17 @@ def render_finding_prompt_panel(
         Markdown for the panel, or an empty string when the entry is a
         question.
     """
-    return render_agent_prompt_panel(
-        findings=(finding,),
-        scope=AgentPromptScope(kind=AgentPromptScopeKind.SINGLE_FINDING),
-        footer=footer,
+    scope = AgentPromptScope(kind=AgentPromptScopeKind.SINGLE_FINDING)
+    prompt = render_finding_prompt(
+        finding=finding,
+        suggested_change=suggested_change,
+    )
+    if not prompt:
+        return ""
+    return render_prompt_panel(
+        prompt=prompt,
+        title=_panel_title(scope=scope, count=1),
+        footer=_FOOTERS[scope.kind] if footer is None else footer,
     )
 
 

--- a/lintro/ai/review/enums/fix_mode.py
+++ b/lintro/ai/review/enums/fix_mode.py
@@ -1,0 +1,22 @@
+"""Rendering mode for an inline finding comment's fix slot."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+
+class FixMode(StrEnum):
+    """Which fix affordance an inline finding comment renders (#1911).
+
+    The inline comment format has one conditional slot: either a committable
+    GitHub ``suggestion`` block or a highlighted one-line fix description.
+
+    Attributes:
+        SUGGESTION: Mode A — a validated ``suggestion`` block the reviewer can
+            commit in one click.
+        DESCRIBED: Mode B — a ``**Fix:**`` one-liner, used whenever a
+            committable suggestion is unavailable or would be rejected.
+    """
+
+    SUGGESTION = auto()
+    DESCRIBED = auto()

--- a/lintro/ai/review/enums/suggestion_rejection.py
+++ b/lintro/ai/review/enums/suggestion_rejection.py
@@ -18,6 +18,9 @@ class SuggestionRejection(StrEnum):
         EMPTY_REPLACEMENT: The replacement is blank, which would delete the
             anchored lines rather than fix them.
         INVALID_RANGE: The line range is not a positive, ordered span.
+        SPAN_TOO_LARGE: The range names more lines than one suggestion may
+            plausibly replace; expanding it would be the model's decision, not
+            the renderer's.
         REPLACEMENT_TOO_LARGE: The replacement is big enough to threaten
             GitHub's comment size limit, which would cost the reader the
             reasoning as well as the suggestion.
@@ -34,6 +37,7 @@ class SuggestionRejection(StrEnum):
     NO_SUGGESTED_CHANGE = auto()
     EMPTY_REPLACEMENT = auto()
     INVALID_RANGE = auto()
+    SPAN_TOO_LARGE = auto()
     REPLACEMENT_TOO_LARGE = auto()
     ANCHOR_OUTSIDE_RANGE = auto()
     CARRIED_OVER = auto()

--- a/lintro/ai/review/enums/suggestion_rejection.py
+++ b/lintro/ai/review/enums/suggestion_rejection.py
@@ -1,0 +1,41 @@
+"""Reasons a committable suggestion was not offered on an inline comment."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+
+class SuggestionRejection(StrEnum):
+    """Why mode A was rejected in favour of mode B (#1911).
+
+    GitHub silently drops an invalid ``suggestion`` block — or rejects the
+    whole review batch — so every rejection is named rather than folded into a
+    single boolean, and the reason is logged when a fix that looked mechanical
+    could not be offered as one click.
+
+    Attributes:
+        NO_SUGGESTED_CHANGE: The finding carries no replacement text at all.
+        EMPTY_REPLACEMENT: The replacement is blank, which would delete the
+            anchored lines rather than fix them.
+        INVALID_RANGE: The line range is not a positive, ordered span.
+        REPLACEMENT_TOO_LARGE: The replacement is big enough to threaten
+            GitHub's comment size limit, which would cost the reader the
+            reasoning as well as the suggestion.
+        ANCHOR_OUTSIDE_RANGE: The finding's own line falls outside the range,
+            so the comment could not be anchored to exactly those lines.
+        CARRIED_OVER: The finding was already reported in an earlier round; its
+            thread is not anchored to this round's posted diff.
+        NO_ROUND_DIFF: This round's diff could not be determined, so no line
+            can be shown to be committable.
+        LINES_NOT_IN_ROUND_DIFF: At least one replaced line was not changed by
+            this round's posted diff.
+    """
+
+    NO_SUGGESTED_CHANGE = auto()
+    EMPTY_REPLACEMENT = auto()
+    INVALID_RANGE = auto()
+    REPLACEMENT_TOO_LARGE = auto()
+    ANCHOR_OUTSIDE_RANGE = auto()
+    CARRIED_OVER = auto()
+    NO_ROUND_DIFF = auto()
+    LINES_NOT_IN_ROUND_DIFF = auto()

--- a/lintro/ai/review/finding_parser.py
+++ b/lintro/ai/review/finding_parser.py
@@ -13,6 +13,7 @@ from lintro.ai.review.enums.evidence_style import EvidenceStyle
 from lintro.ai.review.enums.finding_kind import FindingKind
 from lintro.ai.review.models.finding_occurrence import parse_occurrences
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
+from lintro.ai.review.models.suggested_change import parse_suggested_change
 from lintro.ai.review.narrative_parser import collapse_to_single_line
 from lintro.ai.review.severity_gate import apply_p1_evidence_gate
 
@@ -160,10 +161,10 @@ def parse_findings(
     Returns:
         Parsed findings in payload order. Non-mapping entries are dropped.
         Every field added by #1925 (``kind``, ``failure_scenario``,
-        ``evidence_style``, ``occurrences``) is optional and degrades to its
-        default. Unless ``severity_override`` is set, the P1 evidence gate
-        runs: a P1 without a concrete failure scenario comes back as a marked
-        P2.
+        ``evidence_style``, ``occurrences``) and by #1911
+        (``suggested_change``) is optional and degrades to its default.
+        Unless ``severity_override`` is set, the P1 evidence gate runs: a P1
+        without a concrete failure scenario comes back as a marked P2.
     """
     if not isinstance(raw_findings, list):
         return ()
@@ -215,6 +216,9 @@ def parse_findings(
                     raw=item.get("evidence_style", ""),
                 ),
                 occurrences=parse_occurrences(item.get("occurrences")),
+                suggested_change=parse_suggested_change(
+                    item.get("suggested_change"),
+                ),
             ),
         )
     if severity_override is not None:

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -2,7 +2,7 @@
 
 Renders a rich, telemetry-informative sticky comment (one per PR, updated in
 place) with a severity-count header, TL;DR, per-finding blocks (severity color
-emoji, category/confidence chips, collapsible cause/fix), an always-visible
+emoji, category/confidence chips, visible reasoning), an always-visible
 cumulative telemetry header, per-run mechanics with exact vs approximate (``~``)
 labeling, and a machine-readable state block. All model-derived text is
 sanitized (``@mentions`` neutralized, size capped) since it comes from an
@@ -21,7 +21,7 @@ from loguru import logger
 
 from lintro.ai.integrations.github_pr import GitHubPRReporter
 from lintro.ai.review.enums.checklist_display import ChecklistDisplay
-from lintro.ai.review.finding_matcher import match_findings
+from lintro.ai.review.finding_matcher import fingerprint_for, match_findings
 from lintro.ai.review.github_constants import (
     GITHUB_COMMENT_HARD_LIMIT,
     MAX_COMMENT_CHARS,
@@ -47,6 +47,11 @@ from lintro.ai.review.github_sticky import (
     build_sticky_comment,
     parse_review_state,
     parse_review_state_v2,
+)
+from lintro.ai.review.inline_fix import (
+    finding_suggested_change,
+    normalize_diff_path,
+    plan_inline_fix,
 )
 from lintro.ai.review.models.inline_post_failure import InlinePostFailure
 from lintro.ai.review.models.review_finding import ReviewFinding
@@ -136,6 +141,15 @@ def post_review_to_github(
         findings=result.findings,
         diff_lines=diff_lines,
     )
+    # Matching is pure and deterministic over (prior_state, findings), so the
+    # sticky, the review body and the inline comments all recompute the same
+    # transitions and cannot disagree about what is new or carried over.
+    match = match_findings(
+        previous=prior_state,
+        findings=result.findings,
+        round_number=prior_state.next_round,
+        head_sha=head_sha,
+    )
 
     # A finding that maps to no line in the diff never gets an inline comment,
     # so the sticky is its only surface from the outset — fold its detail in
@@ -157,15 +171,7 @@ def post_review_to_github(
         review_body = build_review_body(
             result=result,
             prior_state=prior_state,
-            # Matching is pure and deterministic over (prior_state, findings),
-            # so recomputing it here yields exactly what the sticky persisted —
-            # the two surfaces cannot disagree about what is new or resolved.
-            match=match_findings(
-                previous=prior_state,
-                findings=result.findings,
-                round_number=prior_state.next_round,
-                head_sha=head_sha,
-            ),
+            match=match,
             head_sha=head_sha,
             sticky_url=_sticky_url(
                 reporter=gh_reporter,
@@ -188,6 +194,15 @@ def post_review_to_github(
             checklist_display=checklist_display,
             question_map=prompt_questions,
             review_body=review_body,
+            round_diff_lines=_round_diff_lines(
+                reporter=gh_reporter,
+                prior_state=prior_state,
+                diff_lines=diff_lines,
+                head_sha=head_sha,
+            ),
+            carried_fingerprints=frozenset(
+                record.fingerprint for record in match.carried
+            ),
         ):
             success = False
             # Degraded path (#1909): the rejected findings now have no surface
@@ -435,6 +450,40 @@ def _upsert_sticky(
     return reporter.post_issue_comment(body)
 
 
+def _round_diff_lines(
+    *,
+    reporter: GitHubPRReporter,
+    prior_state: ReviewState,
+    diff_lines: dict[str, set[int]] | None,
+    head_sha: str,
+) -> dict[str, set[int]] | None:
+    """Determine the lines this round's posted diff changed (#1911).
+
+    A committable ``suggestion`` block is only valid where the review comment
+    is anchored to a line this round posted. On round 1 that is the whole PR
+    diff. Afterwards it is only what arrived since the previously reviewed
+    head, so a finding sitting on untouched code loses its one-click fix even
+    though the line is still inside the PR's cumulative diff.
+
+    Args:
+        reporter: GitHub reporter used to compare commits.
+        prior_state: State decoded from the sticky comment before this round.
+        diff_lines: The PR's cumulative diff lines.
+        head_sha: This round's head commit sha.
+
+    Returns:
+        Lines changed by this round, or ``None`` when the round's diff cannot
+        be established — every suggestion then falls back to a described fix
+        rather than risking a suggestion GitHub will reject.
+    """
+    if not prior_state.runs:
+        return diff_lines
+    prior_sha = prior_state.runs[-1].sha
+    if not prior_sha or not head_sha:
+        return None
+    return reporter.fetch_compare_lines(base=prior_sha, head=head_sha)
+
+
 def _post_inline_findings(
     *,
     reporter: GitHubPRReporter,
@@ -442,8 +491,16 @@ def _post_inline_findings(
     checklist_display: ChecklistDisplay,
     question_map: dict[int, str],
     review_body: str = "",
+    round_diff_lines: dict[str, set[int]] | None = None,
+    carried_fingerprints: frozenset[str] = frozenset(),
 ) -> bool:
     """Post inline PR review comments for mappable findings.
+
+    Each comment's fix slot is chosen by :func:`plan_inline_fix`. A comment in
+    mode A is anchored to *exactly* the lines its suggestion replaces — a
+    multi-line change carries ``start_line``/``line`` rather than a single
+    ``line`` — because GitHub rejects a suggestion that does not cover its
+    anchor exactly.
 
     Args:
         reporter: GitHub reporter used to submit the review.
@@ -452,25 +509,53 @@ def _post_inline_findings(
         question_map: Prompt id to question text for linked display.
         review_body: Markdown body posted with the review. Falls back to a
             plain label when empty.
+        round_diff_lines: Lines changed by this round's posted diff. ``None``
+            disables committable suggestions entirely.
+        carried_fingerprints: Fingerprints of findings already reported in an
+            earlier round; they fall back to a described fix.
 
     Returns:
         True when the review was submitted successfully.
     """
     comments: list[dict[str, Any]] = []
     for finding in findings:
-        rel = finding.file.removeprefix("./").replace("\\", "/")
-        comments.append(
-            {
-                "path": rel,
-                "body": format_finding_comment(
-                    finding=finding,
-                    checklist_display=checklist_display,
-                    question_map=question_map,
-                ),
-                "line": finding.line,
-                "side": "RIGHT",
-            },
+        plan = plan_inline_fix(
+            finding=finding,
+            round_diff_lines=round_diff_lines,
+            carried_over=fingerprint_for(
+                file=finding.file,
+                category=finding.category,
+                title=finding.title,
+            )
+            in carried_fingerprints,
         )
+        comment: dict[str, Any] = {
+            "path": normalize_diff_path(finding.file),
+            "body": format_finding_comment(
+                finding=finding,
+                checklist_display=checklist_display,
+                question_map=question_map,
+                inline_fix=plan,
+            ),
+            "line": finding.line,
+            "side": "RIGHT",
+        }
+        change = plan.committable_change
+        if change is not None and change.is_multiline:
+            comment["start_line"] = change.start_line
+            comment["start_side"] = "RIGHT"
+            comment["line"] = change.end_line
+        elif plan.rejection is not None and finding_suggested_change(finding=finding):
+            # The model did offer a hunk and it was refused. Say which rule
+            # refused it: a silently described fix looks like the model simply
+            # had nothing mechanical to propose.
+            logger.debug(
+                "No committable suggestion for {}:{} — {}",
+                finding.file,
+                finding.line,
+                plan.rejection.value,
+            )
+        comments.append(comment)
 
     if not comments:
         return True

--- a/lintro/ai/review/github_render.py
+++ b/lintro/ai/review/github_render.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from lintro.ai.review.agent_prompts import render_finding_prompt_panel
 from lintro.ai.review.checklist_display import (
     cleared_answers,
     format_review_questions_markdown,
@@ -10,30 +11,22 @@ from lintro.ai.review.checklist_display import (
 )
 from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.github_constants import _MENTION_RE, _SEVERITY_EMOJI
+from lintro.ai.review.inline_fix import InlineFixPlan, normalize_diff_path
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.sanitize import sanitize_comment_text
 
+__all__ = [
+    "format_finding_comment",
+    "format_review_summary",
+    "format_run_mechanics",
+    "sanitize_comment_text",
+]
 
-def sanitize_comment_text(text: str, *, limit: int | None = None) -> str:
-    """Neutralize untrusted model output for safe rendering in a PR comment.
-
-    Breaks GitHub ``@mentions`` (so injected text cannot ping or notify users)
-    by inserting a zero-width space after a leading ``@``, and optionally caps
-    the length. The input originates from an untrusted PR diff, so this is a
-    security boundary, not cosmetic.
-
-    Args:
-        text: Raw model-derived text.
-        limit: Optional maximum character length before truncation.
-
-    Returns:
-        Sanitized text safe to embed in Markdown.
-    """
-    cleaned = _MENTION_RE.sub("@​", text or "")
-    if limit is not None and len(cleaned) > limit:
-        cleaned = cleaned[: max(limit - 1, 0)].rstrip() + "…"
-    return cleaned
+#: Severities that earn a per-finding agent prompt panel (#1911). A P3 nit gets
+#: none: the panel is an affordance, and one on every finding is wallpaper.
+_PROMPT_SEVERITIES: frozenset[Severity] = frozenset({Severity.P1, Severity.P2})
 
 
 def _chip(text: str) -> str:
@@ -132,18 +125,31 @@ def format_finding_comment(
     finding: ReviewFinding,
     checklist_display: ChecklistDisplay = ChecklistDisplay.OFF,
     question_map: dict[int, str] | None = None,
+    inline_fix: InlineFixPlan | None = None,
 ) -> str:
-    """Format a review finding as a rich GitHub markdown comment.
+    """Format a review finding as a GitHub markdown comment (#1911).
 
-    Used both for inline review comments and for the summary's findings list.
-    Renders the severity as a color emoji, category and confidence as ``code``
-    chips, the cause/fix in a collapsible ``<details>``, and a GitHub
-    ``suggestion`` block when the finding carries concrete replacement code.
+    Top to bottom: a severity/category/confidence chip header, a bold title,
+    the reasoning **fully visible** (no collapsible — a reviewer should not
+    have to click to learn why something is flagged), then one conditional fix
+    slot, then the per-finding agent prompt. There is no footer.
+
+    The fix slot follows ``inline_fix``: mode A renders a committable
+    ``suggestion`` block, mode B a highlighted ``**Fix:**`` one-liner. Mode A
+    keeps the prompt panel as well — the suggestion serves click-to-commit
+    reviewers and the prompt serves local-editor and agent users, and both
+    describe the identical change.
 
     Args:
         finding: Review finding to format.
         checklist_display: Structured checklist visibility mode.
         question_map: Prompt id to question text for linked display.
+        inline_fix: Fix slot chosen for this finding's inline comment. ``None``
+            means the body is being embedded in another surface (the sticky
+            comment's folded detail, for instance) rather than posted as an
+            inline review comment: a ``suggestion`` block is not committable
+            there and a per-finding prompt panel would repeat the fix-all
+            prompt already on that surface, so neither is rendered.
 
     Returns:
         Markdown comment body.
@@ -152,7 +158,6 @@ def format_finding_comment(
     title = sanitize_comment_text(finding.title, limit=200)
     description = sanitize_comment_text(finding.description, limit=2000)
     cause = sanitize_comment_text(finding.cause, limit=2000)
-    fix = sanitize_comment_text(finding.fix, limit=2000)
 
     header = (
         f"{_severity_badge(severity=finding.severity)} · "
@@ -161,28 +166,14 @@ def format_finding_comment(
     if finding.source:
         source = sanitize_comment_text(finding.source, limit=100)
         header += f" · {_chip(f'agent: {source}')}"
-    lines = [header, "", f"### {title}", "", description]
-
-    detail: list[str] = []
+    lines = [header, "", f"**{title}**"]
+    if description.strip():
+        lines.extend(["", description])
     if cause.strip():
-        detail.append(f"**Cause:** {cause}")
-    if fix.strip():
-        detail.append(f"**Fix:** {fix}")
-    if detail:
-        lines.extend(
-            [
-                "",
-                "<details><summary>💡 Why this matters &amp; how to fix</summary>",
-                "",
-                "\n\n".join(detail),
-                "",
-                "</details>",
-            ],
-        )
+        lines.extend(["", f"**Root cause:** {cause}"])
 
-    suggestion = _suggestion_block(finding=finding)
-    if suggestion:
-        lines.extend(["", suggestion])
+    lines.extend(_fix_slot(finding=finding, inline_fix=inline_fix))
+    lines.extend(_prompt_slot(finding=finding, inline_fix=inline_fix))
 
     body = "\n".join(lines)
     if checklist_display in {ChecklistDisplay.LINKED, ChecklistDisplay.ALL}:
@@ -191,18 +182,76 @@ def format_finding_comment(
             question_map=prompt_questions,
         )
         body += format_review_questions_markdown(questions=linked)
-    body += "\n\n<sub>lintro · " + _chip(finding.category) + "</sub>"
     return body
 
 
-def _suggestion_block(*, finding: ReviewFinding) -> str:
-    """Render a GitHub ``suggestion`` block when concrete code is available."""
-    code = finding.suggested_code
-    if not code or not code.strip():
-        return ""
+def _fix_slot(
+    *,
+    finding: ReviewFinding,
+    inline_fix: InlineFixPlan | None,
+) -> list[str]:
+    """Render the conditional fix slot for a finding comment.
+
+    Args:
+        finding: Finding being rendered.
+        inline_fix: Chosen fix plan, or ``None`` for a non-inline surface.
+
+    Returns:
+        Markdown lines for the slot; empty when the finding names no fix at
+        all.
+    """
+    change = inline_fix.committable_change if inline_fix is not None else None
+    if change is not None:
+        return ["", _suggestion_block(replacement=change.replacement)]
+    fix = sanitize_comment_text(finding.fix, limit=2000).strip()
+    if not fix:
+        return []
+    return ["", f"**Fix:** {fix}"]
+
+
+def _prompt_slot(
+    *,
+    finding: ReviewFinding,
+    inline_fix: InlineFixPlan | None,
+) -> list[str]:
+    """Render the per-finding agent prompt panel, when it earns its space.
+
+    The panel is gated to P1 and P2 (#1911): a nit does not warrant a
+    copy-paste agent hand-off, and a panel on every P3 turns the affordance
+    into wallpaper. Questions carry no fix and are excluded by the prompt
+    renderer itself.
+
+    Args:
+        finding: Finding being rendered.
+        inline_fix: Chosen fix plan, or ``None`` for a non-inline surface.
+
+    Returns:
+        Markdown lines for the panel, or an empty list when it is gated off.
+    """
+    if inline_fix is None or finding.severity not in _PROMPT_SEVERITIES:
+        return []
+    panel = render_finding_prompt_panel(
+        finding=finding,
+        # In mode A the prompt must land the same edit the suggestion would, or
+        # the two paths silently diverge and whichever the reader picks is a
+        # coin flip.
+        suggested_change=inline_fix.committable_change,
+    )
+    return ["", panel] if panel else []
+
+
+def _suggestion_block(*, replacement: str) -> str:
+    """Render a GitHub ``suggestion`` block around untrusted replacement text.
+
+    Args:
+        replacement: Full replacement for the anchored lines.
+
+    Returns:
+        The fenced ``suggestion`` block.
+    """
     # Neutralize fence break-out and @mentions in untrusted model code. The
     # suggestion body renders as Markdown, so an unescaped `@user` still pings.
-    safe = code.replace("```", "``​`")
+    safe = replacement.replace("```", "``​`")
     safe = _MENTION_RE.sub("@​", safe)
     return "```suggestion\n" + safe + "\n```"
 
@@ -311,7 +360,7 @@ def _is_diff_mappable(
     Returns:
         True when the finding lands on a diff-covered line, else False.
     """
-    rel = finding.file.removeprefix("./").replace("\\", "/")
+    rel = normalize_diff_path(finding.file)
     if not rel or finding.line <= 0 or diff_lines is None:
         return False
     return finding.line in diff_lines.get(rel, set())

--- a/lintro/ai/review/inline_fix.py
+++ b/lintro/ai/review/inline_fix.py
@@ -1,0 +1,159 @@
+"""Fix-slot mode selection for inline finding comments (#1911).
+
+An inline finding comment renders exactly one fix affordance. Mode A is a
+committable GitHub ``suggestion`` block; mode B is a ``**Fix:**`` one-liner.
+Mode A is only *valid* under conditions GitHub does not check for us:
+
+* the comment must be anchored to lines changed in **this round's posted
+  diff** — not merely somewhere in the PR's cumulative diff, so a finding
+  carried over from an earlier round does not qualify; and
+* the block must replace **exactly** the anchored lines, so the finding has to
+  name a line range and its own line has to sit inside it.
+
+Every rejection is a named :class:`SuggestionRejection` so the fallback to mode
+B is explainable rather than mysterious.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lintro.ai.review.enums.fix_mode import FixMode
+from lintro.ai.review.enums.suggestion_rejection import SuggestionRejection
+from lintro.ai.review.models.review_finding import ReviewFinding
+from lintro.ai.review.models.suggested_change import SuggestedChange
+
+__all__ = [
+    "MAX_REPLACEMENT_CHARS",
+    "InlineFixPlan",
+    "finding_suggested_change",
+    "normalize_diff_path",
+    "plan_inline_fix",
+]
+
+#: Largest replacement rendered as a committable suggestion. The block is
+#: repeated in the prompt panel, so an oversized change would push the comment
+#: toward GitHub's 65,536-character limit and cost the reader the reasoning
+#: too — a described fix is the safer trade.
+MAX_REPLACEMENT_CHARS = 4_000
+
+
+def normalize_diff_path(path: str) -> str:
+    """Normalize a finding path to the form the GitHub diff API reports.
+
+    Args:
+        path: Repository-relative path as reported by the model.
+
+    Returns:
+        The path with a leading ``./`` removed and backslashes converted to
+        forward slashes; empty when nothing usable remains.
+    """
+    return path.removeprefix("./").replace("\\", "/").strip()
+
+
+@dataclass(frozen=True, slots=True)
+class InlineFixPlan:
+    """The fix slot chosen for one inline finding comment.
+
+    Attributes:
+        mode: Which affordance to render.
+        change: The validated change when ``mode`` is
+            :attr:`FixMode.SUGGESTION`, else ``None``.
+        rejection: Why mode A was rejected, or ``None`` when it was chosen.
+    """
+
+    mode: FixMode
+    change: SuggestedChange | None = None
+    rejection: SuggestionRejection | None = None
+
+    @property
+    def committable_change(self) -> SuggestedChange | None:
+        """Return the change to render as a suggestion block, if any.
+
+        Returns:
+            The validated change in mode A, else ``None``. Callers branch on
+            this rather than on :attr:`mode` so a mode without a change cannot
+            reach the renderer as a half-built suggestion.
+        """
+        if self.mode is not FixMode.SUGGESTION:
+            return None
+        return self.change
+
+
+def _described(*, rejection: SuggestionRejection) -> InlineFixPlan:
+    """Build a mode B plan carrying the reason mode A was rejected.
+
+    Args:
+        rejection: Why the committable suggestion was not offered.
+
+    Returns:
+        The mode B plan.
+    """
+    return InlineFixPlan(mode=FixMode.DESCRIBED, rejection=rejection)
+
+
+def finding_suggested_change(*, finding: ReviewFinding) -> SuggestedChange | None:
+    """Return the structured change a finding proposes, if any.
+
+    ``suggested_change`` (#1911) is preferred. A finding that only carries the
+    older unranged ``suggested_code`` is treated as replacing its own single
+    line, which is what that field has always meant — otherwise no model output
+    predating the new field could ever produce a committable suggestion.
+
+    Args:
+        finding: Finding to read the proposed change from.
+
+    Returns:
+        The change, or ``None`` when the finding proposes no replacement text.
+    """
+    if finding.suggested_change is not None:
+        return finding.suggested_change
+    if finding.suggested_code:
+        return SuggestedChange(
+            start_line=finding.line,
+            end_line=finding.line,
+            replacement=finding.suggested_code,
+        )
+    return None
+
+
+def plan_inline_fix(
+    *,
+    finding: ReviewFinding,
+    round_diff_lines: dict[str, set[int]] | None,
+    carried_over: bool = False,
+) -> InlineFixPlan:
+    """Choose the fix slot for a finding's inline comment.
+
+    Args:
+        finding: Finding the inline comment is anchored to.
+        round_diff_lines: Lines changed by **this round's** posted diff, keyed
+            by repository-relative path. ``None`` when the round's diff could
+            not be determined, which rejects every suggestion.
+        carried_over: True when this finding was already reported in an earlier
+            round. Its thread predates this round's diff, so a suggestion on it
+            is not committable.
+
+    Returns:
+        The chosen plan. Mode A is only returned when every validity condition
+        holds; otherwise mode B, with the deciding rejection recorded.
+    """
+    change = finding_suggested_change(finding=finding)
+    if change is None:
+        return _described(rejection=SuggestionRejection.NO_SUGGESTED_CHANGE)
+    if not change.replacement.strip():
+        return _described(rejection=SuggestionRejection.EMPTY_REPLACEMENT)
+    if len(change.replacement) > MAX_REPLACEMENT_CHARS:
+        return _described(rejection=SuggestionRejection.REPLACEMENT_TOO_LARGE)
+    if change.start_line < 1 or change.end_line < change.start_line:
+        return _described(rejection=SuggestionRejection.INVALID_RANGE)
+    if finding.line not in change.line_span:
+        return _described(rejection=SuggestionRejection.ANCHOR_OUTSIDE_RANGE)
+    if carried_over:
+        return _described(rejection=SuggestionRejection.CARRIED_OVER)
+    if round_diff_lines is None:
+        return _described(rejection=SuggestionRejection.NO_ROUND_DIFF)
+    changed = round_diff_lines.get(normalize_diff_path(finding.file), set())
+    if not set(change.line_span).issubset(changed):
+        return _described(rejection=SuggestionRejection.LINES_NOT_IN_ROUND_DIFF)
+    return InlineFixPlan(mode=FixMode.SUGGESTION, change=change)

--- a/lintro/ai/review/inline_fix.py
+++ b/lintro/ai/review/inline_fix.py
@@ -24,6 +24,7 @@ from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.suggested_change import SuggestedChange
 
 __all__ = [
+    "MAX_REPLACED_LINES",
     "MAX_REPLACEMENT_CHARS",
     "InlineFixPlan",
     "finding_suggested_change",
@@ -37,6 +38,11 @@ __all__ = [
 #: too — a described fix is the safer trade.
 MAX_REPLACEMENT_CHARS = 4_000
 
+#: Largest line span one committable suggestion may replace. The range comes
+#: from untrusted model output and is expanded into a set on the posting path,
+#: so it is bounded before anything materializes it.
+MAX_REPLACED_LINES = 200
+
 
 def normalize_diff_path(path: str) -> str:
     """Normalize a finding path to the form the GitHub diff API reports.
@@ -45,10 +51,13 @@ def normalize_diff_path(path: str) -> str:
         path: Repository-relative path as reported by the model.
 
     Returns:
-        The path with a leading ``./`` removed and backslashes converted to
-        forward slashes; empty when nothing usable remains.
+        The path with backslashes converted to forward slashes and a leading
+        ``./`` removed; empty when nothing usable remains. Order matters: a
+        Windows-style ``.\\src\\a.py`` only grows a strippable ``./`` after the
+        separators are normalized, and surrounding whitespace has to go first
+        or it hides the prefix from ``removeprefix``.
     """
-    return path.removeprefix("./").replace("\\", "/").strip()
+    return path.strip().replace("\\", "/").removeprefix("./")
 
 
 @dataclass(frozen=True, slots=True)
@@ -147,6 +156,8 @@ def plan_inline_fix(
         return _described(rejection=SuggestionRejection.REPLACEMENT_TOO_LARGE)
     if change.start_line < 1 or change.end_line < change.start_line:
         return _described(rejection=SuggestionRejection.INVALID_RANGE)
+    if change.end_line - change.start_line + 1 > MAX_REPLACED_LINES:
+        return _described(rejection=SuggestionRejection.SPAN_TOO_LARGE)
     if finding.line not in change.line_span:
         return _described(rejection=SuggestionRejection.ANCHOR_OUTSIDE_RANGE)
     if carried_over:
@@ -154,6 +165,6 @@ def plan_inline_fix(
     if round_diff_lines is None:
         return _described(rejection=SuggestionRejection.NO_ROUND_DIFF)
     changed = round_diff_lines.get(normalize_diff_path(finding.file), set())
-    if not set(change.line_span).issubset(changed):
+    if not changed.issuperset(change.line_span):
         return _described(rejection=SuggestionRejection.LINES_NOT_IN_ROUND_DIFF)
     return InlineFixPlan(mode=FixMode.SUGGESTION, change=change)

--- a/lintro/ai/review/inline_fix.py
+++ b/lintro/ai/review/inline_fix.py
@@ -45,7 +45,7 @@ MAX_REPLACED_LINES = 200
 
 
 def normalize_diff_path(path: str) -> str:
-    """Normalize a finding path to the form the GitHub diff API reports.
+    r"""Normalize a finding path to the form the GitHub diff API reports.
 
     Args:
         path: Repository-relative path as reported by the model.

--- a/lintro/ai/review/models/__init__.py
+++ b/lintro/ai/review/models/__init__.py
@@ -22,6 +22,7 @@ from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.review_summary import ReviewSummary
 from lintro.ai.review.models.run_record import RunRecord
 from lintro.ai.review.models.skipped_file import SkippedFile
+from lintro.ai.review.models.suggested_change import SuggestedChange
 from lintro.ai.review.models.summary_bullet import SummaryBullet
 from lintro.ai.review.models.verdict_reasoning import VerdictReasoning
 
@@ -47,6 +48,7 @@ __all__ = [
     "RunRecord",
     "SkippedFile",
     "Severity",
+    "SuggestedChange",
     "SummaryBullet",
     "VerdictReasoning",
 ]

--- a/lintro/ai/review/models/review_finding.py
+++ b/lintro/ai/review/models/review_finding.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 from lintro.ai.review.enums.evidence_style import EvidenceStyle
 from lintro.ai.review.enums.finding_kind import FindingKind
 from lintro.ai.review.models.finding_occurrence import FindingOccurrence
+from lintro.ai.review.models.suggested_change import SuggestedChange
 
 __all__ = ["ReviewFinding", "Severity"]
 
@@ -71,6 +72,13 @@ class ReviewFinding:
         occurrences: Every ``file:line`` at which this pattern occurs. Empty
             when the model reported none, in which case
             :attr:`all_occurrences` falls back to the finding's own location.
+        suggested_change: Structured form of the same fix (#1911): the exact
+            line range replaced plus its full replacement text. Preferred over
+            ``suggested_code`` because a committable GitHub suggestion must
+            replace exactly the lines its comment is anchored to, which an
+            unranged blob cannot express. ``None`` when the model reported no
+            structured change; ``suggested_code`` is then read as a
+            single-line change over the finding's own line.
     """
 
     severity: Severity
@@ -90,6 +98,7 @@ class ReviewFinding:
     severity_downgraded: bool = False
     evidence_style: EvidenceStyle = EvidenceStyle.DIFF_LOCAL
     occurrences: tuple[FindingOccurrence, ...] = field(default_factory=tuple)
+    suggested_change: SuggestedChange | None = None
 
     @property
     def all_occurrences(self) -> tuple[FindingOccurrence, ...]:

--- a/lintro/ai/review/models/suggested_change.py
+++ b/lintro/ai/review/models/suggested_change.py
@@ -1,0 +1,88 @@
+"""Structured replacement hunk carried by a review finding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from lintro.ai.review.models._coerce import coerce_int
+
+__all__ = ["SuggestedChange", "parse_suggested_change"]
+
+
+@dataclass(frozen=True, slots=True)
+class SuggestedChange:
+    """An exact replacement for a contiguous run of lines (#1911).
+
+    A GitHub ``suggestion`` block is only committable when it replaces
+    *exactly* the lines the review comment is anchored to, so the fix has to
+    name its own line range rather than leaving the renderer to guess one.
+    ``suggested_code`` (the older, unranged field) is treated as a change over
+    the finding's own single line.
+
+    Attributes:
+        start_line: First replaced line, 1-based and inclusive.
+        end_line: Last replaced line, 1-based and inclusive.
+        replacement: Full replacement text for those lines, without a trailing
+            newline. Every replaced line must be accounted for — a partial
+            replacement would silently delete the lines it omits.
+    """
+
+    start_line: int
+    end_line: int
+    replacement: str
+
+    @property
+    def line_span(self) -> range:
+        """Return the inclusive line range this change replaces."""
+        return range(self.start_line, self.end_line + 1)
+
+    @property
+    def is_multiline(self) -> bool:
+        """Return True when the change spans more than one source line."""
+        return self.end_line > self.start_line
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the change for the review output payload.
+
+        Returns:
+            JSON-serializable mapping with ``lines`` and ``replacement`` keys.
+        """
+        return {
+            "lines": [self.start_line, self.end_line],
+            "replacement": self.replacement,
+        }
+
+
+def parse_suggested_change(value: Any) -> SuggestedChange | None:
+    """Parse a ``suggested_change`` payload from untrusted model output.
+
+    The field is optional everywhere: a malformed payload degrades to ``None``
+    (the finding then renders without a committable suggestion) rather than
+    failing the run.
+
+    Args:
+        value: Raw ``suggested_change`` value, expected to be a mapping with a
+            two-element ``lines`` list and a string ``replacement``.
+
+    Returns:
+        The parsed change, or ``None`` when the payload is unusable. Range
+        sanity (positive, ordered, matching the anchor) is *not* checked here —
+        that is the renderer's validity gate, which records why a suggestion
+        was rejected.
+    """
+    if not isinstance(value, dict):
+        return None
+    replacement = value.get("replacement")
+    if not isinstance(replacement, str):
+        return None
+    lines = value.get("lines")
+    if not isinstance(lines, list) or len(lines) != 2:
+        return None
+    start_line = coerce_int(lines[0])
+    end_line = coerce_int(lines[1])
+    return SuggestedChange(
+        start_line=start_line,
+        end_line=end_line,
+        replacement=replacement,
+    )

--- a/lintro/ai/review/sanitize.py
+++ b/lintro/ai/review/sanitize.py
@@ -1,0 +1,33 @@
+"""Sanitization of untrusted model text bound for GitHub comment surfaces.
+
+Lives below both the renderers and the prompt builders: every surface that
+embeds model output needs it, and keeping it here is what lets the finding
+renderer render a prompt panel without the two modules importing each other.
+"""
+
+from __future__ import annotations
+
+from lintro.ai.review.github_constants import _MENTION_RE
+
+__all__ = ["sanitize_comment_text"]
+
+
+def sanitize_comment_text(text: str, *, limit: int | None = None) -> str:
+    """Neutralize untrusted model output for safe rendering in a PR comment.
+
+    Breaks GitHub ``@mentions`` (so injected text cannot ping or notify users)
+    by inserting a zero-width space after a leading ``@``, and optionally caps
+    the length. The input originates from an untrusted PR diff, so this is a
+    security boundary, not cosmetic.
+
+    Args:
+        text: Raw model-derived text.
+        limit: Optional maximum character length before truncation.
+
+    Returns:
+        Sanitized text safe to embed in Markdown.
+    """
+    cleaned = _MENTION_RE.sub("@​", text or "")
+    if limit is not None and len(cleaned) > limit:
+        cleaned = cleaned[: max(limit - 1, 0)].rstrip() + "…"
+    return cleaned

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -33,6 +33,7 @@ from lintro.ai.review.github import (
     post_review_to_github,
     sanitize_comment_text,
 )
+from lintro.ai.review.inline_fix import plan_inline_fix
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
@@ -45,6 +46,7 @@ def _fresh_reporter() -> MagicMock:
     reporter.is_available.return_value = True
     reporter.find_issue_comment.return_value = None
     reporter.fetch_pr_diff_lines.return_value = {"src/main.py": {10}}
+    reporter.fetch_compare_lines.return_value = {"src/main.py": {10}}
     reporter.fetch_pr_commit_shas.return_value = []
     reporter.post_issue_comment.return_value = True
     reporter.update_issue_comment.return_value = True
@@ -55,7 +57,7 @@ def _fresh_reporter() -> MagicMock:
     return reporter
 
 
-# --- formatting: severity badges, chips, collapsibles, suggestions ----------
+# --- formatting: severity badges, chips, fix slot, prompt panel -------------
 
 
 def test_format_finding_comment_uses_color_badge_and_chips(
@@ -68,19 +70,25 @@ def test_format_finding_comment_uses_color_badge_and_chips(
     assert_that(comment).contains("🔴 **P1**")
     assert_that(comment).contains("`security`")
     assert_that(comment).contains("`high confidence`")
-    assert_that(comment).contains("<details><summary>")
+    assert_that(comment).contains("**Fail-open default**")
     assert_that(comment).contains("Default to Expired")
 
 
 def test_format_finding_comment_emits_suggestion_block(
     sample_review_result: ReviewResult,
 ) -> None:
-    """A finding with suggested_code renders a GitHub suggestion block."""
+    """A validated mode A plan renders a GitHub suggestion block."""
     finding = replace(
         sample_review_result.findings[0],
         suggested_code="    return Status.EXPIRED",
     )
-    comment = format_finding_comment(finding=finding)
+    comment = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(
+            finding=finding,
+            round_diff_lines={finding.file: {finding.line}},
+        ),
+    )
 
     assert_that(comment).contains("```suggestion")
     assert_that(comment).contains("return Status.EXPIRED")
@@ -230,7 +238,13 @@ def test_suggestion_block_neutralizes_mentions(
         sample_review_result.findings[0],
         suggested_code="# ping @team\nreturn Status.EXPIRED",
     )
-    comment = format_finding_comment(finding=finding)
+    comment = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(
+            finding=finding,
+            round_diff_lines={finding.file: {finding.line}},
+        ),
+    )
 
     assert_that(comment).contains("```suggestion")
     assert_that(comment).does_not_contain("@team")

--- a/tests/unit/ai/review/test_inline_finding_format.py
+++ b/tests/unit/ai/review/test_inline_finding_format.py
@@ -328,6 +328,29 @@ def test_multiline_mode_a_prompt_names_the_full_range() -> None:
     assert_that(body).contains("third")
 
 
+def test_mode_a_prompt_carries_the_replacement_untruncated() -> None:
+    """The prompt and the suggestion must be byte-identical, however long."""
+    long_line = "x" * (MAX_REPLACEMENT_CHARS - 100)
+    finding = _finding(
+        suggested_change=SuggestedChange(
+            start_line=10,
+            end_line=10,
+            replacement=long_line,
+        ),
+    )
+    body = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(
+            finding=finding,
+            round_diff_lines=_round_diff({10}),
+        ),
+    )
+
+    # Once inside the suggestion block, once inside the prompt panel.
+    assert_that(body.count(long_line)).is_equal_to(2)
+    assert_that(body).does_not_contain("…")
+
+
 def test_reasoning_is_fully_visible_with_no_collapsible() -> None:
     """Cause and description render in the body, not behind a details tag."""
     finding = _finding()

--- a/tests/unit/ai/review/test_inline_finding_format.py
+++ b/tests/unit/ai/review/test_inline_finding_format.py
@@ -13,6 +13,7 @@ from lintro.ai.review.enums.suggestion_rejection import SuggestionRejection
 from lintro.ai.review.finding_parser import parse_findings
 from lintro.ai.review.github_render import format_finding_comment
 from lintro.ai.review.inline_fix import (
+    MAX_REPLACED_LINES,
     MAX_REPLACEMENT_CHARS,
     InlineFixPlan,
     finding_suggested_change,
@@ -136,6 +137,19 @@ def test_multiline_change_fully_inside_the_round_diff_selects_mode_a() -> None:
         pytest.param(
             _finding(
                 suggested_change=SuggestedChange(
+                    start_line=10,
+                    end_line=10 + MAX_REPLACED_LINES,
+                    replacement="x",
+                ),
+            ),
+            _round_diff({10}),
+            False,
+            SuggestionRejection.SPAN_TOO_LARGE,
+            id="oversized-span",
+        ),
+        pytest.param(
+            _finding(
+                suggested_change=SuggestedChange(
                     start_line=12,
                     end_line=10,
                     replacement="x",
@@ -226,9 +240,17 @@ def test_every_invalid_case_falls_back_to_mode_b(
     assert_that(plan.committable_change).is_none()
 
 
-def test_windows_style_paths_match_the_round_diff() -> None:
-    """A backslash path still resolves against the API's forward-slash keys."""
-    finding = _finding(file="./src\\example.py")
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("./src\\example.py", id="dot-slash-backslash"),
+        pytest.param(".\\src\\example.py", id="windows-relative"),
+        pytest.param("  src/example.py  ", id="padded"),
+    ],
+)
+def test_awkward_paths_still_match_the_round_diff(path: str) -> None:
+    """Odd path spellings still resolve against the API's forward-slash keys."""
+    finding = _finding(file=path)
 
     plan = plan_inline_fix(finding=finding, round_diff_lines=_round_diff({10}))
 

--- a/tests/unit/ai/review/test_inline_finding_format.py
+++ b/tests/unit/ai/review/test_inline_finding_format.py
@@ -7,6 +7,7 @@ from dataclasses import replace
 import pytest
 from assertpy import assert_that
 
+from lintro.ai.review.agent_prompts import render_finding_prompt
 from lintro.ai.review.enums.finding_kind import FindingKind
 from lintro.ai.review.enums.fix_mode import FixMode
 from lintro.ai.review.enums.suggestion_rejection import SuggestionRejection
@@ -346,9 +347,53 @@ def test_mode_a_prompt_carries_the_replacement_untruncated() -> None:
         ),
     )
 
-    # Once inside the suggestion block, once inside the prompt panel.
+    # Once inside the suggestion block, once inside the prompt panel. A
+    # single-line replacement carries no blockquote prefix in either copy.
     assert_that(body.count(long_line)).is_equal_to(2)
     assert_that(body).does_not_contain("…")
+
+
+def test_mode_a_prompt_preserves_replacement_indentation_verbatim() -> None:
+    """The prompt must not reindent code the suggestion commits as-is."""
+    replacement = "def divide(a, b):\n    if b == 0:\n        raise ValueError()\n    return a / b"
+    finding = _finding(
+        suggested_change=SuggestedChange(
+            start_line=10,
+            end_line=13,
+            replacement=replacement,
+        ),
+    )
+
+    prompt = render_finding_prompt(
+        finding=finding,
+        suggested_change=SuggestedChange(
+            start_line=10,
+            end_line=13,
+            replacement=replacement,
+        ),
+    )
+
+    # Byte-for-byte: a continuation indent here would silently reindent the
+    # code relative to what the suggestion block commits.
+    assert_that(prompt).contains(replacement)
+    assert_that(prompt).contains("replace lines 10-13 with the following, verbatim")
+
+
+def test_mode_a_prompt_fence_survives_backticks_in_the_replacement() -> None:
+    """A replacement containing a fence cannot close the prompt's own block."""
+    finding = _finding(
+        suggested_change=SuggestedChange(
+            start_line=10,
+            end_line=10,
+            replacement='doc = """```md\ntext\n```"""',
+        ),
+    )
+    change = finding.suggested_change
+
+    prompt = render_finding_prompt(finding=finding, suggested_change=change)
+
+    # The wrapping fence must be strictly longer than the longest inner run.
+    assert_that(prompt).contains("````")
 
 
 def test_reasoning_is_fully_visible_with_no_collapsible() -> None:

--- a/tests/unit/ai/review/test_inline_finding_format.py
+++ b/tests/unit/ai/review/test_inline_finding_format.py
@@ -1,0 +1,500 @@
+"""Tests for the redesigned inline finding comment format (#1911)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.review.enums.finding_kind import FindingKind
+from lintro.ai.review.enums.fix_mode import FixMode
+from lintro.ai.review.enums.suggestion_rejection import SuggestionRejection
+from lintro.ai.review.finding_parser import parse_findings
+from lintro.ai.review.github_render import format_finding_comment
+from lintro.ai.review.inline_fix import (
+    MAX_REPLACEMENT_CHARS,
+    InlineFixPlan,
+    finding_suggested_change,
+    plan_inline_fix,
+)
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
+from lintro.ai.review.models.suggested_change import (
+    SuggestedChange,
+    parse_suggested_change,
+)
+
+_PATH = "src/example.py"
+
+
+def _finding(**overrides: object) -> ReviewFinding:
+    """Build a P1 finding with a valid single-line suggested change.
+
+    Args:
+        **overrides: Field values replacing the defaults.
+
+    Returns:
+        The finding.
+    """
+    base = ReviewFinding(
+        severity=Severity.P1,
+        category="security",
+        file=_PATH,
+        line=10,
+        title="Hardcoded password literal in source",
+        description="The credential is assigned at module scope.",
+        cause="It was committed directly instead of read from the environment.",
+        fix='read it from `os.environ["APP_PASSWORD"]`',
+        confidence="high",
+        suggested_change=SuggestedChange(
+            start_line=10,
+            end_line=10,
+            replacement='password = os.environ["APP_PASSWORD"]',
+        ),
+    )
+    return replace(base, **overrides)  # type: ignore[arg-type]
+
+
+def _round_diff(lines: set[int]) -> dict[str, set[int]]:
+    """Build a this-round diff map covering ``lines`` of the sample file.
+
+    Args:
+        lines: Line numbers this round's diff changed.
+
+    Returns:
+        The diff line map.
+    """
+    return {_PATH: lines}
+
+
+# --- mode selection ---------------------------------------------------------
+
+
+def test_valid_change_on_this_rounds_diff_selects_mode_a() -> None:
+    """A hunk on a line this round posted is committable."""
+    plan = plan_inline_fix(
+        finding=_finding(),
+        round_diff_lines=_round_diff({10}),
+    )
+
+    assert_that(plan.mode).is_equal_to(FixMode.SUGGESTION)
+    assert_that(plan.rejection).is_none()
+    assert_that(plan.committable_change).is_not_none()
+
+
+def test_multiline_change_fully_inside_the_round_diff_selects_mode_a() -> None:
+    """Every replaced line, not just the anchor, must be in the round's diff."""
+    finding = _finding(
+        suggested_change=SuggestedChange(
+            start_line=9,
+            end_line=11,
+            replacement="a\nb\nc",
+        ),
+    )
+
+    plan = plan_inline_fix(finding=finding, round_diff_lines=_round_diff({9, 10, 11}))
+
+    assert_that(plan.mode).is_equal_to(FixMode.SUGGESTION)
+
+
+@pytest.mark.parametrize(
+    ("finding", "round_diff_lines", "carried_over", "expected"),
+    [
+        pytest.param(
+            _finding(suggested_change=None),
+            _round_diff({10}),
+            False,
+            SuggestionRejection.NO_SUGGESTED_CHANGE,
+            id="no-change",
+        ),
+        pytest.param(
+            _finding(
+                suggested_change=SuggestedChange(
+                    start_line=10,
+                    end_line=10,
+                    replacement="   \n  ",
+                ),
+            ),
+            _round_diff({10}),
+            False,
+            SuggestionRejection.EMPTY_REPLACEMENT,
+            id="blank-replacement",
+        ),
+        pytest.param(
+            _finding(
+                suggested_change=SuggestedChange(
+                    start_line=10,
+                    end_line=10,
+                    replacement="x" * (MAX_REPLACEMENT_CHARS + 1),
+                ),
+            ),
+            _round_diff({10}),
+            False,
+            SuggestionRejection.REPLACEMENT_TOO_LARGE,
+            id="oversized-replacement",
+        ),
+        pytest.param(
+            _finding(
+                suggested_change=SuggestedChange(
+                    start_line=12,
+                    end_line=10,
+                    replacement="x",
+                ),
+            ),
+            _round_diff({10, 11, 12}),
+            False,
+            SuggestionRejection.INVALID_RANGE,
+            id="reversed-range",
+        ),
+        pytest.param(
+            _finding(
+                suggested_change=SuggestedChange(
+                    start_line=0,
+                    end_line=10,
+                    replacement="x",
+                ),
+            ),
+            _round_diff({10}),
+            False,
+            SuggestionRejection.INVALID_RANGE,
+            id="non-positive-start",
+        ),
+        pytest.param(
+            _finding(
+                suggested_change=SuggestedChange(
+                    start_line=20,
+                    end_line=21,
+                    replacement="x",
+                ),
+            ),
+            _round_diff({20, 21}),
+            False,
+            SuggestionRejection.ANCHOR_OUTSIDE_RANGE,
+            id="anchor-outside-range",
+        ),
+        pytest.param(
+            _finding(),
+            _round_diff({10}),
+            True,
+            SuggestionRejection.CARRIED_OVER,
+            id="carried-over",
+        ),
+        pytest.param(
+            _finding(),
+            None,
+            False,
+            SuggestionRejection.NO_ROUND_DIFF,
+            id="round-diff-unknown",
+        ),
+        pytest.param(
+            _finding(),
+            _round_diff({11}),
+            False,
+            SuggestionRejection.LINES_NOT_IN_ROUND_DIFF,
+            id="line-not-posted-this-round",
+        ),
+        pytest.param(
+            _finding(
+                suggested_change=SuggestedChange(
+                    start_line=9,
+                    end_line=10,
+                    replacement="a\nb",
+                ),
+            ),
+            _round_diff({10}),
+            False,
+            SuggestionRejection.LINES_NOT_IN_ROUND_DIFF,
+            id="range-partly-outside-round-diff",
+        ),
+    ],
+)
+def test_every_invalid_case_falls_back_to_mode_b(
+    finding: ReviewFinding,
+    round_diff_lines: dict[str, set[int]] | None,
+    carried_over: bool,
+    expected: SuggestionRejection,
+) -> None:
+    """Each validity failure falls back to mode B and names its reason."""
+    plan = plan_inline_fix(
+        finding=finding,
+        round_diff_lines=round_diff_lines,
+        carried_over=carried_over,
+    )
+
+    assert_that(plan.mode).is_equal_to(FixMode.DESCRIBED)
+    assert_that(plan.rejection).is_equal_to(expected)
+    assert_that(plan.committable_change).is_none()
+
+
+def test_windows_style_paths_match_the_round_diff() -> None:
+    """A backslash path still resolves against the API's forward-slash keys."""
+    finding = _finding(file="./src\\example.py")
+
+    plan = plan_inline_fix(finding=finding, round_diff_lines=_round_diff({10}))
+
+    assert_that(plan.mode).is_equal_to(FixMode.SUGGESTION)
+
+
+def test_legacy_suggested_code_is_read_as_a_single_line_change() -> None:
+    """A finding predating suggested_change still produces a committable hunk."""
+    finding = _finding(suggested_change=None, suggested_code="    return EXPIRED")
+
+    change = finding_suggested_change(finding=finding)
+
+    assert_that(change).is_not_none()
+    assert_that(change.start_line).is_equal_to(10)  # type: ignore[union-attr]
+    assert_that(change.end_line).is_equal_to(10)  # type: ignore[union-attr]
+
+
+# --- rendering --------------------------------------------------------------
+
+
+def test_mode_a_renders_both_the_suggestion_and_the_prompt() -> None:
+    """Mode A serves click-to-commit and agent users at once."""
+    finding = _finding()
+    body = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(
+            finding=finding,
+            round_diff_lines=_round_diff({10}),
+        ),
+    )
+
+    assert_that(body).contains("```suggestion")
+    assert_that(body).contains('password = os.environ["APP_PASSWORD"]')
+    assert_that(body).contains("⚡ **Prompt for AI agents**")
+    # The prompt must land the same edit the suggestion would.
+    assert_that(body).contains("Apply exactly the change already proposed")
+    assert_that(body).contains("replace line 10 with the following, verbatim")
+    # Mode A's fix slot is the suggestion, not a described one-liner.
+    assert_that(body).does_not_contain("**Fix:**")
+
+
+def test_mode_b_renders_a_highlighted_fix_line_and_no_suggestion() -> None:
+    """Mode B keeps the prompt panel but has nothing to commit."""
+    finding = _finding()
+    body = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(finding=finding, round_diff_lines=None),
+    )
+
+    assert_that(body).does_not_contain("```suggestion")
+    assert_that(body).contains('**Fix:** read it from `os.environ["APP_PASSWORD"]`')
+    assert_that(body).contains("⚡ **Prompt for AI agents**")
+    assert_that(body).does_not_contain("Apply exactly the change already proposed")
+
+
+def test_multiline_mode_a_prompt_names_the_full_range() -> None:
+    """A multi-line suggestion tells the agent the whole span it replaces."""
+    finding = _finding(
+        suggested_change=SuggestedChange(
+            start_line=9,
+            end_line=11,
+            replacement="first\nsecond\nthird",
+        ),
+    )
+    body = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(
+            finding=finding,
+            round_diff_lines=_round_diff({9, 10, 11}),
+        ),
+    )
+
+    assert_that(body).contains("replace lines 9-11 with the following, verbatim")
+    assert_that(body).contains("first")
+    assert_that(body).contains("third")
+
+
+def test_reasoning_is_fully_visible_with_no_collapsible() -> None:
+    """Cause and description render in the body, not behind a details tag."""
+    finding = _finding()
+    body = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(finding=finding, round_diff_lines=None),
+    )
+
+    reasoning_end = body.index("**Fix:**")
+    assert_that(body[:reasoning_end]).contains(
+        "The credential is assigned at module scope.",
+    )
+    assert_that(body[:reasoning_end]).contains(
+        "**Root cause:** It was committed directly",
+    )
+    assert_that(body).does_not_contain("Why this matters")
+
+
+def test_header_carries_severity_category_and_confidence() -> None:
+    """The header is a chip row, not a repeated severity heading."""
+    finding = _finding()
+    body = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(finding=finding, round_diff_lines=None),
+    )
+
+    assert_that(body.splitlines()[0]).is_equal_to(
+        "🔴 **P1** · `security` · `high confidence`",
+    )
+    assert_that(body).contains("**Hardcoded password literal in source**")
+
+
+def test_comment_has_no_footer() -> None:
+    """The redundant ``lintro · category`` footer is gone."""
+    # A P3 has no prompt panel, so the fix line is the last thing in the body —
+    # nothing may follow it.
+    finding = _finding(severity=Severity.P3)
+    body = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(finding=finding, round_diff_lines=None),
+    )
+
+    assert_that(body).does_not_contain("<sub>lintro ·")
+    assert_that(body.rstrip().splitlines()[-1]).starts_with("**Fix:**")
+
+
+@pytest.mark.parametrize(
+    ("severity", "expected"),
+    [
+        pytest.param(Severity.P1, True, id="p1"),
+        pytest.param(Severity.P2, True, id="p2"),
+        pytest.param(Severity.P3, False, id="p3"),
+    ],
+)
+def test_prompt_panel_is_gated_to_p1_and_p2(
+    severity: Severity,
+    expected: bool,
+) -> None:
+    """A nit gets no prompt panel; blockers and warnings do."""
+    finding = _finding(severity=severity)
+    body = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(finding=finding, round_diff_lines=None),
+    )
+
+    assert_that("⚡ **Prompt for AI agents**" in body).is_equal_to(expected)
+
+
+def test_p3_mode_a_keeps_the_suggestion_without_a_prompt() -> None:
+    """Prompt gating does not cost a P3 its one-click fix."""
+    finding = _finding(severity=Severity.P3)
+    body = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(
+            finding=finding,
+            round_diff_lines=_round_diff({10}),
+        ),
+    )
+
+    assert_that(body).contains("```suggestion")
+    assert_that(body).does_not_contain("⚡ **Prompt for AI agents**")
+
+
+def test_question_entries_get_no_prompt_panel() -> None:
+    """A question has nothing to fix, so it has nothing to prompt for."""
+    finding = _finding(kind=FindingKind.QUESTION)
+    body = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(finding=finding, round_diff_lines=None),
+    )
+
+    assert_that(body).does_not_contain("⚡ **Prompt for AI agents**")
+
+
+def test_embedded_rendering_omits_suggestion_and_prompt() -> None:
+    """Without an inline plan, neither affordance would work — so neither renders."""
+    body = format_finding_comment(finding=_finding())
+
+    assert_that(body).does_not_contain("```suggestion")
+    assert_that(body).does_not_contain("⚡ **Prompt for AI agents**")
+    assert_that(body).contains("**Fix:**")
+
+
+def test_mentions_in_the_replacement_cannot_ping_users() -> None:
+    """Untrusted replacement code is sanitized before it reaches the comment."""
+    finding = _finding(
+        suggested_change=SuggestedChange(
+            start_line=10,
+            end_line=10,
+            replacement="# owner @team\npassword = ENV",
+        ),
+    )
+    body = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(
+            finding=finding,
+            round_diff_lines=_round_diff({10}),
+        ),
+    )
+
+    assert_that(body).contains("```suggestion")
+    assert_that(body).does_not_contain("@team")
+
+
+def test_plan_default_is_mode_b() -> None:
+    """A plan constructed without a mode-A change never renders a suggestion."""
+    assert_that(
+        InlineFixPlan(mode=FixMode.DESCRIBED).committable_change,
+    ).is_none()
+
+
+# --- schema round-trip ------------------------------------------------------
+
+
+def test_suggested_change_round_trips_through_the_finding_schema() -> None:
+    """A suggested_change survives model payload to model and back."""
+    payload = {
+        "severity": "P2",
+        "category": "logic-bug",
+        "file": _PATH,
+        "line": 8,
+        "title": "divide() raises unguarded ZeroDivisionError",
+        "description": "d",
+        "cause": "c",
+        "fix": "guard the divisor",
+        "confidence": "high",
+        "suggested_change": {
+            "lines": [7, 8],
+            "replacement": "def divide(a, b):\n    return a / b if b else 0",
+        },
+    }
+
+    findings = parse_findings(raw_findings=[payload])
+
+    assert_that(findings).is_length(1)
+    change = findings[0].suggested_change
+    assert_that(change).is_equal_to(
+        SuggestedChange(
+            start_line=7,
+            end_line=8,
+            replacement="def divide(a, b):\n    return a / b if b else 0",
+        ),
+    )
+    assert_that(change.to_dict()).is_equal_to(  # type: ignore[union-attr]
+        payload["suggested_change"],
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        pytest.param(None, id="absent"),
+        pytest.param("lines 1-2", id="not-a-mapping"),
+        pytest.param({"lines": [1, 2]}, id="no-replacement"),
+        pytest.param({"replacement": "x"}, id="no-lines"),
+        pytest.param({"lines": [1], "replacement": "x"}, id="short-range"),
+        pytest.param({"lines": [1, 2, 3], "replacement": "x"}, id="long-range"),
+        pytest.param({"lines": [1, 2], "replacement": 7}, id="non-string-replacement"),
+    ],
+)
+def test_malformed_suggested_change_degrades_to_none(raw: object) -> None:
+    """A malformed payload costs the suggestion, never the review."""
+    assert_that(parse_suggested_change(raw)).is_none()
+
+
+def test_non_numeric_lines_coerce_rather_than_crash() -> None:
+    """String line numbers from a sloppy model still parse."""
+    change = parse_suggested_change({"lines": ["7", "8"], "replacement": "x"})
+
+    assert_that(change).is_equal_to(
+        SuggestedChange(start_line=7, end_line=8, replacement="x"),
+    )

--- a/tests/unit/ai/review/test_inline_posting_1911.py
+++ b/tests/unit/ai/review/test_inline_posting_1911.py
@@ -69,6 +69,9 @@ def _inline_comments(*, reporter: MagicMock) -> list[dict[str, Any]]:
         The ``comments`` array of the review payload.
     """
     payload = reporter.api_request.call_args.args[2]
+    # Guard the positional index: if the production call ever stops passing the
+    # payload third, this fails naming the cause instead of a bare KeyError.
+    assert_that(payload).is_instance_of(dict)
     comments: list[dict[str, Any]] = payload["comments"]
     return comments
 

--- a/tests/unit/ai/review/test_inline_posting_1911.py
+++ b/tests/unit/ai/review/test_inline_posting_1911.py
@@ -263,6 +263,49 @@ def test_fetch_compare_lines_refuses_non_sha_refs() -> None:
     assert_that(urlopen.called).is_false()
 
 
+def test_fetch_compare_lines_merges_duplicate_filenames_across_pages() -> None:
+    """A file split across comparison pages keeps every line it changed."""
+    reporter = GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)
+    payload = {
+        "files": [
+            {"filename": "src/main.py", "patch": "@@ -1 +1 @@\n+one"},
+            {"filename": "src/main.py", "patch": "@@ -9 +9 @@\n+nine"},
+        ],
+    }
+
+    with patch("urllib.request.urlopen", return_value=_reader(payload)):
+        lines = reporter.fetch_compare_lines(base="aaa111", head="bbb222")
+
+    assert_that(lines).is_equal_to({"src/main.py": {1, 9}})
+
+
+def test_fetch_compare_lines_skips_non_mapping_entries() -> None:
+    """A malformed files array degrades rather than raising past the handler."""
+    reporter = GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)
+    payload = {
+        "files": [
+            "not-a-file",
+            {"filename": "src/main.py", "patch": "@@ -1 +1 @@\n+one"},
+        ],
+    }
+
+    with patch("urllib.request.urlopen", return_value=_reader(payload)):
+        lines = reporter.fetch_compare_lines(base="aaa111", head="bbb222")
+
+    assert_that(lines).is_equal_to({"src/main.py": {1}})
+
+
+def test_fetch_compare_lines_rejects_a_sha_with_a_trailing_newline() -> None:
+    """A trailing newline must not reach URL construction."""
+    reporter = GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)
+
+    with patch("urllib.request.urlopen") as urlopen:
+        lines = reporter.fetch_compare_lines(base="aaa111\n", head="bbb222")
+
+    assert_that(lines).is_none()
+    assert_that(urlopen.called).is_false()
+
+
 def test_fetch_compare_lines_returns_none_on_failure() -> None:
     """A failed comparison is unknown, not an empty diff."""
     reporter = GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)

--- a/tests/unit/ai/review/test_inline_posting_1911.py
+++ b/tests/unit/ai/review/test_inline_posting_1911.py
@@ -1,0 +1,273 @@
+"""Tests for how inline comments are anchored and scoped to a round (#1911)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from assertpy import assert_that
+
+from lintro.ai.integrations.github_pr import GitHubPRReporter
+from lintro.ai.review.github import post_review_to_github
+from lintro.ai.review.github_sticky import build_sticky_comment
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.suggested_change import SuggestedChange
+
+_TEST_TOKEN = (
+    "ghp_test_fixture_token"  # noqa: S105  # nosec B105 — fake test fixture token
+)
+
+
+def _reporter() -> MagicMock:
+    """Build a reporter stub whose PR and round diffs both cover src/main.py:10.
+
+    Returns:
+        The stub reporter.
+    """
+    reporter = MagicMock()
+    reporter.is_available.return_value = True
+    reporter.find_issue_comment.return_value = None
+    reporter.fetch_pr_diff_lines.return_value = {"src/main.py": {9, 10, 11}}
+    reporter.fetch_compare_lines.return_value = {"src/main.py": {9, 10, 11}}
+    reporter.fetch_pr_commit_shas.return_value = []
+    reporter.post_issue_comment.return_value = True
+    reporter.update_issue_comment.return_value = True
+    reporter.api_request.return_value = True
+    reporter.api_base = "https://api.github.com"
+    reporter.repo = "owner/name"
+    reporter.pr_number = 7
+    return reporter
+
+
+def _with_change(
+    *,
+    result: ReviewResult,
+    change: SuggestedChange | None,
+) -> ReviewResult:
+    """Attach a suggested change to the result's first finding.
+
+    Args:
+        result: Review result to adapt.
+        change: Change to attach.
+
+    Returns:
+        The adapted result.
+    """
+    first = replace(result.findings[0], suggested_change=change)
+    return replace(result, findings=(first, *result.findings[1:]))
+
+
+def _inline_comments(*, reporter: MagicMock) -> list[dict[str, Any]]:
+    """Extract the inline comments from the submitted review payload.
+
+    Args:
+        reporter: Reporter stub the review was posted through.
+
+    Returns:
+        The ``comments`` array of the review payload.
+    """
+    payload = reporter.api_request.call_args.args[2]
+    comments: list[dict[str, Any]] = payload["comments"]
+    return comments
+
+
+def test_single_line_mode_a_anchors_to_the_suggestion_line(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The anchor is exactly the replaced line, so the suggestion is valid."""
+    reporter = _reporter()
+    result = _with_change(
+        result=sample_review_result,
+        change=SuggestedChange(start_line=10, end_line=10, replacement="ok"),
+    )
+
+    post_review_to_github(result=result, reporter=reporter)
+
+    comment = _inline_comments(reporter=reporter)[0]
+    assert_that(comment["line"]).is_equal_to(10)
+    assert_that(comment).does_not_contain_key("start_line")
+    assert_that(comment["body"]).contains("```suggestion")
+
+
+def test_multiline_mode_a_anchors_the_whole_replaced_range(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A multi-line suggestion must cover every line its comment spans."""
+    reporter = _reporter()
+    result = _with_change(
+        result=sample_review_result,
+        change=SuggestedChange(start_line=9, end_line=11, replacement="a\nb\nc"),
+    )
+
+    post_review_to_github(result=result, reporter=reporter)
+
+    comment = _inline_comments(reporter=reporter)[0]
+    assert_that(comment["start_line"]).is_equal_to(9)
+    assert_that(comment["start_side"]).is_equal_to("RIGHT")
+    assert_that(comment["line"]).is_equal_to(11)
+
+
+def test_mode_b_anchors_to_the_findings_own_line(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Without a committable suggestion the anchor stays a single line."""
+    reporter = _reporter()
+    result = _with_change(result=sample_review_result, change=None)
+
+    post_review_to_github(result=result, reporter=reporter)
+
+    comment = _inline_comments(reporter=reporter)[0]
+    assert_that(comment["line"]).is_equal_to(10)
+    assert_that(comment).does_not_contain_key("start_line")
+    assert_that(comment["body"]).does_not_contain("```suggestion")
+
+
+def test_round_two_scopes_suggestions_to_the_new_commits(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A line the PR changed earlier but this round did not is not committable."""
+    reporter = _reporter()
+    result = _with_change(
+        result=sample_review_result,
+        change=SuggestedChange(start_line=10, end_line=10, replacement="ok"),
+    )
+    reporter.find_issue_comment.return_value = (
+        42,
+        build_sticky_comment(result=result, head_sha="aaa111"),
+    )
+    # This round only touched line 40, so the finding's line is old ground.
+    reporter.fetch_compare_lines.return_value = {"src/main.py": {40}}
+
+    post_review_to_github(result=result, reporter=reporter)
+
+    assert_that(reporter.fetch_compare_lines.called).is_true()
+    assert_that(_inline_comments(reporter=reporter)[0]["body"]).does_not_contain(
+        "```suggestion",
+    )
+
+
+def test_round_one_treats_the_whole_pr_diff_as_this_rounds_diff(
+    sample_review_result: ReviewResult,
+) -> None:
+    """With no prior round there is nothing to compare against."""
+    reporter = _reporter()
+    result = _with_change(
+        result=sample_review_result,
+        change=SuggestedChange(start_line=10, end_line=10, replacement="ok"),
+    )
+
+    post_review_to_github(result=result, reporter=reporter)
+
+    assert_that(reporter.fetch_compare_lines.called).is_false()
+    assert_that(_inline_comments(reporter=reporter)[0]["body"]).contains(
+        "```suggestion",
+    )
+
+
+def test_carried_over_finding_falls_back_to_mode_b(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A finding already raised in round 1 keeps its thread, loses its one-click fix."""
+    reporter = _reporter()
+    result = _with_change(
+        result=sample_review_result,
+        change=SuggestedChange(start_line=10, end_line=10, replacement="ok"),
+    )
+    # Round 1 recorded the same finding; round 2 reports it again on a line the
+    # new commits did touch, so only the carried-over rule can reject it.
+    reporter.find_issue_comment.return_value = (
+        42,
+        build_sticky_comment(result=result, head_sha="aaa111"),
+    )
+    reporter.fetch_compare_lines.return_value = {"src/main.py": {9, 10, 11}}
+
+    post_review_to_github(result=result, reporter=reporter)
+
+    body = _inline_comments(reporter=reporter)[0]["body"]
+    assert_that(body).does_not_contain("```suggestion")
+    assert_that(body).contains("**Fix:**")
+
+
+def test_round_two_finding_new_to_this_round_keeps_mode_a(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Control for the carried-over rule: only being *carried* rejects it."""
+    reporter = _reporter()
+    prior = _with_change(
+        result=sample_review_result,
+        change=SuggestedChange(start_line=10, end_line=10, replacement="ok"),
+    )
+    reporter.find_issue_comment.return_value = (
+        42,
+        build_sticky_comment(result=prior, head_sha="aaa111"),
+    )
+    reporter.fetch_compare_lines.return_value = {"src/main.py": {9, 10, 11}}
+    # Same location, different finding — round 2 sees it for the first time.
+    first = replace(prior.findings[0], title="A different defect entirely")
+    result = replace(prior, findings=(first, *prior.findings[1:]))
+
+    post_review_to_github(result=result, reporter=reporter)
+
+    assert_that(_inline_comments(reporter=reporter)[0]["body"]).contains(
+        "```suggestion",
+    )
+
+
+# --- compare endpoint -------------------------------------------------------
+
+
+def _reader(payload: dict[str, Any]) -> MagicMock:
+    """Build a urlopen context manager yielding ``payload`` as JSON.
+
+    Args:
+        payload: Response body.
+
+    Returns:
+        The context-manager mock.
+    """
+    response = MagicMock()
+    response.read.return_value = json.dumps(payload).encode()
+    ctx = MagicMock()
+    ctx.__enter__.return_value = response
+    return ctx
+
+
+def test_fetch_compare_lines_parses_the_comparison_patches() -> None:
+    """The comparison's patches reduce to right-side line numbers."""
+    reporter = GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)
+    payload = {
+        "files": [
+            {
+                "filename": "src/main.py",
+                "patch": "@@ -1,2 +1,3 @@\n ctx\n+added\n+also",
+            },
+        ],
+    }
+
+    with patch("urllib.request.urlopen", return_value=_reader(payload)):
+        lines = reporter.fetch_compare_lines(base="aaa111", head="bbb222")
+
+    assert_that(lines).is_equal_to({"src/main.py": {2, 3}})
+
+
+def test_fetch_compare_lines_refuses_non_sha_refs() -> None:
+    """A ref that is not a sha never reaches URL construction."""
+    reporter = GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)
+
+    with patch("urllib.request.urlopen") as urlopen:
+        lines = reporter.fetch_compare_lines(base="main", head="bbb222")
+
+    assert_that(lines).is_none()
+    assert_that(urlopen.called).is_false()
+
+
+def test_fetch_compare_lines_returns_none_on_failure() -> None:
+    """A failed comparison is unknown, not an empty diff."""
+    reporter = GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)
+
+    with patch("urllib.request.urlopen", side_effect=OSError("boom")):
+        lines = reporter.fetch_compare_lines(base="aaa111", head="bbb222")
+
+    assert_that(lines).is_none()

--- a/tests/unit/ai/review/test_inline_posting_1911.py
+++ b/tests/unit/ai/review/test_inline_posting_1911.py
@@ -327,6 +327,23 @@ def test_fetch_compare_lines_skips_non_mapping_entries() -> None:
     assert_that(lines).is_equal_to({"src/main.py": {1}})
 
 
+def test_fetch_compare_lines_skips_malformed_filename_and_patch_values() -> None:
+    """A wrongly-typed field is skipped, not raised past the caller's handler."""
+    reporter = GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)
+    payload = {
+        "files": [
+            {"filename": ["src/main.py"], "patch": "@@ -1 +1 @@\n+one"},
+            {"filename": "src/other.py", "patch": {"not": "a string"}},
+            {"filename": "src/main.py", "patch": "@@ -1 +1 @@\n+one"},
+        ],
+    }
+
+    with patch("urllib.request.urlopen", return_value=_reader(payload)):
+        lines = reporter.fetch_compare_lines(base="aaa111", head="bbb222")
+
+    assert_that(lines).is_equal_to({"src/main.py": {1}})
+
+
 def test_fetch_compare_lines_rejects_a_sha_with_a_trailing_newline() -> None:
     """A trailing newline must not reach URL construction."""
     reporter = GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)

--- a/tests/unit/ai/review/test_inline_posting_1911.py
+++ b/tests/unit/ai/review/test_inline_posting_1911.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import io
 import json
+import urllib.request
 from dataclasses import replace
+from http.client import HTTPMessage
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from assertpy import assert_that
 
 from lintro.ai.integrations.github_pr import GitHubPRReporter
@@ -218,6 +222,31 @@ def test_round_two_finding_new_to_this_round_keeps_mode_a(
     )
 
 
+def test_prior_round_without_a_recorded_sha_falls_back_to_mode_b(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A sticky from a version that never stored a sha leaves the round unknown."""
+    reporter = _reporter()
+    result = _with_change(
+        result=sample_review_result,
+        change=SuggestedChange(start_line=10, end_line=10, replacement="ok"),
+    )
+    # A run entry exists, so this is not round 1, but it carries no sha — there
+    # is nothing to compare against and no suggestion may claim to be on this
+    # round's diff.
+    reporter.find_issue_comment.return_value = (
+        42,
+        build_sticky_comment(result=result, head_sha=""),
+    )
+
+    post_review_to_github(result=result, reporter=reporter)
+
+    assert_that(reporter.fetch_compare_lines.called).is_false()
+    body = _inline_comments(reporter=reporter)[0]["body"]
+    assert_that(body).does_not_contain("```suggestion")
+    assert_that(body).contains("**Fix:**")
+
+
 # --- compare endpoint -------------------------------------------------------
 
 
@@ -266,8 +295,8 @@ def test_fetch_compare_lines_refuses_non_sha_refs() -> None:
     assert_that(urlopen.called).is_false()
 
 
-def test_fetch_compare_lines_merges_duplicate_filenames_across_pages() -> None:
-    """A file split across comparison pages keeps every line it changed."""
+def test_fetch_compare_lines_merges_duplicate_filenames() -> None:
+    """A filename listed twice keeps every line it changed."""
     reporter = GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)
     payload = {
         "files": [
@@ -307,6 +336,65 @@ def test_fetch_compare_lines_rejects_a_sha_with_a_trailing_newline() -> None:
 
     assert_that(lines).is_none()
     assert_that(urlopen.called).is_false()
+
+
+def test_fetch_compare_lines_issues_exactly_one_request() -> None:
+    """The compare endpoint paginates commits, not files — do not walk pages."""
+    reporter = GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)
+    payload = {
+        "files": [
+            {"filename": f"src/f{index}.py", "patch": "@@ -1 +1 @@\n+one"}
+            for index in range(100)
+        ],
+    }
+
+    with patch("urllib.request.urlopen", return_value=_reader(payload)) as urlopen:
+        lines = reporter.fetch_compare_lines(base="aaa111", head="bbb222")
+
+    assert_that(urlopen.call_count).is_equal_to(1)
+    assert_that(lines).is_length(100)
+    requested = urlopen.call_args.args[0].full_url
+    assert_that(requested).does_not_contain("page=")
+
+
+def test_fetch_compare_lines_returns_none_without_a_files_array() -> None:
+    """A response that names no files is unknown, not an empty diff."""
+    reporter = GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)
+
+    with patch("urllib.request.urlopen", return_value=_reader({"status": "identical"})):
+        lines = reporter.fetch_compare_lines(base="aaa111", head="bbb222")
+
+    assert_that(lines).is_none()
+
+
+def test_api_requests_never_replay_the_token_to_a_redirect_target() -> None:
+    """Urllib copies ordinary headers across redirects; the token must not go."""
+    reporter = GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)
+
+    with patch(
+        "urllib.request.urlopen",
+        return_value=_reader({"files": []}),
+    ) as urlopen:
+        reporter.fetch_compare_lines(base="aaa111", head="bbb222")
+
+    request = urlopen.call_args.args[0]
+    # ``header_items()`` merges both maps, so the split is only visible in the
+    # underlying dicts: ordinary headers ride along on a redirect, unredirected
+    # ones do not.
+    assert_that(request.headers).does_not_contain_key("Authorization")
+    assert_that(request.unredirected_hdrs).contains_key("Authorization")
+
+    redirected = urllib.request.HTTPRedirectHandler().redirect_request(
+        request,
+        io.BytesIO(),
+        302,
+        "Found",
+        HTTPMessage(),
+        "http://evil.example/steal",
+    )
+    if redirected is None:  # pragma: no cover - urllib always redirects a 302
+        pytest.fail("expected urllib to build a redirected request")
+    assert_that(dict(redirected.header_items())).does_not_contain_key("Authorization")
 
 
 def test_fetch_compare_lines_returns_none_on_failure() -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(review): rebuild inline finding comments with a conditional fix slot
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Surface 3 of epic #1905 — the inline finding comment — rebuilt to mock-4
section 3, modes A & B.

Each inline comment is now, top to bottom:

1. `🔴 **P1** · security · high confidence` chip header (unchanged shape, plus
   the existing `agent:` chip when a custom agent reported the finding)
2. **Bold title** (was an `###` heading)
3. **Reasoning fully visible** — the `💡 Why this matters & how to fix`
   collapsible is gone; the description and `**Root cause:**` render in the body
4. One **conditional fix slot**
   - **mode A** — a committable `suggestion` block, but only when the fix
     validates as a real hunk on *this round's* posted diff
   - **mode B** — a highlighted `**Fix:** …` one-liner otherwise
5. **⚡ Prompt for AI agents** purple panel, **gated to P1/P2 only** (P3 gets
   none). Mode A keeps *both* the suggestion and the panel, and the prompt
   restates the suggested replacement verbatim so the click-to-commit path and
   the agent path apply the identical change
6. **No footer** — the `lintro · <category>` line is deleted

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1911

## Details

### Suggestion validity, taken literally

The spec's constraint is stricter than GitHub's own: a suggestion must be
anchored to lines changed in **this round's posted diff**, not merely somewhere
in the PR's cumulative diff, and must replace **exactly** the anchored lines.

- New `GitHubPRReporter.fetch_compare_lines(base=…, head=…)` establishes the
  round's diff via `GET /repos/{repo}/compare/{base}...{head}`. Round 1 (no
  prior state) uses the PR diff; later rounds compare against the previously
  reviewed head. Failure returns `None`, treated as *unknown* and never as
  "nothing changed" — every suggestion then falls back to mode B. Refs are
  regex-validated as hex shas before they reach URL construction.
- New `lintro/ai/review/inline_fix.py` holds `plan_inline_fix()`, returning an
  `InlineFixPlan` that names a `FixMode` and, on rejection, a
  `SuggestionRejection`: `no_suggested_change`, `empty_replacement`,
  `replacement_too_large`, `invalid_range`, `anchor_outside_range`,
  `carried_over`, `no_round_diff`, `lines_not_in_round_diff`. A rejection is
  logged at debug when the model *did* offer a hunk, so a silently-described fix
  is explainable rather than mysterious.
- Mode A comments are anchored to exactly the replaced span: a multi-line change
  carries `start_line`/`start_side` alongside `line`.
- Carried-over findings are detected from `match_findings()` — already computed
  for the sticky and the review body, so the call is hoisted and shared rather
  than duplicated — and fall back to mode B.

### Schema

`ReviewFinding` gains an optional `suggested_change: SuggestedChange | None`
(`{lines: [start, end], replacement: str}`), appended last so positional
construction is unaffected. Added to the prompt output schema, the output rules,
and the strict CLI JSON schema. Malformed payloads degrade to `None` rather than
failing the run. A finding carrying only the older `suggested_code` is read as a
single-line change over its own line, so existing model output still produces
committable suggestions.

### Non-inline surfaces

`format_finding_comment(inline_fix=None)` — the sticky's folded detail, including
the #1942 degraded path — renders the described fix and *no* suggestion block or
prompt panel: a suggestion is not committable there, and a per-finding panel
would repeat the fix-all prompt already on that surface.

### Incidental

`sanitize_comment_text` moved to a new `lintro/ai/review/sanitize.py`
(re-exported from `github_render`) so the finding renderer can render a prompt
panel without `github_render` and `agent_prompts` importing each other.

### Testing

New tests in `tests/unit/ai/review/test_inline_finding_format.py` and
`test_inline_posting_1911.py` cover every fallback path of the validity check,
mode A/B selection and rendering, multi-line anchoring, P1/P2/P3 prompt gating,
mode A carrying both affordances with a matching prompt, carried-over fallback
(with a positive control), no-footer, `suggested_change` schema round-trip and
malformed degradation, and the compare endpoint's parse/refuse/failure paths.

Invariants from #1942 (sticky-before-inline ordering, `InlinePostFailure`
degraded path) and #1943 (per-review body, skip reasons, coverage crediting) are
untouched and still covered by their existing suites.
