### PR TITLE
feat(review): close inline finding threads with an addressed lifecycle

### DIFF
--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -288,6 +288,28 @@ review:
   custom_agents: true # true | false | only
 ```
 
+### Addressed lifecycle on inline threads
+
+When `lintro review --post` runs again on a PR, every finding the new round no longer
+reproduces is stamped on its own inline comment rather than only in the sticky summary:
+
+- **Addressed** — the comment gets a `✔ Addressed in <sha> · round N` banner, its
+  copy-paste agent prompt is retitled `(historical)`, and the thread is resolved.
+- **Partially addressed** — a finding reported at several locations resolves only when
+  the whole pattern is gone. Progress shows as `✔ 14/20 addressed in <sha> · round N`
+  and the thread stays open.
+- **Regressed** — a finding that comes back is re-raised on a _fresh_ thread carrying
+  `regression · first raised round X, fixed round Y` plus a link to the original. The
+  old thread is stamped `↩ Regressed in <sha>` and is never reopened.
+
+Thread resolution is the only configurable half; the banner is always written.
+
+```yaml
+# .lintro-config.yaml
+review:
+  auto_resolve: true # default; set false to resolve threads by hand
+```
+
 ## Configuration
 
 ### Basic Setup

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -294,7 +294,9 @@ When `lintro review --post` runs again on a PR, every finding the new round no l
 reproduces is stamped on its own inline comment rather than only in the sticky summary:
 
 - **Addressed** — the comment gets a `✔ Addressed in <sha> · round N` banner, its
-  copy-paste agent prompt is retitled `(historical)`, and the thread is resolved.
+  copy-paste agent prompt is retitled `(historical)`, and the thread is resolved when
+  `review.auto_resolve` is true — which it is by default; set it to `false` to opt out
+  and resolve the thread by hand.
 - **Partially addressed** — a finding reported at several locations resolves only when
   the whole pattern is gone. Progress shows as `✔ 14/20 addressed in <sha> · round N`
   and the thread stays open.

--- a/lintro/ai/integrations/github_pr.py
+++ b/lintro/ai/integrations/github_pr.py
@@ -22,6 +22,36 @@ from loguru import logger
 from lintro.ai.enums import ConfidenceLevel
 from lintro.ai.models import AIFixSuggestion, AISummary
 from lintro.ai.paths import OUTSIDE_WORKSPACE_SENTINEL, to_provider_path
+from lintro.ai.review.models.review_thread import ReviewThread
+
+#: Lists every review thread with its root comment's REST id, so a stored
+#: comment id can be joined to the thread node id the mutation requires.
+_REVIEW_THREADS_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          comments(first: 1) { nodes { databaseId } }
+        }
+      }
+    }
+  }
+}
+"""
+
+#: Marks a thread resolved. There is deliberately no unresolve counterpart:
+#: a regression opens a new thread rather than reopening a settled one (#1912).
+_RESOLVE_THREAD_MUTATION = """
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread { isResolved }
+  }
+}
+"""
 
 #: Commit shas are interpolated into a compare URL, so only hex refs are
 #: accepted — a branch name or user-supplied ref must not reach path building.
@@ -415,6 +445,196 @@ class GitHubPRReporter:
                 return None
             page += 1
 
+    def fetch_review_comments(self) -> list[dict[str, Any]] | None:
+        """Fetch the PR's inline review comments, oldest first.
+
+        Used to recover the comment id of a freshly posted inline finding: the
+        review-submission endpoint answers with the review, not with the
+        comments it created, so the ids are only discoverable by listing.
+
+        Returns:
+            The raw comment mappings, or ``None`` when the listing failed.
+            ``None`` is a refusal, not an empty PR: a caller must not read it
+            as "this PR has no inline comments".
+        """
+        base_url = f"{self.api_base}/repos/{self.repo}/pulls/{self.pr_number}/comments"
+        parsed = urllib.parse.urlparse(base_url)
+        if parsed.scheme != "https":
+            return None
+
+        comments: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            url = f"{base_url}?per_page=100&page={page}"
+            req = self._authorized_request(url=url, method="GET")
+            try:
+                with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
+                    req,
+                    timeout=30,
+                ) as resp:
+                    page_items = json.loads(resp.read().decode())
+            except (urllib.error.URLError, json.JSONDecodeError, OSError):
+                logger.debug("Failed to list PR review comments")
+                return None
+
+            if not isinstance(page_items, list) or not page_items:
+                break
+            comments.extend(item for item in page_items if isinstance(item, dict))
+            if len(page_items) < 100:
+                break
+            page += 1
+        return comments
+
+    def update_review_comment(self, *, comment_id: int, body: str) -> bool:
+        """Edit an existing inline review comment in place.
+
+        Args:
+            comment_id: Numeric id of the review comment to edit.
+            body: New Markdown body.
+
+        Returns:
+            True if the update succeeded.
+        """
+        url = f"{self.api_base}/repos/{self.repo}/pulls/comments/{comment_id}"
+        return self.api_request("PATCH", url, {"body": body})
+
+    @property
+    def graphql_url(self) -> str:
+        """Return the GraphQL endpoint matching this reporter's REST base.
+
+        Returns:
+            ``https://api.github.com/graphql`` for github.com; the sibling
+            ``/api/graphql`` endpoint for a GitHub Enterprise ``/api/v3`` base.
+        """
+        if self.api_base.endswith("/api/v3"):
+            return f"{self.api_base.removesuffix('/v3')}/graphql"
+        return f"{self.api_base}/graphql"
+
+    def graphql_request(
+        self,
+        *,
+        query: str,
+        variables: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Execute a GraphQL query or mutation against the GitHub API.
+
+        Args:
+            query: GraphQL document to execute.
+            variables: Variable bindings for the document.
+
+        Returns:
+            The ``data`` object of a successful response, or ``None`` when the
+            request failed, returned unparsable JSON, or carried GraphQL
+            ``errors`` — GraphQL answers 200 for a failed mutation, so the
+            error array is the only signal that it did not take effect.
+        """
+        url = self.graphql_url
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme != "https":
+            logger.warning("Refusing non-HTTPS GraphQL URL: {}", url)
+            return None
+
+        req = self._authorized_request(
+            url=url,
+            method="POST",
+            data=json.dumps({"query": query, "variables": variables}).encode(),
+            content_type="application/json",
+        )
+        try:
+            with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
+                req,
+                timeout=30,
+            ) as resp:
+                payload = json.loads(resp.read().decode())
+        except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
+            logger.debug("GitHub GraphQL request failed: {}", exc)
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+        if payload.get("errors"):
+            logger.warning(
+                "GitHub GraphQL request returned errors: {}",
+                payload["errors"],
+            )
+            return None
+        data = payload.get("data")
+        return data if isinstance(data, dict) else None
+
+    def fetch_review_threads(self) -> dict[int, ReviewThread] | None:
+        """Map each review thread's root comment id to the thread itself.
+
+        ``resolveReviewThread`` takes a thread node id, and the state blob only
+        stores REST comment ids, so the two must be joined. The join key is the
+        thread's *first* comment: that is the comment lintro posted to open the
+        thread, and it is the id persisted for the finding.
+
+        Returns:
+            Mapping of root comment database id to thread, or ``None`` when the
+            query failed — the caller then skips resolution rather than
+            guessing at thread identity.
+        """
+        if not self.repo or "/" not in self.repo:
+            return None
+        owner, _, name = self.repo.partition("/")
+
+        threads: dict[int, ReviewThread] = {}
+        cursor: str | None = None
+        while True:
+            data = self.graphql_request(
+                query=_REVIEW_THREADS_QUERY,
+                variables={
+                    "owner": owner,
+                    "name": name,
+                    "number": self.pr_number,
+                    "cursor": cursor,
+                },
+            )
+            if data is None:
+                return None
+            container = _dig(data, "repository", "pullRequest", "reviewThreads")
+            if container is None:
+                return None
+            for node in container.get("nodes") or []:
+                if not isinstance(node, dict):
+                    continue
+                node_id = node.get("id")
+                comments = (node.get("comments") or {}).get("nodes") or []
+                root = comments[0] if comments and isinstance(comments[0], dict) else {}
+                database_id = root.get("databaseId")
+                if isinstance(node_id, str) and isinstance(database_id, int):
+                    threads[database_id] = ReviewThread(
+                        node_id=node_id,
+                        is_resolved=bool(node.get("isResolved")),
+                    )
+            page_info = container.get("pageInfo") or {}
+            if not page_info.get("hasNextPage"):
+                return threads
+            next_cursor = page_info.get("endCursor")
+            if not isinstance(next_cursor, str) or next_cursor == cursor:
+                # A server that repeats its cursor would loop forever; stop with
+                # what has been collected instead.
+                return threads
+            cursor = next_cursor
+
+    def resolve_review_thread(self, *, thread_id: str) -> bool:
+        """Resolve a PR review thread via the GraphQL mutation.
+
+        Args:
+            thread_id: GraphQL node id of the thread to resolve.
+
+        Returns:
+            True when GitHub reports the thread as resolved.
+        """
+        data = self.graphql_request(
+            query=_RESOLVE_THREAD_MUTATION,
+            variables={"threadId": thread_id},
+        )
+        if data is None:
+            return False
+        thread = _dig(data, "resolveReviewThread", "thread")
+        return bool(thread and thread.get("isResolved"))
+
     def update_issue_comment(self, *, comment_id: int, body: str) -> bool:
         """Update an existing issue comment in place.
 
@@ -545,6 +765,25 @@ class GitHubPRReporter:
             stacklevel=2,
         )
         return self.api_request(method, url, payload)
+
+
+def _dig(payload: dict[str, Any], *keys: str) -> dict[str, Any] | None:
+    """Walk a chain of mapping keys in an untrusted GraphQL response.
+
+    Args:
+        payload: Decoded response object.
+        *keys: Successive keys to follow.
+
+    Returns:
+        The nested mapping, or ``None`` as soon as a level is missing or is not
+        a mapping — a partial GraphQL response must degrade, not raise.
+    """
+    current: Any = payload
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current if isinstance(current, dict) else None
 
 
 def _detect_repo_root() -> Path | None:

--- a/lintro/ai/review/enums/__init__.py
+++ b/lintro/ai/review/enums/__init__.py
@@ -10,6 +10,7 @@ from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.enums.finding_kind import FindingKind
 from lintro.ai.review.enums.finding_match_outcome import FindingMatchOutcome
 from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.enums.lifecycle_stage import LifecycleStage
 from lintro.ai.review.enums.review_category import ReviewCategory
 from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
 from lintro.ai.review.enums.review_verdict import ReviewVerdict
@@ -23,6 +24,7 @@ __all__ = [
     "FindingKind",
     "FindingMatchOutcome",
     "FindingStatus",
+    "LifecycleStage",
     "ReviewCategory",
     "ReviewContextErrorCode",
     "ReviewVerdict",

--- a/lintro/ai/review/enums/lifecycle_stage.py
+++ b/lintro/ai/review/enums/lifecycle_stage.py
@@ -1,0 +1,25 @@
+"""Lifecycle stages an inline finding thread can be stamped with (#1912)."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+__all__ = ["LifecycleStage"]
+
+
+class LifecycleStage(StrEnum):
+    """What a later round verified about a finding's inline thread.
+
+    Attributes:
+        ADDRESSED: Every occurrence of the finding stopped reproducing, so the
+            thread carries its outcome and may be resolved.
+        PARTIAL: Some, but not all, occurrences of a collapsed pattern are
+            gone. The finding is still open and the thread is never resolved.
+        REGRESSED: A previously addressed finding came back. The old thread is
+            stamped and stays resolved; the finding is re-raised on a fresh
+            thread.
+    """
+
+    ADDRESSED = auto()
+    PARTIAL = auto()
+    REGRESSED = auto()

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -484,6 +484,28 @@ def _partial_progress(
     return progressed
 
 
+def _fresh_thread_id(
+    *,
+    record: FindingRecord,
+    newest: Mapping[str, int],
+) -> int | None:
+    """Return the comment id of a regression's *new* thread, when there is one.
+
+    Args:
+        record: The regressed record, still pointing at its old thread.
+        newest: Highest comment id seen per finding key.
+
+    Returns:
+        The new comment's id, or ``None`` when this round posted no fresh
+        comment for the finding — the old thread carries the same marker, so
+        without this check its banner would link to itself.
+    """
+    candidate = newest.get(record.key)
+    if candidate is None or candidate == record.inline_comment_id:
+        return None
+    return candidate
+
+
 def _run_lifecycle(
     *,
     reporter: GitHubPRReporter,
@@ -557,7 +579,7 @@ def _run_lifecycle(
         new_thread_urls={
             record.key: _comment_url(
                 reporter=reporter,
-                comment_id=newest.get(record.key),
+                comment_id=_fresh_thread_id(record=record, newest=newest),
             )
             for record in regressed
         },

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -15,13 +15,20 @@ Public helpers live in sibling modules and are re-exported here so existing
 
 from __future__ import annotations
 
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
 from typing import Any, Protocol
 
 from loguru import logger
 
 from lintro.ai.integrations.github_pr import GitHubPRReporter
 from lintro.ai.review.enums.checklist_display import ChecklistDisplay
-from lintro.ai.review.finding_matcher import fingerprint_for, match_findings
+from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.finding_matcher import (
+    fingerprint_for,
+    match_findings,
+    normalize_file_path,
+)
 from lintro.ai.review.github_constants import (
     GITHUB_COMMENT_HARD_LIMIT,
     MAX_COMMENT_CHARS,
@@ -29,6 +36,12 @@ from lintro.ai.review.github_constants import (
     STICKY_MARKER,
 )
 from lintro.ai.review.github_errors import format_error_comment
+from lintro.ai.review.github_lifecycle import (
+    finding_marker,
+    parse_finding_marker,
+    regression_provenance,
+    sync_addressed_lifecycle,
+)
 from lintro.ai.review.github_render import (
     _format_findings_section as _format_findings_section,
 )
@@ -53,6 +66,8 @@ from lintro.ai.review.inline_fix import (
     normalize_diff_path,
     plan_inline_fix,
 )
+from lintro.ai.review.models.finding_match_result import FindingMatchResult
+from lintro.ai.review.models.finding_record import FindingRecord
 from lintro.ai.review.models.inline_post_failure import InlinePostFailure
 from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_metadata import ReviewMetadata
@@ -89,13 +104,15 @@ def post_review_to_github(
     transport: str = "",
     auth_mode: str = "",
     config_source: str = "",
+    auto_resolve: bool = True,
 ) -> bool:
     """Post (or update) the sticky review comment and inline findings.
 
     Maintains a single sticky comment per PR (identified by ``STICKY_MARKER``),
     updated in place with cumulative telemetry. Diff-mappable findings are also
     posted as inline review comments, under a review body describing this round
-    (issue #1910).
+    (issue #1910). Threads whose finding this round settled are stamped with
+    their outcome and, when configuration allows, resolved (issue #1912).
 
     Args:
         result: Review result to post.
@@ -108,6 +125,8 @@ def post_review_to_github(
         auth_mode: Authentication mode used by the transport.
         config_source: Human-readable description of where this run's settings
             came from, shown under the review body's run stats.
+        auto_resolve: ``review.auto_resolve``. When false, an addressed thread
+            still gets its banner but is left for a human to resolve.
 
     Returns:
         True when posting succeeded; False on failure or when GitHub context is
@@ -123,7 +142,11 @@ def post_review_to_github(
     diff_lines = gh_reporter.fetch_pr_diff_lines()
     head_sha = result.metadata.head_ref
 
-    def render(*, inline_failure: InlinePostFailure | None) -> str:
+    def render(
+        *,
+        inline_failure: InlinePostFailure | None,
+        comment_ids: dict[str, int] | None = None,
+    ) -> str:
         """Render the sticky body against the unchanged prior state."""
         return build_sticky_comment(
             result=result,
@@ -135,6 +158,7 @@ def post_review_to_github(
             transport=transport,
             auth_mode=auth_mode,
             inline_failure=inline_failure,
+            inline_comment_ids=comment_ids,
         )
 
     inline_findings, fallback = _partition_findings(
@@ -156,11 +180,15 @@ def post_review_to_github(
     # rather than leaving it as a title in a table (#1909). The sticky is also
     # posted before the inline comments so an inline failure still leaves a
     # status comment on the PR.
+    failure = _inline_failure(unmappable=fallback, rejected=[])
+    # "Nothing to post" is not a failure, but it is also not a posted comment:
+    # id capture has nothing to look for, while the lifecycle pass still runs
+    # — a round that fixed everything posts no inline comment and yet has the
+    # most threads to stamp.
+    inline_posted = False
     success = _upsert_sticky(
         reporter=gh_reporter,
-        body=render(
-            inline_failure=_inline_failure(unmappable=fallback, rejected=[]),
-        ),
+        body=render(inline_failure=failure),
         comment_id=comment_id,
     )
 
@@ -188,7 +216,7 @@ def post_review_to_github(
                 prior_state=prior_state,
             ),
         )
-        if not _post_inline_findings(
+        inline_posted = _post_inline_findings(
             reporter=gh_reporter,
             findings=inline_findings,
             checklist_display=checklist_display,
@@ -203,22 +231,41 @@ def post_review_to_github(
             carried_fingerprints=frozenset(
                 record.fingerprint for record in match.carried
             ),
-        ):
+            finding_keys=_record_keys(findings=inline_findings, match=match),
+            provenance=_regression_provenance(reporter=gh_reporter, match=match),
+        )
+        if not inline_posted:
             success = False
             # Degraded path (#1909): the rejected findings now have no surface
-            # either, so re-render with both groups folded in. ``prior_state``
-            # is unchanged, so this round is not double-counted, and the
-            # comment is only ever *updated* — a failed lookup skips rather
-            # than posting a second sticky on the PR.
-            _fold_inline_failure_into_sticky(
-                reporter=gh_reporter,
-                render=render,
-                failure=_inline_failure(
-                    unmappable=fallback,
-                    rejected=inline_findings,
-                ),
-                comment_id=comment_id,
+            # either, so the sticky is re-rendered below with both groups
+            # folded in. ``prior_state`` is unchanged, so this round is not
+            # double-counted.
+            failure = _inline_failure(
+                unmappable=fallback,
+                rejected=inline_findings,
             )
+
+    comment_ids = _run_lifecycle(
+        reporter=gh_reporter,
+        match=match,
+        prior_state=prior_state,
+        head_sha=head_sha,
+        round_number=prior_state.next_round,
+        auto_resolve=auto_resolve,
+        capture_ids=inline_posted,
+    )
+
+    # One follow-up edit at most: it carries the newly captured comment ids
+    # (so a later round can find these threads) and, when inline posting
+    # failed, the folded-in detail for findings that now have no surface.
+    if comment_ids or (inline_findings and not inline_posted):
+        _refresh_sticky(
+            reporter=gh_reporter,
+            render=render,
+            failure=failure,
+            comment_ids=comment_ids,
+            comment_id=comment_id,
+        )
 
     return success
 
@@ -259,11 +306,18 @@ def _inline_failure(
 class _StickyRenderer(Protocol):
     """Callable that renders the sticky body for a given inline-post outcome."""
 
-    def __call__(self, *, inline_failure: InlinePostFailure | None) -> str:
+    def __call__(
+        self,
+        *,
+        inline_failure: InlinePostFailure | None,
+        comment_ids: dict[str, int] | None = None,
+    ) -> str:
         """Render the body.
 
         Args:
             inline_failure: Findings whose inline comments could not be posted.
+            comment_ids: Finding key to inline comment id, persisted in the
+                state blob so a later round can edit those comments.
 
         Returns:
             The complete sticky comment body.
@@ -271,41 +325,256 @@ class _StickyRenderer(Protocol):
         ...  # pragma: no cover - structural type only
 
 
-def _fold_inline_failure_into_sticky(
+def _refresh_sticky(
     *,
     reporter: GitHubPRReporter,
     render: _StickyRenderer,
     failure: InlinePostFailure | None,
+    comment_ids: dict[str, int],
     comment_id: int | None,
 ) -> None:
-    """Re-render the sticky with the unpostable findings' detail folded in.
+    """Re-render the sticky after this round's inline comments are known.
 
-    Failing here is not worth failing the run over — the caller has already
-    recorded the inline failure — but it must not be silent either, or a PR
-    quietly ends up with a verdict whose findings appear nowhere.
+    Two things can only be written once the inline posting has been attempted:
+    the ids of the comments it created (#1912) and, when it failed, the folded
+    detail of findings that now have no surface (#1909). Failing here is not
+    worth failing the run over — the caller has already recorded any inline
+    failure — but it must not be silent either, or a PR quietly ends up with a
+    verdict whose findings appear nowhere, or with threads no later round can
+    find.
 
     Args:
         reporter: GitHub reporter used to locate and update the sticky comment.
-        render: Callable that renders the sticky body for a given failure.
+        render: Callable that renders the sticky body.
         failure: Findings whose inline comments could not be posted.
+        comment_ids: Finding key to inline comment id captured this round.
         comment_id: Sticky comment id known before the upsert, or ``None``.
     """
-    if failure is None:
-        return
     sticky_id = _sticky_comment_id(reporter=reporter, known=comment_id)
     if sticky_id is None:
         logger.warning(
-            "Sticky comment not found — inline-post failure details could not "
-            "be folded into it",
+            "Sticky comment not found — inline comment ids and any inline-post "
+            "failure details could not be written to it",
         )
         return
     if not reporter.update_issue_comment(
         comment_id=sticky_id,
-        body=render(inline_failure=failure),
+        body=render(inline_failure=failure, comment_ids=comment_ids),
     ):
-        logger.warning(
-            "Failed to fold inline-post failure details into the sticky comment",
+        logger.warning("Failed to refresh the sticky comment after inline posting")
+
+
+def _record_keys(
+    *,
+    findings: list[ReviewFinding],
+    match: FindingMatchResult,
+) -> list[str]:
+    """Pair each posted finding with the identity key of its record.
+
+    The key travels in a hidden marker on the inline comment, which is how the
+    comment is recognized again when the PR's comments are listed back — the
+    review-submission endpoint does not report the ids it created.
+
+    Args:
+        findings: Findings being posted inline, in posting order.
+        match: This round's matching outcome, whose records carry the keys.
+
+    Returns:
+        One key per finding, in the same order. An entry is empty when no
+        record could be paired, which leaves that comment unmarked rather than
+        mislabeled as another finding's thread.
+    """
+    slots: dict[tuple[str, str, int], list[str]] = defaultdict(list)
+    for record in match.records:
+        if record.status is FindingStatus.OPEN:
+            slots[(record.fingerprint, record.file, record.line)].append(record.key)
+
+    keys: list[str] = []
+    for finding in findings:
+        slot = (
+            fingerprint_for(
+                file=finding.file,
+                category=finding.category,
+                title=finding.title,
+            ),
+            normalize_file_path(finding.file),
+            finding.line,
         )
+        bucket = slots.get(slot)
+        keys.append(bucket.pop(0) if bucket else "")
+    return keys
+
+
+def _comment_url(*, reporter: GitHubPRReporter, comment_id: int | None) -> str:
+    """Build the browser URL of an inline review comment.
+
+    Args:
+        reporter: GitHub reporter carrying repo and PR context.
+        comment_id: Review comment id, or ``None`` when it is unknown.
+
+    Returns:
+        The comment's anchor URL, or an empty string — a pointer renders
+        unlinked rather than as a dead link.
+    """
+    if comment_id is None:
+        return ""
+    return (
+        f"https://github.com/{reporter.repo}/pull/{reporter.pr_number}"
+        f"#discussion_r{comment_id}"
+    )
+
+
+def _regression_provenance(
+    *,
+    reporter: GitHubPRReporter,
+    match: FindingMatchResult,
+) -> dict[str, str]:
+    """Build the provenance note each regression's fresh comment carries.
+
+    Args:
+        reporter: GitHub reporter used to link back to the original thread.
+        match: This round's matching outcome.
+
+    Returns:
+        Finding key to the note. Regressions are re-raised on a new thread
+        (state D), so without this a reader would be told a finding that was
+        raised and fixed two rounds ago is simply new.
+    """
+    return {
+        record.key: regression_provenance(
+            record=record,
+            thread_url=_comment_url(
+                reporter=reporter,
+                comment_id=record.inline_comment_id,
+            ),
+        )
+        for record in match.regressed
+    }
+
+
+def _partial_progress(
+    *,
+    match: FindingMatchResult,
+    prior_state: ReviewState,
+) -> list[FindingRecord]:
+    """Select collapsed patterns that lost occurrences this round (#1925).
+
+    Args:
+        match: This round's matching outcome.
+        prior_state: State decoded from the sticky comment before this round.
+
+    Returns:
+        Open records whose addressed-occurrence count rose this round. A
+        pattern that merely stayed where it was is excluded, so a long-lived
+        finding is not re-stamped with the same banner every round.
+    """
+    before = {record.key: record for record in prior_state.findings}
+    progressed: list[FindingRecord] = []
+    for record in match.records:
+        if record.status is not FindingStatus.OPEN:
+            continue
+        if record.inline_comment_id is None or record.occurrences_addressed <= 0:
+            continue
+        previous = before.get(record.key)
+        if previous is not None and previous.occurrences_addressed >= (
+            record.occurrences_addressed
+        ):
+            continue
+        progressed.append(record)
+    return progressed
+
+
+def _run_lifecycle(
+    *,
+    reporter: GitHubPRReporter,
+    match: FindingMatchResult,
+    prior_state: ReviewState,
+    head_sha: str,
+    round_number: int,
+    auto_resolve: bool,
+    capture_ids: bool,
+) -> dict[str, int]:
+    """Stamp settled threads and capture the ids of this round's comments.
+
+    Both halves need the PR's inline comments, so the listing is fetched once
+    and shared: the bodies are what the banner is applied to, and the hidden
+    markers are what identifies a freshly posted comment.
+
+    Args:
+        reporter: GitHub reporter used for the listing, edits, and mutations.
+        match: This round's matching outcome.
+        prior_state: State decoded from the sticky comment before this round.
+        head_sha: Head commit sha reviewed in this round.
+        round_number: 1-based round number for this run.
+        auto_resolve: Whether an addressed thread may also be resolved.
+        capture_ids: Whether inline comments were posted this round, and so
+            whether there are new ids to look for.
+
+    Returns:
+        Finding key to inline comment id for records that did not already have
+        one (and for regressions, whose live thread is now the new one). Empty
+        when there was nothing to capture or the listing failed.
+    """
+    partial = _partial_progress(match=match, prior_state=prior_state)
+    regressed = tuple(
+        record for record in match.regressed if record.inline_comment_id is not None
+    )
+    resolved = tuple(
+        record for record in match.resolved if record.inline_comment_id is not None
+    )
+    if not capture_ids and not (partial or regressed or resolved):
+        return {}
+
+    comments = reporter.fetch_review_comments()
+    if not isinstance(comments, list):
+        logger.debug(
+            "Could not list inline review comments — lifecycle banners and "
+            "comment-id capture are skipped this round",
+        )
+        return {}
+
+    bodies: dict[int, str] = {}
+    newest: dict[str, int] = {}
+    for comment in comments:
+        comment_id = comment.get("id")
+        body = comment.get("body")
+        if not isinstance(comment_id, int) or not isinstance(body, str):
+            continue
+        bodies[comment_id] = body
+        key = parse_finding_marker(body=body)
+        if key:
+            newest[key] = max(newest.get(key, 0), comment_id)
+
+    sync_addressed_lifecycle(
+        reporter=reporter,
+        resolved=resolved,
+        partial=partial,
+        regressed=regressed,
+        comment_bodies=bodies,
+        head_sha=head_sha,
+        round_number=round_number,
+        auto_resolve=auto_resolve,
+        new_thread_urls={
+            record.key: _comment_url(
+                reporter=reporter,
+                comment_id=newest.get(record.key),
+            )
+            for record in regressed
+        },
+    )
+
+    if not capture_ids:
+        return {}
+    # A record that already has a thread keeps it: that is the comment the
+    # banners are written onto. A regression is the exception — its live thread
+    # is the fresh one, because the old thread stays resolved.
+    regressed_keys = {record.key for record in match.regressed}
+    return {
+        record.key: newest[record.key]
+        for record in match.records
+        if record.key in newest
+        and (record.inline_comment_id is None or record.key in regressed_keys)
+    }
 
 
 def _sticky_comment_id(
@@ -484,6 +753,23 @@ def _round_diff_lines(
     return reporter.fetch_compare_lines(base=prior_sha, head=head_sha)
 
 
+def _inline_body(*, body: str, key: str, note: str) -> str:
+    """Assemble an inline comment body with provenance and identity marker.
+
+    Args:
+        body: Rendered finding comment.
+        key: Identity key of the finding's record, possibly empty.
+        note: Provenance note for a regression, possibly empty.
+
+    Returns:
+        The body to post. The marker is hidden (an HTML comment) and sits last,
+        so it never affects how the comment reads.
+    """
+    marker = finding_marker(key=key)
+    parts = [part for part in (note, body, marker) if part]
+    return "\n\n".join(parts)
+
+
 def _post_inline_findings(
     *,
     reporter: GitHubPRReporter,
@@ -493,6 +779,8 @@ def _post_inline_findings(
     review_body: str = "",
     round_diff_lines: dict[str, set[int]] | None = None,
     carried_fingerprints: frozenset[str] = frozenset(),
+    finding_keys: Sequence[str] = (),
+    provenance: Mapping[str, str] | None = None,
 ) -> bool:
     """Post inline PR review comments for mappable findings.
 
@@ -513,12 +801,19 @@ def _post_inline_findings(
             disables committable suggestions entirely.
         carried_fingerprints: Fingerprints of findings already reported in an
             earlier round; they fall back to a described fix.
+        finding_keys: Identity key per finding, in the same order, embedded as
+            a hidden marker so the posted comment can be recognized later.
+        provenance: Finding key to a provenance note prepended to its comment.
+            A regression is re-raised on a fresh thread, and the note is what
+            keeps it from reading as a brand-new finding.
 
     Returns:
         True when the review was submitted successfully.
     """
+    notes = provenance or {}
     comments: list[dict[str, Any]] = []
-    for finding in findings:
+    for index, finding in enumerate(findings):
+        key = finding_keys[index] if index < len(finding_keys) else ""
         plan = plan_inline_fix(
             finding=finding,
             round_diff_lines=round_diff_lines,
@@ -531,11 +826,15 @@ def _post_inline_findings(
         )
         comment: dict[str, Any] = {
             "path": normalize_diff_path(finding.file),
-            "body": format_finding_comment(
-                finding=finding,
-                checklist_display=checklist_display,
-                question_map=question_map,
-                inline_fix=plan,
+            "body": _inline_body(
+                body=format_finding_comment(
+                    finding=finding,
+                    checklist_display=checklist_display,
+                    question_map=question_map,
+                    inline_fix=plan,
+                ),
+                key=key,
+                note=notes.get(key, ""),
             ),
             "line": finding.line,
             "side": "RIGHT",

--- a/lintro/ai/review/github_lifecycle.py
+++ b/lintro/ai/review/github_lifecycle.py
@@ -1,0 +1,515 @@
+"""Addressed lifecycle for inline finding threads (#1912).
+
+An inline finding comment is posted once and then *edited* for the rest of the
+PR's life, so the thread carries its own outcome instead of leaving a reader to
+diff two rounds of comments by eye. Three stamps exist, all written into a
+single replaceable block at the end of the comment body:
+
+* ``✔ Addressed in <sha> · round N`` — every occurrence stopped reproducing.
+  The comment's agent-prompt panel is retitled ``(historical)`` so nobody pastes
+  a prompt for a fix that already landed, and the thread is resolved when
+  ``review.auto_resolve`` allows it.
+* ``✔ 14/20 addressed in <sha> · round N`` — partial progress on a collapsed
+  pattern (#1925). The finding is still open, so the thread is **never**
+  resolved and the prompt panel stays live.
+* ``↩ Regressed in <sha> · round N`` — the finding came back. The old thread is
+  stamped and *stays resolved*; the finding is re-raised on a fresh thread that
+  carries the provenance back to here (mock-4 section 3, state D).
+
+Every edit is idempotent: the block is rewritten wholesale and an unchanged
+body is never PATCHed, so re-running a round adds no second banner.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from loguru import logger
+
+from lintro.ai.review.enums.lifecycle_stage import LifecycleStage
+from lintro.ai.review.github_constants import SHORT_SHA_LENGTH
+from lintro.ai.review.models.finding_record import FindingRecord
+from lintro.ai.review.models.review_thread import ReviewThread
+from lintro.ai.review.sanitize import sanitize_comment_text
+
+__all__ = [
+    "FINDING_MARKER_PREFIX",
+    "LIFECYCLE_CLOSE",
+    "LIFECYCLE_OPEN",
+    "LifecycleClient",
+    "LifecycleReport",
+    "apply_lifecycle_block",
+    "finding_marker",
+    "parse_finding_marker",
+    "regression_provenance",
+    "render_lifecycle_block",
+    "sync_addressed_lifecycle",
+]
+
+#: Hidden marker tying an inline comment to the finding record that owns it.
+#: The review-submission endpoint does not answer with the comment ids it
+#: created, so the marker is how a posted comment is recognized when the PR's
+#: comments are listed back.
+FINDING_MARKER_PREFIX = "<!-- lintro-finding:"
+FINDING_MARKER_SUFFIX = " -->"
+
+#: Delimiters of the replaceable lifecycle block at the end of a comment body.
+LIFECYCLE_OPEN = "<!-- lintro-lifecycle -->"
+LIFECYCLE_CLOSE = "<!-- /lintro-lifecycle -->"
+
+#: Suffix appended to a prompt panel's title once its finding is settled.
+HISTORICAL_SUFFIX = " (historical)"
+
+_FINDING_MARKER_RE = re.compile(
+    re.escape(FINDING_MARKER_PREFIX) + r"\s*([0-9a-f]+#\d+)\s*-->",
+)
+_LIFECYCLE_BLOCK_RE = re.compile(
+    re.escape(LIFECYCLE_OPEN) + r".*?" + re.escape(LIFECYCLE_CLOSE),
+    re.DOTALL,
+)
+_PANEL_TITLE_RE = re.compile(r"^> ⚡ \*\*(?P<title>.+?)\*\*\s*$", re.MULTILINE)
+
+#: Keys are hashes and ordinals, never model text, but the value is still
+#: interpolated into a comment body — keep it to the shape the writer emits.
+_KEY_RE = re.compile(r"^[0-9a-f]+#\d+$")
+
+
+class LifecycleClient(Protocol):
+    """The GitHub operations the lifecycle needs, and nothing more.
+
+    Structural typing keeps this module independent of the reporter class: the
+    lifecycle only ever edits a comment and resolves a thread, so a caller can
+    supply any object that does those two things.
+    """
+
+    def update_review_comment(self, *, comment_id: int, body: str) -> bool:
+        """Edit an inline review comment in place.
+
+        Args:
+            comment_id: Comment to edit.
+            body: New Markdown body.
+
+        Returns:
+            True when the edit succeeded.
+        """
+        ...  # pragma: no cover - structural type only
+
+    def fetch_review_threads(self) -> dict[int, ReviewThread] | None:
+        """Map each review thread's root comment id to the thread.
+
+        Returns:
+            The mapping, or ``None`` when it could not be fetched.
+        """
+        ...  # pragma: no cover - structural type only
+
+    def resolve_review_thread(self, *, thread_id: str) -> bool:
+        """Resolve a review thread.
+
+        Args:
+            thread_id: GraphQL node id of the thread.
+
+        Returns:
+            True when GitHub reports the thread as resolved.
+        """
+        ...  # pragma: no cover - structural type only
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleReport:
+    """Outcome of one lifecycle synchronization pass.
+
+    Attributes:
+        edited: Keys of findings whose inline comment body was rewritten.
+        unchanged: Keys whose comment already carried the exact stamp, so no
+            request was made.
+        resolved: Keys whose review thread was resolved this pass.
+        failed: Keys whose comment edit or thread resolution did not take
+            effect. The banner is retried on the next round because the stored
+            body still differs from the rendered one — a failed stamp degrades
+            to "not stamped yet", never to a crash.
+    """
+
+    edited: tuple[str, ...] = field(default_factory=tuple)
+    unchanged: tuple[str, ...] = field(default_factory=tuple)
+    resolved: tuple[str, ...] = field(default_factory=tuple)
+    failed: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def has_failures(self) -> bool:
+        """Return True when any stamp or resolution did not take effect."""
+        return bool(self.failed)
+
+
+def finding_marker(*, key: str) -> str:
+    """Render the hidden marker identifying a finding's inline comment.
+
+    Args:
+        key: The finding record's ``fingerprint#ordinal`` identity key.
+
+    Returns:
+        The HTML comment marker, or an empty string when the key is not a
+        well-formed identity key.
+    """
+    if not _KEY_RE.match(key):
+        return ""
+    return f"{FINDING_MARKER_PREFIX}{key}{FINDING_MARKER_SUFFIX}"
+
+
+def parse_finding_marker(*, body: str) -> str:
+    """Extract the finding key a comment body is marked with.
+
+    Args:
+        body: Inline comment body as returned by the API.
+
+    Returns:
+        The identity key, or an empty string when the body carries no marker
+        (a human's reply, or a comment from another tool).
+    """
+    match = _FINDING_MARKER_RE.search(body)
+    return match.group(1) if match else ""
+
+
+def _short_sha(*, sha: str) -> str:
+    """Return the display-length prefix of a commit sha, or an empty string."""
+    return sanitize_comment_text(sha, limit=64).strip()[:SHORT_SHA_LENGTH]
+
+
+def _sha_label(*, sha: str) -> str:
+    """Render a commit sha for a banner, degrading when it is unknown."""
+    short = _short_sha(sha=sha)
+    return f"`{short}`" if short else "this round's commit"
+
+
+def render_lifecycle_block(
+    *,
+    record: FindingRecord,
+    stage: LifecycleStage,
+    head_sha: str,
+    round_number: int,
+    new_thread_url: str = "",
+) -> str:
+    """Render the lifecycle block stamped onto a finding's inline comment.
+
+    Args:
+        record: Finding record the comment belongs to.
+        stage: What this round verified about the finding.
+        head_sha: Head commit sha reviewed in this round.
+        round_number: 1-based round number for this run.
+        new_thread_url: URL of the fresh thread carrying a regression, when it
+            could be resolved.
+
+    Returns:
+        The delimited block, ready to be appended to (or swapped into) a
+        comment body.
+    """
+    lines = _banner_lines(
+        record=record,
+        stage=stage,
+        head_sha=head_sha,
+        round_number=round_number,
+        new_thread_url=new_thread_url,
+    )
+    return "\n".join([LIFECYCLE_OPEN, *lines, LIFECYCLE_CLOSE])
+
+
+def _banner_lines(
+    *,
+    record: FindingRecord,
+    stage: LifecycleStage,
+    head_sha: str,
+    round_number: int,
+    new_thread_url: str,
+) -> list[str]:
+    """Render the banner blockquote lines for one lifecycle stage.
+
+    Args:
+        record: Finding record the comment belongs to.
+        stage: What this round verified about the finding.
+        head_sha: Head commit sha reviewed in this round.
+        round_number: 1-based round number for this run.
+        new_thread_url: URL of the fresh thread carrying a regression.
+
+    Returns:
+        One or two blockquote lines.
+    """
+    where = _sha_label(sha=head_sha)
+    if stage is LifecycleStage.ADDRESSED:
+        return [f"> ✔ **Addressed in {where} · round {round_number}**"]
+    if stage is LifecycleStage.PARTIAL:
+        return [
+            f"> ✔ **{record.occurrences_addressed}/{record.occurrence_total} "
+            f"addressed in {where} · round {round_number}** — the pattern is "
+            "still open; this thread stays open until every occurrence is gone.",
+        ]
+
+    lines: list[str] = []
+    fixed_in = _short_sha(sha=record.resolved_sha)
+    if fixed_in:
+        lines.append(
+            f"> ✔ **Addressed in `{fixed_in}` · round {record.resolved_round}**",
+        )
+    pointer = (
+        f"see the [new thread]({new_thread_url})"
+        if new_thread_url
+        else "see the new inline comment for this finding"
+    )
+    lines.append(
+        f"> ↩ **Regressed in {where} · round {round_number}** — {pointer}. "
+        "This thread stays resolved.",
+    )
+    return lines
+
+
+def regression_provenance(*, record: FindingRecord, thread_url: str = "") -> str:
+    """Render the provenance note carried by a regression's fresh comment.
+
+    Args:
+        record: The regressed finding record, still carrying the round it was
+            first raised in and the round that had fixed it.
+        thread_url: URL of the original thread, when its comment id is known.
+
+    Returns:
+        A one-line blockquote naming the finding's history, so a reader of the
+        new thread is not told a fixed finding is simply "new".
+    """
+    fixed_in = _short_sha(sha=record.resolved_sha)
+    fixed = f"fixed round {record.resolved_round}" if record.resolved_round else "fixed"
+    if fixed_in:
+        fixed += f" (`{fixed_in}`)"
+    origin = f" — [original thread]({thread_url})" if thread_url else ""
+    return (
+        f"> ↩ **regression** · first raised round {record.since_round}, "
+        f"{fixed}{origin}"
+    )
+
+
+def apply_lifecycle_block(*, body: str, block: str, historical: bool) -> str:
+    """Stamp a lifecycle block onto an existing inline comment body.
+
+    Args:
+        body: The comment's current body.
+        block: Rendered lifecycle block.
+        historical: Whether the comment's agent-prompt panel should be retitled
+            ``(historical)``. Only a settled finding earns that: a partially
+            addressed pattern still wants a live prompt.
+
+    Returns:
+        The new body. An existing block is replaced rather than appended to, so
+        repeated rounds never stack banners.
+    """
+    stamped = _retitle_prompt_panel(body=body) if historical else body
+    if _LIFECYCLE_BLOCK_RE.search(stamped):
+        return _LIFECYCLE_BLOCK_RE.sub(lambda _match: block, stamped, count=1)
+    return f"{stamped.rstrip()}\n\n{block}"
+
+
+def _retitle_prompt_panel(*, body: str) -> str:
+    """Mark the comment's agent-prompt panel as historical, once.
+
+    Args:
+        body: The comment's current body.
+
+    Returns:
+        The body with ``(historical)`` appended to the panel title. A title
+        that already carries the suffix is left alone, so the edit is
+        idempotent across rounds.
+    """
+
+    def _rewrite(match: re.Match[str]) -> str:
+        title = match.group("title")
+        if title.endswith(HISTORICAL_SUFFIX.strip()) or HISTORICAL_SUFFIX in title:
+            return match.group(0)
+        return f"> ⚡ **{title}{HISTORICAL_SUFFIX}**"
+
+    return _PANEL_TITLE_RE.sub(_rewrite, body)
+
+
+@dataclass(frozen=True, slots=True)
+class _LifecycleEdit:
+    """One planned comment edit.
+
+    Attributes:
+        record: Finding record being stamped.
+        stage: Lifecycle stage driving the stamp.
+        historical: Whether the prompt panel is retitled.
+        resolvable: Whether the thread may be resolved when config allows it.
+        new_thread_url: URL of the regression's fresh thread, when known.
+    """
+
+    record: FindingRecord
+    stage: LifecycleStage
+    historical: bool
+    resolvable: bool
+    new_thread_url: str = ""
+
+
+def sync_addressed_lifecycle(
+    *,
+    reporter: LifecycleClient,
+    resolved: Sequence[FindingRecord] = (),
+    partial: Sequence[FindingRecord] = (),
+    regressed: Sequence[FindingRecord] = (),
+    comment_bodies: Mapping[int, str],
+    head_sha: str,
+    round_number: int,
+    auto_resolve: bool = True,
+    new_thread_urls: Mapping[str, str] | None = None,
+) -> LifecycleReport:
+    """Stamp — and optionally resolve — the threads this round settled.
+
+    Args:
+        reporter: GitHub reporter used to edit comments and resolve threads.
+        resolved: Records the matcher resolved this round.
+        partial: Open records of collapsed patterns with some occurrences gone.
+        regressed: Records that came back this round; their *old* thread is
+            stamped and deliberately left resolved.
+        comment_bodies: Current bodies of the PR's inline comments, keyed by
+            comment id. A record whose body is absent is skipped: overwriting
+            a comment whose content is unknown would destroy the finding it
+            carries.
+        head_sha: Head commit sha reviewed in this round.
+        round_number: 1-based round number for this run.
+        auto_resolve: ``review.auto_resolve``. False keeps the banner and skips
+            the GraphQL mutation entirely.
+        new_thread_urls: Finding key to the URL of the fresh thread carrying
+            its regression.
+
+    Returns:
+        What was edited, resolved, already current, or failed. Every failure is
+        logged and reported rather than raised: a review that found real issues
+        must still post, even when GitHub refuses one edit.
+    """
+    urls = new_thread_urls or {}
+    edits = [
+        *(
+            _LifecycleEdit(
+                record=record,
+                stage=LifecycleStage.ADDRESSED,
+                historical=True,
+                resolvable=True,
+            )
+            for record in resolved
+        ),
+        *(
+            _LifecycleEdit(
+                record=record,
+                stage=LifecycleStage.PARTIAL,
+                historical=False,
+                resolvable=False,
+            )
+            for record in partial
+        ),
+        *(
+            _LifecycleEdit(
+                record=record,
+                stage=LifecycleStage.REGRESSED,
+                historical=True,
+                resolvable=False,
+                new_thread_url=urls.get(record.key, ""),
+            )
+            for record in regressed
+        ),
+    ]
+
+    edited: list[str] = []
+    unchanged: list[str] = []
+    failed: list[str] = []
+    resolvable_ids: list[tuple[str, int]] = []
+
+    for edit in edits:
+        comment_id = edit.record.inline_comment_id
+        if comment_id is None:
+            continue
+        current = comment_bodies.get(comment_id)
+        if current is None:
+            logger.debug(
+                "No stored body for comment {} — skipping the {} banner",
+                comment_id,
+                edit.stage.value,
+            )
+            continue
+        body = apply_lifecycle_block(
+            body=current,
+            block=render_lifecycle_block(
+                record=edit.record,
+                stage=edit.stage,
+                head_sha=head_sha,
+                round_number=round_number,
+                new_thread_url=edit.new_thread_url,
+            ),
+            historical=edit.historical,
+        )
+        if body == current:
+            unchanged.append(edit.record.key)
+        elif reporter.update_review_comment(comment_id=comment_id, body=body):
+            edited.append(edit.record.key)
+        else:
+            logger.warning(
+                "Could not stamp the {} banner onto review comment {}; it will "
+                "be retried next round",
+                edit.stage.value,
+                comment_id,
+            )
+            failed.append(edit.record.key)
+            continue
+        if edit.resolvable and auto_resolve:
+            resolvable_ids.append((edit.record.key, comment_id))
+
+    resolved_keys, resolve_failures = _resolve_threads(
+        reporter=reporter,
+        targets=resolvable_ids,
+    )
+    return LifecycleReport(
+        edited=tuple(edited),
+        unchanged=tuple(unchanged),
+        resolved=tuple(resolved_keys),
+        failed=(*failed, *resolve_failures),
+    )
+
+
+def _resolve_threads(
+    *,
+    reporter: LifecycleClient,
+    targets: Sequence[tuple[str, int]],
+) -> tuple[list[str], list[str]]:
+    """Resolve the review threads rooted at the given comments.
+
+    Args:
+        reporter: GitHub reporter used for the GraphQL calls.
+        targets: ``(finding key, root comment id)`` pairs to resolve.
+
+    Returns:
+        Tuple of ``(resolved keys, failed keys)``. A thread GitHub already
+        reports as resolved counts as resolved without a second mutation.
+    """
+    if not targets:
+        return [], []
+    threads: dict[int, ReviewThread] | None = reporter.fetch_review_threads()
+    if threads is None:
+        logger.warning(
+            "Could not list review threads — {} thread(s) keep their banner but "
+            "stay unresolved",
+            len(targets),
+        )
+        return [], [key for key, _ in targets]
+
+    resolved: list[str] = []
+    failed: list[str] = []
+    for key, comment_id in targets:
+        thread = threads.get(comment_id)
+        if thread is None:
+            logger.debug("No review thread found for comment {}", comment_id)
+            failed.append(key)
+            continue
+        if thread.is_resolved:
+            resolved.append(key)
+            continue
+        if reporter.resolve_review_thread(thread_id=thread.node_id):
+            resolved.append(key)
+        else:
+            logger.warning("Could not resolve review thread for comment {}", comment_id)
+            failed.append(key)
+    return resolved, failed

--- a/lintro/ai/review/github_lifecycle.py
+++ b/lintro/ai/review/github_lifecycle.py
@@ -251,10 +251,13 @@ def _banner_lines(
         lines.append(
             f"> ✔ **Addressed in `{fixed_in}` · round {record.resolved_round}**",
         )
+    # Without a url there may be no new thread at all: a finding that no longer
+    # anchors to a line in the diff is re-raised on the sticky comment instead,
+    # so pointing at an inline comment that does not exist would be a lie.
     pointer = (
         f"see the [new thread]({new_thread_url})"
         if new_thread_url
-        else "see the new inline comment for this finding"
+        else "the finding is open again — see the sticky comment's open findings"
     )
     lines.append(
         f"> ↩ **Regressed in {where} · round {round_number}** — {pointer}. "

--- a/lintro/ai/review/github_lifecycle.py
+++ b/lintro/ai/review/github_lifecycle.py
@@ -349,6 +349,53 @@ class _LifecycleEdit:
     new_thread_url: str = ""
 
 
+#: Which stage wins when one thread qualifies for two of them in a round.
+#: Regression sorts first because it is the only stage that subsumes another:
+#: its banner already carries the ``✔ Addressed in <sha>`` line for the round
+#: that had fixed the finding, and it adds what a reader cannot get anywhere
+#: else — this thread is stale, the live discussion moved to the new one
+#: (mock-4 section 3, state D). "Addressed" outranks "partial" for the same
+#: reason a whole is more than a part. Lower sorts first.
+_STAGE_PRECEDENCE: dict[LifecycleStage, int] = {
+    LifecycleStage.REGRESSED: 0,
+    LifecycleStage.ADDRESSED: 1,
+    LifecycleStage.PARTIAL: 2,
+}
+
+
+def _one_edit_per_thread(
+    *,
+    edits: Sequence[_LifecycleEdit],
+) -> list[tuple[int, _LifecycleEdit]]:
+    """Collapse the planned edits to at most one per inline comment.
+
+    A single record can qualify for two stages in one round — a regression that
+    also lost some of its occurrences. Editing its comment twice would apply the
+    second banner to the pre-edit body, silently undoing the first edit's
+    ``(historical)`` retitle and leaving a regression banner beside a live fix
+    prompt.
+
+    Args:
+        edits: Planned edits, in stage order.
+
+    Returns:
+        ``(comment id, edit)`` pairs, one per comment, keeping the stage that
+        most needs saying. Edits without a comment id are dropped: they have no
+        thread to stamp.
+    """
+    chosen: dict[int, _LifecycleEdit] = {}
+    for edit in edits:
+        comment_id = edit.record.inline_comment_id
+        if comment_id is None:
+            continue
+        held = chosen.get(comment_id)
+        if held is None or (
+            _STAGE_PRECEDENCE[edit.stage] < _STAGE_PRECEDENCE[held.stage]
+        ):
+            chosen[comment_id] = edit
+    return list(chosen.items())
+
+
 def sync_addressed_lifecycle(
     *,
     reporter: LifecycleClient,
@@ -416,16 +463,14 @@ def sync_addressed_lifecycle(
             for record in regressed
         ),
     ]
+    planned = _one_edit_per_thread(edits=edits)
 
     edited: list[str] = []
     unchanged: list[str] = []
     failed: list[str] = []
     resolvable_ids: list[tuple[str, int]] = []
 
-    for edit in edits:
-        comment_id = edit.record.inline_comment_id
-        if comment_id is None:
-            continue
+    for comment_id, edit in planned:
         current = comment_bodies.get(comment_id)
         if current is None:
             logger.debug(

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -34,6 +34,7 @@ Two invariants the renderer enforces:
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from typing import Any, Protocol
 
@@ -92,7 +93,38 @@ __all__ = [
     "build_sticky_comment",
     "parse_review_state",
     "parse_review_state_v2",
+    "stamp_comment_ids",
 ]
+
+
+def stamp_comment_ids(
+    *,
+    records: tuple[FindingRecord, ...],
+    comment_ids: Mapping[str, int] | None,
+) -> tuple[FindingRecord, ...]:
+    """Attach captured inline comment ids to the records about to be persisted.
+
+    Args:
+        records: Records produced by this round's matching.
+        comment_ids: Finding key to inline comment id, or ``None`` when no ids
+            were captured.
+
+    Returns:
+        The records, each carrying its comment id when one is known. A record
+        keeps the id it already had when the capture found none, so a failed
+        listing never erases the anchor a later round edits.
+    """
+    if not comment_ids:
+        return records
+    return tuple(
+        (
+            replace(record, inline_comment_id=comment_ids[record.key])
+            if record.key in comment_ids
+            else record
+        )
+        for record in records
+    )
+
 
 #: Emoji rendered next to each readiness verdict's label.
 VERDICT_EMOJI: dict[ReviewVerdict, str] = {
@@ -210,6 +242,7 @@ def build_sticky_comment(
     transport: str = "",
     auth_mode: str = "",
     inline_failure: InlinePostFailure | None = None,
+    inline_comment_ids: Mapping[str, int] | None = None,
 ) -> str:
     """Compose the full v5 "mission control" sticky PR comment body.
 
@@ -236,6 +269,10 @@ def build_sticky_comment(
         inline_failure: Findings whose inline comments could not be posted.
             When set, the sticky renders a warning row above the open-findings
             table and folds those findings' full detail back in.
+        inline_comment_ids: Finding key to the id of the inline comment that
+            carries it, captured after this round's review was submitted
+            (#1912). Stamped onto the persisted records so a later round can
+            edit those comments in place; rendering is unaffected.
 
     Returns:
         Complete Markdown body carrying the hidden marker and state block,
@@ -292,7 +329,10 @@ def build_sticky_comment(
     )
     new_state = ReviewState(
         runs=tuple(all_runs),
-        findings=match.records,
+        findings=stamp_comment_ids(
+            records=match.records,
+            comment_ids=inline_comment_ids,
+        ),
         truncated=state.truncated or runs_dropped,
     )
     return body + render_state_block(

--- a/lintro/ai/review/models/__init__.py
+++ b/lintro/ai/review/models/__init__.py
@@ -20,6 +20,7 @@ from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.review_summary import ReviewSummary
+from lintro.ai.review.models.review_thread import ReviewThread
 from lintro.ai.review.models.run_record import RunRecord
 from lintro.ai.review.models.skipped_file import SkippedFile
 from lintro.ai.review.models.suggested_change import SuggestedChange
@@ -45,6 +46,7 @@ __all__ = [
     "ReviewResult",
     "ReviewState",
     "ReviewSummary",
+    "ReviewThread",
     "RunRecord",
     "SkippedFile",
     "Severity",

--- a/lintro/ai/review/models/review_thread.py
+++ b/lintro/ai/review/models/review_thread.py
@@ -1,0 +1,23 @@
+"""GraphQL review-thread reference for the addressed lifecycle (#1912)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["ReviewThread"]
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewThread:
+    """A PR review thread as addressed by the GraphQL API.
+
+    Attributes:
+        node_id: GraphQL node id, the only handle ``resolveReviewThread``
+            accepts. REST comment ids cannot be used for the mutation.
+        is_resolved: Whether the thread is already resolved. An already
+            resolved thread is skipped rather than re-resolved, which keeps a
+            re-run from writing a second resolution event onto the timeline.
+    """
+
+    node_id: str
+    is_resolved: bool = False

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -478,6 +478,7 @@ def review_command(
             checklist_display=checklist_display,
             question_map=question_map,
             transport=str(effective_ai_config.transport),
+            auto_resolve=lintro_config.review.auto_resolve,
             config_source=_describe_config_source(
                 config_path=lintro_config.config_path,
                 overrides=_cli_overrides(

--- a/lintro/config/review_config.py
+++ b/lintro/config/review_config.py
@@ -156,6 +156,16 @@ class ReviewConfig(BaseModel):
             "(one agent call per chunk) but can surface more per-file doc nits."
         ),
     )
+    auto_resolve: bool = Field(
+        default=True,
+        description=(
+            "Resolve a PR review thread once its finding no longer reproduces. "
+            "The '✔ Addressed' banner is written onto the inline comment either "
+            "way; set false to keep resolving threads a manual ceremony. A "
+            "partially addressed pattern is never resolved, and a regression "
+            "never reopens a resolved thread."
+        ),
+    )
     custom_agents: CustomAgentMode = Field(
         default=CustomAgentMode.ENABLED,
         description=(

--- a/tests/unit/ai/review/test_addressed_lifecycle_1912.py
+++ b/tests/unit/ai/review/test_addressed_lifecycle_1912.py
@@ -1,0 +1,807 @@
+"""Tests for the addressed lifecycle on inline finding threads (#1912)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.integrations.github_pr import GitHubPRReporter
+from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.enums.lifecycle_stage import LifecycleStage
+from lintro.ai.review.finding_matcher import fingerprint_for
+from lintro.ai.review.github import post_review_to_github
+from lintro.ai.review.github_constants import (
+    STATE_MARKER_PREFIX,
+    STATE_MARKER_SUFFIX,
+    STICKY_MARKER,
+)
+from lintro.ai.review.github_lifecycle import (
+    LIFECYCLE_OPEN,
+    apply_lifecycle_block,
+    finding_marker,
+    parse_finding_marker,
+    regression_provenance,
+    render_lifecycle_block,
+    sync_addressed_lifecycle,
+)
+from lintro.ai.review.models.finding_occurrence import FindingOccurrence
+from lintro.ai.review.models.finding_record import FindingRecord
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.review_thread import ReviewThread
+from lintro.ai.review.models.run_record import RunRecord
+from lintro.ai.review.review_state_codec import render_state_block
+
+_TEST_TOKEN = (
+    "ghp_test_fixture_token"  # noqa: S105  # nosec B105 — fake test fixture token
+)
+_HEAD_SHA = "abc1234def5678"
+_COMMENT_ID = 101
+_THREAD_ID = "PRRT_thread_node"
+
+_INLINE_BODY = "\n\n".join(
+    [
+        "🔴 **P1** · `security` · `high confidence`",
+        "**Fail-open default**",
+        "Unknown status grants access.",
+        "> [!IMPORTANT]",
+        "> ⚡ **Prompt for AI agents**",
+        ">",
+        "> </details>",
+    ],
+)
+
+
+class _FakeReporter:
+    """Reporter double recording lifecycle edits and thread resolutions."""
+
+    def __init__(
+        self,
+        *,
+        threads: dict[int, ReviewThread] | None = None,
+        edit_ok: bool = True,
+        resolve_ok: bool = True,
+    ) -> None:
+        """Initialize the double.
+
+        Args:
+            threads: Thread map returned by ``fetch_review_threads``. ``None``
+                simulates a failed listing.
+            edit_ok: Whether comment edits succeed.
+            resolve_ok: Whether the resolve mutation succeeds.
+        """
+        self.repo = "owner/name"
+        self.pr_number = 7
+        self.api_base = "https://api.github.com"
+        self.edits: list[tuple[int, str]] = []
+        self.resolved_threads: list[str] = []
+        self._threads = threads
+        self._edit_ok = edit_ok
+        self._resolve_ok = resolve_ok
+
+    def update_review_comment(self, *, comment_id: int, body: str) -> bool:
+        """Record an inline comment edit.
+
+        Args:
+            comment_id: Comment being edited.
+            body: New body.
+
+        Returns:
+            The configured outcome.
+        """
+        self.edits.append((comment_id, body))
+        return self._edit_ok
+
+    def fetch_review_threads(self) -> dict[int, ReviewThread] | None:
+        """Return the configured thread map."""
+        return self._threads
+
+    def resolve_review_thread(self, *, thread_id: str) -> bool:
+        """Record a thread resolution.
+
+        Args:
+            thread_id: Thread node id.
+
+        Returns:
+            The configured outcome.
+        """
+        self.resolved_threads.append(thread_id)
+        return self._resolve_ok
+
+
+def _record(**overrides: Any) -> FindingRecord:
+    """Build a tracked finding record with lifecycle-relevant defaults.
+
+    Args:
+        **overrides: Field overrides.
+
+    Returns:
+        The record.
+    """
+    base = FindingRecord(
+        fingerprint="a1b2c3d4e5f60718",
+        ordinal=1,
+        category="security",
+        title="Fail-open default",
+        file="src/main.py",
+        line=10,
+        since_round=1,
+        inline_comment_id=_COMMENT_ID,
+    )
+    return replace(base, **overrides)
+
+
+def _threads(*, is_resolved: bool = False) -> dict[int, ReviewThread]:
+    """Build a thread map covering the fixture comment.
+
+    Args:
+        is_resolved: Whether the thread is already resolved.
+
+    Returns:
+        The map.
+    """
+    return {_COMMENT_ID: ReviewThread(node_id=_THREAD_ID, is_resolved=is_resolved)}
+
+
+# --- rendering ---------------------------------------------------------------
+
+
+def test_addressed_banner_names_the_fixing_commit_and_round() -> None:
+    """The banner is the thread's outcome, so it must carry sha and round."""
+    block = render_lifecycle_block(
+        record=_record(status=FindingStatus.RESOLVED),
+        stage=LifecycleStage.ADDRESSED,
+        head_sha=_HEAD_SHA,
+        round_number=3,
+    )
+
+    assert_that(block).contains("✔ **Addressed in `abc1234` · round 3**")
+
+
+def test_applying_the_block_retitles_the_prompt_panel_as_historical() -> None:
+    """A settled finding must not offer a live fix prompt."""
+    block = render_lifecycle_block(
+        record=_record(status=FindingStatus.RESOLVED),
+        stage=LifecycleStage.ADDRESSED,
+        head_sha=_HEAD_SHA,
+        round_number=2,
+    )
+
+    body = apply_lifecycle_block(body=_INLINE_BODY, block=block, historical=True)
+
+    assert_that(body).contains("> ⚡ **Prompt for AI agents (historical)**")
+    assert_that(body).contains("✔ **Addressed in `abc1234` · round 2**")
+
+
+def test_partial_progress_keeps_the_prompt_panel_live() -> None:
+    """A pattern with occurrences left still wants an actionable prompt."""
+    block = render_lifecycle_block(
+        record=_record(
+            occurrences=(FindingOccurrence(file="src/main.py", line=10),) * 6,
+            occurrences_total=20,
+        ),
+        stage=LifecycleStage.PARTIAL,
+        head_sha=_HEAD_SHA,
+        round_number=4,
+    )
+
+    body = apply_lifecycle_block(body=_INLINE_BODY, block=block, historical=False)
+
+    assert_that(body).contains("✔ **14/20 addressed in `abc1234` · round 4**")
+    assert_that(body).does_not_contain("(historical)")
+
+
+def test_reapplying_a_block_replaces_it_instead_of_stacking_banners() -> None:
+    """Re-running a round must not leave two banners on one comment."""
+    first = render_lifecycle_block(
+        record=_record(status=FindingStatus.RESOLVED),
+        stage=LifecycleStage.ADDRESSED,
+        head_sha=_HEAD_SHA,
+        round_number=2,
+    )
+    once = apply_lifecycle_block(body=_INLINE_BODY, block=first, historical=True)
+
+    twice = apply_lifecycle_block(body=once, block=first, historical=True)
+
+    assert_that(twice).is_equal_to(once)
+    assert_that(twice.count(LIFECYCLE_OPEN)).is_equal_to(1)
+    assert_that(twice.count("(historical)")).is_equal_to(1)
+
+
+def test_regression_provenance_names_both_rounds_and_links_the_old_thread() -> None:
+    """A re-raised finding must not read as brand new."""
+    note = regression_provenance(
+        record=_record(
+            since_round=1,
+            resolved_round=2,
+            resolved_sha=_HEAD_SHA,
+        ),
+        thread_url="https://github.com/owner/name/pull/7#discussion_r101",
+    )
+
+    assert_that(note).contains("first raised round 1")
+    assert_that(note).contains("fixed round 2")
+    assert_that(note).contains("#discussion_r101")
+
+
+def test_finding_marker_round_trips_and_rejects_junk_keys() -> None:
+    """The marker is the only handle a later round has on a comment."""
+    marker = finding_marker(key="a1b2c3d4e5f60718#2")
+
+    assert_that(parse_finding_marker(body=f"body\n\n{marker}")).is_equal_to(
+        "a1b2c3d4e5f60718#2",
+    )
+    assert_that(finding_marker(key="not a key -->")).is_empty()
+    assert_that(parse_finding_marker(body="a human reply")).is_empty()
+
+
+# --- synchronization ---------------------------------------------------------
+
+
+def test_resolved_finding_is_bannered_and_its_thread_resolved_by_default() -> None:
+    """``review.auto_resolve`` defaults to true, so the thread closes."""
+    reporter = _FakeReporter(threads=_threads())
+    record = _record(status=FindingStatus.RESOLVED, resolved_round=3)
+
+    report = sync_addressed_lifecycle(
+        reporter=reporter,
+        resolved=(record,),
+        comment_bodies={_COMMENT_ID: _INLINE_BODY},
+        head_sha=_HEAD_SHA,
+        round_number=3,
+    )
+
+    assert_that(report.edited).contains(record.key)
+    assert_that(report.resolved).contains(record.key)
+    assert_that(reporter.resolved_threads).is_equal_to([_THREAD_ID])
+    assert_that(reporter.edits[0][1]).contains("✔ **Addressed in `abc1234` · round 3**")
+
+
+def test_auto_resolve_false_keeps_the_banner_and_skips_the_mutation() -> None:
+    """Opting out is a manual-ceremony choice, not a loss of information."""
+    reporter = _FakeReporter(threads=_threads())
+    record = _record(status=FindingStatus.RESOLVED, resolved_round=3)
+
+    report = sync_addressed_lifecycle(
+        reporter=reporter,
+        resolved=(record,),
+        comment_bodies={_COMMENT_ID: _INLINE_BODY},
+        head_sha=_HEAD_SHA,
+        round_number=3,
+        auto_resolve=False,
+    )
+
+    assert_that(report.edited).contains(record.key)
+    assert_that(report.resolved).is_empty()
+    assert_that(reporter.resolved_threads).is_empty()
+    assert_that(reporter.edits[0][1]).contains("Addressed in")
+
+
+def test_partial_progress_never_resolves_the_thread() -> None:
+    """A pattern is resolved only when every occurrence is gone (#1925)."""
+    reporter = _FakeReporter(threads=_threads())
+    record = _record(
+        occurrences=(FindingOccurrence(file="src/main.py", line=10),) * 6,
+        occurrences_total=20,
+    )
+
+    report = sync_addressed_lifecycle(
+        reporter=reporter,
+        partial=(record,),
+        comment_bodies={_COMMENT_ID: _INLINE_BODY},
+        head_sha=_HEAD_SHA,
+        round_number=4,
+    )
+
+    assert_that(report.edited).contains(record.key)
+    assert_that(report.resolved).is_empty()
+    assert_that(reporter.resolved_threads).is_empty()
+    assert_that(reporter.edits[0][1]).contains("14/20 addressed")
+
+
+def test_regressed_thread_is_bannered_and_stays_resolved() -> None:
+    """A resolved thread is never reopened; the regression gets a new one."""
+    reporter = _FakeReporter(threads=_threads(is_resolved=True))
+    record = _record(
+        regressed=True,
+        resolved_sha="0f0f0f0f",
+        resolved_round=2,
+    )
+
+    report = sync_addressed_lifecycle(
+        reporter=reporter,
+        regressed=(record,),
+        comment_bodies={_COMMENT_ID: _INLINE_BODY},
+        head_sha=_HEAD_SHA,
+        round_number=4,
+        new_thread_urls={
+            record.key: "https://github.com/owner/name/pull/7#discussion_r9",
+        },
+    )
+
+    body = reporter.edits[0][1]
+    assert_that(report.resolved).is_empty()
+    assert_that(reporter.resolved_threads).is_empty()
+    assert_that(body).contains("↩ **Regressed in `abc1234` · round 4**")
+    assert_that(body).contains("This thread stays resolved.")
+    assert_that(body).contains("#discussion_r9")
+
+
+def test_unchanged_body_is_never_patched() -> None:
+    """The second run of a round must make no request at all."""
+    reporter = _FakeReporter(threads=_threads(is_resolved=True))
+    record = _record(status=FindingStatus.RESOLVED, resolved_round=3)
+    stamped = apply_lifecycle_block(
+        body=_INLINE_BODY,
+        block=render_lifecycle_block(
+            record=record,
+            stage=LifecycleStage.ADDRESSED,
+            head_sha=_HEAD_SHA,
+            round_number=3,
+        ),
+        historical=True,
+    )
+
+    report = sync_addressed_lifecycle(
+        reporter=reporter,
+        resolved=(record,),
+        comment_bodies={_COMMENT_ID: stamped},
+        head_sha=_HEAD_SHA,
+        round_number=3,
+    )
+
+    assert_that(reporter.edits).is_empty()
+    assert_that(report.unchanged).contains(record.key)
+
+
+def test_a_failed_comment_edit_is_reported_rather_than_raised() -> None:
+    """GitHub refusing one edit must not sink a review that found real bugs."""
+    reporter = _FakeReporter(threads=_threads(), edit_ok=False)
+    record = _record(status=FindingStatus.RESOLVED, resolved_round=3)
+
+    report = sync_addressed_lifecycle(
+        reporter=reporter,
+        resolved=(record,),
+        comment_bodies={_COMMENT_ID: _INLINE_BODY},
+        head_sha=_HEAD_SHA,
+        round_number=3,
+    )
+
+    assert_that(report.failed).contains(record.key)
+    assert_that(report.edited).is_empty()
+    # The thread is not resolved off the back of a banner that never landed.
+    assert_that(reporter.resolved_threads).is_empty()
+    assert_that(report.has_failures).is_true()
+
+
+def test_a_failed_thread_listing_keeps_the_banner() -> None:
+    """Resolution is best-effort; the recorded outcome is not."""
+    reporter = _FakeReporter(threads=None)
+    record = _record(status=FindingStatus.RESOLVED, resolved_round=3)
+
+    report = sync_addressed_lifecycle(
+        reporter=reporter,
+        resolved=(record,),
+        comment_bodies={_COMMENT_ID: _INLINE_BODY},
+        head_sha=_HEAD_SHA,
+        round_number=3,
+    )
+
+    assert_that(report.edited).contains(record.key)
+    assert_that(report.resolved).is_empty()
+    assert_that(report.failed).contains(record.key)
+
+
+def test_a_comment_whose_body_is_unknown_is_left_alone() -> None:
+    """Overwriting an unread comment would destroy the finding it carries."""
+    reporter = _FakeReporter(threads=_threads())
+    record = _record(status=FindingStatus.RESOLVED, resolved_round=3)
+
+    report = sync_addressed_lifecycle(
+        reporter=reporter,
+        resolved=(record,),
+        comment_bodies={},
+        head_sha=_HEAD_SHA,
+        round_number=3,
+    )
+
+    assert_that(reporter.edits).is_empty()
+    assert_that(report.edited).is_empty()
+    assert_that(report.resolved).is_empty()
+
+
+# --- end to end through the posting adapter ----------------------------------
+
+
+def _sticky_body(*, state: ReviewState) -> str:
+    """Render a prior sticky comment body carrying a state blob.
+
+    Args:
+        state: State to embed.
+
+    Returns:
+        The comment body.
+    """
+    return STICKY_MARKER + "\n\nprior round" + render_state_block(state=state)
+
+
+def _prior_state(*, findings: tuple[FindingRecord, ...]) -> ReviewState:
+    """Build a one-round prior state.
+
+    Args:
+        findings: Records tracked before this round.
+
+    Returns:
+        The state.
+    """
+    return ReviewState(runs=(RunRecord(round=1, sha="0f0f0f0"),), findings=findings)
+
+
+def _posting_reporter(
+    *,
+    prior: ReviewState | None = None,
+    review_comments: list[dict[str, Any]] | None = None,
+) -> MagicMock:
+    """Build a reporter stub whose PR diff covers both fixture findings.
+
+    Args:
+        prior: State to expose through the sticky comment, if any.
+        review_comments: Inline comments the PR already carries.
+
+    Returns:
+        The stub reporter.
+    """
+    reporter = MagicMock()
+    reporter.is_available.return_value = True
+    if prior is None:
+        # Round 1: the sticky does not exist until this run posts it, and is
+        # then found on every later lookup — including the id capture's.
+        lookups = iter([None])
+        reporter.find_issue_comment.side_effect = lambda **_kwargs: next(
+            lookups,
+            (5, STICKY_MARKER),
+        )
+    else:
+        reporter.find_issue_comment.return_value = (5, _sticky_body(state=prior))
+    reporter.fetch_pr_diff_lines.return_value = {
+        "src/main.py": {9, 10, 11},
+        "tests/test_main.py": {5},
+    }
+    reporter.fetch_compare_lines.return_value = {"src/main.py": {9, 10, 11}}
+    reporter.fetch_pr_commit_shas.return_value = []
+    reporter.fetch_review_comments.return_value = review_comments or []
+    reporter.fetch_review_threads.return_value = _threads()
+    reporter.resolve_review_thread.return_value = True
+    reporter.update_review_comment.return_value = True
+    reporter.post_issue_comment.return_value = True
+    reporter.update_issue_comment.return_value = True
+    reporter.api_request.return_value = True
+    reporter.api_base = "https://api.github.com"
+    reporter.repo = "owner/name"
+    reporter.pr_number = 7
+    return reporter
+
+
+def _posted_comments(*, reporter: MagicMock) -> list[dict[str, Any]]:
+    """Return the inline comments of the submitted review payload.
+
+    Args:
+        reporter: Reporter stub the review was posted through.
+
+    Returns:
+        The ``comments`` array.
+    """
+    payload = reporter.api_request.call_args.args[2]
+    comments: list[dict[str, Any]] = payload["comments"]
+    return comments
+
+
+def _persisted_state(*, reporter: MagicMock) -> dict[str, Any]:
+    """Decode the state blob from the last sticky body written.
+
+    Args:
+        reporter: Reporter stub the review was posted through.
+
+    Returns:
+        The decoded state mapping.
+
+    Raises:
+        AssertionError: When no sticky body carrying a state blob was written.
+    """
+    bodies = [call.args[0] for call in reporter.post_issue_comment.call_args_list]
+    bodies += [
+        call.kwargs["body"] for call in reporter.update_issue_comment.call_args_list
+    ]
+    for body in reversed(bodies):
+        if STATE_MARKER_PREFIX in body:
+            encoded = body.rsplit(STATE_MARKER_PREFIX, 1)[1]
+            decoded: dict[str, Any] = json.loads(
+                encoded.rsplit(STATE_MARKER_SUFFIX, 1)[0].strip(),
+            )
+            return decoded
+    msg = "no sticky body with a state blob was written"
+    raise AssertionError(msg)
+
+
+def _resolved_record(*, title: str, comment_id: int) -> FindingRecord:
+    """Build a prior open record this round will not report again.
+
+    Args:
+        title: Finding title, chosen so it does not match the fixtures.
+        comment_id: Inline comment anchoring the finding.
+
+    Returns:
+        The record.
+    """
+    return FindingRecord(
+        fingerprint=fingerprint_for(
+            file="src/old.py",
+            category="performance",
+            title=title,
+        ),
+        category="performance",
+        title=title,
+        file="src/old.py",
+        line=4,
+        inline_comment_id=comment_id,
+    )
+
+
+def test_inline_comments_carry_a_hidden_finding_marker(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Without the marker no later round can find the thread again."""
+    reporter = _posting_reporter()
+
+    post_review_to_github(result=sample_review_result, reporter=reporter)
+
+    bodies = [comment["body"] for comment in _posted_comments(reporter=reporter)]
+    assert_that(bodies).is_not_empty()
+    for body in bodies:
+        assert_that(parse_finding_marker(body=body)).is_not_empty()
+
+
+def test_captured_comment_ids_are_persisted_for_the_next_round(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The banner edit needs an id, and the state blob is where it lives."""
+    reporter = _posting_reporter()
+    key = f"{fingerprint_for(file='src/main.py', category='security', title='Fail-open default')}#1"
+    reporter.fetch_review_comments.return_value = [
+        {"id": 555, "body": f"posted\n\n{finding_marker(key=key)}"},
+    ]
+
+    post_review_to_github(result=sample_review_result, reporter=reporter)
+
+    state = _persisted_state(reporter=reporter)
+    stored = {
+        record["fingerprint"]: record.get("inline_comment_id")
+        for record in state["findings"]
+    }
+    assert_that(stored).contains_entry({key.split("#")[0]: 555})
+
+
+def test_a_finding_gone_from_this_round_is_bannered_and_resolved(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The default configuration closes the loop end to end."""
+    record = _resolved_record(title="Slow loop", comment_id=_COMMENT_ID)
+    reporter = _posting_reporter(
+        prior=_prior_state(findings=(record,)),
+        review_comments=[{"id": _COMMENT_ID, "body": _INLINE_BODY}],
+    )
+
+    post_review_to_github(result=sample_review_result, reporter=reporter)
+
+    edit = reporter.update_review_comment.call_args
+    assert_that(edit.kwargs["comment_id"]).is_equal_to(_COMMENT_ID)
+    assert_that(edit.kwargs["body"]).contains("✔ **Addressed in")
+    assert_that(edit.kwargs["body"]).contains("(historical)")
+    reporter.resolve_review_thread.assert_called_once_with(thread_id=_THREAD_ID)
+
+
+def test_auto_resolve_false_stops_the_mutation_end_to_end(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The opt-out reaches the adapter, not just the config model."""
+    record = _resolved_record(title="Slow loop", comment_id=_COMMENT_ID)
+    reporter = _posting_reporter(
+        prior=_prior_state(findings=(record,)),
+        review_comments=[{"id": _COMMENT_ID, "body": _INLINE_BODY}],
+    )
+
+    post_review_to_github(
+        result=sample_review_result,
+        reporter=reporter,
+        auto_resolve=False,
+    )
+
+    assert_that(reporter.update_review_comment.called).is_true()
+    reporter.resolve_review_thread.assert_not_called()
+
+
+def test_a_regression_posts_a_fresh_comment_carrying_its_provenance(
+    sample_review_result: ReviewResult,
+) -> None:
+    """State D: new thread with history, old thread stamped and left resolved."""
+    fingerprint = fingerprint_for(
+        file="src/main.py",
+        category="security",
+        title="Fail-open default",
+    )
+    prior = FindingRecord(
+        fingerprint=fingerprint,
+        category="security",
+        title="Fail-open default",
+        file="src/main.py",
+        line=10,
+        status=FindingStatus.RESOLVED,
+        since_round=1,
+        resolved_sha="0f0f0f0",
+        resolved_round=1,
+        inline_comment_id=_COMMENT_ID,
+    )
+    reporter = _posting_reporter(
+        prior=_prior_state(findings=(prior,)),
+        review_comments=[{"id": _COMMENT_ID, "body": _INLINE_BODY}],
+    )
+
+    post_review_to_github(result=sample_review_result, reporter=reporter)
+
+    fresh = [
+        comment["body"]
+        for comment in _posted_comments(reporter=reporter)
+        if "↩ **regression**" in comment["body"]
+    ]
+    assert_that(fresh).is_length(1)
+    assert_that(fresh[0]).contains("first raised round 1")
+    edit = reporter.update_review_comment.call_args
+    assert_that(edit.kwargs["body"]).contains("↩ **Regressed in")
+    reporter.resolve_review_thread.assert_not_called()
+
+
+@pytest.mark.parametrize("auto_resolve", [True, False])
+def test_posting_survives_a_refused_comment_edit(
+    sample_review_result: ReviewResult,
+    auto_resolve: bool,
+) -> None:
+    """A refused banner degrades to "not stamped yet", never to a crash."""
+    record = _resolved_record(title="Slow loop", comment_id=_COMMENT_ID)
+    reporter = _posting_reporter(
+        prior=_prior_state(findings=(record,)),
+        review_comments=[{"id": _COMMENT_ID, "body": _INLINE_BODY}],
+    )
+    reporter.update_review_comment.return_value = False
+
+    posted = post_review_to_github(
+        result=sample_review_result,
+        reporter=reporter,
+        auto_resolve=auto_resolve,
+    )
+
+    assert_that(posted).is_true()
+    # The record keeps its comment id, so the next round retries the banner.
+    state = _persisted_state(reporter=reporter)
+    stored = [
+        item for item in state["findings"] if item["fingerprint"] == record.fingerprint
+    ]
+    assert_that(stored).is_length(1)
+    assert_that(stored[0]["inline_comment_id"]).is_equal_to(_COMMENT_ID)
+
+
+# --- transport ---------------------------------------------------------------
+
+
+def _reader(payload: dict[str, Any]) -> MagicMock:
+    """Build a urlopen context manager yielding ``payload`` as JSON.
+
+    Args:
+        payload: Response body.
+
+    Returns:
+        The context-manager mock.
+    """
+    response = MagicMock()
+    response.read.return_value = json.dumps(payload).encode()
+    ctx = MagicMock()
+    ctx.__enter__.return_value = response
+    return ctx
+
+
+def _api_reporter() -> GitHubPRReporter:
+    """Build a real reporter pointed at github.com.
+
+    Returns:
+        The reporter.
+    """
+    return GitHubPRReporter(token=_TEST_TOKEN, repo="owner/name", pr_number=7)
+
+
+def test_review_threads_join_on_the_threads_root_comment() -> None:
+    """The stored comment id is the thread's first comment, and only that."""
+    payload = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": [
+                            {
+                                "id": _THREAD_ID,
+                                "isResolved": True,
+                                "comments": {"nodes": [{"databaseId": _COMMENT_ID}]},
+                            },
+                            {"id": None, "comments": {"nodes": []}},
+                        ],
+                    },
+                },
+            },
+        },
+    }
+
+    with patch("urllib.request.urlopen", return_value=_reader(payload)):
+        threads = _api_reporter().fetch_review_threads()
+
+    assert_that(threads).is_equal_to(
+        {_COMMENT_ID: ReviewThread(node_id=_THREAD_ID, is_resolved=True)},
+    )
+
+
+def test_graphql_errors_are_a_failure_even_under_a_200() -> None:
+    """GraphQL answers 200 for a refused mutation; the errors array decides."""
+    payload = {"data": {"resolveReviewThread": None}, "errors": [{"message": "nope"}]}
+
+    with patch("urllib.request.urlopen", return_value=_reader(payload)):
+        resolved = _api_reporter().resolve_review_thread(thread_id=_THREAD_ID)
+
+    assert_that(resolved).is_false()
+
+
+def test_resolve_review_thread_reports_the_threads_new_state() -> None:
+    """Only GitHub confirming the resolution counts as resolved."""
+    payload = {"data": {"resolveReviewThread": {"thread": {"isResolved": True}}}}
+
+    with patch("urllib.request.urlopen", return_value=_reader(payload)):
+        resolved = _api_reporter().resolve_review_thread(thread_id=_THREAD_ID)
+
+    assert_that(resolved).is_true()
+
+
+def test_update_review_comment_patches_the_pulls_comments_endpoint() -> None:
+    """An inline comment lives under /pulls/comments, not /issues/comments."""
+    reporter = _api_reporter()
+
+    with patch.object(reporter, "api_request", return_value=True) as request:
+        reporter.update_review_comment(comment_id=_COMMENT_ID, body="new")
+
+    method, url, payload = request.call_args.args
+    assert_that(method).is_equal_to("PATCH")
+    assert_that(url).is_equal_to(
+        f"https://api.github.com/repos/owner/name/pulls/comments/{_COMMENT_ID}",
+    )
+    assert_that(payload).is_equal_to({"body": "new"})
+
+
+def test_review_comment_listing_degrades_to_none_on_a_transport_error() -> None:
+    """A failed listing must not read as "this PR has no inline comments"."""
+    with patch("urllib.request.urlopen", side_effect=OSError("boom")):
+        comments = _api_reporter().fetch_review_comments()
+
+    assert_that(comments).is_none()
+
+
+def test_graphql_url_follows_a_github_enterprise_api_base() -> None:
+    """Enterprise serves GraphQL from /api/graphql, not /api/v3/graphql."""
+    reporter = GitHubPRReporter(
+        token=_TEST_TOKEN,
+        repo="owner/name",
+        pr_number=7,
+        api_base="https://ghe.example.com/api/v3",
+    )
+
+    assert_that(reporter.graphql_url).is_equal_to("https://ghe.example.com/api/graphql")

--- a/tests/unit/ai/review/test_addressed_lifecycle_1912.py
+++ b/tests/unit/ai/review/test_addressed_lifecycle_1912.py
@@ -332,6 +332,25 @@ def test_regressed_thread_is_bannered_and_stays_resolved() -> None:
     assert_that(body).contains("#discussion_r9")
 
 
+def test_a_regression_without_a_new_thread_does_not_link_one() -> None:
+    """A finding off the diff gets no fresh comment, so promise none."""
+    reporter = _FakeReporter(threads=_threads(is_resolved=True))
+    record = _record(regressed=True, resolved_sha="0f0f0f0f", resolved_round=2)
+
+    sync_addressed_lifecycle(
+        reporter=reporter,
+        regressed=(record,),
+        comment_bodies={_COMMENT_ID: _INLINE_BODY},
+        head_sha=_HEAD_SHA,
+        round_number=4,
+    )
+
+    body = reporter.edits[0][1]
+    assert_that(body).contains("↩ **Regressed in `abc1234` · round 4**")
+    assert_that(body).contains("see the sticky comment's open findings")
+    assert_that(body).does_not_contain("new thread]")
+
+
 def test_unchanged_body_is_never_patched() -> None:
     """The second run of a round must make no request at all."""
     reporter = _FakeReporter(threads=_threads(is_resolved=True))

--- a/tests/unit/ai/review/test_addressed_lifecycle_1912.py
+++ b/tests/unit/ai/review/test_addressed_lifecycle_1912.py
@@ -351,6 +351,97 @@ def test_a_regression_without_a_new_thread_does_not_link_one() -> None:
     assert_that(body).does_not_contain("new thread]")
 
 
+def test_one_thread_gets_one_banner_even_when_two_stages_apply() -> None:
+    """A regression that also lost occurrences must not be edited twice.
+
+    The second edit would start from the pre-edit body, undoing the first one's
+    ``(historical)`` retitle and leaving a regression banner beside a live fix
+    prompt. Regression wins: partial progress on a thread the discussion has
+    already left is the less useful half of the story.
+    """
+    reporter = _FakeReporter(threads=_threads(is_resolved=True))
+    record = _record(
+        regressed=True,
+        resolved_sha="0f0f0f0f",
+        resolved_round=2,
+        occurrences=(FindingOccurrence(file="src/main.py", line=10),) * 6,
+        occurrences_total=20,
+    )
+
+    sync_addressed_lifecycle(
+        reporter=reporter,
+        partial=(record,),
+        regressed=(record,),
+        comment_bodies={_COMMENT_ID: _INLINE_BODY},
+        head_sha=_HEAD_SHA,
+        round_number=4,
+    )
+
+    assert_that(reporter.edits).is_length(1)
+    body = reporter.edits[0][1]
+    assert_that(body).contains("↩ **Regressed in")
+    assert_that(body).contains("(historical)")
+    assert_that(body).does_not_contain("14/20 addressed")
+
+
+def test_a_regression_outranks_an_addressed_stamp_on_the_same_thread() -> None:
+    """State D: the old thread must point at the new one, not read as fixed.
+
+    The regression banner already carries the ``✔ Addressed in <sha>`` line for
+    the round that had fixed the finding, so it loses nothing — while a bare
+    "addressed" stamp would hide that the finding is open again elsewhere.
+    """
+    reporter = _FakeReporter(threads=_threads(is_resolved=True))
+    record = _record(
+        regressed=True,
+        resolved_sha="0f0f0f0f",
+        resolved_round=2,
+    )
+    url = "https://github.com/owner/name/pull/7#discussion_r9"
+
+    report = sync_addressed_lifecycle(
+        reporter=reporter,
+        resolved=(record,),
+        regressed=(record,),
+        comment_bodies={_COMMENT_ID: _INLINE_BODY},
+        head_sha=_HEAD_SHA,
+        round_number=4,
+        new_thread_urls={record.key: url},
+    )
+
+    assert_that(reporter.edits).is_length(1)
+    body = reporter.edits[0][1]
+    assert_that(body).contains("↩ **Regressed in `abc1234` · round 4**")
+    assert_that(body).contains("#discussion_r9")
+    # A regression never resolves the thread off its own back: it is already
+    # resolved and the live discussion is on the fresh thread.
+    assert_that(report.resolved).is_empty()
+    assert_that(reporter.resolved_threads).is_empty()
+
+
+def test_a_record_without_a_comment_id_is_never_stamped() -> None:
+    """A finding whose thread was never captured has nothing to edit."""
+    reporter = _FakeReporter(threads=_threads())
+    record = _record(
+        status=FindingStatus.RESOLVED,
+        resolved_round=3,
+        inline_comment_id=None,
+    )
+
+    report = sync_addressed_lifecycle(
+        reporter=reporter,
+        resolved=(record,),
+        comment_bodies={_COMMENT_ID: _INLINE_BODY},
+        head_sha=_HEAD_SHA,
+        round_number=3,
+    )
+
+    assert_that(reporter.edits).is_empty()
+    assert_that(report.edited).is_empty()
+    assert_that(report.resolved).is_empty()
+    assert_that(reporter.resolved_threads).is_empty()
+
+
 def test_unchanged_body_is_never_patched() -> None:
     """The second run of a round must make no request at all."""
     reporter = _FakeReporter(threads=_threads(is_resolved=True))
@@ -824,3 +915,19 @@ def test_graphql_url_follows_a_github_enterprise_api_base() -> None:
     )
 
     assert_that(reporter.graphql_url).is_equal_to("https://ghe.example.com/api/graphql")
+
+
+def test_graphql_refuses_a_non_https_api_base() -> None:
+    """A cleartext base must never carry the bearer token."""
+    reporter = GitHubPRReporter(
+        token=_TEST_TOKEN,
+        repo="owner/name",
+        pr_number=7,
+        api_base="http://ghe.example.com/api/v3",
+    )
+
+    with patch("urllib.request.urlopen") as urlopen:
+        resolved = reporter.resolve_review_thread(thread_id=_THREAD_ID)
+
+    assert_that(resolved).is_false()
+    urlopen.assert_not_called()

--- a/tests/unit/config/test_review_config.py
+++ b/tests/unit/config/test_review_config.py
@@ -358,6 +358,36 @@ def test_custom_agents_defaults_to_enabled(
     assert_that(config.review.custom_agents).is_equal_to(CustomAgentMode.ENABLED)
 
 
+def test_auto_resolve_defaults_to_true(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolving an addressed thread is the default; false is the opt-out."""
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text("review:\n  depth: 1\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    config = load_config(config_path=config_file)
+
+    assert_that(config.review.auto_resolve).is_true()
+
+
+def test_auto_resolve_can_be_opted_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A team that resolves threads by hand keeps the banner and nothing else."""
+    config_file = tmp_path / ".lintro-config.yaml"
+    config_file.write_text("review:\n  auto_resolve: false\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    clear_config_cache()
+
+    config = load_config(config_path=config_file)
+
+    assert_that(config.review.auto_resolve).is_false()
+
+
 def test_custom_agents_rejects_unknown_mode() -> None:
     """An unrecognized mode names the offending key in the error."""
     with pytest.raises(ValueError, match=escape("review.custom_agents must be")):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(review): close inline finding threads with an addressed lifecycle
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

The last piece of epic #1905: an inline finding comment is now posted once and then
**edited** for the rest of the PR's life, so each thread carries its own outcome instead
of leaving a reader to diff two rounds of comments by eye.

Three stamps, written into one replaceable block at the end of the comment body:

| Stage | Banner | Prompt panel | Thread |
|---|---|---|---|
| Addressed | `✔ Addressed in <sha> · round N` | retitled `(historical)` | resolved when `review.auto_resolve` |
| Partially addressed | `✔ 14/20 addressed in <sha> · round N` | left live | stays open |
| Regressed | `↩ Regressed in <sha> · round N — see the new thread` | retitled `(historical)` | **stays resolved**, never reopened |

A regression is re-raised on a *fresh* inline comment carrying
`↩ regression · first raised round X, fixed round Y — original thread` (mock-4 section 3,
state D). Pattern-level resolution follows #1925: a collapsed finding resolves only when
every occurrence stops reproducing.

`review.auto_resolve` defaults to **true** (per the 2026-08-03 amendment on #1912,
rationale in #1925 §5). The banner is written either way; `false` is the manual-ceremony
opt-out.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1912

## Details

**Comment-id capture (the missing half of #1906).** `inline_comment_id` existed in the v2
state schema but nothing populated it — the review-submission endpoint answers with the
review, not with the comments it created. Each inline comment now carries a hidden
`<!-- lintro-finding:<fingerprint#ordinal> -->` marker; after the review is submitted the
PR's inline comments are listed once and the markers join comment ids back to records.
That single listing serves both halves of the lifecycle (the bodies are what banners are
applied to). The sticky comment is then refreshed once with the captured ids — the same
follow-up edit that already carried the #1909 degraded fold-in, so at most one extra PATCH
per round.

**Transport.** REST `PATCH /pulls/comments/{id}` for the edit; GraphQL
`resolveReviewThread` for resolution, joined to the stored comment id through
`reviewThreads { nodes { id isResolved comments(first: 1) { databaseId } } }`. There is
deliberately **no** unresolve mutation anywhere in the code. GraphQL answers 200 for a
refused mutation, so the `errors` array is treated as failure. All new calls go through
the existing `_authorized_request` helper (unredirected `Authorization` header).

**Degradation.** Every failure path is reported, never raised: a refused comment edit logs
and leaves the record's comment id in place so the next round retries; a failed thread
listing keeps the banner and skips resolution; a comment whose body could not be read is
left alone rather than overwritten. Edits are idempotent — the block is rewritten wholesale
and an unchanged body is never PATCHed, so re-running a round adds no second banner.

**Testing.** 28 new tests in `tests/unit/ai/review/test_addressed_lifecycle_1912.py`
covering banner content and the `(historical)` retitle, auto-resolve on/off (unit and end
to end), partial progress without resolution, full resolution, the regression provenance
comment plus the old-thread-stays-resolved invariant, idempotency, refused-edit and
failed-listing degradation, marker round-tripping, comment-id capture into the state blob,
and the GraphQL/REST transport shapes (including a GHE `/api/graphql` base). Two config
tests cover the `auto_resolve` default and opt-out.

Reviewed locally with the CodeRabbit CLI (no findings) and `lintro review`; Greptile hit
its free-review limit.
