### PR TITLE
fix(review): close mock-parity gaps from the #1905 comment-surfaces audit

### DIFF
--- a/lintro/ai/review/agent_prompts.py
+++ b/lintro/ai/review/agent_prompts.py
@@ -69,7 +69,7 @@ _PATH_LIMIT = 300
 
 _FOOTERS: dict[AgentPromptScopeKind, str] = {
     AgentPromptScopeKind.ALL_OPEN: (
-        "Regenerated every run · covers exactly the open findings above"
+        "Regenerated every run · covers exactly the open table above"
     ),
     AgentPromptScopeKind.THIS_REVIEW: (
         "For everything still open across all rounds, use the sticky comment's "

--- a/lintro/ai/review/context/collection.py
+++ b/lintro/ai/review/context/collection.py
@@ -25,6 +25,7 @@ from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
 from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
 from lintro.ai.review.exceptions import ReviewContextError
+from lintro.ai.review.glob_utils import path_matches_any_glob
 from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.pr_metadata import PRMetadata
 from lintro.ai.review.models.review_context import ReviewContext
@@ -40,6 +41,7 @@ def collect_review_context(
     pr_number: int | None = None,
     repo: str | None = None,
     paths: list[str] | None = None,
+    exclude_globs: list[str] | None = None,
 ) -> ReviewContext:
     """Collect git diff context for review.
 
@@ -51,6 +53,9 @@ def collect_review_context(
         pr_number: Pull request number to review via ``gh``.
         repo: Optional ``owner/name`` repository for ``--pr`` mode.
         paths: Optional path prefixes to filter changed files and diff hunks.
+        exclude_globs: Optional ``ai.exclude_paths`` globs. Matching files are
+            dropped from the review and recorded as skipped with that reason,
+            so a configured exclusion never reads as coverage.
 
     Returns:
         Parsed review context with unified diff and changed file metadata.
@@ -83,6 +88,11 @@ def collect_review_context(
 
     if paths:
         context = _filter_context_by_paths(context=context, paths=paths)
+    if exclude_globs:
+        context = _filter_context_by_excludes(
+            context=context,
+            exclude_globs=exclude_globs,
+        )
 
     context = _populate_post_image_files(context=context)
 
@@ -485,7 +495,7 @@ def _filter_context_by_paths(
         Filtered review context.
     """
     normalized_paths = [_normalize_path_prefix(path=path) for path in paths]
-    filtered_files = [
+    retained = [
         changed_file
         for changed_file in context.changed_files
         if _changed_file_matches_any_prefix(
@@ -493,42 +503,108 @@ def _filter_context_by_paths(
             prefixes=normalized_paths,
         )
     ]
+    return _restrict_context(
+        context=context,
+        retained=retained,
+        reason=FileSkipReason.PATH_FILTER,
+    )
+
+
+def _filter_context_by_excludes(
+    *,
+    context: ReviewContext,
+    exclude_globs: list[str],
+) -> ReviewContext:
+    """Drop changed files matching the configured exclusion globs.
+
+    ``ai.exclude_paths`` is how a repository says "never send this to a model"
+    — generated code, vendored trees, docs. Dropping those files silently would
+    make the review's file list claim coverage it never had, so each exclusion
+    is recorded with its own reason and surfaces in the skipped list.
+
+    A rename is excluded when *either* of its paths matches: the diff of a file
+    moved out of an excluded tree still carries the excluded content, and an
+    exclusion that a rename can defeat is not an exclusion.
+
+    Args:
+        context: Source review context.
+        exclude_globs: Glob patterns from ``ai.exclude_paths``.
+
+    Returns:
+        The context without the excluded files, carrying a skip record for each.
+    """
+    patterns = tuple(exclude_globs)
+    retained = [
+        changed_file
+        for changed_file in context.changed_files
+        if not any(
+            path_matches_any_glob(path=candidate, patterns=patterns)
+            for candidate in (changed_file.path, changed_file.previous_path)
+            if candidate is not None
+        )
+    ]
+    if len(retained) == len(context.changed_files):
+        return context
+    return _restrict_context(
+        context=context,
+        retained=retained,
+        reason=FileSkipReason.CONFIG_EXCLUDED,
+    )
+
+
+def _restrict_context(
+    *,
+    context: ReviewContext,
+    retained: list[ChangedFile],
+    reason: FileSkipReason,
+) -> ReviewContext:
+    """Rebuild a context around a retained subset of its changed files.
+
+    Args:
+        context: Source review context.
+        retained: Changed files the caller decided to keep.
+        reason: Why the dropped files were dropped, recorded per file.
+
+    Returns:
+        A context whose diff, post-image files and changed-file list cover only
+        the retained paths, with a skip record for every dropped one.
+    """
     per_file_diffs = split_unified_diff_by_file(unified_diff=context.unified_diff)
-    filtered_paths = {changed_file.path for changed_file in filtered_files}
-    filtered_diff_parts = [
+    retained_paths = {changed_file.path for changed_file in retained}
+    retained_diff_parts = [
         diff_text
         for path, diff_text in per_file_diffs.items()
-        if path in filtered_paths
+        if path in retained_paths
     ]
     preamble = (
         unified_diff_preamble(unified_diff=context.unified_diff)
-        if filtered_diff_parts
+        if retained_diff_parts
         else ""
     )
-    unified_diff = preamble + "".join(filtered_diff_parts)
-    filtered_post_image = {
+    unified_diff = preamble + "".join(retained_diff_parts)
+    retained_post_image = {
         path: content
         for path, content in context.post_image_files.items()
-        if path in filtered_paths
+        if path in retained_paths
     }
-    # Record the exclusions rather than letting them vanish: a `--path` filter
-    # is the difference between "the review saw nothing wrong here" and "the
-    # review never looked", and only the per-file reason distinguishes them.
+    # Record the exclusions rather than letting them vanish: a filter is the
+    # difference between "the review saw nothing wrong here" and "the review
+    # never looked", and only the per-file reason distinguishes them.
     skipped = [
         *context.skipped_files,
         *(
-            SkippedFile(path=changed_file.path, reason=FileSkipReason.PATH_FILTER)
+            SkippedFile(path=changed_file.path, reason=reason)
             for changed_file in context.changed_files
-            if changed_file.path not in filtered_paths
+            if changed_file.path not in retained_paths
         ),
     ]
     return ReviewContext(
         base_ref=context.base_ref,
         head_ref=context.head_ref,
-        changed_files=filtered_files,
+        changed_files=retained,
         unified_diff=unified_diff,
         pr_metadata=context.pr_metadata,
-        post_image_files=filtered_post_image,
+        post_image_files=retained_post_image,
         skipped_files=skipped,
     )
 

--- a/lintro/ai/review/enums/file_skip_reason.py
+++ b/lintro/ai/review/enums/file_skip_reason.py
@@ -17,6 +17,7 @@ class FileSkipReason(StrEnum):
     """
 
     PATH_FILTER = auto()
+    CONFIG_EXCLUDED = auto()
     REPETITIVE_DIFF = auto()
     AGENT_SCOPE = auto()
 
@@ -24,6 +25,7 @@ class FileSkipReason(StrEnum):
 #: Human-readable phrase rendered after a skipped file's path.
 FILE_SKIP_REASON_LABELS: dict[FileSkipReason, str] = {
     FileSkipReason.PATH_FILTER: "outside the requested --path filter",
+    FileSkipReason.CONFIG_EXCLUDED: "excluded by config (ai.exclude_paths)",
     FileSkipReason.REPETITIVE_DIFF: (
         "identical to a sampled file's diff (repetitive-diff sampling)"
     ),

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -38,17 +38,15 @@ from lintro.ai.review.github_constants import (
 from lintro.ai.review.github_errors import format_error_comment
 from lintro.ai.review.github_lifecycle import (
     finding_marker,
+    inline_comment_url,
     parse_finding_marker,
     regression_provenance,
     sync_addressed_lifecycle,
 )
 from lintro.ai.review.github_render import (
-    _format_findings_section as _format_findings_section,
-)
-from lintro.ai.review.github_render import (
+    REGRESSED_TITLE_SUFFIX,
     _partition_findings,
     format_finding_comment,
-    format_review_summary,
     format_run_mechanics,
     sanitize_comment_text,
 )
@@ -83,7 +81,6 @@ __all__ = [
     "build_sticky_comment",
     "format_error_comment",
     "format_finding_comment",
-    "format_review_summary",
     "format_run_mechanics",
     "parse_review_state",
     "parse_review_state_v2",
@@ -159,6 +156,8 @@ def post_review_to_github(
             auth_mode=auth_mode,
             inline_failure=inline_failure,
             inline_comment_ids=comment_ids,
+            repo=gh_reporter.repo or "",
+            pr_number=gh_reporter.pr_number,
         )
 
     inline_findings, fallback = _partition_findings(
@@ -416,11 +415,10 @@ def _comment_url(*, reporter: GitHubPRReporter, comment_id: int | None) -> str:
         The comment's anchor URL, or an empty string — a pointer renders
         unlinked rather than as a dead link.
     """
-    if comment_id is None:
-        return ""
-    return (
-        f"https://github.com/{reporter.repo}/pull/{reporter.pr_number}"
-        f"#discussion_r{comment_id}"
+    return inline_comment_url(
+        repo=reporter.repo or "",
+        pr_number=reporter.pr_number,
+        comment_id=comment_id,
     )
 
 
@@ -854,6 +852,10 @@ def _post_inline_findings(
                     checklist_display=checklist_display,
                     question_map=question_map,
                     inline_fix=plan,
+                    # A regression's fresh thread must say so in its title:
+                    # the provenance note explains the history, but the title
+                    # is what a reader scanning the PR's comments sees.
+                    title_suffix=REGRESSED_TITLE_SUFFIX if key in notes else "",
                 ),
                 key=key,
                 note=notes.get(key, ""),

--- a/lintro/ai/review/github_lifecycle.py
+++ b/lintro/ai/review/github_lifecycle.py
@@ -43,6 +43,7 @@ __all__ = [
     "LifecycleReport",
     "apply_lifecycle_block",
     "finding_marker",
+    "inline_comment_url",
     "parse_finding_marker",
     "regression_provenance",
     "render_lifecycle_block",
@@ -264,6 +265,33 @@ def _banner_lines(
         "This thread stays resolved.",
     )
     return lines
+
+
+def inline_comment_url(
+    *,
+    repo: str,
+    pr_number: int | str | None,
+    comment_id: int | None,
+) -> str:
+    """Build the browser URL of an inline review comment.
+
+    Lives here rather than on the posting adapter because more than one surface
+    links to a thread: the lifecycle banners point back at the original one, and
+    the sticky comment's open-findings table points at each finding's live one.
+
+    Args:
+        repo: ``owner/name`` repository slug.
+        pr_number: Pull request number, or ``None`` when it is unknown.
+        comment_id: Review comment id, or ``None`` when it is unknown.
+
+    Returns:
+        The comment's anchor URL, or an empty string when any part of the
+        address is missing — a pointer renders unlinked rather than as a dead
+        link.
+    """
+    if comment_id is None or not repo or pr_number is None:
+        return ""
+    return f"https://github.com/{repo}/pull/{pr_number}#discussion_r{comment_id}"
 
 
 def regression_provenance(*, record: FindingRecord, thread_url: str = "") -> str:

--- a/lintro/ai/review/github_render.py
+++ b/lintro/ai/review/github_render.py
@@ -18,11 +18,15 @@ from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.sanitize import sanitize_comment_text
 
 __all__ = [
+    "REGRESSED_TITLE_SUFFIX",
     "format_finding_comment",
-    "format_review_summary",
     "format_run_mechanics",
     "sanitize_comment_text",
 ]
+
+#: Appended to the title of a regression's freshly raised inline comment, so
+#: the thread does not read as a brand-new finding.
+REGRESSED_TITLE_SUFFIX = " (regressed)"
 
 #: Severities that earn a per-finding agent prompt panel (#1911). A P3 nit gets
 #: none: the panel is an affordance, and one on every finding is wallpaper.
@@ -108,24 +112,13 @@ def _severity_counts(*, findings: tuple[ReviewFinding, ...]) -> dict[Severity, i
     return counts
 
 
-def _count_row(*, counts: dict[Severity, int]) -> list[str]:
-    """Render the severity count table."""
-    return [
-        "| 🔴 P1 | 🟠 P2 | 🟡 P3 |",
-        "|:-:|:-:|:-:|",
-        (
-            f"| **{counts[Severity.P1]}** | **{counts[Severity.P2]}** | "
-            f"**{counts[Severity.P3]}** |"
-        ),
-    ]
-
-
 def format_finding_comment(
     *,
     finding: ReviewFinding,
     checklist_display: ChecklistDisplay = ChecklistDisplay.OFF,
     question_map: dict[int, str] | None = None,
     inline_fix: InlineFixPlan | None = None,
+    title_suffix: str = "",
 ) -> str:
     """Format a review finding as a GitHub markdown comment (#1911).
 
@@ -150,12 +143,16 @@ def format_finding_comment(
             inline review comment: a ``suggestion`` block is not committable
             there and a per-finding prompt panel would repeat the fix-all
             prompt already on that surface, so neither is rendered.
+        title_suffix: Text appended to the bold title, inside the bold run. A
+            regression is re-raised on a *fresh* thread, so without ``"
+            (regressed)"`` on the title it reads as a brand-new finding to
+            anyone who does not read the provenance blockquote above it.
 
     Returns:
         Markdown comment body.
     """
     prompt_questions = question_map or {}
-    title = sanitize_comment_text(finding.title, limit=200)
+    title = sanitize_comment_text(finding.title, limit=200) + title_suffix
     description = sanitize_comment_text(finding.description, limit=2000)
     cause = sanitize_comment_text(finding.cause, limit=2000)
 
@@ -206,7 +203,12 @@ def _fix_slot(
     fix = sanitize_comment_text(finding.fix, limit=2000).strip()
     if not fix:
         return []
-    return ["", f"**Fix:** {fix}"]
+    # Mode B has no committable block to draw the eye, so the described fix is
+    # highlighted instead of sitting as one more bold run in the prose. A
+    # ``[!TIP]`` alert is a plain blockquote to GitHub, so it neither nests
+    # inside nor collides with the ``[!IMPORTANT]`` prompt panel that follows.
+    quoted = [f"> {line}".rstrip() for line in f"**Fix:** {fix}".splitlines()]
+    return ["", "> [!TIP]", *quoted]
 
 
 def _prompt_slot(
@@ -256,90 +258,6 @@ def _suggestion_block(*, replacement: str) -> str:
     return "```suggestion\n" + safe + "\n```"
 
 
-def format_review_summary(
-    *,
-    result: ReviewResult,
-    checklist_display: ChecklistDisplay = ChecklistDisplay.OFF,
-    question_map: dict[int, str] | None = None,
-    diff_lines: dict[str, set[int]] | None = None,
-    findings_char_budget: int | None = None,
-) -> str:
-    """Format the per-run review summary section.
-
-    Produces the scannable body for a single run: header line, partial-state
-    note, severity count table, TL;DR, a compact findings list with collapsible
-    detail, and (optionally) the checklist appendix.
-
-    Args:
-        result: Review result to summarize.
-        checklist_display: Structured checklist visibility mode.
-        question_map: Prompt id to question text for the checklist appendix.
-        diff_lines: Diff line map used to order fallback findings first in the
-            findings section. ``None`` treats all findings as fallback.
-        findings_char_budget: Optional soft character budget for the findings
-            section; overflow is replaced by an explicit truncation marker.
-
-    Returns:
-        Markdown summary section body.
-    """
-    metadata = result.metadata
-    counts = _severity_counts(findings=result.findings)
-    est = metadata.token_usage_estimated
-    head_bits = [
-        f"**{metadata.files_reviewed} files** reviewed",
-        f"depth {metadata.depth}",
-        f"`{sanitize_comment_text(metadata.model, limit=60)}`",
-        _fmt_cost(metadata.cost_estimate_usd, estimated=est),
-    ]
-    lines = [
-        "## 🔎 Lintro Review",
-        "",
-        "> " + " · ".join(head_bits),
-    ]
-    if metadata.partial:
-        reason = sanitize_comment_text(
-            metadata.stopped_reason or "incomplete",
-            limit=60,
-        )
-        if metadata.chunks_reviewed <= 0:
-            note = (
-                f"> ⚠️ **Partial review** — stopped at {reason} before "
-                f"reviewing any of {metadata.chunks_total} chunks. No findings "
-                "were produced. Raise `ai.max_cost_usd` or narrow `--path`, then "
-                "re-run."
-            )
-        else:
-            note = (
-                f"> ⚠️ **Partial review** — stopped at {reason} after "
-                f"{metadata.chunks_reviewed} of {metadata.chunks_total} "
-                "chunks. Findings below cover only the reviewed portion. Raise "
-                "`ai.max_cost_usd` or narrow `--path` to review the rest."
-            )
-        lines.extend(["", note])
-
-    lines.extend(["", *_count_row(counts=counts)])
-
-    summary_text = sanitize_comment_text(result.summary or "(no summary)", limit=4000)
-    lines.extend(["", f"**TL;DR** — {summary_text}"])
-
-    lines.extend(
-        _format_findings_section(
-            findings=result.findings,
-            checklist_display=checklist_display,
-            question_map=question_map or {},
-            diff_lines=diff_lines,
-            char_budget=findings_char_budget,
-        ),
-    )
-
-    lines.append(f"\n**Structured checks:** {metadata.checklist_items}")
-
-    if checklist_display == ChecklistDisplay.ALL:
-        lines.extend(_format_checklist_appendix_markdown(result=result))
-
-    return "\n".join(lines)
-
-
 def _is_diff_mappable(
     *,
     finding: ReviewFinding,
@@ -364,123 +282,6 @@ def _is_diff_mappable(
     if not rel or finding.line <= 0 or diff_lines is None:
         return False
     return finding.line in diff_lines.get(rel, set())
-
-
-def _finding_block(
-    *,
-    finding: ReviewFinding,
-    checklist_display: ChecklistDisplay,
-    question_map: dict[int, str],
-) -> list[str]:
-    """Render the markdown lines for a single finding in the findings list."""
-    location = _location_label(finding=finding)
-    title = sanitize_comment_text(finding.title, limit=200)
-    headline = (
-        f"{_severity_badge(severity=finding.severity)} · "
-        f"{_chip(finding.category)} — **{title}**"
-    )
-    if location:
-        headline += f" · {location}"
-    body = format_finding_comment(
-        finding=finding,
-        checklist_display=checklist_display,
-        question_map=question_map,
-    )
-    return [
-        "",
-        headline,
-        "",
-        "<details><summary>Details</summary>",
-        "",
-        body,
-        "",
-        "</details>",
-    ]
-
-
-def _format_findings_section(
-    *,
-    findings: tuple[ReviewFinding, ...],
-    checklist_display: ChecklistDisplay,
-    question_map: dict[int, str],
-    diff_lines: dict[str, set[int]] | None = None,
-    char_budget: int | None = None,
-) -> list[str]:
-    """Render a compact, collapsible list of all findings.
-
-    Non-diff-mappable ("fallback") findings render first: they have no inline
-    surface, so if truncation must drop anything it only drops findings that
-    also exist as inline comments. When ``char_budget`` is set and the rendered
-    blocks would overflow it, rendering stops early and an explicit marker names
-    how many findings were dropped so nothing silently vanishes.
-
-    Args:
-        findings: Findings to render.
-        checklist_display: Structured checklist visibility mode.
-        question_map: Prompt id to question text for linked display.
-        diff_lines: Diff line map used to order fallback findings first. ``None``
-            treats every finding as fallback (preserving severity ordering).
-        char_budget: Optional soft character budget for the finding blocks. When
-            exceeded, remaining *diff-mappable* findings are replaced by a
-            truncation marker (they still exist as inline comments). Fallback
-            findings are never budget-truncated — they have no other surface.
-
-    Returns:
-        Markdown lines for the findings section.
-    """
-    if not findings:
-        return ["", "### Findings", "", "✅ No actionable findings."]
-
-    ordered = sorted(
-        findings,
-        key=lambda f: (
-            _is_diff_mappable(finding=f, diff_lines=diff_lines),
-            f.severity.value,
-            f.file,
-            f.line,
-        ),
-    )
-    lines = ["", f"### Findings ({len(findings)})"]
-    used = 0
-    for index, finding in enumerate(ordered):
-        block = _finding_block(
-            finding=finding,
-            checklist_display=checklist_display,
-            question_map=question_map,
-        )
-        block_len = len("\n".join(block))
-        # The budget is enforced on *every* finding so the section always fits
-        # inside the caller's char_budget — otherwise ``_cap_body`` would later
-        # trim the sticky from the tail and could silently drop findings.
-        # Fallback (non-diff-mappable) findings sort first, so they are only ever
-        # dropped when fallback content alone exceeds GitHub's hard comment limit
-        # (unavoidable). The marker text adapts: if any dropped finding is a
-        # fallback (no inline surface), it points to the workflow logs rather
-        # than to inline comments that do not exist for it. ``index > 0`` always
-        # renders at least one finding so a single oversized block is not lost.
-        if char_budget is not None and index > 0 and used + block_len > char_budget:
-            remaining = ordered[index:]
-            dropped = len(remaining)
-            any_fallback = any(
-                not _is_diff_mappable(finding=item, diff_lines=diff_lines)
-                for item in remaining
-            )
-            where = (
-                "the workflow logs"
-                if any_fallback
-                else "the inline comments and workflow logs"
-            )
-            lines.extend(
-                [
-                    "",
-                    f"> ✂️ **{dropped} more finding(s) truncated** to fit "
-                    f"GitHub's size limit — see {where} for the full list.",
-                ],
-            )
-            break
-        lines.extend(block)
-        used += block_len
-    return lines
 
 
 def _location_label(*, finding: ReviewFinding) -> str:

--- a/lintro/ai/review/github_review_body.py
+++ b/lintro/ai/review/github_review_body.py
@@ -42,7 +42,7 @@ __all__ = ["REVIEW_BODY_FOOTER", "build_review_body"]
 #: Footer cross-linking the two surfaces this body deliberately does not own.
 REVIEW_BODY_FOOTER = (
     "<sub>🤖 lintro · cumulative status &amp; history → sticky comment · "
-    "finding details → inline comments</sub>"
+    "finding details → inline comments below</sub>"
 )
 
 #: Characters of a commit sha rendered in prose.

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -191,6 +191,11 @@ _DETAILS_TAG_RE = re.compile(r"<(/?)(details|summary)\b", re.IGNORECASE)
 #: Maximum characters of a finding title rendered in a table cell.
 _TITLE_LIMIT = 160
 
+#: End of the first sentence of a round narrative. Terminators other than the
+#: period are matched too: a headline ending in "?" or "!" is one sentence, and
+#: splitting on ". " alone would persist the whole paragraph after it.
+_SENTENCE_BOUNDARY_RE = re.compile(r"(?<=[.!?])\s+")
+
 #: Maximum characters of a stored per-round narrative, on the way in (it is
 #: persisted in the state blob, which competes for the same size cap) and on
 #: the way out.
@@ -1537,8 +1542,12 @@ def _round_narrative(*, result: ReviewResult) -> str:
     text = headline or result.summary.strip()
     if not text:
         return ""
-    sentence, separator, _rest = text.partition(". ")
-    return (sentence + separator).strip()[:_NARRATIVE_LIMIT].strip()
+    # Whitespace is normalized first so a sentence broken across lines is still
+    # recognized as one boundary, and so the stored line cannot carry a newline
+    # into the recap.
+    normalized = " ".join(text.split())
+    sentence = _SENTENCE_BOUNDARY_RE.split(normalized, maxsplit=1)[0]
+    return sentence[:_NARRATIVE_LIMIT].strip()
 
 
 def _cap_body(*, body: str) -> str:

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -9,11 +9,12 @@ inline comments.
 Layout, top to bottom:
 
 1. header — ``🔎 Lintro Review · round N · commit <sha>``
-2. readiness pill + delta line
+2. readiness pill, the verdict rubric as fine-print directly under it, then the
+   delta line
 3. ``Summary`` — headline plus walkthrough bullets, severity-marked when a
    bullet is tied to an open P1/P2
-4. ``Why it's blocked`` — the model's reasoning, the verdict rubric as
-   fine-print, and the files needing attention
+4. ``Why it's blocked`` — the model's reasoning and the files needing
+   attention
 5. severity tiles (blockers / warnings / nits / fixed)
 6. ``Open findings`` — one line per finding, titles only
 7. the fix-all agent prompt panel, scoped to *all* still-open findings
@@ -61,6 +62,7 @@ from lintro.ai.review.github_constants import (
     STICKY_FOOTER,
     STICKY_MARKER,
 )
+from lintro.ai.review.github_lifecycle import inline_comment_url
 from lintro.ai.review.github_render import (
     _fmt_cost,
     _fmt_int,
@@ -189,6 +191,11 @@ _DETAILS_TAG_RE = re.compile(r"<(/?)(details|summary)\b", re.IGNORECASE)
 #: Maximum characters of a finding title rendered in a table cell.
 _TITLE_LIMIT = 160
 
+#: Maximum characters of a stored per-round narrative, on the way in (it is
+#: persisted in the state blob, which competes for the same size cap) and on
+#: the way out.
+_NARRATIVE_LIMIT = 200
+
 #: Upper bound for the finding-count binary searches. No review round
 #: realistically reports more findings than this, and the search costs only
 #: ~log2(n) renders.
@@ -243,6 +250,8 @@ def build_sticky_comment(
     auth_mode: str = "",
     inline_failure: InlinePostFailure | None = None,
     inline_comment_ids: Mapping[str, int] | None = None,
+    repo: str = "",
+    pr_number: int | None = None,
 ) -> str:
     """Compose the full v5 "mission control" sticky PR comment body.
 
@@ -271,8 +280,11 @@ def build_sticky_comment(
             table and folds those findings' full detail back in.
         inline_comment_ids: Finding key to the id of the inline comment that
             carries it, captured after this round's review was submitted
-            (#1912). Stamped onto the persisted records so a later round can
-            edit those comments in place; rendering is unaffected.
+            (#1912). Stamped onto the persisted records, and used to link each
+            open finding's title to the thread that carries its detail.
+        repo: ``owner/name`` slug of the repository, used to build those links.
+        pr_number: Pull request number, likewise. Titles render unlinked when
+            either is unknown rather than as dead links.
 
     Returns:
         Complete Markdown body carrying the hidden marker and state block,
@@ -287,8 +299,21 @@ def build_sticky_comment(
         round_number=round_number,
         head_sha=head_sha,
     )
+    # Stamp the ids before rendering, not only before persisting: the open
+    # table links each title to its thread, and a round-1 finding's id is only
+    # known on the refresh pass that passes ``inline_comment_ids`` in.
+    match = replace(
+        match,
+        records=stamp_comment_ids(
+            records=match.records,
+            comment_ids=inline_comment_ids,
+        ),
+    )
     verdict = derive_verdict(findings=match.records)
     prior = list(state.runs)
+    open_count = sum(
+        1 for record in match.records if record.status is FindingStatus.OPEN
+    )
     current = _run_record(
         result=result,
         round_number=round_number,
@@ -296,6 +321,8 @@ def build_sticky_comment(
         transport=transport,
         auth_mode=auth_mode,
         verdict=verdict,
+        resolved=len(match.resolved),
+        open_after=open_count,
     )
     combined_runs = [*prior, current]
     all_runs = combined_runs[-MAX_STORED_RUNS:]
@@ -316,11 +343,10 @@ def build_sticky_comment(
             question_map=question_map or {},
             inline_failure=inline_failure,
             limits=limits,
+            repo=repo,
+            pr_number=pr_number,
         )
 
-    open_count = sum(
-        1 for record in match.records if record.status is FindingStatus.OPEN
-    )
     body = _fit_body(
         assemble=assemble,
         prior_run_count=len(all_runs) - 1,
@@ -329,10 +355,7 @@ def build_sticky_comment(
     )
     new_state = ReviewState(
         runs=tuple(all_runs),
-        findings=stamp_comment_ids(
-            records=match.records,
-            comment_ids=inline_comment_ids,
-        ),
+        findings=match.records,
         truncated=state.truncated or runs_dropped,
     )
     return body + render_state_block(
@@ -459,6 +482,8 @@ def _assemble_body(
     question_map: dict[int, str],
     inline_failure: InlinePostFailure | None,
     limits: _RenderLimits,
+    repo: str = "",
+    pr_number: int | None = None,
 ) -> str:
     """Render every sticky section in order and join the non-empty ones.
 
@@ -475,6 +500,8 @@ def _assemble_body(
         question_map: Prompt id to question text.
         inline_failure: Findings whose inline comments could not be posted.
         limits: Per-section render limits.
+        repo: ``owner/name`` slug used to link finding titles to their threads.
+        pr_number: Pull request number used for the same links.
 
     Returns:
         The assembled body, without the hidden state block.
@@ -497,6 +524,7 @@ def _assemble_body(
         STICKY_MARKER,
         _header(round_number=round_number, head_sha=head_sha),
         _readiness_pill(verdict=verdict, records=match.records),
+        _verdict_explainer(),
         _delta_line(match=match, round_number=round_number),
         _summary_section(result=result),
         _reasoning_section(result=result, verdict=verdict),
@@ -506,6 +534,8 @@ def _assemble_body(
             records=open_records,
             match=match,
             total=total_open,
+            repo=repo,
+            pr_number=pr_number,
         ),
         _degraded_details(
             failure=inline_failure,
@@ -587,6 +617,22 @@ def _readiness_pill(
     )
     noun = _plural(count=count, noun=_VERDICT_NOUNS[verdict])
     return f"{label} — {count} open {noun}"
+
+
+def _verdict_explainer() -> str:
+    """Render the verdict-derivation rubric as fine-print under the pill.
+
+    It sits directly under the readiness verdict, not inside the reasoning
+    section: the rubric explains the *pill*, and a reader who wants to know how
+    "Blocked" was decided should not have to find it three sections later. It is
+    rendered on every round, including a clean ``READY`` one — that is precisely
+    the round where a reader most needs to know the verdict was derived from
+    open findings rather than asked of the model.
+
+    Returns:
+        The ``<sub>``-wrapped rubric line.
+    """
+    return f"<sub>{VERDICT_RUBRIC_FINE_PRINT}</sub>"
 
 
 def _delta_line(*, match: FindingMatchResult, round_number: int) -> str:
@@ -676,7 +722,10 @@ def _summary_bullet(*, text: str, finding_ref: str, result: ReviewResult) -> str
 
 
 def _reasoning_section(*, result: ReviewResult, verdict: ReviewVerdict) -> str:
-    """Render the model's verdict reasoning plus the derivation fine-print.
+    """Render the model's verdict reasoning and the files it points at.
+
+    The derivation rubric is deliberately *not* here: it explains the readiness
+    pill and is rendered directly under it by :func:`_verdict_explainer`.
 
     Args:
         result: Current review result.
@@ -697,7 +746,6 @@ def _reasoning_section(*, result: ReviewResult, verdict: ReviewVerdict) -> str:
             text = sanitize_comment_text(paragraph, limit=2000).strip()
             if text:
                 lines.extend(["", text])
-    lines.extend(["", f"<sub>{VERDICT_RUBRIC_FINE_PRINT}</sub>"])
     if reasoning is not None and reasoning.files_needing_attention:
         files = " · ".join(
             f"`{sanitize_comment_text(path, limit=200)}`"
@@ -766,16 +814,21 @@ def _open_findings_section(
     records: list[FindingRecord],
     match: FindingMatchResult,
     total: int,
+    repo: str = "",
+    pr_number: int | None = None,
 ) -> str:
     """Render the open-findings index table.
 
     Titles only, one line each: the detail lives on the inline comments, and
-    duplicating it here is what made the previous sticky unreadable.
+    duplicating it here is what made the previous sticky unreadable. Each title
+    links to that detail so the index is one click from the thread.
 
     Args:
         records: Open records to render, already ordered and limited.
         match: Cross-round matching outcome, for the ``Δ`` column.
         total: Total number of open findings before any limit was applied.
+        repo: ``owner/name`` slug used to build the per-finding links.
+        pr_number: Pull request number used for the same links.
 
     Returns:
         The ``Open findings`` section, always present so a reader never has to
@@ -794,7 +847,7 @@ def _open_findings_section(
         lines.append(
             f"| {_delta_cell(record=record, match=match)} "
             f"| {_severity_cell(record=record)} "
-            f"| {_cell(text=record.title, limit=_TITLE_LIMIT)} "
+            f"| {_finding_cell(record=record, repo=repo, pr_number=pr_number)} "
             f"| `{_location(record=record)}` "
             f"| round {record.since_round} |",
         )
@@ -1063,9 +1116,9 @@ def _history_section(
         "",
         badges,
         "",
-        "| Run | Commit | Verdict | Model | Open | Tokens (in/out) | Est. cost "
-        "| Duration |",
-        "|:-:|---|---|---|:-:|---|---|---|",
+        "| Run | Commit | Verdict | Model | Open | Fixed | Tokens (in/out) "
+        "| Est. cost | Duration |",
+        "|:-:|---|---|---|:-:|:-:|---|---|---|",
     ]
     for run in reversed(shown):
         lines.append(_history_row(run=run, latest=run is runs[-1]))
@@ -1087,6 +1140,12 @@ def _history_section(
 def _history_row(*, run: RunRecord, latest: bool) -> str:
     """Render one row of the per-run history table.
 
+    ``Open`` is what was still open *after* the round, not what the round
+    raised: a round that reported three findings and fixed two of them left one
+    open, and the raised count told that story backwards. A record persisted
+    before those counts existed renders the raised total and ``—`` rather than
+    a fabricated zero.
+
     Args:
         run: Run record to render.
         latest: True when this is the most recent run.
@@ -1096,12 +1155,17 @@ def _history_row(*, run: RunRecord, latest: bool) -> str:
     """
     prefix = "~" if run.estimated else ""
     short = _short_sha(sha=run.sha)
+    open_after = (
+        run.open_after if run.open_after is not None else run.p1 + run.p2 + run.p3
+    )
+    fixed = "—" if run.resolved is None else str(run.resolved)
     return (
         f"| {run.round}{' (latest)' if latest else ''} "
         f"| {f'`{short}`' if short else '—'} "
         f"| {VERDICT_EMOJI[run.verdict]} {verdict_label(verdict=run.verdict).lower()} "
         f"| `{_cell(text=run.model or 'unknown', limit=60)}` "
-        f"| {run.p1 + run.p2 + run.p3} "
+        f"| {open_after} "
+        f"| {fixed} "
         f"| {prefix}{_fmt_int(run.prompt)} / {prefix}{_fmt_int(run.completion)} "
         f"| {_fmt_cost(run.cost, estimated=run.estimated)} "
         f"| {run.duration:.0f}s |"
@@ -1109,22 +1173,35 @@ def _history_row(*, run: RunRecord, latest: bool) -> str:
 
 
 def _history_mini_summary(*, run: RunRecord) -> str:
-    """Render one prior round's one-line recap under the history table.
+    """Render one prior round's recap under the history table.
+
+    The round line names the verdict; the line under it is the model's own
+    one-sentence account of that round when it wrote one, because "🔴 1 · 🟠 2"
+    says how many things were wrong and never what they were. A record with no
+    stored narrative — a legacy one, or a round whose model returned no summary
+    — falls back to the severity counts.
 
     Args:
         run: Prior run record to summarize.
 
     Returns:
-        A single Markdown line.
+        Markdown for the recap, as a round line plus its detail line.
     """
     short = _short_sha(sha=run.sha)
     where = f" · `{short}`" if short else ""
-    return (
+    head = (
         f"**Round {run.round}**{where} · "
-        f"{VERDICT_EMOJI[run.verdict]} {verdict_label(verdict=run.verdict).lower()} — "
-        f"🔴 {run.p1} · 🟠 {run.p2} · 🟡 {run.p3}"
+        f"{VERDICT_EMOJI[run.verdict]} {verdict_label(verdict=run.verdict).lower()}"
         + (" · ⚠️ partial" if run.partial else "")
     )
+    # Table-safe *and* collapsible-safe: the recap sits inside the history
+    # <details>, so a model-written closing tag would end it early.
+    narrative = _DETAILS_TAG_RE.sub(
+        r"&lt;\1\2",
+        _cell(text=run.narrative, limit=_NARRATIVE_LIMIT),
+    )
+    detail = narrative or f"🔴 {run.p1} · 🟠 {run.p2} · 🟡 {run.p3}"
+    return f"{head}\n{detail}"
 
 
 # --- ordering and cell helpers ----------------------------------------------
@@ -1227,6 +1304,37 @@ def _delta_cell(*, record: FindingRecord, match: FindingMatchResult) -> str:
     if outcome is FindingMatchOutcome.REGRESSED:
         return "↩ regressed"
     return "—"
+
+
+def _finding_cell(
+    *,
+    record: FindingRecord,
+    repo: str,
+    pr_number: int | None,
+) -> str:
+    """Render the title cell, linked to the finding's inline comment.
+
+    Args:
+        record: Open finding record.
+        repo: ``owner/name`` slug of the repository.
+        pr_number: Pull request number.
+
+    Returns:
+        The title as a Markdown link to its thread, or plain text when the
+        finding has no inline comment (it was never diff-mappable, the posting
+        failed, or its id has not been captured yet). Link syntax inside the
+        title is neutralized by ``_cell``'s sanitizer, so a model-written
+        ``]`` cannot break out of the link label.
+    """
+    title = _cell(text=record.title, limit=_TITLE_LIMIT)
+    url = inline_comment_url(
+        repo=repo,
+        pr_number=pr_number,
+        comment_id=record.inline_comment_id,
+    )
+    if not url:
+        return title
+    return f"[{title.replace('[', '(').replace(']', ')')}]({url})"
 
 
 def _severity_cell(*, record: FindingRecord) -> str:
@@ -1356,6 +1464,8 @@ def _run_record(
     transport: str,
     auth_mode: str,
     verdict: ReviewVerdict,
+    resolved: int,
+    open_after: int,
 ) -> RunRecord:
     """Build a machine-readable run record from a review result.
 
@@ -1366,6 +1476,8 @@ def _run_record(
         transport: Provider transport used for this round.
         auth_mode: Authentication mode used by the transport.
         verdict: Readiness verdict derived from the open findings.
+        resolved: Number of findings this round resolved.
+        open_after: Number of findings still open after this round.
 
     Returns:
         The run record persisted in the state blob.
@@ -1401,7 +1513,32 @@ def _run_record(
         partial=bool(metadata.partial),
         chunks_reviewed=metadata.chunks_reviewed,
         chunks_total=metadata.chunks_total,
+        resolved=resolved,
+        open_after=open_after,
+        narrative=_round_narrative(result=result),
     )
+
+
+def _round_narrative(*, result: ReviewResult) -> str:
+    """Extract the one-line narrative persisted for this round.
+
+    Args:
+        result: Current review result.
+
+    Returns:
+        The structured summary's headline when the model produced one, else the
+        first sentence of the flat summary, else an empty string. Only the
+        first sentence is kept: the recap is one line under a round heading,
+        and a paragraph there turns the history into the wall of text the
+        sticky redesign exists to undo.
+    """
+    summary = result.pr_summary
+    headline = (summary.headline if summary else "").strip()
+    text = headline or result.summary.strip()
+    if not text:
+        return ""
+    sentence, separator, _rest = text.partition(". ")
+    return (sentence + separator).strip()[:_NARRATIVE_LIMIT].strip()
 
 
 def _cap_body(*, body: str) -> str:

--- a/lintro/ai/review/models/run_record.py
+++ b/lintro/ai/review/models/run_record.py
@@ -56,6 +56,16 @@ class RunRecord:
         partial: True when the review stopped before every chunk was reviewed.
         chunks_reviewed: Number of chunks actually reviewed.
         chunks_total: Total number of chunks in the diff.
+        resolved: Number of findings this round resolved. ``None`` on a record
+            persisted before the field existed — history renders that as ``—``
+            rather than as a fabricated zero, which would read as "this round
+            fixed nothing".
+        open_after: Number of findings still open *after* this round, which is
+            what a reader of the history actually wants to know. ``None`` on a
+            legacy record, where only the raised count was ever stored.
+        narrative: One-line recap of the round in the model's own words, taken
+            from the structured summary headline (or the review summary's first
+            sentence). Empty when the model produced neither.
     """
 
     round: int = 1
@@ -86,15 +96,20 @@ class RunRecord:
     partial: bool = False
     chunks_reviewed: int = 0
     chunks_total: int = 0
+    resolved: int | None = None
+    open_after: int | None = None
+    narrative: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the run record for the hidden state blob.
 
         Returns:
             JSON-serializable mapping carrying both the v1 aggregate keys and
-            the v2 additions.
+            the v2 additions. The optional per-round fields are omitted when
+            unset, so a record that predates them round-trips byte-identically
+            and keeps rendering as "unknown" rather than as zero.
         """
-        return {
+        payload: dict[str, Any] = {
             "round": self.round,
             "timestamp": self.timestamp,
             "sha": self.sha,
@@ -124,6 +139,13 @@ class RunRecord:
             "chunks_reviewed": self.chunks_reviewed,
             "chunks_total": self.chunks_total,
         }
+        if self.resolved is not None:
+            payload["resolved"] = self.resolved
+        if self.open_after is not None:
+            payload["open_after"] = self.open_after
+        if self.narrative:
+            payload["narrative"] = self.narrative
+        return payload
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> RunRecord:
@@ -167,7 +189,34 @@ class RunRecord:
             partial=bool(payload.get("partial", False)),
             chunks_reviewed=coerce_int(payload.get("chunks_reviewed")),
             chunks_total=coerce_int(payload.get("chunks_total")),
+            resolved=_optional_count(payload.get("resolved")),
+            open_after=_optional_count(payload.get("open_after")),
+            narrative=str(payload.get("narrative", "")),
         )
+
+
+def _optional_count(value: Any) -> int | None:
+    """Parse a count that may be absent from a legacy record.
+
+    Args:
+        value: Raw value decoded from the state blob, or ``None`` when the key
+            was never written.
+
+    Returns:
+        The parsed count, or ``None`` when the key is absent. A present but
+        unparsable value also yields ``None``: rendering "unknown" is honest,
+        whereas coercing it to zero would claim the round fixed nothing.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int | float | str):
+        try:
+            return max(int(float(value)), 0)
+        except (TypeError, ValueError, OverflowError):
+            # ``int(float("inf"))`` raises OverflowError, and a corrupted blob
+            # must degrade to "unknown" rather than abort the whole decode.
+            return None
+    return None
 
 
 def _parse_verdict(value: Any) -> ReviewVerdict:

--- a/lintro/ai/review/verdict.py
+++ b/lintro/ai/review/verdict.py
@@ -4,8 +4,9 @@ The readiness verdict is **derived in code**, never asked of the model: a
 model-scored verdict drifts from the findings it is supposed to summarize, and
 a reader who sees "Ready" above a P1 finding stops trusting the whole comment.
 The rubric below is the single source of truth — surfaces render it as
-fine-print under the reasoning rather than restating it, and the review prompt
-tells the model the verdict is computed so it writes only the reasoning.
+fine-print directly under the readiness verdict rather than restating it, and
+the review prompt tells the model the verdict is computed so it writes only the
+reasoning.
 """
 
 from __future__ import annotations
@@ -41,15 +42,17 @@ if _missing_verdict_labels:  # pragma: no cover - guards a future verdict
         f"VERDICT_LABELS missing entries for: {_missing_verdict_labels}",
     )
 
-#: Fine-print rendered under the verdict reasoning. Built from
+#: Fine-print rendered directly under the readiness verdict. Built from
 #: :data:`VERDICT_LABELS` rather than restating them, so a relabelled verdict
-#: cannot leave the rendered rubric describing the old one.
+#: cannot leave the rendered rubric describing the old one. The severity dots
+#: match the ones the surfaces use for findings, so the rubric reads as the
+#: same vocabulary as the tables above and below it.
 VERDICT_RUBRIC_FINE_PRINT: str = (
-    "Verdict is derived from open findings: "
-    f"any P1 -> {VERDICT_LABELS[ReviewVerdict.BLOCKED]}; "
-    f"else any P2 -> {VERDICT_LABELS[ReviewVerdict.CHANGES_REQUESTED]}; "
-    f"else any P3 -> {VERDICT_LABELS[ReviewVerdict.NITS_ONLY]}; "
-    f"else {VERDICT_LABELS[ReviewVerdict.READY]}."
+    "Verdict is derived: open 🔴 P1 → "
+    f"{VERDICT_LABELS[ReviewVerdict.BLOCKED]} · else open 🟠 P2 → "
+    f"{VERDICT_LABELS[ReviewVerdict.CHANGES_REQUESTED]} · else 🟡 P3 → "
+    f"{VERDICT_LABELS[ReviewVerdict.NITS_ONLY]} · else ✅ "
+    f"{VERDICT_LABELS[ReviewVerdict.READY]}."
 )
 
 

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -320,6 +320,7 @@ def review_command(
             pr_number=context_pr,
             repo=context_repo,
             paths=paths,
+            exclude_globs=list(ai_config.exclude_paths),
         )
     except ReviewContextError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/tests/unit/ai/review/test_context_collect.py
+++ b/tests/unit/ai/review/test_context_collect.py
@@ -978,3 +978,157 @@ def test_collect_review_context_records_path_filter_skips(
     assert_that(context.skipped_files[0].reason).is_equal_to(
         FileSkipReason.PATH_FILTER,
     )
+
+
+@patch("lintro.ai.review.context.git_ops.subprocess.run")
+@patch(
+    "lintro.ai.review.context.git_ops.shutil.which",
+    side_effect=_which_for_review_tools,
+)
+def test_collect_review_context_records_config_exclusion_skips(
+    _mock_which: MagicMock,
+    mock_run: MagicMock,
+) -> None:
+    """``ai.exclude_paths`` drops files and says so, rather than silently."""
+    dispatcher = SubprocessMock()
+    dispatcher.queue(["git", "rev-parse", "--git-dir"], stdout=".git\n")
+    dispatcher.queue(["git", "rev-parse", "--show-toplevel"], stdout="/repo\n")
+    dispatcher.queue(["git", "merge-base", "main", "HEAD"], stdout="base123\n")
+    dispatcher.queue(["git", "rev-parse", "HEAD"], stdout="head456\n")
+    queue_diff_snapshot(
+        dispatcher,
+        diff_ref="base123...head456",
+        unified=(
+            "diff --git a/src/a.py b/src/a.py\n"
+            "+++ b/src/a.py\n"
+            "+a\n"
+            "diff --git a/docs/guide.md b/docs/guide.md\n"
+            "+++ b/docs/guide.md\n"
+            "+b\n"
+        ),
+        name_status="M\0src/a.py\0M\0docs/guide.md\0",
+        numstat="1\t0\tsrc/a.py\x001\t0\tdocs/guide.md\x00",
+    )
+    mock_run.side_effect = dispatcher
+
+    context = collect_review_context(base="main", exclude_globs=["docs/**"])
+
+    assert_that([file.path for file in context.changed_files]).is_equal_to(
+        ["src/a.py"],
+    )
+    assert_that(context.unified_diff).does_not_contain("docs/guide.md")
+    assert_that([entry.path for entry in context.skipped_files]).is_equal_to(
+        ["docs/guide.md"],
+    )
+    assert_that(context.skipped_files[0].reason).is_equal_to(
+        FileSkipReason.CONFIG_EXCLUDED,
+    )
+
+
+@patch("lintro.ai.review.context.git_ops.subprocess.run")
+@patch(
+    "lintro.ai.review.context.git_ops.shutil.which",
+    side_effect=_which_for_review_tools,
+)
+def test_collect_review_context_excludes_a_rename_out_of_an_excluded_tree(
+    _mock_which: MagicMock,
+    mock_run: MagicMock,
+) -> None:
+    """A file moved out of an excluded tree stays excluded.
+
+    Its diff still carries the excluded pre-image content, so an exclusion a
+    rename can defeat is not an exclusion.
+    """
+    dispatcher = SubprocessMock()
+    dispatcher.queue(["git", "rev-parse", "--git-dir"], stdout=".git\n")
+    dispatcher.queue(["git", "rev-parse", "--show-toplevel"], stdout="/repo\n")
+    dispatcher.queue(["git", "merge-base", "main", "HEAD"], stdout="base123\n")
+    dispatcher.queue(["git", "rev-parse", "HEAD"], stdout="head456\n")
+    queue_diff_snapshot(
+        dispatcher,
+        diff_ref="base123...head456",
+        unified=(
+            "diff --git a/src/a.py b/src/a.py\n"
+            "+++ b/src/a.py\n"
+            "+a\n"
+            "diff --git a/docs/guide.md b/src/moved.md\n"
+            "+++ b/src/moved.md\n"
+            "+b\n"
+        ),
+        name_status="M\0src/a.py\0R100\0docs/guide.md\0src/moved.md\0",
+        numstat="1\t0\tsrc/a.py\x001\t0\t\x00docs/guide.md\x00src/moved.md\x00",
+    )
+    mock_run.side_effect = dispatcher
+
+    unfiltered = collect_review_context(base="main")
+    renamed = next(
+        file for file in unfiltered.changed_files if file.path == "src/moved.md"
+    )
+    # Pin the fixture: without a parsed previous_path the exclusion below would
+    # pass for the wrong reason.
+    assert_that(renamed.previous_path).is_equal_to("docs/guide.md")
+
+    dispatcher = SubprocessMock()
+    dispatcher.queue(["git", "rev-parse", "--git-dir"], stdout=".git\n")
+    dispatcher.queue(["git", "rev-parse", "--show-toplevel"], stdout="/repo\n")
+    dispatcher.queue(["git", "merge-base", "main", "HEAD"], stdout="base123\n")
+    dispatcher.queue(["git", "rev-parse", "HEAD"], stdout="head456\n")
+    queue_diff_snapshot(
+        dispatcher,
+        diff_ref="base123...head456",
+        unified=(
+            "diff --git a/src/a.py b/src/a.py\n"
+            "+++ b/src/a.py\n"
+            "+a\n"
+            "diff --git a/docs/guide.md b/src/moved.md\n"
+            "+++ b/src/moved.md\n"
+            "+b\n"
+        ),
+        name_status="M\0src/a.py\0R100\0docs/guide.md\0src/moved.md\0",
+        numstat="1\t0\tsrc/a.py\x001\t0\t\x00docs/guide.md\x00src/moved.md\x00",
+    )
+    mock_run.side_effect = dispatcher
+
+    context = collect_review_context(base="main", exclude_globs=["docs/**"])
+
+    assert_that([file.path for file in context.changed_files]).is_equal_to(
+        ["src/a.py"],
+    )
+    assert_that([entry.path for entry in context.skipped_files]).is_equal_to(
+        ["src/moved.md"],
+    )
+    assert_that(context.skipped_files[0].reason).is_equal_to(
+        FileSkipReason.CONFIG_EXCLUDED,
+    )
+
+
+@patch("lintro.ai.review.context.git_ops.subprocess.run")
+@patch(
+    "lintro.ai.review.context.git_ops.shutil.which",
+    side_effect=_which_for_review_tools,
+)
+def test_collect_review_context_without_an_exclusion_match_skips_nothing(
+    _mock_which: MagicMock,
+    mock_run: MagicMock,
+) -> None:
+    """Configured globs that match nothing leave the context untouched."""
+    dispatcher = SubprocessMock()
+    dispatcher.queue(["git", "rev-parse", "--git-dir"], stdout=".git\n")
+    dispatcher.queue(["git", "rev-parse", "--show-toplevel"], stdout="/repo\n")
+    dispatcher.queue(["git", "merge-base", "main", "HEAD"], stdout="base123\n")
+    dispatcher.queue(["git", "rev-parse", "HEAD"], stdout="head456\n")
+    queue_diff_snapshot(
+        dispatcher,
+        diff_ref="base123...head456",
+        unified="diff --git a/src/a.py b/src/a.py\n+++ b/src/a.py\n+a\n",
+        name_status="M\0src/a.py\0",
+        numstat="1\t0\tsrc/a.py\0",
+    )
+    mock_run.side_effect = dispatcher
+
+    context = collect_review_context(base="main", exclude_globs=["vendor/**"])
+
+    assert_that([file.path for file in context.changed_files]).is_equal_to(
+        ["src/a.py"],
+    )
+    assert_that(context.skipped_files).is_empty()

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -21,12 +21,10 @@ from lintro.ai.review.github import (
     STICKY_MARKER,
     _cap_body,
     _count_new_commits,
-    _format_findings_section,
     _sticky_comment_id,
     build_sticky_comment,
     format_error_comment,
     format_finding_comment,
-    format_review_summary,
     format_run_mechanics,
     parse_review_state,
     post_review_error_to_github,
@@ -107,32 +105,6 @@ def test_format_finding_comment_linked_includes_review_questions(
 
     assert_that(comment).contains("**Review questions:**")
     assert_that(comment).contains("Does unknown status fail closed?")
-
-
-def test_format_review_summary_has_counts_and_tldr(
-    sample_review_result: ReviewResult,
-) -> None:
-    """Summary renders a severity count table and TL;DR."""
-    summary = format_review_summary(result=sample_review_result)
-
-    assert_that(summary).contains("## 🔎 Lintro Review")
-    assert_that(summary).contains("| 🔴 P1 | 🟠 P2 | 🟡 P3 |")
-    assert_that(summary).contains("**TL;DR**")
-    assert_that(summary).contains("**Structured checks:** 3")
-
-
-def test_format_review_summary_all_includes_appendix(
-    sample_review_result: ReviewResult,
-) -> None:
-    """All mode appends cleared and orphan sections to the summary."""
-    summary = format_review_summary(
-        result=sample_review_result,
-        checklist_display=ChecklistDisplay.ALL,
-    )
-
-    assert_that(summary).contains("### Cleared checks (1)")
-    assert_that(summary).contains("Are access paths covered by tests?")
-    assert_that(summary).contains("### Checklist concerns without findings (1)")
 
 
 # --- per-run mechanics + exact/approximate labeling -------------------------
@@ -307,57 +279,6 @@ def test_round_trip_state_parsing(sample_review_result: ReviewResult) -> None:
 def test_parse_review_state_handles_missing_block() -> None:
     """A body with no state block yields an empty run list."""
     assert_that(parse_review_state(body="no state here")).is_empty()
-
-
-# --- partial state ----------------------------------------------------------
-
-
-def test_summary_renders_partial_state(
-    sample_review_result: ReviewResult,
-) -> None:
-    """A partial review renders an explicit partial note."""
-    metadata = replace(
-        sample_review_result.metadata,
-        partial=True,
-        stopped_reason="cost cap",
-        chunks_reviewed=2,
-        chunks_total=5,
-    )
-    result = ReviewResult(
-        metadata=metadata,
-        summary=sample_review_result.summary,
-        checklist=sample_review_result.checklist,
-        findings=sample_review_result.findings,
-    )
-    summary = format_review_summary(result=result)
-
-    assert_that(summary).contains("Partial review")
-    assert_that(summary).contains("cost cap")
-    assert_that(summary).contains("2 of 5 chunks")
-
-
-def test_summary_renders_partial_state_before_any_chunk(
-    sample_review_result: ReviewResult,
-) -> None:
-    """A cost cap tripping before any chunk renders an actionable note."""
-    metadata = replace(
-        sample_review_result.metadata,
-        partial=True,
-        stopped_reason="cost cap ($0.50) reached",
-        chunks_reviewed=0,
-        chunks_total=4,
-    )
-    result = ReviewResult(
-        metadata=metadata,
-        summary=sample_review_result.summary,
-        checklist=sample_review_result.checklist,
-        findings=(),
-    )
-    summary = format_review_summary(result=result)
-
-    assert_that(summary).contains("Partial review")
-    assert_that(summary).contains("before reviewing any of 4 chunks")
-    assert_that(summary).contains("ai.max_cost_usd")
 
 
 # --- posting: create, update, inline ----------------------------------------
@@ -627,47 +548,6 @@ def _result_with_findings(
     )
 
 
-def test_findings_section_orders_fallback_before_diff_mappable(
-    sample_review_result: ReviewResult,
-) -> None:
-    """Non-diff-mappable findings render ahead of diff-mappable ones."""
-    diff_lines = {"src/mapped.py": {10}}
-    mapped = ReviewFinding(
-        severity=Severity.P1,
-        category="security",
-        file="src/mapped.py",
-        line=10,
-        title="MappedInlineFinding",
-        description="d",
-        cause="c",
-        fix="f",
-        confidence="high",
-    )
-    fallback = ReviewFinding(
-        severity=Severity.P3,
-        category="style",
-        file="src/unmapped.py",
-        line=999,
-        title="FallbackOnlyFinding",
-        description="d",
-        cause="c",
-        fix="f",
-        confidence="low",
-    )
-    result = _result_with_findings(
-        base=sample_review_result,
-        findings=(mapped, fallback),
-    )
-
-    summary = format_review_summary(result=result, diff_lines=diff_lines)
-
-    fallback_at = summary.find("FallbackOnlyFinding")
-    mapped_at = summary.find("MappedInlineFinding")
-    assert_that(fallback_at).is_greater_than(-1)
-    # Fallback (P3) precedes the diff-mappable P1 despite lower severity.
-    assert_that(fallback_at).is_less_than(mapped_at)
-
-
 def test_sticky_indexes_every_finding_and_stays_under_the_cap(
     sample_review_result: ReviewResult,
 ) -> None:
@@ -699,52 +579,12 @@ def test_sticky_indexes_every_finding_and_stays_under_the_cap(
         findings=(*mapped, fallback),
     )
 
-    # The old detail-embedding renderer would blow past the cap on this input.
-    unbudgeted = format_review_summary(result=result, diff_lines=diff_lines)
-    assert_that(len(unbudgeted)).is_greater_than(MAX_COMMENT_CHARS)
-
     body = build_sticky_comment(result=result, diff_lines=diff_lines)
 
     assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
     assert_that(body).contains("### Open findings (41)")
     assert_that(body).contains("FallbackOnlyFinding")
     assert_that(body).contains("MappedFinding1")
-
-
-def test_all_fallback_overflow_truncates_to_logs_not_inline() -> None:
-    """All-fallback overflow drops via an explicit *workflow-logs* marker.
-
-    When ``diff_lines`` is ``None`` every finding is fallback (no inline
-    surface). If they exceed GitHub's hard comment limit, truncation is
-    unavoidable — but it must be explicit and must NOT point readers to inline
-    comments that do not exist for fallback findings.
-    """
-    findings = tuple(
-        _bulky_finding(
-            severity=Severity.P2,
-            file=f"src/unmapped{index}.py",
-            line=900 + index,
-            title=f"FallbackFinding{index}",
-        )
-        for index in range(5)
-    )
-
-    lines = _format_findings_section(
-        findings=findings,
-        checklist_display=ChecklistDisplay.OFF,
-        question_map={},
-        diff_lines=None,
-        char_budget=200,  # forces overflow so the marker path is exercised
-    )
-    body = "\n".join(lines)
-
-    # At least the first fallback finding is always rendered.
-    assert_that(body).contains("FallbackFinding0")
-    # Overflow is explicit, and points at the logs — never at (nonexistent)
-    # inline comments for fallback findings.
-    assert_that(body).contains("more finding(s) truncated")
-    assert_that(body).contains("workflow logs")
-    assert_that(body).does_not_contain("inline comments")
 
 
 def test_sticky_state_round_trips_after_truncation(

--- a/tests/unit/ai/review/test_github_sticky_mission_control.py
+++ b/tests/unit/ai/review/test_github_sticky_mission_control.py
@@ -38,6 +38,7 @@ from lintro.ai.review.models.review_summary import ReviewSummary
 from lintro.ai.review.models.run_record import RunRecord
 from lintro.ai.review.models.summary_bullet import SummaryBullet
 from lintro.ai.review.models.verdict_reasoning import VerdictReasoning
+from lintro.ai.review.verdict import VERDICT_RUBRIC_FINE_PRINT
 
 _DETAILS_TAG_RE = re.compile(r"</?details\b")
 _ROUND_RE = re.compile(r"\*\*Round (\d+)\*\*")
@@ -456,7 +457,7 @@ def test_summary_bullets_tied_to_blockers_are_severity_marked(
 def test_reasoning_section_carries_rubric_and_attention_files(
     sample_review_result: ReviewResult,
 ) -> None:
-    """Model reasoning renders above the derivation fine-print."""
+    """Model reasoning and the attention files render in their own section."""
     body = _body_only(
         body=build_sticky_comment(
             result=_with(
@@ -474,8 +475,10 @@ def test_reasoning_section_carries_rubric_and_attention_files(
     assert_that(body).contains("### Why it's blocked")
     assert_that(body).contains("The credential is evaluated at import time.")
     assert_that(body).contains("Every importer holds the secret.")
-    assert_that(body).contains("Verdict is derived from open findings")
     assert_that(body).contains("**Files needing attention:** `src/example.py`")
+    # The rubric explains the pill and is rendered under it, not buried here.
+    reasoning_at = body.index("### Why it's blocked")
+    assert_that(body.index(VERDICT_RUBRIC_FINE_PRINT)).is_less_than(reasoning_at)
 
 
 # --- honesty and structure ---------------------------------------------------

--- a/tests/unit/ai/review/test_inline_finding_format.py
+++ b/tests/unit/ai/review/test_inline_finding_format.py
@@ -439,7 +439,7 @@ def test_comment_has_no_footer() -> None:
     )
 
     assert_that(body).does_not_contain("<sub>lintro ·")
-    assert_that(body.rstrip().splitlines()[-1]).starts_with("**Fix:**")
+    assert_that(body.rstrip().splitlines()[-1]).starts_with("> **Fix:**")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/ai/review/test_mock_parity_1951.py
+++ b/tests/unit/ai/review/test_mock_parity_1951.py
@@ -1,0 +1,567 @@
+"""Mock-parity gaps closed after the #1905 comment-surfaces audit (#1951).
+
+Each test here pins one behaviour the rendered surfaces were missing relative
+to the epic's mocks: linked finding titles, an honest run-history table, a
+per-round narrative, a regression that says it is one, config-excluded files in
+the skipped list, the verdict rubric under the pill, and the highlighted mode-B
+fix.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.review.context.collection import _filter_context_by_excludes
+from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
+from lintro.ai.review.enums.checklist_display import ChecklistDisplay
+from lintro.ai.review.enums.file_skip_reason import (
+    FileSkipReason,
+    describe_skip_reason,
+)
+from lintro.ai.review.enums.review_verdict import ReviewVerdict
+from lintro.ai.review.github import _post_inline_findings
+from lintro.ai.review.github_constants import STATE_MARKER_PREFIX
+from lintro.ai.review.github_render import (
+    REGRESSED_TITLE_SUFFIX,
+    format_finding_comment,
+)
+from lintro.ai.review.github_review_body import REVIEW_BODY_FOOTER
+from lintro.ai.review.github_sticky import build_sticky_comment, parse_review_state_v2
+from lintro.ai.review.inline_fix import plan_inline_fix
+from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.review_summary import ReviewSummary
+from lintro.ai.review.models.run_record import RunRecord
+from lintro.ai.review.models.suggested_change import SuggestedChange
+from lintro.ai.review.verdict import VERDICT_RUBRIC_FINE_PRINT
+
+_DIFF = """diff --git a/src/main.py b/src/main.py
+--- a/src/main.py
++++ b/src/main.py
+@@ -1,1 +1,1 @@
+-old
++new
+diff --git a/docs/guide.md b/docs/guide.md
+--- a/docs/guide.md
++++ b/docs/guide.md
+@@ -1,1 +1,1 @@
+-old
++new
+"""
+
+
+def _finding(
+    *,
+    title: str = "Leak",
+    severity: Severity = Severity.P1,
+    line: int = 10,
+    file: str = "src/main.py",
+) -> ReviewFinding:
+    """Build a review finding for the parity tests."""
+    return ReviewFinding(
+        severity=severity,
+        category="security",
+        file=file,
+        line=line,
+        title=title,
+        description="Stores an application password as a module-level literal.",
+        cause="Assigned at module scope.",
+        fix="Read it from the environment.",
+        confidence="high",
+    )
+
+
+def _with(
+    *,
+    base: ReviewResult,
+    findings: tuple[ReviewFinding, ...],
+    **overrides: Any,
+) -> ReviewResult:
+    """Return a copy of ``base`` carrying different findings and fields."""
+    return replace(base, findings=findings, **overrides)
+
+
+def _body_only(*, body: str) -> str:
+    """Strip the hidden state blob so assertions only see rendered Markdown."""
+    return body.split(STATE_MARKER_PREFIX, 1)[0]
+
+
+def _changed_file(*, path: str) -> ChangedFile:
+    """Build a modified changed-file entry."""
+    return ChangedFile(
+        path=path,
+        status=ChangedFileStatus.MODIFIED,
+        additions=1,
+        deletions=1,
+    )
+
+
+# --- 1. open findings link to their inline comment ---------------------------
+
+
+def test_open_finding_title_links_to_its_inline_comment(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A finding whose thread is known renders its title as a link to it."""
+    result = _with(base=sample_review_result, findings=(_finding(),))
+    first = build_sticky_comment(result=result, head_sha="sha1")
+    state = parse_review_state_v2(body=first)
+    key = state.findings[0].key
+
+    body = _body_only(
+        body=build_sticky_comment(
+            result=result,
+            prior_state=state,
+            head_sha="sha1",
+            inline_comment_ids={key: 424242},
+            repo="owner/name",
+            pr_number=7,
+        ),
+    )
+
+    assert_that(body).contains(
+        "[Leak](https://github.com/owner/name/pull/7#discussion_r424242)",
+    )
+
+
+def test_open_finding_without_a_comment_id_renders_unlinked(
+    sample_review_result: ReviewResult,
+) -> None:
+    """No thread means no link — never a dead one."""
+    body = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=(_finding(),)),
+            head_sha="sha1",
+            repo="owner/name",
+            pr_number=7,
+        ),
+    )
+
+    assert_that(body).does_not_contain("#discussion_r")
+    assert_that(body).contains("| Leak ")
+
+
+def test_open_finding_renders_unlinked_without_repo_context(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A known comment id is not enough: the URL also needs repo and PR."""
+    result = _with(base=sample_review_result, findings=(_finding(),))
+    state = parse_review_state_v2(body=build_sticky_comment(result=result))
+
+    body = _body_only(
+        body=build_sticky_comment(
+            result=result,
+            prior_state=state,
+            inline_comment_ids={state.findings[0].key: 99},
+        ),
+    )
+
+    assert_that(body).does_not_contain("#discussion_r")
+
+
+# --- 2. run history: fixed count and still-open count ------------------------
+
+
+def test_history_row_reports_open_after_the_round_and_what_it_fixed(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Round two fixed one finding and left one open; the table says so."""
+    first = build_sticky_comment(
+        result=_with(
+            base=sample_review_result,
+            findings=(_finding(title="Leak"), _finding(title="Race", line=20)),
+        ),
+        head_sha="sha1",
+    )
+
+    second = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
+            prior_state=parse_review_state_v2(body=first),
+            head_sha="sha2",
+        ),
+    )
+
+    assert_that(second).contains("| Open | Fixed |")
+    # Round 2: one still open, one fixed. The raised count was also one, so the
+    # fixed column is what proves the round is being reported honestly.
+    assert_that(second).contains("| 1 | 1 |")
+
+
+def test_history_row_falls_back_for_state_without_the_new_counts(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A record persisted before the counts existed renders raised and ``—``."""
+    prior_state = ReviewState(
+        runs=(RunRecord(round=1, sha="sha1", model="m", p1=2, p2=1),),
+    )
+
+    body = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=()),
+            prior_state=prior_state,
+            head_sha="sha2",
+        ),
+    )
+
+    # Legacy round 1: three findings raised, fixed count unknown.
+    assert_that(body).contains("| 3 | — |")
+
+
+def test_legacy_run_payload_without_the_new_fields_loads() -> None:
+    """A v1/v2 payload parses with the new fields absent, not zeroed."""
+    record = RunRecord.from_dict({"round": 1, "sha": "sha1", "p1": 2})
+
+    assert_that(record.resolved).is_none()
+    assert_that(record.open_after).is_none()
+    assert_that(record.narrative).is_equal_to("")
+    assert_that(record.to_dict()).does_not_contain_key(
+        "resolved",
+        "open_after",
+        "narrative",
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("inf", id="non-finite"),
+        pytest.param("not-a-number", id="garbage"),
+        pytest.param(True, id="bool"),
+    ],
+)
+def test_a_corrupted_count_decodes_as_unknown(value: object) -> None:
+    """A malformed blob renders "unknown", and never aborts the decode."""
+    record = RunRecord.from_dict({"round": 1, "resolved": value})
+
+    assert_that(record.resolved).is_none()
+
+
+def test_new_run_fields_round_trip_through_the_state_blob() -> None:
+    """The counts and narrative survive serialization."""
+    record = RunRecord(
+        round=2,
+        resolved=3,
+        open_after=1,
+        narrative="Fixed the fail-open default.",
+    )
+
+    restored = RunRecord.from_dict(record.to_dict())
+
+    assert_that(restored.resolved).is_equal_to(3)
+    assert_that(restored.open_after).is_equal_to(1)
+    assert_that(restored.narrative).is_equal_to("Fixed the fail-open default.")
+
+
+# --- 3. per-round narrative --------------------------------------------------
+
+
+def test_history_recap_renders_the_rounds_narrative(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The model's own account of a round beats a severity tally."""
+    first = build_sticky_comment(
+        result=_with(
+            base=sample_review_result,
+            findings=(_finding(),),
+            pr_summary=ReviewSummary(
+                headline="Adds a fail-open default to the auth path.",
+                walkthrough=(),
+            ),
+        ),
+        head_sha="sha1",
+    )
+
+    second = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=(_finding(),)),
+            prior_state=parse_review_state_v2(body=first),
+            head_sha="sha2",
+        ),
+    )
+
+    assert_that(second).contains("**Round 1** · `sha1`")
+    assert_that(second).contains("Adds a fail-open default to the auth path.")
+
+
+def test_history_recap_falls_back_to_counts_without_a_narrative(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A legacy record has no narrative, so the counts line stands in."""
+    prior_state = ReviewState(
+        runs=(RunRecord(round=1, sha="sha1", model="m", p1=1, p2=2, p3=3),),
+    )
+
+    body = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=()),
+            prior_state=prior_state,
+            head_sha="sha2",
+        ),
+    )
+
+    assert_that(body).contains("🔴 1 · 🟠 2 · 🟡 3")
+
+
+def test_narrative_keeps_only_the_first_sentence(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A recap is one line; the rest of a paragraph is not persisted."""
+    body = build_sticky_comment(
+        result=_with(
+            base=sample_review_result,
+            findings=(),
+            summary="One sentence. And a second one that must not be stored.",
+        ),
+        head_sha="sha1",
+    )
+
+    stored = parse_review_state_v2(body=body).runs[-1]
+
+    assert_that(stored.narrative).is_equal_to("One sentence.")
+
+
+# --- 4. a regression says it is one ------------------------------------------
+
+
+def test_regressed_thread_titles_say_regressed() -> None:
+    """The fresh thread's title carries the suffix, not just a provenance note."""
+    reporter = MagicMock()
+    reporter.api_base = "https://api.github.com"
+    reporter.repo = "owner/name"
+    reporter.pr_number = 7
+    reporter.api_request.return_value = True
+    finding = _finding()
+
+    posted = _post_inline_findings(
+        reporter=reporter,
+        findings=[finding],
+        checklist_display=ChecklistDisplay.OFF,
+        question_map={},
+        finding_keys=["abc#1"],
+        provenance={"abc#1": "> ↩ **regression**"},
+    )
+
+    # Pinned explicitly: the payload is read positionally, so a call-shape
+    # change must fail here loudly rather than silently assert on the URL.
+    args = reporter.api_request.call_args.args
+    assert_that(args).is_length(3)
+    payload = args[2]
+    assert_that(posted).is_true()
+    assert_that(payload["comments"][0]["body"]).contains(
+        f"**Leak{REGRESSED_TITLE_SUFFIX}**",
+    )
+
+
+def test_the_regressed_suffix_lands_inside_the_bold_title() -> None:
+    """Unit-level pin for the contract the posting test exercises end to end."""
+    body = format_finding_comment(
+        finding=_finding(),
+        title_suffix=REGRESSED_TITLE_SUFFIX,
+    )
+
+    assert_that(body).contains("**Leak (regressed)**")
+
+
+def test_a_fresh_finding_title_carries_no_suffix() -> None:
+    """Only a regression is labelled; a new finding reads as itself."""
+    body = format_finding_comment(finding=_finding())
+
+    assert_that(body).contains("**Leak**")
+    assert_that(body).does_not_contain(REGRESSED_TITLE_SUFFIX)
+
+
+# --- 5. config-excluded files are reported as skipped ------------------------
+
+
+def test_config_excluded_files_are_dropped_with_their_reason() -> None:
+    """An ``ai.exclude_paths`` match leaves the review with a skip record."""
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            _changed_file(path="src/main.py"),
+            _changed_file(path="docs/guide.md"),
+        ],
+        unified_diff=_DIFF,
+    )
+
+    filtered = _filter_context_by_excludes(context=context, exclude_globs=["docs/**"])
+
+    assert_that([file.path for file in filtered.changed_files]).is_equal_to(
+        ["src/main.py"],
+    )
+    assert_that(filtered.unified_diff).does_not_contain("docs/guide.md")
+    assert_that(filtered.skipped_files).is_length(1)
+    assert_that(filtered.skipped_files[0].path).is_equal_to("docs/guide.md")
+    assert_that(filtered.skipped_files[0].reason).is_equal_to(
+        FileSkipReason.CONFIG_EXCLUDED,
+    )
+
+
+def test_a_rename_out_of_an_excluded_tree_is_still_excluded() -> None:
+    """The pre-image content is what the exclusion was protecting."""
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(
+                path="src/main.py",
+                status=ChangedFileStatus.RENAMED,
+                additions=1,
+                deletions=1,
+                previous_path="docs/guide.md",
+            ),
+        ],
+        unified_diff=_DIFF,
+    )
+
+    filtered = _filter_context_by_excludes(context=context, exclude_globs=["docs/**"])
+
+    assert_that(filtered.changed_files).is_empty()
+    assert_that(filtered.skipped_files[0].reason).is_equal_to(
+        FileSkipReason.CONFIG_EXCLUDED,
+    )
+
+
+def test_config_exclusion_without_a_match_leaves_the_context_alone() -> None:
+    """Nothing excluded means nothing rewritten and no skip records."""
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[_changed_file(path="src/main.py")],
+        unified_diff=_DIFF,
+    )
+
+    filtered = _filter_context_by_excludes(context=context, exclude_globs=["tests/**"])
+
+    assert_that(filtered).is_same_as(context)
+
+
+def test_config_excluded_reason_reads_as_a_configured_choice() -> None:
+    """The rendered phrase must not read as a coverage gap."""
+    assert_that(
+        describe_skip_reason(reason=FileSkipReason.CONFIG_EXCLUDED),
+    ).is_equal_to("excluded by config (ai.exclude_paths)")
+
+
+# --- 6. the verdict explainer sits under the pill ----------------------------
+
+
+@pytest.mark.parametrize(
+    ("findings", "verdict"),
+    [
+        pytest.param((), ReviewVerdict.READY, id="ready"),
+        pytest.param((_finding(),), ReviewVerdict.BLOCKED, id="blocked"),
+    ],
+)
+def test_verdict_explainer_renders_on_every_round(
+    sample_review_result: ReviewResult,
+    findings: tuple[ReviewFinding, ...],
+    verdict: ReviewVerdict,
+) -> None:
+    """A clean run needs the rubric most: it proves the verdict was derived."""
+    del verdict  # Named for readability of the parametrization only.
+    body = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=findings),
+        ),
+    )
+
+    assert_that(body).contains(f"<sub>{VERDICT_RUBRIC_FINE_PRINT}</sub>")
+
+
+def test_verdict_explainer_sits_directly_under_the_pill(
+    sample_review_result: ReviewResult,
+) -> None:
+    """It explains the pill, so it renders before anything else does."""
+    body = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=(_finding(),)),
+        ),
+    )
+    sections = [section for section in body.split("\n\n") if section.strip()]
+    pill_at = next(
+        index for index, section in enumerate(sections) if "Blocked**" in section
+    )
+
+    assert_that(sections[pill_at + 1]).is_equal_to(
+        f"<sub>{VERDICT_RUBRIC_FINE_PRINT}</sub>",
+    )
+
+
+def test_verdict_rubric_reads_in_the_mock_style() -> None:
+    """The rubric uses severity dots and arrows, not prose semicolons."""
+    assert_that(VERDICT_RUBRIC_FINE_PRINT).is_equal_to(
+        "Verdict is derived: open 🔴 P1 → Blocked · else open 🟠 P2 → Changes "
+        "requested · else 🟡 P3 → Nits only · else ✅ Ready.",
+    )
+
+
+# --- 7. wording --------------------------------------------------------------
+
+
+def test_review_body_footer_points_below_for_finding_detail() -> None:
+    """The inline comments sit under the body, and the footer says so."""
+    assert_that(REVIEW_BODY_FOOTER).contains("finding details → inline comments below")
+
+
+def test_fix_all_panel_caption_names_the_open_table(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The panel covers the table right above it, which is what it now says."""
+    body = _body_only(
+        body=build_sticky_comment(
+            result=_with(base=sample_review_result, findings=(_finding(),)),
+        ),
+    )
+
+    assert_that(body).contains(
+        "Regenerated every run · covers exactly the open table above",
+    )
+
+
+# --- 8. mode B renders the fix as a highlighted line -------------------------
+
+
+def test_mode_b_fix_renders_as_a_tip_callout() -> None:
+    """Without a committable suggestion the described fix is highlighted."""
+    finding = _finding(severity=Severity.P3)
+
+    body = format_finding_comment(
+        finding=finding,
+        inline_fix=plan_inline_fix(finding=finding, round_diff_lines=None),
+    )
+
+    assert_that(body).contains("> [!TIP]\n> **Fix:** Read it from the environment.")
+    # The prompt panel owns [!IMPORTANT]; the two alerts must not collide.
+    assert_that(body).does_not_contain("> [!TIP]\n> [!IMPORTANT]")
+
+
+def test_mode_a_keeps_the_committable_suggestion_block() -> None:
+    """A committable change still wins the fix slot over the tip callout."""
+    finding = replace(
+        _finding(),
+        suggested_change=SuggestedChange(
+            start_line=10,
+            end_line=10,
+            replacement='password = os.environ["APP_PASSWORD"]',
+        ),
+    )
+    plan = plan_inline_fix(
+        finding=finding,
+        round_diff_lines={"src/main.py": {10}},
+    )
+
+    body = format_finding_comment(finding=finding, inline_fix=plan)
+
+    assert_that(body).contains("```suggestion")
+    assert_that(body).does_not_contain("> [!TIP]")

--- a/tests/unit/ai/review/test_mock_parity_1951.py
+++ b/tests/unit/ai/review/test_mock_parity_1951.py
@@ -142,6 +142,44 @@ def test_open_finding_renders_unlinked_without_repo_context(
     assert_that(body).does_not_contain("#discussion_r")
 
 
+def test_a_model_written_bracket_cannot_break_out_of_the_link(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A title is untrusted text, and it is the link's label.
+
+    Without neutralized brackets a title like ``Fix][evil](http://phish)``
+    closes the label early and injects an attacker-chosen URL into the sticky
+    comment, so the guard is load-bearing rather than cosmetic.
+    """
+    hostile = "Fix][evil](https://phishing.example"
+    result = _with(
+        base=sample_review_result,
+        findings=(_finding(title=hostile),),
+    )
+    state = parse_review_state_v2(body=build_sticky_comment(result=result))
+
+    body = _body_only(
+        body=build_sticky_comment(
+            result=result,
+            prior_state=state,
+            inline_comment_ids={state.findings[0].key: 424242},
+            repo="owner/name",
+            pr_number=7,
+        ),
+    )
+
+    row = next(line for line in body.splitlines() if "discussion_r424242" in line)
+
+    assert_that(row).contains(
+        "[Fix)(evil)(https://phishing.example]"
+        "(https://github.com/owner/name/pull/7#discussion_r424242)",
+    )
+    # The label closes exactly once, at the real thread URL. (The raw title
+    # still appears verbatim inside the fix-all prompt's fenced code block,
+    # where Markdown renders it as literal text rather than as a link.)
+    assert_that(row).does_not_contain("](https://phishing.example")
+
+
 # --- 2. run history: fixed count and still-open count ------------------------
 
 

--- a/tests/unit/ai/review/test_mock_parity_1951.py
+++ b/tests/unit/ai/review/test_mock_parity_1951.py
@@ -16,16 +16,15 @@ from unittest.mock import MagicMock
 import pytest
 from assertpy import assert_that
 
-from lintro.ai.review.context.collection import _filter_context_by_excludes
-from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
-from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.enums.file_skip_reason import (
     FileSkipReason,
     describe_skip_reason,
 )
+from lintro.ai.review.enums.finding_status import FindingStatus
 from lintro.ai.review.enums.review_verdict import ReviewVerdict
-from lintro.ai.review.github import _post_inline_findings
-from lintro.ai.review.github_constants import STATE_MARKER_PREFIX
+from lintro.ai.review.finding_matcher import fingerprint_for
+from lintro.ai.review.github import post_review_to_github
+from lintro.ai.review.github_constants import STATE_MARKER_PREFIX, STICKY_MARKER
 from lintro.ai.review.github_render import (
     REGRESSED_TITLE_SUFFIX,
     format_finding_comment,
@@ -33,29 +32,15 @@ from lintro.ai.review.github_render import (
 from lintro.ai.review.github_review_body import REVIEW_BODY_FOOTER
 from lintro.ai.review.github_sticky import build_sticky_comment, parse_review_state_v2
 from lintro.ai.review.inline_fix import plan_inline_fix
-from lintro.ai.review.models.changed_file import ChangedFile
-from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.finding_record import FindingRecord
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.review_summary import ReviewSummary
 from lintro.ai.review.models.run_record import RunRecord
 from lintro.ai.review.models.suggested_change import SuggestedChange
+from lintro.ai.review.review_state_codec import render_state_block
 from lintro.ai.review.verdict import VERDICT_RUBRIC_FINE_PRINT
-
-_DIFF = """diff --git a/src/main.py b/src/main.py
---- a/src/main.py
-+++ b/src/main.py
-@@ -1,1 +1,1 @@
--old
-+new
-diff --git a/docs/guide.md b/docs/guide.md
---- a/docs/guide.md
-+++ b/docs/guide.md
-@@ -1,1 +1,1 @@
--old
-+new
-"""
 
 
 def _finding(
@@ -92,16 +77,6 @@ def _with(
 def _body_only(*, body: str) -> str:
     """Strip the hidden state blob so assertions only see rendered Markdown."""
     return body.split(STATE_MARKER_PREFIX, 1)[0]
-
-
-def _changed_file(*, path: str) -> ChangedFile:
-    """Build a modified changed-file entry."""
-    return ChangedFile(
-        path=path,
-        status=ChangedFileStatus.MODIFIED,
-        additions=1,
-        deletions=1,
-    )
 
 
 # --- 1. open findings link to their inline comment ---------------------------
@@ -311,52 +286,111 @@ def test_history_recap_falls_back_to_counts_without_a_narrative(
     assert_that(body).contains("🔴 1 · 🟠 2 · 🟡 3")
 
 
+@pytest.mark.parametrize(
+    ("summary", "expected"),
+    [
+        pytest.param(
+            "One sentence. And a second that must not be stored.",
+            "One sentence.",
+            id="period",
+        ),
+        pytest.param(
+            "Is this intentional? A second sentence follows.",
+            "Is this intentional?",
+            id="question-mark",
+        ),
+        pytest.param(
+            "It fails outright! A second sentence follows.",
+            "It fails outright!",
+            id="exclamation-mark",
+        ),
+        pytest.param(
+            "First sentence.\nSecond sentence.",
+            "First sentence.",
+            id="newline-boundary",
+        ),
+        pytest.param("No terminator at all", "No terminator at all", id="no-boundary"),
+    ],
+)
 def test_narrative_keeps_only_the_first_sentence(
     sample_review_result: ReviewResult,
+    summary: str,
+    expected: str,
 ) -> None:
     """A recap is one line; the rest of a paragraph is not persisted."""
     body = build_sticky_comment(
-        result=_with(
-            base=sample_review_result,
-            findings=(),
-            summary="One sentence. And a second one that must not be stored.",
-        ),
+        result=_with(base=sample_review_result, findings=(), summary=summary),
         head_sha="sha1",
     )
 
     stored = parse_review_state_v2(body=body).runs[-1]
 
-    assert_that(stored.narrative).is_equal_to("One sentence.")
+    assert_that(stored.narrative).is_equal_to(expected)
 
 
 # --- 4. a regression says it is one ------------------------------------------
 
 
-def test_regressed_thread_titles_say_regressed() -> None:
+def _resolved_state(*, finding: ReviewFinding) -> ReviewState:
+    """Build prior state in which ``finding`` was raised and already fixed."""
+    return ReviewState(
+        runs=(RunRecord(round=1, sha="sha1", model="m"),),
+        findings=(
+            FindingRecord(
+                fingerprint=fingerprint_for(
+                    file=finding.file,
+                    category=finding.category,
+                    title=finding.title,
+                ),
+                severity=finding.severity,
+                category=finding.category,
+                title=finding.title,
+                file=finding.file,
+                line=finding.line,
+                status=FindingStatus.RESOLVED,
+                since_round=1,
+                resolved_sha="sha1",
+                resolved_round=1,
+                inline_comment_id=11,
+            ),
+        ),
+    )
+
+
+def test_regressed_thread_titles_say_regressed(
+    sample_review_result: ReviewResult,
+) -> None:
     """The fresh thread's title carries the suffix, not just a provenance note."""
+    finding = _finding()
+    prior_body = STICKY_MARKER + render_state_block(
+        state=_resolved_state(finding=finding),
+    )
     reporter = MagicMock()
+    reporter.is_available.return_value = True
+    reporter.find_issue_comment.return_value = (5, prior_body)
+    reporter.fetch_pr_diff_lines.return_value = {"src/main.py": {10}}
+    reporter.fetch_compare_lines.return_value = {"src/main.py": {10}}
+    reporter.fetch_pr_commit_shas.return_value = []
+    reporter.fetch_review_comments.return_value = []
+    reporter.update_issue_comment.return_value = True
+    reporter.api_request.return_value = True
     reporter.api_base = "https://api.github.com"
     reporter.repo = "owner/name"
     reporter.pr_number = 7
-    reporter.api_request.return_value = True
-    finding = _finding()
 
-    posted = _post_inline_findings(
+    posted = post_review_to_github(
+        result=_with(base=sample_review_result, findings=(finding,)),
         reporter=reporter,
-        findings=[finding],
-        checklist_display=ChecklistDisplay.OFF,
-        question_map={},
-        finding_keys=["abc#1"],
-        provenance={"abc#1": "> ↩ **regression**"},
     )
 
-    # Pinned explicitly: the payload is read positionally, so a call-shape
-    # change must fail here loudly rather than silently assert on the URL.
-    args = reporter.api_request.call_args.args
-    assert_that(args).is_length(3)
-    payload = args[2]
+    review_calls = [
+        call
+        for call in reporter.api_request.call_args_list
+        if len(call.args) == 3 and str(call.args[1]).endswith("/reviews")
+    ]
     assert_that(posted).is_true()
-    assert_that(payload["comments"][0]["body"]).contains(
+    assert_that(review_calls).is_length(1)
+    assert_that(review_calls[0].args[2]["comments"][0]["body"]).contains(
         f"**Leak{REGRESSED_TITLE_SUFFIX}**",
     )
 
@@ -380,70 +414,9 @@ def test_a_fresh_finding_title_carries_no_suffix() -> None:
 
 
 # --- 5. config-excluded files are reported as skipped ------------------------
-
-
-def test_config_excluded_files_are_dropped_with_their_reason() -> None:
-    """An ``ai.exclude_paths`` match leaves the review with a skip record."""
-    context = ReviewContext(
-        base_ref="main",
-        head_ref="feature",
-        changed_files=[
-            _changed_file(path="src/main.py"),
-            _changed_file(path="docs/guide.md"),
-        ],
-        unified_diff=_DIFF,
-    )
-
-    filtered = _filter_context_by_excludes(context=context, exclude_globs=["docs/**"])
-
-    assert_that([file.path for file in filtered.changed_files]).is_equal_to(
-        ["src/main.py"],
-    )
-    assert_that(filtered.unified_diff).does_not_contain("docs/guide.md")
-    assert_that(filtered.skipped_files).is_length(1)
-    assert_that(filtered.skipped_files[0].path).is_equal_to("docs/guide.md")
-    assert_that(filtered.skipped_files[0].reason).is_equal_to(
-        FileSkipReason.CONFIG_EXCLUDED,
-    )
-
-
-def test_a_rename_out_of_an_excluded_tree_is_still_excluded() -> None:
-    """The pre-image content is what the exclusion was protecting."""
-    context = ReviewContext(
-        base_ref="main",
-        head_ref="feature",
-        changed_files=[
-            ChangedFile(
-                path="src/main.py",
-                status=ChangedFileStatus.RENAMED,
-                additions=1,
-                deletions=1,
-                previous_path="docs/guide.md",
-            ),
-        ],
-        unified_diff=_DIFF,
-    )
-
-    filtered = _filter_context_by_excludes(context=context, exclude_globs=["docs/**"])
-
-    assert_that(filtered.changed_files).is_empty()
-    assert_that(filtered.skipped_files[0].reason).is_equal_to(
-        FileSkipReason.CONFIG_EXCLUDED,
-    )
-
-
-def test_config_exclusion_without_a_match_leaves_the_context_alone() -> None:
-    """Nothing excluded means nothing rewritten and no skip records."""
-    context = ReviewContext(
-        base_ref="main",
-        head_ref="feature",
-        changed_files=[_changed_file(path="src/main.py")],
-        unified_diff=_DIFF,
-    )
-
-    filtered = _filter_context_by_excludes(context=context, exclude_globs=["tests/**"])
-
-    assert_that(filtered).is_same_as(context)
+#
+# The filtering itself is exercised end to end through ``collect_review_context``
+# in ``test_context_collect.py``; only the rendered wording is pinned here.
 
 
 def test_config_excluded_reason_reads_as_a_configured_choice() -> None:

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -449,6 +449,7 @@ def test_review_uncommitted_mode() -> None:
             "pr_number": None,
             "repo": None,
             "paths": None,
+            "exclude_globs": [],
         },
     )
 
@@ -487,6 +488,7 @@ def test_review_pr_mode() -> None:
             "pr_number": 5,
             "repo": "owner/repo",
             "paths": None,
+            "exclude_globs": [],
         },
     )
 
@@ -521,6 +523,7 @@ def test_review_plain_mode() -> None:
             "pr_number": None,
             "repo": None,
             "paths": None,
+            "exclude_globs": [],
         },
     )
 
@@ -614,6 +617,7 @@ def test_review_post_with_repo_without_pr() -> None:
             "pr_number": 42,
             "repo": "owner/repo",
             "paths": None,
+            "exclude_globs": [],
         },
     )
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(review): close mock-parity gaps from the #1905 comment-surfaces audit
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

A post-merge audit of the epic #1905 renderers against the approved mocks found nine deviations; this PR closes all of them:

1. Sticky open-findings table titles now link to their inline comments (`inline_comment_id` → shared `inline_comment_url()` helper); unlinked when the id is unknown.
2. Run history gains a `Fixed` column and the `Open` column now means findings still open after the round, backed by new optional `RunRecord.resolved` / `RunRecord.open_after` fields. Legacy persisted state loads unchanged and renders `—`.
3. Each history round renders a one-line narrative (`RunRecord.narrative`, headline or first sentence of the round summary, split on any sentence boundary), falling back to the count line.
4. Regression re-raise comments get the ` (regressed)` title suffix.
5. New `FileSkipReason.CONFIG_EXCLUDED`: `ai.exclude_paths` (documented but previously never applied in the review pipeline) is now enforced in `collect_review_context(exclude_globs=...)`, and each dropped file appears under "Files reviewed … skipped". Rename `previous_path` is matched too.
6. The verdict-derivation explainer renders directly under the readiness pill, always (including clean READY runs), with the mock's emoji wording.
7. Wording parity: fix-all caption ("…covers exactly the open table above") and review-body footer ("…inline comments below").
8. Mode B fix fallback renders as a `> [!TIP]` blockquote.
9. Dead v4 renderer removed (`format_review_summary`, `_finding_block`, `_format_findings_section`, `_count_row`, `_location_label`) along with its re-exports and dead tests.

Review-pass hardening on top: non-finite stored counts decode as unknown instead of raising `OverflowError`, and a bracket-injection guard test pins that untrusted finding titles cannot break out of the open-table link label.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1951
- Relates to #1905

## Details

Renderers run from the base ref in CI, so these fixes appear on PRs reviewed after this merges. Item 2's schema change is backward compatible: the new `RunRecord` fields are optional and omitted from `to_dict()` when unset, so pre-existing sticky state on live PRs round-trips byte-identically. 27 new tests in `tests/unit/ai/review/test_mock_parity_1951.py` plus coverage in `test_context_collect.py` (config exclusion via the public `collect_review_context` API) and a parametrized sentence-boundary suite for the narrative splitter; all assertions use assertpy. Full suite: 9223 passed, 108 skipped (only the known offline `pip_audit` network tests deselected); `uv run lintro fmt` and `uv run lintro chk` clean. Local review passes: `lintro review` (2 P3s — 1 fixed, 1 dismissed with rationale), CodeRabbit CLI (2 findings, both fixed); Greptile skipped (quota).
