### PR TITLE
fix(review): always render the fix prompt inline in the per-review comment

### DIFF
--- a/lintro/ai/review/agent_prompts.py
+++ b/lintro/ai/review/agent_prompts.py
@@ -37,7 +37,6 @@ __all__ = [
     "render_finding_prompt",
     "render_finding_prompt_panel",
     "render_prompt_panel",
-    "render_sticky_prompt_pointer",
 ]
 
 #: Verbatim verification instruction that opens every generated prompt. Agents
@@ -558,26 +557,3 @@ def render_finding_prompt_panel(
         title=_panel_title(scope=scope, count=1),
         footer=_FOOTERS[scope.kind] if footer is None else footer,
     )
-
-
-def render_sticky_prompt_pointer(*, sticky_url: str = "") -> str:
-    """Render the one-line pointer that replaces a duplicate fix-all panel.
-
-    When this round's findings are exactly the PR's still-open findings, the
-    per-review body would repeat the sticky comment's prompt verbatim. It links
-    to the sticky instead, so there is never a wrong prompt to copy.
-
-    Args:
-        sticky_url: URL of the sticky status comment. When empty (the sticky's
-            id is not known yet, e.g. the comment is being created in this same
-            run) the pointer renders unlinked rather than as a dead link.
-
-    Returns:
-        Markdown for the pointer line.
-    """
-    target = (
-        f"[sticky comment's fix-all]({sticky_url})"
-        if sticky_url
-        else "sticky comment's fix-all"
-    )
-    return f"⚡ Fix prompt: identical to the {target} this round — copy it there."

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -192,21 +192,14 @@ def post_review_to_github(
     )
 
     if inline_findings:
-        # Built after the sticky upsert so the dedup pointer can resolve the
-        # sticky's real id — including on round 1, where it did not exist a
-        # moment ago and the pointer would otherwise render unlinked (#1910).
+        # The body is self-contained — it carries its own fix prompt inline
+        # (#1956) — so it needs nothing from the sticky upsert above and the
+        # ordering here is driven only by the inline-failure fallback.
         review_body = build_review_body(
             result=result,
             prior_state=prior_state,
             match=match,
             head_sha=head_sha,
-            sticky_url=_sticky_url(
-                reporter=gh_reporter,
-                comment_id=_sticky_comment_id(
-                    reporter=gh_reporter,
-                    known=comment_id,
-                ),
-            ),
             transport=transport,
             auth_mode=auth_mode,
             config_source=config_source,
@@ -616,30 +609,6 @@ def _sticky_comment_id(
         return known
     found = reporter.find_issue_comment(marker=STICKY_MARKER)
     return None if found is None else found[0]
-
-
-def _sticky_url(
-    *,
-    reporter: GitHubPRReporter,
-    comment_id: int | None,
-) -> str:
-    """Build the browser URL of the sticky comment, when its id is known.
-
-    Args:
-        reporter: GitHub reporter carrying repo and PR context.
-        comment_id: Sticky comment id as resolved after the upsert, or ``None``
-            when it could not be located at all.
-
-    Returns:
-        The comment's anchor URL, or an empty string when the id is unknown —
-        the pointer then renders unlinked rather than as a dead link.
-    """
-    if comment_id is None:
-        return ""
-    return (
-        f"https://github.com/{reporter.repo}/pull/{reporter.pr_number}"
-        f"#issuecomment-{comment_id}"
-    )
 
 
 def _count_new_commits(

--- a/lintro/ai/review/github_review_body.py
+++ b/lintro/ai/review/github_review_body.py
@@ -8,11 +8,12 @@ scoped fix prompt), what the run cost (visible stats plus the config that
 produced them), and what it looked at (commits and files, with a reason for
 every file it did not look at).
 
-The fix panel is deliberately conditional. When this round's findings are
-*exactly* the PR's still-open findings — round 1, or a round where nothing was
-carried over — the panel would repeat the sticky comment's fix-all byte for
-byte, and two identical prompts on one PR is an invitation to copy the wrong
-one. In that case a one-line pointer to the sticky replaces it.
+The fix panel is unconditional. Even when this round's findings are *exactly*
+the PR's still-open findings — round 1, or a round where nothing was carried
+over — the panel renders in full rather than pointing at the sticky comment's
+fix-all: a reader on the review must be able to copy the prompt where the
+findings are announced, without a navigation hop (#1956). The panel's footer
+still names the sticky's fix-all for everything open across all rounds.
 """
 
 from __future__ import annotations
@@ -21,10 +22,8 @@ from lintro import __version__ as lintro_version
 from lintro.ai.review.agent_prompts import (
     prompt_findings,
     render_agent_prompt_panel,
-    render_sticky_prompt_pointer,
 )
 from lintro.ai.review.enums.agent_prompt_scope_kind import AgentPromptScopeKind
-from lintro.ai.review.enums.finding_status import FindingStatus
 from lintro.ai.review.github_constants import MAX_COMMENT_CHARS
 from lintro.ai.review.github_render import (
     _fmt_cost,
@@ -60,7 +59,6 @@ def build_review_body(
     prior_state: ReviewState,
     match: FindingMatchResult,
     head_sha: str = "",
-    sticky_url: str = "",
     transport: str = "",
     auth_mode: str = "",
     config_source: str = "",
@@ -74,8 +72,6 @@ def build_review_body(
         match: Cross-round matching outcome for this round's findings.
         head_sha: Head commit sha reviewed in this round. Falls back to the
             metadata's head ref.
-        sticky_url: URL of the sticky status comment, used by the dedup
-            pointer and the footer. Empty renders unlinked text.
         transport: Provider transport used for this round (e.g. ``cli``).
         auth_mode: Authentication mode used by the transport.
         config_source: Human-readable description of where this run's settings
@@ -98,9 +94,7 @@ def build_review_body(
         ),
         _prompt_section(
             result=result,
-            match=match,
             round_number=round_number,
-            sticky_url=sticky_url,
         ),
         _run_stats_section(
             result=result,
@@ -192,41 +186,28 @@ def _header(
     return " · ".join(parts)
 
 
-def _open_keys(*, match: FindingMatchResult) -> set[str]:
-    """Return the identity keys of every finding still open after this round."""
-    return {
-        record.key for record in match.records if record.status is FindingStatus.OPEN
-    }
-
-
-def _round_keys(*, match: FindingMatchResult) -> set[str]:
-    """Return the identity keys of the findings reported in this round."""
-    return {record.key for record in (*match.new, *match.carried, *match.regressed)}
-
-
 def _prompt_section(
     *,
     result: ReviewResult,
-    match: FindingMatchResult,
     round_number: int,
-    sticky_url: str,
 ) -> str:
-    """Render the scoped fix prompt, or the sticky pointer when it would dupe.
+    """Render this round's scoped fix prompt panel.
+
+    The panel is rendered on every round, including one whose findings are
+    exactly the PR's still-open set: the review comment must be self-contained
+    (#1956). The panel's footer still sends readers to the sticky comment's
+    fix-all for everything open across all rounds.
 
     Args:
         result: This round's review result.
-        match: Cross-round matching outcome for this round.
         round_number: 1-based round number for this run.
-        sticky_url: URL of the sticky comment for the pointer variant.
 
     Returns:
-        Markdown for the prompt panel or the one-line pointer; empty when the
-        round produced nothing actionable to fix.
+        Markdown for the prompt panel; empty when the round produced nothing
+        actionable to fix.
     """
     if not prompt_findings(findings=result.findings):
         return ""
-    if _round_keys(match=match) == _open_keys(match=match):
-        return render_sticky_prompt_pointer(sticky_url=sticky_url)
     return render_agent_prompt_panel(
         findings=result.findings,
         scope=AgentPromptScope(

--- a/tests/unit/ai/review/test_agent_prompts.py
+++ b/tests/unit/ai/review/test_agent_prompts.py
@@ -522,6 +522,8 @@ def test_this_review_panel_footer_names_the_sticky_fix_all() -> None:
         ),
     )
 
+    assert_that(panel).contains("⚡ **Fix prompt — this round's 1 finding only**")
+    assert_that(panel).contains("round 1")
     assert_that(panel).contains(
         "For everything still open across all rounds, use the sticky comment's "
         "fix-all prompt",

--- a/tests/unit/ai/review/test_agent_prompts.py
+++ b/tests/unit/ai/review/test_agent_prompts.py
@@ -16,7 +16,6 @@ from lintro.ai.review.agent_prompts import (
     render_finding_prompt,
     render_finding_prompt_panel,
     render_prompt_panel,
-    render_sticky_prompt_pointer,
 )
 from lintro.ai.review.enums.agent_prompt_scope_kind import AgentPromptScopeKind
 from lintro.ai.review.enums.evidence_style import EvidenceStyle
@@ -513,13 +512,20 @@ def test_non_int_round_number_is_rejected(round_number: object) -> None:
         )
 
 
-def test_sticky_pointer_links_back_instead_of_duplicating_the_prompt() -> None:
-    """When both scopes coincide the per-review body links to the sticky."""
-    pointer = render_sticky_prompt_pointer(sticky_url="https://example.test/c/1")
-    assert_that(pointer).contains(
-        "[sticky comment's fix-all](https://example.test/c/1)",
+def test_this_review_panel_footer_names_the_sticky_fix_all() -> None:
+    """The round-scoped panel still sends readers to the sticky for all-open."""
+    panel = render_agent_prompt_panel(
+        findings=(_finding(title="Real defect"),),
+        scope=AgentPromptScope(
+            kind=AgentPromptScopeKind.THIS_REVIEW,
+            round_number=1,
+        ),
     )
-    assert_that(pointer).does_not_contain("```")
+
+    assert_that(panel).contains(
+        "For everything still open across all rounds, use the sticky comment's "
+        "fix-all prompt",
+    )
 
 
 def test_questions_are_excluded_from_fix_all_prompts() -> None:

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -692,10 +692,10 @@ def test_post_review_uses_the_rich_review_body(
     assert_that(payload["body"]).does_not_contain("Lintro review findings")
 
 
-def test_post_review_body_links_the_pointer_to_an_existing_sticky(
+def test_post_review_body_carries_the_fix_prompt_inline(
     sample_review_result: ReviewResult,
 ) -> None:
-    """When the sticky already exists, the dedup pointer links straight to it."""
+    """The posted body carries its own prompt, not a pointer to the sticky (#1956)."""
     reporter = _fresh_reporter()
     reporter.find_issue_comment.return_value = (
         42,
@@ -706,9 +706,9 @@ def test_post_review_body_links_the_pointer_to_an_existing_sticky(
     post_review_to_github(result=sample_review_result, reporter=reporter)
 
     payload = reporter.api_request.call_args.args[2]
-    assert_that(payload["body"]).contains(
-        "https://github.com/owner/name/pull/7#issuecomment-42",
-    )
+    assert_that(payload["body"]).contains("Fix prompt — this round's")
+    assert_that(payload["body"]).contains("<details><summary>Show prompt</summary>")
+    assert_that(payload["body"]).does_not_contain("identical to the")
 
 
 # --- new-commit counting (#1910) -------------------------------------------
@@ -759,32 +759,6 @@ def test_count_new_commits_is_none_when_the_listing_fails() -> None:
     assert_that(
         _count_new_commits(reporter=reporter, prior_state=prior_state),
     ).is_none()
-
-
-def test_review_body_links_a_sticky_created_in_this_same_run(
-    sample_review_result: ReviewResult,
-) -> None:
-    """Round 1's pointer resolves the sticky that was just created (#1909/#1910).
-
-    The sticky is upserted before the inline review is posted, so by the time
-    the body is built the comment exists even on the first round — the pointer
-    must link to it rather than fall back to unlinked text.
-    """
-    reporter = _fresh_reporter()
-    reporter.fetch_pr_commit_shas.return_value = []
-    # First lookup loads prior state (no sticky yet); the second runs after the
-    # sticky has been created and finds it.
-    reporter.find_issue_comment.side_effect = [
-        None,
-        (99, build_sticky_comment(result=sample_review_result)),
-    ]
-
-    post_review_to_github(result=sample_review_result, reporter=reporter)
-
-    payload = reporter.api_request.call_args.args[2]
-    assert_that(payload["body"]).contains(
-        "https://github.com/owner/name/pull/7#issuecomment-99",
-    )
 
 
 def test_review_body_and_degraded_sticky_coexist(

--- a/tests/unit/ai/review/test_github_review_body.py
+++ b/tests/unit/ai/review/test_github_review_body.py
@@ -14,7 +14,6 @@ from lintro.ai.review.github_review_body import (
     REVIEW_BODY_FOOTER,
     build_review_body,
 )
-from lintro.ai.review.models.finding_record import FindingRecord
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.run_record import RunRecord
@@ -26,7 +25,6 @@ def _body(
     result: ReviewResult,
     prior_state: ReviewState,
     head_sha: str = "fb740b2aaaa",
-    sticky_url: str = "",
     transport: str = "",
     auth_mode: str = "",
     config_source: str = "",
@@ -38,7 +36,6 @@ def _body(
         result: Review result under test.
         prior_state: State decoded before this round.
         head_sha: Head sha reviewed in this round.
-        sticky_url: URL of the sticky status comment.
         transport: Provider transport used for the round.
         auth_mode: Authentication mode used by the transport.
         config_source: Description of where the run's settings came from.
@@ -58,7 +55,6 @@ def _body(
         prior_state=prior_state,
         match=match,
         head_sha=head_sha,
-        sticky_url=sticky_url,
         transport=transport,
         auth_mode=auth_mode,
         config_source=config_source,
@@ -156,33 +152,30 @@ def test_header_names_the_reviewed_commit_range(
     assert_that(body).contains("commits `484f51c..fb740b2`")
 
 
-# --- fix prompt and the dedup rule -----------------------------------------
+# --- fix prompt -------------------------------------------------------------
 
 
-def test_prompt_panel_points_at_sticky_when_scopes_are_identical(
+def test_prompt_panel_renders_inline_when_scopes_are_identical(
     sample_review_result: ReviewResult,
 ) -> None:
-    """Round 1 findings are all open findings, so the panel is not duplicated."""
-    body = _body(
-        result=sample_review_result,
-        prior_state=ReviewState(),
-        sticky_url="https://github.com/owner/name/pull/7#issuecomment-1",
-    )
-
-    assert_that(body).contains("⚡ Fix prompt: identical to the")
-    assert_that(body).contains("#issuecomment-1")
-    assert_that(body).does_not_contain("Fix prompt — this round's")
-    assert_that(body).does_not_contain("Show prompt")
-
-
-def test_pointer_renders_unlinked_when_the_sticky_id_is_unknown(
-    sample_review_result: ReviewResult,
-) -> None:
-    """A sticky created in this same run has no id yet; no dead link is emitted."""
+    """Round 1 findings are all open findings, and still get the full panel."""
     body = _body(result=sample_review_result, prior_state=ReviewState())
 
-    assert_that(body).contains("sticky comment's fix-all this round")
-    assert_that(body).does_not_contain("]()")
+    assert_that(body).contains("⚡ **Fix prompt — this round's 2 findings only**")
+    assert_that(body).contains("<details><summary>Show prompt</summary>")
+    assert_that(body).does_not_contain("identical to the")
+
+
+def test_prompt_panel_keeps_the_cross_round_sticky_footer(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The inline panel still points at the sticky's fix-all for all-open work."""
+    body = _body(result=sample_review_result, prior_state=ReviewState())
+
+    assert_that(body).contains(
+        "For everything still open across all rounds, use the sticky comment's "
+        "fix-all prompt",
+    )
 
 
 def test_prompt_panel_renders_when_older_findings_remain_open(
@@ -229,7 +222,7 @@ def test_prompt_panel_renders_when_older_findings_remain_open(
 def test_no_prompt_section_when_the_round_found_nothing(
     sample_review_result: ReviewResult,
 ) -> None:
-    """A clean round has nothing to fix, so neither panel nor pointer appears."""
+    """A clean round has nothing to fix, so no prompt panel appears at all."""
     clean = replace(sample_review_result, findings=())
 
     body = _body(result=clean, prior_state=ReviewState())
@@ -254,8 +247,13 @@ def test_run_stats_are_visible_and_ordered(
 
     assert_that(body).contains("**📊 Run stats**")
     stats_index = body.index("**📊 Run stats**")
-    details_index = body.index("<details>")
-    assert_that(stats_index).is_less_than(details_index)
+    # Not hidden inside a collapsible: every <details> opened before the stats
+    # (the fix prompt's) is already closed by the time they render, and the
+    # commits collapsible only opens after them.
+    assert_that(body.count("<details>", 0, stats_index)).is_equal_to(
+        body.count("</details>", 0, stats_index),
+    )
+    assert_that(stats_index).is_less_than(body.index("<details><summary>📥 Commits"))
     assert_that(body).contains("| model | est. cost | tokens in | tokens out |")
     assert_that(body).contains("cli · subscription")
     assert_that(body).contains(f"| {lintro_version} |")
@@ -433,7 +431,11 @@ def test_long_file_lists_are_summarized_not_dumped(
 def test_body_truncation_leaves_a_visible_marker(
     sample_review_result: ReviewResult,
 ) -> None:
-    """Oversized content is cut with a marker, never silently."""
+    """Oversized content is cut with a marker, never silently.
+
+    The prompt panel now renders on every round (#1956), so the size guard has
+    to hold on a round whose findings are exactly the PR's open set too.
+    """
     finding = sample_review_result.findings[0]
     bulk = tuple(
         replace(finding, title=f"Finding {index}", line=index + 1)
@@ -446,13 +448,10 @@ def test_body_truncation_leaves_a_visible_marker(
         round_number=1,
         head_sha="fb740b2aaa",
     )
-    # One extra still-open record makes this round a strict subset of the open
-    # set, so the full prompt panel renders instead of the sticky pointer.
-    carried = FindingRecord(fingerprint="carried", title="Older finding")
     body = build_review_body(
         result=result,
-        prior_state=_prior_state(rounds=1),
-        match=replace(match, records=(*match.records, carried)),
+        prior_state=ReviewState(),
+        match=match,
         head_sha="fb740b2aaa",
     )
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(review): always render the fix prompt inline in the per-review comment
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

The per-review comment dropped its fix prompt whenever this round's findings were exactly
the PR's still-open findings — typically round 1, where everything is new — and rendered a
one-line pointer to the sticky comment's fix-all instead. That mock-4 dedup rule saved a
duplicate prompt at the cost of making the review comment non-self-contained: a reader on
the review had to navigate to the sticky to copy anything.

`_prompt_section()` now renders the full `⚡ Fix prompt — this round's N findings only`
panel on every round, with the collapsible prompt body inline. The panel's footer still
names the sticky comment's fix-all for everything open across all rounds, so the
cross-round path stays discoverable — that line is not the dedup pointer.

With the pointer gone, `render_sticky_prompt_pointer` had no callers and is deleted, along
with the review body's now-unused `sticky_url` parameter and the `_sticky_url` helper in
`github.py`. The sticky is still upserted before the inline review, but now purely so an
inline-post failure leaves a status comment on the PR; the comment that justified the
ordering by the pointer's need for a resolved sticky id is updated to say so.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`uv run pytest` plus `uv run lintro fmt` / `chk`; see Details)

## Closes

- Closes #1956

## Details

The size guard is unchanged and was re-verified with the prompt always present: the
truncation test now builds a round-1 body (findings identical to the open set, the case
that previously took the pointer branch) from 4,000 findings and still asserts the body
fits `MAX_COMMENT_CHARS` and ends with the visible truncation marker.

Test changes pin the new behavior rather than the old rule. Round 1 with all-new findings
asserts the full panel and its `Show prompt` collapsible; a separate test asserts the
cross-round sticky footer line survives; the carried-over-findings test is unchanged and
still covers round N. In `test_github.py` the two pointer-link tests are replaced by one
that asserts the posted body carries the prompt inline and contains no pointer text. The
run-stats ordering test compared the stats offset against the first `<details>` in the
body, which is now the prompt panel's; it asserts instead that every `<details>` opened
before the stats is already closed, and that the commits collapsible opens after them.

Full `uv run pytest`: 9,208 passed, 118 skipped, 16 failed — all 16 are pre-existing local
environment failures (offline `pip_audit`, and stylelint/oxlint/oxfmt/commitlint binaries
below their pinned version floors). The identical 16 fail on `origin/main` in the same
worktree. `uv run lintro fmt` and `uv run lintro chk` are green (health score 100/100).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * GitHub review summaries now include the current round’s actionable fix prompt directly in the review body.
  * Fix prompts remain visible even when findings match previously reported issues.
  * Review details and run statistics continue to appear in the generated summary.

* **Bug Fixes**
  * Removed outdated references directing users to a separate sticky-comment fix prompt.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->