### PR TITLE
fix(review): render the sticky This-run stats as badge tables

### DIFF
--- a/lintro/ai/review/github_render.py
+++ b/lintro/ai/review/github_render.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from lintro.ai.review.agent_prompts import render_finding_prompt_panel
 from lintro.ai.review.checklist_display import (
     cleared_answers,
@@ -19,8 +21,11 @@ from lintro.ai.review.sanitize import sanitize_comment_text
 
 __all__ = [
     "REGRESSED_TITLE_SUFFIX",
+    "format_badge_table",
+    "format_badge_tables",
     "format_finding_comment",
     "format_run_mechanics",
+    "run_stats_primary_cells",
     "sanitize_comment_text",
 ]
 
@@ -60,6 +65,91 @@ def _fmt_tokens(total: int, *, estimated: bool) -> str:
     """Format a token count, prefixing ``~`` when estimated."""
     prefix = "~" if estimated else ""
     return f"{prefix}{_fmt_int(total)} tok"
+
+
+def _escape_cell(text: str) -> str:
+    r"""Escape a badge-table cell so a pipe cannot shear the row.
+
+    Backslashes are doubled first: escaping only the pipe would turn an input
+    of ``\|`` into ``\\|``, leaving the pipe with an even number of
+    preceding backslashes and readable as a delimiter again.
+    """
+    return text.replace("\\", "\\\\").replace("|", "\\|")
+
+
+def format_badge_table(*, cells: Sequence[tuple[str, str]]) -> list[str]:
+    r"""Render one ordered row of ``(label, value)`` pairs as a badge table.
+
+    GitHub-flavored Markdown has no chip primitive, so a single-row table —
+    labels as the header, values as the one body row — is the closest thing to
+    the approved chip design that renders without an external image.
+
+    A literal ``|`` would end the cell it appears in and shear the row, so it
+    is escaped here rather than at each call site — GFM honors ``\|`` inside
+    code spans too, which the code-chipped values rely on. Callers still own
+    their own sanitization and code-chip quoting.
+
+    Args:
+        cells: Ordered ``(label, value)`` pairs.
+
+    Returns:
+        Markdown lines, or an empty list when there is nothing to render.
+    """
+    if not cells:
+        return []
+    keys = " | ".join(_escape_cell(key) for key, _ in cells)
+    dividers = " | ".join("---" for _ in cells)
+    values = " | ".join(_escape_cell(value) for _, value in cells)
+    return [f"| {keys} |", f"| {dividers} |", f"| {values} |"]
+
+
+def format_badge_tables(
+    *,
+    rows: Sequence[Sequence[tuple[str, str]]],
+) -> list[str]:
+    """Render several badge rows as stacked single-row tables.
+
+    Args:
+        rows: Ordered row groups, each an ordered list of ``(label, value)``
+            pairs. Empty groups are skipped rather than emitting a blank table.
+
+    Returns:
+        Markdown lines with one blank line between consecutive tables.
+    """
+    lines: list[str] = []
+    for cells in rows:
+        table = format_badge_table(cells=cells)
+        if not table:
+            continue
+        if lines:
+            lines.append("")
+        lines.extend(table)
+    return lines
+
+
+def run_stats_primary_cells(*, metadata: ReviewMetadata) -> list[tuple[str, str]]:
+    """Build the primary run-stats badge row shared by every review surface.
+
+    Ordering is fixed across surfaces (epic #1905): model, est. cost, tokens
+    in, tokens out. ``~`` marks values estimated locally, so a subscription run
+    never presents an estimate as a billed figure.
+
+    Args:
+        metadata: Review run metadata.
+
+    Returns:
+        Ordered ``(label, value)`` pairs for the primary badge table.
+    """
+    estimated = metadata.token_usage_estimated
+    tilde = "~" if estimated else ""
+    prompt_tokens = int(metadata.token_usage.get("prompt", 0))
+    completion_tokens = int(metadata.token_usage.get("completion", 0))
+    return [
+        ("model", f"`{sanitize_comment_text(metadata.model, limit=60)}`"),
+        ("est. cost", _fmt_cost(metadata.cost_estimate_usd, estimated=estimated)),
+        ("tokens in", f"{tilde}{_fmt_int(prompt_tokens)}"),
+        ("tokens out", f"{tilde}{_fmt_int(completion_tokens)}"),
+    ]
 
 
 def format_run_mechanics(*, metadata: ReviewMetadata) -> str:

--- a/lintro/ai/review/github_render.py
+++ b/lintro/ai/review/github_render.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 
 from lintro.ai.review.agent_prompts import render_finding_prompt_panel
@@ -37,6 +38,10 @@ REGRESSED_TITLE_SUFFIX = " (regressed)"
 #: none: the panel is an affordance, and one on every finding is wallpaper.
 _PROMPT_SEVERITIES: frozenset[Severity] = frozenset({Severity.P1, Severity.P2})
 
+#: Line breaks that would end a badge-table row early. ``\r\n`` is matched as
+#: one break so a Windows-style value collapses to a single space, not two.
+_LINE_BREAK_RE = re.compile(r"\r\n|[\r\n]")
+
 
 def _chip(text: str) -> str:
     """Render a value as an inline code chip, escaping backticks."""
@@ -68,13 +73,20 @@ def _fmt_tokens(total: int, *, estimated: bool) -> str:
 
 
 def _escape_cell(text: str) -> str:
-    r"""Escape a badge-table cell so a pipe cannot shear the row.
+    r"""Flatten and escape a badge-table cell so it cannot shear the row.
+
+    A table row is one line, so a carriage return or line feed in a value ends
+    the row and spills the rest of the cells into the document as prose. Line
+    breaks are therefore collapsed to spaces before escaping — GFM offers no
+    in-cell line break worth preserving here, and ``sanitize_comment_text``
+    caps length without touching them.
 
     Backslashes are doubled first: escaping only the pipe would turn an input
     of ``\|`` into ``\\|``, leaving the pipe with an even number of
     preceding backslashes and readable as a delimiter again.
     """
-    return text.replace("\\", "\\\\").replace("|", "\\|")
+    escaped = text.replace("\\", "\\\\").replace("|", "\\|")
+    return _LINE_BREAK_RE.sub(" ", escaped)
 
 
 def format_badge_table(*, cells: Sequence[tuple[str, str]]) -> list[str]:

--- a/lintro/ai/review/github_review_body.py
+++ b/lintro/ai/review/github_review_body.py
@@ -229,8 +229,12 @@ def _run_stats_section(
     Stats follow the epic's shared ordering rule: model, est. cost, tokens in,
     tokens out on the first line; mechanics on the second. ``~`` marks values
     estimated locally, so a subscription run never presents an estimate as a
-    billed figure. The badge tables come from the shared renderer, so this
-    surface and the sticky's ``This run`` section cannot drift (#1955).
+    billed figure. Both rows are drawn by the shared badge-table renderer, and
+    the primary row's cells come from the shared ``run_stats_primary_cells``,
+    so the model, cost, and token figures cannot drift from the sticky's
+    ``This run`` section (#1955). The secondary rows differ by design: this
+    surface carries ``strictness`` and the ``lintro`` version, which the
+    sticky's leaner status board omits.
 
     Args:
         result: This round's review result.

--- a/lintro/ai/review/github_review_body.py
+++ b/lintro/ai/review/github_review_body.py
@@ -27,8 +27,8 @@ from lintro.ai.review.enums.agent_prompt_scope_kind import AgentPromptScopeKind
 from lintro.ai.review.enums.finding_status import FindingStatus
 from lintro.ai.review.github_constants import MAX_COMMENT_CHARS
 from lintro.ai.review.github_render import (
-    _fmt_cost,
-    _fmt_int,
+    format_badge_tables,
+    run_stats_primary_cells,
     sanitize_comment_text,
 )
 from lintro.ai.review.models.agent_prompt_scope import AgentPromptScope
@@ -236,23 +236,6 @@ def _prompt_section(
     )
 
 
-def _badge_table(*, cells: list[tuple[str, str]]) -> list[str]:
-    """Render key/value stats as a two-row Markdown table.
-
-    Args:
-        cells: Ordered ``(key, value)`` pairs.
-
-    Returns:
-        Markdown lines, or an empty list when there is nothing to render.
-    """
-    if not cells:
-        return []
-    keys = " | ".join(key for key, _ in cells)
-    dividers = " | ".join("---" for _ in cells)
-    values = " | ".join(value for _, value in cells)
-    return [f"| {keys} |", f"| {dividers} |", f"| {values} |"]
-
-
 def _run_stats_section(
     *,
     result: ReviewResult,
@@ -265,7 +248,8 @@ def _run_stats_section(
     Stats follow the epic's shared ordering rule: model, est. cost, tokens in,
     tokens out on the first line; mechanics on the second. ``~`` marks values
     estimated locally, so a subscription run never presents an estimate as a
-    billed figure.
+    billed figure. The badge tables come from the shared renderer, so this
+    surface and the sticky's ``This run`` section cannot drift (#1955).
 
     Args:
         result: This round's review result.
@@ -277,17 +261,7 @@ def _run_stats_section(
         Markdown for the run-stats section.
     """
     metadata = result.metadata
-    estimated = metadata.token_usage_estimated
-    prompt_tokens = int(metadata.token_usage.get("prompt", 0))
-    completion_tokens = int(metadata.token_usage.get("completion", 0))
-    tilde = "~" if estimated else ""
-
-    primary = [
-        ("model", f"`{sanitize_comment_text(metadata.model, limit=60)}`"),
-        ("est. cost", _fmt_cost(metadata.cost_estimate_usd, estimated=estimated)),
-        ("tokens in", f"{tilde}{_fmt_int(prompt_tokens)}"),
-        ("tokens out", f"{tilde}{_fmt_int(completion_tokens)}"),
-    ]
+    primary = run_stats_primary_cells(metadata=metadata)
 
     transport_label = sanitize_comment_text(transport, limit=40)
     if transport_label and auth_mode:
@@ -309,9 +283,7 @@ def _run_stats_section(
     )
 
     lines = ["**📊 Run stats**", ""]
-    lines.extend(_badge_table(cells=primary))
-    lines.append("")
-    lines.extend(_badge_table(cells=secondary))
+    lines.extend(format_badge_tables(rows=[primary, secondary]))
     if config_source:
         source = sanitize_comment_text(config_source, limit=300)
         lines.extend(["", f"<sub>Config source: {source}</sub>"])

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -1019,9 +1019,13 @@ def _this_run_section(
 ) -> str:
     """Render the two badge tables describing the current run.
 
-    The tables come from the same renderer as the per-review body's run stats
-    (#1955), so the two surfaces cannot drift. Ordering is fixed across every
-    surface (epic #1905): model, est. cost, tokens in, tokens out on row 1;
+    Both rows use the same badge-table renderer as the per-review body's run
+    stats, and the primary row's cells come from the shared
+    ``run_stats_primary_cells``, so the model, cost, and token figures cannot
+    drift between the two surfaces (#1955). The secondary row is this
+    surface's own: the status board omits the body's ``strictness`` and
+    ``lintro`` version. Ordering is fixed across every surface (epic #1905):
+    model, est. cost, tokens in, tokens out on row 1;
     transport and mechanics on row 2. No figure is presented as billed — the
     ``transport`` badge and the ``~`` prefix carry that honesty.
 

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -19,7 +19,7 @@ Layout, top to bottom:
 6. ``Open findings`` — one line per finding, titles only
 7. the fix-all agent prompt panel, scoped to *all* still-open findings
 8. ``Resolved`` — struck-through titles with their fixing commit
-9. *This run* badges, two lines (model-first ordering)
+9. *This run* badges, two single-row tables (model-first ordering)
 10. ``---`` then exactly one ``🕘 Run history`` collapsible
 11. a one-line footer
 
@@ -68,6 +68,8 @@ from lintro.ai.review.github_render import (
     _fmt_int,
     _format_checklist_appendix_markdown,
     _severity_counts,
+    format_badge_tables,
+    run_stats_primary_cells,
     sanitize_comment_text,
 )
 from lintro.ai.review.models.agent_prompt_scope import AgentPromptScope
@@ -1015,12 +1017,13 @@ def _this_run_section(
     transport: str,
     auth_mode: str,
 ) -> str:
-    """Render the two-line badge block for the current run.
+    """Render the two badge tables describing the current run.
 
-    Ordering is fixed across every surface (epic #1905): model, est. cost,
-    tokens in, tokens out on line 1; transport and mechanics on line 2. No
-    figure is presented as billed — the ``transport`` badge and the ``~``
-    prefix carry that honesty.
+    The tables come from the same renderer as the per-review body's run stats
+    (#1955), so the two surfaces cannot drift. Ordering is fixed across every
+    surface (epic #1905): model, est. cost, tokens in, tokens out on row 1;
+    transport and mechanics on row 2. No figure is presented as billed — the
+    ``transport`` badge and the ``~`` prefix carry that honesty.
 
     Args:
         result: Current review result.
@@ -1031,27 +1034,20 @@ def _this_run_section(
         The ``This run`` section.
     """
     metadata = result.metadata
-    estimated = metadata.token_usage_estimated
-    prefix = "~" if estimated else ""
-    usage = metadata.token_usage
-    first = " · ".join(
-        [
-            f"model `{sanitize_comment_text(metadata.model, limit=60)}`",
-            f"est. cost `{_fmt_cost(metadata.cost_estimate_usd, estimated=estimated)}`",
-            f"tokens in `{prefix}{_fmt_int(int(usage.get('prompt', 0)))}`",
-            f"tokens out `{prefix}{_fmt_int(int(usage.get('completion', 0)))}`",
-        ],
-    )
-    second = " · ".join(
-        [
-            f"transport `{_transport_label(transport=transport, auth_mode=auth_mode)}`",
-            f"depth `{metadata.depth}`",
-            f"files `{metadata.files_reviewed}`",
-            f"checks `{metadata.checklist_items}`",
-            f"duration `{metadata.duration_seconds:.0f}s`",
-        ],
-    )
-    return f"**This run** — {first}\n\n{second}"
+    primary = run_stats_primary_cells(metadata=metadata)
+    secondary = [
+        (
+            "transport",
+            _transport_label(transport=transport, auth_mode=auth_mode),
+        ),
+        ("depth", str(metadata.depth)),
+        ("files", str(metadata.files_reviewed)),
+        ("checks", str(metadata.checklist_items)),
+        ("duration", f"{metadata.duration_seconds:.0f}s"),
+    ]
+    lines = ["**This run**", ""]
+    lines.extend(format_badge_tables(rows=[primary, secondary]))
+    return "\n".join(lines)
 
 
 def _history_section(

--- a/tests/unit/ai/review/test_github_badge_tables.py
+++ b/tests/unit/ai/review/test_github_badge_tables.py
@@ -1,0 +1,221 @@
+"""Tests for the shared run-stats badge tables (issue #1955).
+
+The sticky comment's ``This run`` section and the per-review body's run stats
+render the same data, so they render it through one helper. These tests pin the
+helper's own contract and the fact that both surfaces still agree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from assertpy import assert_that
+
+from lintro.ai.review.finding_matcher import match_findings
+from lintro.ai.review.github_render import (
+    format_badge_table,
+    format_badge_tables,
+    run_stats_primary_cells,
+)
+from lintro.ai.review.github_review_body import build_review_body
+from lintro.ai.review.github_sticky import build_sticky_comment
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
+
+_PRIMARY_HEADER = "| model | est. cost | tokens in | tokens out |"
+
+
+def _sticky(*, result: ReviewResult) -> str:
+    """Render the sticky comment for ``result`` with a known transport."""
+    return build_sticky_comment(
+        result=result,
+        transport="cli",
+        auth_mode="subscription",
+    )
+
+
+def _body(*, result: ReviewResult) -> str:
+    """Render the per-review body for ``result`` with a known transport."""
+    prior_state = ReviewState()
+    match = match_findings(
+        previous=prior_state,
+        findings=result.findings,
+        round_number=prior_state.next_round,
+        head_sha="fb740b2",
+    )
+    return build_review_body(
+        result=result,
+        prior_state=prior_state,
+        match=match,
+        head_sha="fb740b2",
+        transport="cli",
+        auth_mode="subscription",
+    )
+
+
+def _value_row(*, text: str, header: str) -> str:
+    """Return the value row that follows ``header`` in ``text``.
+
+    The header is asserted rather than indexed blindly: a header-format
+    regression should fail as a named assertion, not as a bare ``ValueError``
+    from :meth:`list.index` that says nothing about what was being looked for.
+    """
+    lines = text.splitlines()
+    assert_that(lines).contains(header)
+    return lines[lines.index(header) + 2]
+
+
+# --- helper contract ---------------------------------------------------------
+
+
+def test_badge_table_renders_one_row_of_label_value_pairs() -> None:
+    """A badge table is a header row, a divider, and exactly one value row."""
+    lines = format_badge_table(cells=[("model", "`gpt`"), ("depth", "2")])
+
+    assert_that(lines).is_equal_to(
+        ["| model | depth |", "| --- | --- |", "| `gpt` | 2 |"],
+    )
+
+
+def test_badge_table_escapes_pipes_so_a_row_cannot_shear() -> None:
+    """An unescaped pipe in a value would end its cell and break the table."""
+    lines = format_badge_table(cells=[("model", "`a|b`")])
+
+    assert_that(lines[-1]).is_equal_to("| `a\\|b` |")
+
+
+def test_badge_table_escapes_a_backslash_before_the_pipe_it_precedes() -> None:
+    """Escaping only the pipe would leave it delimiter-readable again."""
+    lines = format_badge_table(cells=[("model", "a\\|b")])
+
+    assert_that(lines[-1]).is_equal_to("| a\\\\\\|b |")
+
+
+def test_badge_table_renders_nothing_for_no_cells() -> None:
+    """An empty row must not emit a headerless table skeleton."""
+    assert_that(format_badge_table(cells=[])).is_empty()
+
+
+def test_badge_tables_separate_rows_with_a_blank_line() -> None:
+    """Consecutive tables need a blank line or GFM merges them into one."""
+    lines = format_badge_tables(rows=[[("a", "1")], [("b", "2")]])
+
+    assert_that(lines).is_equal_to(
+        [
+            "| a |",
+            "| --- |",
+            "| 1 |",
+            "",
+            "| b |",
+            "| --- |",
+            "| 2 |",
+        ],
+    )
+
+
+def test_badge_tables_skip_empty_rows() -> None:
+    """An empty group is dropped rather than emitting a stray separator."""
+    lines = format_badge_tables(rows=[[], [("b", "2")]])
+
+    assert_that(lines).is_equal_to(["| b |", "| --- |", "| 2 |"])
+
+
+def test_primary_cells_are_ordered_model_cost_tokens(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The shared ordering rule of epic #1905 is model-first on every surface."""
+    cells = run_stats_primary_cells(metadata=sample_review_result.metadata)
+
+    assert_that([label for label, _ in cells]).is_equal_to(
+        ["model", "est. cost", "tokens in", "tokens out"],
+    )
+
+
+def test_primary_cells_prefix_estimated_values_with_a_tilde(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Estimated figures are never presented as billed ones."""
+    result = replace(
+        sample_review_result,
+        metadata=replace(
+            sample_review_result.metadata,
+            token_usage_estimated=True,
+        ),
+    )
+
+    values = dict(run_stats_primary_cells(metadata=result.metadata))
+
+    assert_that(values["est. cost"]).starts_with("~$")
+    assert_that(values["tokens in"]).is_equal_to("~1,000")
+    assert_that(values["tokens out"]).is_equal_to("~200")
+
+
+def test_primary_cells_omit_the_tilde_for_reported_values(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Provider-reported figures carry no estimation marker."""
+    values = dict(run_stats_primary_cells(metadata=sample_review_result.metadata))
+
+    assert_that(values["est. cost"]).is_equal_to("$0.0500")
+    assert_that(values["tokens in"]).is_equal_to("1,000")
+
+
+# --- both surfaces agree -----------------------------------------------------
+
+
+def test_both_surfaces_render_the_same_primary_badge_table(
+    sample_review_result: ReviewResult,
+) -> None:
+    """One renderer means the sticky and the body cannot drift apart."""
+    sticky = _sticky(result=sample_review_result)
+    body = _body(result=sample_review_result)
+
+    assert_that(sticky).contains(_PRIMARY_HEADER)
+    assert_that(body).contains(_PRIMARY_HEADER)
+    assert_that(_value_row(text=sticky, header=_PRIMARY_HEADER)).is_equal_to(
+        _value_row(text=body, header=_PRIMARY_HEADER),
+    )
+
+
+def test_sticky_this_run_section_renders_two_badge_tables(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Snapshot of the sticky's This-run block, heading included."""
+    sticky = _sticky(result=sample_review_result)
+    start = sticky.index("**This run**")
+    section = sticky[start:].split("\n\n<sub>", maxsplit=1)[0].rstrip()
+
+    assert_that(section).is_equal_to(
+        "\n".join(
+            [
+                "**This run**",
+                "",
+                _PRIMARY_HEADER,
+                "| --- | --- | --- | --- |",
+                "| `claude-sonnet-4-20250514` | $0.0500 | 1,000 | 200 |",
+                "",
+                "| transport | depth | files | checks | duration |",
+                "| --- | --- | --- | --- | --- |",
+                "| cli · subscription | 2 | 3 | 3 | 0s |",
+            ],
+        ),
+    )
+
+
+def test_sticky_this_run_tables_keep_the_estimated_prefix(
+    sample_review_result: ReviewResult,
+) -> None:
+    """The ``~`` prefix survived the move from prose lines to tables."""
+    result = replace(
+        sample_review_result,
+        metadata=replace(
+            sample_review_result.metadata,
+            token_usage_estimated=True,
+        ),
+    )
+
+    sticky = _sticky(result=result)
+
+    assert_that(_value_row(text=sticky, header=_PRIMARY_HEADER)).is_equal_to(
+        "| `claude-sonnet-4-20250514` | ~$0.0500 | ~1,000 | ~200 |",
+    )

--- a/tests/unit/ai/review/test_github_badge_tables.py
+++ b/tests/unit/ai/review/test_github_badge_tables.py
@@ -56,13 +56,18 @@ def _body(*, result: ReviewResult) -> str:
 def _value_row(*, text: str, header: str) -> str:
     """Return the value row that follows ``header`` in ``text``.
 
-    The header is asserted rather than indexed blindly: a header-format
-    regression should fail as a named assertion, not as a bare ``ValueError``
-    from :meth:`list.index` that says nothing about what was being looked for.
+    Both the header's presence and the two lines that must follow it are
+    asserted rather than indexed blindly. A table regression should fail as a
+    named assertion naming the header, not as a bare ``ValueError`` or
+    ``IndexError`` that says nothing about what was being looked for.
     """
     lines = text.splitlines()
-    assert_that(lines).contains(header)
-    return lines[lines.index(header) + 2]
+    assert_that(lines).described_as(f"lines containing {header!r}").contains(header)
+    divider_and_value = lines[lines.index(header) + 1 : lines.index(header) + 3]
+    assert_that(divider_and_value).described_as(
+        f"divider and value rows after {header!r}",
+    ).is_length(2)
+    return divider_and_value[1]
 
 
 # --- helper contract ---------------------------------------------------------
@@ -89,6 +94,14 @@ def test_badge_table_escapes_a_backslash_before_the_pipe_it_precedes() -> None:
     lines = format_badge_table(cells=[("model", "a\\|b")])
 
     assert_that(lines[-1]).is_equal_to("| a\\\\\\|b |")
+
+
+def test_badge_table_flattens_line_breaks_into_the_row() -> None:
+    """A row is one line, so a line break in a value would end it early."""
+    lines = format_badge_table(cells=[("model", "a\r\nb\nc\rd")])
+
+    assert_that(lines).is_length(3)
+    assert_that(lines[-1]).is_equal_to("| a b c d |")
 
 
 def test_badge_table_renders_nothing_for_no_cells() -> None:

--- a/tests/unit/ai/review/test_github_sticky_mission_control.py
+++ b/tests/unit/ai/review/test_github_sticky_mission_control.py
@@ -496,9 +496,15 @@ def test_this_run_badges_lead_with_the_model_and_name_the_transport(
         ),
     )
 
-    assert_that(body).contains("**This run** — model `claude-sonnet-4-20250514`")
-    assert_that(body).contains("est. cost")
-    assert_that(body).contains("transport `cli · subscription`")
+    assert_that(body).contains("**This run**")
+    assert_that(body).contains(
+        "| model | est. cost | tokens in | tokens out |",
+    )
+    assert_that(body).contains("| `claude-sonnet-4-20250514` |")
+    assert_that(body).contains(
+        "| transport | depth | files | checks | duration |",
+    )
+    assert_that(body).contains("| cli · subscription |")
 
 
 def test_body_never_nests_details_more_than_one_level(

--- a/tests/unit/ai/review/test_github_sticky_mission_control.py
+++ b/tests/unit/ai/review/test_github_sticky_mission_control.py
@@ -500,11 +500,13 @@ def test_this_run_badges_lead_with_the_model_and_name_the_transport(
     assert_that(body).contains(
         "| model | est. cost | tokens in | tokens out |",
     )
-    assert_that(body).contains("| `claude-sonnet-4-20250514` |")
+    assert_that(body).contains(
+        "| `claude-sonnet-4-20250514` | $0.0500 | 1,000 | 200 |",
+    )
     assert_that(body).contains(
         "| transport | depth | files | checks | duration |",
     )
-    assert_that(body).contains("| cli · subscription |")
+    assert_that(body).contains("| cli · subscription | 2 | 3 | 3 | 0s |")
 
 
 def test_body_never_nests_details_more_than_one_level(


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(review): render the sticky This-run stats as badge tables
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

The sticky comment's *This run* section rendered as two prose lines of inline code chips
while the per-review body rendered the same data as single-row badge tables — two
different looks for one set of numbers, because the sticky predates the body renderer.

The badge-table rendering moves out of `github_review_body.py` into `github_render.py`
as `format_badge_table` / `format_badge_tables`, plus `run_stats_primary_cells` for the
shared model / est. cost / tokens-in / tokens-out row. Both surfaces now call it, so they
cannot drift again.

The sticky's *This run* section becomes a `**This run**` heading over two single-row
tables: model, est. cost, tokens in, tokens out; then transport, depth, files, checks,
duration. That is the sticky's existing field set — no new data, and the `~`
estimated-value prefix is preserved on both cost and token cells.

The shared renderer also escapes a literal `|` in a cell — one would otherwise end that
cell and shear the whole row — so a stray pipe in a model name or transport label cannot
break either surface.

Pure GFM only: no shields.io or other external badge images. The *This run* section stays
outside the sticky's pruning order, and the 65,536-char pruning invariant tests are
unchanged and green.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1955

## Details

The per-review body's rendered output is byte-identical to `main`. That was verified
rather than assumed: the body was rendered from a fixed review result on both refs, for a
provider-reported run and an estimated one, and the two dumps diffed clean.

`_badge_table` is deleted from `github_review_body.py` and `_run_stats_section` now
delegates to `format_badge_tables(rows=[primary, secondary])`, which emits the same blank
line between the two tables that the old hand-rolled sequence did.

New tests live in `tests/unit/ai/review/test_github_badge_tables.py`: the helper's own
contract (one row of label/value pairs, pipe escaping, empty rows dropped, blank line
between tables),
the shared ordering rule, the `~` prefix on estimated values and its absence on reported
ones, a snapshot of the sticky's whole *This run* block, and an equality assertion that
both surfaces emit the same primary value row for identical input. The one existing
assertion in `test_github_sticky_mission_control.py` that pinned the old prose line was
updated deliberately to pin the table headers and value rows instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized run-stat badges to review bodies and sticky comments.
  * “This run” details now appear in organized tables showing model, cost, tokens, transport, depth, files, checks, and duration.
  * Badge content safely handles special Markdown characters and empty values.

* **Bug Fixes**
  * Improved consistency between review summaries and sticky comments.
  * Clarified estimated values and numeric formatting for costs and token counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->