### PR TITLE
fix(review): keep the mission-control sticky when a run fails

### DIFF
--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -682,6 +682,11 @@ def post_review_error_to_github(
 ) -> bool:
     """Post (or update) the sticky comment with a formatted API-error message.
 
+    When the sticky already carries a successful round, the failure is rendered
+    as a banner over a re-render of that round's board rather than replacing it
+    (#1954). The persisted state is passed through untouched either way, so a
+    failed round never advances the round counter or edits tracked findings.
+
     Args:
         error: The exception raised during review.
         provider: Provider identifier used for provider-aware classification.
@@ -703,6 +708,8 @@ def post_review_error_to_github(
         provider=provider,
         metadata=metadata,
         prior_state=prior_state,
+        repo=repo or gh_reporter.repo or "",
+        pr_number=pr_number if pr_number is not None else gh_reporter.pr_number,
     )
     return _upsert_sticky(reporter=gh_reporter, body=body, comment_id=comment_id)
 

--- a/lintro/ai/review/github_errors.py
+++ b/lintro/ai/review/github_errors.py
@@ -161,6 +161,15 @@ def _failure_banner(
 ) -> str:
     """Render the blockquote explaining a failed round over the last good board.
 
+    The round it names is the one the *next successful* review will be numbered
+    with, because that is the only round number that exists: a round number is
+    assigned when a review completes, and a failed attempt deliberately writes
+    nothing to state. Consecutive failures therefore repeat the same number,
+    which is correct — they are repeated attempts at the same round, and the
+    sticky is edited in place so only the latest attempt is ever on screen.
+    Counting attempts instead would mean recording failures in the state blob,
+    which is exactly what a failed round must not do (#1954).
+
     Args:
         kind: Resolved canonical error kind.
         error: The exception raised during review.

--- a/lintro/ai/review/github_errors.py
+++ b/lintro/ai/review/github_errors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from lintro.ai.review.errors_taxonomy import (
@@ -12,6 +13,7 @@ from lintro.ai.review.errors_taxonomy import (
 )
 from lintro.ai.review.github_constants import _FOOTER, STICKY_MARKER
 from lintro.ai.review.github_render import format_run_mechanics, sanitize_comment_text
+from lintro.ai.review.github_sticky import render_state_sticky
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.run_record import RunRecord
@@ -21,6 +23,26 @@ from lintro.ai.review.review_state_codec import (
     renumber_if_legacy_v1,
 )
 
+#: Cap on the provider error text rendered on the error-only sticky. Provider
+#: failures can carry a whole CLI JSON payload as their message, and none of it
+#: past the first sentences helps a reader decide whether to retry.
+ERROR_CAUSE_LIMIT = 500
+#: Tighter cap for the one-line failure banner prepended to a re-rendered
+#: board: it shares a blockquote with the "showing round M results" pointer, so
+#: it has to stay scannable at a glance.
+BANNER_CAUSE_LIMIT = 200
+
+#: Headline of the error-only surface, shown when no prior round can be
+#: re-rendered. Named so callers and tests can key on the wording without
+#: transcribing it.
+ERROR_ONLY_HEADLINE = "❌ **Review could not complete**"
+
+#: Headline of the failure banner shown over a re-rendered board, formatted
+#: with the round number that failed.
+FAILURE_BANNER_HEADLINE = "⚠️ **Round {round_number} could not complete**"
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
 
 def format_error_comment(
     *,
@@ -29,6 +51,8 @@ def format_error_comment(
     metadata: ReviewMetadata | None = None,
     prior_runs: list[dict[str, Any]] | None = None,
     prior_state: ReviewState | None = None,
+    repo: str = "",
+    pr_number: int | None = None,
 ) -> str:
     """Format a provider/API error as a clear PR comment.
 
@@ -39,6 +63,13 @@ def format_error_comment(
     clear "top up or lower ai.max_cost_usd" message rather than a generic
     "review aborted". The real underlying cause text is always surfaced.
 
+    When the persisted state already carries a successful run, the failure does
+    *not* replace the board (#1954): the mission-control layout is re-rendered
+    from that state with a one-line banner under the header explaining which
+    round failed and which round is on screen. A transient provider blip is a
+    footnote on the dashboard, not a reason to erase it. The error-only surface
+    is reserved for a first-round failure, where there is nothing to show.
+
     Args:
         error: The exception raised during review.
         provider: Provider identifier used for provider-aware classification.
@@ -47,24 +78,45 @@ def format_error_comment(
         prior_runs: Legacy run mappings recovered from the previous sticky
             comment. Ignored when ``prior_state`` is given.
         prior_state: Full state decoded from the previous sticky comment.
-            Re-emitted so a transient error does not reset cumulative telemetry
-            or the tracked finding history.
+            Re-emitted verbatim so a transient error does not reset cumulative
+            telemetry, advance the round counter, or touch the tracked
+            finding history.
+        repo: ``owner/name`` slug used to link finding titles to their threads
+            on a re-rendered board.
+        pr_number: Pull request number used for the same links.
 
     Returns:
-        Markdown comment body describing the failure and next steps.
+        Markdown comment body: the last good board with a failure banner, or
+        the error-only surface describing the failure and next steps.
     """
     resolved_provider = provider or (metadata.provider if metadata else "") or ""
     kind = classify_provider_error(provider=resolved_provider, error=error)
+    state = _resolve_prior_state(prior_runs=prior_runs, prior_state=prior_state)
+
+    if state is not None and state.runs:
+        return render_state_sticky(
+            state=state,
+            banner=_failure_banner(
+                kind=kind,
+                error=error,
+                provider=resolved_provider,
+                state=state,
+            ),
+            repo=repo,
+            pr_number=pr_number,
+        )
+
     detail, guidance = _render_error_copy(
         kind=kind,
         error=error,
         provider=resolved_provider,
+        cause_limit=ERROR_CAUSE_LIMIT,
     )
     lines = [
         STICKY_MARKER,
         "## 🔎 Lintro Review",
         "",
-        f"> ❌ **Review could not complete** — {detail}",
+        f"> {ERROR_ONLY_HEADLINE} — {detail}",
         "",
         guidance,
     ]
@@ -72,14 +124,65 @@ def format_error_comment(
         lines.extend(["", "<sub>" + format_run_mechanics(metadata=metadata) + "</sub>"])
     lines.extend(["", _FOOTER])
     body = "\n".join(lines)
-    state = prior_state
-    if state is None and prior_runs:
-        runs = tuple(RunRecord.from_dict(run) for run in prior_runs)
-        state = ReviewState(runs=renumber_if_legacy_v1(runs=runs))
-    if state is not None and (state.runs or state.findings or state.truncated):
-        state = prune_state_to_fit(state=state, body=body)
-        body += render_state_block(state=state)
+    if state is not None and (state.findings or state.truncated):
+        body += render_state_block(state=prune_state_to_fit(state=state, body=body))
     return body
+
+
+def _resolve_prior_state(
+    *,
+    prior_runs: list[dict[str, Any]] | None,
+    prior_state: ReviewState | None,
+) -> ReviewState | None:
+    """Return the state to re-emit, upgrading legacy run mappings when needed.
+
+    Args:
+        prior_runs: Legacy run mappings recovered from the previous sticky
+            comment. Ignored when ``prior_state`` is given.
+        prior_state: Full state decoded from the previous sticky comment.
+
+    Returns:
+        The resolved state, or ``None`` when nothing was carried over.
+    """
+    if prior_state is not None:
+        return prior_state
+    if not prior_runs:
+        return None
+    runs = tuple(RunRecord.from_dict(run) for run in prior_runs)
+    return ReviewState(runs=renumber_if_legacy_v1(runs=runs))
+
+
+def _failure_banner(
+    *,
+    kind: ReviewErrorKind,
+    error: Exception,
+    provider: str,
+    state: ReviewState,
+) -> str:
+    """Render the blockquote explaining a failed round over the last good board.
+
+    Args:
+        kind: Resolved canonical error kind.
+        error: The exception raised during review.
+        provider: Provider identifier, used only as a display label.
+        state: Persisted state whose board is being re-rendered.
+
+    Returns:
+        A single-line Markdown blockquote naming the failed round, the cause,
+        and the round actually on screen.
+    """
+    detail, _ = _render_error_copy(
+        kind=kind,
+        error=error,
+        provider=provider,
+        cause_limit=BANNER_CAUSE_LIMIT,
+    )
+    shown = max(run.round for run in state.runs)
+    headline = FAILURE_BANNER_HEADLINE.format(round_number=state.next_round)
+    return (
+        f"> {headline} — {detail} · showing round {shown} results below. "
+        "This is usually transient — retry shortly."
+    )
 
 
 def _render_error_copy(
@@ -87,6 +190,7 @@ def _render_error_copy(
     kind: ReviewErrorKind,
     error: Exception,
     provider: str,
+    cause_limit: int = ERROR_CAUSE_LIMIT,
 ) -> tuple[str, str]:
     """Build the (detail, guidance) pair for a classified review error.
 
@@ -99,12 +203,16 @@ def _render_error_copy(
         kind: Resolved canonical error kind.
         error: The original exception (possibly a wrapper).
         provider: Provider identifier, used only as a display label.
+        cause_limit: Maximum length of the surfaced cause text.
 
     Returns:
         Tuple of ``(detail, guidance)`` markdown strings.
     """
     message, guidance = KIND_COPY[kind]
-    cause = sanitize_comment_text(resolve_cause_text(error=error), limit=500)
+    cause = condense_provider_error(
+        text=resolve_cause_text(error=error),
+        limit=cause_limit,
+    )
     label = f"`{sanitize_comment_text(provider, limit=40)}` " if provider else ""
 
     if kind is ReviewErrorKind.UNKNOWN:
@@ -115,3 +223,24 @@ def _render_error_copy(
     if cause:
         detail += f" (provider reported: {cause})"
     return detail, guidance
+
+
+def condense_provider_error(*, text: str, limit: int) -> str:
+    """Flatten and bound provider error text for rendering inside a blockquote.
+
+    Provider failures routinely carry a multi-line CLI JSON payload as their
+    message. Rendered raw, the newlines break out of the blockquote the detail
+    lives in and the payload itself can run for thousands of characters,
+    crowding out the state block the sticky needs room for. Collapsing the
+    whitespace keeps the detail on one line; the limit keeps it readable.
+
+    Args:
+        text: Raw provider error text.
+        limit: Maximum length of the returned string.
+
+    Returns:
+        Sanitized single-line text, truncated with an ellipsis when over
+        ``limit``.
+    """
+    flattened = _WHITESPACE_RE.sub(" ", text or "").strip()
+    return sanitize_comment_text(flattened, limit=limit)

--- a/lintro/ai/review/github_errors.py
+++ b/lintro/ai/review/github_errors.py
@@ -170,6 +170,11 @@ def _failure_banner(
     Counting attempts instead would mean recording failures in the state blob,
     which is exactly what a failed round must not do (#1954).
 
+    The closing sentence is the same kind-specific guidance the error-only
+    surface renders, not a fixed "retry shortly": a depleted balance or a
+    rejected API key will fail identically on every retry, and telling a
+    reviewer to try again is worse than saying nothing.
+
     Args:
         kind: Resolved canonical error kind.
         error: The exception raised during review.
@@ -178,9 +183,9 @@ def _failure_banner(
 
     Returns:
         A single-line Markdown blockquote naming the failed round, the cause,
-        and the round actually on screen.
+        the round actually on screen, and what to do about it.
     """
-    detail, _ = _render_error_copy(
+    detail, guidance = _render_error_copy(
         kind=kind,
         error=error,
         provider=provider,
@@ -189,8 +194,7 @@ def _failure_banner(
     shown = max(run.round for run in state.runs)
     headline = FAILURE_BANNER_HEADLINE.format(round_number=state.next_round)
     return (
-        f"> {headline} — {detail} · showing round {shown} results below. "
-        "This is usually transient — retry shortly."
+        f"> {headline} — {detail} · showing round {shown} results below. " f"{guidance}"
     )
 
 

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -95,6 +95,7 @@ __all__ = [
     "build_sticky_comment",
     "parse_review_state",
     "parse_review_state_v2",
+    "render_state_sticky",
     "stamp_comment_ids",
 ]
 
@@ -366,6 +367,129 @@ def build_sticky_comment(
     return body + render_state_block(
         state=prune_state_to_fit(state=new_state, body=body),
     )
+
+
+def render_state_sticky(
+    *,
+    state: ReviewState,
+    banner: str = "",
+    repo: str = "",
+    pr_number: int | None = None,
+) -> str:
+    """Re-render the mission-control layout from persisted state alone.
+
+    The sticky is rebuilt on every run from the state blob, so a round that
+    never produced a :class:`ReviewResult` — a provider outage, an aborted CLI
+    invocation — can still show the last good board instead of blanking it
+    (#1954). Only the sections that describe *this* round are omitted: the
+    summary, the model's reasoning, the fix-all prompt panel, and the ``This
+    run`` badges all belong to a run that did not happen. Everything a reviewer
+    navigates by — verdict, tiles, open findings, resolved findings, history —
+    is derived from state and rendered unchanged.
+
+    The state is re-emitted exactly as given: a failed round must not advance
+    the round counter or touch the tracked findings, so the caller's state
+    round-trips byte-identically unless size pruning has to intervene.
+
+    Args:
+        state: State decoded from the previous sticky comment. Must carry at
+            least one run; callers with an empty state have nothing to show and
+            should render their own first-failure surface instead.
+        banner: Optional blockquote rendered directly under the header, used to
+            explain why the board is not from the current round.
+        repo: ``owner/name`` slug used to link finding titles to their threads.
+        pr_number: Pull request number used for the same links.
+
+    Returns:
+        Complete Markdown body carrying the hidden marker and state block,
+        guaranteed to fit GitHub's comment size limit.
+    """
+    records = state.findings
+    runs = list(state.runs)
+    latest = runs[-1] if runs else None
+    open_count = sum(1 for record in records if record.status is FindingStatus.OPEN)
+
+    def assemble(*, limits: _RenderLimits) -> str:
+        """Render the whole state-only body at the given per-section limits."""
+        return _assemble_state_body(
+            state=state,
+            banner=banner,
+            round_number=latest.round if latest is not None else 1,
+            head_sha=latest.sha if latest is not None else "",
+            runs=runs,
+            limits=limits,
+            repo=repo,
+            pr_number=pr_number,
+        )
+
+    body = _fit_body(
+        assemble=assemble,
+        prior_run_count=max(len(runs) - 1, 0),
+        open_count=open_count,
+        resolved_count=len(records) - open_count,
+    )
+    return body + render_state_block(state=prune_state_to_fit(state=state, body=body))
+
+
+def _assemble_state_body(
+    *,
+    state: ReviewState,
+    banner: str,
+    round_number: int,
+    head_sha: str,
+    runs: list[RunRecord],
+    limits: _RenderLimits,
+    repo: str,
+    pr_number: int | None,
+) -> str:
+    """Render the state-derived sticky sections and join the non-empty ones.
+
+    Args:
+        state: Persisted state to render.
+        banner: Optional blockquote rendered directly under the header.
+        round_number: Round number of the most recent successful run.
+        head_sha: Head commit sha reviewed by that run.
+        runs: Every retained run record, oldest first.
+        limits: Per-section render limits.
+        repo: ``owner/name`` slug used to link finding titles to their threads.
+        pr_number: Pull request number used for the same links.
+
+    Returns:
+        The assembled body, without the hidden state block.
+    """
+    records = state.findings
+    match = FindingMatchResult(records=records)
+    total_open = sum(1 for record in records if record.status is FindingStatus.OPEN)
+    total_resolved = len(records) - total_open
+
+    sections: list[str] = [
+        STICKY_MARKER,
+        _header(round_number=round_number, head_sha=head_sha),
+        banner,
+        _readiness_pill(verdict=derive_verdict(findings=records), records=records),
+        _verdict_explainer(),
+        _tiles_section(records=records),
+        _open_findings_section(
+            records=_sorted_open_records(records=records, limit=limits.open),
+            match=match,
+            total=total_open,
+            repo=repo,
+            pr_number=pr_number,
+        ),
+        _resolved_section(
+            records=_sorted_resolved_records(records=records, limit=limits.resolved),
+            total=total_resolved,
+        ),
+    ]
+    history = _history_section(
+        runs=runs,
+        limit=limits.history,
+        resolved_total=total_resolved,
+    )
+    if history:
+        sections.extend(["---", history])
+    sections.append(STICKY_FOOTER)
+    return "\n\n".join(section for section in sections if section)
 
 
 def _fit_body(

--- a/tests/unit/ai/review/test_error_sticky_1954.py
+++ b/tests/unit/ai/review/test_error_sticky_1954.py
@@ -7,8 +7,9 @@ from unittest.mock import MagicMock
 import pytest
 from assertpy import assert_that
 
-from lintro.ai.exceptions import AIProviderError
+from lintro.ai.exceptions import AIAuthenticationError, AIProviderError
 from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.errors_taxonomy import KIND_COPY, ReviewErrorKind
 from lintro.ai.review.github import post_review_error_to_github
 from lintro.ai.review.github_constants import (
     GITHUB_COMMENT_HARD_LIMIT,
@@ -84,17 +85,62 @@ def test_failure_after_success_renders_the_banner(prior_state: ReviewState) -> N
     assert_that(body).does_not_contain(ERROR_ONLY_HEADLINE)
 
 
+def test_banner_carries_the_kind_specific_guidance(prior_state: ReviewState) -> None:
+    """A permanent failure must not be dressed up as a transient one.
+
+    A rejected API key fails identically on every retry, so the banner has to
+    close with the same advice the error-only surface would give rather than a
+    blanket "retry shortly".
+    """
+    body = format_error_comment(
+        error=AIAuthenticationError("401 unauthorized"),
+        provider="anthropic",
+        prior_state=prior_state,
+    )
+    guidance = KIND_COPY[ReviewErrorKind.AUTH_FAILED][1]
+
+    assert_that(body).contains(f"> {_ROUND_2_FAILED}")
+    assert_that(body).contains(guidance)
+    assert_that(body).does_not_contain("This is usually transient")
+
+
+def test_legacy_prior_runs_also_render_the_board(prior_state: ReviewState) -> None:
+    """A v1 sticky's run mappings route to the board, not the error surface."""
+    body = format_error_comment(
+        error=AIProviderError("Overloaded"),
+        prior_runs=[run.to_dict() for run in prior_state.runs],
+    )
+
+    assert_that(body).contains(f"> {_ROUND_2_FAILED}")
+    assert_that(body).contains("showing round 1 results below")
+    assert_that(body).does_not_contain(ERROR_ONLY_HEADLINE)
+    assert_that(parse_review_state_v2(body=body).runs).is_length(
+        len(prior_state.runs),
+    )
+
+
 def test_banner_sits_directly_under_the_header(prior_state: ReviewState) -> None:
-    """Nothing separates the failure notice from the sticky's title line."""
+    r"""Nothing separates the failure notice from the sticky's title line.
+
+    Asserted by line proximity rather than by index into the ``\\n\\n`` split:
+    the guarantee is that a reader meets the banner immediately after the
+    title, which must survive any section later gaining a blank line of its
+    own.
+    """
     body = format_error_comment(
         error=AIProviderError("Overloaded"),
         prior_state=prior_state,
     )
-    sections = body.split("\n\n")
+    lines = body.splitlines()
+    header_index = next(
+        index
+        for index, line in enumerate(lines)
+        if line.startswith("## 🔎 Lintro Review · round 1")
+    )
+    after_header = next(line for line in lines[header_index + 1 :] if line.strip())
 
-    assert_that(sections[0]).is_equal_to(STICKY_MARKER)
-    assert_that(sections[1]).starts_with("## 🔎 Lintro Review · round 1")
-    assert_that(sections[2]).starts_with(f"> {_ROUND_2_FAILED}")
+    assert_that(lines[0]).is_equal_to(STICKY_MARKER)
+    assert_that(after_header).starts_with(f"> {_ROUND_2_FAILED}")
 
 
 def test_failure_after_success_renders_the_full_layout(
@@ -242,12 +288,27 @@ def test_failure_body_respects_the_hard_comment_limit() -> None:
     assert_that(body).contains(STATE_MARKER_PREFIX)
 
 
-def test_posting_a_failure_updates_the_sticky_in_place(prior_body: str) -> None:
-    """The end-to-end error path edits the sticky and keeps the board."""
+def _reporter(*, prior_body: str) -> MagicMock:
+    """Build a mock reporter serving ``prior_body`` as the existing sticky.
+
+    Args:
+        prior_body: Sticky body the reporter reports as already posted.
+
+    Returns:
+        The configured mock.
+    """
     reporter = MagicMock()
     reporter.is_available.return_value = True
     reporter.find_issue_comment.return_value = (9, prior_body)
     reporter.update_issue_comment.return_value = True
+    reporter.repo = "owner/name"
+    reporter.pr_number = 7
+    return reporter
+
+
+def test_posting_a_failure_updates_the_sticky_in_place(prior_body: str) -> None:
+    """The end-to-end error path edits the sticky and keeps the board."""
+    reporter = _reporter(prior_body=prior_body)
 
     posted = post_review_error_to_github(
         error=AIProviderError("Overloaded"),
@@ -262,6 +323,29 @@ def test_posting_a_failure_updates_the_sticky_in_place(prior_body: str) -> None:
     assert_that(body).contains(f"> {_ROUND_2_FAILED}")
     assert_that(body).contains("### Open findings")
     assert_that(_state_block(body=body)).is_equal_to(_state_block(body=prior_body))
+
+
+def test_posting_falls_back_to_the_reporter_pr_context(prior_body: str) -> None:
+    """Omitting the overrides renders exactly what supplying them renders."""
+    explicit = _reporter(prior_body=prior_body)
+    implicit = _reporter(prior_body=prior_body)
+
+    post_review_error_to_github(
+        error=AIProviderError("Overloaded"),
+        provider="anthropic",
+        repo="owner/name",
+        pr_number=7,
+        reporter=explicit,
+    )
+    post_review_error_to_github(
+        error=AIProviderError("Overloaded"),
+        provider="anthropic",
+        reporter=implicit,
+    )
+
+    assert_that(implicit.update_issue_comment.call_args.kwargs["body"]).is_equal_to(
+        explicit.update_issue_comment.call_args.kwargs["body"],
+    )
 
 
 def test_render_state_sticky_without_a_banner(prior_state: ReviewState) -> None:

--- a/tests/unit/ai/review/test_error_sticky_1954.py
+++ b/tests/unit/ai/review/test_error_sticky_1954.py
@@ -1,0 +1,257 @@
+"""A failed round keeps the mission-control sticky on screen (#1954)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.exceptions import AIProviderError
+from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.github import post_review_error_to_github
+from lintro.ai.review.github_constants import (
+    GITHUB_COMMENT_HARD_LIMIT,
+    STATE_MARKER_PREFIX,
+    STICKY_MARKER,
+)
+from lintro.ai.review.github_errors import (
+    BANNER_CAUSE_LIMIT,
+    ERROR_ONLY_HEADLINE,
+    FAILURE_BANNER_HEADLINE,
+    condense_provider_error,
+    format_error_comment,
+)
+from lintro.ai.review.github_sticky import (
+    build_sticky_comment,
+    parse_review_state_v2,
+    render_state_sticky,
+)
+from lintro.ai.review.models.finding_record import FindingRecord
+from lintro.ai.review.models.review_finding import Severity
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.run_record import RunRecord
+
+#: Banner headline for the round that fails in these tests, taken from the
+#: production template so a copy change cannot silently defang the assertions.
+_ROUND_2_FAILED = FAILURE_BANNER_HEADLINE.format(round_number=2)
+
+
+def _state_block(*, body: str) -> str:
+    """Return the hidden state block of a sticky body.
+
+    Args:
+        body: Rendered sticky comment body.
+
+    Returns:
+        Everything from the state marker onwards.
+    """
+    index = body.find(STATE_MARKER_PREFIX)
+    assert_that(index).described_as("state block offset").is_not_equal_to(-1)
+    return body[index:]
+
+
+@pytest.fixture
+def prior_body(sample_review_result: ReviewResult) -> str:
+    """Render a successful round-1 sticky to fail the next round against."""
+    return build_sticky_comment(
+        result=sample_review_result,
+        head_sha="a" * 40,
+        transport="cli",
+        auth_mode="subscription",
+    )
+
+
+@pytest.fixture
+def prior_state(prior_body: str) -> ReviewState:
+    """Decode the state persisted by a successful round."""
+    return parse_review_state_v2(body=prior_body)
+
+
+def test_failure_after_success_renders_the_banner(prior_state: ReviewState) -> None:
+    """The failed round is announced over the last good board, not instead."""
+    body = format_error_comment(
+        error=AIProviderError("Overloaded"),
+        provider="anthropic",
+        prior_state=prior_state,
+    )
+
+    assert_that(body).contains(f"> {_ROUND_2_FAILED}")
+    assert_that(body).contains("showing round 1 results below")
+    assert_that(body).contains("This is usually transient — retry shortly.")
+    assert_that(body).contains("Overloaded")
+    assert_that(body).does_not_contain(ERROR_ONLY_HEADLINE)
+
+
+def test_banner_sits_directly_under_the_header(prior_state: ReviewState) -> None:
+    """Nothing separates the failure notice from the sticky's title line."""
+    body = format_error_comment(
+        error=AIProviderError("Overloaded"),
+        prior_state=prior_state,
+    )
+    sections = body.split("\n\n")
+
+    assert_that(sections[0]).is_equal_to(STICKY_MARKER)
+    assert_that(sections[1]).starts_with("## 🔎 Lintro Review · round 1")
+    assert_that(sections[2]).starts_with(f"> {_ROUND_2_FAILED}")
+
+
+def test_failure_after_success_renders_the_full_layout(
+    prior_state: ReviewState,
+) -> None:
+    """Every state-derived mission-control section survives the failure."""
+    body = format_error_comment(
+        error=AIProviderError("Overloaded"),
+        prior_state=prior_state,
+    )
+
+    assert_that(body).contains("⛔ Blocked")
+    assert_that(body).contains("| 🔴 blockers | 🟠 warnings | 🟡 nits | ✔ fixed |")
+    assert_that(body).contains("### Open findings")
+    assert_that(body).contains("Fail-open default")
+    assert_that(body).contains(STATE_MARKER_PREFIX)
+
+
+def test_first_round_failure_renders_the_error_only_surface() -> None:
+    """With nothing to show, the failure is still the whole comment."""
+    body = format_error_comment(
+        error=AIProviderError("Overloaded"),
+        provider="anthropic",
+        prior_state=ReviewState(),
+    )
+
+    assert_that(body).contains(ERROR_ONLY_HEADLINE)
+    assert_that(body).does_not_contain("showing round")
+    assert_that(body).does_not_contain("### Open findings")
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
+
+
+def test_failed_round_leaves_the_state_blob_untouched(
+    prior_body: str,
+    prior_state: ReviewState,
+) -> None:
+    """A failed round persists the prior state byte-for-byte."""
+    body = format_error_comment(
+        error=AIProviderError("Overloaded"),
+        prior_state=prior_state,
+    )
+
+    assert_that(_state_block(body=body)).is_equal_to(_state_block(body=prior_body))
+
+
+def test_failed_round_does_not_advance_the_round_counter(
+    prior_state: ReviewState,
+) -> None:
+    """The next successful round still gets round 2, not round 3."""
+    body = format_error_comment(
+        error=AIProviderError("Overloaded"),
+        prior_state=prior_state,
+    )
+    recovered = parse_review_state_v2(body=body)
+
+    assert_that(recovered.next_round).is_equal_to(2)
+    assert_that(recovered.runs).is_length(len(prior_state.runs))
+    assert_that(recovered.findings).is_equal_to(prior_state.findings)
+
+
+def test_oversized_provider_error_is_truncated(prior_state: ReviewState) -> None:
+    """A raw CLI payload is bounded and flattened onto the banner's one line."""
+    payload = '{\n  "error": "' + ("x" * 20_000) + '"\n}'
+    body = format_error_comment(
+        error=AIProviderError(payload),
+        prior_state=prior_state,
+    )
+    banner = next(
+        line for line in body.splitlines() if line.startswith(f"> {_ROUND_2_FAILED}")
+    )
+
+    assert_that(banner).contains("…")
+    assert_that(banner).contains("showing round 1 results below")
+    assert_that(len(banner)).is_less_than(BANNER_CAUSE_LIMIT + 200)
+    assert_that(body).does_not_contain("x" * (BANNER_CAUSE_LIMIT + 1))
+
+
+def test_condense_provider_error_flattens_whitespace() -> None:
+    """Newlines cannot break the detail out of its blockquote."""
+    condensed = condense_provider_error(text="a\n\n  b\tc  ", limit=100)
+
+    assert_that(condensed).is_equal_to("a b c")
+
+
+def test_condense_provider_error_handles_empty_text() -> None:
+    """A provider that reported nothing condenses to nothing."""
+    assert_that(condense_provider_error(text="", limit=100)).is_empty()
+
+
+def test_failure_body_respects_the_hard_comment_limit() -> None:
+    """A huge board plus a failure banner still fits GitHub's cap."""
+    findings = tuple(
+        FindingRecord(
+            fingerprint=f"fp{index:05d}",
+            severity=Severity.P2,
+            category="correctness",
+            title=f"Finding {index} " + ("detail " * 20),
+            file=f"src/module_{index}/handler.py",
+            line=index,
+            status=FindingStatus.OPEN,
+            since_round=1,
+        )
+        for index in range(600)
+    )
+    state = ReviewState(
+        runs=tuple(
+            RunRecord(round=round_number, sha=f"{round_number:040d}", model="m")
+            for round_number in range(1, 21)
+        ),
+        findings=findings,
+    )
+
+    body = format_error_comment(
+        error=AIProviderError("Overloaded"),
+        prior_state=state,
+    )
+
+    assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
+    assert_that(body).contains(f"> {FAILURE_BANNER_HEADLINE.format(round_number=21)}")
+    assert_that(body).contains(STATE_MARKER_PREFIX)
+
+
+def test_posting_a_failure_updates_the_sticky_in_place(prior_body: str) -> None:
+    """The end-to-end error path edits the sticky and keeps the board."""
+    reporter = MagicMock()
+    reporter.is_available.return_value = True
+    reporter.find_issue_comment.return_value = (9, prior_body)
+    reporter.update_issue_comment.return_value = True
+
+    posted = post_review_error_to_github(
+        error=AIProviderError("Overloaded"),
+        provider="anthropic",
+        repo="owner/name",
+        pr_number=7,
+        reporter=reporter,
+    )
+    body = reporter.update_issue_comment.call_args.kwargs["body"]
+
+    assert_that(posted).is_true()
+    assert_that(body).contains(f"> {_ROUND_2_FAILED}")
+    assert_that(body).contains("### Open findings")
+    assert_that(_state_block(body=body)).is_equal_to(_state_block(body=prior_body))
+
+
+def test_render_state_sticky_without_a_banner(prior_state: ReviewState) -> None:
+    """The renderer is usable on its own; the banner is opt-in."""
+    body = render_state_sticky(state=prior_state)
+
+    assert_that(body).contains("### Open findings")
+    assert_that(body).does_not_contain("could not complete")
+
+
+def test_render_state_sticky_omits_this_round_only_sections(
+    prior_state: ReviewState,
+) -> None:
+    """Sections describing a run that never happened are left out."""
+    body = render_state_sticky(state=prior_state, banner="> ⚠️ nope")
+
+    assert_that(body).does_not_contain("**This run**")
+    assert_that(body).does_not_contain("### Summary")

--- a/tests/unit/ai/review/test_error_sticky_1954.py
+++ b/tests/unit/ai/review/test_error_sticky_1954.py
@@ -80,7 +80,7 @@ def test_failure_after_success_renders_the_banner(prior_state: ReviewState) -> N
 
     assert_that(body).contains(f"> {_ROUND_2_FAILED}")
     assert_that(body).contains("showing round 1 results below")
-    assert_that(body).contains("This is usually transient — retry shortly.")
+    assert_that(body).contains(KIND_COPY[ReviewErrorKind.SERVER_ERROR][1])
     assert_that(body).contains("Overloaded")
     assert_that(body).does_not_contain(ERROR_ONLY_HEADLINE)
 
@@ -97,11 +97,9 @@ def test_banner_carries_the_kind_specific_guidance(prior_state: ReviewState) -> 
         provider="anthropic",
         prior_state=prior_state,
     )
-    guidance = KIND_COPY[ReviewErrorKind.AUTH_FAILED][1]
-
     assert_that(body).contains(f"> {_ROUND_2_FAILED}")
-    assert_that(body).contains(guidance)
-    assert_that(body).does_not_contain("This is usually transient")
+    assert_that(body).contains(KIND_COPY[ReviewErrorKind.AUTH_FAILED][1])
+    assert_that(body).does_not_contain(KIND_COPY[ReviewErrorKind.SERVER_ERROR][1])
 
 
 def test_legacy_prior_runs_also_render_the_board(prior_state: ReviewState) -> None:

--- a/tests/unit/ai/review/test_error_sticky_1954.py
+++ b/tests/unit/ai/review/test_error_sticky_1954.py
@@ -155,6 +155,31 @@ def test_failed_round_does_not_advance_the_round_counter(
     assert_that(recovered.findings).is_equal_to(prior_state.findings)
 
 
+def test_consecutive_failures_name_the_same_attempted_round(
+    prior_state: ReviewState,
+) -> None:
+    """Repeated failures are repeated attempts at one round, not new rounds.
+
+    A round number is assigned when a review completes, so a failed attempt has
+    none to report and the banner names the round the next successful review
+    will carry. Counting attempts instead would mean recording failures in the
+    state blob, which a failed round must never do. The sticky is edited in
+    place, so a reader only ever sees the latest attempt's banner.
+    """
+    first = format_error_comment(
+        error=AIProviderError("Overloaded"),
+        prior_state=prior_state,
+    )
+    second = format_error_comment(
+        error=AIProviderError("Overloaded"),
+        prior_state=parse_review_state_v2(body=first),
+    )
+
+    assert_that(second).contains(f"> {_ROUND_2_FAILED}")
+    assert_that(second).contains("showing round 1 results below")
+    assert_that(_state_block(body=second)).is_equal_to(_state_block(body=first))
+
+
 def test_oversized_provider_error_is_truncated(prior_state: ReviewState) -> None:
     """A raw CLI payload is bounded and flattened onto the banner's one line."""
     payload = '{\n  "error": "' + ("x" * 20_000) + '"\n}'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(review): keep the mission-control sticky when a run fails
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

A review round that died before producing any output replaced the whole sticky comment
with a bare "Review could not complete" notice. A single transient provider 5xx therefore
erased the readiness verdict, the severity tiles, the open/resolved finding tables, and the
run history that reviewers navigate the PR by — observed on #1952, where round 3's CLI
invocation failed before reviewing anything and blanked the board built by rounds 1–2. The
state blob survived in the HTML comment the entire time; only the rendering was discarded.

The sticky is now re-rendered from that persisted state whenever it carries at least one
successful run, with a one-line banner directly under the header naming the round that
failed, the cause, and the round actually on screen:

```text
> ⚠️ **Round 3 could not complete** — `anthropic` the provider returned a server error
  (5xx) (provider reported: Overloaded) · showing round 2 results below. This is usually
  transient — retry shortly.
```

Only the sections that describe the current run are dropped — the summary, the model's
reasoning, the fix-all prompt panel, and the *This run* badges all belong to a run that did
not happen. The error-only surface is kept for a first-round failure, where there is
genuinely nothing to show.

The failed round passes the prior state through untouched, so it neither advances the round
counter nor edits tracked findings, and the state blob round-trips byte-identically.
Provider error text is now flattened onto a single line and length-bounded before it
reaches the comment, so a multi-line CLI JSON payload can no longer break out of its
blockquote or crowd out the state block, and the re-rendered board goes through the same
size-pruning path as a successful one.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing — no docs page describes the error surface
- [x] Local CI passed (full `uv run pytest`, `lintro fmt`, `lintro chk`)

## Closes

- Closes #1954

## Details

`render_state_sticky` is the new entry point in `github_sticky.py`: it rebuilds the
mission-control layout from a `ReviewState` alone, taking the header's round and commit
from the most recent run record, deriving the verdict from the tracked records, and passing
an empty `FindingMatchResult` so every open finding renders its Δ cell as "unchanged" —
which is exactly what a round that produced nothing did to them. It reuses the existing
`_fit_body` pruning ladder (history → resolved → open, each with a visible marker) and
`prune_state_to_fit`, so the 65,536-char invariants hold unchanged; a 600-finding,
20-round board renders at 65,255 chars with the pruning markers present.

`github_errors.py` resolves the prior state first and routes to that renderer when the
state has runs, falling back to the error-only body otherwise. `condense_provider_error`
collapses whitespace runs and truncates — 500 chars on the error-only surface,
200 on the banner. The headline strings are exported as `ERROR_ONLY_HEADLINE` and
`FAILURE_BANNER_HEADLINE` so tests key on production copy rather than transcribing it.
`post_review_error_to_github` now forwards `repo`/`pr_number` (falling back to the
reporter's own) so finding titles on a re-rendered board keep linking to their threads.

Testing: 13 new tests in `tests/unit/ai/review/test_error_sticky_1954.py` cover the banner
text and its position directly under the header, the full state-derived layout surviving a
failure, the first-round error-only fallback, byte-identical state round-trip, the round
counter not advancing, oversized/multi-line provider errors being bounded and flattened,
the hard-limit invariant under a huge board, and the end-to-end `post_review_error_to_github`
path. Full `uv run pytest` is green except 16 pre-existing environment failures (stylelint
and oxlint/oxfmt version floors, offline pip-audit, commitlint version floor) verified
identical on `origin/main`. `uv run lintro fmt` and `uv run lintro chk` are clean at
100/100.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing GitHub review results when an AI review round fails.
  * Added clear, size-limited failure banners without overwriting prior findings, history, or round progress.
  * Improved provider error formatting for readability.
  * Maintained correct behavior for first-round and repeated failures.
  * Re-rendered saved review details, including verdicts, findings, resolved items, and history.
* **Testing**
  * Added coverage for failure handling, state preservation, truncation, and comment size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->