### PR TITLE
fix(deps): bump js-yaml to 4.3.1 for GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/apps/site/bun.lock
+++ b/apps/site/bun.lock
@@ -29,7 +29,7 @@
   "overrides": {
     "esbuild": "^0.28.1",
     "fast-uri": "4.1.2",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "postcss": "^8.5.18",
     "sharp": "0.35.3",
     "svgo": "^4.0.2",
@@ -591,7 +591,7 @@
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -39,7 +39,7 @@
   "overrides": {
     "yaml": "^2.9.0",
     "vite": "^8.0.16",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "esbuild": "^0.28.1",
     "fast-uri": "4.1.2",
     "postcss": "^8.5.18",

--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
     "devalue": "5.8.2",
     "esbuild": "^0.28.1",
     "fast-uri": "4.1.2",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "markdown-it": "^14.2.0",
     "postcss": "^8.5.18",
     "sharp": "0.35.3",
@@ -787,7 +787,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "devalue": "5.8.2",
     "esbuild": "^0.28.1",
     "fast-uri": "4.1.2",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "markdown-it": "^14.2.0",
     "postcss": "^8.5.18",
     "svgo": "^4.0.2",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(deps): bump js-yaml to 4.3.1 for GHSA-5p4m-2wfm-xmqj
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Bumps `js-yaml` from 4.3.0 to 4.3.1 in both bun lockfiles (root and `apps/site`), raising the declared range from `^4.2.0` to `^4.3.1`. Advisory GHSA-5p4m-2wfm-xmqj (HIGH, CVSS 7.5, published 2026-08-06) hits js-yaml ≤ 4.3.0 with a quadratic-CPU DoS in `!!omap` resolution; the pinned 4.3.0 fails the 🔐 Security Audit osv scan repo-wide, which also reddens dogfooding-lint, lintro-code-quality, and the Code Quality Gate on main and every open PR.

Dependency-only change; no source code touched.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`bun install` clean in both packages; lockfiles resolve js-yaml@4.3.1; Python suite untouched)

## Closes

- Closes #1963

## Details

`bun install` refreshed both lockfiles after the range bump; the only resolution change is `js-yaml 4.3.0 → 4.3.1`. Verification is CI-side: the Security Audit and quality gates that currently fail on main must go green on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the YAML parsing component to a newer compatible version.
  * Applied the version update consistently across the site and project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->