### PR TITLE
chore(ci): make AI CLI Tier 1 contract check merge-queue safe (#1119)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -26,6 +26,37 @@ comments so Renovate can track digest updates. Policy is enforced by
   (`reusable-quality-lint.yml`, pinned release image) backstopping changed-files PR
   linting; failures open/ping a deduplicated issue via
   `reusable-main-failure-notifier.yml`
+- **ai-contract-tests.yml** — Two-tier AI CLI contract suite (#1609 / #1119). Tier 1
+  (`🧾 AI CLI Flag Surface (Tier 1)`) runs `--version`/`--help` on every
+  `pull_request` / `push` / `merge_group` with no path filter, so the context always
+  reports and is safe to require on `checks-py-lintro` (16132640). Tier 2
+  (`🔥 AI CLI Invocation Smoke (Tier 2)`) is schedule/`workflow_dispatch` only and
+  must stay non-required (live credentials). Admin ruleset PUT (not PATCH; preserve
+  `bypass_actors` from a live GET):
+
+  ```bash
+  gh api orgs/lgtm-hq/rulesets/16132640 \
+    | jq --arg ctx '🧾 AI CLI Flag Surface (Tier 1)' '
+        . as $r
+        | {
+            name: $r.name,
+            target: $r.target,
+            enforcement: $r.enforcement,
+            bypass_actors: ($r.bypass_actors // []),
+            conditions: $r.conditions,
+            rules: [
+              $r.rules[]
+              | if .type == "required_status_checks" then
+                  .parameters.required_status_checks += [{context: $ctx}]
+                else . end
+            ]
+          }
+      ' \
+    | gh api -X PUT orgs/lgtm-hq/rulesets/16132640 --input -
+  ```
+
+  Resulting `required_status_checks` must be the previous twelve contexts plus
+  `🧾 AI CLI Flag Surface (Tier 1)` — never Tier 2.
 
 ## Release
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -48,7 +48,9 @@ comments so Renovate can track digest updates. Policy is enforced by
             conditions: $r.conditions,
             rules: [
               $r.rules[]
-              | if .type == "required_status_checks" then
+              | if .type == "required_status_checks"
+                  and ([.parameters.required_status_checks[]
+                        | select(.context == $ctx)] | length == 0) then
                   .parameters.required_status_checks += [{context: $ctx}]
                 else . end
             ]

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,14 +27,16 @@ comments so Renovate can track digest updates. Policy is enforced by
   linting; failures open/ping a deduplicated issue via
   `reusable-main-failure-notifier.yml`
 - **ai-contract-tests.yml** — Two-tier AI CLI contract suite (#1609 / #1119). Tier 1
-  (`🧾 AI CLI Flag Surface (Tier 1)`) runs `--version`/`--help` on every
-  `pull_request` / `push` / `merge_group` with no path filter, so the context always
-  reports and is safe to require on `checks-py-lintro` (16132640). Tier 2
-  (`🔥 AI CLI Invocation Smoke (Tier 2)`) is schedule/`workflow_dispatch` only and
-  must stay non-required (live credentials). Admin ruleset PUT (not PATCH; preserve
+  (`🧾 AI CLI Flag Surface (Tier 1)`) runs `--version`/`--help` on every `pull_request`
+  / `push` / `merge_group` with no path filter, so the context always reports and is
+  safe to require on `checks-py-lintro` (16132640). Tier 2
+  (`🔥 AI CLI Invocation Smoke (Tier 2)`) is schedule/`workflow_dispatch` only and must
+  stay non-required (live credentials). Admin ruleset PUT (not PATCH; preserve
   `bypass_actors` from a live GET):
 
   ```bash
+  # Context string must match the job name in ai-contract-tests.yml —
+  # source of truth: _AI_CONTRACT_TIER1_CONTEXT in tests/unit/test_workflow_wiring.py
   gh api orgs/lgtm-hq/rulesets/16132640 \
     | jq --arg ctx '🧾 AI CLI Flag Surface (Tier 1)' '
         . as $r

--- a/.github/workflows/ai-contract-tests.yml
+++ b/.github/workflows/ai-contract-tests.yml
@@ -33,6 +33,11 @@ name: AI - CLI Contract Tests
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
+  # Required before adding the Tier 1 context to checks-py-lintro (#1119 /
+  # #1196): a merge-queue ruleset would otherwise wait forever for a check that
+  # this workflow never schedules.
+  merge_group:
+    types: [checks_requested]
   schedule:
     # Weekly (Monday 05:17 UTC), after the ai-tools image rebuild at 03:47 so the
     # scheduled run exercises the freshly published CLIs.

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -2575,6 +2575,56 @@ def test_auto_rerun_matches_docker_hub_buildx_pull_timeout() -> None:
     assert_that(signatures).does_not_contain("context deadline exceeded")
 
 
+# --- AI CLI contract Tier 1 required-check safety (#1119 / #1609) -----------
+#
+# Epic #1609 shipped the free flag-surface check with the intent that it becomes
+# a required gate. Requiring the context before ``merge_group:`` exists arms the
+# #1196 absent-required-check merge-queue trap. These constants and the test
+# below pin the Tier 1 job to the same always-report shape as the dependency
+# vulnerability gate.
+
+_AI_CONTRACT_WORKFLOW = "ai-contract-tests.yml"
+_AI_CONTRACT_TIER1_JOB = "tier1-flag-surface"
+_AI_CONTRACT_TIER1_CONTEXT = "🧾 AI CLI Flag Surface (Tier 1)"
+
+
+def _ai_contract_tier1_job() -> dict[str, Any]:
+    """Return the Tier 1 AI CLI flag-surface job definition.
+
+    Returns:
+        The ``tier1-flag-surface`` job mapping.
+    """
+    workflow = _load_workflow(name=_AI_CONTRACT_WORKFLOW)
+    return cast(dict[str, Any], workflow["jobs"][_AI_CONTRACT_TIER1_JOB])
+
+
+def test_ai_contract_tier1_is_required_check_safe() -> None:
+    """Tier 1 must always report its context (#1119 / #1196).
+
+    A ``paths:`` filter, or a job-level ``if:``, would stop the context from
+    ever being created — which deadlocks the merge queue the moment the
+    context is added to the ``checks-py-lintro`` ruleset. Tier 1 is cheap
+    enough to run unconditionally (help probes only), so it stays a plain job
+    with no path filter and no job-level ``if:``.
+    """
+    workflow = _load_workflow(name=_AI_CONTRACT_WORKFLOW)
+    triggers = workflow["on"]
+
+    assert_that(triggers).contains_key(_GITHUB_PULL_REQUEST_EVENT)
+    assert_that(triggers).contains_key("merge_group")
+    for event in (_GITHUB_PULL_REQUEST_EVENT, "merge_group"):
+        assert_that(triggers[event] or {}).does_not_contain_key("paths")
+        assert_that(triggers[event] or {}).does_not_contain_key("paths-ignore")
+
+    job = _ai_contract_tier1_job()
+    assert_that(job["name"]).is_equal_to(_AI_CONTRACT_TIER1_CONTEXT)
+    assert_that(job).does_not_contain_key("if")
+    # A skipped reusable *caller* collapses its nested contexts, so the gate
+    # must stay a plain job that always reports its own check run.
+    assert_that(job).does_not_contain_key("uses")
+    assert_that(job).contains_key("runs-on")
+
+
 # --- Tool-execution timeout classification wiring (#1653) --------------------
 
 

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -2615,6 +2615,7 @@ def test_ai_contract_tier1_is_required_check_safe() -> None:
     for event in (_GITHUB_PULL_REQUEST_EVENT, "merge_group"):
         assert_that(triggers[event] or {}).does_not_contain_key("paths")
         assert_that(triggers[event] or {}).does_not_contain_key("paths-ignore")
+    assert_that(triggers["merge_group"]["types"]).contains("checks_requested")
 
     job = _ai_contract_tier1_job()
     assert_that(job["name"]).is_equal_to(_AI_CONTRACT_TIER1_CONTEXT)
@@ -2623,6 +2624,13 @@ def test_ai_contract_tier1_is_required_check_safe() -> None:
     # must stay a plain job that always reports its own check run.
     assert_that(job).does_not_contain_key("uses")
     assert_that(job).contains_key("runs-on")
+
+    # The README's admin PUT recipe is the third copy of the context string;
+    # pin it to the constant so a job rename cannot leave the recipe stale.
+    readme = (_REPO_ROOT / ".github" / "workflows" / "README.md").read_text(
+        encoding="utf-8",
+    )
+    assert_that(readme).contains(_AI_CONTRACT_TIER1_CONTEXT)
 
 
 # --- Tool-execution timeout classification wiring (#1653) --------------------


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(ci): make AI CLI Tier 1 contract check merge-queue safe
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Completes the code half of #1119's remaining item: make the Tier 1 AI CLI flag-surface check safe to require on the `checks-py-lintro` ruleset.

- Add `merge_group:` trigger to `.github/workflows/ai-contract-tests.yml` so the Tier 1 context always reports under merge queue (#1196 absent-required-check trap).
- Add `test_ai_contract_tier1_is_required_check_safe` wiring test mirroring `test_dependency_vuln_gate_is_required_check_safe` (no path filter, no job-level `if:`, plain job, name matches the required context).
- Document the admin org-ruleset PUT payload in `.github/workflows/README.md` (ruleset 16132640 is org-level; PUT not PATCH; preserve `bypass_actors`; never require Tier 2).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Relates to #1119

## Details

After merge, the manual admin step remains: PUT `🧾 AI CLI Flag Surface (Tier 1)` into org ruleset `16132640` per the README recipe. Tier 2 stays schedule/dispatch-only (`if:` guard) so merge-group runs execute Tier 1 only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added merge-queue validation for AI CLI flag-surface checks.
  * Added automated workflow checks for pull requests and merge-queue events.

* **Documentation**
  * Documented workflow checks, status requirements, smoke tests, and ruleset configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->