### PR TITLE
refactor(ai): add close/aclose lifecycle to AI provider clients (#1885)

### DIFF
--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -351,6 +351,14 @@ class AnthropicProvider(BaseAIProvider):
         with self._session_lock:
             self._session_id = None
 
+    async def aclose(self) -> None:
+        """Close the Anthropic SDK client and any superseded loop-stale clients.
+
+        Idempotent. CLI transport holds no poolable HTTP client; this still
+        clears any API-transport client created earlier on this instance.
+        """
+        await super().aclose()
+
     async def _complete_cli(
         self,
         prompt: str,

--- a/lintro/ai/providers/base.py
+++ b/lintro/ai/providers/base.py
@@ -13,6 +13,8 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
+from loguru import logger
+
 from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import AIAuthenticationError, AINotAvailableError
 from lintro.ai.liveness import (
@@ -200,6 +202,10 @@ class BaseAIProvider(ABC):
         with HTTP SDK clients override to close those clients. Call-site
         ownership of *when* to close is #1972 Phase 5 — this method only
         provides the provider-side API (#1885).
+
+        Teardown is best-effort: one client's failing ``close`` must not
+        orphan the remaining clients, so per-client errors are logged and
+        swallowed.
         """
         clients = list(self._superseded_clients)
         if self._client is not None:
@@ -208,7 +214,13 @@ class BaseAIProvider(ABC):
         self._client_loop = None
         self._superseded_clients = []
         for client in clients:
-            await self._close_sdk_client(client)
+            try:
+                await self._close_sdk_client(client)
+            except Exception as exc:  # noqa: BLE001 - best-effort teardown
+                logger.debug(
+                    f"Ignoring error while closing {self._provider_name} "
+                    f"SDK client: {exc}",
+                )
 
     def close(self) -> None:
         """Synchronously close open SDK clients.

--- a/lintro/ai/providers/base.py
+++ b/lintro/ai/providers/base.py
@@ -111,9 +111,13 @@ class BaseAIProvider(ABC):
         self._transport = transport
         self._client: Any = None
         self._client_loop: asyncio.AbstractEventLoop | None = None
-        # Clients discarded by a stale-loop rebuild are kept here until
-        # ``aclose`` so their HTTP pools are not orphaned (#1885).
-        self._superseded_clients: list[Any] = []
+        # Clients discarded by a stale-loop rebuild are kept here (with the
+        # loop that created them) until ``aclose`` so their HTTP pools are
+        # not orphaned (#1885). Async pools must close on their creating
+        # loop; the tuple lets ``aclose`` pick the right strategy.
+        self._superseded_clients: list[tuple[Any, asyncio.AbstractEventLoop | None]] = (
+            []
+        )
 
     # -- Client management -------------------------------------------------
 
@@ -130,13 +134,15 @@ class BaseAIProvider(ABC):
             return None
 
     def _retire_client(self, client: Any) -> None:
-        """Queue a superseded client for later ``aclose``.
+        """Queue a superseded client (with its creating loop) for ``aclose``.
 
         Args:
             client: SDK client instance to close when the provider shuts down.
         """
-        if client is not None and client not in self._superseded_clients:
-            self._superseded_clients.append(client)
+        if client is not None and all(
+            existing is not client for existing, _ in self._superseded_clients
+        ):
+            self._superseded_clients.append((client, self._client_loop))
 
     def _get_client(self) -> Any:
         """Get or lazily create the SDK client for the running event loop.
@@ -203,19 +209,43 @@ class BaseAIProvider(ABC):
         ownership of *when* to close is #1972 Phase 5 — this method only
         provides the provider-side API (#1885).
 
-        Teardown is best-effort: one client's failing ``close`` must not
-        orphan the remaining clients, so per-client errors are logged and
-        swallowed.
+        Teardown is best-effort and loop-aware: an async pool must close on
+        its creating loop, so a client is awaited directly only when that
+        loop is the running one; a client whose creating loop still runs
+        elsewhere is closed there via ``run_coroutine_threadsafe``; and a
+        client whose creating loop is gone cannot be gracefully closed —
+        its pool is left to garbage collection, by design. One client's
+        failing ``close`` never orphans the remaining clients.
         """
+        current = self._current_loop()
         clients = list(self._superseded_clients)
         if self._client is not None:
-            clients.append(self._client)
+            clients.append((self._client, self._client_loop))
         self._client = None
         self._client_loop = None
         self._superseded_clients = []
-        for client in clients:
+        for client, creating_loop in clients:
             try:
-                await self._close_sdk_client(client)
+                if creating_loop is None or creating_loop is current:
+                    await self._close_sdk_client(client)
+                elif creating_loop.is_running():
+                    # The creating loop is alive in another thread; close
+                    # the pool there, where it belongs.
+                    future = asyncio.run_coroutine_threadsafe(
+                        self._close_sdk_client(client),
+                        creating_loop,
+                    )
+                    future.result(timeout=5.0)
+                else:
+                    # Closed or idle foreign loop: nothing will execute a
+                    # scheduled close, and awaiting here would bind the
+                    # pool teardown to the wrong loop. Release the
+                    # reference and let garbage collection reclaim it.
+                    logger.debug(
+                        f"Releasing {self._provider_name} SDK client "
+                        "created on a dead or idle foreign event loop; "
+                        "pool reclaimed by garbage collection.",
+                    )
             except Exception as exc:  # noqa: BLE001 - best-effort teardown
                 logger.debug(
                     f"Ignoring error while closing {self._provider_name} "

--- a/lintro/ai/providers/base.py
+++ b/lintro/ai/providers/base.py
@@ -109,6 +109,9 @@ class BaseAIProvider(ABC):
         self._transport = transport
         self._client: Any = None
         self._client_loop: asyncio.AbstractEventLoop | None = None
+        # Clients discarded by a stale-loop rebuild are kept here until
+        # ``aclose`` so their HTTP pools are not orphaned (#1885).
+        self._superseded_clients: list[Any] = []
 
     # -- Client management -------------------------------------------------
 
@@ -123,6 +126,15 @@ class BaseAIProvider(ABC):
             return asyncio.get_running_loop()
         except RuntimeError:
             return None
+
+    def _retire_client(self, client: Any) -> None:
+        """Queue a superseded client for later ``aclose``.
+
+        Args:
+            client: SDK client instance to close when the provider shuts down.
+        """
+        if client is not None and client not in self._superseded_clients:
+            self._superseded_clients.append(client)
 
     def _get_client(self) -> Any:
         """Get or lazily create the SDK client for the running event loop.
@@ -144,6 +156,11 @@ class BaseAIProvider(ABC):
         if self._client is not None and not stale:
             return self._client
 
+        if self._client is not None and stale:
+            self._retire_client(self._client)
+            self._client = None
+            self._client_loop = None
+
         api_key = os.environ.get(self._api_key_env) or ""
         if not api_key and not self._base_url:
             raise AIAuthenticationError(
@@ -157,6 +174,58 @@ class BaseAIProvider(ABC):
         self._client = self._create_client(api_key=api_key)
         self._client_loop = loop
         return self._client
+
+    @staticmethod
+    async def _close_sdk_client(client: Any) -> None:
+        """Await an SDK client's ``close``/``aclose`` when present.
+
+        Args:
+            client: SDK client instance, or ``None``.
+        """
+        if client is None:
+            return
+        close = getattr(client, "aclose", None)
+        if close is None:
+            close = getattr(client, "close", None)
+        if close is None:
+            return
+        result = close()
+        if asyncio.iscoroutine(result):
+            await result
+
+    async def aclose(self) -> None:
+        """Close open SDK clients. Idempotent; safe to call more than once.
+
+        Concrete no-op for providers that hold no poolable client. Subclasses
+        with HTTP SDK clients override to close those clients. Call-site
+        ownership of *when* to close is #1972 Phase 5 — this method only
+        provides the provider-side API (#1885).
+        """
+        clients = list(self._superseded_clients)
+        if self._client is not None:
+            clients.append(self._client)
+        self._client = None
+        self._client_loop = None
+        self._superseded_clients = []
+        for client in clients:
+            await self._close_sdk_client(client)
+
+    def close(self) -> None:
+        """Synchronously close open SDK clients.
+
+        Raises:
+            RuntimeError: If called from a running event loop; use
+                ``await aclose()`` instead.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(self.aclose())
+            return
+        raise RuntimeError(
+            "close() cannot be called from a running event loop; "
+            "use `await aclose()` instead.",
+        )
 
     @abstractmethod
     def _create_client(self, *, api_key: str) -> Any:

--- a/lintro/ai/providers/base.py
+++ b/lintro/ai/providers/base.py
@@ -230,12 +230,16 @@ class BaseAIProvider(ABC):
                     await self._close_sdk_client(client)
                 elif creating_loop.is_running():
                     # The creating loop is alive in another thread; close
-                    # the pool there, where it belongs.
+                    # the pool there, where it belongs — without blocking
+                    # this loop's thread on a concurrent.futures result.
                     future = asyncio.run_coroutine_threadsafe(
                         self._close_sdk_client(client),
                         creating_loop,
                     )
-                    future.result(timeout=5.0)
+                    await asyncio.wait_for(
+                        asyncio.wrap_future(future),
+                        timeout=5.0,
+                    )
                 else:
                     # Closed or idle foreign loop: nothing will execute a
                     # scheduled close, and awaiting here would bind the

--- a/lintro/ai/providers/openai.py
+++ b/lintro/ai/providers/openai.py
@@ -318,6 +318,14 @@ class OpenAIProvider(BaseAIProvider):
             supports_streaming=True,
         )
 
+    async def aclose(self) -> None:
+        """Close the OpenAI SDK client and any superseded loop-stale clients.
+
+        Idempotent. CLI transport holds no poolable HTTP client; this still
+        clears any API-transport client created earlier on this instance.
+        """
+        await super().aclose()
+
     async def _complete_cli(
         self,
         prompt: str,

--- a/tests/unit/ai/providers/test_provider_lifecycle.py
+++ b/tests/unit/ai/providers/test_provider_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -131,12 +132,16 @@ async def test_stale_loop_rebuild_does_not_orphan_client(
     second = provider._get_client()
 
     assert_that(first).is_not_equal_to(second)
-    assert_that(provider._superseded_clients).contains(first)
+    assert_that(
+        [client for client, _loop in provider._superseded_clients],
+    ).contains(first)
     assert_that(first.closed).is_false()
 
     await provider.aclose()
 
-    assert_that(first.closed).is_true()
+    # A client from an idle foreign loop is consciously released, never
+    # awaited on the wrong loop; only the current-loop client closes.
+    assert_that(first.closed).is_false()
     assert_that(second.closed).is_true()
     assert_that(provider._superseded_clients).is_empty()
 
@@ -222,10 +227,65 @@ async def test_aclose_survives_failing_client_and_closes_the_rest() -> None:
     """One client's failing close must not orphan the remaining clients."""
     provider = _LifecycleProvider()
     survivor = _FakeAsyncClient()
-    provider._superseded_clients = [_ExplodingClient(), survivor]
+    provider._superseded_clients = [
+        (_ExplodingClient(), None),
+        (survivor, None),
+    ]
     provider._client = None
 
     await provider.aclose()
 
     assert_that(survivor.closed).is_true()
     assert_that(provider._superseded_clients).is_empty()
+
+
+async def test_aclose_skips_client_whose_creating_loop_is_closed() -> None:
+    """A client from a dead loop is skipped, not awaited on the wrong loop.
+
+    Async pools must close on their creating loop; when that loop is gone the
+    pool is left to garbage collection and the remaining clients still close.
+    """
+    dead_loop = asyncio.new_event_loop()
+    dead_loop.close()
+    stranded = _FakeAsyncClient()
+    survivor = _FakeAsyncClient()
+    provider = _LifecycleProvider()
+    provider._superseded_clients = [(stranded, dead_loop), (survivor, None)]
+
+    await provider.aclose()
+
+    assert_that(stranded.closed).is_false()
+    assert_that(survivor.closed).is_true()
+    assert_that(provider._superseded_clients).is_empty()
+
+
+class _FakeAcloseClient:
+    """SDK-client stand-in exposing ``aclose`` (the preferred spelling)."""
+
+    def __init__(self) -> None:
+        self.aclosed = False
+
+    async def aclose(self) -> None:
+        """Mark the client aclosed."""
+        self.aclosed = True
+
+
+async def test_close_sdk_client_prefers_aclose() -> None:
+    """``aclose`` is used when both spellings exist (httpx-style clients)."""
+    client = _FakeAcloseClient()
+    provider = _LifecycleProvider()
+    provider._client = client
+
+    await provider.aclose()
+
+    assert_that(client.aclosed).is_true()
+
+
+async def test_sync_close_raises_inside_running_loop() -> None:
+    """close() refuses to run inside an event loop and points at aclose()."""
+    provider = _LifecycleProvider()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        provider.close()
+
+    assert_that(str(excinfo.value)).contains("await aclose()")

--- a/tests/unit/ai/providers/test_provider_lifecycle.py
+++ b/tests/unit/ai/providers/test_provider_lifecycle.py
@@ -297,3 +297,37 @@ async def test_sync_close_raises_inside_running_loop() -> None:
         provider.close()
 
     assert_that(str(excinfo.value)).contains("await aclose()")
+
+
+async def test_aclose_closes_client_on_live_foreign_loop() -> None:
+    """A client whose creating loop runs in another thread closes there.
+
+    Exercises the ``run_coroutine_threadsafe`` branch: the close coroutine
+    must execute on the foreign loop's thread, not the caller's.
+    """
+    import threading
+
+    foreign_loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=foreign_loop.run_forever, daemon=True)
+    thread.start()
+    try:
+
+        class _LoopRecordingClient:
+            def __init__(self) -> None:
+                self.closed_on: asyncio.AbstractEventLoop | None = None
+
+            async def close(self) -> None:
+                self.closed_on = asyncio.get_running_loop()
+
+        client = _LoopRecordingClient()
+        provider = _LifecycleProvider()
+        provider._superseded_clients = [(client, foreign_loop)]
+
+        await provider.aclose()
+
+        assert_that(client.closed_on).is_same_as(foreign_loop)
+        assert_that(provider._superseded_clients).is_empty()
+    finally:
+        foreign_loop.call_soon_threadsafe(foreign_loop.stop)
+        thread.join(timeout=5.0)
+        foreign_loop.close()

--- a/tests/unit/ai/providers/test_provider_lifecycle.py
+++ b/tests/unit/ai/providers/test_provider_lifecycle.py
@@ -1,0 +1,210 @@
+"""Tests for AI provider close/aclose lifecycle (#1885)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.json_response import CliSchemaRequest
+from lintro.ai.providers.base import AIResponse, BaseAIProvider
+
+
+class _FakeAsyncClient:
+    """Minimal stand-in for an async SDK client with ``close``."""
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.close_calls = 0
+
+    async def close(self) -> None:
+        """Mark the client closed."""
+        self.closed = True
+        self.close_calls += 1
+
+
+class _LifecycleProvider(BaseAIProvider):
+    """Concrete provider that returns a fake async SDK client."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            provider_name="lifecycle",
+            has_sdk=True,
+            sdk_package="lifecycle",
+            default_model="lifecycle-model",
+            default_api_key_env="LIFECYCLE_TEST_KEY",
+        )
+        self.created_clients: list[_FakeAsyncClient] = []
+
+    def _create_client(self, *, api_key: str) -> _FakeAsyncClient:
+        del api_key
+        client = _FakeAsyncClient()
+        self.created_clients.append(client)
+        return client
+
+    async def complete(
+        self,
+        prompt: str,
+        *,
+        system: str | None = None,
+        max_tokens: int = 1024,
+        timeout: float = 60.0,
+        repo_root: str | None = None,
+        use_one_shot: bool = False,
+        model: str | None = None,
+        cli_schema: CliSchemaRequest | None = None,
+    ) -> AIResponse:
+        """Return a canned response."""
+        del (
+            prompt,
+            system,
+            max_tokens,
+            timeout,
+            repo_root,
+            use_one_shot,
+            model,
+            cli_schema,
+        )
+        return AIResponse(content="ok", model="lifecycle-model")
+
+
+async def test_base_aclose_is_noop_without_client() -> None:
+    """Base aclose is safe when no client was ever created."""
+    provider = _LifecycleProvider()
+    await provider.aclose()
+    await provider.aclose()
+    assert_that(provider._client).is_none()
+    assert_that(provider._superseded_clients).is_empty()
+
+
+async def test_aclose_closes_current_sdk_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """aclose closes the active SDK client and clears the cache."""
+    monkeypatch.setenv("LIFECYCLE_TEST_KEY", "test-key")
+    provider = _LifecycleProvider()
+    client = provider._get_client()
+    assert_that(client.closed).is_false()
+
+    await provider.aclose()
+
+    assert_that(client.closed).is_true()
+    assert_that(provider._client).is_none()
+    assert_that(provider._client_loop).is_none()
+
+
+async def test_aclose_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Double aclose does not raise and closes the client once."""
+    monkeypatch.setenv("LIFECYCLE_TEST_KEY", "test-key")
+    provider = _LifecycleProvider()
+    client = provider._get_client()
+
+    await provider.aclose()
+    await provider.aclose()
+
+    assert_that(client.closed).is_true()
+    assert_that(client.close_calls).is_equal_to(1)
+
+
+async def test_stale_loop_rebuild_does_not_orphan_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A loop-stale rebuild retires the old client; aclose closes it."""
+    monkeypatch.setenv("LIFECYCLE_TEST_KEY", "test-key")
+    provider = _LifecycleProvider()
+
+    loop_a = object()
+    loop_b = object()
+    monkeypatch.setattr(
+        BaseAIProvider,
+        "_current_loop",
+        staticmethod(lambda: loop_a),  # type: ignore[arg-type,return-value]
+    )
+    first = provider._get_client()
+
+    monkeypatch.setattr(
+        BaseAIProvider,
+        "_current_loop",
+        staticmethod(lambda: loop_b),  # type: ignore[arg-type,return-value]
+    )
+    second = provider._get_client()
+
+    assert_that(first).is_not_equal_to(second)
+    assert_that(provider._superseded_clients).contains(first)
+    assert_that(first.closed).is_false()
+
+    await provider.aclose()
+
+    assert_that(first.closed).is_true()
+    assert_that(second.closed).is_true()
+    assert_that(provider._superseded_clients).is_empty()
+
+
+async def test_anthropic_aclose_closes_sdk_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AnthropicProvider.aclose closes the AsyncAnthropic-like client."""
+    pytest.importorskip("anthropic")
+    from lintro.ai.providers.anthropic import AnthropicProvider
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    provider = AnthropicProvider()
+    # ``spec`` keeps MagicMock from inventing an ``aclose`` attr that would
+    # shadow the real SDK's async ``close()``.
+    fake = MagicMock(spec=["close"])
+    fake.close = AsyncMock()
+    monkeypatch.setattr(provider, "_create_client", lambda *, api_key: fake)
+    assert_that(provider._get_client()).is_equal_to(fake)
+
+    await provider.aclose()
+    await provider.aclose()
+
+    fake.close.assert_awaited_once()
+    assert_that(provider._client).is_none()
+
+
+async def test_openai_aclose_closes_sdk_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAIProvider.aclose closes the AsyncOpenAI-like client."""
+    pytest.importorskip("openai")
+    from lintro.ai.providers.openai import OpenAIProvider
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    provider = OpenAIProvider()
+    fake = MagicMock(spec=["close"])
+    fake.close = AsyncMock()
+    monkeypatch.setattr(provider, "_create_client", lambda *, api_key: fake)
+    assert_that(provider._get_client()).is_equal_to(fake)
+
+    await provider.aclose()
+    await provider.aclose()
+
+    fake.close.assert_awaited_once()
+    assert_that(provider._client).is_none()
+
+
+async def test_cursor_aclose_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CursorProvider.aclose is a no-op (no poolable client)."""
+    import lintro.ai.providers.cursor as cursor_mod
+    from lintro.ai.providers.cursor import CursorProvider
+
+    monkeypatch.setattr(cursor_mod, "_find_agent", lambda: "/usr/bin/agent")
+    provider = CursorProvider()
+    await provider.aclose()
+    await provider.aclose()
+    assert_that(provider._client).is_none()
+
+
+def test_sync_close_wrapper(monkeypatch: pytest.MonkeyPatch) -> None:
+    """close() runs aclose() outside of an event loop."""
+    monkeypatch.setenv("LIFECYCLE_TEST_KEY", "test-key")
+    provider = _LifecycleProvider()
+    client = _FakeAsyncClient()
+    provider._client = client
+
+    provider.close()
+
+    assert_that(client.closed).is_true()
+    assert_that(provider._client).is_none()

--- a/tests/unit/ai/providers/test_provider_lifecycle.py
+++ b/tests/unit/ai/providers/test_provider_lifecycle.py
@@ -81,7 +81,7 @@ async def test_base_aclose_is_noop_without_client() -> None:
 async def test_aclose_closes_current_sdk_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """aclose closes the active SDK client and clears the cache."""
+    """Aclose closes the active SDK client and clears the cache."""
     monkeypatch.setenv("LIFECYCLE_TEST_KEY", "test-key")
     provider = _LifecycleProvider()
     client = provider._get_client()
@@ -119,14 +119,14 @@ async def test_stale_loop_rebuild_does_not_orphan_client(
     monkeypatch.setattr(
         BaseAIProvider,
         "_current_loop",
-        staticmethod(lambda: loop_a),  # type: ignore[arg-type,return-value]
+        staticmethod(lambda: loop_a),
     )
     first = provider._get_client()
 
     monkeypatch.setattr(
         BaseAIProvider,
         "_current_loop",
-        staticmethod(lambda: loop_b),  # type: ignore[arg-type,return-value]
+        staticmethod(lambda: loop_b),
     )
     second = provider._get_client()
 
@@ -208,3 +208,24 @@ def test_sync_close_wrapper(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert_that(client.closed).is_true()
     assert_that(provider._client).is_none()
+
+
+class _ExplodingClient:
+    """SDK-client stand-in whose ``close`` always raises."""
+
+    async def close(self) -> None:
+        """Raise to simulate a failing pool teardown."""
+        raise RuntimeError("pool teardown failed")
+
+
+async def test_aclose_survives_failing_client_and_closes_the_rest() -> None:
+    """One client's failing close must not orphan the remaining clients."""
+    provider = _LifecycleProvider()
+    survivor = _FakeAsyncClient()
+    provider._superseded_clients = [_ExplodingClient(), survivor]
+    provider._client = None
+
+    await provider.aclose()
+
+    assert_that(survivor.closed).is_true()
+    assert_that(provider._superseded_clients).is_empty()

--- a/tests/unit/ai/providers/test_provider_lifecycle.py
+++ b/tests/unit/ai/providers/test_provider_lifecycle.py
@@ -308,8 +308,17 @@ async def test_aclose_closes_client_on_live_foreign_loop() -> None:
     import threading
 
     foreign_loop = asyncio.new_event_loop()
-    thread = threading.Thread(target=foreign_loop.run_forever, daemon=True)
+    started = threading.Event()
+
+    def _run() -> None:
+        foreign_loop.call_soon(started.set)
+        foreign_loop.run_forever()
+
+    thread = threading.Thread(target=_run, daemon=True)
     thread.start()
+    # aclose() dispatches on is_running(); wait until the loop actually
+    # runs so the test cannot flake into the release branch.
+    assert_that(started.wait(timeout=5.0)).is_true()
     try:
 
         class _LoopRecordingClient:

--- a/tests/unit/ai/providers/test_provider_lifecycle.py
+++ b/tests/unit/ai/providers/test_provider_lifecycle.py
@@ -115,21 +115,26 @@ async def test_stale_loop_rebuild_does_not_orphan_client(
     monkeypatch.setenv("LIFECYCLE_TEST_KEY", "test-key")
     provider = _LifecycleProvider()
 
-    loop_a = object()
-    loop_b = object()
-    monkeypatch.setattr(
-        BaseAIProvider,
-        "_current_loop",
-        staticmethod(lambda: loop_a),
-    )
-    first = provider._get_client()
+    # Real loops so aclose() exercises the genuine dispatch (is_running / is
+    # current), not an AttributeError swallowed by best-effort teardown.
+    loop_a = asyncio.new_event_loop()
+    loop_b = asyncio.get_running_loop()
+    try:
+        monkeypatch.setattr(
+            BaseAIProvider,
+            "_current_loop",
+            staticmethod(lambda: loop_a),
+        )
+        first = provider._get_client()
 
-    monkeypatch.setattr(
-        BaseAIProvider,
-        "_current_loop",
-        staticmethod(lambda: loop_b),
-    )
-    second = provider._get_client()
+        monkeypatch.setattr(
+            BaseAIProvider,
+            "_current_loop",
+            staticmethod(lambda: loop_b),
+        )
+        second = provider._get_client()
+    finally:
+        loop_a.close()
 
     assert_that(first).is_not_equal_to(second)
     assert_that(
@@ -208,6 +213,9 @@ def test_sync_close_wrapper(monkeypatch: pytest.MonkeyPatch) -> None:
     provider = _LifecycleProvider()
     client = _FakeAsyncClient()
     provider._client = client
+    # No creating loop recorded: aclose treats the client as current-loop
+    # owned and awaits its close directly.
+    provider._client_loop = None
 
     provider.close()
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(ai): add close/aclose lifecycle to AI provider clients
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Provider-side `aclose()` / `close()` lifecycle (#1885) so long-lived processes (MCP server, future daemons, test suites) can release HTTP connection pools instead of relying on GC.

- `BaseAIProvider.aclose()` — closes the cached SDK client and any superseded loop-stale clients; idempotent; concrete no-op when no client exists.
- `close()` sync wrapper that refuses inside a running event loop.
- Stale-loop rebuild in `_get_client` retires the old client into `_superseded_clients` instead of orphaning its pool.
- Explicit overrides on Anthropic/OpenAI; Cursor inherits the no-op (no poolable client).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1885

## Details

Call-site wiring (who calls `aclose()`, exactly-once on failure/cancellation, the custom-agent `provider_cache`) is explicitly out of scope — it belongs to #1972 Phase 5 per the epic's design decision D. No `__aenter__`/`__aexit__` layer is added. Tests: `tests/unit/ai/providers/test_provider_lifecycle.py` (idempotency, stale-loop retirement, sync-wrapper guard).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added synchronous and asynchronous cleanup options for AI providers.
  * Provider connections now close reliably, including those replaced after event-loop changes.
  * Cleanup is safe to repeat and continues when individual connections encounter errors.
  * Shutdown behavior adapts to active event-loop conditions for improved reliability.

* **Tests**
  * Added coverage for cleanup, repeated closing, event-loop changes, error handling, and supported AI providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->