### PR TITLE
perf(ai): honor max_parallel_calls under cost caps (#1969)

### DIFF
--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -426,7 +426,7 @@ ai:
   # Honored even when max_cost_usd is set. (int 1–20, default: 5)
   max_parallel_calls: 5
 
-  # Hard ceiling on total spend per AI session, in USD; the run stops
+  # Spend ceiling per AI session, in USD; the run stops
   # scheduling new calls once spent+reserved reaches the cap. null disables
   # it. A cost cap does NOT force serial execution — chunk reviews still
   # fan out up to max_parallel_calls. Trade-off: calls already in flight
@@ -742,12 +742,12 @@ developer's login.
   binary's egress and version predictable under an egress allowlist.
 - **`ai.max_cost_usd` is API-path accounting.** Lintro prices the tokens it billed
   itself, so under the `cli` transport the cap is advisory — the call bills the
-  subscription, not a metered key. Setting a cap does **not** serialize provider
-  calls: review chunks still fan out up to `ai.max_parallel_calls`. In-flight
-  calls that started before the ceiling was hit still finish, so the session may
-  overshoot by up to (`max_parallel_calls` − 1) calls' cost. Review metadata
-  records per-phase timings (`context_collection`, `provider`, `parse_merge`)
-  so wall-clock regressions are visible in JSON / MCP output.
+  subscription (or, in bare mode with a reachable API key, that key — see the billing
+  note above). Setting a cap does **not** serialize provider calls: review chunks still
+  fan out up to `ai.max_parallel_calls`. In-flight calls that started before the ceiling
+  was hit still finish, so the session may overshoot by up to (`max_parallel_calls` − 1)
+  calls' cost. Review metadata records per-phase timings (`context_collection`,
+  `provider`, `parse_merge`) so wall-clock regressions are visible in JSON / MCP output.
 - **Two tiers of contract testing.** The flag-surface tier runs `--version` / `--help`
   only — no credential, no quota — on every PR. The real-invocation tier spends quota
   and runs weekly, gated behind the free tier.

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -745,7 +745,9 @@ developer's login.
   subscription, not a metered key. Setting a cap does **not** serialize provider
   calls: review chunks still fan out up to `ai.max_parallel_calls`. In-flight
   calls that started before the ceiling was hit still finish, so the session may
-  overshoot by up to (`max_parallel_calls` − 1) calls' cost.
+  overshoot by up to (`max_parallel_calls` − 1) calls' cost. Review metadata
+  records per-phase timings (`context_collection`, `provider`, `parse_merge`)
+  so wall-clock regressions are visible in JSON / MCP output.
 - **Two tiers of contract testing.** The flag-surface tier runs `--version` / `--help`
   only — no credential, no quota — on every PR. The real-invocation tier spends quota
   and runs weekly, gated behind the free tier.

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -422,11 +422,16 @@ ai:
   # suggestions returned. (int >= 1, default: 20)
   max_fix_attempts: 20
 
-  # Concurrent API calls during fix generation. (int 1–20, default: 5)
+  # Concurrent AI provider calls (fixes and review chunk fan-out).
+  # Honored even when max_cost_usd is set. (int 1–20, default: 5)
   max_parallel_calls: 5
 
   # Hard ceiling on total spend per AI session, in USD; the run stops
-  # requesting fixes once the estimate reaches the cap. null disables it.
+  # scheduling new calls once spent+reserved reaches the cap. null disables
+  # it. A cost cap does NOT force serial execution — chunk reviews still
+  # fan out up to max_parallel_calls. Trade-off: calls already in flight
+  # when the ceiling is hit still finish, so the final total may overshoot
+  # by up to (max_parallel_calls − 1) in-flight calls' cost.
   # (float >= 0 | null, default: null)
   max_cost_usd: null
 
@@ -737,7 +742,10 @@ developer's login.
   binary's egress and version predictable under an egress allowlist.
 - **`ai.max_cost_usd` is API-path accounting.** Lintro prices the tokens it billed
   itself, so under the `cli` transport the cap is advisory — the call bills the
-  subscription, not a metered key.
+  subscription, not a metered key. Setting a cap does **not** serialize provider
+  calls: review chunks still fan out up to `ai.max_parallel_calls`. In-flight
+  calls that started before the ceiling was hit still finish, so the session may
+  overshoot by up to (`max_parallel_calls` − 1) calls' cost.
 - **Two tiers of contract testing.** The flag-surface tier runs `--version` / `--help`
   only — no credential, no quota — on every PR. The real-invocation tier spends quota
   and runs weekly, gated behind the free tier.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2744,33 +2744,33 @@ ai:
 
 ### Full AI Config Reference
 
-| Setting                 | Type   | Default     | Description                                      |
-| ----------------------- | ------ | ----------- | ------------------------------------------------ |
-| `enabled`               | bool   | `false`     | Master switch; ANDs with `lint` / `review`       |
-| `lint`                  | bool   | `false`     | Enable AI lint summaries on `chk`/`fmt`          |
-| `review`                | bool   | `false`     | Enable the `lintro review` AI diff review        |
-| `provider`              | string | `anthropic` | AI provider (`anthropic` or `openai`)            |
-| `model`                 | string | (default)   | Model override                                   |
-| `api_key_env`           | string | (default)   | Custom env var for API key                       |
-| `default_fix`           | bool   | `false`     | Always run `--fix` in check                      |
-| `auto_apply`            | bool   | `false`     | Apply fixes without confirmation                 |
-| `auto_apply_safe_fixes` | bool   | `true`      | Auto-apply safe-style fixes in non-interactive   |
-| `max_tokens`            | int    | `4096`      | Max tokens per request                           |
-| `max_fix_attempts`      | int    | `20`        | Max issues to attempt fixing per run             |
+| Setting                 | Type   | Default     | Description                                                                 |
+| ----------------------- | ------ | ----------- | --------------------------------------------------------------------------- |
+| `enabled`               | bool   | `false`     | Master switch; ANDs with `lint` / `review`                                  |
+| `lint`                  | bool   | `false`     | Enable AI lint summaries on `chk`/`fmt`                                     |
+| `review`                | bool   | `false`     | Enable the `lintro review` AI diff review                                   |
+| `provider`              | string | `anthropic` | AI provider (`anthropic` or `openai`)                                       |
+| `model`                 | string | (default)   | Model override                                                              |
+| `api_key_env`           | string | (default)   | Custom env var for API key                                                  |
+| `default_fix`           | bool   | `false`     | Always run `--fix` in check                                                 |
+| `auto_apply`            | bool   | `false`     | Apply fixes without confirmation                                            |
+| `auto_apply_safe_fixes` | bool   | `true`      | Auto-apply safe-style fixes in non-interactive                              |
+| `max_tokens`            | int    | `4096`      | Max tokens per request                                                      |
+| `max_fix_attempts`      | int    | `20`        | Max issues to attempt fixing per run                                        |
 | `max_parallel_calls`    | int    | `5`         | Concurrent AI calls (1-20); honored with a cost cap; n−1 overshoot possible |
-| `max_retries`           | int    | `2`         | Max retries for transient errors (0-10)          |
-| `api_timeout`           | float  | `60.0`      | API request timeout in seconds                   |
-| `validate_after_group`  | bool   | `false`     | Validate immediately after each accepted group   |
-| `show_cost_estimate`    | bool   | `true`      | Show token/cost info in output                   |
-| `context_lines`         | int    | `15`        | Lines of context sent for fix generation (1-100) |
-| `fix_search_radius`     | int    | `5`         | Line search radius for fix application (1-50)    |
-| `checkpoint_retention`  | int    | `10`        | Git checkpoint refs kept (>=0; 0 = current only) |
-| `checkpoint_fmt`        | bool   | `false`     | Git checkpoint before `lintro format` mutations  |
-| `retry_base_delay`      | float  | `1.0`       | Initial retry delay in seconds (min 0.1)         |
-| `retry_max_delay`       | float  | `30.0`      | Maximum retry delay in seconds (min 1.0)         |
-| `retry_backoff_factor`  | float  | `2.0`       | Retry delay multiplier (min 1.0)                 |
-| `transcript_logging`    | bool   | `false`     | Opt-in NDJSON logging of AI provider traffic     |
-| `transcript_retention`  | int    | `10`        | Max transcript files kept under `.lintro-cache`  |
+| `max_retries`           | int    | `2`         | Max retries for transient errors (0-10)                                     |
+| `api_timeout`           | float  | `60.0`      | API request timeout in seconds                                              |
+| `validate_after_group`  | bool   | `false`     | Validate immediately after each accepted group                              |
+| `show_cost_estimate`    | bool   | `true`      | Show token/cost info in output                                              |
+| `context_lines`         | int    | `15`        | Lines of context sent for fix generation (1-100)                            |
+| `fix_search_radius`     | int    | `5`         | Line search radius for fix application (1-50)                               |
+| `checkpoint_retention`  | int    | `10`        | Git checkpoint refs kept (>=0; 0 = current only)                            |
+| `checkpoint_fmt`        | bool   | `false`     | Git checkpoint before `lintro format` mutations                             |
+| `retry_base_delay`      | float  | `1.0`       | Initial retry delay in seconds (min 0.1)                                    |
+| `retry_max_delay`       | float  | `30.0`      | Maximum retry delay in seconds (min 1.0)                                    |
+| `retry_backoff_factor`  | float  | `2.0`       | Retry delay multiplier (min 1.0)                                            |
+| `transcript_logging`    | bool   | `false`     | Opt-in NDJSON logging of AI provider traffic                                |
+| `transcript_retention`  | int    | `10`        | Max transcript files kept under `.lintro-cache`                             |
 
 ### Idiom Review Tool (`idiom-review`)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2757,7 +2757,7 @@ ai:
 | `auto_apply_safe_fixes` | bool   | `true`      | Auto-apply safe-style fixes in non-interactive   |
 | `max_tokens`            | int    | `4096`      | Max tokens per request                           |
 | `max_fix_attempts`      | int    | `20`        | Max issues to attempt fixing per run             |
-| `max_parallel_calls`    | int    | `5`         | Concurrent API calls (1-20)                      |
+| `max_parallel_calls`    | int    | `5`         | Concurrent AI calls (1-20); honored with a cost cap; n−1 overshoot possible |
 | `max_retries`           | int    | `2`         | Max retries for transient errors (0-10)          |
 | `api_timeout`           | float  | `60.0`      | API request timeout in seconds                   |
 | `validate_after_group`  | bool   | `false`     | Validate immediately after each accepted group   |

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -133,7 +133,17 @@ class AIConfig(BaseModel):
         description="Maximum number of issues to attempt fixing per run. "
         "Counts API calls made, not suggestions returned.",
     )
-    max_parallel_calls: int = Field(default=5, ge=1, le=20)
+    max_parallel_calls: int = Field(
+        default=5,
+        ge=1,
+        le=20,
+        description=(
+            "Concurrent AI provider calls for fixes and review chunk fan-out. "
+            "Honored even when max_cost_usd is set. With n concurrent calls and "
+            "no per-call reserve estimate, a session may overshoot max_cost_usd "
+            "by up to n − 1 in-flight calls' cost."
+        ),
+    )
     max_retries: int = Field(default=2, ge=0, le=10)
     api_timeout: float = Field(default=60.0, ge=1.0)
     validate_after_group: bool = False
@@ -198,7 +208,10 @@ class AIConfig(BaseModel):
         default=None,
         ge=0,
         description=(
-            "Maximum total cost in USD per AI session." " None disables the limit."
+            "Maximum total cost in USD per AI session. None disables the limit. "
+            "A cost cap does not serialize provider calls: under "
+            "max_parallel_calls=n concurrent workers the final total may "
+            "exceed this ceiling by up to n − 1 in-flight calls' cost."
         ),
     )
     max_prompt_tokens: int = Field(

--- a/lintro/ai/review/models/review_metadata.py
+++ b/lintro/ai/review/models/review_metadata.py
@@ -37,6 +37,10 @@ class ReviewMetadata:
         stopped_reason (str): Human-readable reason a partial review stopped
             (e.g. "cost cap"). Empty for a complete review.
         duration_seconds (float): Wall-clock duration of the review run.
+        phase_timings (dict[str, float]): Per-phase wall-clock seconds for
+            regression visibility. Keys include ``context_collection``,
+            ``provider`` (chunk + custom-agent provider calls), and
+            ``parse_merge``.
         custom_agents_run (int): Number of user-defined review agents that
             completed a pass in this run (issue #1245).
         custom_agents_skipped (int): Number of discovered agents that did not
@@ -67,6 +71,7 @@ class ReviewMetadata:
     chunks_reviewed: int = 0
     stopped_reason: str = ""
     duration_seconds: float = 0.0
+    phase_timings: dict[str, float] = field(default_factory=dict)
     custom_agents_run: int = 0
     custom_agents_skipped: int = 0
     reviewed_paths: tuple[str, ...] = field(default_factory=tuple)

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -1686,6 +1686,16 @@ async def _generate_extra_checklist(
     lines: list[str] = []
     next_id = next_generated_checklist_id
     for item in questions:
+        # The prompt asks for 5-10 questions, but the count is model-controlled.
+        # Parallel chunks get disjoint id ranges of _GENERATED_CHECKLIST_ID_STRIDE,
+        # so accepting more than the stride would collide with the next chunk's
+        # range and corrupt merge_checklist_answers.
+        if next_id - next_generated_checklist_id >= _GENERATED_CHECKLIST_ID_STRIDE:
+            logger.warning(
+                "Generated checklist overflow: keeping the first "
+                f"{_GENERATED_CHECKLIST_ID_STRIDE} of {len(questions)} questions",
+            )
+            break
         if not isinstance(item, dict):
             continue
         question = item.get("question")

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -358,8 +358,7 @@ async def _review_all_chunks(
             The chunk index paired with its partial or the exception raised.
         """
         chunk_checklist_id = (
-            next_generated_checklist_id
-            + chunk_index * _GENERATED_CHECKLIST_ID_STRIDE
+            next_generated_checklist_id + chunk_index * _GENERATED_CHECKLIST_ID_STRIDE
         )
         async with semaphore:
             try:
@@ -654,6 +653,7 @@ async def run_review_async(
             depth=depth,
             checklist_items=checklist_items,
             context_window_override=context_window_override,
+            context_collection_seconds=context_collection_seconds,
         )
 
     context_window = get_context_window(
@@ -1988,6 +1988,7 @@ def _empty_review_result(
     depth: int,
     checklist_items: list[ChecklistItem],
     context_window_override: int | None,
+    context_collection_seconds: float = 0.0,
 ) -> ReviewResult:
     """Return an empty result when no changes are present."""
     context_window = get_context_window(
@@ -2009,6 +2010,11 @@ def _empty_review_result(
         base_ref=context.base_ref,
         head_ref=context.head_ref,
         timestamp=datetime.now(tz=UTC).isoformat(),
+        phase_timings={
+            "context_collection": max(context_collection_seconds, 0.0),
+            "provider": 0.0,
+            "parse_merge": 0.0,
+        },
     )
     return ReviewResult(
         metadata=metadata,

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -119,6 +119,9 @@ __all__ = [
     "strip_json_fences",
 ]
 _PROMPT_OVERHEAD_TOKENS = 12_000
+# Depth ≥ 2 generates 5–10 checklist questions per chunk. Parallel chunks get
+# disjoint id ranges so merge_checklist_answers does not collide across chunks.
+_GENERATED_CHECKLIST_ID_STRIDE = 32
 
 
 def _aborted_before_completion(
@@ -289,7 +292,7 @@ async def _review_all_chunks(
     diff_budget: int,
     completed_sink: list[_ChunkReviewPartial] | None = None,
 ) -> list[_ChunkReviewPartial]:
-    """Review all chunks sequentially or in parallel.
+    """Review all chunks with bounded concurrency.
 
     When ``completed_sink`` is provided, each successfully reviewed chunk's
     partial is appended to it as soon as it completes. This lets the caller
@@ -298,8 +301,10 @@ async def _review_all_chunks(
     all completed work.
 
     Chunks are reviewed concurrently under a semaphore capped by
-    ``max_parallel_calls``; a ``ReviewExecutionError`` or a cost-cap stop
-    cancels the remaining work and propagates to ``run_review_async``.
+    ``max_parallel_calls`` whether or not a cost cap is set (depth 1–3). A
+    ``ReviewExecutionError`` or a cost-cap stop cancels the remaining work and
+    propagates to ``run_review_async``. Depth ≥ 2 assigns each chunk a disjoint
+    generated-checklist id range so merge stays deterministic under fan-out.
     """
     if len(chunks) <= 1:
         single = await _review_chunk_with_progress(
@@ -326,70 +331,14 @@ async def _review_all_chunks(
             completed_sink.append(single)
         return [single]
 
-    if depth >= 2:
-        sequential_partials: list[_ChunkReviewPartial] = []
-        next_id = next_generated_checklist_id
-        for chunk_index, chunk in enumerate(chunks):
-            budget.check()
-            progress.on_chunk_start(
-                chunk_index=chunk_index,
-                files=list(chunk.files),
-            )
-            try:
-                partial, next_id = await _review_chunk(
-                    chunk=chunk,
-                    context=context,
-                    provider=provider,
-                    ai_config=ai_config,
-                    depth=depth,
-                    checklist_text=checklist_text,
-                    checklist_count=len(checklist_items),
-                    next_generated_checklist_id=next_id,
-                    classifications=classifications,
-                    lint_results=lint_results,
-                    budget=budget,
-                    progress=progress,
-                    chunk_index=chunk_index,
-                    repo_root=repo_root,
-                    use_one_shot=use_one_shot,
-                    strictness_section=strictness_section,
-                    diff_budget=diff_budget,
-                )
-            except Exception as exc:
-                # A cost-cap stop is an expected graceful halt, not a chunk
-                # failure: re-raise it raw (no error-level "aborted" log, no
-                # on_error) so run_review can finalize a partial cleanly.
-                if _is_cost_cap_stop(exc=exc):
-                    raise
-                progress.on_error(
-                    chunk_index=chunk_index,
-                    total_chunks=len(chunks),
-                    step="reviewing",
-                    completed_chunks=chunk_index,
-                    error=exc,
-                )
-                raise _aborted_before_completion(
-                    cause=exc,
-                    provider=provider,
-                    chunk_index=chunk_index,
-                    total_chunks=len(chunks),
-                    step="reviewing",
-                    completed_chunks=chunk_index,
-                ) from exc
-            sequential_partials.append(partial)
-            if completed_sink is not None:
-                completed_sink.append(partial)
-            progress.on_chunk_done(chunk_index=chunk_index)
-        return sequential_partials
-
     partials: list[_ChunkReviewPartial | None] = [None] * len(chunks)
-    effective_parallel = 1 if budget.max_cost_usd is not None else max_parallel_calls
-    max_workers = min(len(chunks), effective_parallel)
+    max_workers = min(len(chunks), max_parallel_calls)
     first_error: ReviewExecutionError | None = None
 
-    # Bounded concurrency on the caller's event loop replaces the former thread
-    # pool: chunk reviews are provider I/O, so tasks under a semaphore keep the
-    # same ``max_parallel_calls`` ceiling without threads.
+    # Bounded concurrency on the caller's event loop: chunk reviews are provider
+    # I/O, so tasks under a semaphore keep the ``max_parallel_calls`` ceiling
+    # without threads. A cost cap does not force serial execution; see
+    # ``CostBudget.execute`` for the accepted n−1-call overshoot bound.
     semaphore = asyncio.Semaphore(max_workers)
 
     async def _run_chunk(
@@ -408,6 +357,10 @@ async def _review_all_chunks(
         Returns:
             The chunk index paired with its partial or the exception raised.
         """
+        chunk_checklist_id = (
+            next_generated_checklist_id
+            + chunk_index * _GENERATED_CHECKLIST_ID_STRIDE
+        )
         async with semaphore:
             try:
                 return chunk_index, await _review_chunk_with_progress(
@@ -427,6 +380,7 @@ async def _review_all_chunks(
                     repo_root=repo_root,
                     use_one_shot=use_one_shot,
                     strictness_section=strictness_section,
+                    next_generated_checklist_id=chunk_checklist_id,
                     diff_budget=diff_budget,
                 )
             except Exception as exc:
@@ -472,6 +426,7 @@ async def _review_all_chunks(
     if first_error is not None:
         raise first_error
 
+    # Index-keyed merge keeps completion order from scrambling chunk order.
     return [partial for partial in partials if partial is not None]
 
 
@@ -567,6 +522,7 @@ def run_review(
     custom_agents: tuple[CustomAgentSpec, ...] = (),
     run_builtin_checklist: bool = True,
     workspace_root: Path | None = None,
+    context_collection_seconds: float = 0.0,
 ) -> ReviewResult:
     """Execute an AI diff review from synchronous code.
 
@@ -594,6 +550,8 @@ def run_review(
             and run only the custom agents (``review.custom_agents: only``).
         workspace_root: Optional workspace root used to build providers for
             agents that declare a ``model`` override.
+        context_collection_seconds: Wall-clock seconds the caller spent in
+            ``collect_review_context`` (recorded in ``phase_timings``).
 
     Returns:
         Complete review result with metadata, checklist, and findings.
@@ -616,6 +574,7 @@ def run_review(
             custom_agents=custom_agents,
             run_builtin_checklist=run_builtin_checklist,
             workspace_root=workspace_root,
+            context_collection_seconds=context_collection_seconds,
         ),
     )
 
@@ -638,6 +597,7 @@ async def run_review_async(
     custom_agents: tuple[CustomAgentSpec, ...] = (),
     run_builtin_checklist: bool = True,
     workspace_root: Path | None = None,
+    context_collection_seconds: float = 0.0,
 ) -> ReviewResult:
     """Execute an AI diff review with depth-controlled passes.
 
@@ -662,6 +622,8 @@ async def run_review_async(
             and run only the custom agents (``review.custom_agents: only``).
         workspace_root: Optional workspace root used to build providers for
             agents that declare a ``model`` override.
+        context_collection_seconds: Wall-clock seconds the caller spent in
+            ``collect_review_context`` (recorded in ``phase_timings``).
 
     Returns:
         Complete review result with metadata, checklist, and findings.
@@ -759,6 +721,9 @@ async def run_review_async(
     filtered_findings: tuple[ReviewFinding, ...] = ()
     custom_findings: tuple[ReviewFinding, ...] = ()
     started_at = time.monotonic()
+    provider_started = started_at
+    provider_seconds = 0.0
+    parse_merge_seconds = 0.0
     try:
         # Open the session inside the try so a failure before or during
         # on_start() still reaches the finally that tears it down.
@@ -766,6 +731,7 @@ async def run_review_async(
             provider.begin_durable_session(repo_root=repo_root)
             durable_session_started = True
         tracker.on_start(total_chunks=len(chunks), depth=depth)
+        provider_started = time.monotonic()
         if chunks:
             partials = await _review_all_chunks(
                 chunks=chunks,
@@ -803,6 +769,8 @@ async def run_review_async(
             on_pass_complete=custom_results.append,
             on_agent_failed=custom_agents_failed.append,
         )
+        provider_seconds = time.monotonic() - provider_started
+        merge_started = time.monotonic()
         merged, filtered_findings, total_findings = _finalize_partials(
             partials=partials,
             policy=review_sensitivity,
@@ -817,6 +785,7 @@ async def run_review_async(
         )
         filtered_findings = filtered_findings + custom_findings
         total_findings = len(filtered_findings)
+        parse_merge_seconds = time.monotonic() - merge_started
         completed = True
     except (AIError, ReviewExecutionError) as exc:
         # A graceful partial review: the cost cap was reached mid-run. Keep the
@@ -830,10 +799,13 @@ async def run_review_async(
         # empty-but-actionable rather than a generic abort.
         if not _is_cost_cap_stop(exc=exc):
             raise
+        if provider_seconds <= 0.0:
+            provider_seconds = time.monotonic() - provider_started
         cap = budget.max_cost_usd
         partials = list(collected)
         partial = True
         stopped_reason = _cost_cap_reason(cap=cap)
+        merge_started = time.monotonic()
         merged, filtered_findings, total_findings = _finalize_partials(
             partials=partials,
             policy=review_sensitivity,
@@ -843,6 +815,7 @@ async def run_review_async(
         )
         filtered_findings = filtered_findings + custom_findings
         total_findings = len(filtered_findings)
+        parse_merge_seconds = time.monotonic() - merge_started
         completed = True
         logger.warning(
             "Review stopped early — {reason} after reviewing {n} of {m} "
@@ -862,6 +835,11 @@ async def run_review_async(
                 tracker.on_abort()
 
     duration_seconds = time.monotonic() - started_at
+    phase_timings = {
+        "context_collection": max(context_collection_seconds, 0.0),
+        "provider": max(provider_seconds, 0.0),
+        "parse_merge": max(parse_merge_seconds, 0.0),
+    }
 
     total_input = sum(item.input_tokens for item in partials) + sum(
         result.input_tokens for result in custom_results
@@ -924,6 +902,7 @@ async def run_review_async(
         chunks_reviewed=chunks_reviewed,
         stopped_reason=stopped_reason,
         duration_seconds=duration_seconds,
+        phase_timings=phase_timings,
         custom_agents_run=len(custom_results),
         custom_agents_skipped=(
             len(agent_selection.skipped) + len(custom_agents_failed)

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -313,6 +314,7 @@ def review_command(
     paths = list(path_filter) if path_filter else None
     context_pr = resolved_pr if post else pr
     context_repo = effective_repo if context_pr is not None else None
+    context_started = time.monotonic()
     try:
         context = collect_review_context(
             base=base,
@@ -324,6 +326,7 @@ def review_command(
         )
     except ReviewContextError as exc:
         raise click.ClickException(str(exc)) from exc
+    context_collection_seconds = time.monotonic() - context_started
 
     classifications = classify_changed_files(context.changed_files)
     checklist_items = get_all_checklist_items(config=lintro_config)
@@ -408,6 +411,7 @@ def review_command(
             custom_agents=custom_agents,
             run_builtin_checklist=custom_agent_mode != CustomAgentMode.ONLY,
             workspace_root=workspace_root,
+            context_collection_seconds=context_collection_seconds,
         )
     except (AIError, ValueError) as exc:
         if post and resolved_pr is not None and effective_repo:

--- a/lintro/mcp/toolkits/review.py
+++ b/lintro/mcp/toolkits/review.py
@@ -455,6 +455,7 @@ def _run_metadata(*, metadata: ReviewMetadata) -> dict[str, Any]:
         "strictness": metadata.strictness,
         "cost_usd": metadata.cost_estimate_usd,
         "duration_seconds": metadata.duration_seconds,
+        "phase_timings": dict(metadata.phase_timings),
         "chunks": {
             "total": metadata.chunks_total,
             "reviewed": metadata.chunks_reviewed,

--- a/lintro/mcp/toolkits/review.py
+++ b/lintro/mcp/toolkits/review.py
@@ -534,6 +534,7 @@ def _no_changes_payload(
     depth: int,
     strictness: str,
     budget: _BudgetPolicy,
+    context_collection_seconds: float = 0.0,
 ) -> dict[str, Any]:
     """Build the result for a diff with nothing in it.
 
@@ -546,6 +547,8 @@ def _no_changes_payload(
         depth: The depth the call asked for.
         strictness: The strictness the call asked for.
         budget: The ceiling the call would have run under.
+        context_collection_seconds: Wall-clock seconds spent collecting the
+            (empty) context, preserved in the payload's timings.
 
     Returns:
         dict[str, Any]: A zero-cost, zero-finding review result.
@@ -564,6 +567,12 @@ def _no_changes_payload(
         files_total=0,
         checklist_items=0,
         strictness=strictness,
+        duration_seconds=max(context_collection_seconds, 0.0),
+        phase_timings={
+            "context_collection": max(context_collection_seconds, 0.0),
+            "provider": 0.0,
+            "parse_merge": 0.0,
+        },
     )
     result = ReviewResult(metadata=metadata, summary="No changes to review.")
     return {
@@ -651,6 +660,7 @@ def _execute_review(*, arguments: dict[str, Any], workspace: Path) -> dict[str, 
             depth=depth,
             strictness=strictness.value,
             budget=budget,
+            context_collection_seconds=context_collection_seconds,
         )
 
     classifications = classify_changed_files(context.changed_files)

--- a/lintro/mcp/toolkits/review.py
+++ b/lintro/mcp/toolkits/review.py
@@ -37,6 +37,7 @@ and callers should expect a single long-running call.
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -640,7 +641,9 @@ def _execute_review(*, arguments: dict[str, Any], workspace: Path) -> dict[str, 
         ).lower(),
     )
 
+    context_started = time.monotonic()
     context = _collect_context(arguments=arguments, workspace=workspace)
+    context_collection_seconds = time.monotonic() - context_started
     if context is None:
         return _no_changes_payload(
             ai_config=ai_config,
@@ -686,6 +689,7 @@ def _execute_review(*, arguments: dict[str, Any], workspace: Path) -> dict[str, 
             ),
             force_semantic_chunking=lintro_config.review.force_semantic_chunking,
             workspace_root=workspace,
+            context_collection_seconds=context_collection_seconds,
         )
     except (AIError, ValueError) as exc:
         failure = _review_failure(provider_name=str(provider.name), error=exc)

--- a/tests/unit/ai/review/test_architecture_characterization.py
+++ b/tests/unit/ai/review/test_architecture_characterization.py
@@ -65,6 +65,7 @@ _MCP_RUN_METADATA_KEYS: frozenset[str] = frozenset(
         "strictness",
         "cost_usd",
         "duration_seconds",
+        "phase_timings",
         "chunks",
         "files",
         "token_usage",

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -1466,3 +1466,62 @@ def test_run_review_records_files_no_custom_agent_covered() -> None:
     assert_that(result.metadata.skipped_files[0].reason).is_equal_to(
         FileSkipReason.AGENT_SCOPE,
     )
+
+
+async def test_generated_checklist_ids_capped_at_stride() -> None:
+    """Model-controlled question counts cannot cross the per-chunk id stride.
+
+    Parallel chunks get disjoint id ranges of ``_GENERATED_CHECKLIST_ID_STRIDE``;
+    accepting more generated questions than the stride would collide with the
+    next chunk's range and corrupt the checklist merge (#1969).
+    """
+    from lintro.ai.budget import CostBudget
+    from lintro.ai.review.orchestrator import (
+        _GENERATED_CHECKLIST_ID_STRIDE,
+        _generate_extra_checklist,
+    )
+
+    oversized = [
+        {"id": f"G{i}", "question": f"Question {i}?"}
+        for i in range(_GENERATED_CHECKLIST_ID_STRIDE + 10)
+    ]
+    payload = json.dumps({"generated_questions": oversized})
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(path="a.py", status="modified", additions=1, deletions=0),
+        ],
+        unified_diff="diff --git a/a.py b/a.py\n+x",
+        pr_metadata=None,
+    )
+    chunk = ReviewChunk(
+        id=1,
+        files=["a.py"],
+        diff="+x",
+        relationship=REL_SINGLE_FILE,
+    )
+    response = AIResponse(
+        content=payload,
+        model="m",
+        input_tokens=1,
+        output_tokens=1,
+        cost_estimate=0.0,
+        provider="anthropic",
+    )
+
+    with patch(
+        "lintro.ai.review.orchestrator.call_ai",
+        return_value=response,
+    ):
+        text, next_id, _usage = await _generate_extra_checklist(
+            chunk=chunk,
+            context=context,
+            provider=_mock_provider(content=payload),
+            ai_config=AIConfig(),
+            budget=CostBudget(max_cost_usd=None),
+            next_generated_checklist_id=100,
+        )
+
+    assert_that(next_id).is_equal_to(100 + _GENERATED_CHECKLIST_ID_STRIDE)
+    assert_that(text.splitlines()).is_length(_GENERATED_CHECKLIST_ID_STRIDE)

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -123,10 +123,12 @@ def test_run_review_marks_cli_transport_tokens_estimated() -> None:
 
     with patch(
         "lintro.ai.review.orchestrator.call_ai",
-        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: provider.complete(
-            user_prompt,
-            system=system_prompt,
-            max_tokens=kwargs.get("max_tokens", 1024),
+        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: (
+            provider.complete(
+                user_prompt,
+                system=system_prompt,
+                max_tokens=kwargs.get("max_tokens", 1024),
+            )
         ),
     ):
         result = run_review(
@@ -197,6 +199,9 @@ def test_run_review_returns_partial_on_cost_cap() -> None:
                 enabled=True,
                 transport=AITransport.API,
                 max_cost_usd=0.01,
+                # Keep this mid-run stop deterministic under the patched
+                # recorder; parallel > 1 accepts n−1 overshoot (#1969).
+                max_parallel_calls=1,
             ),
             depth=1,
             checklist_items=[],
@@ -347,10 +352,12 @@ def test_run_review_depth1_returns_review_result() -> None:
 
     with patch(
         "lintro.ai.review.orchestrator.call_ai",
-        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: provider.complete(
-            user_prompt,
-            system=system_prompt,
-            max_tokens=kwargs.get("max_tokens", 1024),
+        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: (
+            provider.complete(
+                user_prompt,
+                system=system_prompt,
+                max_tokens=kwargs.get("max_tokens", 1024),
+            )
         ),
     ):
         result = run_review(
@@ -433,10 +440,12 @@ def test_run_review_depth2_calls_provider_twice() -> None:
 
     with patch(
         "lintro.ai.review.orchestrator.call_ai",
-        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: provider.complete(
-            user_prompt,
-            system=system_prompt,
-            max_tokens=kwargs.get("max_tokens", 1024),
+        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: (
+            provider.complete(
+                user_prompt,
+                system=system_prompt,
+                max_tokens=kwargs.get("max_tokens", 1024),
+            )
         ),
     ):
         result = run_review(
@@ -1353,9 +1362,11 @@ def _run_single_chunk_review(provider: MagicMock) -> None:
     """
     with patch(
         "lintro.ai.review.orchestrator.call_ai",
-        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: provider.complete(
-            user_prompt,
-            system=system_prompt,
+        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: (
+            provider.complete(
+                user_prompt,
+                system=system_prompt,
+            )
         ),
     ):
         run_review(
@@ -1399,10 +1410,12 @@ def test_run_review_metadata_records_reviewed_and_skipped_files() -> None:
 
     with patch(
         "lintro.ai.review.orchestrator.call_ai",
-        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: provider.complete(
-            user_prompt,
-            system=system_prompt,
-            max_tokens=kwargs.get("max_tokens", 1024),
+        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: (
+            provider.complete(
+                user_prompt,
+                system=system_prompt,
+                max_tokens=kwargs.get("max_tokens", 1024),
+            )
         ),
     ):
         result = run_review(
@@ -1430,10 +1443,12 @@ def test_run_review_records_files_no_custom_agent_covered() -> None:
 
     with patch(
         "lintro.ai.review.orchestrator.call_ai",
-        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: provider.complete(
-            user_prompt,
-            system=system_prompt,
-            max_tokens=kwargs.get("max_tokens", 1024),
+        side_effect=lambda *, provider, user_prompt, system_prompt=None, **kwargs: (
+            provider.complete(
+                user_prompt,
+                system=system_prompt,
+                max_tokens=kwargs.get("max_tokens", 1024),
+            )
         ),
     ):
         result = run_review(

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -710,6 +710,7 @@ def test_run_review_parallelizes_multiple_chunks(tmp_path: Path) -> None:
         )
 
     assert_that(max_active).is_greater_than(1)
+    assert_that(max_active).is_less_than_or_equal_to(4)
     assert_that(provider.complete.call_count).is_equal_to(4)
 
 

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -704,6 +704,393 @@ def test_run_review_parallelizes_multiple_chunks(tmp_path: Path) -> None:
     assert_that(provider.complete.call_count).is_equal_to(4)
 
 
+def _multi_chunk_context(*, tmp_path: Path, count: int = 4) -> ReviewContext:
+    """Build a multi-file review context for fan-out tests.
+
+    Args:
+        tmp_path: Temporary repository root.
+        count: Number of changed files / chunks to synthesize.
+
+    Returns:
+        A ``ReviewContext`` with ``count`` modified files.
+    """
+    return ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(
+                path=f"src/file{index}.py",
+                status="modified",
+                additions=1,
+                deletions=0,
+            )
+            for index in range(count)
+        ],
+        unified_diff="diff",
+        pr_metadata=None,
+        repo_root=str(tmp_path),
+    )
+
+
+def _multi_chunks(*, count: int = 4) -> list[ReviewChunk]:
+    """Build ``count`` single-file review chunks.
+
+    Args:
+        count: Number of chunks.
+
+    Returns:
+        Ordered list of single-file chunks.
+    """
+    return [
+        ReviewChunk(
+            id=index + 1,
+            files=[f"src/file{index}.py"],
+            diff=f"+line{index}",
+            relationship="single-file",
+        )
+        for index in range(count)
+    ]
+
+
+def test_run_review_parallelizes_with_cost_cap(tmp_path: Path) -> None:
+    """A cost cap must not force serial chunk reviews (issue #1969)."""
+    context = _multi_chunk_context(tmp_path=tmp_path, count=4)
+    chunks = _multi_chunks(count=4)
+    provider = _mock_provider(content=_sample_response_json(include_finding=False))
+    active = 0
+    max_active = 0
+
+    async def _track_concurrency(
+        *,
+        provider: MagicMock,
+        budget: CostBudget | None = None,
+        **kwargs: object,
+    ) -> AIResponse:
+        """Overlap chunk reviews and charge a tiny cost against the budget.
+
+        Args:
+            provider: Mock provider returning the canned response.
+            budget: Session cost budget; recorded when present.
+            **kwargs: Ignored call arguments.
+
+        Returns:
+            The provider's canned response.
+        """
+        del kwargs
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.05)
+        active -= 1
+        response: AIResponse = provider.complete("prompt")
+        if budget is not None:
+            budget.record(0.001)
+        return response
+
+    with (
+        patch(
+            "lintro.ai.review.orchestrator.resolve_review_chunks",
+            return_value=chunks,
+        ),
+        patch(
+            "lintro.ai.review.orchestrator.call_ai",
+            side_effect=_track_concurrency,
+        ),
+    ):
+        result = run_review(
+            context,
+            provider=provider,
+            ai_config=AIConfig(
+                enabled=True,
+                transport=AITransport.API,
+                max_parallel_calls=4,
+                max_cost_usd=1.0,
+            ),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+        )
+
+    assert_that(max_active).is_greater_than(1)
+    assert_that(result.metadata.partial).is_false()
+    assert_that(result.metadata.chunks_reviewed).is_equal_to(4)
+
+
+def test_run_review_parallelizes_depth_two_chunks(tmp_path: Path) -> None:
+    """Depth ≥ 2 chunk refinement fans out under max_parallel_calls."""
+    context = _multi_chunk_context(tmp_path=tmp_path, count=4)
+    chunks = _multi_chunks(count=4)
+    provider = _mock_provider(content=_sample_response_json(include_finding=False))
+    active = 0
+    max_active = 0
+
+    async def _track_concurrency(
+        *,
+        provider: MagicMock,
+        **kwargs: object,
+    ) -> AIResponse:
+        """Track overlapping depth-2 provider calls across chunks.
+
+        Args:
+            provider: Mock provider returning the canned response.
+            **kwargs: Ignored call arguments.
+
+        Returns:
+            The provider's canned response.
+        """
+        del kwargs
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.05)
+        active -= 1
+        response: AIResponse = provider.complete("prompt")
+        return response
+
+    with (
+        patch(
+            "lintro.ai.review.orchestrator.resolve_review_chunks",
+            return_value=chunks,
+        ),
+        patch(
+            "lintro.ai.review.orchestrator.call_ai",
+            side_effect=_track_concurrency,
+        ),
+    ):
+        result = run_review(
+            context,
+            provider=provider,
+            ai_config=AIConfig(
+                enabled=True,
+                transport=AITransport.API,
+                max_parallel_calls=4,
+                max_cost_usd=5.0,
+            ),
+            depth=2,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+        )
+
+    assert_that(max_active).is_greater_than(1)
+    assert_that(result.metadata.chunks_reviewed).is_equal_to(4)
+
+
+def test_run_review_merges_chunks_in_index_order(tmp_path: Path) -> None:
+    """Findings merge in chunk-index order even when slow chunks finish last."""
+    context = _multi_chunk_context(tmp_path=tmp_path, count=3)
+    chunks = _multi_chunks(count=3)
+
+    async def _slow_first_chunk(
+        *,
+        provider: MagicMock,
+        user_prompt: str,
+        **kwargs: object,
+    ) -> AIResponse:
+        """Delay the first chunk so later chunks complete first.
+
+        Args:
+            provider: Unused mock provider.
+            user_prompt: Prompt text used to identify the chunk.
+            **kwargs: Ignored call arguments.
+
+        Returns:
+            A review payload whose finding file matches the chunk.
+        """
+        del provider, kwargs
+        if "+line0" in user_prompt:
+            await asyncio.sleep(0.08)
+            path = "src/file0.py"
+        elif "+line1" in user_prompt:
+            path = "src/file1.py"
+        else:
+            path = "src/file2.py"
+        payload = {
+            "summary": f"Summary for {path}",
+            "checklist": [],
+            "findings": [
+                {
+                    "severity": "P2",
+                    "category": "logic",
+                    "file": path,
+                    "line": 1,
+                    "title": f"Issue in {path}",
+                    "description": "x",
+                    "cause": "y",
+                    "fix": "z",
+                    "failure_scenario": "w",
+                    "confidence": "high",
+                    "checklist_ids": [],
+                },
+            ],
+        }
+        return AIResponse(
+            content=json.dumps(payload),
+            model="auto",
+            input_tokens=10,
+            output_tokens=10,
+            cost_estimate=0.0,
+            provider="anthropic",
+        )
+
+    with (
+        patch(
+            "lintro.ai.review.orchestrator.resolve_review_chunks",
+            return_value=chunks,
+        ),
+        patch(
+            "lintro.ai.review.orchestrator.call_ai",
+            side_effect=_slow_first_chunk,
+        ),
+    ):
+        result = run_review(
+            context,
+            provider=_mock_provider(content=_sample_response_json()),
+            ai_config=AIConfig(
+                enabled=True,
+                transport=AITransport.API,
+                max_parallel_calls=3,
+                max_cost_usd=1.0,
+            ),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+        )
+
+    finding_files = [finding.file for finding in result.findings]
+    assert_that(finding_files).is_equal_to(
+        ["src/file0.py", "src/file1.py", "src/file2.py"],
+    )
+
+
+def test_run_review_records_phase_timings(tmp_path: Path) -> None:
+    """Review metadata includes context_collection/provider/parse_merge timings."""
+    context = _multi_chunk_context(tmp_path=tmp_path, count=2)
+    chunks = _multi_chunks(count=2)
+    provider = _mock_provider(content=_sample_response_json(include_finding=False))
+
+    async def _fast_call(
+        *,
+        provider: MagicMock,
+        **kwargs: object,
+    ) -> AIResponse:
+        """Return the canned provider response without sleeping.
+
+        Args:
+            provider: Mock provider under test.
+            **kwargs: Ignored call arguments.
+
+        Returns:
+            The provider's canned response.
+        """
+        del kwargs
+        response: AIResponse = provider.complete("prompt")
+        return response
+
+    with (
+        patch(
+            "lintro.ai.review.orchestrator.resolve_review_chunks",
+            return_value=chunks,
+        ),
+        patch(
+            "lintro.ai.review.orchestrator.call_ai",
+            side_effect=_fast_call,
+        ),
+    ):
+        result = run_review(
+            context,
+            provider=provider,
+            ai_config=AIConfig(enabled=True, transport=AITransport.API),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+            context_collection_seconds=0.123,
+        )
+
+    timings = result.metadata.phase_timings
+    assert_that(timings).contains_key("context_collection")
+    assert_that(timings).contains_key("provider")
+    assert_that(timings).contains_key("parse_merge")
+    assert_that(timings["context_collection"]).is_close_to(0.123, 0.001)
+    assert_that(timings["provider"]).is_greater_than_or_equal_to(0.0)
+    assert_that(timings["parse_merge"]).is_greater_than_or_equal_to(0.0)
+    assert_that(result.metadata.duration_seconds).is_greater_than_or_equal_to(0.0)
+
+
+def test_run_review_budget_cutoff_keeps_completed_under_parallelism(
+    tmp_path: Path,
+) -> None:
+    """Mid-flight cost-cap stops scheduling; completed chunks survive merge."""
+    context = _multi_chunk_context(tmp_path=tmp_path, count=4)
+    chunks = _multi_chunks(count=4)
+    call_count = 0
+
+    async def _expensive_call(
+        *,
+        provider: MagicMock,
+        budget: CostBudget | None = None,
+        **kwargs: object,
+    ) -> AIResponse:
+        """Charge enough that later chunks trip the cost cap.
+
+        Args:
+            provider: Unused mock provider.
+            budget: Session cost budget charged per call.
+            **kwargs: Ignored call arguments.
+
+        Returns:
+            A finding-free review payload.
+        """
+        del provider, kwargs
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.01)
+        if budget is not None:
+            budget.record(0.4)
+        return AIResponse(
+            content=_sample_response_json(include_finding=False),
+            model="auto",
+            input_tokens=10,
+            output_tokens=10,
+            cost_estimate=0.4,
+            provider="anthropic",
+        )
+
+    with (
+        patch(
+            "lintro.ai.review.orchestrator.resolve_review_chunks",
+            return_value=chunks,
+        ),
+        patch(
+            "lintro.ai.review.orchestrator.call_ai",
+            side_effect=_expensive_call,
+        ),
+    ):
+        result = run_review(
+            context,
+            provider=_mock_provider(content=_sample_response_json()),
+            ai_config=AIConfig(
+                enabled=True,
+                transport=AITransport.API,
+                max_parallel_calls=2,
+                max_cost_usd=0.5,
+            ),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+        )
+
+    assert_that(result.metadata.partial).is_true()
+    assert_that(result.metadata.chunks_reviewed).is_greater_than(0)
+    assert_that(result.metadata.chunks_reviewed).is_less_than(4)
+    assert_that(result.metadata.stopped_reason).contains("cost cap")
+    assert_that(call_count).is_less_than(4)
+
+
 def test_run_review_aborts_progress_when_chunk_review_fails() -> None:
     """Progress tracker receives on_abort when a chunk review raises."""
     context = ReviewContext(

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -884,6 +884,7 @@ def test_run_review_parallelizes_depth_two_chunks(tmp_path: Path) -> None:
         )
 
     assert_that(max_active).is_greater_than(1)
+    assert_that(max_active).is_less_than_or_equal_to(4)
     assert_that(result.metadata.chunks_reviewed).is_equal_to(4)
 
 

--- a/tests/unit/mcp/test_toolkit_review.py
+++ b/tests/unit/mcp/test_toolkit_review.py
@@ -179,6 +179,11 @@ def _metadata(
         chunks_reviewed=chunks_reviewed,
         stopped_reason=stopped_reason,
         duration_seconds=12.5,
+        phase_timings={
+            "context_collection": 0.1,
+            "provider": 12.0,
+            "parse_merge": 0.4,
+        },
     )
 
 
@@ -429,6 +434,13 @@ def test_review_returns_findings_and_run_metadata(
     assert_that(run["model"]).is_equal_to("test-model")
     assert_that(run["cost_usd"]).is_equal_to(0.25)
     assert_that(run["duration_seconds"]).is_equal_to(12.5)
+    assert_that(run["phase_timings"]).is_equal_to(
+        {
+            "context_collection": 0.1,
+            "provider": 12.0,
+            "parse_merge": 0.4,
+        },
+    )
     assert_that(run["chunks"]).is_equal_to({"total": 2, "reviewed": 1})
     assert_that(run["partial"]).is_false()
     assert_that(payload["budget"]["exceeded"]).is_false()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  perf(ai): honor max_parallel_calls under cost caps
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Removes the orchestrator gate that forced fully serial chunk reviews whenever `max_cost_usd` was set — which is always, in CI — causing the 17-minute reviews measured in #1962 (#1969).

- Delete `effective_parallel = 1 if budget.max_cost_usd is not None …`; chunk fan-out honors `max_parallel_calls` with or without a cap.
- Unify depth ≥ 2 into the same bounded fan-out with disjoint generated-checklist id ranges (stride 32) for deterministic merges.
- Add `phase_timings` (`context_collection`, `provider`, `parse_merge`) to review metadata.
- Document the accepted n−1-in-flight-call cost overshoot on `max_parallel_calls`, `max_cost_usd`, and in `docs/ai-features.md`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1969

## Details

The overshoot decision is the owner's (2026-08-08, recorded on #1969): with CI's cap and ≤5 workers the worst case is small and the wall-clock win dominates. Cost-cap stops still finalize a graceful partial via the completed-partials sink. Tests cover cap+parallel, depth-2 fan-out, merge order, and phase timings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review metadata now includes timing information for context collection, provider execution, and result processing.
  * Reviews support bounded parallel processing across all review depths, with results merged consistently.
  * Partial results are preserved when cost limits or review failures interrupt processing.
  * Generated checklist items maintain unique identifiers across parallel review chunks.

* **Documentation**
  * Clarified how concurrency and cost limits interact, including possible overshoot from in-flight requests.
  * Documented the new review timing metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->