### PR TITLE
fix(ai): harden CLI transport for large diffs (#1967)

### DIFF
--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -439,6 +439,23 @@ ai:
   # see "Data & Privacy". (int >= 1000, default: 12000)
   max_prompt_tokens: 12000
 
+  # ── CLI-transport review limits (#1967) ───────────────────────
+  # Per-chunk diff token budget under --transport cli; forces the semantic
+  # chunker to split diffs a single CLI turn cannot finish.
+  # (int >= 1000, default: 24000)
+  cli_max_diff_tokens: 24000
+
+  # Hard ceiling on the full unified-diff byte size under --transport cli;
+  # larger diffs fail fast with a --paths / --transport api advisory.
+  # (int >= 10000, default: 1500000)
+  cli_max_diff_bytes: 1500000
+
+  # Max findings one CLI review call may emit, so a response cannot hit the
+  # 32k output-token cap mid-JSON; overflow is summarized, and a chunk that
+  # still exhausts output retries once with a tighter cap.
+  # (int 1–50, default: 12)
+  cli_max_findings_per_call: 12
+
   # Re-prompt to refine a fix that failed verification. (int 0–3, default: 1)
   max_refinement_attempts: 1
 

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -450,9 +450,11 @@ ai:
   # (int >= 10000, default: 1500000)
   cli_max_diff_bytes: 1500000
 
-  # Max findings one CLI review call may emit, so a response cannot hit the
-  # 32k output-token cap mid-JSON; overflow is summarized, and a chunk that
-  # still exhausts output retries once with a tighter cap.
+  # Max findings one CLI review call may emit. The cap is a prompt contract
+  # (the model is instructed to stop at the cap and summarize overflow), not
+  # a post-parse truncation; a chunk that still exhausts the 32k output cap
+  # retries once with a tighter cap, and truncated responses fall back to
+  # the schema-retry / unstructured-recovery ladder.
   # (int 1–50, default: 12)
   cli_max_findings_per_call: 12
 

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -293,6 +293,36 @@ class AIConfig(BaseModel):
             "delegated git retrieval on very large diffs is required."
         ),
     )
+    cli_max_diff_tokens: int = Field(
+        default=24_000,
+        ge=1_000,
+        description=(
+            "Per-chunk diff token budget under --transport cli. The "
+            "context-window budget alone is far too large for a single CLI "
+            "call (timeout / 32k output-token exhaustion on ~1.5k-line PRs); "
+            "this ceiling forces the semantic chunker to split large diffs."
+        ),
+    )
+    cli_max_diff_bytes: int = Field(
+        default=1_500_000,
+        ge=10_000,
+        description=(
+            "Hard ceiling on the full unified-diff byte size under "
+            "--transport cli. Diffs above this fail with an actionable "
+            "advisory to use --paths filtering or --transport api instead of "
+            "spawning an unbounded number of CLI chunks."
+        ),
+    )
+    cli_max_findings_per_call: int = Field(
+        default=12,
+        ge=1,
+        le=50,
+        description=(
+            "Maximum findings a single CLI review call may emit. Bounds the "
+            "JSON response so the model cannot hit the ~32k output-token cap "
+            "mid-object; overflow is summarized rather than truncated."
+        ),
+    )
     transcript_logging: bool = Field(
         default=False,
         description=(
@@ -463,6 +493,9 @@ class AIConfig(BaseModel):
             cache_max_entries=self.cache_max_entries,
             context_lines=self.context_lines,
             fix_search_radius=self.fix_search_radius,
+            cli_max_diff_tokens=self.cli_max_diff_tokens,
+            cli_max_diff_bytes=self.cli_max_diff_bytes,
+            cli_max_findings_per_call=self.cli_max_findings_per_call,
         )
 
     @property

--- a/lintro/ai/config_views.py
+++ b/lintro/ai/config_views.py
@@ -53,6 +53,9 @@ class AIBudgetConfig:
     cache_max_entries: int
     context_lines: int
     fix_search_radius: int
+    cli_max_diff_tokens: int
+    cli_max_diff_bytes: int
+    cli_max_findings_per_call: int
 
 
 @dataclass(frozen=True)

--- a/lintro/ai/prompts/review.py
+++ b/lintro/ai/prompts/review.py
@@ -175,7 +175,42 @@ def format_lint_results_section(*, digest: str | None) -> str:
     return f"<lint_results>\n{digest.strip()}\n</lint_results>"
 
 
-def format_output_rules(*, checklist_count: int) -> str:
+def _findings_cap_rule(*, max_findings: int | None) -> str:
+    """Render the findings-cap bullet for the output rules block.
+
+    Args:
+        max_findings: Optional per-call findings ceiling. ``None`` means no
+            hard cap (API transport).
+
+    Returns:
+        Markdown bullet(s) covering the findings cap and de-duplication rule.
+    """
+    if max_findings is None:
+        cap_line = (
+            "- There is no hard cap on findings, but **do not report the same "
+            "problem twice**."
+        )
+    else:
+        cap_line = (
+            f"- Cap `findings` at **{max_findings}** for this call (questions "
+            "still capped at 3). Prefer the highest-severity issues; summarize "
+            "any overflow in one walkthrough bullet. Never emit truncated or "
+            "mid-object JSON.\n"
+            "- **Do not report the same problem twice**."
+        )
+    return (
+        f"{cap_line} When one problem repeats across locations, report it once "
+        "and list every location in `occurrences` as `file`/`line` pairs — "
+        "including the primary one. It renders as a single collapsed thread, "
+        "and its fix prompt enumerates every location."
+    )
+
+
+def format_output_rules(
+    *,
+    checklist_count: int,
+    max_findings: int | None = None,
+) -> str:
     """Render the shared output rules block for a review prompt.
 
     Both the diff-embedded and git-native review prompts require the exact
@@ -184,6 +219,7 @@ def format_output_rules(*, checklist_count: int) -> str:
 
     Args:
         checklist_count: Number of checklist items the model must answer.
+        max_findings: Optional per-call findings ceiling (CLI transport).
 
     Returns:
         The rendered rules block.
@@ -194,4 +230,5 @@ def format_output_rules(*, checklist_count: int) -> str:
         label_changes_requested=VERDICT_LABELS[ReviewVerdict.CHANGES_REQUESTED],
         label_nits_only=VERDICT_LABELS[ReviewVerdict.NITS_ONLY],
         label_ready=VERDICT_LABELS[ReviewVerdict.READY],
+        findings_cap_rule=_findings_cap_rule(max_findings=max_findings),
     ).strip()

--- a/lintro/ai/prompts/templates/review/output_rules.md
+++ b/lintro/ai/prompts/templates/review/output_rules.md
@@ -51,7 +51,4 @@
   written out verbatim — a described fix is better than a wrong one-click commit. Keep
   `replacement` to at most 4,000 characters and the range to at most 200 lines; anything
   larger is dropped and rendered as a described fix anyway.
-- There is no cap on findings, but **do not report the same problem twice**. When one
-  problem repeats across locations, report it once and list every location in
-  `occurrences` as `file`/`line` pairs — including the primary one. It renders as a
-  single collapsed thread, and its fix prompt enumerates every location.
+{findings_cap_rule}

--- a/lintro/ai/providers/anthropic.py
+++ b/lintro/ai/providers/anthropic.py
@@ -379,11 +379,13 @@ class AnthropicProvider(BaseAIProvider):
         # sent when the binary can reach an API key. Forcing it locked every
         # subscription-authenticated user out of this transport (#1838).
         bare = should_send_bare(configured=self._cli_bare, cwd=working_dir)
+        # Prompt rides on stdin (#1967): a single argv element on Linux is
+        # capped at MAX_ARG_STRLEN (128 KiB), so large review diffs must not
+        # be passed as the ``-p``/``--print`` value.
         cmd = [
             self._cli._binary_path,
             *(("--bare",) if bare else ()),
-            "-p",
-            prompt,
+            "--print",
             "--output-format",
             "json",
             "--permission-mode",
@@ -423,6 +425,7 @@ class AnthropicProvider(BaseAIProvider):
         result = await self._cli.run_guarded(
             cmd,
             optional_args=optional_args,
+            input_text=prompt,
             timeout=timeout,
             cwd=working_dir,
         )

--- a/lintro/ai/providers/cli_transport.py
+++ b/lintro/ai/providers/cli_transport.py
@@ -679,9 +679,13 @@ class CliTransport(ABC):
                 # a leftover oversized argv element (or a huge env) can still
                 # raise E2BIG / "Argument list too long". Map it to a provider
                 # error instead of leaking a raw OSError to callers.
-                if exc.errno == errno.E2BIG or "argument list too long" in str(
-                    exc,
-                ).lower():
+                if (
+                    exc.errno == errno.E2BIG
+                    or "argument list too long"
+                    in str(
+                        exc,
+                    ).lower()
+                ):
                     raise AIProviderError(
                         f"{self._binary_name} CLI could not spawn because the "
                         "argument list is too long (E2BIG). Large prompts must "

--- a/lintro/ai/providers/cli_transport.py
+++ b/lintro/ai/providers/cli_transport.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import json
 import os
 import re
@@ -672,6 +673,23 @@ class CliTransport(ABC):
             except FileNotFoundError as exc:
                 raise AINotAvailableError(
                     f"{self._binary_name} CLI not found on PATH. {self._install_hint}",
+                ) from exc
+            except OSError as exc:
+                # Defense in depth for #1967: even after stdin prompt delivery,
+                # a leftover oversized argv element (or a huge env) can still
+                # raise E2BIG / "Argument list too long". Map it to a provider
+                # error instead of leaking a raw OSError to callers.
+                if exc.errno == errno.E2BIG or "argument list too long" in str(
+                    exc,
+                ).lower():
+                    raise AIProviderError(
+                        f"{self._binary_name} CLI could not spawn because the "
+                        "argument list is too long (E2BIG). Large prompts must "
+                        "be delivered via stdin, not argv. Narrow with --paths "
+                        "or use --transport api when available.",
+                    ) from exc
+                raise AIProviderError(
+                    f"{self._binary_name} CLI failed to start: {exc}",
                 ) from exc
 
             payload = input_text.encode() if input_text is not None else None

--- a/lintro/ai/providers/openai.py
+++ b/lintro/ai/providers/openai.py
@@ -358,8 +358,10 @@ class OpenAIProvider(BaseAIProvider):
             )
 
         optional_args = await self._cli.apply_optional_args(cmd, candidates)
-        # The prompt is a trailing positional, so it must follow every flag.
-        cmd.append(prompt)
+        # Prompt rides on stdin (#1967): a trailing positional would be a
+        # single argv element and hits Linux MAX_ARG_STRLEN (128 KiB) on large
+        # review diffs. The ``-`` sentinel forces stdin-as-prompt.
+        cmd.append("-")
 
         logger.debug(
             f"Codex CLI request: model={effective_model}, prompt_len={len(prompt)}",
@@ -368,6 +370,7 @@ class OpenAIProvider(BaseAIProvider):
         result = await self._cli.run_guarded(
             cmd,
             optional_args=optional_args,
+            input_text=prompt,
             timeout=timeout,
             cwd=repo_root or os.getcwd(),
         )

--- a/lintro/ai/review/cli_limits.py
+++ b/lintro/ai/review/cli_limits.py
@@ -1,0 +1,206 @@
+"""CLI-transport size limits for large-diff review (#1967).
+
+Context-window token budgets alone are transport-blind: a 1.5k-line PR still
+fits a 200k-token window as one chunk, but the CLI path then hits wall-clock
+timeouts and the 32k output-token cap. These helpers apply a tighter,
+transport-aware ceiling keyed off measured diff size so the existing chunker
+actually splits large CLI reviews.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from lintro.ai.exceptions import AIProviderError
+from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
+from lintro.ai.review.exceptions import ReviewContextError
+from lintro.ai.token_budget import estimate_tokens
+
+if TYPE_CHECKING:
+    from lintro.ai.review.models.review_context import ReviewContext
+
+__all__ = [
+    "CLI_DIFF_HARD_CEILING_BYTES",
+    "CLI_FINDINGS_RETRY_CAP",
+    "CLI_MAX_FINDINGS_PER_CALL",
+    "CLI_TRANSPORT_DIFF_TOKEN_BUDGET",
+    "DiffSize",
+    "assert_cli_diff_within_ceiling",
+    "is_output_exhaustion_error",
+    "measure_diff_size",
+    "resolve_cli_diff_budget",
+    "resolve_cli_findings_cap",
+    "tighter_findings_cap",
+]
+
+#: Soft per-chunk budget for CLI transport (~96 KiB of diff text).
+CLI_TRANSPORT_DIFF_TOKEN_BUDGET = 24_000
+
+#: Absolute ceiling on the full unified-diff UTF-8 byte size for CLI reviews.
+CLI_DIFF_HARD_CEILING_BYTES = 1_500_000
+
+#: Prompt-contract cap so one CLI call cannot exhaust the 32k output budget.
+CLI_MAX_FINDINGS_PER_CALL = 12
+
+#: Tighter findings cap used when retrying a chunk after output exhaustion.
+CLI_FINDINGS_RETRY_CAP = 6
+
+
+@dataclass(frozen=True, slots=True)
+class DiffSize:
+    """Measured size of a unified diff before a CLI spawn.
+
+    Attributes:
+        lines: Newline count (plus one when the text has no trailing newline).
+        bytes: UTF-8 byte length.
+        tokens: Estimated tokens via the shared 4-chars-per-token heuristic.
+    """
+
+    lines: int
+    bytes: int
+    tokens: int
+
+
+def measure_diff_size(*, unified_diff: str) -> DiffSize:
+    """Measure effective diff size for transport-aware routing decisions.
+
+    Args:
+        unified_diff: Unified diff text (possibly empty).
+
+    Returns:
+        Line, byte, and estimated-token counts.
+    """
+    if not unified_diff:
+        return DiffSize(lines=0, bytes=0, tokens=0)
+    lines = unified_diff.count("\n")
+    if not unified_diff.endswith("\n"):
+        lines += 1
+    return DiffSize(
+        lines=lines,
+        bytes=len(unified_diff.encode("utf-8")),
+        tokens=estimate_tokens(unified_diff),
+    )
+
+
+def assert_cli_diff_within_ceiling(
+    *,
+    context: ReviewContext,
+    cli_max_diff_bytes: int,
+) -> None:
+    """Refuse a CLI review when the full diff exceeds the hard byte ceiling.
+
+    Args:
+        context: Collected review context whose unified diff is measured.
+        cli_max_diff_bytes: Absolute UTF-8 byte ceiling from AI config.
+
+    Raises:
+        ReviewContextError: When the diff is too large for a healthy CLI run.
+    """
+    size = measure_diff_size(unified_diff=context.unified_diff)
+    if size.bytes <= cli_max_diff_bytes:
+        return
+    raise ReviewContextError(
+        "Diff is too large for CLI-transport review "
+        f"({size.bytes:,} bytes > {cli_max_diff_bytes:,} byte ceiling). "
+        "Narrow with --paths, or re-run with --transport api when an API key "
+        "is available.",
+        code=ReviewContextErrorCode.DIFF_TOO_LARGE,
+    )
+
+
+def resolve_cli_diff_budget(
+    *,
+    context_window_budget: int,
+    cli_max_diff_tokens: int,
+) -> int:
+    """Return the per-chunk token budget for CLI transport.
+
+    Takes the minimum of the model context-window remainder and the CLI soft
+    ceiling so large PRs route through the semantic chunker instead of one shot.
+
+    Args:
+        context_window_budget: Tokens left for diff content after prompt overhead.
+        cli_max_diff_tokens: Configurable CLI soft ceiling.
+
+    Returns:
+        Positive per-chunk token budget.
+    """
+    return max(min(context_window_budget, cli_max_diff_tokens), 1)
+
+
+def resolve_cli_findings_cap(
+    *,
+    transport_is_cli: bool,
+    cli_max_findings_per_call: int,
+) -> int | None:
+    """Return the per-call findings ceiling for CLI transport, else None.
+
+    Args:
+        transport_is_cli: Whether the active transport is CLI.
+        cli_max_findings_per_call: Configured findings ceiling.
+
+    Returns:
+        Findings cap for CLI, or ``None`` for other transports.
+    """
+    if not transport_is_cli:
+        return None
+    return max(cli_max_findings_per_call, 1)
+
+
+def tighter_findings_cap(*, current: int) -> int:
+    """Halve a findings cap for retry after output-token exhaustion.
+
+    Args:
+        current: Current per-call findings ceiling.
+
+    Returns:
+        A strictly smaller positive ceiling (at least 1), preferring the
+        dedicated retry constant when the current cap is still above it.
+    """
+    if current > CLI_FINDINGS_RETRY_CAP:
+        return CLI_FINDINGS_RETRY_CAP
+    return max(current // 2, 1)
+
+
+def is_output_exhaustion_error(message: str) -> bool:
+    """Return True when *message* looks like a mid-JSON 32k output failure.
+
+    Args:
+        message: Exception message from a CLI provider call.
+
+    Returns:
+        True when the message matches known output-cap exhaustion signatures.
+    """
+    text = message.lower()
+    needles = (
+        "output token",
+        "output_tokens",
+        "max output",
+        "maximum output",
+        "max_tokens",
+        "token limit",
+        "length limit",
+        "response truncated",
+        "hit the token limit",
+        "exceeded the maximum number of tokens",
+        "finish_reason",
+        'stop_reason": "length',
+        'stop_reason": "max_tokens',
+        "is_error",
+    )
+    return any(needle in text for needle in needles)
+
+
+def is_cli_output_exhaustion(error: BaseException) -> bool:
+    """Return True when *error* looks like CLI output-token exhaustion.
+
+    Args:
+        error: Exception raised by a CLI provider call.
+
+    Returns:
+        True when the error is an ``AIProviderError`` with a matching message.
+    """
+    if not isinstance(error, AIProviderError):
+        return False
+    return is_output_exhaustion_error(str(error))

--- a/lintro/ai/review/cli_limits.py
+++ b/lintro/ai/review/cli_limits.py
@@ -186,6 +186,10 @@ def is_output_exhaustion_error(message: str) -> bool:
     # ``finish_reason`` — matching those would classify *any* provider error
     # (auth, timeout, 4xx) as output exhaustion and trigger the tighter-cap
     # retry on errors that a smaller response cannot fix.
+    # Output-specific phrasings only: "exceeded the maximum number of
+    # tokens" also matches INPUT context-window violations, and "response
+    # truncated" matches generic proxy/stream errors — both would trigger a
+    # tighter-cap retry that cannot help (#1967 review).
     needles = (
         'stop_reason":"max_tokens',
         'stop_reason":"length',
@@ -193,9 +197,8 @@ def is_output_exhaustion_error(message: str) -> bool:
         "max output tokens",
         "maximum output tokens",
         "output token limit",
-        "response truncated",
         "hit the token limit",
-        "exceeded the maximum number of tokens",
+        "maximum number of output tokens",
     )
     return any(needle in text for needle in needles)
 

--- a/lintro/ai/review/cli_limits.py
+++ b/lintro/ai/review/cli_limits.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from lintro.ai.config import AIConfig
 from lintro.ai.exceptions import AIProviderError
 from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
 from lintro.ai.review.exceptions import ReviewContextError
@@ -34,14 +35,19 @@ __all__ = [
     "tighter_findings_cap",
 ]
 
-#: Soft per-chunk budget for CLI transport (~96 KiB of diff text).
-CLI_TRANSPORT_DIFF_TOKEN_BUDGET = 24_000
-
-#: Absolute ceiling on the full unified-diff UTF-8 byte size for CLI reviews.
-CLI_DIFF_HARD_CEILING_BYTES = 1_500_000
-
-#: Prompt-contract cap so one CLI call cannot exhaust the 32k output budget.
-CLI_MAX_FINDINGS_PER_CALL = 12
+# Single source of truth for the CLI limit defaults is the AIConfig model
+# (cli_max_diff_tokens / cli_max_diff_bytes / cli_max_findings_per_call);
+# these module aliases exist for callers and tests that want the defaults
+# without building a config instance.
+CLI_TRANSPORT_DIFF_TOKEN_BUDGET = int(
+    AIConfig.model_fields["cli_max_diff_tokens"].default,
+)
+CLI_DIFF_HARD_CEILING_BYTES = int(
+    AIConfig.model_fields["cli_max_diff_bytes"].default,
+)
+CLI_MAX_FINDINGS_PER_CALL = int(
+    AIConfig.model_fields["cli_max_findings_per_call"].default,
+)
 
 #: Tighter findings cap used when retrying a chunk after output exhaustion.
 CLI_FINDINGS_RETRY_CAP = 6
@@ -172,22 +178,23 @@ def is_output_exhaustion_error(message: str) -> bool:
     Returns:
         True when the message matches known output-cap exhaustion signatures.
     """
-    text = message.lower()
+    # Normalize JSON spacing so needle matching is layout-independent.
+    text = message.lower().replace('": "', '":"')
+    # Restrictive on purpose: every Claude CLI failure envelope contains
+    # generic tokens like ``is_error``, ``output_tokens`` (usage block), and
+    # ``finish_reason`` — matching those would classify *any* provider error
+    # (auth, timeout, 4xx) as output exhaustion and trigger the tighter-cap
+    # retry on errors that a smaller response cannot fix.
     needles = (
-        "output token",
-        "output_tokens",
-        "max output",
-        "maximum output",
-        "max_tokens",
-        "token limit",
-        "length limit",
+        'stop_reason":"max_tokens',
+        'stop_reason":"length',
+        'finish_reason":"length',
+        "max output tokens",
+        "maximum output tokens",
+        "output token limit",
         "response truncated",
         "hit the token limit",
         "exceeded the maximum number of tokens",
-        "finish_reason",
-        'stop_reason": "length',
-        'stop_reason": "max_tokens',
-        "is_error",
     )
     return any(needle in text for needle in needles)
 

--- a/lintro/ai/review/cli_limits.py
+++ b/lintro/ai/review/cli_limits.py
@@ -197,7 +197,6 @@ def is_output_exhaustion_error(message: str) -> bool:
         "max output tokens",
         "maximum output tokens",
         "output token limit",
-        "hit the token limit",
         "maximum number of output tokens",
     )
     return any(needle in text for needle in needles)

--- a/lintro/ai/review/cli_limits.py
+++ b/lintro/ai/review/cli_limits.py
@@ -28,6 +28,7 @@ __all__ = [
     "CLI_TRANSPORT_DIFF_TOKEN_BUDGET",
     "DiffSize",
     "assert_cli_diff_within_ceiling",
+    "is_cli_output_exhaustion",
     "is_output_exhaustion_error",
     "measure_diff_size",
     "resolve_cli_diff_budget",

--- a/lintro/ai/review/enums/review_context_error_code.py
+++ b/lintro/ai/review/enums/review_context_error_code.py
@@ -25,3 +25,4 @@ class ReviewContextErrorCode(StrEnum):
     INVALID_CHUNK_BUDGET = "invalid-chunk-budget"
     INVALID_REVIEW_MODE = "invalid-review-mode"
     BASH_UNAVAILABLE = "bash-unavailable"
+    DIFF_TOO_LARGE = "diff-too-large"

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -46,7 +46,7 @@ from lintro.ai.raw_response import persist_raw_response
 from lintro.ai.review.chunker import chunk_review_context
 from lintro.ai.review.cli_limits import (
     assert_cli_diff_within_ceiling,
-    is_output_exhaustion_error,
+    is_cli_output_exhaustion,
     resolve_cli_diff_budget,
     resolve_cli_findings_cap,
     tighter_findings_cap,
@@ -1556,6 +1556,7 @@ async def _invoke_chunk_review(
     """
     use_git_native = ai_config.transport == AITransport.CLI
     findings_cap = max_findings
+    allow_output_retry = findings_cap is not None and findings_cap > 1
     started = time.monotonic()
     while True:
         if use_git_native:
@@ -1602,9 +1603,9 @@ async def _invoke_chunk_review(
             raise
         except AIError as exc:
             if (
-                findings_cap is not None
-                and findings_cap > 1
-                and is_output_exhaustion_error(str(exc))
+                allow_output_retry
+                and findings_cap is not None
+                and is_cli_output_exhaustion(exc)
             ):
                 next_cap = tighter_findings_cap(current=findings_cap)
                 if next_cap < findings_cap:
@@ -1613,6 +1614,7 @@ async def _invoke_chunk_review(
                         f"chunk with findings cap {findings_cap} → {next_cap}.",
                     )
                     findings_cap = next_cap
+                    allow_output_retry = False
                     continue
             raise
         return response, time.monotonic() - started

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -1553,6 +1553,11 @@ async def _invoke_chunk_review(
     Returns:
         The provider response and wall-clock seconds spent on the successful
         (or final) call attempt.
+
+    Raises:
+        AICostBudgetExceededError: When the session cost ceiling is hit.
+        AIError: When the provider call fails for a non-retryable reason, or
+            when an output-exhaustion retry still fails.
     """
     use_git_native = ai_config.transport == AITransport.CLI
     findings_cap = max_findings

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -1620,6 +1620,10 @@ async def _invoke_chunk_review(
                     )
                     findings_cap = next_cap
                     allow_output_retry = False
+                    # Each attempt gets its own schema-retry window: charging
+                    # the retry with the first attempt's elapsed time starves
+                    # the recovery the retry exists to provide.
+                    started = time.monotonic()
                     continue
             raise
         return response, time.monotonic() - started

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -17,7 +17,10 @@ from loguru import logger
 from lintro.ai.budget import CostBudget
 from lintro.ai.cli_schemas import cli_schema_for_review
 from lintro.ai.enums import AITransport
-from lintro.ai.exceptions import AICostBudgetExceededError, AIError
+from lintro.ai.exceptions import (
+    AICostBudgetExceededError,
+    AIError,
+)
 from lintro.ai.invoke import call_ai
 from lintro.ai.json_response import parse_review_response_payload, strip_json_fences
 from lintro.ai.model_pricing import (
@@ -41,6 +44,13 @@ from lintro.ai.prompts.review import (
 )
 from lintro.ai.raw_response import persist_raw_response
 from lintro.ai.review.chunker import chunk_review_context
+from lintro.ai.review.cli_limits import (
+    assert_cli_diff_within_ceiling,
+    is_output_exhaustion_error,
+    resolve_cli_diff_budget,
+    resolve_cli_findings_cap,
+    tighter_findings_cap,
+)
 from lintro.ai.review.custom_agent_runner import (
     CustomAgentPassResult,
     run_custom_agent_passes,
@@ -671,6 +681,18 @@ async def run_review_async(
         context_window=context_window,
         prompt_overhead=prompt_overhead,
     )
+    if ai_config.transport == AITransport.CLI:
+        # Context-window budgets are transport-blind and leave ~1.5k-line PRs
+        # as a single CLI chunk (#1967). Tighten before the chunker runs, and
+        # refuse outright when the full diff exceeds the hard ceiling.
+        assert_cli_diff_within_ceiling(
+            context=context,
+            cli_max_diff_bytes=ai_config.cli_max_diff_bytes,
+        )
+        diff_budget = resolve_cli_diff_budget(
+            context_window_budget=diff_budget,
+            cli_max_diff_tokens=ai_config.cli_max_diff_tokens,
+        )
     chunk_skips: list[SkippedFile] = []
     chunks = (
         resolve_review_chunks(
@@ -977,6 +999,7 @@ def build_review_prompt(
     lint_results: str | None = None,
     extra_checklist: str = "",
     strictness_section: str = "",
+    max_findings: int | None = None,
 ) -> tuple[str, str]:
     """Build system and user prompts for a review chunk.
 
@@ -989,6 +1012,7 @@ def build_review_prompt(
         lint_results: Optional lint digest for prompt injection.
         extra_checklist: Additional generated checklist rows for depth 2.
         strictness_section: Sensitivity instructions for the review pass.
+        max_findings: Optional per-call findings ceiling for CLI transport.
 
     Returns:
         Tuple of (system_prompt, user_prompt).
@@ -1029,7 +1053,10 @@ def build_review_prompt(
         ),
         strictness_section=strictness_section,
         output_schema=REVIEW_OUTPUT_SCHEMA,
-        output_rules=format_output_rules(checklist_count=checklist_count),
+        output_rules=format_output_rules(
+            checklist_count=checklist_count,
+            max_findings=max_findings,
+        ),
     )
     return REVIEW_SYSTEM, user_prompt
 
@@ -1046,6 +1073,7 @@ def build_git_native_review_prompt(
     strictness_section: str = "",
     embed_diff: bool = False,
     allow_unredacted_git_native: bool = False,
+    max_findings: int | None = None,
 ) -> tuple[str, str]:
     """Build git-native prompts for CLI-backed review (all providers).
 
@@ -1070,6 +1098,7 @@ def build_git_native_review_prompt(
             ``git diff`` command path (which bypasses secret redaction) when
             ``embed_diff`` is False. Defaults to False so redaction always
             wins and the diff is embedded and redacted instead.
+        max_findings: Optional per-call findings ceiling for CLI transport.
 
     Returns:
         Tuple of (system_prompt, user_prompt).
@@ -1131,7 +1160,10 @@ def build_git_native_review_prompt(
         ),
         strictness_section=strictness_section,
         output_schema=REVIEW_OUTPUT_SCHEMA,
-        output_rules=format_output_rules(checklist_count=checklist_count),
+        output_rules=format_output_rules(
+            checklist_count=checklist_count,
+            max_findings=max_findings,
+        ),
     )
     return REVIEW_SYSTEM, user_prompt
 
@@ -1413,42 +1445,26 @@ async def _review_chunk(
     # Gate before the main provider call so intra-chunk (depth-2/3) work
     # cannot overshoot the budget between the per-chunk checks.
     budget.check()
-    use_git_native = ai_config.transport == AITransport.CLI
-    if use_git_native:
-        embed_diff = estimate_tokens(chunk.diff) <= max(diff_budget, 1)
-        system_prompt, user_prompt = build_git_native_review_prompt(
-            chunk=chunk,
-            context=context,
-            checklist_text=checklist_text,
-            checklist_count=checklist_count,
-            interaction_paths=interaction_paths,
-            lint_results=lint_results,
-            extra_checklist=extra_checklist,
-            strictness_section=strictness_section,
-            embed_diff=embed_diff,
-            allow_unredacted_git_native=ai_config.review_allow_unredacted_git_native,
-        )
-    else:
-        system_prompt, user_prompt = build_review_prompt(
-            chunk=chunk,
-            context=context,
-            checklist_text=checklist_text,
-            checklist_count=checklist_count,
-            interaction_paths=interaction_paths,
-            lint_results=lint_results,
-            extra_checklist=extra_checklist,
-            strictness_section=strictness_section,
-        )
-    started = time.monotonic()
-    response = await call_ai(
+    findings_cap = resolve_cli_findings_cap(
+        transport_is_cli=ai_config.transport == AITransport.CLI,
+        cli_max_findings_per_call=ai_config.cli_max_findings_per_call,
+    )
+    response, elapsed = await _invoke_chunk_review(
+        chunk=chunk,
+        context=context,
         provider=provider,
         ai_config=ai_config,
-        system_prompt=system_prompt,
-        user_prompt=user_prompt,
+        checklist_text=checklist_text,
+        checklist_count=checklist_count,
+        interaction_paths=interaction_paths,
+        lint_results=lint_results,
+        extra_checklist=extra_checklist,
+        strictness_section=strictness_section,
         budget=budget,
-        repo_root=repo_root or None,
+        repo_root=repo_root,
         use_one_shot=use_one_shot,
-        cli_schema=cli_schema_for_review(transport=ai_config.transport),
+        diff_budget=diff_budget,
+        max_findings=findings_cap,
     )
     response, payload = await _parse_review_payload_with_recovery(
         response=response,
@@ -1458,7 +1474,7 @@ async def _review_chunk(
         budget=budget,
         repo_root=repo_root,
         use_one_shot=use_one_shot,
-        elapsed=time.monotonic() - started,
+        elapsed=elapsed,
     )
     partial = _payload_to_partial(response=response, payload=payload)
 
@@ -1492,6 +1508,114 @@ async def _review_chunk(
         )
 
     return partial, next_generated_checklist_id
+
+
+async def _invoke_chunk_review(
+    *,
+    chunk: ReviewChunk,
+    context: ReviewContext,
+    provider: BaseAIProvider,
+    ai_config: AIConfig,
+    checklist_text: str,
+    checklist_count: int,
+    interaction_paths: str,
+    lint_results: str | None,
+    extra_checklist: str,
+    strictness_section: str,
+    budget: CostBudget,
+    repo_root: str,
+    use_one_shot: bool,
+    diff_budget: int,
+    max_findings: int | None,
+) -> tuple[AIResponse, float]:
+    """Build the chunk prompt, call the provider, and retry on output exhaustion.
+
+    When CLI transport hits the ~32k output-token cap mid-JSON, retry once with
+    a tighter findings ceiling so the call can finish a complete object (#1967).
+
+    Args:
+        chunk: The chunk under review.
+        context: Collected review diff context.
+        provider: Configured AI provider instance.
+        ai_config: AI configuration for retries, budget, and timeouts.
+        checklist_text: Pre-formatted checklist prompt text.
+        checklist_count: Number of checklist items in the prompt.
+        interaction_paths: Domain-triggered interaction path text.
+        lint_results: Optional lint digest for prompt injection.
+        extra_checklist: Additional generated checklist rows for depth 2.
+        strictness_section: Pre-formatted strictness prompt section.
+        budget: Session cost budget tracker.
+        repo_root: Absolute path to the repository under review.
+        use_one_shot: When True, avoid durable provider sessions.
+        diff_budget: Token budget available for embedded diffs.
+        max_findings: Optional per-call findings ceiling.
+
+    Returns:
+        The provider response and wall-clock seconds spent on the successful
+        (or final) call attempt.
+    """
+    use_git_native = ai_config.transport == AITransport.CLI
+    findings_cap = max_findings
+    started = time.monotonic()
+    while True:
+        if use_git_native:
+            embed_diff = estimate_tokens(chunk.diff) <= max(diff_budget, 1)
+            system_prompt, user_prompt = build_git_native_review_prompt(
+                chunk=chunk,
+                context=context,
+                checklist_text=checklist_text,
+                checklist_count=checklist_count,
+                interaction_paths=interaction_paths,
+                lint_results=lint_results,
+                extra_checklist=extra_checklist,
+                strictness_section=strictness_section,
+                embed_diff=embed_diff,
+                allow_unredacted_git_native=(
+                    ai_config.review_allow_unredacted_git_native
+                ),
+                max_findings=findings_cap,
+            )
+        else:
+            system_prompt, user_prompt = build_review_prompt(
+                chunk=chunk,
+                context=context,
+                checklist_text=checklist_text,
+                checklist_count=checklist_count,
+                interaction_paths=interaction_paths,
+                lint_results=lint_results,
+                extra_checklist=extra_checklist,
+                strictness_section=strictness_section,
+                max_findings=findings_cap,
+            )
+        try:
+            response = await call_ai(
+                provider=provider,
+                ai_config=ai_config,
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                budget=budget,
+                repo_root=repo_root or None,
+                use_one_shot=use_one_shot,
+                cli_schema=cli_schema_for_review(transport=ai_config.transport),
+            )
+        except AICostBudgetExceededError:
+            raise
+        except AIError as exc:
+            if (
+                findings_cap is not None
+                and findings_cap > 1
+                and is_output_exhaustion_error(str(exc))
+            ):
+                next_cap = tighter_findings_cap(current=findings_cap)
+                if next_cap < findings_cap:
+                    logger.warning(
+                        "CLI review hit an output-token ceiling; retrying "
+                        f"chunk with findings cap {findings_cap} → {next_cap}.",
+                    )
+                    findings_cap = next_cap
+                    continue
+            raise
+        return response, time.monotonic() - started
 
 
 async def _parse_review_payload_with_recovery(

--- a/lintro/mcp/toolkits/review.py
+++ b/lintro/mcp/toolkits/review.py
@@ -152,6 +152,7 @@ _INVALID_INPUT_CONTEXT_CODES: Final[frozenset[str]] = frozenset(
         "invalid-review-mode",
         "diff-desync",
         "no-parseable-diff",
+        "diff-too-large",
     },
 )
 

--- a/lintro/mcp/toolkits/review.py
+++ b/lintro/mcp/toolkits/review.py
@@ -43,6 +43,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 
+from lintro.ai.review.exceptions import ReviewContextError
 from lintro.mcp.enums.mcp_error_code import McpErrorCode
 from lintro.mcp.errors import McpError, McpErrorEnvelope
 from lintro.mcp.registry import McpToolSpec
@@ -342,7 +343,6 @@ def _collect_context(
             otherwise.
     """
     from lintro.ai.review import collect_review_context
-    from lintro.ai.review.exceptions import ReviewContextError
 
     try:
         return collect_review_context(
@@ -703,6 +703,22 @@ def _execute_review(*, arguments: dict[str, Any], workspace: Path) -> dict[str, 
             workspace_root=workspace,
             context_collection_seconds=context_collection_seconds,
         )
+    except ReviewContextError as exc:
+        # Context errors raised inside run_review (e.g. the CLI diff-size
+        # ceiling, #1967) get the same taxonomy mapping as _collect_context,
+        # so a too-large diff reports as invalid input, not a provider crash.
+        code = str(exc.code.value)
+        if code in _UNAVAILABLE_CONTEXT_CODES:
+            mcp_code = McpErrorCode.TOOL_UNAVAILABLE
+        elif code in _INVALID_INPUT_CONTEXT_CODES:
+            mcp_code = McpErrorCode.INVALID_INPUT
+        else:
+            mcp_code = McpErrorCode.EXECUTION_ERROR
+        raise McpError(
+            code=mcp_code,
+            message=str(exc),
+            detail={"tool": "lintro_review", "context_error": code},
+        ) from exc
     except (AIError, ValueError) as exc:
         failure = _review_failure(provider_name=str(provider.name), error=exc)
         raise McpError(

--- a/tests/unit/ai/providers/test_claude_auth.py
+++ b/tests/unit/ai/providers/test_claude_auth.py
@@ -383,7 +383,7 @@ class TestProviderBareFlag:
             cli_bare=CliBareMode.AUTO,
         )
         assert_that(argv).does_not_contain("--bare")
-        assert_that(argv).contains("-p", "--output-format", "json")
+        assert_that(argv).contains("--print", "--output-format", "json")
 
     async def test_never_override_omits_bare_with_api_key(
         self,

--- a/tests/unit/ai/providers/test_cli_capability_guard.py
+++ b/tests/unit/ai/providers/test_cli_capability_guard.py
@@ -522,6 +522,17 @@ async def test_run_raises_not_available_when_binary_missing(
         await transport.run(["/usr/local/bin/fake", "--always"], timeout=5.0)
 
 
+async def test_run_maps_e2big_to_provider_error(transport: _FakeTransport) -> None:
+    """Map OSError(E2BIG) to an actionable AIProviderError (#1967)."""
+    import errno
+
+    with (
+        patch_cli_exec(side_effect=OSError(errno.E2BIG, "Argument list too long")),
+        pytest.raises(AIProviderError, match="E2BIG"),
+    ):
+        await transport.run(["/usr/local/bin/fake", "--always"], timeout=5.0)
+
+
 async def test_run_kills_child_when_cancelled(transport: _FakeTransport) -> None:
     """Cancelling a call stops the child instead of orphaning the CLI."""
     with patch_cli_exec(return_value=HANG) as mock_run:

--- a/tests/unit/ai/providers/test_cli_flag_gating.py
+++ b/tests/unit/ai/providers/test_cli_flag_gating.py
@@ -318,7 +318,7 @@ async def test_codex_sends_output_schema_when_advertised(_codex_on_path: None) -
     cmd = _completion_calls(calls)[-1]
     assert_that(cmd).contains("--output-schema")
     # The prompt stays the trailing positional even after optional flags.
-    assert_that(cmd[-1]).is_equal_to("hello")
+    assert_that(cmd[-1]).is_equal_to("-")
 
 
 async def test_codex_omits_output_schema_when_not_advertised(
@@ -338,7 +338,7 @@ async def test_codex_omits_output_schema_when_not_advertised(
 
     cmd = _completion_calls(calls)[-1]
     assert_that(cmd).does_not_contain("--output-schema")
-    assert_that(cmd[-1]).is_equal_to("hello")
+    assert_that(cmd[-1]).is_equal_to("-")
 
 
 async def test_codex_backstop_retries_without_output_schema(
@@ -364,5 +364,5 @@ async def test_codex_backstop_retries_without_output_schema(
     completions = _completion_calls(calls)
     assert_that(completions).is_length(2)
     assert_that(completions[-1]).does_not_contain("--output-schema")
-    assert_that(completions[-1][-1]).is_equal_to("hello")
+    assert_that(completions[-1][-1]).is_equal_to("-")
     assert_that(response.content).is_equal_to("ok")

--- a/tests/unit/ai/providers/test_cli_stdin_prompt.py
+++ b/tests/unit/ai/providers/test_cli_stdin_prompt.py
@@ -1,0 +1,119 @@
+"""CLI providers deliver the prompt via stdin, not argv (#1967)."""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 - CompletedProcess fixtures only; no process spawn
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.enums import AITransport, CliBareMode
+from lintro.ai.providers.anthropic import AnthropicProvider
+from lintro.ai.providers.openai import OpenAIProvider
+from tests.unit.ai.conftest import patch_cli_exec
+
+
+@pytest.fixture()
+def _mock_claude_on_path() -> Iterator[None]:
+    """Patch claude binary discovery for CLI transport tests."""
+    with patch(
+        "lintro.ai.providers.anthropic._find_claude",
+        return_value="/usr/local/bin/claude",
+    ):
+        yield
+
+
+@pytest.fixture()
+def _mock_codex_on_path() -> Iterator[None]:
+    """Patch codex binary discovery for CLI transport tests."""
+    with patch(
+        "lintro.ai.providers.openai._find_codex",
+        return_value="/usr/local/bin/codex",
+    ):
+        yield
+
+
+def _large_prompt(*, chars: int = 200_000) -> str:
+    """Build a prompt larger than Linux MAX_ARG_STRLEN (128 KiB)."""
+    return "DIFF\n" + ("x" * chars)
+
+
+async def test_claude_cli_prompt_uses_stdin_not_argv(
+    _mock_claude_on_path: None,
+) -> None:
+    """Claude argv stays O(1) while a huge prompt rides on stdin."""
+    provider = AnthropicProvider(
+        transport=AITransport.CLI,
+        cli_bare=CliBareMode.ALWAYS,
+    )
+    prompt = _large_prompt()
+    with patch_cli_exec() as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"result":"ok","usage":{"input_tokens":1,"output_tokens":1}}',
+            stderr="",
+        )
+        await provider.complete(prompt)
+
+    cmd = mock_run.transport_calls[-1].cmd
+    argv_bytes = sum(len(part.encode()) for part in cmd)
+    assert_that(argv_bytes).is_less_than(8_000)
+    assert_that(cmd).does_not_contain(prompt)
+    assert_that(mock_run.transport_calls[-1].input_text).is_equal_to(prompt)
+    assert_that(cmd).contains("--print")
+
+
+async def test_codex_cli_prompt_uses_stdin_not_argv(
+    _mock_codex_on_path: None,
+) -> None:
+    """Codex argv stays O(1) while a huge prompt rides on stdin."""
+    provider = OpenAIProvider(transport=AITransport.CLI)
+    prompt = _large_prompt()
+    with patch_cli_exec() as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=(
+                '{"type":"item.completed","item":{"type":"agent_message",'
+                '"text":"ok"}}\n'
+                '{"type":"turn.completed","usage":{"input_tokens":1,'
+                '"output_tokens":1}}\n'
+            ),
+            stderr="",
+        )
+        await provider.complete(prompt, repo_root="/tmp/repo")
+
+    cmd = mock_run.transport_calls[-1].cmd
+    argv_bytes = sum(len(part.encode()) for part in cmd)
+    assert_that(argv_bytes).is_less_than(8_000)
+    assert_that(cmd).does_not_contain(prompt)
+    assert_that(mock_run.transport_calls[-1].input_text).is_equal_to(prompt)
+
+
+async def test_claude_cli_argv_length_independent_of_diff_size(
+    _mock_claude_on_path: None,
+) -> None:
+    """Doubling the prompt must not grow argv (#1967)."""
+    provider = AnthropicProvider(
+        transport=AITransport.CLI,
+        cli_bare=CliBareMode.NEVER,
+    )
+    small = "small"
+    large = _large_prompt(chars=300_000)
+    argv_lengths: list[int] = []
+    for prompt in (small, large):
+        with patch_cli_exec() as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout='{"result":"ok","usage":{"input_tokens":1,"output_tokens":1}}',
+                stderr="",
+            )
+            await provider.complete(prompt)
+        cmd = mock_run.transport_calls[-1].cmd
+        argv_lengths.append(sum(len(part.encode()) for part in cmd))
+
+    assert_that(argv_lengths[0]).is_equal_to(argv_lengths[1])

--- a/tests/unit/ai/providers/test_cli_stdin_prompt.py
+++ b/tests/unit/ai/providers/test_cli_stdin_prompt.py
@@ -90,6 +90,7 @@ async def test_codex_cli_prompt_uses_stdin_not_argv(
     argv_bytes = sum(len(part.encode()) for part in cmd)
     assert_that(argv_bytes).is_less_than(8_000)
     assert_that(cmd).does_not_contain(prompt)
+    assert_that(cmd[-1]).is_equal_to("-")
     assert_that(mock_run.transport_calls[-1].input_text).is_equal_to(prompt)
 
 

--- a/tests/unit/ai/review/test_cli_large_diff_1967.py
+++ b/tests/unit/ai/review/test_cli_large_diff_1967.py
@@ -39,6 +39,10 @@ from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.review_chunk import ReviewChunk
 from lintro.ai.review.models.review_context import ReviewContext
 from lintro.ai.review.orchestrator import (
+    # Deliberate private import: the retry loop is unit-tested at the helper
+    # seam because driving it through run_review_async needs a full provider
+    # + chunking stack for no extra coverage. Update this import when the
+    # helper is renamed (#1967 review).
     _invoke_chunk_review,
     resolve_review_chunks,
     run_review_async,
@@ -438,7 +442,8 @@ async def test_invoke_chunk_retries_on_cli_output_exhaustion(
         calls.append(prompt)
         if len(calls) == 1:
             raise AIProviderError(
-                "Claude CLI reported error: exceeded the maximum number of tokens",
+                "Claude CLI reported error: exceeded the maximum number of "
+                "output tokens",
             )
         return ok_response
 

--- a/tests/unit/ai/review/test_cli_large_diff_1967.py
+++ b/tests/unit/ai/review/test_cli_large_diff_1967.py
@@ -264,9 +264,15 @@ def test_output_rules_bound_findings_per_call_when_capped() -> None:
 def test_is_output_exhaustion_error_detects_known_signatures() -> None:
     """Output-cap retry only fires on exhaustion-shaped provider messages."""
     assert_that(
-        is_output_exhaustion_error("Claude CLI reported error: hit the token limit"),
+        is_output_exhaustion_error(
+            "Claude CLI reported error: maximum output tokens exceeded",
+        ),
     ).is_true()
     assert_that(is_output_exhaustion_error("authentication required")).is_false()
+    # No output qualifier → could equally be an input context-window error.
+    assert_that(
+        is_output_exhaustion_error("Claude CLI: hit the token limit"),
+    ).is_false()
 
 
 async def test_claude_cli_argv_length_is_constant_in_prompt_size(

--- a/tests/unit/ai/review/test_cli_large_diff_1967.py
+++ b/tests/unit/ai/review/test_cli_large_diff_1967.py
@@ -392,6 +392,71 @@ async def test_run_review_rejects_cli_diff_above_hard_ceiling(
     assert_that(exc_info.value.code).is_equal_to(ReviewContextErrorCode.DIFF_TOO_LARGE)
 
 
+async def test_run_review_chunks_large_cli_diff_end_to_end(
+    tmp_path: Path,
+) -> None:
+    """run_review_async applies the CLI diff budget and reviews in chunks.
+
+    Locks the orchestrator wiring (``diff_budget = resolve_cli_diff_budget``):
+    if that line disappears, a CLI-sized diff runs one-shot again and this
+    test fails on ``chunks_total``, even though every helper unit test passes.
+    """
+    unified_diff, changed = _synthetic_diff(lines=1_600, files=8)
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=changed,
+        unified_diff=unified_diff,
+        pr_metadata=None,
+        repo_root=str(tmp_path),
+    )
+    provider = MagicMock()
+    provider.model_name = "claude-sonnet-4-6"
+    provider.name = "anthropic"
+    provider.capabilities.supports_sessions = False
+    ai_config = AIConfig(enabled=True, review=True, transport=AITransport.CLI)
+
+    ok_payload = {
+        "summary": {
+            "headline": "Large change reviewed.",
+            "walkthrough": [{"text": "Bulk edit.", "finding_ref": ""}],
+        },
+        "checklist": [],
+        "findings": [],
+        "verdict_reasoning": {
+            "deciding_factor": "Nothing blocks.",
+            "failure_mechanism": "n/a",
+            "files_needing_attention": [],
+        },
+        "file_assessments": [],
+    }
+    ok_response = AIResponse(
+        content=json.dumps(ok_payload),
+        model="claude-sonnet-4-6",
+        provider=AIProvider.ANTHROPIC,
+        input_tokens=10,
+        output_tokens=20,
+        cost_estimate=0.0,
+    )
+
+    with patch(
+        "lintro.ai.review.orchestrator.call_ai",
+        new=AsyncMock(return_value=ok_response),
+    ) as mock_call:
+        result = await run_review_async(
+            context=context,
+            provider=provider,
+            ai_config=ai_config,
+            depth=1,
+            checklist_items=[],
+            checklist_text="",
+            classifications=[],
+        )
+
+    assert_that(result.metadata.chunks_total).is_greater_than(1)
+    assert_that(mock_call.await_count).is_equal_to(result.metadata.chunks_total)
+
+
 async def test_invoke_chunk_retries_on_cli_output_exhaustion(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/ai/review/test_cli_large_diff_1967.py
+++ b/tests/unit/ai/review/test_cli_large_diff_1967.py
@@ -1,0 +1,469 @@
+"""Unit tests for CLI-transport large-diff handling (#1967)."""
+
+from __future__ import annotations
+
+import errno
+import json
+import subprocess  # nosec B404 - subprocess drives the CLI under test; shell=False
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
+from lintro.ai.exceptions import AIProviderError
+from lintro.ai.prompts.review import format_output_rules
+from lintro.ai.providers.anthropic import AnthropicProvider
+from lintro.ai.providers.cli_contracts import CliContract
+from lintro.ai.providers.openai import OpenAIProvider
+from lintro.ai.providers.response import AIResponse
+from lintro.ai.registry import AIProvider
+from lintro.ai.review.cli_limits import (
+    CLI_DIFF_HARD_CEILING_BYTES,
+    CLI_FINDINGS_RETRY_CAP,
+    CLI_MAX_FINDINGS_PER_CALL,
+    CLI_TRANSPORT_DIFF_TOKEN_BUDGET,
+    assert_cli_diff_within_ceiling,
+    is_output_exhaustion_error,
+    measure_diff_size,
+    resolve_cli_diff_budget,
+    resolve_cli_findings_cap,
+    tighter_findings_cap,
+)
+from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
+from lintro.ai.review.exceptions import ReviewContextError
+from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.review_chunk import ReviewChunk
+from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.orchestrator import (
+    _invoke_chunk_review,
+    resolve_review_chunks,
+    run_review_async,
+)
+from lintro.ai.token_budget import estimate_tokens
+from tests.unit.ai.conftest import patch_cli_exec
+from tests.unit.ai.providers.test_cli_capability_guard import _FakeTransport
+
+_TEST_CONTRACT = CliContract(
+    binary="fake",
+    display_name="Fake",
+    upgrade_hint="Upgrade the fake CLI.",
+    version_floor=(2, 0, 0),
+    required_flags=("--always",),
+)
+
+
+@pytest.fixture()
+def _mock_claude_on_path() -> Iterator[None]:
+    """Patch claude binary discovery for CLI transport tests."""
+    with patch(
+        "lintro.ai.providers.anthropic._find_claude",
+        return_value="/usr/local/bin/claude",
+    ):
+        yield
+
+
+@pytest.fixture()
+def _mock_codex_on_path() -> Iterator[None]:
+    """Patch codex binary discovery for CLI transport tests."""
+    with patch(
+        "lintro.ai.providers.openai._find_codex",
+        return_value="/usr/local/bin/codex",
+    ):
+        yield
+
+
+def _cli_json(*, result: str = "ok") -> str:
+    return json.dumps(
+        {
+            "result": result,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "total_cost_usd": 0.0,
+        },
+    )
+
+
+def _jsonl_response(*, text: str = "ok") -> str:
+    return "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": text},
+                },
+            ),
+            json.dumps(
+                {
+                    "type": "turn.completed",
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                },
+            ),
+        ],
+    )
+
+
+def _synthetic_diff(*, lines: int, files: int = 4) -> tuple[str, list[ChangedFile]]:
+    """Build a multi-file unified diff with roughly *lines* content lines."""
+    per_file = max(lines // files, 1)
+    changed: list[ChangedFile] = []
+    parts: list[str] = []
+    for index in range(files):
+        path = f"src/module_{index}.py"
+        changed.append(
+            ChangedFile(
+                path=path,
+                status="modified",
+                additions=per_file,
+                deletions=0,
+            ),
+        )
+        # Pad lines so ~1.6k lines exceed the 24k-token CLI soft ceiling.
+        pad = "payload_" + ("x" * 80)
+        hunk_lines = "\n".join(
+            f"+value_{index}_{row} = {row}  # {pad}" for row in range(per_file)
+        )
+        parts.append(
+            f"diff --git a/{path} b/{path}\n"
+            f"--- a/{path}\n"
+            f"+++ b/{path}\n"
+            f"@@ -1,0 +1,{per_file} @@\n"
+            f"{hunk_lines}\n",
+        )
+    return "".join(parts), changed
+
+
+def test_measure_diff_size_counts_lines_bytes_and_tokens() -> None:
+    """Diff size measurement keys off the effective pre-spawn text."""
+    diff = "a\nb\nc"
+    size = measure_diff_size(unified_diff=diff)
+
+    assert_that(size.lines).is_equal_to(3)
+    assert_that(size.bytes).is_equal_to(len(diff.encode("utf-8")))
+    assert_that(size.tokens).is_equal_to(estimate_tokens(diff))
+
+
+def test_resolve_cli_diff_budget_caps_context_window_remainder() -> None:
+    """CLI soft ceiling wins over a huge context-window remainder."""
+    budget = resolve_cli_diff_budget(
+        context_window_budget=190_000,
+        cli_max_diff_tokens=CLI_TRANSPORT_DIFF_TOKEN_BUDGET,
+    )
+
+    assert_that(budget).is_equal_to(CLI_TRANSPORT_DIFF_TOKEN_BUDGET)
+    assert_that(budget).is_less_than(190_000)
+
+
+def test_resolve_cli_diff_budget_keeps_smaller_context_remainder() -> None:
+    """A tiny model window is not inflated to the CLI soft ceiling."""
+    budget = resolve_cli_diff_budget(
+        context_window_budget=1_000,
+        cli_max_diff_tokens=CLI_TRANSPORT_DIFF_TOKEN_BUDGET,
+    )
+
+    assert_that(budget).is_equal_to(1_000)
+
+
+def test_assert_cli_diff_within_ceiling_raises_actionable_error() -> None:
+    """Hard ceiling refusals mention --paths and API transport."""
+    oversized = "z" * (CLI_DIFF_HARD_CEILING_BYTES + 10)
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(
+                path="src/huge.py",
+                status="modified",
+                additions=1,
+                deletions=0,
+            ),
+        ],
+        unified_diff=oversized,
+        pr_metadata=None,
+        repo_root=None,
+    )
+
+    with pytest.raises(ReviewContextError) as exc_info:
+        assert_cli_diff_within_ceiling(
+            context=context,
+            cli_max_diff_bytes=CLI_DIFF_HARD_CEILING_BYTES,
+        )
+
+    assert_that(exc_info.value.code).is_equal_to(ReviewContextErrorCode.DIFF_TOO_LARGE)
+    assert_that(str(exc_info.value)).contains("--paths")
+    assert_that(str(exc_info.value)).contains("--transport api")
+
+
+def test_cli_chunk_threshold_routes_large_diff_through_chunker() -> None:
+    """A ~1.5k-line CLI-sized diff splits once the CLI soft budget applies."""
+    unified_diff, changed = _synthetic_diff(lines=1_600, files=8)
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=changed,
+        unified_diff=unified_diff,
+        pr_metadata=None,
+        repo_root=None,
+    )
+    window_budget = 190_000
+    cli_budget = resolve_cli_diff_budget(
+        context_window_budget=window_budget,
+        cli_max_diff_tokens=CLI_TRANSPORT_DIFF_TOKEN_BUDGET,
+    )
+
+    assert_that(estimate_tokens(unified_diff)).is_greater_than(cli_budget)
+    assert_that(estimate_tokens(unified_diff)).is_less_than(window_budget)
+
+    single = resolve_review_chunks(
+        context=context,
+        diff_budget=window_budget,
+        classifications=[],
+    )
+    chunked = resolve_review_chunks(
+        context=context,
+        diff_budget=cli_budget,
+        classifications=[],
+    )
+
+    assert_that(single).is_length(1)
+    assert_that(len(chunked)).is_greater_than(1)
+
+
+def test_resolve_cli_findings_cap_only_for_cli_transport() -> None:
+    """API transport leaves findings uncapped; CLI applies the configured cap."""
+    assert_that(
+        resolve_cli_findings_cap(transport_is_cli=False, cli_max_findings_per_call=12),
+    ).is_none()
+    assert_that(
+        resolve_cli_findings_cap(transport_is_cli=True, cli_max_findings_per_call=12),
+    ).is_equal_to(12)
+
+
+def test_tighter_findings_cap_reduces_but_stays_positive() -> None:
+    """Output-exhaustion retries halve toward the retry floor."""
+    assert_that(tighter_findings_cap(current=CLI_MAX_FINDINGS_PER_CALL)).is_equal_to(
+        CLI_FINDINGS_RETRY_CAP,
+    )
+    assert_that(tighter_findings_cap(current=1)).is_equal_to(1)
+
+
+def test_output_rules_bound_findings_per_call_when_capped() -> None:
+    """Prompt contract states the findings cap used to avoid mid-JSON cuts."""
+    rules = format_output_rules(checklist_count=4, max_findings=7)
+
+    assert_that(rules).contains("**7**")
+    assert_that(rules.lower()).contains("do not report the same problem twice")
+
+
+def test_is_output_exhaustion_error_detects_known_signatures() -> None:
+    """Output-cap retry only fires on exhaustion-shaped provider messages."""
+    assert_that(
+        is_output_exhaustion_error("Claude CLI reported error: hit the token limit"),
+    ).is_true()
+    assert_that(is_output_exhaustion_error("authentication required")).is_false()
+
+
+async def test_claude_cli_argv_length_is_constant_in_prompt_size(
+    _mock_claude_on_path: None,
+) -> None:
+    """Argv length stays O(1) as the prompt grows; the body rides on stdin."""
+    provider = AnthropicProvider(transport=AITransport.CLI)
+    small = "small prompt"
+    large = "x" * 200_000
+
+    with patch_cli_exec() as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=_cli_json(),
+            stderr="",
+        )
+        await provider.complete(small, system="sys")
+        await provider.complete(large, system="sys")
+
+    completions = [
+        call
+        for call in mock_run.transport_calls
+        if "--print" in call.cmd or "-p" in call.cmd
+    ]
+    assert_that(completions).is_length(2)
+    first, second = completions
+    assert_that(first.input_text).is_equal_to(small)
+    assert_that(second.input_text).is_equal_to(large)
+    assert_that(small).is_not_in(first.cmd)
+    assert_that(large).is_not_in(second.cmd)
+    assert_that(sum(len(token) for token in first.cmd)).is_equal_to(
+        sum(len(token) for token in second.cmd),
+    )
+    assert_that(first.cmd).contains("--print")
+
+
+async def test_codex_cli_uses_stdin_sentinel(
+    _mock_codex_on_path: None,
+) -> None:
+    """Codex uses the ``-`` stdin sentinel so argv does not grow with the prompt."""
+    provider = OpenAIProvider(transport=AITransport.CLI)
+    large = "y" * 180_000
+
+    with patch_cli_exec() as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=_jsonl_response(),
+            stderr="",
+        )
+        await provider.complete(large, repo_root="/tmp/repo")
+
+    call = mock_run.transport_calls[-1]
+    assert_that(call.cmd[-1]).is_equal_to("-")
+    assert_that(call.input_text).is_equal_to(large)
+    assert_that(large).is_not_in(call.cmd)
+
+
+async def test_cli_transport_maps_e2big_to_provider_error() -> None:
+    """E2BIG spawn failures become actionable AIProviderError messages."""
+    transport = _FakeTransport(
+        binary_path="/usr/local/bin/fake",
+        binary_name="Fake",
+        install_hint="Install Fake.",
+        contract=_TEST_CONTRACT,
+    )
+    with (
+        patch_cli_exec(side_effect=OSError(errno.E2BIG, "Argument list too long")),
+        pytest.raises(AIProviderError, match="E2BIG"),
+    ):
+        await transport.run(["/usr/local/bin/fake", "x" * 10], timeout=5.0)
+
+
+async def test_run_review_rejects_cli_diff_above_hard_ceiling(
+    tmp_path: Path,
+) -> None:
+    """CLI reviews above the hard ceiling raise an actionable context error."""
+    unified_diff = "z" * (CLI_DIFF_HARD_CEILING_BYTES + 50)
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(
+                path="src/huge.py",
+                status="modified",
+                additions=1,
+                deletions=0,
+            ),
+        ],
+        unified_diff=unified_diff,
+        pr_metadata=None,
+        repo_root=str(tmp_path),
+    )
+    provider = MagicMock()
+    provider.model_name = "claude-sonnet-4-6"
+    provider.name = "anthropic"
+    provider.capabilities.supports_sessions = False
+    ai_config = AIConfig(
+        enabled=True,
+        transport=AITransport.CLI,
+        cli_max_diff_bytes=CLI_DIFF_HARD_CEILING_BYTES,
+    )
+
+    with pytest.raises(ReviewContextError) as exc_info:
+        await run_review_async(
+            context=context,
+            provider=provider,
+            ai_config=ai_config,
+            depth=1,
+            checklist_items=[],
+            checklist_text="",
+            classifications=[],
+        )
+
+    assert_that(exc_info.value.code).is_equal_to(ReviewContextErrorCode.DIFF_TOO_LARGE)
+
+
+async def test_invoke_chunk_retries_on_cli_output_exhaustion(
+    tmp_path: Path,
+) -> None:
+    """Output-cap failures retry once with a tighter findings budget."""
+    chunk = ReviewChunk(
+        id=1,
+        files=["src/a.py"],
+        diff="+x = 1\n",
+        relationship="single-file",
+    )
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(path="src/a.py", status="modified", additions=1, deletions=0),
+        ],
+        unified_diff=chunk.diff,
+        pr_metadata=None,
+        repo_root=str(tmp_path),
+    )
+    provider = MagicMock()
+    provider.model_name = "claude-sonnet-4-6"
+    provider.name = "anthropic"
+    ai_config = AIConfig(enabled=True, transport=AITransport.CLI)
+    budget = MagicMock()
+    budget.check = MagicMock()
+
+    ok_payload = {
+        "summary": {
+            "headline": "Adds a constant.",
+            "walkthrough": [{"text": "Sets x.", "finding_ref": ""}],
+        },
+        "checklist": [],
+        "findings": [],
+        "verdict_reasoning": {
+            "deciding_factor": "Nothing blocks.",
+            "failure_mechanism": "n/a",
+            "files_needing_attention": [],
+        },
+        "file_assessments": [{"file": "src/a.py", "overview": "Fine."}],
+    }
+    ok_response = AIResponse(
+        content=json.dumps(ok_payload),
+        model="claude-sonnet-4-6",
+        provider=AIProvider.ANTHROPIC,
+        input_tokens=10,
+        output_tokens=20,
+        cost_estimate=0.0,
+    )
+    calls: list[str] = []
+
+    async def _fake_call_ai(**kwargs: object) -> AIResponse:
+        prompt = str(kwargs.get("user_prompt", ""))
+        calls.append(prompt)
+        if len(calls) == 1:
+            raise AIProviderError(
+                "Claude CLI reported error: exceeded the maximum number of tokens",
+            )
+        return ok_response
+
+    with patch(
+        "lintro.ai.review.orchestrator.call_ai",
+        new=AsyncMock(side_effect=_fake_call_ai),
+    ):
+        response, _elapsed = await _invoke_chunk_review(
+            chunk=chunk,
+            context=context,
+            provider=provider,
+            ai_config=ai_config,
+            checklist_text="",
+            checklist_count=0,
+            interaction_paths="",
+            lint_results=None,
+            extra_checklist="",
+            strictness_section="",
+            budget=budget,
+            repo_root=str(tmp_path),
+            use_one_shot=True,
+            diff_budget=10_000,
+            max_findings=CLI_MAX_FINDINGS_PER_CALL,
+        )
+
+    assert_that(calls).is_length(2)
+    assert_that(calls[0]).contains(f"**{CLI_MAX_FINDINGS_PER_CALL}**")
+    assert_that(calls[1]).contains(f"**{CLI_FINDINGS_RETRY_CAP}**")
+    assert_that(response.content).contains("Adds a constant")

--- a/tests/unit/ai/review/test_cli_large_diff_1967.py
+++ b/tests/unit/ai/review/test_cli_large_diff_1967.py
@@ -182,7 +182,7 @@ def test_assert_cli_diff_within_ceiling_raises_actionable_error() -> None:
         ],
         unified_diff=oversized,
         pr_metadata=None,
-        repo_root=None,
+        repo_root="",
     )
 
     with pytest.raises(ReviewContextError) as exc_info:
@@ -205,7 +205,7 @@ def test_cli_chunk_threshold_routes_large_diff_through_chunker() -> None:
         changed_files=changed,
         unified_diff=unified_diff,
         pr_metadata=None,
-        repo_root=None,
+        repo_root="",
     )
     window_budget = 190_000
     cli_budget = resolve_cli_diff_budget(
@@ -363,6 +363,7 @@ async def test_run_review_rejects_cli_diff_above_hard_ceiling(
     provider.capabilities.supports_sessions = False
     ai_config = AIConfig(
         enabled=True,
+        review=True,
         transport=AITransport.CLI,
         cli_max_diff_bytes=CLI_DIFF_HARD_CEILING_BYTES,
     )
@@ -404,7 +405,7 @@ async def test_invoke_chunk_retries_on_cli_output_exhaustion(
     provider = MagicMock()
     provider.model_name = "claude-sonnet-4-6"
     provider.name = "anthropic"
-    ai_config = AIConfig(enabled=True, transport=AITransport.CLI)
+    ai_config = AIConfig(enabled=True, review=True, transport=AITransport.CLI)
     budget = MagicMock()
     budget.check = MagicMock()
 

--- a/tests/unit/ai/review/test_cli_limits.py
+++ b/tests/unit/ai/review/test_cli_limits.py
@@ -101,9 +101,18 @@ def test_tighter_findings_cap_steps_down() -> None:
 def test_is_output_exhaustion_error_matches_known_signatures() -> None:
     """Known 32k / length-limit messages are classified as exhaustion."""
     assert_that(
-        is_output_exhaustion_error("hit the output_tokens cap mid JSON"),
+        is_output_exhaustion_error('... "stop_reason": "max_tokens" ...'),
     ).is_true()
     assert_that(is_output_exhaustion_error("connection reset")).is_false()
+    # Every CLI failure envelope carries is_error/output_tokens/finish_reason;
+    # generic envelope noise must NOT classify as exhaustion (auth 403 shown).
+    assert_that(
+        is_output_exhaustion_error(
+            'Claude CLI exited with code 1: {"is_error":true,'
+            '"usage":{"input_tokens":0,"output_tokens":0},'
+            '"api_error_status":403,"result":"subscription disabled"}',
+        ),
+    ).is_false()
     assert_that(
         is_cli_output_exhaustion(
             AIProviderError("maximum output tokens exceeded"),

--- a/tests/unit/ai/review/test_cli_limits.py
+++ b/tests/unit/ai/review/test_cli_limits.py
@@ -118,3 +118,15 @@ def test_is_output_exhaustion_error_matches_known_signatures() -> None:
             AIProviderError("maximum output tokens exceeded"),
         ),
     ).is_true()
+
+
+def test_measure_diff_size_empty_and_multibyte() -> None:
+    """Empty diffs measure zero; byte counts follow UTF-8, not len()."""
+    empty = measure_diff_size(unified_diff="")
+    assert_that(empty.lines).is_equal_to(0)
+    assert_that(empty.bytes).is_equal_to(0)
+    assert_that(empty.tokens).is_equal_to(0)
+
+    emoji = measure_diff_size(unified_diff="+🎉\n")
+    assert_that(emoji.lines).is_equal_to(1)
+    assert_that(emoji.bytes).is_equal_to(len("+🎉\n".encode()))

--- a/tests/unit/ai/review/test_cli_limits.py
+++ b/tests/unit/ai/review/test_cli_limits.py
@@ -1,0 +1,111 @@
+"""Tests for CLI-transport large-diff limits (#1967)."""
+
+from __future__ import annotations
+
+import pytest
+from assertpy import assert_that
+
+from lintro.ai.exceptions import AIProviderError
+from lintro.ai.review.cli_limits import (
+    CLI_DIFF_HARD_CEILING_BYTES,
+    CLI_FINDINGS_RETRY_CAP,
+    CLI_MAX_FINDINGS_PER_CALL,
+    CLI_TRANSPORT_DIFF_TOKEN_BUDGET,
+    assert_cli_diff_within_ceiling,
+    is_cli_output_exhaustion,
+    is_output_exhaustion_error,
+    measure_diff_size,
+    resolve_cli_diff_budget,
+    resolve_cli_findings_cap,
+    tighter_findings_cap,
+)
+from lintro.ai.review.enums.review_context_error_code import ReviewContextErrorCode
+from lintro.ai.review.exceptions import ReviewContextError
+from lintro.ai.review.models.review_context import ReviewContext
+
+
+def _context(*, unified_diff: str) -> ReviewContext:
+    """Build a minimal review context with the given diff."""
+    return ReviewContext(
+        base_ref="main",
+        head_ref="HEAD",
+        changed_files=[],
+        unified_diff=unified_diff,
+        pr_metadata=None,
+        repo_root="/tmp",
+    )
+
+
+def test_measure_diff_size_counts_lines_bytes_and_tokens() -> None:
+    """Diff measurement reports lines, UTF-8 bytes, and estimated tokens."""
+    diff = "a\nb\nc"
+    size = measure_diff_size(unified_diff=diff)
+    assert_that(size.lines).is_equal_to(3)
+    assert_that(size.bytes).is_equal_to(len(diff.encode("utf-8")))
+    assert_that(size.tokens).is_greater_than(0)
+
+
+def test_resolve_cli_diff_budget_takes_minimum() -> None:
+    """CLI soft ceiling wins when the context-window budget is larger."""
+    budget = resolve_cli_diff_budget(
+        context_window_budget=200_000,
+        cli_max_diff_tokens=CLI_TRANSPORT_DIFF_TOKEN_BUDGET,
+    )
+    assert_that(budget).is_equal_to(CLI_TRANSPORT_DIFF_TOKEN_BUDGET)
+
+
+def test_assert_cli_diff_within_ceiling_accepts_small_diffs() -> None:
+    """Diffs under the hard ceiling do not raise."""
+    assert_cli_diff_within_ceiling(
+        context=_context(unified_diff="diff --git a/x b/x\n+ok\n"),
+        cli_max_diff_bytes=CLI_DIFF_HARD_CEILING_BYTES,
+    )
+
+
+def test_assert_cli_diff_within_ceiling_rejects_oversized_diffs() -> None:
+    """Oversized diffs raise a diff-too-large context error with advice."""
+    huge = "x" * (CLI_DIFF_HARD_CEILING_BYTES + 1)
+    with pytest.raises(ReviewContextError) as exc_info:
+        assert_cli_diff_within_ceiling(
+            context=_context(unified_diff=huge),
+            cli_max_diff_bytes=CLI_DIFF_HARD_CEILING_BYTES,
+        )
+    assert_that(exc_info.value.code).is_equal_to(ReviewContextErrorCode.DIFF_TOO_LARGE)
+    assert_that(str(exc_info.value)).contains("--paths")
+    assert_that(str(exc_info.value)).contains("--transport api")
+
+
+def test_resolve_cli_findings_cap_only_for_cli() -> None:
+    """Findings cap applies only on the CLI transport."""
+    assert_that(
+        resolve_cli_findings_cap(
+            transport_is_cli=True,
+            cli_max_findings_per_call=CLI_MAX_FINDINGS_PER_CALL,
+        ),
+    ).is_equal_to(CLI_MAX_FINDINGS_PER_CALL)
+    assert_that(
+        resolve_cli_findings_cap(
+            transport_is_cli=False,
+            cli_max_findings_per_call=CLI_MAX_FINDINGS_PER_CALL,
+        ),
+    ).is_none()
+
+
+def test_tighter_findings_cap_steps_down() -> None:
+    """Retry caps step down toward one finding."""
+    assert_that(tighter_findings_cap(current=12)).is_equal_to(CLI_FINDINGS_RETRY_CAP)
+    assert_that(tighter_findings_cap(current=CLI_FINDINGS_RETRY_CAP)).is_equal_to(3)
+    assert_that(tighter_findings_cap(current=1)).is_equal_to(1)
+
+
+def test_is_output_exhaustion_error_matches_known_signatures() -> None:
+    """Known 32k / length-limit messages are classified as exhaustion."""
+    assert_that(
+        is_output_exhaustion_error("hit the output_tokens cap mid JSON"),
+    ).is_true()
+    assert_that(is_output_exhaustion_error("connection reset")).is_false()
+    assert_that(
+        is_cli_output_exhaustion(
+            AIProviderError("maximum output tokens exceeded"),
+        ),
+    ).is_true()

--- a/tests/unit/ai/review/test_cli_limits.py
+++ b/tests/unit/ai/review/test_cli_limits.py
@@ -118,6 +118,17 @@ def test_is_output_exhaustion_error_matches_known_signatures() -> None:
             AIProviderError("maximum output tokens exceeded"),
         ),
     ).is_true()
+    # Input context-window violations and generic proxy truncation share
+    # wording with output exhaustion; a tighter findings cap cannot fix
+    # either, so they must not trigger the retry.
+    assert_that(
+        is_output_exhaustion_error(
+            "prompt exceeded the maximum number of tokens for this model",
+        ),
+    ).is_false()
+    assert_that(
+        is_output_exhaustion_error("upstream proxy error: response truncated"),
+    ).is_false()
 
 
 def test_measure_diff_size_empty_and_multibyte() -> None:

--- a/tests/unit/ai/test_claude_cli_provider.py
+++ b/tests/unit/ai/test_claude_cli_provider.py
@@ -62,7 +62,7 @@ def test_claude_cli_init_cli_transport_available(_mock_claude_on_path: None) -> 
 
 
 async def test_claude_cli_complete_success(_mock_claude_on_path: None) -> None:
-    """Parse JSON output from a successful claude -p invocation."""
+    """Parse JSON output from a successful claude --print invocation."""
     provider = AnthropicProvider(
         model="claude-sonnet-4-6",
         transport=AITransport.CLI,
@@ -81,9 +81,13 @@ async def test_claude_cli_complete_success(_mock_claude_on_path: None) -> None:
     assert_that(response.content).contains("summary")
     assert_that(response.provider).is_equal_to(AIProvider.ANTHROPIC)
     cmd = mock_run.call_args.args[0]
-    assert_that(cmd).contains("--bare", "-p", "--output-format", "json")
+    assert_that(cmd).contains("--bare", "--print", "--output-format", "json")
     assert_that(cmd).contains("--append-system-prompt", "Be concise")
     assert_that(cmd).contains("--model", "claude-sonnet-4-6")
+    assert_that(cmd).does_not_contain("Review this diff")
+    assert_that(mock_run.transport_calls[-1].input_text).is_equal_to(
+        "Review this diff",
+    )
 
 
 async def test_claude_cli_complete_cli_schema_flag_when_requested(

--- a/tests/unit/ai/test_codex_cli_provider.py
+++ b/tests/unit/ai/test_codex_cli_provider.py
@@ -81,6 +81,10 @@ async def test_codex_cli_complete_success(_mock_codex_on_path: None) -> None:
     cmd = mock_run.call_args.args[0]
     assert_that(cmd).contains("exec", "--json", "--sandbox", "read-only")
     assert_that(cmd).contains("--model", "gpt-5.2-codex")
+    assert_that(cmd).does_not_contain("Review this diff")
+    assert_that(mock_run.transport_calls[-1].input_text).is_equal_to(
+        "Review this diff",
+    )
 
 
 async def test_codex_cli_complete_auth_error(_mock_codex_on_path: None) -> None:

--- a/tests/unit/ai/test_codex_cli_provider.py
+++ b/tests/unit/ai/test_codex_cli_provider.py
@@ -82,6 +82,7 @@ async def test_codex_cli_complete_success(_mock_codex_on_path: None) -> None:
     assert_that(cmd).contains("exec", "--json", "--sandbox", "read-only")
     assert_that(cmd).contains("--model", "gpt-5.2-codex")
     assert_that(cmd).does_not_contain("Review this diff")
+    assert_that(cmd[-1]).is_equal_to("-")
     assert_that(mock_run.transport_calls[-1].input_text).is_equal_to(
         "Review this diff",
     )

--- a/tests/unit/ai/test_config_views.py
+++ b/tests/unit/ai/test_config_views.py
@@ -71,7 +71,12 @@ def test_provider_config_is_frozen() -> None:
 
 
 def test_budget_config_construction_and_frozen() -> None:
-    """AIBudgetConfig stores budget fields and is immutable."""
+    """AIBudgetConfig stores budget fields and is immutable.
+
+    The CLI limit fields come from ``AIConfig`` defaults rather than literals
+    so a deliberate default change cannot leave this wiring assertion stale.
+    """
+    config_defaults = AIConfig()
     view = AIBudgetConfig(
         max_fix_attempts=3,
         max_parallel_calls=4,
@@ -83,15 +88,17 @@ def test_budget_config_construction_and_frozen() -> None:
         cache_max_entries=500,
         context_lines=3,
         fix_search_radius=5,
-        cli_max_diff_tokens=24_000,
-        cli_max_diff_bytes=1_500_000,
-        cli_max_findings_per_call=12,
+        cli_max_diff_tokens=config_defaults.cli_max_diff_tokens,
+        cli_max_diff_bytes=config_defaults.cli_max_diff_bytes,
+        cli_max_findings_per_call=config_defaults.cli_max_findings_per_call,
     )
 
     assert_that(view.max_fix_attempts).is_equal_to(3)
     assert_that(view.max_cost_usd).is_equal_to(1.5)
     assert_that(view.enable_cache).is_true()
-    assert_that(view.cli_max_diff_tokens).is_equal_to(24_000)
+    assert_that(view.cli_max_diff_tokens).is_equal_to(
+        config_defaults.cli_max_diff_tokens,
+    )
     with pytest.raises(dataclasses.FrozenInstanceError):
         view.max_fix_attempts = 99  # type: ignore[misc]
 

--- a/tests/unit/ai/test_config_views.py
+++ b/tests/unit/ai/test_config_views.py
@@ -83,11 +83,15 @@ def test_budget_config_construction_and_frozen() -> None:
         cache_max_entries=500,
         context_lines=3,
         fix_search_radius=5,
+        cli_max_diff_tokens=24_000,
+        cli_max_diff_bytes=1_500_000,
+        cli_max_findings_per_call=12,
     )
 
     assert_that(view.max_fix_attempts).is_equal_to(3)
     assert_that(view.max_cost_usd).is_equal_to(1.5)
     assert_that(view.enable_cache).is_true()
+    assert_that(view.cli_max_diff_tokens).is_equal_to(24_000)
     with pytest.raises(dataclasses.FrozenInstanceError):
         view.max_fix_attempts = 99  # type: ignore[misc]
 

--- a/tests/unit/mcp/test_toolkit_review.py
+++ b/tests/unit/mcp/test_toolkit_review.py
@@ -590,6 +590,40 @@ def test_review_surfaces_a_provider_failure_with_its_taxonomy(
     )
 
 
+def test_review_maps_a_too_large_diff_to_invalid_input(
+    repo: Path,
+    stub_ai: Callable[..., list[Any]],
+) -> None:
+    """A diff-size refusal raised inside ``run_review`` is invalid input.
+
+    The CLI byte ceiling (#1967) raises ``ReviewContextError`` after context
+    collection; without the dedicated handler it would be misreported as a
+    provider/execution failure instead of a size refusal the caller can fix
+    with ``paths`` or the api transport.
+    """
+    from lintro.ai.review.enums.review_context_error_code import (
+        ReviewContextErrorCode,
+    )
+    from lintro.ai.review.exceptions import ReviewContextError
+
+    stub_ai(
+        error=ReviewContextError(
+            "diff exceeds ai.cli_max_diff_bytes",
+            code=ReviewContextErrorCode.DIFF_TOO_LARGE,
+        ),
+    )
+
+    result, payload = _call(workspace=repo, arguments={"base": "main"})
+
+    assert_that(result.isError).is_true()
+    assert_that(payload["error"]["code"]).is_equal_to(
+        McpErrorCode.INVALID_INPUT.value,
+    )
+    assert_that(payload["error"]["detail"]["context_error"]).is_equal_to(
+        "diff-too-large",
+    )
+
+
 def test_review_is_unavailable_without_the_ai_extra(
     repo: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ai): harden CLI transport for large diffs
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Fixes the three #1967 hard-fail modes on large PRs (E2BIG argv overflow, single-shot wall-clock timeout, 32k output-token exhaustion):

- Deliver Claude/Codex prompts via **stdin** (`--print` with `input_text` / the codex `-` sentinel) instead of a single argv element — Linux caps one argv element at `MAX_ARG_STRLEN` (128 KiB). Cursor already used stdin.
- Map spawn-time `OSError(E2BIG)` (and other spawn OSErrors) to actionable `AIProviderError`s in `cli_transport.run`.
- `cli_limits.py`: transport-aware per-chunk diff token budget (`cli_max_diff_tokens`, default 24k) so the existing semantic chunker actually splits large CLI reviews; hard byte ceiling (`cli_max_diff_bytes`) with a `--paths` / `--transport api` advisory; per-call findings cap (`cli_max_findings_per_call`) with overflow summarization.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1967

## Details

Argv length is now O(1) in diff size (asserted by `test_cli_stdin_prompt.py`). The flat `cli_*` config fields are chunking/output limits and are complementary to #1923's transport profiles (timeout/cost) — no field collision. Capability-guard behavior is regression-tested in `test_cli_capability_guard.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for CLI review diff size, token usage, and findings per call.
  * Large diffs now receive clear validation errors instead of failing unexpectedly.
  * Review output can cap findings and retry with a lower cap when output limits are reached.
  * Large prompts are sent through standard input to improve CLI reliability.

* **Bug Fixes**
  * Improved handling of command startup failures, including oversized command arguments.
  * Standardized review error reporting for invalid or unavailable review contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->