### PR TITLE
fix(ci): bump lintro-tools digest for markdownlint-cli2 0.23.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # Built from docker/tools.Dockerfile and published by docker-tools-publish.yml
 # (cosign-signed, SBOM + provenance). Renovate manages the digest bump (#1360).
 # yamllint / hadolint: pin is immutable by digest; tag is informational.
-FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:8ad3e3037e31e0a94f962e361ed89525adc391ff8533325922391aaad6ef4219 AS tools
+FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:9a976b39ace2f48c49f2f74ed36c11c673ca0e8985d13233ac0d1ac024fe4582 AS tools
 
 # -----------------------------------------------------------------------------
 # Stage: full — lintro application (default target)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): bump lintro-tools digest for markdownlint-cli2 0.23.2
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Single-line digest bump: `Dockerfile`'s `FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:…` moves from `8ad3e303…` to `9a976b39…`, the index published by `docker-tools-publish` on main at 18:42 UTC after #1983 merged. The stale pin ships markdownlint-cli2 0.23.1 while the manifest now requires 0.23.2, failing `verify-image-manifest-tools.sh` (🧪 Docker Integration Tests) on every open PR.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1986

## Details

Digest verified against the GHCR manifest API (`docker-content-digest` for `lintro-tools:latest`). Renovate would land the same bump on its next sweep; this unblocks the #1975–#1982 queue now. No behavior change beyond the tool version the image ships.