### PR TITLE
ci(ai): raise ai-review job ceiling for stacked review calls

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -98,8 +98,11 @@ jobs:
     # posting margin, so lintro's own timeout always fires before the runner
     # kills the job — a runner kill truncates the JSON envelope the outcome
     # classifier reads. Invariant enforced by tests/scripts/
-    # test_run_ai_review.py; bump both values together.
-    timeout-minutes: 30
+    # test_run_ai_review.py; bump both values together. 50 (not 30) because
+    # custom-agent passes stack additional per-call --timeout budgets on top
+    # of the main review call, and provider-heavy diffs were hitting the old
+    # ceiling exactly (#1976 reviews killed at the boundary four times).
+    timeout-minutes: 50
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci(ai): raise ai-review job ceiling for stacked review calls
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

`ai-review.yml`'s `timeout-minutes` goes 30 → 50, with the rationale documented at the pin: custom-agent passes stack additional per-call `--timeout` budgets on top of the main review call, so provider-heavy diffs legitimately exceed 30 minutes — #1976's review was runner-killed at exactly the boundary four times today. The lintro-timeout-fires-first invariant (`test_run_ai_review.py`) still holds, so lintro's own timeout continues to produce a JSON envelope before any runner kill.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Relates to #1969

## Details

Stopgap until #1978 (parallel chunk fan-out under caps) lands from the queue and shrinks review wall-clock structurally. Takes effect for all PR runs once merged (ai-review.yml executes from the base ref).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the AI Review workflow timeout to support longer-running reviews.
  * Added documentation for custom-agent timeout budgets and previous timeout limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->