### PR TITLE
ci(ai): raise ai-review ceiling to 75 until parallel fan-out lands

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -101,8 +101,9 @@ jobs:
     # test_run_ai_review.py; bump both values together. 50 (not 30) because
     # custom-agent passes stack additional per-call --timeout budgets on top
     # of the main review call, and provider-heavy diffs were hitting the old
-    # ceiling exactly (#1976 reviews killed at the boundary four times).
-    timeout-minutes: 50
+    # ceiling exactly (#1976 reviews killed at the boundary four times; #1977's
+    # oscillated around 45-55 min and was killed at 50 twice).
+    timeout-minutes: 75
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -98,7 +98,7 @@ jobs:
     # posting margin, so lintro's own timeout always fires before the runner
     # kills the job — a runner kill truncates the JSON envelope the outcome
     # classifier reads. Invariant enforced by tests/scripts/
-    # test_run_ai_review.py; bump both values together. 50 (not 30) because
+    # test_run_ai_review.py; bump both values together. 75 (was 30, then 50) because
     # custom-agent passes stack additional per-call --timeout budgets on top
     # of the main review call, and provider-heavy diffs were hitting the old
     # ceiling exactly (#1976 reviews killed at the boundary four times; #1977's


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci(ai): raise ai-review ceiling to 75 until parallel fan-out lands
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

`timeout-minutes` 50 → 75 on the ai-review job. #1977's reviews run 45–55 minutes on serial chunk + custom-agent calls and were runner-killed at the 50 ceiling twice; #1976 needed 5 attempts under the old 30/35 boundary. #1978 (next in the merge queue) shrinks review wall-clock structurally — this keeps the queue draining until it lands. Fires-first invariant test still green.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Relates to #1969

## Details

Second bump in this drain (30→50→75) — the ceiling comes back down once #1978 and the #1923 profile timeouts settle the real budget model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the AI review job timeout to better support longer-running reviews.
  * Added guidance covering provider-heavy reviews and an additional 45–55 minute review scenario.
  * Improved handling of extended review durations, reducing the likelihood of reviews ending prematurely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->