### PR TITLE
feat(ai): add env-var and CLI-flag override layer for AI config

### DIFF
--- a/docs/adr/0006-ai-effective-config-and-review-execution.md
+++ b/docs/adr/0006-ai-effective-config-and-review-execution.md
@@ -80,9 +80,10 @@ Contract invariants:
 - Keep security-sensitive caps monotonic: an invocation may lower a configured cap where
   explicitly supported, never raise it (`ai.max_cost_usd` today).
 
-Issue #1970 implements the initial resolver. This epic must not introduce a second
-resolver. Until #1970 lands, the seam remains `resolve_ai_config()` returning
-`AIConfig`, with adapter-local overrides applied afterward.
+Issue #1970 implements the initial resolver (`AIConfig.resolve_from_mapping` returning
+`ResolvedAIConfig`). This epic must not introduce a second resolver. CLI review applies
+`--provider`/`--model`/`--transport` on that object via `apply_cli_overrides`; other
+surfaces consume `resolve_ai_config()` which unwraps the same env-aware parse.
 
 ### B. Shared review domain request and preparation
 

--- a/docs/adr/0006-ai-effective-config-and-review-execution.md
+++ b/docs/adr/0006-ai-effective-config-and-review-execution.md
@@ -40,14 +40,14 @@ Existing suites already pin large parts of review behavior
 `tests/unit/cli/test_review_command.py`). Phase 1 therefore adds only the gaps below
 rather than re-testing those topics:
 
-| Gap                          | Why it matters                                                           | Phase 1 lock                                 |
-| ---------------------------- | ------------------------------------------------------------------------ | -------------------------------------------- |
-| AC10 core → AI import edge   | `#724` boundary; `test_package_imports.py` only checks importability     | `tests/unit/test_core_ai_import_boundary.py` |
-| Shared preparation call set  | CLI/MCP can drift before Phase 3 extracts `prepare_review`               | preparation characterization tests           |
-| Effective-config seam parity | Both surfaces must resolve via `resolve_ai_config`; adapters then differ | config parity tests                          |
-| Review exit 0 / 1 / 2 matrix | Exit 1 for successful P1 findings was under-locked vs exit 0/2           | exit semantics tests                         |
-| Error-contract sharing       | CLI JSON and MCP must keep one diagnosis shape                           | error-mapping characterization               |
-| MCP run-metadata key set     | Agents depend on a stable `run` object                                   | metadata key characterization                |
+| Gap                          | Why it matters                                                                                     | Phase 1 lock                                 |
+| ---------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| AC10 core → AI import edge   | `#724` boundary; `test_package_imports.py` only checks importability                               | `tests/unit/test_core_ai_import_boundary.py` |
+| Shared preparation call set  | CLI/MCP can drift before Phase 3 extracts `prepare_review`                                         | preparation characterization tests           |
+| Effective-config seam parity | MCP via `resolve_ai_config`; CLI review via `resolve_from_mapping` + `apply_cli_overrides` (#1970) | config parity tests                          |
+| Review exit 0 / 1 / 2 matrix | Exit 1 for successful P1 findings was under-locked vs exit 0/2                                     | exit semantics tests                         |
+| Error-contract sharing       | CLI JSON and MCP must keep one diagnosis shape                                                     | error-mapping characterization               |
+| MCP run-metadata key set     | Agents depend on a stable `run` object                                                             | metadata key characterization                |
 
 Prompt golden fixtures, orchestrator phase isolation, and provider lifecycle wiring are
 deferred to Phases 3–5 (and coordinated with #1884 / #1885).

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -645,7 +645,41 @@ ai:
 ```
 
 Both `lintro check` and `lintro review` accept `--transport api|cli` to override the
-config for a single invocation.
+config for a single invocation. `lintro review` also accepts `--provider` and `--model`.
+Environment variables (`LINTRO_AI_PROVIDER`, `LINTRO_AI_MODEL`, `LINTRO_AI_TRANSPORT`,
+`LINTRO_AI_ENABLED`) apply to every AI surface and lose to CLI flags. There is no
+`--enabled` flag and no override for `ai.max_cost_usd`.
+
+### Invocation overrides
+
+Resolution order for `provider`, `model`, `transport`, and `enabled` is:
+
+```text
+CLI flag > environment variable > .lintro-config.yaml > built-in default
+```
+
+| Variable / flag                                   | Overrides      | Notes                                                                                        |
+| ------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------- |
+| `LINTRO_AI_PROVIDER` / `lintro review --provider` | `ai.provider`  | `anthropic`, `openai`, or `cursor`                                                           |
+| `LINTRO_AI_MODEL` / `lintro review --model`       | `ai.model`     | any model id; empty env falls through                                                        |
+| `LINTRO_AI_TRANSPORT` / `--transport`             | `ai.transport` | `api` or `cli`                                                                               |
+| `LINTRO_AI_ENABLED`                               | `ai.enabled`   | `1`/`0`/`true`/`false`. `=1` does not turn on `ai.review` or `ai.lint`. No `--enabled` flag. |
+
+Unset variables are absent (fall through). Invalid values fail at resolution with a
+message naming the variable and the accepted values — they never silently use the config
+default. Review output annotates each resolved field with its source
+(`provider: cursor (env)`).
+
+```bash
+# Try Cursor locally without dirtying .lintro-config.yaml
+LINTRO_AI_PROVIDER=cursor LINTRO_AI_TRANSPORT=cli lintro review --uncommitted
+
+# Same thing with flags (flags win if both are set)
+lintro review --uncommitted --provider cursor --model cursor-grok-4.6-high --transport cli
+
+# Kill switch for this environment
+LINTRO_AI_ENABLED=0 lintro check .
+```
 
 ### Transport authentication
 
@@ -933,13 +967,12 @@ cosign-signed. The `ai` variant is a strict superset built `FROM` the base image
 `full` stage, so nothing is lost by using it — it is simply larger, which is why the
 lint image stays free of it.
 
-To use AI features, pass your API key as an environment variable. The **provider** comes
-from `ai.provider` in the `.lintro-config.yaml` of the mounted workspace — there is no
-provider CLI flag or environment override, and exporting `OPENAI_API_KEY` alone does not
-switch lintro off its `anthropic` default. `--transport` is the one part of the AI
-config the CLI can override per run. The examples pass the key by **name** (`-e VAR`, no
-`=value`), so the secret is inherited from the shell's environment instead of appearing
-in the container's argument list.
+To use AI features, pass your API key as an environment variable. The **provider**
+defaults to `ai.provider` in the mounted `.lintro-config.yaml`, and can be overridden
+per run with `LINTRO_AI_PROVIDER` or `lintro review --provider` without editing that
+file. `--transport` (and `LINTRO_AI_TRANSPORT`) override the invocation path. The
+examples pass the key by **name** (`-e VAR`, no `=value`), so the secret is inherited
+from the shell's environment instead of appearing in the container's argument list.
 
 ```bash
 # API transport, with `ai: {provider: anthropic}` in the mounted config

--- a/docs/architecture/AI-REVIEW-EXECUTION.md
+++ b/docs/architecture/AI-REVIEW-EXECUTION.md
@@ -7,21 +7,23 @@ normative decision record is
 
 ## Ownership boundaries
 
-| Concern                                  | Owner today                                            | Target                                        |
-| ---------------------------------------- | ------------------------------------------------------ | --------------------------------------------- |
-| Typed `AIConfig` from raw `ai:` mapping  | `AIConfig.resolve_from_mapping()` → `ResolvedAIConfig` | Same resolver; #1923 extends it               |
-| Invocation transport / timeout overrides | CLI adapter (`apply_cli_overrides`, `model_copy`)      | Same resolver pipeline (#1970 / #1923)        |
-| Monotonic cost-cap clamp                 | MCP adapter (`resolve_budget_policy`)                  | Shared domain prep; adapters keep policy      |
-| Diff review preparation                  | Duplicated in CLI + MCP                                | `prepare_review` / `execute_review` (Phase 3) |
-| Review execution facade                  | `run_review` / `run_review_async`                      | Unchanged facade; internals split (Phase 4)   |
-| Provider client `aclose()` API           | Not yet (#1885)                                        | Provider-side only in #1885                   |
-| Provider close call-site wiring          | N/A until #1885                                        | Phase 5 of #1972                              |
+| Concern                                  | Owner today                                             | Target                                        |
+| ---------------------------------------- | ------------------------------------------------------- | --------------------------------------------- |
+| Typed `AIConfig` from raw `ai:` mapping  | `AIConfig.resolve_from_mapping()` → `ResolvedAIConfig`  | Same resolver; #1923 extends it               |
+| Invocation transport / timeout overrides | CLI review: `apply_cli_overrides` on `ResolvedAIConfig` | Same resolver pipeline (#1970 / #1923)        |
+| Monotonic cost-cap clamp                 | MCP adapter (`resolve_budget_policy`)                   | Shared domain prep; adapters keep policy      |
+| Diff review preparation                  | Duplicated in CLI + MCP                                 | `prepare_review` / `execute_review` (Phase 3) |
+| Review execution facade                  | `run_review` / `run_review_async`                       | Unchanged facade; internals split (Phase 4)   |
+| Provider client `aclose()` API           | Not yet (#1885)                                         | Provider-side only in #1885                   |
+| Provider close call-site wiring          | N/A until #1885                                         | Phase 5 of #1972                              |
 
 ## Shared preparation (current duplicated steps)
 
 Both the CLI (`lintro review`) and MCP (`lintro_review`) currently:
 
-1. Resolve AI config through `resolve_ai_config`.
+1. Resolve AI config. CLI review uses `AIConfig.resolve_from_mapping` plus
+   `apply_cli_overrides` (keeps provenance). MCP uses `resolve_ai_config`, which unwraps
+   the same env-aware parse.
 2. Gate on `ai.review` being enabled (adapter-specific error shape).
 3. Collect review context, classify changed files, select/format checklist items.
 4. Optionally build a lint digest.

--- a/docs/architecture/AI-REVIEW-EXECUTION.md
+++ b/docs/architecture/AI-REVIEW-EXECUTION.md
@@ -9,8 +9,8 @@ normative decision record is
 
 | Concern                                  | Owner today                                            | Target                                        |
 | ---------------------------------------- | ------------------------------------------------------ | --------------------------------------------- |
-| Typed `AIConfig` from raw `ai:` mapping  | `resolve_ai_config()` in `lintro.ai.interface`         | `ResolvedAIConfig` (+ provenance) via #1970   |
-| Invocation transport / timeout overrides | CLI adapter (`apply_transport_override`, `model_copy`) | Same resolver pipeline (#1970 / #1923)        |
+| Typed `AIConfig` from raw `ai:` mapping  | `AIConfig.resolve_from_mapping()` → `ResolvedAIConfig` | Same resolver; #1923 extends it               |
+| Invocation transport / timeout overrides | CLI adapter (`apply_cli_overrides`, `model_copy`)      | Same resolver pipeline (#1970 / #1923)        |
 | Monotonic cost-cap clamp                 | MCP adapter (`resolve_budget_policy`)                  | Shared domain prep; adapters keep policy      |
 | Diff review preparation                  | Duplicated in CLI + MCP                                | `prepare_review` / `execute_review` (Phase 3) |
 | Review execution facade                  | `run_review` / `run_review_async`                      | Unchanged facade; internals split (Phase 4)   |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -453,6 +453,13 @@ export LINTRO_DOCKER=1
 
 # Opt in to loading external (third-party) plugins. Disabled by default.
 export LINTRO_ENABLE_EXTERNAL_PLUGINS=1
+
+# AI config overlays (flag > env > .lintro-config.yaml > default). See
+# docs/ai-features.md "Invocation overrides".
+export LINTRO_AI_PROVIDER=cursor
+export LINTRO_AI_MODEL=cursor-grok-4.6-high
+export LINTRO_AI_TRANSPORT=cli
+export LINTRO_AI_ENABLED=1
 ```
 
 | Variable                         | Description                                                  | Default   |
@@ -462,6 +469,10 @@ export LINTRO_ENABLE_EXTERNAL_PLUGINS=1
 | `LINTRO_DOCKER`                  | Force Docker install-context detection when set to `1`       | -         |
 | `LINTRO_CONFIG`                  | Shown in the `lintro` environment report; informational only | -         |
 | `LINTRO_ENABLE_EXTERNAL_PLUGINS` | Opt in to loading external (third-party) plugins (`1`/`0`)   | `0`       |
+| `LINTRO_AI_PROVIDER`             | Override `ai.provider` (`anthropic` / `openai` / `cursor`)   | -         |
+| `LINTRO_AI_MODEL`                | Override `ai.model`                                          | -         |
+| `LINTRO_AI_TRANSPORT`            | Override `ai.transport` (`api` / `cli`)                      | -         |
+| `LINTRO_AI_ENABLED`              | Override `ai.enabled` (`1`/`0`/`true`/`false`)               | -         |
 
 > **Note:** There is no environment variable for tool timeouts, verbosity, exclude
 > patterns, output format, or auto-install. Use CLI flags (`--exclude`,

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -31,7 +31,9 @@ from lintro.ai.enums import (
     ConfidenceLevel,
     SanitizeMode,
 )
+from lintro.ai.enums.config_source import ConfigSource
 from lintro.ai.registry import AIProvider
+from lintro.ai.resolved_ai_config import ResolvedAIConfig
 
 __all__ = [
     "AIBudgetConfig",
@@ -41,6 +43,7 @@ __all__ = [
     "AITransportProfiles",
     "ApiTransportProfile",
     "CliTransportProfile",
+    "ResolvedAIConfig",
 ]
 
 
@@ -455,6 +458,11 @@ class AIConfig(BaseModel):
         rejected, because ``AIConfig`` itself forbids extras and a stale key
         in ``.lintro-config.yaml`` must not break the whole run.
 
+        Environment overrides (``LINTRO_AI_PROVIDER``, ``LINTRO_AI_MODEL``,
+        ``LINTRO_AI_TRANSPORT``, ``LINTRO_AI_ENABLED``) are applied here so
+        every consumer of :meth:`from_mapping` — execution, status, doctor,
+        MCP — sees the same effective values (#1970).
+
         This is the boundary that keeps :mod:`lintro.config` free of any
         knowledge of ``AIConfig``'s field set (see issue #724): the loader
         stores the ``ai:`` section verbatim and the AI layer parses it.
@@ -468,23 +476,60 @@ class AIConfig(BaseModel):
                 must not duplicate its output; resolvers leave it True.
 
         Returns:
-            AIConfig: Parsed AI configuration.
+            AIConfig: Parsed AI configuration after env overlays.
         """
-        if not data:
-            return cls()
+        return cls.resolve_from_mapping(data, diagnostics=diagnostics).config
 
-        known_fields = set(cls.model_fields)
-        unknown = set(data) - known_fields
-        if unknown and diagnostics:
-            logger.warning(
-                "Unknown AI config keys ignored: {}",
-                ", ".join(sorted(unknown)),
-            )
-        filtered = {k: v for k, v in data.items() if k in known_fields}
+    @classmethod
+    def resolve_from_mapping(
+        cls,
+        data: Mapping[str, Any] | None,
+        *,
+        diagnostics: bool = True,
+    ) -> ResolvedAIConfig:
+        """Parse ``ai:`` into effective values plus per-field provenance.
+
+        Env overlays are applied after the mapping is validated so a
+        ``LINTRO_AI_ENABLED=1`` overlay cannot trigger the legacy
+        ``ai.enabled``-only sub-toggle default. Invalid env values fail
+        here and never fall through to the config default.
+
+        Args:
+            data: Raw ``ai`` section from config, or None when absent.
+            diagnostics: Whether this parse may emit user-facing diagnostics.
+
+        Returns:
+            Validated config together with provenance for ``provider``,
+            ``model``, ``transport``, and ``enabled``.
+        """
+        from lintro.ai.config_overrides import (
+            OVERRIDE_FIELDS,
+            apply_env_overrides,
+        )
+
+        filtered: dict[str, Any] = {}
+        if data:
+            known_fields = set(cls.model_fields)
+            unknown = set(data) - known_fields
+            if unknown and diagnostics:
+                logger.warning(
+                    "Unknown AI config keys ignored: {}",
+                    ", ".join(sorted(unknown)),
+                )
+            filtered = {k: v for k, v in data.items() if k in known_fields}
+
         if diagnostics:
-            return cls(**filtered)
-        with _suppressed_diagnostics():
-            return cls(**filtered)
+            config = cls(**filtered) if filtered else cls()
+        else:
+            with _suppressed_diagnostics():
+                config = cls(**filtered) if filtered else cls()
+
+        sources: dict[str, ConfigSource] = {
+            field: (ConfigSource.CONFIG if field in filtered else ConfigSource.DEFAULT)
+            for field in OVERRIDE_FIELDS
+        }
+        config, sources = apply_env_overrides(config, sources)
+        return ResolvedAIConfig(config=config, sources=sources)
 
     # -- Effective feature state -------------------------------------------
 

--- a/lintro/ai/config_overrides.py
+++ b/lintro/ai/config_overrides.py
@@ -1,0 +1,276 @@
+"""Env-var and CLI-flag overlays for AI configuration (#1970).
+
+Exactly four environment variables map onto four ``ai:`` fields. Invalid
+values fail at resolution with a calm diagnostic naming the variable (or
+flag) and the accepted values — they never fall through to the config
+default.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from pydantic import ValidationError
+
+from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
+from lintro.ai.enums.config_source import ConfigSource
+from lintro.ai.exceptions import AIConfigOverrideError
+from lintro.ai.provider_enum import AIProvider
+from lintro.ai.resolved_ai_config import ResolvedAIConfig
+
+__all__ = [
+    "ENV_ENABLED",
+    "ENV_MODEL",
+    "ENV_PROVIDER",
+    "ENV_TRANSPORT",
+    "OVERRIDE_FIELDS",
+    "apply_cli_overrides",
+    "apply_env_overrides",
+    "read_env_overrides",
+]
+
+ENV_PROVIDER = "LINTRO_AI_PROVIDER"
+ENV_MODEL = "LINTRO_AI_MODEL"
+ENV_TRANSPORT = "LINTRO_AI_TRANSPORT"
+ENV_ENABLED = "LINTRO_AI_ENABLED"
+
+OVERRIDE_FIELDS: tuple[str, ...] = ("provider", "model", "transport", "enabled")
+
+_ENV_BY_FIELD: dict[str, str] = {
+    "provider": ENV_PROVIDER,
+    "model": ENV_MODEL,
+    "transport": ENV_TRANSPORT,
+    "enabled": ENV_ENABLED,
+}
+
+_ENABLED_TRUE = frozenset({"1", "true"})
+_ENABLED_FALSE = frozenset({"0", "false"})
+_ENABLED_ACCEPTED = "1, 0, true, false"
+
+_FLAG_BY_FIELD: dict[str, str] = {
+    "provider": "--provider",
+    "model": "--model",
+    "transport": "--transport",
+}
+
+
+def read_env_overrides() -> dict[str, Any]:
+    """Read the four ``LINTRO_AI_*`` overrides that are present.
+
+    Unset or whitespace-only variables are omitted (layer absent). There is
+    no meta-gate variable.
+
+    Returns:
+        Field-name to raw/parsed value for every set override.
+    """
+    overlay: dict[str, Any] = {}
+    provider = _env_text(ENV_PROVIDER)
+    if provider is not None:
+        overlay["provider"] = provider
+    model = _env_text(ENV_MODEL)
+    if model is not None:
+        overlay["model"] = model
+    transport = _env_text(ENV_TRANSPORT)
+    if transport is not None:
+        overlay["transport"] = transport
+    enabled_raw = _env_text(ENV_ENABLED)
+    if enabled_raw is not None:
+        overlay["enabled"] = _parse_enabled(enabled_raw)
+    return overlay
+
+
+def apply_env_overrides(
+    config: AIConfig,
+    sources: dict[str, ConfigSource],
+) -> tuple[AIConfig, dict[str, ConfigSource]]:
+    """Overlay environment values onto a parsed config.
+
+    Args:
+        config: Config built from the project ``ai:`` mapping.
+        sources: Mutable provenance map for the override fields.
+
+    Returns:
+        The overlaid config and updated sources.
+    """
+    overlay = read_env_overrides()
+    if not overlay:
+        return config, sources
+    updated = _apply_overlay(
+        config=config,
+        overlay=overlay,
+        names=_ENV_BY_FIELD,
+    )
+    for field in overlay:
+        sources[field] = ConfigSource.ENV
+    return updated, sources
+
+
+def apply_cli_overrides(
+    resolved: ResolvedAIConfig,
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+    transport: str | None = None,
+) -> ResolvedAIConfig:
+    """Apply ``lintro review`` CLI flags on top of a resolved config.
+
+    Flags beat env vars. Omitted flags leave the corresponding field
+    untouched. There is no ``--enabled`` flag.
+
+    Args:
+        resolved: Config + provenance after the env layer.
+        provider: ``--provider`` value, or None when unset.
+        model: ``--model`` value, or None when unset.
+        transport: ``--transport`` value, or None when unset.
+
+    Returns:
+        A new resolved config when any flag is set; *resolved* otherwise.
+    """
+    overlay: dict[str, Any] = {}
+    if provider is not None and str(provider).strip():
+        overlay["provider"] = str(provider).strip()
+    if model is not None and str(model).strip():
+        overlay["model"] = str(model).strip()
+    if transport is not None and str(transport).strip():
+        overlay["transport"] = str(transport).strip()
+    if not overlay:
+        return resolved
+    updated = _apply_overlay(
+        config=resolved.config,
+        overlay=overlay,
+        names=_FLAG_BY_FIELD,
+    )
+    sources = dict(resolved.sources)
+    for field in overlay:
+        sources[field] = ConfigSource.FLAG
+    return ResolvedAIConfig(config=updated, sources=sources)
+
+
+def _env_text(name: str) -> str | None:
+    """Return a stripped env value, or None when the layer is absent.
+
+    Args:
+        name: Environment variable name.
+
+    Returns:
+        The stripped value, or None when unset or whitespace-only.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    return stripped or None
+
+
+def _parse_enabled(raw: str) -> bool:
+    """Parse ``LINTRO_AI_ENABLED`` into a bool.
+
+    Args:
+        raw: Stripped env value.
+
+    Returns:
+        True for ``1``/``true``; False for ``0``/``false`` (case-insensitive).
+
+    Raises:
+        AIConfigOverrideError: If *raw* is not an accepted spelling.
+    """
+    key = raw.lower()
+    if key in _ENABLED_TRUE:
+        return True
+    if key in _ENABLED_FALSE:
+        return False
+    raise AIConfigOverrideError(
+        f"{ENV_ENABLED}={raw!r} is not one of: {_ENABLED_ACCEPTED}",
+    )
+
+
+def _apply_overlay(
+    *,
+    config: AIConfig,
+    overlay: Mapping[str, Any],
+    names: Mapping[str, str],
+) -> AIConfig:
+    """Copy *config* with *overlay* applied through Pydantic validation.
+
+    ``lint`` and ``review`` are passed through so the legacy
+    ``ai.enabled``-only default cannot fire when the master switch comes
+    from an overlay: ``LINTRO_AI_ENABLED=1`` must not imply ``ai.review``.
+
+    Args:
+        config: Base configuration.
+        overlay: Field updates to apply.
+        names: Field name to env-var or flag name, for error text.
+
+    Returns:
+        A validated copy of *config*.
+
+    Raises:
+        AIConfigOverrideError: If Pydantic rejects an overlay value.
+    """
+    update: dict[str, Any] = {
+        **overlay,
+        "lint": config.lint,
+        "review": config.review,
+    }
+    try:
+        payload = config.model_dump()
+        payload.update(update)
+        return AIConfig.model_validate(payload)
+    except ValidationError as exc:
+        raise AIConfigOverrideError(
+            _describe_validation_error(exc=exc, overlay=overlay, names=names),
+        ) from exc
+
+
+def _describe_validation_error(
+    *,
+    exc: ValidationError,
+    overlay: Mapping[str, Any],
+    names: Mapping[str, str],
+) -> str:
+    """Build a calm diagnostic naming the override and accepted values.
+
+    Args:
+        exc: Pydantic validation error from the overlay copy.
+        overlay: Field updates that were attempted.
+        names: Field name to env-var or flag name.
+
+    Returns:
+        A one-line message such as
+        ``LINTRO_AI_PROVIDER='cursur' is not one of: anthropic, openai, cursor``.
+    """
+    for error in exc.errors():
+        loc = error.get("loc", ())
+        if not loc:
+            continue
+        field = str(loc[0])
+        if field not in overlay:
+            continue
+        raw = overlay[field]
+        name = names.get(field, field)
+        accepted = _accepted_values(field)
+        if accepted:
+            return f"{name}={raw!r} is not one of: {accepted}"
+        return f"{name}={raw!r} is not a valid value for ai.{field}"
+    return str(exc)
+
+
+def _accepted_values(field: str) -> str:
+    """Return the comma-separated accepted values for an enum field.
+
+    Args:
+        field: Override-field name.
+
+    Returns:
+        Accepted values, or empty when the field is free-form.
+    """
+    if field == "provider":
+        return ", ".join(provider.value for provider in AIProvider)
+    if field == "transport":
+        return ", ".join(transport.value for transport in AITransport)
+    if field == "enabled":
+        return _ENABLED_ACCEPTED
+    return ""

--- a/lintro/ai/display/status.py
+++ b/lintro/ai/display/status.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
+from lintro.ai.enums.config_source import ConfigSource
+from lintro.ai.resolved_ai_config import ResolvedAIConfig, format_sourced_value
+
 if TYPE_CHECKING:
     from lintro.ai.config import AIConfig
 
@@ -20,17 +23,18 @@ AI_STATUS_NO_CONFIG = "[dim]disabled (no config)[/dim]"
 
 def render_ai_status(
     *,
-    ai_config: AIConfig | Mapping[str, Any] | None,
+    ai_config: AIConfig | ResolvedAIConfig | Mapping[str, Any] | None,
     is_ci: bool,
 ) -> list[str]:
     """Render the pre-execution AI status lines.
 
     Args:
         ai_config: Raw ``ai:`` mapping as held by the core executor, an
-            already-parsed :class:`AIConfig`, or None when unavailable. A
-            mapping is parsed here with diagnostics off, because rendering a
-            summary must not emit unknown-key warnings or migration hints
-            (the resolver on the AI entry path already reports them).
+            already-parsed :class:`AIConfig`, a :class:`ResolvedAIConfig`
+            carrying provenance, or None when unavailable. A mapping is
+            parsed here with diagnostics off, because rendering a summary
+            must not emit unknown-key warnings or migration hints (the
+            resolver on the AI entry path already reports them).
         is_ci: Whether the run is in a CI environment (affects the
             ``auto_apply`` warning wording).
 
@@ -42,12 +46,23 @@ def render_ai_status(
     if ai_config is None:
         ai_parts.append(AI_STATUS_NO_CONFIG)
         return ai_parts
-    if isinstance(ai_config, Mapping):
+
+    sources: Mapping[str, ConfigSource] | None = None
+    if isinstance(ai_config, ResolvedAIConfig):
+        sources = ai_config.sources
+        ai_config = ai_config.config
+    elif isinstance(ai_config, Mapping):
         from lintro.ai.config import AIConfig as _AIConfig
 
-        ai_config = _AIConfig.from_mapping(ai_config, diagnostics=False)
+        resolved = _AIConfig.resolve_from_mapping(ai_config, diagnostics=False)
+        sources = resolved.sources
+        ai_config = resolved.config
+
     if not ai_config.enabled:
-        ai_parts.append("[dim]disabled[/dim]")
+        disabled = "[dim]disabled[/dim]"
+        if sources is not None and sources.get("enabled") is ConfigSource.ENV:
+            disabled = "[dim]disabled (env)[/dim]"
+        ai_parts.append(disabled)
         return ai_parts
 
     import os
@@ -95,16 +110,36 @@ def render_ai_status(
                 f"  [yellow]set {key_env} env var[/yellow]",
             )
 
-    ai_parts.append(f"  provider: {ai_config.provider}")
+    provider_label = str(ai_config.provider)
+    if sources is not None:
+        provider_label = format_sourced_value(
+            provider_label,
+            sources.get("provider"),
+        )
+    ai_parts.append(f"  provider: {provider_label}")
 
     effective_model = ai_config.model or get_default_model(
         provider_name,
     )
     if effective_model:
         model_label = effective_model
-        if not ai_config.model:
+        if sources is not None:
+            model_label = format_sourced_value(
+                model_label,
+                sources.get("model"),
+            )
+        elif not ai_config.model:
             model_label += " [dim](default)[/dim]"
         ai_parts.append(f"  model: {model_label}")
+
+    if sources is not None:
+        transport_value = (
+            ai_config.transport.value if ai_config.transport is not None else "unset"
+        )
+        ai_parts.append(
+            "  transport: "
+            + format_sourced_value(transport_value, sources.get("transport")),
+        )
 
     # auto_apply warning
     if ai_config.auto_apply:

--- a/lintro/ai/enums/__init__.py
+++ b/lintro/ai/enums/__init__.py
@@ -7,6 +7,7 @@ backwards compatibility with existing ``lintro.ai.enums`` importers.
 
 from lintro.ai.enums.ai_transport import AITransport
 from lintro.ai.enums.cli_bare_mode import CliBareMode
+from lintro.ai.enums.config_source import ConfigSource
 from lintro.ai.enums.cost_basis import CostBasis
 from lintro.ai.enums.sanitize_mode import SanitizeMode
 from lintro.enums.confidence_level import ConfidenceLevel
@@ -16,6 +17,7 @@ __all__ = [
     "AITransport",
     "CliBareMode",
     "ConfidenceLevel",
+    "ConfigSource",
     "CostBasis",
     "RiskLevel",
     "SanitizeMode",

--- a/lintro/ai/enums/config_source.py
+++ b/lintro/ai/enums/config_source.py
@@ -1,0 +1,20 @@
+"""Provenance of a resolved AI configuration field."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = ["ConfigSource"]
+
+
+class ConfigSource(StrEnum):
+    """Where one effective AI config value came from.
+
+    Precedence is ``flag > env > config > default``. A future user-config
+    tier (#1235) slots between project config and the built-in default.
+    """
+
+    FLAG = "flag"
+    ENV = "env"
+    CONFIG = "config"
+    DEFAULT = "default"

--- a/lintro/ai/exceptions.py
+++ b/lintro/ai/exceptions.py
@@ -13,6 +13,15 @@ class AIError(LintroError):
     """Base exception for all AI-related errors."""
 
 
+class AIConfigOverrideError(AIError):
+    """An env-var or CLI-flag AI config override failed validation.
+
+    Raised at config resolution so a typo'd provider or transport never
+    silently falls through to the committed default. The message names the
+    variable or flag and the accepted values.
+    """
+
+
 class AICostBudgetExceededError(AIError):
     """The configured AI cost budget (``ai.max_cost_usd``) was reached.
 

--- a/lintro/ai/interface.py
+++ b/lintro/ai/interface.py
@@ -25,6 +25,7 @@ from lintro.models.core.sarif_enrichment import AISarifEnrichment
 if TYPE_CHECKING:
     from lintro.ai.config import AIConfig
     from lintro.ai.models import AIResult
+    from lintro.ai.resolved_ai_config import ResolvedAIConfig
     from lintro.config.lintro_config import LintroConfig
     from lintro.models.core.run_artifact import RunArtifact
     from lintro.models.core.tool_result import ToolResult
@@ -89,7 +90,9 @@ def resolve_ai_config(lintro_config: LintroConfig) -> AIConfig:
     :class:`~lintro.config.lintro_config.LintroConfig` stores the ``ai:``
     section verbatim as a mapping so that :mod:`lintro.config` never imports
     :mod:`lintro.ai` (issue #724). Every caller that needs typed AI settings
-    goes through this function.
+    goes through this function. Environment overlays (``LINTRO_AI_*``) are
+    applied inside :meth:`AIConfig.from_mapping` so every surface sees the
+    same effective values (#1970).
 
     Unknown keys are dropped with a warning, so resolving is also what makes
     a typo'd ``ai.*`` key discoverable. Callers should resolve once per run
@@ -245,7 +248,7 @@ def run_ai_layer(
 
 def render_ai_status(
     *,
-    ai_config: AIConfig | Mapping[str, Any] | None,
+    ai_config: AIConfig | ResolvedAIConfig | Mapping[str, Any] | None,
     is_ci: bool,
 ) -> list[str]:
     """Render the pre-execution AI status lines.

--- a/lintro/ai/resolved_ai_config.py
+++ b/lintro/ai/resolved_ai_config.py
@@ -1,0 +1,59 @@
+"""Effective AI configuration plus per-field provenance (#1970)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from lintro.ai.enums.config_source import ConfigSource
+
+if TYPE_CHECKING:
+    from lintro.ai.config import AIConfig
+
+__all__ = [
+    "ResolvedAIConfig",
+    "format_sourced_value",
+]
+
+
+def format_sourced_value(value: str, source: ConfigSource | str | None) -> str:
+    """Append a provenance annotation when a source is known.
+
+    Args:
+        value: Display value (provider name, model id, transport).
+        source: Field provenance, or empty/None to leave *value* unchanged.
+
+    Returns:
+        ``value`` or ``value (source)``.
+    """
+    if source is None or source == "":
+        return value
+    label = source.value if isinstance(source, ConfigSource) else str(source)
+    return f"{value} ({label})"
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedAIConfig:
+    """Validated effective AI settings together with field provenance.
+
+    Attributes:
+        config: Effective :class:`~lintro.ai.config.AIConfig` after
+            env/flag overlays and Pydantic validation.
+        sources: Provenance for the override fields (``provider``,
+            ``model``, ``transport``, ``enabled``).
+    """
+
+    config: AIConfig
+    sources: Mapping[str, ConfigSource]
+
+    def source_of(self, field: str) -> ConfigSource:
+        """Return provenance for *field*, defaulting to ``default``.
+
+        Args:
+            field: Override-field name.
+
+        Returns:
+            The recorded source, or :attr:`ConfigSource.DEFAULT` when absent.
+        """
+        return self.sources.get(field, ConfigSource.DEFAULT)

--- a/lintro/ai/review/display.py
+++ b/lintro/ai/review/display.py
@@ -8,6 +8,7 @@ from rich.text import Text
 
 from lintro.ai.cost import format_cost
 from lintro.ai.display.shared import cost_str, print_section_header
+from lintro.ai.resolved_ai_config import format_sourced_value
 from lintro.ai.review.checklist_display import (
     cleared_answers,
     orphan_concerns,
@@ -46,8 +47,16 @@ def render_review_terminal(
     metadata = result.metadata
     prompt_questions = question_map or {}
 
+    transport_label = format_sourced_value(
+        metadata.transport or "unset",
+        metadata.transport_source,
+    )
     header_detail = (
-        f"Model: {metadata.model} | Context: {metadata.context_window:,} | "
+        f"Model: {format_sourced_value(metadata.model, metadata.model_source)} | "
+        f"Provider: "
+        f"{format_sourced_value(metadata.provider, metadata.provider_source)} | "
+        f"Transport: {transport_label} | "
+        f"Context: {metadata.context_window:,} | "
         f"Depth: {metadata.depth} | Strictness: {metadata.strictness} | Chunks: "
         f"{metadata.chunks_current}/{metadata.chunks_total} | "
         f"Files: {metadata.files_reviewed}/{metadata.files_total} | "

--- a/lintro/ai/review/github_render.py
+++ b/lintro/ai/review/github_render.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 
+from lintro.ai.resolved_ai_config import format_sourced_value
 from lintro.ai.review.agent_prompts import render_finding_prompt_panel
 from lintro.ai.review.checklist_display import (
     cleared_answers,
@@ -157,7 +158,13 @@ def run_stats_primary_cells(*, metadata: ReviewMetadata) -> list[tuple[str, str]
     prompt_tokens = int(metadata.token_usage.get("prompt", 0))
     completion_tokens = int(metadata.token_usage.get("completion", 0))
     return [
-        ("model", f"`{sanitize_comment_text(metadata.model, limit=60)}`"),
+        (
+            "model",
+            format_sourced_value(
+                f"`{sanitize_comment_text(metadata.model, limit=60)}`",
+                metadata.model_source or None,
+            ),
+        ),
         ("est. cost", _fmt_cost(metadata.cost_estimate_usd, estimated=estimated)),
         ("tokens in", f"{tilde}{_fmt_int(prompt_tokens)}"),
         ("tokens out", f"{tilde}{_fmt_int(completion_tokens)}"),
@@ -180,17 +187,38 @@ def format_run_mechanics(*, metadata: ReviewMetadata) -> str:
     completion_tokens = int(metadata.token_usage.get("completion", 0))
     source = "estimated" if estimated else "provider-reported"
     parts = [
-        f"**Model:** `{sanitize_comment_text(metadata.model, limit=60)}`",
-        f"**Provider:** `{sanitize_comment_text(metadata.provider, limit=40)}`",
-        f"**Depth:** {metadata.depth}",
-        (
-            f"**Tokens:** {_fmt_tokens(total_tokens, estimated=estimated)} "
-            f"(in {_fmt_int(prompt_tokens)} / out {_fmt_int(completion_tokens)}, "
-            f"{source})"
+        "**Model:** "
+        + format_sourced_value(
+            f"`{sanitize_comment_text(metadata.model, limit=60)}`",
+            metadata.model_source or None,
         ),
-        f"**Est. cost:** {_fmt_cost(metadata.cost_estimate_usd, estimated=estimated)}",
-        f"**Duration:** {metadata.duration_seconds:.1f}s",
+        "**Provider:** "
+        + format_sourced_value(
+            f"`{sanitize_comment_text(metadata.provider, limit=40)}`",
+            metadata.provider_source or None,
+        ),
     ]
+    if metadata.transport or metadata.transport_source:
+        parts.append(
+            "**Transport:** "
+            + format_sourced_value(
+                f"`{sanitize_comment_text(metadata.transport or 'unset', limit=40)}`",
+                metadata.transport_source or None,
+            ),
+        )
+    parts.extend(
+        [
+            f"**Depth:** {metadata.depth}",
+            (
+                f"**Tokens:** {_fmt_tokens(total_tokens, estimated=estimated)} "
+                f"(in {_fmt_int(prompt_tokens)} / out {_fmt_int(completion_tokens)}, "
+                f"{source})"
+            ),
+            f"**Est. cost:** "
+            f"{_fmt_cost(metadata.cost_estimate_usd, estimated=estimated)}",
+            f"**Duration:** {metadata.duration_seconds:.1f}s",
+        ],
+    )
     return " · ".join(parts)
 
 

--- a/lintro/ai/review/github_review_body.py
+++ b/lintro/ai/review/github_review_body.py
@@ -19,6 +19,7 @@ still names the sticky's fix-all for everything open across all rounds.
 from __future__ import annotations
 
 from lintro import __version__ as lintro_version
+from lintro.ai.resolved_ai_config import format_sourced_value
 from lintro.ai.review.agent_prompts import (
     prompt_findings,
     render_agent_prompt_panel,
@@ -248,7 +249,10 @@ def _run_stats_section(
     metadata = result.metadata
     primary = run_stats_primary_cells(metadata=metadata)
 
-    transport_label = sanitize_comment_text(transport, limit=40)
+    transport_label = format_sourced_value(
+        sanitize_comment_text(transport, limit=40),
+        metadata.transport_source or None,
+    )
     if transport_label and auth_mode:
         transport_label = (
             f"{transport_label} · {sanitize_comment_text(auth_mode, limit=40)}"

--- a/lintro/ai/review/models/review_metadata.py
+++ b/lintro/ai/review/models/review_metadata.py
@@ -44,6 +44,13 @@ class ReviewMetadata:
             ``lintro.ai.transport.AuthMode``). Empty when unknown.
         cost_basis (str): Provenance of ``cost_estimate_usd`` — ``billed``,
             ``estimated``, or ``unpriceable`` (#1923). Empty when unknown.
+        provider_source (str): Provenance of ``provider`` — ``flag``,
+            ``env``, ``config``, or ``default`` (#1970). Empty on legacy
+            records.
+        model_source (str): Provenance of ``model`` (#1970). Empty on
+            legacy records.
+        transport_source (str): Provenance of ``transport`` (#1970). Empty
+            on legacy records.
         phase_timings (dict[str, float]): Per-phase wall-clock seconds for
             regression visibility. Keys include ``context_collection``,
             ``provider`` (chunk + custom-agent provider calls), and
@@ -81,6 +88,9 @@ class ReviewMetadata:
     transport: str = ""
     auth_mode: str = ""
     cost_basis: str = ""
+    provider_source: str = ""
+    model_source: str = ""
+    transport_source: str = ""
     phase_timings: dict[str, float] = field(default_factory=dict)
     custom_agents_run: int = 0
     custom_agents_skipped: int = 0

--- a/lintro/ai/transport.py
+++ b/lintro/ai/transport.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
+from lintro.ai.config_overrides import apply_cli_overrides
 from lintro.ai.enums import AITransport
 from lintro.ai.enums.cost_basis import CostBasis
 from lintro.ai.providers.claude_auth import should_send_bare
@@ -17,6 +18,7 @@ __all__ = [
     "DEFAULT_API_TIMEOUT",
     "DEFAULT_CLI_TIMEOUT",
     "ResolvedTransportSettings",
+    "apply_cli_overrides",
     "apply_resolved_transport",
     "apply_transport_override",
     "format_resolved_profile_log",

--- a/lintro/api/pipeline.py
+++ b/lintro/api/pipeline.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import click
+
 from lintro.utils.execution.run_renderer import (
     make_result_display,
     render_needs_ai_enrichment,
@@ -52,18 +54,25 @@ def _ai_status_lines(ctx: RunContext) -> list[str] | None:
     Returns:
         list[str] | None: Rich-markup lines for the summary's AI row, or
         ``None`` when no summary will be shown.
+
+    Raises:
+        click.UsageError: When an ``LINTRO_AI_*`` overlay fails validation.
     """
     if ctx.clean_stdout_output or ctx.score_only:
         return None
 
+    from lintro.ai.exceptions import AIConfigOverrideError
     from lintro.ai.interface import render_ai_status
     from lintro.utils.environment import detect_ci_environment
 
     ci_env = detect_ci_environment()
-    return render_ai_status(
-        ai_config=getattr(ctx.lintro_config, "ai", None),
-        is_ci=ci_env is not None and ci_env.is_ci,
-    )
+    try:
+        return render_ai_status(
+            ai_config=getattr(ctx.lintro_config, "ai", None),
+            is_ci=ci_env is not None and ci_env.is_ci,
+        )
+    except AIConfigOverrideError as exc:
+        raise click.UsageError(str(exc)) from exc
 
 
 def _sarif_enrichment(
@@ -211,6 +220,9 @@ def run_lint_artifact(
     Returns:
         RunArtifact: The rendered run's results, totals, health score, and
         exit code.
+
+    Raises:
+        click.UsageError: When an ``LINTRO_AI_*`` overlay fails validation.
     """
     del stream, no_log  # accepted for signature stability; not yet implemented
 
@@ -250,16 +262,20 @@ def run_lint_artifact(
     )
 
     if ai_enabled:
+        from lintro.ai.exceptions import AIConfigOverrideError
         from lintro.ai.interface import enhance_artifact
 
-        artifact = enhance_artifact(
-            artifact,
-            ctx=ctx,
-            output_format=output_format,
-            ai_fix=ai_fix,
-            transport=transport,
-            fail_under=fail_under,
-        )
+        try:
+            artifact = enhance_artifact(
+                artifact,
+                ctx=ctx,
+                output_format=output_format,
+                ai_fix=ai_fix,
+                transport=transport,
+                fail_under=fail_under,
+            )
+        except AIConfigOverrideError as exc:
+            raise click.UsageError(str(exc)) from exc
 
     render_run(
         artifact,

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -25,6 +25,7 @@ from lintro.ai.doctor_checks import (
     check_ai_configuration,
     check_ai_liveness,
 )
+from lintro.ai.exceptions import AIConfigOverrideError
 from lintro.ai.interface import resolve_ai_config
 from lintro.enums.tool_status import ToolStatus
 from lintro.tools.core.install_context import RuntimeContext
@@ -406,7 +407,8 @@ def doctor_command(
 
     Raises:
         SystemExit: When missing or broken tools are detected.
-        click.UsageError: When --fix is combined with --report or --json.
+        click.UsageError: When --fix is combined with --report or --json,
+            or when an ``LINTRO_AI_*`` overlay fails validation.
 
     Examples:
         lintro doctor
@@ -449,7 +451,10 @@ def doctor_command(
     from lintro.config.config_loader import get_config
 
     config = get_config()
-    ai_config = resolve_ai_config(config)
+    try:
+        ai_config = resolve_ai_config(config)
+    except AIConfigOverrideError as exc:
+        raise click.UsageError(str(exc)) from exc
     ai_checks = check_ai_configuration(ai_config)
     if ai_liveness:
         # Appended after the presence checks so the chain reads in order:

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -28,9 +28,10 @@ from loguru import logger
 from rich.console import Console
 
 from lintro.ai.availability import require_ai
-from lintro.ai.exceptions import AIError
-from lintro.ai.interface import resolve_ai_config
+from lintro.ai.config import AIConfig
+from lintro.ai.exceptions import AIConfigOverrideError, AIError
 from lintro.ai.paths import resolve_workspace_root
+from lintro.ai.provider_enum import AIProvider
 from lintro.ai.providers import get_provider
 from lintro.ai.review import (
     classify_changed_files,
@@ -57,8 +58,8 @@ from lintro.ai.review.orchestrator import run_review
 from lintro.ai.review.output import render_review_output
 from lintro.ai.review.sensitivity import resolve_sensitivity_policy
 from lintro.ai.transport import (
+    apply_cli_overrides,
     apply_resolved_transport,
-    apply_transport_override,
     format_resolved_profile_log,
     resolve_transport_settings,
 )
@@ -175,6 +176,22 @@ ADVISORY_DEFAULT_PATHS: tuple[str, ...] = (".",)
     help="Override ai.transport for this invocation.",
 )
 @click.option(
+    "--provider",
+    "provider_override",
+    type=click.Choice(
+        [member.value for member in AIProvider],
+        case_sensitive=False,
+    ),
+    default=None,
+    help="Override ai.provider for this invocation.",
+)
+@click.option(
+    "--model",
+    "model_override",
+    default=None,
+    help="Override ai.model for this invocation.",
+)
+@click.option(
     "--timeout",
     type=float,
     default=None,
@@ -246,6 +263,8 @@ def review_command(
     timeout: float | None,
     path_filter: tuple[str, ...],
     transport: str | None,
+    provider_override: str | None,
+    model_override: str | None,
     list_agents: bool,
     advisory_tools: str | None,
     tool_options: str | None,
@@ -286,7 +305,16 @@ def review_command(
             fail_on_findings=fail_on_findings,
         )
 
-    ai_config = resolve_ai_config(lintro_config)
+    try:
+        resolved_ai = apply_cli_overrides(
+            AIConfig.resolve_from_mapping(lintro_config.ai),
+            provider=provider_override,
+            model=model_override,
+            transport=transport,
+        )
+    except AIConfigOverrideError as exc:
+        raise click.UsageError(str(exc)) from exc
+    ai_config = resolved_ai.config
     if not ai_config.review_enabled:
         raise click.UsageError(
             "AI review is disabled in configuration. Set ai.review: true "
@@ -368,7 +396,7 @@ def review_command(
                 issue_count,
             )
 
-    effective_ai_config = apply_transport_override(ai_config, transport)
+    effective_ai_config = ai_config
     if timeout is not None:
         effective_ai_config = effective_ai_config.model_copy(
             update={"api_timeout": timeout},
@@ -456,6 +484,9 @@ def review_command(
                 transport=resolved_profile.transport.value,
                 auth_mode=resolved_profile.auth_mode,
                 cost_basis=effective_basis.value,
+                provider_source=resolved_ai.source_of("provider").value,
+                model_source=resolved_ai.source_of("model").value,
+                transport_source=resolved_ai.source_of("transport").value,
             ),
         )
     except (AIError, ValueError) as exc:
@@ -539,6 +570,8 @@ def review_command(
                     depth=depth,
                     strictness=strictness,
                     transport=transport,
+                    provider=provider_override,
+                    model=model_override,
                     timeout=timeout,
                     context_window=context_window,
                     semantic_chunks=semantic_chunks,
@@ -560,6 +593,8 @@ def _cli_overrides(
     depth: int | None,
     strictness: str | None,
     transport: str | None,
+    provider: str | None,
+    model: str | None,
     timeout: float | None,
     context_window: int | None,
     semantic_chunks: bool,
@@ -575,6 +610,8 @@ def _cli_overrides(
         depth: ``--depth`` value, or None when unset.
         strictness: ``--strictness`` value, or None when unset.
         transport: ``--transport`` value, or None when unset.
+        provider: ``--provider`` value, or None when unset.
+        model: ``--model`` value, or None when unset.
         timeout: ``--timeout`` value, or None when unset.
         context_window: ``--context-window`` value, or None when unset.
         semantic_chunks: Whether ``--semantic-chunks`` was passed.
@@ -590,6 +627,10 @@ def _cli_overrides(
         overrides.append(f"--strictness {strictness}")
     if transport is not None:
         overrides.append(f"--transport {transport}")
+    if provider is not None:
+        overrides.append(f"--provider {provider}")
+    if model is not None:
+        overrides.append(f"--model {model}")
     if timeout is not None:
         overrides.append(f"--timeout {timeout:g}")
     if context_window is not None:

--- a/lintro/mcp/toolkits/review.py
+++ b/lintro/mcp/toolkits/review.py
@@ -287,9 +287,12 @@ def _resolve_ai_config(*, workspace: Path) -> tuple[Any, AIConfig]:
 
     Raises:
         McpError: :attr:`McpErrorCode.TOOL_UNAVAILABLE` when no AI provider is
-            installed or ``ai.review`` is disabled for this workspace.
+            installed or ``ai.review`` is disabled for this workspace;
+            :attr:`McpErrorCode.INVALID_INPUT` when an ``LINTRO_AI_*`` overlay
+            fails validation.
     """
     from lintro.ai.availability import is_ai_available
+    from lintro.ai.exceptions import AIConfigOverrideError
     from lintro.ai.interface import resolve_ai_config
     from lintro.config.config_loader import get_config
 
@@ -304,7 +307,14 @@ def _resolve_ai_config(*, workspace: Path) -> tuple[Any, AIConfig]:
         )
 
     lintro_config = get_config()
-    ai_config = resolve_ai_config(lintro_config)
+    try:
+        ai_config = resolve_ai_config(lintro_config)
+    except AIConfigOverrideError as exc:
+        raise McpError(
+            code=McpErrorCode.INVALID_INPUT,
+            message=str(exc),
+            detail={"tool": "lintro_review", "reason": "invalid_ai_override"},
+        ) from exc
     if not ai_config.review_enabled:
         raise McpError(
             code=McpErrorCode.TOOL_UNAVAILABLE,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,3 +100,22 @@ def clear_logging_handlers() -> Iterator[None]:
 
     logging.getLogger().handlers.clear()
     yield
+
+
+_AI_OVERRIDE_ENV_VARS: tuple[str, ...] = (
+    "LINTRO_AI_PROVIDER",
+    "LINTRO_AI_MODEL",
+    "LINTRO_AI_TRANSPORT",
+    "LINTRO_AI_ENABLED",
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_ai_config_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep developer ``LINTRO_AI_*`` overrides out of config-resolution tests.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    for name in _AI_OVERRIDE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -343,6 +343,10 @@ _DOCUMENTED_LINTRO_ENV_VARS = {
     "LINTRO_DOCKER",
     "LINTRO_CONFIG",
     "LINTRO_ENABLE_EXTERNAL_PLUGINS",
+    "LINTRO_AI_PROVIDER",
+    "LINTRO_AI_MODEL",
+    "LINTRO_AI_TRANSPORT",
+    "LINTRO_AI_ENABLED",
 }
 
 # Env vars that were historically documented but are NOT read by the runtime.

--- a/tests/unit/ai/review/test_architecture_characterization.py
+++ b/tests/unit/ai/review/test_architecture_characterization.py
@@ -3,8 +3,8 @@
 These tests freeze *current* CLI/MCP review preparation behavior,
 effective-config parity, review metadata shape, error mapping, and exit
 semantics (0/1/2) before later phases extract shared preparation or split the
-orchestrator. They intentionally avoid implementing ``ResolvedAIConfig``,
-``prepare_review``, orchestrator decomposition, or provider close wiring.
+orchestrator. Issue #1970 landed ``ResolvedAIConfig``; Phase 3 still owns
+``prepare_review``, orchestrator decomposition, and provider close wiring.
 """
 
 from __future__ import annotations
@@ -44,7 +44,6 @@ MCP_REVIEW_PATH = PROJECT_ROOT / "lintro/mcp/toolkits/review.py"
 # Domain helpers both adapters must keep calling until Phase 3 extracts them.
 _SHARED_PREPARATION_CALLS: frozenset[str] = frozenset(
     {
-        "resolve_ai_config",
         "collect_review_context",
         "classify_changed_files",
         "get_all_checklist_items",
@@ -251,6 +250,11 @@ def test_cli_and_mcp_review_adapters_call_shared_preparation_helpers() -> None:
 
     assert_that(_SHARED_PREPARATION_CALLS.issubset(cli_calls)).is_true()
     assert_that(_SHARED_PREPARATION_CALLS.issubset(mcp_calls)).is_true()
+    # CLI keeps provenance via resolve_from_mapping (#1970); MCP still goes
+    # through resolve_ai_config, which applies the same env layer internally.
+    assert_that(cli_calls).contains("resolve_from_mapping")
+    assert_that(cli_calls).contains("apply_cli_overrides")
+    assert_that(mcp_calls).contains("resolve_ai_config")
 
 
 def test_cli_owns_posting_and_exit_helpers_mcp_does_not() -> None:

--- a/tests/unit/ai/review/test_architecture_characterization_1972.py
+++ b/tests/unit/ai/review/test_architecture_characterization_1972.py
@@ -404,3 +404,31 @@ def test_mcp_review_disabled_maps_to_tool_unavailable(tmp_path: Path) -> None:
     assert_that(raised.code).is_equal_to(McpErrorCode.TOOL_UNAVAILABLE)
     detail = raised.envelope.detail or {}
     assert_that(detail["reason"]).is_equal_to("review_disabled")
+
+
+def test_mcp_invalid_provider_env_maps_to_invalid_input(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MCP preparation maps a typo'd ``LINTRO_AI_PROVIDER`` to invalid input."""
+    monkeypatch.setenv("LINTRO_AI_PROVIDER", "cursur")
+    workspace = tmp_path.resolve()
+    (workspace / ".lintro-config.yaml").write_text(
+        "ai:\n  enabled: true\n  review: true\n  provider: anthropic\n",
+        encoding="utf-8",
+    )
+    from lintro.config import config_loader
+
+    loaded = config_loader.load_config(config_path=workspace / ".lintro-config.yaml")
+    with (
+        patch("lintro.ai.availability.is_ai_available", return_value=True),
+        patch("lintro.config.config_loader.get_config", return_value=loaded),
+        pytest.raises(McpError) as excinfo,
+    ):
+        mcp_review._resolve_ai_config(workspace=workspace)
+
+    raised = excinfo.value
+    assert_that(raised.code).is_equal_to(McpErrorCode.INVALID_INPUT)
+    assert_that(str(raised)).contains("LINTRO_AI_PROVIDER='cursur'")
+    detail = raised.envelope.detail or {}
+    assert_that(detail["reason"]).is_equal_to("invalid_ai_override")

--- a/tests/unit/ai/review/test_review_command_json_error.py
+++ b/tests/unit/ai/review/test_review_command_json_error.py
@@ -58,8 +58,8 @@ def patched_review(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(
         review_module,
-        "apply_transport_override",
-        lambda ai_config, _transport: ai_config,
+        "apply_cli_overrides",
+        lambda resolved, **_kwargs: resolved,
     )
     monkeypatch.setattr(review_module, "get_provider", lambda _, **_kwargs: provider)
     monkeypatch.setattr(

--- a/tests/unit/ai/test_config_overrides.py
+++ b/tests/unit/ai/test_config_overrides.py
@@ -1,0 +1,336 @@
+"""Tests for the env-var and CLI-flag AI config override layer (#1970)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from assertpy import assert_that
+from rich.console import Console
+
+from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport, ConfigSource
+from lintro.ai.exceptions import AIConfigOverrideError
+from lintro.ai.provider_enum import AIProvider
+from lintro.ai.resolved_ai_config import format_sourced_value
+from lintro.ai.review.display import render_review_terminal
+from lintro.ai.review.github_render import format_run_mechanics
+from lintro.ai.review.models.review_metadata import ReviewMetadata
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.transport import apply_cli_overrides
+from lintro.config.lintro_config import LintroConfig
+
+
+def _mapping(**overrides: object) -> dict[str, object]:
+    """Build a raw ``ai:`` mapping with explicit keys only.
+
+    Args:
+        **overrides: Keys present in the committed config.
+
+    Returns:
+        Mapping suitable for :meth:`AIConfig.resolve_from_mapping`.
+    """
+    return dict(overrides)
+
+
+def test_each_env_var_overrides_its_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each ``LINTRO_AI_*`` variable maps onto exactly one field."""
+    monkeypatch.setenv("LINTRO_AI_PROVIDER", "cursor")
+    monkeypatch.setenv("LINTRO_AI_MODEL", "cursor-grok-4.6-high")
+    monkeypatch.setenv("LINTRO_AI_TRANSPORT", "cli")
+    monkeypatch.setenv("LINTRO_AI_ENABLED", "1")
+
+    resolved = AIConfig.resolve_from_mapping(
+        _mapping(provider="anthropic", model="claude-sonnet", transport="api"),
+    )
+
+    assert_that(resolved.config.provider).is_equal_to(AIProvider.CURSOR)
+    assert_that(resolved.config.model).is_equal_to("cursor-grok-4.6-high")
+    assert_that(resolved.config.transport).is_equal_to(AITransport.CLI)
+    assert_that(resolved.config.enabled).is_true()
+    assert_that(resolved.source_of("provider")).is_equal_to(ConfigSource.ENV)
+    assert_that(resolved.source_of("model")).is_equal_to(ConfigSource.ENV)
+    assert_that(resolved.source_of("transport")).is_equal_to(ConfigSource.ENV)
+    assert_that(resolved.source_of("enabled")).is_equal_to(ConfigSource.ENV)
+
+
+def test_flag_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI flags win over environment variables."""
+    monkeypatch.setenv("LINTRO_AI_PROVIDER", "openai")
+    monkeypatch.setenv("LINTRO_AI_MODEL", "env-model")
+    monkeypatch.setenv("LINTRO_AI_TRANSPORT", "api")
+
+    resolved = apply_cli_overrides(
+        AIConfig.resolve_from_mapping(_mapping(provider="anthropic")),
+        provider="cursor",
+        model="flag-model",
+        transport="cli",
+    )
+
+    assert_that(resolved.config.provider).is_equal_to(AIProvider.CURSOR)
+    assert_that(resolved.config.model).is_equal_to("flag-model")
+    assert_that(resolved.config.transport).is_equal_to(AITransport.CLI)
+    assert_that(resolved.source_of("provider")).is_equal_to(ConfigSource.FLAG)
+    assert_that(resolved.source_of("model")).is_equal_to(ConfigSource.FLAG)
+    assert_that(resolved.source_of("transport")).is_equal_to(ConfigSource.FLAG)
+
+
+def test_env_beats_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Environment values win over the committed ``ai:`` mapping."""
+    monkeypatch.setenv("LINTRO_AI_PROVIDER", "openai")
+
+    resolved = AIConfig.resolve_from_mapping(_mapping(provider="anthropic"))
+
+    assert_that(resolved.config.provider).is_equal_to(AIProvider.OPENAI)
+    assert_that(resolved.source_of("provider")).is_equal_to(ConfigSource.ENV)
+
+
+def test_unset_env_falls_through_to_config() -> None:
+    """An absent env layer leaves the mapping (or default) in place."""
+    resolved = AIConfig.resolve_from_mapping(
+        _mapping(provider="openai", model="gpt-4o", transport="cli", enabled=True),
+    )
+
+    assert_that(resolved.config.provider).is_equal_to(AIProvider.OPENAI)
+    assert_that(resolved.config.model).is_equal_to("gpt-4o")
+    assert_that(resolved.config.transport).is_equal_to(AITransport.CLI)
+    assert_that(resolved.source_of("provider")).is_equal_to(ConfigSource.CONFIG)
+    assert_that(resolved.source_of("model")).is_equal_to(ConfigSource.CONFIG)
+    assert_that(resolved.source_of("transport")).is_equal_to(ConfigSource.CONFIG)
+    assert_that(resolved.source_of("enabled")).is_equal_to(ConfigSource.CONFIG)
+
+
+def test_empty_mapping_uses_built_in_defaults() -> None:
+    """Omitted fields record ``default`` provenance."""
+    resolved = AIConfig.resolve_from_mapping(None)
+
+    assert_that(resolved.config).is_equal_to(AIConfig())
+    assert_that(resolved.source_of("provider")).is_equal_to(ConfigSource.DEFAULT)
+    assert_that(resolved.source_of("model")).is_equal_to(ConfigSource.DEFAULT)
+    assert_that(resolved.source_of("transport")).is_equal_to(ConfigSource.DEFAULT)
+    assert_that(resolved.source_of("enabled")).is_equal_to(ConfigSource.DEFAULT)
+
+
+def test_invalid_provider_env_names_the_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typo'd provider fails loudly and does not fall back."""
+    monkeypatch.setenv("LINTRO_AI_PROVIDER", "cursur")
+
+    with pytest.raises(AIConfigOverrideError) as exc_info:
+        AIConfig.resolve_from_mapping(_mapping(provider="anthropic"))
+
+    message = str(exc_info.value)
+    assert_that(message).contains("LINTRO_AI_PROVIDER='cursur'")
+    assert_that(message).contains("anthropic")
+    assert_that(message).contains("openai")
+    assert_that(message).contains("cursor")
+    assert_that(message).does_not_contain("Traceback")
+
+
+def test_invalid_transport_env_names_the_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typo'd transport fails loudly and does not fall back."""
+    monkeypatch.setenv("LINTRO_AI_TRANSPORT", "ssh")
+
+    with pytest.raises(AIConfigOverrideError) as exc_info:
+        AIConfig.resolve_from_mapping(_mapping(transport="api"))
+
+    message = str(exc_info.value)
+    assert_that(message).contains("LINTRO_AI_TRANSPORT='ssh'")
+    assert_that(message).contains("api")
+    assert_that(message).contains("cli")
+
+
+def test_invalid_enabled_env_names_accepted_spellings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``LINTRO_AI_ENABLED`` rejects values outside 1/0/true/false."""
+    monkeypatch.setenv("LINTRO_AI_ENABLED", "yesmaybe")
+
+    with pytest.raises(AIConfigOverrideError) as exc_info:
+        AIConfig.resolve_from_mapping({})
+
+    assert_that(str(exc_info.value)).contains("LINTRO_AI_ENABLED='yesmaybe'")
+    assert_that(str(exc_info.value)).contains("1, 0, true, false")
+
+
+def test_enabled_zero_disables_globally(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``LINTRO_AI_ENABLED=0`` is a kill switch across lint and review."""
+    monkeypatch.setenv("LINTRO_AI_ENABLED", "0")
+
+    resolved = AIConfig.resolve_from_mapping(
+        _mapping(enabled=True, lint=True, review=True),
+    )
+
+    assert_that(resolved.config.enabled).is_false()
+    assert_that(resolved.config.lint_enabled).is_false()
+    assert_that(resolved.config.review_enabled).is_false()
+    assert_that(resolved.source_of("enabled")).is_equal_to(ConfigSource.ENV)
+
+
+def test_enabled_one_does_not_imply_review(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``LINTRO_AI_ENABLED=1`` does not turn on ``ai.review`` or ``ai.lint``."""
+    monkeypatch.setenv("LINTRO_AI_ENABLED", "1")
+
+    resolved = AIConfig.resolve_from_mapping({})
+
+    assert_that(resolved.config.enabled).is_true()
+    assert_that(resolved.config.lint).is_false()
+    assert_that(resolved.config.review).is_false()
+    assert_that(resolved.config.review_enabled).is_false()
+    assert_that(resolved.config.lint_enabled).is_false()
+
+
+def test_max_cost_usd_has_no_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A spend-cap env var is ignored; the committed cap cannot be raised."""
+    monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "99.0")
+
+    resolved = AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5))
+
+    assert_that(resolved.config.max_cost_usd).is_equal_to(0.5)
+    assert_that(os.environ.get("LINTRO_AI_MAX_COST_USD")).is_equal_to("99.0")
+
+
+def test_whitespace_only_env_is_treated_as_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Blank env values do not overlay the mapping."""
+    monkeypatch.setenv("LINTRO_AI_PROVIDER", "  ")
+    monkeypatch.setenv("LINTRO_AI_MODEL", "")
+
+    resolved = AIConfig.resolve_from_mapping(_mapping(provider="anthropic"))
+
+    assert_that(resolved.config.provider).is_equal_to(AIProvider.ANTHROPIC)
+    assert_that(resolved.source_of("provider")).is_equal_to(ConfigSource.CONFIG)
+    assert_that(resolved.source_of("model")).is_equal_to(ConfigSource.DEFAULT)
+
+
+def test_from_mapping_returns_the_resolved_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``from_mapping`` applies env overlays and returns the effective config."""
+    monkeypatch.setenv("LINTRO_AI_PROVIDER", "cursor")
+
+    config = AIConfig.from_mapping(_mapping(provider="anthropic"))
+
+    assert_that(config.provider).is_equal_to(AIProvider.CURSOR)
+
+
+def test_resolve_ai_config_facade_applies_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The interface facade honors the env layer through ``from_mapping``."""
+    from lintro.ai.interface import resolve_ai_config
+
+    monkeypatch.setenv("LINTRO_AI_TRANSPORT", "cli")
+    config = resolve_ai_config(LintroConfig(ai={"transport": "api"}))
+
+    assert_that(config.transport).is_equal_to(AITransport.CLI)
+
+
+def test_omitted_flags_leave_env_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``apply_cli_overrides`` is a no-op when every flag is omitted."""
+    monkeypatch.setenv("LINTRO_AI_PROVIDER", "openai")
+    resolved = apply_cli_overrides(
+        AIConfig.resolve_from_mapping(_mapping(provider="anthropic")),
+    )
+
+    assert_that(resolved.config.provider).is_equal_to(AIProvider.OPENAI)
+    assert_that(resolved.source_of("provider")).is_equal_to(ConfigSource.ENV)
+
+
+def test_format_sourced_value_annotates_known_sources() -> None:
+    """Display helper appends the source label when one is present."""
+    assert_that(format_sourced_value("cursor", ConfigSource.ENV)).is_equal_to(
+        "cursor (env)",
+    )
+    assert_that(format_sourced_value("cli", "flag")).is_equal_to("cli (flag)")
+    assert_that(format_sourced_value("anthropic", None)).is_equal_to("anthropic")
+    assert_that(format_sourced_value("anthropic", "")).is_equal_to("anthropic")
+
+
+def test_status_annotates_env_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pre-execution status shows env provenance for provider/model/transport."""
+    from lintro.ai.display.status import render_ai_status
+
+    monkeypatch.setattr(
+        "lintro.ai.availability.is_provider_available",
+        lambda _provider: True,
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("LINTRO_AI_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    lines = render_ai_status(
+        ai_config={"enabled": True, "provider": "anthropic", "transport": "api"},
+        is_ci=False,
+    )
+
+    assert_that(lines).contains("  provider: openai (env)")
+    assert_that("".join(lines)).contains("transport: api (config)")
+
+
+def test_status_marks_enabled_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``LINTRO_AI_ENABLED=0`` is visible on the disabled status line."""
+    from lintro.ai.display.status import render_ai_status
+
+    monkeypatch.setenv("LINTRO_AI_ENABLED", "0")
+
+    lines = render_ai_status(
+        ai_config={"enabled": True, "review": True},
+        is_ci=False,
+    )
+
+    assert_that(lines).is_equal_to(["[dim]disabled (env)[/dim]"])
+
+
+def _review_result_with_sources() -> ReviewResult:
+    """Build a review result whose metadata carries field provenance.
+
+    Returns:
+        A result suitable for terminal and PR-comment rendering tests.
+    """
+    return ReviewResult(
+        metadata=ReviewMetadata(
+            model="cursor-grok-4.6-high",
+            provider="cursor",
+            context_window=128_000,
+            depth=1,
+            chunks_total=1,
+            chunks_current=1,
+            files_reviewed=1,
+            files_total=1,
+            checklist_items=0,
+            transport="cli",
+            provider_source="env",
+            model_source="flag",
+            transport_source="config",
+        ),
+        summary="Safe to merge.",
+        checklist=(),
+        findings=(),
+    )
+
+
+def test_terminal_review_annotates_provider_model_transport() -> None:
+    """Terminal output shows provider, model, and transport with sources."""
+    console = Console(record=True)
+    render_review_terminal(result=_review_result_with_sources(), console=console)
+    text = console.export_text()
+
+    assert_that(text).contains("Model: cursor-grok-4.6-high (flag)")
+    assert_that(text).contains("Provider: cursor (env)")
+    assert_that(text).contains("Transport: cli (config)")
+
+
+def test_pr_comment_mechanics_annotates_sources() -> None:
+    """Posted PR comment mechanics name the source of each override field."""
+    mechanics = format_run_mechanics(metadata=_review_result_with_sources().metadata)
+
+    assert_that(mechanics).contains("**Model:** `cursor-grok-4.6-high` (flag)")
+    assert_that(mechanics).contains("**Provider:** `cursor` (env)")
+    assert_that(mechanics).contains("**Transport:** `cli` (config)")

--- a/tests/unit/ai/test_display_status.py
+++ b/tests/unit/ai/test_display_status.py
@@ -225,7 +225,7 @@ def test_render_ai_status_mapping_matches_parsed_config(
 
     from_mapping = render_ai_status(ai_config=mapping, is_ci=is_ci)
     from_model = render_ai_status(
-        ai_config=AIConfig.from_mapping(mapping),
+        ai_config=AIConfig.resolve_from_mapping(mapping),
         is_ci=is_ci,
     )
 

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from assertpy import assert_that
 from click.testing import CliRunner
 
@@ -61,6 +62,27 @@ def test_review_help_shows_flags() -> None:
     assert_that(result.output).contains("--transport")
     assert_that(result.output).contains("--provider")
     assert_that(result.output).contains("--model")
+
+
+def test_review_invalid_provider_env_exits_two(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typo'd ``LINTRO_AI_PROVIDER`` is a usage error, not a traceback."""
+    monkeypatch.setenv("LINTRO_AI_PROVIDER", "cursur")
+    mock_config = MagicMock(ai={"enabled": True, "review": True})
+    runner = CliRunner()
+    with (
+        patch("lintro.cli_utils.commands.review.require_ai"),
+        patch(
+            "lintro.cli_utils.commands.review.get_config",
+            return_value=mock_config,
+        ),
+    ):
+        result = runner.invoke(cli, ["review"])
+
+    assert_that(result.exit_code).is_equal_to(2)
+    assert_that(result.output).contains("LINTRO_AI_PROVIDER='cursur'")
+    assert_that(result.output).does_not_contain("Traceback")
 
 
 def test_review_alias_rev_works() -> None:

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -59,6 +59,8 @@ def test_review_help_shows_flags() -> None:
     assert_that(result.output).contains("--show-checklist")
     assert_that(result.output).contains("--timeout")
     assert_that(result.output).contains("--transport")
+    assert_that(result.output).contains("--provider")
+    assert_that(result.output).contains("--model")
 
 
 def test_review_alias_rev_works() -> None:
@@ -277,6 +279,79 @@ def test_review_passes_transport_override_to_provider() -> None:
     assert_that(provider_config.transport.value).is_equal_to("cli")
 
 
+def test_review_passes_provider_and_model_overrides_to_provider() -> None:
+    """--provider and --model override config when resolving the provider."""
+    runner = CliRunner()
+    mock_context = MagicMock()
+    mock_context.changed_files = []
+    mock_config = MagicMock(
+        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+    )
+    mock_config.review.depth = 1
+    mock_config.review.strictness = ReviewStrictness.BALANCED
+    mock_config.review.sensitivity = MagicMock()
+    mock_config.review.force_semantic_chunking = False
+    mock_config.review.checklist_display = ChecklistDisplay.OFF
+
+    with (
+        patch("lintro.cli_utils.commands.review.require_ai"),
+        patch(
+            "lintro.cli_utils.commands.review.get_config",
+            return_value=mock_config,
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.collect_review_context",
+            return_value=mock_context,
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.classify_changed_files",
+            return_value=[],
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.get_all_checklist_items",
+            return_value=[],
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.select_checklist_items",
+            return_value=[],
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.format_checklist_for_prompt",
+            return_value=("", {}),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.get_provider",
+        ) as mock_get_provider,
+        patch(
+            "lintro.cli_utils.commands.review.run_review",
+            return_value=_empty_result(),
+        ),
+        patch("lintro.cli_utils.commands.review.render_review_output"),
+    ):
+        mock_get_provider.return_value = MagicMock(
+            model_name="cursor-grok-4.6-high",
+            name="cursor",
+        )
+        result = runner.invoke(
+            cli,
+            [
+                "review",
+                "--provider",
+                "cursor",
+                "--model",
+                "cursor-grok-4.6-high",
+                "--transport",
+                "cli",
+            ],
+        )
+
+    assert_that(result.exit_code).is_equal_to(0)
+    provider_config = mock_get_provider.call_args.args[0]
+    assert_that(provider_config.provider.value).is_equal_to("cursor")
+    assert_that(provider_config.model).is_equal_to("cursor-grok-4.6-high")
+    assert_that(provider_config.transport.value).is_equal_to("cli")
+
+
 def test_review_stamps_resolved_transport_provenance_on_metadata() -> None:
     """The rendered result carries transport, auth_mode, and cost_basis.
 
@@ -343,6 +418,8 @@ def test_review_stamps_resolved_transport_provenance_on_metadata() -> None:
     assert_that(rendered.metadata.transport).is_equal_to("api")
     assert_that(rendered.metadata.auth_mode).is_equal_to("api_key")
     assert_that(rendered.metadata.cost_basis).is_equal_to("billed")
+    assert_that(rendered.metadata.provider_source).is_equal_to("config")
+    assert_that(rendered.metadata.transport_source).is_equal_to("config")
 
 
 def test_review_downgrades_billed_to_estimated_without_usage_counters() -> None:
@@ -1316,6 +1393,8 @@ def test_cli_overrides_lists_only_explicit_flags() -> None:
         depth=None,
         strictness=None,
         transport="cli",
+        provider=None,
+        model=None,
         timeout=600.0,
         context_window=None,
         semantic_chunks=False,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai): add env-var and CLI-flag override layer for AI config
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Add a precedence-based overlay so `provider`, `model`, `transport`, and `enabled` can change per invocation without editing `.lintro-config.yaml`. Env overlays run inside `AIConfig.from_mapping` so status, doctor, MCP, and review all see the same values. Invalid overlays fail with a calm diagnostic that names the variable or flag. Terminal and PR output annotate each resolved field with its source (`flag` / `env` / `config` / `default`).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #1970
- Relates to #1971

## Details

Precedence is `flag > env > config > default`. The four env vars are `LINTRO_AI_PROVIDER`, `LINTRO_AI_MODEL`, `LINTRO_AI_TRANSPORT`, and `LINTRO_AI_ENABLED` (`1`/`0`/`true`/`false`). There is no override for `ai.max_cost_usd`, no `--enabled` flag, and `LINTRO_AI_ENABLED=1` does not imply `ai.review` / `ai.lint`.

CLI review gained `--provider` / `--model` beside `--transport`. Provenance rides on `ResolvedAIConfig` (`AIConfig` stays `extra="forbid"`). Overlay uses `model_validate`, not `model_copy`, so enum typos cannot become raw strings.

Invalid overlays map to Click `UsageError` on CLI (`check`/`fmt`/`test`/`review`/`doctor`) and MCP `INVALID_INPUT`. Pre-push review: lintro (cursor-grok-4.6-high) + CodeRabbit (1 minor, dismissed: empty transport already omits the badge). Greptile was rate-limited (`free_reviews_limit_reached`).

Out of scope here (follow-ups / #1972): unifying check `--transport` with `apply_cli_overrides`, and stamping provenance onto the MCP `run` object.