### PR TITLE
feat(ai): grant cursor workspace trust by default

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -211,10 +211,10 @@ jobs:
 
       - name: Enable Cursor workspace trust
         # `agent` exits 1 in non-interactive CI until the workspace is trusted.
-        # lintro maps that to `--trust` via `ai.cursor_trust_workspace`; there
-        # is no env overlay, and the committed YAML stays false for local
-        # checkouts. Safe here: checkout is pull_request.base.sha and fork PRs
-        # never reach this job.
+        # #2023 defaults `ai.cursor_trust_workspace` to true; this step stays
+        # until that default is on main and #2025 deletes the patcher. Safe
+        # here: checkout is pull_request.base.sha and fork PRs never reach
+        # this job.
         run: python3 .ai-review-installer/scripts/ci/enable_cursor_workspace_trust.py
 
       - name: Run AI review (posts comment; fails when nothing was reviewed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **ai**: grant Cursor workspace trust by default (#2023)
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- **ai**: grant Cursor workspace trust by default (#2023)
-
 ### Deprecated
 
 ### Removed

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -555,12 +555,13 @@ ai:
   # (auto | always | never, default: auto)
   cli_bare: auto
 
-  # ── Advanced / trust (leave off unless you understand the risk) ──
-  # Pass "--trust" to the Cursor agent CLI. Security risk: the Cursor provider
-  # can be fed prompt-injectable content (e.g. fork-PR diffs), so keep this
-  # false outside fully trusted local workspaces. (bool, default: false)
-  cursor_trust_workspace: false
+  # ── Cursor workspace trust ──
+  # Choosing provider: cursor grants workspace trust (passes "--trust" to the
+  # agent CLI). Set false to restore the agent's interactive trust prompt.
+  # (bool, default: true)
+  cursor_trust_workspace: true
 
+  # ── Advanced / trust (leave off unless you understand the risk) ──
   # Let the git-native (CLI transport) review path delegate diff retrieval to
   # the provider instead of embedding a redacted diff. Security risk: a
   # delegated diff bypasses lintro's secret-redaction choke point — see the

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -307,15 +307,12 @@ class AIConfig(BaseModel):
     )
 
     cursor_trust_workspace: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Pass '--trust' to the Cursor 'agent' CLI, granting it workspace "
-            "trust. Security risk: the Cursor provider is fed untrusted, "
-            "prompt-injectable content (e.g. 'lintro review --pr N' embeds "
-            "diffs from arbitrary fork PRs). Combining workspace trust with "
-            "such input could let an injected diff drive an agent operating "
-            "with full workspace trust, so this defaults to False and should "
-            "only be enabled for fully trusted local workspaces."
+            "trust. Trust follows from choosing provider: cursor, so this "
+            "defaults to True. Set false to restore the Cursor agent's "
+            "interactive trust prompt."
         ),
     )
 

--- a/scripts/ci/enable_cursor_workspace_trust.py
+++ b/scripts/ci/enable_cursor_workspace_trust.py
@@ -3,13 +3,15 @@
 
 ``lintro review`` with ``LINTRO_AI_PROVIDER=cursor`` shells out to ``agent``,
 which refuses to start in a non-interactive runner until the workspace is
-trusted (``--trust``, ``--yolo``, or ``-f``). lintro's opt-in for that flag is
-``ai.cursor_trust_workspace``; there is no env or CLI overlay for it (#1970).
+trusted (``--trust``, ``--yolo``, or ``-f``). lintro maps that to
+``ai.cursor_trust_workspace``, which defaults to True as of #2023 (trust
+follows from choosing ``provider: cursor``; set ``false`` to restore the
+interactive prompt). There is still no env or CLI overlay for the field.
 
-The dogfood job checks out the PR's trusted BASE ref and never runs for fork
-PRs, so this is the case the flag exists for. The committed
-``.lintro-config.yaml`` stays ``false`` so a local checkout does not silently
-grant workspace trust.
+This patcher remains until #2025 deletes it. It is idempotent when the
+ephemeral checkout already has ``cursor_trust_workspace: true``. The
+dogfood job checks out the PR's trusted BASE ref and never runs for fork
+PRs.
 
 Stdlib only: this runs on the runner before ``uv sync``.
 

--- a/tests/scripts/test_enable_cursor_workspace_trust.py
+++ b/tests/scripts/test_enable_cursor_workspace_trust.py
@@ -1,8 +1,8 @@
 """Tests for ``scripts/ci/enable_cursor_workspace_trust.py``.
 
-The dogfood job has to set ``ai.cursor_trust_workspace`` on the ephemeral
-checkout: the Cursor ``agent`` CLI will not start non-interactively without
-``--trust``, and there is no env overlay for that field.
+The patcher remains until #2025. #2023 defaults ``ai.cursor_trust_workspace``
+to true (trust follows from ``provider: cursor``); the script is still
+idempotent when the field is already true, and there is no env overlay.
 """
 
 from __future__ import annotations

--- a/tests/unit/ai/providers/test_factory.py
+++ b/tests/unit/ai/providers/test_factory.py
@@ -65,34 +65,14 @@ def test_get_provider_passes_model():
         )
 
 
-def test_get_provider_cursor_trust_defaults_off():
-    """Cursor provider does not trust the workspace unless opted in."""
+def test_get_provider_cursor_trust_defaults_on() -> None:
+    """Cursor provider trusts the workspace when AIConfig uses the default."""
     from lintro.ai.enums import AITransport
     from lintro.ai.providers.cursor import CursorProvider
 
     config = AIConfig(
         provider="cursor",  # type: ignore[arg-type]  # Pydantic coerces str
         transport=AITransport.CLI,
-    )
-    with patch(
-        "lintro.ai.providers.cursor._find_agent",
-        return_value="/usr/local/bin/agent",
-    ):
-        provider = get_provider(config)
-    assert_that(isinstance(provider, CursorProvider)).is_true()
-    cursor = cast(CursorProvider, provider)
-    assert_that(cursor._trust_workspace).is_false()
-
-
-def test_get_provider_cursor_trust_threaded_when_enabled():
-    """get_provider threads cursor_trust_workspace into the provider."""
-    from lintro.ai.enums import AITransport
-    from lintro.ai.providers.cursor import CursorProvider
-
-    config = AIConfig(
-        provider="cursor",  # type: ignore[arg-type]  # Pydantic coerces str
-        transport=AITransport.CLI,
-        cursor_trust_workspace=True,
     )
     with patch(
         "lintro.ai.providers.cursor._find_agent",
@@ -102,6 +82,26 @@ def test_get_provider_cursor_trust_threaded_when_enabled():
     assert_that(isinstance(provider, CursorProvider)).is_true()
     cursor = cast(CursorProvider, provider)
     assert_that(cursor._trust_workspace).is_true()
+
+
+def test_get_provider_cursor_trust_opted_out() -> None:
+    """get_provider threads an explicit cursor_trust_workspace=False opt-out."""
+    from lintro.ai.enums import AITransport
+    from lintro.ai.providers.cursor import CursorProvider
+
+    config = AIConfig(
+        provider="cursor",  # type: ignore[arg-type]  # Pydantic coerces str
+        transport=AITransport.CLI,
+        cursor_trust_workspace=False,
+    )
+    with patch(
+        "lintro.ai.providers.cursor._find_agent",
+        return_value="/usr/local/bin/agent",
+    ):
+        provider = get_provider(config)
+    assert_that(isinstance(provider, CursorProvider)).is_true()
+    cursor = cast(CursorProvider, provider)
+    assert_that(cursor._trust_workspace).is_false()
 
 
 def test_get_provider_anthropic_threads_cli_bare() -> None:

--- a/tests/unit/ai/test_config.py
+++ b/tests/unit/ai/test_config.py
@@ -32,16 +32,16 @@ def test_default_config_optional_fields() -> None:
     assert_that(config.api_key_env).is_none()
 
 
-def test_cursor_trust_workspace_defaults_false() -> None:
-    """Cursor workspace trust is opt-in and disabled by default."""
+def test_cursor_trust_workspace_defaults_true() -> None:
+    """Cursor workspace trust is granted by default."""
     config = AIConfig()
-    assert_that(config.cursor_trust_workspace).is_false()
-
-
-def test_cursor_trust_workspace_opt_in() -> None:
-    """Cursor workspace trust can be explicitly enabled via config."""
-    config = AIConfig(cursor_trust_workspace=True)
     assert_that(config.cursor_trust_workspace).is_true()
+
+
+def test_cursor_trust_workspace_opt_out() -> None:
+    """Cursor workspace trust can be explicitly disabled via config."""
+    config = AIConfig(cursor_trust_workspace=False)
+    assert_that(config.cursor_trust_workspace).is_false()
 
 
 def test_cli_bare_defaults_to_auto() -> None:

--- a/tests/unit/ai/test_cursor_provider.py
+++ b/tests/unit/ai/test_cursor_provider.py
@@ -11,11 +11,14 @@ import pytest
 from assertpy import assert_that
 
 from lintro.ai.budget import CostBudget
+from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import (
     AIAuthenticationError,
     AINotAvailableError,
     AIProviderError,
 )
+from lintro.ai.providers import get_provider
 from lintro.ai.providers.cursor import CURSOR_MIN_TIMEOUT, CursorProvider, _find_agent
 from lintro.ai.registry import AIProvider
 from tests.unit.ai.conftest import HANG, patch_cli_exec
@@ -443,8 +446,10 @@ async def test_cursor_cost_accrues_into_budget(provider):
     assert_that(budget.spent).is_greater_than(0.0)
 
 
-async def test_complete_omits_trust_flag_by_default(provider):
-    """The '--trust' flag is absent unless workspace trust is opted in."""
+async def test_complete_omits_trust_flag_when_constructed_directly(
+    provider: CursorProvider,
+) -> None:
+    """CursorProvider constructed without config omits '--trust'."""
     stdout = _cli_json(result="ok")
     with patch_cli_exec() as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
@@ -458,14 +463,49 @@ async def test_complete_omits_trust_flag_by_default(provider):
     assert_that(cmd).does_not_contain("--trust")
 
 
-async def test_complete_includes_trust_flag_when_opted_in(_mock_agent_on_path):
-    """The '--trust' flag is present only when the opt-in is set."""
+async def test_complete_includes_trust_flag_when_constructed_with_trust(
+    _mock_agent_on_path: object,
+) -> None:
+    """CursorProvider constructed with trust enabled appends '--trust'."""
     trusting = CursorProvider(cursor_trust_workspace=True)
     stdout = _cli_json(result="ok")
     with patch_cli_exec(side_effect=_fake_run_with_probes(stdout)) as mock_run:
         await trusting.complete("Hello", repo_root="/tmp/repo")
     cmd = _completion_calls(mock_run)[-1]
     assert_that(cmd).contains("--trust")
+
+
+async def test_complete_includes_trust_flag_by_default(
+    _mock_agent_on_path: object,
+) -> None:
+    """The '--trust' flag is appended when AIConfig uses the default."""
+    config = AIConfig(
+        provider=AIProvider.CURSOR,
+        transport=AITransport.CLI,
+    )
+    cursor = get_provider(config)
+    stdout = _cli_json(result="ok")
+    with patch_cli_exec(side_effect=_fake_run_with_probes(stdout)) as mock_run:
+        await cursor.complete("Hello", repo_root="/tmp/repo")
+    cmd = _completion_calls(mock_run)[-1]
+    assert_that(cmd).contains("--trust")
+
+
+async def test_complete_omits_trust_flag_when_opted_out(
+    _mock_agent_on_path: object,
+) -> None:
+    """The '--trust' flag is absent when workspace trust is explicitly false."""
+    config = AIConfig(
+        provider=AIProvider.CURSOR,
+        transport=AITransport.CLI,
+        cursor_trust_workspace=False,
+    )
+    cursor = get_provider(config)
+    stdout = _cli_json(result="ok")
+    with patch_cli_exec(side_effect=_fake_run_with_probes(stdout)) as mock_run:
+        await cursor.complete("Hello", repo_root="/tmp/repo")
+    cmd = _completion_calls(mock_run)[-1]
+    assert_that(cmd).does_not_contain("--trust")
 
 
 # -- CursorProvider._extract_json_object() ---------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai): grant cursor workspace trust by default
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Flip `ai.cursor_trust_workspace` from `False` to `True` so the Cursor provider works out of the box in non-interactive runs. Choosing `provider: cursor` is the consent to hand the workspace to Cursor's agent; `false` remains an explicit opt-out that restores the interactive trust prompt. No env sniffing and no TTY/CI behavior split.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #2023
- Relates to #2025

## Details

Default change is in `lintro/ai/config.py`. The factory already threads the config value into `CursorProvider`; the provider constructor default is unchanged. Docs in `docs/ai-features.md` now describe the granted default and the opt-out.

CI's ai-review job installs lintro from the base-ref checkout via `uv sync`, so this is live in CI immediately after merge. #2025 depends on that: do not delete the "Enable Cursor workspace trust" step until this is on main.

Tests cover the field default, factory threading, `--trust` appended via AIConfig/factory by default, and `--trust` absent when the field is explicitly `false`.

The CI config patcher `scripts/ci/enable_cursor_workspace_trust.py` is intentionally left in place for #2025.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec9e4898-c04c-47e8-83fa-8c9d35a657a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec9e4898-c04c-47e8-83fa-8c9d35a657a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cursor workspace trust is now enabled by default.
  * Users can disable automatic trust to restore Cursor’s interactive workspace trust prompt.

* **Documentation**
  * Updated AI feature documentation to explain the new default and opt-out behavior.
  * Clarified workspace trust behavior and configuration options.

* **Tests**
  * Added coverage for default-enabled trust and explicit opt-out scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->