### PR TITLE
fix(install): verify local-first discoverability and version progress

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -231,7 +231,7 @@ an early failure or timeout never stops the tools after it from being installed:
 
 | Label     | Meaning                                                          |
 | --------- | ---------------------------------------------------------------- |
-| `OK`      | Discoverable after the command; a parsed version meets `min_version` (unparseable output is still OK). |
+| `OK`      | Discoverable; meets `min_version` (unparseable output still OK). |
 | `PATH`    | Command succeeded, but the tool is still not discoverable.       |
 | `STALE`   | Discoverable after the command, but still below `min_version`.   |
 | `FAIL`    | Command ran and failed; re-running it unchanged will not help.   |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -231,7 +231,7 @@ an early failure or timeout never stops the tools after it from being installed:
 
 | Label     | Meaning                                                          |
 | --------- | ---------------------------------------------------------------- |
-| `OK`      | Command succeeded and the tool is discoverable at `min_version`. |
+| `OK`      | Discoverable after the command; a parsed version meets `min_version` (unparseable output is still OK). |
 | `PATH`    | Command succeeded, but the tool is still not discoverable.       |
 | `STALE`   | Discoverable after the command, but still below `min_version`.   |
 | `FAIL`    | Command ran and failed; re-running it unchanged will not help.   |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -231,18 +231,33 @@ an early failure or timeout never stops the tools after it from being installed:
 
 | Label     | Meaning                                                          |
 | --------- | ---------------------------------------------------------------- |
-| `OK`      | Command succeeded and the tool is discoverable.                  |
-| `PATH`    | Command succeeded, but the tool's own executable is not on PATH. |
+| `OK`      | Command succeeded and the tool is discoverable at `min_version`. |
+| `PATH`    | Command succeeded, but the tool is still not discoverable.       |
+| `STALE`   | Discoverable after the command, but still below `min_version`.   |
 | `FAIL`    | Command ran and failed; re-running it unchanged will not help.   |
 | `TIMEOUT` | Command exceeded the 5-minute install timeout; retry is valid.   |
 | `MANUAL`  | No runnable command exists here; install the tool by hand.       |
 
 Wrapper-probed tools (`bash`/`sh`/`cargo` version commands) still report `OK`, because
-those probes cannot tell whether the tool itself is discoverable.
+those probes cannot tell whether the tool itself is discoverable. A project-local npm
+add whose binary lands in `<project>/node_modules/.bin` **is** discoverable: planning,
+post-install verification, and `lintro doctor` share the same local-first probe, so a
+successful `npm install -D` is not reported as `PATH` just because that directory is not
+on `PATH`. The `bunx`/`npx` registry fallback is **not** an install and is never treated
+as discoverable.
+
+`lintro install` exits 1 when **any** planned action is not a full success, including
+`PATH` (`NOT_DISCOVERABLE`) and `STALE` (`STILL_OUTDATED`). A zero-exit install command
+is not enough.
+
+A `PATH` result names the install destination directory and the PATH remedy. For a
+project-local npm add that directory is the detected project's `node_modules/.bin`.
 
 `lintro doctor` only suggests a quick fix for tools it can actually install in the
 detected environment; anything else is listed under "Needs manual action" with the
-reason, and a command that already failed is not suggested again.
+reason. Failed remedies (`FAIL`, `PATH`, `STALE`, `MANUAL`) are recorded in a
+**per-process** `known_invalid` set: within one run the identical command is never
+re-suggested; a fresh run gets one fresh attempt. There is no state file.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -238,13 +238,14 @@ an early failure or timeout never stops the tools after it from being installed:
 | `TIMEOUT` | Command exceeded the 5-minute install timeout; retry is valid.   |
 | `MANUAL`  | No runnable command exists here; install the tool by hand.       |
 
-Wrapper-probed tools (`bash`/`sh`/`cargo` version commands) still report `OK`, because
-those probes cannot tell whether the tool itself is discoverable. A project-local npm
-add whose binary lands in `<project>/node_modules/.bin` **is** discoverable: planning,
-post-install verification, and `lintro doctor` share the same local-first probe, so a
-successful `npm install -D` is not reported as `PATH` just because that directory is not
-on `PATH`. The `bunx`/`npx` registry fallback is **not** an install and is never treated
-as discoverable.
+Wrapper-probed tools (`bash`/`sh`/`cargo` version commands, or an argv[0] containing
+`/`) still skip the PATH discoverability check, because those probes cannot tell whether
+the tool itself is discoverable. They still report `STALE` when a parsed version is
+below `min_version`. A project-local npm add whose binary lands in
+`<project>/node_modules/.bin` **is** discoverable: planning, post-install verification,
+and `lintro doctor` share the same local-first probe, so a successful `npm install -D`
+is not reported as `PATH` just because that directory is not on `PATH`. The `bunx`/`npx`
+registry fallback is **not** an install and is never treated as discoverable.
 
 `lintro install` exits 1 when **any** planned action is not a full success, including
 `PATH` (`NOT_DISCOVERABLE`) and `STALE` (`STILL_OUTDATED`). A zero-exit install command

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -857,7 +857,9 @@ def _render_quick_fix(
         console: Console to print to.
         results: Production tool check results.
         context: Detected runtime context.
-        known_invalid: Tool names whose install command already failed.
+        known_invalid: Tool names whose install command already failed in this
+            process. Per-process only: a failed remedy is never re-suggested
+            within one run; a fresh run gets one fresh attempt.
     """
     quick_fix = build_quick_fix(
         [

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -857,9 +857,10 @@ def _render_quick_fix(
         console: Console to print to.
         results: Production tool check results.
         context: Detected runtime context.
-        known_invalid: Tool names whose install command already failed in this
-            process. Per-process only: a failed remedy is never re-suggested
-            within one run; a fresh run gets one fresh attempt.
+        known_invalid: Tool names whose prior action in this process was a
+            non-success (failed, undiscoverable, still outdated, timed out,
+            or blocked). Per-process only: a non-success remedy is never
+            re-suggested within one run; a fresh run gets one fresh attempt.
     """
     quick_fix = build_quick_fix(
         [

--- a/lintro/cli_utils/commands/doctor.py
+++ b/lintro/cli_utils/commands/doctor.py
@@ -858,9 +858,11 @@ def _render_quick_fix(
         results: Production tool check results.
         context: Detected runtime context.
         known_invalid: Tool names whose prior action in this process was a
-            non-success (failed, undiscoverable, still outdated, timed out,
-            or blocked). Per-process only: a non-success remedy is never
-            re-suggested within one run; a fresh run gets one fresh attempt.
+            non-success that is not worth retrying unchanged (failed,
+            undiscoverable, still outdated, or blocked). Timeouts are
+            retryable and are not included. Per-process only: a non-success
+            remedy is never re-suggested within one run; a fresh run gets
+            one fresh attempt.
     """
     quick_fix = build_quick_fix(
         [

--- a/lintro/cli_utils/commands/install.py
+++ b/lintro/cli_utils/commands/install.py
@@ -140,6 +140,11 @@ def install_command(
     Specify tool names to install specific tools, or use --profile for
     predefined sets.
 
+    Exits 1 when any planned action is not a full success. That includes a
+    command that ran but left the tool undiscoverable (NOT_DISCOVERABLE) or
+    still below min_version (STILL_OUTDATED), not only a non-zero install
+    command.
+
     \u000c
 
     Args:
@@ -154,7 +159,8 @@ def install_command(
         global_install: Install npm-managed tools globally.
 
     Raises:
-        SystemExit: When tool installation fails.
+        SystemExit: When any install/upgrade action is not a full success
+            (including NOT_DISCOVERABLE and STILL_OUTDATED).
         click.UsageError: When conflicting options or invalid profile given.
 
     Examples:

--- a/lintro/cli_utils/install_output.py
+++ b/lintro/cli_utils/install_output.py
@@ -35,7 +35,7 @@ _SUMMARY_ORDER: tuple[InstallOutcome, ...] = (
 
 _SUMMARY_LABELS: dict[InstallOutcome, str] = {
     InstallOutcome.SUCCESS: "installed",
-    InstallOutcome.NOT_DISCOVERABLE: "installed but not on PATH",
+    InstallOutcome.NOT_DISCOVERABLE: "not discoverable",
     InstallOutcome.STILL_OUTDATED: "still below minimum version",
     InstallOutcome.FAILED: "failed",
     InstallOutcome.TIMED_OUT: "timed out",

--- a/lintro/cli_utils/install_output.py
+++ b/lintro/cli_utils/install_output.py
@@ -18,6 +18,7 @@ from lintro.tools.core.install_plan import InstallResult
 _OUTCOME_STYLES: dict[InstallOutcome, str] = {
     InstallOutcome.SUCCESS: "green",
     InstallOutcome.NOT_DISCOVERABLE: "yellow",
+    InstallOutcome.STILL_OUTDATED: "yellow",
     InstallOutcome.FAILED: "red",
     InstallOutcome.TIMED_OUT: "yellow",
     InstallOutcome.MANUAL_BLOCKED: "yellow",
@@ -26,6 +27,7 @@ _OUTCOME_STYLES: dict[InstallOutcome, str] = {
 _SUMMARY_ORDER: tuple[InstallOutcome, ...] = (
     InstallOutcome.SUCCESS,
     InstallOutcome.NOT_DISCOVERABLE,
+    InstallOutcome.STILL_OUTDATED,
     InstallOutcome.FAILED,
     InstallOutcome.TIMED_OUT,
     InstallOutcome.MANUAL_BLOCKED,
@@ -34,6 +36,7 @@ _SUMMARY_ORDER: tuple[InstallOutcome, ...] = (
 _SUMMARY_LABELS: dict[InstallOutcome, str] = {
     InstallOutcome.SUCCESS: "installed",
     InstallOutcome.NOT_DISCOVERABLE: "installed but not on PATH",
+    InstallOutcome.STILL_OUTDATED: "still below minimum version",
     InstallOutcome.FAILED: "failed",
     InstallOutcome.TIMED_OUT: "timed out",
     InstallOutcome.MANUAL_BLOCKED: "manual action required",
@@ -118,7 +121,11 @@ def unresolved_tool_names(
 
     Returns:
         Names of tools whose action failed in a way that re-running the
-        identical command cannot fix.
+        identical command cannot fix. Includes ``NOT_DISCOVERABLE`` and
+        ``STILL_OUTDATED``. The list is consumed as per-process
+        ``known_invalid``: within one run a failed remedy is never
+        re-suggested; a fresh run gets one fresh attempt. There is no
+        state file.
     """
     return [
         result.tool.name

--- a/lintro/enums/install_outcome.py
+++ b/lintro/enums/install_outcome.py
@@ -10,11 +10,16 @@ class InstallOutcome(StrEnum):
 
     A plain success/failure flag cannot express the states that make a retry
     loop converge: a command may succeed while the binary stays undiscoverable,
-    and a timeout is retryable where an invalid package name is not.
+    a command may succeed while the version stays below ``min_version``, and a
+    timeout is retryable where an invalid package name is not.
 
     Attributes:
         SUCCESS: Command succeeded and the tool is discoverable afterwards.
-        NOT_DISCOVERABLE: Command succeeded but the tool is still not on PATH.
+        NOT_DISCOVERABLE: Command succeeded but the tool is still not
+            discoverable (not on PATH, and not a project-local
+            ``node_modules/.bin`` binary).
+        STILL_OUTDATED: Command succeeded and the tool is discoverable, but
+            the probed version is still below ``min_version``.
         FAILED: Command ran and exited non-zero (or could not be launched).
         TIMED_OUT: Command exceeded the install timeout.
         MANUAL_BLOCKED: No executable command exists in this environment.
@@ -22,6 +27,7 @@ class InstallOutcome(StrEnum):
 
     SUCCESS = auto()
     NOT_DISCOVERABLE = auto()
+    STILL_OUTDATED = auto()
     FAILED = auto()
     TIMED_OUT = auto()
     MANUAL_BLOCKED = auto()
@@ -40,8 +46,9 @@ class InstallOutcome(StrEnum):
         """Whether re-running the same command could still succeed.
 
         Only a timeout is worth retrying. A failed command, a blocked manual
-        step, and an install that left the tool off PATH all reproduce
-        identically, so none of them may be re-emitted as a quick fix.
+        step, an install that left the tool undiscoverable, and an upgrade
+        that left the version below ``min_version`` all reproduce identically,
+        so none of them may be re-emitted as a quick fix.
 
         Returns:
             True when retrying the identical command is meaningful.
@@ -61,6 +68,7 @@ class InstallOutcome(StrEnum):
 _LABELS: dict[InstallOutcome, str] = {
     InstallOutcome.SUCCESS: "OK",
     InstallOutcome.NOT_DISCOVERABLE: "PATH",
+    InstallOutcome.STILL_OUTDATED: "STALE",
     InstallOutcome.FAILED: "FAIL",
     InstallOutcome.TIMED_OUT: "TIMEOUT",
     InstallOutcome.MANUAL_BLOCKED: "MANUAL",

--- a/lintro/enums/install_outcome.py
+++ b/lintro/enums/install_outcome.py
@@ -15,6 +15,8 @@ class InstallOutcome(StrEnum):
 
     Attributes:
         SUCCESS: Command succeeded and the tool is discoverable afterwards.
+            Unparseable version output still counts as success; STILL_OUTDATED
+            applies only when a parsed version is below ``min_version``.
         NOT_DISCOVERABLE: Command succeeded but the tool is still not
             discoverable (not on PATH, and not a project-local
             ``node_modules/.bin`` binary).

--- a/lintro/tools/core/install_quickfix.py
+++ b/lintro/tools/core/install_quickfix.py
@@ -9,6 +9,10 @@ The install-versus-upgrade decision is made per tool, mirroring
 ``ToolInstaller.plan``: a missing tool is installed, an outdated one upgraded.
 A batch-wide flag would suggest ``brew upgrade`` for a tool that is not
 installed yet, or hide an installable tool behind another tool's upgrade.
+
+``known_invalid`` is per-process only. Within one run a failed remedy
+(including ``NOT_DISCOVERABLE`` and ``STILL_OUTDATED``) is never
+re-suggested; a fresh run gets one fresh attempt. There is no state file.
 """
 
 from __future__ import annotations
@@ -75,8 +79,11 @@ def build_quick_fix(
             True for an installed-but-outdated tool and False for a missing one.
         env: The detected install environment.
         known_invalid: Tool names whose command already ran without resolving
-            the tool in this session; they are reported as blocked rather than
-            suggested again.
+            the tool in this process; they are reported as blocked rather than
+            suggested again. The set is per-process only: within one run a
+            failed remedy (including ``NOT_DISCOVERABLE`` and
+            ``STILL_OUTDATED``) is never re-suggested; a fresh run gets one
+            fresh attempt. There is no state file.
         is_brew_managed: Predicate used to confirm that Homebrew really manages
             a formula before suggesting ``brew upgrade``; defaults to the same
             check the installer uses. Injectable so tests stay off subprocess.

--- a/lintro/tools/core/tool_installer.py
+++ b/lintro/tools/core/tool_installer.py
@@ -652,8 +652,9 @@ class ToolInstaller:
         bin_dir = self._install_destination_dir(tool)
         return (
             f"Install command succeeded but {tool.name} is still not "
-            f"discoverable. It was installed to {bin_dir}; add that "
-            f'directory to PATH, for example: export PATH="{bin_dir}:$PATH"'
+            f"discoverable. It was expected under {bin_dir} and was not "
+            f"found; inspect that directory, or add it to PATH, for "
+            f'example: export PATH="{bin_dir}:$PATH"'
         )
 
     def _install_destination_dir(self, tool: ManifestTool) -> Path:
@@ -671,7 +672,7 @@ class ToolInstaller:
         if tool.install_type == "npm":
             npm = shutil.which("npm")
             if npm is not None:
-                return Path(npm).resolve().parent
+                return Path(npm).parent
         if tool.install_type == "pip":
             return Path(sysconfig.get_path("scripts"))
         if tool.install_type == "cargo":

--- a/lintro/tools/core/tool_installer.py
+++ b/lintro/tools/core/tool_installer.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import shlex
 import shutil
 import subprocess  # nosec B404 - subprocess is the core mechanism for invoking external tools; all invocations use shell=False
+import sysconfig
 import time
 from collections.abc import Sequence
 from pathlib import Path
@@ -60,6 +61,21 @@ __all__ = [
     "is_resolved_command_discoverable",
     "resolve_version_command",
 ]
+
+
+def _is_wrapper_probe(command: Sequence[str]) -> bool:
+    """Return whether *command* probes a wrapper or host binary, not the tool.
+
+    Args:
+        command: Version-command argv (manifest or resolved).
+
+    Returns:
+        True when argv[0] is ``sh``/``bash``/``cargo`` or contains ``/``.
+    """
+    if not command:
+        return False
+    main_cmd = command[0]
+    return main_cmd in _INDIRECT_PROBE_COMMANDS or "/" in main_cmd
 
 
 def _is_node_modules_bin(path: Path) -> bool:
@@ -101,9 +117,11 @@ def resolve_version_command(
     command = list(tool.version_command)
     if tool.install_type != "npm":
         return command
-    # Wrapper version commands (vue-tsc's bash helper) are not a Node
-    # binary name; splicing the runtime chain onto them drops the wrapper.
-    if not command or command[0] in ("sh", "bash"):
+    # Wrapper probes cannot answer whether the tool itself is discoverable
+    # (`sh`/`bash`/`cargo`, or an argv[0] containing `/`). Leave them as
+    # the manifest wrote them — the same set `_verify_discoverable` used
+    # before this helper existed — instead of splicing the Node chain on.
+    if _is_wrapper_probe(command):
         return command
 
     from lintro.plugins.execution_preparation import get_executable_command
@@ -153,7 +171,7 @@ def is_resolved_command_discoverable(command: Sequence[str]) -> bool:
     if main_path.is_absolute() and _is_node_modules_bin(main_path):
         return main_path.exists()
 
-    if main_cmd in _INDIRECT_PROBE_COMMANDS or "/" in main_cmd:
+    if _is_wrapper_probe(command):
         return True
 
     return shutil.which(main_cmd) is not None
@@ -631,19 +649,34 @@ class ToolInstaller:
             Message naming the install destination directory and the PATH
             remedy, rather than a generic "needs manual action".
         """
-        dest = self._install_cwd(tool)
-        if dest is not None:
-            bin_dir = dest / "node_modules" / ".bin"
-            return (
-                f"Install command succeeded but {tool.name} is still not "
-                f"discoverable. It was installed to {bin_dir}; add that "
-                f'directory to PATH, for example: export PATH="{bin_dir}:$PATH"'
-            )
+        bin_dir = self._install_destination_dir(tool)
         return (
             f"Install command succeeded but {tool.name} is still not "
-            "discoverable on PATH. Add the install destination directory "
-            "to PATH."
+            f"discoverable. It was installed to {bin_dir}; add that "
+            f'directory to PATH, for example: export PATH="{bin_dir}:$PATH"'
         )
+
+    def _install_destination_dir(self, tool: ManifestTool) -> Path:
+        """Return the directory an install of *tool* is expected to land in.
+
+        Args:
+            tool: Tool whose binary could not be found after install.
+
+        Returns:
+            Concrete destination directory named in the PATH remedy.
+        """
+        dest = self._install_cwd(tool)
+        if dest is not None:
+            return dest / "node_modules" / ".bin"
+        if tool.install_type == "npm":
+            npm = shutil.which("npm")
+            if npm is not None:
+                return Path(npm).resolve().parent
+        if tool.install_type == "pip":
+            return Path(sysconfig.get_path("scripts"))
+        if tool.install_type == "cargo":
+            return Path.home() / ".cargo" / "bin"
+        return Path.home() / ".local" / "bin"
 
     def _verified_result(
         self,

--- a/lintro/tools/core/tool_installer.py
+++ b/lintro/tools/core/tool_installer.py
@@ -23,6 +23,7 @@ import shlex
 import shutil
 import subprocess  # nosec B404 - subprocess is the core mechanism for invoking external tools; all invocations use shell=False
 import time
+from collections.abc import Sequence
 from pathlib import Path
 
 from loguru import logger
@@ -39,6 +40,7 @@ from lintro.tools.core.install_hints import (
 from lintro.tools.core.install_plan import InstallPlan, InstallResult
 from lintro.tools.core.install_strategies import get_strategy
 from lintro.tools.core.install_strategies.package_names import script_tool_name
+from lintro.tools.core.node_fallback import REGISTRY_RUNNERS
 from lintro.tools.core.tool_registry import ManifestRegistry, ManifestTool
 from lintro.tools.core.version_parsing import (
     compare_versions,
@@ -55,7 +57,106 @@ __all__ = [
     "InstallPlan",
     "InstallResult",
     "ToolInstaller",
+    "is_resolved_command_discoverable",
+    "resolve_version_command",
 ]
+
+
+def _is_node_modules_bin(path: Path) -> bool:
+    """Return whether *path* is an executable under ``node_modules/.bin``.
+
+    Args:
+        path: Candidate executable path.
+
+    Returns:
+        True when the immediate parent directory is ``node_modules/.bin``.
+    """
+    return path.parent.name == ".bin" and path.parent.parent.name == "node_modules"
+
+
+def resolve_version_command(
+    tool: ManifestTool,
+    *,
+    context: RuntimeContext,
+) -> list[str]:
+    """Resolve a tool's version command the way a run will resolve it.
+
+    For npm-installed tools the manifest's ``version_command`` names a bare
+    binary, which only ever finds a global install. Since #1811 a run
+    resolves ``node_modules/.bin`` first, so planning, post-install
+    verification, and doctor must share this helper rather than each calling
+    ``shutil.which`` on PATH. The Node chain is
+    :func:`lintro.plugins.execution_preparation.get_executable_command`;
+    ``bunx``/``npx`` is the registry fallback, not an install, so this helper
+    returns the original manifest command in that case (the caller must not
+    treat the runner as evidence the tool is installed).
+
+    Args:
+        tool: Tool whose version command is being resolved.
+        context: Runtime context supplying the detected Node project root.
+
+    Returns:
+        Argv list to run for the version probe.
+    """
+    command = list(tool.version_command)
+    if tool.install_type != "npm":
+        return command
+    # Wrapper version commands (vue-tsc's bash helper) are not a Node
+    # binary name; splicing the runtime chain onto them drops the wrapper.
+    if not command or command[0] in ("sh", "bash"):
+        return command
+
+    from lintro.plugins.execution_preparation import get_executable_command
+
+    project = context.environment.node_project
+    resolved = get_executable_command(
+        tool.name,
+        cwd=project.root if project is not None else None,
+    )
+    # bunx/npx is the registry fallback, not an install. Treating it as
+    # already_ok would skip the project-local add this path exists to make.
+    if not resolved or resolved[0] in REGISTRY_RUNNERS:
+        return command
+    return [*resolved, *command[1:]]
+
+
+def is_resolved_command_discoverable(command: Sequence[str]) -> bool:
+    """Report whether a resolved version-command argv shows the tool is installed.
+
+    Planning, post-install verification, and doctor share this probe so they
+    cannot disagree about a project-local ``node_modules/.bin`` binary.
+
+    * An argv whose first element is ``bunx``/``npx`` is the registry
+      fallback, not an install — not discoverable.
+    * An absolute path under ``node_modules/.bin`` that exists is
+      discoverable even when that directory is not on PATH.
+    * Wrapper probes (``sh``/``bash``/``cargo``, or a path containing ``/``
+      that is not a local Node bin) cannot answer whether the tool itself is
+      discoverable, so they count as discoverable as today.
+    * Anything else is discoverable only when ``shutil.which`` finds it.
+
+    Args:
+        command: Argv returned by :func:`resolve_version_command`.
+
+    Returns:
+        False only when the tool's own executable is provably absent; True
+        when it resolves or when no on-PATH probe applies.
+    """
+    if not command:
+        return True
+
+    main_cmd = command[0]
+    if main_cmd in REGISTRY_RUNNERS:
+        return False
+
+    main_path = Path(main_cmd)
+    if main_path.is_absolute() and _is_node_modules_bin(main_path):
+        return main_path.exists()
+
+    if main_cmd in _INDIRECT_PROBE_COMMANDS or "/" in main_cmd:
+        return True
+
+    return shutil.which(main_cmd) is not None
 
 
 class ToolInstaller:
@@ -224,8 +325,10 @@ class ToolInstaller:
         except ImportError:
             return None
         main_cmd = command[0]
+        if main_cmd in REGISTRY_RUNNERS:
+            return None
         if (
-            main_cmd not in ("sh", "bash", "cargo")
+            main_cmd not in _INDIRECT_PROBE_COMMANDS
             and not Path(main_cmd).is_absolute()
             and not shutil.which(main_cmd)
         ):
@@ -253,13 +356,8 @@ class ToolInstaller:
     def _resolved_version_command(self, tool: ManifestTool) -> list[str]:
         """Resolve a tool's version command the way the run will resolve it.
 
-        For npm-installed tools the manifest's ``version_command`` names a bare
-        binary, which only ever finds a global install. Since #1811 a run
-        resolves ``node_modules/.bin`` first, so planning against ``PATH`` would
-        report a tool as missing (or as the wrong version) while checks happily
-        use the project-local one — the exact "two authorities" split #2005 is
-        about. Route npm tools through the same command-builder registry the
-        executor uses, anchored on the detected project root.
+        Delegates to :func:`resolve_version_command` so planning, post-install
+        verification, and doctor share one Node resolution path.
 
         Args:
             tool: Tool whose version command is being resolved.
@@ -267,26 +365,7 @@ class ToolInstaller:
         Returns:
             Argv list to run for the version probe.
         """
-        command = list(tool.version_command)
-        if tool.install_type != "npm":
-            return command
-        # Wrapper version commands (vue-tsc's bash helper) are not a Node
-        # binary name; splicing the runtime chain onto them drops the wrapper.
-        if command[0] in ("sh", "bash"):
-            return command
-
-        from lintro.plugins.execution_preparation import get_executable_command
-
-        project = self._context.environment.node_project
-        resolved = get_executable_command(
-            tool.name,
-            cwd=project.root if project is not None else None,
-        )
-        # bunx/npx is the registry fallback, not an install. Treating it as
-        # already_ok would skip the project-local add this PR exists to make.
-        if not resolved or resolved[0] in ("bunx", "npx"):
-            return command
-        return [*resolved, *command[1:]]
+        return resolve_version_command(tool, context=self._context)
 
     @staticmethod
     def _version_meets_minimum(installed: str, minimum: str) -> bool:
@@ -417,36 +496,35 @@ class ToolInstaller:
 
         return results
 
-    @staticmethod
-    def _verify_discoverable(tool: ManifestTool) -> bool:
+    def _verify_discoverable(self, tool: ManifestTool) -> bool:
         """Check whether a tool is discoverable after a successful install.
 
-        Only the executable lookup is used as evidence. A version probe can
-        fail for reasons that have nothing to do with discoverability — a
-        repo-relative wrapper script (``bash scripts/...``), a subcommand of
-        another binary (``cargo audit``), unparseable output, or a transient
-        error — and reporting those as NOT_DISCOVERABLE would mark a genuinely
-        successful install as failed and suppress the tool from later quick
-        fixes.
+        Reuses :meth:`_resolved_version_command` so a project-local
+        ``node_modules/.bin`` binary counts as discoverable even when that
+        directory is not on PATH. Only the executable lookup is used as
+        evidence. A version probe can fail for reasons that have nothing to
+        do with discoverability — a repo-relative wrapper script
+        (``bash scripts/...``), a subcommand of another binary
+        (``cargo audit``), unparseable output, or a transient error — and
+        reporting those as NOT_DISCOVERABLE would mark a genuinely successful
+        install as failed and suppress the tool from later quick fixes.
 
         Args:
             tool: Tool that was just installed.
 
         Returns:
-            False only when the tool's own executable is provably absent from
-            PATH; True when it resolves or when no on-PATH probe applies.
+            False only when the tool's own executable is provably absent;
+            True when it resolves or when no on-PATH probe applies.
         """
         if not tool.version_command:
             # Nothing to probe with — trust the exit code.
             return True
 
-        main_cmd = tool.version_command[0]
-        if main_cmd in _INDIRECT_PROBE_COMMANDS or "/" in main_cmd:
-            # The probe runs a wrapper/host binary, not the tool itself, so it
-            # cannot answer whether the tool ended up discoverable.
-            return True
-
-        return shutil.which(main_cmd) is not None
+        try:
+            command = self._resolved_version_command(tool)
+        except ImportError:
+            command = list(tool.version_command)
+        return is_resolved_command_discoverable(command)
 
     _INSTALL_TIMEOUT_SECONDS = 300
 
@@ -543,6 +621,30 @@ class ToolInstaller:
                 command=command,
             )
 
+    def _not_discoverable_message(self, tool: ManifestTool) -> str:
+        """Explain a successful command that left the tool undiscoverable.
+
+        Args:
+            tool: Tool whose binary could not be found after install.
+
+        Returns:
+            Message naming the install destination directory and the PATH
+            remedy, rather than a generic "needs manual action".
+        """
+        dest = self._install_cwd(tool)
+        if dest is not None:
+            bin_dir = dest / "node_modules" / ".bin"
+            return (
+                f"Install command succeeded but {tool.name} is still not "
+                f"discoverable. It was installed to {bin_dir}; add that "
+                f'directory to PATH, for example: export PATH="{bin_dir}:$PATH"'
+            )
+        return (
+            f"Install command succeeded but {tool.name} is still not "
+            "discoverable on PATH. Add the install destination directory "
+            "to PATH."
+        )
+
     def _verified_result(
         self,
         *,
@@ -553,30 +655,51 @@ class ToolInstaller:
     ) -> InstallResult:
         """Build the result for a command that exited zero.
 
+        After discoverability, the same local-first probe is re-run for
+        version. Exit 0 with a version still below ``min_version`` is
+        :attr:`InstallOutcome.STILL_OUTDATED`, not success, so the identical
+        command is never re-suggested within this process.
+
         Args:
             tool: Tool that was installed.
             command: Command that was run.
-            message: Success message to use when the tool is discoverable.
+            message: Success message to use when the tool is discoverable
+                and meets ``min_version``.
             duration: Elapsed seconds for the install.
 
         Returns:
-            InstallResult with SUCCESS or NOT_DISCOVERABLE.
+            InstallResult with SUCCESS, NOT_DISCOVERABLE, or STILL_OUTDATED.
         """
-        if self._verify_discoverable(tool):
+        if not self._verify_discoverable(tool):
             return InstallResult(
                 tool=tool,
-                outcome=InstallOutcome.SUCCESS,
-                message=message,
+                outcome=InstallOutcome.NOT_DISCOVERABLE,
+                message=self._not_discoverable_message(tool),
                 duration_seconds=duration,
                 command=command,
             )
+
+        installed = self._get_installed_version(tool)
+        if (
+            installed is not None
+            and tool.min_version
+            and not self._version_meets_minimum(installed, tool.min_version)
+        ):
+            return InstallResult(
+                tool=tool,
+                outcome=InstallOutcome.STILL_OUTDATED,
+                message=(
+                    f"Install command succeeded but {tool.name} {installed} "
+                    f"is still below minimum {tool.min_version}"
+                ),
+                duration_seconds=duration,
+                command=command,
+            )
+
         return InstallResult(
             tool=tool,
-            outcome=InstallOutcome.NOT_DISCOVERABLE,
-            message=(
-                "Install command succeeded but "
-                f"{tool.name} is still not discoverable on PATH"
-            ),
+            outcome=InstallOutcome.SUCCESS,
+            message=message,
             duration_seconds=duration,
             command=command,
         )

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -30,10 +30,15 @@ import shutil
 import subprocess  # nosec B404 - subprocess is the only way to ask a binary its version; every call below is a fixed argv list with shell=False
 from dataclasses import dataclass
 from enum import StrEnum, auto
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 
 from lintro.enums.tool_status import ToolStatus
 from lintro.tools.core.install_strategies import get_strategy
+from lintro.tools.core.tool_installer import (
+    is_resolved_command_discoverable,
+    resolve_version_command,
+)
 from lintro.tools.core.tool_registry import ManifestRegistry, ManifestTool
 from lintro.tools.core.version_parsing import (
     compare_versions,
@@ -168,11 +173,13 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
             upgrade_hint=upgrade_hint,
         )
 
-    # Find the main executable (may be a wrapper like "sh", "cargo", etc.)
-    main_cmd = tool.version_command[0]
-    tool_path = shutil.which(main_cmd)
+    try:
+        command = resolve_version_command(tool, context=context)
+    except ImportError:
+        command = list(tool.version_command)
 
-    if not tool_path:
+    if not is_resolved_command_discoverable(command):
+        main_cmd = command[0] if command else ""
         return ToolCheckResult(
             tool=tool,
             status=ToolStatus.MISSING,
@@ -182,9 +189,12 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
             upgrade_hint=upgrade_hint,
         )
 
+    main_cmd = command[0]
+    tool_path = main_cmd if Path(main_cmd).is_absolute() else shutil.which(main_cmd)
+
     try:
         result = subprocess.run(  # nosec B603 - argv is an internally-built list run with shell=False; binary resolved from a known command, no user shell input
-            tool.version_command,
+            command,
             capture_output=True,
             text=True,
             timeout=VERSION_PROBE_TIMEOUT_SECONDS,

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -190,7 +190,23 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
         )
 
     main_cmd = command[0]
-    tool_path = main_cmd if Path(main_cmd).is_absolute() else shutil.which(main_cmd)
+    if Path(main_cmd).is_absolute():
+        tool_path = main_cmd
+    else:
+        tool_path = shutil.which(main_cmd)
+        # Wrapper probes (cargo/bash/sh) count as discoverable for install
+        # verification because they cannot prove the *tool* is absent. Doctor
+        # still needs the host binary on PATH; otherwise subprocess raises
+        # FileNotFoundError and we mislabel the miss as os_error (#2026).
+        if tool_path is None and "/" not in main_cmd:
+            return ToolCheckResult(
+                tool=tool,
+                status=ToolStatus.MISSING,
+                error="not_in_path",
+                details=main_cmd,
+                install_hint=hint,
+                upgrade_hint=upgrade_hint,
+            )
 
     try:
         result = subprocess.run(  # nosec B603 - argv is an internally-built list run with shell=False; binary resolved from a known command, no user shell input

--- a/lintro/utils/doctor_report.py
+++ b/lintro/utils/doctor_report.py
@@ -190,6 +190,7 @@ def check_tool(*, tool: ManifestTool, context: RuntimeContext) -> ToolCheckResul
         )
 
     main_cmd = command[0]
+    tool_path: str | None
     if Path(main_cmd).is_absolute():
         tool_path = main_cmd
     else:

--- a/tests/unit/cli_utils/commands/test_install_command.py
+++ b/tests/unit/cli_utils/commands/test_install_command.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from assertpy import assert_that
 from click.testing import CliRunner
 
@@ -249,7 +250,53 @@ def test_install_failure_exit_1() -> None:
     assert_that(result.exit_code).is_equal_to(1)
 
 
-# ── _detect_languages ────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        InstallOutcome.NOT_DISCOVERABLE,
+        InstallOutcome.STILL_OUTDATED,
+    ],
+)
+def test_install_non_success_outcomes_exit_1(outcome: InstallOutcome) -> None:
+    """NOT_DISCOVERABLE and STILL_OUTDATED keep the exit-1-on-any-non-success contract.
+
+    Args:
+        outcome: Non-success outcome that must still fail the process.
+    """
+    runner = CliRunner()
+    p1, p2 = _patches()
+
+    tool = _make_tool()
+    plan = InstallPlan(to_install=[(tool, "pip install ruff>=0.14.0")])
+    with (
+        p1,
+        p2,
+        patch(
+            "lintro.cli_utils.commands.install.ToolInstaller",
+        ) as mock_cls,
+    ):
+        mock_cls.return_value.plan.return_value = plan
+        mock_cls.return_value.execute.return_value = [
+            InstallResult(
+                tool=tool,
+                outcome=outcome,
+                message=str(outcome),
+            ),
+        ]
+        result = runner.invoke(install_command, ["ruff"])
+
+    assert_that(result.exit_code).is_equal_to(1)
+
+
+def test_install_help_documents_exit_1_on_non_success() -> None:
+    """CLI help states that NOT_DISCOVERABLE still exits 1."""
+    runner = CliRunner()
+    result = runner.invoke(install_command, ["--help"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains("Exits 1")
+    assert_that(result.output).contains("NOT_DISCOVERABLE")
+    assert_that(result.output).does_not_contain("Args:")
 
 
 def test_detect_languages_returns_list() -> None:

--- a/tests/unit/cli_utils/test_install_output.py
+++ b/tests/unit/cli_utils/test_install_output.py
@@ -6,12 +6,15 @@ from assertpy import assert_that
 from rich.console import Console
 
 from lintro.cli_utils.install_output import (
+    _OUTCOME_STYLES,
+    _SUMMARY_LABELS,
+    _SUMMARY_ORDER,
     count_outcomes,
     render_install_results,
     render_outcome_summary,
     unresolved_tool_names,
 )
-from lintro.enums.install_outcome import InstallOutcome
+from lintro.enums.install_outcome import _LABELS, InstallOutcome
 from lintro.tools.core.install_plan import InstallResult
 from lintro.tools.core.tool_registry import ManifestTool
 
@@ -107,12 +110,35 @@ def test_unresolved_names_exclude_retryable_outcomes() -> None:
     """Only a timeout is worth retrying unchanged; other issues are not."""
     unresolved = unresolved_tool_names(
         [
-            _result("golangci_lint", InstallOutcome.FAILED, step=1, total=5),
-            _result("clippy", InstallOutcome.TIMED_OUT, step=2, total=5),
-            _result("vale", InstallOutcome.MANUAL_BLOCKED, step=3, total=5),
-            _result("taplo", InstallOutcome.NOT_DISCOVERABLE, step=4, total=5),
-            _result("ruff", InstallOutcome.SUCCESS, step=5, total=5),
+            _result("golangci_lint", InstallOutcome.FAILED, step=1, total=6),
+            _result("clippy", InstallOutcome.TIMED_OUT, step=2, total=6),
+            _result("vale", InstallOutcome.MANUAL_BLOCKED, step=3, total=6),
+            _result("taplo", InstallOutcome.NOT_DISCOVERABLE, step=4, total=6),
+            _result("ruff", InstallOutcome.STILL_OUTDATED, step=5, total=6),
+            _result("black", InstallOutcome.SUCCESS, step=6, total=6),
         ],
     )
 
-    assert_that(unresolved).is_equal_to(["golangci_lint", "vale", "taplo"])
+    assert_that(unresolved).is_equal_to(
+        ["golangci_lint", "vale", "taplo", "ruff"],
+    )
+
+
+def test_every_install_outcome_has_render_maps() -> None:
+    """Every InstallOutcome member has style, summary label, and summary order."""
+    members = set(InstallOutcome)
+
+    assert_that(set(_OUTCOME_STYLES)).is_equal_to(members)
+    assert_that(set(_SUMMARY_LABELS)).is_equal_to(members)
+    assert_that(set(_SUMMARY_ORDER)).is_equal_to(members)
+    assert_that(set(_LABELS)).is_equal_to(members)
+
+
+def test_render_distinguishes_still_outdated_from_success() -> None:
+    """An upgrade that left the version below min_version is not reported as OK."""
+    output = _render(
+        [_result("ruff", InstallOutcome.STILL_OUTDATED, step=1, total=1)],
+    )
+
+    assert_that(output).contains("STALE  ruff")
+    assert_that(output).contains("still below minimum version")

--- a/tests/unit/cli_utils/test_install_output.py
+++ b/tests/unit/cli_utils/test_install_output.py
@@ -92,7 +92,7 @@ def test_render_distinguishes_not_discoverable_from_success() -> None:
     )
 
     assert_that(output).contains("PATH  vale")
-    assert_that(output).contains("installed but not on PATH")
+    assert_that(output).contains("not discoverable")
 
 
 def test_count_outcomes_covers_every_outcome() -> None:

--- a/tests/unit/tools/core/test_install_outcomes.py
+++ b/tests/unit/tools/core/test_install_outcomes.py
@@ -2,16 +2,27 @@
 
 from __future__ import annotations
 
+import json
 import subprocess  # nosec B404 - only TimeoutExpired is referenced; no process is spawned
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from assertpy import assert_that
 
 from lintro.cli_utils.install_output import unresolved_tool_names
+from lintro.enums.install_context import InstallContext, PackageManager
 from lintro.enums.install_outcome import InstallOutcome
 from lintro.tools.core.install_context import RuntimeContext
 from lintro.tools.core.install_plan import InstallPlan
-from lintro.tools.core.tool_installer import ToolInstaller
+from lintro.tools.core.install_quickfix import build_quick_fix
+from lintro.tools.core.install_strategies.environment import InstallEnvironment
+from lintro.tools.core.install_strategies.node_project import detect_node_project
+from lintro.tools.core.tool_installer import (
+    ToolInstaller,
+    is_resolved_command_discoverable,
+)
 from lintro.tools.core.tool_registry import ManifestRegistry, ManifestTool
 
 
@@ -128,7 +139,7 @@ def test_unparseable_version_output_still_counts_as_installed() -> None:
     ):
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="", stderr=""),
-            MagicMock(returncode=0, stdout="faketool 1.2.0", stderr=""),
+            MagicMock(returncode=0, stdout="no version here", stderr=""),
         ]
         result = installer._run_install(tool, "pip install faketool")
 
@@ -290,3 +301,204 @@ def test_execute_continues_after_failure_and_timeout() -> None:
     assert_that([(r.step, r.total_steps) for r in results]).is_equal_to(
         [(1, 3), (2, 3), (3, 3)],
     )
+
+
+def _write_node_project(root: Path) -> Path:
+    """Create a minimal npm-locked Node project.
+
+    Args:
+        root: Directory to write the project into.
+
+    Returns:
+        The project root.
+    """
+    (root / "package.json").write_text(
+        json.dumps({"name": "demo"}),
+        encoding="utf-8",
+    )
+    (root / "package-lock.json").write_text("", encoding="utf-8")
+    return root
+
+
+def _node_installer(root: Path) -> ToolInstaller:
+    """Build an installer anchored on a Node project.
+
+    Args:
+        root: Project root with a package.json.
+
+    Returns:
+        ToolInstaller instance.
+    """
+    return ToolInstaller(
+        ManifestRegistry.load(),
+        RuntimeContext(
+            install_context=InstallContext.PIP,
+            platform_label="Linux x86_64",
+            environment=InstallEnvironment(
+                install_context=InstallContext.PIP,
+                available_managers=frozenset({PackageManager.NPM, PackageManager.UV}),
+                node_project=detect_node_project(root),
+            ),
+            is_ci=False,
+        ),
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fake shell-script binary is not executable on Windows",
+)
+def test_project_local_npm_binary_is_discoverable(tmp_path: Path) -> None:
+    """A binary only under node_modules/.bin is discoverable, not PATH.
+
+    After a project-local ``npm install -D`` the executable is not on PATH.
+    Planning, post-install verification, and doctor must still treat it as
+    installed.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+    """
+    _write_node_project(tmp_path)
+    registry = ManifestRegistry.load()
+    tool = registry.get("prettier")
+    local_bin = tmp_path / "node_modules" / ".bin"
+    local_bin.mkdir(parents=True)
+    binary = local_bin / "prettier"
+    binary.write_text(f'#!/bin/sh\necho "{tool.version}"\n', encoding="utf-8")
+    binary.chmod(0o755)
+
+    installer = _node_installer(tmp_path)
+
+    with (
+        patch("lintro.tools.core.tool_installer.subprocess.run") as mock_run,
+        patch("lintro.tools.core.tool_installer.shutil.which", return_value=None),
+    ):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout=tool.version, stderr=""),
+        ]
+        assert_that(installer._verify_discoverable(tool)).is_true()
+        result = installer._run_install(tool, "npm install -D prettier")
+
+    assert_that(result.outcome).is_not_equal_to(InstallOutcome.NOT_DISCOVERABLE)
+    assert_that(result.outcome).is_equal_to(InstallOutcome.SUCCESS)
+
+
+def test_bunx_npx_fallback_is_not_treated_as_discoverable() -> None:
+    """The registry fallback is a fetch, not an install."""
+    assert_that(
+        is_resolved_command_discoverable(["bunx", "prettier@3.9.4"]),
+    ).is_false()
+    assert_that(
+        is_resolved_command_discoverable(["npx", "prettier@3.9.4"]),
+    ).is_false()
+
+    installer = _installer()
+    tool = ManifestTool(
+        name="prettier",
+        version="3.9.4",
+        min_version="3.9.4",
+        install_type="npm",
+        install_package="prettier",
+        version_command=("prettier", "--version"),
+    )
+    with (
+        patch(
+            "lintro.plugins.execution_preparation.get_executable_command",
+            return_value=["bunx", "prettier@3.9.4"],
+        ),
+        patch("lintro.tools.core.tool_installer.shutil.which", return_value=None),
+        patch("lintro.tools.core.tool_installer.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        assert_that(installer._verify_discoverable(tool)).is_false()
+        result = installer._run_install(tool, "npm install -D prettier@3.9.4")
+
+    assert_that(result.outcome).is_equal_to(InstallOutcome.NOT_DISCOVERABLE)
+
+
+def test_upgrade_exit_0_still_outdated_is_not_re_suggested() -> None:
+    """Exit 0 with a version still below min_version is a non-success.
+
+    The tool is added to known_invalid so post-fix quick-fix does not
+    re-emit the identical command within this process.
+    """
+    installer = _installer()
+    tool = ManifestTool(
+        name="ruff",
+        version="2.0.0",
+        min_version="2.0.0",
+        install_type="pip",
+        install_package="ruff",
+        version_command=("ruff", "--version"),
+    )
+
+    with (
+        patch("lintro.tools.core.tool_installer.subprocess.run") as mock_run,
+        patch(
+            "lintro.tools.core.tool_installer.shutil.which",
+            return_value="/usr/local/bin/ruff",
+        ),
+    ):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="ruff 1.0.0", stderr=""),
+        ]
+        result = installer._run_install(tool, "pip install --upgrade ruff")
+
+    assert_that(result.outcome).is_equal_to(InstallOutcome.STILL_OUTDATED)
+    assert_that(result.success).is_false()
+    assert_that(result.outcome.is_retryable).is_false()
+    assert_that(result.message).contains("1.0.0")
+    assert_that(result.message).contains("2.0.0")
+
+    unresolved = unresolved_tool_names([result])
+    assert_that(unresolved).is_equal_to(["ruff"])
+
+    quick_fix = build_quick_fix(
+        [(tool, True)],
+        InstallEnvironment(
+            install_context=InstallContext.PIP,
+            available_managers=frozenset({PackageManager.UV}),
+        ),
+        known_invalid=unresolved,
+    )
+    assert_that(quick_fix.commands).is_empty()
+    assert_that([name for name, _reason in quick_fix.blocked]).is_equal_to(["ruff"])
+
+
+def test_not_discoverable_message_names_the_destination_directory(
+    tmp_path: Path,
+) -> None:
+    """A PATH outcome for a project-local npm add names node_modules/.bin.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+    """
+    _write_node_project(tmp_path)
+    installer = _node_installer(tmp_path)
+    tool = ManifestTool(
+        name="prettier",
+        version="3.9.4",
+        min_version="3.9.4",
+        install_type="npm",
+        install_package="prettier",
+        version_command=("prettier", "--version"),
+    )
+    expected_bin = tmp_path.resolve() / "node_modules" / ".bin"
+
+    with (
+        patch("lintro.tools.core.tool_installer.subprocess.run") as mock_run,
+        patch("lintro.tools.core.tool_installer.shutil.which", return_value=None),
+        patch(
+            "lintro.plugins.execution_preparation.get_executable_command",
+            return_value=["prettier"],
+        ),
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        result = installer._run_install(tool, "npm install -D prettier@3.9.4")
+
+    assert_that(result.outcome).is_equal_to(InstallOutcome.NOT_DISCOVERABLE)
+    assert_that(result.message).contains(str(expected_bin))
+    assert_that(result.message).contains("PATH")
+    assert_that(result.message).does_not_contain("needs manual action")

--- a/tests/unit/tools/core/test_install_outcomes.py
+++ b/tests/unit/tools/core/test_install_outcomes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import subprocess  # nosec B404 - only TimeoutExpired is referenced; no process is spawned
 import sys
+import sysconfig
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -22,6 +23,7 @@ from lintro.tools.core.install_strategies.node_project import detect_node_projec
 from lintro.tools.core.tool_installer import (
     ToolInstaller,
     is_resolved_command_discoverable,
+    resolve_version_command,
 )
 from lintro.tools.core.tool_registry import ManifestRegistry, ManifestTool
 
@@ -90,6 +92,9 @@ def test_command_success_without_discovery_is_flagged() -> None:
     assert_that(result.outcome).is_equal_to(InstallOutcome.NOT_DISCOVERABLE)
     assert_that(result.success).is_false()
     assert_that(result.message).contains("not discoverable")
+    assert_that(result.message).contains(str(Path(sysconfig.get_path("scripts"))))
+    assert_that(result.message).contains("PATH")
+    assert_that(result.message).does_not_contain("needs manual action")
     # A rerun installs the same package to the same place — it cannot fix PATH.
     assert_that(result.outcome.is_retryable).is_false()
 
@@ -502,3 +507,46 @@ def test_not_discoverable_message_names_the_destination_directory(
     assert_that(result.message).contains(str(expected_bin))
     assert_that(result.message).contains("PATH")
     assert_that(result.message).does_not_contain("needs manual action")
+
+
+@pytest.mark.parametrize(
+    ("argv0", "rest"),
+    [
+        ("bash", ("scripts/vue-tsc-version.sh",)),
+        ("sh", ("scripts/vue-tsc-version.sh",)),
+        ("cargo", ("audit", "--version")),
+        ("scripts/probe.sh", ()),
+    ],
+    ids=["bash", "sh", "cargo", "relative-path"],
+)
+def test_npm_wrapper_probes_are_not_rewritten_by_node_resolution(
+    tmp_path: Path,
+    argv0: str,
+    rest: tuple[str, ...],
+) -> None:
+    """Wrapper probes stay as the manifest wrote them, even for npm tools.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+        argv0: First element of the manifest version command.
+        rest: Remaining argv.
+    """
+    _write_node_project(tmp_path)
+    installer = _node_installer(tmp_path)
+    command = (argv0, *rest)
+    tool = ManifestTool(
+        name="vue_tsc",
+        version="3.0.0",
+        min_version="3.0.0",
+        install_type="npm",
+        install_package="vue-tsc",
+        version_command=command,
+    )
+    with patch(
+        "lintro.plugins.execution_preparation.get_executable_command",
+    ) as mock_resolve:
+        resolved = resolve_version_command(tool, context=installer._context)
+
+    assert_that(resolved).is_equal_to(list(command))
+    mock_resolve.assert_not_called()
+    assert_that(is_resolved_command_discoverable(resolved)).is_true()

--- a/tests/unit/tools/core/test_install_outcomes.py
+++ b/tests/unit/tools/core/test_install_outcomes.py
@@ -505,7 +505,9 @@ def test_not_discoverable_message_names_the_destination_directory(
 
     assert_that(result.outcome).is_equal_to(InstallOutcome.NOT_DISCOVERABLE)
     assert_that(result.message).contains(str(expected_bin))
+    assert_that(result.message).contains("expected under")
     assert_that(result.message).contains("PATH")
+    assert_that(result.message).does_not_contain("was installed to")
     assert_that(result.message).does_not_contain("needs manual action")
 
 
@@ -550,3 +552,41 @@ def test_npm_wrapper_probes_are_not_rewritten_by_node_resolution(
     assert_that(resolved).is_equal_to(list(command))
     mock_resolve.assert_not_called()
     assert_that(is_resolved_command_discoverable(resolved)).is_true()
+
+
+def test_global_npm_destination_uses_which_parent_not_symlink_target(
+    tmp_path: Path,
+) -> None:
+    """Global npm PATH names the executable's parent, not the symlink target.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+    """
+    bindir = tmp_path / "node" / "v22.22.2" / "bin"
+    bindir.mkdir(parents=True)
+    real_npm = tmp_path / "lib" / "node_modules" / "npm" / "bin" / "npm-cli.js"
+    real_npm.parent.mkdir(parents=True)
+    real_npm.write_text("")
+    link = bindir / "npm"
+    link.symlink_to(real_npm)
+
+    installer = _installer()
+    tool = ManifestTool(
+        name="prettier",
+        version="3.9.4",
+        min_version="3.9.4",
+        install_type="npm",
+        install_package="prettier",
+        version_command=("prettier", "--version"),
+    )
+    with (
+        patch.object(installer, "_install_cwd", return_value=None),
+        patch(
+            "lintro.tools.core.tool_installer.shutil.which",
+            return_value=str(link),
+        ),
+    ):
+        dest = installer._install_destination_dir(tool)
+
+    assert_that(dest).is_equal_to(bindir)
+    assert_that(str(dest)).does_not_contain("node_modules")

--- a/tests/unit/utils/test_doctor_report.py
+++ b/tests/unit/utils/test_doctor_report.py
@@ -558,6 +558,23 @@ def test_check_tool_missing_not_in_path() -> None:
     assert_that(result.error).is_equal_to("not_in_path")
 
 
+def test_check_tool_missing_wrapper_host_is_not_in_path() -> None:
+    """A missing cargo host is not_in_path, not an OSError from subprocess."""
+    tool = _make_tool(
+        name="cargo_audit",
+        install_type="cargo",
+        category="rust",
+        version_command=("cargo", "audit", "--version"),
+    )
+    ctx = _make_context()
+
+    with patch("shutil.which", return_value=None):
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(result.error).is_equal_to("not_in_path")
+
+
 def test_check_tool_missing_command_failed() -> None:
     """Tool found but version command exits non-zero."""
     tool = _make_tool()

--- a/tests/unit/utils/test_doctor_report.py
+++ b/tests/unit/utils/test_doctor_report.py
@@ -7,7 +7,10 @@ remediation}`` health report the MCP ``lintro_doctor`` tool serves.
 
 from __future__ import annotations
 
+import json
 import subprocess  # nosec B404 - only used to build the TimeoutExpired the probe must survive
+import sys
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -19,6 +22,7 @@ from lintro.enums.install_context import InstallContext, PackageManager
 from lintro.enums.tool_status import ToolStatus
 from lintro.tools.core.install_context import RuntimeContext
 from lintro.tools.core.install_strategies.environment import InstallEnvironment
+from lintro.tools.core.install_strategies.node_project import detect_node_project
 from lintro.tools.core.tool_registry import ManifestRegistry, ManifestTool
 from lintro.utils import doctor_report
 from lintro.utils.doctor_report import (
@@ -656,6 +660,75 @@ def test_check_tool_upgrade_hint_populated() -> None:
 
     assert_that(result.install_hint).is_not_empty()
     assert_that(result.upgrade_hint).is_not_empty()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fake shell-script binary is not executable on Windows",
+)
+def test_check_tool_agrees_project_local_npm_binary_is_installed(
+    tmp_path: Path,
+) -> None:
+    """Doctor reports a node_modules/.bin binary as installed, not missing.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+    """
+    (tmp_path / "package.json").write_text(
+        json.dumps({"name": "demo"}),
+        encoding="utf-8",
+    )
+    (tmp_path / "package-lock.json").write_text("", encoding="utf-8")
+    registry = ManifestRegistry.load()
+    tool = registry.get("prettier")
+    local_bin = tmp_path / "node_modules" / ".bin"
+    local_bin.mkdir(parents=True)
+    binary = local_bin / "prettier"
+    binary.write_text(f'#!/bin/sh\necho "{tool.version}"\n', encoding="utf-8")
+    binary.chmod(0o755)
+
+    ctx = RuntimeContext(
+        install_context=InstallContext.PIP,
+        platform_label="Linux x86_64",
+        environment=InstallEnvironment(
+            install_context=InstallContext.PIP,
+            available_managers=frozenset({PackageManager.NPM}),
+            node_project=detect_node_project(tmp_path),
+        ),
+        is_ci=False,
+    )
+
+    with patch("shutil.which", return_value=None):
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_not_equal_to(ToolStatus.MISSING)
+    assert_that(result.path).is_not_none()
+    assert_that(result.path).contains("node_modules/.bin")
+    assert_that(result.installed_version).is_equal_to(tool.version)
+
+
+def test_check_tool_does_not_treat_bunx_fallback_as_installed() -> None:
+    """bunx/npx is the registry fallback, not an install doctor can trust."""
+    tool = _make_tool(
+        name="prettier",
+        version="3.9.4",
+        install_type="npm",
+        category="npm",
+        version_command=("prettier", "--version"),
+    )
+    ctx = _make_context()
+
+    with (
+        patch(
+            "lintro.plugins.execution_preparation.get_executable_command",
+            return_value=["bunx", "prettier@3.9.4"],
+        ),
+        patch("shutil.which", return_value=None),
+    ):
+        result = check_tool(tool=tool, context=ctx)
+
+    assert_that(result.status).is_equal_to(ToolStatus.MISSING)
+    assert_that(result.error).is_equal_to("not_in_path")
 
 
 # ── optional MCP extra ───────────────────────────────────────────────


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(install): verify local-first discoverability and version progress
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Close the post-install probe split from #2014 and the version-progress gap from #2004/#2012. Planning, post-install verification, and doctor now share one local-first discoverability probe. An install that exits 0 but leaves the tool below `min_version` is a distinct non-success outcome and is not re-suggested within the same run.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #2026
- Relates to #2014
- Relates to #2012
- Relates to #2004

## Details

`_verify_discoverable` is an instance method that reuses `_resolved_version_command`. An absolute `node_modules/.bin` path that exists is discoverable; `bunx`/`npx` is not. Wrapper probes (`sh`/`bash`/`cargo`) are unchanged. Doctor uses the same helpers.

New `InstallOutcome.STILL_OUTDATED` (`STALE`): exit 0 + still below `min_version`. Non-retryable; joins per-process `known_invalid`. No state file — a fresh run gets one fresh attempt.

`NOT_DISCOVERABLE` names the install destination directory (project `node_modules/.bin` for a local npm add) and the PATH remedy. `lintro install` still exits 1 on any non-success outcome, including `NOT_DISCOVERABLE`; that contract is documented in CLI help and `docs/troubleshooting.md`.

Out of scope: #2014 P2 (auto-run a lockfile-selected manager not on PATH) and the P3s.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec9e4898-c04c-47e8-83fa-8c9d35a657a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec9e4898-c04c-47e8-83fa-8c9d35a657a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer installation outcomes for tools that remain below the required version, labeled “STALE.”
  * Improved detection of project-local npm tools and executable availability.
  * Added destination and `PATH` guidance when installed tools cannot be discovered.
  * Enhanced doctor checks for resolved commands and project-local binaries.

* **Bug Fixes**
  * Install commands now return a failure status for incomplete or unresolved outcomes.

* **Documentation**
  * Expanded troubleshooting and command guidance, including retry behavior and registry fallbacks.
  * Clarified per-process handling of failed remedies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->