### PR TITLE
ci(build): derive builtin index via AST and smoke-test JSON output

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -473,7 +473,10 @@ jobs:
     name: Create Universal Binary
     needs: [get-release-info, build-macos]
     runs-on: macos-latest
-    timeout-minutes: 10
+    # download/lipo/upload (~10 min) + 20 min smoke + 5 min headroom.
+    # The smoke step's 20-minute budget must not sit inside the previous
+    # 10-minute job deadline or the parent would cancel a valid smoke test.
+    timeout-minutes: 35
     permissions:
       contents: write
     if: inputs.arch == 'universal'
@@ -491,13 +494,17 @@ jobs:
             objects.githubusercontent.com:443
             uploads.github.com:443
 
-      # Needed for scripts/build/create_universal.sh. The codeload /
+      # Needed for scripts/build/create_universal.sh and the binary smoke
+      # test (scripts/ci/smoke-test-binary.py reads the generated builtin
+      # index under lintro/plugins). The codeload /
       # objects.githubusercontent.com endpoints above are what actions/checkout
       # fetches through, and match the other sparse-checkout jobs here.
       - name: Checkout scripts
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          sparse-checkout: scripts
+          sparse-checkout: |
+            scripts
+            lintro/plugins
           persist-credentials: false
 
       - name: Download arm64 binary
@@ -518,6 +525,16 @@ jobs:
           binaries/lintro-macos-arm64
           binaries/lintro-macos-x86_64
           binaries/lintro-macos-universal
+
+      # #2006: --version/--help pass even when the frozen binary ships an empty
+      # tool registry. Lipo can also produce a binary that will not launch, so
+      # the post-lipo artifact is smoke-tested independently of the per-arch
+      # inputs.
+      - name: Smoke-test tool registry
+        # 9 min of script-internal timeouts (120s + 120s + 300s) plus slack for
+        # the cold onefile extraction each of the three invocations may pay.
+        timeout-minutes: 20
+        run: python3 scripts/ci/smoke-test-binary.py binaries/lintro-macos-universal
 
       - name: Upload universal artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/scripts/ci/generate-builtin-tool-index.py
+++ b/scripts/ci/generate-builtin-tool-index.py
@@ -25,6 +25,7 @@ dependencies.
 from __future__ import annotations
 
 import argparse
+import ast
 import difflib
 import sys
 from pathlib import Path
@@ -71,8 +72,8 @@ REGISTERING_TOOL_MODULES: tuple[str, ...] = (
 
 _FOOTER = ")\n"
 
-# Decorator that marks a definition module as contributing a registry entry.
-REGISTER_DECORATOR = "@register_tool"
+# Decorator name that marks a definition module as contributing a registry entry.
+REGISTER_TOOL_NAME = "register_tool"
 
 
 def collect_module_names(definitions_dir: Path) -> list[str]:
@@ -98,8 +99,67 @@ def collect_module_names(definitions_dir: Path) -> list[str]:
     )
 
 
+def _is_register_tool_decorator(node: ast.AST) -> bool:
+    """Return whether ``node`` is a ``register_tool`` decorator expression.
+
+    Accepts ``@register_tool``, ``@register_tool()``, and
+    ``@module.register_tool`` (a ``Name`` or ``Attribute``, optionally called).
+
+    Args:
+        node: A decorator AST node from a ``decorator_list``.
+
+    Returns:
+        True when the decorator applies ``register_tool``.
+    """
+    if isinstance(node, ast.Call):
+        return _is_register_tool_decorator(node.func)
+    if isinstance(node, ast.Name):
+        return node.id == REGISTER_TOOL_NAME
+    if isinstance(node, ast.Attribute):
+        return node.attr == REGISTER_TOOL_NAME
+    return False
+
+
+def _source_registers_tool(*, source: str, path: Path) -> bool:
+    """Return whether Python source applies ``@register_tool``.
+
+    Parsed with :mod:`ast` so comments and string literals cannot count as a
+    registration. The generator stays stdlib-only: importing the registry at
+    generation time would pull the ``lintro`` package (and its import cycle
+    with ``lintro.tools``) into minimal CI containers.
+
+    Args:
+        source: Module source text.
+        path: Path of the file, used in parse-error messages.
+
+    Returns:
+        True when a class or function in the module is decorated with
+        ``register_tool``.
+
+    Raises:
+        ValueError: When ``source`` is not valid Python.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        msg = f"could not parse {path}: {exc}"
+        raise ValueError(msg) from exc
+
+    for node in ast.walk(tree):
+        decorator_list = getattr(node, "decorator_list", None)
+        if not decorator_list:
+            continue
+        if any(_is_register_tool_decorator(dec) for dec in decorator_list):
+            return True
+    return False
+
+
 def collect_registering_module_names(definitions_dir: Path) -> list[str]:
     """Collect the definition modules that register a tool.
+
+    Registration is detected by walking each module's AST for a
+    ``register_tool`` decorator (a ``Name`` or ``Attribute``). Comments and
+    docstrings that mention the decorator do not count.
 
     Args:
         definitions_dir: Directory holding the builtin tool definition modules.
@@ -109,17 +169,26 @@ def collect_registering_module_names(definitions_dir: Path) -> list[str]:
 
     Raises:
         FileNotFoundError: When ``definitions_dir`` does not exist.
+        ValueError: When a definition file cannot be parsed as Python.
     """
     if not definitions_dir.is_dir():
         msg = f"Builtin definitions directory not found: {definitions_dir}"
         raise FileNotFoundError(msg)
 
-    return sorted(
-        path.stem
-        for path in definitions_dir.glob("*.py")
-        if not path.name.startswith("_")
-        and REGISTER_DECORATOR in path.read_text(encoding="utf-8")
-    )
+    registering: list[str] = []
+    for path in definitions_dir.glob("*.py"):
+        if path.name.startswith("_"):
+            continue
+        try:
+            registers = _source_registers_tool(
+                source=path.read_text(encoding="utf-8"),
+                path=path,
+            )
+        except ValueError:
+            raise
+        if registers:
+            registering.append(path.stem)
+    return sorted(registering)
 
 
 def render_index(module_names: list[str], registering: list[str]) -> str:
@@ -174,7 +243,7 @@ def main() -> int:
     try:
         module_names = collect_module_names(DEFINITIONS_DIR)
         registering = collect_registering_module_names(DEFINITIONS_DIR)
-    except FileNotFoundError as exc:
+    except (FileNotFoundError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return EXIT_INPUT_ERROR
 

--- a/scripts/ci/smoke-test-binary.py
+++ b/scripts/ci/smoke-test-binary.py
@@ -11,8 +11,10 @@ This script exercises the registry through the binary itself:
 1. ``lintro list-tools --json`` reports **every** builtin the generated index
    says exists — a partially populated registry fails just like an empty one.
 2. ``lintro config --json`` reports builtin tools in the execution order.
-3. ``lintro check`` on a throwaway sample tree reaches tool execution instead
-   of bailing out with ``No tools to run.``.
+3. ``lintro check --output-format json`` on a throwaway sample tree reaches
+   tool execution instead of bailing out with ``No tools to run.``. The JSON
+   document's ``results[].tool`` names are the execution evidence; the default
+   table renderer is never scraped.
 
 Usage:
     python3 scripts/ci/smoke-test-binary.py dist/nuitka/lintro
@@ -51,10 +53,6 @@ CHECK_TIMEOUT_SECONDS = 300
 # is a fast, readable signal rather than the guard of record: the positive
 # tool-execution evidence below is what fails closed if this wording changes.
 EMPTY_REGISTRY_MARKER = "No tools to run."
-
-# Statuses rendered in the per-tool result table. Their presence in a table row
-# is what distinguishes a real result row from prose that names a tool.
-RESULT_ROW_STATUSES = ("PASS", "FAIL", "SKIP")
 
 
 def _run(
@@ -217,6 +215,18 @@ def _tool_spellings(name: str) -> set[str]:
     return {name, name.replace("_", "-"), name.replace("-", "_")}
 
 
+def _normalized_tool_name(name: str) -> str:
+    """Return the canonical spelling used to compare tool names.
+
+    Args:
+        name: Tool name as the registry or a report spells it.
+
+    Returns:
+        The name with hyphens folded to underscores.
+    """
+    return name.replace("-", "_")
+
+
 def _matches_tool(*, text: str, name: str) -> bool:
     """Check whether a complete tool identifier appears in text.
 
@@ -290,62 +300,55 @@ def check_config(binary: Path, builtin_tools: list[str]) -> int:
     return EXIT_OK
 
 
-def _result_table_tool_cell(row: str) -> str:
-    """Return the Tool column of a tabulate grid row.
+def _tools_in_check_json(
+    *,
+    payload: object,
+    builtin_tools: list[str],
+) -> list[str]:
+    """Find builtin tools that produced a per-tool JSON result.
 
-    Matching the complete row would let a Notes cell mentioning ``ruff.py``
-    satisfy builtin ``ruff``. Only the first data cell is the tool identity.
+    Only ``results[].tool`` counts: a result object exists exactly when the
+    registry handed the tool to the executor, which is the property #2006
+    broke. Skip reasons, output text, and other fields that merely mention a
+    tool are not evidence.
 
-    Args:
-        row: A stripped table row starting with ``|``.
-
-    Returns:
-        The first data cell, or the whole row when the shape is unexpected.
-    """
-    data_cells = [cell.strip() for cell in row.split("|") if cell.strip()]
-    return data_cells[0] if data_cells else row
-
-
-def _tools_in_result_table(*, output: str, builtin_tools: list[str]) -> list[str]:
-    """Find builtin tools that produced a per-tool result row.
-
-    Only rows of the rendered result table count: a row exists exactly when the
-    registry handed the tool to the executor, which is the property #2006 broke.
-    Prose lines that merely mention a tool (``Skipping ruff: executable not
-    found``) are not evidence and are ignored.
-
-    Rows with a ``SKIP`` status still count. A release runner has none of the
-    external tool binaries installed, so every row there is a skip — yet the
-    rows themselves prove the registry was populated and dispatched.
+    Skipped tools still count. A release runner has none of the external tool
+    binaries installed, so every result there is a skip — yet the result
+    objects themselves prove the registry was populated and dispatched.
 
     Args:
-        output: Combined stdout and stderr of the ``check`` run.
+        payload: Parsed ``lintro check --output-format json`` document.
         builtin_tools: Builtin tool names reported by ``list-tools --json``.
 
     Returns:
-        Sorted names of builtin tools that have a result row.
+        Sorted names of builtin tools that have a result object.
     """
-    found: set[str] = set()
-    for line in output.splitlines():
-        row = line.strip()
-        if not row.startswith("|"):
+    if not isinstance(payload, dict):
+        return []
+    results = payload.get("results")
+    if not isinstance(results, list):
+        return []
+    reported: set[str] = set()
+    for entry in results:
+        if not isinstance(entry, dict):
             continue
-        if not any(status in row for status in RESULT_ROW_STATUSES):
+        tool = entry.get("tool")
+        if not isinstance(tool, str) or not tool:
             continue
-        tool_cell = _result_table_tool_cell(row)
-        found.update(
-            name for name in builtin_tools if _matches_tool(text=tool_cell, name=name)
-        )
-    return sorted(found)
+        reported.add(_normalized_tool_name(tool))
+    return sorted(
+        name for name in builtin_tools if _normalized_tool_name(name) in reported
+    )
 
 
 def check_reaches_execution(binary: Path, builtin_tools: list[str]) -> int:
     """Assert ``check`` runs tools instead of reporting an empty registry.
 
     The verdict is driven by positive evidence — the run must emit a per-tool
-    result row for at least one builtin the registry advertised — so a binary
+    JSON result for at least one builtin the registry advertised — so a binary
     that dies before tool execution fails even if it never prints the
-    empty-registry marker or a traceback.
+    empty-registry marker or a traceback. ``--output-format json`` is pinned so
+    a default table-style change cannot turn the smoke test red.
 
     Args:
         binary: Path to the lintro binary under test.
@@ -360,7 +363,7 @@ def check_reaches_execution(binary: Path, builtin_tools: list[str]) -> int:
         (sample_root / "sample.yaml").write_text("key: value\n")
 
         result = _run(
-            argv=[str(binary), "check", "."],
+            argv=[str(binary), "check", "--output-format", "json", "."],
             cwd=sample_root,
             timeout=CHECK_TIMEOUT_SECONDS,
         )
@@ -380,16 +383,25 @@ def check_reaches_execution(binary: Path, builtin_tools: list[str]) -> int:
             f"check exited {result.returncode} without a verdict:\n{output[-2000:]}",
         )
 
-    reported = _tools_in_result_table(output=output, builtin_tools=builtin_tools)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return _fail(f"check --output-format json emitted invalid JSON: {exc}")
+    if not isinstance(payload, dict):
+        return _fail("check --output-format json did not emit a JSON object")
+    if not isinstance(payload.get("results"), list):
+        return _fail("check --output-format json has no 'results' array")
+
+    reported = _tools_in_check_json(payload=payload, builtin_tools=builtin_tools)
     if not reported:
         return _fail(
-            "check produced no per-tool result rows for any builtin tool "
+            "check produced no per-tool JSON results for any builtin tool "
             f"(looked for {len(builtin_tools)} registry names):\n{output[-2000:]}",
         )
 
     print(
         f"OK: check reached tool execution (exit {result.returncode}, "
-        f"{len(reported)} builtin tools in the result table)",
+        f"{len(reported)} builtin tools in the JSON results)",
     )
     return EXIT_OK
 

--- a/tests/scripts/test_generate_builtin_tool_index.py
+++ b/tests/scripts/test_generate_builtin_tool_index.py
@@ -86,6 +86,53 @@ def test_collect_registering_module_names_skips_helper_modules(
     )
 
 
+def test_collect_registering_module_names_ignores_comments_and_docstrings(
+    gen: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """A commented or docstring ``@register_tool`` is not a registration.
+
+    Args:
+        gen: Imported generator module.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    (tmp_path / "commented.py").write_text(
+        "# @register_tool\nclass Plugin:\n    pass\n",
+    )
+    (tmp_path / "docstring.py").write_text(
+        '"""This helper mentions @register_tool in the module docstring."""\n'
+        "HELPER = True\n",
+    )
+    (tmp_path / "literal.py").write_text('DECORATOR = "@register_tool"\n')
+    (tmp_path / "real.py").write_text(_registering_module())
+    (tmp_path / "attr.py").write_text(
+        "@registry.register_tool\nclass Plugin:\n    pass\n",
+    )
+    (tmp_path / "called.py").write_text(
+        "@register_tool()\nclass Plugin:\n    pass\n",
+    )
+
+    assert_that(gen.collect_registering_module_names(tmp_path)).is_equal_to(
+        ["attr", "called", "real"],
+    )
+
+
+def test_collect_registering_module_names_fails_closed_on_syntax_error(
+    gen: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """An unparseable definition file is an input error, not a silent skip.
+
+    Args:
+        gen: Imported generator module.
+        tmp_path: Pytest-provided temporary directory.
+    """
+    (tmp_path / "broken.py").write_text("def (\n")
+
+    with pytest.raises(ValueError, match="could not parse"):
+        gen.collect_registering_module_names(tmp_path)
+
+
 def test_collect_module_names_rejects_missing_directory(
     gen: ModuleType,
     tmp_path: Path,

--- a/tests/scripts/test_smoke_test_binary.py
+++ b/tests/scripts/test_smoke_test_binary.py
@@ -28,6 +28,9 @@ RESPONSES = json.loads({responses!r})
 
 args = sys.argv[1:]
 key = args[0] if args else ""
+if key == "check" and ("--output-format" not in args or "json" not in args):
+    sys.stderr.write("check invoked without --output-format json\\n")
+    sys.exit(2)
 response = RESPONSES.get(key, {{"stdout": "", "exit": 0}})
 sys.stdout.write(response["stdout"])
 sys.stderr.write(response.get("stderr", ""))
@@ -60,30 +63,72 @@ def _write_fake_binary(
     return path
 
 
-# Verbatim shape of the rendered result table (tabulate grid + emoji + status
-# glyphs), so the row parser is exercised against production output rather than
-# a simplified stand-in.
-REAL_RESULT_TABLE = """
-+-----------------+----------+----------+-------------------+
-| Tool            | Status   | Issues   | Notes             |
-+=================+==========+==========+===================+
-| \U0001f5a4 black         | \u274c FAIL   | 1        |                   |
-+-----------------+----------+----------+-------------------+
-| \U0001f980 ruff          | \u2705 PASS   | 0        |                   |
-+-----------------+----------+----------+-------------------+
+# Production ``lintro check --output-format json`` shape (see
+# ``lintro.utils.json_output.create_json_output``): a ``results`` array of
+# per-tool objects whose ``tool`` field is the execution evidence.
+HEALTHY_CHECK_JSON = json.dumps(
+    {
+        "results": [
+            {
+                "tool": "black",
+                "success": False,
+                "issues_count": 1,
+                "skipped": False,
+                "skip_reason": None,
+                "timed_out": False,
+                "output": "",
+            },
+            {
+                "tool": "ruff",
+                "success": True,
+                "issues_count": 0,
+                "skipped": False,
+                "skip_reason": None,
+                "timed_out": False,
+                "output": "",
+            },
+        ],
+        "summary": {
+            "total_issues": 1,
+            "total_fixed": 0,
+            "total_remaining": 1,
+            "timed_out_tools": [],
+        },
+    },
+)
 
-\U0001f4ca TOTALS
-"""
-
-# Same table with every tool skipped, as a release runner with no external tool
-# binaries installed produces.
-SKIPPED_RESULT_TABLE = """
-+-----------------+----------+----------+--------------------------------+
-| \U0001f5a4 black         | \u23ed\ufe0f  SKIP | -        | executable not found           |
-+-----------------+----------+----------+--------------------------------+
-| \U0001f980 ruff          | \u23ed\ufe0f  SKIP | -        | executable not found           |
-+-----------------+----------+----------+--------------------------------+
-"""
+# Same document with every tool skipped, as a release runner with no external
+# tool binaries installed produces.
+SKIPPED_CHECK_JSON = json.dumps(
+    {
+        "results": [
+            {
+                "tool": "black",
+                "success": True,
+                "issues_count": 0,
+                "skipped": True,
+                "skip_reason": "executable not found",
+                "timed_out": False,
+                "output": "",
+            },
+            {
+                "tool": "ruff",
+                "success": True,
+                "issues_count": 0,
+                "skipped": True,
+                "skip_reason": "executable not found",
+                "timed_out": False,
+                "output": "",
+            },
+        ],
+        "summary": {
+            "total_issues": 0,
+            "total_fixed": 0,
+            "total_remaining": 0,
+            "timed_out_tools": [],
+        },
+    },
+)
 
 
 def _healthy_responses() -> dict[str, dict[str, object]]:
@@ -108,7 +153,7 @@ def _healthy_responses() -> dict[str, dict[str, object]]:
             ),
             "exit": 0,
         },
-        "check": {"stdout": REAL_RESULT_TABLE, "exit": 0},
+        "check": {"stdout": HEALTHY_CHECK_JSON, "exit": 0},
     }
 
 
@@ -348,17 +393,18 @@ def test_skip_rows_still_prove_registry_dispatch(
     smoke: ModuleType,
     tmp_path: Path,
 ) -> None:
-    """Result rows count as evidence even when every tool is skipped.
+    """JSON results count as evidence even when every tool is skipped.
 
     Release runners have none of the external tool binaries installed, so every
-    row is a skip — the rows themselves are what prove the registry dispatched.
+    result is a skip — the result objects themselves prove the registry
+    dispatched.
 
     Args:
         smoke: Imported smoke-test module.
         tmp_path: Pytest-provided temporary directory.
     """
     responses = _healthy_responses()
-    responses["check"] = {"stdout": SKIPPED_RESULT_TABLE, "exit": 0}
+    responses["check"] = {"stdout": SKIPPED_CHECK_JSON, "exit": 0}
     binary = _write_fake_binary(path=tmp_path / "lintro", responses=responses)
 
     assert_that(smoke.check_reaches_execution(binary, ["ruff", "black"])).is_equal_to(0)
@@ -372,6 +418,12 @@ def test_skip_rows_still_prove_registry_dispatch(
         ("something odd\n", 3, "no-verdict-exit-code"),
         ("nothing ran here\n", 0, "no-tool-named"),
         ("Skipping ruff: executable not found\n", 0, "tool-named-in-prose-only"),
+        (
+            json.dumps({"results": [], "summary": {"total_issues": 0}}),
+            0,
+            "empty-results-array",
+        ),
+        (json.dumps(["ruff", "black"]), 0, "json-array"),
     ],
     ids=[
         "marker=no-tools-to-run",
@@ -379,6 +431,8 @@ def test_skip_rows_still_prove_registry_dispatch(
         "outcome=no-verdict",
         "outcome=no-execution-evidence",
         "outcome=prose-mention-only",
+        "outcome=empty-json-results",
+        "outcome=json-array",
     ],
 )
 def test_check_failures_are_reported(
@@ -415,7 +469,7 @@ def test_issues_found_still_counts_as_reaching_execution(
         tmp_path: Pytest-provided temporary directory.
     """
     responses = _healthy_responses()
-    responses["check"] = {"stdout": REAL_RESULT_TABLE, "exit": 1}
+    responses["check"] = {"stdout": HEALTHY_CHECK_JSON, "exit": 1}
     binary = _write_fake_binary(path=tmp_path / "lintro", responses=responses)
 
     assert_that(smoke.check_reaches_execution(binary, ["ruff", "black"])).is_equal_to(0)
@@ -433,7 +487,27 @@ def test_underscore_tool_names_match_hyphenated_report(
     """
     responses = _healthy_responses()
     responses["check"] = {
-        "stdout": "| \U0001f527 pip-audit     | \u2705 PASS   | 0        |     |\n",
+        "stdout": json.dumps(
+            {
+                "results": [
+                    {
+                        "tool": "pip-audit",
+                        "success": True,
+                        "issues_count": 0,
+                        "skipped": False,
+                        "skip_reason": None,
+                        "timed_out": False,
+                        "output": "",
+                    },
+                ],
+                "summary": {
+                    "total_issues": 0,
+                    "total_fixed": 0,
+                    "total_remaining": 0,
+                    "timed_out_tools": [],
+                },
+            },
+        ),
         "exit": 0,
     }
     binary = _write_fake_binary(path=tmp_path / "lintro", responses=responses)
@@ -458,21 +532,49 @@ def test_matches_tool_requires_complete_identifier(smoke: ModuleType) -> None:
     ).is_true()
 
 
-def test_notes_column_cannot_satisfy_a_different_tool(smoke: ModuleType) -> None:
-    """A Notes cell mentioning another tool is not a result row for that tool.
+def test_skip_reason_cannot_satisfy_a_different_tool(smoke: ModuleType) -> None:
+    """A skip_reason mentioning another tool is not a result for that tool.
 
     Args:
         smoke: Imported smoke-test module.
     """
-    output = (
-        "| black | PASS | 0 | unable to open ruff.py |\n"
-        "| ruff-format | PASS | 0 | |\n"
-    )
-    found = smoke._tools_in_result_table(
-        output=output,
+    payload = {
+        "results": [
+            {
+                "tool": "black",
+                "success": True,
+                "issues_count": 0,
+                "skipped": False,
+                "skip_reason": "unable to open ruff.py",
+                "timed_out": False,
+                "output": "",
+            },
+            {
+                "tool": "ruff-format",
+                "success": True,
+                "issues_count": 0,
+                "skipped": False,
+                "skip_reason": None,
+                "timed_out": False,
+                "output": "",
+            },
+        ],
+    }
+    found = smoke._tools_in_check_json(
+        payload=payload,
         builtin_tools=["ruff", "black"],
     )
     assert_that(found).is_equal_to(["black"])
+
+
+def test_table_scraping_helpers_are_gone(smoke: ModuleType) -> None:
+    """The smoke test must not scrape the default result table.
+
+    Args:
+        smoke: Imported smoke-test module.
+    """
+    assert_that(hasattr(smoke, "_tools_in_result_table")).is_false()
+    assert_that(hasattr(smoke, "_result_table_tool_cell")).is_false()
 
 
 def test_missing_binary_fails(

--- a/tests/unit/plugins/test_discovery.py
+++ b/tests/unit/plugins/test_discovery.py
@@ -623,16 +623,21 @@ def test_shadowed_plugin_gets_no_divergence_advice(
 
 
 def test_registering_index_matches_the_real_registry() -> None:
-    """Every module the index calls registering yields a registered tool.
+    """The index's registering set is exactly the builtin registry.
 
-    The generator detects registering modules statically (``@register_tool`` in
-    the source). This is the behavioral counterpart: the binary smoke test
-    treats that subset as the expected builtin tool set, so a static-scan
-    mismatch would make released binaries fail their own registry assertion.
+    The generator detects registering modules via AST (``@register_tool`` as a
+    Name or Attribute decorator). The binary smoke test treats that subset as
+    the expected builtin tool set, so both over-counting and under-counting
+    would make released binaries fail their own registry assertion — or worse,
+    silently shrink the assertion. Equality catches both directions.
     """
     discover_builtin_tools()
 
-    registered = {name.replace("-", "_") for name in ToolRegistry.get_names()}
+    registered = {
+        name.replace("-", "_")
+        for name in ToolRegistry.get_names()
+        if ToolRegistry.get_origin(name) == ToolRegistry.BUILTIN_ORIGIN
+    }
     expected = {name.replace("-", "_") for name in REGISTERING_TOOL_MODULES}
 
-    assert_that(sorted(expected - registered)).is_empty()
+    assert_that(sorted(registered)).is_equal_to(sorted(expected))

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -1880,6 +1880,43 @@ def test_build_binary_job_timeout_covers_compile_and_smoke() -> None:
         assert_that(headroom).described_as(job_id).is_greater_than_or_equal_to(10)
 
 
+def test_create_universal_binary_smoke_tests_the_post_lipo_artifact() -> None:
+    """The universal macOS binary is smoke-tested after lipo, not only per-arch.
+
+    Lipo can produce a binary that will not launch even when both inputs
+    passed the per-arch smoke test. The post-lipo artifact must be exercised
+    independently, with the same script, timeout, and checkout coverage the
+    per-arch jobs use.
+    """
+    workflow = _load_workflow(name=_BUILD_BINARY_WORKFLOW)
+    job = workflow["jobs"]["create-universal-binary"]
+    steps = job["steps"]
+    by_name = {step.get("name"): step for step in steps}
+
+    smoke = by_name["Smoke-test tool registry"]
+    assert_that(smoke["timeout-minutes"]).is_equal_to(20)
+    assert_that(smoke["run"]).is_equal_to(
+        "python3 scripts/ci/smoke-test-binary.py binaries/lintro-macos-universal",
+    )
+
+    names = [step.get("name") for step in steps]
+    assert_that(names.index("Create universal binary")).is_less_than(
+        names.index("Smoke-test tool registry"),
+    )
+    assert_that(names.index("Smoke-test tool registry")).is_less_than(
+        names.index("Upload universal artifact"),
+    )
+
+    checkout = by_name["Checkout scripts"]
+    sparse = checkout["with"]["sparse-checkout"]
+    assert_that(sparse).contains("scripts")
+    assert_that(sparse).contains("lintro/plugins")
+
+    assert_that(
+        job["timeout-minutes"] - smoke["timeout-minutes"],
+    ).is_greater_than_or_equal_to(10)
+
+
 def test_build_binary_compile_is_wrapped_by_memory_sampler() -> None:
     """Build binary is bracketed by the #1707 sampler with failure-only upload.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  ci(build): derive builtin index via AST and smoke-test JSON output
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Harden builtin-index generation and binary smoke coverage. The index generator derives `REGISTERING_TOOL_MODULES` via AST instead of a substring scan. The post-build smoke test parses `check --output-format json` instead of scraping table rows. The post-lipo universal macOS binary is smoke-tested.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #2027
- Relates to #2009
- Relates to #2006

## Details

Generator stays stdlib-only and keeps the import-cycle constraint (index lives under `lintro/plugins`). Unparseable definition files fail closed. The registry guard test now asserts set equality so over- and under-count both fail.

Smoke test fail-closed contract is unchanged: unreadable index is a `RuntimeError`; check exit codes 0/1 only.

### Follow-up: npm-wrapper resolution smoke

Not in this PR. The wrapper (`npm/lintro/bin/lintro` → `resolveBinary()` → platform package) does not look at `dist/nuitka/lintro`; it needs `scripts/ci/npm/stage_binaries.py` and `scripts/ci/npm/smoke_test.sh`. `build-binary.yml` jobs do not set up Node and their harden-runner allowlists omit `registry.npmjs.org` / `nodejs.org`. `.github/workflows/publish-npm.yml` already runs `scripts/ci/npm/smoke_test.sh` after staging.

Recommended follow-up: extend that publish-time smoke to run `scripts/ci/smoke-test-binary.py` through the launcher (registry completeness, not just `--version`), rather than grafting the packaging pipeline onto `build-binary.yml`. A GitHub issue comment could not be posted from this environment (403); this section is the filed follow-up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec9e4898-c04c-47e8-83fa-8c9d35a657a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec9e4898-c04c-47e8-83fa-8c9d35a657a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

