### PR TITLE
feat(ai): add cost-cap override via env and flag

### DIFF
--- a/docs/adr/0006-ai-effective-config-and-review-execution.md
+++ b/docs/adr/0006-ai-effective-config-and-review-execution.md
@@ -77,13 +77,16 @@ Contract invariants:
   parallel override layer.
 - Be consumed by execution, doctor/status, terminal review output, PR rendering, MCP,
   and advisory tools without reparsing the raw `ai:` mapping.
-- Keep security-sensitive caps monotonic: an invocation may lower a configured cap where
-  explicitly supported, never raise it (`ai.max_cost_usd` today).
+- CLI and env overlays may raise or lift `ai.max_cost_usd` (`LINTRO_AI_MAX_COST_USD` /
+  `lintro review --max-cost-usd`; literal `0` = uncapped, mapped to `None`) (#2024).
+  MCP's per-call `max_cost_usd` argument remains a monotonic clamp: it may lower the
+  effective ceiling, never raise it.
 
 Issue #1970 implements the initial resolver (`AIConfig.resolve_from_mapping` returning
 `ResolvedAIConfig`). This epic must not introduce a second resolver. CLI review applies
-`--provider`/`--model`/`--transport` on that object via `apply_cli_overrides`; other
-surfaces consume `resolve_ai_config()` which unwraps the same env-aware parse.
+`--provider`/`--model`/`--transport`/`--max-cost-usd` on that object via
+`apply_cli_overrides`; other surfaces consume `resolve_ai_config()` which unwraps the
+same env-aware parse.
 
 ### B. Shared review domain request and preparation
 
@@ -178,6 +181,9 @@ time.
   config and review execution architecture.
 - [#1970](https://github.com/lgtm-hq/py-lintro/issues/1970) — env/CLI override layer and
   provenance (owns `ResolvedAIConfig` implementation).
+- [#2024](https://github.com/lgtm-hq/py-lintro/issues/2024) — cost-cap overlay
+  (`LINTRO_AI_MAX_COST_USD` / `--max-cost-usd`; `0` = uncapped). Overturns the #1970
+  non-goal that forbade raising `ai.max_cost_usd`.
 - [#1923](https://github.com/lgtm-hq/py-lintro/issues/1923) — transport profiles must
   extend the same resolver.
 - [#1885](https://github.com/lgtm-hq/py-lintro/issues/1885) — provider-side `aclose()`

--- a/docs/adr/0006-ai-effective-config-and-review-execution.md
+++ b/docs/adr/0006-ai-effective-config-and-review-execution.md
@@ -79,8 +79,9 @@ Contract invariants:
   and advisory tools without reparsing the raw `ai:` mapping.
 - CLI and env overlays may raise or lift `ai.max_cost_usd` (`LINTRO_AI_MAX_COST_USD` /
   `lintro review --max-cost-usd`; literal `0` = uncapped, mapped to `None`) (#2024).
-  MCP's per-call `max_cost_usd` argument remains a monotonic clamp: it may lower the
-  effective ceiling, never raise it.
+  Overlays beat transport profile caps as well as the legacy scalar; YAML `0` remains
+  a $0 cap. MCP's per-call `max_cost_usd` argument remains a monotonic clamp: it may
+  lower the effective ceiling, never raise it.
 
 Issue #1970 implements the initial resolver (`AIConfig.resolve_from_mapping` returning
 `ResolvedAIConfig`). This epic must not introduce a second resolver. CLI review applies

--- a/docs/adr/0006-ai-effective-config-and-review-execution.md
+++ b/docs/adr/0006-ai-effective-config-and-review-execution.md
@@ -79,9 +79,9 @@ Contract invariants:
   and advisory tools without reparsing the raw `ai:` mapping.
 - CLI and env overlays may raise or lift `ai.max_cost_usd` (`LINTRO_AI_MAX_COST_USD` /
   `lintro review --max-cost-usd`; literal `0` = uncapped, mapped to `None`) (#2024).
-  Overlays beat transport profile caps as well as the legacy scalar; YAML `0` remains
-  a $0 cap. MCP's per-call `max_cost_usd` argument remains a monotonic clamp: it may
-  lower the effective ceiling, never raise it.
+  Overlays beat transport profile caps as well as the legacy scalar; YAML `0` remains a
+  $0 cap. MCP's per-call `max_cost_usd` argument remains a monotonic clamp: it may lower
+  the effective ceiling, never raise it.
 
 Issue #1970 implements the initial resolver (`AIConfig.resolve_from_mapping` returning
 `ResolvedAIConfig`). This epic must not introduce a second resolver. CLI review applies

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -658,13 +658,17 @@ Resolution order for `provider`, `model`, `transport`, `enabled`, and `max_cost_
 CLI flag > environment variable > .lintro-config.yaml > built-in default
 ```
 
+Overlays replace the active transport profile's cost cap
+(`ai.transports.api.max_cost_usd` / `ai.transports.cli.max_cost_usd_advisory`) as
+well as the legacy `ai.max_cost_usd` scalar.
+
 | Variable / flag                                           | Overrides         | Notes                                                                                                |
 | --------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
 | `LINTRO_AI_PROVIDER` / `lintro review --provider`         | `ai.provider`     | `anthropic`, `openai`, or `cursor`                                                                   |
 | `LINTRO_AI_MODEL` / `lintro review --model`               | `ai.model`        | any model id; empty env falls through                                                                |
 | `LINTRO_AI_TRANSPORT` / `--transport`                     | `ai.transport`    | `api` or `cli`                                                                                       |
 | `LINTRO_AI_ENABLED`                                       | `ai.enabled`      | `1`/`0`/`true`/`false`. `=1` does not turn on `ai.review` or `ai.lint`. No `--enabled` flag.         |
-| `LINTRO_AI_MAX_COST_USD` / `lintro review --max-cost-usd` | `ai.max_cost_usd` | Positive float = USD cap. **Literal `0` = uncapped** (not a $0 cap). Negative/non-numeric fail loud. |
+| `LINTRO_AI_MAX_COST_USD` / `lintro review --max-cost-usd` | `ai.max_cost_usd` and transport profile caps | Positive float = USD cap. Overlay **`0` = uncapped** (YAML `0` is a $0 cap). Negative/non-numeric fail loud. |
 
 Unset variables are absent (fall through). Invalid values fail at resolution with a
 message naming the variable and the accepted values — they never silently use the config

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -645,30 +645,31 @@ ai:
 ```
 
 Both `lintro check` and `lintro review` accept `--transport api|cli` to override the
-config for a single invocation. `lintro review` also accepts `--provider` and `--model`.
-Environment variables (`LINTRO_AI_PROVIDER`, `LINTRO_AI_MODEL`, `LINTRO_AI_TRANSPORT`,
-`LINTRO_AI_ENABLED`) apply to every AI surface and lose to CLI flags. There is no
-`--enabled` flag and no override for `ai.max_cost_usd`.
+config for a single invocation. `lintro review` also accepts `--provider`, `--model`,
+and `--max-cost-usd`. Environment variables (`LINTRO_AI_PROVIDER`, `LINTRO_AI_MODEL`,
+`LINTRO_AI_TRANSPORT`, `LINTRO_AI_ENABLED`, `LINTRO_AI_MAX_COST_USD`) apply to every AI
+surface and lose to CLI flags. There is no `--enabled` flag.
 
 ### Invocation overrides
 
-Resolution order for `provider`, `model`, `transport`, and `enabled` is:
+Resolution order for `provider`, `model`, `transport`, `enabled`, and `max_cost_usd` is:
 
 ```text
 CLI flag > environment variable > .lintro-config.yaml > built-in default
 ```
 
-| Variable / flag                                   | Overrides      | Notes                                                                                        |
-| ------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------- |
-| `LINTRO_AI_PROVIDER` / `lintro review --provider` | `ai.provider`  | `anthropic`, `openai`, or `cursor`                                                           |
-| `LINTRO_AI_MODEL` / `lintro review --model`       | `ai.model`     | any model id; empty env falls through                                                        |
-| `LINTRO_AI_TRANSPORT` / `--transport`             | `ai.transport` | `api` or `cli`                                                                               |
-| `LINTRO_AI_ENABLED`                               | `ai.enabled`   | `1`/`0`/`true`/`false`. `=1` does not turn on `ai.review` or `ai.lint`. No `--enabled` flag. |
+| Variable / flag                                           | Overrides         | Notes                                                                                                |
+| --------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
+| `LINTRO_AI_PROVIDER` / `lintro review --provider`         | `ai.provider`     | `anthropic`, `openai`, or `cursor`                                                                   |
+| `LINTRO_AI_MODEL` / `lintro review --model`               | `ai.model`        | any model id; empty env falls through                                                                |
+| `LINTRO_AI_TRANSPORT` / `--transport`                     | `ai.transport`    | `api` or `cli`                                                                                       |
+| `LINTRO_AI_ENABLED`                                       | `ai.enabled`      | `1`/`0`/`true`/`false`. `=1` does not turn on `ai.review` or `ai.lint`. No `--enabled` flag.         |
+| `LINTRO_AI_MAX_COST_USD` / `lintro review --max-cost-usd` | `ai.max_cost_usd` | Positive float = USD cap. **Literal `0` = uncapped** (not a $0 cap). Negative/non-numeric fail loud. |
 
 Unset variables are absent (fall through). Invalid values fail at resolution with a
 message naming the variable and the accepted values — they never silently use the config
 default. Review output annotates each resolved field with its source
-(`provider: cursor (env)`).
+(`provider: cursor (env)`, `max cost: uncapped (env)`).
 
 ```bash
 # Try Cursor locally without dirtying .lintro-config.yaml
@@ -676,6 +677,10 @@ LINTRO_AI_PROVIDER=cursor LINTRO_AI_TRANSPORT=cli lintro review --uncommitted
 
 # Same thing with flags (flags win if both are set)
 lintro review --uncommitted --provider cursor --model cursor-grok-4.6-high --transport cli
+
+# Lift the committed cost cap for this run (0 = uncapped, not a $0 cap)
+LINTRO_AI_MAX_COST_USD=0 lintro review --uncommitted
+lintro review --uncommitted --max-cost-usd 0
 
 # Kill switch for this environment
 LINTRO_AI_ENABLED=0 lintro check .

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -660,16 +660,16 @@ CLI flag > environment variable > .lintro-config.yaml > built-in default
 ```
 
 Overlays replace the active transport profile's cost cap
-(`ai.transports.api.max_cost_usd` / `ai.transports.cli.max_cost_usd_advisory`) as
-well as the legacy `ai.max_cost_usd` scalar.
+(`ai.transports.api.max_cost_usd` / `ai.transports.cli.max_cost_usd_advisory`) as well
+as the legacy `ai.max_cost_usd` scalar.
 
-| Variable / flag                                           | Overrides         | Notes                                                                                                |
-| --------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
-| `LINTRO_AI_PROVIDER` / `lintro review --provider`         | `ai.provider`     | `anthropic`, `openai`, or `cursor`                                                                   |
-| `LINTRO_AI_MODEL` / `lintro review --model`               | `ai.model`        | any model id; empty env falls through                                                                |
-| `LINTRO_AI_TRANSPORT` / `--transport`                     | `ai.transport`    | `api` or `cli`                                                                                       |
-| `LINTRO_AI_ENABLED`                                       | `ai.enabled`      | `1`/`0`/`true`/`false`. `=1` does not turn on `ai.review` or `ai.lint`. No `--enabled` flag.         |
-| `LINTRO_AI_MAX_COST_USD` / `lintro review --max-cost-usd` | `ai.max_cost_usd` and transport profile caps | Positive float = USD cap. Overlay **`0` = uncapped** (YAML `0` is a $0 cap). Negative/non-numeric/non-finite fail loud. |
+| Variable / flag                                           | Overrides         | Notes                                                                                        |
+| --------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------------- |
+| `LINTRO_AI_PROVIDER` / `lintro review --provider`         | `ai.provider`     | `anthropic`, `openai`, or `cursor`                                                           |
+| `LINTRO_AI_MODEL` / `lintro review --model`               | `ai.model`        | any model id; empty env falls through                                                        |
+| `LINTRO_AI_TRANSPORT` / `--transport`                     | `ai.transport`    | `api` or `cli`                                                                               |
+| `LINTRO_AI_ENABLED`                                       | `ai.enabled`      | `1`/`0`/`true`/`false`. `=1` does not turn on `ai.review` or `ai.lint`. No `--enabled` flag. |
+| `LINTRO_AI_MAX_COST_USD` / `lintro review --max-cost-usd` | `ai.max_cost_usd` | Positive float = USD cap. Overlay **`0` = uncapped** (YAML `0` is $0). Invalid fails loud.   |
 
 Unset variables are absent (fall through). Invalid values fail at resolution with a
 message naming the variable and the accepted values — they never silently use the config

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -668,7 +668,7 @@ well as the legacy `ai.max_cost_usd` scalar.
 | `LINTRO_AI_MODEL` / `lintro review --model`               | `ai.model`        | any model id; empty env falls through                                                                |
 | `LINTRO_AI_TRANSPORT` / `--transport`                     | `ai.transport`    | `api` or `cli`                                                                                       |
 | `LINTRO_AI_ENABLED`                                       | `ai.enabled`      | `1`/`0`/`true`/`false`. `=1` does not turn on `ai.review` or `ai.lint`. No `--enabled` flag.         |
-| `LINTRO_AI_MAX_COST_USD` / `lintro review --max-cost-usd` | `ai.max_cost_usd` and transport profile caps | Positive float = USD cap. Overlay **`0` = uncapped** (YAML `0` is a $0 cap). Negative/non-numeric fail loud. |
+| `LINTRO_AI_MAX_COST_USD` / `lintro review --max-cost-usd` | `ai.max_cost_usd` and transport profile caps | Positive float = USD cap. Overlay **`0` = uncapped** (YAML `0` is a $0 cap). Negative/non-numeric/non-finite fail loud. |
 
 Unset variables are absent (fall through). Invalid values fail at resolution with a
 message naming the variable and the accepted values — they never silently use the config

--- a/docs/architecture/AI-REVIEW-EXECUTION.md
+++ b/docs/architecture/AI-REVIEW-EXECUTION.md
@@ -7,15 +7,15 @@ normative decision record is
 
 ## Ownership boundaries
 
-| Concern                                  | Owner today                                             | Target                                        |
-| ---------------------------------------- | ------------------------------------------------------- | --------------------------------------------- |
-| Typed `AIConfig` from raw `ai:` mapping  | `AIConfig.resolve_from_mapping()` → `ResolvedAIConfig`  | Same resolver; #1923 extends it               |
-| Invocation transport / timeout overrides | CLI review: `apply_cli_overrides` on `ResolvedAIConfig` | Same resolver pipeline (#1970 / #1923)        |
-| Monotonic cost-cap clamp                 | MCP adapter (`resolve_budget_policy`)                   | Shared domain prep; adapters keep policy      |
-| Diff review preparation                  | Duplicated in CLI + MCP                                 | `prepare_review` / `execute_review` (Phase 3) |
-| Review execution facade                  | `run_review` / `run_review_async`                       | Unchanged facade; internals split (Phase 4)   |
-| Provider client `aclose()` API           | Not yet (#1885)                                         | Provider-side only in #1885                   |
-| Provider close call-site wiring          | N/A until #1885                                         | Phase 5 of #1972                              |
+| Concern                                             | Owner today                                             | Target                                         |
+| --------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------- |
+| Typed `AIConfig` from raw `ai:` mapping             | `AIConfig.resolve_from_mapping()` → `ResolvedAIConfig`  | Same resolver; #1923 extends it                |
+| Invocation transport / timeout / cost-cap overrides | CLI review: `apply_cli_overrides` on `ResolvedAIConfig` | Same resolver pipeline (#1970 / #1923 / #2024) |
+| Monotonic cost-cap clamp                            | MCP adapter (`resolve_budget_policy`)                   | Shared domain prep; adapters keep policy       |
+| Diff review preparation                             | Duplicated in CLI + MCP                                 | `prepare_review` / `execute_review` (Phase 3)  |
+| Review execution facade                             | `run_review` / `run_review_async`                       | Unchanged facade; internals split (Phase 4)    |
+| Provider client `aclose()` API                      | Not yet (#1885)                                         | Provider-side only in #1885                    |
+| Provider close call-site wiring                     | N/A until #1885                                         | Phase 5 of #1972                               |
 
 ## Shared preparation (current duplicated steps)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -460,19 +460,21 @@ export LINTRO_AI_PROVIDER=cursor
 export LINTRO_AI_MODEL=cursor-grok-4.6-high
 export LINTRO_AI_TRANSPORT=cli
 export LINTRO_AI_ENABLED=1
+export LINTRO_AI_MAX_COST_USD=0 # 0 = uncapped; a positive number is a USD cap
 ```
 
-| Variable                         | Description                                                  | Default   |
-| -------------------------------- | ------------------------------------------------------------ | --------- |
-| `LINTRO_LOG_DIR`                 | Base directory for run logs and artifacts                    | `.lintro` |
-| `LINTRO_VERSION_TIMEOUT`         | Timeout in seconds for tool version checks (must be `>= 1`)  | `30`      |
-| `LINTRO_DOCKER`                  | Force Docker install-context detection when set to `1`       | -         |
-| `LINTRO_CONFIG`                  | Shown in the `lintro` environment report; informational only | -         |
-| `LINTRO_ENABLE_EXTERNAL_PLUGINS` | Opt in to loading external (third-party) plugins (`1`/`0`)   | `0`       |
-| `LINTRO_AI_PROVIDER`             | Override `ai.provider` (`anthropic` / `openai` / `cursor`)   | -         |
-| `LINTRO_AI_MODEL`                | Override `ai.model`                                          | -         |
-| `LINTRO_AI_TRANSPORT`            | Override `ai.transport` (`api` / `cli`)                      | -         |
-| `LINTRO_AI_ENABLED`              | Override `ai.enabled` (`1`/`0`/`true`/`false`)               | -         |
+| Variable                         | Description                                                       | Default   |
+| -------------------------------- | ----------------------------------------------------------------- | --------- |
+| `LINTRO_LOG_DIR`                 | Base directory for run logs and artifacts                         | `.lintro` |
+| `LINTRO_VERSION_TIMEOUT`         | Timeout in seconds for tool version checks (must be `>= 1`)       | `30`      |
+| `LINTRO_DOCKER`                  | Force Docker install-context detection when set to `1`            | -         |
+| `LINTRO_CONFIG`                  | Shown in the `lintro` environment report; informational only      | -         |
+| `LINTRO_ENABLE_EXTERNAL_PLUGINS` | Opt in to loading external (third-party) plugins (`1`/`0`)        | `0`       |
+| `LINTRO_AI_PROVIDER`             | Override `ai.provider` (`anthropic` / `openai` / `cursor`)        | -         |
+| `LINTRO_AI_MODEL`                | Override `ai.model`                                               | -         |
+| `LINTRO_AI_TRANSPORT`            | Override `ai.transport` (`api` / `cli`)                           | -         |
+| `LINTRO_AI_ENABLED`              | Override `ai.enabled` (`1`/`0`/`true`/`false`)                    | -         |
+| `LINTRO_AI_MAX_COST_USD`         | Override `ai.max_cost_usd` (positive USD cap; **`0` = uncapped**) | -         |
 
 > **Note:** There is no environment variable for tool timeouts, verbosity, exclude
 > patterns, output format, or auto-install. Use CLI flags (`--exclude`,
@@ -2847,7 +2849,7 @@ ai:
 | `max_fix_attempts`      | int    | `20`           | Max issues to attempt fixing per run                                                         |
 | `max_parallel_calls`    | int    | `5`            | Concurrent AI calls (1-20); honored with a cost cap; n−1 overshoot possible                  |
 | `max_retries`           | int    | `2`            | Max retries for transient errors (0-10)                                                      |
-| `max_cost_usd`          | float  | `null`         | Legacy cost cap (USD); prefer `transports.api.max_cost_usd` / `cli.max_cost_usd_advisory`    |
+| `max_cost_usd`          | float  | `null`         | Legacy cost cap (USD); prefer transport profiles. Overridable; literal `0` = uncapped        |
 | `api_timeout`           | float  | `60.0`         | Legacy timeout (s); prefer `transports.*.timeout`                                            |
 | `transports`            | object | empty profiles | Per-transport profiles (`api` / `cli`) — see [AI review transports](ai-review-transports.md) |
 | `validate_after_group`  | bool   | `false`        | Validate immediately after each accepted group                                               |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2849,7 +2849,7 @@ ai:
 | `max_fix_attempts`      | int    | `20`           | Max issues to attempt fixing per run                                                         |
 | `max_parallel_calls`    | int    | `5`            | Concurrent AI calls (1-20); honored with a cost cap; n−1 overshoot possible                  |
 | `max_retries`           | int    | `2`            | Max retries for transient errors (0-10)                                                      |
-| `max_cost_usd`          | float  | `null`         | Legacy cost cap (USD); prefer transport profiles. Overridable; literal `0` = uncapped        |
+| `max_cost_usd`          | float  | `null`         | Legacy cost cap (USD); prefer transport profiles. Env/flag may overlay; overlay `0` = uncapped (YAML `0` is a $0 cap) |
 | `api_timeout`           | float  | `60.0`         | Legacy timeout (s); prefer `transports.*.timeout`                                            |
 | `transports`            | object | empty profiles | Per-transport profiles (`api` / `cli`) — see [AI review transports](ai-review-transports.md) |
 | `validate_after_group`  | bool   | `false`        | Validate immediately after each accepted group                                               |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2849,7 +2849,7 @@ ai:
 | `max_fix_attempts`      | int    | `20`           | Max issues to attempt fixing per run                                                         |
 | `max_parallel_calls`    | int    | `5`            | Concurrent AI calls (1-20); honored with a cost cap; n−1 overshoot possible                  |
 | `max_retries`           | int    | `2`            | Max retries for transient errors (0-10)                                                      |
-| `max_cost_usd`          | float  | `null`         | Legacy cost cap (USD); prefer transport profiles. Env/flag may overlay; overlay `0` = uncapped (YAML `0` is a $0 cap) |
+| `max_cost_usd`          | float  | `null`         | Legacy USD cap; prefer profiles. Overlay `0` = uncapped (YAML `0` is $0)                     |
 | `api_timeout`           | float  | `60.0`         | Legacy timeout (s); prefer `transports.*.timeout`                                            |
 | `transports`            | object | empty profiles | Per-transport profiles (`api` / `cli`) — see [AI review transports](ai-review-transports.md) |
 | `validate_after_group`  | bool   | `false`        | Validate immediately after each accepted group                                               |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -151,7 +151,7 @@ Arguments (all optional):
 | `strictness`   | `string`   | `review.strictness` | `focused`, `balanced`, or `thorough`                     |
 | `with_lint`    | `boolean`  | `false`             | Include a lint digest of the changed files in the prompt |
 | `paths`        | `string[]` | the whole diff      | Limit the review to these path prefixes                  |
-| `max_cost_usd` | `number`   | effective `ai.max_cost_usd` | Spend ceiling for this call; can only lower the effective cap |
+| `max_cost_usd` | `number`   | effective cap       | Spend ceiling; can only lower the effective cap          |
 
 ```json
 {
@@ -195,9 +195,9 @@ Arguments (all optional):
 
 Cost control:
 
-- The effective `ai.max_cost_usd` (after `LINTRO_AI_MAX_COST_USD` / CLI overlay and
-  the active transport profile) is the ceiling. `max_cost_usd` can only **lower** it;
-  a larger value is clamped to the effective one and reported as `budget.clamped: true`.
+- The effective `ai.max_cost_usd` (after `LINTRO_AI_MAX_COST_USD` / CLI overlay and the
+  active transport profile) is the ceiling. `max_cost_usd` can only **lower** it; a
+  larger value is clamped to the effective one and reported as `budget.clamped: true`.
   If the operator sets no ceiling, the argument becomes the ceiling — set
   `ai.max_cost_usd` (or overlay it) if agents must never spend more than a fixed amount.
 - When the ceiling stops a run **after** some chunks were reviewed, the call succeeds

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -151,7 +151,7 @@ Arguments (all optional):
 | `strictness`   | `string`   | `review.strictness` | `focused`, `balanced`, or `thorough`                     |
 | `with_lint`    | `boolean`  | `false`             | Include a lint digest of the changed files in the prompt |
 | `paths`        | `string[]` | the whole diff      | Limit the review to these path prefixes                  |
-| `max_cost_usd` | `number`   | `ai.max_cost_usd`   | Spend ceiling for this call; can only lower the config   |
+| `max_cost_usd` | `number`   | effective `ai.max_cost_usd` | Spend ceiling for this call; can only lower the effective cap |
 
 ```json
 {
@@ -195,10 +195,11 @@ Arguments (all optional):
 
 Cost control:
 
-- `ai.max_cost_usd` in the workspace config is the ceiling. `max_cost_usd` can only
-  **lower** it; a larger value is clamped to the configured one and reported as
-  `budget.clamped: true`. If the operator sets no ceiling, the argument becomes the
-  ceiling — set `ai.max_cost_usd` if agents must never spend more than a fixed amount.
+- The effective `ai.max_cost_usd` (after `LINTRO_AI_MAX_COST_USD` / CLI overlay and
+  the active transport profile) is the ceiling. `max_cost_usd` can only **lower** it;
+  a larger value is clamped to the effective one and reported as `budget.clamped: true`.
+  If the operator sets no ceiling, the argument becomes the ceiling — set
+  `ai.max_cost_usd` (or overlay it) if agents must never spend more than a fixed amount.
 - When the ceiling stops a run **after** some chunks were reviewed, the call succeeds
   with what was found: `run.partial: true`, `run.stopped_reason`,
   `budget.exceeded: true`.

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -459,9 +459,10 @@ class AIConfig(BaseModel):
         in ``.lintro-config.yaml`` must not break the whole run.
 
         Environment overrides (``LINTRO_AI_PROVIDER``, ``LINTRO_AI_MODEL``,
-        ``LINTRO_AI_TRANSPORT``, ``LINTRO_AI_ENABLED``) are applied here so
-        every consumer of :meth:`from_mapping` — execution, status, doctor,
-        MCP — sees the same effective values (#1970).
+        ``LINTRO_AI_TRANSPORT``, ``LINTRO_AI_ENABLED``,
+        ``LINTRO_AI_MAX_COST_USD``) are applied here so every consumer of
+        :meth:`from_mapping` — execution, status, doctor, MCP — sees the
+        same effective values (#1970, #2024).
 
         This is the boundary that keeps :mod:`lintro.config` free of any
         knowledge of ``AIConfig``'s field set (see issue #724): the loader
@@ -500,7 +501,7 @@ class AIConfig(BaseModel):
 
         Returns:
             Validated config together with provenance for ``provider``,
-            ``model``, ``transport``, and ``enabled``.
+            ``model``, ``transport``, ``enabled``, and ``max_cost_usd``.
         """
         from lintro.ai.config_overrides import (
             OVERRIDE_FIELDS,

--- a/lintro/ai/config_overrides.py
+++ b/lintro/ai/config_overrides.py
@@ -139,7 +139,10 @@ def apply_cli_overrides(
     Flags beat env vars. Omitted flags leave the corresponding field
     untouched. There is no ``--enabled`` flag. Literal ``0`` for
     ``--max-cost-usd`` means uncapped (mapped to ``None`` before overlay
-    so Pydantic cannot treat it as a $0 cap).
+    so Pydantic cannot treat it as a $0 cap). Overlaying ``max_cost_usd``
+    also stamps both transport-profile cost fields so
+    ``apply_resolved_transport`` cannot clobber flag/env with a YAML
+    profile cap (#2024).
 
     Args:
         resolved: Config + provenance after the env layer.
@@ -280,11 +283,38 @@ def _apply_overlay(
     try:
         payload = config.model_dump()
         payload.update(update)
+        if "max_cost_usd" in overlay:
+            _stamp_overlay_cost_on_profiles(
+                payload,
+                overlay["max_cost_usd"],
+            )
         return AIConfig.model_validate(payload)
     except ValidationError as exc:
         raise AIConfigOverrideError(
             _describe_validation_error(exc=exc, overlay=overlay, names=names),
         ) from exc
+
+
+def _stamp_overlay_cost_on_profiles(
+    payload: dict[str, Any],
+    max_cost_usd: float | None,
+) -> None:
+    """Write an overlay cost cap onto both transport profiles.
+
+    ``resolve_transport_settings`` prefers profile caps over the legacy
+    scalar. Flag/env overlays must beat those YAML profile fields (#2024),
+    matching how ``--timeout`` stamps the active profile.
+
+    Args:
+        payload: ``model_dump()`` of the config being overlaid.
+        max_cost_usd: Overlay ceiling, or None when uncapped.
+    """
+    transports = dict(payload.get("transports") or {})
+    api = dict(transports.get("api") or {})
+    cli = dict(transports.get("cli") or {})
+    api["max_cost_usd"] = max_cost_usd
+    cli["max_cost_usd_advisory"] = max_cost_usd
+    payload["transports"] = {**transports, "api": api, "cli": cli}
 
 
 def _describe_validation_error(

--- a/lintro/ai/config_overrides.py
+++ b/lintro/ai/config_overrides.py
@@ -1,6 +1,6 @@
-"""Env-var and CLI-flag overlays for AI configuration (#1970).
+"""Env-var and CLI-flag overlays for AI configuration (#1970, #2024).
 
-Exactly four environment variables map onto four ``ai:`` fields. Invalid
+Exactly five environment variables map onto five ``ai:`` fields. Invalid
 values fail at resolution with a calm diagnostic naming the variable (or
 flag) and the accepted values — they never fall through to the config
 default.
@@ -8,6 +8,7 @@ default.
 
 from __future__ import annotations
 
+import math
 import os
 from collections.abc import Mapping
 from typing import Any
@@ -23,6 +24,7 @@ from lintro.ai.resolved_ai_config import ResolvedAIConfig
 
 __all__ = [
     "ENV_ENABLED",
+    "ENV_MAX_COST_USD",
     "ENV_MODEL",
     "ENV_PROVIDER",
     "ENV_TRANSPORT",
@@ -36,29 +38,39 @@ ENV_PROVIDER = "LINTRO_AI_PROVIDER"
 ENV_MODEL = "LINTRO_AI_MODEL"
 ENV_TRANSPORT = "LINTRO_AI_TRANSPORT"
 ENV_ENABLED = "LINTRO_AI_ENABLED"
+ENV_MAX_COST_USD = "LINTRO_AI_MAX_COST_USD"
 
-OVERRIDE_FIELDS: tuple[str, ...] = ("provider", "model", "transport", "enabled")
+OVERRIDE_FIELDS: tuple[str, ...] = (
+    "provider",
+    "model",
+    "transport",
+    "enabled",
+    "max_cost_usd",
+)
 
 _ENV_BY_FIELD: dict[str, str] = {
     "provider": ENV_PROVIDER,
     "model": ENV_MODEL,
     "transport": ENV_TRANSPORT,
     "enabled": ENV_ENABLED,
+    "max_cost_usd": ENV_MAX_COST_USD,
 }
 
 _ENABLED_TRUE = frozenset({"1", "true"})
 _ENABLED_FALSE = frozenset({"0", "false"})
 _ENABLED_ACCEPTED = "1, 0, true, false"
+_MAX_COST_ACCEPTED = "a positive number (USD cap), or 0 for uncapped"
 
 _FLAG_BY_FIELD: dict[str, str] = {
     "provider": "--provider",
     "model": "--model",
     "transport": "--transport",
+    "max_cost_usd": "--max-cost-usd",
 }
 
 
 def read_env_overrides() -> dict[str, Any]:
-    """Read the four ``LINTRO_AI_*`` overrides that are present.
+    """Read the five ``LINTRO_AI_*`` overrides that are present.
 
     Unset or whitespace-only variables are omitted (layer absent). There is
     no meta-gate variable.
@@ -79,6 +91,12 @@ def read_env_overrides() -> dict[str, Any]:
     enabled_raw = _env_text(ENV_ENABLED)
     if enabled_raw is not None:
         overlay["enabled"] = _parse_enabled(enabled_raw)
+    max_cost_raw = _env_text(ENV_MAX_COST_USD)
+    if max_cost_raw is not None:
+        overlay["max_cost_usd"] = _parse_max_cost_usd(
+            max_cost_raw,
+            name=ENV_MAX_COST_USD,
+        )
     return overlay
 
 
@@ -114,17 +132,21 @@ def apply_cli_overrides(
     provider: str | None = None,
     model: str | None = None,
     transport: str | None = None,
+    max_cost_usd: float | str | None = None,
 ) -> ResolvedAIConfig:
     """Apply ``lintro review`` CLI flags on top of a resolved config.
 
     Flags beat env vars. Omitted flags leave the corresponding field
-    untouched. There is no ``--enabled`` flag.
+    untouched. There is no ``--enabled`` flag. Literal ``0`` for
+    ``--max-cost-usd`` means uncapped (mapped to ``None`` before overlay
+    so Pydantic cannot treat it as a $0 cap).
 
     Args:
         resolved: Config + provenance after the env layer.
         provider: ``--provider`` value, or None when unset.
         model: ``--model`` value, or None when unset.
         transport: ``--transport`` value, or None when unset.
+        max_cost_usd: ``--max-cost-usd`` value, or None when unset.
 
     Returns:
         A new resolved config when any flag is set; *resolved* otherwise.
@@ -136,6 +158,11 @@ def apply_cli_overrides(
         overlay["model"] = str(model).strip()
     if transport is not None and str(transport).strip():
         overlay["transport"] = str(transport).strip()
+    if max_cost_usd is not None:
+        overlay["max_cost_usd"] = _parse_max_cost_usd(
+            max_cost_usd,
+            name=_FLAG_BY_FIELD["max_cost_usd"],
+        )
     if not overlay:
         return resolved
     updated = _apply_overlay(
@@ -185,6 +212,41 @@ def _parse_enabled(raw: str) -> bool:
     raise AIConfigOverrideError(
         f"{ENV_ENABLED}={raw!r} is not one of: {_ENABLED_ACCEPTED}",
     )
+
+
+def _parse_max_cost_usd(raw: object, *, name: str) -> float | None:
+    """Parse a cost-cap override into a USD ceiling, or None if uncapped.
+
+    Literal ``0`` (including ``0.0``) means unlimited, matching
+    :class:`~lintro.ai.budget.CostBudget`. This mapping happens *before*
+    overlay: Pydantic ``max_cost_usd: float | None`` with ``ge=0`` would
+    otherwise accept ``0.0`` as a zero-dollar cap (#2024).
+
+    Args:
+        raw: Env-var string or CLI float.
+        name: Variable or flag name for the error message.
+
+    Returns:
+        A positive finite float, or None when the cap is lifted.
+
+    Raises:
+        AIConfigOverrideError: If *raw* is negative, non-numeric, or
+            non-finite.
+    """
+    text = str(raw).strip()
+    try:
+        value = float(text)
+    except ValueError:
+        raise AIConfigOverrideError(
+            f"{name}={raw!r} is not one of: {_MAX_COST_ACCEPTED}",
+        ) from None
+    if not math.isfinite(value) or value < 0:
+        raise AIConfigOverrideError(
+            f"{name}={raw!r} is not one of: {_MAX_COST_ACCEPTED}",
+        )
+    if value == 0:
+        return None
+    return value
 
 
 def _apply_overlay(
@@ -273,4 +335,6 @@ def _accepted_values(field: str) -> str:
         return ", ".join(transport.value for transport in AITransport)
     if field == "enabled":
         return _ENABLED_ACCEPTED
+    if field == "max_cost_usd":
+        return _MAX_COST_ACCEPTED
     return ""

--- a/lintro/ai/display/status.py
+++ b/lintro/ai/display/status.py
@@ -12,7 +12,11 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from lintro.ai.enums.config_source import ConfigSource
-from lintro.ai.resolved_ai_config import ResolvedAIConfig, format_sourced_value
+from lintro.ai.resolved_ai_config import (
+    ResolvedAIConfig,
+    format_max_cost_label,
+    format_sourced_value,
+)
 
 if TYPE_CHECKING:
     from lintro.ai.config import AIConfig
@@ -139,6 +143,13 @@ def render_ai_status(
         ai_parts.append(
             "  transport: "
             + format_sourced_value(transport_value, sources.get("transport")),
+        )
+        ai_parts.append(
+            "  max_cost_usd: "
+            + format_max_cost_label(
+                max_cost_usd=ai_config.max_cost_usd,
+                source=sources.get("max_cost_usd"),
+            ),
         )
 
     # auto_apply warning

--- a/lintro/ai/display/status.py
+++ b/lintro/ai/display/status.py
@@ -52,13 +52,16 @@ def render_ai_status(
         return ai_parts
 
     sources: Mapping[str, ConfigSource] | None = None
+    resolved_for_cost: ResolvedAIConfig | None = None
     if isinstance(ai_config, ResolvedAIConfig):
+        resolved_for_cost = ai_config
         sources = ai_config.sources
         ai_config = ai_config.config
     elif isinstance(ai_config, Mapping):
         from lintro.ai.config import AIConfig as _AIConfig
 
         resolved = _AIConfig.resolve_from_mapping(ai_config, diagnostics=False)
+        resolved_for_cost = resolved
         sources = resolved.sources
         ai_config = resolved.config
 
@@ -144,11 +147,21 @@ def render_ai_status(
             "  transport: "
             + format_sourced_value(transport_value, sources.get("transport")),
         )
+        from lintro.ai.transport import resolve_max_cost_with_source
+
+        cap, cap_source = (
+            resolve_max_cost_with_source(resolved_for_cost)
+            if resolved_for_cost is not None
+            else (
+                ai_config.max_cost_usd,
+                sources.get("max_cost_usd"),
+            )
+        )
         ai_parts.append(
             "  max_cost_usd: "
             + format_max_cost_label(
-                max_cost_usd=ai_config.max_cost_usd,
-                source=sources.get("max_cost_usd"),
+                max_cost_usd=cap,
+                source=cap_source,
             ),
         )
 

--- a/lintro/ai/resolved_ai_config.py
+++ b/lintro/ai/resolved_ai_config.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ResolvedAIConfig",
+    "format_max_cost_label",
     "format_sourced_value",
 ]
 
@@ -33,6 +34,27 @@ def format_sourced_value(value: str, source: ConfigSource | str | None) -> str:
     return f"{value} ({label})"
 
 
+def format_max_cost_label(
+    max_cost_usd: float | None,
+    source: ConfigSource | str | None = None,
+) -> str:
+    """Format a cost cap for display, including provenance.
+
+    ``None`` renders as ``uncapped`` so a lifted ceiling is never silent
+    (#2024).
+
+    Args:
+        max_cost_usd: Effective USD cap, or None when unlimited.
+        source: Field provenance, or empty/None to omit the suffix.
+
+    Returns:
+        ``$1.50 (env)``, ``uncapped (flag)``, or the bare label when
+        *source* is absent.
+    """
+    value = "uncapped" if max_cost_usd is None else f"${max_cost_usd:.2f}"
+    return format_sourced_value(value, source)
+
+
 @dataclass(frozen=True, slots=True)
 class ResolvedAIConfig:
     """Validated effective AI settings together with field provenance.
@@ -41,7 +63,7 @@ class ResolvedAIConfig:
         config: Effective :class:`~lintro.ai.config.AIConfig` after
             env/flag overlays and Pydantic validation.
         sources: Provenance for the override fields (``provider``,
-            ``model``, ``transport``, ``enabled``).
+            ``model``, ``transport``, ``enabled``, ``max_cost_usd``).
     """
 
     config: AIConfig

--- a/lintro/ai/review/display.py
+++ b/lintro/ai/review/display.py
@@ -8,7 +8,7 @@ from rich.text import Text
 
 from lintro.ai.cost import format_cost
 from lintro.ai.display.shared import cost_str, print_section_header
-from lintro.ai.resolved_ai_config import format_sourced_value
+from lintro.ai.resolved_ai_config import format_max_cost_label, format_sourced_value
 from lintro.ai.review.checklist_display import (
     cleared_answers,
     orphan_concerns,
@@ -51,6 +51,13 @@ def render_review_terminal(
         metadata.transport or "unset",
         metadata.transport_source,
     )
+    max_cost_parts = ""
+    if metadata.max_cost_usd is not None or metadata.max_cost_usd_source:
+        cap_label = format_max_cost_label(
+            max_cost_usd=metadata.max_cost_usd,
+            source=metadata.max_cost_usd_source,
+        )
+        max_cost_parts = f" | Max cost: {cap_label}"
     header_detail = (
         f"Model: {format_sourced_value(metadata.model, metadata.model_source)} | "
         f"Provider: "
@@ -61,6 +68,7 @@ def render_review_terminal(
         f"{metadata.chunks_current}/{metadata.chunks_total} | "
         f"Files: {metadata.files_reviewed}/{metadata.files_total} | "
         f"Structured checks: {metadata.checklist_items}"
+        f"{max_cost_parts}"
     )
     token_info = cost_str(
         metadata.token_usage.get("prompt", 0),

--- a/lintro/ai/review/github_render.py
+++ b/lintro/ai/review/github_render.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 
-from lintro.ai.resolved_ai_config import format_sourced_value
+from lintro.ai.resolved_ai_config import format_max_cost_label, format_sourced_value
 from lintro.ai.review.agent_prompts import render_finding_prompt_panel
 from lintro.ai.review.checklist_display import (
     cleared_answers,
@@ -204,6 +204,14 @@ def format_run_mechanics(*, metadata: ReviewMetadata) -> str:
             + format_sourced_value(
                 f"`{sanitize_comment_text(metadata.transport or 'unset', limit=40)}`",
                 metadata.transport_source or None,
+            ),
+        )
+    if metadata.max_cost_usd is not None or metadata.max_cost_usd_source:
+        parts.append(
+            "**Max cost:** "
+            + format_max_cost_label(
+                max_cost_usd=metadata.max_cost_usd,
+                source=metadata.max_cost_usd_source or None,
             ),
         )
     parts.extend(

--- a/lintro/ai/review/github_review_body.py
+++ b/lintro/ai/review/github_review_body.py
@@ -19,7 +19,7 @@ still names the sticky's fix-all for everything open across all rounds.
 from __future__ import annotations
 
 from lintro import __version__ as lintro_version
-from lintro.ai.resolved_ai_config import format_sourced_value
+from lintro.ai.resolved_ai_config import format_max_cost_label, format_sourced_value
 from lintro.ai.review.agent_prompts import (
     prompt_findings,
     render_agent_prompt_panel,
@@ -249,10 +249,12 @@ def _run_stats_section(
     metadata = result.metadata
     primary = run_stats_primary_cells(metadata=metadata)
 
-    transport_label = format_sourced_value(
-        sanitize_comment_text(transport, limit=40),
-        metadata.transport_source or None,
-    )
+    transport_label = ""
+    if transport:
+        transport_label = format_sourced_value(
+            sanitize_comment_text(transport, limit=40),
+            metadata.transport_source or None,
+        )
     if transport_label and auth_mode:
         transport_label = (
             f"{transport_label} · {sanitize_comment_text(auth_mode, limit=40)}"
@@ -260,6 +262,16 @@ def _run_stats_section(
     secondary: list[tuple[str, str]] = []
     if transport_label:
         secondary.append(("transport", transport_label))
+    if metadata.max_cost_usd is not None or metadata.max_cost_usd_source:
+        secondary.append(
+            (
+                "max cost",
+                format_max_cost_label(
+                    max_cost_usd=metadata.max_cost_usd,
+                    source=metadata.max_cost_usd_source or None,
+                ),
+            ),
+        )
     secondary.extend(
         [
             ("depth", str(metadata.depth)),

--- a/lintro/ai/review/models/review_metadata.py
+++ b/lintro/ai/review/models/review_metadata.py
@@ -51,6 +51,12 @@ class ReviewMetadata:
             legacy records.
         transport_source (str): Provenance of ``transport`` (#1970). Empty
             on legacy records.
+        max_cost_usd (float | None): Effective ``ai.max_cost_usd`` ceiling
+            for this run. ``None`` means uncapped (#2024). Unset on
+            legacy records (same default, so they must not be labeled
+            uncapped without ``max_cost_usd_source``).
+        max_cost_usd_source (str): Provenance of ``max_cost_usd`` (#2024).
+            Empty on legacy records.
         phase_timings (dict[str, float]): Per-phase wall-clock seconds for
             regression visibility. Keys include ``context_collection``,
             ``provider`` (chunk + custom-agent provider calls), and
@@ -91,6 +97,8 @@ class ReviewMetadata:
     provider_source: str = ""
     model_source: str = ""
     transport_source: str = ""
+    max_cost_usd: float | None = None
+    max_cost_usd_source: str = ""
     phase_timings: dict[str, float] = field(default_factory=dict)
     custom_agents_run: int = 0
     custom_agents_skipped: int = 0

--- a/lintro/ai/transport.py
+++ b/lintro/ai/transport.py
@@ -6,10 +6,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 from lintro.ai.config_overrides import apply_cli_overrides
-from lintro.ai.enums import AITransport
+from lintro.ai.enums import AITransport, ConfigSource
 from lintro.ai.enums.cost_basis import CostBasis
 from lintro.ai.providers.claude_auth import should_send_bare
 from lintro.ai.registry import AIProvider
+from lintro.ai.resolved_ai_config import ResolvedAIConfig
 
 if TYPE_CHECKING:
     from lintro.ai.config import AIConfig
@@ -23,6 +24,7 @@ __all__ = [
     "apply_transport_override",
     "format_resolved_profile_log",
     "resolve_cost_basis",
+    "resolve_max_cost_with_source",
     "resolve_transport_settings",
 ]
 
@@ -164,6 +166,40 @@ def resolve_transport_settings(ai_config: AIConfig) -> ResolvedTransportSettings
         auth_mode="api_key",
         cost_basis=CostBasis.BILLED,
     )
+
+
+def resolve_max_cost_with_source(
+    resolved: ResolvedAIConfig,
+) -> tuple[float | None, ConfigSource]:
+    """Return the effective cost cap and its provenance.
+
+    Overlay (flag/env) wins, including when it stamped the profile fields.
+    Otherwise a non-null transport-profile cap is ``config``, even when the
+    legacy scalar was omitted from YAML (so the flat field's source is
+    ``default``).
+
+    Args:
+        resolved: Config plus overlay-field provenance.
+
+    Returns:
+        ``(cap, source)`` after transport-profile resolution.
+    """
+    source = resolved.source_of("max_cost_usd")
+    settings = resolve_transport_settings(resolved.config)
+    if source in (ConfigSource.FLAG, ConfigSource.ENV):
+        return settings.max_cost_usd, source
+
+    config = resolved.config
+    transport = config.transport or AITransport.API
+    profiles = config.transports
+    profile_cap = (
+        profiles.cli.max_cost_usd_advisory
+        if transport is AITransport.CLI
+        else profiles.api.max_cost_usd
+    )
+    if profile_cap is not None:
+        return profile_cap, ConfigSource.CONFIG
+    return settings.max_cost_usd, source
 
 
 def apply_resolved_transport(ai_config: AIConfig) -> AIConfig:

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -194,7 +194,6 @@ ADVISORY_DEFAULT_PATHS: tuple[str, ...] = (".",)
 @click.option(
     "--max-cost-usd",
     "max_cost_usd_override",
-    type=float,
     default=None,
     help=(
         "Override ai.max_cost_usd for this invocation. A positive number is "
@@ -275,7 +274,7 @@ def review_command(
     transport: str | None,
     provider_override: str | None,
     model_override: str | None,
-    max_cost_usd_override: float | None,
+    max_cost_usd_override: str | None,
     list_agents: bool,
     advisory_tools: str | None,
     tool_options: str | None,
@@ -610,7 +609,7 @@ def _cli_overrides(
     transport: str | None,
     provider: str | None,
     model: str | None,
-    max_cost_usd: float | None,
+    max_cost_usd: float | str | None,
     timeout: float | None,
     context_window: int | None,
     semantic_chunks: bool,
@@ -649,7 +648,7 @@ def _cli_overrides(
     if model is not None:
         overrides.append(f"--model {model}")
     if max_cost_usd is not None:
-        overrides.append(f"--max-cost-usd {max_cost_usd:g}")
+        overrides.append(f"--max-cost-usd {max_cost_usd}")
     if timeout is not None:
         overrides.append(f"--timeout {timeout:g}")
     if context_window is not None:

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -192,6 +192,16 @@ ADVISORY_DEFAULT_PATHS: tuple[str, ...] = (".",)
     help="Override ai.model for this invocation.",
 )
 @click.option(
+    "--max-cost-usd",
+    "max_cost_usd_override",
+    type=float,
+    default=None,
+    help=(
+        "Override ai.max_cost_usd for this invocation. A positive number is "
+        "the USD cap; 0 means uncapped (not a $0 cap)."
+    ),
+)
+@click.option(
     "--timeout",
     type=float,
     default=None,
@@ -265,6 +275,7 @@ def review_command(
     transport: str | None,
     provider_override: str | None,
     model_override: str | None,
+    max_cost_usd_override: float | None,
     list_agents: bool,
     advisory_tools: str | None,
     tool_options: str | None,
@@ -311,6 +322,7 @@ def review_command(
             provider=provider_override,
             model=model_override,
             transport=transport,
+            max_cost_usd=max_cost_usd_override,
         )
     except AIConfigOverrideError as exc:
         raise click.UsageError(str(exc)) from exc
@@ -487,6 +499,8 @@ def review_command(
                 provider_source=resolved_ai.source_of("provider").value,
                 model_source=resolved_ai.source_of("model").value,
                 transport_source=resolved_ai.source_of("transport").value,
+                max_cost_usd=effective_ai_config.max_cost_usd,
+                max_cost_usd_source=resolved_ai.source_of("max_cost_usd").value,
             ),
         )
     except (AIError, ValueError) as exc:
@@ -572,6 +586,7 @@ def review_command(
                     transport=transport,
                     provider=provider_override,
                     model=model_override,
+                    max_cost_usd=max_cost_usd_override,
                     timeout=timeout,
                     context_window=context_window,
                     semantic_chunks=semantic_chunks,
@@ -595,6 +610,7 @@ def _cli_overrides(
     transport: str | None,
     provider: str | None,
     model: str | None,
+    max_cost_usd: float | None,
     timeout: float | None,
     context_window: int | None,
     semantic_chunks: bool,
@@ -612,6 +628,7 @@ def _cli_overrides(
         transport: ``--transport`` value, or None when unset.
         provider: ``--provider`` value, or None when unset.
         model: ``--model`` value, or None when unset.
+        max_cost_usd: ``--max-cost-usd`` value, or None when unset.
         timeout: ``--timeout`` value, or None when unset.
         context_window: ``--context-window`` value, or None when unset.
         semantic_chunks: Whether ``--semantic-chunks`` was passed.
@@ -631,6 +648,8 @@ def _cli_overrides(
         overrides.append(f"--provider {provider}")
     if model is not None:
         overrides.append(f"--model {model}")
+    if max_cost_usd is not None:
+        overrides.append(f"--max-cost-usd {max_cost_usd:g}")
     if timeout is not None:
         overrides.append(f"--timeout {timeout:g}")
     if context_window is not None:

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -61,6 +61,7 @@ from lintro.ai.transport import (
     apply_cli_overrides,
     apply_resolved_transport,
     format_resolved_profile_log,
+    resolve_max_cost_with_source,
     resolve_transport_settings,
 )
 from lintro.config.config_loader import get_config
@@ -488,6 +489,7 @@ def review_command(
         ):
             effective_basis = CostBasis.ESTIMATED
 
+        cap, cap_source = resolve_max_cost_with_source(resolved_ai)
         result = dc_replace(
             result,
             metadata=dc_replace(
@@ -498,8 +500,8 @@ def review_command(
                 provider_source=resolved_ai.source_of("provider").value,
                 model_source=resolved_ai.source_of("model").value,
                 transport_source=resolved_ai.source_of("transport").value,
-                max_cost_usd=effective_ai_config.max_cost_usd,
-                max_cost_usd_source=resolved_ai.source_of("max_cost_usd").value,
+                max_cost_usd=cap,
+                max_cost_usd_source=cap_source.value,
             ),
         )
     except (AIError, ValueError) as exc:

--- a/lintro/mcp/toolkits/review.py
+++ b/lintro/mcp/toolkits/review.py
@@ -17,10 +17,11 @@ Three things are deliberately different from the CLI:
   rather than the reviewed tree, in the same class as the run-log directory
   :mod:`lintro.mcp.toolkits.runner` redirects. No tool argument can turn it on,
   so an agent cannot make the server write anything.
-* **Cost is capped from the server side.** ``ai.max_cost_usd`` in the
-  workspace's ``.lintro-config.yaml`` is the ceiling. The ``max_cost_usd``
-  argument can only *lower* it — a larger value is clamped, never honored — so
-  a misbehaving agent cannot raise its own spend limit.
+* **Cost is capped from the server side.** The effective ``ai.max_cost_usd``
+  (after ``LINTRO_AI_MAX_COST_USD`` / CLI overlay and the active transport
+  profile) is the ceiling. The ``max_cost_usd`` argument can only *lower*
+  it — a larger value is clamped, never honored — so a misbehaving agent
+  cannot raise its own spend limit.
 * **Unavailability is data, not a missing tool.** Without the ``[ai]`` extra, a
   usable provider, or ``ai.review: true``, the tool is still listed and returns
   a ``tool_unavailable`` envelope. An agent gets a reason it can report instead

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,7 @@ _AI_OVERRIDE_ENV_VARS: tuple[str, ...] = (
     "LINTRO_AI_MODEL",
     "LINTRO_AI_TRANSPORT",
     "LINTRO_AI_ENABLED",
+    "LINTRO_AI_MAX_COST_USD",
 )
 
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -347,6 +347,7 @@ _DOCUMENTED_LINTRO_ENV_VARS = {
     "LINTRO_AI_MODEL",
     "LINTRO_AI_TRANSPORT",
     "LINTRO_AI_ENABLED",
+    "LINTRO_AI_MAX_COST_USD",
 }
 
 # Env vars that were historically documented but are NOT read by the runtime.

--- a/tests/unit/ai/review/test_github_review_body.py
+++ b/tests/unit/ai/review/test_github_review_body.py
@@ -259,6 +259,54 @@ def test_run_stats_are_visible_and_ordered(
     assert_that(body).contains(f"| {lintro_version} |")
 
 
+def test_empty_transport_is_omitted_even_when_source_is_set(
+    sample_review_result: ReviewResult,
+) -> None:
+    """An empty transport stays omitted; a source suffix must not make it truthy.
+
+    ``format_sourced_value("", "config")`` is ``" (config)"``, which used to
+    pass ``if transport_label:`` and emit a blank transport cell (#1972).
+    """
+    sourced = replace(
+        sample_review_result,
+        metadata=replace(
+            sample_review_result.metadata,
+            transport_source="config",
+        ),
+    )
+
+    body = _body(
+        result=sourced,
+        prior_state=ReviewState(),
+        transport="",
+    )
+
+    assert_that(body).does_not_contain("| transport |")
+
+
+def test_run_stats_show_uncapped_max_cost_with_source(
+    sample_review_result: ReviewResult,
+) -> None:
+    """An uncapped overlay is visible on the PR comment stats row (#2024)."""
+    uncapped = replace(
+        sample_review_result,
+        metadata=replace(
+            sample_review_result.metadata,
+            max_cost_usd=None,
+            max_cost_usd_source="env",
+        ),
+    )
+
+    body = _body(
+        result=uncapped,
+        prior_state=ReviewState(),
+        transport="cli",
+    )
+
+    assert_that(body).contains("| transport | max cost |")
+    assert_that(body).contains("uncapped (env)")
+
+
 def test_estimated_token_counts_are_marked_approximate(
     sample_review_result: ReviewResult,
 ) -> None:

--- a/tests/unit/ai/test_config_overrides.py
+++ b/tests/unit/ai/test_config_overrides.py
@@ -15,7 +15,11 @@ from lintro.ai.review.display import render_review_terminal
 from lintro.ai.review.github_render import format_run_mechanics
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
-from lintro.ai.transport import apply_cli_overrides, apply_resolved_transport
+from lintro.ai.transport import (
+    apply_cli_overrides,
+    apply_resolved_transport,
+    resolve_max_cost_with_source,
+)
 from lintro.config.lintro_config import LintroConfig
 
 
@@ -295,6 +299,38 @@ def test_max_cost_usd_overlay_raises_profile_cap() -> None:
     assert_that(resolved.source_of("max_cost_usd")).is_equal_to(ConfigSource.FLAG)
 
 
+def test_profile_only_cap_is_config_provenance() -> None:
+    """A YAML transport-profile cap is ``config``, not ``default`` (#2024)."""
+    resolved = AIConfig.resolve_from_mapping(
+        {
+            "transport": "cli",
+            "transports": {"cli": {"max_cost_usd_advisory": 1.25}},
+        },
+    )
+    cap, source = resolve_max_cost_with_source(resolved)
+
+    assert_that(resolved.source_of("max_cost_usd")).is_equal_to(ConfigSource.DEFAULT)
+    assert_that(cap).is_equal_to(1.25)
+    assert_that(source).is_equal_to(ConfigSource.CONFIG)
+
+
+def test_flag_overlay_provenance_beats_profile_cap() -> None:
+    """Flag provenance is kept when the overlay lifts a profile cap."""
+    resolved = apply_cli_overrides(
+        AIConfig.resolve_from_mapping(
+            {
+                "transport": "api",
+                "transports": {"api": {"max_cost_usd": 1.25}},
+            },
+        ),
+        max_cost_usd=0,
+    )
+    cap, source = resolve_max_cost_with_source(resolved)
+
+    assert_that(cap).is_none()
+    assert_that(source).is_equal_to(ConfigSource.FLAG)
+
+
 def test_invalid_max_cost_usd_env_fails_loud(monkeypatch: pytest.MonkeyPatch) -> None:
     """A non-numeric cost cap names the variable and accepted values (#2024)."""
     monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "plenty")
@@ -451,6 +487,32 @@ def test_status_annotates_env_max_cost_usd(monkeypatch: pytest.MonkeyPatch) -> N
     )
 
     assert_that(lines).contains("  max_cost_usd: $2.50 (env)")
+
+
+def test_status_annotates_profile_cap_as_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A YAML profile cap is shown as config, not uncapped default (#2024)."""
+    from lintro.ai.display.status import render_ai_status
+
+    monkeypatch.setattr(
+        "lintro.ai.availability.is_provider_available",
+        lambda _provider: True,
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    lines = render_ai_status(
+        ai_config={
+            "enabled": True,
+            "provider": "anthropic",
+            "transport": "cli",
+            "transports": {"cli": {"max_cost_usd_advisory": 1.25}},
+        },
+        is_ci=False,
+    )
+
+    assert_that(lines).contains("  max_cost_usd: $1.25 (config)")
+    assert_that(lines).does_not_contain("  max_cost_usd: uncapped (default)")
 
 
 def test_status_marks_enabled_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/ai/test_config_overrides.py
+++ b/tests/unit/ai/test_config_overrides.py
@@ -370,6 +370,19 @@ def test_nonnumeric_max_cost_usd_flag_fails_loud() -> None:
     assert_that(message).contains("0 for uncapped")
 
 
+def test_nonfinite_max_cost_usd_fails_loud() -> None:
+    """NaN and inf are rejected rather than stored as a cap (#2024)."""
+    for raw in ("nan", "inf", "-inf"):
+        with pytest.raises(AIConfigOverrideError) as exc_info:
+            apply_cli_overrides(
+                AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5)),
+                max_cost_usd=raw,
+            )
+        message = str(exc_info.value)
+        assert_that(message).contains(f"--max-cost-usd='{raw}'")
+        assert_that(message).contains("0 for uncapped")
+
+
 def test_whitespace_max_cost_usd_env_is_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/ai/test_config_overrides.py
+++ b/tests/unit/ai/test_config_overrides.py
@@ -1,8 +1,6 @@
-"""Tests for the env-var and CLI-flag AI config override layer (#1970)."""
+"""Tests for the env-var and CLI-flag AI config override layer (#1970, #2024)."""
 
 from __future__ import annotations
-
-import os
 
 import pytest
 from assertpy import assert_that
@@ -12,7 +10,7 @@ from lintro.ai.config import AIConfig
 from lintro.ai.enums import AITransport, ConfigSource
 from lintro.ai.exceptions import AIConfigOverrideError
 from lintro.ai.provider_enum import AIProvider
-from lintro.ai.resolved_ai_config import format_sourced_value
+from lintro.ai.resolved_ai_config import format_max_cost_label, format_sourced_value
 from lintro.ai.review.display import render_review_terminal
 from lintro.ai.review.github_render import format_run_mechanics
 from lintro.ai.review.models.review_metadata import ReviewMetadata
@@ -39,6 +37,7 @@ def test_each_env_var_overrides_its_field(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setenv("LINTRO_AI_MODEL", "cursor-grok-4.6-high")
     monkeypatch.setenv("LINTRO_AI_TRANSPORT", "cli")
     monkeypatch.setenv("LINTRO_AI_ENABLED", "1")
+    monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "2.5")
 
     resolved = AIConfig.resolve_from_mapping(
         _mapping(provider="anthropic", model="claude-sonnet", transport="api"),
@@ -48,10 +47,12 @@ def test_each_env_var_overrides_its_field(monkeypatch: pytest.MonkeyPatch) -> No
     assert_that(resolved.config.model).is_equal_to("cursor-grok-4.6-high")
     assert_that(resolved.config.transport).is_equal_to(AITransport.CLI)
     assert_that(resolved.config.enabled).is_true()
+    assert_that(resolved.config.max_cost_usd).is_equal_to(2.5)
     assert_that(resolved.source_of("provider")).is_equal_to(ConfigSource.ENV)
     assert_that(resolved.source_of("model")).is_equal_to(ConfigSource.ENV)
     assert_that(resolved.source_of("transport")).is_equal_to(ConfigSource.ENV)
     assert_that(resolved.source_of("enabled")).is_equal_to(ConfigSource.ENV)
+    assert_that(resolved.source_of("max_cost_usd")).is_equal_to(ConfigSource.ENV)
 
 
 def test_flag_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -109,6 +110,8 @@ def test_empty_mapping_uses_built_in_defaults() -> None:
     assert_that(resolved.source_of("model")).is_equal_to(ConfigSource.DEFAULT)
     assert_that(resolved.source_of("transport")).is_equal_to(ConfigSource.DEFAULT)
     assert_that(resolved.source_of("enabled")).is_equal_to(ConfigSource.DEFAULT)
+    assert_that(resolved.source_of("max_cost_usd")).is_equal_to(ConfigSource.DEFAULT)
+    assert_that(resolved.config.max_cost_usd).is_none()
 
 
 def test_invalid_provider_env_names_the_variable(
@@ -183,14 +186,92 @@ def test_enabled_one_does_not_imply_review(monkeypatch: pytest.MonkeyPatch) -> N
     assert_that(resolved.config.lint_enabled).is_false()
 
 
-def test_max_cost_usd_has_no_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A spend-cap env var is ignored; the committed cap cannot be raised."""
+def test_max_cost_usd_env_overrides_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``LINTRO_AI_MAX_COST_USD`` raises the committed cap (#2024)."""
     monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "99.0")
 
     resolved = AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5))
 
+    assert_that(resolved.config.max_cost_usd).is_equal_to(99.0)
+    assert_that(resolved.source_of("max_cost_usd")).is_equal_to(ConfigSource.ENV)
+
+
+def test_max_cost_usd_flag_overrides_config() -> None:
+    """``--max-cost-usd`` overlays the committed cap (#2024)."""
+    resolved = apply_cli_overrides(
+        AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5)),
+        max_cost_usd=3.25,
+    )
+
+    assert_that(resolved.config.max_cost_usd).is_equal_to(3.25)
+    assert_that(resolved.source_of("max_cost_usd")).is_equal_to(ConfigSource.FLAG)
+
+
+def test_max_cost_usd_flag_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The cost-cap flag wins over the env var (#2024)."""
+    monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "1.0")
+
+    resolved = apply_cli_overrides(
+        AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5)),
+        max_cost_usd=5.0,
+    )
+
+    assert_that(resolved.config.max_cost_usd).is_equal_to(5.0)
+    assert_that(resolved.source_of("max_cost_usd")).is_equal_to(ConfigSource.FLAG)
+
+
+def test_max_cost_usd_zero_is_uncapped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Literal ``0`` lifts the ceiling to ``None``, matching CostBudget (#2024)."""
+    monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "0")
+
+    from_env = AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5))
+    from_flag = apply_cli_overrides(
+        AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5)),
+        max_cost_usd=0.0,
+    )
+
+    assert_that(from_env.config.max_cost_usd).is_none()
+    assert_that(from_env.source_of("max_cost_usd")).is_equal_to(ConfigSource.ENV)
+    assert_that(from_flag.config.max_cost_usd).is_none()
+    assert_that(from_flag.source_of("max_cost_usd")).is_equal_to(ConfigSource.FLAG)
+
+
+def test_invalid_max_cost_usd_env_fails_loud(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-numeric cost cap names the variable and accepted values (#2024)."""
+    monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "plenty")
+
+    with pytest.raises(AIConfigOverrideError) as exc_info:
+        AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5))
+
+    message = str(exc_info.value)
+    assert_that(message).contains("LINTRO_AI_MAX_COST_USD='plenty'")
+    assert_that(message).contains("0 for uncapped")
+    assert_that(message).does_not_contain("Traceback")
+
+
+def test_negative_max_cost_usd_fails_loud() -> None:
+    """A negative ``--max-cost-usd`` is rejected rather than stored (#2024)."""
+    with pytest.raises(AIConfigOverrideError) as exc_info:
+        apply_cli_overrides(
+            AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5)),
+            max_cost_usd=-1.0,
+        )
+
+    message = str(exc_info.value)
+    assert_that(message).contains("--max-cost-usd=-1.0")
+    assert_that(message).contains("0 for uncapped")
+
+
+def test_whitespace_max_cost_usd_env_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitespace-only ``LINTRO_AI_MAX_COST_USD`` leaves the mapping (#2024)."""
+    monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "  ")
+
+    resolved = AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5))
+
     assert_that(resolved.config.max_cost_usd).is_equal_to(0.5)
-    assert_that(os.environ.get("LINTRO_AI_MAX_COST_USD")).is_equal_to("99.0")
+    assert_that(resolved.source_of("max_cost_usd")).is_equal_to(ConfigSource.CONFIG)
 
 
 def test_whitespace_only_env_is_treated_as_unset(
@@ -251,6 +332,12 @@ def test_format_sourced_value_annotates_known_sources() -> None:
     assert_that(format_sourced_value("cli", "flag")).is_equal_to("cli (flag)")
     assert_that(format_sourced_value("anthropic", None)).is_equal_to("anthropic")
     assert_that(format_sourced_value("anthropic", "")).is_equal_to("anthropic")
+    assert_that(
+        format_max_cost_label(max_cost_usd=None, source=ConfigSource.ENV),
+    ).is_equal_to("uncapped (env)")
+    assert_that(
+        format_max_cost_label(max_cost_usd=1.5, source="flag"),
+    ).is_equal_to("$1.50 (flag)")
 
 
 def test_status_annotates_env_provider(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -272,6 +359,26 @@ def test_status_annotates_env_provider(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert_that(lines).contains("  provider: openai (env)")
     assert_that("".join(lines)).contains("transport: api (config)")
+    assert_that(lines).contains("  max_cost_usd: uncapped (default)")
+
+
+def test_status_annotates_env_max_cost_usd(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pre-execution status shows env provenance for the cost cap (#2024)."""
+    from lintro.ai.display.status import render_ai_status
+
+    monkeypatch.setattr(
+        "lintro.ai.availability.is_provider_available",
+        lambda _provider: True,
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "2.5")
+
+    lines = render_ai_status(
+        ai_config={"enabled": True, "provider": "anthropic", "transport": "api"},
+        is_ci=False,
+    )
+
+    assert_that(lines).contains("  max_cost_usd: $2.50 (env)")
 
 
 def test_status_marks_enabled_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -309,6 +416,8 @@ def _review_result_with_sources() -> ReviewResult:
             provider_source="env",
             model_source="flag",
             transport_source="config",
+            max_cost_usd=None,
+            max_cost_usd_source="env",
         ),
         summary="Safe to merge.",
         checklist=(),
@@ -317,7 +426,7 @@ def _review_result_with_sources() -> ReviewResult:
 
 
 def test_terminal_review_annotates_provider_model_transport() -> None:
-    """Terminal output shows provider, model, and transport with sources."""
+    """Terminal output shows provider, model, transport, and max cost with sources."""
     console = Console(record=True)
     render_review_terminal(result=_review_result_with_sources(), console=console)
     text = console.export_text()
@@ -325,6 +434,7 @@ def test_terminal_review_annotates_provider_model_transport() -> None:
     assert_that(text).contains("Model: cursor-grok-4.6-high (flag)")
     assert_that(text).contains("Provider: cursor (env)")
     assert_that(text).contains("Transport: cli (config)")
+    assert_that(text).contains("Max cost: uncapped (env)")
 
 
 def test_pr_comment_mechanics_annotates_sources() -> None:
@@ -334,3 +444,4 @@ def test_pr_comment_mechanics_annotates_sources() -> None:
     assert_that(mechanics).contains("**Model:** `cursor-grok-4.6-high` (flag)")
     assert_that(mechanics).contains("**Provider:** `cursor` (env)")
     assert_that(mechanics).contains("**Transport:** `cli` (config)")
+    assert_that(mechanics).contains("**Max cost:** uncapped (env)")

--- a/tests/unit/ai/test_config_overrides.py
+++ b/tests/unit/ai/test_config_overrides.py
@@ -15,7 +15,7 @@ from lintro.ai.review.display import render_review_terminal
 from lintro.ai.review.github_render import format_run_mechanics
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
-from lintro.ai.transport import apply_cli_overrides
+from lintro.ai.transport import apply_cli_overrides, apply_resolved_transport
 from lintro.config.lintro_config import LintroConfig
 
 
@@ -236,6 +236,65 @@ def test_max_cost_usd_zero_is_uncapped(monkeypatch: pytest.MonkeyPatch) -> None:
     assert_that(from_flag.source_of("max_cost_usd")).is_equal_to(ConfigSource.FLAG)
 
 
+def test_yaml_zero_is_a_zero_dollar_cap_not_uncapped() -> None:
+    """Committed YAML ``0`` is a $0 cap; only overlay ``0`` is uncapped (#2024)."""
+    resolved = AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0))
+
+    assert_that(resolved.config.max_cost_usd).is_equal_to(0.0)
+    assert_that(resolved.source_of("max_cost_usd")).is_equal_to(ConfigSource.CONFIG)
+
+
+def test_max_cost_usd_overlay_beats_transport_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flag/env overlays beat YAML transport-profile caps (#2024)."""
+    mapping = {
+        "max_cost_usd": 0.5,
+        "transport": "cli",
+        "transports": {"cli": {"max_cost_usd_advisory": 1.25}},
+    }
+    monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "0")
+
+    from_env = AIConfig.resolve_from_mapping(mapping)
+    applied_env = apply_resolved_transport(from_env.config)
+
+    assert_that(applied_env.max_cost_usd).is_none()
+    assert_that(from_env.source_of("max_cost_usd")).is_equal_to(ConfigSource.ENV)
+
+    monkeypatch.delenv("LINTRO_AI_MAX_COST_USD")
+    from_flag = apply_cli_overrides(
+        AIConfig.resolve_from_mapping(
+            {
+                "max_cost_usd": 0.5,
+                "transport": "cli",
+                "transports": {"cli": {"max_cost_usd_advisory": 1.25}},
+            },
+        ),
+        max_cost_usd=0,
+    )
+    applied_flag = apply_resolved_transport(from_flag.config)
+
+    assert_that(applied_flag.max_cost_usd).is_none()
+    assert_that(from_flag.source_of("max_cost_usd")).is_equal_to(ConfigSource.FLAG)
+
+
+def test_max_cost_usd_overlay_raises_profile_cap() -> None:
+    """A positive overlay replaces the profile cap, not only the legacy scalar."""
+    resolved = apply_cli_overrides(
+        AIConfig.resolve_from_mapping(
+            {
+                "transport": "api",
+                "transports": {"api": {"max_cost_usd": 1.25}},
+            },
+        ),
+        max_cost_usd=9.0,
+    )
+    applied = apply_resolved_transport(resolved.config)
+
+    assert_that(applied.max_cost_usd).is_equal_to(9.0)
+    assert_that(resolved.source_of("max_cost_usd")).is_equal_to(ConfigSource.FLAG)
+
+
 def test_invalid_max_cost_usd_env_fails_loud(monkeypatch: pytest.MonkeyPatch) -> None:
     """A non-numeric cost cap names the variable and accepted values (#2024)."""
     monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "plenty")
@@ -259,6 +318,19 @@ def test_negative_max_cost_usd_fails_loud() -> None:
 
     message = str(exc_info.value)
     assert_that(message).contains("--max-cost-usd=-1.0")
+    assert_that(message).contains("0 for uncapped")
+
+
+def test_nonnumeric_max_cost_usd_flag_fails_loud() -> None:
+    """A non-numeric ``--max-cost-usd`` uses the overlay error, not Click (#2024)."""
+    with pytest.raises(AIConfigOverrideError) as exc_info:
+        apply_cli_overrides(
+            AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5)),
+            max_cost_usd="plenty",
+        )
+
+    message = str(exc_info.value)
+    assert_that(message).contains("--max-cost-usd='plenty'")
     assert_that(message).contains("0 for uncapped")
 
 

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -86,6 +86,94 @@ def test_review_invalid_provider_env_exits_two(
     assert_that(result.output).does_not_contain("Traceback")
 
 
+def test_review_nonnumeric_max_cost_usd_exits_two() -> None:
+    """Non-numeric ``--max-cost-usd`` uses the overlay error, not Click's float."""
+    mock_config = MagicMock(ai={"enabled": True, "review": True})
+    runner = CliRunner()
+    with (
+        patch("lintro.cli_utils.commands.review.require_ai"),
+        patch(
+            "lintro.cli_utils.commands.review.get_config",
+            return_value=mock_config,
+        ),
+    ):
+        result = runner.invoke(cli, ["review", "--max-cost-usd", "plenty"])
+
+    assert_that(result.exit_code).is_equal_to(2)
+    assert_that(result.output).contains("--max-cost-usd='plenty'")
+    assert_that(result.output).contains("0 for uncapped")
+    assert_that(result.output).does_not_contain("Traceback")
+
+
+def test_review_max_cost_flag_beats_transport_profile() -> None:
+    """``--max-cost-usd 0`` lifts a YAML transport-profile cap (#2024)."""
+    runner = CliRunner()
+    mock_context = MagicMock()
+    mock_context.changed_files = []
+    mock_context.unified_diff = ""
+    mock_config = MagicMock(
+        ai={
+            "enabled": True,
+            "review": True,
+            "transport": "cli",
+            "transports": {"cli": {"max_cost_usd_advisory": 1.25}},
+        },
+    )
+    mock_config.review.depth = 1
+    mock_config.review.strictness = ReviewStrictness.BALANCED
+    mock_config.review.sensitivity = MagicMock()
+    mock_config.review.force_semantic_chunking = False
+    mock_config.review.checklist_display = ChecklistDisplay.OFF
+
+    with (
+        patch("lintro.cli_utils.commands.review.require_ai"),
+        patch(
+            "lintro.cli_utils.commands.review.get_config",
+            return_value=mock_config,
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.collect_review_context",
+            return_value=mock_context,
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.classify_changed_files",
+            return_value=[],
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.get_all_checklist_items",
+            return_value=[],
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.select_checklist_items",
+            return_value=[],
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.format_checklist_for_prompt",
+            return_value=("", {}),
+        ),
+        patch("lintro.cli_utils.commands.review.get_provider") as mock_get_provider,
+        patch(
+            "lintro.cli_utils.commands.review.run_review",
+            return_value=_empty_result(),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.render_review_output",
+        ) as mock_render,
+    ):
+        mock_get_provider.return_value = MagicMock(
+            model_name="gpt-4o",
+            name="openai",
+        )
+        result = runner.invoke(cli, ["review", "--max-cost-usd", "0"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    provider_config = mock_get_provider.call_args.args[0]
+    assert_that(provider_config.max_cost_usd).is_none()
+    rendered = mock_render.call_args.kwargs["result"]
+    assert_that(rendered.metadata.max_cost_usd).is_none()
+    assert_that(rendered.metadata.max_cost_usd_source).is_equal_to("flag")
+
+
 def test_review_alias_rev_works() -> None:
     """Alias rev resolves to the review command help."""
     runner = CliRunner()
@@ -387,7 +475,12 @@ def test_review_stamps_resolved_transport_provenance_on_metadata() -> None:
     mock_context.changed_files = []
     mock_context.unified_diff = ""
     mock_config = MagicMock(
-        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+        ai={
+            "enabled": True,
+            "review": True,
+            "provider": "anthropic",
+            "transport": "api",
+        },
     )
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
@@ -444,7 +537,7 @@ def test_review_stamps_resolved_transport_provenance_on_metadata() -> None:
     assert_that(rendered.metadata.provider_source).is_equal_to("config")
     assert_that(rendered.metadata.transport_source).is_equal_to("config")
     assert_that(rendered.metadata.max_cost_usd).is_none()
-    assert_that(rendered.metadata.max_cost_usd_source).is_equal_to("config")
+    assert_that(rendered.metadata.max_cost_usd_source).is_equal_to("default")
 
 
 def test_review_downgrades_billed_to_estimated_without_usage_counters() -> None:

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -174,6 +174,73 @@ def test_review_max_cost_flag_beats_transport_profile() -> None:
     assert_that(rendered.metadata.max_cost_usd_source).is_equal_to("flag")
 
 
+def test_review_profile_cap_provenance_is_config() -> None:
+    """A YAML-only transport-profile cap is sourced as config, not default."""
+    runner = CliRunner()
+    mock_context = MagicMock()
+    mock_context.changed_files = []
+    mock_context.unified_diff = ""
+    mock_config = MagicMock(
+        ai={
+            "enabled": True,
+            "review": True,
+            "transport": "cli",
+            "transports": {"cli": {"max_cost_usd_advisory": 1.25}},
+        },
+    )
+    mock_config.review.depth = 1
+    mock_config.review.strictness = ReviewStrictness.BALANCED
+    mock_config.review.sensitivity = MagicMock()
+    mock_config.review.force_semantic_chunking = False
+    mock_config.review.checklist_display = ChecklistDisplay.OFF
+
+    with (
+        patch("lintro.cli_utils.commands.review.require_ai"),
+        patch(
+            "lintro.cli_utils.commands.review.get_config",
+            return_value=mock_config,
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.collect_review_context",
+            return_value=mock_context,
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.classify_changed_files",
+            return_value=[],
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.get_all_checklist_items",
+            return_value=[],
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.select_checklist_items",
+            return_value=[],
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.format_checklist_for_prompt",
+            return_value=("", {}),
+        ),
+        patch("lintro.cli_utils.commands.review.get_provider") as mock_get_provider,
+        patch(
+            "lintro.cli_utils.commands.review.run_review",
+            return_value=_empty_result(),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.render_review_output",
+        ) as mock_render,
+    ):
+        mock_get_provider.return_value = MagicMock(
+            model_name="gpt-4o",
+            name="openai",
+        )
+        result = runner.invoke(cli, ["review"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    rendered = mock_render.call_args.kwargs["result"]
+    assert_that(rendered.metadata.max_cost_usd).is_equal_to(1.25)
+    assert_that(rendered.metadata.max_cost_usd_source).is_equal_to("config")
+
+
 def test_review_alias_rev_works() -> None:
     """Alias rev resolves to the review command help."""
     runner = CliRunner()

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -62,6 +62,7 @@ def test_review_help_shows_flags() -> None:
     assert_that(result.output).contains("--transport")
     assert_that(result.output).contains("--provider")
     assert_that(result.output).contains("--model")
+    assert_that(result.output).contains("--max-cost-usd")
 
 
 def test_review_invalid_provider_env_exits_two(
@@ -442,6 +443,8 @@ def test_review_stamps_resolved_transport_provenance_on_metadata() -> None:
     assert_that(rendered.metadata.cost_basis).is_equal_to("billed")
     assert_that(rendered.metadata.provider_source).is_equal_to("config")
     assert_that(rendered.metadata.transport_source).is_equal_to("config")
+    assert_that(rendered.metadata.max_cost_usd).is_none()
+    assert_that(rendered.metadata.max_cost_usd_source).is_equal_to("config")
 
 
 def test_review_downgrades_billed_to_estimated_without_usage_counters() -> None:
@@ -1417,6 +1420,7 @@ def test_cli_overrides_lists_only_explicit_flags() -> None:
         transport="cli",
         provider=None,
         model=None,
+        max_cost_usd=None,
         timeout=600.0,
         context_window=None,
         semantic_chunks=False,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai): add cost-cap override via env and flag
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Add `max_cost_usd` to the AI config override layer. `LINTRO_AI_MAX_COST_USD` and `lintro review --max-cost-usd` can raise, lower, or remove the committed cap. Literal `0` means uncapped and is provenance-visible. This overturns #1970's non-goal that a ceiling ambient env can raise is not a ceiling.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #2024
- Relates to #1970
- Relates to #2016

## Details

Precedence is flag > env > config > default, through the same `_apply_overlay` re-validation as the existing overrides. Positive float = cap; literal `0` maps to `None` (uncapped) before Pydantic so it cannot become a $0 cap; negative/non-numeric/non-finite fail loud with `AIConfigOverrideError` naming the var/flag; whitespace-only env is unset.

Provenance is stamped as `max_cost_usd_source` on `ReviewMetadata` and rendered in terminal output, PR comment stats, and pre-execution status (e.g. `max cost: uncapped (env)`).

Also guards `github_review_body._run_stats_section` so an empty transport is checked before `format_sourced_value` (scoped item from #1972: a source suffix must not make a blank cell truthy). The check/fmt `--transport` overlay unification from that epic is still out of scope.

The test that asserted `max_cost_usd` is not overridable is replaced and references #2024.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec9e4898-c04c-47e8-83fa-8c9d35a657a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec9e4898-c04c-47e8-83fa-8c9d35a657a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--max-cost-usd` and `LINTRO_AI_MAX_COST_USD` overrides for AI review cost limits.
  * Added uncapped mode with value `0`; invalid values now produce clear errors.
  * Review output and posted reports show the effective maximum cost and its source.
  * CLI and environment overrides can raise or remove configured caps, while per-call limits remain lowering-only.

* **Documentation**
  * Updated configuration, usage, and architecture documentation with cost-limit behavior and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->