### PR TITLE
fix(tools): make npx fallback non-interactive and bound node_modules walk

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -891,16 +891,18 @@ Rationale:
 `prettier`, `stylelint`, `svelte-check`, `tsc` and `vue-tsc` alike:
 
 1. **`node_modules/.bin/<binary>`**, searched **upward** from the directory being
-   checked — the target project's own install, not Lintro's. This is the preferred
-   answer: it is lockfile-pinned, offline, and it is the same binary your editor and
-   your own `npm run` scripts use.
-2. **`<binary>` on `PATH`** — a global install (`bun add -g`, `npm install -g`) or a
-   Homebrew formula.
-3. **`bunx <package>@<pinned>` / `npx <package>@<pinned>`** — a registry fetch at the
-   version Lintro pins in its manifest. `bunx` is tried first, then `npx`. When the
-   executable name differs from the package name (`tsc` lives in `typescript`,
-   `commitlint` in `@commitlint/cli`), the runner is invoked as
-   `bunx --package typescript@<pinned> tsc`.
+   checked until the nearest `package.json` or `.git` (whichever is hit first). A nested
+   package with its own `package.json` stops there; a decoy `node_modules` above that
+   boundary is ignored. This is the preferred answer: it is lockfile-pinned, offline,
+   and it is the same binary your editor and your own `npm run` scripts use.
+2. **the `PATH`-resolved absolute path of `<binary>`** — a global install (`bun add -g`,
+   `npm install -g`) or a Homebrew formula.
+3. **`bunx <package>@<pinned>` / `npx --yes --package <package>@<pinned> <binary>`** — a
+   registry fetch at the version Lintro pins in its manifest. `bunx` is tried first,
+   then `npx`. `bunx` keeps the short form when the executable name matches the package
+   name (`bunx prettier@<pinned>`); it uses `--package` when they differ
+   (`bunx --package typescript@<pinned> tsc`). `npx` always uses `--yes --package` so it
+   cannot hang waiting for a TTY prompt.
 4. **bare `<binary>`** — last resort, fails if nothing is installed.
 
 `@latest` is never resolved at runtime, for any tool. Branch 3 emits a one-time warning
@@ -1864,10 +1866,11 @@ does every other Node.js tool; see [Node.js Tool Resolution](#nodejs-tool-resolu
 **Executable resolution order:**
 
 1. `node_modules/.bin/html-validate`, searched upward from the directory being checked
-   (the target project's own install, not Lintro's).
-2. `html-validate` on `PATH` (e.g. a global install).
+   until the nearest `package.json` or `.git`.
+2. the `PATH`-resolved absolute path of `html-validate` (e.g. a global install).
 3. `bunx html-validate@<pinned>` — registry fallback, only if `bunx` is available.
-4. `npx html-validate@<pinned>` — registry fallback, only if `npx` is available.
+4. `npx --yes --package html-validate@<pinned> html-validate` — registry fallback, only
+   if `npx` is available.
 5. bare `html-validate` (fails if nothing is installed).
 
 `<pinned>` is the version Lintro pins in its manifest; `@latest` is never resolved at

--- a/lintro/tools/core/command_builders.py
+++ b/lintro/tools/core/command_builders.py
@@ -457,6 +457,12 @@ def find_local_node_binary(
     the project's own install. A local install is lockfile-tracked, so it is
     preferred over any registry fetch.
 
+    The walk stops at the nearest ancestor that contains ``package.json`` or
+    ``.git`` (a file or directory). That marker directory is still searched;
+    directories above it are not, so a decoy ``node_modules`` outside the
+    project — or a monorepo root above a nested package with its own
+    ``package.json`` — cannot win.
+
     On Windows the package manager writes a ``.cmd`` shim; the extension-less
     shim there is a shell script that cannot be executed with ``shell=False``.
 
@@ -474,6 +480,8 @@ def find_local_node_binary(
         candidate = directory / "node_modules" / ".bin" / name
         if candidate.is_file():
             return candidate.as_posix()
+        if (directory / "package.json").is_file() or (directory / ".git").exists():
+            break
     return None
 
 
@@ -615,7 +623,10 @@ class NodeJSBuilder(CommandBuilder):
         When the executable name differs from the package name (``tsc`` in
         ``typescript``, ``commitlint`` in ``@commitlint/cli``) the runner is
         given both via ``--package``; bare ``bunx typescript`` would look for a
-        ``typescript`` executable that does not exist.
+        ``typescript`` executable that does not exist. ``npx`` always uses
+        ``--yes --package spec binary`` so a CI/non-TTY run cannot hang on an
+        install prompt, even when the names match. ``bunx`` keeps the shorter
+        ``[bunx, spec]`` form when they match.
 
         ``--package`` (``-p``) is assumed present on both runners. Verified
         against bun 1.3.14 (``bunx --help`` documents ``-p, --package <package>``
@@ -639,18 +650,20 @@ class NodeJSBuilder(CommandBuilder):
             logger.debug(f"Using project-local {binary_name}: {local}")
             return [local]
 
-        if shutil.which(binary_name):
-            logger.debug(f"Using {binary_name} from PATH")
-            return [binary_name]
+        tool_path = shutil.which(binary_name)
+        if tool_path:
+            logger.debug(f"Using {binary_name} from PATH: {tool_path}")
+            return [tool_path]
 
         spec = pinned_npm_spec(package_name)
         for runner in ("bunx", "npx"):
             if shutil.which(runner):
-                command = (
-                    [runner, spec]
-                    if package_name == binary_name
-                    else [runner, "--package", spec, binary_name]
-                )
+                if runner == "npx":
+                    command = ["npx", "--yes", "--package", spec, binary_name]
+                elif package_name == binary_name:
+                    command = [runner, spec]
+                else:
+                    command = [runner, "--package", spec, binary_name]
                 notify_registry_fallback_selected(command)
                 return command
         return [binary_name]

--- a/lintro/tools/core/command_builders.py
+++ b/lintro/tools/core/command_builders.py
@@ -652,8 +652,9 @@ class NodeJSBuilder(CommandBuilder):
 
         tool_path = shutil.which(binary_name)
         if tool_path:
-            logger.debug(f"Using {binary_name} from PATH: {tool_path}")
-            return [tool_path]
+            posix_path = Path(tool_path).as_posix().replace("\\", "/")
+            logger.debug(f"Using {binary_name} from PATH: {posix_path}")
+            return [posix_path]
 
         spec = pinned_npm_spec(package_name)
         for runner in ("bunx", "npx"):

--- a/lintro/tools/core/node_fallback.py
+++ b/lintro/tools/core/node_fallback.py
@@ -23,8 +23,14 @@ REGISTRY_RUNNERS: frozenset[str] = frozenset({"bunx", "npx"})
 
 # Runner flags that carry the package spec when it differs from the executable
 # name (``bunx --package typescript@6.0.3 tsc``). Both ``bunx`` and ``npx``
-# accept the short and long spelling.
+# accept the short and long spelling. ``--yes`` is *not* a package flag; it is
+# a boolean runner flag (see ``RUNNER_FLAGS``).
 PACKAGE_FLAGS: frozenset[str] = frozenset({"-p", "--package"})
+
+# Boolean runner flags that may precede the package spec or ``--package``.
+# Skipped when recovering the spec from a resolved command. ``--yes`` / ``-y``
+# is npx's non-interactive install flag, not a package selector.
+RUNNER_FLAGS: frozenset[str] = frozenset({"--yes", "-y"})
 
 # Node runtime floors that a pinned npm tool imposes on the consumer once the
 # registry fallback (or a local install) is used. These come from the pinned
@@ -72,9 +78,16 @@ def split_npm_spec(spec: str) -> tuple[str, str | None]:
 def registry_fallback_spec(command: Sequence[str]) -> str | None:
     """Extract the npm spec from a resolved registry-fallback command.
 
-    Handles both shapes the builder emits: ``[runner, spec]`` when the
-    executable and package share a name, and ``[runner, "--package", spec,
-    binary]`` when they differ.
+    Handles the shapes the builder emits:
+
+    - ``[bunx, spec]`` when the executable and package share a name
+    - ``[bunx, "--package", spec, binary]`` when they differ
+    - ``[npx, "--yes", "--package", spec, binary]`` always, including when
+      the names match
+
+    Boolean runner flags such as ``--yes`` are skipped until ``--package``
+    or the spec is reached. ``--yes`` is not a package flag and must not be
+    added to :data:`PACKAGE_FLAGS`.
 
     Args:
         command: Resolved command list, as returned by a command builder.
@@ -85,11 +98,16 @@ def registry_fallback_spec(command: Sequence[str]) -> str | None:
     """
     if len(command) < 2 or command[0] not in REGISTRY_RUNNERS:
         return None
-    if command[1] in PACKAGE_FLAGS:
-        # The --package shape is ``[runner, flag, spec, binary]``; anything
+    index = 1
+    while index < len(command) and command[index] in RUNNER_FLAGS:
+        index += 1
+    if index >= len(command):
+        return None
+    if command[index] in PACKAGE_FLAGS:
+        # The --package shape is ``[..., flag, spec, binary]``; anything
         # shorter is a malformed command, not a fallback to report on.
-        return command[2] if len(command) >= 4 else None
-    return command[1]
+        return command[index + 1] if len(command) >= index + 3 else None
+    return command[index]
 
 
 def is_registry_fallback_command(command: Sequence[str]) -> bool:
@@ -132,10 +150,9 @@ def registry_fallback_install_hint(command: Sequence[str]) -> str:
 def _format_fallback_command(command: Sequence[str]) -> str:
     """Render a registry-fallback command for logs and user-facing hints.
 
-    Both builder shapes must round-trip: ``[runner, spec]`` when the
-    executable and package share a name, and ``[runner, "--package", spec,
-    binary]`` when they differ. Joining the resolved argv is the only
-    representation that stays accurate for both.
+    Every builder shape must round-trip, including npx's
+    ``[npx, "--yes", "--package", spec, binary]``. Joining the resolved argv
+    is the only representation that stays accurate for all of them.
 
     Args:
         command: Resolved command list, as returned by a command builder.

--- a/tests/unit/plugins/base/test_execution.py
+++ b/tests/unit/plugins/base/test_execution.py
@@ -612,7 +612,7 @@ def test_get_executable_command_nodejs_tool_with_bunx(
     with patch("shutil.which", return_value="/usr/bin/markdownlint-cli2"):
         result = fake_tool_plugin._get_executable_command(ToolName.MARKDOWNLINT)
 
-        assert_that(result).is_equal_to(["markdownlint-cli2"])
+        assert_that(result).is_equal_to(["/usr/bin/markdownlint-cli2"])
 
 
 def test_get_executable_command_astro_check_with_bunx(
@@ -629,7 +629,7 @@ def test_get_executable_command_astro_check_with_bunx(
     with patch("shutil.which", return_value="/usr/bin/astro"):
         result = fake_tool_plugin._get_executable_command("astro-check")
 
-        assert_that(result).is_equal_to(["astro"])
+        assert_that(result).is_equal_to(["/usr/bin/astro"])
 
 
 def test_get_executable_command_vue_tsc_with_bunx(
@@ -646,7 +646,7 @@ def test_get_executable_command_vue_tsc_with_bunx(
     with patch("shutil.which", return_value="/usr/bin/vue-tsc"):
         result = fake_tool_plugin._get_executable_command("vue-tsc")
 
-        assert_that(result).is_equal_to(["vue-tsc"])
+        assert_that(result).is_equal_to(["/usr/bin/vue-tsc"])
 
 
 def test_get_executable_command_nodejs_tool_without_bunx(

--- a/tests/unit/tools/astro_check/test_non_interactive.py
+++ b/tests/unit/tools/astro_check/test_non_interactive.py
@@ -206,7 +206,7 @@ def test_check_windows_shell_shim_falls_back_to_global(
     ):
         astro_check_plugin.check([str(astro_project)], {})
 
-    assert_that(captured["cmd"][:2]).is_equal_to(["astro", "check"])
+    assert_that(captured["cmd"][:2]).is_equal_to(["/usr/bin/astro", "check"])
 
 
 def test_check_ignores_astro_directory_in_bin(
@@ -240,7 +240,7 @@ def test_check_ignores_astro_directory_in_bin(
     ):
         astro_check_plugin.check([str(astro_project)], {})
 
-    assert_that(captured["cmd"][:2]).is_equal_to(["astro", "check"])
+    assert_that(captured["cmd"][:2]).is_equal_to(["/usr/bin/astro", "check"])
 
 
 def test_check_falls_back_to_global_astro(
@@ -270,7 +270,7 @@ def test_check_falls_back_to_global_astro(
     ):
         astro_check_plugin.check([str(astro_project)], {})
 
-    assert_that(captured["cmd"][:2]).is_equal_to(["astro", "check"])
+    assert_that(captured["cmd"][:2]).is_equal_to(["/usr/bin/astro", "check"])
 
 
 def test_check_timeout_returns_timeout_result(

--- a/tests/unit/tools/astro_check/test_options.py
+++ b/tests/unit/tools/astro_check/test_options.py
@@ -190,6 +190,7 @@ def test_build_command_basic(
     # First element is the PATH/runner-resolved astro binary or a bunx/npx
     # wrapper — not a project-local node_modules path.
     assert_that(Path(cmd[0]).name).is_in("astro", "bunx", "npx")
+    assert_that(Path(cmd[0]).parts).does_not_contain("node_modules")
 
 
 def test_build_command_with_root(astro_check_plugin: AstroCheckPlugin) -> None:

--- a/tests/unit/tools/astro_check/test_options.py
+++ b/tests/unit/tools/astro_check/test_options.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from assertpy import assert_that
 
@@ -187,7 +189,7 @@ def test_build_command_basic(
     assert_that(cmd).contains("check")
     # First element is the PATH/runner-resolved astro binary or a bunx/npx
     # wrapper — not a project-local node_modules path.
-    assert_that(cmd[0]).is_in("astro", "bunx", "npx")
+    assert_that(Path(cmd[0]).name).is_in("astro", "bunx", "npx")
 
 
 def test_build_command_with_root(astro_check_plugin: AstroCheckPlugin) -> None:

--- a/tests/unit/tools/astro_check/test_options.py
+++ b/tests/unit/tools/astro_check/test_options.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from assertpy import assert_that
@@ -183,7 +184,8 @@ def test_build_command_basic(
         no_local_node_install: Fixture removing any project-local Node install
             from resolution.
     """
-    cmd = astro_check_plugin._build_command()
+    with patch("shutil.which", return_value="/usr/local/bin/astro"):
+        cmd = astro_check_plugin._build_command()
 
     # Should contain astro and check subcommand
     assert_that(cmd).contains("check")

--- a/tests/unit/tools/core/test_command_builders.py
+++ b/tests/unit/tools/core/test_command_builders.py
@@ -856,6 +856,29 @@ def test_node_path_branch_returns_absolute_resolved_path(
     assert_that(Path(cmd[0]).is_absolute()).is_true()
 
 
+def test_node_path_branch_normalizes_windows_which_path(
+    no_local_node_install: None,
+) -> None:
+    """A Windows PATH hit is posix-normalized so subprocess validation accepts it.
+
+    Args:
+        no_local_node_install: Fixture removing any project-local Node install
+            from resolution.
+    """
+    builder = NodeJSBuilder()
+
+    def _windows_which(name: str, *_args: object, **_kwargs: object) -> str | None:
+        if name == "prettier":
+            return r"C:\Users\me\AppData\Roaming\npm\prettier.cmd"
+        return None
+
+    with patch("shutil.which", _windows_which):
+        cmd = builder.get_command("prettier", ToolName.PRETTIER)
+
+    assert_that("\\" in cmd[0]).is_false()
+    assert_that(cmd[0]).contains("prettier.cmd")
+
+
 def test_node_tool_prefers_local_install_over_path(tmp_path: Path) -> None:
     """A project-local install wins over a PATH binary for a newly pinned tool."""
     local_bin = tmp_path / "node_modules" / ".bin"

--- a/tests/unit/tools/core/test_command_builders.py
+++ b/tests/unit/tools/core/test_command_builders.py
@@ -26,7 +26,6 @@ from lintro.tools.core.command_builders import (
 )
 from lintro.tools.core.node_fallback import (
     NODE_ENGINE_REQUIREMENTS,
-    PACKAGE_FLAGS,
     is_registry_fallback_command,
     notify_registry_fallback_selected,
     registry_fallback_guidance,
@@ -1283,12 +1282,6 @@ def test_is_registry_fallback_command_detects_package_runners() -> None:
     assert_that(is_registry_fallback_command(["/local/html-validate"])).is_false()
     assert_that(is_registry_fallback_command(["html-validate"])).is_false()
     assert_that(is_registry_fallback_command(["bunx"])).is_false()
-
-
-def test_yes_is_not_a_package_flag() -> None:
-    """``--yes`` is a runner flag, not a package selector."""
-    assert_that(PACKAGE_FLAGS).does_not_contain("--yes")
-    assert_that(PACKAGE_FLAGS).does_not_contain("-y")
 
 
 def test_registry_fallback_spec_round_trips_npx_yes_package_shape() -> None:

--- a/tests/unit/tools/core/test_command_builders.py
+++ b/tests/unit/tools/core/test_command_builders.py
@@ -26,9 +26,11 @@ from lintro.tools.core.command_builders import (
 )
 from lintro.tools.core.node_fallback import (
     NODE_ENGINE_REQUIREMENTS,
+    PACKAGE_FLAGS,
     is_registry_fallback_command,
     notify_registry_fallback_selected,
     registry_fallback_guidance,
+    registry_fallback_spec,
     reset_registry_fallback_notices,
     split_npm_spec,
 )
@@ -515,7 +517,7 @@ def test_nodejs_builder_astro_check_uses_astro_binary(
     builder = NodeJSBuilder()
     with patch("shutil.which", _which_only("astro")):
         cmd = builder.get_command("astro-check", ToolName.ASTRO_CHECK)
-    assert_that(cmd).is_equal_to(["astro"])
+    assert_that(cmd).is_equal_to(["/usr/local/bin/astro"])
 
 
 def test_nodejs_builder_handles_vue_tsc() -> None:
@@ -536,7 +538,7 @@ def test_nodejs_builder_vue_tsc_uses_vue_tsc_binary(
     builder = NodeJSBuilder()
     with patch("shutil.which", _which_only("vue-tsc")):
         cmd = builder.get_command("vue-tsc", ToolName.VUE_TSC)
-    assert_that(cmd).is_equal_to(["vue-tsc"])
+    assert_that(cmd).is_equal_to(["/usr/local/bin/vue-tsc"])
 
 
 # =============================================================================
@@ -558,6 +560,25 @@ def _which_only(*available: str) -> Callable[..., str | None]:
         return f"/usr/local/bin/{name}" if name in available else None
 
     return _which
+
+
+def _write_local_node_binary(root: Path, binary_name: str) -> Path:
+    """Create a fake ``node_modules/.bin`` executable under *root*.
+
+    Args:
+        root: Directory that should contain ``node_modules/.bin``.
+        binary_name: Executable name.
+
+    Returns:
+        Path to the created executable.
+    """
+    local_bin = root / "node_modules" / ".bin"
+    local_bin.mkdir(parents=True, exist_ok=True)
+    binary = local_bin / (
+        f"{binary_name}.cmd" if sys.platform == "win32" else binary_name
+    )
+    binary.write_text("#!/bin/sh\n")
+    return binary
 
 
 def test_builder_package_names_match_the_manifest() -> None:
@@ -634,7 +655,7 @@ def test_html_validate_prefers_path_binary_over_bunx() -> None:
     ):
         cmd = builder.get_command("html_validate", ToolName.HTML_VALIDATE)
 
-    assert_that(cmd).is_equal_to(["html-validate"])
+    assert_that(cmd).is_equal_to(["/usr/local/bin/html-validate"])
 
 
 def test_html_validate_bunx_fallback_is_version_pinned() -> None:
@@ -667,8 +688,9 @@ def test_html_validate_npx_fallback_is_version_pinned() -> None:
     ):
         cmd = builder.get_command("html_validate", ToolName.HTML_VALIDATE)
 
+    spec = f"html-validate@{get_tool_version('html-validate')}"
     assert_that(cmd).is_equal_to(
-        ["npx", f"html-validate@{get_tool_version('html-validate')}"],
+        ["npx", "--yes", "--package", spec, "html-validate"],
     )
 
 
@@ -694,13 +716,13 @@ def test_pinned_npm_spec_falls_back_to_bare_name() -> None:
 
 
 def test_find_local_node_binary_walks_up_to_project_root(tmp_path: Path) -> None:
-    """Resolution walks up so subdirectories still find the project install."""
-    local_bin = tmp_path / "node_modules" / ".bin"
-    local_bin.mkdir(parents=True)
-    binary = local_bin / (
-        "html-validate.cmd" if sys.platform == "win32" else "html-validate"
-    )
-    binary.write_text("#!/bin/sh\n")
+    """Resolution walks up so subdirectories still find the project install.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+    """
+    (tmp_path / "package.json").write_text("{}\n")
+    binary = _write_local_node_binary(tmp_path, "html-validate")
     nested = tmp_path / "src" / "pages"
     nested.mkdir(parents=True)
 
@@ -710,9 +732,98 @@ def test_find_local_node_binary_walks_up_to_project_root(tmp_path: Path) -> None
 
 
 def test_find_local_node_binary_returns_none_when_absent(tmp_path: Path) -> None:
-    """No local install resolves to None."""
+    """No local install resolves to None.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+    """
     found = find_local_node_binary("html-validate", start=tmp_path)
     assert_that(found).is_none()
+
+
+def test_find_local_node_binary_ignores_decoy_above_package_json(
+    tmp_path: Path,
+) -> None:
+    """A ``node_modules`` above the nearest ``package.json`` is not used.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+    """
+    decoy = _write_local_node_binary(tmp_path, "html-validate")
+    project = tmp_path / "project"
+    nested = project / "src"
+    nested.mkdir(parents=True)
+    (project / "package.json").write_text("{}\n")
+
+    found = find_local_node_binary("html-validate", start=nested)
+
+    assert_that(found).is_none()
+    assert_that(decoy.is_file()).is_true()
+
+
+def test_find_local_node_binary_finds_install_inside_package_json_boundary(
+    tmp_path: Path,
+) -> None:
+    """The local install under the nearest ``package.json`` still wins.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+    """
+    _write_local_node_binary(tmp_path, "html-validate")
+    project = tmp_path / "project"
+    nested = project / "src"
+    nested.mkdir(parents=True)
+    (project / "package.json").write_text("{}\n")
+    local = _write_local_node_binary(project, "html-validate")
+
+    found = find_local_node_binary("html-validate", start=nested)
+
+    assert_that(found).is_equal_to(local.resolve().as_posix())
+
+
+def test_find_local_node_binary_ignores_decoy_above_git_boundary(
+    tmp_path: Path,
+) -> None:
+    """A ``node_modules`` above the nearest ``.git`` is not used.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+    """
+    _write_local_node_binary(tmp_path, "html-validate")
+    project = tmp_path / "project"
+    nested = project / "src"
+    nested.mkdir(parents=True)
+    (project / ".git").mkdir()
+
+    found = find_local_node_binary("html-validate", start=nested)
+
+    assert_that(found).is_none()
+
+
+def test_find_local_node_binary_stops_at_nested_package_json(
+    tmp_path: Path,
+) -> None:
+    """A monorepo subpackage with its own ``package.json`` is the boundary.
+
+    The workspace root's ``node_modules`` must not win over a nested package
+    that has declared its own ``package.json``, even when that nested package
+    has no local install of the tool.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+    """
+    (tmp_path / "package.json").write_text("{}\n")
+    (tmp_path / ".git").mkdir()
+    root_bin = _write_local_node_binary(tmp_path, "html-validate")
+    subpackage = tmp_path / "packages" / "app"
+    nested = subpackage / "src"
+    nested.mkdir(parents=True)
+    (subpackage / "package.json").write_text("{}\n")
+
+    found = find_local_node_binary("html-validate", start=nested)
+
+    assert_that(found).is_none()
+    assert_that(root_bin.is_file()).is_true()
 
 
 def test_node_tool_prefers_path_binary_over_bunx(
@@ -727,7 +838,23 @@ def test_node_tool_prefers_path_binary_over_bunx(
     builder = NodeJSBuilder()
     with patch("shutil.which", _which_only("bunx", "markdownlint-cli2")):
         cmd = builder.get_command("markdownlint", ToolName.MARKDOWNLINT)
-    assert_that(cmd).is_equal_to(["markdownlint-cli2"])
+    assert_that(cmd).is_equal_to(["/usr/local/bin/markdownlint-cli2"])
+
+
+def test_node_path_branch_returns_absolute_resolved_path(
+    no_local_node_install: None,
+) -> None:
+    """A PATH hit is the shutil.which-resolved absolute path, not the bare name.
+
+    Args:
+        no_local_node_install: Fixture removing any project-local Node install
+            from resolution.
+    """
+    builder = NodeJSBuilder()
+    with patch("shutil.which", _which_only("prettier")):
+        cmd = builder.get_command("prettier", ToolName.PRETTIER)
+    assert_that(cmd).is_equal_to(["/usr/local/bin/prettier"])
+    assert_that(Path(cmd[0]).is_absolute()).is_true()
 
 
 def test_node_tool_prefers_local_install_over_path(tmp_path: Path) -> None:
@@ -773,9 +900,10 @@ def test_prettier_falls_back_to_pinned_runner_spec(
     builder = NodeJSBuilder()
     with patch("shutil.which", _which_only("npx")):
         cmd = builder.get_command("prettier", ToolName.PRETTIER)
-    assert_that(cmd).is_length(2)
-    assert_that(cmd[0]).is_equal_to("npx")
-    assert_that(cmd[1]).starts_with("prettier@")
+    assert_that(cmd).is_length(5)
+    assert_that(cmd[:3]).is_equal_to(["npx", "--yes", "--package"])
+    assert_that(cmd[3]).starts_with("prettier@")
+    assert_that(cmd[4]).is_equal_to("prettier")
 
 
 def test_runner_fallback_names_package_when_binary_differs(
@@ -807,9 +935,9 @@ def test_commitlint_runner_fallback_uses_scoped_package(
     builder = NodeJSBuilder()
     with patch("shutil.which", _which_only("npx")):
         cmd = builder.get_command("commitlint", ToolName.COMMITLINT)
-    assert_that(cmd[:2]).is_equal_to(["npx", "--package"])
-    assert_that(cmd[2]).starts_with("@commitlint/cli@")
-    assert_that(cmd[3]).is_equal_to("commitlint")
+    assert_that(cmd[:3]).is_equal_to(["npx", "--yes", "--package"])
+    assert_that(cmd[3]).starts_with("@commitlint/cli@")
+    assert_that(cmd[4]).is_equal_to("commitlint")
 
 
 # =============================================================================
@@ -1147,9 +1275,41 @@ def test_is_registry_fallback_command_detects_package_runners() -> None:
     """Only ``bunx``/``npx`` invocations count as the registry fallback."""
     assert_that(is_registry_fallback_command(["bunx", "html-validate@1.0.0"])).is_true()
     assert_that(is_registry_fallback_command(["npx", "html-validate@1.0.0"])).is_true()
+    assert_that(
+        is_registry_fallback_command(
+            ["npx", "--yes", "--package", "html-validate@1.0.0", "html-validate"],
+        ),
+    ).is_true()
     assert_that(is_registry_fallback_command(["/local/html-validate"])).is_false()
     assert_that(is_registry_fallback_command(["html-validate"])).is_false()
     assert_that(is_registry_fallback_command(["bunx"])).is_false()
+
+
+def test_yes_is_not_a_package_flag() -> None:
+    """``--yes`` is a runner flag, not a package selector."""
+    assert_that(PACKAGE_FLAGS).does_not_contain("--yes")
+    assert_that(PACKAGE_FLAGS).does_not_contain("-y")
+
+
+def test_registry_fallback_spec_round_trips_npx_yes_package_shape() -> None:
+    """``--yes`` is skipped so the spec is recovered from the npx argv."""
+    spec = "html-validate@11.5.6"
+    command = ["npx", "--yes", "--package", spec, "html-validate"]
+    assert_that(registry_fallback_spec(command)).is_equal_to(spec)
+
+
+def test_registry_fallback_spec_round_trips_package_flag_shapes() -> None:
+    """Bunx and npx ``--package`` shapes recover the spec; bunx bare-spec too."""
+    assert_that(
+        registry_fallback_spec(["bunx", "prettier@3.0.0"]),
+    ).is_equal_to("prettier@3.0.0")
+    assert_that(
+        registry_fallback_spec(["bunx", "--package", "typescript@5.9.3", "tsc"]),
+    ).is_equal_to("typescript@5.9.3")
+    # npx without ``--yes`` (the pre-#2028 shape) still recovers the spec.
+    assert_that(
+        registry_fallback_spec(["npx", "--package", "typescript@5.9.3", "tsc"]),
+    ).is_equal_to("typescript@5.9.3")
 
 
 def test_split_npm_spec_handles_scoped_packages() -> None:

--- a/tests/unit/tools/svelte_check/test_options.py
+++ b/tests/unit/tools/svelte_check/test_options.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from assertpy import assert_that
@@ -222,7 +223,8 @@ def test_build_command_basic(
         no_local_node_install: Fixture removing any project-local Node install
             from resolution.
     """
-    cmd = svelte_check_plugin._build_command()
+    with patch("shutil.which", return_value="/usr/local/bin/svelte-check"):
+        cmd = svelte_check_plugin._build_command()
 
     # Should contain machine-verbose output format
     assert_that(cmd).contains("--output")

--- a/tests/unit/tools/svelte_check/test_options.py
+++ b/tests/unit/tools/svelte_check/test_options.py
@@ -230,6 +230,7 @@ def test_build_command_basic(
     # First element is the PATH/runner-resolved svelte-check binary or a bunx/npx
     # wrapper — not a project-local node_modules path.
     assert_that(Path(cmd[0]).name).is_in("svelte-check", "bunx", "npx")
+    assert_that(Path(cmd[0]).parts).does_not_contain("node_modules")
     # The svelte-check package must be named somewhere in the command
     assert_that(" ".join(cmd)).contains("svelte-check")
 

--- a/tests/unit/tools/svelte_check/test_options.py
+++ b/tests/unit/tools/svelte_check/test_options.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from assertpy import assert_that
 
@@ -227,7 +229,7 @@ def test_build_command_basic(
     assert_that(cmd).contains("machine-verbose")
     # First element is the PATH/runner-resolved svelte-check binary or a bunx/npx
     # wrapper — not a project-local node_modules path.
-    assert_that(cmd[0]).is_in("svelte-check", "bunx", "npx")
+    assert_that(Path(cmd[0]).name).is_in("svelte-check", "bunx", "npx")
     # The svelte-check package must be named somewhere in the command
     assert_that(" ".join(cmd)).contains("svelte-check")
 

--- a/tests/unit/tools/tsc/test_options.py
+++ b/tests/unit/tools/tsc/test_options.py
@@ -222,7 +222,7 @@ def test_get_tsc_command_with_tsc_available(
     with patch("shutil.which", return_value="/usr/bin/tsc"):
         cmd = tsc_plugin._get_tsc_command()
 
-    assert_that(cmd).is_equal_to(["tsc"])
+    assert_that(cmd).is_equal_to(["/usr/bin/tsc"])
 
 
 def test_get_tsc_command_with_bunx_fallback(
@@ -274,9 +274,12 @@ def test_get_tsc_command_with_npx_fallback(
     with patch("shutil.which", side_effect=which_side_effect):
         cmd = tsc_plugin._get_tsc_command()
 
-    assert_that(cmd[:2]).is_equal_to(["npx", "--package"])
-    assert_that(cmd[2]).starts_with("typescript@")
-    assert_that(cmd[3]).is_equal_to("tsc")
+    # tsc ships inside the ``typescript`` package, so the runner needs
+    # ``--package`` to find the executable (#1811). npx is always
+    # non-interactive (#2028).
+    assert_that(cmd[:3]).is_equal_to(["npx", "--yes", "--package"])
+    assert_that(cmd[3]).starts_with("typescript@")
+    assert_that(cmd[4]).is_equal_to("tsc")
 
 
 def test_get_tsc_command_fallback_to_tsc(

--- a/tests/unit/tools/vue_tsc/test_options.py
+++ b/tests/unit/tools/vue_tsc/test_options.py
@@ -241,6 +241,7 @@ def test_build_command_basic(
     # First element is the PATH/runner-resolved vue-tsc binary or a bunx/npx
     # wrapper — not a project-local node_modules path.
     assert_that(Path(cmd[0]).name).is_in("vue-tsc", "bunx", "npx")
+    assert_that(Path(cmd[0]).parts).does_not_contain("node_modules")
 
 
 def test_build_command_with_project(vue_tsc_plugin: VueTscPlugin) -> None:

--- a/tests/unit/tools/vue_tsc/test_options.py
+++ b/tests/unit/tools/vue_tsc/test_options.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from assertpy import assert_that
 
@@ -238,7 +240,7 @@ def test_build_command_basic(
     assert_that(cmd).contains("false")
     # First element is the PATH/runner-resolved vue-tsc binary or a bunx/npx
     # wrapper — not a project-local node_modules path.
-    assert_that(cmd[0]).is_in("vue-tsc", "bunx", "npx")
+    assert_that(Path(cmd[0]).name).is_in("vue-tsc", "bunx", "npx")
 
 
 def test_build_command_with_project(vue_tsc_plugin: VueTscPlugin) -> None:

--- a/tests/unit/tools/vue_tsc/test_options.py
+++ b/tests/unit/tools/vue_tsc/test_options.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from assertpy import assert_that
@@ -232,7 +233,8 @@ def test_build_command_basic(
         no_local_node_install: Fixture removing any project-local Node install
             from resolution.
     """
-    cmd = vue_tsc_plugin._build_command(files=[])
+    with patch("shutil.which", return_value="/usr/local/bin/vue-tsc"):
+        cmd = vue_tsc_plugin._build_command(files=[])
 
     # Should contain --noEmit and --pretty false
     assert_that(cmd).contains("--noEmit")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- markdownlint-disable MD041 -- PR template does not start with a top-level heading -->

## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(tools): make npx fallback non-interactive and bound node_modules walk
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.
- Valid examples:
  - `feat(cli): add --group-by`
  - `fix(parser): handle empty config`
  - `perf: optimize grouping performance`
  - `feat(api)!: remove deprecated flags`

## What’s Changing

Harden the Node tool resolution chain now that it is the default for every Node tool. npx fallback is non-interactive (`--yes`), the upward `node_modules` walk stops at the nearest `package.json` or `.git`, and the PATH branch returns the resolved absolute path.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #2028
- Relates to #2013
- Relates to #940

## Details

npx fallback is always `["npx", "--yes", "--package", spec, binary]`. bunx is unchanged. `registry_fallback_spec()` skips `--yes`/`-y` so the spec still round-trips; `--yes` is not added to `PACKAGE_FLAGS`.

`find_local_node_binary` stops at the first ancestor containing `package.json` or `.git` (nearest marker wins; the marker directory is still searched). A decoy `node_modules` above that boundary is ignored. A nested package with its own `package.json` stops there, not at repo root.

The PATH branch returns the `shutil.which`-resolved absolute path, matching `PythonBundledBuilder`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec9e4898-c04c-47e8-83fa-8c9d35a657a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec9e4898-c04c-47e8-83fa-8c9d35a657a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved Node.js tool detection by prioritizing available executables on the system `PATH`.
  * Local project tools are now discovered within the nearest project boundary.
  * Added more reliable fallback commands for packages unavailable locally.
  * Fallback executions now run non-interactively and consistently specify the requested package.
  * Improved handling of Windows executable paths and common runner options.

* **Documentation**
  * Updated configuration guidance and examples to describe tool resolution and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->