### PR TITLE
fix(ci): harden ai-review audit, Cursor egress, and 0.50 provenance

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -23,9 +23,9 @@ name: AI Review - Dogfood
 #
 # Spend ceiling is the committed `ai.max_cost_usd: 2.00` in `.lintro-config.yaml`
 # (the empirically validated value from #1976/#1977; the 0.50 that landed with
-# #1971 was a side-effect, restored here by #2025). Under the CLI transport the
-# call bills the subscription, so the figure is advisory rather than enforced
-# spend control (#1923).
+# #2018 / 9f43a98a was a side-effect, restored here by #2025). Under the CLI
+# transport the call bills the subscription, so the figure is advisory rather
+# than enforced spend control (#1923).
 #
 # Posts a review comment: the review runs with `--post`, so lintro maintains a
 # single sticky comment on the PR (rich findings + cumulative telemetry) and
@@ -121,15 +121,22 @@ jobs:
     # ceiling exactly (#1976 reviews killed at the boundary four times; #1977's
     # oscillated around 45-55 min and was killed at 50 twice).
     timeout-minutes: 75
+    # Cursor shards are appended only when the dogfood provider is Cursor.
+    # They stay out of the anthropic path so that job cannot reach Cursor
+    # hosts. A rotated shard (e.g. repo43.cursor.sh) is named in the
+    # harden-runner summary of the failed run; fix is a one-line allowlist
+    # PR on AI_REVIEW_CURSOR_EGRESS. No wildcards on this job.
+    env:
+      # yamllint disable-line rule:line-length
+      AI_REVIEW_CURSOR_EGRESS: ${{ vars.LINTRO_AI_PROVIDER == 'cursor' && 'downloads.cursor.com:443 api2.cursor.sh:443 api3.cursor.sh:443 agentn.global.api5.cursor.sh:443 repo42.cursor.sh:443' || '' }}
 
     steps:
       - name: Harden Runner
         # Cursor shards observed on live dogfood (runs 31779466126 /
         # 31782811574): downloads.cursor.com, api2.cursor.sh, api3.cursor.sh,
-        # agentn.global.api5.cursor.sh, repo42.cursor.sh. A rotated shard
-        # (e.g. repo43.cursor.sh) is named in the harden-runner summary of
-        # the failed run; fix is a one-line allowlist PR. No wildcards on
-        # this job. release-assets.githubusercontent.com is setup-node's
+        # agentn.global.api5.cursor.sh, repo42.cursor.sh. Gated via
+        # AI_REVIEW_CURSOR_EGRESS so the anthropic path never allowlists
+        # them. release-assets.githubusercontent.com is setup-node's
         # GitHub releases CDN; those runs blocked it and the action fell
         # back to nodejs.org — allowlisted so Node install is not a silent
         # fallback.
@@ -151,11 +158,7 @@ jobs:
             files.pythonhosted.org:443
             nodejs.org:443
             registry.npmjs.org:443
-            downloads.cursor.com:443
-            api2.cursor.sh:443
-            api3.cursor.sh:443
-            agentn.global.api5.cursor.sh:443
-            repo42.cursor.sh:443
+            ${{ env.AI_REVIEW_CURSOR_EGRESS }}
 
       - name: Checkout base ref (trusted lintro install)
         # Install lintro from the PR's BASE ref (main), NOT the PR head. The

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -835,7 +835,7 @@ def test_workflow_allows_the_npm_registry_egress() -> None:
     assert_that(harden_steps).is_length(1)
 
     endpoints_raw = harden_steps[0]["with"]["allowed-endpoints"]
-    unconditional = re.sub(r"\$\{\{.*?\}\}", "", endpoints_raw, flags=re.DOTALL)
+    unconditional = endpoints_raw.replace("${{ env.AI_REVIEW_CURSOR_EGRESS }}", "")
     endpoints = unconditional.split()
     cursor_hosts = _CURSOR_EGRESS_HOSTS
     assert_that(endpoints).contains(
@@ -843,14 +843,14 @@ def test_workflow_allows_the_npm_registry_egress() -> None:
         "nodejs.org:443",
         "release-assets.githubusercontent.com:443",
     )
-    assert_that(endpoints).does_not_contain(*cursor_hosts)
-    assert_that(endpoints).does_not_contain(
-        "api.cursor.com:443",
-        "*.cursor.sh:443",
-        "*.cursorapi.com:443",
-    )
     for endpoint in endpoints:
         assert_that(endpoint).described_as(endpoint).does_not_contain("*")
+        assert_that(endpoint.lower()).described_as(endpoint).does_not_contain(
+            "cursor.sh",
+        )
+        assert_that(endpoint.lower()).described_as(endpoint).does_not_contain(
+            "cursor.com",
+        )
 
     job_env = loaded["jobs"]["ai-review"]["env"]
     cursor_egress = job_env["AI_REVIEW_CURSOR_EGRESS"]

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -32,6 +32,54 @@ PROJECT_CONFIG = REPO_ROOT / ".lintro-config.yaml"
 CREDENTIAL_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
 CURSOR_CREDENTIAL_ENV = "CURSOR_API_KEY"
 PROVIDER_CREDENTIAL_ENVS = (CREDENTIAL_ENV, CURSOR_CREDENTIAL_ENV)
+_PINNED_CHECKOUT = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+_HEAD_REF_RE = re.compile(
+    r"github\.event\.pull_request\.head\.(?:sha|ref|name)\b",
+)
+_GIT_HEAD_FETCH_RE = re.compile(
+    r"\bgit\s+(?:fetch|pull|checkout)\b",
+)
+_GH_PR_CHECKOUT_RE = re.compile(r"\bgh\s+pr\s+checkout\b")
+_PULL_HEAD_REF_RE = re.compile(r"pull/\S*/head")
+_CHECKOUT_LIKE_RE = re.compile(
+    r"(?:^|/)(?:checkout|checkout-[^/@]+|[^/@]+-checkout)$",
+)
+_CURSOR_EGRESS_HOSTS = (
+    "downloads.cursor.com:443",
+    "api2.cursor.sh:443",
+    "api3.cursor.sh:443",
+    "agentn.global.api5.cursor.sh:443",
+    "repo42.cursor.sh:443",
+)
+
+
+def _executable_run_text(run_block: str) -> str:
+    """Return a ``run:`` block with full-line shell comments removed.
+
+    Args:
+        run_block: Raw workflow ``run`` string.
+
+    Returns:
+        Executable lines only, joined with newlines.
+    """
+    lines = [
+        line for line in run_block.splitlines() if not line.lstrip().startswith("#")
+    ]
+    return "\n".join(lines)
+
+
+def _is_checkout_like_action(uses: str) -> bool:
+    """Return whether a ``uses:`` value is a checkout-like action.
+
+    Args:
+        uses: Workflow ``uses`` pin (``owner/repo@sha``).
+
+    Returns:
+        True when the action repo looks like a checkout action.
+    """
+    name = uses.split("@", 1)[0].split("#", 1)[0].strip().lower()
+    repo = name.rsplit("/", 1)[-1]
+    return bool(_CHECKOUT_LIKE_RE.search(f"/{repo}"))
 
 
 def _run_shell(
@@ -70,13 +118,17 @@ def test_committed_config_keeps_ai_off_with_review_ready() -> None:
 
     ``ai.review: true`` is committed so enabling the master switch does not
     rely on the deprecated implied-sub-toggle path. ``ai.max_cost_usd`` is the
-    spend ceiling (2.00; restored by #2025 after the 0.50 side-effect in #1971).
+    spend ceiling (2.00; restored by #2025 after the 0.50 side-effect in
+    #2018 / 9f43a98a).
     """
     loaded = yaml.safe_load(PROJECT_CONFIG.read_text(encoding="utf-8"))
     ai_section = loaded["ai"]
     assert_that(ai_section["enabled"]).is_false()
     assert_that(ai_section["review"]).is_true()
     assert_that(ai_section["max_cost_usd"]).is_equal_to(2.00)
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    assert_that(workflow_text).contains("#2018 / 9f43a98a")
+    assert_that(workflow_text).does_not_contain("0.50 that landed with\n# #1971")
 
 
 def test_workflow_feeds_lintro_ai_env_from_repo_variables() -> None:
@@ -375,6 +427,121 @@ def test_workflow_installs_from_base_ref_not_pr_head() -> None:
     assert_that(workflow_text).does_not_contain("enable_cursor_workspace_trust")
 
 
+@pytest.mark.parametrize(
+    ("uses", "expected"),
+    [
+        (_PINNED_CHECKOUT, True),
+        ("evil/checkout@deadbeef", True),
+        ("acme/checkout-action@1", True),
+        ("acme/pr-checkout@1", True),
+        ("actions/setup-node@820762786026740c76f36085b0efc47a31fe5020", False),
+        ("astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9", False),
+    ],
+    ids=[
+        "pinned-actions-checkout",
+        "forked-checkout",
+        "checkout-prefix",
+        "checkout-suffix",
+        "setup-node",
+        "setup-uv",
+    ],
+)
+def test_is_checkout_like_action(*, uses: str, expected: bool) -> None:
+    """Checkout-like ``uses:`` values are the ones the audit must pin.
+
+    Args:
+        uses: A workflow ``uses`` pin.
+        expected: Whether the pin is checkout-like.
+    """
+    assert_that(_is_checkout_like_action(uses)).is_equal_to(expected)
+
+
+@pytest.mark.parametrize(
+    ("run_block", "banned"),
+    [
+        ("gh pr checkout 12\n", True),
+        ("git fetch origin pull/12/head\n", True),
+        ("git pull origin ${{ github.event.pull_request.head.sha }}\n", True),
+        (
+            "# gh pr checkout is banned in executable steps\npython3 scripts/ci/ai_tools_arg_pin.py\n",
+            False,
+        ),
+        ("python3 scripts/ci/ai_tools_arg_pin.py NODE_VERSION\n", False),
+    ],
+    ids=[
+        "gh-pr-checkout",
+        "git-fetch-pull-head",
+        "git-pull-head-sha",
+        "comment-only-mention",
+        "pin-script",
+    ],
+)
+def test_head_ref_fetch_patterns(*, run_block: str, banned: bool) -> None:
+    """Banned head-ref fetch shapes are detected in executable ``run:`` text.
+
+    Args:
+        run_block: A sample workflow ``run`` block.
+        banned: Whether the block must fail the audit.
+    """
+    executable = _executable_run_text(run_block)
+    matched = any(
+        pattern.search(executable)
+        for pattern in (
+            _GH_PR_CHECKOUT_RE,
+            _GIT_HEAD_FETCH_RE,
+            _PULL_HEAD_REF_RE,
+            _HEAD_REF_RE,
+        )
+    )
+    assert_that(matched).is_equal_to(banned)
+
+
+def test_workflow_forbids_head_ref_fetches() -> None:
+    """Head-ref fetches and checkout forks fail the structural audit (#2047).
+
+    The existing one-checkout assertion cannot see ``gh pr checkout``,
+    ``git fetch origin pull/N/head``, ``github.event.pull_request.head.sha``
+    as a checkout ref, or a forked checkout action. Those all execute
+    PR-authored code on the credential-holding job. Comments and the
+    same-repo ``head.repo.full_name`` guard are not fetches.
+    """
+    loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = loaded["jobs"]["ai-review"]["steps"]
+
+    checkout_uses: list[str] = []
+    for step in steps:
+        uses = step.get("uses")
+        if isinstance(uses, str) and _is_checkout_like_action(uses):
+            pin = uses.split("#", 1)[0].strip()
+            checkout_uses.append(pin)
+            assert_that(pin).is_equal_to(_PINNED_CHECKOUT)
+
+        with_block = step.get("with") or {}
+        ref = str(with_block.get("ref", ""))
+        assert_that(ref).does_not_contain("pull_request.head")
+        assert_that(ref).does_not_contain("github.sha")
+        assert_that(_PULL_HEAD_REF_RE.search(ref)).is_none()
+
+        run = step.get("run")
+        if not isinstance(run, str):
+            continue
+        executable = _executable_run_text(run)
+        assert_that(_GH_PR_CHECKOUT_RE.search(executable)).described_as(
+            f"step {step.get('name')!r} must not run gh pr checkout",
+        ).is_none()
+        assert_that(_GIT_HEAD_FETCH_RE.search(executable)).described_as(
+            f"step {step.get('name')!r} must not git fetch/pull/checkout",
+        ).is_none()
+        assert_that(_PULL_HEAD_REF_RE.search(executable)).described_as(
+            f"step {step.get('name')!r} must not fetch pull/*/head",
+        ).is_none()
+        assert_that(_HEAD_REF_RE.search(executable)).described_as(
+            f"step {step.get('name')!r} must not use pull_request.head sha/ref",
+        ).is_none()
+
+    assert_that(checkout_uses).is_equal_to([_PINNED_CHECKOUT])
+
+
 def test_workflow_does_not_patch_cursor_workspace_trust() -> None:
     """#2023 defaults ``ai.cursor_trust_workspace``; the CI patcher is gone."""
     assert_that(
@@ -601,17 +768,16 @@ def test_workflow_allows_the_npm_registry_egress() -> None:
     ]
     assert_that(harden_steps).is_length(1)
 
-    endpoints = harden_steps[0]["with"]["allowed-endpoints"].split()
+    endpoints_raw = harden_steps[0]["with"]["allowed-endpoints"]
+    unconditional = re.sub(r"\$\{\{.*?\}\}", "", endpoints_raw, flags=re.DOTALL)
+    endpoints = unconditional.split()
+    cursor_hosts = _CURSOR_EGRESS_HOSTS
     assert_that(endpoints).contains(
         "registry.npmjs.org:443",
         "nodejs.org:443",
-        "downloads.cursor.com:443",
-        "api2.cursor.sh:443",
-        "api3.cursor.sh:443",
-        "agentn.global.api5.cursor.sh:443",
-        "repo42.cursor.sh:443",
         "release-assets.githubusercontent.com:443",
     )
+    assert_that(endpoints).does_not_contain(*cursor_hosts)
     assert_that(endpoints).does_not_contain(
         "api.cursor.com:443",
         "*.cursor.sh:443",
@@ -619,6 +785,13 @@ def test_workflow_allows_the_npm_registry_egress() -> None:
     )
     for endpoint in endpoints:
         assert_that(endpoint).described_as(endpoint).does_not_contain("*")
+
+    job_env = loaded["jobs"]["ai-review"]["env"]
+    cursor_egress = job_env["AI_REVIEW_CURSOR_EGRESS"]
+    assert_that(cursor_egress).contains("vars.LINTRO_AI_PROVIDER == 'cursor'")
+    for host in cursor_hosts:
+        assert_that(cursor_egress).contains(host)
+    assert_that(endpoints_raw).contains("${{ env.AI_REVIEW_CURSOR_EGRESS }}")
 
 
 def test_review_timeout_fits_inside_the_job_timeout() -> None:

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -62,9 +62,8 @@ def _executable_run_text(run_block: str) -> str:
     Returns:
         Executable lines only, joined with newlines.
     """
-    lines = [
-        line for line in run_block.splitlines() if not line.lstrip().startswith("#")
-    ]
+    joined = run_block.replace("\\\n", " ")
+    lines = [line for line in joined.splitlines() if not line.lstrip().startswith("#")]
     return "\n".join(lines)
 
 
@@ -458,12 +457,58 @@ def test_is_checkout_like_action(*, uses: str, expected: bool) -> None:
     assert_that(_is_checkout_like_action(uses)).is_equal_to(expected)
 
 
+_TRUSTED_CHECKOUT_REF = "${{ github.event.pull_request.base.sha }}"
+
+
+@pytest.mark.parametrize(
+    ("ref", "trusted"),
+    [
+        (_TRUSTED_CHECKOUT_REF, True),
+        ("", False),
+        ("${{ github.head_ref }}", False),
+        ("${{ github.ref }}", False),
+        ("${{ github.ref_name }}", False),
+        ("${{ github.sha }}", False),
+        ("${{ github.event.pull_request.head.sha }}", False),
+    ],
+    ids=[
+        "base-sha",
+        "omitted-ref",
+        "head-ref",
+        "github-ref",
+        "ref-name",
+        "github-sha",
+        "pr-head-sha",
+    ],
+)
+def test_checkout_ref_must_be_base_sha(*, ref: str, trusted: bool) -> None:
+    """Only the PR base SHA is a trusted checkout ref for this job.
+
+    Args:
+        ref: A checkout ``with.ref`` value, or empty when omitted.
+        trusted: Whether the audit must accept the ref.
+    """
+    assert_that(ref == _TRUSTED_CHECKOUT_REF).is_equal_to(trusted)
+    if ref:
+        banned = any(
+            marker in ref
+            for marker in (
+                "pull_request.head",
+                "github.sha",
+                "github.head_ref",
+                "github.ref",
+            )
+        )
+        assert_that(banned).is_equal_to(not trusted)
+
+
 @pytest.mark.parametrize(
     ("run_block", "banned"),
     [
         ("gh pr checkout 12\n", True),
         ("gh --repo lgtm-hq/py-lintro pr checkout 12\n", True),
         ("gh pr --repo lgtm-hq/py-lintro checkout 12\n", True),
+        ("gh pr \\\n  checkout 12\n", True),
         ("git fetch origin pull/12/head\n", True),
         ("git pull origin ${{ github.event.pull_request.head.sha }}\n", True),
         (
@@ -476,6 +521,7 @@ def test_is_checkout_like_action(*, uses: str, expected: bool) -> None:
         "gh-pr-checkout",
         "gh-repo-pr-checkout",
         "gh-pr-repo-checkout",
+        "gh-pr-checkout-continued",
         "git-fetch-pull-head",
         "git-pull-head-sha",
         "comment-only-mention",
@@ -524,8 +570,14 @@ def test_workflow_forbids_head_ref_fetches() -> None:
 
         with_block = step.get("with") or {}
         ref = str(with_block.get("ref", ""))
+        if isinstance(uses, str) and _is_checkout_like_action(uses):
+            assert_that(ref).is_equal_to(
+                "${{ github.event.pull_request.base.sha }}",
+            )
         assert_that(ref).does_not_contain("pull_request.head")
         assert_that(ref).does_not_contain("github.sha")
+        assert_that(ref).does_not_contain("github.head_ref")
+        assert_that(ref).does_not_contain("github.ref")
         assert_that(_PULL_HEAD_REF_RE.search(ref)).is_none()
 
         run = step.get("run")
@@ -795,8 +847,12 @@ def test_workflow_allows_the_npm_registry_egress() -> None:
     job_env = loaded["jobs"]["ai-review"]["env"]
     cursor_egress = job_env["AI_REVIEW_CURSOR_EGRESS"]
     assert_that(cursor_egress).contains("vars.LINTRO_AI_PROVIDER == 'cursor'")
-    for host in cursor_hosts:
-        assert_that(cursor_egress).contains(host)
+    cursor_branch = re.search(r"&&\s+'([^']+)'\s*\|\|\s*''", cursor_egress)
+    assert_that(cursor_branch).is_not_none()
+    parsed_hosts = set(cursor_branch.group(1).split())
+    assert_that(parsed_hosts).is_equal_to(set(cursor_hosts))
+    for host in parsed_hosts:
+        assert_that(host).described_as(host).does_not_contain("*")
     assert_that(endpoints_raw).contains("${{ env.AI_REVIEW_CURSOR_EGRESS }}")
 
 

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -848,7 +848,8 @@ def test_workflow_allows_the_npm_registry_egress() -> None:
     cursor_egress = job_env["AI_REVIEW_CURSOR_EGRESS"]
     assert_that(cursor_egress).contains("vars.LINTRO_AI_PROVIDER == 'cursor'")
     cursor_branch = re.search(r"&&\s+'([^']+)'\s*\|\|\s*''", cursor_egress)
-    assert_that(cursor_branch).is_not_none()
+    if cursor_branch is None:
+        pytest.fail("cursor egress expression must quote hosts and default to empty")
     parsed_hosts = set(cursor_branch.group(1).split())
     assert_that(parsed_hosts).is_equal_to(set(cursor_hosts))
     for host in parsed_hosts:

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -34,10 +34,11 @@ CURSOR_CREDENTIAL_ENV = "CURSOR_API_KEY"
 PROVIDER_CREDENTIAL_ENVS = (CREDENTIAL_ENV, CURSOR_CREDENTIAL_ENV)
 _PINNED_CHECKOUT = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
 _HEAD_REF_RE = re.compile(
-    r"github\.event\.pull_request\.head\.(?:sha|ref|name)\b",
+    r"github\.event\.pull_request\.head\.(?:sha|ref|name)\b"
+    r"|github\.(?:head_ref|sha|ref_name|ref)\b",
 )
 _GIT_HEAD_FETCH_RE = re.compile(
-    r"\bgit\s+(?:fetch|pull|checkout)\b",
+    r"\bgit(?:\s+\S+)*\s+(?:fetch|pull|checkout)\b",
 )
 _GH_PR_CHECKOUT_RE = re.compile(
     r"\bgh(?:\s+\S+)*\s+pr(?:\s+\S+)*\s+checkout\b",
@@ -62,9 +63,10 @@ def _executable_run_text(run_block: str) -> str:
     Returns:
         Executable lines only, joined with newlines.
     """
-    joined = run_block.replace("\\\n", " ")
-    lines = [line for line in joined.splitlines() if not line.lstrip().startswith("#")]
-    return "\n".join(lines)
+    without_comments = "\n".join(
+        line for line in run_block.splitlines() if not line.lstrip().startswith("#")
+    )
+    return without_comments.replace("\\\n", " ")
 
 
 def _is_checkout_like_action(uses: str) -> bool:
@@ -509,7 +511,10 @@ def test_checkout_ref_must_be_base_sha(*, ref: str, trusted: bool) -> None:
         ("gh --repo lgtm-hq/py-lintro pr checkout 12\n", True),
         ("gh pr --repo lgtm-hq/py-lintro checkout 12\n", True),
         ("gh pr \\\n  checkout 12\n", True),
+        ("# decoy \\\ngh pr checkout 12\n", True),
         ("git fetch origin pull/12/head\n", True),
+        ("git -C . checkout ${{ github.head_ref }}\n", True),
+        ("git --git-dir=.git fetch origin pull/12/head\n", True),
         ("git pull origin ${{ github.event.pull_request.head.sha }}\n", True),
         (
             "# gh pr checkout is banned in executable steps\npython3 scripts/ci/ai_tools_arg_pin.py\n",
@@ -522,7 +527,10 @@ def test_checkout_ref_must_be_base_sha(*, ref: str, trusted: bool) -> None:
         "gh-repo-pr-checkout",
         "gh-pr-repo-checkout",
         "gh-pr-checkout-continued",
+        "comment-backslash-then-checkout",
         "git-fetch-pull-head",
+        "git-dash-c-checkout-head-ref",
+        "git-git-dir-fetch-pull-head",
         "git-pull-head-sha",
         "comment-only-mention",
         "pin-script",

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -39,11 +39,11 @@ _HEAD_REF_RE = re.compile(
 _GIT_HEAD_FETCH_RE = re.compile(
     r"\bgit\s+(?:fetch|pull|checkout)\b",
 )
-_GH_PR_CHECKOUT_RE = re.compile(r"\bgh\s+pr\s+checkout\b")
-_PULL_HEAD_REF_RE = re.compile(r"pull/\S*/head")
-_CHECKOUT_LIKE_RE = re.compile(
-    r"(?:^|/)(?:checkout|checkout-[^/@]+|[^/@]+-checkout)$",
+_GH_PR_CHECKOUT_RE = re.compile(
+    r"\bgh(?:\s+\S+)*\s+pr(?:\s+\S+)*\s+checkout\b",
 )
+_PULL_HEAD_REF_RE = re.compile(r"pull/\S*/head")
+_CHECKOUT_LIKE_RE = re.compile(r"checkout")
 _CURSOR_EGRESS_HOSTS = (
     "downloads.cursor.com:443",
     "api2.cursor.sh:443",
@@ -434,6 +434,7 @@ def test_workflow_installs_from_base_ref_not_pr_head() -> None:
         ("evil/checkout@deadbeef", True),
         ("acme/checkout-action@1", True),
         ("acme/pr-checkout@1", True),
+        ("acme/pr-checkout-action@1", True),
         ("actions/setup-node@820762786026740c76f36085b0efc47a31fe5020", False),
         ("astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9", False),
     ],
@@ -442,6 +443,7 @@ def test_workflow_installs_from_base_ref_not_pr_head() -> None:
         "forked-checkout",
         "checkout-prefix",
         "checkout-suffix",
+        "checkout-infix",
         "setup-node",
         "setup-uv",
     ],
@@ -460,6 +462,8 @@ def test_is_checkout_like_action(*, uses: str, expected: bool) -> None:
     ("run_block", "banned"),
     [
         ("gh pr checkout 12\n", True),
+        ("gh --repo lgtm-hq/py-lintro pr checkout 12\n", True),
+        ("gh pr --repo lgtm-hq/py-lintro checkout 12\n", True),
         ("git fetch origin pull/12/head\n", True),
         ("git pull origin ${{ github.event.pull_request.head.sha }}\n", True),
         (
@@ -470,6 +474,8 @@ def test_is_checkout_like_action(*, uses: str, expected: bool) -> None:
     ],
     ids=[
         "gh-pr-checkout",
+        "gh-repo-pr-checkout",
+        "gh-pr-repo-checkout",
         "git-fetch-pull-head",
         "git-pull-head-sha",
         "comment-only-mention",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): harden ai-review audit, Cursor egress, and 0.50 provenance
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Bounded hardening for #2047 only — no trigger flip, no trust-semantics change.

1. Broaden the `ai-review.yml` structural audit so it fails on `gh pr checkout` (including flag-interleaved and backslash-continued forms), `git fetch`/`git pull`/`git checkout` of head refs, omitted/`github.head_ref`/`github.ref` checkouts, and any checkout-like action that is not the pinned `actions/checkout@<sha>` with `ref: pull_request.base.sha`.
2. Gate the five Cursor egress hosts on `vars.LINTRO_AI_PROVIDER == 'cursor'` via job-level `AI_REVIEW_CURSOR_EGRESS`, so the anthropic path no longer allowlists Cursor shards. Tests parse the `&& '…' || ''` branch and assert host-set equality plus no wildcards.
3. Correct the workflow-header provenance comment: the 0.50 cap landed in #2018 (`9f43a98a`), not #1971.

PR 2 will flip `pull_request` → `pull_request_target` after this lands.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Relates to #2047

## Details

This is the first of two PRs for #2047. It does not close the issue; the trigger flip in PR 2 does.

Round-1 lintro review (Cursor / Grok 4.6, both CI and local) requested the continuation/`head_ref`/host-set tightenings above; those are in follow-up test commits on this branch.

Testing: `uv run lintro fmt`, `uv run lintro chk` (0 findings on the changed files), and `uv run pytest tests/scripts/test_run_ai_review.py` (53 passed). Full suite on the first commit: 9383 passed; 6 env-only integration failures (`python3.12-venv` on the project interpreter, rustfmt 1.8.0 below the 1.9.0 pin).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ee5582c-2a96-4c7f-9d1d-80c30656e42d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ee5582c-2a96-4c7f-9d1d-80c30656e42d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Network access is now limited to endpoints associated with the selected AI provider.
  - Added safeguards to prevent unsafe pull request code checkout and fetching patterns.
  - Restored the AI review cost ceiling and clarified that CLI transport billing is advisory.
  - Expanded workflow auditing for checkout behavior, endpoint configuration, and security settings.
  - Added validation to ensure secure, pinned source revisions are used consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->