### PR TITLE
fix(ci): run ai-review on pull_request_target

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -71,7 +71,7 @@ name: AI Review - Dogfood
 permissions: {}
 
 concurrency:
-  group: ai-review-${{ github.ref }}
+  group: ai-review-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -65,7 +65,7 @@ name: AI Review - Dogfood
 # filter dated from API-metered billing; under subscription billing the CI and
 # workflow diffs it skipped are exactly where recent regressions shipped.
 'on':
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions: {}

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -322,11 +322,12 @@ def test_workflow_yaml_parses() -> None:
     assert_that(loaded).contains_key("jobs")
     assert_that(loaded["jobs"]).contains_key("ai-review")
     trigger = loaded[True] if True in loaded else loaded["on"]
-    assert_that(trigger).contains_key("pull_request")
+    assert_that(trigger).contains_key("pull_request_target")
+    assert_that(trigger).does_not_contain_key("pull_request")
 
 
 def test_workflow_runs_on_every_pr_without_a_paths_filter() -> None:
-    """The pull_request trigger carries no ``paths`` filter (#1902).
+    """The pull_request_target trigger carries no ``paths`` filter (#1902).
 
     The old ``lintro/**`` filter meant CI, script, and workflow PRs shipped with
     no AI review at all — the #1900 timeout bug went out exactly that way. Under
@@ -335,7 +336,7 @@ def test_workflow_runs_on_every_pr_without_a_paths_filter() -> None:
     loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
 
     trigger = loaded[True] if True in loaded else loaded["on"]
-    pull_request = trigger["pull_request"]
+    pull_request = trigger["pull_request_target"]
     assert_that(pull_request).does_not_contain_key("paths")
     assert_that(pull_request).does_not_contain_key("paths-ignore")
 

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -326,6 +326,21 @@ def test_workflow_yaml_parses() -> None:
     assert_that(trigger).does_not_contain_key("pull_request")
 
 
+def test_workflow_concurrency_keys_on_the_pr_number() -> None:
+    """``pull_request_target`` sets ``github.ref`` to the base branch.
+
+    Keying concurrency on ``github.ref`` would cancel every in-flight review
+    whenever any other PR targeting that branch synchronized.
+    """
+    loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+    concurrency = loaded["concurrency"]
+    assert_that(concurrency["group"]).is_equal_to(
+        "ai-review-${{ github.event.pull_request.number || github.ref }}",
+    )
+    assert_that(concurrency["cancel-in-progress"]).is_true()
+
+
 def test_workflow_runs_on_every_pr_without_a_paths_filter() -> None:
     """The pull_request_target trigger carries no ``paths`` filter (#1902).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): run ai-review on pull_request_target
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

#2047 PR 2 — trigger flip. No audit, egress, or provenance changes.

1. `on.pull_request` → `on.pull_request_target` in `.github/workflows/ai-review.yml`.
2. Tests that asserted the old trigger now require `pull_request_target` and reject a leftover `pull_request` key.
3. Concurrency group is `ai-review-${{ github.event.pull_request.number || github.ref }}`. Under `pull_request_target`, `github.ref` is the base branch, so the old `ai-review-${{ github.ref }}` group would cancel every in-flight review.

Checkout remains `${{ github.event.pull_request.base.sha }}`. Credentials stay on the final review step. The #2051 hardening is already on `main`.

This PR's own AI Review job may not run: `pull_request_target` reads the workflow from the base branch, and `main` still triggers on `pull_request`. The flip takes effect for later PRs after this lands.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #2047

## Details

Local `tests/scripts/test_run_ai_review.py`: 57 passed. Full suite on the trigger commit: 9404 passed; 4 rustfmt integration failures are the known env-only rustfmt 1.8.0 &lt; 1.9.0 gap. Local lintro review (Cursor / Grok 4.6) flagged the concurrency collapse; that is the follow-up commit. Comment/docs wording about the old `pull_request` secret model is left for a follow-up so this PR stays the flip.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ee5582c-2a96-4c7f-9d1d-80c30656e42d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ee5582c-2a96-4c7f-9d1d-80c30656e42d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated review workflow reliability by ensuring it runs with the appropriate pull request context.
  * Updated concurrency handling to cancel outdated runs and prioritize the current pull request.
* **Tests**
  * Expanded workflow validation to cover the updated trigger and concurrency behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->