### PR TITLE
feat(ci): post AI review comments as lintro-review[bot]

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -235,6 +235,8 @@ jobs:
         with:
           app-id: ${{ secrets.LINTRO_REVIEW_APP_ID }}
           private-key: ${{ secrets.LINTRO_REVIEW_APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Run AI review (posts comment; fails when nothing was reviewed)
         run: scripts/ci/run-ai-review.sh

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -106,11 +106,10 @@ jobs:
       && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
-      # `--post` maintains the sticky review comment and posts inline review
-      # comments as lintro-review[bot] via the App token (#2050). The
-      # workflow GITHUB_TOKEN still needs pull-requests: write for `gh`
-      # to read the PR diff.
-      pull-requests: write
+      # `--post` writes as lintro-review[bot] via the App token (#2050).
+      # The workflow GITHUB_TOKEN is only used by `gh` to fetch the PR
+      # diff, which needs pull-requests: read.
+      pull-requests: read
     # COUPLED to ai.transports.cli.timeout (default 900 s,
     # lintro.ai.transport.DEFAULT_CLI_TIMEOUT): the
     # job budget must cover setup (~7 min) + the full review timeout (15 min) +

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -107,7 +107,9 @@ jobs:
     permissions:
       contents: read
       # `--post` maintains the sticky review comment and posts inline review
-      # comments, both of which require write access to pull requests.
+      # comments as lintro-review[bot] via the App token (#2050). The
+      # workflow GITHUB_TOKEN still needs pull-requests: write for `gh`
+      # to read the PR diff.
       pull-requests: write
     # COUPLED to ai.transports.cli.timeout (default 900 s,
     # lintro.ai.transport.DEFAULT_CLI_TIMEOUT): the
@@ -223,6 +225,17 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra ai
 
+      - name: Mint lintro-review App token
+        id: lintro-review-app
+        # Repo-scoped installation token (#2050). Default current-repo scope —
+        # do not pass `owner:` without `repositories:`. Only the review step
+        # below sees `outputs.token`; inference credentials stay separate.
+        # yamllint disable-line rule:line-length
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.LINTRO_REVIEW_APP_ID }}
+          private-key: ${{ secrets.LINTRO_REVIEW_APP_PRIVATE_KEY }}
+
       - name: Run AI review (posts comment; fails when nothing was reviewed)
         run: scripts/ci/run-ai-review.sh
         env:
@@ -246,8 +259,10 @@ jobs:
           # binary the contract tests verified.
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
           DISABLE_AUTOUPDATER: '1'
+          # `gh` fetches the PR diff with the workflow token (contents: read).
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # `--post` writes as lintro-review[bot] via the App token (#2050).
+          GITHUB_TOKEN: ${{ steps.lintro-review-app.outputs.token }}
           # Repo Actions variables named identically to the env vars they feed
           # (#1971). Unset variables keep today's pinned CI defaults (cli /
           # anthropic); a set variable is the experiment loop (`gh variable set`

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -237,6 +237,7 @@ jobs:
           private-key: ${{ secrets.LINTRO_REVIEW_APP_PRIVATE_KEY }}
           permission-issues: write
           permission-pull-requests: write
+          permission-contents: read
 
       - name: Run AI review (posts comment; fails when nothing was reviewed)
         run: scripts/ci/run-ai-review.sh

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -105,6 +105,7 @@ jobs:
       github.event.pull_request.draft == false
       && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
+      # actions/checkout reads the trusted base ref with the workflow token.
       contents: read
       # `--post` writes as lintro-review[bot] via the App token (#2050).
       # The workflow GITHUB_TOKEN is only used by `gh` to fetch the PR
@@ -261,7 +262,8 @@ jobs:
           # binary the contract tests verified.
           CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
           DISABLE_AUTOUPDATER: '1'
-          # `gh` fetches the PR diff with the workflow token (contents: read).
+          # `gh` fetches the PR diff with the workflow token
+          # (contents: read + pull-requests: read).
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # `--post` writes as lintro-review[bot] via the App token (#2050).
           GITHUB_TOKEN: ${{ steps.lintro-review-app.outputs.token }}

--- a/lintro/ai/integrations/github_pr.py
+++ b/lintro/ai/integrations/github_pr.py
@@ -693,6 +693,48 @@ class GitHubPRReporter:
         url = f"{self.api_base}/repos/{self.repo}/issues/comments/{comment_id}"
         return self.api_request(method="DELETE", url=url)
 
+    def create_issue_comment(self, *, body: str) -> int | None:
+        """Post a top-level issue comment and return its id.
+
+        Args:
+            body: Comment body in Markdown.
+
+        Returns:
+            The created comment id, or ``None`` when the request failed or
+            the response did not include a numeric id.
+        """
+        url = f"{self.api_base}/repos/{self.repo}/issues/{self.pr_number}/comments"
+        data = json.dumps({"body": body}).encode()
+        req = self._authorized_request(
+            url=url,
+            method="POST",
+            data=data,
+            content_type="application/json",
+        )
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme != "https":
+            logger.warning("Refusing non-HTTPS URL: {}", url)
+            return None
+        try:
+            with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
+                req,
+                timeout=30,
+            ) as resp:
+                if not (200 <= int(resp.status) < 300):
+                    return None
+                payload = json.loads(resp.read().decode())
+        except (
+            urllib.error.URLError,
+            json.JSONDecodeError,
+            OSError,
+        ) as exc:
+            logger.warning("Failed to create issue comment: {}", exc)
+            return None
+        if not isinstance(payload, dict):
+            return None
+        comment_id = payload.get("id")
+        return comment_id if isinstance(comment_id, int) else None
+
     def post_issue_comment(self, body: str) -> bool:
         """Post a top-level issue comment on the PR.
 
@@ -702,8 +744,7 @@ class GitHubPRReporter:
         Returns:
             True if posted successfully.
         """
-        url = f"{self.api_base}/repos/{self.repo}/issues/{self.pr_number}/comments"
-        return self.api_request(method="POST", url=url, payload={"body": body})
+        return self.create_issue_comment(body=body) is not None
 
     def api_http_status(
         self,

--- a/lintro/ai/integrations/github_pr.py
+++ b/lintro/ai/integrations/github_pr.py
@@ -638,6 +638,30 @@ class GitHubPRReporter:
         thread = _dig(data, "resolveReviewThread", "thread")
         return bool(thread and thread.get("isResolved"))
 
+    def update_issue_comment_status(
+        self,
+        *,
+        comment_id: int,
+        body: str,
+    ) -> int | None:
+        """PATCH an issue comment and return the HTTP status.
+
+        Args:
+            comment_id: Numeric id of the comment to edit.
+            body: New Markdown body.
+
+        Returns:
+            The HTTP status, or ``None`` when the request did not complete.
+            ``403`` is the actor-mismatch GitHub returns when this token did
+            not create the comment.
+        """
+        url = f"{self.api_base}/repos/{self.repo}/issues/comments/{comment_id}"
+        return self.api_http_status(
+            method="PATCH",
+            url=url,
+            payload={"body": body},
+        )
+
     def update_issue_comment(self, *, comment_id: int, body: str) -> bool:
         """Update an existing issue comment in place.
 
@@ -648,8 +672,11 @@ class GitHubPRReporter:
         Returns:
             True if the update succeeded.
         """
-        url = f"{self.api_base}/repos/{self.repo}/issues/comments/{comment_id}"
-        return self.api_request(method="PATCH", url=url, payload={"body": body})
+        status = self.update_issue_comment_status(
+            comment_id=comment_id,
+            body=body,
+        )
+        return status is not None and 200 <= status < 300
 
     def delete_issue_comment(self, *, comment_id: int) -> bool:
         """Delete an issue comment by id.
@@ -678,6 +705,58 @@ class GitHubPRReporter:
         url = f"{self.api_base}/repos/{self.repo}/issues/{self.pr_number}/comments"
         return self.api_request(method="POST", url=url, payload={"body": body})
 
+    def api_http_status(
+        self,
+        method: str,
+        url: str,
+        payload: dict[str, Any] | None = None,
+    ) -> int | None:
+        """Make an authenticated GitHub API request and return the status.
+
+        Args:
+            method: HTTP method.
+            url: Full API URL.
+            payload: JSON payload, or ``None`` for methods with no body.
+
+        Returns:
+            The HTTP status when GitHub answered, or ``None`` when the
+            request was refused locally or failed in transit.
+        """
+        data = None if payload is None else json.dumps(payload).encode()
+        req = self._authorized_request(
+            url=url,
+            method=method,
+            data=data,
+            content_type="application/json" if data is not None else "",
+        )
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme != "https":
+            logger.warning("Refusing non-HTTPS URL: {}", url)
+            return None
+
+        try:
+            with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
+                req,
+                timeout=30,
+            ) as resp:
+                return int(resp.status)
+        except urllib.error.HTTPError as e:
+            try:
+                body = e.read().decode("utf-8", "replace")[:500]
+            except (AttributeError, UnicodeDecodeError, ValueError, OSError):
+                body = "<unreadable>"
+            logger.warning(
+                "GitHub API request failed: {} {} -> {}: {}",
+                method,
+                url,
+                e.code,
+                body,
+            )
+            return int(e.code)
+        except urllib.error.URLError as e:
+            logger.warning("GitHub API request error: {}", e.reason)
+            return None
+
     def api_request(
         self,
         method: str,
@@ -694,41 +773,8 @@ class GitHubPRReporter:
         Returns:
             True if the request succeeded (2xx status).
         """
-        data = None if payload is None else json.dumps(payload).encode()
-        req = self._authorized_request(
-            url=url,
-            method=method,
-            data=data,
-            content_type="application/json" if data is not None else "",
-        )
-        parsed = urllib.parse.urlparse(url)
-        if parsed.scheme != "https":
-            logger.warning("Refusing non-HTTPS URL: {}", url)
-            return False
-
-        try:
-            with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected — HTTPS-only validated above  # nosec B310 — HTTPS-only validated above
-                req,
-                timeout=30,
-            ) as resp:
-                status: int = resp.status
-                return 200 <= status < 300
-        except urllib.error.HTTPError as e:
-            try:
-                body = e.read().decode("utf-8", "replace")[:500]
-            except (AttributeError, UnicodeDecodeError, ValueError, OSError):
-                body = "<unreadable>"
-            logger.warning(
-                "GitHub API request failed: {} {} -> {}: {}",
-                method,
-                url,
-                e.code,
-                body,
-            )
-            return False
-        except urllib.error.URLError as e:
-            logger.warning("GitHub API request error: {}", e.reason)
-            return False
+        status = self.api_http_status(method=method, url=url, payload=payload)
+        return status is not None and 200 <= status < 300
 
     def _fetch_pr_diff_lines(self) -> dict[str, set[int]] | None:
         """Deprecated alias for :meth:`fetch_pr_diff_lines`.

--- a/lintro/ai/integrations/github_pr.py
+++ b/lintro/ai/integrations/github_pr.py
@@ -407,9 +407,9 @@ class GitHubPRReporter:
         Paginates through the PR's issue comments and returns the first one
         whose body contains ``marker`` (an HTML comment used to identify a
         sticky comment maintained across runs). Matching is by marker only —
-        not by author — so the first ``lintro-review[bot]`` run updates an
-        existing ``github-actions[bot]`` sticky instead of posting a second
-        (#2050).
+        not by author — so the first ``lintro-review[bot]`` run can find an
+        existing ``github-actions[bot]`` sticky (#2050). GitHub forbids editing
+        another actor's comment; ``_upsert_sticky`` then deletes and recreates.
 
         Args:
             marker: Substring to search for (e.g. ``<!-- lintro-ai-review -->``).
@@ -649,7 +649,22 @@ class GitHubPRReporter:
             True if the update succeeded.
         """
         url = f"{self.api_base}/repos/{self.repo}/issues/comments/{comment_id}"
-        return self.api_request("PATCH", url, {"body": body})
+        return self.api_request(method="PATCH", url=url, payload={"body": body})
+
+    def delete_issue_comment(self, *, comment_id: int) -> bool:
+        """Delete an issue comment by id.
+
+        Used to supersede a sticky that this token cannot edit (GitHub binds
+        PATCH to the creating actor). Write access can still delete it.
+
+        Args:
+            comment_id: Numeric id of the comment to delete.
+
+        Returns:
+            True if the deletion succeeded.
+        """
+        url = f"{self.api_base}/repos/{self.repo}/issues/comments/{comment_id}"
+        return self.api_request(method="DELETE", url=url)
 
     def post_issue_comment(self, body: str) -> bool:
         """Post a top-level issue comment on the PR.
@@ -661,30 +676,30 @@ class GitHubPRReporter:
             True if posted successfully.
         """
         url = f"{self.api_base}/repos/{self.repo}/issues/{self.pr_number}/comments"
-        return self.api_request("POST", url, {"body": body})
+        return self.api_request(method="POST", url=url, payload={"body": body})
 
     def api_request(
         self,
         method: str,
         url: str,
-        payload: dict[str, Any],
+        payload: dict[str, Any] | None = None,
     ) -> bool:
         """Make an authenticated GitHub API request.
 
         Args:
             method: HTTP method.
             url: Full API URL.
-            payload: JSON payload.
+            payload: JSON payload, or ``None`` for methods with no body.
 
         Returns:
             True if the request succeeded (2xx status).
         """
-        data = json.dumps(payload).encode()
+        data = None if payload is None else json.dumps(payload).encode()
         req = self._authorized_request(
             url=url,
             method=method,
             data=data,
-            content_type="application/json",
+            content_type="application/json" if data is not None else "",
         )
         parsed = urllib.parse.urlparse(url)
         if parsed.scheme != "https":

--- a/lintro/ai/integrations/github_pr.py
+++ b/lintro/ai/integrations/github_pr.py
@@ -406,7 +406,10 @@ class GitHubPRReporter:
 
         Paginates through the PR's issue comments and returns the first one
         whose body contains ``marker`` (an HTML comment used to identify a
-        sticky comment maintained across runs).
+        sticky comment maintained across runs). Matching is by marker only —
+        not by author — so the first ``lintro-review[bot]`` run updates an
+        existing ``github-actions[bot]`` sticky instead of posting a second
+        (#2050).
 
         Args:
             marker: Substring to search for (e.g. ``<!-- lintro-ai-review -->``).

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -738,8 +738,20 @@ def _upsert_sticky(
     """
     if comment_id is None:
         return reporter.post_issue_comment(body), None
-    if reporter.update_issue_comment(comment_id=comment_id, body=body):
+    status = _sticky_patch_status(
+        reporter=reporter,
+        comment_id=comment_id,
+        body=body,
+    )
+    if status is not None and 200 <= status < 300:
         return True, comment_id
+    if status != 403:
+        logger.warning(
+            "Could not edit sticky comment {} (HTTP {}); leaving it in place",
+            comment_id,
+            status,
+        )
+        return False, None
     logger.warning(
         "Could not edit sticky comment {}; deleting and recreating "
         "(GitHub only lets the creating actor PATCH)",
@@ -751,10 +763,54 @@ def _upsert_sticky(
             comment_id,
         )
         return False, None
-    if not reporter.post_issue_comment(body):
+    if not _post_sticky(reporter=reporter, body=body):
         return False, None
     found = reporter.find_issue_comment(marker=STICKY_MARKER)
     return True, None if found is None else found[0]
+
+
+def _sticky_patch_status(
+    *,
+    reporter: GitHubPRReporter,
+    comment_id: int,
+    body: str,
+) -> int | None:
+    """Return the sticky PATCH status, with a bool-reporter fallback.
+
+    Args:
+        reporter: GitHub reporter used to edit the sticky.
+        comment_id: Existing sticky id.
+        body: Markdown body to write.
+
+    Returns:
+        HTTP status when the reporter exposes one. Bool-only test doubles
+        map success to ``200`` and failure to ``403`` so the actor-mismatch
+        path stays covered without a status method.
+    """
+    status_fn = getattr(reporter, "update_issue_comment_status", None)
+    if callable(status_fn):
+        status = status_fn(comment_id=comment_id, body=body)
+        if isinstance(status, int):
+            return status
+    if reporter.update_issue_comment(comment_id=comment_id, body=body):
+        return 200
+    return 403
+
+
+def _post_sticky(*, reporter: GitHubPRReporter, body: str) -> bool:
+    """Create the sticky comment, retrying once after a failed POST.
+
+    Args:
+        reporter: GitHub reporter used to post the comment.
+        body: Markdown body to write.
+
+    Returns:
+        True when a create attempt succeeded.
+    """
+    if reporter.post_issue_comment(body):
+        return True
+    logger.warning("Failed to recreate sticky comment; retrying once")
+    return reporter.post_issue_comment(body)
 
 
 def _round_diff_lines(

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -189,7 +189,7 @@ def post_review_to_github(
     # — a round that fixed everything posts no inline comment and yet has the
     # most threads to stamp.
     inline_posted = False
-    success = _upsert_sticky(
+    success, comment_id = _upsert_sticky(
         reporter=gh_reporter,
         body=render(inline_failure=failure),
         comment_id=comment_id,
@@ -344,7 +344,8 @@ def _refresh_sticky(
         render: Callable that renders the sticky body.
         failure: Findings whose inline comments could not be posted.
         comment_ids: Finding key to inline comment id captured this round.
-        comment_id: Sticky comment id known before the upsert, or ``None``.
+        comment_id: Live sticky comment id after the upsert, or ``None``
+            when the comment was just created and must be re-located.
     """
     sticky_id = _sticky_comment_id(reporter=reporter, known=comment_id)
     if sticky_id is None:
@@ -603,8 +604,8 @@ def _sticky_comment_id(
 
     Args:
         reporter: GitHub reporter used to list PR comments.
-        known: The id known before the sticky was upserted, or ``None`` when it
-            did not exist yet.
+        known: The live sticky id after upsert, or ``None`` when it was just
+            created and must be re-located by marker.
 
     Returns:
         The comment id to update, or ``None`` when it still cannot be found.
@@ -684,7 +685,11 @@ def post_review_error_to_github(
         repo=repo or gh_reporter.repo or "",
         pr_number=pr_number if pr_number is not None else gh_reporter.pr_number,
     )
-    return _upsert_sticky(reporter=gh_reporter, body=body, comment_id=comment_id)
+    return _upsert_sticky(
+        reporter=gh_reporter,
+        body=body,
+        comment_id=comment_id,
+    )[0]
 
 
 def _load_prior_state(
@@ -712,29 +717,44 @@ def _upsert_sticky(
     reporter: GitHubPRReporter,
     body: str,
     comment_id: int | None,
-) -> bool:
+) -> tuple[bool, int | None]:
     """Update the sticky comment in place, or create it when absent.
 
     GitHub only lets the creating actor PATCH a comment. After #2050 the
     poster is ``lintro-review[bot]``, so a leftover ``github-actions[bot]``
     sticky must be deleted and recreated rather than edited in place.
+
+    Args:
+        reporter: GitHub reporter used to create, edit, or replace the sticky.
+        body: Markdown body to write.
+        comment_id: Existing sticky id, or ``None`` when one has not been
+            posted yet.
+
+    Returns:
+        ``(success, live_id)``. ``live_id`` is the comment later refreshes
+        must PATCH: the original id after an in-place edit, the replacement
+        id after a delete-and-recreate, or ``None`` after a first-time
+        create (the caller re-locates by marker) or when the write failed.
     """
     if comment_id is None:
-        return reporter.post_issue_comment(body)
+        return reporter.post_issue_comment(body), None
     if reporter.update_issue_comment(comment_id=comment_id, body=body):
-        return True
+        return True, comment_id
     logger.warning(
         "Could not edit sticky comment {}; deleting and recreating "
         "(GitHub only lets the creating actor PATCH)",
         comment_id,
     )
-    if reporter.delete_issue_comment(comment_id=comment_id):
-        return reporter.post_issue_comment(body)
-    logger.warning(
-        "Failed to delete sticky comment {}; leaving it in place",
-        comment_id,
-    )
-    return False
+    if not reporter.delete_issue_comment(comment_id=comment_id):
+        logger.warning(
+            "Failed to delete sticky comment {}; leaving it in place",
+            comment_id,
+        )
+        return False, None
+    if not reporter.post_issue_comment(body):
+        return False, None
+    found = reporter.find_issue_comment(marker=STICKY_MARKER)
+    return True, None if found is None else found[0]
 
 
 def _round_diff_lines(

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -753,20 +753,21 @@ def _upsert_sticky(
         )
         return False, None
     logger.warning(
-        "Could not edit sticky comment {}; deleting and recreating "
-        "(GitHub only lets the creating actor PATCH)",
+        "Could not edit sticky comment {}; posting a replacement "
+        "before deleting it (GitHub only lets the creating actor PATCH)",
         comment_id,
     )
+    live_id = _post_sticky(reporter=reporter, body=body)
+    if live_id is None:
+        return False, None
     if not reporter.delete_issue_comment(comment_id=comment_id):
         logger.warning(
-            "Failed to delete sticky comment {}; leaving it in place",
+            "Posted replacement sticky {} but failed to delete {}; "
+            "both comments may remain",
+            live_id,
             comment_id,
         )
-        return False, None
-    if not _post_sticky(reporter=reporter, body=body):
-        return False, None
-    found = reporter.find_issue_comment(marker=STICKY_MARKER)
-    return True, None if found is None else found[0]
+    return True, live_id
 
 
 def _sticky_patch_status(
@@ -790,14 +791,35 @@ def _sticky_patch_status(
     status_fn = getattr(reporter, "update_issue_comment_status", None)
     if callable(status_fn):
         status = status_fn(comment_id=comment_id, body=body)
-        if isinstance(status, int):
+        if isinstance(status, int) or status is None:
             return status
     if reporter.update_issue_comment(comment_id=comment_id, body=body):
         return 200
     return 403
 
 
-def _post_sticky(*, reporter: GitHubPRReporter, body: str) -> bool:
+def _create_sticky_id(*, reporter: GitHubPRReporter, body: str) -> int | None:
+    """Create a sticky comment and return its id.
+
+    Args:
+        reporter: GitHub reporter used to post the comment.
+        body: Markdown body to write.
+
+    Returns:
+        The new comment id, or ``None`` when creation failed.
+    """
+    create_fn = getattr(reporter, "create_issue_comment", None)
+    if callable(create_fn):
+        created = create_fn(body=body)
+        if isinstance(created, int) or created is None:
+            return created
+    if not reporter.post_issue_comment(body):
+        return None
+    found = reporter.find_issue_comment(marker=STICKY_MARKER)
+    return None if found is None else found[0]
+
+
+def _post_sticky(*, reporter: GitHubPRReporter, body: str) -> int | None:
     """Create the sticky comment, retrying once after a failed POST.
 
     Args:
@@ -805,12 +827,13 @@ def _post_sticky(*, reporter: GitHubPRReporter, body: str) -> bool:
         body: Markdown body to write.
 
     Returns:
-        True when a create attempt succeeded.
+        The new comment id, or ``None`` when both create attempts failed.
     """
-    if reporter.post_issue_comment(body):
-        return True
+    created = _create_sticky_id(reporter=reporter, body=body)
+    if created is not None:
+        return created
     logger.warning("Failed to recreate sticky comment; retrying once")
-    return reporter.post_issue_comment(body)
+    return _create_sticky_id(reporter=reporter, body=body)
 
 
 def _round_diff_lines(

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -713,10 +713,28 @@ def _upsert_sticky(
     body: str,
     comment_id: int | None,
 ) -> bool:
-    """Update the sticky comment in place, or create it when absent."""
-    if comment_id is not None:
-        return reporter.update_issue_comment(comment_id=comment_id, body=body)
-    return reporter.post_issue_comment(body)
+    """Update the sticky comment in place, or create it when absent.
+
+    GitHub only lets the creating actor PATCH a comment. After #2050 the
+    poster is ``lintro-review[bot]``, so a leftover ``github-actions[bot]``
+    sticky must be deleted and recreated rather than edited in place.
+    """
+    if comment_id is None:
+        return reporter.post_issue_comment(body)
+    if reporter.update_issue_comment(comment_id=comment_id, body=body):
+        return True
+    logger.warning(
+        "Could not edit sticky comment {}; deleting and recreating "
+        "(GitHub only lets the creating actor PATCH)",
+        comment_id,
+    )
+    if reporter.delete_issue_comment(comment_id=comment_id):
+        return reporter.post_issue_comment(body)
+    logger.warning(
+        "Failed to delete sticky comment {}; leaving it in place",
+        comment_id,
+    )
+    return False
 
 
 def _round_diff_lines(

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -389,16 +389,16 @@ def test_workflow_job_is_same_repo_only() -> None:
     )
 
 
-def test_workflow_job_can_write_pull_requests() -> None:
-    """The review job has pull-requests: write so --post can publish comments.
+def test_workflow_job_reads_pull_requests() -> None:
+    """The workflow token only needs pull-requests: read for ``gh``.
 
-    Contents stays read-only (the diff is fetched via ``gh``), but posting the
-    sticky comment and inline review comments requires write access to PRs.
+    ``--post`` writes as ``lintro-review[bot]`` via the App token (#2050),
+    so the job-scoped ``GITHUB_TOKEN`` stays read-only for the PR diff.
     """
     loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
 
     perms = loaded["jobs"]["ai-review"]["permissions"]
-    assert_that(perms["pull-requests"]).is_equal_to("write")
+    assert_that(perms["pull-requests"]).is_equal_to("read")
     assert_that(perms["contents"]).is_equal_to("read")
 
 

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -716,6 +716,7 @@ def test_workflow_reviews_pr_via_gh_not_working_tree() -> None:
         "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
         "astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9",
         "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
+        "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
     ],
 )
 def test_workflow_pins_actions_to_sha(*, action_ref: str) -> None:
@@ -727,6 +728,73 @@ def test_workflow_pins_actions_to_sha(*, action_ref: str) -> None:
     content = WORKFLOW.read_text(encoding="utf-8")
 
     assert_that(content).contains(action_ref)
+
+
+def test_workflow_mints_lintro_review_app_token_for_posting() -> None:
+    """The App token is minted repo-scoped and used only for ``--post``.
+
+    ``gh`` still fetches the PR diff with the workflow ``GITHUB_TOKEN``. The
+    mint step must not pass ``owner:`` (that would mint an org-wide token)
+    and must not be a second checkout.
+    """
+    loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = loaded["jobs"]["ai-review"]["steps"]
+
+    mint_steps = [
+        step
+        for step in steps
+        if str(step.get("uses", "")).startswith("actions/create-github-app-token@")
+    ]
+    assert_that(mint_steps).is_length(1)
+    mint = mint_steps[0]
+    assert_that(mint["id"]).is_equal_to("lintro-review-app")
+    assert_that(mint["uses"]).is_equal_to(
+        "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
+    )
+    mint_with = mint["with"]
+    assert_that(mint_with["app-id"]).is_equal_to(
+        "${{ secrets.LINTRO_REVIEW_APP_ID }}",
+    )
+    assert_that(mint_with["private-key"]).is_equal_to(
+        "${{ secrets.LINTRO_REVIEW_APP_PRIVATE_KEY }}",
+    )
+    assert_that(mint_with).does_not_contain_key("owner")
+    assert_that(mint_with).does_not_contain_key("repositories")
+    assert_that(_is_checkout_like_action(mint["uses"])).is_false()
+
+    review_steps = [
+        step for step in steps if str(step.get("name", "")).startswith("Run AI review")
+    ]
+    assert_that(review_steps).is_length(1)
+    review_env = review_steps[0]["env"]
+    assert_that(review_env["GITHUB_TOKEN"]).is_equal_to(
+        "${{ steps.lintro-review-app.outputs.token }}",
+    )
+    assert_that(review_env["GH_TOKEN"]).is_equal_to("${{ secrets.GITHUB_TOKEN }}")
+
+    mint_index = steps.index(mint)
+    review_index = steps.index(review_steps[0])
+    assert_that(review_index).is_equal_to(mint_index + 1)
+
+    app_secret_values = (
+        "${{ secrets.LINTRO_REVIEW_APP_ID }}",
+        "${{ secrets.LINTRO_REVIEW_APP_PRIVATE_KEY }}",
+        "${{ steps.lintro-review-app.outputs.token }}",
+    )
+    for step in steps:
+        if step is mint or step is review_steps[0]:
+            continue
+        step_env = step.get("env") or {}
+        step_with = step.get("with") or {}
+        blob = " ".join(
+            str(value) for value in (*step_env.values(), *step_with.values())
+        )
+        for secret_value in app_secret_values:
+            assert_that(blob).described_as(
+                f"step {step.get('name')!r}",
+            ).does_not_contain(
+                secret_value,
+            )
 
 
 def test_workflow_never_puts_an_api_key_in_scope() -> None:

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -760,6 +760,7 @@ def test_workflow_mints_lintro_review_app_token_for_posting() -> None:
     )
     assert_that(mint_with["permission-issues"]).is_equal_to("write")
     assert_that(mint_with["permission-pull-requests"]).is_equal_to("write")
+    assert_that(mint_with["permission-contents"]).is_equal_to("read")
     assert_that(mint_with).does_not_contain_key("owner")
     assert_that(mint_with).does_not_contain_key("repositories")
     assert_that(_is_checkout_like_action(mint["uses"])).is_false()

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -758,6 +758,8 @@ def test_workflow_mints_lintro_review_app_token_for_posting() -> None:
     assert_that(mint_with["private-key"]).is_equal_to(
         "${{ secrets.LINTRO_REVIEW_APP_PRIVATE_KEY }}",
     )
+    assert_that(mint_with["permission-issues"]).is_equal_to("write")
+    assert_that(mint_with["permission-pull-requests"]).is_equal_to("write")
     assert_that(mint_with).does_not_contain_key("owner")
     assert_that(mint_with).does_not_contain_key("repositories")
     assert_that(_is_checkout_like_action(mint["uses"])).is_false()

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -390,10 +390,12 @@ def test_workflow_job_is_same_repo_only() -> None:
 
 
 def test_workflow_job_reads_pull_requests() -> None:
-    """The workflow token only needs pull-requests: read for ``gh``.
+    """The workflow token only needs contents + pull-requests read.
 
-    ``--post`` writes as ``lintro-review[bot]`` via the App token (#2050),
-    so the job-scoped ``GITHUB_TOKEN`` stays read-only for the PR diff.
+    ``actions/checkout`` reads the trusted base ref (``contents: read``).
+    ``gh`` fetches the PR diff (``pull-requests: read``). ``--post`` writes
+    as ``lintro-review[bot]`` via the App token (#2050), so the job-scoped
+    ``GITHUB_TOKEN`` stays read-only.
     """
     loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
 

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -22,6 +22,7 @@ from lintro.ai.review.github import (
     _cap_body,
     _count_new_commits,
     _sticky_comment_id,
+    _upsert_sticky,
     build_sticky_comment,
     format_error_comment,
     format_finding_comment,
@@ -48,6 +49,7 @@ def _fresh_reporter() -> MagicMock:
     reporter.fetch_pr_commit_shas.return_value = []
     reporter.post_issue_comment.return_value = True
     reporter.update_issue_comment.return_value = True
+    reporter.delete_issue_comment.return_value = True
     reporter.api_request.return_value = True
     reporter.api_base = "https://api.github.com"
     reporter.repo = "owner/name"
@@ -417,9 +419,66 @@ def test_post_review_updates_existing_sticky(
     assert_that(posted).is_true()
     reporter.update_issue_comment.assert_called_once()
     reporter.post_issue_comment.assert_not_called()
+    reporter.delete_issue_comment.assert_not_called()
     kwargs = reporter.update_issue_comment.call_args.kwargs
     assert_that(kwargs["comment_id"]).is_equal_to(42)
     assert_that(kwargs["body"]).contains("2 runs")
+
+
+def test_upsert_sticky_creates_when_missing() -> None:
+    """A first review posts a new sticky comment."""
+    reporter = _fresh_reporter()
+
+    posted = _upsert_sticky(reporter=reporter, body="hello", comment_id=None)
+
+    assert_that(posted).is_true()
+    reporter.post_issue_comment.assert_called_once_with("hello")
+    reporter.update_issue_comment.assert_not_called()
+    reporter.delete_issue_comment.assert_not_called()
+
+
+def test_upsert_sticky_patches_when_update_succeeds() -> None:
+    """Same-actor updates edit the sticky in place."""
+    reporter = _fresh_reporter()
+
+    posted = _upsert_sticky(reporter=reporter, body="hello", comment_id=42)
+
+    assert_that(posted).is_true()
+    reporter.update_issue_comment.assert_called_once_with(
+        comment_id=42,
+        body="hello",
+    )
+    reporter.delete_issue_comment.assert_not_called()
+    reporter.post_issue_comment.assert_not_called()
+
+
+def test_upsert_sticky_supersedes_when_patch_fails() -> None:
+    """GitHub forbids editing another actor's comment; delete then recreate."""
+    reporter = _fresh_reporter()
+    reporter.update_issue_comment.return_value = False
+
+    posted = _upsert_sticky(reporter=reporter, body="hello", comment_id=42)
+
+    assert_that(posted).is_true()
+    reporter.update_issue_comment.assert_called_once_with(
+        comment_id=42,
+        body="hello",
+    )
+    reporter.delete_issue_comment.assert_called_once_with(comment_id=42)
+    reporter.post_issue_comment.assert_called_once_with("hello")
+
+
+def test_upsert_sticky_returns_false_when_delete_fails() -> None:
+    """A failed delete leaves the prior sticky in place and reports failure."""
+    reporter = _fresh_reporter()
+    reporter.update_issue_comment.return_value = False
+    reporter.delete_issue_comment.return_value = False
+
+    posted = _upsert_sticky(reporter=reporter, body="hello", comment_id=42)
+
+    assert_that(posted).is_false()
+    reporter.delete_issue_comment.assert_called_once_with(comment_id=42)
+    reporter.post_issue_comment.assert_not_called()
 
 
 def test_post_review_posts_inline_findings(

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -464,7 +464,7 @@ def test_upsert_sticky_patches_when_update_succeeds() -> None:
 
 
 def test_upsert_sticky_supersedes_when_patch_fails() -> None:
-    """GitHub forbids editing another actor's comment; delete then recreate."""
+    """GitHub forbids editing another actor's comment; recreate then delete."""
     reporter = _fresh_reporter()
     reporter.update_issue_comment.return_value = False
     reporter.find_issue_comment.return_value = (99, "hello")
@@ -499,7 +499,7 @@ def test_upsert_sticky_supersedes_only_on_actor_mismatch(
     status: int,
     should_recreate: bool,
 ) -> None:
-    """Only a 403 PATCH (wrong actor) deletes the leftover sticky."""
+    """Only a 403 PATCH (wrong actor) replaces the leftover sticky."""
     reporter = _fresh_reporter()
     reporter.update_issue_comment_status.return_value = status
     reporter.find_issue_comment.return_value = (99, "hello")
@@ -523,7 +523,7 @@ def test_upsert_sticky_supersedes_only_on_actor_mismatch(
 
 
 def test_upsert_sticky_retries_post_after_recreate_failure() -> None:
-    """A failed create after DELETE is retried once so state is not dropped."""
+    """A failed create is retried once before the leftover sticky is deleted."""
     reporter = _fresh_reporter()
     reporter.update_issue_comment_status.return_value = 403
     reporter.post_issue_comment.side_effect = [False, True]
@@ -540,11 +540,29 @@ def test_upsert_sticky_retries_post_after_recreate_failure() -> None:
     assert_that(reporter.post_issue_comment.call_count).is_equal_to(2)
 
 
-def test_upsert_sticky_returns_false_when_delete_fails() -> None:
-    """A failed delete leaves the prior sticky in place and reports failure."""
+def test_upsert_sticky_keeps_replacement_when_delete_fails() -> None:
+    """A failed delete after a successful create still returns the new id."""
     reporter = _fresh_reporter()
     reporter.update_issue_comment.return_value = False
     reporter.delete_issue_comment.return_value = False
+    reporter.find_issue_comment.return_value = (99, "hello")
+
+    posted, live_id = _upsert_sticky(
+        reporter=reporter,
+        body="hello",
+        comment_id=42,
+    )
+
+    assert_that(posted).is_true()
+    assert_that(live_id).is_equal_to(99)
+    reporter.post_issue_comment.assert_called_once_with("hello")
+    reporter.delete_issue_comment.assert_called_once_with(comment_id=42)
+
+
+def test_upsert_sticky_does_not_delete_when_patch_status_unknown() -> None:
+    """A transport failure must not be treated as actor-mismatch."""
+    reporter = _fresh_reporter()
+    reporter.update_issue_comment_status.return_value = None
 
     posted, live_id = _upsert_sticky(
         reporter=reporter,
@@ -554,8 +572,22 @@ def test_upsert_sticky_returns_false_when_delete_fails() -> None:
 
     assert_that(posted).is_false()
     assert_that(live_id).is_none()
-    reporter.delete_issue_comment.assert_called_once_with(comment_id=42)
+    reporter.delete_issue_comment.assert_not_called()
     reporter.post_issue_comment.assert_not_called()
+
+
+def test_upsert_sticky_posts_replacement_before_deleting() -> None:
+    """Create the new sticky first so a failed POST leaves the old one."""
+    reporter = _fresh_reporter()
+    reporter.update_issue_comment_status.return_value = 403
+    reporter.find_issue_comment.return_value = (99, "hello")
+
+    _upsert_sticky(reporter=reporter, body="hello", comment_id=42)
+
+    names = [call[0] for call in reporter.method_calls]
+    assert_that(names.index("post_issue_comment")).is_less_than(
+        names.index("delete_issue_comment"),
+    )
 
 
 def test_refresh_uses_replacement_id_after_cross_actor_recreate(

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -486,6 +486,60 @@ def test_upsert_sticky_supersedes_when_patch_fails() -> None:
     reporter.find_issue_comment.assert_called_once_with(marker=STICKY_MARKER)
 
 
+@pytest.mark.parametrize(
+    ("status", "should_recreate"),
+    [
+        (403, True),
+        (500, False),
+        (429, False),
+    ],
+    ids=["attr=actor_mismatch", "attr=server_error", "attr=rate_limit"],
+)
+def test_upsert_sticky_supersedes_only_on_actor_mismatch(
+    status: int,
+    should_recreate: bool,
+) -> None:
+    """Only a 403 PATCH (wrong actor) deletes the leftover sticky."""
+    reporter = _fresh_reporter()
+    reporter.update_issue_comment_status.return_value = status
+    reporter.find_issue_comment.return_value = (99, "hello")
+
+    posted, live_id = _upsert_sticky(
+        reporter=reporter,
+        body="hello",
+        comment_id=42,
+    )
+
+    if should_recreate:
+        assert_that(posted).is_true()
+        assert_that(live_id).is_equal_to(99)
+        reporter.delete_issue_comment.assert_called_once_with(comment_id=42)
+        reporter.post_issue_comment.assert_called_once_with("hello")
+    else:
+        assert_that(posted).is_false()
+        assert_that(live_id).is_none()
+        reporter.delete_issue_comment.assert_not_called()
+        reporter.post_issue_comment.assert_not_called()
+
+
+def test_upsert_sticky_retries_post_after_recreate_failure() -> None:
+    """A failed create after DELETE is retried once so state is not dropped."""
+    reporter = _fresh_reporter()
+    reporter.update_issue_comment_status.return_value = 403
+    reporter.post_issue_comment.side_effect = [False, True]
+    reporter.find_issue_comment.return_value = (99, "hello")
+
+    posted, live_id = _upsert_sticky(
+        reporter=reporter,
+        body="hello",
+        comment_id=42,
+    )
+
+    assert_that(posted).is_true()
+    assert_that(live_id).is_equal_to(99)
+    assert_that(reporter.post_issue_comment.call_count).is_equal_to(2)
+
+
 def test_upsert_sticky_returns_false_when_delete_fails() -> None:
     """A failed delete leaves the prior sticky in place and reports failure."""
     reporter = _fresh_reporter()

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -429,9 +429,14 @@ def test_upsert_sticky_creates_when_missing() -> None:
     """A first review posts a new sticky comment."""
     reporter = _fresh_reporter()
 
-    posted = _upsert_sticky(reporter=reporter, body="hello", comment_id=None)
+    posted, live_id = _upsert_sticky(
+        reporter=reporter,
+        body="hello",
+        comment_id=None,
+    )
 
     assert_that(posted).is_true()
+    assert_that(live_id).is_none()
     reporter.post_issue_comment.assert_called_once_with("hello")
     reporter.update_issue_comment.assert_not_called()
     reporter.delete_issue_comment.assert_not_called()
@@ -441,31 +446,44 @@ def test_upsert_sticky_patches_when_update_succeeds() -> None:
     """Same-actor updates edit the sticky in place."""
     reporter = _fresh_reporter()
 
-    posted = _upsert_sticky(reporter=reporter, body="hello", comment_id=42)
+    posted, live_id = _upsert_sticky(
+        reporter=reporter,
+        body="hello",
+        comment_id=42,
+    )
 
     assert_that(posted).is_true()
+    assert_that(live_id).is_equal_to(42)
     reporter.update_issue_comment.assert_called_once_with(
         comment_id=42,
         body="hello",
     )
     reporter.delete_issue_comment.assert_not_called()
     reporter.post_issue_comment.assert_not_called()
+    reporter.find_issue_comment.assert_not_called()
 
 
 def test_upsert_sticky_supersedes_when_patch_fails() -> None:
     """GitHub forbids editing another actor's comment; delete then recreate."""
     reporter = _fresh_reporter()
     reporter.update_issue_comment.return_value = False
+    reporter.find_issue_comment.return_value = (99, "hello")
 
-    posted = _upsert_sticky(reporter=reporter, body="hello", comment_id=42)
+    posted, live_id = _upsert_sticky(
+        reporter=reporter,
+        body="hello",
+        comment_id=42,
+    )
 
     assert_that(posted).is_true()
+    assert_that(live_id).is_equal_to(99)
     reporter.update_issue_comment.assert_called_once_with(
         comment_id=42,
         body="hello",
     )
     reporter.delete_issue_comment.assert_called_once_with(comment_id=42)
     reporter.post_issue_comment.assert_called_once_with("hello")
+    reporter.find_issue_comment.assert_called_once_with(marker=STICKY_MARKER)
 
 
 def test_upsert_sticky_returns_false_when_delete_fails() -> None:
@@ -474,11 +492,49 @@ def test_upsert_sticky_returns_false_when_delete_fails() -> None:
     reporter.update_issue_comment.return_value = False
     reporter.delete_issue_comment.return_value = False
 
-    posted = _upsert_sticky(reporter=reporter, body="hello", comment_id=42)
+    posted, live_id = _upsert_sticky(
+        reporter=reporter,
+        body="hello",
+        comment_id=42,
+    )
+
+    assert_that(posted).is_false()
+    assert_that(live_id).is_none()
+    reporter.delete_issue_comment.assert_called_once_with(comment_id=42)
+    reporter.post_issue_comment.assert_not_called()
+
+
+def test_refresh_uses_replacement_id_after_cross_actor_recreate(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A follow-up refresh must PATCH the recreated sticky, not the deleted id.
+
+    When the App token cannot edit a leftover ``github-actions[bot]`` sticky,
+    upsert deletes and recreates it. The refresh that persists inline-post
+    failure details has to target the replacement id; the deleted id 404s.
+    """
+    reporter = _fresh_reporter()
+    prior_body = build_sticky_comment(result=sample_review_result)
+    reporter.find_issue_comment.side_effect = [
+        (42, prior_body),
+        (99, "replacement"),
+    ]
+    reporter.update_issue_comment.side_effect = [False, True]
+    reporter.api_request.return_value = False
+
+    posted = post_review_to_github(
+        result=sample_review_result,
+        reporter=reporter,
+    )
 
     assert_that(posted).is_false()
     reporter.delete_issue_comment.assert_called_once_with(comment_id=42)
-    reporter.post_issue_comment.assert_not_called()
+    reporter.post_issue_comment.assert_called_once()
+    refresh = reporter.update_issue_comment.call_args_list[1]
+    assert_that(refresh.kwargs["comment_id"]).is_equal_to(99)
+    assert_that(refresh.kwargs["body"]).contains(
+        "could not be posted",
+    )
 
 
 def test_post_review_posts_inline_findings(

--- a/tests/unit/ai/test_github_pr.py
+++ b/tests/unit/ai/test_github_pr.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+import urllib.error
+from email.message import Message
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -248,9 +251,10 @@ def test_find_issue_comment_matches_marker_regardless_of_author(
 ) -> None:
     """Sticky lookup is by marker, so the App-token identity can take over.
 
-    The first ``lintro-review[bot]`` run must PATCH the existing
-    ``github-actions[bot]`` ``<!-- lintro-ai-review -->`` comment instead of
-    posting a second sticky (#2050).
+    The first ``lintro-review[bot]`` run finds the existing
+    ``github-actions[bot]`` ``<!-- lintro-ai-review -->`` comment by marker
+    and then deletes and recreates it — GitHub forbids PATCHing another
+    actor's comment (#2050).
     """
     reporter = GitHubPRReporter(token=test_token, repo="owner/repo", pr_number=5)
 
@@ -292,6 +296,25 @@ def test_find_issue_comment_returns_none_without_match(test_token: str) -> None:
         found = reporter.find_issue_comment(marker="<!-- lintro-ai-review -->")
 
     assert_that(found).is_none()
+
+
+def test_update_issue_comment_status_returns_forbidden(
+    test_token: str,
+) -> None:
+    """Actor-mismatch PATCH surfaces HTTP 403 instead of a bare False."""
+    reporter = GitHubPRReporter(token=test_token, repo="owner/repo", pr_number=5)
+    error = urllib.error.HTTPError(
+        url="https://api.github.com/repos/owner/repo/issues/comments/42",
+        code=403,
+        msg="Forbidden",
+        hdrs=Message(),
+        fp=BytesIO(b"must be the creating actor"),
+    )
+
+    with patch("urllib.request.urlopen", side_effect=error):
+        status = reporter.update_issue_comment_status(comment_id=42, body="new")
+
+    assert_that(status).is_equal_to(403)
 
 
 def test_update_issue_comment_patches(test_token: str) -> None:

--- a/tests/unit/ai/test_github_pr.py
+++ b/tests/unit/ai/test_github_pr.py
@@ -243,6 +243,42 @@ def test_find_issue_comment_matches_marker(test_token: str) -> None:
     assert_that(found_id).is_equal_to(2)
 
 
+def test_find_issue_comment_matches_marker_regardless_of_author(
+    test_token: str,
+) -> None:
+    """Sticky lookup is by marker, so the App-token identity can take over.
+
+    The first ``lintro-review[bot]`` run must PATCH the existing
+    ``github-actions[bot]`` ``<!-- lintro-ai-review -->`` comment instead of
+    posting a second sticky (#2050).
+    """
+    reporter = GitHubPRReporter(token=test_token, repo="owner/repo", pr_number=5)
+
+    page = [
+        {
+            "id": 11,
+            "body": "hello <!-- lintro-ai-review --> world",
+            "user": {"login": "github-actions[bot]", "type": "Bot"},
+        },
+        {
+            "id": 12,
+            "body": "unrelated",
+            "user": {"login": "lintro-review[bot]", "type": "Bot"},
+        },
+    ]
+    mock_response = MagicMock()
+    mock_response.read.return_value = json.dumps(page).encode()
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_response):
+        found = reporter.find_issue_comment(marker="<!-- lintro-ai-review -->")
+
+    assert_that(found).is_not_none()
+    found_id, _body = found or (0, "")
+    assert_that(found_id).is_equal_to(11)
+
+
 def test_find_issue_comment_returns_none_without_match(test_token: str) -> None:
     """find_issue_comment returns None when no comment carries the marker."""
     reporter = GitHubPRReporter(token=test_token, repo="owner/repo", pr_number=5)

--- a/tests/unit/ai/test_github_pr.py
+++ b/tests/unit/ai/test_github_pr.py
@@ -312,6 +312,25 @@ def test_update_issue_comment_patches(test_token: str) -> None:
     assert_that(req.full_url).contains("/issues/comments/42")
 
 
+def test_delete_issue_comment_deletes(test_token: str) -> None:
+    """delete_issue_comment issues a DELETE with no body."""
+    reporter = GitHubPRReporter(token=test_token, repo="owner/repo", pr_number=5)
+
+    mock_response = MagicMock()
+    mock_response.status = 204
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_response) as mock_open:
+        result = reporter.delete_issue_comment(comment_id=42)
+
+    assert_that(result).is_true()
+    req = mock_open.call_args[0][0]
+    assert_that(req.get_method()).is_equal_to("DELETE")
+    assert_that(req.full_url).contains("/issues/comments/42")
+    assert_that(req.data).is_none()
+
+
 # -- TestFormatSummaryComment: Tests for summary comment formatting. ---------
 
 

--- a/tests/unit/ai/test_github_pr.py
+++ b/tests/unit/ai/test_github_pr.py
@@ -317,6 +317,24 @@ def test_update_issue_comment_status_returns_forbidden(
     assert_that(status).is_equal_to(403)
 
 
+def test_create_issue_comment_returns_id(test_token: str) -> None:
+    """create_issue_comment parses the new comment id from a 201 response."""
+    reporter = GitHubPRReporter(token=test_token, repo="owner/repo", pr_number=5)
+    mock_response = MagicMock()
+    mock_response.status = 201
+    mock_response.read.return_value = json.dumps({"id": 99, "body": "hello"}).encode()
+    mock_response.__enter__ = MagicMock(return_value=mock_response)
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_response) as mock_open:
+        comment_id = reporter.create_issue_comment(body="hello")
+
+    assert_that(comment_id).is_equal_to(99)
+    req = mock_open.call_args[0][0]
+    assert_that(req.get_method()).is_equal_to("POST")
+    assert_that(req.full_url).contains("/issues/5/comments")
+
+
 def test_update_issue_comment_patches(test_token: str) -> None:
     """update_issue_comment issues a PATCH to the comment endpoint."""
     reporter = GitHubPRReporter(token=test_token, repo="owner/repo", pr_number=5)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ci): post AI review comments as lintro-review[bot]
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

#2050 — post dogfood AI review comments as `lintro-review[bot]`.

1. SHA-pinned `actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1` (v3.2.0) mints a **repo-scoped** token from org secrets `LINTRO_REVIEW_APP_ID` / `LINTRO_REVIEW_APP_PRIVATE_KEY`. No `owner:` (would mint org-wide). The mint step sets `permission-issues: write` and `permission-pull-requests: write` so the token is not the App's full installation grant.
2. That token is `GITHUB_TOKEN` on the review step only (`--post`). `GH_TOKEN` stays `secrets.GITHUB_TOKEN` so `gh` can still fetch the PR diff with `contents: read`. Inference credentials are unchanged.
3. Sticky lookup stays marker-only (`<!-- lintro-ai-review -->`). GitHub forbids PATCH of another actor's comment, so `_upsert_sticky` PATCHes when it can and otherwise DELETEs then POSTs a replacement. `pr-comment-cleanup.yml` already matches by marker, not author.

This PR cannot self-verify the new identity: `pull_request_target` runs the workflow from `main`. Effect is visible on the next PR after merge. If that next review does not post as `lintro-review[bot]` or fails to replace the old sticky, stop.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #2050

## Details

Follow-up commit `f9a14693` covers the actor-mismatch supersede path and the restricted App-token permissions. Local `tests/unit` + `tests/scripts`: 8993 passed, 85% coverage. Lint: 0 issues (local stylelint `EOVERRIDE` is the known npm yaml pin).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ee5582c-2a96-4c7f-9d1d-80c30656e42d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ee5582c-2a96-4c7f-9d1d-80c30656e42d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request review comment handling so marked comments are recognized regardless of author.
  - Added fallback behavior to replace comments when direct updates are forbidden, with retry support and accurate tracking of replacement comments.
  - Separated permissions for retrieving pull request changes and posting review comments, improving workflow security and reliability.

- **Tests**
  - Added coverage for token permissions, cross-author comments, comment replacement and deletion failures, retries, and refresh handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->