### PR TITLE
fix(ci): mint lintro-review token without contents:read

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -230,6 +230,9 @@ jobs:
         # Repo-scoped installation token (#2050). Default current-repo scope —
         # do not pass `owner:` without `repositories:`. Only the review step
         # below sees `outputs.token`; inference credentials stay separate.
+        # Request only permissions the App installation grants. Asking for
+        # `permission-contents: read` 422s the whole mint when Contents is
+        # not on the install; compare then degrades instead of posting nothing.
         # yamllint disable-line rule:line-length
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -237,7 +240,6 @@ jobs:
           private-key: ${{ secrets.LINTRO_REVIEW_APP_PRIVATE_KEY }}
           permission-issues: write
           permission-pull-requests: write
-          permission-contents: read
 
       - name: Run AI review (posts comment; fails when nothing was reviewed)
         run: scripts/ci/run-ai-review.sh

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -762,7 +762,7 @@ def test_workflow_mints_lintro_review_app_token_for_posting() -> None:
     )
     assert_that(mint_with["permission-issues"]).is_equal_to("write")
     assert_that(mint_with["permission-pull-requests"]).is_equal_to("write")
-    assert_that(mint_with["permission-contents"]).is_equal_to("read")
+    assert_that(mint_with).does_not_contain_key("permission-contents")
     assert_that(mint_with).does_not_contain_key("owner")
     assert_that(mint_with).does_not_contain_key("repositories")
     assert_that(_is_checkout_like_action(mint["uses"])).is_false()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): mint lintro-review token without contents:read
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

The `lintro-review` App installation grants `issues: write` and `pull-requests: write` only. Requesting `permission-contents: read` at mint time 422s the entire token, so AI Review never posts.

Drop that extra permission so mint matches the #2050 install. `GET /compare` may degrade; the sticky still posts. `gh` continues to fetch the PR diff with the workflow `GITHUB_TOKEN`.

`pull_request_target` runs this YAML from `main`, so this PR’s own AI Review will still fail until this lands. After merge, re-run AI Review on #2057 and confirm the sticky is `lintro-review[bot]`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Related #2050
- Related #2057

## Details

Workflow mint `with:` is now only `permission-issues: write` and `permission-pull-requests: write`. Structural test asserts `permission-contents` is absent.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ee5582c-2a96-4c7f-9d1d-80c30656e42d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ee5582c-2a96-4c7f-9d1d-80c30656e42d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

