### PR TITLE
chore(deps): pin lintro-tools digest to 48a00d2 after #1858

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # Built from docker/tools.Dockerfile and published by docker-tools-publish.yml
 # (cosign-signed, SBOM + provenance). Renovate manages the digest bump (#1360).
 # yamllint / hadolint: pin is immutable by digest; tag is informational.
-FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:9a976b39ace2f48c49f2f74ed36c11c673ca0e8985d13233ac0d1ac024fe4582 AS tools
+FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:48a00d2ebe0a992f5d8176e574c6da19bf02030e40ed7185e8fea64397bf363e AS tools
 
 # -----------------------------------------------------------------------------
 # Stage: full — lintro application (default target)

--- a/docker/ai-tools.Dockerfile
+++ b/docker/ai-tools.Dockerfile
@@ -26,7 +26,7 @@
 # =============================================================================
 
 # yamllint / hadolint: pin is immutable by digest; tag is informational.
-FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:9a976b39ace2f48c49f2f74ed36c11c673ca0e8985d13233ac0d1ac024fe4582 AS ai-tools
+FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:48a00d2ebe0a992f5d8176e574c6da19bf02030e40ed7185e8fea64397bf363e AS ai-tools
 
 # Renovate: npm datasource for the two published CLIs, node-version for the
 # runtime. CURSOR_AGENT_VERSION has no Renovate datasource -- Cursor ships the

--- a/tests/unit/test_ai_tools_image.py
+++ b/tests/unit/test_ai_tools_image.py
@@ -26,6 +26,9 @@ _ROOT_DOCKERFILE = _REPO_ROOT / "Dockerfile"
 _INSTALLER = _REPO_ROOT / "scripts" / "utils" / "install-ai-tools.sh"
 _RENOVATE = _REPO_ROOT / "renovate.json"
 _WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
+_LINTRO_TOOLS_FROM = re.compile(
+    r"^FROM ghcr\.io/lgtm-hq/lintro-tools:latest@sha256:([a-f0-9]{64}) AS ",
+)
 
 # Cursor ships the agent CLI only as a tarball behind https://cursor.com/install
 # — no registry, no release feed, and no checksum sidecar — so there is nothing
@@ -80,6 +83,24 @@ def _from_line(*, stage: str) -> str:
     )
 
 
+def _lintro_tools_digest(*, dockerfile: Path) -> str:
+    """Return the digest-pinned lintro-tools FROM digest in *dockerfile*.
+
+    Args:
+        dockerfile: Dockerfile that must contain exactly one lintro-tools pin.
+
+    Returns:
+        The 64-character sha256 digest.
+    """
+    matches = [
+        match.group(1)
+        for line in _read(dockerfile).splitlines()
+        if (match := _LINTRO_TOOLS_FROM.match(line))
+    ]
+    assert_that(matches).is_length(1)
+    return matches[0]
+
+
 def _contract_binaries() -> list[str]:
     return sorted({contract.binary for contract in CLI_CONTRACTS.values()})
 
@@ -120,6 +141,19 @@ def test_ai_tools_image_builds_on_the_pinned_tools_base() -> None:
     assert_that(from_lines[0]).matches(
         r"^FROM ghcr\.io/lgtm-hq/lintro-tools:latest@sha256:[a-f0-9]{64} AS ",
     )
+
+
+def test_root_and_ai_tools_dockerfiles_pin_the_same_lintro_tools_digest() -> None:
+    """The app image and ai-tools base must consume the same tools layer.
+
+    After a manifest bump the drift gate on main has no ``--allow-version-lag``.
+    Pinning two different lintro-tools digests would rebuild one image on
+    current tools and leave the other on the pre-bump layer (#1858).
+    """
+    root_digest = _lintro_tools_digest(dockerfile=_ROOT_DOCKERFILE)
+    ai_digest = _lintro_tools_digest(dockerfile=_AI_TOOLS_DOCKERFILE)
+
+    assert_that(root_digest).is_equal_to(ai_digest)
 
 
 def test_ai_tools_dockerfile_passes_every_arg_to_the_installer() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title:

  ```text
  chore(deps): pin lintro-tools digest to 48a00d2 after #1858
  ```

- Type:
  - [x] chore / ci / style

## What’s Changing

Main `CI - Docker` for `fix(deps): update linting tools (#1858)` failed at **Verify CI image tools against manifest** with exit 1 (not 143). On main there is no `--allow-version-lag`, so the freshly built `py-lintro:latest` still FROMs the pre-bump `lintro-tools` digest `9a976b39`.

Pinned the post-#1858 tools image `sha256:48a00d2ebe0a992f5d8176e574c6da19bf02030e40ed7185e8fea64397bf363e` in `Dockerfile` and `docker/ai-tools.Dockerfile`. Added a lockstep unit test so those two FROM sites cannot drift.

## Evidence

- #1858 main failure (run `31955610516`): 7 version mismatches (hadolint 2.15.1 vs 2.14.0, etc.).
- PR #2066 Docker Integration Tests: `Verified 36 tool(s) against manifest tiers: tools`.
- Main after merge (run `31965558384`): `Verified 36 tool(s) against manifest tiers: tools`.
- `Release - Version PR` on this chore push: success, no version PR opened.

[Unit tests for digest lockstep](https://cursor.com/agents/bc-2ea18646-02ca-4e80-9fac-2958325041f1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_ai_tools_image_pytest.log)

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed

## Related Issues

Related #1858, #2062, #1360, #1511, #1582

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ea18646-02ca-4e80-9fac-2958325041f1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ea18646-02ca-4e80-9fac-2958325041f1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s containerized tooling environment to a newer verified version.
  * Improved consistency between standard and AI-focused build environments.

* **Tests**
  * Added validation to ensure both build environments use the same immutable tooling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->