### PR TITLE
chore(deps): update dependency lgtm-hq/lgtm-ci to v0.63.6

### DIFF
--- a/.github/workflows/auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/auto-rerun-on-infra-failure.yml
@@ -78,12 +78,12 @@ jobs:
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_repository.full_name == github.repository
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       actions: write
       contents: read
     with:
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       # run id/attempt are numbers in the event payload; format() passes them
       # as the strings the reusable workflow inputs expect.
       run-id: ${{ format('{0}', github.event.workflow_run.id) }}

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -624,7 +624,7 @@ jobs:
 
       - name: Dispatch formula update
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/trigger-homebrew-update@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/trigger-homebrew-update@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           formula: lintro
           version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   codeql:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       # Org ruleset (checks-py-lintro): codeql / 🔬 CodeQL Analysis
       job-name: '🔬 CodeQL Analysis'
@@ -38,7 +38,7 @@ jobs:
       build-mode: none
       config-file: .github/codeql/codeql-config.yml
       category: '/language:all'
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       # Full list (v0.50.0+ replace semantics): the reusable passes

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,10 +18,10 @@ concurrency:
 jobs:
   dependency-review:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       fail-on-severity: high
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: scorecard
       # Full list (v0.50.0+ replace semantics): the reusable passes

--- a/.github/workflows/dependency-vuln-gate.yml
+++ b/.github/workflows/dependency-vuln-gate.yml
@@ -101,7 +101,7 @@ jobs:
         # filter true, so infrastructure trouble scans rather than silently
         # skipping the gate.
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/detect-changes@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/detect-changes@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           filters: |
             # Anything that can change the dependency graph the release gate
@@ -172,7 +172,7 @@ jobs:
           steps.changes.outputs.changes == '' ||
           fromJSON(steps.changes.outputs.changes).deps
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/generate-sbom@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/generate-sbom@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           target: .
           target-type: dir
@@ -187,7 +187,7 @@ jobs:
           steps.changes.outputs.changes == '' ||
           fromJSON(steps.changes.outputs.changes).deps
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/scan-vulnerabilities@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/scan-vulnerabilities@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           target: ${{ steps.sbom.outputs.sbom-file }}
           target-type: sbom

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -37,7 +37,7 @@ jobs:
     # (lgtm-ci#300). v0.32.3 left gh unauthenticated and blocked Pages deploy
     # after #974 (see #1227). Pin with the repo-standard v0.52.3 tooling.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       site-root: apps/site/dist
       build-command: bash scripts/ci/site/build.sh
@@ -47,7 +47,7 @@ jobs:
       bundle-manifest: .github/pages-bundle-manifest.json
       commit-sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       fallback-ref: main
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       # Since lgtm-ci v0.50.0 the enforcing harden-runner step runs before
       # preset resolution, and harden-runner splits allowed-endpoints on
       # spaces, so the reusable's newline-separated per-job defaults collapse

--- a/.github/workflows/docker-ai-tools-publish.yml
+++ b/.github/workflows/docker-ai-tools-publish.yml
@@ -57,7 +57,7 @@ jobs:
   ai-tools-image:
     name: 🤖 Lintro AI Tools Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       packages: write # push image, cache, and staging tags to GHCR
@@ -93,7 +93,7 @@ jobs:
       cosign-sign: true
       scan: true
       scan-exit-code: '0'
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: docker
       # Full list (v0.50.0+ replace semantics): the reusable passes

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -96,7 +96,7 @@ jobs:
     # Base image (tools layer) publishes before full; a full-image failure must
     # not block repairing py-lintro-base tags during backfill dispatch.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       packages: write
@@ -144,7 +144,7 @@ jobs:
       provenance: false
       sbom: false
       cosign-sign: true
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: docker
       # Shared allowlist, maintained once in
@@ -165,7 +165,7 @@ jobs:
       needs.resolve-endpoints.result == 'success' &&
       needs.docker-base.result == 'success'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       packages: write
@@ -213,7 +213,7 @@ jobs:
       provenance: false
       sbom: false
       cosign-sign: true
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: docker
       # Shared allowlist, maintained once in
@@ -242,7 +242,7 @@ jobs:
       needs.resolve-endpoints.result == 'success' &&
       needs.docker-full.result == 'success'
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       packages: write
@@ -290,7 +290,7 @@ jobs:
       provenance: false
       sbom: false
       cosign-sign: true
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: docker
       # Shared allowlist, maintained once in

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -111,7 +111,7 @@ jobs:
         id: detect
         if: github.event_name == 'pull_request'
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/detect-changes@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/detect-changes@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           # Pipeline relevance is NOT decided here (#1369): the resolve
           # step below computes it deny-by-default from the changed-file
@@ -484,12 +484,12 @@ jobs:
         needs.manifest-sync.result == 'skipped'
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: '🛠️ Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,semgrep:timeout=600,osv_scanner:check_suppressions=false
@@ -742,12 +742,12 @@ jobs:
         needs.manifest-sync.result == 'skipped'
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: '🛠️ Dogfooding Lint (retry)'
       lintro-tool-options: >-
         pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,semgrep:timeout=600,osv_scanner:check_suppressions=false
@@ -870,7 +870,7 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.draft == false
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       pull-requests: write # post lintro results as PR comment
@@ -884,7 +884,7 @@ jobs:
           needs.dogfooding_lint_retry.outputs.exit-code
         )
         || needs.dogfooding-lint.outputs.exit-code }}
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: '🛠️ Dogfooding Lint PR Comment'
       egress-policy: block
 
@@ -904,11 +904,11 @@ jobs:
         github.event.pull_request.draft == false
       )
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
     with:
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: '🛠️ Lintro Code Quality'
       runner-image: ubuntu-24.04
       # Consumes the rolled-up gate verdict (#1313), which itself mirrors
@@ -1000,7 +1000,7 @@ jobs:
           github.event_name == 'pull_request'
         continue-on-error: true
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/post-pr-comment@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           file: security-audit-comment.txt
           marker: security-audit-report

--- a/.github/workflows/docker-tools-publish.yml
+++ b/.github/workflows/docker-tools-publish.yml
@@ -61,7 +61,7 @@ jobs:
   tools-image:
     name: 🐳 Lintro Tools Image
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       packages: write # push image, cache, and staging tags to GHCR
@@ -95,7 +95,7 @@ jobs:
       cosign-sign: true
       scan: true
       scan-exit-code: '0'
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: docker
       # Full list (v0.50.0+ replace semantics): the reusable passes

--- a/.github/workflows/dogfood-nightly.yml
+++ b/.github/workflows/dogfood-nightly.yml
@@ -29,12 +29,12 @@ jobs:
     # Same reusable workflow and tool options as the docker-ci.yml full run
     # (dogfooding-lint) so nightly coverage matches the pre-merge gate.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
       packages: read # pull lintro-image from GHCR in reusable-quality-lint
     with:
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: '🌙 Nightly Dogfooding Lint'
       lintro-tool-options: >-
         pydoclint:timeout=120,bandit:timeout=120,prettier:timeout=120,mypy:timeout=120,semgrep:timeout=600,osv_scanner:check_suppressions=false
@@ -189,11 +189,11 @@ jobs:
     # first failure opens `fix(ci): main workflow failed: dogfood-nightly`,
     # repeat failures comment on the open issue instead of piling up.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-main-failure-notifier.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-main-failure-notifier.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       actions: read # read workflow/job metadata for the failure context
       contents: read # repository context for the issue body
       issues: write # open or ping the deduplicated failure issue
     with:
       workflow-key: dogfood-nightly
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -46,7 +46,7 @@ permissions: {}
 jobs:
   prune-untagged:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read # checkout repo and lgtm-ci tooling sparse checkout
       packages: write # delete untagged GHCR package versions via Packages API
@@ -55,7 +55,7 @@ jobs:
       min-age-days: >-
         ${{ github.event_name != 'workflow_dispatch' && 7 || inputs.min_age_days }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       # Full list (v0.50.0+ replace semantics): the reusable passes
@@ -161,7 +161,7 @@ jobs:
 
   prune-untagged-base:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read # checkout repo and lgtm-ci tooling sparse checkout
       packages: write # delete untagged GHCR package versions via Packages API
@@ -170,7 +170,7 @@ jobs:
       min-age-days: >-
         ${{ github.event_name != 'workflow_dispatch' && 7 || inputs.min_age_days }}
       dry-run: ${{ inputs.dry_run == true }}
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       # Full list (v0.50.0+ replace semantics): the reusable passes

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,10 +12,10 @@ permissions: {}
 jobs:
   assign:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-auto-assign.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       codeowners-path: .github/CODEOWNERS
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,11 +12,11 @@ permissions: {}
 jobs:
   label:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-pr-labeler.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       configuration-path: .github/labeler.yml
       sync-labels: false
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/publish-pypi-on-tag.yml
+++ b/.github/workflows/publish-pypi-on-tag.yml
@@ -65,7 +65,7 @@ jobs:
     name: Generate and verify SBOM
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       target: .
       target-type: dir
@@ -75,7 +75,7 @@ jobs:
       # Remediation landed in #1126; Dependabot shows no open high alerts.
       fail-on-severity: high
       create-attestation: true
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: sbom
     permissions:
@@ -98,14 +98,14 @@ jobs:
       github.ref_type == 'tag' &&
       !startsWith(github.ref_name, 'actions-v')
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
     with:
       python-version: '3.14'
       artifact-name: python-dist
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: pypi
       # Full list (v0.50.0+ replace semantics): the reusable passes
@@ -171,11 +171,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+          tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       - name: Upload to PyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
@@ -194,14 +194,14 @@ jobs:
     needs: [pypi-upload]
     if: ${{ !startsWith(github.ref_name, 'actions-v') }}
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       # write: create GitHub Release and upload dist assets
       contents: write
     with:
       artifact-name: python-dist
       generate-release-notes: true
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
       # Full list (v0.50.0+ replace semantics): the reusable passes

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -18,7 +18,7 @@ jobs:
   pypi-build:
     name: Build Python distribution
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       # read: checkout and build sdist/wheel (reusable-build-python-dist)
       contents: read
@@ -27,7 +27,7 @@ jobs:
       verify-tag-version: false
       ensure-tag-on-default-branch: false
       artifact-name: python-dist
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: pypi
       # Full list (v0.50.0+ replace semantics): the reusable passes
@@ -94,11 +94,11 @@ jobs:
       - name: Prepare PyPI upload
         id: prepare
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/prepare-pypi-upload@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           artifact-name: python-dist
           python-version: '3.14'
-          tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+          tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       - name: Upload to TestPyPI
         # yamllint disable-line rule:line-length
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -23,10 +23,10 @@ concurrency:
 jobs:
   auto-tag:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       create-release: false
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       # Paired with release-version-pr.yml (egress-preset: pypi).
       # Guarded by test_release_workflows_use_paired_egress_presets.

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   version-pr:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       ecosystems: python
       auto-merge: true
@@ -35,7 +35,7 @@ jobs:
       # line so minor/major bumps do not go stale and block the unattended
       # release PR (#1372). Logic lives in dedicated scripts, not inline runs.
       version-update-script: scripts/ci/finalize-version-pr.py
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       # Paired with release-auto-tag.yml (egress-preset: github-tooling).
       # Guarded by test_release_workflows_use_paired_egress_presets.

--- a/.github/workflows/release-version-skew-audit.yml
+++ b/.github/workflows/release-version-skew-audit.yml
@@ -89,11 +89,11 @@ jobs:
     # first failure opens `fix(ci): main workflow failed: release-version-skew`,
     # repeat failures comment on it instead of piling up one issue per run.
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-main-failure-notifier.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-main-failure-notifier.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       actions: read # read workflow/job metadata for the failure context
       contents: read # repository context for the issue body
       issues: write # open or ping the deduplicated failure issue
     with:
       workflow-key: release-version-skew
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           fetch-depth: 1
           persist-credentials: true

--- a/.github/workflows/sbom-on-main.yml
+++ b/.github/workflows/sbom-on-main.yml
@@ -17,14 +17,14 @@ concurrency:
 jobs:
   sbom:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       target: .
       target-type: dir
       sbom-format: cyclonedx-json
       scan-vulnerabilities: true
       create-attestation: true
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: sbom
     permissions:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   scorecards:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-scorecards.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       # v0.52.4 drops lgtm-ci composites from this job so scorecard-action
       # publish_results passes workflow verification (#518, lgtm-ci #535).

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -18,11 +18,11 @@ concurrency:
 jobs:
   semantic-title:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       # Org ruleset (checks-py-lintro): semantic-title / 📝 Validate PR Title
       job-name: '📝 Validate PR Title'
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -59,18 +59,18 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           python-version: '3.12'
           install-dependencies: false
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           node-version: '24'
           working-directory: apps/site
@@ -89,7 +89,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: 9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+          ref: 396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -153,18 +153,18 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           python-version: '3.12'
           install-dependencies: false
 
       - name: Setup Node and Bun
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-node@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           node-version: '24'
           working-directory: apps/site

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -43,7 +43,7 @@ jobs:
   # Compat mode: multi-runtime matrix, no coverage or PR comments
   test-compat:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       publish-test-summary: false
       python-versions: '3.11,3.14'
@@ -54,7 +54,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: pypi
       # Full list (v0.50.0+ replace semantics): the reusable passes
@@ -83,7 +83,7 @@ jobs:
   # Coverage mode: single runtime with coverage reporting
   test-coverage:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
       publish-test-summary: true
       python-version: '3.14'
@@ -96,7 +96,7 @@ jobs:
       draft-pr-skip: true
       job-name: Python Coverage
       runner-image: ubuntu-24.04
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: pypi
       # Full list (v0.50.0+ replace semantics): the reusable passes
@@ -158,11 +158,11 @@ jobs:
     needs: test-gate
     if: always()
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: read
     with:
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       job-name: '🧪 Test Suite & Coverage'
       runner-image: ubuntu-24.04
       upstream-result: ${{ needs.test-gate.outputs.result }}
@@ -205,11 +205,11 @@ jobs:
 
       - name: Checkout
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/secure-checkout@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
 
       - name: Setup Python and uv
         # yamllint disable-line rule:line-length
-        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+        uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
         with:
           python-version: '3.14'
           install-dependencies: 'true'

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -22,9 +22,9 @@ concurrency:
 jobs:
   validate:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     with:
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       egress-policy: block
       egress-preset: github-tooling
     permissions:

--- a/.github/workflows/vuln-suppression-check.yml
+++ b/.github/workflows/vuln-suppression-check.yml
@@ -18,13 +18,13 @@ concurrency:
 jobs:
   check-suppressions:
     # yamllint disable-line rule:line-length
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@9c92a06c66cbce667a043eb532e1e54537369bc1 # v0.63.2
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@396e1e28f14d371761558178e75be9c56cc994cf # v0.63.6
     permissions:
       contents: write # commit auto-remediation suppressions on default branch
       pull-requests: write # open PRs for stale/expired suppressions
     with:
       job-name: '🔍 Check Vulnerability Suppressions'
-      tooling-ref: '9c92a06c66cbce667a043eb532e1e54537369bc1' # v0.63.2
+      tooling-ref: '396e1e28f14d371761558178e75be9c56cc994cf' # v0.63.6
       workflow-file: vuln-suppression-check.yml
       install-script: scripts/ci/security/install-osv-scanner.sh
       check-script: scripts/ci/security/check-vuln-suppressions.sh


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Bumps all 27 lgtm-ci workflow pins from v0.63.2 (`9c92a06c`) to v0.63.6 (`396e1e28`) — `uses:` refs and `tooling-ref:` inputs together.

This pulls in **lgtm-ci#866**, which fixes the failure that has turned the `sbom / SBOM & Supply Chain` job red on **every merge to main since v0.63.2 landed** (#2068): lgtm-ci's v0.63.2 syft bump (1.42.3 → 1.51.0) started emitting CycloneDX 1.7 SBOMs, which the grype v0.110.0 bundled by scan-action cannot parse (`unable to decode sbom: sbom format not recognized`). The `scan-vulnerabilities` action now pins grype v0.117.0 (≥ v0.115.0 is the CycloneDX 1.7 floor) for both the scan and SARIF steps.

Also included from v0.63.4–v0.63.6: auto-rerun max-reruns raised to 3 for runner-kill streaks (lgtm-ci#862), shell-tests log-noise reduction (lgtm-ci#863), and resource-monitor samples teed into the live job log (lgtm-ci#857).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (pins-only change; covered by lgtm-ci contract tests)
- [ ] Docs updated if user-facing (not user-facing)
- [x] Local CI passed (full pytest suite: 9668 passed, 120 skipped; 3 excluded for local-env breakage unrelated to this change)

## Related Issues

Related lgtm-hq/lgtm-ci#865, lgtm-hq/lgtm-ci#867

## Details

Verification plan: the `sbom / SBOM & Supply Chain` job on this PR / on main after merge is the end-to-end proof — it exercises the real syft 1.51.0 → grype v0.117.0 path that has been failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated build, test, release, deployment, security, and maintenance workflows to the latest tooling release.
  - Improved consistency and reliability across continuous integration and delivery processes.
  - Preserved existing workflow settings and behavior while refreshing pinned workflow components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->