### PR TITLE
chore(deps): update ghcr.io/lgtm-hq/lintro-tools:latest docker digest to fde87fd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # Built from docker/tools.Dockerfile and published by docker-tools-publish.yml
 # (cosign-signed, SBOM + provenance). Renovate manages the digest bump (#1360).
 # yamllint / hadolint: pin is immutable by digest; tag is informational.
-FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:96992b5c1dfa15bd137fff9615b5c51abc81aed415b2c7f432bd9dba6cb06a7b AS tools
+FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:fde87fd20366c6a813404c0c0d2570db2d253fd28091e46edc1a34aa554b4bd1 AS tools
 
 # -----------------------------------------------------------------------------
 # Stage: full — lintro application (default target)

--- a/docker/ai-tools.Dockerfile
+++ b/docker/ai-tools.Dockerfile
@@ -26,7 +26,7 @@
 # =============================================================================
 
 # yamllint / hadolint: pin is immutable by digest; tag is informational.
-FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:96992b5c1dfa15bd137fff9615b5c51abc81aed415b2c7f432bd9dba6cb06a7b AS ai-tools
+FROM ghcr.io/lgtm-hq/lintro-tools:latest@sha256:fde87fd20366c6a813404c0c0d2570db2d253fd28091e46edc1a34aa554b4bd1 AS ai-tools
 
 # Renovate: npm datasource for the two published CLIs, node-version for the
 # runtime. CURSOR_AGENT_VERSION has no Renovate datasource -- Cursor ships the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(deps): update ghcr.io/lgtm-hq/lintro-tools:latest docker digest to fde87fd
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Pin the app and AI images to the `lintro-tools` image published after #2087 so the baked `osv-scanner` binary is **2.5.1**, matching `lintro/tools/manifest.json`.

#2087 updated the manifest while Dockerfiles still pinned `96992b5` (#2086, osv-scanner 2.5.0). `verify-image-manifest-tools.sh` on `main` has no `--allow-version-lag`, so docker-ci on `main` and every follow-up PR fails with:

```text
osv_scanner: version mismatch (expected 2.5.1, got 2.5.0)
```

The replacement digest is `sha256:fde87fd20366c6a813404c0c0d2570db2d253fd28091e46edc1a34aa554b4bd1` (`latest` / `main` / `sha-0f0c1eb` from [tools-image publish](https://github.com/lgtm-hq/py-lintro/actions/runs/32072514801)).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated (`tests/unit/test_ai_tools_image.py` still requires both Dockerfiles to share the digest)
- [x] Docs updated if user-facing
- [x] Local `uv run pytest tests/unit/test_ai_tools_image.py` passed

## Related Issues

Fixes #2092
Related #1511 #1582 #1360 #2086 #2087

## Details

This is the same Renovate digest bump that would normally follow a tools-image publish. Landing it first unblocks `main` docker-ci and the rest of the merge queue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f9639ed-7837-4ad6-b65a-760b0288e5ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f9639ed-7837-4ad6-b65a-760b0288e5ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container tooling image to a newer pinned version.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->