### PR TITLE
fix(ci): always run Python tests so bump PRs report required checks

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -37,7 +37,8 @@ name: CI - Docker
 # "version-bump PR". Only the pull_request run is skipped: the merge push
 # to main still builds and publishes (digest promotion, #1358/#1368), and
 # the release-auto-tag → publish-pypi-on-tag chain is untouched. test-ci.yml
-# skips its matrix on verified bump PRs the same way (#1359 pipeline-skip).
+# still runs the Python matrix on bump PRs so nested required names report
+# (#2108); Docker keeps path-skip because its required checks use static names.
 #
 # Dogfooding lint scope (#1361): the `changes` job also maps the diff to a
 # `full-lint` filter (paths with global lint impact — tool configs, the

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -13,8 +13,8 @@ name: CI - Tests
 #
 # Instead: a `changes` job classifies the PR diff (same deny-by-default
 # skip-list as docker-ci.yml via resolve-pipeline-relevance.sh) and the reusable
-# callers always run (`if: '!cancelled()'` fail-open on classifier failure —
-# empty pipeline != 'false' → full matrix). merge_group, push, and
+# callers always run (`if: '!cancelled()'` fail-open on classifier failure).
+# merge_group, push, and
 # workflow_dispatch always run the full matrix. The test-suite-coverage gate
 # always mirrors test-gate: the Python matrix no longer path-skips (#2108), so
 # a pipeline=false shortcut would false-green a required check while tests

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -16,8 +16,9 @@ name: CI - Tests
 # callers always run (`if: '!cancelled()'` fail-open on classifier failure —
 # empty pipeline != 'false' → full matrix). merge_group, push, and
 # workflow_dispatch always run the full matrix. The test-suite-coverage gate
-# reports success only when changes succeeded and the matrix was path-skipped;
-# otherwise it mirrors test-gate.
+# always mirrors test-gate: the Python matrix no longer path-skips (#2108), so
+# a pipeline=false shortcut would false-green a required check while tests
+# actually ran and failed.
 #
 # Do NOT pass pipeline-skip=true to these Python reusables (#2108). When
 # reusable-test-python skips its `test` job via `if: !inputs.pipeline-skip`,
@@ -223,11 +224,8 @@ jobs:
           fi
 
   # Org ruleset (checks-py-lintro): test-suite-coverage / 🧪 Test Suite & Coverage
-  # Always-green gate: reports success only when changes succeeded AND the
-  # matrix was intentionally path-skipped (pipeline == 'false'). A failed
-  # changes job never takes the success shortcut — empty pipeline fails open
-  # into the full matrix via !cancelled() on the reusable callers, and this
-  # gate mirrors test-gate.
+  # Mirrors test-gate. Do not shortcut on pipeline=false: the Python matrix
+  # always runs (#2108), so a skip-shaped success would hide a real failure.
   test-suite-coverage:
     needs: [changes, test-gate]
     if: always() && !cancelled()
@@ -239,18 +237,8 @@ jobs:
       tooling-ref: 'f8ce689b2453b7520a41b617d1a72051bfb1c1c0' # v0.63.7
       job-name: '🧪 Test Suite & Coverage'
       runner-image: ubuntu-24.04
-      upstream-result: >-
-        ${{
-          needs.changes.result == 'success' &&
-          needs.changes.outputs.pipeline == 'false' && 'success'
-          || needs.test-gate.outputs.result
-        }}
-      passed-output: >-
-        ${{
-          needs.changes.result == 'success' &&
-          needs.changes.outputs.pipeline == 'false' && 'true'
-          || needs.test-gate.outputs.passed
-        }}
+      upstream-result: ${{ needs.test-gate.outputs.result }}
+      passed-output: ${{ needs.test-gate.outputs.passed }}
       egress-policy: block
       egress-preset: github-tooling
 

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -14,16 +14,24 @@ name: CI - Tests
 # Instead: a `changes` job classifies the PR diff (same deny-by-default
 # skip-list as docker-ci.yml via resolve-pipeline-relevance.sh) and the reusable
 # callers always run (`if: '!cancelled()'` fail-open on classifier failure —
-# empty pipeline != 'false' → full matrix), passing pipeline-skip=true when
-# pipeline=false so jobs skip INSIDE the reusable and still report their nested
-# contexts as skipped (lgtm-ci reusable-test-python pipeline-skip input).
-# merge_group, push, and workflow_dispatch always run the full matrix. The
-# test-suite-coverage gate reports success only when changes succeeded and the
-# matrix was path-skipped; otherwise it mirrors test-gate.
+# empty pipeline != 'false' → full matrix). merge_group, push, and
+# workflow_dispatch always run the full matrix. The test-suite-coverage gate
+# reports success only when changes succeeded and the matrix was path-skipped;
+# otherwise it mirrors test-gate.
 #
-# Version-bump PRs (#1362): release-bump-only.sh can force pipeline=false on
-# verified bump PRs, so the matrix skips exactly like docs-only PRs once
-# pipeline-skip is wired (previously blocked on the nested-context constraint).
+# Do NOT pass pipeline-skip=true to these Python reusables (#2108). When
+# reusable-test-python skips its `test` job via `if: !inputs.pipeline-skip`,
+# GitHub never interpolates `name: ${{ inputs.job-name }}` and records the
+# check as `test-compat / inputs.job-name` instead of the org-required
+# `test-compat / Python Compatibility` (same for Python Coverage). Version-bump
+# PR #2106 deadlocked on those two missing contexts; admin merge cannot bypass
+# them. Re-enable pipeline-skip here only after lgtm-ci always-runs a job whose
+# published name is the interpolated job-name. Docker CI can still path-skip:
+# its required checks use static always-green names and already report.
+#
+# Version-bump PRs (#1362): release-bump-only.sh can still force pipeline=false
+# so Docker/dogfood skip; the Python matrix still runs so the nested required
+# names exist.
 
 'on':
   push:
@@ -88,8 +96,7 @@ jobs:
 
   # Compat mode: multi-runtime matrix, no coverage or PR comments.
   # !cancelled() fail-opens like docker-ci docker-build: a failed changes
-  # job leaves pipeline empty (!= 'false'), so pipeline-skip is false and
-  # the full matrix runs instead of collapsing to skipped → false green.
+  # job must not skip this caller. pipeline-skip is hard-false (#2108).
   test-compat:
     needs: [changes]
     if: '!cancelled()'
@@ -103,7 +110,8 @@ jobs:
       extra-args: '-x --ignore=tests/integration'
       coverage: false
       draft-pr-skip: true
-      pipeline-skip: ${{ needs.changes.outputs.pipeline == 'false' }}
+      # Hard-false: see file-header note on #2108 / interpolated job names.
+      pipeline-skip: false
       job-name: Python Compatibility
       runner-image: ubuntu-24.04
       tooling-ref: 'f8ce689b2453b7520a41b617d1a72051bfb1c1c0' # v0.63.7
@@ -151,7 +159,8 @@ jobs:
       coverage-threshold: 80
       upload-coverage: true
       draft-pr-skip: true
-      pipeline-skip: ${{ needs.changes.outputs.pipeline == 'false' }}
+      # Hard-false: see file-header note on #2108 / interpolated job names.
+      pipeline-skip: false
       job-name: Python Coverage
       runner-image: ubuntu-24.04
       tooling-ref: 'f8ce689b2453b7520a41b617d1a72051bfb1c1c0' # v0.63.7

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -827,7 +827,7 @@ def test_test_ci_changes_job_resolves_pipeline_relevance() -> None:
     )
 
 
-def test_test_ci_reusables_wire_pipeline_skip() -> None:
+def test_test_ci_reusables_never_path_skip() -> None:
     """Reusable callers fail-open on changes failure and never path-skip.
 
     ``if: '!cancelled()'`` mirrors docker-ci's docker-build gate: a failed

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -840,12 +840,17 @@ def test_test_ci_reusables_wire_pipeline_skip() -> None:
     equivalent), which deadlocks version-bump merges. Re-enable only when
     that reusable interpolates the skipped job name.
     """
+    expected_job_names = {
+        "test-compat": "Python Compatibility",
+        "test-coverage": "Python Coverage",
+    }
     test_ci = _load_workflow(name="test-ci.yml")
-    for job_name in ("test-compat", "test-coverage"):
+    for job_name, published_name in expected_job_names.items():
         job = test_ci["jobs"][job_name]
         assert_that(job["needs"]).contains("changes")
         assert_that(job["if"]).is_equal_to("!cancelled()")
         assert_that(job["with"]["pipeline-skip"]).is_false()
+        assert_that(job["with"]["job-name"]).is_equal_to(published_name)
 
 
 def test_test_ci_suite_coverage_gate_mirrors_test_gate() -> None:

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -828,20 +828,24 @@ def test_test_ci_changes_job_resolves_pipeline_relevance() -> None:
 
 
 def test_test_ci_reusables_wire_pipeline_skip() -> None:
-    """Reusable callers fail-open on changes failure and wire pipeline-skip.
+    """Reusable callers fail-open on changes failure and never path-skip.
 
     ``if: '!cancelled()'`` mirrors docker-ci's docker-build gate: a failed
-    changes job must still run the matrix (empty pipeline != 'false' →
-    pipeline-skip false) instead of collapsing to skipped → false green.
+    changes job must still run the matrix (empty pipeline != 'false')
+    instead of collapsing to skipped → false green.
+
+    ``pipeline-skip`` stays hard-false (#2108): lgtm-ci's skipped ``test``
+    job publishes as ``test-compat / inputs.job-name`` rather than the
+    org-required ``test-compat / Python Compatibility`` (and the coverage
+    equivalent), which deadlocks version-bump merges. Re-enable only when
+    that reusable interpolates the skipped job name.
     """
     test_ci = _load_workflow(name="test-ci.yml")
     for job_name in ("test-compat", "test-coverage"):
         job = test_ci["jobs"][job_name]
         assert_that(job["needs"]).contains("changes")
         assert_that(job["if"]).is_equal_to("!cancelled()")
-        assert_that(job["with"]["pipeline-skip"]).is_equal_to(
-            "${{ needs.changes.outputs.pipeline == 'false' }}",
-        )
+        assert_that(job["with"]["pipeline-skip"]).is_false()
 
 
 def test_test_ci_suite_coverage_gate_is_always_green_when_path_skipped() -> None:

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -848,31 +848,24 @@ def test_test_ci_reusables_wire_pipeline_skip() -> None:
         assert_that(job["with"]["pipeline-skip"]).is_false()
 
 
-def test_test_ci_suite_coverage_gate_is_always_green_when_path_skipped() -> None:
-    """Required gate greens only on intentional path-skip after changes success.
+def test_test_ci_suite_coverage_gate_mirrors_test_gate() -> None:
+    """Required coverage gate mirrors test-gate with no pipeline=false shortcut.
 
-    A failed changes job must never take the success shortcut — even if
-    pipeline were somehow empty/false — and must mirror test-gate instead.
+    The Python matrix always runs (#2108), so a path-skip success shortcut
+    would false-green this required check while tests actually failed.
     """
     test_ci = _load_workflow(name="test-ci.yml")
     gate = test_ci["jobs"]["test-suite-coverage"]
 
-    assert_that(gate["needs"]).contains("changes", "test-gate")
-    upstream = _normalize_github_expr(gate["with"]["upstream-result"])
-    assert_that(upstream).is_equal_to(
-        _normalize_github_expr(
-            "${{ needs.changes.result == 'success' && "
-            "needs.changes.outputs.pipeline == 'false' && 'success' "
-            "|| needs.test-gate.outputs.result }}",
-        ),
+    assert_that(gate["needs"]).contains(
+        "changes",
+        "test-gate",
     )
-    passed_output = _normalize_github_expr(gate["with"]["passed-output"])
-    assert_that(passed_output).is_equal_to(
-        _normalize_github_expr(
-            "${{ needs.changes.result == 'success' && "
-            "needs.changes.outputs.pipeline == 'false' && 'true' "
-            "|| needs.test-gate.outputs.passed }}",
-        ),
+    assert_that(gate["with"]["upstream-result"]).is_equal_to(
+        "${{ needs.test-gate.outputs.result }}",
+    )
+    assert_that(gate["with"]["passed-output"]).is_equal_to(
+        "${{ needs.test-gate.outputs.passed }}",
     )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): always run Python tests so bump PRs report required checks
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Version-bump PRs such as #2106 cannot merge: the org ruleset waits for
`test-compat / Python Compatibility` and `test-coverage / Python Coverage`,
which never report when `pipeline-skip=true`.

lgtm-ci `reusable-test-python` skips its `test` job via `if: !inputs.pipeline-skip`.
GitHub then publishes the skipped check as `test-compat / inputs.job-name` instead
of interpolating `job-name`. Admin merge cannot bypass the missing required
contexts.

This PR stops passing `pipeline-skip: true` to the Python test reusables so those
nested names always exist. Docker CI keeps path-skip (its required checks use
static always-green names and already report on bump PRs).

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run pytest tests/unit/test_workflow_wiring.py` and `uv run lintro chk` on the touched files)

## Related Issues

Closes #2112
Fixes #2108
Related #2106
Related #1386
Related #1362

## Details

Durable fix belongs in lgtm-ci: always-run a job whose published name is the
interpolated `job-name` and no-op when `pipeline-skip` is set. Until then,
always running the Python matrix is the py-lintro-side unblocker.

This is in front of the #2106 → #2102 merge queue because #2106 is otherwise
permanently blocked.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d316f2c1-ba08-47ed-a4c7-c69169831efe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d316f2c1-ba08-47ed-a4c7-c69169831efe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured compatibility and coverage checks run the complete test matrix.
  - Preserved required check names when change detection encounters an error.
  - Prevented skipped pipelines from incorrectly reporting successful coverage results.
  - Ensured coverage status accurately mirrors the main test-gate result.
  - Retained appropriate path-based skipping for Docker checks.

- **Tests**
  - Updated workflow validation to confirm reusable test jobs remain fully enabled and report required checks consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->