### PR TITLE
refactor(mcp): migrate to mcp SDK 2.x and drop the 1.x implementation

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -4,8 +4,8 @@ Lintro can expose tools to MCP-compatible agents over **stdio**.
 
 ## Install
 
-The MCP server depends on the optional Python `mcp` SDK, kept out of the base install so
-the CLI stays light:
+The MCP server depends on the optional Python `mcp` SDK **2.x** (`mcp>=2,<3`), kept out
+of the base install so the CLI stays light:
 
 ```bash
 uv pip install 'lintro[mcp]'
@@ -381,10 +381,12 @@ Synchronous handlers run in a worker thread, and every call is bounded by the sp
 ## Errors
 
 Every tool-call failure — unknown tool, bad arguments, workspace escape, handler crash
-or timeout — comes back as `isError: true` with the same envelope in both
-`structuredContent` and the JSON text content. The envelope is nested under `error`, the
-same outer key `lintro review --output json` uses for its (differently shaped)
-provider-failure body, so it can never be confused with a tool's own successful payload:
+or timeout — comes back as a tool-level error (`isError: true` on the JSON-RPC wire;
+Python SDK 2.x exposes that as `is_error`) with the same envelope in both
+`structuredContent` (`structured_content` in the SDK) and the JSON text content. The
+envelope is nested under `error`, the same outer key `lintro review --output json` uses
+for its (differently shaped) provider-failure body, so it can never be confused with a
+tool's own successful payload:
 
 ```json
 {

--- a/lintro/mcp/server.py
+++ b/lintro/mcp/server.py
@@ -10,8 +10,6 @@ functions that need them so importing :mod:`lintro.mcp` — which the ``doctor``
 command and the CLI do — never pulls the optional stack.
 """
 
-# mypy: disable-error-code="untyped-decorator,no-untyped-call"
-
 from __future__ import annotations
 
 import inspect
@@ -19,7 +17,7 @@ import json
 from collections.abc import Callable
 from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
@@ -27,6 +25,9 @@ from lintro.mcp.enums.mcp_error_code import McpErrorCode
 from lintro.mcp.errors import McpError, McpErrorEnvelope
 from lintro.mcp.registry import McpToolRegistry, McpToolSpec
 from lintro.mcp.validation import resolve_path_arguments, validate_arguments
+
+if TYPE_CHECKING:
+    from mcp.types import CallToolResult
 
 __all__ = [
     "build_default_registry",
@@ -106,22 +107,22 @@ def build_default_registry(*, workspace: Path) -> McpToolRegistry:
     return registry
 
 
-def _error_result(*, envelope: McpErrorEnvelope) -> Any:
-    """Build an MCP ``CallToolResult`` marking a structured error.
+def _tool_result(*, payload: dict[str, Any], is_error: bool) -> CallToolResult:
+    """Build an MCP ``CallToolResult`` from a JSON object payload.
 
     Args:
-        envelope: The structured error to report.
+        payload: Structured content to return to the client.
+        is_error: Whether this is a tool-level error (not a JSON-RPC error).
 
     Returns:
-        A ``mcp.types.CallToolResult`` with ``isError`` set, carrying the
-        envelope as both structured content and JSON text.
+        A ``mcp.types.CallToolResult`` carrying the payload as both
+        structured content and JSON text.
     """
     import mcp.types as types
 
-    payload = envelope.to_payload()
     return types.CallToolResult(
-        isError=True,
-        structuredContent=payload,
+        is_error=is_error,
+        structured_content=payload,
         content=[
             types.TextContent(
                 type="text",
@@ -129,6 +130,19 @@ def _error_result(*, envelope: McpErrorEnvelope) -> Any:
             ),
         ],
     )
+
+
+def _error_result(*, envelope: McpErrorEnvelope) -> CallToolResult:
+    """Build an MCP ``CallToolResult`` marking a structured error.
+
+    Args:
+        envelope: The structured error to report.
+
+    Returns:
+        A ``mcp.types.CallToolResult`` with ``is_error`` set, carrying the
+        envelope as both structured content and JSON text.
+    """
+    return _tool_result(payload=envelope.to_payload(), is_error=True)
 
 
 async def _dispatch(*, spec: McpToolSpec, arguments: dict[str, Any]) -> Any:
@@ -188,10 +202,11 @@ def create_mcp_server(
 
     workspace_root = workspace.resolve()
     tool_registry = registry or build_default_registry(workspace=workspace_root)
-    server = Server("lintro")
 
-    @server.list_tools()
-    async def list_tools() -> list[types.Tool]:
+    async def list_tools(
+        _ctx: Any,
+        _params: types.PaginatedRequestParams | None,
+    ) -> types.ListToolsResult:
         tools: list[types.Tool] = []
         for spec in tool_registry.list_tools():
             hints = spec.to_annotations()
@@ -199,22 +214,27 @@ def create_mcp_server(
                 types.Tool(
                     name=spec.name,
                     description=spec.description,
-                    inputSchema=spec.input_schema,
+                    input_schema=spec.input_schema,
                     annotations=types.ToolAnnotations(
-                        readOnlyHint=hints["readOnlyHint"],
-                        destructiveHint=hints["destructiveHint"],
-                        idempotentHint=hints["idempotentHint"],
+                        read_only_hint=hints["readOnlyHint"],
+                        destructive_hint=hints["destructiveHint"],
+                        idempotent_hint=hints["idempotentHint"],
                     ),
                 ),
             )
-        return tools
+        return types.ListToolsResult(tools=tools)
 
-    # validate_input=False: the SDK's built-in schema check reports failures as
-    # opaque prose, which would bypass the structured envelope this server
-    # promises. Validation happens below so every failure mode — unknown tool,
-    # bad arguments, workspace escape, handler crash — shares one shape.
-    @server.call_tool(validate_input=False)
-    async def call_tool(name: str, arguments: dict[str, Any] | None) -> Any:
+    # SDK 2.x no longer wraps handler exceptions into ``is_error`` results and
+    # has no ``validate_input=False`` decorator knob. We validate via our JSON
+    # Schema layer and return ``CallToolResult(is_error=True, ...)`` ourselves
+    # so every failure mode — unknown tool, bad arguments, workspace escape,
+    # handler crash — shares the documented envelope instead of becoming a
+    # JSON-RPC error the LLM never sees.
+    async def call_tool(
+        _ctx: Any,
+        params: types.CallToolRequestParams,
+    ) -> types.CallToolResult:
+        name = params.name
         spec = tool_registry.get(name=name)
         if spec is None:
             return _error_result(
@@ -226,14 +246,20 @@ def create_mcp_server(
             )
 
         try:
-            raw_arguments = arguments or {}
+            raw_arguments = dict(params.arguments or {})
             validate_arguments(spec=spec, arguments=raw_arguments)
             safe_arguments = resolve_path_arguments(
                 spec=spec,
                 arguments=raw_arguments,
                 workspace=workspace_root,
             )
-            return await _dispatch(spec=spec, arguments=safe_arguments)
+            payload = await _dispatch(spec=spec, arguments=safe_arguments)
+            if not isinstance(payload, dict):
+                raise TypeError(
+                    f"MCP tool {name!r} returned {type(payload).__name__}, "
+                    "expected dict",
+                )
+            return _tool_result(payload=payload, is_error=False)
         except McpError as exc:
             return _error_result(envelope=exc.envelope)
         except TimeoutError:
@@ -263,7 +289,11 @@ def create_mcp_server(
                 ),
             )
 
-    return server
+    return Server(
+        "lintro",
+        on_list_tools=list_tools,
+        on_call_tool=call_tool,
+    )
 
 
 async def run_stdio_server_async(

--- a/lintro/mcp/server.py
+++ b/lintro/mcp/server.py
@@ -210,6 +210,8 @@ def create_mcp_server(
         tools: list[types.Tool] = []
         for spec in tool_registry.list_tools():
             hints = spec.to_annotations()
+            # MCP hint names stay camelCase on the spec dict; SDK 2.x
+            # ToolAnnotations attributes are snake_case.
             tools.append(
                 types.Tool(
                     name=spec.name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,12 +85,11 @@ full = [
   "yamllint>=1.37.1",
 ]
 ai = ["anthropic>=0.39.0", "openai>=1.50.0"]
-# Floor: 1.10.0 is the first release carrying both
-# `Server.call_tool(validate_input=...)` and `CallToolResult.structuredContent`.
-# Ceiling: the decorator-based low-level `Server` API this module builds on is
-# not guaranteed across a major SDK bump, so 2.x needs a deliberate migration
-# rather than a silent lockfile update.
-mcp = ["mcp>=1.10.0,<2"]
+# Floor: 2.0 is the first release of the constructor-registered low-level
+# `Server` API (`on_list_tools` / `on_call_tool`), explicit `ListToolsResult`,
+# and snake_case type fields (`input_schema`, `is_error`).
+# Ceiling: 3.x is not yet a supported migration.
+mcp = ["mcp>=2,<3"]
 # Semgrep is intentionally absent: it ships from the isolated lockfile
 # ``requirements-semgrep.txt`` (#2104) so its pins cannot collide with
 # lintro's shared resolver. sqlfluff and pip-audit remain here.
@@ -129,7 +128,7 @@ dev = [
   # Kept in the default dev group (not just the optional `mcp` extra) so the
   # MCP server tests really execute in CI, which syncs `--extra full` plus the
   # default groups. Without it they would importorskip into a silent pass.
-  "mcp>=1.10.0,<2",
+  "mcp>=2,<3",
   "pytest-asyncio>=1.3.0",
 ]
 build = ["nuitka>=2.8.9", "ordered-set>=4.1.0", "zstandard>=0.25.0"]

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -19,8 +19,9 @@ from typing import TypeVar
 
 import pytest
 from assertpy import assert_that
-from mcp import ClientSession, StdioServerParameters, types
-from mcp.client.stdio import stdio_client
+from mcp.client import Client
+from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.types import TextContent
 
 from lintro import __version__
 
@@ -30,13 +31,13 @@ _T = TypeVar("_T")
 async def _with_mcp_session(
     *,
     workspace: Path,
-    check: Callable[[ClientSession], Awaitable[_T]],
+    check: Callable[[Client], Awaitable[_T]],
 ) -> _T:
     """Spawn ``python -m lintro mcp`` and run an async client callback.
 
     Args:
         workspace: Workspace root passed via ``--workspace``.
-        check: Async callback receiving an initialized client session.
+        check: Async callback receiving an initialized client.
 
     Returns:
         Whatever ``check`` returns.
@@ -46,27 +47,25 @@ async def _with_mcp_session(
         args=["-m", "lintro", "mcp", "--workspace", str(workspace)],
         cwd=str(workspace),
     )
-    async with stdio_client(params) as (read_stream, write_stream):
-        async with ClientSession(read_stream, write_stream) as session:
-            await session.initialize()
-            return await check(session)
+    async with Client(stdio_client(params), mode="legacy") as client:
+        return await check(client)
 
 
 @pytest.mark.integration
 def test_mcp_stdio_server_lists_and_calls_ping(tmp_path: Path) -> None:
     """A real stdio server lists lintro_ping and answers a call."""
 
-    async def _check(session: ClientSession) -> None:
+    async def _check(session: Client) -> None:
         listed = await session.list_tools()
         assert_that([tool.name for tool in listed.tools]).contains("lintro_ping")
 
-        result = await session.call_tool("lintro_ping", {})
-        assert_that(result.isError).is_false()
-        if result.structuredContent:
-            payload: dict[str, object] = dict(result.structuredContent)
+        result = await session.call_tool(name="lintro_ping", arguments={})
+        assert_that(result.is_error).is_false()
+        if result.structured_content:
+            payload: dict[str, object] = dict(result.structured_content)
         else:
             block = result.content[0]
-            assert isinstance(block, types.TextContent)
+            assert isinstance(block, TextContent)
             payload = dict(json.loads(block.text))
         assert_that(payload["status"]).is_equal_to("ok")
         assert_that(payload["lintro_version"]).is_equal_to(__version__)

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -62,7 +62,7 @@ def test_mcp_stdio_server_lists_and_calls_ping(tmp_path: Path) -> None:
 
         result = await session.call_tool(name="lintro_ping", arguments={})
         assert_that(result.is_error).is_false()
-        if result.structured_content:
+        if result.structured_content is not None:
             payload: dict[str, object] = dict(result.structured_content)
         else:
             block = result.content[0]

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -12,7 +12,6 @@ for our low-level ``Server.run`` stdio handshake; do not pin ``mode="legacy"``.
 from __future__ import annotations
 
 import asyncio
-import json
 import sys
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -22,9 +21,9 @@ import pytest
 from assertpy import assert_that
 from mcp.client import Client
 from mcp.client.stdio import StdioServerParameters, stdio_client
-from mcp.types import TextContent
 
 from lintro import __version__
+from tests.unit.mcp.session_helpers import payload_from_result
 
 _T = TypeVar("_T")
 
@@ -62,12 +61,7 @@ def test_mcp_stdio_server_lists_and_calls_ping(tmp_path: Path) -> None:
 
         result = await session.call_tool(name="lintro_ping", arguments={})
         assert_that(result.is_error).is_false()
-        if result.structured_content is not None:
-            payload: dict[str, object] = dict(result.structured_content)
-        else:
-            block = result.content[0]
-            assert isinstance(block, TextContent)
-            payload = dict(json.loads(block.text))
+        payload = payload_from_result(result)
         assert_that(payload["status"]).is_equal_to("ok")
         assert_that(payload["lintro_version"]).is_equal_to(__version__)
         assert_that(payload["workspace"]).is_equal_to(str(tmp_path.resolve()))

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -5,7 +5,8 @@ The protocol surface itself is covered on every PR by
 the one thing that cannot be faked in-process: that ``lintro mcp`` really is a
 launchable stdio server for an agent host, and that it does not corrupt the
 JSON-RPC stream with stray stdout. CI runs with ``--ignore=tests/integration``,
-so this is a local/manual gate.
+so this is a local/manual gate. Default ``mcp.client.Client`` mode is enough
+for our low-level ``Server.run`` stdio handshake; do not pin ``mode="legacy"``.
 """
 
 from __future__ import annotations
@@ -47,7 +48,7 @@ async def _with_mcp_session(
         args=["-m", "lintro", "mcp", "--workspace", str(workspace)],
         cwd=str(workspace),
     )
-    async with Client(stdio_client(params), mode="legacy") as client:
+    async with Client(stdio_client(params)) as client:
         return await check(client)
 
 

--- a/tests/unit/mcp/session_helpers.py
+++ b/tests/unit/mcp/session_helpers.py
@@ -53,10 +53,10 @@ def run_in_memory_client(
 
 
 def payload_from_result(result: CallToolResult) -> dict[str, Any]:
-    """Extract a tool result payload as a dict.
+    """Extract a tool result payload and require the dual-write contract.
 
-    Prefers ``structured_content`` and falls back to parsing the JSON text
-    block, so the assertions hold regardless of which the SDK populates.
+    Production always sets the same JSON object on ``structured_content`` and
+    the text block. Tests must fail if either side is missing or they drift.
 
     Args:
         result: The ``CallToolResult`` returned by ``client.call_tool``.
@@ -64,8 +64,9 @@ def payload_from_result(result: CallToolResult) -> dict[str, Any]:
     Returns:
         The payload the server sent.
     """
-    if result.structured_content is not None:
-        return dict(result.structured_content)
+    assert result.structured_content is not None
+    payload = dict(result.structured_content)
     block = result.content[0]
     assert isinstance(block, TextContent)
-    return dict(json.loads(block.text))
+    assert dict(json.loads(block.text)) == payload
+    return payload

--- a/tests/unit/mcp/session_helpers.py
+++ b/tests/unit/mcp/session_helpers.py
@@ -64,7 +64,7 @@ def payload_from_result(result: CallToolResult) -> dict[str, Any]:
     Returns:
         The payload the server sent.
     """
-    if result.structured_content:
+    if result.structured_content is not None:
         return dict(result.structured_content)
     block = result.content[0]
     assert isinstance(block, TextContent)

--- a/tests/unit/mcp/session_helpers.py
+++ b/tests/unit/mcp/session_helpers.py
@@ -1,0 +1,71 @@
+"""Shared in-memory MCP 2.x client helper for unit tests.
+
+SDK 2.0 removed ``mcp.shared.memory.create_connected_server_and_client_session``.
+``mcp.client.Client`` accepts a low-level ``Server`` directly and owns the
+in-memory transport plus session handshake.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+from mcp.client import Client
+from mcp.types import CallToolResult, TextContent
+
+from lintro.mcp.registry import McpToolRegistry
+from lintro.mcp.server import create_mcp_server
+
+_T = TypeVar("_T")
+
+__all__ = [
+    "payload_from_result",
+    "run_in_memory_client",
+]
+
+
+def run_in_memory_client(
+    *,
+    workspace: Path,
+    check: Callable[[Client], Awaitable[_T]],
+    registry: McpToolRegistry | None = None,
+) -> _T:
+    """Run ``check`` against an in-memory MCP client bound to a lintro server.
+
+    Args:
+        workspace: Workspace root for the server under test.
+        check: Async callback receiving an initialized ``Client``.
+        registry: Optional registry override; defaults to the built-ins.
+
+    Returns:
+        Whatever ``check`` returns.
+    """
+    server = create_mcp_server(workspace=workspace, registry=registry)
+
+    async def _main() -> _T:
+        async with Client(server) as client:
+            return await check(client)
+
+    return asyncio.run(_main())
+
+
+def payload_from_result(result: CallToolResult) -> dict[str, Any]:
+    """Extract a tool result payload as a dict.
+
+    Prefers ``structured_content`` and falls back to parsing the JSON text
+    block, so the assertions hold regardless of which the SDK populates.
+
+    Args:
+        result: The ``CallToolResult`` returned by ``client.call_tool``.
+
+    Returns:
+        The payload the server sent.
+    """
+    if result.structured_content:
+        return dict(result.structured_content)
+    block = result.content[0]
+    assert isinstance(block, TextContent)
+    return dict(json.loads(block.text))

--- a/tests/unit/mcp/test_sdk_constraint.py
+++ b/tests/unit/mcp/test_sdk_constraint.py
@@ -50,3 +50,33 @@ def test_no_sdk_1x_memory_helper_imports_remain() -> None:
             if _FORBIDDEN_IMPORT.search(text):
                 offenders.append(str(path.relative_to(_REPO_ROOT)))
     assert_that(offenders).is_empty()
+
+
+def test_sdk_types_serialize_camelcase_jsonrpc_aliases() -> None:
+    """Python snake_case fields must still dump as MCP wire camelCase."""
+    from mcp.types import CallToolResult, TextContent, Tool, ToolAnnotations
+
+    tool = Tool(
+        name="lintro_ping",
+        description="health",
+        input_schema={"type": "object"},
+        annotations=ToolAnnotations(
+            read_only_hint=True,
+            destructive_hint=False,
+            idempotent_hint=True,
+        ),
+    )
+    tool_dump = tool.model_dump(by_alias=True)
+    assert_that(tool_dump).contains_key("inputSchema")
+    assert_that(tool_dump["annotations"]["readOnlyHint"]).is_true()
+    assert_that(tool_dump["annotations"]["destructiveHint"]).is_false()
+    assert_that(tool_dump["annotations"]["idempotentHint"]).is_true()
+
+    result = CallToolResult(
+        is_error=True,
+        structured_content={"error": {"code": "invalid_input"}},
+        content=[TextContent(type="text", text="{}")],
+    )
+    result_dump = result.model_dump(by_alias=True)
+    assert_that(result_dump["isError"]).is_true()
+    assert_that(result_dump).contains_key("structuredContent")

--- a/tests/unit/mcp/test_sdk_constraint.py
+++ b/tests/unit/mcp/test_sdk_constraint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import re
 import tomllib
 from pathlib import Path
@@ -13,10 +14,36 @@ _PYPROJECT = _REPO_ROOT / "pyproject.toml"
 _UV_LOCK = _REPO_ROOT / "uv.lock"
 _MCP_FLOOR = "mcp>=2,<3"
 _SOURCE_ROOTS = (_REPO_ROOT / "lintro", _REPO_ROOT / "tests")
-_FORBIDDEN_IMPORT = re.compile(
-    r"^\s*(?:from\s+mcp\.shared\.memory\s+import|import\s+mcp\.shared\.memory)\b",
-    re.MULTILINE,
-)
+
+
+def _mcp_shared_memory_imports(source: str) -> list[str]:
+    """Return ``mcp.shared.memory`` import forms found in ``source``.
+
+    Args:
+        source: Python source to scan.
+
+    Returns:
+        Human-readable import forms, empty when none are present.
+    """
+    tree = ast.parse(source)
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "mcp.shared.memory" or alias.name.startswith(
+                    "mcp.shared.memory.",
+                ):
+                    found.append(f"import {alias.name}")
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "mcp.shared.memory" or module.startswith("mcp.shared.memory."):
+                names = ", ".join(alias.name for alias in node.names)
+                found.append(f"from {module} import {names}")
+            elif module == "mcp.shared" and any(
+                alias.name == "memory" for alias in node.names
+            ):
+                found.append("from mcp.shared import memory")
+    return found
 
 
 def test_mcp_extra_and_dev_group_require_sdk_2() -> None:
@@ -41,13 +68,34 @@ def test_uv_lock_resolves_a_single_mcp_2_x() -> None:
     assert_that(re.findall(r'(?m)^name = "mcp"$', text)).is_length(1)
 
 
+def test_forbidden_import_detector_covers_aliased_and_from_forms() -> None:
+    """``from mcp.shared import memory`` is a 1.x import, not only the dotted form."""
+    assert_that(
+        _mcp_shared_memory_imports("from mcp.shared.memory import create_session"),
+    ).is_not_empty()
+    assert_that(
+        _mcp_shared_memory_imports("import mcp.shared.memory as memory"),
+    ).is_not_empty()
+    assert_that(
+        _mcp_shared_memory_imports("from mcp.shared import memory"),
+    ).is_not_empty()
+    assert_that(
+        _mcp_shared_memory_imports("from mcp.shared import memory as memory"),
+    ).is_not_empty()
+    assert_that(_mcp_shared_memory_imports("from mcp.client import Client")).is_empty()
+
+
 def test_no_sdk_1x_memory_helper_imports_remain() -> None:
     """``mcp.shared.memory`` was removed in 2.0; tests must not import it."""
     offenders: list[str] = []
     for root in _SOURCE_ROOTS:
         for path in root.rglob("*.py"):
             text = path.read_text(encoding="utf-8")
-            if _FORBIDDEN_IMPORT.search(text):
+            try:
+                hits = _mcp_shared_memory_imports(text)
+            except SyntaxError:
+                continue
+            if hits:
                 offenders.append(str(path.relative_to(_REPO_ROOT)))
     assert_that(offenders).is_empty()
 

--- a/tests/unit/mcp/test_sdk_constraint.py
+++ b/tests/unit/mcp/test_sdk_constraint.py
@@ -1,0 +1,52 @@
+"""Pin the MCP extra and lockfile to SDK 2.x, and keep 1.x imports out."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+from assertpy import assert_that
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_UV_LOCK = _REPO_ROOT / "uv.lock"
+_MCP_FLOOR = "mcp>=2,<3"
+_SOURCE_ROOTS = (_REPO_ROOT / "lintro", _REPO_ROOT / "tests")
+_FORBIDDEN_IMPORT = re.compile(
+    r"^\s*(?:from\s+mcp\.shared\.memory\s+import|import\s+mcp\.shared\.memory)\b",
+    re.MULTILINE,
+)
+
+
+def test_mcp_extra_and_dev_group_require_sdk_2() -> None:
+    """The extra and the default dev group share the 2.x floor and 3.x ceiling."""
+    pyproject = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    extras = pyproject["project"]["optional-dependencies"]
+    assert_that(extras["mcp"]).is_equal_to([_MCP_FLOOR])
+    assert_that(pyproject["dependency-groups"]["dev"]).contains(_MCP_FLOOR)
+
+
+def test_uv_lock_resolves_a_single_mcp_2_x() -> None:
+    """``uv.lock`` must resolve ``mcp`` 2.x, not a 1.x leftover."""
+    text = _UV_LOCK.read_text(encoding="utf-8")
+    match = re.search(
+        r'(?m)^name = "mcp"\nversion = "([^"]+)"',
+        text,
+    )
+    assert_that(match).is_not_none()
+    assert match is not None
+    version = match.group(1)
+    assert_that(version).starts_with("2.")
+    assert_that(re.findall(r'(?m)^name = "mcp"$', text)).is_length(1)
+
+
+def test_no_sdk_1x_memory_helper_imports_remain() -> None:
+    """``mcp.shared.memory`` was removed in 2.0; tests must not import it."""
+    offenders: list[str] = []
+    for root in _SOURCE_ROOTS:
+        for path in root.rglob("*.py"):
+            text = path.read_text(encoding="utf-8")
+            if _FORBIDDEN_IMPORT.search(text):
+                offenders.append(str(path.relative_to(_REPO_ROOT)))
+    assert_that(offenders).is_empty()

--- a/tests/unit/mcp/test_server_session.py
+++ b/tests/unit/mcp/test_server_session.py
@@ -11,7 +11,6 @@ covered on every PR.
 from __future__ import annotations
 
 import asyncio
-import json
 import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -19,7 +18,7 @@ from typing import Any, TypeVar
 
 from assertpy import assert_that
 from mcp.client import Client
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult
 
 from lintro import __version__
 from lintro.mcp.errors import McpError, McpErrorCode
@@ -176,24 +175,6 @@ def _failing_registry(workspace: Path) -> McpToolRegistry:
     return registry
 
 
-def _assert_dual_write(result: CallToolResult) -> dict[str, Any]:
-    """Require structured content and the JSON text block to carry the same object.
-
-    Args:
-        result: Tool result from ``client.call_tool``.
-
-    Returns:
-        The shared payload.
-    """
-    payload = _payload(result)
-    assert result.structured_content is not None
-    assert_that(dict(result.structured_content)).is_equal_to(payload)
-    block = result.content[0]
-    assert isinstance(block, TextContent)
-    assert_that(json.loads(block.text)).is_equal_to(payload)
-    return payload
-
-
 def test_session_lists_ping_with_annotation_hints(tmp_path: Path) -> None:
     """tools/list exposes lintro_ping with read-only annotation hints."""
 
@@ -222,7 +203,7 @@ def test_session_call_ping_returns_server_info(tmp_path: Path) -> None:
         result = await session.call_tool(name="lintro_ping", arguments={})
         assert_that(result.is_error).is_false()
 
-        payload = _assert_dual_write(result)
+        payload = _payload(result)
         assert_that(payload["status"]).is_equal_to("ok")
         result_dump = result.model_dump(by_alias=True)
         assert_that(result_dump["isError"]).is_false()
@@ -239,7 +220,7 @@ def test_session_unknown_tool_returns_tool_unavailable(tmp_path: Path) -> None:
     async def _check(session: Client) -> None:
         result = await session.call_tool(name="lintro_nope", arguments={})
         assert_that(result.is_error).is_true()
-        assert_that(_assert_dual_write(result)["error"]["code"]).is_equal_to(
+        assert_that(_payload(result)["error"]["code"]).is_equal_to(
             "tool_unavailable",
         )
 
@@ -332,7 +313,7 @@ def test_session_non_dict_handler_returns_execution_error(tmp_path: Path) -> Non
     async def _check(session: Client) -> None:
         result = await session.call_tool(name="demo_not_dict", arguments={})
         assert_that(result.is_error).is_true()
-        envelope = _assert_dual_write(result)["error"]
+        envelope = _payload(result)["error"]
         assert_that(envelope["code"]).is_equal_to("execution_error")
         assert_that(envelope["message"]).contains("list")
 

--- a/tests/unit/mcp/test_server_session.py
+++ b/tests/unit/mcp/test_server_session.py
@@ -1,8 +1,8 @@
 """End-to-end MCP client/server session tests over in-memory streams.
 
 These exercise the same ``Server`` object the stdio transport serves, through a
-real :class:`mcp.ClientSession` (initialize handshake, ``tools/list``,
-``tools/call``), without spawning a subprocess. The subprocess variant lives in
+real :class:`mcp.client.Client` (``tools/list``, ``tools/call``), without
+spawning a subprocess. The subprocess variant lives in
 ``tests/integration/test_mcp_server.py``; CI runs the test suite with
 ``--ignore=tests/integration``, so this file is what keeps the protocol surface
 covered on every PR.
@@ -11,20 +11,19 @@ covered on every PR.
 from __future__ import annotations
 
 import asyncio
-import json
 import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, TypeVar
 
 from assertpy import assert_that
-from mcp import ClientSession, types
-from mcp.shared.memory import create_connected_server_and_client_session
+from mcp.client import Client
 
 from lintro import __version__
 from lintro.mcp.errors import McpError, McpErrorCode
 from lintro.mcp.registry import McpToolRegistry, McpToolSpec
-from lintro.mcp.server import build_default_registry, create_mcp_server
+from lintro.mcp.server import build_default_registry
+from tests.unit.mcp.session_helpers import payload_from_result, run_in_memory_client
 
 _T = TypeVar("_T")
 
@@ -33,44 +32,35 @@ def _run_session(
     *,
     workspace: Path,
     registry: McpToolRegistry | None,
-    check: Callable[[ClientSession], Awaitable[_T]],
+    check: Callable[[Client], Awaitable[_T]],
 ) -> _T:
     """Run ``check`` against a connected in-memory MCP client session.
 
     Args:
         workspace: Workspace root for the server under test.
         registry: Optional registry override; defaults to the built-ins.
-        check: Async callback receiving an initialized client session.
+        check: Async callback receiving an initialized client.
 
     Returns:
         Whatever ``check`` returns.
     """
-    server = create_mcp_server(workspace=workspace, registry=registry)
-
-    async def _main() -> _T:
-        async with create_connected_server_and_client_session(server) as session:
-            return await check(session)
-
-    return asyncio.run(_main())
+    return run_in_memory_client(
+        workspace=workspace,
+        registry=registry,
+        check=check,
+    )
 
 
-def _payload(result: types.CallToolResult) -> dict[str, Any]:
+def _payload(result: Any) -> dict[str, Any]:
     """Extract a tool result payload as a dict.
 
-    Prefers ``structuredContent`` and falls back to parsing the JSON text
-    block, so the assertions hold regardless of which the SDK populates.
-
     Args:
-        result: The ``CallToolResult`` returned by ``session.call_tool``.
+        result: The ``CallToolResult`` returned by ``client.call_tool``.
 
     Returns:
         The payload the server sent.
     """
-    if result.structuredContent:
-        return dict(result.structuredContent)
-    block = result.content[0]
-    assert isinstance(block, types.TextContent)
-    return dict(json.loads(block.text))
+    return payload_from_result(result)
 
 
 def _failing_registry(workspace: Path) -> McpToolRegistry:
@@ -175,7 +165,7 @@ def _failing_registry(workspace: Path) -> McpToolRegistry:
 def test_session_lists_ping_with_annotation_hints(tmp_path: Path) -> None:
     """tools/list exposes lintro_ping with read-only annotation hints."""
 
-    async def _check(session: ClientSession) -> None:
+    async def _check(session: Client) -> None:
         listed = await session.list_tools()
         names = [tool.name for tool in listed.tools]
         assert_that(names).contains("lintro_ping")
@@ -183,9 +173,9 @@ def test_session_lists_ping_with_annotation_hints(tmp_path: Path) -> None:
         ping = next(tool for tool in listed.tools if tool.name == "lintro_ping")
         annotations = ping.annotations
         assert annotations is not None
-        assert_that(annotations.readOnlyHint).is_true()
-        assert_that(annotations.destructiveHint).is_false()
-        assert_that(annotations.idempotentHint).is_true()
+        assert_that(annotations.read_only_hint).is_true()
+        assert_that(annotations.destructive_hint).is_false()
+        assert_that(annotations.idempotent_hint).is_true()
 
     _run_session(workspace=tmp_path, registry=None, check=_check)
 
@@ -193,9 +183,9 @@ def test_session_lists_ping_with_annotation_hints(tmp_path: Path) -> None:
 def test_session_call_ping_returns_server_info(tmp_path: Path) -> None:
     """Calling lintro_ping returns status, version, and workspace root."""
 
-    async def _check(session: ClientSession) -> None:
-        result = await session.call_tool("lintro_ping", {})
-        assert_that(result.isError).is_false()
+    async def _check(session: Client) -> None:
+        result = await session.call_tool(name="lintro_ping", arguments={})
+        assert_that(result.is_error).is_false()
 
         payload = _payload(result)
         assert_that(payload["status"]).is_equal_to("ok")
@@ -208,9 +198,9 @@ def test_session_call_ping_returns_server_info(tmp_path: Path) -> None:
 def test_session_unknown_tool_returns_tool_unavailable(tmp_path: Path) -> None:
     """An unregistered tool name yields the tool_unavailable envelope."""
 
-    async def _check(session: ClientSession) -> None:
-        result = await session.call_tool("lintro_nope", {})
-        assert_that(result.isError).is_true()
+    async def _check(session: Client) -> None:
+        result = await session.call_tool(name="lintro_nope", arguments={})
+        assert_that(result.is_error).is_true()
         assert_that(_payload(result)["error"]["code"]).is_equal_to(
             "tool_unavailable",
         )
@@ -225,9 +215,9 @@ def test_session_unknown_tool_returns_tool_unavailable(tmp_path: Path) -> None:
 def test_session_invalid_arguments_return_invalid_input(tmp_path: Path) -> None:
     """Schema-invalid arguments yield the invalid_input envelope, not prose."""
 
-    async def _check(session: ClientSession) -> None:
-        result = await session.call_tool("demo_strict", {"name": 42})
-        assert_that(result.isError).is_true()
+    async def _check(session: Client) -> None:
+        result = await session.call_tool(name="demo_strict", arguments={"name": 42})
+        assert_that(result.is_error).is_true()
         envelope = _payload(result)["error"]
         assert_that(envelope["code"]).is_equal_to("invalid_input")
         assert_that(envelope["detail"]["tool"]).is_equal_to("demo_strict")
@@ -244,9 +234,12 @@ def test_session_path_argument_escape_returns_workspace_violation(
 ) -> None:
     """A path argument outside the workspace is refused before dispatch."""
 
-    async def _check(session: ClientSession) -> None:
-        result = await session.call_tool("demo_paths", {"target": "/etc/passwd"})
-        assert_that(result.isError).is_true()
+    async def _check(session: Client) -> None:
+        result = await session.call_tool(
+            name="demo_paths",
+            arguments={"target": "/etc/passwd"},
+        )
+        assert_that(result.is_error).is_true()
         assert_that(_payload(result)["error"]["code"]).is_equal_to(
             "workspace_violation",
         )
@@ -262,9 +255,12 @@ def test_session_path_argument_is_resolved_for_handler(tmp_path: Path) -> None:
     """A contained path argument reaches the handler already resolved."""
     (tmp_path / "a.py").write_text("a = 1\n", encoding="utf-8")
 
-    async def _check(session: ClientSession) -> None:
-        result = await session.call_tool("demo_paths", {"target": "a.py"})
-        assert_that(result.isError).is_false()
+    async def _check(session: Client) -> None:
+        result = await session.call_tool(
+            name="demo_paths",
+            arguments={"target": "a.py"},
+        )
+        assert_that(result.is_error).is_false()
         payload = _payload(result)
         assert_that(payload["target"]).is_equal_to(str((tmp_path / "a.py").resolve()))
 
@@ -278,9 +274,9 @@ def test_session_path_argument_is_resolved_for_handler(tmp_path: Path) -> None:
 def test_session_handler_exception_returns_execution_error(tmp_path: Path) -> None:
     """An unexpected handler exception is shaped into execution_error."""
 
-    async def _check(session: ClientSession) -> None:
-        result = await session.call_tool("demo_boom", {})
-        assert_that(result.isError).is_true()
+    async def _check(session: Client) -> None:
+        result = await session.call_tool(name="demo_boom", arguments={})
+        assert_that(result.is_error).is_true()
         envelope = _payload(result)["error"]
         assert_that(envelope["code"]).is_equal_to("execution_error")
         assert_that(envelope["message"]).contains("handler exploded")
@@ -295,9 +291,9 @@ def test_session_handler_exception_returns_execution_error(tmp_path: Path) -> No
 def test_session_structured_mcp_error_is_preserved(tmp_path: Path) -> None:
     """A handler-raised McpError keeps its own code rather than being wrapped."""
 
-    async def _check(session: ClientSession) -> None:
-        result = await session.call_tool("demo_unavailable", {})
-        assert_that(result.isError).is_true()
+    async def _check(session: Client) -> None:
+        result = await session.call_tool(name="demo_unavailable", arguments={})
+        assert_that(result.is_error).is_true()
         envelope = _payload(result)["error"]
         assert_that(envelope["code"]).is_equal_to("tool_unavailable")
         assert_that(envelope["detail"]["binary"]).is_equal_to("ruff")
@@ -312,9 +308,9 @@ def test_session_structured_mcp_error_is_preserved(tmp_path: Path) -> None:
 def test_session_supports_async_handlers(tmp_path: Path) -> None:
     """Coroutine handlers are awaited before their result is returned."""
 
-    async def _check(session: ClientSession) -> None:
-        result = await session.call_tool("demo_async", {"value": "hi"})
-        assert_that(result.isError).is_false()
+    async def _check(session: Client) -> None:
+        result = await session.call_tool(name="demo_async", arguments={"value": "hi"})
+        assert_that(result.is_error).is_false()
         payload = _payload(result)
         assert_that(payload["echo"]).is_equal_to("hi")
 
@@ -328,9 +324,9 @@ def test_session_supports_async_handlers(tmp_path: Path) -> None:
 def test_session_slow_handler_times_out(tmp_path: Path) -> None:
     """A handler that outlives its budget returns a timeout execution_error."""
 
-    async def _check(session: ClientSession) -> None:
-        result = await session.call_tool("demo_slow", {})
-        assert_that(result.isError).is_true()
+    async def _check(session: Client) -> None:
+        result = await session.call_tool(name="demo_slow", arguments={})
+        assert_that(result.is_error).is_true()
         envelope = _payload(result)["error"]
         assert_that(envelope["code"]).is_equal_to("execution_error")
         assert_that(envelope["detail"]["reason"]).is_equal_to("timeout")

--- a/tests/unit/mcp/test_server_session.py
+++ b/tests/unit/mcp/test_server_session.py
@@ -11,6 +11,7 @@ covered on every PR.
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -18,6 +19,7 @@ from typing import Any, TypeVar
 
 from assertpy import assert_that
 from mcp.client import Client
+from mcp.types import CallToolResult, TextContent
 
 from lintro import __version__
 from lintro.mcp.errors import McpError, McpErrorCode
@@ -51,7 +53,7 @@ def _run_session(
     )
 
 
-def _payload(result: Any) -> dict[str, Any]:
+def _payload(result: CallToolResult) -> dict[str, Any]:
     """Extract a tool result payload as a dict.
 
     Args:
@@ -159,7 +161,37 @@ def _failing_registry(workspace: Path) -> McpToolRegistry:
             handler=_explicit_error,
         ),
     )
+
+    def _not_a_dict(_arguments: dict[str, Any]) -> list[str]:
+        return ["not", "a", "dict"]
+
+    registry.register(
+        spec=McpToolSpec(
+            name="demo_not_dict",
+            description="returns a list instead of a dict",
+            input_schema={"type": "object", "properties": {}},
+            handler=_not_a_dict,
+        ),
+    )
     return registry
+
+
+def _assert_dual_write(result: CallToolResult) -> dict[str, Any]:
+    """Require structured content and the JSON text block to carry the same object.
+
+    Args:
+        result: Tool result from ``client.call_tool``.
+
+    Returns:
+        The shared payload.
+    """
+    payload = _payload(result)
+    assert result.structured_content is not None
+    assert_that(dict(result.structured_content)).is_equal_to(payload)
+    block = result.content[0]
+    assert isinstance(block, TextContent)
+    assert_that(json.loads(block.text)).is_equal_to(payload)
+    return payload
 
 
 def test_session_lists_ping_with_annotation_hints(tmp_path: Path) -> None:
@@ -187,7 +219,7 @@ def test_session_call_ping_returns_server_info(tmp_path: Path) -> None:
         result = await session.call_tool(name="lintro_ping", arguments={})
         assert_that(result.is_error).is_false()
 
-        payload = _payload(result)
+        payload = _assert_dual_write(result)
         assert_that(payload["status"]).is_equal_to("ok")
         assert_that(payload["lintro_version"]).is_equal_to(__version__)
         assert_that(payload["workspace"]).is_equal_to(str(tmp_path.resolve()))
@@ -201,7 +233,7 @@ def test_session_unknown_tool_returns_tool_unavailable(tmp_path: Path) -> None:
     async def _check(session: Client) -> None:
         result = await session.call_tool(name="lintro_nope", arguments={})
         assert_that(result.is_error).is_true()
-        assert_that(_payload(result)["error"]["code"]).is_equal_to(
+        assert_that(_assert_dual_write(result)["error"]["code"]).is_equal_to(
             "tool_unavailable",
         )
 
@@ -280,6 +312,23 @@ def test_session_handler_exception_returns_execution_error(tmp_path: Path) -> No
         envelope = _payload(result)["error"]
         assert_that(envelope["code"]).is_equal_to("execution_error")
         assert_that(envelope["message"]).contains("handler exploded")
+
+    _run_session(
+        workspace=tmp_path,
+        registry=_failing_registry(tmp_path),
+        check=_check,
+    )
+
+
+def test_session_non_dict_handler_returns_execution_error(tmp_path: Path) -> None:
+    """A handler that returns a non-dict is wrapped, not a JSON-RPC error."""
+
+    async def _check(session: Client) -> None:
+        result = await session.call_tool(name="demo_not_dict", arguments={})
+        assert_that(result.is_error).is_true()
+        envelope = _assert_dual_write(result)["error"]
+        assert_that(envelope["code"]).is_equal_to("execution_error")
+        assert_that(envelope["message"]).contains("list")
 
     _run_session(
         workspace=tmp_path,

--- a/tests/unit/mcp/test_server_session.py
+++ b/tests/unit/mcp/test_server_session.py
@@ -208,6 +208,9 @@ def test_session_lists_ping_with_annotation_hints(tmp_path: Path) -> None:
         assert_that(annotations.read_only_hint).is_true()
         assert_that(annotations.destructive_hint).is_false()
         assert_that(annotations.idempotent_hint).is_true()
+        ping_dump = ping.model_dump(by_alias=True)
+        assert_that(ping_dump).contains_key("inputSchema")
+        assert_that(ping_dump["annotations"]["readOnlyHint"]).is_true()
 
     _run_session(workspace=tmp_path, registry=None, check=_check)
 
@@ -221,6 +224,9 @@ def test_session_call_ping_returns_server_info(tmp_path: Path) -> None:
 
         payload = _assert_dual_write(result)
         assert_that(payload["status"]).is_equal_to("ok")
+        result_dump = result.model_dump(by_alias=True)
+        assert_that(result_dump["isError"]).is_false()
+        assert_that(result_dump).contains_key("structuredContent")
         assert_that(payload["lintro_version"]).is_equal_to(__version__)
         assert_that(payload["workspace"]).is_equal_to(str(tmp_path.resolve()))
 

--- a/tests/unit/mcp/test_session_helpers.py
+++ b/tests/unit/mcp/test_session_helpers.py
@@ -2,13 +2,53 @@
 
 from __future__ import annotations
 
+import pytest
 from mcp.types import CallToolResult, TextContent
 
 from tests.unit.mcp.session_helpers import payload_from_result
 
 
-def test_payload_from_result_prefers_structured_content() -> None:
-    """Structured content wins when the SDK populates both representations."""
+def test_payload_from_result_requires_matching_structured_and_text() -> None:
+    """Both representations must carry the same object."""
+    result = CallToolResult(
+        is_error=False,
+        structured_content={"status": "ok"},
+        content=[
+            TextContent(type="text", text='{"status": "ok"}'),
+        ],
+    )
+
+    assert payload_from_result(result) == {"status": "ok"}
+
+
+def test_payload_from_result_keeps_empty_structured_content() -> None:
+    """An explicit empty object is a payload when the text block matches."""
+    result = CallToolResult(
+        is_error=False,
+        structured_content={},
+        content=[
+            TextContent(type="text", text="{}"),
+        ],
+    )
+
+    assert payload_from_result(result) == {}
+
+
+def test_payload_from_result_rejects_missing_structured_content() -> None:
+    """A text-only result is not the production contract."""
+    result = CallToolResult(
+        is_error=False,
+        content=[
+            TextContent(type="text", text='{"echo": "hi"}'),
+        ],
+    )
+
+    with pytest.raises(AssertionError):
+        payload_from_result(result)
+
+
+def test_payload_from_result_rejects_conflicting_representations() -> None:
+    """Drift between structured content and the text block must fail the test."""
     result = CallToolResult(
         is_error=False,
         structured_content={"status": "ok"},
@@ -17,29 +57,5 @@ def test_payload_from_result_prefers_structured_content() -> None:
         ],
     )
 
-    assert payload_from_result(result) == {"status": "ok"}
-
-
-def test_payload_from_result_keeps_empty_structured_content() -> None:
-    """An explicit empty object is a payload, not a missing structured body."""
-    result = CallToolResult(
-        is_error=False,
-        structured_content={},
-        content=[
-            TextContent(type="text", text='{"echo": "conflict"}'),
-        ],
-    )
-
-    assert payload_from_result(result) == {}
-
-
-def test_payload_from_result_falls_back_to_json_text() -> None:
-    """A text-only result still decodes as the tool payload."""
-    result = CallToolResult(
-        is_error=False,
-        content=[
-            TextContent(type="text", text='{"echo": "hi"}'),
-        ],
-    )
-
-    assert payload_from_result(result) == {"echo": "hi"}
+    with pytest.raises(AssertionError):
+        payload_from_result(result)

--- a/tests/unit/mcp/test_session_helpers.py
+++ b/tests/unit/mcp/test_session_helpers.py
@@ -1,0 +1,32 @@
+"""Unit tests for the in-memory MCP 2.x session helpers."""
+
+from __future__ import annotations
+
+from mcp.types import CallToolResult, TextContent
+
+from tests.unit.mcp.session_helpers import payload_from_result
+
+
+def test_payload_from_result_prefers_structured_content() -> None:
+    """Structured content wins when the SDK populates both representations."""
+    result = CallToolResult(
+        is_error=False,
+        structured_content={"status": "ok"},
+        content=[
+            TextContent(type="text", text='{"status": "ignored"}'),
+        ],
+    )
+
+    assert payload_from_result(result) == {"status": "ok"}
+
+
+def test_payload_from_result_falls_back_to_json_text() -> None:
+    """A text-only result still decodes as the tool payload."""
+    result = CallToolResult(
+        is_error=False,
+        content=[
+            TextContent(type="text", text='{"echo": "hi"}'),
+        ],
+    )
+
+    assert payload_from_result(result) == {"echo": "hi"}

--- a/tests/unit/mcp/test_session_helpers.py
+++ b/tests/unit/mcp/test_session_helpers.py
@@ -20,6 +20,19 @@ def test_payload_from_result_prefers_structured_content() -> None:
     assert payload_from_result(result) == {"status": "ok"}
 
 
+def test_payload_from_result_keeps_empty_structured_content() -> None:
+    """An explicit empty object is a payload, not a missing structured body."""
+    result = CallToolResult(
+        is_error=False,
+        structured_content={},
+        content=[
+            TextContent(type="text", text='{"echo": "conflict"}'),
+        ],
+    )
+
+    assert payload_from_result(result) == {}
+
+
 def test_payload_from_result_falls_back_to_json_text() -> None:
     """A text-only result still decodes as the tool payload."""
     result = CallToolResult(

--- a/tests/unit/mcp/test_toolkit_introspection.py
+++ b/tests/unit/mcp/test_toolkit_introspection.py
@@ -1,6 +1,6 @@
 """End-to-end tests for the introspection MCP tools.
 
-Every test drives a real :class:`mcp.ClientSession` over in-memory streams
+Every test drives a real :class:`mcp.client.Client` over in-memory streams
 against the same ``Server`` object the stdio transport serves, so the payloads
 asserted here are the bytes an agent receives.
 
@@ -12,21 +12,18 @@ themselves are covered in ``tests/unit/utils/test_doctor_report.py``.
 
 from __future__ import annotations
 
-import asyncio
-import json
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, TypeVar
 
 import pytest
 from assertpy import assert_that
-from mcp import ClientSession, types
-from mcp.shared.memory import create_connected_server_and_client_session
+from mcp.client import Client
+from mcp.types import Tool
 
 from lintro.config.lintro_config import LintroConfig
 from lintro.enums.tool_status import ToolStatus
 from lintro.mcp.registry import DEFAULT_TOOL_TIMEOUT_SECONDS
-from lintro.mcp.server import create_mcp_server
 from lintro.mcp.toolkits.introspection import (
     INTROSPECTION_TIMEOUT_SECONDS,
     build_introspection_toolkit,
@@ -35,6 +32,7 @@ from lintro.tools.core.tool_registry import ManifestTool
 from lintro.tools.core.version_parsing import ToolVersionInfo
 from lintro.utils import doctor_report
 from lintro.utils.doctor_report import ToolCheckResult
+from tests.unit.mcp.session_helpers import payload_from_result, run_in_memory_client
 
 _T = TypeVar("_T")
 
@@ -42,40 +40,30 @@ _T = TypeVar("_T")
 def _run_session(
     *,
     workspace: Path,
-    check: Callable[[ClientSession], Awaitable[_T]],
+    check: Callable[[Client], Awaitable[_T]],
 ) -> _T:
-    """Run ``check`` against a connected in-memory MCP client session.
+    """Run ``check`` against a connected in-memory MCP client.
 
     Args:
         workspace: Workspace root for the server under test.
-        check: Async callback receiving an initialized client session.
+        check: Async callback receiving an initialized client.
 
     Returns:
         Whatever ``check`` returns.
     """
-    server = create_mcp_server(workspace=workspace)
-
-    async def _main() -> _T:
-        async with create_connected_server_and_client_session(server) as session:
-            return await check(session)
-
-    return asyncio.run(_main())
+    return run_in_memory_client(workspace=workspace, check=check)
 
 
-def _payload(result: types.CallToolResult) -> dict[str, Any]:
+def _payload(result: Any) -> dict[str, Any]:
     """Extract a tool result payload as a dict.
 
     Args:
-        result: The ``CallToolResult`` returned by ``session.call_tool``.
+        result: The ``CallToolResult`` returned by ``client.call_tool``.
 
     Returns:
         The payload the server sent.
     """
-    if result.structuredContent:
-        return dict(result.structuredContent)
-    block = result.content[0]
-    assert isinstance(block, types.TextContent)
-    return dict(json.loads(block.text))
+    return payload_from_result(result)
 
 
 def _call(*, workspace: Path, tool: str) -> dict[str, Any]:
@@ -89,8 +77,9 @@ def _call(*, workspace: Path, tool: str) -> dict[str, Any]:
         The decoded payload.
     """
 
-    async def _check(session: ClientSession) -> dict[str, Any]:
-        return _payload(await session.call_tool(tool, {}))
+    async def _check(session: Client) -> dict[str, Any]:
+        result = await session.call_tool(name=tool, arguments={})
+        return _payload(result)
 
     return _run_session(workspace=workspace, check=_check)
 
@@ -154,7 +143,7 @@ def test_introspection_tools_are_advertised_as_read_only_and_idempotent(
 ) -> None:
     """The annotations tell a host these three calls are always safe to make."""
 
-    async def _check(session: ClientSession) -> dict[str, types.Tool]:
+    async def _check(session: Client) -> dict[str, Tool]:
         listed = await session.list_tools()
         return {tool.name: tool for tool in listed.tools}
 
@@ -168,9 +157,9 @@ def test_introspection_tools_are_advertised_as_read_only_and_idempotent(
     for name in ("lintro_list_tools", "lintro_versions", "lintro_doctor"):
         annotations = tools[name].annotations
         assert annotations is not None
-        assert_that(annotations.readOnlyHint).is_true()
-        assert_that(annotations.destructiveHint).is_false()
-        assert_that(annotations.idempotentHint).is_true()
+        assert_that(annotations.read_only_hint).is_true()
+        assert_that(annotations.destructive_hint).is_false()
+        assert_that(annotations.idempotent_hint).is_true()
 
 
 def test_introspection_tools_budget_for_probing_every_binary() -> None:

--- a/tests/unit/mcp/test_toolkit_lint.py
+++ b/tests/unit/mcp/test_toolkit_lint.py
@@ -1,6 +1,6 @@
 """End-to-end tests for the ``lintro_check`` / ``lintro_format`` MCP tools.
 
-Every test drives a real :class:`mcp.ClientSession` over in-memory streams
+Every test drives a real :class:`mcp.client.Client` over in-memory streams
 against the same ``Server`` object the stdio transport serves, and every one
 runs the real ``ruff`` binary against a throwaway workspace. Stubbing the
 runner would leave the interesting part — that a dry run really does leave the
@@ -9,8 +9,6 @@ tree byte-identical — untested.
 
 from __future__ import annotations
 
-import asyncio
-import json
 import os
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -18,10 +16,10 @@ from typing import Any, TypeVar
 
 import pytest
 from assertpy import assert_that
-from mcp import ClientSession, types
-from mcp.shared.memory import create_connected_server_and_client_session
+from mcp.client import Client
+from mcp.types import CallToolResult, Tool
 
-from lintro.mcp.server import create_mcp_server
+from tests.unit.mcp.session_helpers import payload_from_result, run_in_memory_client
 
 _T = TypeVar("_T")
 
@@ -32,40 +30,30 @@ _UNFIXABLE = "undefined_name_here\n"
 def _run_session(
     *,
     workspace: Path,
-    check: Callable[[ClientSession], Awaitable[_T]],
+    check: Callable[[Client], Awaitable[_T]],
 ) -> _T:
-    """Run ``check`` against a connected in-memory MCP client session.
+    """Run ``check`` against a connected in-memory MCP client.
 
     Args:
         workspace: Workspace root for the server under test.
-        check: Async callback receiving an initialized client session.
+        check: Async callback receiving an initialized client.
 
     Returns:
         Whatever ``check`` returns.
     """
-    server = create_mcp_server(workspace=workspace)
-
-    async def _main() -> _T:
-        async with create_connected_server_and_client_session(server) as session:
-            return await check(session)
-
-    return asyncio.run(_main())
+    return run_in_memory_client(workspace=workspace, check=check)
 
 
-def _payload(result: types.CallToolResult) -> dict[str, Any]:
+def _payload(result: CallToolResult) -> dict[str, Any]:
     """Extract a tool result payload as a dict.
 
     Args:
-        result: The ``CallToolResult`` returned by ``session.call_tool``.
+        result: The ``CallToolResult`` returned by ``client.call_tool``.
 
     Returns:
         The payload the server sent.
     """
-    if result.structuredContent:
-        return dict(result.structuredContent)
-    block = result.content[0]
-    assert isinstance(block, types.TextContent)
-    return dict(json.loads(block.text))
+    return payload_from_result(result)
 
 
 def _call(
@@ -73,7 +61,7 @@ def _call(
     workspace: Path,
     tool: str,
     arguments: dict[str, Any],
-) -> tuple[types.CallToolResult, dict[str, Any]]:
+) -> tuple[CallToolResult, dict[str, Any]]:
     """Call one MCP tool and return its raw result and decoded payload.
 
     Args:
@@ -86,9 +74,9 @@ def _call(
     """
 
     async def _check(
-        session: ClientSession,
-    ) -> tuple[types.CallToolResult, dict[str, Any]]:
-        result = await session.call_tool(tool, arguments)
+        session: Client,
+    ) -> tuple[CallToolResult, dict[str, Any]]:
+        result = await session.call_tool(name=tool, arguments=arguments)
         return result, _payload(result)
 
     return _run_session(workspace=workspace, check=_check)
@@ -111,7 +99,7 @@ def workspace(tmp_path: Path) -> Path:
 def test_lint_tools_are_listed_with_their_annotations(workspace: Path) -> None:
     """Both tools are advertised with the safety hints their contract implies."""
 
-    async def _check(session: ClientSession) -> dict[str, types.Tool]:
+    async def _check(session: Client) -> dict[str, Tool]:
         listed = await session.list_tools()
         return {tool.name: tool for tool in listed.tools}
 
@@ -121,15 +109,15 @@ def test_lint_tools_are_listed_with_their_annotations(workspace: Path) -> None:
 
     check_hints = tools["lintro_check"].annotations
     assert check_hints is not None
-    assert_that(check_hints.readOnlyHint).is_true()
-    assert_that(check_hints.destructiveHint).is_false()
-    assert_that(check_hints.idempotentHint).is_true()
+    assert_that(check_hints.read_only_hint).is_true()
+    assert_that(check_hints.destructive_hint).is_false()
+    assert_that(check_hints.idempotent_hint).is_true()
 
     format_hints = tools["lintro_format"].annotations
     assert format_hints is not None
-    assert_that(format_hints.readOnlyHint).is_false()
-    assert_that(format_hints.destructiveHint).is_true()
-    assert_that(format_hints.idempotentHint).is_false()
+    assert_that(format_hints.read_only_hint).is_false()
+    assert_that(format_hints.destructive_hint).is_true()
+    assert_that(format_hints.idempotent_hint).is_false()
 
 
 def test_check_returns_structured_findings_and_tool_summary(workspace: Path) -> None:
@@ -142,7 +130,7 @@ def test_check_returns_structured_findings_and_tool_summary(workspace: Path) -> 
         arguments={"tools": ["ruff"]},
     )
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(payload["findings"]).is_not_empty()
     finding = payload["findings"][0]
     assert_that(finding).contains_key(
@@ -176,7 +164,7 @@ def test_check_on_a_clean_workspace_returns_no_findings(tmp_path: Path) -> None:
         arguments={"tools": ["ruff"]},
     )
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(payload["findings"]).is_empty()
     assert_that(payload["summary"]["total_findings"]).is_equal_to(0)
     assert_that(payload["tools"][0]["status"]).is_equal_to("passed")
@@ -202,7 +190,7 @@ def test_check_rejects_an_unknown_tool_with_tool_unavailable(workspace: Path) ->
         arguments={"tools": ["not-a-real-linter"]},
     )
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     envelope = payload["error"]
     assert_that(envelope["code"]).is_equal_to("tool_unavailable")
     assert_that(envelope["detail"]["tools"]).is_equal_to(["not-a-real-linter"])
@@ -216,7 +204,7 @@ def test_check_rejects_an_advisory_tool(workspace: Path) -> None:
         arguments={"tools": ["idiom-review"]},
     )
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     assert_that(payload["error"]["code"]).is_equal_to("tool_unavailable")
     assert_that(payload["error"]["message"]).contains("advisory")
 
@@ -236,7 +224,7 @@ def test_check_rejects_a_tool_the_workspace_config_disabled(tmp_path: Path) -> N
         arguments={"tools": ["ruff"]},
     )
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     envelope = payload["error"]
     assert_that(envelope["code"]).is_equal_to("tool_unavailable")
     assert_that(envelope["detail"]["skipped"]).contains_key("ruff")
@@ -250,7 +238,7 @@ def test_check_rejects_a_path_outside_the_workspace(workspace: Path) -> None:
         arguments={"paths": ["../elsewhere"], "tools": ["ruff"]},
     )
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     assert_that(payload["error"]["code"]).is_equal_to("workspace_violation")
 
 
@@ -262,7 +250,7 @@ def test_check_rejects_arguments_that_violate_the_schema(workspace: Path) -> Non
         arguments={"nonsense": True},
     )
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     assert_that(payload["error"]["code"]).is_equal_to("invalid_input")
 
 
@@ -278,7 +266,7 @@ def test_format_dry_run_returns_diffs_and_leaves_the_tree_untouched(
         arguments={"tools": ["ruff"]},
     )
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(payload["dry_run"]).is_true()
     assert_that(payload["changed_files"]).is_equal_to(["bad.py"])
 
@@ -298,7 +286,7 @@ def test_format_apply_writes_the_changes_and_reports_them(workspace: Path) -> No
         arguments={"tools": ["ruff"], "dry_run": False},
     )
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(payload["dry_run"]).is_false()
     assert_that(payload["changed_files"]).is_equal_to(["bad.py"])
     assert_that(payload["diffs"][0]["diff"]).contains("-import os")
@@ -336,7 +324,7 @@ def test_format_on_a_clean_workspace_reports_no_changes(tmp_path: Path) -> None:
         arguments={"tools": ["ruff"]},
     )
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(payload["changed_files"]).is_empty()
     assert_that(payload["diffs"]).is_empty()
 
@@ -349,7 +337,7 @@ def test_check_does_not_leave_run_logs_in_the_workspace(workspace: Path) -> None
         arguments={"tools": ["ruff"]},
     )
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that((workspace / ".lintro").exists()).is_false()
 
 
@@ -379,5 +367,5 @@ def test_format_rejects_a_tool_that_cannot_format(workspace: Path) -> None:
         arguments={"tools": ["bandit"]},
     )
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     assert_that(payload["error"]["code"]).is_equal_to("tool_unavailable")

--- a/tests/unit/mcp/test_toolkit_review.py
+++ b/tests/unit/mcp/test_toolkit_review.py
@@ -1,6 +1,6 @@
 """End-to-end tests for the ``lintro_review`` MCP tool.
 
-Every call goes through a real :class:`mcp.ClientSession` over in-memory
+Every call goes through a real :class:`mcp.client.Client` over in-memory
 streams, so the schema validation, the workspace path guard, and the error
 envelope under test are the ones the stdio server actually applies.
 
@@ -13,8 +13,6 @@ exercising context collection, budget resolution, and payload shaping for real.
 
 from __future__ import annotations
 
-import asyncio
-import json
 import subprocess  # nosec B404 - subprocess runs fixed git argv in a temp repo
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -22,20 +20,20 @@ from typing import Any, TypeVar
 
 import pytest
 from assertpy import assert_that
-from mcp import ClientSession, types
-from mcp.shared.memory import create_connected_server_and_client_session
+from mcp.client import Client
+from mcp.types import CallToolResult, Tool
 
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.mcp.enums.mcp_error_code import McpErrorCode
-from lintro.mcp.server import create_mcp_server
 from lintro.mcp.toolkits.review import (
     REVIEW_TIMEOUT_SECONDS,
     STRICTNESS_VALUES,
     build_review_toolkit,
     resolve_budget_policy,
 )
+from tests.unit.mcp.session_helpers import payload_from_result, run_in_memory_client
 
 _T = TypeVar("_T")
 
@@ -57,47 +55,37 @@ _CONFIG_REVIEW_OFF = """ai:
 def _run_session(
     *,
     workspace: Path,
-    check: Callable[[ClientSession], Awaitable[_T]],
+    check: Callable[[Client], Awaitable[_T]],
 ) -> _T:
-    """Run ``check`` against a connected in-memory MCP client session.
+    """Run ``check`` against a connected in-memory MCP client.
 
     Args:
         workspace: Workspace root for the server under test.
-        check: Async callback receiving an initialized client session.
+        check: Async callback receiving an initialized client.
 
     Returns:
         Whatever ``check`` returns.
     """
-    server = create_mcp_server(workspace=workspace)
-
-    async def _main() -> _T:
-        async with create_connected_server_and_client_session(server) as session:
-            return await check(session)
-
-    return asyncio.run(_main())
+    return run_in_memory_client(workspace=workspace, check=check)
 
 
-def _payload(result: types.CallToolResult) -> dict[str, Any]:
+def _payload(result: CallToolResult) -> dict[str, Any]:
     """Extract a tool result payload as a dict.
 
     Args:
-        result: The ``CallToolResult`` returned by ``session.call_tool``.
+        result: The ``CallToolResult`` returned by ``client.call_tool``.
 
     Returns:
         The payload the server sent.
     """
-    if result.structuredContent:
-        return dict(result.structuredContent)
-    block = result.content[0]
-    assert isinstance(block, types.TextContent)
-    return dict(json.loads(block.text))
+    return payload_from_result(result)
 
 
 def _call(
     *,
     workspace: Path,
     arguments: dict[str, Any],
-) -> tuple[types.CallToolResult, dict[str, Any]]:
+) -> tuple[CallToolResult, dict[str, Any]]:
     """Call ``lintro_review`` and return its raw result and decoded payload.
 
     Args:
@@ -109,9 +97,12 @@ def _call(
     """
 
     async def _check(
-        session: ClientSession,
-    ) -> tuple[types.CallToolResult, dict[str, Any]]:
-        result = await session.call_tool("lintro_review", arguments)
+        session: Client,
+    ) -> tuple[CallToolResult, dict[str, Any]]:
+        result = await session.call_tool(
+            name="lintro_review",
+            arguments=arguments,
+        )
         return result, _payload(result)
 
     return _run_session(workspace=workspace, check=_check)
@@ -296,7 +287,7 @@ def stub_ai(monkeypatch: pytest.MonkeyPatch) -> Callable[..., list[Any]]:
 def test_review_is_listed_as_read_only_and_not_idempotent(tmp_path: Path) -> None:
     """The tool advertises the hints its cost and side-effect profile implies."""
 
-    async def _check(session: ClientSession) -> dict[str, types.Tool]:
+    async def _check(session: Client) -> dict[str, Tool]:
         listed = await session.list_tools()
         return {tool.name: tool for tool in listed.tools}
 
@@ -305,9 +296,9 @@ def test_review_is_listed_as_read_only_and_not_idempotent(tmp_path: Path) -> Non
     assert_that(tools).contains_key("lintro_review")
     hints = tools["lintro_review"].annotations
     assert hints is not None
-    assert_that(hints.readOnlyHint).is_true()
-    assert_that(hints.destructiveHint).is_false()
-    assert_that(hints.idempotentHint).is_false()
+    assert_that(hints.read_only_hint).is_true()
+    assert_that(hints.destructive_hint).is_false()
+    assert_that(hints.idempotent_hint).is_false()
 
 
 def test_review_spec_allows_more_time_than_the_default_budget(tmp_path: Path) -> None:
@@ -373,7 +364,7 @@ def test_review_rejects_a_base_combined_with_uncommitted(
         arguments={"base": "main", "uncommitted": True},
     )
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     assert_that(payload["error"]["code"]).is_equal_to(McpErrorCode.INVALID_INPUT.value)
     assert_that(payload["error"]["detail"]["context_error"]).is_equal_to(
         "invalid-review-mode",
@@ -412,7 +403,7 @@ def test_review_returns_findings_and_run_metadata(
 
     result, payload = _call(workspace=repo, arguments={"base": "main"})
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(payload["summary"]).is_equal_to("One blocking issue.")
     finding = payload["findings"][0]
     assert_that(finding).contains_key(
@@ -458,7 +449,7 @@ def test_review_passes_depth_and_strictness_through(
         arguments={"base": "main", "depth": 3, "strictness": "focused"},
     )
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(calls[0]["depth"]).is_equal_to(3)
     assert_that(calls[0]["sensitivity"].strictness.value).is_equal_to("focused")
 
@@ -481,7 +472,7 @@ def test_review_applies_the_resolved_transport_profile(
 
     result, _payload_body = _call(workspace=repo, arguments={"base": "main"})
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(calls[0]["ai_config"].api_timeout).is_equal_to(555.0)
 
 
@@ -497,7 +488,7 @@ def test_review_clamps_the_requested_budget_to_the_configured_ceiling(
         arguments={"base": "main", "max_cost_usd": 50.0},
     )
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(calls[0]["ai_config"].max_cost_usd).is_equal_to(1.0)
     assert_that(payload["budget"]["requested_usd"]).is_equal_to(50.0)
     assert_that(payload["budget"]["configured_usd"]).is_equal_to(1.0)
@@ -517,7 +508,7 @@ def test_review_honors_a_lower_requested_budget(
         arguments={"base": "main", "max_cost_usd": 0.05},
     )
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(calls[0]["ai_config"].max_cost_usd).is_equal_to(0.05)
     assert_that(payload["budget"]["clamped"]).is_false()
 
@@ -537,7 +528,7 @@ def test_review_reports_a_partial_run_without_discarding_findings(
 
     result, payload = _call(workspace=repo, arguments={"base": "main"})
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(payload["findings"]).is_length(1)
     assert_that(payload["run"]["partial"]).is_true()
     assert_that(payload["run"]["stopped_reason"]).contains("cost cap")
@@ -565,7 +556,7 @@ def test_review_reports_budget_exceeded_when_nothing_was_reviewed(
         arguments={"base": "main", "max_cost_usd": 0.01},
     )
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     assert_that(payload["error"]["code"]).is_equal_to(
         McpErrorCode.BUDGET_EXCEEDED.value,
     )
@@ -582,7 +573,7 @@ def test_review_reports_an_empty_diff_as_a_result_not_a_failure(
 
     result, payload = _call(workspace=repo, arguments={"base": "feature"})
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(payload["findings"]).is_empty()
     assert_that(payload["run"]).contains_key("model", "cost_usd", "chunks")
     assert_that(payload["run"]["cost_usd"]).is_equal_to(0.0)
@@ -600,7 +591,7 @@ def test_review_surfaces_a_provider_failure_with_its_taxonomy(
 
     result, payload = _call(workspace=repo, arguments={"base": "main"})
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     assert_that(payload["error"]["code"]).is_in(
         McpErrorCode.EXECUTION_ERROR.value,
         McpErrorCode.TOOL_UNAVAILABLE.value,
@@ -637,7 +628,7 @@ def test_review_maps_a_too_large_diff_to_invalid_input(
 
     result, payload = _call(workspace=repo, arguments={"base": "main"})
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     assert_that(payload["error"]["code"]).is_equal_to(
         McpErrorCode.INVALID_INPUT.value,
     )
@@ -657,7 +648,7 @@ def test_review_is_unavailable_without_the_ai_extra(
 
     result, payload = _call(workspace=repo, arguments={"base": "main"})
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     assert_that(payload["error"]["code"]).is_equal_to(
         McpErrorCode.TOOL_UNAVAILABLE.value,
     )
@@ -676,7 +667,7 @@ def test_review_is_unavailable_when_the_workspace_disables_it(
 
     result, payload = _call(workspace=repo, arguments={"base": "main"})
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     assert_that(payload["error"]["code"]).is_equal_to(
         McpErrorCode.TOOL_UNAVAILABLE.value,
     )
@@ -687,7 +678,7 @@ def test_review_rejects_a_depth_outside_the_supported_range(repo: Path) -> None:
     """Schema validation refuses depth 4 before any provider call is made."""
     result, payload = _call(workspace=repo, arguments={"base": "main", "depth": 4})
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     assert_that(payload["error"]["code"]).is_equal_to(McpErrorCode.INVALID_INPUT.value)
 
 
@@ -695,7 +686,7 @@ def test_review_rejects_an_unknown_argument(repo: Path) -> None:
     """``--post`` has no MCP equivalent, and no argument is silently ignored."""
     result, payload = _call(workspace=repo, arguments={"post": True})
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     assert_that(payload["error"]["code"]).is_equal_to(McpErrorCode.INVALID_INPUT.value)
 
 
@@ -706,7 +697,7 @@ def test_review_rejects_a_path_outside_the_workspace(repo: Path) -> None:
         arguments={"base": "main", "paths": ["../secrets"]},
     )
 
-    assert_that(result.isError).is_true()
+    assert_that(result.is_error).is_true()
     assert_that(payload["error"]["code"]).is_equal_to(
         McpErrorCode.WORKSPACE_VIOLATION.value,
     )
@@ -724,7 +715,7 @@ def test_review_filters_the_diff_to_the_requested_paths(
         arguments={"base": "main", "paths": ["app.py"]},
     )
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(calls).is_length(1)
     reviewed = [file.path for file in calls[0]["context"].changed_files]
     assert_that(reviewed).is_equal_to(["app.py"])
@@ -755,7 +746,7 @@ def test_review_includes_a_lint_digest_when_asked(
         arguments={"base": "main", "with_lint": True},
     )
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(calls[0]["lint_results"]).is_equal_to("ruff: 1 issue")
 
 
@@ -768,7 +759,7 @@ def test_review_omits_the_lint_digest_by_default(
 
     result, _payload_body = _call(workspace=repo, arguments={"base": "main"})
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(calls[0]["lint_results"]).is_none()
 
 
@@ -785,6 +776,6 @@ def test_review_reports_no_changes_for_a_path_matching_nothing(
         arguments={"base": "main", "paths": ["other.py"]},
     )
 
-    assert_that(result.isError).is_false()
+    assert_that(result.is_error).is_false()
     assert_that(payload["findings"]).is_empty()
     assert_that(calls).is_empty()

--- a/uv.lock
+++ b/uv.lock
@@ -951,15 +951,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
-]
-
-[[package]]
 name = "httpx2"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1460,7 +1451,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.1" },
     { name = "identify", specifier = ">=2.6.19" },
     { name = "loguru", specifier = ">=0.7.3" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.10.0,<2" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2,<3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.1" },
     { name = "mypy", marker = "extra == 'full'", specifier = ">=1.19.1" },
     { name = "openai", marker = "extra == 'ai'", specifier = ">=1.50.0" },
@@ -1503,7 +1494,7 @@ dev = [
     { name = "black", specifier = ">=26.3.1" },
     { name = "build", specifier = ">=1.4.0" },
     { name = "click-man", specifier = ">=0.5.1" },
-    { name = "mcp", specifier = ">=1.10.0,<2" },
+    { name = "mcp", specifier = ">=2,<3" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
@@ -1621,15 +1612,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1639,9 +1630,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1851,6 +1855,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/58/9b/d45911bf9abfc5a754d800d79fe56e4dcf6e7b679d6ff4b7e9689b56bc02/openai-3.1.0.tar.gz", hash = "sha256:3ae7190da63f718727f9c525740d3f713e85553d2bf1d0cc9247346bd9063a4d", size = 1131016, upload-time = "2026-08-14T23:49:46.325Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/45/84b9e909968c0f4c3112a828bba9aa8be6a5ee322fcb3d781145ee53d88e/openai-3.1.0-py3-none-any.whl", hash = "sha256:f06d5a5c8d06a0aead3a67d33fe5a3c3c31540a0f7a8017b02ba8cd99bc5c736", size = 1670762, upload-time = "2026-08-14T23:49:43.998Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -2101,20 +2117,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
-]
-
-[[package]]
 name = "pydoclint"
 version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2283,15 +2285,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/b7/ac44da2cf0e53ada0e419033c2d058219c95dc1403126f163304c9e814b1/python_discovery-1.5.2.tar.gz", hash = "sha256:45fd4f20a4e3f9b7bf2e0817870bc8e3b320a19658da177af800768c82dbf354", size = 82350, upload-time = "2026-08-12T14:05:26.419Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/45/689603d04b3bb8d7faa00f25c24acef993aab7813b3dbbfc472a459ab0b5/python_discovery-1.5.2-py3-none-any.whl", hash = "sha256:3e338c2d0f15dfaeea57493f4c2c6caebe0e998ea815c30ae8bf8ee21f1112d3", size = 38350, upload-time = "2026-08-12T14:05:25.113Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(mcp): migrate to mcp SDK 2.x and drop the 1.x implementation
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Migrate `lintro mcp` from the mcp python-sdk 1.x decorator `Server` onto the 2.x
constructor-registered API and drop 1.x support. This is the follow-up to #2104
(semgrep isolation), which removed the shared `mcp==1.23.3` / `mcp>=1.28.1`
override that blocked the bump.

- Extra and default dev group: `mcp>=2,<3`; `uv.lock` resolves mcp 2.0.0.
- `create_mcp_server` registers `on_list_tools` / `on_call_tool`, returns
  explicit `ListToolsResult`, and uses snake_case type fields
  (`input_schema`, `is_error`, `structured_content`).
- Handler exceptions stay inside our documented `{error: {code, message, detail}}`
  envelope (`CallToolResult(is_error=True)`); they do not become JSON-RPC errors.
- JSON Schema validation remains in `lintro/mcp/validation.py` (no SDK
  `validate_input` knob in 2.x).
- Tests use `mcp.client.Client` in-process; the stdio integration test uses
  default `Client(stdio_client(...))` mode.
- `docs/mcp.md` names the 2.x extra floor and the wire vs SDK field names.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`uv run pytest tests/unit` 8276 passed; `tests/unit/mcp` + stdio integration; `uv run lintro chk` on the touched files)

## Related Issues

Closes #2102
Related #2104
Related #2082
Related #2106

## Details

Do not reintroduce semgrep into `lintro[tools]` / shared `uv.lock`. The mcp bump
lands here, not via grouped Renovate #2082.

Local `lintro review --pr 2113 --provider cursor --model cursor-grok-4.6-high --transport cli --depth 1` reported 7 findings; the P2 test gaps (non-dict handler, dual-write, wire aliases, stdio default mode) are addressed in the follow-up commit. Left as-is: no `!` on the title (matches #2102; `lintro mcp` CLI contract is unchanged) and handler context params stay `Any` to keep the SDK import lazy.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d316f2c1-ba08-47ed-a4c7-c69169831efe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d316f2c1-ba08-47ed-a4c7-c69169831efe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated MCP support for SDK version 2.x.
  * Tool responses now provide consistent structured success and error results.
  * Non-dictionary tool results are reported as execution errors.

* **Documentation**
  * Clarified MCP installation requirements and response field naming for SDK 2.x.

* **Tests**
  * Expanded coverage for tool discovery, validation, structured responses, errors, and session handling.
  * Added checks for SDK version constraints and response serialization compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->