### PR TITLE
ci(docker): repin setup-buildx-action to v4.3.0 tag SHA

### DIFF
--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -32,7 +32,7 @@ runs:
         echo "[setup-docker] Registry: ${{ inputs.registry }}"
     - name: Set up Docker Buildx
       # yamllint disable-line rule:line-length
-      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       with:
         driver: ${{ inputs.driver }}
 

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -347,7 +347,7 @@ jobs:
           needs.changes.outputs.pipeline != 'false' &&
           steps.fork-check.outputs.is-fork == 'true'
         # yamllint disable-line rule:line-length
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
           driver: docker
       - name: Set up Docker Buildx
@@ -355,7 +355,7 @@ jobs:
           needs.changes.outputs.pipeline != 'false' &&
           steps.fork-check.outputs.is-fork != 'true'
         # yamllint disable-line rule:line-length
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Log in to GitHub Container Registry
         if: >-
           needs.changes.outputs.pipeline != 'false' &&


### PR DESCRIPTION
## Summary
- `docker/setup-buildx-action` was pinned to `bb05f3f5` with a `# v4` comment; upstream's `v4` tag now resolves to `37fe6310` (v4.3.0), so the Action Pinning validator fails on every PR that touches workflows.
- Repin both uses in `docker-ci.yml` to the current v4.3.0 tag SHA with an exact version comment.

## Test plan
- [x] `Quality Check - Action Pinning Validation` on this PR

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR consistently repins `docker/setup-buildx-action` to the immutable v4.3.0 commit across the shared Docker setup action and both Docker CI branches.

- Updates all three repository references to the same commit SHA and exact version annotation.
- Preserves the existing `docker` and default `docker-container` driver configurations.
- Satisfies the repository’s immutable third-party Action pinning convention.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

All setup-buildx references are consistently pinned to the v4.3.0 commit, and the existing workflow conditions, inputs, and downstream behavior remain unchanged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/setup-docker/action.yml | Updates the shared composite action’s Buildx dependency from v4.2.0 to the consistently pinned v4.3.0 commit without changing inputs or behavior. |
| .github/workflows/docker-ci.yml | Repins both mutually exclusive Buildx setup steps to v4.3.0 while preserving their existing conditions and driver configuration. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(docker): repin setup-buildx-action in..."](https://github.com/lgtm-hq/py-lintro/commit/5f8ac8b14262b656962b812241395fbdcaeb9070) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55049602)</sub>

**Context used:**

- Knowledge Base — [CI/CD Workflows](https://app.greptile.com/lgtm-hq/-/custom-context/knowledge-base/lgtm-hq/py-lintro/-/docs/ci-workflows.md)

<!-- /greptile_comment -->