### PR TITLE
feat(ai)!: require an explicit AI provider

### DIFF
--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -151,7 +151,14 @@ class AIConfig(BaseModel):
             "when ai.enabled is also true (the two are ANDed)."
         ),
     )
-    provider: AIProvider = AIProvider.ANTHROPIC
+    provider: AIProvider | None = Field(
+        default=None,
+        description=(
+            "Required when any AI feature (ai.lint or ai.review) is enabled. "
+            "Set via `ai.provider` in config, LINTRO_AI_PROVIDER, or --provider. "
+            "Accepted providers: anthropic, cursor, openai."
+        ),
+    )
     transport: AITransport | None = Field(
         default=None,
         description=(

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -32,6 +32,7 @@ from lintro.ai.enums import (
     SanitizeMode,
 )
 from lintro.ai.enums.config_source import ConfigSource
+from lintro.ai.provider_enum import accepted_provider_values
 from lintro.ai.registry import AIProvider
 from lintro.ai.resolved_ai_config import ResolvedAIConfig
 
@@ -156,7 +157,7 @@ class AIConfig(BaseModel):
         description=(
             "Required when any AI feature (ai.lint or ai.review) is enabled. "
             "Set via `ai.provider` in config, LINTRO_AI_PROVIDER, or --provider. "
-            "Accepted providers: anthropic, cursor, openai."
+            f"Accepted providers: {accepted_provider_values()}."
         ),
     )
     transport: AITransport | None = Field(

--- a/lintro/ai/config_overrides.py
+++ b/lintro/ai/config_overrides.py
@@ -19,7 +19,7 @@ from lintro.ai.config import AIConfig
 from lintro.ai.enums import AITransport
 from lintro.ai.enums.config_source import ConfigSource
 from lintro.ai.exceptions import AIConfigOverrideError
-from lintro.ai.provider_enum import AIProvider
+from lintro.ai.provider_enum import accepted_provider_values
 from lintro.ai.resolved_ai_config import ResolvedAIConfig
 
 __all__ = [
@@ -360,7 +360,7 @@ def _accepted_values(field: str) -> str:
         Accepted values, or empty when the field is free-form.
     """
     if field == "provider":
-        return ", ".join(provider.value for provider in AIProvider)
+        return accepted_provider_values()
     if field == "transport":
         return ", ".join(transport.value for transport in AITransport)
     if field == "enabled":

--- a/lintro/ai/config_views.py
+++ b/lintro/ai/config_views.py
@@ -23,7 +23,7 @@ from lintro.ai.registry import AIProvider
 class AIProviderConfig:
     """Read-only view of provider-related AI settings."""
 
-    provider: AIProvider
+    provider: AIProvider | None
     transport: AITransport | None
     cli_bare: CliBareMode
     model: str | None

--- a/lintro/ai/display/status.py
+++ b/lintro/ai/display/status.py
@@ -85,7 +85,8 @@ def render_ai_status(
     if ai_config.provider is None:
         provider_name = ""
         ai_parts.append("[yellow]enabled (provider unset)[/yellow]")
-        ai_parts.append(f"  [yellow]{provider_required_error()}[/yellow]")
+        if ai_config.any_feature_enabled:
+            ai_parts.append(f"  [yellow]{provider_required_error()}[/yellow]")
     else:
         provider_name = str(ai_config.provider).lower()
     supported = set(AIProvider)
@@ -95,8 +96,7 @@ def render_ai_status(
         ai_parts.append("[red]enabled (unknown provider)[/red]")
         names = accepted_provider_values()
         ai_parts.append(
-            f"  [yellow]'{ai_config.provider}' is not supported. "
-            f"Use: {names}[/yellow]",
+            f"  [yellow]'{ai_config.provider}' is not supported. Use: {names}[/yellow]",
         )
     elif provider_name:
         # Check SDK availability

--- a/lintro/ai/display/status.py
+++ b/lintro/ai/display/status.py
@@ -75,21 +75,30 @@ def render_ai_status(
     import os
 
     from lintro.ai.availability import is_provider_available
+    from lintro.ai.provider_enum import (
+        accepted_provider_values,
+        provider_required_error,
+    )
     from lintro.ai.providers import get_default_model
     from lintro.ai.registry import PROVIDERS, AIProvider
 
-    provider_name = ai_config.provider.lower()
+    if ai_config.provider is None:
+        provider_name = ""
+        ai_parts.append("[yellow]enabled (provider unset)[/yellow]")
+        ai_parts.append(f"  [yellow]{provider_required_error()}[/yellow]")
+    else:
+        provider_name = str(ai_config.provider).lower()
     supported = set(AIProvider)
 
     # Check: unknown provider
-    if provider_name not in supported:
+    if provider_name and provider_name not in supported:
         ai_parts.append("[red]enabled (unknown provider)[/red]")
-        names = ", ".join(sorted(supported))
+        names = accepted_provider_values()
         ai_parts.append(
             f"  [yellow]'{ai_config.provider}' is not supported. "
             f"Use: {names}[/yellow]",
         )
-    else:
+    elif provider_name:
         # Check SDK availability
         sdk_ok = is_provider_available(provider_name)
 
@@ -117,7 +126,9 @@ def render_ai_status(
                 f"  [yellow]set {key_env} env var[/yellow]",
             )
 
-    provider_label = str(ai_config.provider)
+    provider_label = (
+        str(ai_config.provider) if ai_config.provider is not None else "unset"
+    )
     if sources is not None:
         provider_label = format_sourced_value(
             provider_label,
@@ -125,8 +136,8 @@ def render_ai_status(
         )
     ai_parts.append(f"  provider: {provider_label}")
 
-    effective_model = ai_config.model or get_default_model(
-        provider_name,
+    effective_model = ai_config.model or (
+        get_default_model(provider_name) if provider_name else None
     )
     if effective_model:
         model_label = effective_model

--- a/lintro/ai/doctor_checks.py
+++ b/lintro/ai/doctor_checks.py
@@ -16,6 +16,7 @@ from lintro.ai.config import AIConfig
 from lintro.ai.enums import AITransport
 from lintro.ai.liveness import LivenessState, check_liveness_sync
 from lintro.ai.paths import resolve_workspace_root
+from lintro.ai.provider_enum import accepted_provider_values, provider_required_error
 from lintro.ai.registry import AIProvider
 from lintro.ai.transcript import TRANSCRIPT_DIR, is_transcript_enabled
 from lintro.enums.tool_status import ToolStatus
@@ -62,9 +63,13 @@ def check_ai_liveness(config: AIConfig) -> list[AICheckResult]:
 
     Returns:
         A single-element list describing the probe, or an empty list when no AI
-        feature is enabled or no transport is configured.
+        feature is enabled or provider/transport is unset.
     """
-    if not config.any_feature_enabled or config.transport is None:
+    if (
+        not config.any_feature_enabled
+        or config.transport is None
+        or config.provider is None
+    ):
         return []
     if config.provider == AIProvider.CURSOR and config.transport == AITransport.API:
         # Structurally impossible pairing. check_ai_configuration already reports
@@ -119,6 +124,19 @@ def check_ai_configuration(config: AIConfig) -> list[AICheckResult]:
     if not config.any_feature_enabled:
         return results
 
+    if config.provider is None:
+        results.append(
+            AICheckResult(
+                name="ai.provider",
+                status=ToolStatus.INCOMPATIBLE,
+                message=provider_required_error(),
+                hint=(
+                    "Set `ai.provider` in config, LINTRO_AI_PROVIDER, or "
+                    f"--provider. Accepted: {accepted_provider_values()}"
+                ),
+            ),
+        )
+
     if config.transport is None:
         results.append(
             AICheckResult(
@@ -130,6 +148,8 @@ def check_ai_configuration(config: AIConfig) -> list[AICheckResult]:
                 hint="Add `transport: api` or `transport: cli` under `ai:` in config",
             ),
         )
+
+    if config.provider is None or config.transport is None:
         return results
 
     if config.provider == AIProvider.CURSOR and config.transport == AITransport.API:

--- a/lintro/ai/exceptions.py
+++ b/lintro/ai/exceptions.py
@@ -22,6 +22,16 @@ class AIConfigOverrideError(AIError):
     """
 
 
+class AIProviderRequiredError(AIError):
+    """AI is enabled but no provider was named.
+
+    Raised by :func:`~lintro.ai.providers.get_provider` when ``ai.provider``
+    is unset. The message names the three set paths (config, env, flag)
+    and the accepted providers. This is a configuration error, not a
+    malformed model response.
+    """
+
+
 class AICostBudgetExceededError(AIError):
     """The configured AI cost budget (``ai.max_cost_usd``) was reached.
 

--- a/lintro/ai/liveness.py
+++ b/lintro/ai/liveness.py
@@ -408,7 +408,7 @@ def check_liveness_sync(
         provider = get_provider(config)
     except (AIError, ValueError) as exc:
         return LivenessResult(
-            provider=config.provider,
+            provider=(str(config.provider) if config.provider is not None else "unset"),
             transport=transport,
             state=LivenessState.MISSING_CREDENTIAL,
             message=f"provider could not be constructed: {exc}",

--- a/lintro/ai/orchestrator.py
+++ b/lintro/ai/orchestrator.py
@@ -135,8 +135,11 @@ async def run_ai_enhancement_async(
 
         # P5-4: Verbose — log provider, model, and workspace at info level
         if ai_config.verbose:
+            provider_name = (
+                ai_config.provider.value if ai_config.provider is not None else "unset"
+            )
             loguru_logger.info(
-                f"AI: provider={ai_config.provider.value}, "
+                f"AI: provider={provider_name}, "
                 f"model={ai_config.model or 'default'}, "
                 f"workspace_root={workspace_root}",
             )

--- a/lintro/ai/provider_enum.py
+++ b/lintro/ai/provider_enum.py
@@ -17,3 +17,26 @@ class AIProvider(StrEnum):
     ANTHROPIC = auto()
     OPENAI = auto()
     CURSOR = auto()
+
+
+def accepted_provider_values() -> str:
+    """Return accepted provider names in alphabetical order.
+
+    Returns:
+        Comma-separated provider names with no implied ranking.
+    """
+    return ", ".join(sorted(member.value for member in AIProvider))
+
+
+def provider_required_error() -> str:
+    """Return the migration error used when AI is on but no provider is set.
+
+    Returns:
+        A message naming the three ways to set ``ai.provider`` and the
+        accepted providers in alphabetical order.
+    """
+    return (
+        "ai.provider is required when ai.lint or ai.review is enabled. "
+        "Set it via `ai.provider` in config, LINTRO_AI_PROVIDER, or --provider. "
+        f"Accepted providers: {accepted_provider_values()}."
+    )

--- a/lintro/ai/providers/__init__.py
+++ b/lintro/ai/providers/__init__.py
@@ -10,7 +10,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lintro.ai.enums import AITransport
-from lintro.ai.exceptions import AINotAvailableError  # noqa: F401 -- public re-export
+from lintro.ai.exceptions import (
+    AINotAvailableError,  # noqa: F401 -- public re-export
+    AIProviderRequiredError,
+)
 from lintro.ai.paths import resolve_workspace_root
 from lintro.ai.provider_enum import (
     accepted_provider_values,
@@ -48,12 +51,12 @@ def get_provider(
         BaseAIProvider: Configured provider instance.
 
     Raises:
-        ValueError: If no provider is set, or the provider name is not
-            recognized. The unset-provider message names ``ai.provider``,
-            ``LINTRO_AI_PROVIDER``, and ``--provider``.
+        AIProviderRequiredError: If no provider is set. The message names
+            ``ai.provider``, ``LINTRO_AI_PROVIDER``, and ``--provider``.
+        ValueError: If the provider name is not recognized.
     """
     if config.provider is None:
-        raise ValueError(provider_required_error())
+        raise AIProviderRequiredError(provider_required_error())
     try:
         provider_enum = AIProvider(str(config.provider).lower())
     except ValueError as exc:

--- a/lintro/ai/providers/__init__.py
+++ b/lintro/ai/providers/__init__.py
@@ -12,7 +12,10 @@ from typing import TYPE_CHECKING
 from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import AINotAvailableError  # noqa: F401 -- public re-export
 from lintro.ai.paths import resolve_workspace_root
-from lintro.ai.provider_enum import provider_required_error
+from lintro.ai.provider_enum import (
+    accepted_provider_values,
+    provider_required_error,
+)
 from lintro.ai.registry import PROVIDERS, AIProvider
 from lintro.ai.transcript import maybe_start_transcript
 
@@ -54,10 +57,9 @@ def get_provider(
     try:
         provider_enum = AIProvider(str(config.provider).lower())
     except ValueError as exc:
-        supported = ", ".join(sorted(p.value for p in AIProvider))
         raise ValueError(
             f"Unknown AI provider: '{config.provider}'. "
-            f"Supported providers: {supported}",
+            f"Supported providers: {accepted_provider_values()}",
         ) from exc
 
     provider_classes: dict[AIProvider, tuple[str, str]] = {

--- a/lintro/ai/providers/__init__.py
+++ b/lintro/ai/providers/__init__.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import AINotAvailableError  # noqa: F401 -- public re-export
 from lintro.ai.paths import resolve_workspace_root
+from lintro.ai.provider_enum import provider_required_error
 from lintro.ai.registry import PROVIDERS, AIProvider
 from lintro.ai.transcript import maybe_start_transcript
 
@@ -44,12 +45,16 @@ def get_provider(
         BaseAIProvider: Configured provider instance.
 
     Raises:
-        ValueError: If the provider name is not recognized.
+        ValueError: If no provider is set, or the provider name is not
+            recognized. The unset-provider message names ``ai.provider``,
+            ``LINTRO_AI_PROVIDER``, and ``--provider``.
     """
+    if config.provider is None:
+        raise ValueError(provider_required_error())
     try:
-        provider_enum = AIProvider(config.provider.lower())
+        provider_enum = AIProvider(str(config.provider).lower())
     except ValueError as exc:
-        supported = ", ".join(p.value for p in AIProvider)
+        supported = ", ".join(sorted(p.value for p in AIProvider))
         raise ValueError(
             f"Unknown AI provider: '{config.provider}'. "
             f"Supported providers: {supported}",

--- a/lintro/ai/review/error_contract.py
+++ b/lintro/ai/review/error_contract.py
@@ -84,6 +84,7 @@ UNAVAILABLE_KINDS: Final[frozenset[ReviewErrorKind]] = frozenset(
         ReviewErrorKind.RATE_LIMITED,
         ReviewErrorKind.SERVER_ERROR,
         ReviewErrorKind.TIMEOUT,
+        ReviewErrorKind.PROVIDER_UNAVAILABLE,
     },
 )
 

--- a/lintro/ai/review/error_display.py
+++ b/lintro/ai/review/error_display.py
@@ -11,6 +11,7 @@ from rich.text import Text
 from lintro.ai.exceptions import (
     AIAuthenticationError,
     AIProviderError,
+    AIProviderRequiredError,
     AIRateLimitError,
 )
 from lintro.ai.review.exceptions import ReviewContextError, ReviewExecutionError
@@ -82,6 +83,14 @@ def _format_error(error: AIError | ValueError) -> tuple[str, str, list[str]]:
             "rate limit",
             str(error),
             ["Wait and retry, or switch provider/model in config"],
+        )
+    if isinstance(error, AIProviderRequiredError):
+        return (
+            "provider unset",
+            str(error),
+            [
+                "Set `ai.provider` in config, LINTRO_AI_PROVIDER, or --provider",
+            ],
         )
     if isinstance(error, AIProviderError):
         body = str(error)

--- a/lintro/ai/review/errors_taxonomy.py
+++ b/lintro/ai/review/errors_taxonomy.py
@@ -19,7 +19,11 @@ import re
 from dataclasses import dataclass
 from enum import StrEnum, auto
 
-from lintro.ai.exceptions import AIAuthenticationError, AIRateLimitError
+from lintro.ai.exceptions import (
+    AIAuthenticationError,
+    AIProviderRequiredError,
+    AIRateLimitError,
+)
 
 
 class ReviewErrorKind(StrEnum):
@@ -38,6 +42,8 @@ class ReviewErrorKind(StrEnum):
         INVALID_RESPONSE: The model returned a malformed/unparseable response
             (a lintro-side parse/validation failure, not a provider transport
             error).
+        PROVIDER_UNAVAILABLE: No provider is configured, so the review never
+            reached a model. Distinct from a malformed response.
         UNKNOWN: No signature matched; the surfaced cause text is shown as-is.
     """
 
@@ -49,6 +55,7 @@ class ReviewErrorKind(StrEnum):
     SERVER_ERROR = auto()
     TIMEOUT = auto()
     INVALID_RESPONSE = auto()
+    PROVIDER_UNAVAILABLE = auto()
     UNKNOWN = auto()
 
 
@@ -294,6 +301,10 @@ KIND_COPY: dict[ReviewErrorKind, tuple[str, str]] = {
         "Retry the review — model output may have been malformed — or try a "
         "different model via `ai.model`.",
     ),
+    ReviewErrorKind.PROVIDER_UNAVAILABLE: (
+        "no AI provider is configured",
+        "Set `ai.provider` in config, LINTRO_AI_PROVIDER, or --provider.",
+    ),
     ReviewErrorKind.UNKNOWN: (
         "the review could not be completed",
         "See the cause above and the workflow logs; retry if it looks transient.",
@@ -394,6 +405,8 @@ def classify_provider_error(*, provider: str, error: Exception) -> ReviewErrorKi
         return ReviewErrorKind.AUTH_FAILED
     if isinstance(cause_exc, AIRateLimitError):
         return ReviewErrorKind.RATE_LIMITED
+    if isinstance(cause_exc, AIProviderRequiredError):
+        return ReviewErrorKind.PROVIDER_UNAVAILABLE
 
     # A bare ``ValueError`` cause is a lintro-side parse/validation failure of
     # the model response, not a provider transport error — surface it as such

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -149,6 +149,33 @@ def _fail_review_command(
     raise SystemExit(REVIEW_ERROR_EXIT_CODE) from exc
 
 
+def _advisory_failure_error(results: list[ToolResult]) -> AIError:
+    """Build the exception for an advisory tool that failed to run.
+
+    Args:
+        results: Advisory tool results that include at least one error.
+
+    Returns:
+        ``AIProviderRequiredError`` when the failure is a missing provider,
+        otherwise a generic ``AIError`` with the tool's output.
+    """
+    from lintro.enums.tool_run_status import ToolRunStatus, tool_run_status
+
+    failed = next(
+        result
+        for result in results
+        if tool_run_status(
+            result=result,
+            issue_count=result.issues_count or 0,
+        )
+        in {ToolRunStatus.ERRORED, ToolRunStatus.TIMED_OUT}
+    )
+    message = failed.output or f"{failed.name} failed"
+    if "ai.provider is required" in message:
+        return AIProviderRequiredError(message)
+    return AIError(message)
+
+
 @click.command("review")
 @click.option(
     "--base",
@@ -370,18 +397,6 @@ def review_command(
         )
 
     require_ai()
-    if advisory_only:
-        # Advisory-only needs no diff context and no review checklist, so it
-        # deliberately bypasses the ai.review gate: the user asked for the
-        # finder tools, not the diff review (#1308).
-        _run_advisory_only(
-            advisory_tools=advisory_tools,
-            tool_options=tool_options,
-            path_filter=path_filter,
-            output_format=output_format,
-            fail_on_findings=fail_on_findings,
-        )
-
     try:
         resolved_ai = apply_cli_overrides(
             AIConfig.resolve_from_mapping(lintro_config.ai),
@@ -393,6 +408,30 @@ def review_command(
     except AIConfigOverrideError as exc:
         raise click.UsageError(str(exc)) from exc
     ai_config = resolved_ai.config
+    if advisory_only:
+        # Advisory-only needs no diff context and no review checklist, so it
+        # deliberately bypasses the ai.review gate: the user asked for the
+        # finder tools, not the diff review (#1308). --provider still applies.
+        if ai_config.provider is None:
+            _fail_review_command(
+                AIProviderRequiredError(provider_required_error()),
+                output_format=output_format,
+                provider_label="unset",
+                post=False,
+                resolved_pr=None,
+                effective_repo=None,
+            )
+        _run_advisory_only(
+            advisory_tools=advisory_tools,
+            tool_options=tool_options,
+            path_filter=path_filter,
+            output_format=output_format,
+            fail_on_findings=fail_on_findings,
+            provider_label=(
+                ai_config.provider.value if ai_config.provider is not None else "unset"
+            ),
+        )
+
     if not ai_config.review_enabled:
         raise click.UsageError(
             "AI review is disabled in configuration. Set ai.review: true "
@@ -604,6 +643,16 @@ def review_command(
             workspace_root=workspace_root,
         ),
     )
+    if advisory_tools_errored(advisory_results):
+        _fail_review_command(
+            _advisory_failure_error(advisory_results),
+            output_format=output_format,
+            provider_label=(str(provider.name) if provider is not None else "unset"),
+            post=post,
+            resolved_pr=resolved_pr,
+            effective_repo=effective_repo,
+            console=console,
+        )
 
     output = render_review_output(
         result=result,
@@ -657,10 +706,6 @@ def review_command(
         if not posted:
             logger.warning("GitHub review posting skipped or failed")
 
-    if advisory_tools_errored(advisory_results):
-        from lintro.ai.review.error_contract import REVIEW_ERROR_EXIT_CODE
-
-        raise SystemExit(REVIEW_ERROR_EXIT_CODE)
     exit_code = 1 if result.has_p1_findings else 0
     if fail_on_findings and advisory_findings_count(advisory_results):
         exit_code = 1
@@ -830,6 +875,7 @@ def _run_advisory_only(
     path_filter: tuple[str, ...],
     output_format: str,
     fail_on_findings: bool,
+    provider_label: str,
 ) -> None:
     """Run only the advisory tools, render their findings, and exit.
 
@@ -839,6 +885,7 @@ def _run_advisory_only(
         path_filter: ``--path`` values; defaults to the current directory.
         output_format: ``terminal`` or ``json``.
         fail_on_findings: Whether findings should produce exit code 1.
+        provider_label: Resolved provider name for the error contract.
 
     Raises:
         SystemExit: Always; carries the resolved exit code.
@@ -854,6 +901,15 @@ def _run_advisory_only(
         tool_options=tool_options,
         paths=paths,
     )
+    if advisory_tools_errored(results):
+        _fail_review_command(
+            _advisory_failure_error(results),
+            output_format=output_format,
+            provider_label=provider_label,
+            post=False,
+            resolved_pr=None,
+            effective_repo=None,
+        )
     if output_format == "json":
         click.echo(
             json.dumps(
@@ -865,10 +921,6 @@ def _run_advisory_only(
         click.echo(
             render_advisory_results(results=results) or "No advisory tools ran.",
         )
-    if advisory_tools_errored(results):
-        from lintro.ai.review.error_contract import REVIEW_ERROR_EXIT_CODE
-
-        raise SystemExit(REVIEW_ERROR_EXIT_CODE)
     findings = advisory_findings_count(results)
     raise SystemExit(1 if (fail_on_findings and findings) else 0)
 

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -21,7 +21,7 @@ import os
 import time
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NoReturn
 
 import click
 from loguru import logger
@@ -29,9 +29,13 @@ from rich.console import Console
 
 from lintro.ai.availability import require_ai
 from lintro.ai.config import AIConfig
-from lintro.ai.exceptions import AIConfigOverrideError, AIError
+from lintro.ai.exceptions import (
+    AIConfigOverrideError,
+    AIError,
+    AIProviderRequiredError,
+)
 from lintro.ai.paths import resolve_workspace_root
-from lintro.ai.provider_enum import AIProvider
+from lintro.ai.provider_enum import AIProvider, provider_required_error
 from lintro.ai.providers import get_provider
 from lintro.ai.review import (
     classify_changed_files,
@@ -81,6 +85,67 @@ if TYPE_CHECKING:
 
 #: Default paths scanned by ``--advisory-only`` when no ``--path`` is given.
 ADVISORY_DEFAULT_PATHS: tuple[str, ...] = (".",)
+
+
+def _fail_review_command(
+    exc: AIError | ValueError,
+    *,
+    output_format: str,
+    provider_label: str,
+    post: bool,
+    resolved_pr: int | None,
+    effective_repo: str | None,
+    console: Console | None = None,
+) -> NoReturn:
+    """Render a review failure and exit with the review-error contract.
+
+    Used for both early provider validation and mid-run provider failures so
+    JSON, terminal, and GitHub error rendering stay on one path.
+
+    Args:
+        exc: The failure that prevented a review from running.
+        output_format: CLI ``--output`` value (``json`` or ``terminal``).
+        provider_label: Provider name, or ``unset`` when construction failed.
+        post: Whether ``--post`` requested a GitHub comment.
+        resolved_pr: PR number when posting is requested.
+        effective_repo: ``owner/repo`` when posting is requested.
+        console: Terminal console; created on demand for non-JSON output.
+
+    Raises:
+        SystemExit: Always, with the review-error exit code.
+    """
+    if post and resolved_pr is not None and effective_repo:
+        from lintro.ai.review.github import post_review_error_to_github
+
+        with suppress(Exception):
+            post_review_error_to_github(
+                error=exc,
+                provider=provider_label,
+                pr_number=resolved_pr,
+                repo=effective_repo,
+            )
+    from lintro.ai.review.error_contract import (
+        REVIEW_ERROR_EXIT_CODE,
+        render_error_contract_json,
+    )
+
+    if output_format == "json":
+        click.echo(
+            render_error_contract_json(
+                provider=provider_label,
+                error=exc,
+            ),
+        )
+    else:
+        render_review_error(
+            error=exc,
+            console=console if console is not None else Console(),
+        )
+    # Same exit code in both output formats: no review was produced, which
+    # must never be confusable with "reviewed, found P1 issues" (exit 1).
+    # A wrapper that cannot tell the two apart reports a green check for a
+    # review that never ran (#1826).
+    raise SystemExit(REVIEW_ERROR_EXIT_CODE) from exc
 
 
 @click.command("review")
@@ -356,6 +421,18 @@ def review_command(
                 "--post requires --repo or GITHUB_REPOSITORY environment variable.",
             )
 
+    # Fail on a missing provider before git/gh work so an invalid base or a
+    # non-repo cwd cannot hide the required-provider migration error.
+    if ai_config.provider is None:
+        _fail_review_command(
+            AIProviderRequiredError(provider_required_error()),
+            output_format=output_format,
+            provider_label="unset",
+            post=post,
+            resolved_pr=resolved_pr,
+            effective_repo=effective_repo,
+        )
+
     paths = list(path_filter) if path_filter else None
     context_pr = resolved_pr if post else pr
     context_repo = effective_repo if context_pr is not None else None
@@ -506,36 +583,15 @@ def review_command(
             ),
         )
     except (AIError, ValueError) as exc:
-        provider_label = str(provider.name) if provider is not None else "unset"
-        if post and resolved_pr is not None and effective_repo:
-            from lintro.ai.review.github import post_review_error_to_github
-
-            with suppress(Exception):
-                post_review_error_to_github(
-                    error=exc,
-                    provider=provider_label,
-                    pr_number=resolved_pr,
-                    repo=effective_repo,
-                )
-        from lintro.ai.review.error_contract import (
-            REVIEW_ERROR_EXIT_CODE,
-            render_error_contract_json,
+        _fail_review_command(
+            exc,
+            output_format=output_format,
+            provider_label=(str(provider.name) if provider is not None else "unset"),
+            post=post,
+            resolved_pr=resolved_pr,
+            effective_repo=effective_repo,
+            console=console,
         )
-
-        if output_format == "json":
-            click.echo(
-                render_error_contract_json(
-                    provider=provider_label,
-                    error=exc,
-                ),
-            )
-        else:
-            render_review_error(error=exc, console=console)
-        # Same exit code in both output formats: no review was produced, which
-        # must never be confusable with "reviewed, found P1 issues" (exit 1).
-        # A wrapper that cannot tell the two apart reports a green check for a
-        # review that never ran (#1826).
-        raise SystemExit(REVIEW_ERROR_EXIT_CODE) from exc
 
     result = enrich_review_result(result=result, question_map=question_map)
 

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -73,6 +73,7 @@ from lintro.enums.advisory_tools_value import AdvisoryToolsValue
 from lintro.utils.execution.advisory import (
     advisory_findings_count,
     advisory_results_to_payload,
+    advisory_tools_errored,
     render_advisory_results,
     resolve_advisory_tools,
     run_advisory_tools,
@@ -656,6 +657,10 @@ def review_command(
         if not posted:
             logger.warning("GitHub review posting skipped or failed")
 
+    if advisory_tools_errored(advisory_results):
+        from lintro.ai.review.error_contract import REVIEW_ERROR_EXIT_CODE
+
+        raise SystemExit(REVIEW_ERROR_EXIT_CODE)
     exit_code = 1 if result.has_p1_findings else 0
     if fail_on_findings and advisory_findings_count(advisory_results):
         exit_code = 1
@@ -860,6 +865,10 @@ def _run_advisory_only(
         click.echo(
             render_advisory_results(results=results) or "No advisory tools ran.",
         )
+    if advisory_tools_errored(results):
+        from lintro.ai.review.error_contract import REVIEW_ERROR_EXIT_CODE
+
+        raise SystemExit(REVIEW_ERROR_EXIT_CODE)
     findings = advisory_findings_count(results)
     raise SystemExit(1 if (fail_on_findings and findings) else 0)
 

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -430,7 +430,7 @@ def review_command(
         format_resolved_profile_log(resolved_profile),
     )
 
-    provider = get_provider(effective_ai_config, workspace_root=workspace_root)
+    provider = None
     effective_depth = depth if depth is not None else lintro_config.review.depth
     effective_strictness = ReviewStrictness(
         (strictness or lintro_config.review.strictness.value).lower(),
@@ -456,6 +456,7 @@ def review_command(
         progress_tracker = RichReviewProgress(console=console)
 
     try:
+        provider = get_provider(effective_ai_config, workspace_root=workspace_root)
         result = run_review(
             context,
             provider=provider,
@@ -505,13 +506,14 @@ def review_command(
             ),
         )
     except (AIError, ValueError) as exc:
+        provider_label = str(provider.name) if provider is not None else "unset"
         if post and resolved_pr is not None and effective_repo:
             from lintro.ai.review.github import post_review_error_to_github
 
             with suppress(Exception):
                 post_review_error_to_github(
                     error=exc,
-                    provider=str(provider.name),
+                    provider=provider_label,
                     pr_number=resolved_pr,
                     repo=effective_repo,
                 )
@@ -523,7 +525,7 @@ def review_command(
         if output_format == "json":
             click.echo(
                 render_error_contract_json(
-                    provider=str(provider.name),
+                    provider=provider_label,
                     error=exc,
                 ),
             )

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -12,6 +12,9 @@
 
 Advisory findings are scoped to the review's changed files (or ``--path``)
 and never change the exit code unless ``--fail-on-findings`` is passed.
+An advisory tool that failed to run fails ``--advisory-only``; a full
+review still renders the completed review and records the advisory
+failure in the advisory payload.
 """
 
 from __future__ import annotations
@@ -71,6 +74,8 @@ from lintro.ai.transport import (
 from lintro.config.config_loader import get_config
 from lintro.enums.advisory_tools_value import AdvisoryToolsValue
 from lintro.utils.execution.advisory import (
+    ADVISORY_ERROR_METADATA_KEY,
+    ADVISORY_ERROR_PROVIDER_REQUIRED,
     advisory_findings_count,
     advisory_results_to_payload,
     advisory_tools_errored,
@@ -171,7 +176,8 @@ def _advisory_failure_error(results: list[ToolResult]) -> AIError:
         in {ToolRunStatus.ERRORED, ToolRunStatus.TIMED_OUT}
     )
     message = failed.output or f"{failed.name} failed"
-    if "ai.provider is required" in message:
+    metadata = failed.metadata or {}
+    if metadata.get(ADVISORY_ERROR_METADATA_KEY) == (ADVISORY_ERROR_PROVIDER_REQUIRED):
         return AIProviderRequiredError(message)
     return AIError(message)
 
@@ -430,6 +436,7 @@ def review_command(
             provider_label=(
                 ai_config.provider.value if ai_config.provider is not None else "unset"
             ),
+            ai_config=ai_config,
         )
 
     if not ai_config.review_enabled:
@@ -642,17 +649,8 @@ def review_command(
             changed_files=context.changed_files,
             workspace_root=workspace_root,
         ),
+        ai_config=effective_ai_config,
     )
-    if advisory_tools_errored(advisory_results):
-        _fail_review_command(
-            _advisory_failure_error(advisory_results),
-            output_format=output_format,
-            provider_label=(str(provider.name) if provider is not None else "unset"),
-            post=post,
-            resolved_pr=resolved_pr,
-            effective_repo=effective_repo,
-            console=console,
-        )
 
     output = render_review_output(
         result=result,
@@ -829,6 +827,7 @@ def _execute_advisory(
     advisory_tools: str | None,
     tool_options: str | None,
     paths: list[str],
+    ai_config: AIConfig | None = None,
 ) -> list[ToolResult]:
     """Resolve and run the advisory tools requested for this review.
 
@@ -836,6 +835,7 @@ def _execute_advisory(
         advisory_tools: Raw ``--advisory-tools`` value.
         tool_options: Raw ``--tool-options`` value for advisory tools.
         paths: Paths to scan (typically the review's changed files).
+        ai_config: CLI-resolved AI configuration forwarded to each tool.
 
     Returns:
         One result per advisory tool that ran; empty when none were selected.
@@ -865,6 +865,7 @@ def _execute_advisory(
         paths=paths,
         tool_names=selection.to_run,
         tool_options=tool_options,
+        ai_config=ai_config,
     )
 
 
@@ -876,6 +877,7 @@ def _run_advisory_only(
     output_format: str,
     fail_on_findings: bool,
     provider_label: str,
+    ai_config: AIConfig | None = None,
 ) -> None:
     """Run only the advisory tools, render their findings, and exit.
 
@@ -886,6 +888,7 @@ def _run_advisory_only(
         output_format: ``terminal`` or ``json``.
         fail_on_findings: Whether findings should produce exit code 1.
         provider_label: Resolved provider name for the error contract.
+        ai_config: CLI-resolved AI configuration forwarded to each tool.
 
     Raises:
         SystemExit: Always; carries the resolved exit code.
@@ -900,6 +903,7 @@ def _run_advisory_only(
         advisory_tools=advisory_tools,
         tool_options=tool_options,
         paths=paths,
+        ai_config=ai_config,
     )
     if advisory_tools_errored(results):
         _fail_review_command(

--- a/lintro/mcp/toolkits/review.py
+++ b/lintro/mcp/toolkits/review.py
@@ -651,7 +651,7 @@ def _execute_review(*, arguments: dict[str, Any], workspace: Path) -> dict[str, 
     Raises:
         McpError: For every failure mode the tool contract defines.
     """
-    from lintro.ai.exceptions import AIError
+    from lintro.ai.exceptions import AIError, AIProviderRequiredError
     from lintro.ai.providers import get_provider
     from lintro.ai.review import (
         classify_changed_files,
@@ -706,7 +706,7 @@ def _execute_review(*, arguments: dict[str, Any], workspace: Path) -> dict[str, 
 
     try:
         provider = get_provider(effective_ai_config, workspace_root=workspace)
-    except ValueError as exc:
+    except (AIProviderRequiredError, ValueError) as exc:
         raise McpError(
             code=McpErrorCode.TOOL_UNAVAILABLE,
             message=str(exc),

--- a/lintro/mcp/toolkits/review.py
+++ b/lintro/mcp/toolkits/review.py
@@ -288,7 +288,8 @@ def _resolve_ai_config(*, workspace: Path) -> tuple[Any, AIConfig]:
 
     Raises:
         McpError: :attr:`McpErrorCode.TOOL_UNAVAILABLE` when no AI provider is
-            installed or ``ai.review`` is disabled for this workspace;
+            installed, ``ai.provider`` is unset, or ``ai.review`` is disabled
+            for this workspace;
             :attr:`McpErrorCode.INVALID_INPUT` when an ``LINTRO_AI_*`` overlay
             fails validation.
     """
@@ -326,6 +327,18 @@ def _resolve_ai_config(*, workspace: Path) -> tuple[Any, AIConfig]:
             detail={
                 "tool": "lintro_review",
                 "reason": "review_disabled",
+                "workspace": str(workspace),
+            },
+        )
+    if ai_config.provider is None:
+        from lintro.ai.provider_enum import provider_required_error
+
+        raise McpError(
+            code=McpErrorCode.TOOL_UNAVAILABLE,
+            message=provider_required_error(),
+            detail={
+                "tool": "lintro_review",
+                "reason": "provider_unavailable",
                 "workspace": str(workspace),
             },
         )

--- a/lintro/mcp/toolkits/review.py
+++ b/lintro/mcp/toolkits/review.py
@@ -570,7 +570,9 @@ def _no_changes_payload(
 
     metadata = ReviewMetadata(
         model=ai_config.model or "",
-        provider=str(ai_config.provider),
+        provider=(
+            str(ai_config.provider) if ai_config.provider is not None else "unset"
+        ),
         context_window=0,
         depth=depth,
         chunks_total=0,

--- a/lintro/tools/definitions/idiom_review.py
+++ b/lintro/tools/definitions/idiom_review.py
@@ -166,10 +166,18 @@ class IdiomReviewPlugin(BaseToolPlugin):
         try:
             return self._run_review(files=ctx.files, options=merged)
         except AIProviderRequiredError as exc:
+            from lintro.utils.execution.advisory import (
+                ADVISORY_ERROR_METADATA_KEY,
+                ADVISORY_ERROR_PROVIDER_REQUIRED,
+            )
+
             return ToolResult(
                 name=IDIOM_REVIEW_TOOL_NAME,
                 success=False,
                 output=str(exc),
+                metadata={
+                    ADVISORY_ERROR_METADATA_KEY: ADVISORY_ERROR_PROVIDER_REQUIRED,
+                },
             )
         except AIError as exc:
             # Depleted credits / auth / rate limits degrade gracefully.
@@ -197,13 +205,18 @@ class IdiomReviewPlugin(BaseToolPlugin):
             ToolResult with the aggregated, confidence-filtered findings.
         """
         from lintro.ai.budget import CostBudget
+        from lintro.ai.config import AIConfig
         from lintro.ai.interface import resolve_ai_config
         from lintro.ai.paths import resolve_workspace_root
         from lintro.ai.providers import get_provider
         from lintro.tools.idiom_review.engine import IdiomReviewEngine
 
         lintro_config = self._get_lintro_config()
-        ai_config = resolve_ai_config(lintro_config)
+        injected = options.get("ai_config")
+        if isinstance(injected, AIConfig):
+            ai_config = injected
+        else:
+            ai_config = resolve_ai_config(lintro_config)
         workspace_root = resolve_workspace_root(lintro_config.config_path)
         provider = get_provider(ai_config, workspace_root=workspace_root)
         budget = CostBudget(max_cost_usd=ai_config.max_cost_usd)

--- a/lintro/tools/definitions/idiom_review.py
+++ b/lintro/tools/definitions/idiom_review.py
@@ -123,6 +123,10 @@ class IdiomReviewPlugin(BaseToolPlugin):
         Returns:
             ToolResult with idiom findings, or a skipped result when the
             tool is not opted in or no AI provider is available.
+
+        Raises:
+            AIProviderRequiredError: When AI is enabled but ``ai.provider``
+                is unset. This is a configuration error, not a skip.
         """
         merged: dict[str, object] = dict(self.options)
         merged.update(options)
@@ -144,7 +148,7 @@ class IdiomReviewPlugin(BaseToolPlugin):
         # tool definition, so a top-level ``lintro.ai`` import would drag the
         # AI stack into every ``chk`` invocation (#1305).
         from lintro.ai.availability import is_ai_available
-        from lintro.ai.exceptions import AIError
+        from lintro.ai.exceptions import AIError, AIProviderRequiredError
 
         # Graceful no-credentials path — never require live API access.
         if not is_ai_available():
@@ -164,6 +168,8 @@ class IdiomReviewPlugin(BaseToolPlugin):
 
         try:
             return self._run_review(files=ctx.files, options=merged)
+        except AIProviderRequiredError:
+            raise
         except AIError as exc:
             # Depleted credits / auth / rate limits degrade gracefully.
             logger.warning("[idiom-review] AI unavailable, skipping: {}", exc)

--- a/lintro/tools/definitions/idiom_review.py
+++ b/lintro/tools/definitions/idiom_review.py
@@ -121,12 +121,9 @@ class IdiomReviewPlugin(BaseToolPlugin):
             options: Runtime options overriding defaults.
 
         Returns:
-            ToolResult with idiom findings, or a skipped result when the
-            tool is not opted in or no AI provider is available.
-
-        Raises:
-            AIProviderRequiredError: When AI is enabled but ``ai.provider``
-                is unset. This is a configuration error, not a skip.
+            ToolResult with idiom findings, a skipped result when the
+            tool is not opted in or no AI provider is available, or a
+            failed result when ``ai.provider`` is unset.
         """
         merged: dict[str, object] = dict(self.options)
         merged.update(options)
@@ -168,8 +165,12 @@ class IdiomReviewPlugin(BaseToolPlugin):
 
         try:
             return self._run_review(files=ctx.files, options=merged)
-        except AIProviderRequiredError:
-            raise
+        except AIProviderRequiredError as exc:
+            return ToolResult(
+                name=IDIOM_REVIEW_TOOL_NAME,
+                success=False,
+                output=str(exc),
+            )
         except AIError as exc:
             # Depleted credits / auth / rate limits degrade gracefully.
             logger.warning("[idiom-review] AI unavailable, skipping: {}", exc)

--- a/lintro/utils/execution/advisory.py
+++ b/lintro/utils/execution/advisory.py
@@ -25,7 +25,6 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from lintro.ai.config import AIConfig
 from lintro.config.config_loader import get_config
 from lintro.enums.action import Action
 from lintro.enums.advisory_tools_value import AdvisoryToolsValue
@@ -39,6 +38,8 @@ from lintro.utils.execution.tool_configuration import (
 from lintro.utils.unified_config import UnifiedConfigManager
 
 if TYPE_CHECKING:
+    # TYPE_CHECKING-only: this module is on the core → AI import boundary.
+    from lintro.ai.config import AIConfig
     from lintro.config.lintro_config import LintroConfig
 
 __all__ = [
@@ -199,7 +200,6 @@ def run_advisory_tools(
     if not tool_names or not paths:
         return []
 
-    from lintro.ai.exceptions import AIProviderRequiredError
     from lintro.utils.tool_options import parse_tool_options
 
     config = lintro_config or get_config()
@@ -227,18 +227,6 @@ def run_advisory_tools(
                 lintro_config=config,
             )
             results.append(tool.check(paths, check_options))
-        except AIProviderRequiredError as exc:
-            logger.warning("[{}] advisory tool failed: {}", tool_name, exc)
-            results.append(
-                ToolResult(
-                    name=tool_name,
-                    success=False,
-                    output=str(exc),
-                    metadata={
-                        ADVISORY_ERROR_METADATA_KEY: (ADVISORY_ERROR_PROVIDER_REQUIRED),
-                    },
-                ),
-            )
         except (
             Exception
         ) as exc:  # noqa: BLE001 - swallow into ToolResult; later tools still run; the review command decides the exit code

--- a/lintro/utils/execution/advisory.py
+++ b/lintro/utils/execution/advisory.py
@@ -210,7 +210,9 @@ def run_advisory_tools(
                 lintro_config=config,
             )
             results.append(tool.check(paths, {}))
-        except Exception as exc:  # noqa: BLE001 - advisory runs never abort review
+        except (
+            Exception
+        ) as exc:  # noqa: BLE001 - swallow into ToolResult; later tools still run; the review command decides the exit code
             logger.warning("[{}] advisory tool failed: {}", tool_name, exc)
             results.append(
                 ToolResult(

--- a/lintro/utils/execution/advisory.py
+++ b/lintro/utils/execution/advisory.py
@@ -9,8 +9,12 @@ violations (#1308). This module is the counterpart runner that
 
 It is deliberately a thin, sequential runner rather than a second copy of the
 full :mod:`lintro.utils.tool_executor` pipeline: advisory tools never fix,
-never participate in post-checks, never feed the health score, and never
-affect the exit code unless the user opts in with ``--fail-on-findings``.
+never participate in post-checks, and never feed the health score. Findings
+do not change the exit code unless the user opts in with
+``--fail-on-findings``. An advisory tool that failed to run
+(:attr:`~lintro.enums.tool_run_status.ToolRunStatus.ERRORED` or
+:attr:`~lintro.enums.tool_run_status.ToolRunStatus.TIMED_OUT`) is not a
+finding and fails the review.
 """
 
 from __future__ import annotations
@@ -23,6 +27,7 @@ from loguru import logger
 from lintro.config.config_loader import get_config
 from lintro.enums.action import Action
 from lintro.enums.advisory_tools_value import AdvisoryToolsValue
+from lintro.enums.tool_run_status import ToolRunStatus, tool_run_status
 from lintro.models.core.tool_result import ToolResult
 from lintro.tools import tool_manager
 from lintro.utils.execution.tool_configuration import (
@@ -38,6 +43,7 @@ __all__ = [
     "AdvisorySelection",
     "advisory_findings_count",
     "advisory_results_to_payload",
+    "advisory_tools_errored",
     "get_advisory_tool_names",
     "render_advisory_results",
     "resolve_advisory_tools",
@@ -232,6 +238,30 @@ def advisory_findings_count(results: list[ToolResult]) -> int:
     )
 
 
+def advisory_tools_errored(results: list[ToolResult]) -> bool:
+    """Return whether any advisory tool failed to run.
+
+    Findings also set ``success=False``; those still have issues and are
+    not errors. A skip is not an error. Use
+    :func:`~lintro.enums.tool_run_status.tool_run_status` so this stays
+    aligned with the other result surfaces.
+
+    Args:
+        results: Advisory tool results.
+
+    Returns:
+        True when at least one tool errored or timed out.
+    """
+    return any(
+        tool_run_status(
+            result=result,
+            issue_count=result.issues_count or 0,
+        )
+        in {ToolRunStatus.ERRORED, ToolRunStatus.TIMED_OUT}
+        for result in results
+    )
+
+
 def render_advisory_results(
     *,
     results: list[ToolResult],
@@ -285,6 +315,8 @@ def advisory_results_to_payload(results: list[ToolResult]) -> list[dict[str, obj
         payload.append(
             {
                 "tool": result.name,
+                "success": bool(result.success),
+                "output": result.output,
                 "skipped": bool(getattr(result, "skipped", False)),
                 "skip_reason": result.skip_reason,
                 "issues_count": result.issues_count or 0,

--- a/lintro/utils/execution/advisory.py
+++ b/lintro/utils/execution/advisory.py
@@ -14,7 +14,8 @@ do not change the exit code unless the user opts in with
 ``--fail-on-findings``. An advisory tool that failed to run
 (:attr:`~lintro.enums.tool_run_status.ToolRunStatus.ERRORED` or
 :attr:`~lintro.enums.tool_run_status.ToolRunStatus.TIMED_OUT`) is not a
-finding and fails the review.
+finding: ``--advisory-only`` fails closed, while a full review still
+renders the completed review and records the advisory failure.
 """
 
 from __future__ import annotations
@@ -24,6 +25,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from lintro.ai.config import AIConfig
 from lintro.config.config_loader import get_config
 from lintro.enums.action import Action
 from lintro.enums.advisory_tools_value import AdvisoryToolsValue
@@ -40,6 +42,8 @@ if TYPE_CHECKING:
     from lintro.config.lintro_config import LintroConfig
 
 __all__ = [
+    "ADVISORY_ERROR_METADATA_KEY",
+    "ADVISORY_ERROR_PROVIDER_REQUIRED",
     "AdvisorySelection",
     "advisory_findings_count",
     "advisory_results_to_payload",
@@ -49,6 +53,11 @@ __all__ = [
     "resolve_advisory_tools",
     "run_advisory_tools",
 ]
+
+#: Typed ``ToolResult.metadata`` key for an advisory execution failure.
+ADVISORY_ERROR_METADATA_KEY = "advisory_error"
+#: Marker written when the failure is a missing ``ai.provider``.
+ADVISORY_ERROR_PROVIDER_REQUIRED = "provider_required"
 
 
 @dataclass(frozen=True)
@@ -167,6 +176,7 @@ def run_advisory_tools(
     tool_names: list[str],
     tool_options: str | None = None,
     lintro_config: LintroConfig | None = None,
+    ai_config: AIConfig | None = None,
 ) -> list[ToolResult]:
     """Execute the given advisory tools over ``paths``.
 
@@ -177,6 +187,9 @@ def run_advisory_tools(
             (``tool:option=value,...``) applied on top of configuration.
         lintro_config: Optional config override; the global config is loaded
             when omitted.
+        ai_config: CLI-resolved AI configuration (includes ``--provider``).
+            Forwarded into each tool's ``check()`` options so advisory
+            tools see the same overlays as the review command.
 
     Returns:
         One :class:`~lintro.models.core.tool_result.ToolResult` per tool, in
@@ -186,11 +199,15 @@ def run_advisory_tools(
     if not tool_names or not paths:
         return []
 
+    from lintro.ai.exceptions import AIProviderRequiredError
     from lintro.utils.tool_options import parse_tool_options
 
     config = lintro_config or get_config()
     config_manager = UnifiedConfigManager()
     tool_option_dict = parse_tool_options(tool_options)
+    check_options: dict[str, object] = {}
+    if ai_config is not None:
+        check_options["ai_config"] = ai_config
     results: list[ToolResult] = []
     for tool_name in tool_names:
         # Lookup and configuration are inside the guard too: a plugin that
@@ -209,7 +226,19 @@ def run_advisory_tools(
                 post_tools=set(),
                 lintro_config=config,
             )
-            results.append(tool.check(paths, {}))
+            results.append(tool.check(paths, check_options))
+        except AIProviderRequiredError as exc:
+            logger.warning("[{}] advisory tool failed: {}", tool_name, exc)
+            results.append(
+                ToolResult(
+                    name=tool_name,
+                    success=False,
+                    output=str(exc),
+                    metadata={
+                        ADVISORY_ERROR_METADATA_KEY: (ADVISORY_ERROR_PROVIDER_REQUIRED),
+                    },
+                ),
+            )
         except (
             Exception
         ) as exc:  # noqa: BLE001 - swallow into ToolResult; later tools still run; the review command decides the exit code

--- a/tests/unit/ai/providers/test_factory.py
+++ b/tests/unit/ai/providers/test_factory.py
@@ -40,16 +40,19 @@ def test_get_provider_unknown_raises():
 
 def test_get_provider_requires_explicit_provider() -> None:
     """An enabled-but-unset provider fails with the three-way migration path."""
-    from lintro.ai.provider_enum import accepted_provider_values
+    from lintro.ai.exceptions import AIProviderRequiredError
 
     config = AIConfig(enabled=True, lint=True, review=False)
-    with pytest.raises(ValueError, match="ai.provider is required") as exc_info:
+    with pytest.raises(
+        AIProviderRequiredError,
+        match="ai.provider is required",
+    ) as exc_info:
         get_provider(config)
     message = str(exc_info.value)
     assert_that(message).contains("`ai.provider` in config")
     assert_that(message).contains("LINTRO_AI_PROVIDER")
     assert_that(message).contains("--provider")
-    assert_that(message).contains(accepted_provider_values())
+    assert_that(message).contains("anthropic, cursor, openai")
 
 
 def test_get_provider_case_insensitive():

--- a/tests/unit/ai/providers/test_factory.py
+++ b/tests/unit/ai/providers/test_factory.py
@@ -40,16 +40,13 @@ def test_get_provider_unknown_raises():
 
 def test_get_provider_requires_explicit_provider() -> None:
     """An enabled-but-unset provider fails with the three-way migration path."""
-    from lintro.ai.provider_enum import (
-        accepted_provider_values,
-        provider_required_error,
-    )
+    from lintro.ai.provider_enum import accepted_provider_values
 
     config = AIConfig(enabled=True, lint=True, review=False)
     with pytest.raises(ValueError, match="ai.provider is required") as exc_info:
         get_provider(config)
     message = str(exc_info.value)
-    assert_that(message).is_equal_to(provider_required_error())
+    assert_that(message).contains("`ai.provider` in config")
     assert_that(message).contains("LINTRO_AI_PROVIDER")
     assert_that(message).contains("--provider")
     assert_that(message).contains(accepted_provider_values())

--- a/tests/unit/ai/providers/test_factory.py
+++ b/tests/unit/ai/providers/test_factory.py
@@ -38,6 +38,23 @@ def test_get_provider_unknown_raises():
         get_provider(config)
 
 
+def test_get_provider_requires_explicit_provider() -> None:
+    """An enabled-but-unset provider fails with the three-way migration path."""
+    from lintro.ai.provider_enum import (
+        accepted_provider_values,
+        provider_required_error,
+    )
+
+    config = AIConfig(enabled=True, lint=True, review=False)
+    with pytest.raises(ValueError, match="ai.provider is required") as exc_info:
+        get_provider(config)
+    message = str(exc_info.value)
+    assert_that(message).is_equal_to(provider_required_error())
+    assert_that(message).contains("LINTRO_AI_PROVIDER")
+    assert_that(message).contains("--provider")
+    assert_that(message).contains(accepted_provider_values())
+
+
 def test_get_provider_case_insensitive():
     """Verify that get_provider handles provider names case-insensitively."""
     # Bypass Pydantic Literal validation to test the factory lowercases.

--- a/tests/unit/ai/review/test_architecture_characterization.py
+++ b/tests/unit/ai/review/test_architecture_characterization.py
@@ -187,7 +187,9 @@ def _invoke_review(*, run_review_return: ReviewResult) -> Any:
     mock_context = MagicMock()
     mock_context.changed_files = []
     mock_context.unified_diff = ""
-    mock_config = MagicMock(ai={"enabled": True, "review": True})
+    mock_config = MagicMock(
+        ai={"enabled": True, "review": True, "provider": "openai"},
+    )
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
     mock_config.review.sensitivity = MagicMock()
@@ -432,7 +434,9 @@ def test_review_exit_two_when_orchestrator_raises() -> None:
     runner = CliRunner()
     mock_context = MagicMock()
     mock_context.changed_files = []
-    mock_config = MagicMock(ai={"enabled": True, "review": True})
+    mock_config = MagicMock(
+        ai={"enabled": True, "review": True, "provider": "openai"},
+    )
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
     mock_config.review.sensitivity = MagicMock()

--- a/tests/unit/ai/review/test_error_contract.py
+++ b/tests/unit/ai/review/test_error_contract.py
@@ -21,7 +21,7 @@ from lintro.ai.review.error_contract import (
     is_retryable_kind,
     render_error_contract_json,
 )
-from lintro.ai.review.errors_taxonomy import ReviewErrorKind
+from lintro.ai.review.errors_taxonomy import KIND_COPY, ReviewErrorKind
 from lintro.ai.review.exceptions import ReviewExecutionError
 
 
@@ -258,6 +258,11 @@ def test_every_error_kind_is_covered_by_the_unavailable_partition() -> None:
     }
 
     assert_that(covered).is_equal_to(set(ReviewErrorKind))
+
+
+def test_kind_copy_covers_every_error_kind() -> None:
+    """GitHub sticky copy must exist for every kind or ``--post`` KeyErrors."""
+    assert_that(set(KIND_COPY)).is_equal_to(set(ReviewErrorKind))
 
 
 def test_render_json_is_parseable_and_indented(

--- a/tests/unit/ai/review/test_error_contract.py
+++ b/tests/unit/ai/review/test_error_contract.py
@@ -223,6 +223,7 @@ def test_retryable_kinds_membership() -> None:
         # or the response it got back is what failed, not the account.
         (ReviewErrorKind.CONTEXT_LENGTH, False),
         (ReviewErrorKind.INVALID_RESPONSE, False),
+        (ReviewErrorKind.PROVIDER_UNAVAILABLE, True),
         (ReviewErrorKind.UNKNOWN, False),
     ],
 )
@@ -252,6 +253,7 @@ def test_every_error_kind_is_covered_by_the_unavailable_partition() -> None:
         ReviewErrorKind.TIMEOUT,
         ReviewErrorKind.CONTEXT_LENGTH,
         ReviewErrorKind.INVALID_RESPONSE,
+        ReviewErrorKind.PROVIDER_UNAVAILABLE,
         ReviewErrorKind.UNKNOWN,
     }
 

--- a/tests/unit/ai/review/test_error_display.py
+++ b/tests/unit/ai/review/test_error_display.py
@@ -38,13 +38,14 @@ def test_render_timeout_includes_actionable_hints() -> None:
 
 def test_render_unset_provider_is_not_invalid_response() -> None:
     """A missing provider is a configuration failure, not a parse failure."""
-    from lintro.ai.provider_enum import provider_required_error
-
     buf = StringIO()
     console = Console(file=buf, width=120, force_terminal=True)
 
     render_review_error(
-        error=AIProviderRequiredError(provider_required_error()),
+        error=AIProviderRequiredError(
+            "ai.provider is required when ai.lint or ai.review is enabled. "
+            "Set it via `ai.provider` in config, LINTRO_AI_PROVIDER, or --provider.",
+        ),
         console=console,
     )
     output = buf.getvalue()

--- a/tests/unit/ai/review/test_error_display.py
+++ b/tests/unit/ai/review/test_error_display.py
@@ -7,7 +7,7 @@ from io import StringIO
 from assertpy import assert_that
 from rich.console import Console
 
-from lintro.ai.exceptions import AIProviderError
+from lintro.ai.exceptions import AIProviderError, AIProviderRequiredError
 from lintro.ai.review.error_display import render_review_error
 from lintro.ai.review.exceptions import ReviewExecutionError
 
@@ -34,6 +34,27 @@ def test_render_timeout_includes_actionable_hints() -> None:
     assert_that(output).contains("api_timeout")
     assert_that(output).contains("inline")
     assert_that(output).does_not_contain("Traceback")
+
+
+def test_render_unset_provider_is_not_invalid_response() -> None:
+    """A missing provider is a configuration failure, not a parse failure."""
+    from lintro.ai.provider_enum import provider_required_error
+
+    buf = StringIO()
+    console = Console(file=buf, width=120, force_terminal=True)
+
+    render_review_error(
+        error=AIProviderRequiredError(provider_required_error()),
+        console=console,
+    )
+    output = buf.getvalue()
+
+    assert_that(output).contains("provider unset")
+    assert_that(output).contains("ai.provider")
+    assert_that(output).contains("LINTRO_AI_PROVIDER")
+    assert_that(output).contains("--provider")
+    assert_that(output).does_not_contain("invalid response")
+    assert_that(output).does_not_contain("malformed")
 
 
 def test_render_provider_error_without_traceback() -> None:

--- a/tests/unit/ai/review/test_errors_taxonomy.py
+++ b/tests/unit/ai/review/test_errors_taxonomy.py
@@ -199,9 +199,9 @@ def test_classify_unknown_falls_back() -> None:
 
 def test_provider_required_classifies_as_unavailable() -> None:
     """An unset provider is unavailable, not a malformed model response."""
-    from lintro.ai.provider_enum import provider_required_error
-
-    error = AIProviderRequiredError(provider_required_error())
+    error = AIProviderRequiredError(
+        "ai.provider is required when ai.lint or ai.review is enabled.",
+    )
     kind = classify_provider_error(provider="unset", error=error)
 
     assert_that(kind).is_equal_to(ReviewErrorKind.PROVIDER_UNAVAILABLE)

--- a/tests/unit/ai/review/test_errors_taxonomy.py
+++ b/tests/unit/ai/review/test_errors_taxonomy.py
@@ -7,6 +7,7 @@ from assertpy import assert_that
 from lintro.ai.exceptions import (
     AIAuthenticationError,
     AIProviderError,
+    AIProviderRequiredError,
     AIRateLimitError,
 )
 from lintro.ai.review.errors_taxonomy import (
@@ -194,6 +195,17 @@ def test_classify_unknown_falls_back() -> None:
     kind = classify_provider_error(provider="anthropic", error=error)
 
     assert_that(kind).is_equal_to(ReviewErrorKind.UNKNOWN)
+
+
+def test_provider_required_classifies_as_unavailable() -> None:
+    """An unset provider is unavailable, not a malformed model response."""
+    from lintro.ai.provider_enum import provider_required_error
+
+    error = AIProviderRequiredError(provider_required_error())
+    kind = classify_provider_error(provider="unset", error=error)
+
+    assert_that(kind).is_equal_to(ReviewErrorKind.PROVIDER_UNAVAILABLE)
+    assert_that(kind).is_not_equal_to(ReviewErrorKind.INVALID_RESPONSE)
 
 
 def test_value_error_classifies_as_invalid_response() -> None:

--- a/tests/unit/ai/review/test_errors_taxonomy.py
+++ b/tests/unit/ai/review/test_errors_taxonomy.py
@@ -312,6 +312,21 @@ def test_error_comment_surfaces_real_cause_for_depleted_credits() -> None:
     assert_that(body).contains("`anthropic`")
 
 
+def test_error_comment_provider_required_uses_unavailable_copy() -> None:
+    """An unset provider sticky uses PROVIDER_UNAVAILABLE copy, not parse copy."""
+    error = AIProviderRequiredError(
+        "ai.provider is required when ai.lint or ai.review is enabled. "
+        "Set it via `ai.provider` in config, LINTRO_AI_PROVIDER, or --provider.",
+    )
+    body = format_error_comment(error=error, provider="unset")
+
+    assert_that(body).contains("no AI provider is configured")
+    assert_that(body).contains("`ai.provider` in config")
+    assert_that(body).contains("LINTRO_AI_PROVIDER")
+    assert_that(body).contains("--provider")
+    assert_that(body).does_not_contain("malformed")
+
+
 def test_error_comment_unknown_includes_surfaced_cause() -> None:
     """An unknown error still surfaces its cause text in the sticky."""
     error = AIProviderError("some brand new failure mode")

--- a/tests/unit/ai/review/test_review_command_json_error.py
+++ b/tests/unit/ai/review/test_review_command_json_error.py
@@ -11,6 +11,7 @@ from click.testing import CliRunner
 
 from lintro.ai.exceptions import AIAuthenticationError
 from lintro.ai.review.enums.checklist_display import ChecklistDisplay
+from lintro.ai.review.enums.custom_agent_mode import CustomAgentMode
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
 from lintro.cli_utils.commands import review as review_module
 from lintro.cli_utils.commands.review import review_command
@@ -91,6 +92,64 @@ def test_json_error_emits_envelope_and_exits_two(
     assert_that(payload["error"]["status"]).is_equal_to(401)
     assert_that(payload["error"]["retryable"]).is_false()
     assert_that(payload["error"]["provider_unavailable"]).is_true()
+
+
+def test_json_unset_provider_exits_two(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An enabled review with no provider uses the error contract, not exit 1."""
+    from lintro.ai.config import AIConfig
+    from lintro.ai.review.error_contract import REVIEW_ERROR_EXIT_CODE
+
+    config = MagicMock()
+    config.ai = {"enabled": True, "review": True}
+    config.review.depth = 1
+    config.review.strictness = ReviewStrictness.BALANCED
+    config.review.sensitivity = {}
+    config.review.checklist_display = "off"
+    config.review.force_semantic_chunking = False
+    config.review.custom_agents = CustomAgentMode.DISABLED
+
+    monkeypatch.setattr(review_module, "require_ai", lambda: None)
+    monkeypatch.setattr(review_module, "get_config", lambda: config)
+    monkeypatch.setattr(
+        review_module,
+        "collect_review_context",
+        lambda **_: MagicMock(changed_files=[]),
+    )
+    monkeypatch.setattr(review_module, "classify_changed_files", lambda _: [])
+    monkeypatch.setattr(review_module, "get_all_checklist_items", lambda **_: [])
+    monkeypatch.setattr(review_module, "select_checklist_items", lambda **_: [])
+    monkeypatch.setattr(
+        review_module,
+        "format_checklist_for_prompt",
+        lambda **_: ("", {}),
+    )
+    monkeypatch.setattr(review_module, "build_prompt_question_map", lambda **_: {})
+    monkeypatch.setattr(
+        review_module,
+        "resolve_checklist_display",
+        lambda **_: ChecklistDisplay.OFF,
+    )
+    monkeypatch.setattr(
+        review_module,
+        "apply_cli_overrides",
+        lambda _resolved, **_kwargs: AIConfig.resolve_from_mapping(
+            {"enabled": True, "review": True},
+        ),
+    )
+    monkeypatch.setattr(
+        review_module,
+        "resolve_sensitivity_policy",
+        lambda **_: MagicMock(),
+    )
+
+    result = CliRunner().invoke(review_command, ["--output", "json"])
+
+    assert_that(result.exit_code).is_equal_to(REVIEW_ERROR_EXIT_CODE)
+    payload = json.loads(result.output[result.output.index("{") :])
+    assert_that(payload["error"]["provider"]).is_equal_to("unset")
+    assert_that(payload["error"]["message"]).contains("`ai.provider` in config")
+    assert_that(payload["error"]["message"]).contains("LINTRO_AI_PROVIDER")
+    assert_that(payload["error"]["message"]).contains("--provider")
 
 
 def test_terminal_error_exits_two_not_one(patched_review: None) -> None:

--- a/tests/unit/ai/review/test_review_command_json_error.py
+++ b/tests/unit/ai/review/test_review_command_json_error.py
@@ -146,7 +146,9 @@ def test_json_unset_provider_exits_two(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert_that(result.exit_code).is_equal_to(REVIEW_ERROR_EXIT_CODE)
     payload = json.loads(result.output[result.output.index("{") :])
+    assert_that(payload["error"]["kind"]).is_equal_to("provider_unavailable")
     assert_that(payload["error"]["provider"]).is_equal_to("unset")
+    assert_that(payload["error"]["provider_unavailable"]).is_true()
     assert_that(payload["error"]["message"]).contains("`ai.provider` in config")
     assert_that(payload["error"]["message"]).contains("LINTRO_AI_PROVIDER")
     assert_that(payload["error"]["message"]).contains("--provider")

--- a/tests/unit/ai/review/test_review_command_json_error.py
+++ b/tests/unit/ai/review/test_review_command_json_error.py
@@ -25,8 +25,10 @@ def patched_review(monkeypatch: pytest.MonkeyPatch) -> None:
     drive a single failure mode (``run_review`` raising) through the real
     ``--output json`` error branch.
     """
+    from lintro.ai.config import AIConfig
+
     config = MagicMock()
-    config.ai = {"enabled": True}
+    config.ai = {"enabled": True, "review": True, "provider": "anthropic"}
     config.review.depth = 1
     config.review.strictness = ReviewStrictness.BALANCED
     config.review.sensitivity = {}
@@ -60,7 +62,9 @@ def patched_review(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         review_module,
         "apply_cli_overrides",
-        lambda resolved, **_kwargs: resolved,
+        lambda _resolved, **_kwargs: AIConfig.resolve_from_mapping(
+            {"enabled": True, "review": True, "provider": "anthropic"},
+        ),
     )
     monkeypatch.setattr(review_module, "get_provider", lambda _, **_kwargs: provider)
     monkeypatch.setattr(
@@ -152,6 +156,63 @@ def test_json_unset_provider_exits_two(monkeypatch: pytest.MonkeyPatch) -> None:
     assert_that(payload["error"]["message"]).contains("`ai.provider` in config")
     assert_that(payload["error"]["message"]).contains("LINTRO_AI_PROVIDER")
     assert_that(payload["error"]["message"]).contains("--provider")
+
+
+def test_json_unset_provider_beats_context_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unset provider wins over a failing context collection.
+
+    ``lintro review`` used to collect the git diff before constructing a
+    provider. An invalid base or a non-repo cwd then hid the required-provider
+    migration error behind ``ReviewContextError``.
+    """
+    from lintro.ai.config import AIConfig
+    from lintro.ai.review.enums.review_context_error_code import (
+        ReviewContextErrorCode,
+    )
+    from lintro.ai.review.error_contract import REVIEW_ERROR_EXIT_CODE
+    from lintro.ai.review.exceptions import ReviewContextError
+
+    config = MagicMock()
+    config.ai = {"enabled": True, "review": True}
+    config.review.depth = 1
+    config.review.strictness = ReviewStrictness.BALANCED
+    config.review.sensitivity = {}
+    config.review.checklist_display = "off"
+    config.review.force_semantic_chunking = False
+    config.review.custom_agents = CustomAgentMode.DISABLED
+
+    def _raise_context(**_: object) -> None:
+        raise ReviewContextError(
+            "not a git repository",
+            code=ReviewContextErrorCode.NOT_GIT_REPO,
+        )
+
+    monkeypatch.setattr(review_module, "require_ai", lambda: None)
+    monkeypatch.setattr(review_module, "get_config", lambda: config)
+    monkeypatch.setattr(
+        review_module,
+        "collect_review_context",
+        _raise_context,
+    )
+    monkeypatch.setattr(
+        review_module,
+        "apply_cli_overrides",
+        lambda _resolved, **_kwargs: AIConfig.resolve_from_mapping(
+            {"enabled": True, "review": True},
+        ),
+    )
+
+    result = CliRunner().invoke(review_command, ["--output", "json"])
+
+    assert_that(result.exit_code).is_equal_to(REVIEW_ERROR_EXIT_CODE)
+    payload = json.loads(result.output[result.output.index("{") :])
+    assert_that(payload["error"]["kind"]).is_equal_to("provider_unavailable")
+    assert_that(payload["error"]["provider"]).is_equal_to("unset")
+    assert_that(payload["error"]["provider_unavailable"]).is_true()
+    assert_that(payload["error"]["message"]).contains("`ai.provider` in config")
+    assert_that(payload["error"]["message"]).does_not_contain("not a git repository")
 
 
 def test_terminal_error_exits_two_not_one(patched_review: None) -> None:

--- a/tests/unit/ai/test_config.py
+++ b/tests/unit/ai/test_config.py
@@ -110,6 +110,15 @@ def test_provider_deferred_when_ai_enabled() -> None:
     assert_that(config.provider).is_none()
 
 
+def test_provider_field_description_lists_accepted_values() -> None:
+    """Schema help lists providers alphabetically from the shared helper."""
+    description = AIConfig.model_fields["provider"].description
+    assert_that(description).contains("`ai.provider` in config")
+    assert_that(description).contains("LINTRO_AI_PROVIDER")
+    assert_that(description).contains("--provider")
+    assert_that(description).contains("anthropic, cursor, openai")
+
+
 # -- Boolean overrides -----------------------------------------------------
 
 

--- a/tests/unit/ai/test_config.py
+++ b/tests/unit/ai/test_config.py
@@ -17,7 +17,7 @@ def test_default_config_booleans_and_provider() -> None:
     """All boolean defaults and provider are correct out of the box."""
     config = AIConfig()
     assert_that(config.enabled).is_false()
-    assert_that(config.provider).is_equal_to("anthropic")
+    assert_that(config.provider).is_none()
     assert_that(config.default_fix).is_false()
     assert_that(config.auto_apply).is_false()
     assert_that(config.auto_apply_safe_fixes).is_true()
@@ -96,6 +96,18 @@ def test_provider_invalid_rejected() -> None:
     """An invalid provider string is rejected by validation."""
     with pytest.raises(ValidationError):
         AIConfig.model_validate({"provider": "gemini"})
+
+
+def test_provider_optional_when_ai_disabled() -> None:
+    """Disabled AI config does not require a provider."""
+    config = AIConfig(enabled=False)
+    assert_that(config.provider).is_none()
+
+
+def test_provider_deferred_when_ai_enabled() -> None:
+    """Enabled AI config may omit provider until doctor or get_provider."""
+    config = AIConfig(enabled=True)
+    assert_that(config.provider).is_none()
 
 
 # -- Boolean overrides -----------------------------------------------------

--- a/tests/unit/ai/test_config_overrides.py
+++ b/tests/unit/ai/test_config_overrides.py
@@ -129,9 +129,7 @@ def test_invalid_provider_env_names_the_variable(
 
     message = str(exc_info.value)
     assert_that(message).contains("LINTRO_AI_PROVIDER='cursur'")
-    assert_that(message).contains("anthropic")
-    assert_that(message).contains("openai")
-    assert_that(message).contains("cursor")
+    assert_that(message).contains("anthropic, cursor, openai")
     assert_that(message).does_not_contain("Traceback")
 
 

--- a/tests/unit/ai/test_config_resolution.py
+++ b/tests/unit/ai/test_config_resolution.py
@@ -72,7 +72,7 @@ def test_from_mapping_applies_known_keys() -> None:
     assert_that(config.lint).is_true()
     assert_that(config.review).is_false()
     assert_that(config.max_tokens).is_equal_to(1234)
-    assert_that(config.provider).is_equal_to(AIProvider.ANTHROPIC)
+    assert_that(config.provider).is_none()
 
 
 def test_from_mapping_drops_unknown_keys_and_warns_sorted(

--- a/tests/unit/ai/test_display_status.py
+++ b/tests/unit/ai/test_display_status.py
@@ -64,29 +64,28 @@ def test_render_ai_status_disabled() -> None:
 
 def test_render_ai_status_unset_provider() -> None:
     """An enabled config with no provider names the three-way migration path."""
-    from lintro.ai.provider_enum import provider_required_error
-
     lines = render_ai_status(
         ai_config=AIConfig(enabled=True, lint=True, review=False),
         is_ci=False,
     )
 
     assert_that(lines[0]).is_equal_to("[yellow]enabled (provider unset)[/yellow]")
-    assert_that(lines[1]).contains(provider_required_error())
+    assert_that(lines[1]).contains("`ai.provider` in config")
+    assert_that(lines[1]).contains("LINTRO_AI_PROVIDER")
+    assert_that(lines[1]).contains("--provider")
+    assert_that(lines[1]).contains("anthropic, cursor, openai")
     assert_that(lines).contains("  provider: unset")
 
 
 def test_render_ai_status_unset_provider_without_features() -> None:
     """Master on with both features off is informational, not a migration error."""
-    from lintro.ai.provider_enum import provider_required_error
-
     lines = render_ai_status(
         ai_config=AIConfig(enabled=True, lint=False, review=False),
         is_ci=False,
     )
 
     assert_that(lines[0]).is_equal_to("[yellow]enabled (provider unset)[/yellow]")
-    assert_that("".join(lines)).does_not_contain(provider_required_error())
+    assert_that("".join(lines)).does_not_contain("ai.provider is required")
     assert_that(lines).contains("  provider: unset")
 
 

--- a/tests/unit/ai/test_display_status.py
+++ b/tests/unit/ai/test_display_status.py
@@ -62,6 +62,20 @@ def test_render_ai_status_disabled() -> None:
     )
 
 
+def test_render_ai_status_unset_provider() -> None:
+    """An enabled config with no provider names the three-way migration path."""
+    from lintro.ai.provider_enum import provider_required_error
+
+    lines = render_ai_status(
+        ai_config=AIConfig(enabled=True, lint=True, review=False),
+        is_ci=False,
+    )
+
+    assert_that(lines[0]).is_equal_to("[yellow]enabled (provider unset)[/yellow]")
+    assert_that(lines[1]).contains(provider_required_error())
+    assert_that(lines).contains("  provider: unset")
+
+
 def test_render_ai_status_unknown_provider() -> None:
     """An unsupported provider renders the red unknown-provider lines."""
     lines = render_ai_status(

--- a/tests/unit/ai/test_display_status.py
+++ b/tests/unit/ai/test_display_status.py
@@ -76,6 +76,20 @@ def test_render_ai_status_unset_provider() -> None:
     assert_that(lines).contains("  provider: unset")
 
 
+def test_render_ai_status_unset_provider_without_features() -> None:
+    """Master on with both features off is informational, not a migration error."""
+    from lintro.ai.provider_enum import provider_required_error
+
+    lines = render_ai_status(
+        ai_config=AIConfig(enabled=True, lint=False, review=False),
+        is_ci=False,
+    )
+
+    assert_that(lines[0]).is_equal_to("[yellow]enabled (provider unset)[/yellow]")
+    assert_that("".join(lines)).does_not_contain(provider_required_error())
+    assert_that(lines).contains("  provider: unset")
+
+
 def test_render_ai_status_unknown_provider() -> None:
     """An unsupported provider renders the red unknown-provider lines."""
     lines = render_ai_status(

--- a/tests/unit/ai/test_doctor_liveness.py
+++ b/tests/unit/ai/test_doctor_liveness.py
@@ -19,6 +19,7 @@ from lintro.ai.config import AIConfig
 from lintro.ai.doctor_checks import check_ai_liveness
 from lintro.ai.enums import AITransport
 from lintro.ai.liveness import LivenessResult, LivenessState
+from lintro.ai.registry import AIProvider
 from lintro.cli import cli
 from lintro.enums.tool_status import ToolStatus
 
@@ -54,7 +55,16 @@ def test_liveness_is_skipped_when_ai_is_disabled() -> None:
 
 def test_liveness_is_skipped_without_a_transport() -> None:
     """Transport resolution is a prerequisite; doctor reports that separately."""
-    assert_that(check_ai_liveness(AIConfig(enabled=True))).is_empty()
+    assert_that(
+        check_ai_liveness(AIConfig(enabled=True, provider=AIProvider.ANTHROPIC)),
+    ).is_empty()
+
+
+def test_liveness_is_skipped_without_a_provider() -> None:
+    """Provider resolution is a prerequisite; doctor reports that separately."""
+    assert_that(
+        check_ai_liveness(AIConfig(enabled=True, transport=AITransport.API)),
+    ).is_empty()
 
 
 @pytest.mark.parametrize(
@@ -89,7 +99,11 @@ def test_liveness_states_map_to_doctor_statuses(
     )
 
     results = check_ai_liveness(
-        AIConfig(enabled=True, transport=AITransport.API),
+        AIConfig(
+            enabled=True,
+            provider=AIProvider.ANTHROPIC,
+            transport=AITransport.API,
+        ),
     )
 
     assert_that(results).is_length(1)
@@ -141,7 +155,12 @@ def test_doctor_probes_when_the_flag_is_given(monkeypatch: Any) -> None:
     )
     monkeypatch.setattr(
         "lintro.cli_utils.commands.doctor.resolve_ai_config",
-        lambda config: AIConfig(enabled=True, review=True, transport=AITransport.API),
+        lambda config: AIConfig(
+            enabled=True,
+            review=True,
+            provider=AIProvider.ANTHROPIC,
+            transport=AITransport.API,
+        ),
     )
 
     CliRunner().invoke(cli, ["doctor", "--tools", "ruff"])
@@ -211,7 +230,12 @@ def test_report_mode_renders_the_liveness_result(
     )
     monkeypatch.setattr(
         "lintro.cli_utils.commands.doctor.resolve_ai_config",
-        lambda config: AIConfig(enabled=True, review=True, transport=AITransport.API),
+        lambda config: AIConfig(
+            enabled=True,
+            review=True,
+            provider=AIProvider.ANTHROPIC,
+            transport=AITransport.API,
+        ),
     )
 
     result = CliRunner().invoke(

--- a/tests/unit/ai/test_liveness.py
+++ b/tests/unit/ai/test_liveness.py
@@ -50,6 +50,7 @@ from tests.unit.ai.conftest import MockAIProvider
         (ReviewErrorKind.RATE_LIMITED, LivenessState.RATE_LIMITED),
         (ReviewErrorKind.SERVER_ERROR, LivenessState.UNREACHABLE),
         (ReviewErrorKind.TIMEOUT, LivenessState.UNREACHABLE),
+        (ReviewErrorKind.PROVIDER_UNAVAILABLE, LivenessState.UNKNOWN),
         (ReviewErrorKind.UNKNOWN, LivenessState.UNKNOWN),
     ],
 )

--- a/tests/unit/ai/test_orchestrator_edge.py
+++ b/tests/unit/ai/test_orchestrator_edge.py
@@ -148,6 +148,52 @@ def test_ai_result_error_on_exception():
     assert_that(ai_result.error).is_true()
 
 
+def test_unset_provider_skips_enhancement_without_fail_on_ai_error() -> None:
+    """Chk treats an unset provider as an enhancement skip, not a crash."""
+    config = LintroConfig(
+        ai=AIConfig(enabled=True, lint=True).model_dump(),
+    )
+    logger = MagicMock()
+
+    with patch("lintro.ai.orchestrator.require_ai"):
+        ai_result = run_ai_enhancement(
+            action=Action.CHECK,
+            all_results=[],
+            lintro_config=config,
+            logger=logger,
+            output_format="json",
+        )
+
+    assert_that(ai_result).is_instance_of(AIResult)
+    assert_that(ai_result.error).is_true()
+
+
+def test_unset_provider_reraises_when_fail_on_ai_error() -> None:
+    """fail_on_ai_error re-raises the required-provider configuration error."""
+    from lintro.ai.exceptions import AIProviderRequiredError
+
+    config = LintroConfig(
+        ai=AIConfig(
+            enabled=True,
+            lint=True,
+            fail_on_ai_error=True,
+        ).model_dump(),
+    )
+    logger = MagicMock()
+
+    with (
+        patch("lintro.ai.orchestrator.require_ai"),
+        pytest.raises(AIProviderRequiredError, match="ai.provider is required"),
+    ):
+        run_ai_enhancement(
+            action=Action.CHECK,
+            all_results=[],
+            lintro_config=config,
+            logger=logger,
+            output_format="json",
+        )
+
+
 def test_ai_result_error_propagates_when_fail_on_ai_error():
     """Exceptions propagate when fail_on_ai_error=True."""
     config = LintroConfig(

--- a/tests/unit/ai/test_registry.py
+++ b/tests/unit/ai/test_registry.py
@@ -7,6 +7,10 @@ from dataclasses import FrozenInstanceError, asdict
 import pytest
 from assertpy import assert_that
 
+from lintro.ai.provider_enum import (
+    accepted_provider_values,
+    provider_required_error,
+)
 from lintro.ai.registry import (
     DEFAULT_PRICING,
     PROVIDERS,
@@ -47,6 +51,20 @@ def test_aiprovider_invalid_value_raises():
     """Constructing AIProvider with an unknown value raises ValueError."""
     with pytest.raises(ValueError, match="not a valid"):
         AIProvider("gemini")
+
+
+def test_accepted_provider_values_are_alphabetical() -> None:
+    """User-visible provider lists carry no ranking."""
+    assert_that(accepted_provider_values()).is_equal_to("anthropic, cursor, openai")
+
+
+def test_provider_required_error_names_the_three_set_paths() -> None:
+    """The migration error names config, env, and flag, then accepted values."""
+    message = provider_required_error()
+    assert_that(message).contains("`ai.provider` in config")
+    assert_that(message).contains("LINTRO_AI_PROVIDER")
+    assert_that(message).contains("--provider")
+    assert_that(message).contains("anthropic, cursor, openai")
 
 
 # -- ModelPricing ----------------------------------------------------------

--- a/tests/unit/ai/test_transport_config.py
+++ b/tests/unit/ai/test_transport_config.py
@@ -26,7 +26,9 @@ def test_transport_deferred_to_doctor_when_ai_enabled() -> None:
 
 def test_doctor_reports_missing_transport_when_ai_enabled() -> None:
     """Doctor surfaces missing transport instead of raw config validation."""
-    results = check_ai_configuration(AIConfig(enabled=True))
+    results = check_ai_configuration(
+        AIConfig(enabled=True, provider=AIProvider.ANTHROPIC),
+    )
     assert_that(results).is_length(1)
     assert_that(results[0].name).is_equal_to("ai.transport")
     assert_that(results[0].status).is_equal_to(ToolStatus.INCOMPATIBLE)
@@ -34,7 +36,14 @@ def test_doctor_reports_missing_transport_when_ai_enabled() -> None:
 
 def test_doctor_reports_missing_transport_when_only_lint_enabled() -> None:
     """Doctor validates transport when only ai.lint is enabled."""
-    results = check_ai_configuration(AIConfig(enabled=True, lint=True, review=False))
+    results = check_ai_configuration(
+        AIConfig(
+            enabled=True,
+            lint=True,
+            review=False,
+            provider=AIProvider.ANTHROPIC,
+        ),
+    )
     assert_that(results).is_length(1)
     assert_that(results[0].name).is_equal_to("ai.transport")
     assert_that(results[0].message).contains("ai.lint or ai.review")
@@ -42,9 +51,45 @@ def test_doctor_reports_missing_transport_when_only_lint_enabled() -> None:
 
 def test_doctor_reports_missing_transport_when_only_review_enabled() -> None:
     """Doctor validates transport when only ai.review is enabled."""
-    results = check_ai_configuration(AIConfig(enabled=True, lint=False, review=True))
+    results = check_ai_configuration(
+        AIConfig(
+            enabled=True,
+            lint=False,
+            review=True,
+            provider=AIProvider.ANTHROPIC,
+        ),
+    )
     assert_that(results).is_length(1)
     assert_that(results[0].name).is_equal_to("ai.transport")
+
+
+def test_doctor_reports_missing_provider_when_ai_enabled() -> None:
+    """Doctor surfaces missing provider with the three-way migration path."""
+    from lintro.ai.provider_enum import (
+        accepted_provider_values,
+        provider_required_error,
+    )
+
+    results = check_ai_configuration(
+        AIConfig(enabled=True, transport=AITransport.API),
+    )
+    assert_that(results).is_length(1)
+    assert_that(results[0].name).is_equal_to("ai.provider")
+    assert_that(results[0].status).is_equal_to(ToolStatus.INCOMPATIBLE)
+    assert_that(results[0].message).is_equal_to(provider_required_error())
+    assert_that(results[0].message).contains("ai.provider")
+    assert_that(results[0].message).contains("LINTRO_AI_PROVIDER")
+    assert_that(results[0].message).contains("--provider")
+    assert_that(results[0].message).contains(accepted_provider_values())
+    assert_that(accepted_provider_values()).is_equal_to("anthropic, cursor, openai")
+
+
+def test_doctor_reports_missing_provider_and_transport_together() -> None:
+    """Doctor reports both required fields when neither is set."""
+    results = check_ai_configuration(AIConfig(enabled=True))
+    names = [result.name for result in results]
+    assert_that(names).contains("ai.provider")
+    assert_that(names).contains("ai.transport")
 
 
 def test_doctor_skips_when_master_switch_off() -> None:

--- a/tests/unit/ai/test_transport_config.py
+++ b/tests/unit/ai/test_transport_config.py
@@ -65,10 +65,7 @@ def test_doctor_reports_missing_transport_when_only_review_enabled() -> None:
 
 def test_doctor_reports_missing_provider_when_ai_enabled() -> None:
     """Doctor surfaces missing provider with the three-way migration path."""
-    from lintro.ai.provider_enum import (
-        accepted_provider_values,
-        provider_required_error,
-    )
+    from lintro.ai.provider_enum import accepted_provider_values
 
     results = check_ai_configuration(
         AIConfig(enabled=True, transport=AITransport.API),
@@ -76,7 +73,6 @@ def test_doctor_reports_missing_provider_when_ai_enabled() -> None:
     assert_that(results).is_length(1)
     assert_that(results[0].name).is_equal_to("ai.provider")
     assert_that(results[0].status).is_equal_to(ToolStatus.INCOMPATIBLE)
-    assert_that(results[0].message).is_equal_to(provider_required_error())
     assert_that(results[0].message).contains("ai.provider")
     assert_that(results[0].message).contains("LINTRO_AI_PROVIDER")
     assert_that(results[0].message).contains("--provider")

--- a/tests/unit/ai/test_transport_profiles.py
+++ b/tests/unit/ai/test_transport_profiles.py
@@ -7,6 +7,7 @@ from assertpy import assert_that
 
 from lintro.ai.config import AIConfig, AITransportProfiles, CliTransportProfile
 from lintro.ai.enums import AITransport, CostBasis
+from lintro.ai.registry import AIProvider
 from lintro.ai.transport import (
     DEFAULT_API_TIMEOUT,
     DEFAULT_CLI_TIMEOUT,
@@ -152,7 +153,10 @@ def test_cli_auth_mode_reports_api_key_when_bare_billing_engages(
     subscription/unpriceable (#1923).
     """
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-    config = AIConfig(transport=AITransport.CLI)
+    config = AIConfig(
+        provider=AIProvider.ANTHROPIC,
+        transport=AITransport.CLI,
+    )
 
     resolved = resolve_transport_settings(config)
 

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -1375,6 +1375,39 @@ def _advisory_error_result() -> ToolResult:
     )
 
 
+def test_advisory_only_unset_provider_exits_two_before_tools() -> None:
+    """--advisory-only fails closed on an unset provider before tools run."""
+    from lintro.ai.review.error_contract import REVIEW_ERROR_EXIT_CODE
+
+    runner = CliRunner()
+    with (
+        patch("lintro.cli_utils.commands.review.require_ai"),
+        patch(
+            "lintro.cli_utils.commands.review.get_config",
+            return_value=MagicMock(ai={"enabled": True, "review": True}),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.apply_cli_overrides",
+            lambda _resolved, **_kwargs: AIConfig.resolve_from_mapping(
+                {"enabled": True, "review": True},
+            ),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.run_advisory_tools",
+        ) as run_advisory,
+    ):
+        result = runner.invoke(
+            cli,
+            ["review", "--advisory-only", "--output", "json"],
+        )
+
+    assert_that(result.exit_code).is_equal_to(REVIEW_ERROR_EXIT_CODE)
+    payload = json.loads(result.output[result.output.index("{") :])
+    assert_that(payload["error"]["kind"]).is_equal_to("provider_unavailable")
+    assert_that(payload["error"]["message"]).contains("--provider")
+    assert_that(run_advisory.called).is_false()
+
+
 def test_advisory_only_exits_zero_with_findings() -> None:
     """Advisory findings are advisory: exit 0 by default."""
     runner = CliRunner()
@@ -1449,10 +1482,11 @@ def test_advisory_only_errored_tool_exits_two() -> None:
         )
 
     assert_that(result.exit_code).is_equal_to(REVIEW_ERROR_EXIT_CODE)
-    payload = json.loads(result.output)
-    assert_that(payload["advisory"][0]["success"]).is_false()
-    assert_that(payload["advisory"][0]["output"]).contains("`ai.provider` in config")
-    assert_that(payload["advisory"][0]["issues_count"]).is_equal_to(0)
+    payload = json.loads(result.output[result.output.index("{") :])
+    assert_that(payload["error"]["kind"]).is_equal_to("provider_unavailable")
+    assert_that(payload["error"]["message"]).contains("`ai.provider` in config")
+    assert_that(payload).does_not_contain_key("advisory")
+    assert_that(payload).does_not_contain_key("findings")
 
 
 def test_advisory_only_rejects_diff_flags() -> None:
@@ -1627,7 +1661,7 @@ def test_full_review_json_merges_advisory_key() -> None:
 
 
 def test_full_review_errored_advisory_exits_two() -> None:
-    """A full review that produced results still fails if advisory errored."""
+    """Advisory execution failure emits the error contract, not a review."""
     from lintro.ai.review.error_contract import REVIEW_ERROR_EXIT_CODE
 
     runner = CliRunner()
@@ -1643,15 +1677,28 @@ def test_full_review_errored_advisory_exits_two() -> None:
         patches["format_checklist_for_prompt"],
         patches["get_provider"],
         patches["run_review"],
-        patches["render_review_output"],
+        patch(
+            "lintro.cli_utils.commands.review.render_review_output",
+            return_value=json.dumps({"summary": "ok", "findings": []}),
+        ) as mock_render,
         patch(
             "lintro.cli_utils.commands.review.run_advisory_tools",
             return_value=[_advisory_error_result()],
         ),
+        patch(
+            "lintro.ai.review.github.post_review_to_github",
+            return_value=True,
+        ) as mock_post,
     ):
-        result = runner.invoke(cli, ["review"])
+        result = runner.invoke(cli, ["review", "--output", "json"])
 
     assert_that(result.exit_code).is_equal_to(REVIEW_ERROR_EXIT_CODE)
+    payload = json.loads(result.output[result.output.index("{") :])
+    assert_that(payload["error"]["kind"]).is_equal_to("provider_unavailable")
+    assert_that(payload).does_not_contain_key("findings")
+    assert_that(payload).does_not_contain_key("summary")
+    assert_that(mock_render.called).is_false()
+    assert_that(mock_post.called).is_false()
 
 
 def test_cli_overrides_lists_only_explicit_flags() -> None:

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -13,6 +13,7 @@ from click.testing import CliRunner
 
 from lintro.ai.config import AIConfig
 from lintro.ai.enums import AITransport
+from lintro.ai.provider_enum import AIProvider
 from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.enums.custom_agent_mode import CustomAgentMode
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
@@ -115,6 +116,7 @@ def test_review_max_cost_flag_beats_transport_profile() -> None:
         ai={
             "enabled": True,
             "review": True,
+            "provider": "openai",
             "transport": "cli",
             "transports": {"cli": {"max_cost_usd_advisory": 1.25}},
         },
@@ -184,6 +186,7 @@ def test_review_profile_cap_provenance_is_config() -> None:
         ai={
             "enabled": True,
             "review": True,
+            "provider": "openai",
             "transport": "cli",
             "transports": {"cli": {"max_cost_usd_advisory": 1.25}},
         },
@@ -297,6 +300,7 @@ def test_review_runs_when_review_enabled_without_lint() -> None:
             enabled=True,
             lint=False,
             review=True,
+            provider=AIProvider.OPENAI,
             transport=AITransport.API,
         ).model_dump(),
     )
@@ -332,7 +336,7 @@ def test_review_json_output_echoes_payload() -> None:
     mock_context = MagicMock()
     mock_context.changed_files = []
     mock_context.unified_diff = ""
-    mock_config = MagicMock(ai={"enabled": True})
+    mock_config = MagicMock(ai={"enabled": True, "provider": "openai"})
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
     mock_config.review.sensitivity = MagicMock()
@@ -400,7 +404,11 @@ def test_review_passes_transport_override_to_provider() -> None:
     mock_context.changed_files = []
     mock_context.unified_diff = ""
     mock_config = MagicMock(
-        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+        ai=AIConfig(
+            enabled=True,
+            provider=AIProvider.OPENAI,
+            transport=AITransport.API,
+        ).model_dump(),
     )
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
@@ -463,7 +471,11 @@ def test_review_passes_provider_and_model_overrides_to_provider() -> None:
     mock_context = MagicMock()
     mock_context.changed_files = []
     mock_config = MagicMock(
-        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+        ai=AIConfig(
+            enabled=True,
+            provider=AIProvider.OPENAI,
+            transport=AITransport.API,
+        ).model_dump(),
     )
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
@@ -622,7 +634,11 @@ def test_review_downgrades_billed_to_estimated_without_usage_counters() -> None:
     mock_context.changed_files = []
     mock_context.unified_diff = ""
     mock_config = MagicMock(
-        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+        ai=AIConfig(
+            enabled=True,
+            provider=AIProvider.OPENAI,
+            transport=AITransport.API,
+        ).model_dump(),
     )
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
@@ -688,7 +704,7 @@ def test_review_exits_zero_without_p1_findings() -> None:
     mock_context = MagicMock()
     mock_context.changed_files = []
     mock_context.unified_diff = ""
-    mock_config = MagicMock(ai={"enabled": True})
+    mock_config = MagicMock(ai={"enabled": True, "provider": "openai"})
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
     mock_config.review.sensitivity = MagicMock()
@@ -754,8 +770,8 @@ def _mock_review_pipeline(
     Args:
         mock_collect: Replacement for the context-collection patch.
         mock_config: Replacement lintro config. Defaults to a minimal config
-            with AI enabled; pass one to exercise config-dependent wiring
-            without duplicating the whole patch stack.
+            with AI enabled and an explicit provider; pass one to exercise
+            config-dependent wiring without duplicating the whole patch stack.
 
     Returns:
         Named patchers to enter around a ``CliRunner`` invocation.
@@ -764,7 +780,7 @@ def _mock_review_pipeline(
     mock_context.changed_files = []
     mock_context.unified_diff = ""
     if mock_config is None:
-        mock_config = MagicMock(ai={"enabled": True})
+        mock_config = MagicMock(ai={"enabled": True, "provider": "openai"})
         mock_config.review.depth = 1
         mock_config.review.strictness = ReviewStrictness.BALANCED
         mock_config.review.sensitivity = MagicMock()
@@ -1042,7 +1058,7 @@ def test_review_failure_renders_friendly_error_without_traceback() -> None:
         completed_chunks=2,
         cause_message="Cursor CLI timed out after 300s",
     )
-    mock_config = MagicMock(ai={"enabled": True})
+    mock_config = MagicMock(ai={"enabled": True, "provider": "openai"})
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
     mock_config.review.sensitivity = MagicMock()
@@ -1125,7 +1141,7 @@ def _agent_mode_config(*, tmp_path: Path, mode: CustomAgentMode) -> MagicMock:
     Returns:
         The configured mock.
     """
-    mock_config = MagicMock(ai={"enabled": True})
+    mock_config = MagicMock(ai={"enabled": True, "provider": "openai"})
     mock_config.config_path = str(tmp_path / ".lintro-config.yaml")
     mock_config.review.depth = 1
     mock_config.review.strictness = ReviewStrictness.BALANCED
@@ -1617,7 +1633,11 @@ def test_review_post_reports_config_source_and_transport() -> None:
     """
     runner = CliRunner()
     mock_config = MagicMock(
-        ai=AIConfig(enabled=True, transport=AITransport.API).model_dump(),
+        ai=AIConfig(
+            enabled=True,
+            provider=AIProvider.OPENAI,
+            transport=AITransport.API,
+        ).model_dump(),
     )
     mock_config.config_path = "/home/runner/work/repo/repo/.lintro-config.yaml"
     mock_config.review.depth = 1

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -1362,6 +1362,19 @@ def test_review_help_shows_advisory_flags() -> None:
     assert_that(result.output).contains("--fail-on-findings")
 
 
+def _advisory_error_result() -> ToolResult:
+    """Build an advisory tool result for a configuration/runtime failure."""
+    return ToolResult(
+        name="idiom-review",
+        success=False,
+        output=(
+            "ai.provider is required when ai.lint or ai.review is enabled. "
+            "Set it via `ai.provider` in config, LINTRO_AI_PROVIDER, or --provider. "
+            "Accepted providers: anthropic, cursor, openai."
+        ),
+    )
+
+
 def test_advisory_only_exits_zero_with_findings() -> None:
     """Advisory findings are advisory: exit 0 by default."""
     runner = CliRunner()
@@ -1415,6 +1428,31 @@ def test_advisory_only_json_output() -> None:
     payload = json.loads(result.output)
     assert_that(payload["advisory"]).is_length(1)
     assert_that(payload["advisory"][0]["tool"]).is_equal_to("idiom-review")
+    assert_that(payload["advisory"][0]["success"]).is_false()
+
+
+def test_advisory_only_errored_tool_exits_two() -> None:
+    """An advisory tool that failed to run is not a finding and exits 2."""
+    from lintro.ai.review.error_contract import REVIEW_ERROR_EXIT_CODE
+
+    runner = CliRunner()
+    with (
+        patch("lintro.cli_utils.commands.review.require_ai"),
+        patch(
+            "lintro.cli_utils.commands.review.run_advisory_tools",
+            return_value=[_advisory_error_result()],
+        ),
+    ):
+        result = runner.invoke(
+            cli,
+            ["review", "--advisory-only", "--output", "json"],
+        )
+
+    assert_that(result.exit_code).is_equal_to(REVIEW_ERROR_EXIT_CODE)
+    payload = json.loads(result.output)
+    assert_that(payload["advisory"][0]["success"]).is_false()
+    assert_that(payload["advisory"][0]["output"]).contains("`ai.provider` in config")
+    assert_that(payload["advisory"][0]["issues_count"]).is_equal_to(0)
 
 
 def test_advisory_only_rejects_diff_flags() -> None:
@@ -1586,6 +1624,34 @@ def test_full_review_json_merges_advisory_key() -> None:
     payload = json.loads(result.output)
     assert_that(payload["summary"]).is_equal_to("ok")
     assert_that(payload["advisory"][0]["tool"]).is_equal_to("idiom-review")
+
+
+def test_full_review_errored_advisory_exits_two() -> None:
+    """A full review that produced results still fails if advisory errored."""
+    from lintro.ai.review.error_contract import REVIEW_ERROR_EXIT_CODE
+
+    runner = CliRunner()
+    patches = _mock_review_pipeline()
+
+    with (
+        patches["require_ai"],
+        patches["get_config"],
+        patches["collect_review_context"],
+        patches["classify_changed_files"],
+        patches["get_all_checklist_items"],
+        patches["select_checklist_items"],
+        patches["format_checklist_for_prompt"],
+        patches["get_provider"],
+        patches["run_review"],
+        patches["render_review_output"],
+        patch(
+            "lintro.cli_utils.commands.review.run_advisory_tools",
+            return_value=[_advisory_error_result()],
+        ),
+    ):
+        result = runner.invoke(cli, ["review"])
+
+    assert_that(result.exit_code).is_equal_to(REVIEW_ERROR_EXIT_CODE)
 
 
 def test_cli_overrides_lists_only_explicit_flags() -> None:

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -1372,6 +1372,7 @@ def _advisory_error_result() -> ToolResult:
             "Set it via `ai.provider` in config, LINTRO_AI_PROVIDER, or --provider. "
             "Accepted providers: anthropic, cursor, openai."
         ),
+        metadata={"advisory_error": "provider_required"},
     )
 
 
@@ -1472,6 +1473,16 @@ def test_advisory_only_errored_tool_exits_two() -> None:
     with (
         patch("lintro.cli_utils.commands.review.require_ai"),
         patch(
+            "lintro.cli_utils.commands.review.get_config",
+            return_value=MagicMock(ai={"enabled": True, "review": True}),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.apply_cli_overrides",
+            lambda _resolved, **_kwargs: AIConfig.resolve_from_mapping(
+                {"enabled": True, "review": True, "provider": "openai"},
+            ),
+        ),
+        patch(
             "lintro.cli_utils.commands.review.run_advisory_tools",
             return_value=[_advisory_error_result()],
         ),
@@ -1487,6 +1498,55 @@ def test_advisory_only_errored_tool_exits_two() -> None:
     assert_that(payload["error"]["message"]).contains("`ai.provider` in config")
     assert_that(payload).does_not_contain_key("advisory")
     assert_that(payload).does_not_contain_key("findings")
+
+
+def test_advisory_only_provider_flag_reaches_advisory_tools() -> None:
+    """``--provider`` overlays YAML that omits ``ai.provider`` before tools run."""
+    runner = CliRunner()
+    with (
+        patch("lintro.cli_utils.commands.review.require_ai"),
+        patch(
+            "lintro.cli_utils.commands.review.get_config",
+            return_value=MagicMock(ai={"enabled": True, "review": True}),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.run_advisory_tools",
+            return_value=[],
+        ) as run_advisory,
+    ):
+        result = runner.invoke(
+            cli,
+            ["review", "--advisory-only", "--provider", "openai"],
+        )
+
+    assert_that(result.exit_code).is_equal_to(0)
+    ai_config = run_advisory.call_args.kwargs["ai_config"]
+    assert_that(ai_config.provider).is_equal_to(AIProvider.OPENAI)
+
+
+def test_advisory_failure_error_uses_metadata_not_prose() -> None:
+    """Classification keys off the typed marker, not error-message copy."""
+    from lintro.ai.exceptions import AIError, AIProviderRequiredError
+    from lintro.cli_utils.commands.review import _advisory_failure_error
+
+    marked = ToolResult(
+        name="idiom-review",
+        success=False,
+        output="tool failed for an unrelated reason",
+        metadata={"advisory_error": "provider_required"},
+    )
+    assert_that(_advisory_failure_error([marked])).is_instance_of(
+        AIProviderRequiredError,
+    )
+
+    prose_only = ToolResult(
+        name="idiom-review",
+        success=False,
+        output=("ai.provider is required when ai.lint or ai.review is enabled."),
+    )
+    error = _advisory_failure_error([prose_only])
+    assert_that(error).is_instance_of(AIError)
+    assert_that(error.__class__).is_equal_to(AIError)
 
 
 def test_advisory_only_rejects_diff_flags() -> None:
@@ -1660,10 +1720,8 @@ def test_full_review_json_merges_advisory_key() -> None:
     assert_that(payload["advisory"][0]["tool"]).is_equal_to("idiom-review")
 
 
-def test_full_review_errored_advisory_exits_two() -> None:
-    """Advisory execution failure emits the error contract, not a review."""
-    from lintro.ai.review.error_contract import REVIEW_ERROR_EXIT_CODE
-
+def test_full_review_keeps_results_when_advisory_errors() -> None:
+    """Advisory failure after a finished review does not discard the review."""
     runner = CliRunner()
     patches = _mock_review_pipeline()
 
@@ -1692,13 +1750,42 @@ def test_full_review_errored_advisory_exits_two() -> None:
     ):
         result = runner.invoke(cli, ["review", "--output", "json"])
 
-    assert_that(result.exit_code).is_equal_to(REVIEW_ERROR_EXIT_CODE)
-    payload = json.loads(result.output[result.output.index("{") :])
-    assert_that(payload["error"]["kind"]).is_equal_to("provider_unavailable")
-    assert_that(payload).does_not_contain_key("findings")
-    assert_that(payload).does_not_contain_key("summary")
-    assert_that(mock_render.called).is_false()
+    assert_that(result.exit_code).is_equal_to(0)
+    payload = json.loads(result.output)
+    assert_that(payload["summary"]).is_equal_to("ok")
+    assert_that(payload["findings"]).is_equal_to([])
+    assert_that(payload["advisory"][0]["success"]).is_false()
+    assert_that(payload["advisory"][0]["output"]).contains("ai.provider is required")
+    assert_that(mock_render.called).is_true()
     assert_that(mock_post.called).is_false()
+
+
+def test_full_review_forwards_effective_ai_config_to_advisory() -> None:
+    """The review command passes the resolved AIConfig into advisory tools."""
+    runner = CliRunner()
+    patches = _mock_review_pipeline()
+
+    with (
+        patches["require_ai"],
+        patches["get_config"],
+        patches["collect_review_context"],
+        patches["classify_changed_files"],
+        patches["get_all_checklist_items"],
+        patches["select_checklist_items"],
+        patches["format_checklist_for_prompt"],
+        patches["get_provider"],
+        patches["run_review"],
+        patches["render_review_output"],
+        patch(
+            "lintro.cli_utils.commands.review.run_advisory_tools",
+            return_value=[],
+        ) as run_advisory,
+    ):
+        result = runner.invoke(cli, ["review"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    ai_config = run_advisory.call_args.kwargs["ai_config"]
+    assert_that(ai_config.provider).is_equal_to(AIProvider.OPENAI)
 
 
 def test_cli_overrides_lists_only_explicit_flags() -> None:

--- a/tests/unit/mcp/test_toolkit_review.py
+++ b/tests/unit/mcp/test_toolkit_review.py
@@ -51,6 +51,11 @@ _CONFIG_REVIEW_OFF = """ai:
   provider: anthropic
 """
 
+_CONFIG_NO_PROVIDER = """ai:
+  enabled: true
+  review: true
+"""
+
 
 def _run_session(
     *,
@@ -653,6 +658,33 @@ def test_review_is_unavailable_without_the_ai_extra(
         McpErrorCode.TOOL_UNAVAILABLE.value,
     )
     assert_that(payload["error"]["detail"]["reason"]).is_equal_to("ai_unavailable")
+
+
+def test_review_is_unavailable_when_provider_is_unset(
+    repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An enabled review without ``ai.provider`` is unavailable, even on empty diffs."""
+    import lintro.ai.availability as availability
+
+    monkeypatch.setattr(availability, "is_ai_available", lambda: True)
+    (repo / ".lintro-config.yaml").write_text(_CONFIG_NO_PROVIDER, encoding="utf-8")
+
+    empty_result, empty_payload = _call(workspace=repo, arguments={"base": "feature"})
+    changed_result, changed_payload = _call(workspace=repo, arguments={"base": "main"})
+
+    for result, payload in (
+        (empty_result, empty_payload),
+        (changed_result, changed_payload),
+    ):
+        assert_that(result.is_error).is_true()
+        assert_that(payload["error"]["code"]).is_equal_to(
+            McpErrorCode.TOOL_UNAVAILABLE.value,
+        )
+        assert_that(payload["error"]["detail"]["reason"]).is_equal_to(
+            "provider_unavailable",
+        )
+        assert_that(payload["error"]["message"]).contains("ai.provider")
 
 
 def test_review_is_unavailable_when_the_workspace_disables_it(

--- a/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
+++ b/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
@@ -197,6 +197,27 @@ def test_engine_is_built_from_the_raw_ai_mapping(
     assert_that(recorded["cache_ttl"]).is_equal_to(99)
 
 
+def test_unset_provider_fails_before_the_engine(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An enabled run with no provider fails closed at construction."""
+    monkeypatch.setattr(availability_module, "is_ai_available", lambda: True)
+    monkeypatch.setattr(
+        IdiomReviewPlugin,
+        "_get_lintro_config",
+        lambda _self: LintroConfig(
+            ai={"enabled": True, "lint": True},
+        ),
+    )
+
+    with pytest.raises(ValueError, match="ai.provider is required"):
+        IdiomReviewPlugin().check(
+            [_write_py(tmp_path)],
+            {"enabled": True, "min_confidence": "low"},
+        )
+
+
 def test_min_confidence_filters_low_findings(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
+++ b/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
@@ -16,6 +16,7 @@ import lintro.ai.providers as providers_module
 import lintro.tools.idiom_review.engine as engine_module
 from lintro.ai.config import AIConfig
 from lintro.ai.exceptions import AIAuthenticationError
+from lintro.ai.provider_enum import AIProvider
 from lintro.config.lintro_config import LintroConfig
 from lintro.parsers.idiom_review.idiom_review_issue import IdiomReviewIssue
 from lintro.plugins.registry import ToolRegistry
@@ -222,10 +223,44 @@ def test_unset_provider_fails_before_the_engine(
     assert_that(result.output).contains("`ai.provider` in config")
     assert_that(result.output).contains("LINTRO_AI_PROVIDER")
     assert_that(result.output).contains("--provider")
+    assert_that(result.metadata).is_equal_to(
+        {"advisory_error": "provider_required"},
+    )
 
     from lintro.utils.execution.advisory import advisory_tools_errored
 
     assert_that(advisory_tools_errored([result])).is_true()
+
+
+def test_check_uses_injected_ai_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CLI-resolved AIConfig in options wins over LintroConfig.ai."""
+    recorded: dict[str, Any] = {}
+
+    class _RecordingEngine(_FakeEngine):
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            recorded.update(kwargs)
+            super().__init__(*args, **kwargs)
+
+    injected = AIConfig(provider=AIProvider.OPENAI, max_cost_usd=7.5)
+    monkeypatch.setattr(availability_module, "is_ai_available", lambda: True)
+    monkeypatch.setattr(providers_module, "get_provider", lambda cfg, **_kwargs: cfg)
+    monkeypatch.setattr(engine_module, "IdiomReviewEngine", _RecordingEngine)
+    monkeypatch.setattr(
+        IdiomReviewPlugin,
+        "_get_lintro_config",
+        lambda _self: LintroConfig(ai={"enabled": True, "lint": True}),
+    )
+
+    IdiomReviewPlugin().check(
+        [_write_py(tmp_path)],
+        {"enabled": True, "ai_config": injected},
+    )
+
+    assert_that(recorded["ai_config"]).is_equal_to(injected)
+    assert_that(recorded["ai_config"].provider).is_equal_to(AIProvider.OPENAI)
 
 
 def test_min_confidence_filters_low_findings(

--- a/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
+++ b/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
@@ -15,7 +15,7 @@ import lintro.ai.availability as availability_module
 import lintro.ai.providers as providers_module
 import lintro.tools.idiom_review.engine as engine_module
 from lintro.ai.config import AIConfig
-from lintro.ai.exceptions import AIAuthenticationError
+from lintro.ai.exceptions import AIAuthenticationError, AIProviderRequiredError
 from lintro.config.lintro_config import LintroConfig
 from lintro.parsers.idiom_review.idiom_review_issue import IdiomReviewIssue
 from lintro.plugins.registry import ToolRegistry
@@ -211,7 +211,7 @@ def test_unset_provider_fails_before_the_engine(
         ),
     )
 
-    with pytest.raises(ValueError, match="ai.provider is required"):
+    with pytest.raises(AIProviderRequiredError, match="ai.provider is required"):
         IdiomReviewPlugin().check(
             [_write_py(tmp_path)],
             {"enabled": True, "min_confidence": "low"},

--- a/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
+++ b/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
@@ -223,6 +223,10 @@ def test_unset_provider_fails_before_the_engine(
     assert_that(result.output).contains("LINTRO_AI_PROVIDER")
     assert_that(result.output).contains("--provider")
 
+    from lintro.utils.execution.advisory import advisory_tools_errored
+
+    assert_that(advisory_tools_errored([result])).is_true()
+
 
 def test_min_confidence_filters_low_findings(
     tmp_path: Path,

--- a/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
+++ b/tests/unit/tools/idiom_review/test_idiom_review_plugin.py
@@ -15,7 +15,7 @@ import lintro.ai.availability as availability_module
 import lintro.ai.providers as providers_module
 import lintro.tools.idiom_review.engine as engine_module
 from lintro.ai.config import AIConfig
-from lintro.ai.exceptions import AIAuthenticationError, AIProviderRequiredError
+from lintro.ai.exceptions import AIAuthenticationError
 from lintro.config.lintro_config import LintroConfig
 from lintro.parsers.idiom_review.idiom_review_issue import IdiomReviewIssue
 from lintro.plugins.registry import ToolRegistry
@@ -211,11 +211,17 @@ def test_unset_provider_fails_before_the_engine(
         ),
     )
 
-    with pytest.raises(AIProviderRequiredError, match="ai.provider is required"):
-        IdiomReviewPlugin().check(
-            [_write_py(tmp_path)],
-            {"enabled": True, "min_confidence": "low"},
-        )
+    result = IdiomReviewPlugin().check(
+        [_write_py(tmp_path)],
+        {"enabled": True, "min_confidence": "low"},
+    )
+
+    assert_that(result.success).is_false()
+    assert_that(result.skipped).is_false()
+    assert_that(result.output).contains("ai.provider is required")
+    assert_that(result.output).contains("`ai.provider` in config")
+    assert_that(result.output).contains("LINTRO_AI_PROVIDER")
+    assert_that(result.output).contains("--provider")
 
 
 def test_min_confidence_filters_low_findings(

--- a/tests/unit/utils/execution/test_advisory.py
+++ b/tests/unit/utils/execution/test_advisory.py
@@ -19,6 +19,7 @@ from lintro.utils.execution import advisory as advisory_module
 from lintro.utils.execution.advisory import (
     advisory_findings_count,
     advisory_results_to_payload,
+    advisory_tools_errored,
     get_advisory_tool_names,
     render_advisory_results,
     resolve_advisory_tools,
@@ -146,6 +147,24 @@ def test_advisory_findings_count_ignores_skipped_results() -> None:
     assert_that(advisory_findings_count(results)).is_equal_to(2)
 
 
+def test_advisory_tools_errored_ignores_findings_and_skips() -> None:
+    """Findings and skips are not execution errors; a bare failure is."""
+    findings = ToolResult(name="b", success=False, issues_count=2)
+    skipped = ToolResult(
+        name="a",
+        skipped=True,
+        skip_reason="opt-in required",
+    )
+    failed = ToolResult(
+        name="idiom-review",
+        success=False,
+        output="ai.provider is required",
+    )
+
+    assert_that(advisory_tools_errored([findings, skipped])).is_false()
+    assert_that(advisory_tools_errored([findings, skipped, failed])).is_true()
+
+
 def test_render_advisory_results_reports_skip_reason() -> None:
     """A skipped advisory tool renders its reason."""
     rendered = render_advisory_results(
@@ -190,6 +209,8 @@ def test_advisory_results_to_payload_is_json_shaped() -> None:
 
     assert_that(payload).is_length(1)
     assert_that(payload[0]["tool"]).is_equal_to("idiom-review")
+    assert_that(payload[0]["success"]).is_false()
+    assert_that(payload[0]["output"]).is_none()
     assert_that(payload[0]["issues_count"]).is_equal_to(1)
     issues = cast("list[dict[str, str]]", payload[0]["issues"])
     assert_that(issues[0]["file"]).is_equal_to("a.py")

--- a/tests/unit/utils/execution/test_advisory.py
+++ b/tests/unit/utils/execution/test_advisory.py
@@ -8,6 +8,8 @@ from typing import cast
 import pytest
 from assertpy import assert_that
 
+from lintro.ai.config import AIConfig
+from lintro.ai.provider_enum import AIProvider
 from lintro.config.lintro_config import LintroConfig, LintroToolConfig
 from lintro.enums.execution_class import (
     ExecutionClass,
@@ -130,6 +132,33 @@ def test_run_advisory_tools_reports_tool_failures(
     assert_that(results).is_length(1)
     assert_that(results[0].success).is_false()
     assert_that(results[0].output).contains("provider exploded")
+
+
+def test_run_advisory_tools_forwards_ai_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CLI-resolved AIConfig is passed into each tool's check() options."""
+    captured: dict[str, object] = {}
+
+    class _Capture:
+        def check(self, paths: list[str], options: dict[str, object]) -> ToolResult:
+            captured.update(options)
+            return ToolResult(name="idiom-review", success=True)
+
+    monkeypatch.setattr(
+        advisory_module,
+        "configure_tool_for_execution",
+        lambda **_kwargs: _Capture(),
+    )
+    ai_config = AIConfig(provider=AIProvider.OPENAI)
+    run_advisory_tools(
+        paths=[str(tmp_path)],
+        tool_names=["idiom-review"],
+        ai_config=ai_config,
+    )
+
+    assert_that(captured["ai_config"]).is_equal_to(ai_config)
 
 
 def test_advisory_findings_count_ignores_skipped_results() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai)!: require an explicit AI provider
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [x] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Finding 1 of #2143: stop treating Anthropic as the implicit `ai.provider`. The field is now `AIProvider | None = None`, matching `transport`. Enabling any AI feature without naming a provider fails in `lintro doctor` and `get_provider` with a migration error that lists the three set paths (`ai.provider`, `LINTRO_AI_PROVIDER`, `--provider`) and the accepted providers in alphabetical order (`anthropic, cursor, openai`).

Configs that already set `ai.provider` (including this repo's committed dogfood) are unchanged. Configs that enable AI without a provider must name one.

Follow-ups after review:

- Status only emits the required-provider diagnostic when an AI feature is on.
- `lintro review` constructs the provider inside the existing error contract (JSON envelope, exit 2, provider label `unset`).
- MCP `lintro_review` returns `TOOL_UNAVAILABLE` / `provider_unavailable` before empty-diff success when `ai.provider` is unset.
- An unset provider raises `AIProviderRequiredError` and classifies as `kind: provider_unavailable`, not `invalid_response`.
- Idiom-review returns `ToolResult(success=False)` when the provider is unset, so sequential chk does not abort later tools.
- Tests assert the public migration literals, not helper identity.
- The `AIConfig.provider` Field description interpolates `accepted_provider_values()`.
- `lintro review` validates the provider after flag checks and before `collect_review_context`, so a git/context error cannot hide the migration message.
- CLI overlays, including `--provider`, apply before `--advisory-only`.
- The CLI-resolved `AIConfig` is forwarded into advisory tools so `--provider` reaches idiom-review.
- `--advisory-only` still fails closed when an advisory tool errors.
- A full review that already finished `run_review` keeps render/post and records advisory failure in the advisory payload (`success`/`output`).
- Provider-required advisory errors are classified by `metadata.advisory_error = provider_required`, not by matching error-message prose.
- The advisory runner keeps `AIConfig` behind `TYPE_CHECKING` so `utils/execution` stays on the core side of the #724 / #1972 import boundary.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing (docs sweep is finding 2 of #2143)
- [x] Local unit suite passed (`uv run pytest tests/unit`; focused follow-up tests green)

## Related Issues

Relates to #2143

## Details

### Breaking change

`AIConfig.provider` no longer defaults to `anthropic`. A config that enables `ai.lint` or `ai.review` without `ai.provider` / `LINTRO_AI_PROVIDER` / `--provider` now errors instead of silently calling Anthropic.

`lintro chk` still treats AI as an enhancement: an unset provider is skipped unless `fail_on_ai_error` is set. Doctor and `lintro review` fail closed.

### Implementation

- Shared `provider_required_error()` / `accepted_provider_values()` on `lintro.ai.provider_enum`
- `get_provider` raises `AIProviderRequiredError` when the provider is unset
- Doctor reports missing provider alongside missing transport
- Review CLI and MCP fail closed and report `provider_unavailable`
- Review CLI validates the provider before collecting git context
- `--advisory-only` execution errors emit the error contract; a finished full review is kept
- Advisory tools receive the CLI-resolved `AIConfig` (including `--provider`) without a runtime `lintro.ai` import in `utils/execution`
- Status, liveness, and orchestrator guard the optional provider

### Testing

- Default config provider is `None`
- Doctor + `get_provider` name the three set paths and alphabetical providers
- Review CLI JSON error uses exit 2, kind `provider_unavailable`, provider `unset`
- Unset provider beats a failing context collection
- `--advisory-only` with an unset provider exits 2 before tools run
- `--advisory-only --provider openai` reaches advisory tools with `provider=openai` when YAML omits `ai.provider`
- MCP reports `provider_unavailable` on empty and non-empty diffs
- Idiom-review returns a failed `ToolResult` when the provider is unset
- Full review keeps `summary`/`findings` when advisory later errors
- Core packages still have no runtime `lintro.ai` imports
- Existing transport-missing / liveness tests now set an explicit provider so they stay single-purpose

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29e56a44-9c36-448f-a5fe-9e5df5902e41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29e56a44-9c36-448f-a5fe-9e5df5902e41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - AI configuration no longer defaults to Anthropic when no provider is specified.
  - AI features now clearly indicate when a provider is required and explain how to configure one.
  - Improved handling of missing or invalid providers across status checks, reviews, diagnostics, and advisory tools.
  - Provider names are normalized consistently, with clearer supported-provider listings.
  - Prevented errors in verbose logging and structured output when the provider is unset.
  - Review and advisory failures now return consistent error results without publishing incomplete output.

- **Tests**
  - Added comprehensive coverage for missing-provider configuration, diagnostics, validation, and advisory-tool failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->