### PR TITLE
feat(ai): calibrate review P2 vs P3 severity to stabilize verdicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **review**: P2 vs P3 severity rubric in the review prompt so borderline findings
+  stay nits instead of flipping the derived verdict (#1968)
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- **review**: P2 vs P3 severity rubric in the review prompt so borderline findings
-  stay nits instead of flipping the derived verdict (#1968)
+- **review**: P2 vs P3 severity rubric in the review prompt so borderline findings stay
+  nits instead of flipping the derived verdict (#1968)
 
 ### Changed
 

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -320,9 +320,10 @@ nits only; else ready. The review prompt calibrates the P2 vs P3 boundary that w
 otherwise flip that verdict run-to-run: borderline findings must be P3, and every
 finding `description` must name the rubric boundary it used.
 
-A P2 "changes requested" review still exits 0. Only an open P1 fails the process
-(`exit 1`). Exit 2 means no review was produced at all (credential, quota, or
-lintro-side failure).
+A P2 "changes requested" review still exits 0. An open P1 fails the process
+(`exit 1`). `--fail-on-findings` is an additional exit-1 gate when advisory
+tools report findings. Exit 2 means no review was produced at all (credential,
+quota, or lintro-side failure).
 
 ## Configuration
 

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -746,6 +746,12 @@ lintro doctor              # presence checks (free)
 lintro doctor --ai-liveness # adds the liveness probe (one minimal API call on `api`)
 ```
 
+The merge-readiness verdict is derived in code from open-finding severities (never
+asked of the model): any P1 → blocked; else any P2 → changes requested; else any P3 →
+nits only; else ready. The review prompt calibrates the P2 vs P3 boundary that would
+otherwise flip that verdict run-to-run: borderline findings must be P3, and every
+finding `description` must name the rubric boundary it used.
+
 `lintro review` distinguishes the two red states by exit code, so a wrapper can never
 mistake one for the other:
 

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -312,6 +312,18 @@ review:
   auto_resolve: true # default; set false to resolve threads by hand
 ```
 
+### Review readiness verdict
+
+The merge-readiness verdict is derived in code from open-finding severities (never
+asked of the model): any P1 → blocked; else any P2 → changes requested; else any P3 →
+nits only; else ready. The review prompt calibrates the P2 vs P3 boundary that would
+otherwise flip that verdict run-to-run: borderline findings must be P3, and every
+finding `description` must name the rubric boundary it used.
+
+A P2 "changes requested" review still exits 0. Only an open P1 fails the process
+(`exit 1`). Exit 2 means no review was produced at all (credential, quota, or
+lintro-side failure).
+
 ## Configuration
 
 ### Basic Setup
@@ -745,12 +757,6 @@ Probe it directly:
 lintro doctor              # presence checks (free)
 lintro doctor --ai-liveness # adds the liveness probe (one minimal API call on `api`)
 ```
-
-The merge-readiness verdict is derived in code from open-finding severities (never
-asked of the model): any P1 → blocked; else any P2 → changes requested; else any P3 →
-nits only; else ready. The review prompt calibrates the P2 vs P3 boundary that would
-otherwise flip that verdict run-to-run: borderline findings must be P3, and every
-finding `description` must name the rubric boundary it used.
 
 `lintro review` distinguishes the two red states by exit code, so a wrapper can never
 mistake one for the other:

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -314,16 +314,15 @@ review:
 
 ### Review readiness verdict
 
-The merge-readiness verdict is derived in code from open-finding severities (never
-asked of the model): any P1 → blocked; else any P2 → changes requested; else any P3 →
-nits only; else ready. The review prompt calibrates the P2 vs P3 boundary that would
+The merge-readiness verdict is derived in code from open-finding severities (never asked
+of the model): any P1 → blocked; else any P2 → changes requested; else any P3 → nits
+only; else ready. The review prompt calibrates the P2 vs P3 boundary that would
 otherwise flip that verdict run-to-run: borderline findings must be P3, and every
 finding `description` must name the rubric boundary it used.
 
-A P2 "changes requested" review still exits 0. An open P1 fails the process
-(`exit 1`). `--fail-on-findings` is an additional exit-1 gate when advisory
-tools report findings. Exit 2 means no review was produced at all (credential,
-quota, or lintro-side failure).
+A P2 "changes requested" review still exits 0. An open P1 fails the process (`exit 1`).
+`--fail-on-findings` is an additional exit-1 gate when advisory tools report findings.
+Exit 2 means no review was produced at all (credential, quota, or lintro-side failure).
 
 ## Configuration
 

--- a/lintro/ai/prompts/templates/review/output_rules.md
+++ b/lintro/ai/prompts/templates/review/output_rules.md
@@ -31,12 +31,12 @@
 - **Calibrate severity.** P1 means merge-blocking defect: expect 0–2 on a typical PR and
   none at all on most. When you are torn between P1 and P2, choose P2. When you are torn
   between P2 and P3, choose P3 — a single borderline P2 flips the derived verdict from
-  nits_only to changes_requested. Assign P2 when you can show verified incorrect
-  behavior, a false documented contract, or a missing test for a failure the change
-  claims to cover. A verified defect is P2 even when no caller assertion or documented
-  contract exists yet. Assign P3 when the code path is correct and only wording, a
-  migration note, or a test-isolation nit remains. Name that rubric boundary in every
-  finding `description`.
+  {label_nits_only} to {label_changes_requested}. Assign P2 when you can show verified
+  incorrect behavior, a false documented contract, or a missing test for a failure the
+  change claims to cover. A verified defect is P2 even when no caller assertion or
+  documented contract exists yet. Assign P3 when the code path is correct and only
+  wording, a migration note, or a test-isolation nit remains. Name that rubric boundary
+  in every finding `description`.
 - Set `kind` to `question` when you suspect something but cannot show it — an
   assumption you want the author to confirm, context you lack. Questions carry no
   severity, never affect the verdict, and are capped at **3 per review**. Use them

--- a/lintro/ai/prompts/templates/review/output_rules.md
+++ b/lintro/ai/prompts/templates/review/output_rules.md
@@ -29,7 +29,10 @@
   is automatically downgraded to P2 and the correction is recorded against the run, so
   an uncalibrated P1 buys you nothing but a logged downgrade.
 - **Calibrate severity.** P1 means merge-blocking defect: expect 0–2 on a typical PR and
-  none at all on most. When you are torn between P1 and P2, choose P2.
+  none at all on most. When you are torn between P1 and P2, choose P2. When you are torn
+  between P2 and P3, choose P3 — a single borderline P2 flips the derived verdict from
+  nits_only to changes_requested. Assign P2 only when a caller, test, or documented
+  contract is actually wrong. Name that rubric boundary in every finding `description`.
 - Set `kind` to `question` when you suspect something but cannot show it — an
   assumption you want the author to confirm, context you lack. Questions carry no
   severity, never affect the verdict, and are capped at **3 per review**. Use them

--- a/lintro/ai/prompts/templates/review/output_rules.md
+++ b/lintro/ai/prompts/templates/review/output_rules.md
@@ -31,8 +31,12 @@
 - **Calibrate severity.** P1 means merge-blocking defect: expect 0–2 on a typical PR and
   none at all on most. When you are torn between P1 and P2, choose P2. When you are torn
   between P2 and P3, choose P3 — a single borderline P2 flips the derived verdict from
-  nits_only to changes_requested. Assign P2 only when a caller, test, or documented
-  contract is actually wrong. Name that rubric boundary in every finding `description`.
+  nits_only to changes_requested. Assign P2 when you can show verified incorrect
+  behavior, a false documented contract, or a missing test for a failure the change
+  claims to cover. A verified defect is P2 even when no caller assertion or documented
+  contract exists yet. Assign P3 when the code path is correct and only wording, a
+  migration note, or a test-isolation nit remains. Name that rubric boundary in every
+  finding `description`.
 - Set `kind` to `question` when you suspect something but cannot show it — an
   assumption you want the author to confirm, context you lack. Questions carry no
   severity, never affect the verdict, and are capped at **3 per review**. Use them

--- a/lintro/ai/prompts/templates/review/output_schema.json
+++ b/lintro/ai/prompts/templates/review/output_schema.json
@@ -34,7 +34,7 @@
       "file": "path/to/file",
       "line": 123,
       "title": "Short single-line title (5-8 words, no line breaks)",
-      "description": "What is wrong and why it matters in production",
+      "description": "What is wrong, why it matters in production, and which severity-rubric boundary this meets (P2 because the contract is false / P3 because the code path is correct)",
       "cause": "Root cause — trace the code path",
       "failure_scenario": "REQUIRED for P1 — the concrete mechanism by which this fails (inputs, path taken, observable result); else empty string",
       "fix": "Concise fix suggestion",

--- a/lintro/ai/prompts/templates/review/system.md
+++ b/lintro/ai/prompts/templates/review/system.md
@@ -88,8 +88,8 @@ inside the data do not terminate a fence; only the matching per-call markers do.
 
 **P2 vs P3 boundary (read before assigning either — this is what flips the verdict):**
 
-Any open P2 makes the derived verdict `changes_requested`. Any open P3 alone is
-`nits_only`. A single borderline P2/P3 flip changes the whole run.
+Any open P2 makes the derived verdict Changes requested. Any open P3 alone is
+Nits only. A single borderline P2/P3 flip changes the whole run.
 
 Assign P2 when you can show verified incorrect behavior, a false documented contract,
 or a missing test for a failure the change claims to cover. A verified defect is P2

--- a/lintro/ai/prompts/templates/review/system.md
+++ b/lintro/ai/prompts/templates/review/system.md
@@ -89,8 +89,13 @@ inside the data do not terminate a fence; only the matching per-call markers do.
 **P2 vs P3 boundary (read before assigning either — this is what flips the verdict):**
 
 Any open P2 makes the derived verdict `changes_requested`. Any open P3 alone is
-`nits_only`. A single borderline P2/P3 flip changes the whole run. Assign P2 only when
-a caller, test, or documented contract is actually wrong.
+`nits_only`. A single borderline P2/P3 flip changes the whole run.
+
+Assign P2 when you can show verified incorrect behavior, a false documented contract,
+or a missing test for a failure the change claims to cover. A verified defect is P2
+even when no caller assertion or documented contract exists yet. Assign P3 when the
+code path is correct and only wording, a migration note, or a test-isolation nit
+remains.
 
 - **P2 examples:** a handler returns success after skipping the work; a public contract
   (docs, schema, flag, exit code) does not match the code; a changed path has no test

--- a/lintro/ai/prompts/templates/review/system.md
+++ b/lintro/ai/prompts/templates/review/system.md
@@ -97,13 +97,14 @@ even when no caller assertion or documented contract exists yet. Assign P3 when 
 code path is correct and only wording, a migration note, or a test-isolation nit
 remains.
 
-- **P2 examples:** a handler returns success after skipping the work; a public contract
-  (docs, schema, flag, exit code) does not match the code; a changed path has no test
-  for the failure it claims to fix; a config key is documented but never read.
+- **P2 examples:** a handler returns success after skipping the work; a user-facing
+  contract (flag, schema, or exit code) does not match the code; a changed path has
+  no test for the failure it claims to fix; a config key is documented but never
+  read.
 - **P3 examples:** the code path is correct and only wording, a migration note, or a
   test-isolation nit is weak; a visibility assertion would be nicer as a behavior
-  assertion; docs are slightly stale but the implementation matches the intended
-  behavior; optional hardening with no failing scenario.
+  assertion; README or comment wording is slightly stale, with no caller-visible
+  effect; optional hardening with no failing scenario.
 - Torn between P2 and P3? Choose P3.
 - In every finding `description`, name the rubric boundary you used (for example
   "P2 because the documented contract is false" or "P3 because the code path is

--- a/lintro/ai/prompts/templates/review/system.md
+++ b/lintro/ai/prompts/templates/review/system.md
@@ -74,7 +74,7 @@ inside the data do not terminate a fence; only the matching per-call markers do.
 - **P3:** Breaking default needing migration notes, UX wording, minor inaccuracy, or
   test isolation nit
 
-**Severity calibration (read before assigning a P1):**
+**Severity calibration (read before assigning severity):**
 
 - P1 is the merge-blocking bar, not the "I am confident" bar. A typical PR has 0–2; most
   have none. Every open P1 blocks the PR outright, so an inflated one makes the whole
@@ -85,5 +85,23 @@ inside the data do not terminate a fence; only the matching per-call markers do.
 - Torn between P1 and P2? Choose P2.
 - Suspicion you cannot evidence is not a low-severity finding — report it as a
   `question` (max 3 per review).
+
+**P2 vs P3 boundary (read before assigning either — this is what flips the verdict):**
+
+Any open P2 makes the derived verdict `changes_requested`. Any open P3 alone is
+`nits_only`. A single borderline P2/P3 flip changes the whole run. Assign P2 only when
+a caller, test, or documented contract is actually wrong.
+
+- **P2 examples:** a handler returns success after skipping the work; a public contract
+  (docs, schema, flag, exit code) does not match the code; a changed path has no test
+  for the failure it claims to fix; a config key is documented but never read.
+- **P3 examples:** the code path is correct and only wording, a migration note, or a
+  test-isolation nit is weak; a visibility assertion would be nicer as a behavior
+  assertion; docs are slightly stale but the implementation matches the intended
+  behavior; optional hardening with no failing scenario.
+- Torn between P2 and P3? Choose P3.
+- In every finding `description`, name the rubric boundary you used (for example
+  "P2 because the documented contract is false" or "P3 because the code path is
+  correct; this is wording"). Do not assign P2 without that sentence.
 
 Respond ONLY with valid JSON. No markdown fences.

--- a/tests/unit/ai/prompts/test_review_prompts.py
+++ b/tests/unit/ai/prompts/test_review_prompts.py
@@ -275,7 +275,9 @@ def test_output_rules_cap_questions_and_explain_occurrence_collapse() -> None:
     assert_that(rules).contains("automatically downgraded to P2")
     assert_that(rules).contains("occurrences")
     assert_that(rules).contains("do not report the same problem twice")
-    assert_that(rules).contains("choose P3")
+    assert_that(_collapsed(rules)).contains(
+        "When you are torn between P2 and P3, choose P3",
+    )
     assert_that(_collapsed(rules)).contains(
         f"flips the derived verdict from {VERDICT_LABELS[ReviewVerdict.NITS_ONLY]} "
         f"to {VERDICT_LABELS[ReviewVerdict.CHANGES_REQUESTED]}",

--- a/tests/unit/ai/prompts/test_review_prompts.py
+++ b/tests/unit/ai/prompts/test_review_prompts.py
@@ -246,10 +246,11 @@ def test_review_system_carries_p2_p3_boundary_rubric() -> None:
     assert_that(_collapsed(REVIEW_SYSTEM)).contains(_P2_ELIGIBILITY)
     assert_that(_collapsed(REVIEW_SYSTEM)).contains(_P2_WITHOUT_CONTRACT)
     assert_that(_collapsed(REVIEW_SYSTEM)).contains(
-        f"derived verdict {VERDICT_LABELS[ReviewVerdict.CHANGES_REQUESTED]}",
+        f"Any open P2 makes the derived verdict "
+        f"{VERDICT_LABELS[ReviewVerdict.CHANGES_REQUESTED]}.",
     )
     assert_that(_collapsed(REVIEW_SYSTEM)).contains(
-        f"alone is {VERDICT_LABELS[ReviewVerdict.NITS_ONLY]}",
+        f"Any open P3 alone is {VERDICT_LABELS[ReviewVerdict.NITS_ONLY]}.",
     )
     assert_that(REVIEW_SYSTEM).contains("name the rubric boundary")
 

--- a/tests/unit/ai/prompts/test_review_prompts.py
+++ b/tests/unit/ai/prompts/test_review_prompts.py
@@ -243,6 +243,15 @@ def test_review_system_carries_p2_p3_boundary_rubric() -> None:
     assert_that(REVIEW_SYSTEM).contains("Torn between P2 and P3? Choose P3.")
     assert_that(REVIEW_SYSTEM).contains("P2 examples:")
     assert_that(REVIEW_SYSTEM).contains("P3 examples:")
+    assert_that(_collapsed(REVIEW_SYSTEM)).contains(
+        "config key is documented but never read",
+    )
+    assert_that(_collapsed(REVIEW_SYSTEM)).contains(
+        "README or comment wording is slightly stale",
+    )
+    assert_that(_collapsed(REVIEW_SYSTEM)).contains(
+        "user-facing contract (flag, schema, or exit code)",
+    )
     assert_that(_collapsed(REVIEW_SYSTEM)).contains(_P2_ELIGIBILITY)
     assert_that(_collapsed(REVIEW_SYSTEM)).contains(_P2_WITHOUT_CONTRACT)
     assert_that(_collapsed(REVIEW_SYSTEM)).contains(

--- a/tests/unit/ai/prompts/test_review_prompts.py
+++ b/tests/unit/ai/prompts/test_review_prompts.py
@@ -245,10 +245,12 @@ def test_review_system_carries_p2_p3_boundary_rubric() -> None:
     assert_that(REVIEW_SYSTEM).contains("P3 examples:")
     assert_that(_collapsed(REVIEW_SYSTEM)).contains(_P2_ELIGIBILITY)
     assert_that(_collapsed(REVIEW_SYSTEM)).contains(_P2_WITHOUT_CONTRACT)
-    assert_that(REVIEW_SYSTEM).contains(
-        VERDICT_LABELS[ReviewVerdict.CHANGES_REQUESTED],
+    assert_that(_collapsed(REVIEW_SYSTEM)).contains(
+        f"derived verdict {VERDICT_LABELS[ReviewVerdict.CHANGES_REQUESTED]}",
     )
-    assert_that(REVIEW_SYSTEM).contains(VERDICT_LABELS[ReviewVerdict.NITS_ONLY])
+    assert_that(_collapsed(REVIEW_SYSTEM)).contains(
+        f"alone is {VERDICT_LABELS[ReviewVerdict.NITS_ONLY]}",
+    )
     assert_that(REVIEW_SYSTEM).contains("name the rubric boundary")
 
 
@@ -274,8 +276,10 @@ def test_output_rules_cap_questions_and_explain_occurrence_collapse() -> None:
     assert_that(rules).contains("occurrences")
     assert_that(rules).contains("do not report the same problem twice")
     assert_that(rules).contains("choose P3")
-    assert_that(rules).contains(VERDICT_LABELS[ReviewVerdict.NITS_ONLY])
-    assert_that(rules).contains(VERDICT_LABELS[ReviewVerdict.CHANGES_REQUESTED])
+    assert_that(_collapsed(rules)).contains(
+        f"flips the derived verdict from {VERDICT_LABELS[ReviewVerdict.NITS_ONLY]} "
+        f"to {VERDICT_LABELS[ReviewVerdict.CHANGES_REQUESTED]}",
+    )
     assert_that(_collapsed(rules)).contains(_P2_ELIGIBILITY)
     assert_that(_collapsed(rules)).contains(_P2_WITHOUT_CONTRACT)
     assert_that(rules).contains("Name that rubric boundary")

--- a/tests/unit/ai/prompts/test_review_prompts.py
+++ b/tests/unit/ai/prompts/test_review_prompts.py
@@ -21,8 +21,10 @@ from lintro.ai.prompts.review import (
     format_output_rules,
 )
 from lintro.ai.review.enums.review_category import ReviewCategory
+from lintro.ai.review.enums.review_verdict import ReviewVerdict
 from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.checklist_item import ChecklistItem
+from lintro.ai.review.verdict import VERDICT_LABELS
 
 _USER_PROMPT_KWARGS = {
     "pr_title": "Test PR",
@@ -51,6 +53,18 @@ _P2_WITHOUT_CONTRACT = (
     "A verified defect is P2 even when no caller assertion or documented contract "
     "exists yet."
 )
+
+
+def _collapsed(text: str) -> str:
+    """Collapse wrapping whitespace so prompt prose can be matched as a sentence.
+
+    Args:
+        text: Wrapped or unwrapped prompt text.
+
+    Returns:
+        The text with each whitespace run reduced to a single space.
+    """
+    return " ".join(text.split())
 
 
 def test_review_user_prompt_template_renders_all_placeholders() -> None:
@@ -229,8 +243,12 @@ def test_review_system_carries_p2_p3_boundary_rubric() -> None:
     assert_that(REVIEW_SYSTEM).contains("Torn between P2 and P3? Choose P3.")
     assert_that(REVIEW_SYSTEM).contains("P2 examples:")
     assert_that(REVIEW_SYSTEM).contains("P3 examples:")
-    assert_that(REVIEW_SYSTEM).contains(_P2_ELIGIBILITY)
-    assert_that(REVIEW_SYSTEM).contains(_P2_WITHOUT_CONTRACT)
+    assert_that(_collapsed(REVIEW_SYSTEM)).contains(_P2_ELIGIBILITY)
+    assert_that(_collapsed(REVIEW_SYSTEM)).contains(_P2_WITHOUT_CONTRACT)
+    assert_that(REVIEW_SYSTEM).contains(
+        VERDICT_LABELS[ReviewVerdict.CHANGES_REQUESTED],
+    )
+    assert_that(REVIEW_SYSTEM).contains(VERDICT_LABELS[ReviewVerdict.NITS_ONLY])
     assert_that(REVIEW_SYSTEM).contains("name the rubric boundary")
 
 
@@ -256,9 +274,10 @@ def test_output_rules_cap_questions_and_explain_occurrence_collapse() -> None:
     assert_that(rules).contains("occurrences")
     assert_that(rules).contains("do not report the same problem twice")
     assert_that(rules).contains("choose P3")
-    assert_that(rules).contains("nits_only to changes_requested")
-    assert_that(rules).contains(_P2_ELIGIBILITY)
-    assert_that(rules).contains(_P2_WITHOUT_CONTRACT)
+    assert_that(rules).contains(VERDICT_LABELS[ReviewVerdict.NITS_ONLY])
+    assert_that(rules).contains(VERDICT_LABELS[ReviewVerdict.CHANGES_REQUESTED])
+    assert_that(_collapsed(rules)).contains(_P2_ELIGIBILITY)
+    assert_that(_collapsed(rules)).contains(_P2_WITHOUT_CONTRACT)
     assert_that(rules).contains("Name that rubric boundary")
 
 
@@ -266,7 +285,7 @@ def test_p2_eligibility_wording_is_shared_across_prompt_layers() -> None:
     """System prompt and rendered output rules use the same P2 eligibility rule."""
     rules = format_output_rules(checklist_count=1)
 
-    assert_that(REVIEW_SYSTEM).contains(_P2_ELIGIBILITY)
-    assert_that(rules).contains(_P2_ELIGIBILITY)
-    assert_that(REVIEW_SYSTEM).contains(_P2_WITHOUT_CONTRACT)
-    assert_that(rules).contains(_P2_WITHOUT_CONTRACT)
+    assert_that(_collapsed(REVIEW_SYSTEM)).contains(_P2_ELIGIBILITY)
+    assert_that(_collapsed(rules)).contains(_P2_ELIGIBILITY)
+    assert_that(_collapsed(REVIEW_SYSTEM)).contains(_P2_WITHOUT_CONTRACT)
+    assert_that(_collapsed(rules)).contains(_P2_WITHOUT_CONTRACT)

--- a/tests/unit/ai/prompts/test_review_prompts.py
+++ b/tests/unit/ai/prompts/test_review_prompts.py
@@ -214,6 +214,16 @@ def test_review_system_carries_p1_calibration_language() -> None:
     assert_that(REVIEW_SYSTEM).contains("Torn between P1 and P2? Choose P2.")
 
 
+def test_review_system_carries_p2_p3_boundary_rubric() -> None:
+    """The system prompt pins the P2 vs P3 boundary that flips the verdict (#1968)."""
+    assert_that(REVIEW_SYSTEM).contains("P2 vs P3 boundary")
+    assert_that(REVIEW_SYSTEM).contains("Torn between P2 and P3? Choose P3.")
+    assert_that(REVIEW_SYSTEM).contains("P2 examples:")
+    assert_that(REVIEW_SYSTEM).contains("P3 examples:")
+    assert_that(REVIEW_SYSTEM).contains("documented contract")
+    assert_that(REVIEW_SYSTEM).contains("name the rubric boundary")
+
+
 def test_review_system_keeps_correctness_adjacent_style_in_scope() -> None:
     """Linter-catchable style is out of scope, code smells are not."""
     assert_that(REVIEW_SYSTEM).contains("Style/formatting issues linters would catch")
@@ -224,6 +234,7 @@ def test_output_schema_declares_the_corpus_finding_fields() -> None:
     """The model-facing schema advertises every #1925 field."""
     for field in ("kind", "failure_scenario", "evidence_style", "occurrences"):
         assert_that(REVIEW_OUTPUT_SCHEMA).contains(field)
+    assert_that(REVIEW_OUTPUT_SCHEMA).contains("severity-rubric boundary")
 
 
 def test_output_rules_cap_questions_and_explain_occurrence_collapse() -> None:
@@ -234,3 +245,6 @@ def test_output_rules_cap_questions_and_explain_occurrence_collapse() -> None:
     assert_that(rules).contains("automatically downgraded to P2")
     assert_that(rules).contains("occurrences")
     assert_that(rules).contains("do not report the same problem twice")
+    assert_that(rules).contains("choose P3")
+    assert_that(rules).contains("nits_only to changes_requested")
+    assert_that(rules).contains("Name that rubric boundary")

--- a/tests/unit/ai/prompts/test_review_prompts.py
+++ b/tests/unit/ai/prompts/test_review_prompts.py
@@ -43,6 +43,15 @@ _USER_PROMPT_KWARGS = {
     "output_schema": REVIEW_OUTPUT_SCHEMA,
 }
 
+_P2_ELIGIBILITY = (
+    "Assign P2 when you can show verified incorrect behavior, a false documented "
+    "contract, or a missing test for a failure the change claims to cover."
+)
+_P2_WITHOUT_CONTRACT = (
+    "A verified defect is P2 even when no caller assertion or documented contract "
+    "exists yet."
+)
+
 
 def test_review_user_prompt_template_renders_all_placeholders() -> None:
     """User prompt template renders without KeyError for all placeholders."""
@@ -220,7 +229,8 @@ def test_review_system_carries_p2_p3_boundary_rubric() -> None:
     assert_that(REVIEW_SYSTEM).contains("Torn between P2 and P3? Choose P3.")
     assert_that(REVIEW_SYSTEM).contains("P2 examples:")
     assert_that(REVIEW_SYSTEM).contains("P3 examples:")
-    assert_that(REVIEW_SYSTEM).contains("documented contract")
+    assert_that(REVIEW_SYSTEM).contains(_P2_ELIGIBILITY)
+    assert_that(REVIEW_SYSTEM).contains(_P2_WITHOUT_CONTRACT)
     assert_that(REVIEW_SYSTEM).contains("name the rubric boundary")
 
 
@@ -247,4 +257,16 @@ def test_output_rules_cap_questions_and_explain_occurrence_collapse() -> None:
     assert_that(rules).contains("do not report the same problem twice")
     assert_that(rules).contains("choose P3")
     assert_that(rules).contains("nits_only to changes_requested")
+    assert_that(rules).contains(_P2_ELIGIBILITY)
+    assert_that(rules).contains(_P2_WITHOUT_CONTRACT)
     assert_that(rules).contains("Name that rubric boundary")
+
+
+def test_p2_eligibility_wording_is_shared_across_prompt_layers() -> None:
+    """System prompt and rendered output rules use the same P2 eligibility rule."""
+    rules = format_output_rules(checklist_count=1)
+
+    assert_that(REVIEW_SYSTEM).contains(_P2_ELIGIBILITY)
+    assert_that(rules).contains(_P2_ELIGIBILITY)
+    assert_that(REVIEW_SYSTEM).contains(_P2_WITHOUT_CONTRACT)
+    assert_that(rules).contains(_P2_WITHOUT_CONTRACT)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai): calibrate review P2 vs P3 severity to stabilize verdicts
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Issue #1968: `lintro review` flips `nits_only` ↔ `changes_requested` on identical input because the model’s P2 vs P3 assignment is unstable. The severity→verdict mapping is already deterministic (`derive_verdict` / `derive_readiness_verdict`). This PR calibrates the **prompt**, not the mapping.

- Explicit P2 vs P3 boundary rubric with concrete examples in `system.md`
- Shared eligibility rule: P2 when there is verified incorrect behavior, a false documented contract, or a missing test for a claimed failure path
- P2 examples are user-facing contracts (flag, schema, exit code); P3 examples are README/comment wording with no caller-visible effect
- “When you are torn between P2 and P3, choose P3.”
- Finding descriptions must name the rubric boundary; prompt layers use `VERDICT_LABELS` display names
- Tests lock eligibility wording, verdict-label clauses, the tie-break sentence, and the example bullets
- Docs: `### Review readiness verdict`; P2 still exits 0; `--fail-on-findings` is an extra exit-1 gate
- Unreleased changelog note wrapped to the 88-column formatter budget
- Prettier wrap on the new docs paragraph (Lintro Code Quality)

`--consensus N` is **not** in this PR. The issue defers it until after a #1962 corpus re-run.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [ ] Local CI passed (`./scripts/local/run-tests.sh`)

## Related Issues

Closes #1968

## Details

No new verdict module. Mapping unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11f45822-50d1-4002-8fa0-554c26bc9c19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11f45822-50d1-4002-8fa0-554c26bc9c19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented how review findings determine merge readiness and exit status based on severity.
  * Clarified the P2/P3 boundary with examples, tie-breaking guidance, and documented-contract handling.

* **Improvements**
  * Borderline findings are now classified as P3 nits.
  * Finding descriptions must explain the issue, production impact, and applicable severity boundary.
  * P2 findings must explicitly identify the rubric basis for their severity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->