### PR TITLE
feat(ai): present providers without a default

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,9 @@ export ANTHROPIC_API_KEY=sk-ant-...   # or CURSOR_API_KEY / OPENAI_API_KEY
 # .lintro-config.yaml
 # ai:
 #   enabled: true
-#   provider: <anthropic|cursor|openai>
+#   # Required when AI is on. No default.
+#   # Accepted: anthropic, cursor, openai (cursor requires transport: cli).
+#   provider: anthropic
 ```
 
 See the [AI Features Guide](docs/ai-features.md) for full documentation.

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Lintro includes optional AI-powered features that provide actionable summaries a
 interactive fix suggestions. AI features are **BYO (Bring Your Own) API key** — not
 enabled by default.
 
-- **Providers:** Anthropic Claude, OpenAI GPT
+- **Providers:** Anthropic Claude, Cursor, OpenAI GPT
 - **AI Summary** — high-level assessment with pattern analysis (1 API call per run)
 - **Interactive Fix Suggestions** — AI-generated code diffs with risk classification
 - **Post-fix Summary** — contextualizes what was fixed and what remains
@@ -343,13 +343,13 @@ enabled by default.
 ```bash
 # Install with AI support
 uv pip install 'lintro[ai]'
-export ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI_API_KEY
+export ANTHROPIC_API_KEY=sk-ant-...   # or CURSOR_API_KEY / OPENAI_API_KEY
 
 # Enable in config
 # .lintro-config.yaml
 # ai:
 #   enabled: true
-#   provider: anthropic
+#   provider: <anthropic|cursor|openai>
 ```
 
 See the [AI Features Guide](docs/ai-features.md) for full documentation.

--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ export ANTHROPIC_API_KEY=sk-ant-...   # or CURSOR_API_KEY / OPENAI_API_KEY
 #   # Required when AI is on. No default.
 #   # Accepted: anthropic, cursor, openai (cursor requires transport: cli).
 #   provider: anthropic
+#   transport: api
 ```
 
 See the [AI Features Guide](docs/ai-features.md) for full documentation.

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -22,6 +22,7 @@ interactive fix suggestions on top of standard linting results.
 #   # Required when AI is on. No default.
 #   # Accepted: anthropic, cursor, openai (cursor requires transport: cli).
 #   provider: anthropic
+#   transport: api
 
 # Run check — AI summary is generated automatically (1 API call)
 lintro check
@@ -332,7 +333,9 @@ ai:
   review: true
   provider: anthropic
   transport: api
+```
 
+```yaml
 # Cursor (CLI-only)
 ai:
   enabled: true
@@ -340,7 +343,9 @@ ai:
   review: true
   provider: cursor
   transport: cli
+```
 
+```yaml
 # OpenAI
 ai:
   enabled: true

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -611,8 +611,8 @@ CLI flags always override config: passing `--fix` on the CLI turns it on even if
 
 ### Providers
 
-None of these is preferred. Set `ai.provider` (or `LINTRO_AI_PROVIDER` / `--provider`)
-whenever AI is on.
+None of these is preferred. Set `ai.provider` or `LINTRO_AI_PROVIDER` whenever AI is on.
+`lintro review` also accepts `--provider`.
 
 #### [Anthropic](https://docs.anthropic.com/)
 
@@ -744,13 +744,13 @@ LINTRO_AI_ENABLED=0 lintro check .
 **Every transport needs a credential of its own — CLI transport is not
 credential-free.**
 
-| Provider    | Transport | Credential                                                        |
-| ----------- | --------- | ----------------------------------------------------------------- |
-| `anthropic` | `api`     | `ANTHROPIC_API_KEY`                                               |
-| `anthropic` | `cli`     | `claude` login session, `ANTHROPIC_API_KEY`, or an `apiKeyHelper` |
-| `cursor`    | `cli`     | `agent login` session or `CURSOR_API_KEY` (CLI-only provider)     |
-| `openai`    | `api`     | `OPENAI_API_KEY`                                                  |
-| `openai`    | `cli`     | `codex login` session (`~/.codex/auth.json`) or `CODEX_API_KEY`   |
+| Provider    | Transport | Credential                                                                        |
+| ----------- | --------- | --------------------------------------------------------------------------------- |
+| `anthropic` | `api`     | `ANTHROPIC_API_KEY`                                                               |
+| `anthropic` | `cli`     | `claude` login, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, or `apiKeyHelper` |
+| `cursor`    | `cli`     | `agent login` session or `CURSOR_API_KEY` (CLI-only provider)                     |
+| `openai`    | `api`     | `OPENAI_API_KEY`                                                                  |
+| `openai`    | `cli`     | `codex login` session (`~/.codex/auth.json`) or `CODEX_API_KEY`                   |
 
 `ai.api_key_env` overrides the API-transport variable name if you keep the key somewhere
 else.

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -1001,7 +1001,7 @@ When AI is enabled, the pre-execution summary table includes AI configuration:
 ├───────────────┼────────────────────────────────────────────┤
 │ AI            │ enabled                                    │
 │               │   provider: anthropic                      │
-│               │   model: (provider default if omitted)     │
+│               │   model: claude-sonnet-4-6 (default)       │
 │               │   parallel: 5 workers                      │
 │               │   safe-auto-apply: on                      │
 │               │   verify-fixes: off                        │

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -7,7 +7,9 @@ interactive fix suggestions on top of standard linting results.
 >
 > ```bash
 > pip install -e '.[ai]'
-> export ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI_API_KEY for OpenAI
+> export ANTHROPIC_API_KEY=sk-ant-...   # anthropic
+> # export CURSOR_API_KEY=...           # cursor (CLI-only)
+> # export OPENAI_API_KEY=sk-...        # openai
 > ```
 
 ## Quick Start
@@ -17,7 +19,7 @@ interactive fix suggestions on top of standard linting results.
 # .lintro-config.yaml
 # ai:
 #   enabled: true
-#   provider: anthropic
+#   provider: <anthropic|cursor|openai>
 
 # Run check — AI summary is generated automatically (1 API call)
 lintro check
@@ -198,7 +200,7 @@ degrades gracefully to a skipped result rather than failing the run.
 # .lintro-config.yaml
 ai:
   enabled: true
-  provider: anthropic
+  provider: <anthropic|cursor|openai>
   transport: api
 tools:
   idiom-review:
@@ -323,7 +325,7 @@ ai:
   enabled: true # master switch (AND-ed with the toggles below)
   lint: true # AI lint summaries during chk/fmt
   review: true # the `lintro review` AI diff review
-  provider: anthropic # or "openai" / "cursor" ("cursor" needs transport: cli)
+  provider: <anthropic|cursor|openai> # cursor requires transport: cli
   transport: api # "api" (SDK) or "cli" (local agent binary); no default
   # model: claude-sonnet-4-6  # uses provider default if omitted
   # api_key_env: ANTHROPIC_API_KEY   # uses provider default if omitted
@@ -375,9 +377,9 @@ ai:
   lint: true # AI lint summaries during chk/fmt
   review: true # the `lintro review` AI diff review
 
-  # Provider: "anthropic", "openai" or "cursor" ("cursor" is CLI-only).
-  # (default: anthropic)
-  provider: anthropic
+  # Provider: "anthropic", "cursor", or "openai" ("cursor" is CLI-only).
+  # Required when ai.lint or ai.review is enabled. No default.
+  provider: <anthropic|cursor|openai>
 
   # How to invoke the provider: "api" (SDK) or "cli" (local agent binary).
   # No default — set it explicitly whenever ai.lint or ai.review is enabled.
@@ -585,7 +587,10 @@ CLI flags always override config: passing `--fix` on the CLI turns it on even if
 
 ### Providers
 
-#### [Anthropic](https://docs.anthropic.com/) (default)
+None of these is preferred. Set `ai.provider` (or `LINTRO_AI_PROVIDER` / `--provider`)
+whenever AI is on.
+
+#### [Anthropic](https://docs.anthropic.com/)
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
@@ -594,11 +599,28 @@ export ANTHROPIC_API_KEY=sk-ant-...
 ```yaml
 ai:
   provider: anthropic
-  # model: claude-sonnet-4-6  # default
+  # model: claude-sonnet-4-6  # provider default if omitted
 ```
 
 See the [Anthropic API docs](https://docs.anthropic.com/en/api/) for model options and
 pricing.
+
+#### [Cursor](https://cursor.com/docs)
+
+Cursor is CLI-only. Pair it with `transport: cli` and the `agent` binary.
+
+```bash
+export CURSOR_API_KEY=...
+```
+
+```yaml
+ai:
+  provider: cursor
+  transport: cli
+  # model: auto  # provider default if omitted
+```
+
+See the [Cursor CLI docs](https://cursor.com/docs/cli/overview) for model options.
 
 #### [OpenAI](https://platform.openai.com/docs/)
 
@@ -609,7 +631,7 @@ export OPENAI_API_KEY=sk-...
 ```yaml
 ai:
   provider: openai
-  # model: gpt-4o  # default
+  # model: gpt-4o  # provider default if omitted
 ```
 
 See the [OpenAI API docs](https://platform.openai.com/docs/api-reference/) for model
@@ -641,8 +663,8 @@ support both transports.
 ai:
   enabled: true
   review: true
-  provider: anthropic
-  transport: api # or "cli"
+  provider: <anthropic|cursor|openai>
+  transport: api # or "cli"; cursor requires cli
 ```
 
 Both `lintro check` and `lintro review` accept `--transport api|cli` to override the
@@ -665,7 +687,7 @@ as the legacy `ai.max_cost_usd` scalar.
 
 | Variable / flag                                           | Overrides         | Notes                                                                                        |
 | --------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------------- |
-| `LINTRO_AI_PROVIDER` / `lintro review --provider`         | `ai.provider`     | `anthropic`, `openai`, or `cursor`                                                           |
+| `LINTRO_AI_PROVIDER` / `lintro review --provider`         | `ai.provider`     | `anthropic`, `cursor`, or `openai`                                                           |
 | `LINTRO_AI_MODEL` / `lintro review --model`               | `ai.model`        | any model id; empty env falls through                                                        |
 | `LINTRO_AI_TRANSPORT` / `--transport`                     | `ai.transport`    | `api` or `cli`                                                                               |
 | `LINTRO_AI_ENABLED`                                       | `ai.enabled`      | `1`/`0`/`true`/`false`. `=1` does not turn on `ai.review` or `ai.lint`. No `--enabled` flag. |
@@ -700,9 +722,9 @@ credential-free.**
 | ----------- | --------- | ----------------------------------------------------------------- |
 | `anthropic` | `api`     | `ANTHROPIC_API_KEY`                                               |
 | `anthropic` | `cli`     | `claude` login session, `ANTHROPIC_API_KEY`, or an `apiKeyHelper` |
+| `cursor`    | `cli`     | `agent login` session or `CURSOR_API_KEY` (CLI-only provider)     |
 | `openai`    | `api`     | `OPENAI_API_KEY`                                                  |
 | `openai`    | `cli`     | `codex login` session (`~/.codex/auth.json`) or `CODEX_API_KEY`   |
-| `cursor`    | `cli`     | `agent login` session or `CURSOR_API_KEY` (CLI-only provider)     |
 
 `ai.api_key_env` overrides the API-transport variable name if you keep the key somewhere
 else.
@@ -765,8 +787,8 @@ instead of a confusing runtime error.
 | Provider    | Binary   | Minimum version | Upgrade                                           |
 | ----------- | -------- | --------------- | ------------------------------------------------- |
 | `anthropic` | `claude` | `2.0.0`         | `npm install -g @anthropic-ai/claude-code@latest` |
-| `openai`    | `codex`  | `0.20.0`        | `npm install -g @openai/codex@latest`             |
 | `cursor`    | `agent`  | `2025.1.1`      | `curl https://cursor.com/install -fsS \| bash`    |
+| `openai`    | `codex`  | `0.20.0`        | `npm install -g @openai/codex@latest`             |
 
 Source of truth: `lintro/ai/providers/cli_contracts.py`.
 
@@ -948,16 +970,16 @@ lost to truncation.
 When AI is enabled, the pre-execution summary table includes AI configuration:
 
 ```text
-┌───────────────┬──────────────────────────────────┐
-│ Setting       │ Value                            │
-├───────────────┼──────────────────────────────────┤
-│ AI            │ enabled                          │
-│               │   provider: anthropic            │
-│               │   model: claude-sonnet-4-...     │
-│               │   parallel: 5 workers            │
-│               │   safe-auto-apply: on            │
-│               │   verify-fixes: off               │
-└───────────────┴──────────────────────────────────┘
+┌───────────────┬────────────────────────────────────────────┐
+│ Setting       │ Value                                      │
+├───────────────┼────────────────────────────────────────────┤
+│ AI            │ enabled                                    │
+│               │   provider: <anthropic|cursor|openai>      │
+│               │   model: (provider default if omitted)     │
+│               │   parallel: 5 workers                      │
+│               │   safe-auto-apply: on                      │
+│               │   verify-fixes: off                        │
+└───────────────┴────────────────────────────────────────────┘
 ```
 
 This shows provider status, SDK availability, API key presence, and operational settings
@@ -985,24 +1007,24 @@ examples pass the key by **name** (`-e VAR`, no `=value`), so the secret is inhe
 from the shell's environment instead of appearing in the container's argument list.
 
 ```bash
-# API transport, with `ai: {provider: anthropic}` in the mounted config
+# Anthropic API — mounted config has `ai: {provider: anthropic, transport: api}`
 docker run --rm \
   -e ANTHROPIC_API_KEY \
   -v $(pwd):/code \
   ghcr.io/lgtm-hq/py-lintro-ai:latest check . --transport api
 
-# API transport, with `ai: {provider: openai}` in the mounted config
+# Cursor CLI — mounted config has `ai: {provider: cursor, transport: cli}`
+# The agent binaries are already on PATH in this image.
+docker run --rm \
+  -e CURSOR_API_KEY \
+  -v $(pwd):/code \
+  ghcr.io/lgtm-hq/py-lintro-ai:latest check . --transport cli
+
+# OpenAI API — mounted config has `ai: {provider: openai, transport: api}`
 docker run --rm \
   -e OPENAI_API_KEY \
   -v $(pwd):/code \
   ghcr.io/lgtm-hq/py-lintro-ai:latest check . --transport api
-
-# CLI transport — the agent binaries are already on PATH in this image.
-# The credential is still required (see "Transport authentication" above).
-docker run --rm \
-  -e ANTHROPIC_API_KEY \
-  -v $(pwd):/code \
-  ghcr.io/lgtm-hq/py-lintro-ai:latest check . --transport cli
 ```
 
 The agent CLIs live in `/opt/ai-tools`, installed from the digest-pinned
@@ -1050,7 +1072,7 @@ export OPENAI_API_KEY=sk-...
 
 **Unknown provider:**
 
-Only `anthropic`, `openai` and `cursor` are supported (`cursor` is CLI-transport only).
+Only `anthropic`, `cursor`, and `openai` are supported (`cursor` is CLI-transport only).
 Check your `ai.provider` value.
 
 ### Rate Limits

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -19,7 +19,9 @@ interactive fix suggestions on top of standard linting results.
 # .lintro-config.yaml
 # ai:
 #   enabled: true
-#   provider: <anthropic|cursor|openai>
+#   # Required when AI is on. No default.
+#   # Accepted: anthropic, cursor, openai (cursor requires transport: cli).
+#   provider: anthropic
 
 # Run check — AI summary is generated automatically (1 API call)
 lintro check
@@ -200,7 +202,9 @@ degrades gracefully to a skipped result rather than failing the run.
 # .lintro-config.yaml
 ai:
   enabled: true
-  provider: <anthropic|cursor|openai>
+  # Required when AI is on. No default.
+  # Accepted: anthropic, cursor, openai (cursor requires transport: cli).
+  provider: anthropic
   transport: api
 tools:
   idiom-review:
@@ -321,14 +325,29 @@ review:
 Add the `ai` section to `.lintro-config.yaml`:
 
 ```yaml
+# Anthropic
 ai:
-  enabled: true # master switch (AND-ed with the toggles below)
-  lint: true # AI lint summaries during chk/fmt
-  review: true # the `lintro review` AI diff review
-  provider: <anthropic|cursor|openai> # cursor requires transport: cli
-  transport: api # "api" (SDK) or "cli" (local agent binary); no default
-  # model: claude-sonnet-4-6  # uses provider default if omitted
-  # api_key_env: ANTHROPIC_API_KEY   # uses provider default if omitted
+  enabled: true
+  lint: true
+  review: true
+  provider: anthropic
+  transport: api
+
+# Cursor (CLI-only)
+ai:
+  enabled: true
+  lint: true
+  review: true
+  provider: cursor
+  transport: cli
+
+# OpenAI
+ai:
+  enabled: true
+  lint: true
+  review: true
+  provider: openai
+  transport: api
 ```
 
 ### Feature Toggles
@@ -379,7 +398,7 @@ ai:
 
   # Provider: "anthropic", "cursor", or "openai" ("cursor" is CLI-only).
   # Required when ai.lint or ai.review is enabled. No default.
-  provider: <anthropic|cursor|openai>
+  provider: anthropic
 
   # How to invoke the provider: "api" (SDK) or "cli" (local agent binary).
   # No default — set it explicitly whenever ai.lint or ai.review is enabled.
@@ -663,8 +682,10 @@ support both transports.
 ai:
   enabled: true
   review: true
-  provider: <anthropic|cursor|openai>
-  transport: api # or "cli"; cursor requires cli
+  # Required when AI is on. No default.
+  # Accepted: anthropic, cursor, openai (cursor requires transport: cli).
+  provider: anthropic
+  transport: api # or "cli"
 ```
 
 Both `lintro check` and `lintro review` accept `--transport api|cli` to override the
@@ -974,7 +995,7 @@ When AI is enabled, the pre-execution summary table includes AI configuration:
 │ Setting       │ Value                                      │
 ├───────────────┼────────────────────────────────────────────┤
 │ AI            │ enabled                                    │
-│               │   provider: <anthropic|cursor|openai>      │
+│               │   provider: anthropic                      │
 │               │   model: (provider default if omitted)     │
 │               │   parallel: 5 workers                      │
 │               │   safe-auto-apply: on                      │

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -1082,6 +1082,9 @@ uv pip install 'lintro[ai]'
 # Anthropic
 export ANTHROPIC_API_KEY=sk-ant-...
 
+# Cursor (CLI-only)
+export CURSOR_API_KEY=...
+
 # OpenAI
 export OPENAI_API_KEY=sk-...
 

--- a/docs/ai-review-transports.md
+++ b/docs/ai-review-transports.md
@@ -68,16 +68,15 @@ ai:
 
 ## Credentials
 
-| Provider    | Transport | Credential                |
-| ----------- | --------- | ------------------------- |
-| `anthropic` | `api`     | `ANTHROPIC_API_KEY`       |
-| `anthropic` | `cli`     | `CLAUDE_CODE_OAUTH_TOKEN` |
-| `cursor`    | `cli`     | `CURSOR_API_KEY`          |
-| `openai`    | `api`     | `OPENAI_API_KEY`          |
-| `openai`    | `cli`     | `CODEX_API_KEY`           |
+| Provider    | Transport | Credential                                                                        |
+| ----------- | --------- | --------------------------------------------------------------------------------- |
+| `anthropic` | `api`     | `ANTHROPIC_API_KEY`                                                               |
+| `anthropic` | `cli`     | `claude` login, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, or `apiKeyHelper` |
+| `cursor`    | `cli`     | `agent login` session or `CURSOR_API_KEY`                                         |
+| `openai`    | `api`     | `OPENAI_API_KEY`                                                                  |
+| `openai`    | `cli`     | `codex login` (`~/.codex/auth.json`) or `CODEX_API_KEY`                           |
 
-`cursor` is CLI-only. CLI transport also accepts a login session for the matching binary
-(`claude`, `agent`, `codex`) — see `docs/ai-features.md`.
+`cursor` is CLI-only. See `docs/ai-features.md` for per-binary login details.
 
 ### Anthropic `--bare` and `LINTRO_CLI_BARE`
 

--- a/docs/ai-review-transports.md
+++ b/docs/ai-review-transports.md
@@ -8,7 +8,7 @@ and reported numbers mean different things. Configure them under `ai.transports.
 
 | Dimension           | `api`                                       | `cli`                                                                                 |
 | ------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Credential          | `ANTHROPIC_API_KEY` (or provider key)       | `CLAUDE_CODE_OAUTH_TOKEN` / `claude` login                                            |
+| Credential          | Provider API key — see matrix below         | Provider CLI login or CLI key — see matrix below                                      |
 | Billing             | Metered API spend                           | Subscription / OAuth session                                                          |
 | Default timeout     | 60s (stream-sized per call)                 | 900s (whole-turn)                                                                     |
 | Cost cap field      | `ai.transports.api.max_cost_usd` (enforced) | `ai.transports.cli.max_cost_usd_advisory` (advisory)                                  |
@@ -17,10 +17,9 @@ and reported numbers mean different things. Configure them under `ai.transports.
 | Cost basis recorded | `billed`                                    | `unpriceable`                                                                         |
 | Typical CI failures | `insufficient_credits`, `auth_failed:key`   | `auth_failed:oauth_session`, `cli_version_drift`, `turn_timeout`, `killed_externally` |
 
-The credential rows above are Anthropic-specific (the dogfood default). Other CLI
-providers authenticate with their own logins and keys — `codex login` / `CODEX_API_KEY`
-for `openai`, `agent login` / `CURSOR_API_KEY` for `cursor` — see `docs/ai-features.md`,
-which also covers Claude's settings-file `apiKeyHelper` as a reachable API credential.
+Every `(provider, transport)` pair has its own credential. None is a default. Login
+sessions also satisfy CLI transport — see `docs/ai-features.md` for `apiKeyHelper` and
+per-binary login details.
 
 **Bare-billing exception:** under `cli` with Anthropic, when `ai.cli_bare` resolves to
 sending `--bare` (`auto` with a reachable `ANTHROPIC_API_KEY`, or `always`, #1859), the
@@ -47,7 +46,7 @@ transport=cli auth=subscription timeout=900 cap=advisory:$0.50 cost_basis=unpric
 ```yaml
 ai:
   enabled: true
-  provider: anthropic
+  provider: <anthropic|cursor|openai>
   transport: cli
   transports:
     api:
@@ -60,12 +59,25 @@ ai:
 
 ## When to use which
 
-- Prefer **`cli`** when you have a Claude Code / subscription OAuth session and want
-  dogfood CI without burning a metered API key.
-- Prefer **`api`** when you need enforced spend caps, streaming, or non-Claude providers
-  with API keys.
+- Prefer **`cli`** when you have a local agent login or subscription and want to avoid
+  metered API spend.
+- Prefer **`api`** when you need enforced spend caps, streaming, or an SDK-backed
+  provider.
 
-## Credentials and `LINTRO_CLI_BARE`
+## Credentials
+
+| Provider    | Transport | Credential                |
+| ----------- | --------- | ------------------------- |
+| `anthropic` | `api`     | `ANTHROPIC_API_KEY`       |
+| `anthropic` | `cli`     | `CLAUDE_CODE_OAUTH_TOKEN` |
+| `cursor`    | `cli`     | `CURSOR_API_KEY`          |
+| `openai`    | `api`     | `OPENAI_API_KEY`          |
+| `openai`    | `cli`     | `CODEX_API_KEY`           |
+
+`cursor` is CLI-only. CLI transport also accepts a login session for the matching binary
+(`claude`, `agent`, `codex`) — see `docs/ai-features.md`.
+
+### Anthropic `--bare` and `LINTRO_CLI_BARE`
 
 | Variable / setting                | Transport                    | Role                                                   |
 | --------------------------------- | ---------------------------- | ------------------------------------------------------ |
@@ -74,8 +86,8 @@ ai:
 | `ai.cli_bare` / `LINTRO_CLI_BARE` | cli                          | `auto` / `always` / `never` — whether to pass `--bare` |
 
 `--bare` disables OAuth session login and authenticates only against an API key
-(#1838/#1859). Dogfood CI pins `LINTRO_CLI_BARE=never` and keeps `ANTHROPIC_API_KEY` out
-of scope so the subscription token is actually used.
+(#1838/#1859). When dogfooding Anthropic CLI, pin `LINTRO_CLI_BARE=never` and keep
+`ANTHROPIC_API_KEY` out of scope so the subscription token is actually used.
 
 ## Reported numbers
 

--- a/docs/ai-review-transports.md
+++ b/docs/ai-review-transports.md
@@ -46,7 +46,9 @@ transport=cli auth=subscription timeout=900 cap=advisory:$0.50 cost_basis=unpric
 ```yaml
 ai:
   enabled: true
-  provider: <anthropic|cursor|openai>
+  # Required when AI is on. No default.
+  # Accepted: anthropic, cursor, openai (cursor requires transport: cli).
+  provider: cursor
   transport: cli
   transports:
     api:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2946,7 +2946,9 @@ ai:
   enabled: true
   lint: true # AI summaries / --fix on chk/fmt
   review: false # lintro review (opt-in separately)
-  provider: <anthropic|cursor|openai>
+  # Required when AI is on. No default.
+  # Accepted: anthropic, cursor, openai (cursor requires transport: cli).
+  provider: anthropic
 ```
 
 ### AI CLI Flags
@@ -3044,7 +3046,9 @@ skipped result rather than failing the run. Findings are cached by content hash 
 # .lintro-config.yaml
 ai:
   enabled: true
-  provider: <anthropic|cursor|openai>
+  # Required when AI is on. No default.
+  # Accepted: anthropic, cursor, openai (cursor requires transport: cli).
+  provider: anthropic
   transport: api
 tools:
   idiom-review:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2979,6 +2979,7 @@ ai:
 | `lint`                  | bool   | `false`        | Enable AI lint summaries on `chk`/`fmt`                                                      |
 | `review`                | bool   | `false`        | Enable the `lintro review` AI diff review                                                    |
 | `provider`              | string | none           | Required when AI is on (`anthropic`, `cursor`, or `openai`)                                  |
+| `transport`             | string | none           | Required when AI is on (`api` or `cli`; `cursor` requires `cli`)                             |
 | `model`                 | string | (default)      | Model override                                                                               |
 | `api_key_env`           | string | (default)      | Custom env var for API key                                                                   |
 | `default_fix`           | bool   | `false`        | Always run `--fix` in check                                                                  |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2949,6 +2949,7 @@ ai:
   # Required when AI is on. No default.
   # Accepted: anthropic, cursor, openai (cursor requires transport: cli).
   provider: anthropic
+  transport: api
 ```
 
 ### AI CLI Flags

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -492,7 +492,7 @@ export LINTRO_AI_MAX_COST_USD=0 # 0 = uncapped; a positive number is a USD cap
 | `LINTRO_DOCKER`                  | Force Docker install-context detection when set to `1`            | -         |
 | `LINTRO_CONFIG`                  | Shown in the `lintro` environment report; informational only      | -         |
 | `LINTRO_ENABLE_EXTERNAL_PLUGINS` | Opt in to loading external (third-party) plugins (`1`/`0`)        | `0`       |
-| `LINTRO_AI_PROVIDER`             | Override `ai.provider` (`anthropic` / `openai` / `cursor`)        | -         |
+| `LINTRO_AI_PROVIDER`             | Override `ai.provider` (`anthropic` / `cursor` / `openai`)        | -         |
 | `LINTRO_AI_MODEL`                | Override `ai.model`                                               | -         |
 | `LINTRO_AI_TRANSPORT`            | Override `ai.transport` (`api` / `cli`)                           | -         |
 | `LINTRO_AI_ENABLED`              | Override `ai.enabled` (`1`/`0`/`true`/`false`)                    | -         |
@@ -2931,10 +2931,13 @@ uv pip install 'lintro[ai]'
 uv sync --extra ai
 
 # Set API key for your configured provider
-# Anthropic (default): ANTHROPIC_API_KEY
-# OpenAI:              OPENAI_API_KEY
-# Custom:              set ai.api_key_env in config to use any env var name
-export ANTHROPIC_API_KEY=sk-ant-...
+# Anthropic: ANTHROPIC_API_KEY
+# Cursor:    CURSOR_API_KEY (CLI-only)
+# OpenAI:    OPENAI_API_KEY
+# Custom:    set ai.api_key_env in config to use any env var name
+# export ANTHROPIC_API_KEY=sk-ant-...
+# export CURSOR_API_KEY=...
+# export OPENAI_API_KEY=sk-...
 ```
 
 ```yaml
@@ -2943,7 +2946,7 @@ ai:
   enabled: true
   lint: true # AI summaries / --fix on chk/fmt
   review: false # lintro review (opt-in separately)
-  provider: anthropic
+  provider: <anthropic|cursor|openai>
 ```
 
 ### AI CLI Flags
@@ -2972,7 +2975,7 @@ ai:
 | `enabled`               | bool   | `false`        | Master switch; ANDs with `lint` / `review`                                                   |
 | `lint`                  | bool   | `false`        | Enable AI lint summaries on `chk`/`fmt`                                                      |
 | `review`                | bool   | `false`        | Enable the `lintro review` AI diff review                                                    |
-| `provider`              | string | `anthropic`    | AI provider (`anthropic` or `openai`)                                                        |
+| `provider`              | string | none           | Required when AI is on (`anthropic`, `cursor`, or `openai`)                                  |
 | `model`                 | string | (default)      | Model override                                                                               |
 | `api_key_env`           | string | (default)      | Custom env var for API key                                                                   |
 | `default_fix`           | bool   | `false`        | Always run `--fix` in check                                                                  |
@@ -3009,7 +3012,7 @@ is classified **advisory**, so it runs under `lintro review` — never under
 
 ```bash
 uv pip install 'lintro[ai]'
-export ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI_API_KEY for OpenAI
+export ANTHROPIC_API_KEY=sk-ant-...   # or CURSOR_API_KEY / OPENAI_API_KEY
 ```
 
 The tool is **disabled by default** and is a no-op until explicitly opted in. When no AI
@@ -3041,7 +3044,7 @@ skipped result rather than failing the run. Findings are cached by content hash 
 # .lintro-config.yaml
 ai:
   enabled: true
-  provider: anthropic
+  provider: <anthropic|cursor|openai>
   transport: api
 tools:
   idiom-review:

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -132,7 +132,7 @@ failures without scraping human-readable stderr prose:
 | Field       | Type            | Meaning                                                                 |
 | ----------- | --------------- | ----------------------------------------------------------------------- |
 | `kind`      | string (enum)   | Canonical classification (see below). Stable across providers.          |
-| `provider`  | string          | Provider identifier, lowercased (e.g. `anthropic`, `openai`, `cursor`). |
+| `provider`  | string          | Provider identifier, lowercased (e.g. `anthropic`, `cursor`, `openai`). |
 | `status`    | integer \| null | Extracted HTTP status (e.g. `401`, `429`, `529`), or `null` when none.  |
 | `retryable` | boolean         | `true` for transient conditions safe to retry unchanged.                |
 | `message`   | string          | The most specific underlying cause text.                                |

--- a/lintro/ai/availability.py
+++ b/lintro/ai/availability.py
@@ -25,6 +25,7 @@ from lintro.ai.liveness import (
     LivenessState,
     check_liveness_sync,
 )
+from lintro.ai.provider_enum import accepted_provider_values
 from lintro.ai.registry import AIProvider
 
 __all__ = [
@@ -114,11 +115,10 @@ def is_provider_available(
 
     provider_enum = _resolve_provider(provider)
     if provider_enum is None:
-        supported = ", ".join(p.value for p in AIProvider)
         logger.warning(
             "Unknown AI provider {!r}; supported providers: {}",
             provider,
-            supported,
+            accepted_provider_values(),
         )
         return False
 

--- a/lintro/ai/config_overrides.py
+++ b/lintro/ai/config_overrides.py
@@ -332,7 +332,7 @@ def _describe_validation_error(
 
     Returns:
         A one-line message such as
-        ``LINTRO_AI_PROVIDER='cursur' is not one of: anthropic, openai, cursor``.
+        ``LINTRO_AI_PROVIDER='cursur' is not one of: anthropic, cursor, openai``.
     """
     for error in exc.errors():
         loc = error.get("loc", ())

--- a/lintro/ai/provider_enum.py
+++ b/lintro/ai/provider_enum.py
@@ -19,13 +19,22 @@ class AIProvider(StrEnum):
     CURSOR = auto()
 
 
-def accepted_provider_values() -> str:
+def accepted_provider_names() -> list[str]:
     """Return accepted provider names in alphabetical order.
+
+    Returns:
+        Sorted provider values suitable for help text and ``click.Choice``.
+    """
+    return sorted(member.value for member in AIProvider)
+
+
+def accepted_provider_values() -> str:
+    """Return the user-facing accepted-provider list, alphabetically.
 
     Returns:
         Comma-separated provider names with no implied ranking.
     """
-    return ", ".join(sorted(member.value for member in AIProvider))
+    return ", ".join(accepted_provider_names())
 
 
 def provider_required_error() -> str:

--- a/lintro/ai/providers/__init__.py
+++ b/lintro/ai/providers/__init__.py
@@ -35,6 +35,21 @@ DEFAULT_API_KEY_ENVS: dict[str, str] = {
     p.value: e for p, e in PROVIDERS.default_api_key_envs.items()
 }
 
+_PROVIDER_CLASSES: dict[AIProvider, tuple[str, str]] = {
+    AIProvider.ANTHROPIC: (
+        "lintro.ai.providers.anthropic",
+        "AnthropicProvider",
+    ),
+    AIProvider.OPENAI: (
+        "lintro.ai.providers.openai",
+        "OpenAIProvider",
+    ),
+    AIProvider.CURSOR: (
+        "lintro.ai.providers.cursor",
+        "CursorProvider",
+    ),
+}
+
 
 def _implemented_provider_list(
     provider_classes: Mapping[AIProvider, object],
@@ -80,25 +95,10 @@ def get_provider(
             f"Supported providers: {accepted_provider_values()}",
         ) from exc
 
-    provider_classes: dict[AIProvider, tuple[str, str]] = {
-        AIProvider.ANTHROPIC: (
-            "lintro.ai.providers.anthropic",
-            "AnthropicProvider",
-        ),
-        AIProvider.OPENAI: (
-            "lintro.ai.providers.openai",
-            "OpenAIProvider",
-        ),
-        AIProvider.CURSOR: (
-            "lintro.ai.providers.cursor",
-            "CursorProvider",
-        ),
-    }
-
-    entry = provider_classes.get(provider_enum)
+    entry = _PROVIDER_CLASSES.get(provider_enum)
     if entry is None:
         implemented = _implemented_provider_list(
-            provider_classes=provider_classes,
+            provider_classes=_PROVIDER_CLASSES,
         )
         raise ValueError(
             f"AI provider '{provider_enum.value}' is recognized but not "

--- a/lintro/ai/providers/__init__.py
+++ b/lintro/ai/providers/__init__.py
@@ -82,7 +82,7 @@ def get_provider(
 
     entry = provider_classes.get(provider_enum)
     if entry is None:
-        implemented = ", ".join(p.value for p in provider_classes)
+        implemented = ", ".join(sorted(p.value for p in provider_classes))
         raise ValueError(
             f"AI provider '{provider_enum.value}' is recognized but not "
             f"implemented. Implemented providers: {implemented}",

--- a/lintro/ai/providers/__init__.py
+++ b/lintro/ai/providers/__init__.py
@@ -6,6 +6,7 @@ the appropriate AI provider based on configuration.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -33,6 +34,20 @@ DEFAULT_MODELS: dict[str, str] = {
 DEFAULT_API_KEY_ENVS: dict[str, str] = {
     p.value: e for p, e in PROVIDERS.default_api_key_envs.items()
 }
+
+
+def _implemented_provider_list(
+    provider_classes: Mapping[AIProvider, object],
+) -> str:
+    """Return implemented provider names in alphabetical order.
+
+    Args:
+        provider_classes: Mapping of implemented providers.
+
+    Returns:
+        Comma-separated provider values with no implied ranking.
+    """
+    return ", ".join(sorted(member.value for member in provider_classes))
 
 
 def get_provider(
@@ -82,7 +97,9 @@ def get_provider(
 
     entry = provider_classes.get(provider_enum)
     if entry is None:
-        implemented = ", ".join(sorted(p.value for p in provider_classes))
+        implemented = _implemented_provider_list(
+            provider_classes=provider_classes,
+        )
         raise ValueError(
             f"AI provider '{provider_enum.value}' is recognized but not "
             f"implemented. Implemented providers: {implemented}",

--- a/lintro/ai/providers/__init__.py
+++ b/lintro/ai/providers/__init__.py
@@ -6,7 +6,6 @@ the appropriate AI provider based on configuration.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -34,35 +33,6 @@ DEFAULT_MODELS: dict[str, str] = {
 DEFAULT_API_KEY_ENVS: dict[str, str] = {
     p.value: e for p, e in PROVIDERS.default_api_key_envs.items()
 }
-
-_PROVIDER_CLASSES: dict[AIProvider, tuple[str, str]] = {
-    AIProvider.ANTHROPIC: (
-        "lintro.ai.providers.anthropic",
-        "AnthropicProvider",
-    ),
-    AIProvider.OPENAI: (
-        "lintro.ai.providers.openai",
-        "OpenAIProvider",
-    ),
-    AIProvider.CURSOR: (
-        "lintro.ai.providers.cursor",
-        "CursorProvider",
-    ),
-}
-
-
-def _implemented_provider_list(
-    provider_classes: Mapping[AIProvider, object],
-) -> str:
-    """Return implemented provider names in alphabetical order.
-
-    Args:
-        provider_classes: Mapping of implemented providers.
-
-    Returns:
-        Comma-separated provider values with no implied ranking.
-    """
-    return ", ".join(sorted(member.value for member in provider_classes))
 
 
 def get_provider(
@@ -94,16 +64,6 @@ def get_provider(
             f"Unknown AI provider: '{config.provider}'. "
             f"Supported providers: {accepted_provider_values()}",
         ) from exc
-
-    entry = _PROVIDER_CLASSES.get(provider_enum)
-    if entry is None:
-        implemented = _implemented_provider_list(
-            provider_classes=_PROVIDER_CLASSES,
-        )
-        raise ValueError(
-            f"AI provider '{provider_enum.value}' is recognized but not "
-            f"implemented. Implemented providers: {implemented}",
-        )
 
     maybe_start_transcript(
         workspace_root=workspace_root or resolve_workspace_root(None),

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -38,7 +38,10 @@ from lintro.ai.exceptions import (
     AIProviderRequiredError,
 )
 from lintro.ai.paths import resolve_workspace_root
-from lintro.ai.provider_enum import AIProvider, provider_required_error
+from lintro.ai.provider_enum import (
+    accepted_provider_names,
+    provider_required_error,
+)
 from lintro.ai.providers import get_provider
 from lintro.ai.review import (
     classify_changed_files,
@@ -279,7 +282,7 @@ def _advisory_failure_error(results: list[ToolResult]) -> AIError:
     "--provider",
     "provider_override",
     type=click.Choice(
-        [member.value for member in AIProvider],
+        accepted_provider_names(),
         case_sensitive=False,
     ),
     default=None,

--- a/tests/unit/ai/providers/test_factory.py
+++ b/tests/unit/ai/providers/test_factory.py
@@ -9,8 +9,9 @@ import pytest
 from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
+from lintro.ai.provider_enum import AIProvider
+from lintro.ai.providers import _implemented_provider_list, get_provider
 from lintro.ai.providers import anthropic as anthropic_mod
-from lintro.ai.providers import get_provider
 from lintro.ai.providers import openai as openai_mod
 
 
@@ -36,6 +37,18 @@ def test_get_provider_unknown_raises():
     config = AIConfig.model_construct(provider="unknown")
     with pytest.raises(ValueError, match="Unknown AI provider"):
         get_provider(config)
+
+
+def test_implemented_provider_list_is_alphabetical() -> None:
+    """The unimplemented-provider error lists names alphabetically."""
+    classes = {
+        AIProvider.ANTHROPIC: object(),
+        AIProvider.OPENAI: object(),
+        AIProvider.CURSOR: object(),
+    }
+    assert_that(
+        _implemented_provider_list(provider_classes=classes),
+    ).is_equal_to("anthropic, cursor, openai")
 
 
 def test_get_provider_requires_explicit_provider() -> None:

--- a/tests/unit/ai/providers/test_factory.py
+++ b/tests/unit/ai/providers/test_factory.py
@@ -9,7 +9,6 @@ import pytest
 from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
-from lintro.ai.provider_enum import AIProvider
 from lintro.ai.providers import anthropic as anthropic_mod
 from lintro.ai.providers import get_provider
 from lintro.ai.providers import openai as openai_mod
@@ -37,39 +36,6 @@ def test_get_provider_unknown_raises():
     config = AIConfig.model_construct(provider="unknown")
     with pytest.raises(ValueError, match="Unknown AI provider"):
         get_provider(config)
-
-
-def test_get_provider_unimplemented_lists_alphabetically(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A recognized-but-unimplemented provider lists names alphabetically."""
-    import lintro.ai.providers as providers_mod
-
-    monkeypatch.setattr(
-        providers_mod,
-        "_PROVIDER_CLASSES",
-        {
-            AIProvider.OPENAI: (
-                "lintro.ai.providers.openai",
-                "OpenAIProvider",
-            ),
-            AIProvider.ANTHROPIC: (
-                "lintro.ai.providers.anthropic",
-                "AnthropicProvider",
-            ),
-        },
-    )
-    config = AIConfig.model_construct(provider=AIProvider.CURSOR)
-    with pytest.raises(
-        ValueError,
-        match="recognized but not implemented",
-    ) as exc_info:
-        get_provider(config)
-    message = str(exc_info.value)
-    assert_that(message).contains("Implemented providers: anthropic, openai")
-    assert_that(message).does_not_contain(
-        "Implemented providers: openai, anthropic",
-    )
 
 
 def test_get_provider_requires_explicit_provider() -> None:

--- a/tests/unit/ai/providers/test_factory.py
+++ b/tests/unit/ai/providers/test_factory.py
@@ -10,8 +10,8 @@ from assertpy import assert_that
 
 from lintro.ai.config import AIConfig
 from lintro.ai.provider_enum import AIProvider
-from lintro.ai.providers import _implemented_provider_list, get_provider
 from lintro.ai.providers import anthropic as anthropic_mod
+from lintro.ai.providers import get_provider
 from lintro.ai.providers import openai as openai_mod
 
 
@@ -39,16 +39,37 @@ def test_get_provider_unknown_raises():
         get_provider(config)
 
 
-def test_implemented_provider_list_is_alphabetical() -> None:
-    """The unimplemented-provider error lists names alphabetically."""
-    classes = {
-        AIProvider.ANTHROPIC: object(),
-        AIProvider.OPENAI: object(),
-        AIProvider.CURSOR: object(),
-    }
-    assert_that(
-        _implemented_provider_list(provider_classes=classes),
-    ).is_equal_to("anthropic, cursor, openai")
+def test_get_provider_unimplemented_lists_alphabetically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recognized-but-unimplemented provider lists names alphabetically."""
+    import lintro.ai.providers as providers_mod
+
+    monkeypatch.setattr(
+        providers_mod,
+        "_PROVIDER_CLASSES",
+        {
+            AIProvider.OPENAI: (
+                "lintro.ai.providers.openai",
+                "OpenAIProvider",
+            ),
+            AIProvider.ANTHROPIC: (
+                "lintro.ai.providers.anthropic",
+                "AnthropicProvider",
+            ),
+        },
+    )
+    config = AIConfig.model_construct(provider=AIProvider.CURSOR)
+    with pytest.raises(
+        ValueError,
+        match="recognized but not implemented",
+    ) as exc_info:
+        get_provider(config)
+    message = str(exc_info.value)
+    assert_that(message).contains("Implemented providers: anthropic, openai")
+    assert_that(message).does_not_contain(
+        "Implemented providers: openai, anthropic",
+    )
 
 
 def test_get_provider_requires_explicit_provider() -> None:

--- a/tests/unit/ai/test_availability.py
+++ b/tests/unit/ai/test_availability.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import click
 import pytest
 from assertpy import assert_that
+from loguru import logger
 
 from lintro.ai.availability import (
     is_ai_available,
@@ -58,6 +59,24 @@ def test_availability_unknown_provider():
     """Verify that an unknown provider is reported as unavailable."""
     result = is_provider_available("unknown")
     assert_that(result).is_false()
+
+
+def test_availability_unknown_provider_lists_providers_alphabetically() -> None:
+    """Unknown-provider warnings list accepted names alphabetically."""
+    messages: list[str] = []
+    handler_id = logger.add(
+        lambda message: messages.append(str(message)),
+        level="WARNING",
+    )
+    try:
+        result = is_provider_available("unknown")
+    finally:
+        logger.remove(handler_id)
+
+    assert_that(result).is_false()
+    assert_that(messages).is_not_empty()
+    assert_that(messages[0]).contains("anthropic, cursor, openai")
+    assert_that(messages[0]).does_not_contain("anthropic, openai, cursor")
 
 
 def test_availability_require_raises_when_unavailable():

--- a/tests/unit/ai/test_registry.py
+++ b/tests/unit/ai/test_registry.py
@@ -8,6 +8,7 @@ import pytest
 from assertpy import assert_that
 
 from lintro.ai.provider_enum import (
+    accepted_provider_names,
     accepted_provider_values,
     provider_required_error,
 )
@@ -51,6 +52,13 @@ def test_aiprovider_invalid_value_raises():
     """Constructing AIProvider with an unknown value raises ValueError."""
     with pytest.raises(ValueError, match="not a valid"):
         AIProvider("gemini")
+
+
+def test_accepted_provider_names_are_alphabetical() -> None:
+    """Choice lists and help text use the same sorted names."""
+    assert_that(accepted_provider_names()).is_equal_to(
+        ["anthropic", "cursor", "openai"],
+    )
 
 
 def test_accepted_provider_values_are_alphabetical() -> None:

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -66,6 +66,16 @@ def test_review_help_shows_flags() -> None:
     assert_that(result.output).contains("--max-cost-usd")
 
 
+def test_review_help_lists_providers_alphabetically() -> None:
+    """``--provider`` help lists providers alphabetically, with no ranking."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["review", "--help"])
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(result.output).contains("anthropic|cursor|openai")
+    assert_that(result.output).does_not_contain("anthropic|openai|cursor")
+
+
 def test_review_invalid_provider_env_exits_two(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai): present providers without a default
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Findings 2 and 5 of #2143: stop presenting Anthropic as the default provider, and list every user-visible provider enumeration alphabetically so the order carries no ranking.

Docs no longer mark Anthropic as `(default)`. Provider sections in `docs/ai-features.md` are equal-shape and alphabetical (Anthropic, Cursor, OpenAI). Basic setup shows three separate, copy-pasteable configs. Other AI-on examples list the accepted set and include required `provider` + `transport`. `docs/ai-review-transports.md` has the full `(provider, transport)` credential matrix, including CLI login sessions.

`--provider` help, unknown-provider warnings, and override error examples list `anthropic, cursor, openai` via `accepted_provider_names()` / `accepted_provider_values()`. The `AIProvider` enum definition order is unchanged.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Targeted unit suite passed
- [x] Follow-up commits address review nits

## Related Issues

Relates to #2143

## Details

### Docs

- `docs/ai-features.md`: remove default claims; add a Cursor section; alphabetize tables and Docker examples
- `docs/configuration.md`: `ai.provider` and `ai.transport` are none / required when AI is on
- `docs/ai-review-transports.md`: provider-neutral decision table + credential matrix
- `README.md` and `docs/github-integration.md`: include Cursor; alphabetical lists
- `--provider` is scoped to `lintro review`; `LINTRO_AI_PROVIDER` applies to check/format

### Code

- `accepted_provider_names()` returns `["anthropic", "cursor", "openai"]`
- `lintro review --provider` uses that list for `click.Choice`
- Unknown-provider availability warnings use `accepted_provider_values()`

### Tests

- `test_review_help_lists_providers_alphabetically`
- `test_accepted_provider_names_are_alphabetical`
- `test_availability_unknown_provider_lists_providers_alphabetically`

### Review follow-ups

- CodeRabbit: valid provider values; required `transport` on AI-on examples; three separate Basic Setup fences
- Lintro: aligned credential matrices; status example matches `render_ai_status`; unused factory class map removed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29e56a44-9c36-448f-a5fe-9e5df5902e41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29e56a44-9c36-448f-a5fe-9e5df5902e41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documented support for Cursor as an AI provider, including CLI authentication, configuration, models, Docker usage, and troubleshooting.
  * Clarified API and CLI transport options and provider-specific credential requirements.
  * Documented explicit provider and transport selection when AI features are enabled.

* **Documentation**
  * Updated configuration, review, integration, and AI feature guides with Anthropic, Cursor, and OpenAI examples.
  * Clarified provider defaults, supported-provider ordering, environment variables, and CLI login behavior.

* **Bug Fixes**
  * Standardized provider listings alphabetically across warnings, validation messages, and command-line help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->